### PR TITLE
Rename Account settings page to Profile

### DIFF
--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -300,7 +300,7 @@ impl MainSettingsPageView {
 
         widgets.push(Box::new(LogoutWidget::default()));
 
-        let page = PageType::new_uncategorized(widgets, Some("Account"));
+        let page = PageType::new_uncategorized(widgets, Some("Profile"));
 
         MainSettingsPageView { page, auth_state }
     }
@@ -621,7 +621,7 @@ impl SettingsWidget for AccountWidget {
     type View = MainSettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "account sign up"
+        "profile account sign up"
     }
 
     fn render(

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -290,6 +290,7 @@ use crate::util::bindings::custom_tag_to_keystroke;
 impl Display for SettingsSection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            SettingsSection::Account => write!(f, "Profile"),
             SettingsSection::BillingAndUsage => write!(f, "Billing and usage"),
             SettingsSection::Keybindings => write!(f, "Keyboard shortcuts"),
             SettingsSection::SharedBlocks => write!(f, "Shared blocks"),
@@ -382,7 +383,8 @@ impl FromStr for SettingsSection {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "About" => Ok(Self::About),
-            "Account" => Ok(Self::Account),
+            // This page was called "Account" at one point, keep for backward compatibility.
+            "Account" | "Profile" => Ok(Self::Account),
             "AI" => Ok(Self::AI),
             "MCP Servers" => Ok(Self::MCPServers),
             "Billing and usage" => Ok(Self::BillingAndUsage),

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -1527,7 +1527,7 @@ fn add_open_setting_pages_as_editable_binding(app: &mut AppContext) {
         .with_custom_action(CustomAction::ShowSettings),
         EditableBinding::new(
             "workspace:show_settings_account_page",
-            "Open Settings: Account",
+            "Open Settings: Profile",
             WorkspaceAction::ShowSettingsPage(SettingsSection::Account),
         )
         .with_context_predicate(id!("Workspace"))


### PR DESCRIPTION
## Description
Renames the user-facing label of the Settings > Account page to **Profile**:
- Settings sidebar nav item ("Account" → "Profile")
- Page heading at the top of the page
- Command palette entry ("Open Settings: Account" → "Open Settings: Profile")

The internal `SettingsSection::Account` variant is unchanged, and `FromStr` keeps accepting `"Account"` (in addition to `"Profile"`) so existing deeplinks and saved references keep working. The Account widget's search terms now also match "profile".

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo check -p warp`, `cargo clippy -p warp --all-targets -- -D warnings`, and `./script/format` all pass.
- Manually verified in a locally built app via computer use: the first settings sidebar item and the page heading both read "Profile", and the page content (account info, Settings sync, Refer a friend, Log out) is unchanged.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- oz:computer-use-screenshots start run=019f821b-0bfe-7913-aad4-11ea974d7563 -->
### Computer-use screenshots

![Warp Settings pane open showing the left sidebar navigation and the "Profile" page (first sidebar item) with account info, Settings sync toggle, Refer a friend, Staging IAP credentials, and Log out button.](https://staging.warp.dev/api/v1/agent/artifacts/019f822f-1bb9-79fd-af5f-98140a9e3289/download "Warp Settings pane open showing the left sidebar navigation and the \"Profile\" page (first sidebar item) with account info, Settings sync toggle, Refer a friend, Staging IAP credentials, and Log out button.")
![Warp Command Palette (Ctrl+Shift+P) filtered by "Open Settings", showing command results "Open Settings" (with Ctrl+, shortcut) and "Open Settings File" at the top, followed by document/workflow matches.](https://staging.warp.dev/api/v1/agent/artifacts/019f8230-9e44-7ccf-9279-2a1735b0687f/download "Warp Command Palette (Ctrl+Shift+P) filtered by \"Open Settings\", showing command results \"Open Settings\" (with Ctrl+, shortcut) and \"Open Settings File\" at the top, followed by document/workflow matches.")
<!-- oz:computer-use-screenshots end -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Renamed the "Account" settings page to "Profile".

_Conversation: https://staging.warp.dev/conversation/bc38f818-6797-4e1d-a898-1bb5ccca21a3_
_Run: https://oz.staging.warp.dev/runs/019f821b-0bfe-7913-aad4-11ea974d7563_

_This PR was generated with [Oz](https://warp.dev/oz)._
