### PR TITLE
[CODE-1871] Persist TUI prompts for history

### DIFF
--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -119,6 +119,8 @@ pub(crate) use passive_suggestions::{
 pub use permissions::{BlocklistAIPermissions, CommandExecutionPermissionAllowedReason};
 #[cfg_attr(target_family = "wasm", allow(unused))]
 pub(crate) use persistence::PersistedAIInputType;
+#[cfg_attr(target_family = "wasm", allow(unused))]
+pub use persistence::maybe_build_ai_query_upsert_event;
 pub(crate) use persistence::{PersistedAIInput, SerializedBlockListItem};
 pub(crate) use queued_query::{
     AutofireAction, QueuedQuery, QueuedQueryEvent, QueuedQueryId, QueuedQueryModel,

--- a/app/src/ai/blocklist/persistence.rs
+++ b/app/src/ai/blocklist/persistence.rs
@@ -8,8 +8,11 @@ use anyhow::anyhow;
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Deserializer, Serialize};
 use uuid::Uuid;
+use warpui::{AppContext, EntityId, SingletonEntity};
 
-use super::AIQueryHistoryOutputStatus;
+use super::history_model::{
+    AIQueryHistoryOutputStatus, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
+};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentActionType, AIAgentAttachment, AIAgentContext, AIAgentExchangeId, AIAgentInput,
@@ -18,7 +21,9 @@ use crate::ai::agent::{
     UserQueryMode,
 };
 use crate::ai::llms::LLMId;
+use crate::persistence::ModelEvent;
 use crate::terminal::model::block::{BlockId, SerializedBlock};
+
 /// Data we persist for each [`AIAgentExchange`] for use in history. Does not contain output data.
 #[derive(Debug, Deserialize, Clone)]
 pub struct PersistedAIInput {
@@ -124,6 +129,80 @@ impl TryFrom<PersistedAIInputType> for AIAgentInput {
             }),
         }
     }
