### PR TITLE
add TUI file-edit permission requests

### DIFF
--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -489,11 +489,22 @@ impl TuiAIBlock {
                 continue;
             }
             let view_action_id = action_id.clone();
+            let conversation_id = self.conversation_id;
             let view = ctx.add_typed_action_tui_view(move |ctx| {
-                TuiFileEditsView::new(view_action_id, action_model, ctx)
+                TuiFileEditsView::new(view_action_id, conversation_id, action_model, ctx)
             });
             ctx.subscribe_to_view(&view, |me, _, event, ctx| match event {
+                TuiFileEditsViewEvent::BlockingStateChanged => {
+                    ctx.emit(TuiAIBlockEvent::BlockingStateChanged);
+                    me.invalidate_layout(ctx);
+                }
                 TuiFileEditsViewEvent::LayoutChanged => me.invalidate_layout(ctx),
+                TuiFileEditsViewEvent::ReplacementGuidanceSubmitted(text) => {
+                    ctx.emit(TuiAIBlockEvent::ReplacementGuidanceSubmitted {
+                        conversation_id: me.conversation_id,
+                        text: text.clone(),
+                    });
+                }
             });
             self.action_views
                 .insert(action_id, TuiToolCallView::FileEdits(view));
@@ -649,9 +660,12 @@ impl TuiAIBlock {
                 .as_ref(ctx)
                 .active_permission_prompt(ctx)
                 .map(TuiBlockingChild::Permission),
+            TuiToolCallView::FileEdits(view) => view
+                .as_ref(ctx)
+                .active_permission_prompt(ctx)
+                .map(TuiBlockingChild::Permission),
             // These tool views render inline and never replace the input.
             TuiToolCallView::AskQuestion(_)
-            | TuiToolCallView::FileEdits(_)
             | TuiToolCallView::Plan(_)
             | TuiToolCallView::ShellCommand(_) => None,
         }

--- a/crates/warp_tui/src/tui_file_edits_view.rs
+++ b/crates/warp_tui/src/tui_file_edits_view.rs
@@ -26,7 +26,8 @@ use ai::diff_validation::{DiffDelta, DiffType};
 use itertools::Itertools;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::tui_export::{
-    AIAgentActionId, BlocklistAIActionEvent, BlocklistAIActionModel, DiffSessionType, FileDiff,
+    AIActionStatus, AIAgentActionId, AIConversationId, BlocklistAIActionEvent,
+    BlocklistAIActionModel, CancellationReason, DiffSessionType, FileDiff,
 };
 use warp_editor::content::buffer::InitialBufferState;
 use warpui_core::elements::MouseStateHandle;
@@ -34,12 +35,17 @@ use warpui_core::elements::tui::{
     Modifier, TuiContainer, TuiElement, TuiFlex, TuiParentElement, TuiStyle, TuiText,
     tui_collapsible,
 };
-use warpui_core::{AppContext, Entity, ModelHandle, TuiView, TypedActionView, ViewContext};
+use warpui_core::{
+    AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
+};
 
 use crate::editor_element::{TuiEditorElement, TuiEditorStyles};
 use crate::tool_call_labels::{ToolCallDisplayState, tool_call_display_state};
 use crate::tui_builder::TuiUiBuilder;
 use crate::tui_diff_storage::{TuiDiffStorage, TuiDiffStorageEvent, TuiDiffStorageHandle};
+use crate::tui_permission_prompt::{
+    TuiPermissionPrompt, TuiPermissionPromptEvent, render_permission_card,
+};
 
 /// Unchanged context lines rendered on each side of a hunk.
 const CONTEXT_LINES: usize = 3;
