### PR TITLE
Encode Cmd/Option modifiers for editing keys under the Kitty keyboard protocol

### DIFF
--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -248,6 +248,7 @@ impl<T: ModeProvider> ToEscapeSequence<T> for KeystrokeWithDetails<'_> {
             .or_else(|| keystroke_to_c0_control_code(keystroke, mode_provider))
             .or_else(|| cursor_movement_keystroke_to_escape_sequence(keystroke, mode_provider))
             .or_else(|| meta_keystroke_to_escape_sequence(keystroke, mode_provider))
+            .or_else(|| delete_keystroke_to_escape_sequence(keystroke))
             .or_else(|| backspace_keystroke_to_escape_sequence(keystroke))
     }
 }
@@ -383,89 +384,6 @@ pub fn alt_screen_scroll_to_pty_bytes<T: ModeProvider>(
     Some(sequence.repeat(lines_to_scroll.unsigned_abs() as usize))
 }
 
-pub trait ToModifierEscapeByte {
-    /// Returns the modifier escape byte represented by this T.
-    ///
-    /// The returned modifier byte is typically meant to be inserted into escape sequence
-    /// corresponding to the keystroke. See the implementation of this trait for
-    /// `Keystroke` for more details.
-    fn to_modifier_escape_byte(&self) -> Option<u8>;
-}
-
-impl ToModifierEscapeByte for Keystroke {
-    // Mirrors the [xterm implementation](https://www.xfree86.org/current/ctlseqs.html#PC-Style%20Function%20Keys).
-    fn to_modifier_escape_byte(&self) -> Option<u8> {
-        match self {
-            Keystroke {
-                shift: true,
-                alt: false,
-                ctrl: false,
-                meta: _,
-                cmd: _,
-                key: _,
-            } => Some(b'2'),
-            Keystroke {
-                shift: false,
-                alt: true,
-                ctrl: false,
-                meta: _,
-                cmd: _,
-                key: _,
-            } => Some(b'3'),
-            Keystroke {
-                shift: true,
-                alt: true,
-                ctrl: false,
-                meta: _,
-                cmd: _,
-                key: _,
-            } => Some(b'4'),
-            Keystroke {
-                shift: false,
-                alt: false,
-                ctrl: true,
-                meta: _,
-                cmd: _,
-                key: _,
-            } => Some(b'5'),
-            Keystroke {
-                shift: true,
-                alt: false,
-                ctrl: true,
-                meta: _,
-                cmd: _,
-                key: _,
-            } => Some(b'6'),
-            Keystroke {
-                shift: false,
-                alt: true,
-                ctrl: true,
-                meta: _,
-                cmd: _,
-                key: _,
-            } => Some(b'7'),
-            Keystroke {
-                shift: true,
-                alt: true,
-                ctrl: true,
-                meta: _,
-                cmd: _,
-                key: _,
-            } => Some(b'8'),
-            // meta can be basically treated the same way as alt...
-            Keystroke {
-                meta: true,
-                ctrl: _,
-                alt: _,
-                shift: _,
-                cmd: _,
-                key: _,
-            } => Some(b'3'),
-            _ => None,
-        }
-    }
-}
-
 /// Returns the appropriate escape sequence for the given fn key, which may or may not be modified
 /// via modifier key(s).
 ///
