### PR TITLE
Clear stale Git chips after .git is removed

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -160,6 +160,11 @@ pub struct CurrentPrompt {
     /// When set, branch, branch status, and diff stats are populated from
     /// `GitRepoStatusModel` filesystem events.
     git_repo_status: Option<WeakModelHandle<GitRepoStatusModel>>,
+    /// Whether the current git status model has produced metadata. This keeps
+    /// transient initial `None` values from clearing shell-provided branch
+    /// information while still allowing a later `Some` -> `None` transition
+    /// to invalidate stale git chips.
+    git_repo_metadata_available: bool,
 
     /// When set, the `GithubPullRequest` chip value is populated from
     /// `GitHubRepoModel` for the current repository.
@@ -234,6 +239,7 @@ impl CurrentPrompt {
             same_line_prompt_enabled: prompt.as_ref(ctx).same_line_prompt_enabled(),
             separator: prompt.as_ref(ctx).separator(),
             git_repo_status: None,
+            git_repo_metadata_available: false,
             github_repo_model: None,
         }
     }
@@ -1388,25 +1394,23 @@ impl CurrentPrompt {
         handle: Option<WeakModelHandle<GitRepoStatusModel>>,
         ctx: &mut ModelContext<Self>,
     ) {
+        let had_git_repo_metadata = self.git_repo_metadata_available;
+
         // Unsubscribe from the previous model, if any.
         if let Some(old_weak) = self.git_repo_status.take() {
             if let Some(old_strong) = old_weak.upgrade(ctx) {
                 ctx.unsubscribe_from_model(&old_strong);
             }
         }
+        self.git_repo_metadata_available = false;
 
         // Repo detached, clear git chips that require repository metadata.
         if handle.is_none() {
-            for chip_kind in [
-                ContextChipKind::GitDiffStats,
-                ContextChipKind::GitBranchStatus,
-            ] {
-                if let Some(state) = self.states.get_mut(&chip_kind) {
-                    state.clear_abort_handlers();
-                    state.clear_cache();
-                }
+            if had_git_repo_metadata {
+                self.clear_git_repo_metadata();
+            } else {
+                self.clear_git_status_chips();
             }
-            let _ = self.update_tx.try_send(());
             return;
         }
 
@@ -1483,8 +1487,13 @@ impl CurrentPrompt {
             .and_then(|h| h.as_ref(ctx).metadata(ctx).cloned());
 
         let Some(metadata) = metadata else {
+            if self.git_repo_metadata_available {
+                self.git_repo_metadata_available = false;
+                self.clear_git_repo_metadata();
+            }
             return;
         };
+        self.git_repo_metadata_available = true;
 
         // Update ShellGitBranch.
         let new_branch = ChipValue::Text(metadata.current_branch_name.clone());
@@ -1520,6 +1529,31 @@ impl CurrentPrompt {
         if current_diff_stats.as_ref() != Some(&new_diff_stats) {
             self.update_chip_value(&ContextChipKind::GitDiffStats, Some(new_diff_stats));
         }
+    }
+
+    fn clear_git_repo_metadata(&mut self) {
+        self.clear_git_chips(&[
+            ContextChipKind::ShellGitBranch,
+            ContextChipKind::GitBranchStatus,
+            ContextChipKind::GitDiffStats,
+        ]);
+    }
+
+    fn clear_git_status_chips(&mut self) {
+        self.clear_git_chips(&[
+            ContextChipKind::GitBranchStatus,
+            ContextChipKind::GitDiffStats,
+        ]);
+    }
+
+    fn clear_git_chips(&mut self, chip_kinds: &[ContextChipKind]) {
+        for chip_kind in chip_kinds {
+            if let Some(state) = self.states.get_mut(chip_kind) {
+                state.clear_abort_handlers();
+                state.clear_cache();
+            }
+        }
+        let _ = self.update_tx.try_send(());
     }
 
     /// Reads PR info from the per-repo `GitHubRepoModel` and updates the

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -711,6 +711,157 @@ fn test_git_status_change_updates_branch_status_chip_value() {
 
 #[cfg(feature = "local_fs")]
 #[test]
+fn test_initial_missing_git_status_metadata_preserves_shell_branch() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [ContextChipKind::ShellGitBranch],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+        let git_status = app
+            .add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repo_handle, None, ctx));
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+            cp.update_states_with_new_context(ctx);
+            cp.update_chip_value(
+                &ContextChipKind::ShellGitBranch,
+                Some(crate::context_chips::ChipValue::Text("main".to_string())),
+            );
+        });
+
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(None, ctx);
+        });
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.set_git_repo_status(None, ctx);
+        });
+
+        app.read(|ctx| {
+            assert_eq!(
+                current_prompt
+                    .as_ref(ctx)
+                    .latest_chip_value(&ContextChipKind::ShellGitBranch),
+                Some(&crate::context_chips::ChipValue::Text("main".to_string())),
+                "Initial missing metadata should not clear the shell-provided branch"
+            );
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_git_status_metadata_removal_clears_git_chips() {
+    App::test((), |mut app| async move {
+        let git_chip_kinds = [
+            ContextChipKind::ShellGitBranch,
+            ContextChipKind::GitBranchStatus,
+            ContextChipKind::GitDiffStats,
+        ];
+        let prompt_git_chip_kinds = git_chip_kinds.clone();
+        app.add_singleton_model(move |_| {
+            Prompt::mock_with(prompt_git_chip_kinds, false, WarpPromptSeparator::None)
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+        let git_status = app
+            .add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repo_handle, None, ctx));
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+            cp.update_states_with_new_context(ctx);
+        });
+
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(Some(git_status_metadata("main")), ctx);
+        });
+
+        app.read(|ctx| {
+            for chip_kind in &git_chip_kinds {
+                assert!(
+                    current_prompt
+                        .as_ref(ctx)
+                        .latest_chip_value(chip_kind)
+                        .is_some(),
+                    "{chip_kind:?} should be populated while git metadata is available"
+                );
+            }
+        });
+
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(None, ctx);
+        });
+
+        app.read(|ctx| {
+            for chip_kind in &git_chip_kinds {
+                assert!(
+                    current_prompt
+                        .as_ref(ctx)
+                        .latest_chip_value(chip_kind)
+                        .is_none(),
+                    "{chip_kind:?} should be cleared when git metadata is unavailable"
+                );
+            }
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
 fn test_git_status_pr_info_updates_github_pr_chip_value() {
     let _flag_guard = FeatureFlag::GithubPrPromptChip.override_enabled(true);
     App::test((), |mut app| async move {

--- a/app/src/integration_testing/context_chips/assertions.rs
+++ b/app/src/integration_testing/context_chips/assertions.rs
@@ -21,3 +21,25 @@ pub fn assert_working_dir_is_present(tab_index: usize) -> AssertionCallback {
         })
     })
 }
+
+/// Assertion that the Git branch prompt chip either has a value or is absent.
+pub fn assert_git_branch_prompt_chip_presence(
+    tab_index: usize,
+    should_be_present: bool,
+) -> AssertionCallback {
+    Box::new(move |app, window_id| {
+        let terminal_view = single_terminal_view_for_tab(app, window_id, tab_index);
+        terminal_view.read(app, |view, ctx| {
+            let prompt = view.current_prompt();
+            prompt.read(ctx, |prompt, ctx| {
+                let is_present = prompt
+                    .latest_chip_value(&ContextChipKind::ShellGitBranch, ctx)
+                    .is_some();
+                async_assert!(
+                    is_present == should_be_present,
+                    "Git branch prompt chip presence mismatch: expected={should_be_present}, actual={is_present}"
+                )
+            })
+        })
+    })
+}

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -292,6 +292,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_inline_model_selector_restores_prompt_on_dismissal);
     register_test!(test_inline_model_selector_restores_prompt_on_model_selection);
     register_test!(test_inline_model_selector_restores_prompt_on_chip_toggle_close);
+    register_test!(test_deleting_git_marker_clears_git_branch_prompt_chip);
     register_test!(test_paste_and_type_characters_before_bootstrap);
     register_test!(test_code_review_scroll_anchor_preserved_when_inserting_above);
     register_test!(test_code_review_scroll_anchor_unchanged_when_inserting_below);

--- a/crates/integration/src/test/input.rs
+++ b/crates/integration/src/test/input.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Duration;
 
+use command::blocking::Command;
+use settings::Setting as _;
 use warp::features::FeatureFlag;
 use warp::integration_testing::clipboard::write_to_clipboard;
+use warp::integration_testing::context_chips::assert_git_branch_prompt_chip_presence;
 use warp::integration_testing::input::{
     assert_autosuggestion_state, input_contains_string, input_is_empty,
     latest_buffer_operations_are_empty, open_inline_model_selector_from_chip,
@@ -17,6 +22,7 @@ use warp::integration_testing::terminal::{
 use warp::integration_testing::view_getters::{
     single_input_view_for_tab, single_terminal_view_for_tab,
 };
+use warp::terminal::session_settings::HonorPS1;
 use warp::terminal::shell::ShellType;
 use warpui_core::integration::TestStep;
 use warpui_core::{async_assert_eq, Event};
@@ -318,5 +324,100 @@ pub fn test_git_prompt_chips() -> Builder {
                         })
                     })
             }),
+        )
+}
+
+/// Checks that deleting a repository's `.git` marker clears the Git branch
+/// prompt chip in the existing pane.
+pub fn test_deleting_git_marker_clears_git_branch_prompt_chip() -> Builder {
+    new_builder()
+        .use_tmp_filesystem_for_test_root_directory()
+        .with_user_defaults(HashMap::from([
+            (HonorPS1::storage_key().to_owned(), false.to_string()),
+            (String::from("SavedPrompt"), String::from("Default")),
+        ]))
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Create a dirty Git repository outside the shell")
+                .with_action(|app, window_id, _| {
+                    let terminal_view = single_terminal_view_for_tab(app, window_id, 0);
+                    let repo_path = terminal_view
+                        .read(app, |terminal_view, _| terminal_view.pwd())
+                        .map(PathBuf::from)
+                        .expect("terminal should have a working directory")
+                        .join("repo");
+                    std::fs::create_dir(&repo_path)
+                        .expect("must be able to create the repository directory");
+                    assert!(
+                        Command::new("git")
+                            .args(["init", "-b", "main"])
+                            .current_dir(&repo_path)
+                            .status()
+                            .expect("git init should run")
+                            .success(),
+                        "git init should succeed"
+                    );
+                    std::fs::write(repo_path.join("file"), "initial\n")
+                        .expect("must be able to create the tracked file");
+                    assert!(
+                        Command::new("git")
+                            .args(["add", "file"])
+                            .current_dir(&repo_path)
+                            .status()
+                            .expect("git add should run")
+                            .success(),
+                        "git add should succeed"
+                    );
+                    assert!(
+                        Command::new("git")
+                            .args([
+                                "-c",
+                                "user.email=test@test.com",
+                                "-c",
+                                "user.name=Git TestUser",
+                                "commit",
+                                "-m",
+                                "initial",
+                            ])
+                            .current_dir(&repo_path)
+                            .status()
+                            .expect("git commit should run")
+                            .success(),
+                        "git commit should succeed"
+                    );
+                    std::fs::write(repo_path.join("file"), "initial\nchange\n")
+                        .expect("must be able to modify the tracked file");
+                }),
+        )
+        .with_step(execute_command_for_single_terminal_in_tab(
+            0,
+            "cd repo".into(),
+            ExpectedExitStatus::Success,
+            (),
+        ))
+        .with_step(
+            new_step_with_default_assertions("Git branch prompt chip should be populated")
+                .set_timeout(Duration::from_secs(15))
+                .add_named_assertion(
+                    "Git branch prompt chip has a value",
+                    assert_git_branch_prompt_chip_presence(0, true),
+                ),
+        )
+        .with_step(
+            new_step_with_default_assertions("Git branch prompt chip should be cleared")
+                .with_action(|app, window_id, _| {
+                    let terminal_view = single_terminal_view_for_tab(app, window_id, 0);
+                    let repo_path = terminal_view
+                        .read(app, |terminal_view, _| terminal_view.pwd())
+                        .map(PathBuf::from)
+                        .expect("terminal should have a working directory");
+                    std::fs::rename(repo_path.join(".git"), repo_path.join(".git-disabled"))
+                        .expect("must be able to move the .git marker");
+                })
+                .set_timeout(Duration::from_secs(15))
+                .add_named_assertion(
+                    "Git branch prompt chip is absent",
+                    assert_git_branch_prompt_chip_presence(0, false),
+                ),
         )
 }

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -143,6 +143,7 @@ integration_tests! {
     test_inline_model_selector_restores_prompt_on_dismissal,
     test_inline_model_selector_restores_prompt_on_model_selection,
     test_inline_model_selector_restores_prompt_on_chip_toggle_close,
+    test_deleting_git_marker_clears_git_branch_prompt_chip,
     test_paste_and_type_characters_before_bootstrap,
     #[ignore = "Flaking on CI - KC looking into 3/31/26"]
     test_code_review_scroll_anchor_preserved_when_inserting_above,

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -703,6 +703,10 @@ pub fn is_git_internal_path(path: &Path) -> bool {
     })
 }
 
