### PR TITLE
feat(tui): placeholder ghost text + agent-mode input hints (CODE-1897, CODE-1898)

### DIFF
--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -72,6 +72,9 @@ pub enum TuiEditorAction {
 /// Handler receiving the element's [`TuiEditorAction`]s during event dispatch.
 type TuiEditorActionHandler = Rc<dyn for<'a> Fn(TuiEditorAction, &mut TuiEventContext<'a>)>;
 
+/// Resolves the placeholder ghost text (and its style) from fresh app state.
+type PlaceholderGhostTextProvider = Rc<dyn Fn(&AppContext) -> Option<(String, TuiStyle)>>;
+
 /// Whole-row styles by row kind, plus per-line overrides — all consumer
 /// policy. Gutter cells take their row's style.
 #[derive(Debug, Clone, Default)]
@@ -125,6 +128,11 @@ pub(crate) struct TuiEditorElement {
     hide_trailing_empty_line: bool,
     styles: TuiEditorStyles,
     trailing_ghost_text: Option<(String, TuiStyle)>,
+    /// Resolves the empty-buffer placeholder hint against fresh app state
+    /// during every layout pass; see [`Self::with_placeholder_ghost_text`].
+    placeholder_ghost_text_provider: Option<PlaceholderGhostTextProvider>,
+    /// The provider's most recent resolution, refreshed in [`Self::build`].
+    placeholder_ghost_text: Option<(String, TuiStyle)>,
     on_action: Option<TuiEditorActionHandler>,
 
     // ── Built during layout ─────────────────────────────────────────────────
@@ -190,6 +198,8 @@ impl TuiEditorElement {
             hide_trailing_empty_line: false,
             styles: TuiEditorStyles::default(),
             trailing_ghost_text: None,
+            placeholder_ghost_text_provider: None,
+            placeholder_ghost_text: None,
             on_action: None,
             column: TuiFlex::column(),
             gutter_cols: 0,
@@ -251,6 +261,44 @@ impl TuiEditorElement {
         self
     }
 
+    /// Ghost text painted while the buffer is empty — placeholder-style
+    /// guidance (e.g. mode-dependent keybinding hints). Painted starting one
+    /// cell after the cursor so the terminal's block cursor never obscures
+    /// the first glyph (matching the design's cursor·gap·hint layout).
+    /// Rendered under the same conditions as trailing ghost text (editable,
+    /// focused, cursor visible); a configured trailing ghost text takes
+    /// precedence when both are set.
+    ///
+    /// `provider` is re-evaluated against fresh app state during every layout
+    /// pass — the element may stay cached across frames while the state the
+    /// hint depends on (e.g. transcript emptiness) changes without this
+    /// view being invalidated, so the content must never be snapshotted at
+    /// construction time.
+    pub(crate) fn with_placeholder_ghost_text(
+        mut self,
+        provider: impl Fn(&AppContext) -> Option<(String, TuiStyle)> + 'static,
+    ) -> Self {
+        self.placeholder_ghost_text_provider = Some(Rc::new(provider));
+        self
+    }
+
+    /// The ghost text to paint this frame and the column offset from the
+    /// cursor to start painting at: the trailing ghost text when set
+    /// (contextual hints like slash-command arguments outrank passive
+    /// placeholders) painted at the cursor, else the placeholder one cell
+    /// after the cursor while the buffer is empty.
+    fn active_ghost_text(&self) -> Option<(&str, TuiStyle, u16)> {
+        if let Some((text, style)) = &self.trailing_ghost_text {
+            return Some((text, *style, 0));
+        }
+        if self.text.is_empty()
+            && let Some((text, style)) = &self.placeholder_ghost_text
+        {
+            return Some((text, *style, 1));
+        }
+        None
+    }
+
     /// Elide the buffer's final empty line (buffers whose text ends with a
     /// newline have one). Diff bodies set this so a file's conventional
     /// trailing newline doesn't render as a blank numbered row; the input must
@@ -294,6 +342,11 @@ impl TuiEditorElement {
     /// Builds the visible rows, cursor position, and selection spans at
     /// `full_width`, storing them for `render`/`cursor_position`.
     fn build(&mut self, full_width: u16, app: &AppContext) {
+        // Placeholder hints depend on app state that changes without this
+        // element's view being invalidated; re-resolve them every layout.
+        if let Some(provider) = &self.placeholder_ghost_text_provider {
+            self.placeholder_ghost_text = provider(app);
+        }
         let render_state = self.model.as_ref(app).render_state().clone();
         let render_state = render_state.as_ref(app);
         let Some(char_cell) = render_state.char_cell() else {
@@ -686,7 +739,7 @@ impl TuiElement for TuiEditorElement {
             return;
         };
         self.column.render(origin, surface, ctx);
-        if let Some((text, style)) = &self.trailing_ghost_text {
+        if let Some((text, style, cursor_gap)) = self.active_ghost_text() {
             let cursor_at_end =
                 self.cursor_offset.as_usize().saturating_sub(1) == self.text.chars().count();
             if cursor_at_end
@@ -694,7 +747,7 @@ impl TuiElement for TuiEditorElement {
                 && self.cursor_col < size.width
                 && self.cursor_row_in_view < size.height
             {
-                let mut col = self.cursor_col;
+                let mut col = self.cursor_col.saturating_add(cursor_gap);
                 for char in text.chars() {
                     if col >= size.width {
                         break;
@@ -703,7 +756,7 @@ impl TuiElement for TuiEditorElement {
                         origin.offset(i32::from(col), i32::from(self.cursor_row_in_view));
                     if let Some(cell) = surface.cell_mut(position) {
                         cell.set_char(char);
-                        cell.set_style(*style);
+                        cell.set_style(style);
                     }
                     col += 1;
                 }

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -75,6 +75,18 @@ fn render_buffer(
     width: u16,
     height: u16,
 ) -> TuiBuffer {
+    render_buffer_in_place(ctx, &mut element, width, height)
+}
+
+/// Like [`render_buffer`], but leaves the element usable so tests can lay the
+/// same cached element out repeatedly (the presenter reuses elements across
+/// frames).
+fn render_buffer_in_place(
+    ctx: &AppContext,
+    element: &mut TuiEditorElement,
+    width: u16,
+    height: u16,
+) -> TuiBuffer {
     let mut rendered_views = EntityIdMap::default();
     let mut lctx = TuiLayoutContext {
         rendered_views: &mut rendered_views,
@@ -330,6 +342,133 @@ fn width_change_follows_cursor_after_reflow() {
             let render = model.as_ref(ctx).render_state().as_ref(ctx);
             let char_cell = render.char_cell().expect("char-cell model");
             assert_eq!(char_cell.scroll_offset(), 1);
+        });
+    });
+}
+
+/// An editable, view-focused element over `model` with fixed `placeholder`
+/// ghost text in the given `style`.
+fn placeholder_element(
+    ctx: &AppContext,
+    model: &ModelHandle<CodeEditorModel>,
+    placeholder: &str,
+    style: TuiStyle,
+) -> TuiEditorElement {
+    let placeholder = placeholder.to_owned();
+    TuiEditorElement::new(model, ctx)
+        .editable()
+        .with_view_focused(true)
+        .with_placeholder_ghost_text(move |_| Some((placeholder.clone(), style)))
+}
+
+#[test]
+fn placeholder_ghost_text_renders_only_while_buffer_empty() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let empty = model(ctx, "");
+            let element = placeholder_element(ctx, &empty, "type here", TuiStyle::default());
+            // One pad cell separates the cursor from the hint.
+            assert_eq!(render_lines(ctx, element, 20, 5), vec![" type here"]);
+
+            let populated = model(ctx, "draft");
+            let element = placeholder_element(ctx, &populated, "type here", TuiStyle::default());
+            assert_eq!(render_lines(ctx, element, 20, 5), vec!["draft"]);
+        });
+    });
+}
+
+#[test]
+fn placeholder_ghost_text_requires_view_focus() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let empty = model(ctx, "");
+            let element = TuiEditorElement::new(&empty, ctx)
+                .editable()
+                .with_view_focused(false)
+                .with_placeholder_ghost_text(|_| {
+                    Some(("type here".to_owned(), TuiStyle::default()))
+                });
+            assert_eq!(render_lines(ctx, element, 20, 5), vec![""]);
+        });
+    });
+}
+
+/// The presenter caches elements across frames while the state a hint depends
+/// on changes without the owning view being invalidated; the provider must
+/// therefore be re-resolved on every layout pass, not snapshotted once.
+#[test]
+fn placeholder_ghost_text_provider_resolves_on_every_layout() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let empty = model(ctx, "");
+            let hint = Rc::new(RefCell::new("first".to_owned()));
+            let hint_for_provider = hint.clone();
+            let mut element = TuiEditorElement::new(&empty, ctx)
+                .editable()
+                .with_view_focused(true)
+                .with_placeholder_ghost_text(move |_| {
+                    Some((hint_for_provider.borrow().clone(), TuiStyle::default()))
+                });
+            let lines = |buffer: TuiBuffer| {
+                buffer
+                    .to_lines()
+                    .into_iter()
+                    .map(|line| line.trim_end().to_string())
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(
+                lines(render_buffer_in_place(ctx, &mut element, 20, 5)),
+                vec![" first"]
+            );
+            *hint.borrow_mut() = "second".to_owned();
+            assert_eq!(
+                lines(render_buffer_in_place(ctx, &mut element, 20, 5)),
+                vec![" second"]
+            );
+        });
+    });
+}
+
+#[test]
+fn trailing_ghost_text_outranks_placeholder_ghost_text() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let empty = model(ctx, "");
+            let element = placeholder_element(ctx, &empty, "placeholder", TuiStyle::default())
+                .with_trailing_ghost_text("<argument>", TuiStyle::default());
+            assert_eq!(render_lines(ctx, element, 20, 5), vec!["<argument>"]);
+        });
+    });
+}
+
+#[test]
+fn placeholder_ghost_text_paints_with_configured_style() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let empty = model(ctx, "");
+            let style = TuiStyle::default().fg(Color::Blue);
+            let element = placeholder_element(ctx, &empty, "hint", style);
+            let buffer = render_buffer(ctx, element, 20, 5);
+            assert_eq!(buffer[(1, 0)].symbol(), "h");
+            assert_eq!(buffer[(1, 0)].fg, Color::Blue);
+            assert_eq!(buffer[(4, 0)].fg, Color::Blue);
+        });
+    });
+}
+
+#[test]
+fn placeholder_ghost_text_truncates_to_element_width() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let empty = model(ctx, "");
+            let element = placeholder_element(ctx, &empty, "a very long hint", TuiStyle::default());
+            assert_eq!(render_lines(ctx, element, 6, 5), vec![" a ver"]);
         });
     });
 }

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -46,6 +46,7 @@ use crate::editor_interaction::{
     apply_editor_action, follow_editor_cursor,
 };
 use crate::inline_menu::{TuiInlineMenu, TuiInlineMenuAccepted, active_inline_menu};
