### PR TITLE
Show modal with gcloud auth login hint when IAP credentials fail

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -196,7 +196,8 @@ use std::collections::HashSet;
 use std::ops::Deref;
 #[cfg(feature = "local_fs")]
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use ::settings::{Setting, ToggleableSetting};
 #[cfg(feature = "local_tty")]
@@ -204,6 +205,7 @@ use anyhow::Context;
 use anyhow::{Result, anyhow};
 use appearance::{Appearance, AppearanceManager};
 use channel::ChannelState;
+use instant::Instant;
 use interval_timer::IntervalTimer;
 use itertools::Itertools;
 #[cfg(feature = "integration_tests")]
@@ -233,6 +235,7 @@ use warp_logging::LogDestination;
 use warp_managed_secrets::ManagedSecretManager;
 use warp_server_client::iap::{IapManager, IapManagerEvent, IapState, ManagedIapMint};
 use warp_server_client::network_logging::NetworkLogModel;
+use warpui::clipboard::ClipboardContent;
 use warpui::integration::TestDriver;
 use warpui::modals::{AlertDialogWithCallbacks, AppModalCallback, ModalButton};
 use warpui::platform::TerminationMode;
@@ -283,6 +286,7 @@ use crate::notebooks::editor::keys::NotebookKeybindings;
 use crate::notebooks::manager::NotebookManager;
 use crate::notification::NotificationContext;
 use crate::palette::PaletteMode;
+use crate::pane_group::Direction;
 use crate::persistence::PersistenceWriter;
 use crate::persistence::model::AgentConversationData;
 use crate::projects::ProjectManagementModel;
@@ -2238,8 +2242,11 @@ pub(crate) fn initialize_app(
         });
         IapManager::new(iap_state, path_resolver, managed_iap_mint, ctx)
     });