@@ -54,6 +60,8 @@ pub(super) struct TuiFileEditsView {
     /// Consulted for the action's status (header state) and terminal result
     /// (fallback label when the storage was never seeded).
     action_model: ModelHandle<BlocklistAIActionModel>,
+    conversation_id: AIConversationId,
+    permission_prompt: ViewHandle<TuiPermissionPrompt>,
     /// One section per resolved file diff, in storage order; empty until the
     /// executor seeds the storage.
     sections: Vec<FileSection>,
@@ -63,7 +71,9 @@ pub(super) struct TuiFileEditsView {
 }
 /// Events emitted to the owning agent block.
 pub(super) enum TuiFileEditsViewEvent {
+    BlockingStateChanged,
     LayoutChanged,
+    ReplacementGuidanceSubmitted(String),
 }
 
 /// User interactions handled by the file-edits view.
@@ -120,22 +130,29 @@ struct SectionStates {
 }
 
 /// UI state for a single collapsible section.
-#[derive(Default)]
 struct SectionUiState {
     collapsed: bool,
     /// Hover state for the header row. Owned here so it survives element-tree
     /// rebuilds (the GUI `MouseStateHandle` pattern).
     hover_state: MouseStateHandle,
 }
+impl Default for SectionUiState {
+    fn default() -> Self {
+        Self {
+            collapsed: true,
+            hover_state: MouseStateHandle::default(),
+        }
+    }
+}
 
 impl SectionStates {
-    /// Whether the keyed section is collapsed (default: expanded).
+    /// Whether the keyed section is collapsed (default: collapsed).
     fn is_collapsed(&self, key: SectionKey) -> bool {
         self.states
             .borrow()
             .get(&key)
             .map(|state| state.collapsed)
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     /// Flips the collapse state of the keyed section.
@@ -159,6 +176,7 @@ impl SectionStates {
 impl TuiFileEditsView {
     pub(super) fn new(
         action_id: AIAgentActionId,
+        conversation_id: AIConversationId,
         action_model: &ModelHandle<BlocklistAIActionModel>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
@@ -194,10 +212,33 @@ impl TuiFileEditsView {
             });
         }
 
+        let prompt_action_id = action_id.clone();
+        let prompt_action_model = action_model.clone();
+        let permission_prompt = ctx.add_typed_action_tui_view(move |ctx| {
+            TuiPermissionPrompt::new(prompt_action_model, prompt_action_id, false, ctx)
+        });
+        ctx.subscribe_to_view(&permission_prompt, |view, _, event, ctx| match event {
+            TuiPermissionPromptEvent::AcceptRequested => view.accept(ctx),
+            TuiPermissionPromptEvent::ReplacementGuidanceSubmitted(text) => {
+                ctx.emit(TuiFileEditsViewEvent::ReplacementGuidanceSubmitted(
+                    text.clone(),
+                ));
+            }
+            TuiPermissionPromptEvent::RejectRequested => view.reject(ctx),
+            TuiPermissionPromptEvent::BlockingStateChanged => {
+                ctx.emit(TuiFileEditsViewEvent::BlockingStateChanged);
+                view.invalidate_layout(ctx);
+            }
+            TuiPermissionPromptEvent::LayoutChanged => view.invalidate_layout(ctx),
+            TuiPermissionPromptEvent::EditBodyRequested => {}
+        });
+
         Self {
             storage,
             action_id,
             action_model: action_model.clone(),
+            conversation_id,
+            permission_prompt,
             sections: Vec::new(),
             section_states: SectionStates::default(),
         }
@@ -492,13 +533,70 @@ fn verb_and_name(diff: &FileDiff) -> (&'static str, String) {
 impl Entity for TuiFileEditsView {
     type Event = TuiFileEditsViewEvent;
 }
+impl TuiFileEditsView {
+    pub(super) fn active_permission_prompt(
+        &self,
+        app: &AppContext,
+    ) -> Option<ViewHandle<TuiPermissionPrompt>> {
+        self.permission_prompt
+            .as_ref(app)
+            .is_active(app)
+            .then(|| self.permission_prompt.clone())
+    }
 
+    fn accept(&self, ctx: &mut ViewContext<Self>) {
+        let action_id = self.action_id.clone();
+        self.action_model.update(ctx, |action_model, ctx| {
+            action_model.execute_action(&action_id, self.conversation_id, ctx);
+        });
+    }
+
+    fn reject(&self, ctx: &mut ViewContext<Self>) {
+        let action_id = self.action_id.clone();
+        self.action_model.update(ctx, |action_model, ctx| {
+            action_model.cancel_action_with_id(
+                self.conversation_id,
+                &action_id,
+                CancellationReason::ManuallyCancelled,
+                ctx,
+            );
+        });
+    }
+
+    fn invalidate_layout(&self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(TuiFileEditsViewEvent::LayoutChanged);
+        ctx.notify();
+    }
+}
 impl TuiView for TuiFileEditsView {
     fn ui_name() -> &'static str {
         "TuiFileEditsView"
     }
+    fn child_view_ids(&self, _app: &AppContext) -> Vec<EntityId> {
+        vec![self.permission_prompt.id()]
+    }
 
     fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let content = self.render_diff_content(app);
+        let status = self
+            .action_model
+            .as_ref(app)
+            .get_action_status(&self.action_id);
+        if !matches!(status, Some(AIActionStatus::Blocked)) {
+            return content;
+        }
+
+        render_permission_card(
+            &self.permission_prompt,
+            "Is it OK if I make these file edits?",
+            content,
+            app,
+        )
+    }
+}
+
+impl TuiFileEditsView {
+    fn render_diff_content(&self, app: &AppContext) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(app);
 
         if self.sections.is_empty() {

--- a/crates/warp_tui/src/tui_file_edits_view.rs
+++ b/crates/warp_tui/src/tui_file_edits_view.rs
@@ -14,9 +14,10 @@
 //! element. It never walks diff hunks, computes hidden ranges, or builds
 //! rows. Multi-file edits nest the per-file sections, indented, under one
 //! collapsible summary header (`✓ Edited 3 files +a −r ▾`); single-file edits
-//! render the file section alone. When the storage was never seeded (failed
-//! or cancelled actions, or actions that resolved before this view existed),
-//! the view falls back to a one-line label from the action's recorded result.
+//! render the file section alone. Blocked edits use the in-progress `Editing`
+//! verb while awaiting approval. When the storage was never seeded (failed or
+//! cancelled actions, or actions that resolved before this view existed), the
+//! view falls back to a one-line label from the action's recorded result.
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Path;
@@ -433,15 +434,17 @@ impl TuiFileEditsView {
         builder: &TuiUiBuilder,
         app: &AppContext,
     ) -> Box<dyn TuiElement> {
+        let state = self.display_state(app);
         let last_index = self.sections.len() - 1;
         let mut column = TuiFlex::column();
         for (index, section) in self.sections.iter().enumerate() {
             let line_stats = section.line_stats(app);
             // Zero-change (and not-yet-computed) diffs have no body to toggle.
             let has_body = line_stats.is_some_and(|stats| stats != (0, 0));
+            let label = file_edit_header_label(state, section.verb, &section.name);
             let file_section = self.render_section(
                 SectionKey::File(index),
-                &format!("{} {}", section.verb, section.name),
+                &label,
                 line_stats,
                 builder,
                 app,
@@ -501,6 +504,19 @@ fn deltas_for(diff_type: &DiffType) -> Vec<DiffDelta> {
         DiffType::Create { delta } | DiffType::Delete { delta } => vec![delta.clone()],
         DiffType::Update { deltas, .. } => deltas.clone(),
     }
+}
+
+fn file_edit_header_label(
+    state: ToolCallDisplayState,
+    completed_verb: &str,
+    subject: &str,
+) -> String {
+    let verb = if state == ToolCallDisplayState::Blocked {
+        "Editing"
+    } else {
+        completed_verb
+    };
+    format!("{verb} {subject}")
 }
 
 /// The header verb and display name for a diff: file names only (no
@@ -615,7 +631,11 @@ impl TuiFileEditsView {
 
         self.render_section(
             SectionKey::Summary,
-            &format!("Edited {} files", self.sections.len()),
+            &file_edit_header_label(
+                self.display_state(app),
+                "Edited",
+                &format!("{} files", self.sections.len()),
+            ),
             self.aggregate_stats(app),
             &builder,
             app,

--- a/crates/warp_tui/src/tui_file_edits_view_tests.rs
+++ b/crates/warp_tui/src/tui_file_edits_view_tests.rs
@@ -9,13 +9,27 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::model::CoreEditorModel;
 use warpui::App;
 
-use super::{deltas_for, verb_and_name};
+use super::{SectionKey, SectionStates, deltas_for, verb_and_name};
 
 fn delta(range: std::ops::Range<usize>, insertion: &str) -> DiffDelta {
     DiffDelta {
         replacement_line_range: range,
         insertion: insertion.to_owned(),
     }
+}
+
+#[test]
+fn all_file_edit_sections_start_collapsed_and_toggle_independently() {
+    let states = SectionStates::default();
+
+    assert!(states.is_collapsed(SectionKey::Summary));
+    assert!(states.is_collapsed(SectionKey::File(0)));
+    assert!(states.is_collapsed(SectionKey::File(1)));
+
+    states.toggle_collapsed(SectionKey::File(0));
+    assert!(states.is_collapsed(SectionKey::Summary));
+    assert!(!states.is_collapsed(SectionKey::File(0)));
+    assert!(states.is_collapsed(SectionKey::File(1)));
 }
 
 fn update_diff(path: &str, rename: Option<&str>) -> FileDiff {

--- a/crates/warp_tui/src/tui_file_edits_view_tests.rs
+++ b/crates/warp_tui/src/tui_file_edits_view_tests.rs
@@ -9,7 +9,10 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::model::CoreEditorModel;
 use warpui::App;
 
-use super::{SectionKey, SectionStates, deltas_for, verb_and_name};
+use super::{
+    SectionKey, SectionStates, ToolCallDisplayState, deltas_for, file_edit_header_label,
+    verb_and_name,
+};
 
 fn delta(range: std::ops::Range<usize>, insertion: &str) -> DiffDelta {
     DiffDelta {
@@ -30,6 +33,26 @@ fn all_file_edit_sections_start_collapsed_and_toggle_independently() {
     assert!(states.is_collapsed(SectionKey::Summary));
     assert!(!states.is_collapsed(SectionKey::File(0)));
     assert!(states.is_collapsed(SectionKey::File(1)));
+}
+#[test]
+fn blocked_file_edit_headers_use_in_progress_wording() {
+    assert_eq!(
+        file_edit_header_label(ToolCallDisplayState::Blocked, "Edited", "2 files"),
+        "Editing 2 files"
+    );
+    assert_eq!(
+        file_edit_header_label(ToolCallDisplayState::Blocked, "Updated", "lib.rs"),
+        "Editing lib.rs"
+    );
+
+    assert_eq!(
+        file_edit_header_label(ToolCallDisplayState::Succeeded, "Edited", "2 files"),
+        "Edited 2 files"
+    );
+    assert_eq!(
+        file_edit_header_label(ToolCallDisplayState::Succeeded, "Updated", "lib.rs"),
+        "Updated lib.rs"
+    );
 }
 
 fn update_diff(path: &str, rename: Option<&str>) -> FileDiff {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR implements permissions requests for file edits. The UI is pretty much the same as the PR below this one, but we show the actual file edits in the permissions card. These file edits are collapsed by default (so the card is small and readable instead of very large for large edits), and each edit is expandable.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/82bcaeef4bb54a668a1173599c6c8f6b

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode