### PR TITLE
Stop Workspace's chdir-to-home from leaking the process cwd across tests

### DIFF
--- a/app/src/util/path_tests.rs
+++ b/app/src/util/path_tests.rs
@@ -18,6 +18,11 @@ fn test_trim_newline() {
 /// TODO(CORE-3626): write an equivalent test with Windows paths.
 #[cfg(not(windows))]
 #[test]
+// Reads the ambient process PATH; must not race tests elsewhere in the crate that
+// temporarily override PATH (e.g. `local_harness_launch_tests`'s `EnvVarGuard`). Those
+// tests are already `#[serial_test::serial]`, so joining the same (default) serial group
+// here is what actually synchronizes against them. See #13980.
+#[serial_test::serial]
 fn test_resolve_command() {
     use std::path::Path;
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -2864,6 +2864,12 @@ impl Workspace {
             model.insert(window_id, new_resizable_modal_sizes)
         });
 
+        // Skipped under test: on macOS this changes the process's current working
+        // directory to the user's home directory with no restoration afterward. Since it's
+        // never undone, the first test in the binary that constructs a `Workspace` would
+        // otherwise permanently relocate the whole test process's cwd, breaking every later
+        // test that resolves a relative path (see #13980).
+        #[cfg(not(test))]
         terminal::platform::init().expect("Terminal platform initialized");
 
         let tab_bar_overflow_menu = Self::build_tab_bar_overflow_menu(ctx);


### PR DESCRIPTION
Closes #13980

## Description

`Workspace::new` ([`view.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/workspace/view.rs)) unconditionally called `terminal::platform::init()`, which on macOS ([`platform.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/terminal/platform.rs)) does `env::set_current_dir(home_dir)` with no restoration. The first test in a shared process that constructs a `Workspace` permanently relocates the whole test binary's cwd to `$HOME` — a first-writer-wins process-global side effect (same shape as #13974's cache cluster, via the OS cwd instead of a static). Every later test resolving a crate-relative path then fails depending on scheduling: `test_load_local` / `test_load_before_session` (open `../README.md`), `test_resolve_command` (resolves `../script/run`).

### Fix

`#[cfg(not(test))]` on the `platform::init()` call site in `Workspace::new`, matching the crate's existing pattern for process-global side effects under test (`block.rs`, `context_chips/logging.rs`, `keyboard.rs`). `platform::init()` itself is untouched — its non-test callers keep it.

### Secondary fix

`test_resolve_command` also reads the ambient `PATH` with no synchronization against the already-`#[serial]` PATH-overriding tests in `pane_group::pane::local_harness_launch_tests`; added the same marker so it joins that serial group. Independent of the cwd leak, and would otherwise still flake.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).
  - _Not applicable: test-only change, no UI._

## Testing

Full crate suite under plain `cargo test -p warp --lib` (nextest's per-process isolation masks this class):

- Before: `FAILED. 5779 passed; 13 failed` — including all three ticketed tests, panic sites matching the ticket verbatim (`markdown len assertion`, `dunce::canonicalize` NotFound, `Option::unwrap()` on None).
- After: `FAILED. 5782 passed; 10 failed` — the three ticketed tests all pass; the remaining 10 are pre-existing and tracked in the sibling flake tickets (#13972–#13975).
- `cargo clippy -p warp --lib --tests`: zero warnings.

- [ ] I have manually tested my changes locally with `./script/run`
  - _Not applicable: the issue only applies to test builds (the guard only affects code compiled into test binaries)._

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
