### PR TITLE
Set up a real macOS main thread run loop for headless warpui backend.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16083,6 +16083,7 @@ dependencies = [
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
  "objc2-av-foundation",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
  "objc2-quartz-core 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.3",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse 0.2.2",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -529,6 +544,15 @@ name = "anstyle-parse"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse 0.2.2",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse 0.2.2",
 ]
@@ -2844,7 +2868,7 @@ version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -4783,6 +4807,12 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
 name = "euclid"
@@ -7647,6 +7677,18 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
+dependencies = [
+ "anstream 1.0.0",
+ "anstyle",
+ "clap",
+ "escape8259",
 ]
 
 [[package]]
@@ -16072,6 +16114,7 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "libc",
+ "libtest-mimic",
  "log",
  "markdown_parser",
  "memmap2 0.9.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,7 @@ dependencies = [
  "clap",
  "command",
  "computer_use",
+ "dispatch2",
  "futures",
  "image",
  "instant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ jsonschema = { version = "0.45", default-features = false }
 lasso = { version = "0.7.3", features = ["multi-threaded"] }
 lazy_static = "1.4.0"
 libc = "0.2.81"
+libtest-mimic = "0.8.2"
 line-ending = "1.4.0"
 log = { version = "0.4", features = ["serde", "std"] }
 mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "8d3f789c2eb49335d7bf247a06bb649f59b6d4ed" }

