### PR TITLE
Promote CloudRunners and CloudAgentRunners to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -697,6 +697,8 @@ default = [
     "remote_code_review",
     "git_operations_in_code_review",
     "terminal_lifecycle_recovery",
+    "cloud_runners",
+    "cloud_agent_runners",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.
@@ -947,6 +949,7 @@ integration_command = []
 artifact_command = []
 cloud_environments = []
 cloud_runners = []
+cloud_agent_runners = []
 create_environment_slash_command = []
 summarize_conversation_command = []
 mcp_grouped_server_context = []

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -85,6 +85,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::CloudEnvironments,
         #[cfg(feature = "cloud_runners")]
         FeatureFlag::CloudRunners,
+        #[cfg(feature = "cloud_agent_runners")]
+        FeatureFlag::CloudAgentRunners,
         #[cfg(all(feature = "simulate_github_unauthed", debug_assertions))]
         FeatureFlag::SimulateGithubUnauthed,
         #[cfg(feature = "session_sharing_acls")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -987,12 +987,10 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::BackgroundComputerUse,
     FeatureFlag::ContextWindowUsageBreakdown,
     FeatureFlag::JupyterNotebookRendering,
-    FeatureFlag::CloudRunners,
     FeatureFlag::WaitForEventsParentRegistration,
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::GeminiEnterprise,
     FeatureFlag::BoxDrawingGlyphs,
-    FeatureFlag::CloudAgentRunners,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

Promotes `CloudRunners` and `CloudAgentRunners` feature flags to stable so they are enabled for all Warp users, not just dogfood builds.

Changes:
- `app/Cargo.toml`: Added `cloud_runners` and `cloud_agent_runners` to the `default` features array; added `cloud_agent_runners = []` feature definition
- `app/src/features.rs`: Added `#[cfg(feature = "cloud_agent_runners")] FeatureFlag::CloudAgentRunners` bridge entry
- `crates/warp_features/src/lib.rs`: Removed `CloudRunners` and `CloudAgentRunners` from `DOGFOOD_FLAGS` (they're now in `default`)

Also fixes pre-existing clippy lints in `warp_completer/src/completer/engine/argument/v2.rs` (collapsible-if and let-and-return warnings) that were blocking the presubmit check.

## Linked Issue

N/A

## Testing

- [x] Presubmit clippy and format checks pass (`./script/format`, `cargo clippy` per `./script/presubmit`)
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/6bdfbd6d-ecc3-4633-8336-fb6d400ff3ee_
_Run: https://oz.staging.warp.dev/runs/019f7ffb-bded-715b-a1be-5664801bbd44_

_This PR was generated with [Oz](https://warp.dev/oz)._