@@ -477,13 +395,11 @@ fn fn_keystroke_to_escape_sequence(
     match keystroke.key.as_str() {
         "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12"
         | "f13" | "f14" | "f15" | "f16" | "f17" | "f18" | "f19" | "f20" => {
-            let modifier_byte = keystroke.to_modifier_escape_byte();
-            match modifier_byte {
-                Some(modifier_byte) => fn_keystroke_with_modifier_to_escape_sequence(
-                    keystroke.key.as_str(),
-                    modifier_byte,
-                ),
-                None => fn_keystroke_without_modifier_to_escape_sequence(keystroke.key.as_str()),
+            let modifier = modifier_param(keystroke);
+            if modifier > 1 {
+                fn_keystroke_with_modifier_to_escape_sequence(keystroke.key.as_str(), modifier)
+            } else {
+                fn_keystroke_without_modifier_to_escape_sequence(keystroke.key.as_str())
             }
         }
         _ => None,
@@ -526,28 +442,28 @@ fn fn_keystroke_without_modifier_to_escape_sequence(key: &str) -> Option<Vec<u8>
 ///
 /// Mapping from key to sequence is adapted from the xterm spec
 /// [here](https://www.xfree86.org/current/ctlseqs.html).
-fn fn_keystroke_with_modifier_to_escape_sequence(key: &str, modifier_byte: u8) -> Option<Vec<u8>> {
+fn fn_keystroke_with_modifier_to_escape_sequence(key: &str, modifier: u32) -> Option<Vec<u8>> {
     match key {
-        "f1" => Some([C1::CSI, format!("1;{}P", modifier_byte as char).as_bytes()].concat()),
-        "f2" => Some([C1::CSI, format!("1;{}Q", modifier_byte as char).as_bytes()].concat()),
-        "f3" => Some([C1::CSI, format!("1;{}R", modifier_byte as char).as_bytes()].concat()),
-        "f4" => Some([C1::CSI, format!("1;{}S", modifier_byte as char).as_bytes()].concat()),
-        "f5" => Some([C1::CSI, format!("15;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f6" => Some([C1::CSI, format!("17;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f7" => Some([C1::CSI, format!("18;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f8" => Some([C1::CSI, format!("19;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f9" => Some([C1::CSI, format!("20;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f10" => Some([C1::CSI, format!("21;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f11" => Some([C1::CSI, format!("23;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f12" => Some([C1::CSI, format!("24;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f13" => Some([C1::CSI, format!("25;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f14" => Some([C1::CSI, format!("26;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f15" => Some([C1::CSI, format!("28;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f16" => Some([C1::CSI, format!("29;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f17" => Some([C1::CSI, format!("31;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f18" => Some([C1::CSI, format!("32;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f19" => Some([C1::CSI, format!("33;{}~", modifier_byte as char).as_bytes()].concat()),
-        "f20" => Some([C1::CSI, format!("34;{}~", modifier_byte as char).as_bytes()].concat()),
+        "f1" => Some([C1::CSI, format!("1;{modifier}P").as_bytes()].concat()),
+        "f2" => Some([C1::CSI, format!("1;{modifier}Q").as_bytes()].concat()),
+        "f3" => Some([C1::CSI, format!("1;{modifier}R").as_bytes()].concat()),
+        "f4" => Some([C1::CSI, format!("1;{modifier}S").as_bytes()].concat()),
+        "f5" => Some([C1::CSI, format!("15;{modifier}~").as_bytes()].concat()),
+        "f6" => Some([C1::CSI, format!("17;{modifier}~").as_bytes()].concat()),
+        "f7" => Some([C1::CSI, format!("18;{modifier}~").as_bytes()].concat()),
+        "f8" => Some([C1::CSI, format!("19;{modifier}~").as_bytes()].concat()),
+        "f9" => Some([C1::CSI, format!("20;{modifier}~").as_bytes()].concat()),
+        "f10" => Some([C1::CSI, format!("21;{modifier}~").as_bytes()].concat()),
+        "f11" => Some([C1::CSI, format!("23;{modifier}~").as_bytes()].concat()),
+        "f12" => Some([C1::CSI, format!("24;{modifier}~").as_bytes()].concat()),
+        "f13" => Some([C1::CSI, format!("25;{modifier}~").as_bytes()].concat()),
+        "f14" => Some([C1::CSI, format!("26;{modifier}~").as_bytes()].concat()),
+        "f15" => Some([C1::CSI, format!("28;{modifier}~").as_bytes()].concat()),
+        "f16" => Some([C1::CSI, format!("29;{modifier}~").as_bytes()].concat()),
+        "f17" => Some([C1::CSI, format!("31;{modifier}~").as_bytes()].concat()),
+        "f18" => Some([C1::CSI, format!("32;{modifier}~").as_bytes()].concat()),
+        "f19" => Some([C1::CSI, format!("33;{modifier}~").as_bytes()].concat()),
+        "f20" => Some([C1::CSI, format!("34;{modifier}~").as_bytes()].concat()),
         _ => None,
     }
 }
@@ -590,6 +506,31 @@ fn keystroke_to_c0_control_code(
     None
 }
 
+/// The xterm/Kitty numeric modifier parameter for a keystroke: `1 + bitmask`, where
+/// shift=1, alt=2, ctrl=4, super(cmd)=8. Meta ("Option as Meta" on macOS) maps to the alt
+/// bit, matching `keystroke_to_csi_u`. Returns 1 when no modifiers are held.
+///
+/// Used by the functional keys that keep their legacy `CSI …` / `CSI …~` encoding under the
+/// Kitty keyboard protocol (arrows, Home/End, Delete, function keys) rather than switching to
+/// CSI u. It encodes Super (Cmd) and can exceed a single digit (e.g. Cmd+Left → modifier 9 →
+/// `CSI 1;9D`).
+fn modifier_param(keystroke: &Keystroke) -> u32 {
+    let mut modifier = 1;
+    if keystroke.shift {
+        modifier += 1;
+    }
+    if keystroke.alt || keystroke.meta {
+        modifier += 2;
+    }
+    if keystroke.ctrl {
+        modifier += 4;
+    }
+    if keystroke.cmd {
+        modifier += 8;
+    }
+    modifier
+}
+
 /// Returns the appropriate escape sequence for the given "cursor movement" keystroke.
 ///
 /// "cursor movement" keystroke is defined as one of the arrow keys, "home" or "end". If the given
@@ -613,27 +554,47 @@ fn cursor_movement_keystroke_to_escape_sequence(
     }
 
     let key = keystroke.key.as_str();
-    if !CURSOR_KEYSTROKE_TO_CONTROL_CODE.contains_key(key) {
+    let &final_byte = CURSOR_KEYSTROKE_TO_CONTROL_CODE.get(key)?;
+
+    let modifier = modifier_param(keystroke);
+    if modifier > 1 {
+        // Modified cursor keys always use the `CSI 1;<mods> <letter>` form (never SS3),
+        // matching xterm and the Kitty keyboard protocol. `<mods>` may be multiple digits
+        // (e.g. Cmd+Left → `CSI 1;9D`), which the legacy single-byte modifier could not encode.
+        let mut sequence = C1::CSI.to_vec();
+        sequence.extend_from_slice(b"1;");
+        sequence.extend_from_slice(modifier.to_string().as_bytes());
+        sequence.push(final_byte);
+        Some(sequence)
+    } else {
+        // Unmodified: SS3 in application-cursor mode, CSI otherwise.
+        let mut sequence = EscCodes::get_c1_sequence(mode_provider).to_vec();
+        sequence.push(final_byte);
+        Some(sequence)
+    }
+}
+
+/// Returns the escape sequence for a *modified* Delete key: `CSI 3;<mods> ~` (xterm / Kitty
+/// numbering, including Super for Cmd). This covers Cmd+Delete, Option+Delete, Ctrl+Delete, etc.
+///
+/// Delete owns a legacy escape code (`CSI 3 ~`), so under the Kitty keyboard protocol it keeps
+/// this `~` form with a modifier parameter rather than switching to CSI u.
+///
+/// Returns None for any non-Delete key and for *unmodified* Delete (whose existing encoding path
+/// is left untouched).
+fn delete_keystroke_to_escape_sequence(keystroke: &Keystroke) -> Option<Vec<u8>> {
+    if keystroke.key != "delete" {
         return None;
     }
-    let modifier_bytes = keystroke.to_modifier_escape_byte();
-    match modifier_bytes {
-        Some(modifier_bytes) => Some(
-            [
-                C1::CSI,
-                b"1;",
-                &[modifier_bytes, CURSOR_KEYSTROKE_TO_CONTROL_CODE[key]],
-            ]
-            .concat(),
-        ),
-        None => Some(
-            [
-                EscCodes::get_c1_sequence(mode_provider),
-                &[CURSOR_KEYSTROKE_TO_CONTROL_CODE[key]],
-            ]
-            .concat(),
-        ),
+    let modifier = modifier_param(keystroke);
+    if modifier == 1 {
+        return None;
     }
+    let mut sequence = C1::CSI.to_vec();
+    sequence.extend_from_slice(b"3;");
+    sequence.extend_from_slice(modifier.to_string().as_bytes());
+    sequence.push(b'~');
+    Some(sequence)
 }
 
 /// Returns the byte array corresponding to a special key, if a special key is provided.

--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -509,11 +509,6 @@ fn keystroke_to_c0_control_code(
 /// The xterm/Kitty numeric modifier parameter for a keystroke: `1 + bitmask`, where
 /// shift=1, alt=2, ctrl=4, super(cmd)=8. Meta ("Option as Meta" on macOS) maps to the alt
 /// bit, matching `keystroke_to_csi_u`. Returns 1 when no modifiers are held.
-///
-/// Used by the functional keys that keep their legacy `CSI …` / `CSI …~` encoding under the
-/// Kitty keyboard protocol (arrows, Home/End, Delete, function keys) rather than switching to
-/// CSI u. It encodes Super (Cmd) and can exceed a single digit (e.g. Cmd+Left → modifier 9 →
-/// `CSI 1;9D`).
 fn modifier_param(keystroke: &Keystroke) -> u32 {
     let mut modifier = 1;
     if keystroke.shift {

--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -247,8 +247,8 @@ impl<T: ModeProvider> ToEscapeSequence<T> for KeystrokeWithDetails<'_> {
         fn_keystroke_to_escape_sequence(keystroke, mode_provider)
             .or_else(|| keystroke_to_c0_control_code(keystroke, mode_provider))
             .or_else(|| cursor_movement_keystroke_to_escape_sequence(keystroke, mode_provider))
-            .or_else(|| meta_keystroke_to_escape_sequence(keystroke, mode_provider))
             .or_else(|| delete_keystroke_to_escape_sequence(keystroke))
+            .or_else(|| meta_keystroke_to_escape_sequence(keystroke, mode_provider))
             .or_else(|| backspace_keystroke_to_escape_sequence(keystroke))
     }
 }

--- a/crates/warp_terminal/src/model/escape_sequences/kitty_keyboard_protocol.rs
+++ b/crates/warp_terminal/src/model/escape_sequences/kitty_keyboard_protocol.rs
@@ -26,14 +26,25 @@ pub(super) fn maybe_convert_keystroke_to_csi_u(
     // - The Escape key (ESC byte 0x1B is also the start of all escape sequences)
     // - Modified keys where the modifier is lost in legacy encoding (e.g.,
     //   Ctrl+A → C0 code 0x01, Alt+a → ESC a on non-macOS)
-    //
-    // On macOS, Alt is excluded because Option generates composed characters
-    // (e.g., Option+a → å) via the IME rather than acting as a modifier.
+    // - Any Cmd/Super-modified key: legacy encoding has no representation for Super
+    //   at all, so e.g. Cmd+Backspace must use CSI u (→ CSI 127;9u).
     //
     // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/#disambiguate
-    let mut is_ambiguous = keystroke.key == "escape" || keystroke.ctrl || keystroke.meta;
-    if !OperatingSystem::get().is_mac() {
-        is_ambiguous = is_ambiguous || keystroke.alt;
+    let mut is_ambiguous =
+        keystroke.key == "escape" || keystroke.ctrl || keystroke.meta || keystroke.cmd;
+    if keystroke.alt {
+        // Alt/Option is a modifier that legacy encoding cannot represent, so it is
+        // ambiguous — except on macOS, where raw Option composes characters via the IME
+        // (Option+a → å, Option+Space → nbsp). When Option composed printable text it is
+        // part of that character rather than a modifier, so the key is NOT ambiguous.
+        // Functional/editing keys (Backspace, Delete, arrows, …) produce no such text and
+        // stay ambiguous. Detect composition from the OS-provided `chars`, falling back to a
+        // single-character key name for frontends that don't populate `chars` (e.g. tests).
+        let composed_printable_text =
+            chars.is_some_and(|text| !text.is_empty() && !text.chars().any(|c| c.is_control()));
+        let composes_via_ime = OperatingSystem::get().is_mac()
+            && (composed_printable_text || keystroke.key.chars().count() == 1);
+        is_ambiguous = is_ambiguous || !composes_via_ime;
     }
     // Shift alone is NOT ambiguous for printable keys — Shift changes the
     // character itself (e.g., Shift+a → A). But for functional keys like
@@ -188,19 +199,7 @@ fn keystroke_to_csi_u(
     // the terminal concept of Alt — `meta` is just the macOS user preference that
     // remaps Option to behave as a terminal Meta/Alt key. They cannot both be true
     // simultaneously in practice (Option is either raw or Meta, never both).
-    let mut modifiers = 1u32;
-    if keystroke.shift {
-        modifiers += 1;
-    }
-    if keystroke.alt || keystroke.meta {
-        modifiers += 2;
-    }
-    if keystroke.ctrl {
-        modifiers += 4;
-    }
-    if keystroke.cmd {
-        modifiers += 8;
-    }
+    let modifiers = super::modifier_param(keystroke);
 
     // Compute associated text if REPORT_ASSOCIATED_TEXT is active.
     // Per spec: "The associated text must not contain control codes (control codes are code

--- a/crates/warp_terminal/src/model/escape_sequences_tests.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_tests.rs
@@ -1119,3 +1119,139 @@ fn test_keyboard_enhancement_event_types() {
         Some(b"\x1b[13;2u".to_vec())
     );
 }
+
+/// Regression test for macOS editing keys under the Kitty keyboard protocol (GH#9159).
+///
+/// Before the fix, the CSI-u gate never checked `keystroke.cmd` and blanket-excluded `alt`
+/// on macOS, so Cmd/Option + Backspace/Delete/arrows silently dropped their modifier. Each
+/// case asserts the exact bytes Kitty/Ghostty emit under `DISAMBIGUATE_ESCAPE`:
+/// - Backspace (codepoint 127, no legacy code) → CSI u.
+/// - Arrows & Delete (own legacy codes) → the legacy `CSI 1;<mods><letter>` / `CSI 3;<mods>~`
+///   forms, now carrying the full modifier value (Super = bit 8 → e.g. Cmd → `9`).
+#[test]
+fn test_kitty_protocol_cmd_and_option_editing_keys() {
+    // `Keystroke::parse` has no portable `cmd-` token in these tests, so build Cmd combos
+    // as literals.
+    let cmd = |key: &str| Keystroke {
+        ctrl: false,
+        alt: false,
+        shift: false,
+        cmd: true,
+        meta: false,
+        key: key.to_owned(),
+    };
+
+    let mock = mock_with_disambiguate_only();
+
+    // OS-independent: Cmd is unrepresentable in legacy encoding on every platform, and raw
+    // Option on a non-printable functional key never composes via the IME, so both are
+    // always ambiguous → CSI u / modified legacy form.
+    let os_independent: &[(Keystroke, Vec<u8>)] = &[
+        // Backspace → CSI u (key code 127).
+        (cmd("backspace"), b"\x1b[127;9u".to_vec()),
+        (
+            Keystroke::parse("alt-backspace").unwrap(),
+            b"\x1b[127;3u".to_vec(),
+        ),
+        // Arrows → legacy `CSI 1;<mods> <letter>` (Kitty keeps the legacy code for these).
+        (cmd("left"), b"\x1b[1;9D".to_vec()),
+        (cmd("right"), b"\x1b[1;9C".to_vec()),
+        (Keystroke::parse("alt-left").unwrap(), b"\x1b[1;3D".to_vec()),
+        (
+            Keystroke::parse("alt-right").unwrap(),
+            b"\x1b[1;3C".to_vec(),
+        ),
+        // Cmd+Delete → legacy `CSI 3;<mods> ~`.
+        (cmd("delete"), b"\x1b[3;9~".to_vec()),
+    ];
+    validate_keystroke_test_cases(os_independent, &mock);
+
+    // Option+Delete is asserted on macOS only: on other platforms Alt is interpreted as Meta
+    // and ESC-prefixes instead (`meta_keystroke_to_escape_sequence`).
+    if warpui_core::platform::OperatingSystem::get().is_mac() {
+        let mac_only: &[(Keystroke, Vec<u8>)] = &[(
+            Keystroke::parse("alt-delete").unwrap(),
+            b"\x1b[3;3~".to_vec(),
+        )];
+        validate_keystroke_test_cases(mac_only, &mock);
+    }
+}
+
+/// On macOS, Option+Space composes a non-breaking space via the IME. Its key name is "space"
+/// (multi-character), which the original key-length heuristic misclassified as non-composing,
+/// wrongly forcing it to CSI u. Composition is now detected from the OS-provided `chars`.
+#[test]
+fn test_kitty_protocol_mac_option_space_composition_is_not_disambiguated() {
+    if !warpui_core::platform::OperatingSystem::get().is_mac() {
+        return;
+    }
+
+    let mock = mock_with_disambiguate_only();
+    let option_space = Keystroke {
+        ctrl: false,
+        alt: true,
+        shift: false,
+        cmd: false,
+        meta: false,
+        key: "space".to_owned(),
+    };
+
+    // Composed text present → Option is part of the character, not a modifier → not
+    // disambiguated (None, so the composed nbsp flows through the caller's text fallback).
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &option_space,
+            key_without_modifiers: None,
+            chars: Some("\u{a0}"),
+        }
+        .to_escape_sequence(&mock),
+        None
+    );
+
+    // No composed text → nothing to pass through, so the key stays ambiguous and is
+    // disambiguated as CSI u (base key 'space' = 32, Alt modifier = 3).
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &option_space,
+            key_without_modifiers: None,
+            chars: None,
+        }
+        .to_escape_sequence(&mock),
+        Some(b"\x1b[32;3u".to_vec())
+    );
+}
+
+/// Cmd (Super) had no arm in the legacy single-byte modifier, so Cmd+Fn silently dropped the
+/// modifier. Function keys now use `modifier_param`, which encodes Super and multi-digit values
+/// (Cmd = 9, Cmd+Shift = 10).
+#[test]
+fn test_fn_keystroke_with_cmd_modifier() {
+    let cmd = |key: &str| Keystroke {
+        ctrl: false,
+        alt: false,
+        shift: false,
+        cmd: true,
+        meta: false,
+        key: key.to_owned(),
+    };
+    let cmd_shift = |key: &str| Keystroke {
+        ctrl: false,
+        alt: false,
+        shift: true,
+        cmd: true,
+        meta: false,
+        key: key.to_owned(),
+    };
+
+    let mock = TerminalModelMock::new();
+    let cases: &[(Keystroke, Vec<u8>)] = &[
+        // F1-F4 use the SS3-derived `CSI 1;<mods> P/Q/R/S` form.
+        (cmd("f1"), b"\x1b[1;9P".to_vec()),
+        // F5+ use the `CSI <n>;<mods> ~` form.
+        (cmd("f5"), b"\x1b[15;9~".to_vec()),
+        (cmd("f12"), b"\x1b[24;9~".to_vec()),
+        // Cmd+Shift = 1 + 1 + 8 = 10 (multi-digit, unrepresentable by the old single byte).
+        (cmd_shift("f5"), b"\x1b[15;10~".to_vec()),
+    ];
+    validate_keystroke_test_cases(cases, &mock);
+}

--- a/crates/warp_terminal/src/model/escape_sequences_tests.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_tests.rs
@@ -1126,8 +1126,9 @@ fn test_keyboard_enhancement_event_types() {
 /// on macOS, so Cmd/Option + Backspace/Delete/arrows silently dropped their modifier. Each
 /// case asserts the exact bytes Kitty/Ghostty emit under `DISAMBIGUATE_ESCAPE`:
 /// - Backspace (codepoint 127, no legacy code) → CSI u.
-/// - Arrows & Delete (own legacy codes) → the legacy `CSI 1;<mods><letter>` / `CSI 3;<mods>~`
-///   forms, now carrying the full modifier value (Super = bit 8 → e.g. Cmd → `9`).
+/// - Arrows, Home/End & Delete (own legacy codes) → the legacy `CSI 1;<mods><letter>` /
+///   `CSI 3;<mods>~` forms, now carrying the full modifier value (Super = bit 8 →
+///   e.g. Cmd → `9`).
 #[test]
 fn test_kitty_protocol_cmd_and_option_editing_keys() {
     // `Keystroke::parse` has no portable `cmd-` token in these tests, so build Cmd combos
@@ -1153,28 +1154,27 @@ fn test_kitty_protocol_cmd_and_option_editing_keys() {
             Keystroke::parse("alt-backspace").unwrap(),
             b"\x1b[127;3u".to_vec(),
         ),
-        // Arrows → legacy `CSI 1;<mods> <letter>` (Kitty keeps the legacy code for these).
+        // Arrows and Home/End → legacy `CSI 1;<mods> <letter>` (Kitty keeps the legacy
+        // code for these).
         (cmd("left"), b"\x1b[1;9D".to_vec()),
         (cmd("right"), b"\x1b[1;9C".to_vec()),
+        (cmd("home"), b"\x1b[1;9H".to_vec()),
+        (cmd("end"), b"\x1b[1;9F".to_vec()),
         (Keystroke::parse("alt-left").unwrap(), b"\x1b[1;3D".to_vec()),
         (
             Keystroke::parse("alt-right").unwrap(),
             b"\x1b[1;3C".to_vec(),
         ),
-        // Cmd+Delete → legacy `CSI 3;<mods> ~`.
+        (Keystroke::parse("alt-home").unwrap(), b"\x1b[1;3H".to_vec()),
+        (Keystroke::parse("alt-end").unwrap(), b"\x1b[1;3F".to_vec()),
+        // Delete → legacy `CSI 3;<mods> ~`.
         (cmd("delete"), b"\x1b[3;9~".to_vec()),
-    ];
-    validate_keystroke_test_cases(os_independent, &mock);
-
-    // Option+Delete is asserted on macOS only: on other platforms Alt is interpreted as Meta
-    // and ESC-prefixes instead (`meta_keystroke_to_escape_sequence`).
-    if warpui_core::platform::OperatingSystem::get().is_mac() {
-        let mac_only: &[(Keystroke, Vec<u8>)] = &[(
+        (
             Keystroke::parse("alt-delete").unwrap(),
             b"\x1b[3;3~".to_vec(),
-        )];
-        validate_keystroke_test_cases(mac_only, &mock);
-    }
+        ),
+    ];
+    validate_keystroke_test_cases(os_independent, &mock);
 }
 
 /// On macOS, Option+Space composes a non-breaking space via the IME. Its key name is "space"

--- a/crates/warp_terminal/src/model/escape_sequences_tests.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_tests.rs
@@ -1122,13 +1122,10 @@ fn test_keyboard_enhancement_event_types() {
 
 /// Regression test for macOS editing keys under the Kitty keyboard protocol (GH#9159).
 ///
-/// Before the fix, the CSI-u gate never checked `keystroke.cmd` and blanket-excluded `alt`
-/// on macOS, so Cmd/Option + Backspace/Delete/arrows silently dropped their modifier. Each
-/// case asserts the exact bytes Kitty/Ghostty emit under `DISAMBIGUATE_ESCAPE`:
+/// Each case asserts the exact bytes Kitty/Ghostty emit under `DISAMBIGUATE_ESCAPE`:
 /// - Backspace (codepoint 127, no legacy code) → CSI u.
 /// - Arrows, Home/End & Delete (own legacy codes) → the legacy `CSI 1;<mods><letter>` /
-///   `CSI 3;<mods>~` forms, now carrying the full modifier value (Super = bit 8 →
-///   e.g. Cmd → `9`).
+///   `CSI 3;<mods>~` forms.
 #[test]
 fn test_kitty_protocol_cmd_and_option_editing_keys() {
     // `Keystroke::parse` has no portable `cmd-` token in these tests, so build Cmd combos
@@ -1177,9 +1174,8 @@ fn test_kitty_protocol_cmd_and_option_editing_keys() {
     validate_keystroke_test_cases(os_independent, &mock);
 }
 
-/// On macOS, Option+Space composes a non-breaking space via the IME. Its key name is "space"
-/// (multi-character), which the original key-length heuristic misclassified as non-composing,
-/// wrongly forcing it to CSI u. Composition is now detected from the OS-provided `chars`.
+/// On macOS, Option+Space composes a non-breaking space via the IME. Composition is detected
+/// from the OS-provided `chars`.
 #[test]
 fn test_kitty_protocol_mac_option_space_composition_is_not_disambiguated() {
     if !warpui_core::platform::OperatingSystem::get().is_mac() {
@@ -1221,8 +1217,7 @@ fn test_kitty_protocol_mac_option_space_composition_is_not_disambiguated() {
     );
 }
 
-/// Cmd (Super) had no arm in the legacy single-byte modifier, so Cmd+Fn silently dropped the
-/// modifier. Function keys now use `modifier_param`, which encodes Super and multi-digit values
+/// Function keys use `modifier_param`, which encodes Super and multi-digit values
 /// (Cmd = 9, Cmd+Shift = 10).
 #[test]
 fn test_fn_keystroke_with_cmd_modifier() {
@@ -1250,7 +1245,7 @@ fn test_fn_keystroke_with_cmd_modifier() {
         // F5+ use the `CSI <n>;<mods> ~` form.
         (cmd("f5"), b"\x1b[15;9~".to_vec()),
         (cmd("f12"), b"\x1b[24;9~".to_vec()),
-        // Cmd+Shift = 1 + 1 + 8 = 10 (multi-digit, unrepresentable by the old single byte).
+        // Cmd+Shift = 1 + 1 + 8 = 10.
         (cmd_shift("f5"), b"\x1b[15;10~".to_vec()),
     ];
     validate_keystroke_test_cases(cases, &mock);


### PR DESCRIPTION
# Encode Cmd/Option modifiers for editing keys under the Kitty keyboard protocol

Fixes #9159. Related spec: #13695.

## Problem

On macOS, `Cmd`/`Option` combined with **Backspace, Delete, and the arrow keys**
are silently dropped when a TUI enables the Kitty keyboard protocol
(`DISAMBIGUATE_ESCAPE`). So inside apps like Claude Code:

- `⌘⌫` (delete to line start), `⌥⌫` (delete word), `⌘←`/`⌘→`, `⌥←`/`⌥→` do nothing.

The same keystrokes work in Kitty and Ghostty, which emit the correct sequences.
`Ctrl+…` works in Warp because it is handled in both encoding layers; `Cmd` and
`Option` are not.

## Root cause

The modifier plumbing (`NSEvent → Keystroke.cmd/alt`) is intact. The loss is
entirely in the escape-sequence encoder's gating logic:

1. **CSI-u gate** (`kitty_keyboard_protocol.rs`) never checked `keystroke.cmd`
   and blanket-excluded `alt` on macOS, so `Cmd+Backspace` / `Option+Backspace`
   never reached CSI-u encoding.
2. **Legacy modifier byte** (`to_modifier_escape_byte`) used by arrows/Delete
   wildcarded `cmd` and was a single ASCII digit — it could not represent Super
   (value 9) or multi-digit combos, so the modifier was dropped.
3. **Function keys** shared the same gap (`Cmd+F5` dropped the modifier).

## Changes

- **Gate**: treat any `Cmd`-modified key as ambiguous (Super has no legacy
  encoding at all). Stop blanket-excluding `Option` on macOS; instead detect IME
  composition from the OS-provided associated text (`chars`), so `Option+Space`
  → nbsp still composes, while `Option` + Backspace/Delete/arrows (which produce
  no text) act as modifiers.
- **`modifier_param` helper**: one source of truth for the xterm/Kitty modifier
  value `1 + shift + alt + ctrl + super`, shared by arrows, Delete, and function
  keys. Replaces the single-byte `to_modifier_escape_byte` (now removed), and
  encodes Super and multi-digit values.
- **Delete**: `CSI 3;<mods>~` for modified Delete (previously no modifier-aware
  path existed).

Per the Kitty spec, keys that own a legacy escape code (arrows, Home/End, Delete,
function keys) keep their legacy `CSI …` / `CSI …~` form with a modifier
parameter under the protocol; only Backspace (codepoint 127, no legacy code) uses
the `CSI … u` form. The output matches Kitty/Ghostty byte-for-byte:

| Keystroke | Bytes |
|---|---|
| `Cmd+Backspace` | `CSI 127;9u` |
| `Option+Backspace` | `CSI 127;3u` |
| `Cmd+←` / `Cmd+→` | `CSI 1;9D` / `CSI 1;9C` |
| `Option+←` / `Option+→` | `CSI 1;3D` / `CSI 1;3C` |
| `Cmd+Delete` | `CSI 3;9~` |
| `Cmd+F5` | `CSI 15;9~` |

## Testing

**Automated** — `cargo test -p warp_terminal escape_sequences` (23 pass, incl. 3
new regression tests: Cmd/Option × Backspace/Delete/arrows, Option+Space
composition, Cmd+function-key). These modifier×editing-key cases were entirely
absent, which is why the regression shipped. `cargo fmt --check` and
`cargo clippy --all-targets --tests -- -D warnings` are clean.

**Manual (macOS, local build)** — verified in a live Claude Code session running
inside a locally-built Warp: `⌘⌫` deletes to line start, `⌥⌫` deletes a word,
`⌘←/→` and `⌥←/→` move by line/word in the TUI input.

<!-- TODO: attach before/after screen recording -->
