### PR TITLE
add editable TUI shell-command permission requests

### DIFF
--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -1415,6 +1415,7 @@ impl TuiAIBlock {
                 TuiToolCallView::ShellCommand(view) => view.as_ref(app).is_expanded(),
                 TuiToolCallView::AskQuestion(_)
                 | TuiToolCallView::FileEdits(_)
+                | TuiToolCallView::Generic(_)
                 | TuiToolCallView::Plan(_)
                 | TuiToolCallView::OrchestrationBlock(_) => false,
             })

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -665,19 +665,36 @@ impl TuiAIBlock {
         for action in shell_command_actions {
             if let Some(TuiToolCallView::ShellCommand(view)) = self.action_views.get(&action.id) {
                 view.update(ctx, |view, ctx| {
-                    view.update_action(action, output_streaming);
-                    ctx.notify();
+                    view.update_action(action, output_streaming, ctx);
                 });
                 continue;
             }
             let action_id = action.id.clone();
             let action_model = action_model.clone();
+            let conversation_id = self.conversation_id;
             let terminal_model = self.terminal_model.clone();
-            let view = ctx.add_typed_action_tui_view(|_| {
-                TuiShellCommandView::new(action, output_streaming, action_model, terminal_model)
+            let view = ctx.add_typed_action_tui_view(|ctx| {
+                TuiShellCommandView::new(
+                    action,
+                    output_streaming,
+                    action_model,
+                    conversation_id,
+                    terminal_model,
+                    ctx,
+                )
             });
             ctx.subscribe_to_view(&view, |me, _, event, ctx| match event {
+                TuiShellCommandViewEvent::BlockingStateChanged => {
+                    ctx.emit(TuiAIBlockEvent::BlockingStateChanged);
+                    me.invalidate_layout(ctx);
+                }
                 TuiShellCommandViewEvent::LayoutChanged => me.invalidate_layout(ctx),
+                TuiShellCommandViewEvent::ReplacementGuidanceSubmitted(text) => {
+                    ctx.emit(TuiAIBlockEvent::ReplacementGuidanceSubmitted {
+                        conversation_id: me.conversation_id,
+                        text: text.clone(),
+                    });
+                }
             });
             self.action_views
                 .insert(action_id, TuiToolCallView::ShellCommand(view));
@@ -796,10 +813,12 @@ impl TuiAIBlock {
                 .as_ref(ctx)
                 .active_permission_prompt(ctx)
                 .map(TuiBlockingChild::Permission),
+            TuiToolCallView::ShellCommand(view) => view
+                .as_ref(ctx)
+                .active_permission_prompt(ctx)
+                .map(TuiBlockingChild::Permission),
             // These tool views render inline and never replace the input.
-            TuiToolCallView::AskQuestion(_)
-            | TuiToolCallView::Plan(_)
-            | TuiToolCallView::ShellCommand(_) => None,
+            TuiToolCallView::AskQuestion(_) | TuiToolCallView::Plan(_) => None,
         }
     }
 

--- a/crates/warp_tui/src/editor_interaction.rs
+++ b/crates/warp_tui/src/editor_interaction.rs
@@ -125,7 +125,7 @@ const SHARED_EDITOR_BINDINGS: &[EditorBindingSpec] = &[
     EditorBindingSpec {
         command: TuiEditorCommand::InsertNewline,
         input_name: Some("tui:input:insert_newline"),
-        editor_name: None,
+        editor_name: Some("tui:editor:insert_newline"),
         description: "Insert a newline",
         keys: &["shift-enter", "ctrl-j", "alt-enter"],
     },

--- a/crates/warp_tui/src/editor_view.rs
+++ b/crates/warp_tui/src/editor_view.rs
@@ -39,7 +39,6 @@ pub(crate) struct TuiEditorView {
     model: ModelHandle<CodeEditorModel>,
     editor_state: TuiEditorState,
     editor_behavior: TuiEditorBehavior,
-    editable: bool,
     focused: bool,
     mouse_state: MouseStateHandle,
 }
@@ -60,7 +59,6 @@ impl TuiEditorView {
             model,
             editor_state: TuiEditorState::default(),
             editor_behavior: TuiEditorBehavior::single_line(),
-            editable: true,
             focused: false,
             mouse_state: MouseStateHandle::default(),
         }
@@ -89,12 +87,6 @@ impl TuiEditorView {
         self.focused
     }
 
-    /// Enables or disables editing and pointer focus for this field.
-    pub(crate) fn set_editable(&mut self, editable: bool, ctx: &mut ViewContext<Self>) {
-        self.editable = editable;
-        ctx.notify();
-    }
-
     /// Replaces editor content without emitting `Changed`.
     pub(crate) fn set_text(&mut self, text: impl Into<String>, ctx: &mut ViewContext<Self>) {
         let text = text.into();
@@ -110,13 +102,9 @@ impl TuiEditorView {
 
     /// Renders the shared editor configured as a one-row field.
     fn render_editor(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
-        let editor = TuiEditorElement::new(&self.model, ctx).with_view_focused(self.focused);
-        let editor = if self.editable {
-            editor.editable()
-        } else {
-            editor
-        };
-        editor
+        TuiEditorElement::new(&self.model, ctx)
+            .with_view_focused(self.focused)
+            .editable()
             .with_viewport_rows(self.editor_behavior.viewport_rows())
             .on_action(|action, event_ctx| {
                 event_ctx.dispatch_typed_action(TuiEditorViewAction::Editor(action));
@@ -164,15 +152,11 @@ impl TuiView for TuiEditorView {
 
     fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
         let editor = self.render_editor(app);
-        if self.editable {
-            TuiHoverable::new(self.mouse_state.clone(), editor)
-                .on_click(|event_ctx, _| {
-                    event_ctx.dispatch_typed_action(TuiEditorViewAction::FocusRequested);
-                })
-                .finish()
-        } else {
-            editor
-        }
+        TuiHoverable::new(self.mouse_state.clone(), editor)
+            .on_click(|event_ctx, _| {
+                event_ctx.dispatch_typed_action(TuiEditorViewAction::FocusRequested);
+            })
+            .finish()
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
@@ -194,9 +178,6 @@ impl TypedActionView for TuiEditorView {
     type Action = TuiEditorViewAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
-        if !self.editable {
-            return;
-        }
         let outcome = match action {
             TuiEditorViewAction::FocusRequested => {
                 ctx.focus_self();

--- a/crates/warp_tui/src/editor_view.rs
+++ b/crates/warp_tui/src/editor_view.rs
@@ -39,6 +39,7 @@ pub(crate) struct TuiEditorView {
     model: ModelHandle<CodeEditorModel>,
     editor_state: TuiEditorState,
     editor_behavior: TuiEditorBehavior,
+    editable: bool,
     focused: bool,
     mouse_state: MouseStateHandle,
 }
@@ -59,9 +60,17 @@ impl TuiEditorView {
             model,
             editor_state: TuiEditorState::default(),
             editor_behavior: TuiEditorBehavior::single_line(),
+            editable: true,
             focused: false,
             mouse_state: MouseStateHandle::default(),
         }
+    }
+
+    /// Creates an empty multiline editor with a bounded viewport.
+    pub(crate) fn multiline(viewport_rows: u32, ctx: &mut ViewContext<Self>) -> Self {
+        let mut view = Self::single_line(ctx);
+        view.editor_behavior = TuiEditorBehavior::multiline(viewport_rows);
+        view
     }
 
     /// Returns the current editor text.
@@ -80,6 +89,12 @@ impl TuiEditorView {
         self.focused
     }
 
+    /// Enables or disables editing and pointer focus for this field.
+    pub(crate) fn set_editable(&mut self, editable: bool, ctx: &mut ViewContext<Self>) {
+        self.editable = editable;
+        ctx.notify();
+    }
+
     /// Replaces editor content without emitting `Changed`.
     pub(crate) fn set_text(&mut self, text: impl Into<String>, ctx: &mut ViewContext<Self>) {
         let text = text.into();
@@ -95,9 +110,13 @@ impl TuiEditorView {
 
     /// Renders the shared editor configured as a one-row field.
     fn render_editor(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
-        TuiEditorElement::new(&self.model, ctx)
-            .editable()
-            .with_view_focused(self.focused)
+        let editor = TuiEditorElement::new(&self.model, ctx).with_view_focused(self.focused);
+        let editor = if self.editable {
+            editor.editable()
+        } else {
+            editor
+        };
+        editor
             .with_viewport_rows(self.editor_behavior.viewport_rows())
             .on_action(|action, event_ctx| {
                 event_ctx.dispatch_typed_action(TuiEditorViewAction::Editor(action));
@@ -144,11 +163,16 @@ impl TuiView for TuiEditorView {
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
-        TuiHoverable::new(self.mouse_state.clone(), self.render_editor(app))
-            .on_click(|event_ctx, _| {
-                event_ctx.dispatch_typed_action(TuiEditorViewAction::FocusRequested);
-            })
-            .finish()
+        let editor = self.render_editor(app);
+        if self.editable {
+            TuiHoverable::new(self.mouse_state.clone(), editor)
+                .on_click(|event_ctx, _| {
+                    event_ctx.dispatch_typed_action(TuiEditorViewAction::FocusRequested);
+                })
+                .finish()
+        } else {
+            editor
+        }
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
@@ -170,6 +194,9 @@ impl TypedActionView for TuiEditorView {
     type Action = TuiEditorViewAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        if !self.editable {
+            return;
+        }
         let outcome = match action {
             TuiEditorViewAction::FocusRequested => {
                 ctx.focus_self();

--- a/crates/warp_tui/src/editor_view_tests.rs
+++ b/crates/warp_tui/src/editor_view_tests.rs
@@ -276,7 +276,14 @@ fn keybinding_initializer_registers_line_start_for_input_and_editor() {
                 "alt-enter".to_string(),
             ])
         );
-        assert!(triggers_for("tui:editor:insert_newline").is_empty());
+        assert_eq!(
+            triggers_for("tui:editor:insert_newline"),
+            HashSet::from([
+                "shift-enter".to_string(),
+                "ctrl-j".to_string(),
+                "alt-enter".to_string(),
+            ])
+        );
         assert!(app.read(|ctx| ctx.get_binding_by_name("tui:editor:move_up").is_none()));
     });
 }

--- a/crates/warp_tui/src/keybindings.rs
+++ b/crates/warp_tui/src/keybindings.rs
@@ -88,6 +88,7 @@ pub(crate) fn init(app: &mut AppContext) {
     crate::orchestration_block::init(app);
     crate::tui_ask_question_view::init(app);
     crate::tui_permission_prompt::init(app);
+    crate::tui_shell_command_view::init(app);
 
     register_binding_validators(app);
 }

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -253,6 +253,10 @@ struct SelectorInteractionState {
 pub(crate) struct TuiOptionSelector {
     page: OptionSelectorPage,
     interaction: SelectorInteractionState,
+    /// Optional host-owned editor rendered above the options.
+    leading_editor: Option<ViewHandle<TuiEditorView>>,
+    /// Validation copy rendered directly below the host-owned editor.
+    leading_editor_error: Option<String>,
     search_field: Option<ViewHandle<TuiEditorView>>,
     custom_text: CustomTextState,
     /// Selected question option ids, independent of the keyboard highlight.
@@ -285,6 +289,8 @@ impl TuiOptionSelector {
         Self {
             page: OptionSelectorPage::default(),
             interaction: SelectorInteractionState::default(),
+            leading_editor: None,
+            leading_editor_error: None,
             search_field: None,
             custom_text: CustomTextState::new(custom_text_editor),
             selected_ids: HashSet::new(),
@@ -314,11 +320,59 @@ impl TuiOptionSelector {
         ctx.emit(TuiOptionSelectorEvent::LayoutInvalidated);
         ctx.notify();
     }
+
+    /// Installs a host-owned editor above the option list.
+    pub(crate) fn set_leading_editor(
+        &mut self,
+        editor: ViewHandle<TuiEditorView>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.leading_editor = Some(editor);
+        self.invalidate_layout(ctx);
+    }
+    /// Updates validation copy shown below the host-owned editor.
+    pub(crate) fn set_leading_editor_error(
+        &mut self,
+        error: Option<String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.leading_editor_error == error {
+            return;
+        }
+        self.leading_editor_error = error;
+        self.invalidate_layout(ctx);
+    }
+
     /// Whether the optional search editor currently owns focus.
     fn search_field_is_focused(&self, ctx: &AppContext) -> bool {
         self.search_field
             .as_ref()
             .is_some_and(|field| field.as_ref(ctx).is_focused())
+    }
+
+    /// Whether the host-owned leading editor currently owns focus.
+    fn leading_editor_is_focused(&self, ctx: &AppContext) -> bool {
+        self.leading_editor
+            .as_ref()
+            .is_some_and(|editor| editor.as_ref(ctx).is_focused())
+    }
+
+    /// The editor that participates in top-of-list focus cycling.
+    fn top_editor(&self) -> Option<&ViewHandle<TuiEditorView>> {
+        self.leading_editor.as_ref().or_else(|| {
+            self.page
+                .searchable
+                .then_some(self.search_field.as_ref())
+                .flatten()
+        })
+    }
+
+    /// Moves focus from the option list to its top editor.
+    pub(crate) fn focus_leading_editor(&self, ctx: &mut ViewContext<Self>) {
+        if let Some(editor) = self.top_editor() {
+            ctx.focus(editor);
+            ctx.notify();
+        }
     }
 
     /// Resets all transient interaction state for the newly installed page.
@@ -367,15 +421,11 @@ impl TuiOptionSelector {
     }
 
     /// The highlighted item index, including a trailing custom-text entry.
+    #[cfg(test)]
     pub(crate) fn highlighted_index(&self) -> Option<usize> {
         (!self.custom_text.is_editing())
             .then(|| self.interaction.selection.selected_index())
             .flatten()
-    }
-
-    /// Whether the custom-text editor currently owns the interaction.
-    pub(crate) fn is_editing_custom_text(&self) -> bool {
-        self.custom_text.is_editing()
     }
 
     /// Moves the option highlight upward.
@@ -386,12 +436,6 @@ impl TuiOptionSelector {
     /// Moves the option highlight downward.
     pub(crate) fn move_down(&mut self, ctx: &mut ViewContext<Self>) {
         self.move_selection(true, ctx);
-    }
-
-    /// Clears the visible option highlight while a host-owned editor is active.
-    pub(crate) fn clear_highlight(&mut self, ctx: &mut ViewContext<Self>) {
-        self.interaction.selection.clear();
-        ctx.notify();
     }
 
     /// Restores the first option as the active highlight.
@@ -673,7 +717,7 @@ impl TuiOptionSelector {
             return;
         }
         let items_len = self.items().len();
-        if self.search_field_is_focused(ctx) {
+        if self.search_field_is_focused(ctx) || self.leading_editor_is_focused(ctx) {
             if items_len > 0 {
                 let target = if forward { 0 } else { items_len - 1 };
                 self.interaction
@@ -685,18 +729,16 @@ impl TuiOptionSelector {
             ctx.notify();
             return;
         }
-        let move_to_search = self.page.searchable
+        let move_to_editor = self.top_editor().is_some()
             && match (forward, self.interaction.selection.selected_index()) {
                 (false, None | Some(0)) => true,
                 (true, Some(index)) => index + 1 >= items_len,
                 (true, None) | (false, Some(_)) => false,
             };
-        if move_to_search {
+        if move_to_editor {
             self.interaction.selection.clear();
             self.interaction.scroll_offset = 0;
-            if let Some(search_field) = self.search_field.as_ref() {
-                ctx.focus(search_field);
-            }
+            self.focus_leading_editor(ctx);
             ctx.notify();
             return;
         }
@@ -1094,7 +1136,17 @@ impl TuiView for TuiOptionSelector {
         if let Some(header) = &self.page.header {
             content.add_child(Self::render_header(header, &builder));
         }
-        if let Some(search_field) = self
+        if let Some(leading_editor) = self.leading_editor.as_ref() {
+            content.add_child(TuiChildView::new(leading_editor).finish());
+            if let Some(error) = self.leading_editor_error.as_ref() {
+                content.add_child(
+                    TuiText::new(error.clone())
+                        .with_style(builder.error_text_style())
+                        .finish(),
+                );
+            }
+            content.add_child(TuiText::new(" ").finish());
+        } else if let Some(search_field) = self
             .page
             .searchable
             .then_some(self.search_field.as_ref())
@@ -1119,6 +1171,7 @@ impl TuiView for TuiOptionSelector {
 
     fn child_view_ids(&self, _app: &AppContext) -> Vec<EntityId> {
         let mut ids = vec![self.custom_text.editor.id()];
+        ids.extend(self.leading_editor.iter().map(ViewHandle::id));
         if self.page.searchable {
             ids.extend(self.search_field.iter().map(ViewHandle::id));
         }
@@ -1131,9 +1184,13 @@ impl TuiView for TuiOptionSelector {
             FocusContext::DescendentFocused(view_id) => {
                 self.focused = false;
                 if self
-                    .search_field
+                    .leading_editor
                     .as_ref()
-                    .is_some_and(|search_field| *view_id == search_field.id())
+                    .is_some_and(|editor| *view_id == editor.id())
+                    || self
+                        .search_field
+                        .as_ref()
+                        .is_some_and(|search_field| *view_id == search_field.id())
                 {
                     self.interaction.selection.clear();
                 }

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -394,6 +394,14 @@ impl TuiOptionSelector {
         ctx.notify();
     }
 
+    /// Restores the first option as the active highlight.
+    pub(crate) fn select_first(&mut self, ctx: &mut ViewContext<Self>) {
+        self.select_id(self.page.snapshot.rows.first().map(|row| row.id.clone()));
+        self.sync_after_items_changed();
+        ctx.focus_self();
+        ctx.notify();
+    }
+
     /// The current inline Other buffer, trimmed for questionnaire transitions.
     pub(crate) fn active_custom_text(&self, ctx: &AppContext) -> Option<String> {
         self.custom_text.is_editing().then(|| {

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -103,6 +103,8 @@ pub(crate) enum TuiOptionSelectorAction {
     ConfirmSelected,
     MoveUp,
     MoveDown,
+    /// Selects an item at an absolute index without confirming it.
+    SelectItemWithoutConfirm(usize),
     /// Select the viewport-relative item and confirm it when enabled.
     SelectNumberedOption(u8),
     /// Select the row assigned to a host-defined shortcut.
@@ -443,11 +445,21 @@ impl TuiOptionSelector {
         self.move_selection(true, ctx);
     }
 
-    /// Restores the first option as the active highlight.
-    pub(crate) fn select_first(&mut self, ctx: &mut ViewContext<Self>) {
-        self.select_id(self.page.snapshot.rows.first().map(|row| row.id.clone()));
-        self.sync_after_items_changed();
+    /// Moves focus and highlight to an item without confirming it.
+    pub(crate) fn select_item_without_confirm(
+        &mut self,
+        index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let items_len = self.items().len();
+        if index >= items_len {
+            return;
+        }
+        self.interaction
+            .selection
+            .select(index, items_len, |_| true);
         ctx.focus_self();
+        self.scroll_to_keep_visible(items_len, index, ctx);
         ctx.notify();
     }
 
@@ -1247,6 +1259,9 @@ impl TypedActionView for TuiOptionSelector {
             }
             TuiOptionSelectorAction::MoveUp => self.move_selection(false, ctx),
             TuiOptionSelectorAction::MoveDown => self.move_selection(true, ctx),
+            TuiOptionSelectorAction::SelectItemWithoutConfirm(index) => {
+                self.select_item_without_confirm(*index, ctx);
+            }
             TuiOptionSelectorAction::SelectNumberedOption(digit) => {
                 let index = self.interaction.scroll_offset + usize::from(*digit) - 1;
                 let item_has_custom_shortcut = self.items().get(index).is_some_and(|item| {

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -10,7 +10,7 @@
 //! since the selector is only rendered while its host is the active blocking
 //! interaction. Escape remains host policy, with an element-level fallback
 //! through [`TuiOptionSelector::handle_back`].
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use warp::tui_export::{OptionBadge, OptionFooter, OptionRow, OptionSnapshot, OptionSourceStatus};
 use warp_search_core::inline_menu::InlineMenuSelection;
@@ -55,6 +55,8 @@ pub(crate) struct OptionSelectorPage {
     pub(crate) snapshot: OptionSnapshot,
     /// Whether this page offers label filtering.
     pub(crate) searchable: bool,
+    /// Non-numeric shortcuts keyed by option row id.
+    pub(crate) row_shortcuts: HashMap<String, char>,
 }
 
 impl Default for OptionSelectorPage {
@@ -68,6 +70,7 @@ impl Default for OptionSelectorPage {
                 footer: None,
             },
             searchable: false,
+            row_shortcuts: HashMap::new(),
         }
     }
 }
@@ -102,6 +105,8 @@ pub(crate) enum TuiOptionSelectorAction {
     MoveDown,
     /// Select the viewport-relative item and confirm it when enabled.
     SelectNumberedOption(u8),
+    /// Select the row assigned to a host-defined shortcut.
+    SelectShortcut(char),
     /// Select the item at an absolute index and confirm it when enabled.
     /// Dispatched by row clicks.
     SelectItem(usize),
@@ -786,6 +791,27 @@ impl TuiOptionSelector {
         true
     }
 
+    /// Confirms the visible row assigned to `shortcut`.
+    fn confirm_shortcut(&mut self, shortcut: char, ctx: &mut ViewContext<Self>) -> bool {
+        let items = self.items();
+        let visible_end =
+            (self.interaction.scroll_offset + MAX_VISIBLE_OPTION_ROWS).min(items.len());
+        let Some(index) = (self.interaction.scroll_offset..visible_end).find(|index| {
+            let SelectorItem::Row(row_index) = items[*index] else {
+                return false;
+            };
+            self.page
+                .snapshot
+                .rows
+                .get(row_index)
+                .and_then(|row| self.page.row_shortcuts.get(&row.id))
+                .is_some_and(|candidate| candidate.eq_ignore_ascii_case(&shortcut))
+        }) else {
+            return false;
+        };
+        self.confirm_item(index, ctx)
+    }
+
     /// Validates and submits the custom-text editor: the value
     /// is trimmed; empty input stays editable with a concise error.
     fn submit_custom_text(&mut self, ctx: &mut ViewContext<Self>) -> bool {
@@ -869,12 +895,12 @@ impl TuiOptionSelector {
             .finish()
     }
 
-    /// One option row: viewport-relative digit, label, badge, and disabled
+    /// One option row: shortcut, label, badge, and disabled
     /// reason, with the current selection rendered in bold magenta.
     fn render_row(
         &self,
         row: &OptionRow,
-        digit: Option<usize>,
+        shortcut: Option<char>,
         is_highlighted: bool,
         builder: &TuiUiBuilder,
     ) -> Box<dyn TuiElement> {
@@ -903,11 +929,11 @@ impl TuiOptionSelector {
         } else {
             builder.muted_text_style()
         };
-        let digit_prefix = match digit {
-            Some(digit) => format!("({digit}) "),
+        let shortcut_prefix = match shortcut {
+            Some(shortcut) => format!("({shortcut}) "),
             None => "    ".to_string(),
         };
-        let mut spans = vec![(digit_prefix, detail_style)];
+        let mut spans = vec![(shortcut_prefix, detail_style)];
         if self.show_selection_markers {
             spans.push((
                 if is_selected { "✓ " } else { "  " }.to_string(),
@@ -1025,50 +1051,55 @@ impl TuiOptionSelector {
             let digit = (position < 9).then_some(position + 1);
             let is_selected = !self.custom_text.is_editing()
                 && self.interaction.selection.selected_index() == Some(index);
-            let element = match item {
-                SelectorItem::Row(row_index) => {
-                    let Some(row) = self.page.snapshot.rows.get(row_index) else {
-                        continue;
-                    };
-                    self.render_row(row, digit, is_selected, builder)
-                }
-                SelectorItem::Retry => self.render_virtual_row(
-                    "↻ Retry".to_string(),
-                    digit,
-                    is_selected,
-                    builder.error_text_style(),
-                    builder,
-                ),
-                SelectorItem::CustomText => {
-                    match (&self.page.snapshot.footer, self.custom_text.is_editing()) {
-                        (Some(OptionFooter::CustomText { label }), true) => self
-                            .render_editor_field(
-                                digit.map_or_else(
-                                    || "    ".to_string(),
-                                    |digit| format!("({digit}) "),
-                                ),
-                                label,
-                                &self.custom_text.editor,
-                                self.custom_text
-                                    .error_is_visible()
-                                    .then_some(CUSTOM_TEXT_EMPTY_ERROR),
-                                builder,
-                            ),
-                        (Some(OptionFooter::CustomText { label }), false) => self
-                            .render_virtual_row(
-                                self.custom_text
-                                    .committed_value
-                                    .clone()
-                                    .unwrap_or_else(|| label.clone()),
-                                digit,
-                                is_selected,
-                                builder.primary_text_style(),
-                                builder,
-                            ),
-                        (Some(OptionFooter::CreateNewAuthSecret) | None, _) => continue,
+            let element =
+                match item {
+                    SelectorItem::Row(row_index) => {
+                        let Some(row) = self.page.snapshot.rows.get(row_index) else {
+                            continue;
+                        };
+                        let shortcut =
+                            self.page.row_shortcuts.get(&row.id).copied().or_else(|| {
+                                digit.and_then(|digit| char::from_digit(digit as u32, 10))
+                            });
+                        self.render_row(row, shortcut, is_selected, builder)
                     }
-                }
-            };
+                    SelectorItem::Retry => self.render_virtual_row(
+                        "↻ Retry".to_string(),
+                        digit,
+                        is_selected,
+                        builder.error_text_style(),
+                        builder,
+                    ),
+                    SelectorItem::CustomText => {
+                        match (&self.page.snapshot.footer, self.custom_text.is_editing()) {
+                            (Some(OptionFooter::CustomText { label }), true) => self
+                                .render_editor_field(
+                                    digit.map_or_else(
+                                        || "    ".to_string(),
+                                        |digit| format!("({digit}) "),
+                                    ),
+                                    label,
+                                    &self.custom_text.editor,
+                                    self.custom_text
+                                        .error_is_visible()
+                                        .then_some(CUSTOM_TEXT_EMPTY_ERROR),
+                                    builder,
+                                ),
+                            (Some(OptionFooter::CustomText { label }), false) => self
+                                .render_virtual_row(
+                                    self.custom_text
+                                        .committed_value
+                                        .clone()
+                                        .unwrap_or_else(|| label.clone()),
+                                    digit,
+                                    is_selected,
+                                    builder.primary_text_style(),
+                                    builder,
+                                ),
+                            (Some(OptionFooter::CreateNewAuthSecret) | None, _) => continue,
+                        }
+                    }
+                };
             // Each visible row is clickable through its own persistent
             // mouse-state handle.
             let element = match self.item_mouse_states.get(index) {
@@ -1165,6 +1196,7 @@ impl TuiView for TuiOptionSelector {
             child: content.finish(),
             list_focused: self.focused,
             searchable: self.page.searchable,
+            row_shortcuts: self.page.row_shortcuts.values().copied().collect(),
         }
         .finish()
     }
@@ -1217,7 +1249,22 @@ impl TypedActionView for TuiOptionSelector {
             TuiOptionSelectorAction::MoveDown => self.move_selection(true, ctx),
             TuiOptionSelectorAction::SelectNumberedOption(digit) => {
                 let index = self.interaction.scroll_offset + usize::from(*digit) - 1;
-                self.confirm_item(index, ctx);
+                let item_has_custom_shortcut = self.items().get(index).is_some_and(|item| {
+                    let SelectorItem::Row(row_index) = item else {
+                        return false;
+                    };
+                    self.page
+                        .snapshot
+                        .rows
+                        .get(*row_index)
+                        .is_some_and(|row| self.page.row_shortcuts.contains_key(&row.id))
+                });
+                if !item_has_custom_shortcut {
+                    self.confirm_item(index, ctx);
+                }
+            }
+            TuiOptionSelectorAction::SelectShortcut(shortcut) => {
+                self.confirm_shortcut(*shortcut, ctx);
             }
             TuiOptionSelectorAction::SelectItem(index) => {
                 self.confirm_item(*index, ctx);
@@ -1255,6 +1302,7 @@ struct SelectorInputElement {
     child: Box<dyn TuiElement>,
     list_focused: bool,
     searchable: bool,
+    row_shortcuts: Vec<char>,
 }
 
 impl TuiElement for SelectorInputElement {
@@ -1322,6 +1370,21 @@ impl TuiElement for SelectorInputElement {
                     }
                     "down" if self.list_focused => {
                         event_ctx.dispatch_typed_action(TuiOptionSelectorAction::MoveDown);
+                        true
+                    }
+                    key if self.list_focused
+                        && key.chars().next().is_some_and(|candidate| {
+                            key.chars().count() == 1
+                                && self
+                                    .row_shortcuts
+                                    .iter()
+                                    .any(|shortcut| shortcut.eq_ignore_ascii_case(&candidate))
+                        }) =>
+                    {
+                        let shortcut = key.chars().next().expect("checked one-character key");
+                        event_ctx.dispatch_typed_action(TuiOptionSelectorAction::SelectShortcut(
+                            shortcut,
+                        ));
                         true
                     }
                     key if self.list_focused => match key.parse::<u8>() {

--- a/crates/warp_tui/src/option_selector_tests.rs
+++ b/crates/warp_tui/src/option_selector_tests.rs
@@ -67,6 +67,7 @@ fn page(snapshot: OptionSnapshot, searchable: bool) -> OptionSelectorPage {
         }),
         snapshot,
         searchable,
+        row_shortcuts: Default::default(),
     }
 }
 
@@ -586,6 +587,34 @@ fn digits_confirm_the_corresponding_visible_row() {
     });
 }
 
+#[test]
+fn custom_row_shortcut_renders_and_confirms_instead_of_its_digit() {
+    App::test((), |mut app| async move {
+        let (selector, events) = add_selector(&mut app);
+        selector.update(&mut app, |selector, ctx| {
+            let mut page = page(snapshot(&["yes", "no", "edit command"], Some("yes")), false);
+            page.row_shortcuts.insert("edit command".to_owned(), 'e');
+            selector.set_page(page, ctx);
+        });
+
+        let lines = render_lines(&app, &selector, 60);
+        assert!(lines.iter().any(|line| line.contains("(e) edit command")));
+        assert!(!lines.iter().any(|line| line.contains("(3) edit command")));
+        assert!(dispatch(&app, &selector, &key_down("e")));
+
+        act(
+            &mut app,
+            &selector,
+            TuiOptionSelectorAction::SelectShortcut('e'),
+        );
+        assert_eq!(
+            primary_events(&events),
+            [TuiOptionSelectorEvent::Confirmed {
+                id: "edit command".to_owned()
+            }],
+        );
+    });
+}
 #[test]
 fn digits_are_viewport_relative_in_scrolled_lists() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/option_selector_tests.rs
+++ b/crates/warp_tui/src/option_selector_tests.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use crate::editor_element::TuiEditorAction;
 use crate::editor_interaction::TuiEditorCommand;
-use crate::editor_view::TuiEditorViewAction;
+use crate::editor_view::{TuiEditorView, TuiEditorViewAction};
 use crate::test_fixtures::TestHostView;
 use crate::tui_builder::TuiUiBuilder;
 
@@ -204,6 +204,33 @@ fn up_from_top_focuses_search_and_down_returns_to_first_row() {
     });
 }
 
+#[test]
+fn select_item_without_confirm_moves_focus_to_an_arbitrary_option() {
+    App::test((), |mut app| async move {
+        let (selector, events) = add_selector(&mut app);
+        let leading_editor = app.update(|ctx| {
+            ctx.add_typed_action_tui_view(selector.window_id(ctx), TuiEditorView::single_line)
+        });
+        selector.update(&mut app, |selector, ctx| {
+            selector.set_leading_editor(leading_editor.clone(), ctx);
+            selector.set_page(page(snapshot(&["yes", "no"], Some("yes")), false), ctx);
+            selector.focus_leading_editor(ctx);
+        });
+        assert!(leading_editor.read(&app, |editor, _| editor.is_focused()));
+
+        act(
+            &mut app,
+            &selector,
+            TuiOptionSelectorAction::SelectItemWithoutConfirm(1),
+        );
+        assert!(!leading_editor.read(&app, |editor, _| editor.is_focused()));
+        assert_eq!(
+            selector.read(&app, |selector, _| selector.highlighted_index()),
+            Some(1)
+        );
+        assert!(primary_events(&events).is_empty());
+    });
+}
 #[test]
 fn search_and_last_option_wrap_in_both_directions() {
     App::test((), |mut app| async move {
@@ -423,6 +450,9 @@ fn laid_out_element(
     );
     if let Some(search_field) = selector_ref.search_field.as_ref() {
         rendered_views.insert(search_field.id(), search_field.as_ref(app).render(app));
+    }
+    if let Some(leading_editor) = selector_ref.leading_editor.as_ref() {
+        rendered_views.insert(leading_editor.id(), leading_editor.as_ref(app).render(app));
     }
     let mut element = selector_ref.render(app);
     let size = {

--- a/crates/warp_tui/src/orchestration_block.rs
+++ b/crates/warp_tui/src/orchestration_block.rs
@@ -476,6 +476,7 @@ impl TuiOrchestrationBlock {
             }),
             snapshot: self.snapshot_for_page(page, ctx),
             searchable: page.is_searchable(),
+            row_shortcuts: Default::default(),
         };
         self.selector.update(ctx, |selector, ctx| {
             selector.set_page(selector_page, ctx);

--- a/crates/warp_tui/src/tui_ask_question_view.rs
+++ b/crates/warp_tui/src/tui_ask_question_view.rs
@@ -228,6 +228,7 @@ impl TuiAskQuestionView {
                     header: None,
                     snapshot,
                     searchable: false,
+                    row_shortcuts: Default::default(),
                 },
                 ctx,
             );

--- a/crates/warp_tui/src/tui_file_edits_view.rs
+++ b/crates/warp_tui/src/tui_file_edits_view.rs
@@ -216,7 +216,7 @@ impl TuiFileEditsView {
         let prompt_action_id = action_id.clone();
         let prompt_action_model = action_model.clone();
         let permission_prompt = ctx.add_typed_action_tui_view(move |ctx| {
-            TuiPermissionPrompt::new(prompt_action_model, prompt_action_id, false, ctx)
+            TuiPermissionPrompt::new(prompt_action_model, prompt_action_id, None, ctx)
         });
         ctx.subscribe_to_view(&permission_prompt, |view, _, event, ctx| match event {
             TuiPermissionPromptEvent::AcceptRequested => view.accept(ctx),
@@ -231,7 +231,6 @@ impl TuiFileEditsView {
                 view.invalidate_layout(ctx);
             }
             TuiPermissionPromptEvent::LayoutChanged => view.invalidate_layout(ctx),
-            TuiPermissionPromptEvent::EditBodyRequested => {}
         });
 
         Self {
@@ -605,7 +604,7 @@ impl TuiView for TuiFileEditsView {
         render_permission_card(
             &self.permission_prompt,
             "Is it OK if I make these file edits?",
-            content,
+            Some(content),
             app,
         )
     }

--- a/crates/warp_tui/src/tui_generic_tool_call_view.rs
+++ b/crates/warp_tui/src/tui_generic_tool_call_view.rs
@@ -75,7 +75,7 @@ impl TuiGenericToolCallView {
         let action_id = self.action.id.clone();
         let action_model = self.action_model.clone();
         let prompt = ctx.add_typed_action_tui_view(move |ctx| {
-            TuiPermissionPrompt::new(action_model, action_id, false, ctx)
+            TuiPermissionPrompt::new(action_model, action_id, None, ctx)
         });
         ctx.subscribe_to_view(&prompt, |view, _, event, ctx| match event {
             TuiPermissionPromptEvent::AcceptRequested => view.accept(ctx),
@@ -90,7 +90,6 @@ impl TuiGenericToolCallView {
                 view.invalidate_layout(ctx);
             }
             TuiPermissionPromptEvent::LayoutChanged => view.invalidate_layout(ctx),
-            TuiPermissionPromptEvent::EditBodyRequested => {}
         });
         self.permission_prompt = Some(prompt);
         self.invalidate_layout(ctx);
@@ -279,9 +278,11 @@ impl TuiGenericToolCallView {
         render_permission_card(
             prompt,
             self.permission_question(),
-            TuiText::new(self.details())
-                .with_style(builder.primary_text_style())
-                .finish(),
+            Some(
+                TuiText::new(self.details())
+                    .with_style(builder.primary_text_style())
+                    .finish(),
+            ),
             app,
         )
     }

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -18,7 +18,9 @@ use warpui_core::{
 
 use crate::editor_view::TuiEditorView;
 use crate::keybindings::{TUI_BINDING_GROUP, is_tui_owned_binding};
-use crate::option_selector::{OptionSelectorPage, TuiOptionSelector, TuiOptionSelectorEvent};
+use crate::option_selector::{
+    OptionSelectorPage, TuiOptionSelector, TuiOptionSelectorAction, TuiOptionSelectorEvent,
+};
 use crate::tui_builder::TuiUiBuilder;
 
 const PERMISSION_PROMPT_ACTIVE: &str = "TuiPermissionPromptActive";
@@ -209,8 +211,9 @@ impl TuiPermissionPrompt {
 
     /// Restores Yes as the highlighted response after body editing.
     pub(crate) fn restore_options_focus(&self, ctx: &mut ViewContext<Self>) {
-        self.selector
-            .update(ctx, |selector, ctx| selector.select_first(ctx));
+        self.selector.update(ctx, |selector, ctx| {
+            selector.handle_action(&TuiOptionSelectorAction::SelectItemWithoutConfirm(0), ctx)
+        });
     }
     #[cfg(test)]
     pub(crate) fn highlighted_index(&self, app: &AppContext) -> Option<usize> {
@@ -359,8 +362,20 @@ impl TypedActionView for TuiPermissionPrompt {
         }
         match action {
             TuiPermissionPromptAction::Confirm => {
-                self.selector
-                    .update(ctx, |selector, ctx| selector.confirm_selected(ctx));
+                let body_editor_focused = self
+                    .body_editor
+                    .as_ref()
+                    .is_some_and(|editor| editor.as_ref(ctx).is_focused());
+                self.selector.update(ctx, |selector, ctx| {
+                    if body_editor_focused {
+                        selector.handle_action(
+                            &TuiOptionSelectorAction::SelectItemWithoutConfirm(0),
+                            ctx,
+                        );
+                    } else {
+                        selector.confirm_selected(ctx);
+                    }
+                });
             }
             TuiPermissionPromptAction::MoveUp => {
                 self.selector

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -342,7 +342,11 @@ impl TuiView for TuiPermissionPrompt {
 
     fn keymap_context(&self, app: &AppContext) -> warpui_core::keymap::Context {
         let mut context = Self::default_keymap_context();
-        if self.is_active(app) {
+        let body_editor_focused = self
+            .body_editor
+            .as_ref()
+            .is_some_and(|editor| editor.as_ref(app).is_focused());
+        if self.is_active(app) && !body_editor_focused {
             context.set.insert(PERMISSION_PROMPT_ACTIVE);
         }
         context

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -1,4 +1,6 @@
-//! Reusable Yes/No/Other interaction for TUI tool-call permission requests.
+//! Reusable interaction for TUI tool-call permission requests.
+
+use std::collections::HashMap;
 
 use warp::tui_export::{
     AIAgentActionId, BlocklistAIActionEvent, BlocklistAIActionModel, OptionFooter, OptionRow,
@@ -22,6 +24,7 @@ use crate::tui_builder::TuiUiBuilder;
 const PERMISSION_PROMPT_ACTIVE: &str = "TuiPermissionPromptActive";
 const YES_ID: &str = "yes";
 const NO_ID: &str = "no";
+const EDIT_ID: &str = "edit";
 
 /// Registers controls used while a permission prompt owns focus.
 pub(crate) fn init(app: &mut AppContext) {
@@ -98,7 +101,7 @@ pub(crate) enum TuiPermissionPromptEvent {
     LayoutChanged,
 }
 
-/// Reusable Yes/No/Other selector for one blocked tool action.
+/// Reusable selector for one blocked tool action.
 pub(crate) struct TuiPermissionPrompt {
     action_model: ModelHandle<BlocklistAIActionModel>,
     action_id: AIAgentActionId,
@@ -119,33 +122,48 @@ impl TuiPermissionPrompt {
             if let Some(body_editor) = body_editor.as_ref() {
                 selector.set_leading_editor(body_editor.clone(), ctx);
             }
+            let mut rows = vec![
+                OptionRow {
+                    id: YES_ID.to_owned(),
+                    label: "yes".to_owned(),
+                    harness: None,
+                    badge: None,
+                    disabled_reason: None,
+                },
+                OptionRow {
+                    id: NO_ID.to_owned(),
+                    label: "no".to_owned(),
+                    harness: None,
+                    badge: None,
+                    disabled_reason: None,
+                },
+            ];
+            if body_editor.is_some() {
+                rows.push(OptionRow {
+                    id: EDIT_ID.to_owned(),
+                    label: "edit command".to_owned(),
+                    harness: None,
+                    badge: None,
+                    disabled_reason: None,
+                });
+            }
             selector.set_page(
                 OptionSelectorPage {
                     header: None,
                     snapshot: OptionSnapshot {
-                        rows: vec![
-                            OptionRow {
-                                id: YES_ID.to_owned(),
-                                label: "yes".to_owned(),
-                                harness: None,
-                                badge: None,
-                                disabled_reason: None,
-                            },
-                            OptionRow {
-                                id: NO_ID.to_owned(),
-                                label: "no".to_owned(),
-                                harness: None,
-                                badge: None,
-                                disabled_reason: None,
-                            },
-                        ],
+                        rows,
                         selected_id: Some(YES_ID.to_owned()),
                         status: OptionSourceStatus::Ready,
-                        footer: Some(OptionFooter::CustomText {
+                        footer: body_editor.is_none().then(|| OptionFooter::CustomText {
                             label: "Other".to_owned(),
                         }),
                     },
                     searchable: false,
+                    row_shortcuts: if body_editor.is_some() {
+                        HashMap::from([(EDIT_ID.to_owned(), 'e')])
+                    } else {
+                        Default::default()
+                    },
                 },
                 ctx,
             );
@@ -217,6 +235,10 @@ impl TuiPermissionPrompt {
             }
             TuiOptionSelectorEvent::Confirmed { id } if id == NO_ID => {
                 ctx.emit(TuiPermissionPromptEvent::RejectRequested);
+            }
+            TuiOptionSelectorEvent::Confirmed { id } if id == EDIT_ID => {
+                self.selector
+                    .update(ctx, |selector, ctx| selector.focus_leading_editor(ctx));
             }
             TuiOptionSelectorEvent::CustomTextSubmitted { value } => {
                 ctx.emit(TuiPermissionPromptEvent::ReplacementGuidanceSubmitted(

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -6,7 +6,7 @@ use warp::tui_export::{
 };
 use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::elements::tui::{
-    Modifier, TuiChildView, TuiContainer, TuiElement, TuiFlex, TuiText,
+    Modifier, TuiChildView, TuiContainer, TuiElement, TuiFlex, TuiParentElement, TuiText,
 };
 use warpui_core::keymap::macros::*;
 use warpui_core::keymap::{EditableBinding, FixedBinding};
@@ -14,6 +14,7 @@ use warpui_core::{
     AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
 };
 
+use crate::editor_view::TuiEditorView;
 use crate::keybindings::{TUI_BINDING_GROUP, is_tui_owned_binding};
 use crate::option_selector::{OptionSelectorPage, TuiOptionSelector, TuiOptionSelectorEvent};
 use crate::tui_builder::TuiUiBuilder;
@@ -73,11 +74,11 @@ pub(crate) fn init(app: &mut AppContext) {
 pub(crate) enum TuiPermissionPromptAction {
     /// Confirms the highlighted response.
     Confirm,
-    /// Moves to the previous response or requests body editing above Yes.
+    /// Moves to the previous response, cycling through the optional body editor.
     MoveUp,
-    /// Moves to the next response.
+    /// Moves to the next response, cycling through the optional body editor.
     MoveDown,
-    /// Requests editing from a host with an editable action body.
+    /// Focuses the optional editable action body.
     EditBody,
     /// Unwinds Other editing, otherwise rejects the request.
     CancelOrBack,
@@ -87,8 +88,6 @@ pub(crate) enum TuiPermissionPromptAction {
 pub(crate) enum TuiPermissionPromptEvent {
     /// The user selected Yes.
     AcceptRequested,
-    /// The user requested editing of the action body.
-    EditBodyRequested,
     /// The user submitted replacement guidance from Other.
     ReplacementGuidanceSubmitted(String),
     /// The user selected No or cancelled the request.
@@ -104,8 +103,7 @@ pub(crate) struct TuiPermissionPrompt {
     action_model: ModelHandle<BlocklistAIActionModel>,
     action_id: AIAgentActionId,
     selector: ViewHandle<TuiOptionSelector>,
-    body_editable: bool,
-    body_editing: bool,
+    body_editor: Option<ViewHandle<TuiEditorView>>,
 }
 
 impl TuiPermissionPrompt {
@@ -113,11 +111,14 @@ impl TuiPermissionPrompt {
     pub(crate) fn new(
         action_model: ModelHandle<BlocklistAIActionModel>,
         action_id: AIAgentActionId,
-        body_editable: bool,
+        body_editor: Option<ViewHandle<TuiEditorView>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let selector = ctx.add_typed_action_tui_view(TuiOptionSelector::new);
         selector.update(ctx, |selector, ctx| {
+            if let Some(body_editor) = body_editor.as_ref() {
+                selector.set_leading_editor(body_editor.clone(), ctx);
+            }
             selector.set_page(
                 OptionSelectorPage {
                     header: None,
@@ -171,8 +172,7 @@ impl TuiPermissionPrompt {
             action_model,
             action_id,
             selector,
-            body_editable,
-            body_editing: false,
+            body_editor,
         }
     }
 
@@ -184,21 +184,26 @@ impl TuiPermissionPrompt {
             .is_some_and(|status| status.is_blocked())
     }
 
-    /// Focuses the option selector or its active Other editor.
+    /// Focuses the option selector.
     pub(crate) fn focus(&self, ctx: &mut ViewContext<Self>) {
         ctx.focus(&self.selector);
     }
 
-    /// Returns whether the option selector should currently consume input.
-    fn owns_input(&self, app: &AppContext) -> bool {
-        self.is_active(app) && !self.body_editing
-    }
-
     /// Restores Yes as the highlighted response after body editing.
-    pub(crate) fn restore_options_focus(&mut self, ctx: &mut ViewContext<Self>) {
-        self.body_editing = false;
+    pub(crate) fn restore_options_focus(&self, ctx: &mut ViewContext<Self>) {
         self.selector
             .update(ctx, |selector, ctx| selector.select_first(ctx));
+    }
+    #[cfg(test)]
+    pub(crate) fn highlighted_index(&self, app: &AppContext) -> Option<usize> {
+        self.selector.as_ref(app).highlighted_index()
+    }
+
+    /// Updates validation copy rendered below the optional body editor.
+    pub(crate) fn set_body_error(&self, error: Option<String>, ctx: &mut ViewContext<Self>) {
+        self.selector.update(ctx, |selector, ctx| {
+            selector.set_leading_editor_error(error, ctx)
+        });
     }
     /// Translates selector outcomes into tool-host permission events.
     fn handle_selector_event(
@@ -226,19 +231,6 @@ impl TuiPermissionPrompt {
             TuiOptionSelectorEvent::Confirmed { .. } | TuiOptionSelectorEvent::RetryRequested => {}
         }
     }
-
-    /// Hands focus to an editable action body when the host supports one.
-    fn request_body_edit(&mut self, ctx: &mut ViewContext<Self>) {
-        if !self.body_editable {
-            return;
-        }
-        self.body_editing = true;
-        self.selector
-            .update(ctx, |selector, ctx| selector.clear_highlight(ctx));
-        ctx.emit(TuiPermissionPromptEvent::EditBodyRequested);
-        self.invalidate_layout(ctx);
-    }
-
     /// Requests remeasurement by the tool host.
     fn invalidate_layout(&self, ctx: &mut ViewContext<Self>) {
         ctx.emit(TuiPermissionPromptEvent::LayoutChanged);
@@ -252,7 +244,7 @@ impl TuiPermissionPrompt {
             ("Esc".to_owned(), builder.primary_text_style()),
             (" to cancel  ".to_owned(), builder.muted_text_style()),
         ];
-        if self.body_editable {
+        if self.body_editor.is_some() {
             spans.extend([
                 ("Ctrl+E".to_owned(), builder.primary_text_style()),
                 (" to edit/save  ".to_owned(), builder.muted_text_style()),
@@ -270,7 +262,7 @@ impl TuiPermissionPrompt {
 pub(crate) fn render_permission_card(
     prompt: &ViewHandle<TuiPermissionPrompt>,
     title: impl Into<String>,
-    body: Box<dyn TuiElement>,
+    body: Option<Box<dyn TuiElement>>,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
@@ -287,18 +279,17 @@ pub(crate) fn render_permission_card(
     .with_background(builder.permission_header_background())
     .with_padding_x(1)
     .finish();
-    let body = TuiContainer::new(
-        TuiFlex::column()
-            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .child(body)
-            .child(TuiText::new(" ").finish())
-            .child(TuiChildView::new(prompt).finish())
-            .finish(),
-    )
-    .with_background(builder.permission_surface_background())
-    .with_padding_x(3)
-    .with_padding_y(1)
-    .finish();
+    let mut body_content = TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+    if let Some(body) = body {
+        body_content.add_child(body);
+        body_content.add_child(TuiText::new(" ").finish());
+    }
+    body_content.add_child(TuiChildView::new(prompt).finish());
+    let body = TuiContainer::new(body_content.finish())
+        .with_background(builder.permission_surface_background())
+        .with_padding_x(3)
+        .with_padding_y(1)
+        .finish();
     TuiFlex::column()
         .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
         .child(header)
@@ -326,7 +317,7 @@ impl TuiView for TuiPermissionPrompt {
 
     fn keymap_context(&self, app: &AppContext) -> warpui_core::keymap::Context {
         let mut context = Self::default_keymap_context();
-        if self.owns_input(app) {
+        if self.is_active(app) {
             context.set.insert(PERMISSION_PROMPT_ACTIVE);
         }
         context
@@ -341,7 +332,7 @@ impl TypedActionView for TuiPermissionPrompt {
     type Action = TuiPermissionPromptAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
-        if !self.owns_input(ctx) {
+        if !self.is_active(ctx) {
             return;
         }
         match action {
@@ -350,23 +341,17 @@ impl TypedActionView for TuiPermissionPrompt {
                     .update(ctx, |selector, ctx| selector.confirm_selected(ctx));
             }
             TuiPermissionPromptAction::MoveUp => {
-                let edit_body = self.body_editable
-                    && self.selector.read(ctx, |selector, _| {
-                        !selector.is_editing_custom_text()
-                            && selector.highlighted_index() == Some(0)
-                    });
-                if edit_body {
-                    self.request_body_edit(ctx);
-                } else {
-                    self.selector
-                        .update(ctx, |selector, ctx| selector.move_up(ctx));
-                }
+                self.selector
+                    .update(ctx, |selector, ctx| selector.move_up(ctx));
             }
             TuiPermissionPromptAction::MoveDown => {
                 self.selector
                     .update(ctx, |selector, ctx| selector.move_down(ctx));
             }
-            TuiPermissionPromptAction::EditBody => self.request_body_edit(ctx),
+            TuiPermissionPromptAction::EditBody => {
+                self.selector
+                    .update(ctx, |selector, ctx| selector.focus_leading_editor(ctx));
+            }
             TuiPermissionPromptAction::CancelOrBack => {
                 let handled = self
                     .selector

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -366,19 +366,8 @@ impl TypedActionView for TuiPermissionPrompt {
         }
         match action {
             TuiPermissionPromptAction::Confirm => {
-                let body_editor_focused = self
-                    .body_editor
-                    .as_ref()
-                    .is_some_and(|editor| editor.as_ref(ctx).is_focused());
                 self.selector.update(ctx, |selector, ctx| {
-                    if body_editor_focused {
-                        selector.handle_action(
-                            &TuiOptionSelectorAction::SelectItemWithoutConfirm(0),
-                            ctx,
-                        );
-                    } else {
-                        selector.confirm_selected(ctx);
-                    }
+                    selector.confirm_selected(ctx);
                 });
             }
             TuiPermissionPromptAction::MoveUp => {

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -194,6 +194,12 @@ impl TuiPermissionPrompt {
         self.is_active(app) && !self.body_editing
     }
 
+    /// Restores Yes as the highlighted response after body editing.
+    pub(crate) fn restore_options_focus(&mut self, ctx: &mut ViewContext<Self>) {
+        self.body_editing = false;
+        self.selector
+            .update(ctx, |selector, ctx| selector.select_first(ctx));
+    }
     /// Translates selector outcomes into tool-host permission events.
     fn handle_selector_event(
         &mut self,

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -144,58 +144,6 @@ fn leading_editor_participates_in_selector_focus_cycle() {
 }
 
 #[test]
-fn confirm_from_leading_editor_selects_yes_without_accepting() {
-    App::test((), |mut app| async move {
-        let prompt = add_prompt(&mut app, true);
-        let (action_model, action) = app.read(|ctx| {
-            let prompt = prompt.as_ref(ctx);
-            (prompt.action_model.clone(), pending_action(prompt))
-        });
-        action_model.update(&mut app, |model, ctx| {
-            queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
-        });
-        let accepted = Rc::new(RefCell::new(false));
-        let accepted_for_event = accepted.clone();
-        app.update(|ctx| {
-            ctx.subscribe_to_view(&prompt, move |_, event, _| {
-                if matches!(event, TuiPermissionPromptEvent::AcceptRequested) {
-                    *accepted_for_event.borrow_mut() = true;
-                }
-            });
-        });
-
-        prompt.update(&mut app, |prompt, ctx| {
-            prompt.handle_action(&TuiPermissionPromptAction::MoveUp, ctx);
-        });
-        assert!(app.read(|ctx| {
-            prompt
-                .as_ref(ctx)
-                .body_editor
-                .as_ref()
-                .expect("editable prompt has a body editor")
-                .as_ref(ctx)
-                .is_focused()
-        }));
-        prompt.update(&mut app, |prompt, ctx| {
-            prompt.handle_action(&TuiPermissionPromptAction::Confirm, ctx);
-        });
-
-        app.read(|ctx| {
-            let prompt = prompt.as_ref(ctx);
-            assert!(
-                !prompt
-                    .body_editor
-                    .as_ref()
-                    .expect("editable prompt has a body editor")
-                    .as_ref(ctx)
-                    .is_focused()
-            );
-            assert_eq!(prompt.selector.as_ref(ctx).highlighted_index(), Some(0));
-        });
-        assert!(!*accepted.borrow());
-    });
-}
-#[test]
 fn editable_prompt_uses_edit_option_for_shortcut_and_click() {
     App::test((), |mut app| async move {
         let prompt = add_prompt(&mut app, true);

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -144,6 +144,58 @@ fn leading_editor_participates_in_selector_focus_cycle() {
 }
 
 #[test]
+fn confirm_from_leading_editor_selects_yes_without_accepting() {
+    App::test((), |mut app| async move {
+        let prompt = add_prompt(&mut app, true);
+        let (action_model, action) = app.read(|ctx| {
+            let prompt = prompt.as_ref(ctx);
+            (prompt.action_model.clone(), pending_action(prompt))
+        });
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
+        });
+        let accepted = Rc::new(RefCell::new(false));
+        let accepted_for_event = accepted.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&prompt, move |_, event, _| {
+                if matches!(event, TuiPermissionPromptEvent::AcceptRequested) {
+                    *accepted_for_event.borrow_mut() = true;
+                }
+            });
+        });
+
+        prompt.update(&mut app, |prompt, ctx| {
+            prompt.handle_action(&TuiPermissionPromptAction::MoveUp, ctx);
+        });
+        assert!(app.read(|ctx| {
+            prompt
+                .as_ref(ctx)
+                .body_editor
+                .as_ref()
+                .expect("editable prompt has a body editor")
+                .as_ref(ctx)
+                .is_focused()
+        }));
+        prompt.update(&mut app, |prompt, ctx| {
+            prompt.handle_action(&TuiPermissionPromptAction::Confirm, ctx);
+        });
+
+        app.read(|ctx| {
+            let prompt = prompt.as_ref(ctx);
+            assert!(
+                !prompt
+                    .body_editor
+                    .as_ref()
+                    .expect("editable prompt has a body editor")
+                    .as_ref(ctx)
+                    .is_focused()
+            );
+            assert_eq!(prompt.selector.as_ref(ctx).highlighted_index(), Some(0));
+        });
+        assert!(!*accepted.borrow());
+    });
+}
+#[test]
 fn editable_prompt_uses_edit_option_for_shortcut_and_click() {
     App::test((), |mut app| async move {
         let prompt = add_prompt(&mut app, true);

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -124,7 +124,7 @@ fn leading_editor_participates_in_selector_focus_cycle() {
             );
             assert_eq!(prompt.selector.as_ref(ctx).highlighted_index(), None);
             assert!(
-                prompt
+                !prompt
                     .keymap_context(ctx)
                     .set
                     .contains(PERMISSION_PROMPT_ACTIVE)

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -16,7 +16,7 @@ use super::{
     TuiPermissionPromptEvent, render_permission_card,
 };
 use crate::editor_view::TuiEditorView;
-use crate::option_selector::TuiOptionSelectorEvent;
+use crate::option_selector::{TuiOptionSelectorAction, TuiOptionSelectorEvent};
 use crate::test_fixtures::{TestHostView, add_test_action_model};
 fn add_prompt(app: &mut App, body_editable: bool) -> ViewHandle<TuiPermissionPrompt> {
     app.add_singleton_model(|_| Appearance::mock());
@@ -140,6 +140,52 @@ fn leading_editor_participates_in_selector_focus_cycle() {
                 Some(2)
             );
         });
+    });
+}
+
+#[test]
+fn editable_prompt_uses_edit_option_for_shortcut_and_click() {
+    App::test((), |mut app| async move {
+        let prompt = add_prompt(&mut app, true);
+        let lines = render_lines(&mut app, &prompt);
+        assert!(lines.iter().any(|line| line == "(e) edit command"));
+        assert!(lines.iter().all(|line| !line.contains("Other")));
+
+        let (action_model, action) = app.read(|ctx| {
+            let prompt = prompt.as_ref(ctx);
+            (prompt.action_model.clone(), pending_action(prompt))
+        });
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
+        });
+
+        let selector = prompt.read(&app, |prompt, _| prompt.selector.clone());
+        selector.update(&mut app, |selector, ctx| {
+            selector.handle_action(&TuiOptionSelectorAction::SelectShortcut('e'), ctx);
+        });
+        assert!(app.read(|ctx| {
+            prompt
+                .as_ref(ctx)
+                .body_editor
+                .as_ref()
+                .expect("editable prompt has a body editor")
+                .as_ref(ctx)
+                .is_focused()
+        }));
+
+        prompt.update(&mut app, |prompt, ctx| prompt.restore_options_focus(ctx));
+        selector.update(&mut app, |selector, ctx| {
+            selector.handle_action(&TuiOptionSelectorAction::SelectItem(2), ctx);
+        });
+        assert!(app.read(|ctx| {
+            prompt
+                .as_ref(ctx)
+                .body_editor
+                .as_ref()
+                .expect("editable prompt has a body editor")
+                .as_ref(ctx)
+                .is_focused()
+        }));
     });
 }
 

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -15,9 +15,9 @@ use super::{
     PERMISSION_PROMPT_ACTIVE, TuiPermissionPrompt, TuiPermissionPromptAction,
     TuiPermissionPromptEvent, render_permission_card,
 };
+use crate::editor_view::TuiEditorView;
 use crate::option_selector::TuiOptionSelectorEvent;
 use crate::test_fixtures::{TestHostView, add_test_action_model};
-
 fn add_prompt(app: &mut App, body_editable: bool) -> ViewHandle<TuiPermissionPrompt> {
     app.add_singleton_model(|_| Appearance::mock());
     let action_model = add_test_action_model(app);
@@ -30,10 +30,12 @@ fn add_prompt(app: &mut App, body_editable: bool) -> ViewHandle<TuiPermissionPro
             |_| TestHostView,
         );
         ctx.add_typed_action_tui_view(window_id, move |ctx| {
+            let body_editor =
+                body_editable.then(|| ctx.add_typed_action_tui_view(TuiEditorView::single_line));
             TuiPermissionPrompt::new(
                 action_model,
                 AIAgentActionId::from("permission-action".to_owned()),
-                body_editable,
+                body_editor,
                 ctx,
             )
         })
@@ -51,8 +53,13 @@ fn render_lines(app: &mut App, prompt: &ViewHandle<TuiPermissionPrompt>) -> Vec<
         presenter.invalidate(&invalidation, ctx, prompt.window_id(ctx));
         presenter
             .present_element(
-                render_permission_card(prompt, "Permission", TuiText::new("details").finish(), ctx),
-                TuiRect::new(0, 0, 80, 10),
+                render_permission_card(
+                    prompt,
+                    "Permission",
+                    Some(TuiText::new("details").finish()),
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 80, 12),
                 ctx,
             )
             .buffer
@@ -90,7 +97,7 @@ fn permission_prompt_defaults_to_yes_and_renders_other() {
 }
 
 #[test]
-fn body_editing_suspends_option_navigation() {
+fn leading_editor_participates_in_selector_focus_cycle() {
     App::test((), |mut app| async move {
         let prompt = add_prompt(&mut app, true);
         let (action_model, action) = app.read(|ctx| {
@@ -103,18 +110,34 @@ fn body_editing_suspends_option_navigation() {
 
         prompt.update(&mut app, |prompt, ctx| {
             prompt.handle_action(&TuiPermissionPromptAction::MoveUp, ctx);
-            prompt.handle_action(&TuiPermissionPromptAction::MoveUp, ctx);
         });
 
         app.read(|ctx| {
             let prompt = prompt.as_ref(ctx);
-            assert!(prompt.body_editing);
+            assert!(
+                prompt
+                    .body_editor
+                    .as_ref()
+                    .expect("editable prompt has a body editor")
+                    .as_ref(ctx)
+                    .is_focused()
+            );
             assert_eq!(prompt.selector.as_ref(ctx).highlighted_index(), None);
             assert!(
-                !prompt
+                prompt
                     .keymap_context(ctx)
                     .set
                     .contains(PERMISSION_PROMPT_ACTIVE)
+            );
+        });
+
+        prompt.update(&mut app, |prompt, ctx| {
+            prompt.handle_action(&TuiPermissionPromptAction::MoveUp, ctx);
+        });
+        app.read(|ctx| {
+            assert_eq!(
+                prompt.as_ref(ctx).selector.as_ref(ctx).highlighted_index(),
+                Some(2)
             );
         });
     });
@@ -203,7 +226,6 @@ fn other_emits_guidance_without_requesting_rejection() {
                     *rejected_for_event.borrow_mut() = true;
                 }
                 TuiPermissionPromptEvent::AcceptRequested
-                | TuiPermissionPromptEvent::EditBodyRequested
                 | TuiPermissionPromptEvent::BlockingStateChanged
                 | TuiPermissionPromptEvent::LayoutChanged => {}
             });

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -56,14 +56,16 @@ pub(crate) fn init(app: &mut AppContext) {
         )
         .with_group(TUI_BINDING_GROUP),
     ]);
-    app.register_editable_bindings([EditableBinding::new(
-        "tui:shell-permission:save",
-        "Save the edited shell command",
-        TuiShellCommandViewAction::SaveCommandEdit,
-    )
-    .with_context_predicate(predicate)
-    .with_group(TUI_BINDING_GROUP)
-    .with_key_binding("down")]);
+    app.register_editable_bindings(["enter", "numpadenter", "down"].map(|key| {
+        EditableBinding::new(
+            "tui:shell-permission:save",
+            "Save the edited shell command",
+            TuiShellCommandViewAction::SaveCommandEdit,
+        )
+        .with_context_predicate(predicate.clone())
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding(key)
+    }));
     app.register_tui_binding_validator::<TuiShellCommandView>(is_tui_owned_binding);
 }
 

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -55,16 +55,14 @@ pub(crate) fn init(app: &mut AppContext) {
             predicate.clone(),
         )
         .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "enter",
+            TuiShellCommandViewAction::SaveCommandEdit,
+            predicate.clone(),
+        )
+        .with_group(TUI_BINDING_GROUP),
     ]);
     app.register_editable_bindings([
-        EditableBinding::new(
-            "tui:shell-permission:save",
-            "Save the edited shell command",
-            TuiShellCommandViewAction::SaveCommandEdit,
-        )
-        .with_context_predicate(predicate.clone())
-        .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("enter"),
         EditableBinding::new(
             "tui:shell-permission:save",
             "Save the edited shell command",

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -55,23 +55,15 @@ pub(crate) fn init(app: &mut AppContext) {
             predicate.clone(),
         )
         .with_group(TUI_BINDING_GROUP),
-        FixedBinding::new(
-            "enter",
-            TuiShellCommandViewAction::SaveCommandEdit,
-            predicate.clone(),
-        )
-        .with_group(TUI_BINDING_GROUP),
     ]);
-    app.register_editable_bindings([
-        EditableBinding::new(
-            "tui:shell-permission:save",
-            "Save the edited shell command",
-            TuiShellCommandViewAction::SaveCommandEdit,
-        )
-        .with_context_predicate(predicate)
-        .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("down"),
-    ]);
+    app.register_editable_bindings([EditableBinding::new(
+        "tui:shell-permission:save",
+        "Save the edited shell command",
+        TuiShellCommandViewAction::SaveCommandEdit,
+    )
+    .with_context_predicate(predicate)
+    .with_group(TUI_BINDING_GROUP)
+    .with_key_binding("down")]);
     app.register_tui_binding_validator::<TuiShellCommandView>(is_tui_owned_binding);
 }
 

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -17,9 +17,7 @@ use warp::tui_export::{
 };
 use warpui_core::r#async::Timer;
 use warpui_core::elements::MouseStateHandle;
-use warpui_core::elements::tui::{
-    Modifier, TuiChildView, TuiElement, TuiFlex, TuiParentElement, TuiText, tui_collapsible,
-};
+use warpui_core::elements::tui::{Modifier, TuiChildView, TuiElement, TuiFlex, tui_collapsible};
 use warpui_core::keymap::macros::*;
 use warpui_core::keymap::{EditableBinding, FixedBinding};
 use warpui_core::{
@@ -121,9 +119,7 @@ pub(super) struct TuiShellCommandView {
     terminal_model: Arc<FairMutex<TerminalModel>>,
     command_editor: ViewHandle<TuiEditorView>,
     permission_prompt: ViewHandle<TuiPermissionPrompt>,
-    editing_command: bool,
     command_was_edited: bool,
-    command_error: bool,
     state: ShellCommandViewState,
     command_running: Cell<bool>,
     header_mouse_state: MouseStateHandle,
@@ -159,26 +155,27 @@ impl TuiShellCommandView {
         ));
         let command = Self::action_command(&action).to_owned();
         let command_editor = ctx.add_typed_action_tui_view(|ctx| TuiEditorView::multiline(4, ctx));
-        command_editor.update(ctx, |editor, ctx| {
-            editor.set_text(command, ctx);
-            editor.set_editable(false, ctx);
-        });
+        command_editor.update(ctx, |editor, ctx| editor.set_text(command, ctx));
         let prompt_action_id = action.id.clone();
         let prompt_action_model = action_model.clone();
+        let prompt_command_editor = command_editor.clone();
         let permission_prompt = ctx.add_typed_action_tui_view(move |ctx| {
-            TuiPermissionPrompt::new(prompt_action_model, prompt_action_id, true, ctx)
+            TuiPermissionPrompt::new(
+                prompt_action_model,
+                prompt_action_id,
+                Some(prompt_command_editor),
+                ctx,
+            )
         });
         ctx.subscribe_to_view(&command_editor, |view, _, event, ctx| {
             let TuiEditorViewEvent::Changed(_) = event;
-            if view.editing_command {
-                view.command_was_edited = true;
-                view.command_error = false;
-                view.invalidate_layout(ctx);
-            }
+            view.command_was_edited = true;
+            view.permission_prompt
+                .update(ctx, |prompt, ctx| prompt.set_body_error(None, ctx));
+            view.invalidate_layout(ctx);
         });
         ctx.subscribe_to_view(&permission_prompt, |view, _, event, ctx| match event {
             TuiPermissionPromptEvent::AcceptRequested => view.accept(ctx),
-            TuiPermissionPromptEvent::EditBodyRequested => view.begin_command_edit(ctx),
             TuiPermissionPromptEvent::ReplacementGuidanceSubmitted(text) => {
                 ctx.emit(TuiShellCommandViewEvent::ReplacementGuidanceSubmitted(
                     text.clone(),
@@ -199,9 +196,7 @@ impl TuiShellCommandView {
             terminal_model,
             command_editor,
             permission_prompt,
-            editing_command: false,
             command_was_edited: false,
-            command_error: false,
             state: ShellCommandViewState::new_collapsed(),
             command_running: Cell::new(false),
             header_mouse_state: MouseStateHandle::default(),
@@ -216,7 +211,7 @@ impl TuiShellCommandView {
         output_streaming: bool,
         ctx: &mut ViewContext<Self>,
     ) {
-        if !self.command_was_edited && !self.editing_command {
+        if !self.command_was_edited && !self.command_editor.as_ref(ctx).is_focused() {
             let command = Self::action_command(&action).to_owned();
             self.command_editor
                 .update(ctx, |editor, ctx| editor.set_text(command, ctx));
@@ -242,23 +237,10 @@ impl TuiShellCommandView {
         }
     }
 
-    fn begin_command_edit(&mut self, ctx: &mut ViewContext<Self>) {
-        self.editing_command = true;
-        self.command_error = false;
-        self.command_editor.update(ctx, |editor, ctx| {
-            editor.set_editable(true, ctx);
-            ctx.focus_self();
-        });
-        self.invalidate_layout(ctx);
-    }
-
-    fn save_command_edit(&mut self, ctx: &mut ViewContext<Self>) {
-        if !self.editing_command {
+    fn save_command_edit(&self, ctx: &mut ViewContext<Self>) {
+        if !self.command_editor.as_ref(ctx).is_focused() {
             return;
         }
-        self.editing_command = false;
-        self.command_editor
-            .update(ctx, |editor, ctx| editor.set_editable(false, ctx));
         self.permission_prompt
             .update(ctx, |prompt, ctx| prompt.restore_options_focus(ctx));
         self.invalidate_layout(ctx);
@@ -267,7 +249,9 @@ impl TuiShellCommandView {
     fn accept(&mut self, ctx: &mut ViewContext<Self>) {
         let command = self.command_editor.as_ref(ctx).text(ctx);
         if command.trim().is_empty() {
-            self.command_error = true;
+            self.permission_prompt.update(ctx, |prompt, ctx| {
+                prompt.set_body_error(Some("Enter a command to continue.".to_owned()), ctx);
+            });
             self.invalidate_layout(ctx);
             return;
         }
@@ -295,19 +279,10 @@ impl TuiShellCommandView {
     }
 
     fn render_blocked(&self, app: &AppContext) -> Box<dyn TuiElement> {
-        let builder = TuiUiBuilder::from_app(app);
-        let mut body = TuiFlex::column().child(TuiChildView::new(&self.command_editor).finish());
-        if self.command_error {
-            body.add_child(
-                TuiText::new("Enter a command to continue.")
-                    .with_style(builder.error_text_style())
-                    .finish(),
-            );
-        }
         render_permission_card(
             &self.permission_prompt,
             "Is it OK if I run this command and read the output?",
-            body.finish(),
+            None,
             app,
         )
     }
@@ -427,7 +402,7 @@ impl TuiView for TuiShellCommandView {
     }
 
     fn child_view_ids(&self, _app: &AppContext) -> Vec<EntityId> {
-        let mut ids = vec![self.command_editor.id(), self.permission_prompt.id()];
+        let mut ids = vec![self.permission_prompt.id()];
         ids.extend(self.cli_subagent_view.iter().map(|view| view.id()));
         ids
     }
@@ -439,7 +414,7 @@ impl TuiView for TuiShellCommandView {
             .as_ref(app)
             .get_action_status(&self.action.id)
             .is_some_and(|status| status.is_blocked());
-        if blocked && self.editing_command {
+        if blocked && self.command_editor.as_ref(app).is_focused() {
             context.set.insert(SHELL_COMMAND_EDITING);
         }
         context

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -12,17 +12,23 @@ use std::time::Duration;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    AIActionStatus, AIAgentAction, AIAgentActionResultType, AIAgentActionType, BlockId,
-    BlocklistAIActionModel, RequestCommandOutputResult, TerminalModel,
+    AIActionStatus, AIAgentAction, AIAgentActionResultType, AIAgentActionType, AIConversationId,
+    BlockId, BlocklistAIActionModel, CancellationReason, RequestCommandOutputResult, TerminalModel,
 };
 use warpui_core::r#async::Timer;
 use warpui_core::elements::MouseStateHandle;
-use warpui_core::elements::tui::{Modifier, TuiChildView, TuiElement, TuiFlex, tui_collapsible};
+use warpui_core::elements::tui::{
+    Modifier, TuiChildView, TuiElement, TuiFlex, TuiParentElement, TuiText, tui_collapsible,
+};
+use warpui_core::keymap::macros::*;
+use warpui_core::keymap::{EditableBinding, FixedBinding};
 use warpui_core::{
     AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
 };
 
 use crate::agent_block_sections::render_fallback_tool_call_section;
+use crate::editor_view::{TuiEditorView, TuiEditorViewEvent};
+use crate::keybindings::{TUI_BINDING_GROUP, is_tui_owned_binding};
 use crate::terminal_block::TerminalBlockElement;
 use crate::terminal_use::user_controls_running_command;
 use crate::tool_call_labels::{
@@ -30,7 +36,48 @@ use crate::tool_call_labels::{
 };
 use crate::tui_builder::TuiUiBuilder;
 use crate::tui_cli_subagent_view::{TuiCLISubagentView, TuiCLISubagentViewEvent};
+use crate::tui_permission_prompt::{
+    TuiPermissionPrompt, TuiPermissionPromptEvent, render_permission_card,
+};
 const COMMAND_AUTO_EXPAND_DELAY: Duration = Duration::from_secs(3);
+const SHELL_COMMAND_EDITING: &str = "TuiShellCommandEditing";
+
+pub(crate) fn init(app: &mut AppContext) {
+    let predicate = id!(TuiShellCommandView::ui_name()) & id!(SHELL_COMMAND_EDITING);
+    app.register_fixed_bindings([
+        FixedBinding::new(
+            "escape",
+            TuiShellCommandViewAction::CancelPermission,
+            predicate.clone(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "ctrl-e",
+            TuiShellCommandViewAction::SaveCommandEdit,
+            predicate.clone(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+    ]);
+    app.register_editable_bindings([
+        EditableBinding::new(
+            "tui:shell-permission:save",
+            "Save the edited shell command",
+            TuiShellCommandViewAction::SaveCommandEdit,
+        )
+        .with_context_predicate(predicate.clone())
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("enter"),
+        EditableBinding::new(
+            "tui:shell-permission:save",
+            "Save the edited shell command",
+            TuiShellCommandViewAction::SaveCommandEdit,
+        )
+        .with_context_predicate(predicate)
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("down"),
+    ]);
+    app.register_tui_binding_validator::<TuiShellCommandView>(is_tui_owned_binding);
+}
 
 struct ShellCommandViewState {
     collapsed: bool,
@@ -70,7 +117,13 @@ pub(super) struct TuiShellCommandView {
     action: AIAgentAction,
     output_streaming: bool,
     action_model: ModelHandle<BlocklistAIActionModel>,
+    conversation_id: AIConversationId,
     terminal_model: Arc<FairMutex<TerminalModel>>,
+    command_editor: ViewHandle<TuiEditorView>,
+    permission_prompt: ViewHandle<TuiPermissionPrompt>,
+    editing_command: bool,
+    command_was_edited: bool,
+    command_error: bool,
     state: ShellCommandViewState,
     command_running: Cell<bool>,
     header_mouse_state: MouseStateHandle,
@@ -79,12 +132,16 @@ pub(super) struct TuiShellCommandView {
 
 /// Events emitted to the owning agent block.
 pub(super) enum TuiShellCommandViewEvent {
+    BlockingStateChanged,
     LayoutChanged,
+    ReplacementGuidanceSubmitted(String),
 }
 
 /// User interactions handled by the shell-command view.
 #[derive(Clone, Debug)]
 pub(super) enum TuiShellCommandViewAction {
+    CancelPermission,
+    SaveCommandEdit,
     ToggleExpanded,
 }
 impl TuiShellCommandView {
@@ -92,17 +149,59 @@ impl TuiShellCommandView {
         action: AIAgentAction,
         output_streaming: bool,
         action_model: ModelHandle<BlocklistAIActionModel>,
+        conversation_id: AIConversationId,
         terminal_model: Arc<FairMutex<TerminalModel>>,
+        ctx: &mut ViewContext<Self>,
     ) -> Self {
         debug_assert!(matches!(
             &action.action,
             AIAgentActionType::RequestCommandOutput { .. }
         ));
+        let command = Self::action_command(&action).to_owned();
+        let command_editor = ctx.add_typed_action_tui_view(|ctx| TuiEditorView::multiline(4, ctx));
+        command_editor.update(ctx, |editor, ctx| {
+            editor.set_text(command, ctx);
+            editor.set_editable(false, ctx);
+        });
+        let prompt_action_id = action.id.clone();
+        let prompt_action_model = action_model.clone();
+        let permission_prompt = ctx.add_typed_action_tui_view(move |ctx| {
+            TuiPermissionPrompt::new(prompt_action_model, prompt_action_id, true, ctx)
+        });
+        ctx.subscribe_to_view(&command_editor, |view, _, event, ctx| {
+            let TuiEditorViewEvent::Changed(_) = event;
+            if view.editing_command {
+                view.command_was_edited = true;
+                view.command_error = false;
+                view.invalidate_layout(ctx);
+            }
+        });
+        ctx.subscribe_to_view(&permission_prompt, |view, _, event, ctx| match event {
+            TuiPermissionPromptEvent::AcceptRequested => view.accept(ctx),
+            TuiPermissionPromptEvent::EditBodyRequested => view.begin_command_edit(ctx),
+            TuiPermissionPromptEvent::ReplacementGuidanceSubmitted(text) => {
+                ctx.emit(TuiShellCommandViewEvent::ReplacementGuidanceSubmitted(
+                    text.clone(),
+                ));
+            }
+            TuiPermissionPromptEvent::RejectRequested => view.reject(ctx),
+            TuiPermissionPromptEvent::BlockingStateChanged => {
+                ctx.emit(TuiShellCommandViewEvent::BlockingStateChanged);
+                view.invalidate_layout(ctx);
+            }
+            TuiPermissionPromptEvent::LayoutChanged => view.invalidate_layout(ctx),
+        });
         Self {
             action,
             output_streaming,
             action_model,
+            conversation_id,
             terminal_model,
+            command_editor,
+            permission_prompt,
+            editing_command: false,
+            command_was_edited: false,
+            command_error: false,
             state: ShellCommandViewState::new_collapsed(),
             command_running: Cell::new(false),
             header_mouse_state: MouseStateHandle::default(),
@@ -111,9 +210,106 @@ impl TuiShellCommandView {
     }
 
     /// Refreshes streamed action arguments without replacing interaction state.
-    pub(super) fn update_action(&mut self, action: AIAgentAction, output_streaming: bool) {
+    pub(super) fn update_action(
+        &mut self,
+        action: AIAgentAction,
+        output_streaming: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !self.command_was_edited && !self.editing_command {
+            let command = Self::action_command(&action).to_owned();
+            self.command_editor
+                .update(ctx, |editor, ctx| editor.set_text(command, ctx));
+        }
         self.action = action;
         self.output_streaming = output_streaming;
+    }
+
+    pub(super) fn active_permission_prompt(
+        &self,
+        app: &AppContext,
+    ) -> Option<ViewHandle<TuiPermissionPrompt>> {
+        self.permission_prompt
+            .as_ref(app)
+            .is_active(app)
+            .then(|| self.permission_prompt.clone())
+    }
+
+    fn action_command(action: &AIAgentAction) -> &str {
+        match &action.action {
+            AIAgentActionType::RequestCommandOutput { command, .. } => command,
+            _ => "",
+        }
+    }
+
+    fn begin_command_edit(&mut self, ctx: &mut ViewContext<Self>) {
+        self.editing_command = true;
+        self.command_error = false;
+        self.command_editor.update(ctx, |editor, ctx| {
+            editor.set_editable(true, ctx);
+            ctx.focus_self();
+        });
+        self.invalidate_layout(ctx);
+    }
+
+    fn save_command_edit(&mut self, ctx: &mut ViewContext<Self>) {
+        if !self.editing_command {
+            return;
+        }
+        self.editing_command = false;
+        self.command_editor
+            .update(ctx, |editor, ctx| editor.set_editable(false, ctx));
+        self.permission_prompt
+            .update(ctx, |prompt, ctx| prompt.restore_options_focus(ctx));
+        self.invalidate_layout(ctx);
+    }
+
+    fn accept(&mut self, ctx: &mut ViewContext<Self>) {
+        let command = self.command_editor.as_ref(ctx).text(ctx);
+        if command.trim().is_empty() {
+            self.command_error = true;
+            self.invalidate_layout(ctx);
+            return;
+        }
+        let action_id = self.action.id.clone();
+        self.action_model.update(ctx, |action_model, ctx| {
+            action_model.handle_requested_command_accepted(&action_id, command, ctx);
+        });
+    }
+
+    fn reject(&self, ctx: &mut ViewContext<Self>) {
+        let action_id = self.action.id.clone();
+        self.action_model.update(ctx, |action_model, ctx| {
+            action_model.cancel_action_with_id(
+                self.conversation_id,
+                &action_id,
+                CancellationReason::ManuallyCancelled,
+                ctx,
+            );
+        });
+    }
+
+    fn invalidate_layout(&self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(TuiShellCommandViewEvent::LayoutChanged);
+        ctx.notify();
+    }
+
+    fn render_blocked(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(app);
+        let mut body = TuiFlex::column().child(TuiChildView::new(&self.command_editor).finish());
+        if self.command_error {
+            body.add_child(
+                TuiText::new("Enter a command to continue.")
+                    .with_style(builder.error_text_style())
+                    .finish(),
+            );
+        }
+        render_permission_card(
+            &self.permission_prompt,
+            "Is it OK if I run this command and read the output?",
+            body.finish(),
+            app,
+        )
     }
 
     pub(super) fn set_cli_subagent_view(
@@ -231,10 +427,22 @@ impl TuiView for TuiShellCommandView {
     }
 
     fn child_view_ids(&self, _app: &AppContext) -> Vec<EntityId> {
-        self.cli_subagent_view
-            .iter()
-            .map(|view| view.id())
-            .collect()
+        let mut ids = vec![self.command_editor.id(), self.permission_prompt.id()];
+        ids.extend(self.cli_subagent_view.iter().map(|view| view.id()));
+        ids
+    }
+
+    fn keymap_context(&self, app: &AppContext) -> warpui_core::keymap::Context {
+        let mut context = Self::default_keymap_context();
+        let blocked = self
+            .action_model
+            .as_ref(app)
+            .get_action_status(&self.action.id)
+            .is_some_and(|status| status.is_blocked());
+        if blocked && self.editing_command {
+            context.set.insert(SHELL_COMMAND_EDITING);
+        }
+        context
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
@@ -242,6 +450,10 @@ impl TuiView for TuiShellCommandView {
             .action_model
             .as_ref(app)
             .get_action_status(&self.action.id);
+        if matches!(status, Some(AIActionStatus::Blocked)) {
+            self.command_running.set(false);
+            return self.render_blocked(app);
+        }
         let Some(block) = self.resolved_block(status.as_ref()) else {
             self.command_running.set(false);
             return render_fallback_tool_call_section(
@@ -297,6 +509,8 @@ impl TypedActionView for TuiShellCommandView {
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
+            TuiShellCommandViewAction::CancelPermission => self.reject(ctx),
+            TuiShellCommandViewAction::SaveCommandEdit => self.save_command_edit(ctx),
             TuiShellCommandViewAction::ToggleExpanded => {
                 if self.user_controls_command() {
                     return;

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -208,6 +208,7 @@ impl TuiShellCommandView {
         }
         self.action = action;
         self.output_streaming = output_streaming;
+        self.invalidate_layout(ctx);
     }
 
     pub(super) fn active_permission_prompt(

--- a/crates/warp_tui/src/tui_shell_command_view_tests.rs
+++ b/crates/warp_tui/src/tui_shell_command_view_tests.rs
@@ -110,21 +110,49 @@ fn command_editing_saves_text_without_executing() {
         let action = command_action("action-1", "echo original");
         let view = add_shell_view(
             &mut app,
-            action,
+            action.clone(),
             Arc::new(FairMutex::new(TerminalModel::mock(None, None))),
         );
+        let (action_model, conversation_id, prompt) = app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            (
+                view.action_model.clone(),
+                view.conversation_id,
+                view.permission_prompt.clone(),
+            )
+        });
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action, conversation_id, ctx);
+        });
 
+        prompt.update(&mut app, |prompt, ctx| {
+            prompt.handle_action(
+                &crate::tui_permission_prompt::TuiPermissionPromptAction::MoveUp,
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(view.command_editor.as_ref(ctx).is_focused());
+            assert_eq!(
+                view.permission_prompt.as_ref(ctx).highlighted_index(ctx),
+                None
+            );
+        });
         view.update(&mut app, |view, ctx| {
-            view.begin_command_edit(ctx);
             view.command_editor.update(ctx, |editor, ctx| {
-                editor.set_text("echo edited\necho second", ctx);
+                editor.set_text("echo edited\necho second", ctx)
             });
-            view.save_command_edit(ctx);
+            view.handle_action(&TuiShellCommandViewAction::SaveCommandEdit, ctx);
         });
 
         app.read(|ctx| {
             let view = view.as_ref(ctx);
-            assert!(!view.editing_command);
+            assert!(!view.command_editor.as_ref(ctx).is_focused());
+            assert_eq!(
+                view.permission_prompt.as_ref(ctx).highlighted_index(ctx),
+                Some(0)
+            );
             assert_eq!(
                 view.command_editor.as_ref(ctx).text(ctx),
                 "echo edited\necho second"

--- a/crates/warp_tui/src/tui_shell_command_view_tests.rs
+++ b/crates/warp_tui/src/tui_shell_command_view_tests.rs
@@ -5,18 +5,23 @@ use std::sync::Arc;
 use parking_lot::FairMutex;
 use warp::tui_export::{
     AIAgentAction, AIAgentActionId, AIAgentActionType, AIConversationId, Appearance, TaskId,
-    TerminalModel,
+    TerminalModel, queue_tui_permission_action,
 };
 use warpui::AddWindowOptions;
 use warpui::platform::WindowStyle;
-use warpui_core::elements::tui::{TuiBufferExt, TuiConstraint, TuiLayoutContext, TuiRect, TuiSize};
+use warpui_core::elements::tui::{
+    Color, TuiBufferExt, TuiConstraint, TuiLayoutContext, TuiRect, TuiSize,
+};
 use warpui_core::presenter::tui::TuiPresenter;
-use warpui_core::{App, AppContext, EntityIdMap, TuiView, TypedActionView, ViewHandle};
+use warpui_core::{
+    App, AppContext, EntityIdMap, TuiView, TypedActionView, ViewHandle, WindowInvalidation,
+};
 
 use super::{
     ShellCommandViewState, TuiShellCommandView, TuiShellCommandViewAction, TuiShellCommandViewEvent,
 };
 use crate::test_fixtures::{TestHostView, add_test_action_model};
+use crate::tui_builder::TuiUiBuilder;
 
 #[test]
 fn command_without_terminal_block_uses_fallback_row() {
@@ -39,6 +44,102 @@ fn command_without_terminal_block_uses_fallback_row() {
 }
 
 #[test]
+fn blocked_command_card_matches_permission_layout() {
+    App::test((), |mut app| async move {
+        let action = command_action("action-1", "echo 1");
+        let view = add_shell_view(
+            &mut app,
+            action.clone(),
+            Arc::new(FairMutex::new(TerminalModel::mock(None, None))),
+        );
+        let (action_model, conversation_id) = app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            (view.action_model.clone(), view.conversation_id)
+        });
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action, conversation_id, ctx);
+        });
+
+        let mut presenter = TuiPresenter::new();
+        let frame = app.update(|ctx| {
+            let view_ref = view.as_ref(ctx);
+            let prompt = &view_ref.permission_prompt;
+            let mut invalidation = WindowInvalidation::default();
+            invalidation.updated.insert(view.id());
+            invalidation.updated.insert(view_ref.command_editor.id());
+            invalidation.updated.insert(prompt.id());
+            invalidation
+                .updated
+                .extend(prompt.as_ref(ctx).child_view_ids(ctx));
+            presenter.invalidate(&invalidation, ctx, view.window_id(ctx));
+            presenter.present(ctx, &view, TuiRect::new(0, 0, 80, 16))
+        });
+        let lines = frame.buffer.to_lines();
+        let row_containing = |text: &str| {
+            u16::try_from(
+                lines
+                    .iter()
+                    .position(|line| line.contains(text))
+                    .unwrap_or_else(|| panic!("missing {text:?} in {lines:?}")),
+            )
+            .expect("row fits in the TUI")
+        };
+        let header_row = row_containing("Is it OK if I run this command");
+        let command_row = row_containing("echo 1");
+        let first_option_row = row_containing("(1) yes");
+        let footer_row = row_containing("Esc to cancel");
+        assert!(first_option_row >= command_row + 2);
+
+        let (header_background, surface_background) = app.read(|ctx| {
+            let builder = TuiUiBuilder::from_app(ctx);
+            (
+                builder.permission_header_background(),
+                builder.permission_surface_background(),
+            )
+        });
+        assert_ne!(header_background, surface_background);
+        assert_eq!(frame.buffer[(79, header_row)].bg, header_background);
+        assert_eq!(frame.buffer[(79, command_row)].bg, surface_background);
+        assert_eq!(frame.buffer[(79, footer_row)].bg, Color::Reset);
+    });
+}
+
+#[test]
+fn command_editing_saves_text_without_executing() {
+    App::test((), |mut app| async move {
+        let action = command_action("action-1", "echo original");
+        let view = add_shell_view(
+            &mut app,
+            action,
+            Arc::new(FairMutex::new(TerminalModel::mock(None, None))),
+        );
+
+        view.update(&mut app, |view, ctx| {
+            view.begin_command_edit(ctx);
+            view.command_editor.update(ctx, |editor, ctx| {
+                editor.set_text("echo edited\necho second", ctx);
+            });
+            view.save_command_edit(ctx);
+        });
+
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(!view.editing_command);
+            assert_eq!(
+                view.command_editor.as_ref(ctx).text(ctx),
+                "echo edited\necho second"
+            );
+            assert!(
+                view.action_model
+                    .as_ref(ctx)
+                    .get_action_result(&view.action.id)
+                    .is_none()
+            );
+        });
+    });
+}
+
+#[test]
 fn terminal_block_is_collapsed_by_default_and_expands_inline() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
@@ -53,6 +154,8 @@ fn terminal_block_is_collapsed_by_default_and_expands_inline() {
                 TuiShellCommandViewEvent::LayoutChanged => {
                     invalidations_for_subscription.set(invalidations_for_subscription.get() + 1);
                 }
+                TuiShellCommandViewEvent::BlockingStateChanged
+                | TuiShellCommandViewEvent::ReplacementGuidanceSubmitted(_) => {}
             });
         });
         let collapsed_height = app.read(|app| {
@@ -120,8 +223,15 @@ fn add_shell_view(
             },
             |_| TestHostView,
         );
-        ctx.add_typed_action_tui_view(window_id, move |_| {
-            TuiShellCommandView::new(action, false, action_model, terminal_model)
+        ctx.add_typed_action_tui_view(window_id, move |ctx| {
+            TuiShellCommandView::new(
+                action,
+                false,
+                action_model,
+                AIConversationId::new(),
+                terminal_model,
+                ctx,
+            )
         })
     })
 }

--- a/crates/warp_tui/src/tui_shell_command_view_tests.rs
+++ b/crates/warp_tui/src/tui_shell_command_view_tests.rs
@@ -168,6 +168,36 @@ fn finishing_command_editing_selects_yes_without_executing() {
 }
 
 #[test]
+fn streamed_action_refresh_invalidates_layout() {
+    App::test((), |mut app| async move {
+        let action = command_action("action-1", "echo original");
+        let view = add_shell_view(
+            &mut app,
+            action.clone(),
+            Arc::new(FairMutex::new(TerminalModel::mock(None, None))),
+        );
+        let layout_invalidations = Rc::new(Cell::new(0));
+        let invalidations_for_subscription = layout_invalidations.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&view, move |_, event, _| match event {
+                TuiShellCommandViewEvent::LayoutChanged => {
+                    invalidations_for_subscription.set(invalidations_for_subscription.get() + 1);
+                }
+                TuiShellCommandViewEvent::BlockingStateChanged
+                | TuiShellCommandViewEvent::ReplacementGuidanceSubmitted(_) => {}
+            });
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.command_was_edited = true;
+            view.update_action(action, true, ctx);
+        });
+
+        assert_eq!(layout_invalidations.get(), 1);
+    });
+}
+
+#[test]
 fn terminal_block_is_collapsed_by_default_and_expands_inline() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());

--- a/crates/warp_tui/src/tui_shell_command_view_tests.rs
+++ b/crates/warp_tui/src/tui_shell_command_view_tests.rs
@@ -105,7 +105,7 @@ fn blocked_command_card_matches_permission_layout() {
 }
 
 #[test]
-fn command_editing_saves_text_without_executing() {
+fn finishing_command_editing_selects_yes_without_executing() {
     App::test((), |mut app| async move {
         let action = command_action("action-1", "echo original");
         let view = add_shell_view(

--- a/crates/warp_tui/src/tui_shell_command_view_tests.rs
+++ b/crates/warp_tui/src/tui_shell_command_view_tests.rs
@@ -12,6 +12,7 @@ use warpui::platform::WindowStyle;
 use warpui_core::elements::tui::{
     Color, TuiBufferExt, TuiConstraint, TuiLayoutContext, TuiRect, TuiSize,
 };
+use warpui_core::keymap::Keystroke;
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{
     App, AppContext, EntityIdMap, TuiView, TypedActionView, ViewHandle, WindowInvalidation,
@@ -107,6 +108,7 @@ fn blocked_command_card_matches_permission_layout() {
 #[test]
 fn finishing_command_editing_selects_yes_without_executing() {
     App::test((), |mut app| async move {
+        app.update(super::init);
         let action = command_action("action-1", "echo original");
         let view = add_shell_view(
             &mut app,
@@ -139,12 +141,20 @@ fn finishing_command_editing_selects_yes_without_executing() {
                 None
             );
         });
-        view.update(&mut app, |view, ctx| {
-            view.command_editor.update(ctx, |editor, ctx| {
-                editor.set_text("echo edited\necho second", ctx)
-            });
-            view.handle_action(&TuiShellCommandViewAction::SaveCommandEdit, ctx);
+        let command_editor = app.read(|ctx| view.as_ref(ctx).command_editor.clone());
+        command_editor.update(&mut app, |editor, ctx| {
+            editor.set_text("echo edited\necho second", ctx)
         });
+        let window_id = app.read(|ctx| view.window_id(ctx));
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &[view.id(), prompt.id(), command_editor.id()],
+                &Keystroke::parse("enter").expect("valid Enter keystroke"),
+                false,
+            )
+            .expect("Enter dispatch succeeds");
+        assert!(handled);
 
         app.read(|ctx| {
             let view = view.as_ref(ctx);


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR adds permissions requests for shell commands. The unique thing about these is that the shell commands are actually editable (if you up arrow or click on the shell command itself). This arg-editing logic is moved into a shared location, as it (plus the up arrow behavior, acceptance behavior, etc) is shared w/ the model selector in the orchestration model-selection flow.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/4ce1ce3650e14a4da7944f8de367c112

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode