### PR TITLE
Use scoped feature-flag overrides in view_tests instead of global set_enabled

### DIFF
--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -145,7 +145,7 @@ fn has_pending_user_query_block(view: &TerminalView) -> bool {
 fn agent_view_lifecycle_updates_input_mode() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
         let terminal = add_window_with_terminal(&mut app, None);
 
         terminal.read(&app, |view, ctx| {
@@ -736,7 +736,7 @@ fn unregister_cli_agent_session_restores_unlocked_input_config() {
 fn clear_buffer_action_in_fullscreen_agent_view_starts_new_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -1477,8 +1477,8 @@ fn root_cloud_mode_pane_sets_root_cloud_mode_context_key() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         app.add_singleton_model(ImportedConfigModel::new);
-        FeatureFlag::AgentView.set_enabled(true);
-        FeatureFlag::CloudMode.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
 
         let terminal = add_window_with_cloud_mode_terminal(&mut app);
         let nested_terminal = add_window_with_cloud_mode_terminal(&mut app);
@@ -1540,8 +1540,8 @@ fn root_cloud_mode_pane_sets_root_cloud_mode_context_key() {
 fn set_input_mode_agent_does_not_enter_local_agent_from_root_cloud_mode_pane() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
-        FeatureFlag::CloudMode.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
 
         let terminal = add_window_with_cloud_mode_terminal(&mut app);
 
@@ -5154,7 +5154,7 @@ fn test_prompt_context_menu_items_for_agent_toolbelt_flag() {
 fn agent_footer_updates_chip_groups_when_side_assignment_changes() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -5335,7 +5335,7 @@ fn test_scroll_position_doesnt_change_when_block_finished() {
 fn inline_agent_view_exits_when_tagged_in_long_running_command_is_tagged_out() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -5397,7 +5397,7 @@ fn inline_agent_view_exits_when_tagged_in_long_running_command_is_tagged_out() {
 fn ctrl_c_after_stop_takeover_cancels_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
         let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
@@ -5457,7 +5457,7 @@ fn ctrl_c_after_stop_takeover_cancels_conversation() {
 fn ctrl_c_after_transfer_takeover_does_not_cancel_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
         let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
@@ -5520,7 +5520,7 @@ fn ctrl_c_after_transfer_takeover_does_not_cancel_conversation() {
 fn completed_user_controlled_lrc_resumes_when_not_suppressed() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
         terminal.update(&mut app, |view, ctx| {
@@ -5579,7 +5579,7 @@ fn completed_user_controlled_lrc_resumes_when_not_suppressed() {
 fn completed_user_controlled_lrc_skips_resume_when_suppressed() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
         terminal.update(&mut app, |view, ctx| {
@@ -5627,7 +5627,7 @@ fn completed_user_controlled_lrc_skips_resume_when_suppressed() {
 fn inline_agent_view_persists_across_transfer_takeover_for_monitored_long_running_command() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -5709,7 +5709,7 @@ fn inline_agent_view_persists_across_transfer_takeover_for_monitored_long_runnin
 fn use_agent_footer_renders_for_transfer_handoff_even_when_user_command_footer_setting_disabled() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
         AISettings::handle(&app).update(&mut app, |settings, ctx| {
             let _ = settings
                 .should_render_use_agent_footer_for_user_commands
@@ -5838,7 +5838,7 @@ fn exiting_agent_view_removes_empty_conversations() {
 fn ctrl_c_exit_agent_view_requires_confirmation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -5886,7 +5886,7 @@ fn ctrl_c_exit_agent_view_requires_confirmation() {
 fn ctrl_c_buffer_clear_then_exit_requires_three_presses_in_agent_view() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -5944,7 +5944,7 @@ fn ctrl_c_buffer_clear_then_exit_requires_three_presses_in_agent_view() {
 fn terminal_action_ctrl_c_exit_agent_view_requires_confirmation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -7464,7 +7464,7 @@ fn linear_deeplink_populates_input_as_draft_when_not_in_agent_view() {
 
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -7510,7 +7510,7 @@ fn linear_deeplink_does_not_auto_submit_when_already_in_agent_view() {
 
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -7591,7 +7591,7 @@ fn linear_deeplink_via_default_entrypoint_does_not_auto_submit_in_fullscreen() {
 
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -7906,7 +7906,7 @@ fn cmd_k_does_not_clear_buffer_when_agent_is_driving_command() {
 fn cmd_k_in_agent_view_clears_active_block_not_full_buffer_when_agent_driving_command() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -7975,7 +7975,7 @@ fn cmd_k_in_agent_view_clears_active_block_not_full_buffer_when_agent_driving_co
 fn cmd_k_in_agent_view_cancels_in_progress_conversation_and_starts_new_one() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 


### PR DESCRIPTION
Closes #13972

## Description

[`view_tests.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/terminal/view_tests.rs) had 22 call sites flipping the process-global `FeatureFlag::AgentView`/`FeatureFlag::CloudMode` state via `set_enabled(true)` with no reset. Under plain `cargo test`, every test in the `warp` lib target shares one process, so the flag state leaked into whichever tests ran next — five tests that assume `AgentView` defaults to `false` failed whenever they ran after an offender.

This converts all 22 sites to `override_enabled(true)`, the thread-local RAII guard the same module already uses elsewhere; the override reverts on drop at the end of each test. Thread-locality is sufficient: `App::test`'s executor is a single-threaded `LocalExecutor`, and none of the converted tests spawn OS threads (so no `get_overrides()`/`set_overrides()` propagation is needed). Two tests set both flags and bind both guards for the full test body. `override_enabled` itself is unchanged.

## Why CI didn't catch this

CI runs `cargo nextest`, which isolates each test in its own process — the leak needs a shared-process runner to manifest.

The `set_enabled` panic guard that should have flagged the misuse ([`warp_features/src/lib.rs`](https://github.com/warpdotdev/warp/blob/master/crates/warp_features/src/lib.rs): `if cfg!(test) && cfg!(not(feature = "integration_tests")) { panic!(…) }`) is dead code by construction: `cfg!(test)` resolves per-crate at the point it's written, and `warp_features` is a normal `[dependencies]` library that's never compiled as a test binary — so the check is unconditionally `false` for every caller.

<details><summary>Ruled out along the way: feature unification</summary>

The issue originally theorized that `crates/integration` enabling `integration_tests` defeats the guard via Cargo feature unification. Verified false: [`warp_core/Cargo.toml`](https://github.com/warpdotdev/warp/blob/master/crates/warp_core/Cargo.toml)'s `integration_tests` feature is `[]` and never forwards to `warp_features/integration_tests`, and `app` doesn't depend on `warp_features` directly — so that feature can't be reached from a normal `app`/`warp` build at all. The guard's deadness is independent of feature flags.

</details>

## Reproduction

Deterministic single-process repro — a flag-setting test followed by affected tests:

```
cargo test -p warp --lib -- --test-threads=1 --exact \
  terminal::view::tests::agent_view_lifecycle_updates_input_mode \
  terminal::view::tests::test_insert \
  terminal::view::tests::test_scroll_position_doesnt_change_when_block_finished \
  terminal::view::tests::test_viewport_iter_most_recent_at_bottom
```

Before: `FAILED. 1 passed; 3 failed` (assertions like ``left: "One" / right: "None"``, scroll-position and viewport-iter panics — matching the issue's reported failures). After: all originally-affected tests plus the flag-setter pass together, `ok. 6 passed; 0 failed`.

`cargo nextest run -p warp -E 'test(view_tests) or test(terminal::view)'`: 307 passed before and after (process isolation always masked this).

## Preventing recurrence

I looked at catching this class mechanically going forward. Verdicts:

| Option | Verdict | Why |
|---|---|---|
| Clippy `disallowed-methods` on `set_enabled` (repo already has `.clippy.toml` + `-D warnings` CI) | Not implemented | ~74 legitimate call sites (≈26 production, ≈48 `crates/integration` tests that want real global state) would each need `#[allow(clippy::disallowed_methods)]` — and every allow looks identical to a reintroduced leak, burying the signal |
| Repair the `cfg!(test)` panic guard | Not implemented — maintainer call | Dead by construction (above). A real fix needs a runtime "in test" signal or a test-only-constructible token (≈ re-deriving `override_enabled` for the global case) — design work, and it inherits the same production/integration scoping problem |
| Grep-style check in `./script/presubmit` | Noted only | Cruder duplicate of `disallowed-methods`; only worth it if the lint is rejected specifically on annotation-noise grounds |

## Testing

- [x] `cargo test -p warp --lib` targeted repro (before/after above)
- [x] `cargo nextest run -p warp -E 'test(view_tests) or test(terminal::view)'` — 307 passed
- [x] `./script/format --check` — clean
- [x] `cargo clippy -p warp --lib --tests` — zero warnings
- [ ] I have manually tested my changes locally with `./script/run`
  - _Not applicable: the issue only applies to test builds._

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
