### PR TITLE
Rename Account settings page to Profile

### DIFF
--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -300,7 +300,7 @@ impl MainSettingsPageView {
 
         widgets.push(Box::new(LogoutWidget::default()));
 
-        let page = PageType::new_uncategorized(widgets, Some("Account"));
+        let page = PageType::new_uncategorized(widgets, Some("Profile"));
 
         MainSettingsPageView { page, auth_state }
     }
@@ -621,7 +621,7 @@ impl SettingsWidget for AccountWidget {
     type View = MainSettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "account sign up"
+        "account profile sign up"
     }
 
     fn render(

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -290,6 +290,7 @@ use crate::util::bindings::custom_tag_to_keystroke;
 impl Display for SettingsSection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            SettingsSection::Account => write!(f, "Profile"),
             SettingsSection::BillingAndUsage => write!(f, "Billing and usage"),
             SettingsSection::Keybindings => write!(f, "Keyboard shortcuts"),
             SettingsSection::SharedBlocks => write!(f, "Shared blocks"),
@@ -382,7 +383,8 @@ impl FromStr for SettingsSection {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "About" => Ok(Self::About),
-            "Account" => Ok(Self::Account),
+            // This page was called "Account" at one point, keep for backward compatibility.
+            "Account" | "Profile" => Ok(Self::Account),
             "AI" => Ok(Self::AI),
             "MCP Servers" => Ok(Self::MCPServers),
             "Billing and usage" => Ok(Self::BillingAndUsage),

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -1527,7 +1527,7 @@ fn add_open_setting_pages_as_editable_binding(app: &mut AppContext) {
         .with_custom_action(CustomAction::ShowSettings),
         EditableBinding::new(
             "workspace:show_settings_account_page",
-            "Open Settings: Account",
+            "Open Settings: Profile",
             WorkspaceAction::ShowSettingsPage(SettingsSection::Account),
         )
         .with_context_predicate(id!("Workspace"))


### PR DESCRIPTION
## Description
Renames the "Account" settings page to "Profile" in the client. This updates the settings sidebar label, the page header, and the command palette entry ("Open Settings: Profile"). Deep links and persisted strings that reference "Account" keep working — the section parser accepts both names.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Verified the change compiles with `cargo check -p warp`. `./script/format` (rustfmt) is clean on the touched files. The change is a string-only rename with no behavior changes; the existing settings-view unit tests don't assert the "Account" display string. Note: `cargo clippy` in the sandbox failed on pre-existing lints in `crates/warp_completer` unrelated to this change (toolchain-version mismatch in the sandbox environment).

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Renamed the Account settings page to Profile.

_Conversation: https://staging.warp.dev/conversation/75a116f5-7774-4de7-ad0b-5c37fdfbddcb_
_Run: https://oz.staging.warp.dev/runs/019f820f-b0a9-76f9-90cd-a319c5662a86_

_This PR was generated with [Oz](https://warp.dev/oz)._
