### PR TITLE
fix: prevent conversations from getting stuck loading

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -125,12 +125,46 @@ enum TaskFetchState {
     TransientlyFailed { at: Instant, error: TaskFetchError },
 }
 
-/// Availability state for cloud conversation metadata.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-enum CloudConversationMetadataLoadState {
-    #[default]
-    Available,
-    Failed,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InitialConversationLoadState {
+    LoadingLocal,
+    WaitingForCloud,
+    LoadingCloud,
+    Loaded,
+    CloudFailed,
+}
+
+impl InitialConversationLoadState {
+    fn is_loading_local(self) -> bool {
+        match self {
+            InitialConversationLoadState::LoadingLocal => true,
+            InitialConversationLoadState::WaitingForCloud
+            | InitialConversationLoadState::LoadingCloud
+            | InitialConversationLoadState::Loaded
+            | InitialConversationLoadState::CloudFailed => false,
+        }
+    }
+
+    fn can_start_cloud_load(self) -> bool {
+        match self {
+            InitialConversationLoadState::WaitingForCloud => true,
+            InitialConversationLoadState::LoadingLocal
+            | InitialConversationLoadState::LoadingCloud
+            | InitialConversationLoadState::Loaded
+            | InitialConversationLoadState::CloudFailed => false,
+        }
+    }
+
+    fn can_poll(self) -> bool {
+        match self {
+            InitialConversationLoadState::Loaded | InitialConversationLoadState::CloudFailed => {
+                true
+            }
+            InitialConversationLoadState::LoadingLocal
+            | InitialConversationLoadState::WaitingForCloud
+            | InitialConversationLoadState::LoadingCloud => false,
+        }
+    }
 }
 
 /// Tracks the cooldown window for RTC-triggered task-list refreshes. Pending events keep
