### PR TITLE
[REMOTE-1626] Remove FeatureFlag::OzIdentityFederation after stabilization

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -622,7 +622,6 @@ default = [
     "cloud_mode_image_context",
     "agent_mode_computer_use",
     "oz_platform_skills",
-    "oz_identity_federation",
     "sync_ambient_plans",
     "conversation_artifacts",
     "agent_view",
@@ -984,7 +983,6 @@ inline_model_selector = ["agent_view"]
 inline_profile_selector = ["agent_view"]
 restore_prompt_on_inline_model_selector_search = []
 oz_platform_skills = []
-oz_identity_federation = []
 oz_launch_modal = []
 open_warp_launch_modal = []
 orchestration_launch_modal = []

--- a/app/src/ai/agent_sdk/federate.rs
+++ b/app/src/ai/agent_sdk/federate.rs
@@ -5,7 +5,6 @@ use serde_json::json;
 use warp_cli::GlobalOptions;
 use warp_cli::agent::OutputFormat;
 use warp_cli::federate::{FederateCommand, IssueGcpTokenArgs, IssueTokenArgs};
-use warp_core::features::FeatureFlag;
 use warp_errors::report_error;
 use warp_managed_secrets::ManagedSecretManager;
 use warpui::platform::TerminationMode;
@@ -19,9 +18,6 @@ pub fn run(
     global_options: GlobalOptions,
     command: FederateCommand,
 ) -> Result<()> {
-    if !FeatureFlag::OzIdentityFederation.is_enabled() {
-        return Err(anyhow::anyhow!("This feature is not enabled"));
-    }
     match command {
         FederateCommand::IssueToken(args) => issue_token(ctx, args, global_options.output_format),
         FederateCommand::IssueGcpToken(args) => issue_gcp_token(ctx, args),

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -191,12 +191,7 @@ fn dispatch_command(
             }
             secret::run(ctx, global_options, secret_cmd)
         }
-        CliCommand::Federate(federate_cmd) => {
-            if !FeatureFlag::OzIdentityFederation.is_enabled() {
-                return Err(anyhow::anyhow!("invalid value 'federate'"));
-            }
-            federate::run(ctx, global_options, federate_cmd)
-        }
+        CliCommand::Federate(federate_cmd) => federate::run(ctx, global_options, federate_cmd),
         CliCommand::HarnessSupport(args) => {
             if !FeatureFlag::AgentHarness.is_enabled() {
                 return Err(anyhow::anyhow!("invalid value 'harness-support'"));
@@ -1456,15 +1451,13 @@ impl AgentDriverRunner {
             })
             .await??;
 
-        if FeatureFlag::OzIdentityFederation.is_enabled() {
-            let run_id = driver_options
-                .task_id
-                .map(|id| id.to_string())
-                .unwrap_or_else(|| "local".to_string());
-            driver_options.cloud_providers =
-                driver::cloud_provider::load_providers(&environment.providers, &run_id)
-                    .map_err(AgentDriverError::CloudProviderSetupFailed)?;
-        }
+        let run_id = driver_options
+            .task_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "local".to_string());
+        driver_options.cloud_providers =
+            driver::cloud_provider::load_providers(&environment.providers, &run_id)
+                .map_err(AgentDriverError::CloudProviderSetupFailed)?;
 
         driver_options.environment = Some(environment);
         Ok(())

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -550,9 +550,6 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
 
     fn enablement_state(&self) -> EnablementState {
         match self {
-            Self::FederateIssueToken | Self::FederateIssueGcpToken => {
-                EnablementState::Flag(FeatureFlag::OzIdentityFederation)
-            }
             Self::HarnessSupportPing
             | Self::HarnessSupportReportArtifact
             | Self::HarnessSupportNotifyUser

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -395,8 +395,6 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::InlineProfileSelector,
         #[cfg(feature = "oz_platform_skills")]
         FeatureFlag::OzPlatformSkills,
-        #[cfg(feature = "oz_identity_federation")]
-        FeatureFlag::OzIdentityFederation,
         #[cfg(feature = "oz_changelog_updates")]
         FeatureFlag::OzChangelogUpdates,
         #[cfg(feature = "bundled_skills")]

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -247,15 +247,6 @@ impl Args {
                     }
                 }
 
-                if !FeatureFlag::OzIdentityFederation.is_enabled() {
-                    let args: Vec<String> = env::args().collect();
-                    if args.len() > 1 && args[1] == "federate" {
-                        eprintln!("error: unrecognized subcommand 'federate'\n");
-                        eprintln!("For more information, try '--help'");
-                        std::process::exit(2);
-                    }
-                }
-
                 if !FeatureFlag::ArtifactCommand.is_enabled() {
                     let args: Vec<String> = env::args().collect();
                     if args.len() > 1 && args[1] == "artifact" {
@@ -369,11 +360,6 @@ impl Args {
         // Hide the secret subcommand from help text.
         if !FeatureFlag::WarpManagedSecrets.is_enabled() {
             command = command.mut_subcommand("secret", |c| c.hide(true));
-        }
-
-        // Hide the federate subcommand from help text.
-        if !FeatureFlag::OzIdentityFederation.is_enabled() {
-            command = command.mut_subcommand("federate", |c| c.hide(true));
         }
 
         // Hide the harness-support subcommand from help text.

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -645,8 +645,6 @@ pub enum FeatureFlag {
     /// Skills are loaded from `.agents/skills/`, `.warp/skills/`, `.claude/skills/`, and `.codex/skills/`
     /// directories to provide base prompts for agent runs.
     OzPlatformSkills,
-    /// Enables Oz identity federation commands.
-    OzIdentityFederation,
 
     /// Gates populating/reading oz updates from channel versions in the changelog model.
     OzChangelogUpdates,


### PR DESCRIPTION
## Description

Remove `FeatureFlag::OzIdentityFederation` and all associated dead code now that the flag has been promoted to stable. The `federate` subcommand and identity federation functionality are unconditionally available.

Changes:
- Removed `OzIdentityFederation` variant from `FeatureFlag` enum in `crates/warp_features/src/lib.rs`
- Removed `oz_identity_federation` from the `default` feature array and feature definition in `app/Cargo.toml`
- Removed the cfg-gated registration block in `app/src/features.rs`
- Removed two early-exit guards in `crates/warp_cli/src/lib.rs` (arg parsing and help text hiding for `federate`)
- Removed the early-return guard in `app/src/ai/agent_sdk/federate.rs` and the now-unused `FeatureFlag` import
- Changed `EnablementState` for `FederateIssueToken`/`FederateIssueGcpToken` in `telemetry.rs` from `Flag(OzIdentityFederation)` to always-enabled
- Made cloud provider loading in `resolve_environment` unconditional (removed `if OzIdentityFederation.is_enabled()` guard)
- Removed the feature flag dispatch guard in `mod.rs`

## Linked Issue

Closes REMOTE-1626

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). _(N/A - internal cleanup)_

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Code compiles cleanly (`cargo check --bin warp` passes). The pre-existing clippy failures in `warp_completer` are unrelated to this PR and exist on the base branch.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/4752c6f6-595c-4b5b-beee-d42a2964f2ae_
_Run: https://oz.staging.warp.dev/runs/019f7ef3-6fff-7173-99b8-da7668700915_

_This PR was generated with [Oz](https://warp.dev/oz)._