+use crate::input_hints;
 use crate::input_mode_policy::{self, AI_LOCKED_CONFIG, SHELL_LOCKED_CONFIG};
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 use crate::keybindings::{
@@ -353,7 +354,28 @@ impl TuiInputView {
         {
             element = element.with_trailing_ghost_text(hint_text, builder.dim_text_style());
         }
-        element
+        // Empty-buffer placeholder hints depend on state that changes without
+        // this view re-rendering (transcript emptiness flips when blocks land
+        // via history events or PTY wakeups), so the hint is resolved by a
+        // provider on every layout pass instead of being snapshotted here.
+        // Shell mode gets its own copy in a follow-up, so it renders no
+        // placeholder yet.
+        let input_mode = self.input_mode.clone();
+        let transcript = self.transcript.clone();
+        element.with_placeholder_ghost_text(move |app| {
+            if input_mode_policy::is_shell_mode(input_mode.as_ref(app)) {
+                return None;
+            }
+            // Inputs constructed without a transcript (isolated tests) count
+            // as zero-state.
+            let transcript_is_empty = transcript
+                .as_ref()
+                .is_none_or(|transcript| transcript.as_ref(app).is_empty());
+            Some((
+                input_hints::agent_input_hint(transcript_is_empty).to_owned(),
+                TuiUiBuilder::from_app(app).muted_text_style(),
+            ))
+        })
     }
     /// Collapses the current text selection to its head without changing text.
     pub(crate) fn clear_selection(&mut self, ctx: &mut ViewContext<Self>) {

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -151,6 +151,50 @@ fn slash_command_argument_hint_renders_after_menu_closes() {
     });
 }
 
