### PR TITLE
feat(tui): shell-mode ghosted input hint (CODE-1899)

### DIFF
--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -358,21 +358,23 @@ impl TuiInputView {
         // this view re-rendering (transcript emptiness flips when blocks land
         // via history events or PTY wakeups), so the hint is resolved by a
         // provider on every layout pass instead of being snapshotted here.
-        // Shell mode gets its own copy in a follow-up, so it renders no
-        // placeholder yet.
+        // Shell mode teaches how to exit; agent mode adapts to the transcript
+        // state.
         let input_mode = self.input_mode.clone();
         let transcript = self.transcript.clone();
         element.with_placeholder_ghost_text(move |app| {
-            if input_mode_policy::is_shell_mode(input_mode.as_ref(app)) {
-                return None;
-            }
-            // Inputs constructed without a transcript (isolated tests) count
-            // as zero-state.
-            let transcript_is_empty = transcript
-                .as_ref()
-                .is_none_or(|transcript| transcript.as_ref(app).is_empty());
+            let hint = if input_mode_policy::is_shell_mode(input_mode.as_ref(app)) {
+                input_hints::SHELL_HINT
+            } else {
+                // Inputs constructed without a transcript (isolated tests)
+                // count as zero-state.
+                let transcript_is_empty = transcript
+                    .as_ref()
+                    .is_none_or(|transcript| transcript.as_ref(app).is_empty());
+                input_hints::agent_input_hint(transcript_is_empty)
+            };
             Some((
-                input_hints::agent_input_hint(transcript_is_empty).to_owned(),
+                hint.to_owned(),
                 TuiUiBuilder::from_app(app).muted_text_style(),
             ))
         })

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -179,7 +179,7 @@ fn agent_mode_placeholder_hint_renders_only_while_empty() {
 }
 
 #[test]
-fn shell_mode_renders_no_placeholder_hint() {
+fn shell_mode_placeholder_hint_teaches_exit() {
     App::test((), |mut app| async move {
         app.update(|ctx| {
             let view = build_view(ctx);
@@ -190,7 +190,18 @@ fn shell_mode_renders_no_placeholder_hint() {
             );
             assert!(view.as_ref(ctx).is_shell_mode(ctx));
             let buffer = render_input_buffer(&view, ctx);
-            assert_eq!(buffer.to_lines()[0].trim_end(), "");
+            let line = &buffer.to_lines()[0];
+            assert!(
+                line.starts_with(&format!(" {}", crate::input_hints::SHELL_HINT)),
+                "unexpected line: {line:?}"
+            );
+
+            // Typing a command hides the hint.
+            type_str(&view, ctx, "ls");
+            let buffer = render_input_buffer(&view, ctx);
+            let line = &buffer.to_lines()[0];
+            assert!(line.starts_with("ls"), "unexpected line: {line:?}");
+            assert!(!line.contains("Run a shell command"));
         });
     });
 }

--- a/crates/warp_tui/src/input_hints.rs
+++ b/crates/warp_tui/src/input_hints.rs
@@ -18,6 +18,11 @@ pub(crate) const ZERO_STATE_AGENT_HINT: &str = "/ for commands • ← for conve
 /// TUI has a shortcuts menu to open.
 pub(crate) const AGENT_HINT: &str = "Ask the agent anything • ! for shell mode • / for commands";
 
+/// Ghost text for an empty `!` shell-mode input: how to run and how to get
+/// back to agent mode (esc is the input's contextual escape; backspace on the
+/// empty input exits too).
+pub(crate) const SHELL_HINT: &str = "Run a shell command • esc for agent mode";
+
 /// The agent-mode placeholder hint for the current transcript state.
 pub(crate) fn agent_input_hint(transcript_is_empty: bool) -> &'static str {
     if transcript_is_empty {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -169,8 +169,10 @@ const SWITCH_UNAVAILABLE_HINT: &str = "That conversation is no longer available.
 const LOADING_CONVERSATION_HINT: &str = "Loading conversation…";
 const MODEL_PERSISTENCE_FAILED_HINT: &str = "Could not save the selected model.";
 
-/// Footer hint shown while the input is in `!` shell mode.
-const SHELL_MODE_HINT: &str = "shell mode · esc to exit";
+/// Footer label shown while the input is in `!` shell mode. The how-to-exit
+/// guidance lives in the input's placeholder ghost text, so the footer only
+/// names the mode.
+const SHELL_MODE_HINT: &str = "shell mode";
 const COPY_SELECTION_HINT: &str = "copied to clipboard";
 const COPY_FAILED_HINT: &str = "failed to copy to clipboard";
 const LOG_BUNDLE_FAILED_HINT: &str = "Failed to create log bundle (check logs)";


### PR DESCRIPTION
## Description
Second PR of the TUI ghosted keybinding hints stack ([CODE-1889](https://linear.app/warpdotdev/issue/CODE-1889/ghosted-text-for-keybinding-hints)); stacked on #14036.

**What**
- An empty `!` shell-mode input now shows ghosted guidance in the box: `Run a shell command • esc for agent mode`.
- Footer dedupe: the shell-mode footer slot drops the duplicated `· esc to exit` copy and now just names the mode (`shell mode`), since the how-to-exit guidance lives in the input's ghost text.

**Why**
Shell mode previously explained itself only via the footer; the design moves mode guidance into the input box.

**Notes**
- Ghost copy for shell mode is proposed (the shell-mode mocks show no in-box ghost) — flagged for design confirmation in [CODE-1899](https://linear.app/warpdotdev/issue/CODE-1899).

Linear: [CODE-1899](https://linear.app/warpdotdev/issue/CODE-1899) (parent [CODE-1889](https://linear.app/warpdotdev/issue/CODE-1889))

## Linked Issue
Internal work tracked in Linear (CODE-1899); no GitHub issue.

## Testing
- [x] I have manually tested my changes locally with `./script/run-tui`

Unit tests: `input/view_tests.rs::shell_mode_placeholder_hint_teaches_exit` (hint shows on entering `!` mode, hides on typing), plus hint-content assertions in `input_hints_tests.rs`.

Live verification (tmux `capture-pane`):
```
┌──────────────────────────────────────────────────────────────────────────────┐
│ !  Run a shell command • esc for agent mode
└──────────────────────────────────────────────────────────────────────────────┘
shell mode                     auto (genius) ~/warp ↬ ian/code-1900-tui-long-running-command-hint-row
```

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
