### PR TITLE
[Oz CLI] Support --model flag with --harness claude/codex

### DIFF
--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -463,10 +463,11 @@ impl AmbientAgentRunner {
             );
 
             // We must wait until after workspace metadata is refreshed to check available LLMs.
-            // For third-party harnesses, the model ID is harness-specific and validated
-            // server-side, so skip Oz model validation here.
+            // For third-party harnesses, the model is in harness.model_id and is validated
+            // server-side. Clear the top-level model_id slot to prevent any Oz model ID
+            // that leaked in from a config file from being sent alongside the harness model.
             let model_id = if merged_config.harness.is_some() {
-                merged_config.model_id.clone()
+                None
             } else {
                 match merged_config
                     .model_id

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -422,9 +422,13 @@ impl AmbientAgentRunner {
                     }
                 };
 
+            // When using a third-party harness, --model specifies a harness-specific
+            // model identifier (e.g. "sonnet", "claude-opus-4-8" for Claude Code;
+            // "gpt-5.5" for Codex) rather than an Oz model ID. Route it directly
+            // into HarnessConfig.model_id so it reaches the harness unchanged.
             let harness_override = (args.harness != Harness::Oz).then_some(HarnessConfig {
                 harness_type: args.harness,
-                model_id: None,
+                model_id: args.model.model.clone(),
                 reasoning_level: None,
             });
             let harness_auth_secrets = (args.claude_auth_secret.is_some()
@@ -440,7 +444,13 @@ impl AmbientAgentRunner {
                     name: args.name,
                     environment_id,
                     runner_id: args.runner,
-                    model_id: args.model.model.clone(),
+                    // For third-party harnesses the model goes into harness config above;
+                    // leave the Oz model_id slot empty so Oz validation is not attempted.
+                    model_id: if args.harness == Harness::Oz {
+                        args.model.model.clone()
+                    } else {
+                        None
+                    },
                     base_prompt: None,
                     mcp_servers: cli_mcp_servers,
                     profile_id: None,
@@ -453,16 +463,24 @@ impl AmbientAgentRunner {
             );
 
             // We must wait until after workspace metadata is refreshed to check available LLMs.
-            let model_id = match merged_config
-                .model_id
-                .as_deref()
-                .map(|model_id| super::common::validate_agent_mode_base_model_id(model_id, ctx))
-                .transpose()
-            {
-                Ok(id) => id.map(|id| id.to_string()),
-                Err(err) => {
-                    super::report_fatal_error(err, ctx);
-                    return;
+            // For third-party harnesses, the model ID is harness-specific and validated
+            // server-side, so skip Oz model validation here.
+            let model_id = if merged_config.harness.is_some() {
+                merged_config.model_id.clone()
+            } else {
+                match merged_config
+                    .model_id
+                    .as_deref()
+                    .map(|model_id| {
+                        super::common::validate_agent_mode_base_model_id(model_id, ctx)
+                    })
+                    .transpose()
+                {
+                    Ok(id) => id.map(|id| id.to_string()),
+                    Err(err) => {
+                        super::report_fatal_error(err, ctx);
+                        return;
+                    }
                 }
             };
 

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -604,11 +604,6 @@ pub struct RunCloudArgs {
     /// "oz" (the default) runs on Warp's built-in agent infrastructure. Other
     /// values delegate the run to an external agent CLI; see the possible
     /// values below.
-    ///
-    /// To select a specific model for a third-party harness, combine with
-    /// `--model`. For example: `--harness claude --model opus` or
-    /// `--harness claude --model claude-opus-4-8`. See `--model --help` for
-    /// the full list of accepted values per harness.
     #[arg(long = "harness", value_name = "HARNESS", default_value_t = Harness::Oz)]
     pub harness: Harness,
 

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -604,6 +604,11 @@ pub struct RunCloudArgs {
     /// "oz" (the default) runs on Warp's built-in agent infrastructure. Other
     /// values delegate the run to an external agent CLI; see the possible
     /// values below.
+    ///
+    /// To select a specific model for a third-party harness, combine with
+    /// `--model`. For example: `--harness claude --model opus` or
+    /// `--harness claude --model claude-opus-4-8`. See `--model --help` for
+    /// the full list of accepted values per harness.
     #[arg(long = "harness", value_name = "HARNESS", default_value_t = Harness::Oz)]
     pub harness: Harness,
 

--- a/crates/warp_cli/src/model.rs
+++ b/crates/warp_cli/src/model.rs
@@ -18,7 +18,21 @@ impl ModelCommand {
 /// Shared CLI args for selecting a base model.
 #[derive(Debug, Clone, Args, Default)]
 pub struct ModelArgs {
-    /// Override the base model used by this command. Use `warp model list` to see available models.
+    /// Override the base model used by this command.
+    ///
+    /// For the default Oz harness, use `oz model list` to see available model IDs.
+    ///
+    /// For third-party harnesses (`--harness claude` or `--harness codex`), this
+    /// sets the harness-specific model. The value is passed directly to the harness
+    /// and validated server-side.
+    ///
+    /// Accepted values for `--harness claude` (Claude Code):
+    ///   Aliases: best, fable, opus, sonnet, haiku, opus[1m], sonnet[1m], opusplan
+    ///   Pinned:  claude-fable-5, claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5
+    ///
+    /// Accepted values for `--harness codex`:
+    ///   gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna,
+    ///   gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, gpt-5.2
     #[arg(long = "model", value_name = "MODEL_ID")]
     pub model: Option<String>,
 }

--- a/crates/warp_cli/src/model.rs
+++ b/crates/warp_cli/src/model.rs
@@ -3,7 +3,8 @@ use clap::{Args, Subcommand};
 /// Model-related subcommands.
 #[derive(Debug, Clone, Subcommand)]
 pub enum ModelCommand {
-    /// List available models.
+    /// List available models for the Warp Agent harness. For third party harnesses,
+    /// consult third party harness docs for available models.
     List,
 }
 

--- a/crates/warp_cli/src/model.rs
+++ b/crates/warp_cli/src/model.rs
@@ -23,16 +23,8 @@ pub struct ModelArgs {
     /// For the default Oz harness, use `oz model list` to see available model IDs.
     ///
     /// For third-party harnesses (`--harness claude` or `--harness codex`), this
-    /// sets the harness-specific model. The value is passed directly to the harness
-    /// and validated server-side.
-    ///
-    /// Accepted values for `--harness claude` (Claude Code):
-    ///   Aliases: best, fable, opus, sonnet, haiku, opus[1m], sonnet[1m], opusplan
-    ///   Pinned:  claude-fable-5, claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5
-    ///
-    /// Accepted values for `--harness codex`:
-    ///   gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna,
-    ///   gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, gpt-5.2
+    /// sets the harness-specific model. The value is passed directly to the harness.
+    /// See third party harness docs for list of accepted values.
     #[arg(long = "model", value_name = "MODEL_ID")]
     pub model: Option<String>,
 }


### PR DESCRIPTION
## Description

When using `oz agent run-cloud --harness claude` (or `--harness codex`), the `--model` flag was silently broken:

1. It was validated against Oz model IDs, so harness-specific values like `sonnet` or `claude-opus-4-8` were rejected with "Unknown model id".
2. Even if validation passed, the model was placed in the Oz top-level `model_id` field, which the server strips for non-Oz harnesses — so no model was ever forwarded.

### Changes

**`app/src/ai/agent_sdk/ambient.rs`**
- When `--harness` is a third-party harness (Claude Code, Codex), the `--model` value is now routed into `HarnessConfig.model_id` instead of the top-level Oz `model_id`.
- Oz model validation is skipped for non-Oz harnesses; the model is passed through and validated server-side.

**`crates/warp_cli/src/model.rs`**
- Updated `--model` help text to document that harness-specific model identifiers are accepted when combined with `--harness`, with the full list of accepted values for Claude Code and Codex.

**`crates/warp_cli/src/agent.rs`**
- Updated `--harness` documentation to mention using `--model` for model selection.

### Usage (after this fix)

```sh
# Claude Code with a specific model
oz agent run-cloud --harness claude --model opus --prompt "..."
oz agent run-cloud --harness claude --model claude-opus-4-8 --prompt "..."
oz agent run-cloud --harness claude --model sonnet --prompt "..."

# Codex with a specific model
oz agent run-cloud --harness codex --model gpt-5.5 --prompt "..."
```

## Linked Issue

Fixes REMOTE-2240 (Linear)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Spawned this run with `oz-local agent run-cloud --harness claude --model sonnet --claude-auth-secret oz-staging-team-anthropic-key --prompt "this is a test"`: https://oz.staging.warp.dev/runs/019f902e-df2b-71d6-aafc-9e0752082b43

It uses sonnet

The fix is in the CLI argument routing path. The behavior change is: `oz agent run-cloud --harness claude --model sonnet --prompt "..."` now sends `harness.model_id = "sonnet"` to the server instead of failing with "Unknown model id 'sonnet'".

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-OZ: `oz agent run-cloud --harness claude/codex` now accepts `--model` to select a harness-specific model (e.g. `--model opus`, `--model claude-opus-4-8`, `--model gpt-5.5`).
-->

_Conversation: https://staging.warp.dev/conversation/3913e747-63d0-4745-9e10-ec8485c5cf4f_
_Run: https://oz.staging.warp.dev/runs/019f8010-d855-704c-a8ab-f4d92898c306_

_This PR was generated with [Oz](https://warp.dev/oz)._