+#[test]
+fn agent_mode_placeholder_hint_renders_only_while_empty() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            let buffer = render_input_buffer(&view, ctx);
+            let line = &buffer.to_lines()[0];
+            // One pad cell separates the cursor from the hint.
+            assert!(
+                line.starts_with(&format!(" {}", crate::input_hints::ZERO_STATE_AGENT_HINT)),
+                "unexpected line: {line:?}"
+            );
+            let expected = TuiUiBuilder::from_app(ctx)
+                .muted_text_style()
+                .fg
+                .expect("placeholder hint has a foreground");
+            assert_eq!(buffer[(1, 0)].fg, expected);
+
+            type_str(&view, ctx, "x");
+            let buffer = render_input_buffer(&view, ctx);
+            let line = &buffer.to_lines()[0];
+            assert!(line.starts_with('x'), "unexpected line: {line:?}");
+            assert!(!line.contains("for conversations"));
+        });
+    });
+}
+
+#[test]
+fn shell_mode_renders_no_placeholder_hint() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            dispatch(
+                &view,
+                ctx,
+                &[TuiInputAction::Editor(TuiEditorAction::InsertChar('!'))],
+            );
+            assert!(view.as_ref(ctx).is_shell_mode(ctx));
+            let buffer = render_input_buffer(&view, ctx);
+            assert_eq!(buffer.to_lines()[0].trim_end(), "");
+        });
+    });
+}
+
 fn render_input_buffer(view: &ViewHandle<TuiInputView>, ctx: &AppContext) -> TuiBuffer {
     let mut element = view.as_ref(ctx).render_element(ctx);
     let mut rendered_views = EntityIdMap::default();

--- a/crates/warp_tui/src/input_hints.rs
+++ b/crates/warp_tui/src/input_hints.rs
@@ -1,0 +1,32 @@
+//! Mode-dependent ghosted placeholder hints for the TUI prompt input.
+//!
+//! Content policy for the input's empty-buffer ghost text: keybinding
+//! guidance whose entries adapt to the transcript state. The keys referenced
+//! here are typed characters (`!`, `/`) or fixed navigation keys (`←`), not
+//! remappable bindings, so the strings are static; binding-backed hints must
+//! resolve their keystroke display through the live keymap instead (see
+//! `crate::keybindings::plan_toggle_hint`).
+
+/// Ghost text for an empty agent-mode input before the transcript has any
+/// visible content. Per design review, the zero state teaches the entry
+/// points instead of pitching an example prompt: slash commands, and the
+/// conversation list (`←` opens it from an empty input).
+pub(crate) const ZERO_STATE_AGENT_HINT: &str = "/ for commands • ← for conversations";
+
+/// Ghost text for an empty agent-mode input once the transcript has content.
+/// The design's `? for shortcuts` segment is intentionally omitted until the
+/// TUI has a shortcuts menu to open.
+pub(crate) const AGENT_HINT: &str = "Ask the agent anything • ! for shell mode • / for commands";
+
+/// The agent-mode placeholder hint for the current transcript state.
+pub(crate) fn agent_input_hint(transcript_is_empty: bool) -> &'static str {
+    if transcript_is_empty {
+        ZERO_STATE_AGENT_HINT
+    } else {
+        AGENT_HINT
+    }
+}
+
+#[cfg(test)]
+#[path = "input_hints_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/input_hints_tests.rs
+++ b/crates/warp_tui/src/input_hints_tests.rs
@@ -1,0 +1,20 @@
+use super::{AGENT_HINT, ZERO_STATE_AGENT_HINT, agent_input_hint};
+
+#[test]
+fn transcript_state_selects_the_hint_variant() {
+    assert_eq!(agent_input_hint(true), ZERO_STATE_AGENT_HINT);
+    assert_eq!(agent_input_hint(false), AGENT_HINT);
+    assert_ne!(agent_input_hint(true), agent_input_hint(false));
+}
+
+#[test]
+fn zero_state_hint_teaches_commands_and_conversations() {
+    assert!(ZERO_STATE_AGENT_HINT.contains("/ for commands"));
+    assert!(ZERO_STATE_AGENT_HINT.contains("← for conversations"));
+}
+
+#[test]
+fn started_transcript_hint_teaches_shell_mode_and_commands() {
+    assert!(AGENT_HINT.contains("! for shell mode"));
+    assert!(AGENT_HINT.contains("/ for commands"));
+}

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -31,6 +31,7 @@ mod editor_interaction;
 mod editor_view;
 mod exit_confirmation;
 mod inline_menu;
