### PR TITLE
Specify when SSH warpification setting changes take effect

### DIFF
--- a/specs/gh-11347/PRODUCT.md
+++ b/specs/gh-11347/PRODUCT.md
@@ -1,0 +1,48 @@
+# GH-11347 — Clarify when SSH warpification takes effect
+
+Issue: [#11347 — SSH warpification toggle does not apply to current session](https://github.com/warpdotdev/warp/issues/11347)
+
+## Summary
+
+Changing **Warpify SSH Sessions** does not affect an SSH connection that is already running. Warp will explain in Settings that users must open a new terminal tab or pane and reconnect before the new value takes effect.
+
+## Problem
+
+The toggle currently has no timing guidance. A user can enable it while viewing an unwarpified SSH session, return to that session, and reasonably conclude that the setting is broken because the connection remains unchanged. Disabling it is similarly ambiguous: an already-warpified connection cannot be safely converted back to a plain SSH session in place.
+
+## Goals
+
+- State where the setting takes effect at the point where the user changes it.
+- Give users a concrete, safe next step when they want the new value to apply.
+- Preserve running terminals and SSH connections without reconnecting, terminating, or partially reconfiguring them.
+
+## Non-goals
+
+- Warpifying or unwarpifying an already-running SSH connection.
+- Opening a new terminal tab or pane, reconnecting SSH, or installing/removing the SSH extension automatically.
+- Applying the new value to terminal tabs or panes that were already open when the setting changed.
+- Changing host eligibility, denylist, extension installation-mode, ControlMaster, or remote-server fallback behavior.
+
+## Figma
+
+Figma: none provided
+
+## Behavior
+
+1. The **Warpify SSH Sessions** setting row always includes the following supporting text: **“Changes apply to new terminal sessions. Open a new tab or pane, then reconnect to SSH.”**
+
+2. Turning the setting on saves the enabled value immediately, but it does not alter, reconnect, or interrupt any local terminal or SSH connection that was already running when the value changed.
+
+3. After turning the setting on, an eligible SSH connection launched from a newly opened terminal tab or pane follows the existing SSH warpification and extension-installation flow. Existing host eligibility, denylist, installation-mode, platform, and fallback rules continue to decide the outcome.
+
+4. Turning the setting off saves the disabled value immediately, but it does not remove Warp features from an already-warpified SSH connection and does not terminate or reconnect that connection.
+
+5. After turning the setting off, SSH connections launched from newly opened terminal tabs or panes do not enter Warp's SSH warpification or extension-installation flow.
+
+6. Exiting SSH and rerunning `ssh` in a terminal tab or pane that was already open when the setting changed does not adopt the new value. The user must open a new tab or pane and reconnect to SSH.
+
+7. The setting continues to control whether its dependent SSH extension installation-mode and ControlMaster controls are interactive; adding the supporting text does not change those controls or their saved values.
+
+8. The supporting text is visible in enabled and disabled states, uses the standard Settings description style, remains readable at supported Settings widths and text scales, and is exposed to assistive technologies as descriptive text rather than as an interactive control.
+
+9. No success toast, warning modal, confirmation dialog, or terminal-side banner is shown when the value changes. The persistent supporting text is the single explanation of when the change takes effect.

--- a/specs/gh-11347/TECH.md
+++ b/specs/gh-11347/TECH.md
@@ -1,0 +1,73 @@
+# GH-11347 — Clarify when SSH warpification takes effect
+
+Issue: [#11347 — SSH warpification toggle does not apply to current session](https://github.com/warpdotdev/warp/issues/11347)
+
+## Context
+
+The Settings action currently toggles and persists `WarpifySettings.enable_ssh_warpification`, sends telemetry, and enables or disables the extension-install dropdown. It does not notify a terminal or reconnect SSH ([`warpify_page.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/settings_view/warpify_page.rs#L378-L410)). The toggle row has no description today ([`warpify_page.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/settings_view/warpify_page.rs#L631-L657)).
+
+That behavior reflects a real lifecycle boundary rather than only a missing event dispatch. When a local PTY is created, Warp reads the setting into `PtyOptions.enable_ssh_wrapper` ([`terminal_manager.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/local_tty/terminal_manager.rs#L785-L806)). The Unix launcher then writes that captured value to `WARP_USE_SSH_WRAPPER` in the new shell environment ([`unix.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/local_tty/unix.rs#L360-L365)); the equivalent value is also set when constructing sandboxed terminal environments ([`unix.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/local_tty/unix.rs#L883-L890)). Updating the persisted setting cannot mutate the environment or wrapper setup of a shell process that is already running.
+
+The remote-server path has a second hard boundary. `ModelEventDispatcher` enters it only when an `InitShell` payload identifies an SSH-wrapper session ([`model_events.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/model_events.rs#L71-L89)). `RemoteServerController` then requires the wrapper-provided socket and ControlMaster ownership before it can check, install, or connect the extension ([`remote_server_controller.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/writeable_pty/remote_server_controller.rs#L193-L242)). An unwrapped SSH connection already in progress does not provide a safe input to that state machine.
+
+Retrofitting the current connection would therefore require substantially broader work: live shell-environment reconfiguration, a recoverable way to establish or adopt a ControlMaster for an existing SSH process, session bootstrap migration, and cancellation semantics for in-flight setup. This spec instead implements the issue's accepted UX outcome: clearly state that the setting applies to newly created terminal sessions and leave running connections untouched (PRODUCT invariants 1–9).
+
+## Proposed changes
+
+### Settings copy
+
+In [`app/src/settings_view/warpify_page.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/settings_view/warpify_page.rs#L600-L657), define a local constant for the user-facing description and pass it as the existing description argument of `render_body_item` for **Warpify SSH Sessions**:
+
+> Changes apply to new terminal sessions. Open a new tab or pane, then reconnect to SSH.
+
+Use the existing Settings description renderer and styling; do not add a custom text element, action, toast, modal, or terminal event. The copy remains present regardless of the toggle value so enable and disable have the same lifecycle contract (PRODUCT invariants 1, 8, and 9).
+
+Do not change the setting definition, storage key, synchronization behavior, telemetry event, or toggle handler. `EnableSshWarpification` remains the canonical persisted boolean ([`settings.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/warpify/settings.rs#L49-L58)), and dependent controls retain their current state handling ([`warpify_page.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/settings_view/warpify_page.rs#L659-L723)) (PRODUCT invariants 2–7).
+
+### End-to-end state flow
+
+```text
+User toggles Warpify SSH Sessions
+  -> persist enable_ssh_warpification and send existing telemetry
+  -> update existing dependent Settings controls
+  -> leave all running local terminals and SSH sessions unchanged
+  -> user opens a new terminal
+  -> terminal creation snapshots the new value into WARP_USE_SSH_WRAPPER
+  -> user starts SSH
+     -> disabled: normal SSH path
+     -> enabled and eligible: existing wrapper -> SshInitShell -> remote-server flow
+```
+
+The last enabled branch keeps the existing controller state machine: wrapper session detection, binary/preinstall checks, existing-binary connect or auto-update, install-mode choice, and safe fallback ([`remote_server_controller.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/writeable_pty/remote_server_controller.rs#L245-L352)). No transition is added for a setting change during `AwaitingCheck`, `AwaitingUserChoice`, `AwaitingInstall`, or `AwaitingConnect`; those states belong to the already-started connection and finish under the policy captured when that terminal was created (PRODUCT invariants 2, 4, and 6).
+
+## Testing and validation
+
+### Automated checks
+
+- Add a focused Settings rendering assertion if the existing test harness can inspect `WarpifyPageView`: assert that the **Warpify SSH Sessions** row renders the exact supporting text while enabled and while disabled (PRODUCT invariants 1 and 8).
+- If that view is not exposed to a lightweight render test, keep this copy-only change covered by the visual checks below rather than introducing a new broad GUI harness solely for one static description.
+- Run `./script/format` and the repository-prescribed `cargo clippy` command before publishing the implementation PR.
+- Run the narrow Settings/view tests that own `WarpifyPageView`. The existing remote-server integration builder already covers the new-terminal enabled path by setting the install mode before terminal creation and then entering SSH ([`remote_server.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/integration/src/test/remote_server.rs#L31-L62)); this copy-only change does not require duplicating that expensive connection test.
+
+### Visual evidence mapping
+
+Capture GUI evidence from the Warpify Settings page at the default window size and at the narrowest supported Settings width:
+
+| Evidence | Expected result | Product invariants |
+| --- | --- | --- |
+| Toggle enabled | Description is visible under **Warpify SSH Sessions**, wraps without clipping, and dependent controls remain enabled | 1, 7, 8 |
+| Toggle disabled | The same description remains visible and readable; dependent controls retain their existing disabled treatment | 1, 7, 8 |
+| Accessibility inspection | Description is exposed as readable static text and does not create an extra focus target | 8 |
+
+No terminal screenshot is required to prove that a running connection remains unchanged: the implementation deliberately adds no terminal mutation. If maintainers request behavioral evidence, record a short manual sequence showing an existing SSH connection survives both toggle directions and the new copy tells the user to open a new terminal (PRODUCT invariants 2, 4, 6, and 9).
+
+## Risks
+
+- **Copy precision:** saying only “new SSH sessions” would be misleading because the wrapper policy is captured by the containing local terminal. The proposed copy explicitly says “new terminal sessions.”
+- **Expectation gap:** users may prefer immediate warpification. The description resolves the reported ambiguity but does not deliver live migration; that remains a separate, substantially larger product and architecture project.
+- **Localization and wrapping:** the added sentence increases row height. Visual verification at narrow width and enlarged text must ensure the switch stays aligned and the description is not clipped.
+- **Architecture drift:** the SSH remote-server implementation is evolving. The UX contract depends only on the stable process boundary—an existing shell environment and SSH process cannot be retroactively replaced by persisting a setting—not on a particular controller state name.
+
+## Parallelization
+
+Implementation should be completed as one workstream. The code change and its visual verification both touch the same Settings row, so parallel implementation would add coordination overhead without reducing risk. Repository-wide format and clippy checks can run concurrently after the final edit; GUI screenshots should run after formatting so they represent the exact submitted state.


### PR DESCRIPTION
## Description

Clarify the lifecycle of the **Warpify SSH Sessions** setting and specify a safe, narrowly scoped resolution for #11347.

Current code snapshots the setting when a terminal session is created, so an existing tab or pane cannot safely adopt a new wrapper policy. The product spec therefore requires persistent Settings copy directing users to open a new tab or pane and reconnect, while leaving running SSH connections untouched. The technical spec grounds that behavior in the current PTY, wrapper, and remote-server flow.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots or video are not applicable to this spec-only PR; the implementation spec defines the required Settings and accessibility evidence.

Closes #11347

## Testing

- [x] Reviewed PRODUCT behavior against enable and disable transitions for existing and newly created terminal sessions.
- [x] Verified every TECH code reference against upstream commit `abea51cd1e102b363935f1b25ef03d335bc7b36f`.
- [x] Checked both Markdown files for whitespace errors.
- [ ] I have manually tested my changes locally with `./script/run` (not applicable: specification-only change).

### Screenshots / Videos

Not applicable to this specification-only PR. The proposed implementation validation covers enabled and disabled Settings states, narrow layout, and accessibility exposure.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Warp <agent@warp.dev>
