### PR TITLE
feat(tui): ghosted interrupt hint row during long-running commands (CODE-1900)

### DIFF
--- a/crates/warp_tui/src/input_hints.rs
+++ b/crates/warp_tui/src/input_hints.rs
@@ -23,6 +23,11 @@ pub(crate) const AGENT_HINT: &str = "Ask the agent anything • ! for shell mode
 /// empty input exits too).
 pub(crate) const SHELL_HINT: &str = "Run a shell command • esc for agent mode";
 
+/// Ghosted hint row shown in the input's slot while a user-controlled
+/// long-running command owns input (the input box itself stays hidden).
+/// ctrl-c is the reserved interrupt key in both the TUI keymap and the PTY.
+pub(crate) const LONG_RUNNING_COMMAND_HINT: &str = "ctrl-c to interrupt";
+
 /// The agent-mode placeholder hint for the current transcript state.
 pub(crate) fn agent_input_hint(transcript_is_empty: bool) -> &'static str {
     if transcript_is_empty {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -69,6 +69,7 @@ use crate::exit_confirmation::{CTRL_C_EXIT_WINDOW, ExitConfirmation};
 use crate::inline_menu::{MAX_INLINE_MENU_ROWS, TuiInlineMenu, active_inline_menu};
 use crate::input::view::TuiInputAction;
 use crate::input::{TuiInputView, TuiInputViewEvent};
+use crate::input_hints;
 use crate::input_mode_policy::{self, TuiInputModePolicy};
 use crate::input_suggestions_mode::TuiInputSuggestionsModeModel;
 use crate::keybindings::{
@@ -93,7 +94,8 @@ use crate::tab_bar::{TuiTabBarConfig, TuiTabBarEvent, TuiTabBarView};
 use crate::terminal_content_element::TuiTerminalContentElement;
 use crate::terminal_use::{
     TerminalUseInterruptAction, TuiInputTarget, hide_agent_requested_command_from_top_level,
-    terminal_use_conversation_to_resume, terminal_use_interrupt_action, tui_input_target,
+    inline_process_owns_input, terminal_use_conversation_to_resume, terminal_use_interrupt_action,
+    tui_input_target,
 };
 use crate::transcript_view::{TuiTranscriptView, TuiTranscriptViewEvent};
 use crate::transient_hint::{TransientHint, TransientHintTone};
@@ -2969,11 +2971,12 @@ impl TuiView for TuiTerminalSessionView {
         }
         // While a full-screen (alt-screen) app is active, hand the whole pane to
         // it: render its grid and forward input, instead of the block UI.
-        let (alt_screen_active, input_target) = {
+        let (alt_screen_active, input_target, user_owns_running_command) = {
             let terminal_model = self.terminal_model.lock();
             (
                 terminal_model.is_alt_screen_active(),
                 tui_input_target(&terminal_model),
+                inline_process_owns_input(&terminal_model),
             )
         };
         if alt_screen_active {
@@ -3092,6 +3095,26 @@ impl TuiView for TuiTerminalSessionView {
                     );
                 }
             }
+        }
+        // While a user-controlled long-running command owns input, the input
+        // box and footer stay hidden; a one-line ghosted hint row takes the
+        // input's slot so the interrupt affordance stays discoverable. Gated
+        // on the user-controlled-command predicate, not the broader PTY input
+        // target: visible startup-script execution also routes input to the
+        // PTY but is not a command the user should be told to interrupt.
+        // (Agent-driven terminal use keeps the composer, and its control
+        // hints come from the CLI-subagent status line.)
+        if !blocker_active && user_owns_running_command {
+            content = content.child(
+                TuiContainer::new(
+                    TuiText::new(input_hints::LONG_RUNNING_COMMAND_HINT)
+                        .with_style(builder.muted_text_style())
+                        .truncate()
+                        .finish(),
+                )
+                .with_padding_top(1)
+                .finish(),
+            );
         }
         if !blocker_active
             && (input_target.agent_editor_owns_input()

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -496,6 +496,47 @@ fn long_running_command_keeps_input_hidden() {
             "LRC must keep the input editor hidden:\n{}",
             lines.join("\n")
         );
+        // The interrupt affordance renders as a ghosted row in the input's
+        // slot while the command owns input.
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.trim() == crate::input_hints::LONG_RUNNING_COMMAND_HINT),
+            "LRC must render the interrupt hint row:\n{}",
+            lines.join("\n")
+        );
+    });
+}
+
+/// Visible startup-script execution also routes input to the PTY, but it is
+/// not a user-controlled command: the interrupt hint row must not appear.
+#[test]
+fn visible_startup_script_shows_no_interrupt_hint() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, _| {
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model.block_list_mut().reinit_shell();
+            terminal_model.update_blockheight_items(TRANSCRIPT_BLOCK_SPACING.block_padding, 0.0);
+            // Advance past WarpInput, then leave an unfinished startup-script
+            // block with visible output owning PTY input.
+            terminal_model.simulate_block("bootstrap", "");
+            terminal_model.simulate_long_running_block("shell init", "startup output\r\n");
+        });
+        assert!(
+            view.read(&app, |view, _| view.input_target().pty_owns_input()),
+            "fixture should route input to the PTY during the visible startup script"
+        );
+
+        let lines = render_session(&mut app, &view, 80, 40);
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.trim() == crate::input_hints::LONG_RUNNING_COMMAND_HINT),
+            "startup-script execution must not advertise the interrupt hint:\n{}",
+            lines.join("\n")
+        );
     });
 }
 


### PR DESCRIPTION
## Description
Final PR of the TUI ghosted keybinding hints stack ([CODE-1889](https://linear.app/warpdotdev/issue/CODE-1889/ghosted-text-for-keybinding-hints)); stacked on #14037.

**What**
While a user-controlled long-running command owns input (`TuiInputTarget::Pty`), the input box and footer stay hidden — previously with no affordance at all. This adds a one-line ghosted `ctrl-c to interrupt` row in the input's slot.

**Why**
The interrupt affordance should stay discoverable while a command owns the PTY. Agent-driven terminal use is unaffected: it keeps the composer and its own CLI-subagent control hints (`ctrl-c to take control` / `ctrl-g to hand back`).

Linear: [CODE-1900](https://linear.app/warpdotdev/issue/CODE-1900) (parent [CODE-1889](https://linear.app/warpdotdev/issue/CODE-1889))

## Linked Issue
Internal work tracked in Linear (CODE-1900); no GitHub issue.

## Testing
- [x] I have manually tested my changes locally with `./script/run-tui`

Unit test: `terminal_session_view_tests.rs::long_running_command_keeps_input_hidden` extended to assert the interrupt hint row renders while the command owns input.

Live verification (tmux `capture-pane`, `! sleep 30` then interrupt):
```
  sleep 30

  ctrl-c to interrupt
```
After `ctrl-c`, the input box returns with the in-conversation agent hints.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: The Warp TUI input now shows ghosted keybinding hints that adapt to your mode — agent mode, ! shell mode, and while a long-running command is in progress.

Co-Authored-By: Oz <oz-agent@warp.dev>
