### PR TITLE
Skip GPU adapter dump without a display

### DIFF
--- a/app/src/debug_dump.rs
+++ b/app/src/debug_dump.rs
@@ -26,6 +26,8 @@ pub(crate) fn run() -> anyhow::Result<()> {
     #[cfg_attr(windows, expect(unused_mut))]
     #[cfg_attr(any(target_os = "macos", target_family = "wasm"), expect(unused))]
     let mut windowing_system: Option<windowing::System> = None;
+    #[cfg(any(target_os = "linux", target_os = "freebsd", windows))]
+    let mut wgpu_initialized = false;
 
     // On non-macOS platforms, initialize winit and wgpu.
     #[cfg(not(target_os = "macos"))]
@@ -34,6 +36,10 @@ pub(crate) fn run() -> anyhow::Result<()> {
             warpui::rendering::wgpu::init_wgpu_instance(Box::new(
                 event_loop.owned_display_handle(),
             ));
+            #[cfg(any(target_os = "linux", target_os = "freebsd", windows))]
+            {
+                wgpu_initialized = true;
+            }
 
             // Log some additional windowing system information on Linux.
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -84,11 +90,15 @@ pub(crate) fn run() -> anyhow::Result<()> {
         println!("##################################################");
         println!("# wgpu Adapters");
         println!("##################################################");
-        warpui::r#async::block_on(warpui::rendering::wgpu::print_wgpu_adapters(
-            gpu_power_preference,
-            backend_preference,
-            windowing_system,
-        ));
+        if wgpu_initialized {
+            warpui::r#async::block_on(warpui::rendering::wgpu::print_wgpu_adapters(
+                gpu_power_preference,
+                backend_preference,
+                windowing_system,
+            ));
+        } else {
+            println!("Unavailable: no display event loop could be initialized");
+        }
     }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]


### PR DESCRIPTION
## Description

Prevent `warp-terminal --dump-debug-info` from attempting to enumerate wgpu adapters when a headless Linux/FreeBSD/Windows process could not initialize a display event loop. The dump now reports that GPU adapter information is unavailable and continues producing the remaining diagnostics instead of panicking.

## Linked Issue

Fixes #13956.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots/video are not applicable to this headless CLI diagnostic path.

## Testing

- [x] `./script/format`
- [x] `cargo check -p warp --lib`
- [ ] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` (reaches Warp after all native prerequisites, then fails on 17 pre-existing Linux unused/dead-code warnings outside this change)
- [ ] I have manually tested my changes locally with `./script/run` (not applicable to the headless debug-dump path)

No automated test was added because the failure depends on OS display-event-loop initialization. The focused Warp library build covers every changed branch at compile time on Linux.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevent debug info dumps from crashing in headless environments.
