### PR TITLE
Isolate secret-redaction tests from the shared SECRETS_REGEX global

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/grep_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep_tests.rs
@@ -1,10 +1,13 @@
+use serial_test::serial;
+
 use super::*;
 use crate::terminal::model::secrets::regexes::FIREBASE_AUTH_DOMAIN;
 use crate::terminal::shell::ShellType;
 
 #[test]
+#[serial(secrets_regex)]
 fn test_create_redacted_grep_error_event() {
-    crate::terminal::model::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&regex::Regex::new(FIREBASE_AUTH_DOMAIN).expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );

--- a/app/src/ai/blocklist/block/secret_redaction_tests.rs
+++ b/app/src/ai/blocklist/block/secret_redaction_tests.rs
@@ -307,21 +307,31 @@ fn test_merge_ranges_with_same_end() {
 // rather than system default regexes.
 
 #[test]
+#[serial(secrets_regex)]
 fn test_detect_secrets_no_regexes_configured() {
+    // Explicitly clear the global regex registry rather than relying on its initial state, since
+    // other tests in this serial group leave their own regexes installed until their guard drops.
+    let _secrets_regex_guard =
+        secrets::test_set_secrets_regex(std::iter::empty(), std::iter::empty());
+
     // With no regexes configured, no secrets should be detected
     let text = "foo warp-server-staging.firebaseapp.com bar";
     let detected_secrets = find_secrets_in_text(text);
     assert_eq!(detected_secrets, vec![]);
 }
 
-// #[serial] is used to ensure custom regexes state does not interfere with other tests,
-// as the custom regexes are global state.
+// #[serial(secrets_regex)] is used to ensure custom regexes state does not interfere with other
+// tests, as the custom regexes are global state. A named group is used (rather than the crate's
+// default `#[serial]` group) so these tests don't needlessly serialize against unrelated tests
+// elsewhere in the crate that also use `#[serial]`. The guard returned by `test_set_secrets_regex`
+// restores the previous regexes on drop, so tests are also isolated from state left behind by a
+// previous test — serialization alone only prevents concurrent interleaving, not leakage.
 
 #[test]
-#[serial]
+#[serial(secrets_regex)]
 fn test_detect_secrets_single_secret_custom() {
     // Set as user secret (enterprise secrets is empty)
-    secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = secrets::test_set_secrets_regex(
         [&Regex::new("ABCD").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -338,11 +348,11 @@ fn test_detect_secrets_single_secret_custom() {
 }
 
 #[test]
-#[serial]
+#[serial(secrets_regex)]
 fn test_detect_secrets_single_secret_custom_with_multibyte() {
     // Set a custom secret regex that matches a Chinese multibyte secret, e.g., "秘密"
     // Set as user secret (enterprise secrets is empty)
-    secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = secrets::test_set_secrets_regex(
         [&Regex::new("秘密").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -361,10 +371,10 @@ fn test_detect_secrets_single_secret_custom_with_multibyte() {
 }
 
 #[test]
-#[serial]
+#[serial(secrets_regex)]
 fn test_detect_secrets_multiple_secrets() {
     // Set custom regexes to include patterns that would previously have been system defaults
-    secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = secrets::test_set_secrets_regex(
         [
             &Regex::new("ABCD").expect("Should be able to construct regex"),
             &Regex::new(r"\bghp_[A-Za-z0-9_]{36}\b").expect("Should be able to construct regex"),
@@ -483,10 +493,10 @@ fn test_add_secret_redaction_to_text_with_multibyte_characters() {
 
 // Test case-sensitive matching by default
 #[test]
-#[serial]
+#[serial(secrets_regex)]
 fn test_detect_secrets_case_sensitive() {
     // Set as user secret (enterprise secrets is empty)
-    secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = secrets::test_set_secrets_regex(
         [&Regex::new("ABCD").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -510,10 +520,10 @@ fn test_detect_secrets_case_sensitive() {
 
 // Test opt-in case-insensitive matching with (?i) flag
 #[test]
-#[serial]
+#[serial(secrets_regex)]
 fn test_detect_secrets_case_insensitive_opt_in() {
     // Set as user secret with case-insensitive flag
-    secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = secrets::test_set_secrets_regex(
         [&Regex::new("(?i)ABCD").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -538,10 +548,10 @@ fn test_detect_secrets_case_insensitive_opt_in() {
 
 // Test case sensitivity for default regex patterns
 #[test]
-#[serial]
+#[serial(secrets_regex)]
 fn test_detect_secrets_default_regex_case_sensitivity() {
     // Set user secret with a stripe-key like pattern, but enforce case sensitivity
-    secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = secrets::test_set_secrets_regex(
         [&Regex::new(r"\bsk_test_[0-9a-z]{24}\b").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -584,11 +594,11 @@ fn test_detect_secrets_default_regex_case_sensitivity() {
 // Regression test for panic `assertion failed: self.is_char_boundary(n)`.
 // End-to-end detection and redaction of custom multibyte secrets.
 #[test]
-#[serial]
+#[serial(secrets_regex)]
 fn test_detect_and_redact_custom_multibyte_secrets() {
     // Set the custom secret regex to detect both "テストファイル" and "ABCD"
     // Set as user secrets (enterprise secrets is empty)
-    secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = secrets::test_set_secrets_regex(
         [
             &Regex::new("テストファイル").expect("Should be able to construct regex"),
             &Regex::new("ABCD").expect("Should be able to construct regex"),

--- a/app/src/terminal/model/grid/secrets_tests.rs
+++ b/app/src/terminal/model/grid/secrets_tests.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use serial_test::serial;
 
 use super::*;
 use crate::terminal::SizeInfo;
@@ -31,8 +32,9 @@ fn empty_blockgrid(
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_secret_redacted_after_byte_processing() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("ABCD").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -65,9 +67,10 @@ fn test_secret_redacted_after_byte_processing() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_secret_redacted_after_multibyte_prefix() {
     let secret = "AAAAC3NzaC1lZDI1NTE5AAAAIThisIsNotARealKeyItIsJustForTestingWarpRedact";
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("AAAAC3NzaC1lZDI1NTE5[A-Za-z0-9+/=]{20,}")
             .expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
@@ -100,8 +103,9 @@ fn test_secret_redacted_after_multibyte_prefix() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_secret_with_word_boundaries_redacted_after_multibyte_prefix() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new(r"\bTOKEN123\b").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -132,8 +136,9 @@ fn test_secret_with_word_boundaries_redacted_after_multibyte_prefix() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_secret_redacted_after_multiple_byte_processing() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("ABCD").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -172,8 +177,9 @@ fn test_secret_redacted_after_multiple_byte_processing() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_secret_redaction_unobfuscated_secret_remains_after_byte_processing() -> anyhow::Result<()> {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("ABCD").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -230,8 +236,9 @@ fn test_secret_redaction_unobfuscated_secret_remains_after_byte_processing() -> 
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_secret_redaction_secret_remains_after_resize() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("ABCD").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -267,8 +274,9 @@ fn test_secret_redaction_secret_remains_after_resize() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_bytes_processed_for_secrets_after_turning_redaction() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("abcd").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -298,8 +306,9 @@ fn test_bytes_processed_for_secrets_after_turning_redaction() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_bytes_processed_for_secrets_after_turning_redaction_on() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("abcd").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -324,8 +333,9 @@ fn test_bytes_processed_for_secrets_after_turning_redaction_on() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_bytes_processed_for_secrets_after_turning_redaction_off_then_on() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("abcd").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );
@@ -359,8 +369,9 @@ fn test_bytes_processed_for_secrets_after_turning_redaction_off_then_on() {
 }
 
 #[test]
+#[serial(secrets_regex)]
 fn test_bytes_processed_for_secrets_after_turning_redaction_on_then_off() {
-    crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes(
+    let _secrets_regex_guard = crate::terminal::model::secrets::test_set_secrets_regex(
         [&Regex::new("abcd").expect("Should be able to construct regex")],
         std::iter::empty(), // No enterprise secrets
     );

--- a/app/src/terminal/model/secrets.rs
+++ b/app/src/terminal/model/secrets.rs
@@ -406,6 +406,40 @@ pub fn set_user_and_enterprise_secret_regexes<'a>(
     *SECRETS_REGEX.lock() = Arc::new(secrets_regex);
 }
 
+/// Sets [`SECRETS_REGEX`] for the duration of a test, restoring the previous value when the
+/// returned guard is dropped.
+///
+/// [`SECRETS_REGEX`] is a single process-global (not thread-local), so this guard only protects
+/// against state leaking *across* tests — it does not, by itself, prevent two tests running
+/// concurrently from clobbering each other's regexes mid-test. Callers must also serialize with
+/// `#[serial(secrets_regex)]` (from the `serial_test` crate) on every test that reads or writes
+/// this global, using the same key, so they never interleave.
+#[cfg(any(test, feature = "test-util"))]
+#[must_use = "if unused the override will be immediately cleared"]
+pub struct SecretsRegexTestGuard {
+    previous: Arc<SecretsRegex>,
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl Drop for SecretsRegexTestGuard {
+    fn drop(&mut self) {
+        *SECRETS_REGEX.lock() = self.previous.clone();
+    }
+}
+
+/// Test helper: installs `user_secrets`/`enterprise_secrets` into [`SECRETS_REGEX`] and returns a
+/// guard that restores the previous value on drop. See [`SecretsRegexTestGuard`] for the
+/// serialization requirement this helper does not provide on its own.
+#[cfg(any(test, feature = "test-util"))]
+pub fn test_set_secrets_regex<'a>(
+    user_secrets: impl IntoIterator<Item = &'a regex::Regex>,
+    enterprise_secrets: impl IntoIterator<Item = &'a regex::Regex>,
+) -> SecretsRegexTestGuard {
+    let previous = SECRETS_REGEX.lock().clone();
+    set_user_and_enterprise_secret_regexes(user_secrets, enterprise_secrets);
+    SecretsRegexTestGuard { previous }
+}
+
 /// A wrapper around a [`Point`] that implements [`StepLite`], allowing us to store it in a
 /// `RangeMap`. Used for secret redaction so we efficiently map from a given range to an underlying
 /// secret stored at that range.


### PR DESCRIPTION
Closes #13973

## Description

The secret-redaction tests install their own regexes into the single process-global `SECRETS_REGEX` ([`secrets.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/terminal/model/secrets.rs)) with no isolation. Under plain `cargo test`, one test's regexes could overwrite another's before its assertion ran — the loser panics `left: 0, right: 1`, and which test loses rotates run to run, which is why this reported as a rotating flake rather than one consistent failure.

Fix: `test_set_secrets_regex()` returns a `#[must_use]` RAII guard (modeled on the existing `FeatureFlag::override_enabled` → `OverrideGuard` pattern) that snapshots the global and restores it on drop. Since the global is process-wide (not thread-local), the guard prevents cross-test leakage but not mid-test interleaving — so the affected tests are also `#[serial(secrets_regex)]`, a named group that avoids serializing against unrelated `#[serial]` tests. Converted all racing call sites in the three files from the issue: [`grid/secrets_tests.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/terminal/model/grid/secrets_tests.rs) (9 tests), [`block/secret_redaction_tests.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/ai/blocklist/block/secret_redaction_tests.rs), and [`execute/grep_tests.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/ai/blocklist/action_model/execute/grep_tests.rs).

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).
  - _Not applicable: test-only change, no user-visible behavior._

## Testing

Repeated invocations of the affected modules under plain `cargo test` — the harness where the flake manifests (nextest's per-process isolation masks it):

- Before: `cargo test -p warp --lib terminal::model::grid::grid_handler::secrets` → `FAILED. 3 passed; 7 failed` (e.g. `assertion left == right failed: left: 0, right: 1`).
- After: same command ×3 → `ok. 10 passed` every run. The other two modules: `ai::blocklist::block::secret_redaction` → `ok. 19 passed` ×3; `…execute::grep` → `ok. 4 passed` ×3.
- Nextest (CI parity, was already green): `cargo nextest run -p warp --lib -E 'test(secrets) + test(secret_redaction) + test(grep_tests)'` → 72/72 passed.
- `cargo clippy -p warp --lib --tests` and `cargo check -p warp --lib --features test-util`: zero warnings.

- [ ] I have manually tested my changes locally with `./script/run`
  - _Not applicable: the issue only applies to test builds._

### Screenshots / Videos

_Not applicable: test-only change._

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
