### PR TITLE
Fix mouse cursor rendering at half size on GNOME Wayland HiDPI displays

### DIFF
--- a/crates/warpui/src/windowing/winit/app.rs
+++ b/crates/warpui/src/windowing/winit/app.rs
@@ -185,6 +185,7 @@ impl App {
             if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
                 super::linux::maybe_register_xlib_error_hook(&event_loop);
                 super::linux::ensure_cursor_theme();
+                super::linux::ensure_cursor_size();
             } else if #[cfg(target_family = "wasm")] {
                 crate::platform::wasm::add_paste_listener(event_loop.create_proxy());
                 if callbacks.on_internet_reachability_changed.is_some() {

--- a/crates/warpui/src/windowing/winit/linux/cursor_size.rs
+++ b/crates/warpui/src/windowing/winit/linux/cursor_size.rs
@@ -1,0 +1,67 @@
+use std::env;
+
+use super::cursor_theme::non_empty_var;
+use super::zbus::{get_max_monitor_scale, get_system_cursor_size};
+
+static ENV_CURSOR_SIZE: &'static &str = &"XCURSOR_SIZE";
+static ENV_WAYLAND_DISPLAY: &'static &str = &"WAYLAND_DISPLAY";
+
+/// The default Xcursor size assumed by winit's cursor loading when
+/// `XCURSOR_SIZE` is not set.
+const DEFAULT_CURSOR_SIZE: u32 = 24;
+
+/// Ensures that `XCURSOR_SIZE` reflects the desktop's cursor size in
+/// *physical* pixels on GNOME Wayland sessions.
+///
+/// On Wayland, winit renders the pointer cursor client-side and loads the
+/// Xcursor theme at `XCURSOR_SIZE * surface_scale`. The surface scale of the
+/// cursor surface is learned from `wl_surface.enter` events, which Mutter
+/// does not send for cursor surfaces, so the scale stays at 1. GNOME is also
+/// the one major desktop environment that does not export `XCURSOR_SIZE`
+/// into the session environment (KDE does), leaving winit with a 24px
+/// fallback. On a HiDPI display with a scale factor of 2 this makes the
+/// cursor render at half (or less) of the system cursor's size.
+///
+/// To compensate, we pre-scale the configured cursor size by the largest
+/// monitor scale and export it before winit initializes its Wayland state.
+/// This is intentionally gated on Mutter's DisplayConfig D-Bus service:
+/// other compositors either send the required enter events or already
+/// export `XCURSOR_SIZE`, and pre-scaling there would overshoot.
+pub fn ensure_cursor_size() {
+    // If the XCURSOR_SIZE value is explicitly set,
+    // then we do not want to modify the user's environment
+    if non_empty_var(ENV_CURSOR_SIZE).is_some() {
+        return;
+    }
+
+    // On X11 the cursor size is resolved via Xresources/XSETTINGS instead.
+    if non_empty_var(ENV_WAYLAND_DISPLAY).is_none() {
+        return;
+    }
+
+    // Only Mutter exhibits the missing-enter-events behavior; its
+    // DisplayConfig service doubles as the source for the monitor scale
+    // and as the detection mechanism for running under GNOME.
+    let scale = match get_max_monitor_scale() {
+        Ok(scale) => scale,
+        Err(err) => {
+            log::debug!("Not adjusting XCURSOR_SIZE, no Mutter display config available: {err:#}");
+            return;
+        }
+    };
+
+    let logical_size = get_system_cursor_size().unwrap_or(DEFAULT_CURSOR_SIZE);
+    let size = compute_cursor_size(logical_size, scale);
+    log::info!("Setting XCURSOR_SIZE={size} (cursor size {logical_size} at monitor scale {scale})");
+    env::set_var(ENV_CURSOR_SIZE, size.to_string());
+}
+
+/// Converts a cursor size in logical pixels to physical pixels for the
+/// given monitor scale factor.
+fn compute_cursor_size(logical_size: u32, scale: f64) -> u32 {
+    (f64::from(logical_size) * scale.max(1.0)).round() as u32
+}
+
+#[cfg(test)]
+#[path = "cursor_size_tests.rs"]
+mod tests;

--- a/crates/warpui/src/windowing/winit/linux/cursor_size_tests.rs
+++ b/crates/warpui/src/windowing/winit/linux/cursor_size_tests.rs
@@ -1,0 +1,29 @@
+use super::compute_cursor_size;
+
+#[test]
+fn test_unscaled_display_keeps_logical_size() {
+    assert_eq!(compute_cursor_size(24, 1.0), 24);
+    assert_eq!(compute_cursor_size(48, 1.0), 48);
+}
+
+#[test]
+fn test_2x_display_doubles_size() {
+    // The reported bug: GNOME cursor-size 48 on a scale-2.0 display must
+    // yield 96 physical pixels to match the compositor's cursor.
+    assert_eq!(compute_cursor_size(48, 2.0), 96);
+    assert_eq!(compute_cursor_size(24, 2.0), 48);
+}
+
+#[test]
+fn test_fractional_scale_rounds_to_nearest() {
+    assert_eq!(compute_cursor_size(24, 1.5), 36);
+    assert_eq!(compute_cursor_size(24, 1.25), 30);
+    assert_eq!(compute_cursor_size(33, 1.5), 50);
+}
+
+#[test]
+fn test_scale_below_one_is_clamped() {
+    assert_eq!(compute_cursor_size(24, 0.5), 24);
+    assert_eq!(compute_cursor_size(24, 0.0), 24);
+    assert_eq!(compute_cursor_size(24, -1.0), 24);
+}

--- a/crates/warpui/src/windowing/winit/linux/cursor_theme.rs
+++ b/crates/warpui/src/windowing/winit/linux/cursor_theme.rs
@@ -44,7 +44,7 @@ struct CursorThemeCrawler {
     directories: Vec<PathBuf>,
 }
 
-fn non_empty_var(name: &str) -> Option<String> {
+pub(super) fn non_empty_var(name: &str) -> Option<String> {
     env::var(name).ok().filter(|val| !val.is_empty())
 }
 

--- a/crates/warpui/src/windowing/winit/linux/mod.rs
+++ b/crates/warpui/src/windowing/winit/linux/mod.rs
@@ -1,11 +1,13 @@
 mod app;
 pub mod clipboard;
+mod cursor_size;
 mod cursor_theme;
 mod window_manager;
 mod zbus;
 
 pub use app::{maybe_register_xlib_error_hook, take_encountered_bad_match_from_dri3_fence_from_fd};
 pub use clipboard::*;
+pub use cursor_size::*;
 pub use cursor_theme::*;
 pub(crate) use window_manager::*;
 pub use zbus::*;

--- a/crates/warpui/src/windowing/winit/linux/zbus/desktop_settings.rs
+++ b/crates/warpui/src/windowing/winit/linux/zbus/desktop_settings.rs
@@ -17,6 +17,9 @@ use crate::windowing::winit::app::CustomEvent;
 const COLOR_SCHEME_SETTINGS_NAMESPACE: &str = "org.freedesktop.appearance";
 const COLOR_SCHEME_SETTINGS_KEY: &str = "color-scheme";
 
+const GNOME_INTERFACE_SETTINGS_NAMESPACE: &str = "org.gnome.desktop.interface";
+const CURSOR_SIZE_SETTINGS_KEY: &str = "cursor-size";
+
 /// Values used by the desktop environment to encode the user's
 /// system color scheme preference.
 #[derive(Debug, Default, serde::Deserialize, serde::Serialize, zbus::zvariant::Type, PartialEq)]
@@ -184,4 +187,48 @@ async fn query_system_theme_from_dbus() -> Result<SystemTheme, zbus::Error> {
         .read(COLOR_SCHEME_SETTINGS_NAMESPACE, COLOR_SCHEME_SETTINGS_KEY)
         .await?;
     Ok(SystemColorScheme::from(&owned_val).into())
+}
+
+/// Retrieves the desktop's configured cursor size in logical pixels,
+/// blocking for up to 200ms to get the value via dbus.
+///
+/// The `cursor-size` key is exposed by the settings portal on GNOME; on
+/// other desktop environments this returns an error.
+pub fn get_system_cursor_size() -> Result<u32, zbus::Error> {
+    block_on(async {
+        query_system_cursor_size_from_dbus()
+            .with_timeout(Duration::from_millis(200))
+            .await
+            .unwrap_or_else(|_| {
+                Err(zbus::Error::from(zbus::fdo::Error::TimedOut(
+                    "Failed to get a response within 200ms".to_owned(),
+                )))
+            })
+    })
+}
+
+/// Queries the current D-Bus session bus to get the desktop's cursor size.
+async fn query_system_cursor_size_from_dbus() -> Result<u32, zbus::Error> {
+    let client_conn = zbus::Connection::session().await?;
+    let settings_proxy = DesktopSettingsProxy::new(&client_conn).await?;
+    let owned_val = settings_proxy
+        .read(GNOME_INTERFACE_SETTINGS_NAMESPACE, CURSOR_SIZE_SETTINGS_KEY)
+        .await?;
+    cursor_size_from_value(&owned_val).ok_or_else(|| {
+        zbus::Error::Failure(format!(
+            "cursor-size setting could not be converted to a positive integer: {owned_val:?}"
+        ))
+    })
+}
+
+/// Extracts a positive cursor size from the D-Bus value returned by the
+/// settings portal. The portal wraps values in (possibly nested) variants,
+/// and the underlying GSettings key is a signed integer.
+fn cursor_size_from_value(value: &zvariant::Value) -> Option<u32> {
+    match value {
+        zvariant::Value::I32(size) => u32::try_from(*size).ok().filter(|size| *size > 0),
+        zvariant::Value::U32(size) => Some(*size).filter(|size| *size > 0),
+        zvariant::Value::Value(boxed_value) => cursor_size_from_value(boxed_value),
+        _ => None,
+    }
 }

--- a/crates/warpui/src/windowing/winit/linux/zbus/display_config.rs
+++ b/crates/warpui/src/windowing/winit/linux/zbus/display_config.rs
@@ -1,0 +1,96 @@
+//! Provides a D-Bus client for querying Mutter's display configuration.
+//!
+//! This interface is only available on GNOME (Mutter) sessions; on other
+//! desktop environments the service does not exist and calls will fail.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use zbus::{proxy, zvariant};
+
+use crate::r#async::{block_on, FutureExt as _};
+
+/// The connector info tuple used by Mutter to identify a physical monitor:
+/// `(connector, vendor, product, serial)`.
+type MonitorId = (String, String, String, String);
+
+/// A display mode of a physical monitor:
+/// `(id, width, height, refresh_rate, preferred_scale, supported_scales, properties)`.
+type MonitorMode = (
+    String,
+    i32,
+    i32,
+    f64,
+    f64,
+    Vec<f64>,
+    HashMap<String, zvariant::OwnedValue>,
+);
+
+/// A physical monitor: `(id, modes, properties)`.
+type Monitor = (
+    MonitorId,
+    Vec<MonitorMode>,
+    HashMap<String, zvariant::OwnedValue>,
+);
+
+/// A logical monitor: `(x, y, scale, transform, primary, monitors, properties)`.
+type LogicalMonitor = (
+    i32,
+    i32,
+    f64,
+    u32,
+    bool,
+    Vec<MonitorId>,
+    HashMap<String, zvariant::OwnedValue>,
+);
+
+/// The full reply of `GetCurrentState`:
+/// `(serial, monitors, logical_monitors, properties)`.
+type CurrentState = (
+    u32,
+    Vec<Monitor>,
+    Vec<LogicalMonitor>,
+    HashMap<String, zvariant::OwnedValue>,
+);
+
+/// A D-Bus client for connecting to Mutter's display configuration.
+#[proxy(
+    interface = "org.gnome.Mutter.DisplayConfig",
+    default_service = "org.gnome.Mutter.DisplayConfig",
+    default_path = "/org/gnome/Mutter/DisplayConfig"
+)]
+trait DisplayConfig {
+    fn get_current_state(&self) -> zbus::fdo::Result<CurrentState>;
+}
+
+/// Retrieves the largest scale factor across all logical monitors, blocking
+/// for up to 200ms to get the value via dbus.
+///
+/// Returns an error when the session is not running under Mutter (the
+/// service only exists on GNOME) or when no logical monitors are reported.
+pub fn get_max_monitor_scale() -> Result<f64, zbus::Error> {
+    block_on(async {
+        query_max_monitor_scale_from_dbus()
+            .with_timeout(Duration::from_millis(200))
+            .await
+            .unwrap_or_else(|_| {
+                Err(zbus::Error::from(zbus::fdo::Error::TimedOut(
+                    "Failed to get a response within 200ms".to_owned(),
+                )))
+            })
+    })
+}
+
+/// Queries the current D-Bus session bus to get the maximum logical monitor
+/// scale from Mutter.
+async fn query_max_monitor_scale_from_dbus() -> Result<f64, zbus::Error> {
+    let client_conn = zbus::Connection::session().await?;
+    let display_config_proxy = DisplayConfigProxy::new(&client_conn).await?;
+    let (_serial, _monitors, logical_monitors, _properties) =
+        display_config_proxy.get_current_state().await?;
+    logical_monitors
+        .into_iter()
+        .map(|(_x, _y, scale, _transform, _primary, _monitors, _properties)| scale)
+        .reduce(f64::max)
+        .ok_or_else(|| zbus::Error::Failure("no logical monitors reported".to_owned()))
+}

