### PR TITLE
Add specs for Project Explorer directory symlinks

### DIFF
--- a/specs/gh-11528/PRODUCT.md
+++ b/specs/gh-11528/PRODUCT.md
@@ -15,7 +15,8 @@ when links are broken, unreadable, outside the workspace, or cyclic.
 - Keep file-tree updates, selection, and open-file paths anchored to the workspace-visible symlink
   path.
 - Preserve existing ignore, lazy-loading, and file-budget behavior.
-- Keep this capability limited to user-initiated Project Explorer browsing and file operations.
+- Keep this capability limited to user-initiated Project Explorer browsing, explicit path
+  attachment, and file operations.
 
 ## Non-goals
 
@@ -24,8 +25,9 @@ when links are broken, unreadable, outside the workspace, or cyclic.
 - Expose the target's parent directory or any sibling outside the linked subtree.
 - Resolve permission failures, repair broken links, or change filesystem permissions.
 - Make Project Explorer follow shell aliases, Finder aliases, or other non-filesystem shortcuts.
-- Add linked target contents to repository search/indexing, agent context, standing-query or skill
-  discovery, or remote repository snapshots.
+- Add linked target contents to repository search/indexing, automatically collected agent context,
+  standing-query or skill discovery, or remote repository snapshots. This does not exclude the
+  existing explicit **Attach as context** action described below.
 - Change remote-backed, Windows, or Linux Project Explorer behavior; those surfaces remain as they
   are today.
 
@@ -51,10 +53,16 @@ expandable tree behavior; this change introduces no new visual treatment.
    appears and opens as `/workspace/vendor/src/lib.rs`. Project Explorer does not replace the link
    with `/shared/library` or expose `/shared`.
 
-4. Opening, selecting, copying the path of, renaming, or deleting a descendant under a linked
-   directory uses the workspace-visible path. The operating system continues to apply its normal
-   symlink semantics to that explicit descendant operation; Warp does not silently redirect the
-   operation to a different visible tree entry.
+4. Opening, selecting, copying the path of, attaching as context, renaming, or deleting a
+   descendant under a linked directory uses the workspace-visible path. The operating system
+   continues to apply its normal symlink semantics to that explicit descendant operation; Warp
+   does not silently redirect the operation to a different visible tree entry.
+
+   **Attach as context** is available on an alias root and on visible file or directory descendants,
+   just as it is on ordinary Project Explorer entries. It sends the repository-relative lexical
+   path (for example, `vendor/src/lib.rs`) through the existing path-attachment flow. Selecting the
+   action does not canonicalize the path, reveal the external target, recursively enumerate a
+   directory, or add the linked subtree to automatically collected agent context.
 
    The directory-symlink root is a separate destructive boundary. Renaming the root renames only
    the symlink entry at its workspace-visible path; the target directory, its name, and its contents
@@ -79,6 +87,23 @@ expandable tree behavior; this change introduces no new visual treatment.
    `A → B → A` chain one directory at a time, the final cycle-closing directory remains visible but
    has no recursively repeated descendants. Project Explorer never hangs, grows the tree
    indefinitely, or loses the cycle boundary between lazy loads.
+
+   Nested directory symlinks use the same rules at every depth:
+   - A directory symlink discovered anywhere below an alias is a new lexical alias boundary. It is
+     shown at the path reached through its parent alias and starts unloaded; classifying it does not
+     enumerate its target.
+   - Its target may be inside or outside the workspace, may also be reachable by another alias, and
+     may contain further directory symlinks. Each lexical alias keeps independent expansion,
+     selection, refresh, and destructive-action identity.
+   - Its canonical target is checked against the full canonical ancestry inherited from the outer
+     alias. A repeated identity produces one visible, loaded, childless cycle closer. A distinct
+     identity extends the ancestry for later lazy expansions.
+   - Retargeting or breaking a nested alias clears only that alias's stale subtree and watches; it
+     does not collapse or replace readable siblings or the containing alias. An in-flight result
+     from the old nested target cannot repopulate it.
+   - Renaming or deleting a nested alias root changes or unlinks only that symlink entry. The target
+     and its contents are never renamed or recursively deleted. Ordinary directories and existing
+     file symlinks encountered below an alias retain their existing behavior.
 
 9. Link failures follow this observable matrix and never block readable siblings:
    - If resolving the target reports `NotFound`, or the link is broken or no longer targets a
@@ -129,14 +154,19 @@ expandable tree behavior; this change introduces no new visual treatment.
 
 18. Existing symbolic links to files continue to appear and open as they do before this change.
     Existing project-skill discovery through symlinked provider directories also continues to find
-    the same skill files through its existing explicit discovery rule, independently of Project
-    Explorer expansion.
+    the same skill files through its existing explicit provider allowlist and `SKILL.md` discovery
+    rule, independently of Project Explorer expansion. A nested Project Explorer alias does not
+    become a skill provider merely because it is browsable; if its lexical path separately matches
+    the configured skill rule, the existing skill-discovery path remains the sole owner of that
+    standing-query result.
 
 19. A malformed or inaccessible symlink anywhere below a linked target is isolated to that entry.
     Readable siblings and the rest of the repository continue to load and update.
 
 20. Linked descendants added for Project Explorer are not repository contents. They do not appear
-    in repository-wide search or indexing, agent context, generic standing-query or skill-rule
-    discovery, or serialized local-to-remote repository trees. Only the existing explicitly
-    configured symlinked-skill discovery behavior in (18) may read such a target outside Project
-    Explorer.
+    in repository-wide search or indexing, automatically collected or ambient agent context,
+    generic standing-query or skill-rule discovery, or serialized local-to-remote repository
+    trees. The explicit **Attach as context** action in (4) may insert only the selected lexical path
+    into the active terminal or agent input; it does not place overlay contents in the shared
+    repository context. Only the existing explicitly configured symlinked-skill discovery behavior
+    in (18) may otherwise read such a target outside Project Explorer.

--- a/specs/gh-11528/PRODUCT.md
+++ b/specs/gh-11528/PRODUCT.md
@@ -36,9 +36,11 @@ expandable tree behavior; this change introduces no new visual treatment.
 
 ## Behavior
 
-1. In a local macOS workspace, a symbolic link whose target is a readable directory appears in
-   Project Explorer at the link's path and with the link's filename, in the same sorted position as
-   an ordinary directory.
+1. In a local macOS workspace, a symbolic link whose target can be identified as a directory
+   appears in Project Explorer at the link's path and with the link's filename, in the same sorted
+   position as an ordinary directory. Directory classification does not require enumerating the
+   target's contents, so a directory whose contents are temporarily unreadable still appears as an
+   unloaded, retryable alias.
 
 2. The linked directory is loaded on demand. Before it is expanded, Project Explorer retains it as
    an unloaded directory, does not walk the target, and does not begin watching an external target.

--- a/specs/gh-11528/PRODUCT.md
+++ b/specs/gh-11528/PRODUCT.md
@@ -51,10 +51,16 @@ expandable tree behavior; this change introduces no new visual treatment.
    appears and opens as `/workspace/vendor/src/lib.rs`. Project Explorer does not replace the link
    with `/shared/library` or expose `/shared`.
 
-4. Opening, selecting, copying the path of, renaming, or deleting an item under a linked directory
-   uses the workspace-visible path. The operating system continues to apply its normal symlink
-   semantics to the resulting filesystem operation; Warp does not silently redirect the operation
-   to a different visible tree entry.
+4. Opening, selecting, copying the path of, renaming, or deleting a descendant under a linked
+   directory uses the workspace-visible path. The operating system continues to apply its normal
+   symlink semantics to that explicit descendant operation; Warp does not silently redirect the
+   operation to a different visible tree entry.
+
+   The directory-symlink root is a separate destructive boundary. Renaming the root renames only
+   the symlink entry at its workspace-visible path; the target directory, its name, and its contents
+   do not move or change. Deleting the root unlinks only the symlink entry and never recursively
+   deletes or modifies the target directory or any target descendant. Rename/delete confirmation
+   and error UI identify the workspace-visible alias path, not the canonical external target.
 
 5. A link may target a directory outside the workspace. Only the target directory and its
    descendants are reachable through the link; the target's parent and siblings do not become