--- a/crates/computer_use/Cargo.toml
+++ b/crates/computer_use/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["rt", "macros"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 command.workspace = true
+dispatch2.workspace = true
 image.workspace = true
 # `instant` is already provided by the common [dependencies] table above.
 libc.workspace = true

--- a/crates/computer_use/src/mac/keycode_cache.rs
+++ b/crates/computer_use/src/mac/keycode_cache.rs
@@ -4,14 +4,12 @@
 //! The translation depends on the current keyboard layout.
 //!
 //! The Carbon APIs used for translation (`TISCopyCurrentKeyboardInputSource`,
-//! `UCKeyTranslate`) are not thread-safe, so all cache builds are serialized through a
-//! process-wide mutex. This matters because concurrent computer-use agents can build the cache
-//! from different worker threads at the same time.
+//! `UCKeyTranslate`) must run on the main thread, so cache construction dispatches there.
 
 use std::collections::HashMap;
 use std::ptr::NonNull;
-use std::sync::Mutex;
 
+use dispatch2::run_on_main;
 use objc2_core_foundation::{CFData, CFRetained, CFString, CFType};
 use objc2_core_graphics::CGKeyCode;
 
@@ -60,36 +58,14 @@ const SHIFT_MODIFIER: u32 = 1 << 1;
 
 /// Builds a character-to-keycode cache for the current keyboard layout.
 ///
-/// # Threading
-/// This MUST be called on the main thread. `get_keyboard_layout_data` calls Carbon Text Input
-/// Source APIs (`TISCopyCurrentKeyboardInputSource` etc.) that contain an internal
-/// `dispatch_assert_queue(main)` check, so invoking them off the main thread aborts the process
-/// with a libdispatch main-thread assertion (`BUG IN CLIENT OF LIBDISPATCH ... com.apple.main-thread`).
-/// We deliberately do NOT dispatch the work to the main queue ourselves: in the headless
-/// `agent run` CLI the main thread never services the GCD main queue, so a synchronous main-queue
-/// dispatch would deadlock. Instead, callers construct the keyboard/actor on the main thread (both
-/// the GUI app and the headless runtime run the computer-use action-model body on the main thread).
-///
-/// The Carbon translation APIs (`UCKeyTranslate`) are also not thread-safe, so the build is
-/// additionally serialized through a process-wide mutex.
+/// This function dispatches to the main thread to call Carbon APIs safely.
 /// TODO(QUALITY-271): Store the modifier keys as well.
 pub fn build_cache() -> HashMap<char, CGKeyCode> {
-    // Fail loudly in debug if a caller ever invokes this off the main thread, so the regression is
-    // caught here rather than as an opaque libdispatch abort deep inside the Carbon TIS call.
-    // `MainThreadMarker::new()` returns `Some` only on the main thread.
-    debug_assert!(
-        objc2::MainThreadMarker::new().is_some(),
-        "keycode cache must be built on the main thread; Carbon Text Input Source APIs assert \
-         they run on the main thread"
-    );
-    static BUILD_LOCK: Mutex<()> = Mutex::new(());
-    let _guard = BUILD_LOCK.lock().unwrap();
-    build_cache_locked()
+    run_on_main(|_| build_cache_on_main_thread())
 }
 
-/// Builds the cache while the process-wide build lock is held, serializing access to the
-/// non-thread-safe Carbon APIs.
-fn build_cache_locked() -> HashMap<char, CGKeyCode> {
+/// Builds the cache on the main thread where Carbon APIs are safe to call.
+fn build_cache_on_main_thread() -> HashMap<char, CGKeyCode> {
     let mut cache = HashMap::new();
 
     // Get the keyboard layout data.

--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -103,6 +103,7 @@ objc2-app-kit = { workspace = true, features = [
     "objc2-quartz-core",
 ] }
 objc2-av-foundation = { workspace = true, features = ["AVCaptureDevice", "AVMediaFormat"] }
+objc2-core-foundation.workspace = true
 objc2-foundation = { workspace = true, features = [
     "NSArray",
     "NSData",

--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 authors.workspace = true
 publish.workspace = true
 license = "MIT"
+
 [[test]]
 name = "headless_main_thread"
 path = "tests/headless_main_thread.rs"
@@ -66,6 +67,7 @@ asset_cache.workspace = true
 env_logger.workspace = true
 futures-timer = "3.0.2"
 image = { workspace = true, default-features = false, features = ["png"] }
+libtest-mimic.workspace = true
 rust-embed.workspace = true
 warpui = { workspace = true, features = ["test-util"] }
 warpui_core = { workspace = true, features = ["test-util"] }

--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 authors.workspace = true
 publish.workspace = true
 license = "MIT"
+[[test]]
+name = "headless_main_thread"
+path = "tests/headless_main_thread.rs"
+harness = false
 
 [features]
 # Enabling this feature works around a bug in Metal frame capture by loading

--- a/crates/warpui/src/platform/headless/app.rs
+++ b/crates/warpui/src/platform/headless/app.rs
@@ -1,9 +1,7 @@
-use std::sync::mpsc;
-
 use futures::future::LocalBoxFuture;
 
 use super::delegate::{self, AppDelegate};
-use super::event_loop::{self, AppEvent};
+use super::event_loop;
 use super::windowing::WindowManager;
 use crate::integration::TestDriver;
 use crate::platform::app::TerminationResult;
@@ -34,10 +32,9 @@ impl App {
     ) -> TerminationResult {
         let App { callbacks, assets } = self;
 
-        let (sender, receiver) = mpsc::channel::<AppEvent>();
-
         // Mark this thread as the main thread for DispatchDelegate checks.
         delegate::mark_current_thread_as_main();
+        let (sender, receiver) = event_loop::channel();
 
         let platform_delegate = Box::new(AppDelegate::new(sender.clone()));
         let window_manager = Box::new(WindowManager::new(sender.clone()));

--- a/crates/warpui/src/platform/headless/delegate.rs
+++ b/crates/warpui/src/platform/headless/delegate.rs
@@ -1,11 +1,10 @@
 use std::mem::ManuallyDrop;
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, OnceLock};
 use std::thread;
 
 use parking_lot::Mutex;
 
-use super::event_loop::AppEvent;
+use super::event_loop::{AppEvent, EventSender};
 use crate::clipboard::InMemoryClipboard;
 use crate::notification::{NotificationSendError, RequestPermissionsOutcome};
 use crate::platform::{self, Cursor};
@@ -26,11 +25,11 @@ pub(super) fn mark_current_thread_as_main() {
 pub struct AppDelegate {
     clipboard: InMemoryClipboard,
     cursor_shape: Mutex<Cursor>,
-    event_sender: Sender<AppEvent>,
+    event_sender: EventSender,
 }
 
 impl AppDelegate {
-    pub(super) fn new(event_sender: Sender<AppEvent>) -> Self {
+    pub(super) fn new(event_sender: EventSender) -> Self {
         Self {
             clipboard: InMemoryClipboard::default(),
             cursor_shape: Mutex::new(Cursor::Arrow),
@@ -192,7 +191,7 @@ impl platform::Delegate for AppDelegate {
 }
 
 struct DispatchDelegate {
-    event_sender: Sender<AppEvent>,
+    event_sender: EventSender,
 }
 
 impl platform::DispatchDelegate for DispatchDelegate {

--- a/crates/warpui/src/platform/headless/event_loop.rs
+++ b/crates/warpui/src/platform/headless/event_loop.rs
@@ -7,11 +7,8 @@ use std::sync::mpsc::TryRecvError;
 use std::sync::mpsc::{self, Receiver, SendError};
 
 #[cfg(target_os = "macos")]
-use core_foundation::base::{TCFType, kCFAllocatorDefault};
-#[cfg(target_os = "macos")]
-use core_foundation::runloop::{
-    CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext, CFRunLoopSourceCreate,
-    CFRunLoopSourceSignal, CFRunLoopWakeUp, kCFRunLoopDefaultMode,
+use objc2_core_foundation::{
+    CFRetained, CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext, kCFRunLoopDefaultMode,
 };
 
 use crate::platform::app::{
@@ -82,8 +79,8 @@ pub(super) fn channel() -> (EventSender, EventReceiver) {
 
 #[cfg(target_os = "macos")]
 struct RunLoopSignal {
-    run_loop: CFRunLoop,
-    source: CFRunLoopSource,
+    run_loop: CFRetained<CFRunLoop>,
+    source: CFRetained<CFRunLoopSource>,
 }
 
 #[cfg(target_os = "macos")]
@@ -92,7 +89,7 @@ impl RunLoopSignal {
         objc2::MainThreadMarker::new()
             .expect("the macOS headless event loop must run on the process main thread");
 
-        let run_loop = CFRunLoop::get_current();
+        let run_loop = CFRunLoop::current().expect("the current thread must have a run loop");
         let mut context = CFRunLoopSourceContext {
             version: 0,
             info: std::ptr::null_mut(),
@@ -103,30 +100,21 @@ impl RunLoopSignal {
             hash: None,
             schedule: None,
             cancel: None,
-            perform: stop_run_loop,
+            perform: Some(stop_run_loop),
         };
         // SAFETY: Core Foundation copies the context during this call. The context has no
         // associated data, and its callback does not access the context pointer.
-        let source = unsafe {
-            CFRunLoopSource::wrap_under_create_rule(CFRunLoopSourceCreate(
-                kCFAllocatorDefault,
-                0,
-                &mut context,
-            ))
-        };
+        let source = unsafe { CFRunLoopSource::new(None, 0, &mut context) }
+            .expect("Core Foundation should have successfully created the run-loop source");
         // SAFETY: The source and mode are valid for the lifetime of the headless event loop.
-        run_loop.add_source(&source, unsafe { kCFRunLoopDefaultMode });
+        run_loop.add_source(Some(&source), unsafe { kCFRunLoopDefaultMode });
 
         Self { run_loop, source }
     }
 
     fn signal(&self) {
-        // SAFETY: Signaling a run-loop source and waking its run loop are thread-safe Core
-        // Foundation operations. Both objects remain retained by this value.
-        unsafe {
-            CFRunLoopSourceSignal(self.source.as_concrete_TypeRef());
-            CFRunLoopWakeUp(self.run_loop.as_concrete_TypeRef());
-        }
+        self.source.signal();
+        self.run_loop.wake_up();
     }
 }
 
@@ -141,8 +129,10 @@ unsafe impl Send for RunLoopSignal {}
 unsafe impl Sync for RunLoopSignal {}
 
 #[cfg(target_os = "macos")]
-extern "C" fn stop_run_loop(_info: *const std::ffi::c_void) {
-    CFRunLoop::get_current().stop();
+unsafe extern "C-unwind" fn stop_run_loop(_info: *mut std::ffi::c_void) {
+    CFRunLoop::current()
+        .expect("the run-loop source callback should be running on a thread with a run loop")
+        .stop();
 }
 
 /// Run a simple, blocking event loop that processes AppEvent messages until termination.
@@ -163,7 +153,7 @@ pub(super) fn run(
     #[cfg(target_os = "macos")]
     {
         'event_loop: loop {
-            CFRunLoop::run_current();
+            CFRunLoop::run();
             loop {
                 match receiver.receiver.try_recv() {
                     Ok(event) => {

--- a/crates/warpui/src/platform/headless/event_loop.rs
+++ b/crates/warpui/src/platform/headless/event_loop.rs
@@ -1,5 +1,18 @@
 use std::mem::ManuallyDrop;
-use std::sync::mpsc::{Receiver, Sender};
+use std::ops::ControlFlow;
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use std::sync::mpsc::TryRecvError;
+use std::sync::mpsc::{self, Receiver, SendError};
+
+#[cfg(target_os = "macos")]
+use core_foundation::base::{TCFType, kCFAllocatorDefault};
+#[cfg(target_os = "macos")]
+use core_foundation::runloop::{
+    CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext, CFRunLoopSourceCreate,
+    CFRunLoopSourceSignal, CFRunLoopWakeUp, kCFRunLoopDefaultMode,
+};
 
 use crate::platform::app::{
     AppCallbackDispatcher, ApproveTerminateResult, TerminationRequestSource, TerminationResult,
@@ -21,50 +34,155 @@ pub(super) enum AppEvent {
     Terminate(TerminationMode),
 }
 
+#[derive(Clone)]
+pub(super) struct EventSender {
+    sender: mpsc::Sender<AppEvent>,
+    #[cfg(target_os = "macos")]
+    run_loop_signal: Arc<RunLoopSignal>,
+}
+
+impl EventSender {
+    pub(super) fn send(&self, event: AppEvent) -> Result<(), SendError<AppEvent>> {
+        self.sender.send(event)?;
+        #[cfg(target_os = "macos")]
+        self.run_loop_signal.signal();
+        Ok(())
+    }
+}
+
+pub(super) struct EventReceiver {
+    receiver: Receiver<AppEvent>,
+    #[cfg(target_os = "macos")]
+    _run_loop_signal: Arc<RunLoopSignal>,
+}
+
+pub(super) fn channel() -> (EventSender, EventReceiver) {
+    let (sender, receiver) = mpsc::channel();
+
+    #[cfg(target_os = "macos")]
+    {
+        let run_loop_signal = Arc::new(RunLoopSignal::new());
+        (
+            EventSender {
+                sender,
+                run_loop_signal: run_loop_signal.clone(),
+            },
+            EventReceiver {
+                receiver,
+                _run_loop_signal: run_loop_signal,
+            },
+        )
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        (EventSender { sender }, EventReceiver { receiver })
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct RunLoopSignal {
+    run_loop: CFRunLoop,
+    source: CFRunLoopSource,
+}
+
+#[cfg(target_os = "macos")]
+impl RunLoopSignal {
+    fn new() -> Self {
+        objc2::MainThreadMarker::new()
+            .expect("the macOS headless event loop must run on the process main thread");
+
+        let run_loop = CFRunLoop::get_current();
+        let mut context = CFRunLoopSourceContext {
+            version: 0,
+            info: std::ptr::null_mut(),
+            retain: None,
+            release: None,
+            copyDescription: None,
+            equal: None,
+            hash: None,
+            schedule: None,
+            cancel: None,
+            perform: stop_run_loop,
+        };
+        // SAFETY: Core Foundation copies the context during this call. The context has no
+        // associated data, and its callback does not access the context pointer.
+        let source = unsafe {
+            CFRunLoopSource::wrap_under_create_rule(CFRunLoopSourceCreate(
+                kCFAllocatorDefault,
+                0,
+                &mut context,
+            ))
+        };
+        // SAFETY: The source and mode are valid for the lifetime of the headless event loop.
+        run_loop.add_source(&source, unsafe { kCFRunLoopDefaultMode });
+
+        Self { run_loop, source }
+    }
+
+    fn signal(&self) {
+        // SAFETY: Signaling a run-loop source and waking its run loop are thread-safe Core
+        // Foundation operations. Both objects remain retained by this value.
+        unsafe {
+            CFRunLoopSourceSignal(self.source.as_concrete_TypeRef());
+            CFRunLoopWakeUp(self.run_loop.as_concrete_TypeRef());
+        }
+    }
+}
+
+// SAFETY: `RunLoopSignal` only exposes the thread-safe `CFRunLoopSourceSignal` and
+// `CFRunLoopWakeUp` operations to other threads. The source is installed and serviced only by
+// the process main thread.
+#[cfg(target_os = "macos")]
+unsafe impl Send for RunLoopSignal {}
+
+// SAFETY: See the `Send` implementation. Concurrent calls only signal and wake the run loop.
+#[cfg(target_os = "macos")]
+unsafe impl Sync for RunLoopSignal {}
+
+#[cfg(target_os = "macos")]
+extern "C" fn stop_run_loop(_info: *const std::ffi::c_void) {
+    CFRunLoop::get_current().stop();
+}
+
 /// Run a simple, blocking event loop that processes AppEvent messages until termination.
 pub(super) fn run(
     mut ui_app: crate::App,
     callbacks: &mut AppCallbackDispatcher,
     init_fn: platform::app::AppInitCallbackFn,
-    receiver: Receiver<AppEvent>,
-    sender: Sender<AppEvent>,
+    receiver: EventReceiver,
+    sender: EventSender,
 ) -> TerminationResult {
-    // Set up Ctrl-C handler to gracefully terminate the app
+    // Set up the Ctrl-C handler to gracefully terminate the app.
     setup_signal_handler(sender);
 
-    // First, initialize the app.
+    // Initialize the app before processing events.
     callbacks.initialize_app(init_fn);
 
-    // Then, process events until termination.
-    for event in receiver.iter() {
-        match event {
-            AppEvent::RunCallback(callback) => ui_app.update(callback),
-            AppEvent::RunTask(task) => {
-                // Poll a task on the main thread.
-                let task = ManuallyDrop::into_inner(task);
-                task.run();
-            }
-            AppEvent::Terminate(termination_mode) => {
-                let should_terminate = match termination_mode {
-                    TerminationMode::Cancellable => {
-                        matches!(
-                            callbacks.should_terminate_app(TerminationRequestSource::User),
-                            ApproveTerminateResult::Terminate
-                        )
+    // Process events until termination.
+    #[cfg(target_os = "macos")]
+    {
+        'event_loop: loop {
+            CFRunLoop::run_current();
+            loop {
+                match receiver.receiver.try_recv() {
+                    Ok(event) => {
+                        if process_event(event, &mut ui_app, callbacks).is_break() {
+                            break 'event_loop;
+                        }
                     }
-                    TerminationMode::ForceTerminate | TerminationMode::ContentTransferred => true,
-                };
-                if should_terminate {
-                    break;
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => break 'event_loop,
                 }
             }
-            AppEvent::CloseWindow(window_id) => {
-                // Notify the app that a window is closing. The app will then remove the window
-                // from WindowManager.
-                callbacks.window_will_close(window_id);
-            }
-            AppEvent::ActiveWindowChanged(window_id) => {
-                callbacks.active_window_changed(window_id);
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        for event in receiver.receiver.iter() {
+            if process_event(event, &mut ui_app, callbacks).is_break() {
+                break;
             }
         }
     }
@@ -80,12 +198,50 @@ pub(super) fn run(
     ui_app.termination_result().unwrap_or(Ok(()))
 }
 
+fn process_event(
+    event: AppEvent,
+    ui_app: &mut crate::App,
+    callbacks: &mut AppCallbackDispatcher,
+) -> ControlFlow<()> {
+    match event {
+        AppEvent::RunCallback(callback) => ui_app.update(callback),
+        AppEvent::RunTask(task) => {
+            // Poll a task on the main thread.
+            let task = ManuallyDrop::into_inner(task);
+            task.run();
+        }
+        AppEvent::Terminate(termination_mode) => {
+            let should_terminate = match termination_mode {
+                TerminationMode::Cancellable => {
+                    matches!(
+                        callbacks.should_terminate_app(TerminationRequestSource::User),
+                        ApproveTerminateResult::Terminate
+                    )
+                }
+                TerminationMode::ForceTerminate | TerminationMode::ContentTransferred => true,
+            };
+            if should_terminate {
+                return ControlFlow::Break(());
+            }
+        }
+        AppEvent::CloseWindow(window_id) => {
+            // Notify the app that a window is closing. The app will then remove the window
+            // from WindowManager.
+            callbacks.window_will_close(window_id);
+        }
+        AppEvent::ActiveWindowChanged(window_id) => {
+            callbacks.active_window_changed(window_id);
+        }
+    }
+    ControlFlow::Continue(())
+}
+
 /// Set up a signal handler for Ctrl-C (SIGINT) to gracefully terminate the app.
 ///
 /// When Ctrl-C is received, this will send a Terminate event to the event loop,
 /// allowing the app to shut down gracefully via the existing termination logic.
 #[cfg(not(target_family = "wasm"))]
-fn setup_signal_handler(sender: Sender<AppEvent>) {
+fn setup_signal_handler(sender: EventSender) {
     let result = ctrlc::set_handler(move || {
         log::info!("Received Ctrl-C signal in headless mode, terminating application");
         // Send a ForceTerminate event to ensure the app exits cleanly.
@@ -96,7 +252,7 @@ fn setup_signal_handler(sender: Sender<AppEvent>) {
             .is_err()
         {
             log::warn!("Failed to send termination event - event loop may have already stopped");
-            // If we can't send the event, force exit
+            // If the event cannot be sent, force an exit.
             std::process::exit(130); // 128 + SIGINT (2) = 130
         }
     });
@@ -107,6 +263,6 @@ fn setup_signal_handler(sender: Sender<AppEvent>) {
 }
 
 #[cfg(target_family = "wasm")]
-fn setup_signal_handler(_sender: Sender<AppEvent>) {
-    // No signal handling on WASM
+fn setup_signal_handler(_sender: EventSender) {
+    // Signal handling is unavailable on WASM.
 }

--- a/crates/warpui/src/platform/headless/windowing.rs
+++ b/crates/warpui/src/platform/headless/windowing.rs
@@ -1,11 +1,10 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::mpsc;
 
 use anyhow::Result;
 
-use super::event_loop::AppEvent;
+use super::event_loop::{AppEvent, EventSender};
 use crate::WindowId;
 use crate::geometry::rect::RectF;
 use crate::geometry::vector::{Vector2F, vec2f};
@@ -15,11 +14,11 @@ use crate::windowing::WindowCallbacks;
 pub struct WindowManager {
     windows: HashMap<WindowId, Rc<Window>>,
     active_window: RefCell<Option<WindowId>>,
-    event_sender: mpsc::Sender<AppEvent>,
+    event_sender: EventSender,
 }
 
 impl WindowManager {
-    pub(super) fn new(event_sender: mpsc::Sender<AppEvent>) -> Self {
+    pub(super) fn new(event_sender: EventSender) -> Self {
         Self {
             windows: HashMap::new(),
             active_window: RefCell::new(None),

--- a/crates/warpui/tests/headless_main_thread.rs
+++ b/crates/warpui/tests/headless_main_thread.rs
@@ -1,25 +1,21 @@
+use libtest_mimic::{Arguments, Trial};
+
 const TEST_NAME: &str = "services_main_dispatch_queue";
 
 fn main() {
-    let args: Vec<_> = std::env::args().skip(1).collect();
-    if args.iter().any(|arg| arg == "--list") {
-        if cfg!(target_os = "macos") && !args.iter().any(|arg| arg == "--ignored") {
-            println!("{TEST_NAME}: test");
-        }
-        return;
-    }
+    let mut args = Arguments::from_args();
+    // This test must run on the process main thread to service the macOS run loop.
+    args.test_threads = Some(1);
 
     #[cfg(target_os = "macos")]
-    {
-        if let Some(exact_index) = args.iter().position(|arg| arg == "--exact")
-            && args
-                .get(exact_index + 1)
-                .is_some_and(|name| name != TEST_NAME)
-        {
-            return;
-        }
-        macos::services_main_dispatch_queue();
-    }
+    let tests = vec![Trial::test(TEST_NAME, || {
+        macos::services_main_dispatch_queue().map_err(|error| format!("{error:#}").into())
+    })];
+
+    #[cfg(not(target_os = "macos"))]
+    let tests = Vec::<Trial>::new();
+
+    libtest_mimic::run(&args, tests).exit();
 }
 
 #[cfg(target_os = "macos")]
@@ -36,14 +32,14 @@ mod macos {
     use warpui::platform::TerminationMode;
     use warpui::platform::app::{AppBuilder, AppCallbacks};
 
-    pub(super) fn services_main_dispatch_queue() {
+    pub(super) fn services_main_dispatch_queue() -> anyhow::Result<()> {
         objc2::MainThreadMarker::new()
             .expect("the custom test harness must run on the process main thread");
         let process_main_thread = thread::current().id();
         let dispatched_on_main = Arc::new(AtomicBool::new(false));
         let worker_returned = Arc::new(AtomicBool::new(false));
 
-        let result = AppBuilder::new_headless(AppCallbacks::default(), Box::new(()), None).run({
+        AppBuilder::new_headless(AppCallbacks::default(), Box::new(()), None).run({
             let dispatched_on_main = dispatched_on_main.clone();
             let worker_returned = worker_returned.clone();
             move |ctx| {
@@ -92,8 +88,6 @@ mod macos {
                     })
                     .detach();
             }
-        });
-
-        result.expect("headless main-thread dispatch test failed");
+        })
     }
 }

--- a/crates/warpui/tests/headless_main_thread.rs
+++ b/crates/warpui/tests/headless_main_thread.rs
@@ -1,14 +1,12 @@
 use libtest_mimic::{Arguments, Trial};
 
-const TEST_NAME: &str = "services_main_dispatch_queue";
-
 fn main() {
     let mut args = Arguments::from_args();
     // This test must run on the process main thread to service the macOS run loop.
     args.test_threads = Some(1);
 
     #[cfg(target_os = "macos")]
-    let tests = vec![Trial::test(TEST_NAME, || {
+    let tests = vec![Trial::test("services_main_dispatch_queue", || {
         macos::services_main_dispatch_queue().map_err(|error| format!("{error:#}").into())
     })];
 

--- a/crates/warpui/tests/headless_main_thread.rs
+++ b/crates/warpui/tests/headless_main_thread.rs
@@ -1,0 +1,100 @@
+const TEST_NAME: &str = "services_main_dispatch_queue";
+
+fn main() {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    if args.iter().any(|arg| arg == "--list") {
+        if cfg!(target_os = "macos") && !args.iter().any(|arg| arg == "--ignored") {
+            println!("{TEST_NAME}: test");
+        }
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(exact_index) = args.iter().position(|arg| arg == "--exact") {
+            if args
+                .get(exact_index + 1)
+                .is_some_and(|name| name != TEST_NAME)
+            {
+                return;
+            }
+        }
+        macos::services_main_dispatch_queue();
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use anyhow::anyhow;
+    use dispatch2::run_on_main;
+    use instant::Instant;
+    use warpui::r#async::Timer;
+    use warpui::platform::TerminationMode;
+    use warpui::platform::app::{AppBuilder, AppCallbacks};
+
+    pub(super) fn services_main_dispatch_queue() {
+        objc2::MainThreadMarker::new()
+            .expect("the custom test harness must run on the process main thread");
+        let process_main_thread = thread::current().id();
+        let dispatched_on_main = Arc::new(AtomicBool::new(false));
+        let worker_returned = Arc::new(AtomicBool::new(false));
+
+        let result = AppBuilder::new_headless(AppCallbacks::default(), Box::new(()), None).run({
+            let dispatched_on_main = dispatched_on_main.clone();
+            let worker_returned = worker_returned.clone();
+            move |ctx| {
+                thread::spawn({
+                    let dispatched_on_main = dispatched_on_main.clone();
+                    let worker_returned = worker_returned.clone();
+                    move || {
+                        run_on_main(|_| {
+                            dispatched_on_main.store(
+                                thread::current().id() == process_main_thread,
+                                Ordering::SeqCst,
+                            );
+                        });
+                        worker_returned.store(true, Ordering::SeqCst);
+                    }
+                });
+
+                let weak_app = ctx.weak_app();
+                ctx.foreground_executor()
+                    .spawn(async move {
+                        let deadline = Instant::now() + Duration::from_secs(5);
+                        while Instant::now() < deadline
+                            && !(dispatched_on_main.load(Ordering::SeqCst)
+                                && worker_returned.load(Ordering::SeqCst))
+                        {
+                            Timer::after(Duration::from_millis(10)).await;
+                        }
+
+                        let test_result = if dispatched_on_main.load(Ordering::SeqCst)
+                            && worker_returned.load(Ordering::SeqCst)
+                        {
+                            Ok(())
+                        } else {
+                            Err(anyhow!(
+                                "headless Warp did not service the GCD main queue before timeout"
+                            ))
+                        };
+                        if let Some(mut app) = weak_app.upgrade() {
+                            app.update(|ctx| {
+                                ctx.terminate_app(
+                                    TerminationMode::ForceTerminate,
+                                    Some(test_result),
+                                );
+                            });
+                        }
+                    })
+                    .detach();
+            }
+        });
+
+        result.expect("headless main-thread dispatch test failed");
+    }
+}

--- a/crates/warpui/tests/headless_main_thread.rs
+++ b/crates/warpui/tests/headless_main_thread.rs
@@ -11,13 +11,12 @@ fn main() {
 
     #[cfg(target_os = "macos")]
     {
-        if let Some(exact_index) = args.iter().position(|arg| arg == "--exact") {
-            if args
+        if let Some(exact_index) = args.iter().position(|arg| arg == "--exact")
+            && args
                 .get(exact_index + 1)
                 .is_some_and(|name| name != TEST_NAME)
-            {
-                return;
-            }
+        {
+            return;
         }
         macos::services_main_dispatch_queue();
     }


### PR DESCRIPTION
## Description

The macOS headless `warpui` backend currently blocks the process main thread waiting on its Rust event channel. Although work handled by that loop runs on the main thread, the loop does not service the native CFRunLoop or GCD main queue. A worker that calls `dispatch2::run_on_main` can therefore deadlock indefinitely.

This limitation led #11671 to replace main-thread dispatch in the Carbon keycode cache with mutex-based serialization. The mutex prevented concurrent Carbon calls, but did not satisfy Carbon's main-thread requirement; #13547 provides the immediate call-site fix for that regression.

This PR fixes the underlying headless event-loop behavior:

- On macOS, headless event senders enqueue the existing `AppEvent`, signal a `CFRunLoopSource`, and wake the process main thread's CFRunLoop.
- The run-loop source stops the current run-loop invocation so queued Warp events can be drained and handled in ordinary Rust code.
- The headless run loop verifies that it is initialized on the process main thread.
- Non-macOS headless backends retain the existing blocking channel behavior.
- The Carbon keycode cache can use `dispatch2::run_on_main` again, transparently running inline on the main thread or synchronously dispatching from a worker.

This preserves the existing Warp foreground executor and event dispatch model while allowing native main-queue work to make progress.

## Related changes

- #11671 introduced the mutex workaround because headless Warp did not service the GCD main queue.
- #13547 moves current computer-use actor construction onto the main thread as an immediate regression fix.

## Testing

Added a custom `harness = false` regression test that owns the process main thread, starts the headless backend, invokes `dispatch2::run_on_main` from a worker, and verifies that the callback executes on the primordial thread and returns without deadlocking.

- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo check -p warpui -p computer_use --tests`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo nextest run -p warpui` — 42 passed, 1 skipped.
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo nextest run -p warpui -E 'test(services_main_dispatch_queue)'`
- `cargo nextest run -p computer_use --no-tests=pass` — test targets compiled; the package currently has no tests.
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo clippy -p warpui -p computer_use --all-targets --no-deps -- -D warnings`
- `./script/format`
- `git diff --check`

A full dependency clippy run remains blocked by pre-existing `clippy::unnecessary_unwrap` findings in `warpui_core/src/elements/gui/hoverable.rs`; clippy passes for both modified packages.

- [x] I have manually tested a headless computer-use action locally.

### Screenshots / Videos

Not applicable; this PR has no user-visible UI changes.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
