### PR TITLE
ci: notify docs when Settings UI files change

### DIFF
--- a/.github/workflows/notify-docs-settings-changed.yml
+++ b/.github/workflows/notify-docs-settings-changed.yml
@@ -1,0 +1,64 @@
+name: Notify docs of Settings UI changes
+
+# Fires when any Settings view source file is merged to master, signalling
+# that valid_paths.json in warpdotdev/docs may need to be refreshed.
+#
+# If this job fails:
+#   1. GitHub will email the commit author automatically.
+#   2. If SLACK_BOT_TOKEN is configured in this repo's secrets, a message
+#      is also posted to #growth-docs.
+#   3. To trigger the refresh manually, go to:
+#      warpdotdev/docs > Actions > Refresh UI paths snapshot > Run workflow
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'app/src/settings_view/**'
+
+jobs:
+  dispatch:
+    name: Dispatch settings-ui-changed to docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to warpdotdev/docs
+        id: dispatch
+        env:
+          DOCS_DISPATCH_PAT: ${{ secrets.DOCS_DISPATCH_PAT }}
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer $DOCS_DISPATCH_PAT" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/warpdotdev/docs/dispatches \
+            -d "{\"event_type\":\"settings-ui-changed\",\"client_payload\":{\"sha\":\"$GITHUB_SHA\",\"ref\":\"$GITHUB_REF\"}}")
+
+          if [ "$HTTP_STATUS" -eq 204 ]; then
+            echo "Dispatched settings-ui-changed to warpdotdev/docs (SHA: $GITHUB_SHA)"
+          else
+            echo "Dispatch failed with HTTP $HTTP_STATUS" >&2
+            exit 1
+          fi
+
+      # Optional Slack alert on failure. Only fires if SLACK_BOT_TOKEN is
+      # configured as a repository secret. If it's not set, this step is
+      # skipped silently (GitHub will still send email to the commit author).
+      - name: Notify Slack on dispatch failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ]; then
+            echo "SLACK_BOT_TOKEN not configured — skipping Slack alert."
+            echo "Trigger the docs refresh manually: warpdotdev/docs > Actions > Refresh UI paths snapshot > Run workflow"
+            exit 0
+          fi
+          curl -s -X POST \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            https://slack.com/api/chat.postMessage \
+            -d "{
+              \"channel\": \"C09BVK0PL3Y\",
+              \"text\": \":warning: *notify-docs-settings-changed* failed for <https://github.com/warpdotdev/warp-internal/commit/$GITHUB_SHA|$GITHUB_SHA>.\\n\\nThe \`valid_paths.json\` snapshot in the docs repo was *not* refreshed automatically.\\n\\n:point_right: Trigger it manually: <https://github.com/warpdotdev/docs/actions/workflows/refresh-ui-paths.yml|Refresh UI paths snapshot workflow>\"
+            }"

--- a/.github/workflows/notify-docs-settings-changed.yml
+++ b/.github/workflows/notify-docs-settings-changed.yml
@@ -27,23 +27,16 @@ jobs:
     steps:
       - name: Send repository_dispatch to warpdotdev/docs
         id: dispatch
-        env:
-          DOCS_DISPATCH_PAT: ${{ secrets.DOCS_DISPATCH_PAT }}
-        run: |
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X POST \
-            -H "Authorization: Bearer $DOCS_DISPATCH_PAT" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/warpdotdev/docs/dispatches \
-            -d "{\"event_type\":\"settings-ui-changed\",\"client_payload\":{\"sha\":\"$GITHUB_SHA\",\"ref\":\"$GITHUB_REF\"}}")
-
-          if [ "$HTTP_STATUS" -eq 204 ]; then
-            echo "Dispatched settings-ui-changed to warpdotdev/docs (SHA: $GITHUB_SHA)"
-          else
-            echo "Dispatch failed with HTTP $HTTP_STATUS" >&2
-            exit 1
-          fi
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          repository: warpdotdev/docs
+          token: ${{ secrets.DOCS_REPOSITORY_DISPATCH_TOKEN }}
+          event-type: settings-ui-changed
+          client-payload: |
+            {
+              "sha": "${{ github.sha }}",
+              "ref": "${{ github.ref }}"
+            }
 
       # Optional Slack alert on failure. Only fires if SLACK_BOT_TOKEN is
       # configured as a repository secret. If it's not set, this step is