+}
+
+/// Builds the persistence-writer event for a query-bearing exchange update.
+///
+/// GUI panes and TUI sessions both consume the global history model, so the
+/// serialization and filtering rules must stay shared even though each
+/// frontend writes to its own persistence scope.
+///
+/// Returns `None` when the event is irrelevant to this terminal surface or the
+/// exchange should not be persisted.
+pub fn maybe_build_ai_query_upsert_event(
+    event: &BlocklistAIHistoryEvent,
+    terminal_surface_id: EntityId,
+    is_shared_ambient_agent_session: bool,
+    app: &AppContext,
+) -> Option<ModelEvent> {
+    if event
+        .terminal_surface_id()
+        .is_some_and(|id| id != terminal_surface_id)
+    {
+        return None;
+    }
+
+    let (exchange_id, conversation_id, is_hidden) = match event {
+        BlocklistAIHistoryEvent::AppendedExchange {
+            exchange_id,
+            conversation_id,
+            is_hidden,
+            ..
+        }
+        | BlocklistAIHistoryEvent::UpdatedStreamingExchange {
+            exchange_id,
+            conversation_id,
+            is_hidden,
+            ..
+        } => (*exchange_id, *conversation_id, *is_hidden),
+        _ => return None,
+    };
+
+    let history_model = BlocklistAIHistoryModel::as_ref(app);
+    let Some(conversation) = history_model.conversation(&conversation_id) else {
+        log::warn!("Received event with invalid conversation ID: {conversation_id:?}");
+        return None;
+    };
+    let Some(exchange) = conversation.exchange_with_id(exchange_id) else {
+        log::warn!("Received event with invalid exchange ID: {exchange_id:?}");
+        return None;
+    };
+
+    if is_hidden || conversation.is_entirely_passive() || is_shared_ambient_agent_session {
+        return None;
+    }
+
+    let inputs: Vec<_> = exchange
+        .input
+        .iter()
+        .filter_map(|input| PersistedAIInputType::try_from(input).ok())
+        .collect();
+    if inputs.is_empty() {
+        return None;
+    }
+
+    Some(ModelEvent::UpsertAIQuery {
+        query: Arc::new(PersistedAIInput {
+            start_ts: exchange.start_time,
+            inputs,
+            exchange_id: exchange.id,
+            conversation_id,
+            output_status: AIQueryHistoryOutputStatus::from(&exchange.output_status),
+            working_directory: exchange.working_directory.clone(),
+            model_id: exchange.model_id.clone(),
+            coding_model_id: exchange.coding_model_id.clone(),
+        }),
+    })
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -533,3 +612,7 @@ impl From<SerializedBlock> for SerializedBlockListItem {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "persistence_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/persistence_tests.rs
+++ b/app/src/ai/blocklist/persistence_tests.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use warpui::{App, EntityId};
+
+use super::{PersistedAIInputType, maybe_build_ai_query_upsert_event};
+use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
+use crate::persistence::ModelEvent;
+
+fn user_query_message(task_id: &str, query: &str) -> warp_multi_agent_api::Message {
+    warp_multi_agent_api::Message {
+        fetched_memories: Vec::new(),
+        id: "message-id".to_owned(),
+        task_id: task_id.to_owned(),
+        server_message_data: String::new(),
+        citations: Vec::new(),
+        message: Some(warp_multi_agent_api::message::Message::UserQuery(
+            warp_multi_agent_api::message::UserQuery {
+                query: query.to_owned(),
+                context: None,
+                referenced_attachments: HashMap::new(),
+                mode: None,
+                intended_agent: Default::default(),
+            },
+        )),
+        request_id: "request-id".to_owned(),
+        timestamp: None,
+    }
+}
+
+#[test]
+fn query_exchange_event_builds_persistence_upsert() {
+    App::test((), |mut app| async move {
+        let terminal_surface_id = EntityId::new();
+        let conversation_id = AIConversationId::new();
+        let task_id = "task-id";
+        let conversation = AIConversation::new_restored(
+            conversation_id,
+            vec![warp_multi_agent_api::Task {
+                id: task_id.to_owned(),
+                messages: vec![user_query_message(task_id, "persist this prompt")],
+                dependencies: None,
+                description: String::new(),
+                summary: String::new(),
+                server_data: String::new(),
+            }],
+            None,
+        )
+        .expect("conversation should restore");
+        let exchange_id = conversation
+            .root_task_exchanges()
+            .next()
+            .expect("conversation should contain the query exchange")
+            .id;
+        let task_id = conversation.get_root_task_id().clone();
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_surface_id, vec![conversation], ctx);
+        });
+
+        let event = BlocklistAIHistoryEvent::AppendedExchange {
+            exchange_id,
+            task_id,
+            terminal_surface_id,
+            conversation_id,
+            is_hidden: false,
+            response_stream_id: None,
+        };
+        let persistence_event = app
+            .read(|ctx| maybe_build_ai_query_upsert_event(&event, terminal_surface_id, false, ctx))
+            .expect("query exchange should produce a persistence event");
+        let ModelEvent::UpsertAIQuery { query } = persistence_event else {
+            panic!("query exchange should produce an AI-query upsert");
+        };
+        assert_eq!(query.conversation_id, conversation_id);
+        assert_eq!(query.exchange_id, exchange_id);
+        assert_eq!(
+            query.inputs,
+            vec![PersistedAIInputType::Query {
+                text: "persist this prompt".to_owned(),
+                context: Default::default(),
+                referenced_attachments: Default::default(),
+            }]
+        );
+    });
+}

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -2120,11 +2120,7 @@ fn handle_ai_history_event(
     is_shared_ambient_agent_session: bool,
     ctx: &mut ViewContext<PaneGroup>,
 ) {
-    use std::sync::Arc;
-
-    use crate::ai::blocklist::{
-        AIQueryHistoryOutputStatus, PersistedAIInput, PersistedAIInputType,
-    };
+    use crate::ai::blocklist::maybe_build_ai_query_upsert_event;
 
     if event
         .terminal_surface_id()
@@ -2134,74 +2130,21 @@ fn handle_ai_history_event(
     }
 
     match event {
-        BlocklistAIHistoryEvent::AppendedExchange {
-            exchange_id,
-            conversation_id,
-            is_hidden,
-            ..
-        }
-        | BlocklistAIHistoryEvent::UpdatedStreamingExchange {
-            exchange_id,
-            conversation_id,
-            is_hidden,
-            ..
-        } => {
+        BlocklistAIHistoryEvent::AppendedExchange { .. }
+        | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. } => {
             // Check if session restoration is enabled.
             if !*GeneralSettings::as_ref(ctx).restore_session
                 || !AppExecutionMode::as_ref(ctx).can_save_session()
             {
                 return;
             }
-
-            let Some(conversation) =
-                BlocklistAIHistoryModel::as_ref(ctx).conversation(conversation_id)
-            else {
-                log::warn!("Received event with invalid conversation ID: {conversation_id:?}");
+            let Some(upsert_ai_query_event) = maybe_build_ai_query_upsert_event(
+                event,
+                terminal_view_id,
+                is_shared_ambient_agent_session,
+                ctx,
+            ) else {
                 return;
-            };
-
-            let Some(exchange) = conversation.exchange_with_id(*exchange_id) else {
-                log::warn!("Received event with invalid exchange ID: {exchange_id:?}");
-                return;
-            };
-
-            // Hidden blocks and passive-only conversations should not be restored, so we skip
-            // them.
-            if *is_hidden || conversation.is_entirely_passive() {
-                return;
-            }
-
-            // Do not persist AI queries from shared ambient agent sessions that we've viewed,
-            // as these were sent as part of an ambient agent run and shouldn't polute the up arrow history.
-            if is_shared_ambient_agent_session {
-                return;
-            }
-
-            // Only query-bearing inputs (e.g. user queries) are persisted for
-            // up-arrow history. Early return and skip writing for exchanges that
-            // carry empty input.
-            let inputs: Vec<_> = exchange
-                .input
-                .iter()
-                .filter_map(|input| PersistedAIInputType::try_from(input).ok())
-                .collect();
-            if inputs.is_empty() {
-                return;
-            }
-
-            let persisted_query = PersistedAIInput {
-                start_ts: exchange.start_time,
-                inputs,
-                exchange_id: exchange.id,
-                conversation_id: *conversation_id,
-                output_status: AIQueryHistoryOutputStatus::from(&exchange.output_status),
-                working_directory: exchange.working_directory.clone(),
-                // TODO(CORE-3546): shell: exchange.shell.clone(),
-                model_id: exchange.model_id.clone(),
-                coding_model_id: exchange.coding_model_id.clone(),
-            };
-            let upsert_ai_query_event = ModelEvent::UpsertAIQuery {
-                query: Arc::new(persisted_query),
             };
             let _ = ctx.spawn(
                 // Sending over a sync sender can block the current thread, so we

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -82,6 +82,7 @@ pub use crate::ai::blocklist::{
     RunAgentsSpawningSnapshot, ShellCommandExecutor, ShellCommandExecutorEvent, StartAgentExecutor,
     StartAgentExecutorEvent, StartAgentOutcome, StartAgentRequest, StartAgentRequestId,
     block_context_from_terminal_model, inherit_child_agent_settings,
+    maybe_build_ai_query_upsert_event,
 };
 #[cfg(not(target_family = "wasm"))]
 pub use crate::ai::blocklist::{
@@ -121,6 +122,7 @@ pub use crate::code_review::git_repo_model::{
     GitRepoModels, GitRepoStatusModel, GitStatusMetadata,
 };
 pub use crate::completer::SessionContext;
+pub use crate::persistence::PersistenceWriter;
 pub use crate::search::slash_command_menu::static_commands::commands::{
     self as slash_commands, COMMAND_REGISTRY,
 };

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -24,16 +24,17 @@ use warp::tui_export::{
     ConversationFileExport, ConversationSelection, ConversationSelectionHandle,
     ConversationUsageTotals, ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels,
     GitRepoStatusModel, GitStatusMetadata, LLMId, LLMPreferences, LLMPreferencesEvent,
-    LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, ModelEvent, ParsedSlashCommandInput, PtyIntent,
-    PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
-    ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference, SlashCommandDataSource as _,
-    SlashCommandSelectionBehavior, StartAgentExecutorEvent, StartAgentRequest, StaticCommand,
-    TerminalModel, TerminalSurface, TerminalSurfaceInit, TranscriptScope, TuiMcpAction,
-    TuiMcpManager, TuiSlashCommand, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
-    TuiZeroStateDataSource, UserTakeOverReason, WAKEUP_THROTTLE_PERIOD,
-    block_context_from_terminal_model, build_slash_command_mixer, detect_possible_git_repo,
-    export_conversation_markdown, prepare_conversation_block_restoration,
-    record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
+    LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, ModelEvent, ParsedSlashCommandInput,
+    PersistenceWriter, PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
+    ServerConversationToken, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
+    SlashCommandDataSource as _, SlashCommandSelectionBehavior, StartAgentExecutorEvent,
+    StartAgentRequest, StaticCommand, TerminalModel, TerminalSurface, TerminalSurfaceInit,
+    TranscriptScope, TuiMcpAction, TuiMcpManager, TuiSlashCommand, TuiSlashCommandDataSource,
+    TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource, UserTakeOverReason,
+    WAKEUP_THROTTLE_PERIOD, block_context_from_terminal_model, build_slash_command_mixer,
+    detect_possible_git_repo, export_conversation_markdown, maybe_build_ai_query_upsert_event,
+    prepare_conversation_block_restoration, record_saved_prompt_accepted,
+    record_static_slash_command_accepted, saved_prompt_text_for_id,
     slash_command_selection_behavior, throttle,
 };
 use warp_core::features::FeatureFlag;
@@ -1802,6 +1803,22 @@ impl TuiTerminalSessionView {
             .is_some_and(|id| id != self.terminal_surface_id)
         {
             return;
+        }
+        if let Some(persistence_event) =
+            maybe_build_ai_query_upsert_event(event, self.terminal_surface_id, false, ctx)
+            && let Some(model_event_sender) = PersistenceWriter::handle(ctx).as_ref(ctx).sender()
+        {
+            let _ = ctx.spawn(
+                async move { model_event_sender.send(persistence_event) },
+                |_, result, _| {
+                    if let Err(error) = result {
+                        report_error!(
+                            anyhow::Error::new(error)
+                                .context("Error sending TUI upsert AI query event")
+                        );
+                    }
+                },
+            );
         }
         if matches!(
             event,

--- a/specs/CODE-1871-prompt-persistence/TECH.md
+++ b/specs/CODE-1871-prompt-persistence/TECH.md
@@ -1,0 +1,34 @@
+# Persist TUI agent prompts for history
+## Context
+The shared [`BlocklistAIHistoryModel`](https://github.com/warpdotdev/warp/blob/41b922e0/app/src/ai/blocklist/history_model.rs) owns in-memory agent conversations for both the GUI and TUI. Prompt submission updates that model and emits `BlocklistAIHistoryEvent` values, but persistence is a downstream projection rather than part of submission.
+
+The GUI projection lives in [`app/src/pane_group/pane/terminal_pane.rs`](https://github.com/warpdotdev/warp/blob/41b922e0/app/src/pane_group/pane/terminal_pane.rs): its per-pane history subscription filters events for the pane's terminal surface, serializes query-bearing exchanges as `PersistedAIInput`, and sends `ModelEvent::UpsertAIQuery` to the persistence writer. The TUI subscribes to the same history model in [`crates/warp_tui/src/terminal_session_view.rs`](https://github.com/warpdotdev/warp/blob/41b922e0/crates/warp_tui/src/terminal_session_view.rs), but does not currently project those events into its persistence writer. TUI prompts therefore remain available only while their conversations are in memory.
+
+The GUI and TUI use separate SQLite scopes. [`PersistenceScope::Tui`](https://github.com/warpdotdev/warp/blob/41b922e0/app/src/persistence/mod.rs#L63-L72) prevents schema/version skew between the two frontends, so the TUI must write its own prompt rows for later TUI launches to restore them.
+## Proposed changes
+### Share the query persistence projection
+Move the event filtering and `PersistedAIInput` construction from the GUI pane handler into `maybe_build_ai_query_upsert_event` in `app/src/ai/blocklist/persistence.rs`.
+
+The helper:
+- accepts `AppendedExchange` and `UpdatedStreamingExchange` events for the requested terminal surface;
+- reads the corresponding conversation and exchange from `BlocklistAIHistoryModel`;
+- excludes hidden exchanges, passive-only conversations, shared ambient-agent sessions, and exchanges without persistable inputs;
+- returns `ModelEvent::UpsertAIQuery` with the exchange's current output status and metadata.
+
+Keep writer ownership outside the history model. Persistence availability, execution policy, and surface lifecycle remain frontend concerns, while serialization and exclusion rules have one implementation.
+### Preserve GUI behavior
+Update `handle_ai_history_event` in `app/src/pane_group/pane/terminal_pane.rs` to call the shared helper. Retain the existing GUI checks for session restoration and execution modes that can save sessions, the pane-scoped terminal-surface filter, and asynchronous delivery through the pane group's writer sender.
+### Add the TUI writer path
+Expose `maybe_build_ai_query_upsert_event` and `PersistenceWriter` through `app/src/tui_export.rs`.
+
+In `TuiTerminalSessionView::handle_history_event`, build an upsert for matching history events and send it asynchronously through the TUI process's `PersistenceWriter`. TUI terminal sessions are not shared ambient-agent viewers, so the helper receives `false` for that exclusion input.
+
+The TUI does not apply the GUI's `GeneralSettings::restore_session` gate. That setting belongs to the GUI settings surface and controls restoration of GUI windows, tabs, panes, and blocks; TUI prompt history uses an independent settings and persistence scope.
+## Testing and validation
+- Unit-test `maybe_build_ai_query_upsert_event` with a restored conversation containing a user query. Verify the resulting `UpsertAIQuery` preserves the conversation ID, exchange ID, and serialized query input.
+- Run the blocklist persistence unit tests covering the shared projection.
+- Run the `warp_tui` test suite to ensure the new writer lookup and history-event subscription compile with the TUI feature.
+- Run `./script/format` and the repository clippy command before submitting.
+- Manually submit a prompt in the TUI, restart the TUI, and verify the query is present in the TUI-scoped `ai_queries` table.
+## Parallelization
+Parallel agents are not useful for this change. The shared projection, GUI call site, TUI call site, and focused tests form one small dependency chain and touch overlapping APIs.


### PR DESCRIPTION
## Description
Fixes TUI-submitted agent prompts not being written to the TUI persistence scope. Prompt submission already updates the shared `BlocklistAIHistoryModel`, but only the GUI pane subscriber projected those history events into `ModelEvent::UpsertAIQuery`.

This PR:
- extracts the shared event filtering and `PersistedAIInput` construction into `maybe_build_ai_query_upsert_event`;
- keeps the GUI's existing writer policy while switching it to the shared helper;
- adds the equivalent TUI history-event projection through the TUI-scoped `PersistenceWriter`;
- adds a focused regression test and technical spec at `specs/CODE-1871-prompt-persistence/TECH.md`.

The stacked up-arrow UI PR reads this persisted history but does not own persistence behavior.

## Linked Issue
CODE-1871

## Testing
- [x] I have manually tested prompt persistence across a TUI restart
Note: there's no user-facing change in this PR — that comes in the PR above this one.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/b66e63e5-e8d8-4e22-8a31-fd7e3f1e4e27

Co-Authored-By: Oz <oz-agent@warp.dev>