### PR TITLE
fix: use configured shell path for SSH bootstrap

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1110,7 +1110,7 @@ fi
 
 case "'${SHELL##*/}'" in
   bash)
-    exec -a bash bash --rcfile <(echo '"'
+    exec -a bash "'$SHELL'" --rcfile <(echo '"'
       command -p stty raw
       HISTCONTROL=ignorespace
       HISTIGNORE=" *"
@@ -1137,7 +1137,7 @@ if [[ "'$?'" == 0 ]]; then
 else
   echo \"Failed to bootstrap warp. Continuing with a non-bootstrapped shell.\"
 fi
-TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" ZDOTDIR="'$WARP_TMP_DIR'" exec -l zsh -g $TRACE_FLAG_IF_WARP_SHELL_DEBUG_MODE
+TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" ZDOTDIR="'$WARP_TMP_DIR'" exec -l "'$SHELL'" -g $TRACE_FLAG_IF_WARP_SHELL_DEBUG_MODE
       ;;
 esac
 "

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -727,7 +727,7 @@ fi
 
 case "'${SHELL##*/}'" in
 bash)
-    exec -a bash bash --rcfile <(echo '"'
+    exec -a bash "'$SHELL'" --rcfile <(echo '"'
       stty raw
       HISTCONTROL=ignorespace
       HISTIGNORE=" *"
@@ -755,7 +755,7 @@ if [[ "'$?'" == 0 ]]; then
 else
   echo \"Failed to bootstrap warp. Continuing with a non-bootstrapped shell.\"
 fi
-TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" ZDOTDIR="'$WARP_TMP_DIR'" exec -l zsh -g $TRACE_FLAG_IF_WARP_SHELL_DEBUG_MODE
+TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" ZDOTDIR="'$WARP_TMP_DIR'" exec -l "'$SHELL'" -g $TRACE_FLAG_IF_WARP_SHELL_DEBUG_MODE
     ;;
 esac
 "

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1037,7 +1037,7 @@ fi
 
 case "'${SHELL##*/}'" in
   bash)
-    exec -a bash bash --rcfile <(echo '"'
+    exec -a bash "'$SHELL'" --rcfile <(echo '"'
       command -p stty raw
       HISTCONTROL=ignorespace
       HISTIGNORE=" *"
@@ -1066,7 +1066,7 @@ case "'${SHELL##*/}'" in
     else
       echo \"Failed to bootstrap warp. Continuing with a non-bootstrapped shell.\"
     fi
-    TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" WARP_HONOR_PS1="'$WARP_HONOR_PS1'" ZDOTDIR="'$WARP_TMP_DIR'" exec -l zsh -g $TRACE_FLAG_IF_WARP_SHELL_DEBUG_MODE
+    TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" WARP_HONOR_PS1="'$WARP_HONOR_PS1'" ZDOTDIR="'$WARP_TMP_DIR'" exec -l "'$SHELL'" -g $TRACE_FLAG_IF_WARP_SHELL_DEBUG_MODE
       ;;
 esac
 "

--- a/app/src/terminal/bootstrap_tests.rs
+++ b/app/src/terminal/bootstrap_tests.rs
@@ -59,6 +59,31 @@ fn test_trims_powershell_specifics() {
     );
 }
 
+#[test]
+fn test_ssh_wrapper_reexecs_configured_login_shell() {
+    for path in [
+        "bundled/bootstrap/bash_body.sh",
+        "bundled/bootstrap/fish.sh",
+        "bundled/bootstrap/zsh_body.sh",
+    ] {
+        let script = crate::ASSETS
+            .get(path)
+            .unwrap_or_else(|_| panic!("failed to retrieve {path} from assets"));
+        let script = decode_script(&script);
+
+        assert!(
+            script.contains(r#"exec -a bash "'$SHELL'" --rcfile"#),
+            "{path} must use the configured bash path"
+        );
+        assert!(
+            script.contains(r#"exec -l "'$SHELL'" -g"#),
+            "{path} must use the configured zsh path"
+        );
+        assert!(!script.contains("exec -a bash bash --rcfile"));
+        assert!(!script.contains("exec -l zsh -g"));
+    }
+}
+
 fn decode_script(bytes: &[u8]) -> &str {
     std::str::from_utf8(bytes).expect("should not fail to decode")
 }


### PR DESCRIPTION
## Description

Fixes SSH/Warpify bootstrap when the remote bash or zsh executable is only available at the absolute path configured by sshd in `$SHELL`, rather than by its bare name in the default SSH `PATH`.

The three embedded SSH wrapper payloads now re-exec `"$SHELL"` for bash and zsh while preserving the existing bash argv0 and zsh login-shell flags. A regression test covers every duplicated payload and rejects the former bare-name commands.

## Linked Issue

Fixes #13934

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
  - The issue is triaged with `repro:high`, but currently has neither ready label.
- [x] Screenshots or video are not applicable to this shell bootstrap change.

## Testing

Automated and manual verification performed:

- [x] `./script/format`
- [x] `./script/format --check`
- [x] `git diff --check`
- [x] `bash -n app/assets/bundled/bootstrap/bash_body.sh`
- [x] Verified all three payloads use the configured `$SHELL` path and no longer contain the bare-name bash/zsh re-exec commands.
- [x] Simulated a restricted remote `PATH` with `PATH=/nonexistent` and confirmed an absolute bash `$SHELL` path still re-execs successfully.
- [x] Installed and verified the Debian 13 Clang 19 runtime and generic headers; the previously blocked `minimp4-sys` bindgen build now completes successfully.
- [ ] `cargo test -p warp --lib test_ssh_wrapper_reexecs_configured_login_shell -j 1` compiled through the Warp application crate, but the final test-binary link was stopped after the 7.5 GiB host entered heavy swapping; the test did not execute.
- [ ] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -j 1 -- -D warnings` passed the former bindgen failure and checked the supporting workspace through the main `warp` crate without lint diagnostics, but the final application analysis was stopped under the same host memory constraint before the command completed.
- [ ] I have manually tested my changes locally with `./script/run` (not run; this requires a remote Nix/home-manager SSH setup and the full GUI toolchain).

## Maintainer review checklist

- [ ] Confirm `$SHELL` is the intended source of the executable path across supported sshd configurations.
- [ ] Confirm the existing bash argv0 and zsh login-shell semantics remain intact.
- [ ] Run the targeted Rust regression test and complete Clippy in CI or a development environment with sufficient memory.
- [ ] Verify an end-to-end SSH/Warpify session where zsh is installed outside sshd's default `PATH` (for example, through Nix/home-manager).

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: SSH sessions now bootstrap correctly when the remote login shell is installed outside the default PATH.