--- a/.github/workflows/notify-docs-settings-changed.yml
+++ b/.github/workflows/notify-docs-settings-changed.yml
@@ -16,6 +16,10 @@ on:
     paths:
       - 'app/src/settings_view/**'
 
+# This workflow does not use GITHUB_TOKEN, but we set an explicit empty
+# permissions block to satisfy CodeQL and follow least-privilege conventions.
+permissions: {}
+
 jobs:
   dispatch:
     name: Dispatch settings-ui-changed to docs
@@ -60,5 +64,5 @@ jobs:
             https://slack.com/api/chat.postMessage \
             -d "{
               \"channel\": \"C09BVK0PL3Y\",
-              \"text\": \":warning: *notify-docs-settings-changed* failed for <https://github.com/warpdotdev/warp-internal/commit/$GITHUB_SHA|$GITHUB_SHA>.\\n\\nThe \`valid_paths.json\` snapshot in the docs repo was *not* refreshed automatically.\\n\\n:point_right: Trigger it manually: <https://github.com/warpdotdev/docs/actions/workflows/refresh-ui-paths.yml|Refresh UI paths snapshot workflow>\"
+              \"text\": \":warning: *notify-docs-settings-changed* failed for <https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA|$GITHUB_SHA>.\\n\\nThe \`valid_paths.json\` snapshot in the docs repo was *not* refreshed automatically.\\n\\n:point_right: Trigger it manually: <https://github.com/warpdotdev/docs/actions/workflows/refresh-ui-paths.yml|Refresh UI paths snapshot workflow>\"
             }"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/notify-docs-settings-changed.yml` — fires whenever `app/src/settings_view/**` is merged to `master` and sends a `repository_dispatch` event (`settings-ui-changed`) to `warpdotdev/docs`. This triggers the `refresh-ui-paths` workflow in docs, which re-extracts `valid_paths.json` from source and auto-fixes any stale UI path references.

## Context

Our docs validate Settings menu paths (e.g. `Settings > Agents > Oz > Active AI`) against a snapshot extracted from this codebase's source. That snapshot has to be kept in sync whenever the Settings UI restructures — previously this was manual and it silently drifted for months. This workflow closes that gap.

## Changes

**New workflow: `notify-docs-settings-changed.yml`**
- Watches `app/src/settings_view/**` on `master` pushes
- Dispatches `settings-ui-changed` to `warpdotdev/docs` via `peter-evans/repository-dispatch@v4` using the already-provisioned `DOCS_REPOSITORY_DISPATCH_TOKEN` secret
- On failure: posts to `#growth-docs` via Slack if `SLACK_BOT_TOKEN` is configured (optional — silently skipped if not set); GitHub also emails the commit author automatically
- Header comment documents the three failure recovery paths
- `permissions: {}` to satisfy CodeQL and follow least-privilege conventions

## Companion PR

**warpdotdev/docs#328** adds the `refresh-ui-paths` workflow that this dispatch triggers, updates `valid_paths.json`, and updates the skill docs. **Merge docs#328 first, then this PR.**

## Post-merge: secrets to provision

| Secret | Status | Notes |
|---|---|---|
| `DOCS_REPOSITORY_DISPATCH_TOKEN` | ✅ Already provisioned in this repo | No action needed |
| `SLACK_BOT_TOKEN` | Needs provisioning in `warpdotdev/docs` | Slack bot, `chat:write` — optional, only for failure alerts |
| `WARP_INTERNAL_READ_PAT` | Needs provisioning in `warpdotdev/docs` | Fine-grained PAT, Contents read on `warpdotdev/warp-internal`, create from `warpmachineuser` |

## If this workflow fails

1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitActi1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1. GitHu1.
[Oz conversation](https://staging.warp.dev/conversation/b0234d81-272f-4037-8b64-1956af27e3f8) | [Plan](https://staging.warp.dev/drive/notebook/nY4iA8mXvyRJgjUBaHNfH0)

Co-Authored-By: Oz <oz-agent@warp.dev>