+mod input_hints;
 mod input_mode_policy;
 mod input_suggestions_mode;
 mod keybindings;

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -4,8 +4,8 @@ use warp::settings::TuiUsageDisplayMode;
 use warp::tui_export::{
     AIConversationId, AgentViewEntryOrigin, BlockPadding, BlocklistAIHistoryModel,
     ConversationStatus, ConversationUsageTotals, Harness, InputType, PtyIntent, PtyIntentEvent,
-    SizeInfo, SizeUpdate, export_conversation_markdown, register_tui_session_view_test_singletons,
-    slash_commands,
+    SizeInfo, SizeUpdate, TranscriptScope, export_conversation_markdown,
+    register_tui_session_view_test_singletons, slash_commands,
 };
 use warp_core::telemetry::testing::MockTelemetryContextProvider;
 use warp_editor::model::CoreEditorModel;
@@ -212,6 +212,74 @@ fn bootstrap_renders_starting_shell_above_input() {
             .map(|(index, _)| index)
             .expect("bootstrap input border should render below the status");
         assert!(status_index < input_index);
+    });
+}
+
+/// The input child's rendered element is cached by the presenter, and
+/// transcript emptiness can flip without any input-owned event (a terminal
+/// block landing via the PTY wakeup path only invalidates the session view).
+/// The placeholder hint must still switch off the zero-state copy because the
+/// provider re-resolves on every layout pass.
+#[test]
+fn agent_hint_tracks_transcript_emptiness_without_input_invalidation() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let mut presenter = TuiPresenter::new();
+
+        // Initial full present: every child renders once and is cached.
+        let lines = app.update(|ctx| {
+            let mut invalidation = WindowInvalidation::default();
+            invalidation.updated.insert(view.id());
+            invalidation
+                .updated
+                .extend(view.as_ref(ctx).child_view_ids(ctx));
+            presenter.invalidate(&invalidation, ctx, view.window_id(ctx));
+            presenter
+                .present(ctx, &view, TuiRect::new(0, 0, 100, 40))
+                .buffer
+                .to_lines()
+        });
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("← for conversations")),
+            "zero state should show the zero-state hint:\n{}",
+            lines.join("\n")
+        );
+
+        // A finished terminal block lands without any input-owned event; only
+        // the session view is invalidated, mirroring the PTY wakeup path.
+        view.update(&mut app, |view, _| {
+            let mut model = view.terminal_model.lock();
+            model
+                .block_list_mut()
+                .set_transcript_scope(TranscriptScope::Unfiltered);
+            model.simulate_block("echo hi", "hi\r\n");
+        });
+        let lines = app.update(|ctx| {
+            let mut invalidation = WindowInvalidation::default();
+            invalidation.updated.insert(view.id());
+            presenter.invalidate(&invalidation, ctx, view.window_id(ctx));
+            presenter
+                .present(ctx, &view, TuiRect::new(0, 0, 100, 40))
+                .buffer
+                .to_lines()
+        });
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.contains("← for conversations")),
+            "the cached input element must drop the zero-state hint:\n{}",
+            lines.join("\n")
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Ask the agent anything")),
+            "the started-conversation hint should render:\n{}",
+            lines.join("\n")
+        );
     });
 }
 