+pub(crate) fn is_git_repository_marker(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some(".git")
+}
+
 /// Returns `true` when `path` is, contains, or lies on the way to one of the
 /// `force_included_paths`. Each force-included path is a relative component
 /// sequence (e.g. `.agents/skills`) matched against the tail of `path`, so a
@@ -921,6 +925,9 @@ pub(crate) fn is_index_lock_file(path: &Path) -> bool {
 pub fn should_ignore_git_path(path: &Path) -> bool {
     if !is_git_internal_path(path) {
         return false; // Not a git path, don't ignore
+    }
+    if is_git_repository_marker(path) {
+        return false;
     }
     // Ignore everything inside .git/ except the allowlisted patterns.
     !is_commit_related_git_file(path)

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -28,8 +28,11 @@ fn test_git_path_filtering_allowlist() {
         "/home/user/project/README.md"
     )));
 
-    // .git directory itself should be ignored
-    assert!(should_ignore_git_path(Path::new("/home/user/project/.git")));
+    // The .git marker itself must be emitted so deletion and move events can
+    // invalidate repository metadata.
+    assert!(!should_ignore_git_path(Path::new(
+        "/home/user/project/.git"
+    )));
 
     // Allowlisted: commit-related files are NOT ignored
     assert!(!should_ignore_git_path(Path::new(

--- a/crates/repo_metadata/src/watcher.rs
+++ b/crates/repo_metadata/src/watcher.rs
@@ -18,8 +18,8 @@ cfg_if::cfg_if! {
         use watcher::{BulkFilesystemWatcher, BulkFilesystemWatcherEvent};
         use crate::entry::{
             extract_worktree_git_dir, is_commit_related_git_file, is_git_internal_path,
-            is_common_git_config, is_index_lock_file, is_remote_tracking_ref,
-            is_shared_git_ref, is_tracking_state_git_file,
+            is_git_repository_marker, is_common_git_config, is_index_lock_file,
+            is_remote_tracking_ref, is_shared_git_ref, is_tracking_state_git_file,
         };
         /// Duration between filesystem watch events in milliseconds
         const FILESYSTEM_WATCHER_DEBOUNCE_MILLI_SECS: u64 = 500;
@@ -143,17 +143,20 @@ impl DirectoryWatcher {
     }
 
     /// Find repositories affected by a git directory change using scope-aware
-    /// scope-aware routing:
+    /// routing:
     ///
-    /// 1. **Worktree-specific** (`.git/worktrees/<name>/…`): only the repo
+    /// 1. **Repository marker** (`<repo>/.git`): the repo whose working tree
+    ///    contains the marker. This is matched lexically because deleted paths
+    ///    cannot be canonicalized.
+    /// 2. **Worktree-specific** (`.git/worktrees/<name>/…`): only the repo
     ///    whose `external_git_directory` matches the extracted worktree gitdir.
-    /// 2. **Remote refs** (`.git/refs/remotes/*`): repos whose cached tracked
+    /// 3. **Remote refs** (`.git/refs/remotes/*`): repos whose cached tracked
     ///    upstream ref resolves to the changed loose remote ref.
-    /// 3. **Shared refs** (`.git/refs/heads/*`): all repos whose
+    /// 4. **Shared refs** (`.git/refs/heads/*`): all repos whose
     ///    `common_git_dir()` is a prefix of the event path (main repo +
     ///    all linked worktrees).
-    /// 4. **Common config** (`.git/config`): all repos sharing that common Git directory.
-    /// 5. **Repo-specific** (`.git/HEAD`, `.git/index.lock`, etc.): only the
+    /// 5. **Common config** (`.git/config`): all repos sharing that common Git directory.
+    /// 6. **Repo-specific** (`.git/HEAD`, `.git/index.lock`, etc.): only the
     ///    repo whose working tree directly contains `.git` (main repo).
     #[cfg(feature = "local_fs")]
     fn find_repos_for_git_event(
@@ -163,8 +166,27 @@ impl DirectoryWatcher {
     ) -> Vec<ModelHandle<Repository>> {
         let mut affected: Vec<ModelHandle<Repository>> = Vec::new();
 
-        // Tier 1: route to the single linked worktree.
-        if let Some(wt_dir) = extract_worktree_git_dir(git_path) {
+        // Tier 1: route a repository marker without canonicalizing it. The
+        // marker may have just been deleted, and linked worktrees use a .git
+        // file whose Git directory lives outside the working tree.
+        if is_git_repository_marker(git_path) {
+            log::debug!(
+                "[GIT_EVENT_ROUTING] tier=repository-marker path={}",
+                git_path.display()
+            );
+            let marker_path = StandardizedPath::try_from_local(git_path).ok();
+            for repo_handle in self.directories.values() {
+                let marker_matches = repo_handle.read(ctx, |repo, _| {
+                    marker_path
+                        .as_ref()
+                        .is_some_and(|marker| &repo.root_dir().join(".git") == marker)
+                });
+                if marker_matches && !affected.iter().any(|r| r == repo_handle) {
+                    affected.push(repo_handle.clone());
+                }
+            }
+        } else if let Some(wt_dir) = extract_worktree_git_dir(git_path) {
+            // Tier 2: route to the single linked worktree.
             log::debug!(
                 "[GIT_EVENT_ROUTING] tier=worktree-specific path={}",
                 git_path.display()
@@ -449,6 +471,7 @@ impl DirectoryWatcher {
     fn record_git_internal_path_update(
         &self,
         path: &Path,
+        invalidate_repository_marker: bool,
         repo_updates: &mut HashMap<ModelHandle<Repository>, RepositoryUpdate>,
         repos_to_refresh_tracked_remote_ref: &mut HashSet<ModelHandle<Repository>>,
         ctx: &ModelContext<Self>,
@@ -458,11 +481,13 @@ impl DirectoryWatcher {
         let is_lock = is_index_lock_file(path);
         let is_remote_ref = is_remote_tracking_ref(path);
         let is_tracking_state = is_tracking_state_git_file(path);
+        let invalidates_metadata =
+            is_commit || (invalidate_repository_marker && is_git_repository_marker(path));
 
         for repo_handle in &affected {
-            if is_commit || is_lock || is_remote_ref {
+            if invalidates_metadata || is_lock || is_remote_ref {
                 let repo_update = repo_updates.entry(repo_handle.clone()).or_default();
-                if is_commit {
+                if invalidates_metadata {
                     repo_update.commit_updated = true;
                 }
                 if is_lock {
@@ -479,7 +504,7 @@ impl DirectoryWatcher {
 
         if !affected.is_empty() {
             log::debug!(
-                "[GIT_EVENT_ROUTING] dispatched path={} commit_updated={is_commit} remote_ref_updated={is_remote_ref} index_lock={is_lock} tracking_state={is_tracking_state} to {} repo(s)",
+                "[GIT_EVENT_ROUTING] dispatched path={} commit_updated={invalidates_metadata} remote_ref_updated={is_remote_ref} index_lock={is_lock} tracking_state={is_tracking_state} to {} repo(s)",
                 path.display(),
                 affected.len()
             );
@@ -508,6 +533,7 @@ impl DirectoryWatcher {
                         if is_git_internal_path(path) {
                             self.record_git_internal_path_update(
                                 path,
+                                false,
                                 &mut repo_updates,
                                 &mut repos_to_refresh_tracked_remote_ref,
                                 ctx,
@@ -551,6 +577,7 @@ impl DirectoryWatcher {
             if is_git_internal_path(path) {
                 self.record_git_internal_path_update(
                     path,
+                    true,
                     &mut repo_updates,
                     &mut repos_to_refresh_tracked_remote_ref,
                     ctx,
@@ -578,6 +605,7 @@ impl DirectoryWatcher {
                 if is_git_internal_path(to_path) {
                     self.record_git_internal_path_update(
                         to_path,
+                        false,
                         &mut repo_updates,
                         &mut repos_to_refresh_tracked_remote_ref,
                         ctx,
@@ -586,6 +614,7 @@ impl DirectoryWatcher {
                 if is_git_internal_path(from_path) {
                     self.record_git_internal_path_update(
                         from_path,
+                        true,
                         &mut repo_updates,
                         &mut repos_to_refresh_tracked_remote_ref,
                         ctx,

--- a/crates/repo_metadata/src/watcher_tests.rs
+++ b/crates/repo_metadata/src/watcher_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::future::Future;
 use std::pin::Pin;
@@ -453,6 +454,70 @@ fn test_is_git_internal_path() {
     // Non-git files should not be detected
     assert!(!is_git_internal_path(Path::new("/repo/src/main.rs")));
     assert!(!is_git_internal_path(Path::new("/repo/README.md")));
+}
+
+#[test]
+fn test_deleted_git_marker_invalidates_repository_metadata() {
+    VirtualFS::test(
+        "deleted_git_marker_invalidates_repository",
+        |dirs, mut vfs| {
+            stub_git_repository(&mut vfs, "repo");
+
+            let repo_path = dirs.tests().join("repo");
+            let git_marker_path = repo_path.join(".git");
+            App::test((), |mut app| async move {
+                let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+                let repo_handle = watcher_handle
+                    .update(&mut app, |watcher, ctx| {
+                        watcher.add_directory(
+                            StandardizedPath::from_local_canonicalized(&repo_path).unwrap(),
+                            ctx,
+                        )
+                    })
+                    .unwrap();
+
+                let created_update = watcher_handle.update(&mut app, |watcher, ctx| {
+                    let mut repo_updates = HashMap::new();
+                    let mut repos_to_refresh_tracked_remote_ref = HashSet::new();
+                    watcher.record_git_internal_path_update(
+                        &git_marker_path,
+                        false,
+                        &mut repo_updates,
+                        &mut repos_to_refresh_tracked_remote_ref,
+                        ctx,
+                    );
+                    repo_updates.remove(&repo_handle)
+                });
+                assert!(
+                    created_update.is_none(),
+                    "creating .git should not invalidate repository metadata"
+                );
+
+                fs::remove_dir_all(&git_marker_path).expect("failed to remove .git directory");
+
+                let update = watcher_handle.update(&mut app, |watcher, ctx| {
+                    let affected = watcher.find_repos_for_git_event(&git_marker_path, ctx);
+                    assert_eq!(affected, vec![repo_handle.clone()]);
+
+                    let mut repo_updates = HashMap::new();
+                    let mut repos_to_refresh_tracked_remote_ref = HashSet::new();
+                    watcher.record_git_internal_path_update(
+                        &git_marker_path,
+                        true,
+                        &mut repo_updates,
+                        &mut repos_to_refresh_tracked_remote_ref,
+                        ctx,
+                    );
+                    repo_updates.remove(&repo_handle)
+                });
+
+                assert!(
+                    update.is_some_and(|update| update.commit_updated),
+                    "deleting .git should invalidate cached repository metadata"
+                );
+            });
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Deleting or moving a repository's `.git` marker left existing panes subscribed to stale repository metadata, so the branch, branch-status, and diff-stat prompt chips remained visible.

This change:

- routes deleted and moved-from repository-marker events lexically, without trying to canonicalize a path that no longer exists;
- invalidates cached repository metadata only when the marker is removed, preserving `git init` and transient initial discovery behavior;
- clears all Git-backed prompt chips after a confirmed metadata transition from available to unavailable;
- adds unit coverage and a GUI integration regression test that removes `.git` outside the terminal process while the pane remains open.

## Linked Issue

Fixes #12366

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`
- `cargo run -p integration --bin integration -- test_deleting_git_marker_clears_git_branch_prompt_chip`
- `cargo nextest run --no-fail-fast --workspace test_deleting_git_marker_clears_git_branch_prompt_chip` (1 passed)
- Regression A/B: the same integration-test-only patch fails on `origin/master` with `expected=false, actual=true`, then passes with this fix.
- `./script/presubmit`: format, inline-test-module check, all three Clippy configurations, clang-format, and WGSL formatting passed; 9,391/9,396 workspace tests passed. The five unavailable private SSH tests are excluded for fork PRs by the repository CI configuration.
- Fork-CI-equivalent workspace run: 9,272 passed, 209 skipped.
- `cargo nextest run -p warp_completer --features v2` (117 passed, 4 skipped)
- `cargo test --doc` (passed)

### Screenshots / Videos

**Before:** The existing pane shows branch, branch-status, and diff-stat chips.

<img width="1412" height="768" alt="Git chips visible before removing .git" src="https://github.com/user-attachments/assets/4933e3cd-e745-4e3b-b8c2-2376c8f62002" />

**After:** Moving `.git` outside the shell clears the stale Git chips in the same pane.

<img width="1412" height="768" alt="Git chips cleared after removing .git" src="https://github.com/user-attachments/assets/df6eccc1-c1ff-48b0-9ef7-d2b6266aa17e" />

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed stale Git prompt chips remaining visible after repository metadata is removed.

Co-Authored-By: Warp <agent@warp.dev>
