### PR TITLE
Store the staging IAP cache in the Warp home directory

### DIFF
--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -763,9 +763,8 @@ fn parse_aud_from_jwt(token: &str) -> Option<String> {
 /// it instead of each doing their own STS/IAM mint. The file stores the raw IAP
 /// JWT; validity is derived from its own `exp` claim on read.
 ///
-/// This is a plain owner-only file rather than OS secure storage: it only exists
-/// in the staging Oz runner (headless Linux), where no keyring is available and
-/// the container already holds the bootstrap JWT / API key / GitHub token.
+/// This is a plain owner-only file rather than OS secure storage so short-lived
+/// child processes can read it directly.
 #[cfg(not(target_family = "wasm"))]
 mod cache {
     use std::time::Duration;
@@ -779,8 +778,7 @@ mod cache {
     const CACHE_SKEW: Duration = Duration::from_secs(30);
 
     fn cache_path() -> std::path::PathBuf {
-        warp_core::paths::secure_state_dir()
-            .unwrap_or_else(warp_core::paths::state_dir)
+        warp_core::paths::state_dir()
             .join("staging")
             .join("iap_cache.jwt")
     }

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -778,7 +778,8 @@ mod cache {
     const CACHE_SKEW: Duration = Duration::from_secs(30);
 
     fn cache_path() -> std::path::PathBuf {
-        warp_core::paths::state_dir()
+        warp_core::paths::warp_home_config_dir()
+            .unwrap_or_else(warp_core::paths::state_dir)
             .join("staging")
             .join("iap_cache.jwt")
     }


### PR DESCRIPTION
see original slack thread here for context: https://warpdev.slack.com/archives/C0B9XLRE6UE/p1784502573576239

## Summary
- store the staging IAP token cache under `warp_core::paths::warp_home_config_dir()`
- use `~/.warp-dev/staging/iap_cache.jwt` consistently across macOS and Linux
- preserve development-profile isolation through the existing Warp home directory derivation

## Validation
- `cargo fmt --all -- --check` passed before the final path-only adjustment
- `git diff --check`

Focused `warp_server_client` IAP tests were started but interrupted before completion.

Companion: https://github.com/warpdotdev/factory-agents/pull/127
Conversation: https://staging.warp.dev/conversation/e54a361e-2d94-4106-aeb1-783aa75d3188

Co-Authored-By: Oz <oz-agent@warp.dev>