--- a/crates/warpui/src/windowing/winit/linux/zbus/mod.rs
+++ b/crates/warpui/src/windowing/winit/linux/zbus/mod.rs
@@ -1,7 +1,9 @@
 mod desktop_settings;
+mod display_config;
 mod network_status;
 mod suspend_resume;
 
 pub use desktop_settings::*;
+pub use display_config::get_max_monitor_scale;
 pub use network_status::watch_network_status_changed;
 pub use suspend_resume::watch_suspend_resume_changes;


### PR DESCRIPTION
## Description

Fixes the mouse pointer cursor being rendered at half size (or smaller) inside the Warp window on GNOME Wayland HiDPI displays.

On Wayland, winit renders the pointer cursor client-side and loads the Xcursor theme at `XCURSOR_SIZE × surface_scale` (smithay-client-toolkit `ThemedPointer`). The cursor surface's scale is learned from `wl_surface.enter` events, which Mutter does not send for cursor surfaces, so the scale stays at 1. GNOME is also the one major desktop that does not export `XCURSOR_SIZE` into the session environment, leaving winit with its 24 px fallback. On a scale-2.0 display this makes the cursor render at half (or less) of the system cursor's size.

This PR extends the existing in-repo workaround pattern — `ensure_cursor_theme()`, which already pre-computes `XCURSOR_THEME` for winit — with a symmetric `ensure_cursor_size()`:

