### PR TITLE
Fix alt screen persisting when viewing cloud agent conversation after live session (REMOTE-2238)

### DIFF
--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1524,6 +1524,23 @@ impl TerminalModel {
         status: Option<ConversationTranscriptViewerStatus>,
     ) {
         self.conversation_transcript_viewer_status = status;
+        // When becoming a loaded transcript viewer (not just entering the Loading
+        // state), forcibly exit the alt screen so the block list is always
+        // visible. This fixes the case where a live cloud agent session had an
+        // active alt screen (e.g., from a tool like pnpm running a build) when
+        // the session ended or was reopened: without this, the alt screen persists
+        // and the user sees a blank/black terminal instead of the AI conversation
+        // blocks, with no scrollbar to recover.
+        let is_loaded_viewer = matches!(
+            &self.conversation_transcript_viewer_status,
+            Some(
+                ConversationTranscriptViewerStatus::ViewingAmbientConversation(_)
+                    | ConversationTranscriptViewerStatus::ViewingLocalConversation
+            )
+        );
+        if is_loaded_viewer {
+            self.exit_alt_screen(true);
+        }
     }
 
     pub fn colors(&self) -> color::List {


### PR DESCRIPTION
## Description

When a live cloud agent session has an active alt screen (e.g., triggered by a tool like `pnpm` running a build with a full-screen TUI progress display), and the user reopens or views the conversation after the session ends, the alt screen state persists instead of being deactivated.

This causes the terminal to show a blank/black screen (the empty alt screen after the program exited but before alt screen was properly deactivated) instead of the AI conversation blocks. Since the alt screen view has no scrollbar for the underlying block list, users had no way to scroll back to see the AI blocks. The blocks appeared briefly during the loading transition before the persisted alt screen took over.

### Root Cause

When `set_conversation_transcript_viewer_status` transitions a terminal to a loaded viewer state (`ViewingAmbientConversation` or `ViewingLocalConversation`), it did not exit the alt screen. This is problematic when:
- A live shared cloud agent session had an active alt screen when the session ended
- The conversation is reopened (transcript viewer mode) with the alt screen still active from the live session

The `exit()` method already does this forcibly ("Forcibly exit the alt screen so that we can show the user the banner informing them that the shell process exited"), but the transcript viewer transition path was missing this.

### Fix

In `set_conversation_transcript_viewer_status`, when transitioning to a loaded viewer state, call `exit_alt_screen(true)`. If the alt screen is not active, `exit_alt_screen` is a no-op (it just logs and returns), so this is safe for the `create_conversation_viewer` path where the model starts fresh.

## Linked Issue

Linear: REMOTE-2238

## Testing

- The fix is a defensive guard — it exits the alt screen when becoming a transcript viewer
- `cargo check` passes cleanly with no errors
- `cargo clippy` on the changed file shows no new warnings
- Pre-existing `warp_completer` clippy failures are unrelated to this change

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed AI conversation blocks disappearing and showing a blank screen when reopening a cloud agent conversation that had run a full-screen terminal program (e.g., pnpm build).

_Conversation: https://staging.warp.dev/conversation/e4e46e5e-d716-48b5-a8af-3fdab003b0a4_
_Run: https://oz.staging.warp.dev/runs/019f7fa1-5ff1-7728-8a01-b126711f9971_

_This PR was generated with [Oz](https://warp.dev/oz)._