-    // Subscribe to IAP manager events to show a modal when refresh fails.
-    ctx.subscribe_to_model(&IapManager::handle(ctx), |_, e, ctx| {
+    // Subscribe to IAP manager events to show a Warp-native modal when refresh fails.
+    // Track when the user last snoozed the modal so we can enforce a 5-minute cooldown.
+    let iap_modal_cooldown: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+    let iap_modal_cooldown_sub = iap_modal_cooldown.clone();
+    ctx.subscribe_to_model(&IapManager::handle(ctx), move |_, e, ctx| {
         let IapManagerEvent::RefreshFailed {
             message,
             is_first_failure_of_streak,
@@ -2250,27 +2257,59 @@ pub(crate) fn initialize_app(
         if !*is_first_failure_of_streak {
             return;
         }
-        let dialog = AlertDialogWithCallbacks::for_app(
-            "IAP credential refresh failed",
-            format!("{message}\n\nHave you tried running `gcloud auth login`?"),
-            vec![ModalButton::for_app("Dismiss", |_| {})],
-            |_| {},
-        );
-        if cfg!(all(not(target_family = "wasm"), target_os = "macos")) {
-            ctx.show_native_platform_modal(dialog);
-        } else {
-            let window_id = ctx
-                .windows()
-                .active_window()
-                .or_else(|| ctx.windows().ordered_window_ids().first().copied());
-            if let Some(window_id) = window_id
-                && let Some(workspaces) = ctx.views_of_type::<Workspace>(window_id)
-                && let Some(handle) = workspaces.first().cloned()
-            {
-                handle.update(ctx, |view, ctx| {
-                    view.show_native_modal(dialog, ctx);
-                });
+        // Respect the 5-minute snooze: if the user dismissed with the checkbox
+        // checked recently, suppress the modal until the cooldown expires.
+        {
+            let cooldown = iap_modal_cooldown_sub
+                .lock()
+                .expect("IAP modal cooldown lock poisoned");
+            if cooldown.is_some_and(|t| t.elapsed() < Duration::from_secs(5 * 60)) {
+                return;
             }
+        }
+        let error_msg_for_copy = message.clone();
+        let iap_modal_cooldown_for_snooze = iap_modal_cooldown_sub.clone();
+        let mut dialog = AlertDialogWithCallbacks::for_app(
+            "IAP credential refresh failed",
+            // Show the raw error so the user can read/copy it, then the gcloud hint.
+            format!("{message}\n\nHave you tried running `gcloud auth login`?"),
+            vec![
+                // "Copy Error" lets users grab the error text: the Warp-native modal
+                // renders info_text as static (non-selectable) text.
+                ModalButton::for_app("Copy Error", move |ctx| {
+                    ctx.clipboard()
+                        .write(ClipboardContent::plain_text(error_msg_for_copy));
+                }),
+                // Opens a new split pane and pre-fills the input with `gcloud auth login`.
+                ModalButton::for_app("Open New Pane", move |ctx| {
+                    open_new_pane_with_gcloud_auth_login(ctx);
+                }),
+                ModalButton::for_app("Dismiss", |_| {}),
+            ],
+            // on_disable: called when the "Don't show again for 5 mins" checkbox is
+            // checked. Records the snooze time so future failures are suppressed.
+            move |_| {
+                if let Ok(mut cooldown) = iap_modal_cooldown_for_snooze.lock() {
+                    *cooldown = Some(Instant::now());
+                }
+            },
+        );
+        // Label the checkbox to make the cooldown duration clear, and pre-check it
+        // so the default dismiss behaviour is to snooze for 5 minutes.
+        dialog.disable_label = Some("Don't show again for 5 mins.".to_string());
+        dialog.disable_initially_checked = true;
+        // Show the Warp-native modal for all platforms (no macOS-native dialog).
+        let window_id = ctx
+            .windows()
+            .active_window()
+            .or_else(|| ctx.windows().ordered_window_ids().first().copied());
+        if let Some(window_id) = window_id
+            && let Some(workspaces) = ctx.views_of_type::<Workspace>(window_id)
+            && let Some(handle) = workspaces.first().cloned()
+        {
+            handle.update(ctx, |view, ctx| {
+                view.show_native_modal(dialog, ctx);
+            });
         }
     });
 
@@ -2790,6 +2829,28 @@ fn focus_running_window_and_show_native_modal(
     {
         handle.update(ctx, |view, ctx| {
             view.show_native_modal(dialog_with_callbacks, ctx);
+        });
+    }
+}
+
+/// Opens a new terminal pane to the right and pre-fills its input buffer with
+/// `gcloud auth login`, providing a one-click re-authentication path when IAP
+/// credential refresh fails.
+fn open_new_pane_with_gcloud_auth_login(ctx: &mut AppContext) {
+    let window_id = ctx
+        .windows()
+        .active_window()
+        .or_else(|| ctx.windows().ordered_window_ids().first().copied());
+    if let Some(window_id) = window_id
+        && let Some(workspaces) = ctx.views_of_type::<Workspace>(window_id)
+        && let Some(workspace_handle) = workspaces.first().cloned()
+    {
+        workspace_handle.update(ctx, |workspace, ctx| {
+            let pane_group_handle = workspace.active_tab_pane_group().clone();
+            pane_group_handle.update(ctx, |pane_group, ctx| {
+                pane_group.add_terminal_pane(Direction::Right, None, ctx);
+            });
+            workspace.set_active_terminal_input_contents_and_focus_app("gcloud auth login", ctx);
         });
     }
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -196,8 +196,7 @@ use std::collections::HashSet;
 use std::ops::Deref;
 #[cfg(feature = "local_fs")]
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::sync::Arc;
 
 use ::settings::{Setting, ToggleableSetting};
 #[cfg(feature = "local_tty")]
@@ -205,7 +204,6 @@ use anyhow::Context;
 use anyhow::{Result, anyhow};
 use appearance::{Appearance, AppearanceManager};
 use channel::ChannelState;
-use instant::Instant;
 use interval_timer::IntervalTimer;
 use itertools::Itertools;
 #[cfg(feature = "integration_tests")]
@@ -233,11 +231,10 @@ use warp_errors::{report_error, report_if_error};
 use warp_files::FileModel;
 use warp_logging::LogDestination;
 use warp_managed_secrets::ManagedSecretManager;
-use warp_server_client::iap::{IapManager, IapManagerEvent, IapState, ManagedIapMint};
+use warp_server_client::iap::{IapManager, IapState, ManagedIapMint};
 use warp_server_client::network_logging::NetworkLogModel;
-use warpui::clipboard::ClipboardContent;
 use warpui::integration::TestDriver;
-use warpui::modals::{AlertDialogWithCallbacks, AppModalCallback, ModalButton};
+use warpui::modals::{AlertDialogWithCallbacks, AppModalCallback};
 use warpui::platform::TerminationMode;
 use warpui::platform::app::{ApproveTerminateResult, TerminationRequestSource};
 use warpui::windowing::state::ApplicationStage;
@@ -286,7 +283,6 @@ use crate::notebooks::editor::keys::NotebookKeybindings;
 use crate::notebooks::manager::NotebookManager;
 use crate::notification::NotificationContext;
 use crate::palette::PaletteMode;
-use crate::pane_group::Direction;
 use crate::persistence::PersistenceWriter;
 use crate::persistence::model::AgentConversationData;
 use crate::projects::ProjectManagementModel;
@@ -2242,76 +2238,7 @@ pub(crate) fn initialize_app(
         });
         IapManager::new(iap_state, path_resolver, managed_iap_mint, ctx)
     });
-    // Subscribe to IAP manager events to show a Warp-native modal when refresh fails.
-    // Track when the user last snoozed the modal so we can enforce a 5-minute cooldown.
-    let iap_modal_cooldown: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
-    let iap_modal_cooldown_sub = iap_modal_cooldown.clone();
-    ctx.subscribe_to_model(&IapManager::handle(ctx), move |_, e, ctx| {
-        let IapManagerEvent::RefreshFailed {
-            message,
-            is_first_failure_of_streak,
-        } = e
-        else {
-            return;
-        };
-        if !*is_first_failure_of_streak {
-            return;
-        }
-        // Respect the 5-minute snooze: if the user dismissed with the checkbox
-        // checked recently, suppress the modal until the cooldown expires.
-        {
-            let cooldown = iap_modal_cooldown_sub
-                .lock()
-                .expect("IAP modal cooldown lock poisoned");
-            if cooldown.is_some_and(|t| t.elapsed() < Duration::from_secs(5 * 60)) {
-                return;
-            }
-        }
-        let error_msg_for_copy = message.clone();
-        let iap_modal_cooldown_for_snooze = iap_modal_cooldown_sub.clone();
-        let mut dialog = AlertDialogWithCallbacks::for_app(
-            "IAP credential refresh failed",
-            // Show the raw error so the user can read/copy it, then the gcloud hint.
-            format!("{message}\n\nHave you tried running `gcloud auth login`?"),
-            vec![
-                // "Copy Error" lets users grab the error text: the Warp-native modal
-                // renders info_text as static (non-selectable) text.
-                ModalButton::for_app("Copy Error", move |ctx| {
-                    ctx.clipboard()
-                        .write(ClipboardContent::plain_text(error_msg_for_copy));
-                }),
-                // Opens a new split pane and pre-fills the input with `gcloud auth login`.
-                ModalButton::for_app("Open New Pane", move |ctx| {
-                    open_new_pane_with_gcloud_auth_login(ctx);
-                }),
-                ModalButton::for_app("Dismiss", |_| {}),
-            ],
-            // on_disable: called when the "Don't show again for 5 mins" checkbox is
-            // checked. Records the snooze time so future failures are suppressed.
-            move |_| {
-                if let Ok(mut cooldown) = iap_modal_cooldown_for_snooze.lock() {
-                    *cooldown = Some(Instant::now());
-                }
-            },
-        );
-        // Label the checkbox to make the cooldown duration clear, and pre-check it
-        // so the default dismiss behaviour is to snooze for 5 minutes.
-        dialog.disable_label = Some("Don't show again for 5 mins.".to_string());
-        dialog.disable_initially_checked = true;
-        // Show the Warp-native modal for all platforms (no macOS-native dialog).
-        let window_id = ctx
-            .windows()
-            .active_window()
-            .or_else(|| ctx.windows().ordered_window_ids().first().copied());
-        if let Some(window_id) = window_id
-            && let Some(workspaces) = ctx.views_of_type::<Workspace>(window_id)
-            && let Some(handle) = workspaces.first().cloned()
-        {
-            handle.update(ctx, |view, ctx| {
-                view.show_native_modal(dialog, ctx);
-            });
-        }
-    });
+    server::iap_refresh_failure_modal::init(ctx);
 
     // Add a singleton model that holds the current prompt configuration.
     ctx.add_singleton_model(Prompt::new);
@@ -2829,28 +2756,6 @@ fn focus_running_window_and_show_native_modal(
     {
         handle.update(ctx, |view, ctx| {
             view.show_native_modal(dialog_with_callbacks, ctx);
-        });
-    }
-}
-
-/// Opens a new terminal pane to the right and pre-fills its input buffer with
-/// `gcloud auth login`, providing a one-click re-authentication path when IAP
-/// credential refresh fails.
-fn open_new_pane_with_gcloud_auth_login(ctx: &mut AppContext) {
-    let window_id = ctx
-        .windows()
-        .active_window()
-        .or_else(|| ctx.windows().ordered_window_ids().first().copied());
-    if let Some(window_id) = window_id
-        && let Some(workspaces) = ctx.views_of_type::<Workspace>(window_id)
-        && let Some(workspace_handle) = workspaces.first().cloned()
-    {
-        workspace_handle.update(ctx, |workspace, ctx| {
-            let pane_group_handle = workspace.active_tab_pane_group().clone();
-            pane_group_handle.update(ctx, |pane_group, ctx| {
-                pane_group.add_terminal_pane(Direction::Right, None, ctx);
-            });
-            workspace.set_active_terminal_input_contents_and_focus_app("gcloud auth login", ctx);
         });
     }
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -188,7 +188,6 @@ use crate::ai::aws_credentials::AwsCredentialRefresher as _;
 use crate::ai::geap_credentials::GeapCredentialRefresher as _;
 use crate::ai::mcp::{FileBasedMCPManager, FileMCPWatcher};
 use crate::uri::web_intent_parser::maybe_rewrite_web_url_to_intent;
-use crate::view_components::DismissibleToast;
 pub mod workflows;
 pub mod workspace;
 
@@ -235,7 +234,7 @@ use warp_managed_secrets::ManagedSecretManager;
 use warp_server_client::iap::{IapManager, IapManagerEvent, IapState, ManagedIapMint};
 use warp_server_client::network_logging::NetworkLogModel;
 use warpui::integration::TestDriver;
-use warpui::modals::{AlertDialogWithCallbacks, AppModalCallback};
+use warpui::modals::{AlertDialogWithCallbacks, AppModalCallback, ModalButton};
 use warpui::platform::TerminationMode;
 use warpui::platform::app::{ApproveTerminateResult, TerminationRequestSource};
 use warpui::windowing::state::ApplicationStage;
@@ -2239,28 +2238,40 @@ pub(crate) fn initialize_app(
         });
         IapManager::new(iap_state, path_resolver, managed_iap_mint, ctx)
     });
-    // Subscribe to IAP manager events to show toasts when refresh fails.
+    // Subscribe to IAP manager events to show a modal when refresh fails.
     ctx.subscribe_to_model(&IapManager::handle(ctx), |_, e, ctx| {
-        match e {
-            IapManagerEvent::RefreshFailed {
-                message,
-                is_first_failure_of_streak,
-            } if *is_first_failure_of_streak => {
-                let window_id = ctx
-                    .windows()
-                    .active_window()
-                    .or_else(|| ctx.windows().ordered_window_ids().first().copied());
-                let Some(window_id) = window_id else {
-                    return;
-                };
-                let toast: DismissibleToast<WorkspaceAction> =
-                    DismissibleToast::error(format!("IAP credential refresh failed: {message}"));
-                ToastStack::handle(ctx).update(ctx, |stack, ctx| {
-                    stack.add_ephemeral_toast(toast, window_id, ctx);
+        let IapManagerEvent::RefreshFailed {
+            message,
+            is_first_failure_of_streak,
+        } = e
+        else {
+            return;
+        };
+        if !*is_first_failure_of_streak {
+            return;
+        }
+        let dialog = AlertDialogWithCallbacks::for_app(
+            "IAP credential refresh failed",
+            format!("{message}\n\nHave you tried running `gcloud auth login`?"),
+            vec![ModalButton::for_app("Dismiss", |_| {})],
+            |_| {},
+        );
+        if cfg!(all(not(target_family = "wasm"), target_os = "macos")) {
+            ctx.show_native_platform_modal(dialog);
+        } else {
+            let window_id = ctx
+                .windows()
+                .active_window()
+                .or_else(|| ctx.windows().ordered_window_ids().first().copied());
+            if let Some(window_id) = window_id
+                && let Some(workspaces) = ctx.views_of_type::<Workspace>(window_id)
+                && let Some(handle) = workspaces.first().cloned()
+            {
+                handle.update(ctx, |view, ctx| {
+                    view.show_native_modal(dialog, ctx);
                 });
             }
-            _ => {}
-        };
+        }
     });
 
     // Add a singleton model that holds the current prompt configuration.

--- a/app/src/server/iap_refresh_failure_modal.rs
+++ b/app/src/server/iap_refresh_failure_modal.rs
@@ -1,0 +1,96 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use instant::Instant;
+use warp_server_client::iap::{IapManager, IapManagerEvent};
+use warpui::{AppContext, SingletonEntity, ViewHandle, WindowId};
+
+use crate::workspace::{Workspace, WorkspaceRegistry, WorkspaceRegistryEvent};
+
+const COOLDOWN: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Default)]
+struct State {
+    cooldown_started_at: Option<Instant>,
+    pending_message: Option<String>,
+}
+
+pub fn init(ctx: &mut AppContext) {
+    let state = Arc::new(Mutex::new(State::default()));
+    let state_for_failure = state.clone();
+    ctx.subscribe_to_model(&IapManager::handle(ctx), move |_, event, ctx| {
+        let IapManagerEvent::RefreshFailed {
+            message,
+            is_first_failure_of_streak: true,
+        } = event
+        else {
+            return;
+        };
+
+        if state_for_failure
+            .lock()
+            .expect("IAP modal state lock poisoned")
+            .cooldown_started_at
+            .is_some_and(|started_at| started_at.elapsed() < COOLDOWN)
+        {
+            return;
+        }
+
+        if !show_dialog(message.clone(), state_for_failure.clone(), None, ctx) {
+            state_for_failure
+                .lock()
+                .expect("IAP modal state lock poisoned")
+                .pending_message = Some(message.clone());
+        }
+    });
+
+    ctx.subscribe_to_model(&WorkspaceRegistry::handle(ctx), move |_, event, ctx| {
+        let WorkspaceRegistryEvent::Registered(window_id) = event;
+        let message = state
+            .lock()
+            .expect("IAP modal state lock poisoned")
+            .pending_message
+            .take();
+        if let Some(message) = message
+            && !show_dialog(message.clone(), state.clone(), Some(*window_id), ctx)
+        {
+            state
+                .lock()
+                .expect("IAP modal state lock poisoned")
+                .pending_message = Some(message);
+        }
+    });
+}
+
+fn show_dialog(
+    message: String,
+    state: Arc<Mutex<State>>,
+    window_id: Option<WindowId>,
+    ctx: &mut AppContext,
+) -> bool {
+    let Some(workspace) = find_workspace(window_id, ctx) else {
+        return false;
+    };
+
+    workspace.update(ctx, |workspace, ctx| {
+        workspace.show_iap_refresh_failure_modal(
+            message,
+            move || {
+                if let Ok(mut state) = state.lock() {
+                    state.cooldown_started_at = Some(Instant::now());
+                }
+            },
+            ctx,
+        );
+    });
+    true
+}
+
+fn find_workspace(window_id: Option<WindowId>, ctx: &AppContext) -> Option<ViewHandle<Workspace>> {
+    let window_id = window_id.or_else(|| {
+        ctx.windows()
+            .active_window()
+            .or_else(|| ctx.windows().ordered_window_ids().first().copied())
+    })?;
+    WorkspaceRegistry::as_ref(ctx).get(window_id, ctx)
+}

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -2,6 +2,7 @@ pub mod block;
 pub mod cloud_objects;
 pub mod experiments;
 pub mod graphql;
+pub(crate) mod iap_refresh_failure_modal;
 // Runner-only: the minter is constructed solely in the native, ambient-agent-run
 // code path (see lib.rs), so it doesn't compile or ship on wasm.
 #[cfg(not(target_family = "wasm"))]

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -60,7 +60,7 @@ pub fn panel_header_corner_radius() -> warpui::elements::CornerRadius {
 }
 
 pub use one_time_modal_model::OneTimeModalModel;
-pub use registry::WorkspaceRegistry;
+pub use registry::{WorkspaceRegistry, WorkspaceRegistryEvent};
 pub use toast_stack::ToastStack;
 
 use crate::workspace::view::{
@@ -96,6 +96,7 @@ pub fn init(app: &mut AppContext) {
     view::cloud_agent_capacity_modal::init(app);
     view::codex_modal::init(app);
     view::free_ai_removal_modal::init(app);
+    view::iap_refresh_failure_modal::init(app);
     view::global_search::view::GlobalSearchView::init(app);
     view::right_panel::RightPanelView::init(app);
     header_toolbar_editor::init(app);

--- a/app/src/workspace/native_modal.rs
+++ b/app/src/workspace/native_modal.rs
@@ -83,6 +83,9 @@ impl NativeModal {
         for _ in 0..alert_dialog.button_data.len() {
             self.modal_button_mouse_states.push(Default::default());
         }
+        if alert_dialog.disable_initially_checked {
+            self.dont_show_again = true;
+        }
         self.alert_dialog = Some(alert_dialog);
     }
 
@@ -134,10 +137,14 @@ impl View for NativeModal {
             ..Default::default()
         };
 
+        let disable_label = alert_dialog
+            .disable_label
+            .as_deref()
+            .unwrap_or("Don't show again.");
         let dont_show_again_checkbox = appearance
             .ui_builder()
             .checkbox(self.dont_show_again_mouse_state.clone(), Some(14.))
-            .with_label(Span::new("Don't show again.", Default::default()))
+            .with_label(Span::new(disable_label.to_string(), Default::default()))
             .check(self.dont_show_again)
             .build()
             .with_cursor(Cursor::PointingHand)

--- a/app/src/workspace/registry.rs
+++ b/app/src/workspace/registry.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use warpui::{AppContext, Entity, SingletonEntity, WeakViewHandle, WindowId};
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity, WeakViewHandle, WindowId};
 
 use super::Workspace;
 
@@ -10,6 +10,10 @@ use super::Workspace;
 /// that `views_of_type::<Workspace>` performs.
 pub struct WorkspaceRegistry {
     workspaces: HashMap<WindowId, WeakViewHandle<Workspace>>,
+}
+
+pub enum WorkspaceRegistryEvent {
+    Registered(WindowId),
 }
 
 impl Default for WorkspaceRegistry {
@@ -26,8 +30,14 @@ impl WorkspaceRegistry {
     }
 
     /// Registers a workspace for the given window.
-    pub fn register(&mut self, window_id: WindowId, workspace: WeakViewHandle<Workspace>) {
+    pub fn register(
+        &mut self,
+        window_id: WindowId,
+        workspace: WeakViewHandle<Workspace>,
+        ctx: &mut ModelContext<Self>,
+    ) {
         self.workspaces.insert(window_id, workspace);
+        ctx.emit(WorkspaceRegistryEvent::Registered(window_id));
     }
 
     /// Unregisters the workspace for the given window.
@@ -60,7 +70,7 @@ impl WorkspaceRegistry {
 }
 
 impl Entity for WorkspaceRegistry {
-    type Event = ();
+    type Event = WorkspaceRegistryEvent;
 }
 
 impl SingletonEntity for WorkspaceRegistry {}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8,6 +8,7 @@ mod crash_recovery;
 pub(crate) mod feature_intro_modal;
 pub(crate) mod free_ai_removal_modal;
 pub mod global_search;
+pub(crate) mod iap_refresh_failure_modal;
 pub(crate) mod launch_modal;
 pub(crate) mod left_panel;
 pub(crate) mod onboarding;
@@ -519,6 +520,9 @@ use crate::workspace::view::free_ai_removal_modal::{
     FreeAiRemovalModalVariant,
 };
 use crate::workspace::view::global_search::view::GlobalSearchEntryFocus;
+use crate::workspace::view::iap_refresh_failure_modal::{
+    IapRefreshFailureModal, IapRefreshFailureModalEvent,
+};
 use crate::workspace::view::launch_modal::{LaunchModal, LaunchModalEvent, OzLaunchSlide};
 use crate::workspace::view::left_panel::{
     LeftPanelAction, LeftPanelEvent, LeftPanelView, ToolPanelView,
@@ -1116,6 +1120,7 @@ pub struct Workspace {
     codex_modal: ViewHandle<CodexModal>,
     cloud_agent_capacity_modal: ViewHandle<CloudAgentCapacityModal>,
     free_ai_removal_modal: ViewHandle<FreeAiRemovalModal>,
+    iap_refresh_failure_modal: ViewHandle<IapRefreshFailureModal>,
     /// Second instance of the free-AI-removal modal, opened on demand when a
     /// Free user activates Prompt Suggestions while out of credits.
     prompt_suggestions_unavailable_modal: ViewHandle<FreeAiRemovalModal>,
@@ -2969,6 +2974,10 @@ impl Workspace {
         ctx.subscribe_to_view(&free_ai_removal_modal, |me, _, event, ctx| {
             me.handle_free_ai_removal_modal_event(event, ctx);
         });
+        let iap_refresh_failure_modal = ctx.add_typed_action_view(IapRefreshFailureModal::new);
+        ctx.subscribe_to_view(&iap_refresh_failure_modal, |me, _, event, ctx| {
+            me.handle_iap_refresh_failure_modal_event(event, ctx);
+        });
 
         let prompt_suggestions_unavailable_modal = ctx.add_typed_action_view(|ctx| {
             FreeAiRemovalModal::new(FreeAiRemovalModalVariant::PromptSuggestions, ctx)
@@ -3496,6 +3505,7 @@ impl Workspace {
             codex_modal,
             cloud_agent_capacity_modal,
             free_ai_removal_modal,
+            iap_refresh_failure_modal,
             prompt_suggestions_unavailable_modal,
             lightbox_view: None,
             hoa_onboarding_flow: None,
@@ -3529,8 +3539,8 @@ impl Workspace {
         ws.sync_settings_error_state_into_settings_pane(ctx);
 
         let weak_handle = ctx.handle();
-        WorkspaceRegistry::handle(ctx).update(ctx, |registry, _| {
-            registry.register(window_id, weak_handle);
+        WorkspaceRegistry::handle(ctx).update(ctx, |registry, ctx| {
+            registry.register(window_id, weak_handle, ctx);
         });
 
         ws
@@ -12252,8 +12262,8 @@ impl Workspace {
         // `Workspace::new`, so register it again.
         let window_id = ctx.window_id();
         let weak_handle = ctx.handle();
-        WorkspaceRegistry::handle(ctx).update(ctx, |registry, _| {
-            registry.register(window_id, weak_handle);
+        WorkspaceRegistry::handle(ctx).update(ctx, |registry, ctx| {
+            registry.register(window_id, weak_handle, ctx);
         });
     }
 
@@ -19093,6 +19103,36 @@ impl Workspace {
         }
     }
 
+    fn handle_iap_refresh_failure_modal_event(
+        &mut self,
+        event: &IapRefreshFailureModalEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            IapRefreshFailureModalEvent::Dismiss => {
+                self.focus_active_tab(ctx);
+            }
+            IapRefreshFailureModalEvent::LogIn => {
+                self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
+                    pane_group.add_terminal_pane(Direction::Right, None, ctx);
+                });
+                self.set_active_terminal_input_contents_and_focus_app("gcloud auth login", ctx);
+            }
+        }
+        ctx.notify();
+    }
+
+    pub fn show_iap_refresh_failure_modal(
+        &mut self,
+        message: String,
+        on_snooze: impl Fn() + 'static,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.iap_refresh_failure_modal
+            .update(ctx, |modal, ctx| modal.show(message, on_snooze, ctx));
+        ctx.focus(&self.iap_refresh_failure_modal);
+        ctx.notify();
+    }
     fn handle_prompt_suggestions_unavailable_modal_event(
         &mut self,
         event: &FreeAiRemovalModalEvent,
@@ -27183,6 +27223,9 @@ impl View for Workspace {
 
         if should_show_modal && one_time_modal_model.is_free_ai_removal_modal_open() {
             stack.add_child(ChildView::new(&self.free_ai_removal_modal).finish());
+        }
+        if self.iap_refresh_failure_modal.as_ref(app).is_open() {
+            stack.add_child(ChildView::new(&self.iap_refresh_failure_modal).finish());
         }
 
         if self

--- a/app/src/workspace/view/iap_refresh_failure_modal.rs
+++ b/app/src/workspace/view/iap_refresh_failure_modal.rs
@@ -1,0 +1,268 @@
+use pathfinder_color::ColorU;
+use warp_core::ui::theme::Fill;
+use warpui::clipboard::ClipboardContent;
+use warpui::elements::{
+    Align, Border, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox,
+    Container, CornerRadius, CrossAxisAlignment, DropShadow, Flex, MainAxisAlignment, MainAxisSize,
+    MouseStateHandle, ParentElement, Radius, ScrollbarWidth, Text,
+};
+use warpui::fonts::{Properties, Weight};
+use warpui::keymap::FixedBinding;
+use warpui::platform::Cursor;
+use warpui::ui_components::components::UiComponent;
+use warpui::ui_components::text::Span;
+use warpui::{
+    AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
+};
+
+use crate::appearance::Appearance;
+use crate::view_components::action_button::{ActionButton, PrimaryTheme, SecondaryTheme};
+
+const MODAL_WIDTH: f32 = 400.;
+const ERROR_MAX_HEIGHT: f32 = 240.;
+
+pub fn init(app: &mut AppContext) {
+    use warpui::keymap::macros::*;
+
+    app.register_fixed_bindings([
+        FixedBinding::new(
+            "escape",
+            IapRefreshFailureModalAction::Dismiss,
+            id!(IapRefreshFailureModal::ui_name()),
+        ),
+        FixedBinding::new(
+            "enter",
+            IapRefreshFailureModalAction::LogIn,
+            id!(IapRefreshFailureModal::ui_name()),
+        ),
+    ]);
+}
+
+#[derive(Clone, Debug)]
+pub enum IapRefreshFailureModalAction {
+    CopyError,
+    Dismiss,
+    LogIn,
+    ToggleSnooze,
+}
+
+#[derive(Clone, Debug)]
+pub enum IapRefreshFailureModalEvent {
+    Dismiss,
+    LogIn,
+}
+
+pub struct IapRefreshFailureModal {
+    message: Option<String>,
+    snooze: bool,
+    on_snooze: Option<Box<dyn Fn()>>,
+    scroll_state: ClippedScrollStateHandle,
+    checkbox_mouse_state: MouseStateHandle,
+    copy_button: ViewHandle<ActionButton>,
+    dismiss_button: ViewHandle<ActionButton>,
+    login_button: ViewHandle<ActionButton>,
+}
+
+impl IapRefreshFailureModal {
+    pub fn new(ctx: &mut ViewContext<Self>) -> Self {
+        let copy_button = ctx.add_view(|_| {
+            ActionButton::new("Copy Error", SecondaryTheme)
+                .on_click(|ctx| ctx.dispatch_typed_action(IapRefreshFailureModalAction::CopyError))
+        });
+        let dismiss_button = ctx.add_view(|_| {
+            ActionButton::new("Dismiss", SecondaryTheme)
+                .on_click(|ctx| ctx.dispatch_typed_action(IapRefreshFailureModalAction::Dismiss))
+        });
+        let login_button = ctx.add_view(|_| {
+            ActionButton::new("Log in", PrimaryTheme)
+                .on_click(|ctx| ctx.dispatch_typed_action(IapRefreshFailureModalAction::LogIn))
+        });
+
+        Self {
+            message: None,
+            snooze: true,
+            on_snooze: None,
+            scroll_state: Default::default(),
+            checkbox_mouse_state: Default::default(),
+            copy_button,
+            dismiss_button,
+            login_button,
+        }
+    }
+
+    pub fn show(
+        &mut self,
+        message: String,
+        on_snooze: impl Fn() + 'static,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.message = Some(message);
+        self.snooze = true;
+        self.on_snooze = Some(Box::new(on_snooze));
+        self.scroll_state = Default::default();
+        ctx.focus_self();
+        ctx.notify();
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.message.is_some()
+    }
+
+    fn close(&mut self, event: IapRefreshFailureModalEvent, ctx: &mut ViewContext<Self>) {
+        self.message = None;
+        if self.snooze {
+            if let Some(on_snooze) = self.on_snooze.take() {
+                on_snooze();
+            }
+        } else {
+            self.on_snooze = None;
+        }
+        ctx.emit(event);
+        ctx.notify();
+    }
+
+    fn render_error(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let error = Text::new(
+            self.message.clone().unwrap_or_default(),
+            appearance.monospace_font_family(),
+            12.,
+        )
+        .with_style(Properties::default().weight(Weight::Normal))
+        .with_color(theme.main_text_color(theme.surface_2()).into_solid())
+        .finish();
+        let scrollable = ClippedScrollable::vertical(
+            self.scroll_state.clone(),
+            Container::new(error)
+                .with_uniform_padding(12.)
+                .with_margin_right(8.)
+                .finish(),
+            ScrollbarWidth::Custom(4.),
+            theme.nonactive_ui_text_color().into(),
+            theme.active_ui_text_color().into(),
+            warpui::elements::Fill::None,
+        )
+        .with_overlayed_scrollbar()
+        .with_padding_start(0.)
+        .with_padding_end(0.)
+        .finish();
+
+        ConstrainedBox::new(
+            Container::new(scrollable)
+                .with_background(theme.surface_2())
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+                .finish(),
+        )
+        .with_height(ERROR_MAX_HEIGHT)
+        .finish()
+    }
+
+    fn render_checkbox(&self, appearance: &Appearance) -> Box<dyn Element> {
+        appearance
+            .ui_builder()
+            .checkbox(self.checkbox_mouse_state.clone(), Some(14.))
+            .with_label(Span::new(
+                "Don't show again for 5 mins.".to_string(),
+                Default::default(),
+            ))
+            .check(self.snooze)
+            .build()
+            .with_cursor(Cursor::PointingHand)
+            .on_click(|ctx, _, _| {
+                ctx.dispatch_typed_action(IapRefreshFailureModalAction::ToggleSnooze)
+            })
+            .finish()
+    }
+
+    fn render_buttons(&self) -> Box<dyn Element> {
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::End)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(8.)
+            .with_child(ChildView::new(&self.copy_button).finish())
+            .with_child(ChildView::new(&self.dismiss_button).finish())
+            .with_child(ChildView::new(&self.login_button).finish())
+            .finish()
+    }
+}
+
+impl Entity for IapRefreshFailureModal {
+    type Event = IapRefreshFailureModalEvent;
+}
+
+impl View for IapRefreshFailureModal {
+    fn ui_name() -> &'static str {
+        "IapRefreshFailureModal"
+    }
+
+    fn on_focus(&mut self, _focus_ctx: &warpui::FocusContext, ctx: &mut ViewContext<Self>) {
+        ctx.focus_self();
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let background = theme.surface_3();
+        let title = Text::new(
+            "IAP credential refresh failed",
+            appearance.ui_font_family(),
+            18.,
+        )
+        .with_style(Properties::default().weight(Weight::Bold))
+        .with_color(theme.main_text_color(background).into_solid())
+        .finish();
+        let content = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(16.)
+            .with_child(title)
+            .with_child(self.render_error(appearance))
+            .with_child(self.render_checkbox(appearance))
+            .with_child(self.render_buttons())
+            .finish();
+        let card = ConstrainedBox::new(
+            Container::new(content)
+                .with_background(background)
+                .with_border(Border::all(1.).with_border_fill(theme.outline()))
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+                .with_drop_shadow(DropShadow::default())
+                .with_uniform_padding(24.)
+                .finish(),
+        )
+        .with_width(MODAL_WIDTH)
+        .finish();
+
+        Container::new(Align::new(card).finish())
+            .with_background(Fill::Solid(ColorU::new(97, 97, 97, 255)).with_opacity(50))
+            .finish()
+    }
+}
+
+impl TypedActionView for IapRefreshFailureModal {
+    type Action = IapRefreshFailureModalAction;
+
+    fn handle_action(
+        &mut self,
+        action: &IapRefreshFailureModalAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match action {
+            IapRefreshFailureModalAction::CopyError => {
+                if let Some(message) = &self.message {
+                    ctx.clipboard()
+                        .write(ClipboardContent::plain_text(message.clone()));
+                }
+            }
+            IapRefreshFailureModalAction::Dismiss => {
+                self.close(IapRefreshFailureModalEvent::Dismiss, ctx);
+            }
+            IapRefreshFailureModalAction::LogIn => {
+                self.close(IapRefreshFailureModalEvent::LogIn, ctx);
+            }
+            IapRefreshFailureModalAction::ToggleSnooze => {
+                self.snooze = !self.snooze;
+                ctx.notify();
+            }
+        }
+    }
+}

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -671,11 +671,6 @@ fn fetch_iap_token(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
-        // Disable interactive prompts (e.g. browser-based auth flows triggered when
-        // credentials expire) so gcloud fails immediately instead of blocking until
-        // GCLOUD_TIMEOUT. Some users have shorter OAuth refresh-token lifetimes that
-        // cause more frequent credential expiry, making this guard especially important.
-        .env("CLOUDSDK_CORE_DISABLE_PROMPTS", "1")
         .args(args);
     // allows warp to resolve `gcloud` cli path
     if let Some(path_env) = path_env {

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -671,6 +671,11 @@ fn fetch_iap_token(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        // Disable interactive prompts (e.g. browser-based auth flows triggered when
+        // credentials expire) so gcloud fails immediately instead of blocking until
+        // GCLOUD_TIMEOUT. Some users have shorter OAuth refresh-token lifetimes that
+        // cause more frequent credential expiry, making this guard especially important.
+        .env("CLOUDSDK_CORE_DISABLE_PROMPTS", "1")
         .args(args);
     // allows warp to resolve `gcloud` cli path
     if let Some(path_env) = path_env {

--- a/crates/warpui_core/src/modals.rs
+++ b/crates/warpui_core/src/modals.rs
@@ -39,6 +39,12 @@ pub struct AlertDialogWithCallbacks<F> {
     /// Callback to run if the user clicks the "don't ask again" checkbox. This should prevent that
     /// type of modal in the future.
     pub on_disable: F,
+    /// Custom label for the "don't show again" checkbox shown in the Warp-native modal.
+    /// When `None`, the modal uses its default label.
+    pub disable_label: Option<String>,
+    /// When `true`, the "don't show again" checkbox starts checked when the modal opens.
+    /// When `false`, the modal uses its own persisted default.
+    pub disable_initially_checked: bool,
 }
 
 /// Wraps the button text with its click handler.
@@ -88,6 +94,8 @@ impl AlertDialogWithCallbacks<AppModalCallback> {
             info_text: info_text.into(),
             button_data,
             on_disable: Box::new(on_disable),
+            disable_label: None,
+            disable_initially_checked: false,
         }
     }
 }
@@ -124,6 +132,8 @@ impl<V: View> AlertDialogWithCallbacks<ViewModalCallback<V>> {
             info_text: info_text.into(),
             button_data,
             on_disable: Box::new(on_disable),
+            disable_label: None,
+            disable_initially_checked: false,
         }
     }
 }


### PR DESCRIPTION

<img width="1303" height="818" alt="image" src="https://github.com/user-attachments/assets/a60d05c0-7872-410b-b154-e93c0de02c5c" />



## Description

Improves the IAP credential refresh failure modal with four changes requested in the Slack thread:

**a) Modal instead of toast** (already done in earlier commit) — native Warp modal replaces the ephemeral toast.

**b) Selectable error message** — The Warp-native modal renders `info_text` as static (non-selectable) text. Added a **"Copy Error"** button that writes the full error string to the clipboard as a workaround.

**c) "Open New Pane" button** — Opens a new split pane to the right and pre-fills the input buffer with `gcloud auth login`. The user just hits Enter to re-authenticate.

**d) Fix `gcloud auth print-identity-token` interactive blocking** — Added `CLOUDSDK_CORE_DISABLE_PROMPTS=1` to the gcloud invocation in `crates/warp_server_client/src/iap.rs`. This makes gcloud fail immediately instead of hanging on a browser OAuth flow when credentials expire (up to the 30 s `GCLOUD_TIMEOUT`). Especially important for users with shorter OAuth refresh-token lifetimes who see more frequent credential expiry.

**e) Cross-platform consistency** — Removed the macOS-native `NSAlert` path. All OSes now use the same Warp-native modal for a consistent UX.

**f) 5-minute cooldown / anti-spam** — Added a `"Don't show again for 5 mins."` checkbox to the modal, **checked by default**. When any button is clicked with the box checked, the modal is suppressed for 5 minutes. Implemented via `Arc<Mutex<Option<Instant>>>` captured in the event subscription.

**Infrastructure change** — Extended `AlertDialogWithCallbacks` with two optional fields (`disable_label`, `disable_initially_checked`) so callers can customise the NativeModal's "don't show again" checkbox label and initial checked state. All existing call sites use the defaults (`None` / `false`) and are unaffected.

## Linked Issue

N/A — internal staging/dogfood usability improvement.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

The modal triggers when `IapManager` emits a `RefreshFailed` event with `is_first_failure_of_streak = true`. Reproduce by revoking credentials (`gcloud auth revoke --all`) on a staging build.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_This PR was generated with [Oz](https://warp.dev/oz)._
