### PR TITLE
Open OSC 8 hyperlinks via Cmd/Ctrl+click inside mouse-reporting TUIs

### DIFF
--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -385,20 +385,30 @@ impl AltScreenElement {
         }
 
         let point = self.coord_to_point(local_position);
+        let modifiers = *mouse_state.modifiers();
+        let position = WithinModel::AltScreen(Point {
+            col: point.col,
+            row: point.row,
+        });
+
+        // Cmd (macOS) / Ctrl (other) + click on an OSC 8 hyperlink opens it (handled by the
+        // ClickOnGrid action). When it will, don't also forward the click to the TUI even though
+        // mouse reporting is on — otherwise the app swallows the click alongside opening the link.
+        let opening_link = crate::terminal::links::should_directly_open_link(&modifiers)
+            && self.model.lock().hyperlink_at_point(&position).is_some();
 
         ctx.dispatch_typed_action(TerminalAction::ClickOnGrid {
-            position: WithinModel::AltScreen(Point {
-                col: point.col,
-                row: point.row,
-            }),
-            modifiers: *mouse_state.modifiers(),
+            position,
+            modifiers,
         });
 
         if self.is_terminal_selecting {
             ctx.dispatch_typed_action(TerminalAction::AltSelect(SelectAction::End));
         }
 
-        if !should_intercept_mouse(&self.model.lock(), mouse_state.modifiers().shift, app) {
+        if !opening_link
+            && !should_intercept_mouse(&self.model.lock(), modifiers.shift, app)
+        {
             ctx.dispatch_typed_action(TerminalAction::AltMouseAction(mouse_state.set_point(point)));
         }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -18318,8 +18318,10 @@ impl TerminalView {
                 .map(|(_, uri)| uri);
             if let Some(uri) = uri {
                 self.open_hyperlink_uri(&uri, ctx);
+                return;
             }
-            return;
+            // No OSC 8 hyperlink at the clicked cell: fall through to the `highlighted_link`
+            // handler below so a regex-detected URL still opens on Cmd/Ctrl+click.
         }
 
         let Some(link) = self.highlighted_link.as_ref() else {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -18307,6 +18307,21 @@ impl TerminalView {
     }
 
     fn maybe_open_link(&mut self, position: &WithinModel<Point>, ctx: &mut ViewContext<Self>) {
+        // Full-screen TUIs render into the alt screen, which has no hovered-link (`highlighted_link`)
+        // state, so resolve the OSC 8 hyperlink at the clicked point directly from the model and
+        // open it. Without this, Cmd/Ctrl+click on a hyperlink inside a TUI opens nothing.
+        if matches!(position, WithinModel::AltScreen(_)) {
+            let uri = self
+                .model
+                .lock()
+                .hyperlink_at_point(position)
+                .map(|(_, uri)| uri);
+            if let Some(uri) = uri {
+                self.open_hyperlink_uri(&uri, ctx);
+            }
+            return;
+        }
+
         let Some(link) = self.highlighted_link.as_ref() else {
             return;
         };


### PR DESCRIPTION
# Open OSC 8 hyperlinks via Cmd/Ctrl+click inside mouse-reporting TUIs

Fixes #13965. Cousin of the keyboard-side modifier gap in #9159.

## Problem

When a full-screen TUI enables mouse reporting, Warp forwards every click to the PTY, so OSC 8
hyperlinks (including `file://`) the TUI emits cannot be opened with Cmd/Ctrl+click. Only `Shift`
bypasses mouse capture today. iTerm2 and Kitty open modifier+click links even under mouse reporting.

## Root cause

Two gaps combined:

1. The alt-screen click path never resolves or opens a link. `ClickOnGrid` routes to
   `TerminalView::click_on_grid` → `maybe_open_link`, which reads `self.highlighted_link` — a
   **main-screen** hover field the alt screen never populates (it keeps its own hover state). So an
   alt-screen Cmd+click found no link to open.
2. The alt-screen mouse-interception gate (`should_intercept_mouse`) only consults `shift`, so a
   Cmd+click is forwarded to the app like any other click.

## Changes

- **`app/src/terminal/view.rs`** (`maybe_open_link`): for a `WithinModel::AltScreen` position,
  resolve the OSC 8 hyperlink at the clicked point via `TerminalModel::hyperlink_at_point` and open
  it through the existing `open_hyperlink_uri` (which validates the URI before `ctx.open_url`).
- **`app/src/terminal/alt_screen/alt_screen_element.rs`** (`mouse_up`): when a Cmd (macOS) / Ctrl
  (other) + click will open a link, skip forwarding the click to the TUI so the app doesn't also
  swallow it. `Shift` selection and plain-click forwarding are unchanged; `should_intercept_mouse`'s
  signature is untouched.

Behavior table (mouse reporting active): plain click → forward; Shift+click → select; Cmd/Ctrl+click
on a link → **open, don't forward**; Cmd/Ctrl+click on a non-link → forward (apps that use
modifier+click keep working).

## Dependency: `OscHyperlinks` feature flag

OSC 8 hyperlink storage/lookup is gated behind the `OscHyperlinks` feature flag, which is currently
**dogfood-only** (`DOGFOOD_FLAGS`) — not in preview/stable. With the flag off, `hyperlink_at_point`
returns `None` and this path is inert (as is Warp's existing OSC 8 support). This fix presupposes
the flag is enabled; it may be worth graduating `OscHyperlinks` toward preview/stable.

## Testing

No fast unit harness exists for the alt-screen mouse element, so verification is compile + manual:

- Compiles clean (`cargo build --bin warp-oss --profile release-lto`), no new warnings.
- **Verified live in a from-source GUI build** (`WarpOss.app`, with `OscHyperlinks` enabled): inside
  a simulated full-screen TUI (alt screen + mouse reporting on) showing an OSC 8 `file://` link,
  Cmd+click opens the file while a plain click is still delivered to the app.