--- a/specs/gh-11528/PRODUCT.md
+++ b/specs/gh-11528/PRODUCT.md
@@ -1,0 +1,134 @@
+# Project Explorer Directory Symlinks — Product Spec
+
+## Summary
+
+For a local macOS workspace, Project Explorer displays and traverses directory symbolic links using
+their path inside the workspace, so users can browse and open the linked files without leaving Warp.
+The behavior fixes [#11528](https://github.com/warpdotdev/warp/issues/11528) while remaining bounded
+when links are broken, unreadable, outside the workspace, or cyclic.
+
+## Goals
+
+- Make a directory symlink usable from Project Explorer in the same place and under the same name
+  as it appears on disk.
+- Keep traversal finite and responsive for cyclic or very large linked directory graphs.
+- Keep file-tree updates, selection, and open-file paths anchored to the workspace-visible symlink
+  path.
+- Preserve existing ignore, lazy-loading, and file-budget behavior.
+- Keep this capability limited to user-initiated Project Explorer browsing and file operations.
+
+## Non-goals
+
+- Add a new icon, badge, warning, or context-menu action for symbolic links.
+- Change the behavior of symbolic links to files.
+- Expose the target's parent directory or any sibling outside the linked subtree.
+- Resolve permission failures, repair broken links, or change filesystem permissions.
+- Make Project Explorer follow shell aliases, Finder aliases, or other non-filesystem shortcuts.
+- Add linked target contents to repository search/indexing, agent context, standing-query or skill
+  discovery, or remote repository snapshots.
+- Change remote-backed, Windows, or Linux Project Explorer behavior; those surfaces remain as they
+  are today.
+
+## Figma
+
+Figma: none provided. The issue contains screenshots of the current Warp result and the expected
+expandable tree behavior; this change introduces no new visual treatment.
+
+## Behavior
+
+1. In a local macOS workspace, a symbolic link whose target is a readable directory appears in
+   Project Explorer at the link's path and with the link's filename, in the same sorted position as
+   an ordinary directory.
+
+2. The linked directory is loaded on demand. Before it is expanded, Project Explorer retains it as
+   an unloaded directory, does not walk the target, and does not begin watching an external target.
+   Expanding it reveals the target directory's children without eagerly walking the entire target.
+
+3. Every descendant is presented under the link's workspace-visible path. For example, if
+   `/workspace/vendor` links to `/shared/library`, the target file `/shared/library/src/lib.rs`
+   appears and opens as `/workspace/vendor/src/lib.rs`. Project Explorer does not replace the link
+   with `/shared/library` or expose `/shared`.
+
+4. Opening, selecting, copying the path of, renaming, or deleting an item under a linked directory
+   uses the workspace-visible path. The operating system continues to apply its normal symlink
+   semantics to the resulting filesystem operation; Warp does not silently redirect the operation
+   to a different visible tree entry.
+
+5. A link may target a directory outside the workspace. Only the target directory and its
+   descendants are reachable through the link; the target's parent and siblings do not become
+   Project Explorer roots.
+
+6. A link may target a directory that is also reachable through an ordinary workspace path. Both
+   entries remain visible: the ordinary path and each symlink path are separate Project Explorer
+   locations, even though they resolve to the same filesystem objects.
+
+7. Multiple directory links to the same target remain separate entries. Expanding, collapsing, or
+   selecting one alias does not change the expansion, collapse, or selection state of another
+   alias.
+
+8. Traversal is cycle-safe across separate expansion actions. Warp remembers the canonical
+   ancestry of an unloaded linked directory when it is added to the tree. If the user expands an
+   `A → B → A` chain one directory at a time, the final cycle-closing directory remains visible but
+   has no recursively repeated descendants. Project Explorer never hangs, grows the tree
+   indefinitely, or loses the cycle boundary between lazy loads.
+
+9. Link failures follow this observable matrix and never block readable siblings:
+   - If resolving the target reports `NotFound`, or the link is broken or no longer targets a
+     directory, Warp removes the alias and all previously loaded descendants from Project Explorer.
+   - If the alias root exists but reading it reports `PermissionDenied` or another transient I/O
+     error, Warp keeps the alias as an unloaded directory with no stale children. Expanding it again
+     retries the read.
+   - If one descendant is unreadable, Warp keeps that descendant as an unloaded directory, omits
+     its stale children, and continues loading readable siblings.
+   - If the link is retargeted, Warp removes every child from the old target before showing children
+     from the new target. Events from the old target cannot repopulate the alias.
+
+10. Restoring access to an unreadable alias allows a later expansion to repopulate it without
+    reopening the workspace. Restoring a broken target requires a link-path filesystem event or a
+    normal Project Explorer/workspace refresh; Warp does not keep an unbounded watch on a missing
+    external target.
+
+11. Workspace ignore rules are evaluated against the workspace-visible symlink path. A rule that
+    ignores the link or one of its aliased descendants has the same visible/lazy behavior as the
+    equivalent rule for an ordinary directory.
+
+12. A `.gitignore` inside the linked target applies to descendants viewed through that link. Ignore
+    status does not leak between separate aliases except where the same workspace rule matches both
+    alias paths.
+
+13. Existing Project Explorer settings, including hidden-file visibility, apply to linked
+    descendants exactly as they do to ordinary descendants.
+
+14. Creating, modifying, renaming, moving, or deleting content in the target refreshes every
+    expanded alias that points to the affected target. The same change also refreshes an ordinary
+    workspace path to that target when one is present. Warp non-recursively watches each resolved
+    directory that is actually expanded in Project Explorer. A child directory receives its own
+    watch only when the user expands that child. Collapsing the last view of a directory releases
+    that watch, and expanding it again refreshes the directory before presenting it as current.
+
+15. Replacing or retargeting the symbolic link replaces its visible descendants with those of the
+    new target. Events from the old target no longer update the alias after the retarget is
+    observed.
+
+16. Watcher-driven refreshes preserve alias identity: updates remain addressed by the
+    workspace-visible path, do not introduce a second canonical-target path beneath the root, and
+    do not move selection to another alias.
+
+17. Lazy-loading depth, ignored-directory treatment, and non-ignored file budgets apply
+    independently to each explicit expansion. Every expansion receives a fresh file budget.
+    Exhausting that budget leaves remaining linked directories unloaded and available for a later
+    expansion with a new budget rather than omitting unrelated workspace entries.
+
+18. Existing symbolic links to files continue to appear and open as they do before this change.
+    Existing project-skill discovery through symlinked provider directories also continues to find
+    the same skill files through its existing explicit discovery rule, independently of Project
+    Explorer expansion.
+
+19. A malformed or inaccessible symlink anywhere below a linked target is isolated to that entry.
+    Readable siblings and the rest of the repository continue to load and update.
+
+20. Linked descendants added for Project Explorer are not repository contents. They do not appear
+    in repository-wide search or indexing, agent context, generic standing-query or skill-rule
+    discovery, or serialized local-to-remote repository trees. Only the existing explicitly
+    configured symlinked-skill discovery behavior in (18) may read such a target outside Project
+    Explorer.

--- a/specs/gh-11528/PRODUCT.md
+++ b/specs/gh-11528/PRODUCT.md
@@ -98,9 +98,11 @@ expandable tree behavior; this change introduces no new visual treatment.
    - Its canonical target is checked against the full canonical ancestry inherited from the outer
      alias. A repeated identity produces one visible, loaded, childless cycle closer. A distinct
      identity extends the ancestry for later lazy expansions.
-   - Retargeting or breaking a nested alias clears only that alias's stale subtree and watches; it
-     does not collapse or replace readable siblings or the containing alias. An in-flight result
-     from the old nested target cannot repopulate it.
+   - A successful retarget of an expanded nested alias keeps that alias expanded and atomically
+     replaces only its visible descendants and watches with those for the new target. A failed
+     retarget follows (9) without leaving stale children. Neither case collapses or replaces
+     readable siblings or the containing alias, and an in-flight result from the old target cannot
+     repopulate it.
    - Renaming or deleting a nested alias root changes or unlinks only that symlink entry. The target
      and its contents are never renamed or recursively deleted. Ordinary directories and existing
      file symlinks encountered below an alias retain their existing behavior.
@@ -113,8 +115,10 @@ expandable tree behavior; this change introduces no new visual treatment.
      retries the read.
    - If one descendant is unreadable, Warp keeps that descendant as an unloaded directory, omits
      its stale children, and continues loading readable siblings.
-   - If the link is retargeted, Warp removes every child from the old target before showing children
-     from the new target. Events from the old target cannot repopulate the alias.
+   - If the link is retargeted and the new target loads successfully, Warp keeps an expanded alias
+     expanded and atomically replaces every child from the old target with the new target's
+     children. If classifying or reading the new target fails, the preceding failure behavior
+     applies. Events from the old target cannot repopulate the alias.
 
 10. Restoring access to an unreadable alias allows a later expansion to repopulate it without
     reopening the workspace. Restoring a broken target requires a link-path filesystem event or a
@@ -139,9 +143,10 @@ expandable tree behavior; this change introduces no new visual treatment.
     watch only when the user expands that child. Collapsing the last view of a directory releases
     that watch, and expanding it again refreshes the directory before presenting it as current.
 
-15. Replacing or retargeting the symbolic link replaces its visible descendants with those of the
-    new target. Events from the old target no longer update the alias after the retarget is
-    observed.
+15. When an expanded symbolic link is replaced or retargeted successfully to a readable directory,
+    it remains expanded and atomically replaces its visible descendants with those of the new
+    target. Failure states follow (9). Events from the old target no longer update the alias after
+    the retarget is observed.
 
 16. Watcher-driven refreshes preserve alias identity: updates remain addressed by the
     workspace-visible path, do not introduce a second canonical-target path beneath the root, and

--- a/specs/gh-11528/TECH.md
+++ b/specs/gh-11528/TECH.md
@@ -85,6 +85,23 @@ The overlay stores lexical paths, so Project Explorer selection, path copy, open
 actions keep using `/workspace/alias/...`. Canonical targets remain private model metadata and never
 become `FileTreeEntry` keys.
 
+Before a destructive action, use overlay metadata to distinguish an alias root from a descendant.
+For an alias root:
+
+- Revalidate its generation and `symlink_metadata` at the lexical path immediately before the
+  operation. If it is no longer the expected symlink, fail closed and refresh the projection rather
+  than applying ordinary-directory behavior to the replacement.
+- Rename passes only the lexical symlink path to the platform rename primitive. It never
+  canonicalizes the source or substitutes `resolved_path`.
+- Delete uses the macOS unlink/remove-file operation for the symlink entry. It never passes the
+  lexical or resolved target to a recursive directory-delete API and never traverses the target.
+- After success, update or remove that alias generation, subtree, cursors, and leases. The canonical
+  target state is not mutated.
+
+Descendant actions retain the existing lexical-path behavior from PRODUCT invariant 4. This typed
+root/descendant boundary prevents a future generic directory action from treating an alias root as
+an external target directory.
+
 ### 2. Route UI expansion through the existing completion path
 
 Keep `FileTreeView::load_directory_from_model` → `RepoMetadataModel::load_directory` →
@@ -268,7 +285,11 @@ behavior. Add:
    must refresh before display (PRODUCT 14–16).
 8. Project Explorer action tests selecting and opening a descendant and invoking copy, rename, and
    delete paths, asserting every emitted/requested path uses the lexical alias rather than the
-   canonical target (PRODUCT 4).
+   canonical target. Add alias-root destructive-boundary tests with an external target containing a
+   sentinel file: renaming the root moves only the symlink entry, and deleting the renamed root
+   removes only that symlink, while the target directory and sentinel remain byte-for-byte intact.
+   Also replace the link with an ordinary directory immediately before delete and assert generation
+   plus `symlink_metadata` revalidation fails closed without recursive deletion (PRODUCT 4).
 9. `view_tests.rs` coverage with hidden files and directories below an alias, verifying the existing
    setting hides them by default and reveals them after `show_hidden_files` changes (PRODUCT 13).
 10. Budget/depth tests proving every explicit expansion starts with a fresh
@@ -301,6 +322,8 @@ On macOS, create one workspace-local target and one external target, then captur
 2. A short recording that opens a target file through its alias, changes target content while
    expanded, collapses/re-expands the alias, and retargets the link without stale children.
 3. A cycle fixture showing repeated `A → B → A` expansion terminates and Warp remains responsive.
+4. An external-target fixture showing root rename and delete affect only the workspace symlink while
+   the target directory and a sentinel file remain present and unchanged.
 
 The issue screenshots establish the before state. No Linux-only visual evidence is required for
 this macOS-reported bug.
@@ -340,3 +363,7 @@ macOS evidence runs only after integration.
    leases; assert every overlay node and UI operation uses the lexical prefix.
 7. **Explicit skill discovery could regress.** Leave its current standing-query path separate and
    retain its existing symlink regression test unchanged.
+8. **A root rename/delete could be misrouted through an ordinary-directory action and mutate an
+   external target.** Represent the alias-root boundary in action dispatch, revalidate the lexical
+   symlink immediately before mutation, use rename/unlink without canonicalization or recursion, and
+   fail closed on replacement races.

--- a/specs/gh-11528/TECH.md
+++ b/specs/gh-11528/TECH.md
@@ -51,9 +51,19 @@ crate-private `ProjectExplorerAliasState` per local repository with:
   directory.
 
 Return lightweight `ProjectExplorerAliasRoot` descriptors as side metadata whenever a shared build
-encounters readable directory symlinks, while continuing to omit them from the shared `Entry`, flat
-`files` list, standing-query results, and incremental remote updates. Descriptor production must run
-through all three discovery lifecycles:
+encounters directory symlinks, while continuing to omit them from the shared `Entry`, flat `files`
+list, standing-query results, and incremental remote updates. Discovery first uses
+`symlink_metadata` to identify the lexical link, then follows metadata only far enough to classify
+the target; it does not call `read_dir`. A target classified as a directory therefore receives an
+unloaded descriptor even when enumerating its contents would return `PermissionDenied`.
+
+The failure matrix's root read errors refer to `read_dir` after this type-only probe has already
+identified a directory and created its descriptor. If the type probe itself cannot determine
+whether a newly encountered symlink targets a directory, Project Explorer must not fabricate a
+directory entry and change file-symlink behavior. A refresh or link-path event retries
+classification; for an already-known alias, a transient type-probe failure preserves its unloaded
+descriptor while clearing stale children. Descriptor production must run through all three
+discovery lifecycles:
 
 1. The initial repository build records aliases whose shared parents are loaded.
 2. An ordinary shared lazy-parent expansion returns descriptors discovered immediately below the
@@ -61,9 +71,9 @@ through all three discovery lifecycles:
 3. Shared watcher create/remove/retarget deltas add, remove, or replace descriptors and overlay
    subtrees without waiting for a full repository rebuild.
 
-Descriptors contain the lexical path and resolved target only; discovery does not traverse or watch
-the target. If an alias sits below an unloaded shared parent, it becomes visible only after that
-ordinary parent is expanded and its descriptor is returned.
+Descriptors contain the lexical path and resolved target. Discovery does not traverse or watch the
+target. If an alias sits below an unloaded shared parent, it becomes visible only after that ordinary
+parent is expanded and its descriptor is returned.
 
 Expose an explicit wrapper query such as `project_explorer_entry(repository_id)` that returns the
 shared entry plus the overlay as a copy-on-write projection. Update only `FileTreeView` to use that
@@ -155,14 +165,18 @@ Classify alias-resolution and read failures before applying the completion resul
 | Condition | Overlay result | Cursor/watch result |
 | --- | --- | --- |
 | `NotFound`, broken link, or target no longer a directory | Remove alias root and stale descendants | Drop all cursors, generation, and leases for the alias |
-| Root `PermissionDenied` | Replace stale subtree with the unloaded alias root | Retain a retry cursor; release target watch if it cannot be maintained |
-| Other transient root I/O error | Replace stale subtree with the unloaded alias root | Retain a retry cursor; keep only a valid existing expansion lease |
+| Root `read_dir` returns `PermissionDenied` after directory classification | Replace stale subtree with the unloaded alias root, including on first expansion | Retain a retry cursor; release the target watch if it cannot be maintained |
+| Other transient root `read_dir` error after directory classification | Replace stale subtree with the unloaded alias root, including on first expansion | Retain a retry cursor; keep only a valid existing expansion lease |
 | Unreadable descendant | Keep that descendant as an unloaded placeholder; continue siblings | Persist a retry cursor for that descendant |
 | Retargeted link | Remove old subtree before installing a new unloaded alias root | Increment generation, release old-target lease, discard stale completions |
 
 The completion future may still resolve with a typed `RepoMetadataError` for logging/tests, but its
-callback first establishes the table's safe visible state and emits a refresh. A retry always starts
-from the retained cursor and revalidates the current link target.
+callback first establishes the table's safe visible state and emits a refresh. Error display and
+logging must not include the canonical external target path: structured events record only the
+workspace-relative lexical alias path, alias generation, and error class, and user-visible errors
+follow the same rule. Tests may inspect typed fields directly but must not format or snapshot an
+external target path. A retry always starts from the retained cursor and revalidates the current
+link target.
 
 ### 6. Bound target watches to expanded aliases
 
@@ -227,16 +241,21 @@ behavior. Add:
    both in-workspace and external targets without inserting canonical target paths (PRODUCT 1–6).
 3. Descriptor-lifecycle tests covering an alias found during initial indexing, an alias below an
    initially unloaded ordinary shared parent discovered only when that parent loads, and alias
-   create/remove/retarget watcher deltas after indexing. Assert every path adds or removes the same
-   unloaded overlay descriptor without traversing or watching its target.
+   create/remove/retarget watcher deltas after indexing. Include a directory that is classified and
+   added without enumerating its unreadable contents, then restores access and populates on retry.
+   Assert every path adds or removes the same unloaded overlay descriptor without traversing or
+   watching its target.
 4. A multi-step completion test that expands `A → B → A` in three separate
    `load_directory_with_completion` calls and asserts the final `A` is loaded and childless. Also
    assert every cursor includes its own `resolved_path` as the last lineage item; cover root
    initialization, a direct self-cycle, and two independent aliases to one target (PRODUCT 7–8).
 5. Table-driven local-model tests for every failure-matrix row: `NotFound`, broken/non-directory,
-   root `PermissionDenied`, transient root error, unreadable descendant with readable sibling, and
-   retarget during an in-flight load. Assert stale children/cursors/watches are removed exactly as
-   specified (PRODUCT 9–10, 15, 19).
+   root `read_dir` `PermissionDenied`, other transient root read errors, unreadable descendant with
+   readable sibling, a transient type-probe failure for an already-known alias, and retarget during
+   an in-flight load. Assert initial enumeration failures remain visible and retryable, and stale
+   children/cursors/watches are removed exactly as specified (PRODUCT 9–10, 15, 19). Add a
+   logging/redaction assertion proving a typed external-target error formats only the lexical alias
+   path, generation, and error class.
 6. Scope-boundary tests proving an expanded external alias is present in
    `project_explorer_entry` but absent from `get_repo_contents`, repository search/index input,
    agent-context collection, generic standing-query/skill-rule results, `RepoMetadataUpdate`, and

--- a/specs/gh-11528/TECH.md
+++ b/specs/gh-11528/TECH.md
@@ -34,7 +34,19 @@ Warp already has a separate, explicit exception for symlinked project-skill prov
 maintain standing-query results without materializing those directories in the canonical tree, and
 [`entry_tests.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/repo_metadata/src/entry_tests.rs#L424-L470)
 locks in that behavior. Project Explorer traversal must remain independent of that allowlisted skill
-rule.
+rule. The implementation may share pure symlink classification and path-identity primitives with
+that path, but not its provider matching, standing-query updates, or watcher side effects.
+
+Project Explorer's current **Attach as context** action also has a narrower contract than repository
+context collection:
+
+1. [`FileTreeView::attach_as_context`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/code/file_tree/view.rs#L2482-L2503)
+   obtains `relative_path_for_item` and emits that path.
+2. [`WorkspaceView::attach_path_as_context`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/workspace/view.rs#L8534-L8544)
+   forwards the path to the active terminal session.
+3. [`TerminalView::attach_path_as_context`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/terminal/view.rs#L5710-L5728)
+   inserts its string into the active agent/terminal input (or the CLI-agent input path); it does not
+   read the selected file or traverse a selected directory.
 
 ## Proposed changes
 
@@ -146,7 +158,75 @@ Persist cursors for ordinary and symlinked directories below an alias, not only 
 This is what preserves the boundary when the user expands `A`, then `B`, then `A` in separate model
 tasks. A process-local ancestry set inside one tree walk is insufficient.
 
-### 4. Keep traversal out of indexing, context, standing queries, and remote sync
+### 4. Define nested aliases and the skills-sharing boundary
+
+Run directory-symlink classification for every child produced by an alias-level load, not only for
+aliases found in the shared repository tree. A nested symlink receives its own stable `AliasId` and
+generation, its lexical path is formed below the parent alias, and its resolved directory identity
+is appended to the parent's `canonical_lineage` only after the cycle check succeeds. Its cursor also
+retains the generations of the enclosing alias chain. Completion applies a result only when every
+generation in that chain is still current.
+
+If the nested target repeats any identity in `canonical_lineage`, emit the lexical nested alias as a
+loaded, childless cycle closer and create no cursor or watch lease. Otherwise emit it unloaded with a
+cursor for its resolved directory. This algorithm applies recursively to arbitrary nesting, whether
+each target is inside or outside the workspace. An ordinary directory below an alias keeps the same
+lineage and receives its normal lazy cursor; a file symlink keeps the existing file-entry behavior.
+
+A create, remove, or retarget event at a nested alias path increments only that nested alias's
+generation, removes its descendants and leases, and leaves its parent and siblings intact. Alias
+root action dispatch uses the same typed destructive boundary for a nested alias as for a top-level
+one: rename or delete receives the nested lexical symlink path and never the resolved target.
+
+Factor a small, side-effect-free symlink primitive for both Project Explorer and project skills. For
+example, `classify_directory_symlink(lexical_path)` can use `symlink_metadata`, follow target
+metadata, and return a typed result containing the lexical path, canonical directory identity, and
+redacted failure class. The callers may also share a pure helper that maps a resolved direct-child
+suffix back onto a lexical binding. These are the only initially shared responsibilities.
+
+Keep these responsibilities unique to project skills:
+
+- Matching configured provider roots and direct provider children.
+- Checking for `SKILL.md` and updating `StandingQueryResults` through
+  `record_followed_project_skill_directory`.
+- Maintaining the `symlink_targets` map, translating target watcher events into standing-query
+  deltas, and refreshing those watches through `refresh_symlink_targets` and
+  `add_symlink_target_updates`.
+
+Keep these responsibilities unique to Project Explorer:
+
+- Discovering directory aliases at arbitrary nesting depths and maintaining overlay nodes,
+  generations, traversal lineage, and cycle closers.
+- User-driven lazy expansion, ignore/file-budget behavior, per-view watch leases, and lexical UI
+  operations.
+- Emitting only a local projected-tree refresh and never a standing-query or remote update.
+
+Do not call `record_followed_project_skill_directory`, `refresh_symlink_targets`, or
+`add_symlink_target_updates` from an alias load, and do not generalize the skills provider allowlist
+into a rule for browsable aliases. Conversely, skill discovery must not depend on whether Project
+Explorer has expanded an alias. A later refactor may share a resolved-target watch registry, but
+only if each caller retains its separate lifecycle and output semantics.
+
+### 5. Preserve explicit Attach as context without widening automatic context
+
+The projected entry keeps each alias root and descendant under its lexical `StandardizedPath`, so
+the existing `relative_path_for_item` calculation yields paths such as `vendor` and
+`vendor/src/lib.rs`. Keep the existing `FileTreeAction::AttachAsContext` path unchanged: it remains
+available for file and directory overlay entries, emits the repository-relative lexical path, and
+routes through `WorkspaceView` to `TerminalView::attach_path_as_context`.
+
+Do not canonicalize, open, or enumerate the selected item while handling this action. In
+particular, attaching an unloaded alias root inserts only its lexical path; attaching a visible
+descendant inserts only that descendant's lexical path. Existing terminal/agent input handling then
+decides how the user-authored path is consumed. The action must not copy overlay nodes into
+`get_repo_contents`, construct an `AIAgentContext`, trigger a standing query, or reveal the resolved
+external target in input, telemetry, or errors.
+
+This explicit path reference is the sole agent-context exception for the overlay. Automatic codebase
+indexing, repository context, and ambient context continue to read only the shared tree as described
+below.
+
+### 6. Keep traversal out of indexing, automatic context, standing queries, and remote sync
 
 Make traversal purpose explicit with a private enum or separate APIs:
 
@@ -173,9 +253,10 @@ Enforce the boundary at these points:
    state is persisted to disk.
 
 This preserves PRODUCT invariants 18 and 20 and prevents an external link from silently enlarging
-the codebase indexed or supplied to an agent.
+the codebase indexed or automatically supplied to an agent. The explicit lexical path insertion in
+section 5 does not traverse or export the overlay.
 
-### 5. Define classified failure handling
+### 7. Define classified failure handling
 
 Classify alias-resolution and read failures before applying the completion result:
 
@@ -195,7 +276,7 @@ follow the same rule. Tests may inspect typed fields directly but must not forma
 external target path. A retry always starts from the retained cursor and revalidates the current
 link target.
 
-### 6. Bound target watches to expanded aliases
+### 8. Bound target watches to expanded aliases
 
 Initial lazy alias discovery never registers an external-target watch. Add a
 `ProjectExplorerAliasLease` owned by each active `FileTreeView` subscription:
@@ -226,7 +307,7 @@ leased lexical directory. If a precise event cannot be translated safely, rebuil
 directory level. Never send these events through shared-tree mutations or remote incremental
 serialization.
 
-### 7. Preserve ignore, visibility, and budget semantics
+### 9. Preserve ignore, visibility, and budget semantics
 
 Evaluate repository ignore patterns against the lexical alias path. Reading
 `lexical_path/.gitignore` follows the filesystem link, but matches remain relative to that alias.
@@ -265,7 +346,10 @@ behavior. Add:
 4. A multi-step completion test that expands `A → B → A` in three separate
    `load_directory_with_completion` calls and asserts the final `A` is loaded and childless. Also
    assert every cursor includes its own `resolved_path` as the last lineage item; cover root
-   initialization, a direct self-cycle, and two independent aliases to one target (PRODUCT 7–8).
+   initialization, a direct self-cycle, two independent aliases to one target, and a nested alias
+   whose target is outside the workspace. Retarget that nested alias during an in-flight load and
+   assert only its subtree is invalidated. Exercise nested alias-root rename/delete against a target
+   sentinel to prove the destructive boundary applies at every depth (PRODUCT 4, 7–8).
 5. Table-driven local-model tests for every failure-matrix row: `NotFound`, broken/non-directory,
    root `read_dir` `PermissionDenied`, other transient root read errors, unreadable descendant with
    readable sibling, a transient type-probe failure for an already-known alias, and retarget during
@@ -276,8 +360,9 @@ behavior. Add:
 6. Scope-boundary tests proving an expanded external alias is present in
    `project_explorer_entry` but absent from `get_repo_contents`, repository search/index input,
    agent-context collection, generic standing-query/skill-rule results, `RepoMetadataUpdate`, and
-   remote snapshots. Retain the existing explicit symlinked project-skill discovery regression
-   unchanged (PRODUCT 18, 20).
+   remote snapshots. Separately invoke **Attach as context** and assert it emits only the
+   repository-relative lexical path without changing any of those shared outputs. Retain the
+   existing explicit symlinked project-skill discovery regression unchanged (PRODUCT 18, 20).
 7. Watch-lease tests proving initial lazy aliases create zero external watches; expanding the alias
    root creates one non-recursive watch; an unexpanded child creates none; expanding the child adds
    its own non-recursive watch; a second alias/view shares matching resolved-directory watches; and
@@ -285,11 +370,14 @@ behavior. Add:
    must refresh before display (PRODUCT 14–16).
 8. Project Explorer action tests selecting and opening a descendant and invoking copy, rename, and
    delete paths, asserting every emitted/requested path uses the lexical alias rather than the
-   canonical target. Add alias-root destructive-boundary tests with an external target containing a
-   sentinel file: renaming the root moves only the symlink entry, and deleting the renamed root
-   removes only that symlink, while the target directory and sentinel remain byte-for-byte intact.
-   Also replace the link with an ordinary directory immediately before delete and assert generation
-   plus `symlink_metadata` revalidation fails closed without recursive deletion (PRODUCT 4).
+   canonical target. Invoke **Attach as context** for an unloaded root, nested directory, and file;
+   assert the existing event chain receives `alias`, `alias/nested`, and
+   `alias/nested/file.rs` respectively, with no filesystem read or canonical target in the input.
+   Add alias-root destructive-boundary tests with an external target containing a sentinel file:
+   renaming the root moves only the symlink entry, and deleting the renamed root removes only that
+   symlink, while the target directory and sentinel remain byte-for-byte intact. Also replace the
+   link with an ordinary directory immediately before delete and assert generation plus
+   `symlink_metadata` revalidation fails closed without recursive deletion (PRODUCT 4).
 9. `view_tests.rs` coverage with hidden files and directories below an alias, verifying the existing
    setting hides them by default and reveals them after `show_hidden_files` changes (PRODUCT 13).
 10. Budget/depth tests proving every explicit expansion starts with a fresh
@@ -299,7 +387,10 @@ behavior. Add:
 11. Ignore tests proving workspace rules match lexical paths and a target `.gitignore` applies only
     within that alias projection (PRODUCT 11–12).
 12. File-symlink regression tests and overlay generation tests proving stale async completion cannot
-    overwrite a retargeted alias (PRODUCT 15, 18).
+    overwrite a retargeted alias. Add focused tests for the shared pure symlink classifier, then
+    prove Project Explorer expansion does not call the skills standing-query/update path and skill
+    discovery produces the same results before and after Project Explorer expansion (PRODUCT 15,
+    18).
 
 Implementation PR checks:
 
@@ -307,12 +398,14 @@ Implementation PR checks:
 cargo nextest run -p repo_metadata --features local_fs
 cargo nextest run -p warp --features integration_tests -E 'test(file_tree)'
 ./script/format
-cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
+cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings
+cargo clippy -p warp --all-targets --tests -- -D warnings
+cargo clippy -p warp_completer --all-targets --tests -- -D warnings
 ```
 
-Both `./script/format` and the full workspace clippy command must pass before opening or updating the
-PR, as required by `AGENTS.md`. Cross-platform CI must compile the unchanged non-macOS paths even
-though symlink-creation behavior tests are macOS-gated.
+`./script/format` and all three Clippy profiles from `script/presubmit` must pass before opening or
+updating the PR, as required by `AGENTS.md`. Cross-platform CI must compile the unchanged non-macOS
+paths even though symlink-creation behavior tests are macOS-gated.
 
 ### Manual evidence
 
@@ -324,6 +417,8 @@ On macOS, create one workspace-local target and one external target, then captur
 3. A cycle fixture showing repeated `A → B → A` expansion terminates and Warp remains responsive.
 4. An external-target fixture showing root rename and delete affect only the workspace symlink while
    the target directory and a sentinel file remain present and unchanged.
+5. A nested external alias fixture showing **Attach as context** inserts only the lexical relative
+   path in the active input and never displays the canonical target path.
 
 The issue screenshots establish the before state. No Linux-only visual evidence is required for
 this macOS-reported bug.
@@ -348,8 +443,9 @@ macOS evidence runs only after integration.
 
 ## Risks and mitigations
 
-1. **Alias contents could leak into indexing or agent context.** Keep the overlay behind an explicit
-   Project Explorer projection type/API and add negative tests at every shared export boundary.
+1. **Alias contents could leak into indexing or automatic agent context.** Keep the overlay behind
+   an explicit Project Explorer projection type/API and add negative tests at every shared export
+   boundary. Test explicit **Attach as context** separately as lexical path insertion only.
 2. **Lazy loads could forget cycle ancestry.** Persist canonical lineage in every unloaded alias
    cursor and test `A → B → A` across separate completion tasks.
 3. **Stale loads could repopulate a retargeted link.** Tie cursors and completion callbacks to an
@@ -367,3 +463,7 @@ macOS evidence runs only after integration.
    external target.** Represent the alias-root boundary in action dispatch, revalidate the lexical
    symlink immediately before mutation, use rename/unlink without canonicalization or recursion, and
    fail closed on replacement races.
+9. **Project Explorer and skill discovery could become coupled through shared symlink support.**
+   Share only pure classification/path-identity helpers initially; keep provider matching,
+   standing-query deltas, overlay traversal, and watch lifecycles behind separate APIs and regression
+   tests.

--- a/specs/gh-11528/TECH.md
+++ b/specs/gh-11528/TECH.md
@@ -1,0 +1,323 @@
+# Project Explorer Directory Symlinks — Technical Spec
+
+## Context
+
+This spec translates the local macOS Project Explorer-only contract in
+[PRODUCT.md](./PRODUCT.md) into a bounded filesystem design. Remote-backed, Windows, and Linux
+Project Explorer behavior is unchanged. The spec is grounded in Warp commit
+[`abea51cd1e102b363935f1b25ef03d335bc7b36f`](https://github.com/warpdotdev/warp/tree/abea51cd1e102b363935f1b25ef03d335bc7b36f).
+
+The current shared tree builder excludes directory symlinks before they become entries:
+
+- [`Entry::build_tree_with_force_included_paths_and_ancestor`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/repo_metadata/src/entry.rs#L238-L430)
+  skips a child when `is_symlink()` and `is_dir()` are both true.
+- [`evaluate_entry`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/repo_metadata/src/entry.rs#L567-L635)
+  rejects a directory symlink presented as a build root.
+
+Project Explorer does not use `Entry::load` as its primary expansion path. The real UI flow is:
+
+1. [`FileTreeView::load_directory_from_model`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/app/src/code/file_tree/view.rs#L1397-L1443)
+   calls `RepoMetadataModel::load_directory` after the user expands an unloaded item.
+2. [`RepoMetadataModel::load_directory`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/repo_metadata/src/wrapper_model.rs#L343-L372)
+   delegates to the local model; tests use its completion-returning sibling directly.
+3. [`LocalRepoMetadataModel::load_directory_with_completion`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/repo_metadata/src/local_model.rs#L1223-L1365)
+   performs the background build, validates that the target did not change, applies the subtree,
+   starts any required watch, and emits `FileTreeEntryUpdated`.
+
+That model owns a shared repository tree. Project Explorer reads it directly, while repository
+content APIs can feed indexing, search, and agent context. Putting external target descendants in
+the shared tree would broaden #11528 beyond user-initiated browsing. The implementation therefore
+needs a Project Explorer projection rather than changing the contents of the shared tree.
+
+Warp already has a separate, explicit exception for symlinked project-skill providers:
+[`add_symlink_target_updates` and `refresh_symlink_targets`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/repo_metadata/src/local_model.rs#L453-L532)
+maintain standing-query results without materializing those directories in the canonical tree, and
+[`entry_tests.rs`](https://github.com/warpdotdev/warp/blob/abea51cd1e102b363935f1b25ef03d335bc7b36f/crates/repo_metadata/src/entry_tests.rs#L424-L470)
+locks in that behavior. Project Explorer traversal must remain independent of that allowlisted skill
+rule.
+
+## Proposed changes
+
+### 1. Add a Project Explorer-only alias projection
+
+Keep `IndexedRepoState::Indexed(FileTreeState)` as the shared, canonical repository tree. Add a
+crate-private `ProjectExplorerAliasState` per local repository with:
+
+- An overlay `FileTreeEntry` containing only lexical directory aliases and descendants loaded by
+  Project Explorer.
+- A map of `AliasTraversalCursor` values for unloaded overlay directories.
+- A monotonically increasing generation for each alias root.
+- Expansion/watch leases, keyed by Project Explorer subscriber and each expanded lexical overlay
+  directory.
+
+Return lightweight `ProjectExplorerAliasRoot` descriptors as side metadata whenever a shared build
+encounters readable directory symlinks, while continuing to omit them from the shared `Entry`, flat
+`files` list, standing-query results, and incremental remote updates. Descriptor production must run
+through all three discovery lifecycles:
+
+1. The initial repository build records aliases whose shared parents are loaded.
+2. An ordinary shared lazy-parent expansion returns descriptors discovered immediately below the
+   newly loaded parent and merges them into the overlay in the same completion callback.
+3. Shared watcher create/remove/retarget deltas add, remove, or replace descriptors and overlay
+   subtrees without waiting for a full repository rebuild.
+
+Descriptors contain the lexical path and resolved target only; discovery does not traverse or watch
+the target. If an alias sits below an unloaded shared parent, it becomes visible only after that
+ordinary parent is expanded and its descriptor is returned.
+
+Expose an explicit wrapper query such as `project_explorer_entry(repository_id)` that returns the
+shared entry plus the overlay as a copy-on-write projection. Update only `FileTreeView` to use that
+query when constructing or refreshing its visible root. `get_repository`, `get_repo_contents`, and
+`standing_query_results` continue to expose shared state with no overlay. A distinct query/type
+boundary is preferable to a visibility flag that every future consumer could forget to filter.
+
+The overlay stores lexical paths, so Project Explorer selection, path copy, open, rename, and delete
+actions keep using `/workspace/alias/...`. Canonical targets remain private model metadata and never
+become `FileTreeEntry` keys.
+
+### 2. Route UI expansion through the existing completion path
+
+Keep `FileTreeView::load_directory_from_model` → `RepoMetadataModel::load_directory` →
+`LocalRepoMetadataModel::load_directory_with_completion` as the authoritative UI path. At the local
+model boundary:
+
+- If `dir_path` is in the shared tree, preserve the existing load behavior.
+- If `dir_path` has an `AliasTraversalCursor`, invoke a new scoped
+  `build_project_explorer_alias_level` helper and apply its result to the overlay only.
+- Validate the alias generation in the completion callback, just as the current code validates the
+  unloaded entry identity, so an old async load cannot overwrite a retargeted link.
+- Emit the existing `FileTreeEntryUpdated` event after an overlay update; the view then refreshes
+  from `project_explorer_entry`.
+
+`Entry::load` can remain unchanged and is not relied upon for this feature.
+
+### 3. Persist traversal lineage across lazy expansions
+
+Each `AliasTraversalCursor` contains:
+
+- `alias_root` and `generation`.
+- `lexical_path`, used for visible nodes, ignore matching, and file operations.
+- `resolved_path`, used for `read_dir` and target watch translation.
+- `canonical_lineage`, the canonical directory identities already visited on the route from the
+  alias root through this unloaded directory.
+- The inherited ignore state needed by the next load.
+
+The invariant is `canonical_lineage.last() == resolved_path`: every cursor's lineage includes its
+own resolved directory. Initialize an alias-root cursor with
+`canonical_lineage = [canonical_target]`. A child cursor clones the parent lineage and appends the
+child's resolved identity only after confirming it is not already present.
+
+When one level is loaded, form a child lexical path from the discovered filename without
+canonicalizing that visible path. Resolve the filesystem identity separately. Before emitting an
+unloaded child cursor, compare its resolved identity with the persisted lineage:
+
+- If it repeats an ancestor, emit a loaded, childless lexical directory and no cursor.
+- Otherwise append the child's resolved directory to the lineage and persist the resulting cursor
+  with the child.
+
+Persist cursors for ordinary and symlinked directories below an alias, not only for the alias root.
+This is what preserves the boundary when the user expands `A`, then `B`, then `A` in separate model
+tasks. A process-local ancestry set inside one tree walk is insufficient.
+
+### 4. Keep traversal out of indexing, context, standing queries, and remote sync
+
+Make traversal purpose explicit with a private enum or separate APIs:
+
+- `SharedRepository` builds the current canonical tree, files/index inputs, and standing-query
+  results. It may collect unloaded alias-root descriptors but never their contents.
+- `ProjectExplorerAlias` builds only overlay nodes and cursors. It cannot receive a shared `files`
+  sink or `StandingQueryResults`, and its result type cannot be passed to
+  `flatten_entry_metadata`.
+- Existing explicit symlinked project-skill discovery remains on its current standing-query path
+  and allowlisted provider rules; Project Explorer expansion neither adds nor removes those results.
+
+Enforce the boundary at these points:
+
+1. `LocalRepoMetadataModel::get_repo_contents` traverses only `FileTreeState.entry`, so repository
+   search/indexing and agent-context callers cannot observe overlay descendants.
+2. `standing_results` are updated only by shared/explicit standing-query builds. Alias loads do not
+   call `record_path`, `record_followed_project_skill_directory`, or skill-rule matchers.
+3. `FileTreeMutation`, `RepoMetadataUpdate`, and `flatten_entry_metadata` accept only shared-tree
+   results. Overlay mutations emit a local view refresh but never `IncrementalUpdateReady`.
+4. Remote snapshot and incremental serialization omit alias roots, cursors, target paths, and loaded
+   overlay contents. Remote-backed, Windows, and Linux Project Explorer behavior is unchanged by
+   this local macOS fix.
+5. Repository removal destroys both the shared state and its local-only overlay/leases; no overlay
+   state is persisted to disk.
+
+This preserves PRODUCT invariants 18 and 20 and prevents an external link from silently enlarging
+the codebase indexed or supplied to an agent.
+
+### 5. Define classified failure handling
+
+Classify alias-resolution and read failures before applying the completion result:
+
+| Condition | Overlay result | Cursor/watch result |
+| --- | --- | --- |
+| `NotFound`, broken link, or target no longer a directory | Remove alias root and stale descendants | Drop all cursors, generation, and leases for the alias |
+| Root `PermissionDenied` | Replace stale subtree with the unloaded alias root | Retain a retry cursor; release target watch if it cannot be maintained |
+| Other transient root I/O error | Replace stale subtree with the unloaded alias root | Retain a retry cursor; keep only a valid existing expansion lease |
+| Unreadable descendant | Keep that descendant as an unloaded placeholder; continue siblings | Persist a retry cursor for that descendant |
+| Retargeted link | Remove old subtree before installing a new unloaded alias root | Increment generation, release old-target lease, discard stale completions |
+
+The completion future may still resolve with a typed `RepoMetadataError` for logging/tests, but its
+callback first establishes the table's safe visible state and emits a refresh. A retry always starts
+from the retained cursor and revalidates the current link target.
+
+### 6. Bound target watches to expanded aliases
+
+Initial lazy alias discovery never registers an external-target watch. Add a
+`ProjectExplorerAliasLease` owned by each active `FileTreeView` subscription:
+
+- Expanding an alias directory acquires a lease for that directory's `resolved_path` only after
+  resolution succeeds. If the directory is already covered by the repository root watcher, no extra
+  watch is registered.
+- An external resolved directory uses `RecursiveMode::NonRecursive`, reference-counted by canonical
+  directory across views and aliases. Expanding a child directory acquires a separate non-recursive
+  watch for that child's resolved path; an unexpanded child never causes a watch.
+- Events from a leased directory are translated only to the direct lexical children of currently
+  leased aliases for that resolved directory. Deeper updates are observed by the separate lease for
+  the expanded descendant that contains them.
+- Collapsing a directory (including any expanded descendants hidden by that collapse),
+  deactivating/dropping its view, removing the repository, breaking the link, or retargeting it
+  releases the corresponding leases. Each external watch is unregistered when its count reaches
+  zero.
+- A collapsed overlay may remain cached, but it is treated as stale. Re-expansion revalidates and
+  refreshes the alias before presenting it as current and reacquires the lease.
+
+Wire both branches of `FileTreeView::toggle_folder_expansion` to a model method such as
+`set_project_explorer_alias_expanded(subscriber, repo, path, expanded)`. This notification must run
+even when the cached directory state is already `loaded`; otherwise re-expansion would skip refresh
+and lease acquisition because the existing `ensure_loaded_path` early return sees a loaded entry.
+
+Target events translate the direct-child suffix below the watched resolved directory onto every
+leased lexical directory. If a precise event cannot be translated safely, rebuild that one lexical
+directory level. Never send these events through shared-tree mutations or remote incremental
+serialization.
+
+### 7. Preserve ignore, visibility, and budget semantics
+
+Evaluate repository ignore patterns against the lexical alias path. Reading
+`lexical_path/.gitignore` follows the filesystem link, but matches remain relative to that alias.
+Hidden-file filtering stays in `FileTreeView`, so the merged projection follows the existing
+`show_hidden_files` setting without a new rendering path.
+
+Initialize a fresh `LAZY_LOAD_FILE_LIMIT` for every explicit alias-directory expansion, matching the
+existing local-model load path. Do not persist a remaining budget in `AliasTraversalCursor`.
+Directory placeholders and cycle closers do not consume file quota. If an expansion exhausts its
+fresh quota, emit the remaining directories as unloaded entries with cursors; expanding one later
+starts with another fresh `LAZY_LOAD_FILE_LIMIT`. Alias loads never spend the shared repository's
+indexing budget.
+
+No feature flag is proposed: the change is a scoped correction to local macOS Project Explorer
+behavior, introduces no setting, and is compiled behind the existing `local_fs` plus macOS target
+boundary. Non-macOS and remote wrapper paths continue to return their existing trees.
+
+## Testing and validation
+
+### Automated tests
+
+Use macOS-gated real temporary directories and `std::os::unix::fs::symlink` for filesystem
+behavior. Add:
+
+1. `view_tests.rs`/wrapper coverage proving a user expansion follows
+   `FileTreeView` → `RepoMetadataModel::load_directory` →
+   `LocalRepoMetadataModel::load_directory_with_completion`, then refreshes the projected entry.
+2. Traversal tests proving a readable alias starts unloaded, stores lexical children, and supports
+   both in-workspace and external targets without inserting canonical target paths (PRODUCT 1–6).
+3. Descriptor-lifecycle tests covering an alias found during initial indexing, an alias below an
+   initially unloaded ordinary shared parent discovered only when that parent loads, and alias
+   create/remove/retarget watcher deltas after indexing. Assert every path adds or removes the same
+   unloaded overlay descriptor without traversing or watching its target.
+4. A multi-step completion test that expands `A → B → A` in three separate
+   `load_directory_with_completion` calls and asserts the final `A` is loaded and childless. Also
+   assert every cursor includes its own `resolved_path` as the last lineage item; cover root
+   initialization, a direct self-cycle, and two independent aliases to one target (PRODUCT 7–8).
+5. Table-driven local-model tests for every failure-matrix row: `NotFound`, broken/non-directory,
+   root `PermissionDenied`, transient root error, unreadable descendant with readable sibling, and
+   retarget during an in-flight load. Assert stale children/cursors/watches are removed exactly as
+   specified (PRODUCT 9–10, 15, 19).
+6. Scope-boundary tests proving an expanded external alias is present in
+   `project_explorer_entry` but absent from `get_repo_contents`, repository search/index input,
+   agent-context collection, generic standing-query/skill-rule results, `RepoMetadataUpdate`, and
+   remote snapshots. Retain the existing explicit symlinked project-skill discovery regression
+   unchanged (PRODUCT 18, 20).
+7. Watch-lease tests proving initial lazy aliases create zero external watches; expanding the alias
+   root creates one non-recursive watch; an unexpanded child creates none; expanding the child adds
+   its own non-recursive watch; a second alias/view shares matching resolved-directory watches; and
+   collapse, retarget, repository removal, and view teardown release the exact leases. Re-expansion
+   must refresh before display (PRODUCT 14–16).
+8. Project Explorer action tests selecting and opening a descendant and invoking copy, rename, and
+   delete paths, asserting every emitted/requested path uses the lexical alias rather than the
+   canonical target (PRODUCT 4).
+9. `view_tests.rs` coverage with hidden files and directories below an alias, verifying the existing
+   setting hides them by default and reveals them after `show_hidden_files` changes (PRODUCT 13).
+10. Budget/depth tests proving every explicit expansion starts with a fresh
+    `LAZY_LOAD_FILE_LIMIT`, cursors retain no remaining budget, cycle placeholders spend no quota,
+    and budget-exhausted child directories remain unloaded for a later fresh-budget expansion
+    without changing the shared repository (PRODUCT 17).
+11. Ignore tests proving workspace rules match lexical paths and a target `.gitignore` applies only
+    within that alias projection (PRODUCT 11–12).
+12. File-symlink regression tests and overlay generation tests proving stale async completion cannot
+    overwrite a retargeted alias (PRODUCT 15, 18).
+
+Implementation PR checks:
+
+```sh
+cargo nextest run -p repo_metadata --features local_fs
+cargo nextest run -p warp --features integration_tests -E 'test(file_tree)'
+./script/format
+cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
+```
+
+Both `./script/format` and the full workspace clippy command must pass before opening or updating the
+PR, as required by `AGENTS.md`. Cross-platform CI must compile the unchanged non-macOS paths even
+though symlink-creation behavior tests are macOS-gated.
+
+### Manual evidence
+
+On macOS, create one workspace-local target and one external target, then capture:
+
+1. Before/after Project Explorer screenshots showing each alias expanded under its lexical path.
+2. A short recording that opens a target file through its alias, changes target content while
+   expanded, collapses/re-expands the alias, and retargets the link without stale children.
+3. A cycle fixture showing repeated `A → B → A` expansion terminates and Warp remains responsive.
+
+The issue screenshots establish the before state. No Linux-only visual evidence is required for
+this macOS-reported bug.
+
+## Parallelization
+
+After agreeing on `ProjectExplorerAliasState`, `AliasTraversalCursor`, and the projection API, two
+local agents can work in parallel and land in one implementation PR:
+
+- **Traversal/projection agent** — owns the alias traversal module, projection merge, and their unit
+  tests; worktree `../warp-gh11528-alias-tree`, branch `codex/gh11528-alias-tree`. It implements
+  lexical/resolved paths, persisted lineage, error classification, ignore handling, and quotas.
+- **UI/watcher agent** — owns `wrapper_model.rs`, `local_model.rs`, `view.rs`, and corresponding
+  model/view tests; worktree `../warp-gh11528-alias-ui`, branch `codex/gh11528-alias-ui`. It wires
+  the real completion path, projection refresh, leases, event translation, and teardown.
+
+An integration owner uses `../warp-gh11528-integration` on
+`codex/gh11528-symlink-directories`, merges traversal/projection before UI/watcher, adds the
+cross-surface scope-boundary tests, runs validation, and opens one implementation PR. Agents do not
+edit sibling-owned files and must agree on the cursor/result interfaces before starting. Manual
+macOS evidence runs only after integration.
+
+## Risks and mitigations
+
+1. **Alias contents could leak into indexing or agent context.** Keep the overlay behind an explicit
+   Project Explorer projection type/API and add negative tests at every shared export boundary.
+2. **Lazy loads could forget cycle ancestry.** Persist canonical lineage in every unloaded alias
+   cursor and test `A → B → A` across separate completion tasks.
+3. **Stale loads could repopulate a retargeted link.** Tie cursors and completion callbacks to an
+   alias generation and discard mismatches.
+4. **External watches could grow without bound.** Acquire them only for expanded aliases, share them
+   by canonical target, and release them on collapse, view/repository teardown, breakage, or
+   retargeting.
+5. **Permission failures could leave stale or misleading children.** Apply the classified failure
+   matrix before completing the task and retain retry cursors only where the target may recover.
+6. **Canonicalization could erase visible identity.** Store canonical paths only in cursors/watch
+   leases; assert every overlay node and UI operation uses the lexical prefix.
+7. **Explicit skill discovery could regress.** Leave its current standing-query path separate and
+   retain its existing symlink regression test unchanged.

--- a/specs/gh-11528/TECH.md
+++ b/specs/gh-11528/TECH.md
@@ -81,7 +81,9 @@ discovery lifecycles:
 2. An ordinary shared lazy-parent expansion returns descriptors discovered immediately below the
    newly loaded parent and merges them into the overlay in the same completion callback.
 3. Shared watcher create/remove/retarget deltas add, remove, or replace descriptors and overlay
-   subtrees without waiting for a full repository rebuild.
+   subtrees without waiting for a full repository rebuild. A successful retarget of an expanded
+   alias preserves that expansion state and publishes the new target's descendants in one atomic
+   overlay replacement.
 
 Descriptors contain the lexical path and resolved target. Discovery does not traverse or watch the
 target. If an alias sits below an unloaded shared parent, it becomes visible only after that ordinary
@@ -174,9 +176,13 @@ each target is inside or outside the workspace. An ordinary directory below an a
 lineage and receives its normal lazy cursor; a file symlink keeps the existing file-entry behavior.
 
 A create, remove, or retarget event at a nested alias path increments only that nested alias's
-generation, removes its descendants and leases, and leaves its parent and siblings intact. Alias
-root action dispatch uses the same typed destructive boundary for a nested alias as for a top-level
-one: rename or delete receives the nested lexical symlink path and never the resolved target.
+generation and leaves its parent and siblings intact. On retarget, invalidate the old descendants,
+cursors, and leases; snapshot whether the lexical alias is expanded; and build the new target's
+first level off-overlay. A successful current-generation completion atomically replaces the visible
+descendants, keeps an expanded alias expanded, and acquires the new-target lease. A failed
+classification or load applies section 7 instead. Alias root action dispatch uses the same typed
+destructive boundary for a nested alias as for a top-level one: rename or delete receives the nested
+lexical symlink path and never the resolved target.
 
 Factor a small, side-effect-free symlink primitive for both Project Explorer and project skills. For
 example, `classify_directory_symlink(lexical_path)` can use `symlink_metadata`, follow target
@@ -266,7 +272,7 @@ Classify alias-resolution and read failures before applying the completion resul
 | Root `read_dir` returns `PermissionDenied` after directory classification | Replace stale subtree with the unloaded alias root, including on first expansion | Retain a retry cursor; release the target watch if it cannot be maintained |
 | Other transient root `read_dir` error after directory classification | Replace stale subtree with the unloaded alias root, including on first expansion | Retain a retry cursor; keep only a valid existing expansion lease |
 | Unreadable descendant | Keep that descendant as an unloaded placeholder; continue siblings | Persist a retry cursor for that descendant |
-| Retargeted link | Remove old subtree before installing a new unloaded alias root | Increment generation, release old-target lease, discard stale completions |
+| Successful retarget of an expanded alias to a readable directory | Keep the lexical alias expanded; atomically replace the old descendants with the new target's first-level descendants in one overlay update | Increment generation before loading, discard stale completions, release the old-target lease, and acquire the new-target lease when the swap commits |
 
 The completion future may still resolve with a typed `RepoMetadataError` for logging/tests, but its
 callback first establishes the table's safe visible state and emits a refresh. Error display and
@@ -275,6 +281,10 @@ workspace-relative lexical alias path, alias generation, and error class, and us
 follow the same rule. Tests may inspect typed fields directly but must not format or snapshot an
 external target path. A retry always starts from the retained cursor and revalidates the current
 link target.
+
+Retarget classification and enumeration failures do not use the successful-retarget row. They take
+the matching `NotFound`/non-directory or root `read_dir` failure row above, so stale descendants are
+never retained and retryability remains explicit.
 
 ### 8. Bound target watches to expanded aliases
 
@@ -291,8 +301,10 @@ Initial lazy alias discovery never registers an external-target watch. Add a
   leased aliases for that resolved directory. Deeper updates are observed by the separate lease for
   the expanded descendant that contains them.
 - Collapsing a directory (including any expanded descendants hidden by that collapse),
-  deactivating/dropping its view, removing the repository, breaking the link, or retargeting it
-  releases the corresponding leases. Each external watch is unregistered when its count reaches
+  deactivating/dropping its view, removing the repository, or breaking the link releases the
+  corresponding leases. Retargeting detaches the old-target leases immediately; when the new target
+  loads successfully for an expanded alias, the atomic subtree swap acquires its replacement lease
+  without collapsing the lexical alias. Each external watch is unregistered when its count reaches
   zero.
 - A collapsed overlay may remain cached, but it is treated as stale. Re-expansion revalidates and
   refreshes the alias before presenting it as current and reacquires the lease.
@@ -341,22 +353,26 @@ behavior. Add:
    initially unloaded ordinary shared parent discovered only when that parent loads, and alias
    create/remove/retarget watcher deltas after indexing. Include a directory that is classified and
    added without enumerating its unreadable contents, then restores access and populates on retry.
-   Assert every path adds or removes the same unloaded overlay descriptor without traversing or
-   watching its target.
+   Assert discovery/create/remove paths add or remove the same unloaded overlay descriptor without
+   traversing or watching its target. For an expanded alias retarget, stage the replacement target
+   and atomically swap in its descendants without publishing an unloaded-root intermediate state.
 4. A multi-step completion test that expands `A → B → A` in three separate
    `load_directory_with_completion` calls and asserts the final `A` is loaded and childless. Also
    assert every cursor includes its own `resolved_path` as the last lineage item; cover root
    initialization, a direct self-cycle, two independent aliases to one target, and a nested alias
-   whose target is outside the workspace. Retarget that nested alias during an in-flight load and
-   assert only its subtree is invalidated. Exercise nested alias-root rename/delete against a target
-   sentinel to prove the destructive boundary applies at every depth (PRODUCT 4, 7–8).
+   whose target is outside the workspace. Retarget that expanded nested alias during an in-flight
+   load and assert only its subtree is invalidated, its parent and siblings stay unchanged, the
+   stale completion is discarded, and a successful current-generation completion keeps it expanded
+   with the new target's descendants. Exercise nested alias-root rename/delete against a target
+   sentinel to prove the destructive boundary applies at every depth (PRODUCT 4, 7–8, 15).
 5. Table-driven local-model tests for every failure-matrix row: `NotFound`, broken/non-directory,
    root `read_dir` `PermissionDenied`, other transient root read errors, unreadable descendant with
-   readable sibling, a transient type-probe failure for an already-known alias, and retarget during
-   an in-flight load. Assert initial enumeration failures remain visible and retryable, and stale
-   children/cursors/watches are removed exactly as specified (PRODUCT 9–10, 15, 19). Add a
-   logging/redaction assertion proving a typed external-target error formats only the lexical alias
-   path, generation, and error class.
+   readable sibling, a transient type-probe failure for an already-known alias, a successful
+   readable retarget, and retarget during an in-flight load. Assert a successful retarget preserves
+   the expanded state and atomically swaps descendants and leases, while classification/read
+   failures remain visible and retryable without stale children, cursors, or watches (PRODUCT 9–10,
+   15, 19). Add a logging/redaction assertion proving a typed external-target error formats only the
+   lexical alias path, generation, and error class.
 6. Scope-boundary tests proving an expanded external alias is present in
    `project_explorer_entry` but absent from `get_repo_contents`, repository search/index input,
    agent-context collection, generic standing-query/skill-rule results, `RepoMetadataUpdate`, and
@@ -366,8 +382,9 @@ behavior. Add:
 7. Watch-lease tests proving initial lazy aliases create zero external watches; expanding the alias
    root creates one non-recursive watch; an unexpanded child creates none; expanding the child adds
    its own non-recursive watch; a second alias/view shares matching resolved-directory watches; and
-   collapse, retarget, repository removal, and view teardown release the exact leases. Re-expansion
-   must refresh before display (PRODUCT 14–16).
+   collapse, repository removal, and view teardown release the exact leases. Assert retarget
+   releases the old-target lease, and a successful retarget of an expanded alias acquires the
+   new-target lease without collapsing it. Re-expansion must refresh before display (PRODUCT 14–16).
 8. Project Explorer action tests selecting and opening a descendant and invoking copy, rename, and
    delete paths, asserting every emitted/requested path uses the lexical alias rather than the
    canonical target. Invoke **Attach as context** for an unloaded root, nested directory, and file;
@@ -387,10 +404,10 @@ behavior. Add:
 11. Ignore tests proving workspace rules match lexical paths and a target `.gitignore` applies only
     within that alias projection (PRODUCT 11–12).
 12. File-symlink regression tests and overlay generation tests proving stale async completion cannot
-    overwrite a retargeted alias. Add focused tests for the shared pure symlink classifier, then
-    prove Project Explorer expansion does not call the skills standing-query/update path and skill
-    discovery produces the same results before and after Project Explorer expansion (PRODUCT 15,
-    18).
+    overwrite a retargeted alias or its atomic current-generation replacement subtree. Add focused
+    tests for the shared pure symlink classifier, then prove Project Explorer expansion does not call
+    the skills standing-query/update path and skill discovery produces the same results before and
+    after Project Explorer expansion (PRODUCT 15, 18).
 
 Implementation PR checks:
 
@@ -413,7 +430,8 @@ On macOS, create one workspace-local target and one external target, then captur
 
 1. Before/after Project Explorer screenshots showing each alias expanded under its lexical path.
 2. A short recording that opens a target file through its alias, changes target content while
-   expanded, collapses/re-expands the alias, and retargets the link without stale children.
+   expanded, collapses/re-expands the alias, and retargets the link while it remains expanded and
+   atomically replaces the old children with the new target's children.
 3. A cycle fixture showing repeated `A → B → A` expansion terminates and Warp remains responsive.
 4. An external-target fixture showing root rename and delete affect only the workspace symlink while
    the target directory and a sentinel file remain present and unchanged.
@@ -449,10 +467,13 @@ macOS evidence runs only after integration.
 2. **Lazy loads could forget cycle ancestry.** Persist canonical lineage in every unloaded alias
    cursor and test `A → B → A` across separate completion tasks.
 3. **Stale loads could repopulate a retargeted link.** Tie cursors and completion callbacks to an
-   alias generation and discard mismatches.
+   alias generation, discard mismatches, stage the current-generation replacement off-overlay, and
+   commit one atomic subtree swap that preserves the alias's expanded state. Apply section 7 instead
+   when the replacement target cannot be classified or read.
 4. **External watches could grow without bound.** Acquire them only for expanded aliases, share them
-   by canonical target, and release them on collapse, view/repository teardown, breakage, or
-   retargeting.
+   by canonical target, and release them on collapse, view/repository teardown, or breakage. A
+   retarget releases the old-target leases and acquires replacements only when an expanded alias's
+   new target loads successfully.
 5. **Permission failures could leave stale or misleading children.** Apply the classified failure
    matrix before completing the task and retain retry cursors only where the target may recover.
 6. **Canonicalization could erase visible identity.** Store canonical paths only in cursors/watch


### PR DESCRIPTION
## Description

Adds product and technical specs for directory symlink support in the local macOS Project Explorer.

The specs define:

- lazy traversal that preserves the workspace-visible alias path;
- cycle safety across separate expansion actions;
- classified behavior for broken, unreadable, and retargeted links;
- bounded, non-recursive watches for expanded directories only; and
- a Project Explorer-only overlay so external targets do not enter repository indexing, agent context, standing queries, or remote snapshots.

The technical plan is grounded in Warp commit `abea51cd1e102b363935f1b25ef03d335bc7b36f` and the actual `FileTreeView` → `RepoMetadataModel` → `LocalRepoMetadataModel::load_directory_with_completion` path.

## Linked Issue

Closes #11528

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots are not applicable to this spec-only change; the issue already contains the before/expected reference images, and no UI implementation is included here.

## Testing

- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `git diff --check`
- Two independent spec reviews, including follow-up verification after cycle, scope-boundary, watcher, and lifecycle corrections

- [ ] I have manually tested my changes locally with `./script/run` — N/A, spec-only.

### Screenshots / Videos

N/A — spec-only change. The implementation spec defines the macOS screenshot and recording evidence required for the later code PR.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-NONE -->

Co-Authored-By: Warp <agent@warp.dev>