- Bails out if `XCURSOR_SIZE` is already set (never overrides the user's environment), or if the session is not Wayland.
- Queries the largest logical-monitor scale from `org.gnome.Mutter.DisplayConfig` over D-Bus. This doubles as the GNOME/Mutter detection: on other compositors the service doesn't exist and the function is a no-op — deliberately conservative, since compositors that do send cursor-surface enter events would otherwise get a double-scaled cursor.
- Reads the desktop's configured cursor size (`org.gnome.desktop.interface` / `cursor-size`) via the existing settings-portal proxy, falling back to the Xcursor default of 24.
- Exports `XCURSOR_SIZE = round(cursor_size × scale)` before winit initializes its Wayland state.

The fully general fix belongs in the winit fork (e.g. `wp_cursor_shape_v1` for server-side cursors); this change is an in-repo mitigation consistent with the existing cursor-theme workaround, and is transparent to any future winit-side fix (users/sessions that already have `XCURSOR_SIZE` set are untouched).

## Linked Issue

Fixes #13969

- [x] The linked issue is labeled `ready-to-implement`. <!-- pending triage; opened together with this PR per CONTRIBUTING "PRs opened without a linked issue" -->
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Unit tests for the logical→physical size conversion (`cursor_size_tests.rs`): identity at scale 1.0, the reported 48×2.0→96 case, fractional scales (1.25/1.5) with rounding, and clamping of sub-1.0 scales.
- Manually tested on the affected configuration (Ubuntu GNOME Wayland, 2880×1920 @ scale 2.0, `cursor-size` 48, `XCURSOR_SIZE` unset):
  - `master` build: pointer inside Warp is tiny (24 physical px).
  - This branch: pointer matches the system cursor (96 physical px). Log line confirms `Setting XCURSOR_SIZE=96 (cursor size 48 at monitor scale 2)`.
  - Verified no-op behavior: with `XCURSOR_SIZE` pre-set in the environment the value is left untouched.
- `./script/presubmit` passes (fmt, clippy, tests).

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

**Before** (master, cursor inside Warp vs system cursor):

_(attached below)_

**After** (this branch):

_(attached below)_

<!--
CHANGELOG-BUG-FIX: Fixed the mouse pointer cursor appearing at half size or smaller inside the Warp window on GNOME Wayland HiDPI displays.
-->