### PR DESCRIPTION
## Description
First PR of the TUI ghosted keybinding hints stack ([CODE-1889](https://linear.app/warpdotdev/issue/CODE-1889/ghosted-text-for-keybinding-hints)).

**What**
- Adds general placeholder-style ghost text to `TuiEditorElement`: shown only while the buffer is empty, painted one cell after the cursor (so the block cursor never obscures the first glyph), truncated to the element width. A configured trailing ghost text (slash-command argument hints) still takes precedence. The hint content is supplied by a **provider closure re-resolved on every layout pass**, so cached input elements pick up state changes (e.g. transcript emptiness) without needing their own invalidation.
- Adds a small `input_hints` module and wires mode-aware agent hints into `TuiInputView`:
  - Zero state (empty transcript): `/ for commands • ← for conversations` — per design review in Slack (Erica/Kevin), the zero state teaches entry-point shortcuts instead of the earlier example-prompt copy from the [zero-state mock](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1253-22785).
  - Conversation started: `Ask the agent anything • ! for shell mode • / for commands` — [Figma](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1232-21282)

**Why**
The TUI input gave no in-place guidance about available keys/modes. Hints are ghosted in the input box per design.

**Notes**
- The design's `? for shortcuts` segment is intentionally omitted until the TUI has a shortcuts menu to open (availability-gated copy).
- Styling comes from `TuiUiBuilder::muted_text_style()`; no hardcoded colors.

Linear: [CODE-1897](https://linear.app/warpdotdev/issue/CODE-1897), [CODE-1898](https://linear.app/warpdotdev/issue/CODE-1898) (parent [CODE-1889](https://linear.app/warpdotdev/issue/CODE-1889))

## Linked Issue
Internal work tracked in Linear (CODE-1897, CODE-1898); no GitHub issue.

## Testing
- [x] I have manually tested my changes locally with `./script/run-tui`

New render-to-lines unit tests:
- `editor_element_tests.rs`: placeholder renders only while empty, requires view focus, is outranked by trailing ghost text, paints with the configured style, truncates to width, and the provider re-resolves on every layout pass of a cached element.
- `input/view_tests.rs`: agent-mode placeholder renders while empty and hides on typing.
- `input_hints_tests.rs`: hint variant selection per transcript state; content assertions per mode.
- `terminal_session_view_tests.rs::agent_hint_tracks_transcript_emptiness_without_input_invalidation`: presenter-level regression — the transcript flips from empty to non-empty while only the session view is invalidated, and the cached input element still swaps hints.

Live verification (tmux `capture-pane` of the running TUI, per the `tui-verify-change` skill — the TUI has no GUI integration harness, so render-to-lines tests + live terminal capture are the coverage):

Zero state (current copy):
```
┌──────────────────────────────────────────────────────────────────────────────┐
│  / for commands • ← for conversations
└──────────────────────────────────────────────────────────────────────────────┘
```

After a conversation has started:
```
┌──────────────────────────────────────────────────────────────────────────────┐
│  Ask the agent anything • ! for shell mode • / for commands
└──────────────────────────────────────────────────────────────────────────────┘
```

Typing any character hides the ghost text.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