@@ -593,10 +627,7 @@ pub struct AgentConversationsModel {
     /// Set of view IDs actively consuming this model's data per window.
     /// When a window has at least one consumer, we poll for new tasks while that window is active.
     active_data_consumers_per_window: HashMap<WindowId, HashSet<EntityId>>,
-    /// Whether we have finished the initial task load
-    has_finished_initial_load: bool,
-    /// Availability state for cloud conversation metadata.
-    cloud_conversation_metadata_load_state: CloudConversationMetadataLoadState,
+    initial_load_state: InitialConversationLoadState,
     /// Per-task fetch state for `get_or_async_fetch_task_data`. See [`TaskFetchState`] for
     /// the meaning of each variant. Tasks that have been successfully fetched live in `tasks`
     /// and are absent from this map.
@@ -608,7 +639,7 @@ pub struct AgentConversationsModel {
 }
 
 pub enum AgentConversationsModelEvent {
-    /// Initial load of tasks completed.
+    /// Conversation data was loaded or refreshed.
     ConversationsLoaded,
     /// New tasks were received during polling (view should diff against its local state).
     NewTasksReceived,
@@ -651,9 +682,7 @@ impl AgentConversationsModel {
                 in_flight_poll_abort_handle: None,
                 next_poll_abort_handle: None,
                 active_data_consumers_per_window: HashMap::new(),
-                has_finished_initial_load: true,
-                cloud_conversation_metadata_load_state:
-                    CloudConversationMetadataLoadState::Available,
+                initial_load_state: InitialConversationLoadState::Loaded,
                 task_fetch_state: HashMap::new(),
                 rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
                 dirty_since: None,
@@ -692,8 +721,7 @@ impl AgentConversationsModel {
             in_flight_poll_abort_handle: None,
             next_poll_abort_handle: None,
             active_data_consumers_per_window: HashMap::new(),
-            has_finished_initial_load: false,
-            cloud_conversation_metadata_load_state: CloudConversationMetadataLoadState::Available,
+            initial_load_state: InitialConversationLoadState::LoadingLocal,
             task_fetch_state: HashMap::new(),
             rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
             dirty_since: None,
@@ -705,19 +733,19 @@ impl AgentConversationsModel {
         if AppExecutionMode::as_ref(ctx).can_fetch_agent_runs_for_management() {
             model.sync_conversations(ctx);
         } else {
-            model.has_finished_initial_load = true;
+            model.initial_load_state = InitialConversationLoadState::Loaded;
         }
         model
     }
 
     pub fn is_loading(&self) -> bool {
-        !self.has_finished_initial_load
+        self.initial_load_state.is_loading_local()
     }
 
     /// Returns whether cloud conversation metadata failed to load.
     #[cfg_attr(not(feature = "tui"), allow(dead_code))]
     pub(crate) fn cloud_conversation_metadata_load_failed(&self) -> bool {
-        self.cloud_conversation_metadata_load_state == CloudConversationMetadataLoadState::Failed
+        self.initial_load_state == InitialConversationLoadState::CloudFailed
     }
 
     fn handle_network_status_changed(
@@ -760,10 +788,10 @@ impl AgentConversationsModel {
         event: &AuthManagerEvent,
         ctx: &mut ModelContext<Self>,
     ) {
-        // When auth completes, retry the initial task sync if we haven't loaded tasks yet
+        // When auth completes, start the initial cloud sync if it has not started yet.
         // Only sync if we're not in CLI mode
         if matches!(event, AuthManagerEvent::AuthComplete)
-            && !self.has_finished_initial_load
+            && self.initial_load_state.can_start_cloud_load()
             && AppExecutionMode::as_ref(ctx).can_fetch_agent_runs_for_management()
         {
             self.fetch_ambient_agent_tasks_and_cloud_convo_metadata(ctx);
@@ -916,6 +944,9 @@ impl AgentConversationsModel {
             let metadata = ConversationMetadata { nav_data };
             self.conversations.insert(conversation_id, metadata);
         }
+        if self.initial_load_state == InitialConversationLoadState::LoadingLocal {
+            self.initial_load_state = InitialConversationLoadState::WaitingForCloud;
+        }
 
         ctx.emit(AgentConversationsModelEvent::ConversationsLoaded);
     }
@@ -937,6 +968,7 @@ impl AgentConversationsModel {
             // If we don't have AI enabled, don't pull tasks
             return;
         }
+        self.initial_load_state = InitialConversationLoadState::LoadingCloud;
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
 
@@ -1031,11 +1063,10 @@ impl AgentConversationsModel {
                     cloud_metadata_loaded,
                 )) = result
                 {
-                    model.has_finished_initial_load = true;
-                    model.cloud_conversation_metadata_load_state = if cloud_metadata_loaded {
-                        CloudConversationMetadataLoadState::Available
+                    model.initial_load_state = if cloud_metadata_loaded {
+                        InitialConversationLoadState::Loaded
                     } else {
-                        CloudConversationMetadataLoadState::Failed
+                        InitialConversationLoadState::CloudFailed
                     };
 
                     // Update tasks if we got any
@@ -1063,9 +1094,7 @@ impl AgentConversationsModel {
                     model.update_polling_state(ctx);
                     ctx.emit(AgentConversationsModelEvent::ConversationsLoaded);
                 } else if let RequestState::RequestFailed(e) = result {
-                    model.has_finished_initial_load = true;
-                    model.cloud_conversation_metadata_load_state =
-                        CloudConversationMetadataLoadState::Failed;
+                    model.initial_load_state = InitialConversationLoadState::CloudFailed;
                     model.update_polling_state(ctx);
                     report_error!(e);
                 }
@@ -1123,7 +1152,7 @@ impl AgentConversationsModel {
 
     /// Returns true if we should be polling: online, not loading, and active window has the view open.
     fn should_be_polling(&self, ctx: &ModelContext<Self>) -> bool {
-        if !self.has_finished_initial_load {
+        if !self.initial_load_state.can_poll() {
             return false;
         }
 
@@ -2018,8 +2047,7 @@ impl AgentConversationsModel {
         self.active_data_consumers_per_window.clear();
         self.task_fetch_state.clear();
         self.dirty_since = None;
-        // Reset the initial load flag so that we can retry the initial sync with the new logged in user
-        self.has_finished_initial_load = false;
+        self.initial_load_state = InitialConversationLoadState::WaitingForCloud;
     }
 }
 

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -16,11 +16,10 @@ use super::entry::{
 use super::query::{DEFAULT_RESULT_COUNT, MAX_SEARCH_RESULTS};
 use super::{
     AgentConversationsModel, AgentConversationsModelEvent, AgentManagementFilters,
-    AgentRunDisplayStatus, ArtifactFilter, CloudConversationMetadataLoadState,
-    ConversationMetadata, ConversationUpdateKind, EnvironmentFilter, HarnessFilter,
-    MAX_PERSONAL_TASKS, MAX_TEAM_TASKS, OwnerFilter, RtcTaskRefreshThrottleState, StatusFilter,
-    TaskFetchError, TaskFetchState, query_conversation_entries,
-    record_earliest_rtc_task_refresh_timestamp,
+    AgentRunDisplayStatus, ArtifactFilter, ConversationMetadata, ConversationUpdateKind,
+    EnvironmentFilter, HarnessFilter, InitialConversationLoadState, MAX_PERSONAL_TASKS,
+    MAX_TEAM_TASKS, OwnerFilter, RtcTaskRefreshThrottleState, StatusFilter, TaskFetchError,
+    TaskFetchState, query_conversation_entries, record_earliest_rtc_task_refresh_timestamp,
 };
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::api::ServerConversationToken;
@@ -43,7 +42,7 @@ use crate::server::ids::ServerId;
 use crate::server::server_api::presigned_upload::HttpStatusError;
 use crate::test_util::ai_agent_tasks::{create_api_task, create_message};
 use crate::test_util::settings::initialize_history_persistence_for_tests;
-use crate::workspace::WorkspaceAction;
+use crate::workspace::{WorkspaceAction, WorkspaceRegistry};
 
 /// Creates a test task with specified creator UID and updated_at time
 fn create_test_task(
@@ -665,8 +664,7 @@ fn create_test_model() -> AgentConversationsModel {
         in_flight_poll_abort_handle: None,
         next_poll_abort_handle: None,
         active_data_consumers_per_window: HashMap::new(),
-        has_finished_initial_load: false,
-        cloud_conversation_metadata_load_state: CloudConversationMetadataLoadState::Available,
+        initial_load_state: InitialConversationLoadState::LoadingLocal,
         task_fetch_state: Default::default(),
         rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
         dirty_since: None,
@@ -674,11 +672,31 @@ fn create_test_model() -> AgentConversationsModel {
 }
 
 #[test]
+fn local_conversation_sync_finishes_initial_load_without_starting_cloud_load() {
+    App::test((), |mut app| async move {
+        let _interactive_management_guard =
+            FeatureFlag::InteractiveConversationManagementView.override_enabled(true);
+        add_entry_projection_test_models(&mut app);
+        let model = app.add_singleton_model(|_| create_test_model());
+
+        model.update(&mut app, |model, ctx| model.sync_conversations(ctx));
+
+        model.read(&app, |model, _| {
+            assert!(!model.is_loading());
+            assert_eq!(
+                model.initial_load_state,
+                InitialConversationLoadState::WaitingForCloud
+            );
+        });
+    });
+}
+
+#[test]
 fn cloud_conversation_metadata_reports_failed_load() {
     let mut model = create_test_model();
     assert!(!model.cloud_conversation_metadata_load_failed());
 
-    model.cloud_conversation_metadata_load_state = CloudConversationMetadataLoadState::Failed;
+    model.initial_load_state = InitialConversationLoadState::CloudFailed;
     assert!(model.cloud_conversation_metadata_load_failed());
 }
 
@@ -866,6 +884,7 @@ fn add_entry_projection_test_models(app: &mut App) {
     app.add_singleton_model(|_| AuthStateProvider::new_for_test());
     app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
     app.add_singleton_model(|_| ActiveAgentViewsModel::new());
+    app.add_singleton_model(|_| WorkspaceRegistry::new());
 }
 
 fn mock_server_metadata() -> ServerMetadata {

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1293,6 +1293,31 @@ pub struct UpdateQuakeModeEventArg {
     active_window_id: Option<WindowId>,
 }
 
+fn refresh_user_after_iap_access(ctx: &mut AppContext) {
+    let iap_manager = IapManager::handle(ctx);
+    if !iap_manager.as_ref(ctx).is_enabled() || iap_manager.as_ref(ctx).has_valid_token() {
+        AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
+            auth_manager.refresh_user(ctx);
+        });
+        return;
+    }
+
+    let mut refresh_started = false;
+    ctx.subscribe_to_model(&iap_manager, move |iap_manager, event, ctx| {
+        if refresh_started
+            || !matches!(event, IapManagerEvent::StateChanged)
+            || !iap_manager.as_ref(ctx).has_valid_token()
+        {
+            return;
+        }
+        refresh_started = true;
+        AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
+            auth_manager.refresh_user(ctx);
+        });
+    });
+    iap_manager.update(ctx, |manager, ctx| manager.ensure_access(ctx));
+}
+
 #[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 pub(crate) fn initialize_app(
     launch_mode: &LaunchMode,
@@ -1751,15 +1776,6 @@ pub(crate) fn initialize_app(
     let user_is_logged_in = auth_state.is_logged_in();
 
     if user_is_logged_in {
-        // Skip refresh_user for CLI mode — the CLI handles auth refresh in
-        // ensure_auth_state so it can detect invalid credentials before running
-        // a command.
-        if !matches!(launch_mode, LaunchMode::CommandLine { .. }) {
-            AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
-                auth_manager.refresh_user(ctx);
-            });
-        }
-
         // Set the first frame callback to record the app's startup time.
         // This is only sent for logged-in users so that new users don't skew performance metrics.
         let is_screen_reader_enabled = ctx.is_screen_reader_enabled();
@@ -2262,6 +2278,13 @@ pub(crate) fn initialize_app(
             _ => {}
         };
     });
+
+    // CLI commands establish IAP access and refresh auth in their dispatch path so they can
+    // surface failures synchronously. Interactive clients wait for IAP here before refreshing
+    // their persisted user, since the refresh itself calls the IAP-gated warp-server.
+    if user_is_logged_in && !matches!(launch_mode, LaunchMode::CommandLine { .. }) {
+        refresh_user_after_iap_access(ctx);
+    }
 
     // Add a singleton model that holds the current prompt configuration.
     ctx.add_singleton_model(Prompt::new);


### PR DESCRIPTION
## Description
Prevents conversation lists from remaining stuck in a loading state when startup authentication races staging IAP initialization.

Local conversations are now available as soon as the local sync completes, while a single exhaustive load-state enum independently tracks the initial cloud phase. Logged-in non-CLI clients also wait for IAP access before refreshing the persisted user; the Oz CLI retains its existing IAP-gated dispatch path.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
