### PR TITLE
Broken-image placeholder + alt-text tooltip and accessibility in the Markdown viewer

### DIFF
--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -47,10 +47,10 @@ use warp_editor::editor::TextDecoration;
 use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
 use warp_editor::multiline::{AnyMultilineString, LF, MultilineString};
 use warp_editor::render::model::{
-    AutoScrollMode, BlockItem, BlockSpacings, BrokenLinkStyle, CheckBoxStyle, ColumnUnit,
-    Decoration, HorizontalRuleStyle, InlineCodeStyle, LineCount, LineDecoration, ParagraphStyles,
-    RenderEvent, RenderLineLocation, RenderState, RichTextStyles, StyleUpdateAction, TableStyle,
-    UpdateDecorationAfterLayout, WidthSetting,
+    AutoScrollMode, BlockItem, BlockSpacings, BrokenImageStyle, BrokenLinkStyle, CheckBoxStyle,
+    ColumnUnit, Decoration, HorizontalRuleStyle, InlineCodeStyle, LineCount, LineDecoration,
+    ParagraphStyles, RenderEvent, RenderLineLocation, RenderState, RichTextStyles,
+    StyleUpdateAction, TableStyle, UpdateDecorationAfterLayout, WidthSetting,
 };
 use warp_editor::selection::{SelectionMode, SelectionModel, TextDirection, TextUnit};
 use warp_util::standardized_path::StandardizedPath;
@@ -524,6 +524,10 @@ impl CodeEditorModel {
                 color: TRANSPARENT,
             },
             broken_link_style: BrokenLinkStyle {
+                icon_path: "",
+                icon_color: TRANSPARENT,
+            },
+            broken_image_style: BrokenImageStyle {
                 icon_path: "",
                 icon_color: TRANSPARENT,
             },

--- a/app/src/notebooks/editor/mod.rs
+++ b/app/src/notebooks/editor/mod.rs
@@ -10,8 +10,8 @@ use warp_editor::content::text::{
     BlockHeaderSize, BlockType as ContentBlockType, BufferBlockStyle, CodeBlockType,
 };
 use warp_editor::render::model::{
-    BrokenLinkStyle, CheckBoxStyle, EmbeddedItem, HorizontalRuleStyle, InlineCodeStyle,
-    ParagraphStyles, RichTextStyles, TableStyle,
+    BrokenImageStyle, BrokenLinkStyle, CheckBoxStyle, EmbeddedItem, HorizontalRuleStyle,
+    InlineCodeStyle, ParagraphStyles, RichTextStyles, TableStyle,
 };
 use warp_util::user_input::UserInput;
 use warpui::elements::{Border, ListIndentLevel};
@@ -266,6 +266,10 @@ pub fn rich_text_styles(appearance: &Appearance, font_settings: &FontSettings) -
         },
         broken_link_style: BrokenLinkStyle {
             icon_path: "bundled/svg/link-broken-02.svg",
+            icon_color: theme.terminal_colors().normal.red.into(),
+        },
+        broken_image_style: BrokenImageStyle {
+            icon_path: "bundled/svg/image-01.svg",
             icon_color: theme.terminal_colors().normal.red.into(),
         },
         block_spacings: Default::default(),

--- a/app/src/notebooks/editor/view.rs
+++ b/app/src/notebooks/editor/view.rs
@@ -14,7 +14,9 @@ use warp_editor::model::{CoreEditorModel, RichTextEditorModel};
 use warp_editor::render::element::{
     DisplayOptions, DisplayStateHandle, RichTextAction, RichTextElement, VerticalExpansionBehavior,
 };
-use warp_editor::render::model::{BlockItem, HitTestBlockType, Location, RenderState};
+use warp_editor::render::model::{
+    BlockItem, HitTestBlockType, Location, RenderState, image_alt_texts_announcement,
+};
 use warp_editor::selection::{TextDirection, TextUnit};
 use warp_util::path::LineAndColumnArg;
 use warp_util::user_input::UserInput;
@@ -2799,6 +2801,26 @@ impl View for RichTextEditorView {
             ctx.notify();
         }
         self.has_focus_within = false;
+    }
+
+    fn accessibility_contents(&self, ctx: &AppContext) -> Option<AccessibilityContent> {
+        // Warp's a11y is a single per-view announcement, so images can only reach
+        // a screen reader through the announcement of the view that renders them.
+        // Surface each image's alt text; images without alt text carry nothing a
+        // screen reader can convey and are omitted (see the announcement builder).
+        let render_state = self.model.as_ref(ctx).render_state().clone();
+        let render_state = render_state.as_ref(ctx);
+        let value = image_alt_texts_announcement(render_state.content().block_items().filter_map(
+            |block| match block {
+                BlockItem::Image { alt_text, .. } => Some(alt_text.as_str()),
+                _ => None,
+            },
+        ))?;
+
+        Some(AccessibilityContent::new_without_help(
+            value,
+            WarpA11yRole::ImageRole,
+        ))
     }
 }
 

--- a/crates/editor/src/content/edit.rs
+++ b/crates/editor/src/content/edit.rs
@@ -17,6 +17,7 @@ use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::Fill as ThemeFill;
 use warp_errors::report_error;
 use warpui_core::assets::asset_cache::{AssetCache, AssetSource, AssetState};
+use warpui_core::elements::MouseStateHandle;
 use warpui_core::fonts::Weight;
 use warpui_core::image_cache::ImageType;
 use warpui_core::text::char_slice;
@@ -890,6 +891,7 @@ impl LayoutTask {
                         source,
                         asset_source,
                         config,
+                        mouse_state: MouseStateHandle::default(),
                     },
                     true, // Images are always followed by a trailing newline in the buffer
                 ))

--- a/crates/editor/src/render/element/hidden_section.rs
+++ b/crates/editor/src/render/element/hidden_section.rs
@@ -28,7 +28,9 @@ use crate::render::model::{BlockItem, LineCount, RichTextStyles};
 const LABEL_LEFT_PADDING: f32 = 8.;
 /// Slightly smaller than the default UI font size.
 const LABEL_FONT_SIZE: f32 = 11.;
-const TOOLTIP_HOVER_DELAY: Duration = Duration::from_millis(500);
+/// The shared framework tooltip show delay, so this bar's tooltip matches every
+/// other hover tooltip (including the pointer-anchored image alt-text tooltip).
+const TOOLTIP_HOVER_DELAY: Duration = warpui_core::elements::TOOLTIP_SHOW_DELAY;
 /// A hidden-section bar with a link to expand all lines.
 pub struct RenderableHiddenSection {
     element: Box<dyn Element>,

--- a/crates/editor/src/render/element/image.rs
+++ b/crates/editor/src/render/element/image.rs
@@ -16,6 +16,15 @@ use crate::render::model::{BlockItem, RenderState, RichTextStyles};
 /// tooltip's vertical offset from its anchor.
 const TOOLTIP_OFFSET: f32 = 4.;
 
+/// Whether an image should carry an alt-text hover tooltip. Only images with
+/// non-empty (non-whitespace) alt text do: an image without alt text is
+/// decorative, and a tooltip with nothing to say shouldn't exist. This mirrors
+/// the accessibility-tree rule (`alt=""` → decorative) so the two affordances
+/// agree on which images are meaningful.
+fn image_has_tooltip(alt_text: &str) -> bool {
+    !alt_text.trim().is_empty()
+}
+
 /// Text shown alongside the broken-image glyph when an image fails to load.
 /// Prefers the image's alt text; falls back to a generic notice when the alt
 /// text is empty or whitespace-only.
@@ -122,9 +131,7 @@ impl RenderableBlock for RenderableImage {
         // (and remains available for the broken-image placeholder). Use the
         // overlay variant so the tooltip escapes the editor's viewport clip, and
         // anchor it below the image, mirroring the hidden-section tooltip.
-        let mut element: Box<dyn Element> = if self.alt_text.trim().is_empty() {
-            image
-        } else {
+        let mut element: Box<dyn Element> = if image_has_tooltip(&self.alt_text) {
             Appearance::as_ref(app)
                 .ui_builder()
                 .overlay_tool_tip_on_element(
@@ -135,6 +142,8 @@ impl RenderableBlock for RenderableImage {
                     ChildAnchor::TopLeft,
                     vec2f(0., TOOLTIP_OFFSET),
                 )
+        } else {
+            image
         };
 
         let constraint = SizeConstraint::new(vec2f(0., 0.), size);
@@ -217,7 +226,20 @@ impl RenderableBlock for RenderableImage {
 
 #[cfg(test)]
 mod tests {
-    use super::broken_image_label;
+    use super::{broken_image_label, image_has_tooltip};
+
+    #[test]
+    fn tooltip_present_when_alt_text_non_empty() {
+        assert!(image_has_tooltip("A red bicycle"));
+        assert!(image_has_tooltip("  spaced alt  "));
+    }
+
+    #[test]
+    fn tooltip_absent_when_alt_text_empty_or_whitespace() {
+        assert!(!image_has_tooltip(""));
+        assert!(!image_has_tooltip("   "));
+        assert!(!image_has_tooltip("\t\n"));
+    }
 
     #[test]
     fn label_uses_alt_text_when_present() {

--- a/crates/editor/src/render/element/image.rs
+++ b/crates/editor/src/render/element/image.rs
@@ -133,9 +133,10 @@ impl RenderableBlock for RenderableImage {
         // Show the alt text on hover so it's reachable without loading the image
         // (and remains available for the broken-image placeholder). Use the
         // overlay variant so the tooltip escapes the editor's viewport clip, and
-        // anchor it at the mouse pointer with browser-`title` show/dismiss
-        // hysteresis (rest to show, motion to dismiss, re-rest to relocate) so it
-        // reads as a cursor tooltip rather than a caption pinned to the image.
+        // anchor it at the mouse pointer with a browser-`title` fade animation
+        // (fade in on rest, fade out on motion or exit, relocate on re-rest at a
+        // new spot) so it reads as a cursor tooltip rather than a caption pinned
+        // to the image.
         let mut element: Box<dyn Element> = if image_has_tooltip(&self.alt_text) {
             Appearance::as_ref(app)
                 .ui_builder()

--- a/crates/editor/src/render/element/image.rs
+++ b/crates/editor/src/render/element/image.rs
@@ -133,8 +133,9 @@ impl RenderableBlock for RenderableImage {
         // Show the alt text on hover so it's reachable without loading the image
         // (and remains available for the broken-image placeholder). Use the
         // overlay variant so the tooltip escapes the editor's viewport clip, and
-        // anchor it at the mouse pointer so it reads as a cursor tooltip rather
-        // than a caption pinned to the image's bounds.
+        // anchor it at the mouse pointer with browser-`title` show/dismiss
+        // hysteresis (rest to show, motion to dismiss, re-rest to relocate) so it
+        // reads as a cursor tooltip rather than a caption pinned to the image.
         let mut element: Box<dyn Element> = if image_has_tooltip(&self.alt_text) {
             Appearance::as_ref(app)
                 .ui_builder()

--- a/crates/editor/src/render/element/image.rs
+++ b/crates/editor/src/render/element/image.rs
@@ -1,4 +1,7 @@
-use warpui_core::elements::{CacheOption, Image};
+use warpui_core::elements::{
+    CacheOption, ConstrainedBox, Container, CrossAxisAlignment, Flex, Icon, Image, ParentElement,
+    Text,
+};
 use warpui_core::geometry::vector::vec2f;
 use warpui_core::{Element, SizeConstraint};
 
@@ -6,7 +9,54 @@ use super::{RenderContext, RenderableBlock};
 use crate::extract_block;
 use crate::render::element::paint::{CursorData, CursorDisplayType};
 use crate::render::model::viewport::ViewportItem;
-use crate::render::model::{BlockItem, RenderState};
+use crate::render::model::{BlockItem, RenderState, RichTextStyles};
+
+/// Text shown alongside the broken-image glyph when an image fails to load.
+/// Prefers the image's alt text; falls back to a generic notice when the alt
+/// text is empty or whitespace-only.
+fn broken_image_label(alt_text: &str) -> String {
+    let trimmed = alt_text.trim();
+    if trimmed.is_empty() {
+        "Image failed to load".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Builds the placeholder element painted in place of an image that failed to
+/// load: a failed-image glyph followed by the image's alt text (or a generic
+/// notice when no alt text is present).
+fn broken_image_placeholder(alt_text: &str, styles: &RichTextStyles) -> Box<dyn Element> {
+    let icon = ConstrainedBox::new(
+        Icon::new(
+            styles.broken_image_style.icon_path,
+            styles.broken_image_style.icon_color,
+        )
+        .with_opacity(1.0)
+        .finish(),
+    )
+    .with_height(styles.base_text.font_size + 2.)
+    .with_width(styles.base_text.font_size + 2.)
+    .finish();
+
+    let text = Container::new(
+        Text::new(
+            broken_image_label(alt_text),
+            styles.base_text.font_family,
+            styles.base_text.font_size,
+        )
+        .with_color(styles.placeholder_color)
+        .finish(),
+    )
+    .with_padding_left(8.)
+    .finish();
+
+    Flex::row()
+        .with_child(icon)
+        .with_child(text)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .finish()
+}
 
 pub struct RenderableImage {
     viewport_item: ViewportItem,
@@ -37,16 +87,19 @@ impl RenderableBlock for RenderableImage {
         app: &warpui_core::AppContext,
     ) {
         let content = model.content();
-        let (asset_source, config) = extract_block!(
+        let (asset_source, config, alt_text) = extract_block!(
             self.viewport_item,
             content,
-            (_block, BlockItem::Image { asset_source, config, .. }) => (asset_source.clone(), *config)
+            (_block, BlockItem::Image { asset_source, config, alt_text, .. }) => (asset_source.clone(), *config, alt_text.clone())
         );
+
+        let placeholder = broken_image_placeholder(&alt_text, model.styles());
 
         let size = vec2f(config.width.as_f32(), config.height.as_f32());
         let mut image = Image::new(asset_source, CacheOption::BySize)
             .contain()
-            .first_frame_preview();
+            .first_frame_preview()
+            .on_load_failure(placeholder);
 
         let constraint = SizeConstraint::new(vec2f(0., 0.), size);
         image.layout(constraint, ctx, app);
@@ -99,5 +152,30 @@ impl RenderableBlock for RenderableImage {
                 model.styles(),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::broken_image_label;
+
+    #[test]
+    fn label_uses_alt_text_when_present() {
+        assert_eq!(broken_image_label("A red bicycle"), "A red bicycle");
+    }
+
+    #[test]
+    fn label_trims_surrounding_whitespace() {
+        assert_eq!(broken_image_label("  spaced alt  "), "spaced alt");
+    }
+
+    #[test]
+    fn label_falls_back_when_alt_text_empty() {
+        assert_eq!(broken_image_label(""), "Image failed to load");
+    }
+
+    #[test]
+    fn label_falls_back_when_alt_text_only_whitespace() {
+        assert_eq!(broken_image_label("   \t"), "Image failed to load");
     }
 }

--- a/crates/editor/src/render/element/image.rs
+++ b/crates/editor/src/render/element/image.rs
@@ -1,15 +1,20 @@
+use warp_core::ui::appearance::Appearance;
 use warpui_core::elements::{
-    CacheOption, ConstrainedBox, Container, CrossAxisAlignment, Flex, Icon, Image, ParentElement,
-    Text,
+    CacheOption, ChildAnchor, ConstrainedBox, Container, CrossAxisAlignment, Flex, Icon, Image,
+    MouseStateHandle, ParentAnchor, ParentElement, Text,
 };
 use warpui_core::geometry::vector::vec2f;
-use warpui_core::{Element, SizeConstraint};
+use warpui_core::{Element, SingletonEntity, SizeConstraint};
 
 use super::{RenderContext, RenderableBlock};
 use crate::extract_block;
 use crate::render::element::paint::{CursorData, CursorDisplayType};
 use crate::render::model::viewport::ViewportItem;
 use crate::render::model::{BlockItem, RenderState, RichTextStyles};
+
+/// Gap between the image and its alt-text tooltip, matching the hidden-section
+/// tooltip's vertical offset from its anchor.
+const TOOLTIP_OFFSET: f32 = 4.;
 
 /// Text shown alongside the broken-image glyph when an image fails to load.
 /// Prefers the image's alt text; falls back to a generic notice when the alt
@@ -60,6 +65,11 @@ fn broken_image_placeholder(alt_text: &str, styles: &RichTextStyles) -> Box<dyn 
 
 pub struct RenderableImage {
     viewport_item: ViewportItem,
+    /// The image's alt text, shown as a hover tooltip. Empty when the source
+    /// markdown gave no alt text, in which case no tooltip is attached.
+    alt_text: String,
+    /// Persists hover state across re-layouts so tooltip hover tracking is stable.
+    mouse_state: MouseStateHandle,
     // TODO: The AssetCache does not currently support automatic eviction of assets when they are
     // dropped. We should consider implementing a mechanism to unload images when they are no longer
     // visible or referenced.
@@ -67,9 +77,15 @@ pub struct RenderableImage {
 }
 
 impl RenderableImage {
-    pub fn new(viewport_item: ViewportItem) -> Self {
+    pub fn new(
+        viewport_item: ViewportItem,
+        alt_text: String,
+        mouse_state: MouseStateHandle,
+    ) -> Self {
         Self {
             viewport_item,
+            alt_text,
+            mouse_state,
             image_element: None,
         }
     }
@@ -87,24 +103,44 @@ impl RenderableBlock for RenderableImage {
         app: &warpui_core::AppContext,
     ) {
         let content = model.content();
-        let (asset_source, config, alt_text) = extract_block!(
+        let (asset_source, config) = extract_block!(
             self.viewport_item,
             content,
-            (_block, BlockItem::Image { asset_source, config, alt_text, .. }) => (asset_source.clone(), *config, alt_text.clone())
+            (_block, BlockItem::Image { asset_source, config, .. }) => (asset_source.clone(), *config)
         );
 
-        let placeholder = broken_image_placeholder(&alt_text, model.styles());
+        let placeholder = broken_image_placeholder(&self.alt_text, model.styles());
 
         let size = vec2f(config.width.as_f32(), config.height.as_f32());
-        let mut image = Image::new(asset_source, CacheOption::BySize)
+        let image = Image::new(asset_source, CacheOption::BySize)
             .contain()
             .first_frame_preview()
-            .on_load_failure(placeholder);
+            .on_load_failure(placeholder)
+            .finish();
+
+        // Show the alt text on hover so it's reachable without loading the image
+        // (and remains available for the broken-image placeholder). Use the
+        // overlay variant so the tooltip escapes the editor's viewport clip, and
+        // anchor it below the image, mirroring the hidden-section tooltip.
+        let mut element: Box<dyn Element> = if self.alt_text.trim().is_empty() {
+            image
+        } else {
+            Appearance::as_ref(app)
+                .ui_builder()
+                .overlay_tool_tip_on_element(
+                    self.alt_text.clone(),
+                    self.mouse_state.clone(),
+                    image,
+                    ParentAnchor::BottomLeft,
+                    ChildAnchor::TopLeft,
+                    vec2f(0., TOOLTIP_OFFSET),
+                )
+        };
 
         let constraint = SizeConstraint::new(vec2f(0., 0.), size);
-        image.layout(constraint, ctx, app);
+        element.layout(constraint, ctx, app);
 
-        self.image_element = Some(Box::new(image));
+        self.image_element = Some(element);
     }
 
     fn paint(
@@ -151,6 +187,30 @@ impl RenderableBlock for RenderableImage {
                 CursorData::default(),
                 model.styles(),
             );
+        }
+    }
+
+    fn after_layout(
+        &mut self,
+        ctx: &mut warpui_core::AfterLayoutContext,
+        app: &warpui_core::AppContext,
+    ) {
+        if let Some(ref mut image_element) = self.image_element {
+            image_element.after_layout(ctx, app);
+        }
+    }
+
+    fn dispatch_event(
+        &mut self,
+        _model: &RenderState,
+        event: &warpui_core::event::DispatchedEvent,
+        ctx: &mut warpui_core::EventContext,
+        app: &warpui_core::AppContext,
+    ) -> bool {
+        if let Some(ref mut image_element) = self.image_element {
+            image_element.dispatch_event(event, ctx, app)
+        } else {
+            false
         }
     }
 }

--- a/crates/editor/src/render/element/image.rs
+++ b/crates/editor/src/render/element/image.rs
@@ -1,9 +1,9 @@
 use warp_core::ui::appearance::Appearance;
 use warpui_core::elements::{
-    CacheOption, ChildAnchor, ConstrainedBox, Container, CrossAxisAlignment, Flex, Icon, Image,
-    MouseStateHandle, ParentAnchor, ParentElement, Text,
+    CacheOption, ConstrainedBox, Container, CrossAxisAlignment, Flex, Icon, Image,
+    MouseStateHandle, ParentElement, Text,
 };
-use warpui_core::geometry::vector::vec2f;
+use warpui_core::geometry::vector::{Vector2F, vec2f};
 use warpui_core::{Element, SingletonEntity, SizeConstraint};
 
 use super::{RenderContext, RenderableBlock};
@@ -12,9 +12,12 @@ use crate::render::element::paint::{CursorData, CursorDisplayType};
 use crate::render::model::viewport::ViewportItem;
 use crate::render::model::{BlockItem, RenderState, RichTextStyles};
 
-/// Gap between the image and its alt-text tooltip, matching the hidden-section
-/// tooltip's vertical offset from its anchor.
-const TOOLTIP_OFFSET: f32 = 4.;
+/// Below-right nudge of the alt-text tooltip from the mouse pointer, so the
+/// cursor sits just above-left of the tooltip's top-left corner rather than
+/// covering its text. Mirrors the conventional pointer-anchored tooltip offset.
+fn tooltip_pointer_offset() -> Vector2F {
+    vec2f(12., 16.)
+}
 
 /// Whether an image should carry an alt-text hover tooltip. Only images with
 /// non-empty (non-whitespace) alt text do: an image without alt text is
@@ -130,17 +133,16 @@ impl RenderableBlock for RenderableImage {
         // Show the alt text on hover so it's reachable without loading the image
         // (and remains available for the broken-image placeholder). Use the
         // overlay variant so the tooltip escapes the editor's viewport clip, and
-        // anchor it below the image, mirroring the hidden-section tooltip.
+        // anchor it at the mouse pointer so it reads as a cursor tooltip rather
+        // than a caption pinned to the image's bounds.
         let mut element: Box<dyn Element> = if image_has_tooltip(&self.alt_text) {
             Appearance::as_ref(app)
                 .ui_builder()
-                .overlay_tool_tip_on_element(
+                .overlay_tool_tip_at_pointer(
                     self.alt_text.clone(),
                     self.mouse_state.clone(),
                     image,
-                    ParentAnchor::BottomLeft,
-                    ChildAnchor::TopLeft,
-                    vec2f(0., TOOLTIP_OFFSET),
+                    tooltip_pointer_offset(),
                 )
         } else {
             image

--- a/crates/editor/src/render/element/mod.rs
+++ b/crates/editor/src/render/element/mod.rs
@@ -917,7 +917,11 @@ impl<V: EditorView> RichTextElement<V> {
                     } => RenderableTemporaryBlock::new(item, *decoration, text_decoration.clone())
                         .finish(),
                     BlockItem::HorizontalRule(_) => HorizontalRule::new(item).finish(),
-                    BlockItem::Image { .. } => RenderableImage::new(item).finish(),
+                    BlockItem::Image {
+                        alt_text,
+                        mouse_state,
+                        ..
+                    } => RenderableImage::new(item, alt_text.clone(), mouse_state.clone()).finish(),
                     BlockItem::Table { .. } => RenderableTable::new(item).finish(),
                     BlockItem::TrailingNewLine(_) => Empty::new(item).finish(),
                     BlockItem::Hidden(config) => {

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -1101,6 +1101,8 @@ pub struct RichTextStyles {
     pub horizontal_rule_style: HorizontalRuleStyle,
     /// Path to the broken link icon svg.
     pub broken_link_style: BrokenLinkStyle,
+    /// Icon and color for the placeholder shown when an image fails to load.
+    pub broken_image_style: BrokenImageStyle,
     /// Spacing configuration for blocks.
     pub block_spacings: BlockSpacings,
     /// Minimum height a paragraph will take. This currently
@@ -1194,6 +1196,12 @@ pub struct CheckBoxStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BrokenLinkStyle {
+    pub icon_path: &'static str,
+    pub icon_color: ColorU,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BrokenImageStyle {
     pub icon_path: &'static str,
     pub icon_color: ColorU,
 }

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -2298,8 +2298,10 @@ pub fn gutter_expansion_button_types(
 
 /// Builds the screen-reader announcement describing the images in a document,
 /// from their alt texts. Alt text is the only image content a screen reader can
-/// convey, so images without alt text are omitted rather than announced as
-/// unlabeled — an unlabeled image adds noise without conveying meaning.
+/// convey, so an image with empty or whitespace-only alt text is treated as
+/// decorative and omitted entirely — the equivalent of a browser mapping
+/// `alt=""` to `role="presentation"`. Announcing it as an unlabeled image would
+/// add noise without conveying meaning.
 ///
 /// Returns [`None`] when no image carries alt text (the caller then contributes
 /// nothing to the view's accessibility contents). Each labeled image is prefixed

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -1491,6 +1491,10 @@ pub enum BlockItem {
         source: String,
         asset_source: AssetSource,
         config: ImageBlockConfig,
+        /// Persists hover state across re-layouts so the alt-text tooltip's
+        /// hover tracking is stable, mirroring [`BlockItem::TaskList`] and
+        /// [`HiddenBlockConfig`].
+        mouse_state: MouseStateHandle,
     },
     Table(Box<LaidOutTable>),
     TrailingNewLine(Cursor),

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -2291,6 +2291,28 @@ pub fn gutter_expansion_button_types(
         }
     }
 }
+
+/// Builds the screen-reader announcement describing the images in a document,
+/// from their alt texts. Alt text is the only image content a screen reader can
+/// convey, so images without alt text are omitted rather than announced as
+/// unlabeled — an unlabeled image adds noise without conveying meaning.
+///
+/// Returns [`None`] when no image carries alt text (the caller then contributes
+/// nothing to the view's accessibility contents). Each labeled image is prefixed
+/// with `Image:` so screen-reader users can tell an image label apart from the
+/// surrounding prose.
+pub fn image_alt_texts_announcement<'a>(
+    alt_texts: impl Iterator<Item = &'a str>,
+) -> Option<String> {
+    let labels: Vec<String> = alt_texts
+        .filter_map(|alt| {
+            let trimmed = alt.trim();
+            (!trimmed.is_empty()).then(|| format!("Image: {trimmed}"))
+        })
+        .collect();
+
+    (!labels.is_empty()).then(|| labels.join(". "))
+}
 // `Clone`, not `Copy`: holds a `MouseStateHandle` (`Arc`-backed), like
 // `BlockItem::TaskList`. The hidden-range dedupe paths clone configs accordingly.
 #[derive(Debug, Clone)]

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -29,7 +29,33 @@ use crate::content::text::{
 use crate::render::model::test_utils::{TEST_STYLES, laid_out_paragraph, mock_paragraph};
 use crate::render::model::{
     ColumnUnit, Height, LayoutSummary, LineCount, RenderedSelection, SoftWrapPoint, TEXT_SPACING,
+    image_alt_texts_announcement,
 };
+
+#[test]
+fn alt_text_announcement_is_none_without_labeled_images() {
+    assert_eq!(image_alt_texts_announcement(std::iter::empty()), None);
+    assert_eq!(
+        image_alt_texts_announcement(["", "   ", "\t"].into_iter()),
+        None
+    );
+}
+
+#[test]
+fn alt_text_announcement_labels_and_trims_single_image() {
+    assert_eq!(
+        image_alt_texts_announcement(["  A red bicycle  "].into_iter()),
+        Some("Image: A red bicycle".to_string())
+    );
+}
+
+#[test]
+fn alt_text_announcement_joins_labeled_images_and_skips_unlabeled() {
+    assert_eq!(
+        image_alt_texts_announcement(["First", "", "Second"].into_iter()),
+        Some("Image: First. Image: Second".to_string())
+    );
+}
 
 #[test]
 fn test_height() {

--- a/crates/editor/src/render/model/offset_map_tests.rs
+++ b/crates/editor/src/render/model/offset_map_tests.rs
@@ -89,8 +89,9 @@ fn test_end_to_end() {
     use crate::render::layout::TextLayout;
     use crate::render::model::test_utils::TEST_BASELINE_OFFSET;
     use crate::render::model::{
-        BlockItem, BrokenLinkStyle, CheckBoxStyle, HorizontalRuleStyle, InlineCodeStyle,
-        PARAGRAPH_MIN_HEIGHT, ParagraphStyles, RenderLayoutOptions, RichTextStyles, TableStyle,
+        BlockItem, BrokenImageStyle, BrokenLinkStyle, CheckBoxStyle, HorizontalRuleStyle,
+        InlineCodeStyle, PARAGRAPH_MIN_HEIGHT, ParagraphStyles, RenderLayoutOptions,
+        RichTextStyles, TableStyle,
     };
 
     App::test((), |mut app| async move {
@@ -129,6 +130,10 @@ fn test_end_to_end() {
             icon_path: "bundled/svg/link-broken-02.svg",
             icon_color: ColorU::black(),
         };
+        let broken_image = BrokenImageStyle {
+            icon_path: "bundled/svg/image-01.svg",
+            icon_color: ColorU::black(),
+        };
         let styles = RichTextStyles {
             base_text: paragraph_styles,
             code_text: paragraph_styles,
@@ -143,6 +148,7 @@ fn test_end_to_end() {
             check_box_style: checkbox,
             horizontal_rule_style: horizontal_rule,
             broken_link_style: broken_link,
+            broken_image_style: broken_image,
             block_spacings: Default::default(),
             show_placeholder_text_on_empty_block: false,
             minimum_paragraph_height: Some(PARAGRAPH_MIN_HEIGHT),

--- a/crates/editor/src/render/model/test_utils.rs
+++ b/crates/editor/src/render/model/test_utils.rs
@@ -14,9 +14,9 @@ use warpui_core::text_layout::{CaretPosition, Glyph, Line, Run, TextFrame};
 use warpui_core::units::{IntoPixels, Pixels};
 
 use super::{
-    BlockItem, BrokenLinkStyle, CheckBoxStyle, DEFAULT_BLOCK_SPACINGS, HorizontalRuleStyle,
-    InlineCodeStyle, OffsetMap, PARAGRAPH_MIN_HEIGHT, Paragraph, ParagraphStyles, RichTextStyles,
-    TEXT_SPACING, TableStyle,
+    BlockItem, BrokenImageStyle, BrokenLinkStyle, CheckBoxStyle, DEFAULT_BLOCK_SPACINGS,
+    HorizontalRuleStyle, InlineCodeStyle, OffsetMap, PARAGRAPH_MIN_HEIGHT, Paragraph,
+    ParagraphStyles, RichTextStyles, TEXT_SPACING, TableStyle,
 };
 use crate::content::text::BufferBlockStyle;
 
@@ -193,6 +193,10 @@ pub const TEST_STYLES: RichTextStyles = RichTextStyles {
     },
     broken_link_style: BrokenLinkStyle {
         icon_path: "bundled/svg/link-broken-02.svg",
+        icon_color: WHITE,
+    },
+    broken_image_style: BrokenImageStyle {
+        icon_path: "bundled/svg/image-01.svg",
         icon_color: WHITE,
     },
     block_spacings: DEFAULT_BLOCK_SPACINGS,

--- a/crates/warp_core/src/ui/builder.rs
+++ b/crates/warp_core/src/ui/builder.rs
@@ -5,7 +5,7 @@ use warpui_core::color::ColorU;
 use warpui_core::elements::{
     ChildAnchor, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex, Hoverable,
     Icon, MouseStateHandle, OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds,
-    Radius, Stack, Text,
+    Radius, Stack, TOOLTIP_JITTER_THRESHOLD, TOOLTIP_SHOW_DELAY, Text, TooltipState,
 };
 use warpui_core::fonts::{FamilyId, Properties, Weight};
 use warpui_core::geometry::vector::{Vector2F, vec2f};
@@ -497,18 +497,19 @@ impl UiBuilder {
     }
 
     /// Like `overlay_tool_tip_on_element`, but anchors the tooltip at the mouse
-    /// pointer rather than at the hovered element's rect. The tooltip's top-left
-    /// is placed at the cursor position captured when hover began (see
-    /// [`MouseState::hover_position`]), nudged by `pointer_offset` (a small
-    /// below-right nudge is conventional so the pointer doesn't cover the text).
+    /// pointer with the browser-`title` show/dismiss hysteresis model rather than
+    /// pinning it to the hovered element's rect. The tooltip's top-left is placed
+    /// at the pointer position the machine reports, nudged by `pointer_offset` (a
+    /// small below-right nudge so the pointer doesn't cover the text).
     ///
-    /// This is a position-at-show affordance, not a cursor follower: the
-    /// `Hoverable` only rebuilds on hover-state changes, so the tooltip stays put
-    /// as the pointer moves within the element. It renders as an overlay (escapes
-    /// parent clips) and is repositioned to stay within the window on both axes.
-    /// If no pointer snapshot is available (e.g. hover was entered synthetically
-    /// without a recorded position), it falls back to anchoring below the
-    /// element's bottom-left, matching the element-anchored variant.
+    /// Behavior (see [`TooltipHysteresis`]): the tooltip appears after the
+    /// pointer comes to rest over the element for [`TOOLTIP_SHOW_DELAY`]; while
+    /// visible, sustained pointer movement dismisses it after the same delay,
+    /// while coming to rest again first relocates it in place with no new delay;
+    /// leaving the element dismisses it immediately. It renders as an overlay
+    /// (escapes parent clips) and is kept within the window on both axes. This is
+    /// driven from timers, not per-move rebuilds, so it has no document-layout
+    /// impact.
     pub fn overlay_tool_tip_at_pointer(
         &self,
         label: String,
@@ -518,32 +519,22 @@ impl UiBuilder {
     ) -> Box<dyn Element> {
         Hoverable::new(mouse_state_handle, |state| {
             let mut stack = Stack::new().with_child(element);
-            if state.is_hovered() {
+            // Consult the hysteresis machine — not `is_hovered` — for whether and
+            // where to show. `Some(Visible { at })` means the pointer settled and
+            // the show/relocate timing has been satisfied.
+            if let Some(TooltipState::Visible { at }) = state.tooltip_hysteresis_state() {
                 let tool_tip = self.tool_tip(label).build().finish();
-                let offset = match state.hover_position() {
-                    // Pointer-relative: `hover_position` is already the cursor
-                    // offset from the element's (parent's) top-left, so anchoring
-                    // the tooltip's top-left to the parent's top-left plus that
-                    // offset places it at the cursor.
-                    Some(pointer) => OffsetPositioning::offset_from_parent(
-                        pointer + pointer_offset,
-                        ParentOffsetBounds::WindowByPosition,
-                        ParentAnchor::TopLeft,
-                        ChildAnchor::TopLeft,
-                    ),
-                    // Fallback: element-anchored below the bottom-left, mirroring
-                    // `overlay_tool_tip_on_element`.
-                    None => OffsetPositioning::offset_from_parent(
-                        vec2f(0., pointer_offset.y().abs()),
-                        ParentOffsetBounds::WindowByPosition,
-                        ParentAnchor::BottomLeft,
-                        ChildAnchor::TopLeft,
-                    ),
-                };
+                let offset = OffsetPositioning::offset_from_parent(
+                    at + pointer_offset,
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::TopLeft,
+                    ChildAnchor::TopLeft,
+                );
                 stack.add_positioned_overlay_child(tool_tip, offset);
             }
             stack.finish()
         })
+        .with_pointer_hysteresis(TOOLTIP_SHOW_DELAY, TOOLTIP_JITTER_THRESHOLD)
         .finish()
     }
 

--- a/crates/warp_core/src/ui/builder.rs
+++ b/crates/warp_core/src/ui/builder.rs
@@ -5,7 +5,7 @@ use warpui_core::color::ColorU;
 use warpui_core::elements::{
     ChildAnchor, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Fill as UiFill, Flex,
     Hoverable, Icon, MouseStateHandle, OffsetPositioning, ParentAnchor, ParentElement,
-    ParentOffsetBounds, Radius, Stack, TOOLTIP_JITTER_THRESHOLD, TOOLTIP_SHOW_DELAY, Text,
+    ParentOffsetBounds, Radius, Stack, TOOLTIP_JITTER_THRESHOLD, TOOLTIP_POINTER_FADE_DELAY, Text,
     TooltipState,
 };
 use warpui_core::fonts::{FamilyId, Properties, Weight};
@@ -505,7 +505,7 @@ impl UiBuilder {
     ///
     /// Behavior (see [`TooltipHysteresis`]): opacity animates toward full while
     /// the pointer is at rest over the element and toward zero while it moves
-    /// (a full fade spans [`TOOLTIP_SHOW_DELAY`]); the fade-in *is* the rest
+    /// (a full fade spans [`TOOLTIP_POINTER_FADE_DELAY`]); the fade-in *is* the rest
     /// delay, and moving mid-fade reverses from the current opacity. The tooltip
     /// colors are scaled by that opacity so the whole affordance fades together.
     /// Position is captured when a fade-in starts from zero and held fixed while
@@ -543,7 +543,7 @@ impl UiBuilder {
             }
             stack.finish()
         })
-        .with_pointer_hysteresis(TOOLTIP_SHOW_DELAY, TOOLTIP_JITTER_THRESHOLD)
+        .with_pointer_hysteresis(TOOLTIP_POINTER_FADE_DELAY, TOOLTIP_JITTER_THRESHOLD)
         .finish()
     }
 

--- a/crates/warp_core/src/ui/builder.rs
+++ b/crates/warp_core/src/ui/builder.rs
@@ -496,6 +496,57 @@ impl UiBuilder {
         )
     }
 
+    /// Like `overlay_tool_tip_on_element`, but anchors the tooltip at the mouse
+    /// pointer rather than at the hovered element's rect. The tooltip's top-left
+    /// is placed at the cursor position captured when hover began (see
+    /// [`MouseState::hover_position`]), nudged by `pointer_offset` (a small
+    /// below-right nudge is conventional so the pointer doesn't cover the text).
+    ///
+    /// This is a position-at-show affordance, not a cursor follower: the
+    /// `Hoverable` only rebuilds on hover-state changes, so the tooltip stays put
+    /// as the pointer moves within the element. It renders as an overlay (escapes
+    /// parent clips) and is repositioned to stay within the window on both axes.
+    /// If no pointer snapshot is available (e.g. hover was entered synthetically
+    /// without a recorded position), it falls back to anchoring below the
+    /// element's bottom-left, matching the element-anchored variant.
+    pub fn overlay_tool_tip_at_pointer(
+        &self,
+        label: String,
+        mouse_state_handle: MouseStateHandle,
+        element: Box<dyn Element>,
+        pointer_offset: Vector2F,
+    ) -> Box<dyn Element> {
+        Hoverable::new(mouse_state_handle, |state| {
+            let mut stack = Stack::new().with_child(element);
+            if state.is_hovered() {
+                let tool_tip = self.tool_tip(label).build().finish();
+                let offset = match state.hover_position() {
+                    // Pointer-relative: `hover_position` is already the cursor
+                    // offset from the element's (parent's) top-left, so anchoring
+                    // the tooltip's top-left to the parent's top-left plus that
+                    // offset places it at the cursor.
+                    Some(pointer) => OffsetPositioning::offset_from_parent(
+                        pointer + pointer_offset,
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::TopLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                    // Fallback: element-anchored below the bottom-left, mirroring
+                    // `overlay_tool_tip_on_element`.
+                    None => OffsetPositioning::offset_from_parent(
+                        vec2f(0., pointer_offset.y().abs()),
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::BottomLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                };
+                stack.add_positioned_overlay_child(tool_tip, offset);
+            }
+            stack.finish()
+        })
+        .finish()
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn styled_tool_tip_on_element_internal(
         &self,

--- a/crates/warp_core/src/ui/builder.rs
+++ b/crates/warp_core/src/ui/builder.rs
@@ -3,9 +3,10 @@ use std::rc::Rc;
 
 use warpui_core::color::ColorU;
 use warpui_core::elements::{
-    ChildAnchor, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex, Hoverable,
-    Icon, MouseStateHandle, OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds,
-    Radius, Stack, TOOLTIP_JITTER_THRESHOLD, TOOLTIP_SHOW_DELAY, Text, TooltipState,
+    ChildAnchor, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Fill as UiFill, Flex,
+    Hoverable, Icon, MouseStateHandle, OffsetPositioning, ParentAnchor, ParentElement,
+    ParentOffsetBounds, Radius, Stack, TOOLTIP_JITTER_THRESHOLD, TOOLTIP_SHOW_DELAY, Text,
+    TooltipState,
 };
 use warpui_core::fonts::{FamilyId, Properties, Weight};
 use warpui_core::geometry::vector::{Vector2F, vec2f};
@@ -497,19 +498,22 @@ impl UiBuilder {
     }
 
     /// Like `overlay_tool_tip_on_element`, but anchors the tooltip at the mouse
-    /// pointer with the browser-`title` show/dismiss hysteresis model rather than
-    /// pinning it to the hovered element's rect. The tooltip's top-left is placed
-    /// at the pointer position the machine reports, nudged by `pointer_offset` (a
+    /// pointer with a browser-`title` *fade animation* rather than pinning it to
+    /// the hovered element's rect. The tooltip's top-left is placed at the
+    /// pointer position the fade machine reports, nudged by `pointer_offset` (a
     /// small below-right nudge so the pointer doesn't cover the text).
     ///
-    /// Behavior (see [`TooltipHysteresis`]): the tooltip appears after the
-    /// pointer comes to rest over the element for [`TOOLTIP_SHOW_DELAY`]; while
-    /// visible, sustained pointer movement dismisses it after the same delay,
-    /// while coming to rest again first relocates it in place with no new delay;
-    /// leaving the element dismisses it immediately. It renders as an overlay
-    /// (escapes parent clips) and is kept within the window on both axes. This is
-    /// driven from timers, not per-move rebuilds, so it has no document-layout
-    /// impact.
+    /// Behavior (see [`TooltipHysteresis`]): opacity animates toward full while
+    /// the pointer is at rest over the element and toward zero while it moves
+    /// (a full fade spans [`TOOLTIP_SHOW_DELAY`]); the fade-in *is* the rest
+    /// delay, and moving mid-fade reverses from the current opacity. The tooltip
+    /// colors are scaled by that opacity so the whole affordance fades together.
+    /// Position is captured when a fade-in starts from zero and held fixed while
+    /// visible; resting at a new spot lets the old fade out before the new fades
+    /// in (single tooltip instance). Leaving the element fades out faster. It
+    /// renders as an overlay (escapes parent clips) and is kept within the window
+    /// on both axes, driven from per-frame re-sample timers rather than per-move
+    /// rebuilds, so it has no document-layout impact.
     pub fn overlay_tool_tip_at_pointer(
         &self,
         label: String,
@@ -517,13 +521,18 @@ impl UiBuilder {
         element: Box<dyn Element>,
         pointer_offset: Vector2F,
     ) -> Box<dyn Element> {
-        Hoverable::new(mouse_state_handle, |state| {
+        let styles = self.default_tool_tip_styles();
+        Hoverable::new(mouse_state_handle, move |state| {
             let mut stack = Stack::new().with_child(element);
-            // Consult the hysteresis machine — not `is_hovered` — for whether and
-            // where to show. `Some(Visible { at })` means the pointer settled and
-            // the show/relocate timing has been satisfied.
-            if let Some(TooltipState::Visible { at }) = state.tooltip_hysteresis_state() {
-                let tool_tip = self.tool_tip(label).build().finish();
+            // Consult the fade machine — not `is_hovered` — for whether, where,
+            // and at what opacity to show. `Some(Visible { at, opacity })` means
+            // the tooltip is at least partly faded in at the settled position.
+            if let Some(TooltipState::Visible { at, opacity }) = state.tooltip_hysteresis_state() {
+                // Scale the tooltip's colors by the current fade opacity so the
+                // whole affordance (background, border, text) fades together.
+                let tool_tip = Tooltip::new(label.clone(), scale_tool_tip_opacity(styles, opacity))
+                    .build()
+                    .finish();
                 let offset = OffsetPositioning::offset_from_parent(
                     at + pointer_offset,
                     ParentOffsetBounds::WindowByPosition,
@@ -1239,6 +1248,44 @@ impl UiBuilder {
     pub fn line_height_ratio(&self) -> f32 {
         self.line_height_ratio
     }
+}
+
+/// Scale a `ColorU`'s alpha channel by `opacity` (`0.0..=1.0`), leaving RGB
+/// untouched. Used to fade a tooltip's colors together as one affordance.
+fn coloru_scaled(color: ColorU, opacity: f32) -> ColorU {
+    let a = (color.a as f32 * opacity.clamp(0.0, 1.0)).round() as u8;
+    ColorU::new(color.r, color.g, color.b, a)
+}
+
+/// Scale every color in a `UiFill` by `opacity`, preserving its shape (solid
+/// stays solid, gradient stays a gradient with both stops faded, none stays
+/// none).
+fn fill_scaled(fill: UiFill, opacity: f32) -> UiFill {
+    match fill {
+        UiFill::None => UiFill::None,
+        UiFill::Solid(color) => UiFill::Solid(coloru_scaled(color, opacity)),
+        UiFill::Gradient {
+            start,
+            end,
+            start_color,
+            end_color,
+        } => UiFill::Gradient {
+            start,
+            end,
+            start_color: coloru_scaled(start_color, opacity),
+            end_color: coloru_scaled(end_color, opacity),
+        },
+    }
+}
+
+/// Return a copy of `styles` with the tooltip's background, border, and font
+/// colors' alpha scaled by `opacity`, so the whole tooltip fades uniformly as
+/// the fade animation progresses. An `opacity` of `1.0` is a no-op.
+fn scale_tool_tip_opacity(mut styles: UiComponentStyles, opacity: f32) -> UiComponentStyles {
+    styles.background = styles.background.map(|f| fill_scaled(f, opacity));
+    styles.border_color = styles.border_color.map(|f| fill_scaled(f, opacity));
+    styles.font_color = styles.font_color.map(|c| coloru_scaled(c, opacity));
+    styles
 }
 
 /// Options for how to render an animated button.

--- a/crates/warpui_core/src/elements/gui/hoverable.rs
+++ b/crates/warpui_core/src/elements/gui/hoverable.rs
@@ -6,6 +6,7 @@ use instant::Instant;
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
 
+use super::tooltip_hysteresis::{TooltipHysteresis, TooltipState};
 use super::{Point, SelectableElement, Selection, SelectionFragment, ZIndex};
 use crate::event::{DispatchedEvent, ModifiersState};
 use crate::platform::Cursor;
@@ -63,6 +64,15 @@ pub struct Hoverable {
     //
     suppress_drag: bool,
     defer_events_to_children: bool,
+
+    /// Whether this `Hoverable` opted into browser-`title` tooltip hysteresis
+    /// (via [`Self::with_pointer_hysteresis`]). When set, a [`TooltipHysteresis`]
+    /// lives in the shared [`MouseState`] and intra-element mouse moves are routed
+    /// through it, so a pointer-anchored tooltip shows on rest, relocates on
+    /// re-rest, and dismisses on sustained motion or exit — independently of the
+    /// plain hover-in/out delays. The delay `D` and jitter threshold live on the
+    /// machine itself.
+    pointer_hysteresis: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -110,6 +120,20 @@ pub struct MouseState {
     ///
     /// Only [`Some`] if [`Hoverable::hover_out_delay`] is set.
     hover_out_timer: Option<HoverTimer>,
+
+    /// The browser-`title` tooltip hysteresis machine, present only when the
+    /// owning [`Hoverable`] opted in via [`Hoverable::with_pointer_hysteresis`].
+    ///
+    /// When set, it — not [`Self::is_hovered`] — governs whether a
+    /// pointer-anchored tooltip is shown and where. Read it from a hover build
+    /// closure via [`Self::tooltip_hysteresis_state`]; the [`Hoverable`] feeds it
+    /// pointer samples and drives its timers.
+    tooltip_hysteresis: Option<TooltipHysteresis>,
+
+    /// The notify timer currently armed to re-evaluate [`Self::tooltip_hysteresis`]
+    /// at its next deadline (show or dismiss), if any. Distinct from the
+    /// hover-in/out timers so the two mechanisms never clobber each other.
+    hysteresis_timer: Option<HoverTimer>,
 }
 
 impl MouseState {
@@ -158,9 +182,20 @@ impl MouseState {
         self.hover_position
     }
 
+    /// The current browser-`title` tooltip hysteresis outcome, or [`None`] when
+    /// the owning [`Hoverable`] did not opt into pointer hysteresis. A hover
+    /// build closure reads this to decide whether to show a pointer-anchored
+    /// tooltip and at what position, instead of consulting [`Self::is_hovered`].
+    pub fn tooltip_hysteresis_state(&self) -> Option<TooltipState> {
+        self.tooltip_hysteresis.as_ref().map(|h| h.state())
+    }
+
     pub fn reset_hover_state(&mut self) {
         self.is_hovered = false;
         self.hover_position = None;
+        if let Some(hysteresis) = self.tooltip_hysteresis.as_mut() {
+            hysteresis.on_pointer_left();
+        }
     }
 
     /// Fully clear interaction state. Useful when a click triggers navigation or focus changes,
@@ -178,6 +213,11 @@ impl MouseState {
         // Cancel any pending hover timers
         self.hover_in_timer = None;
         self.hover_out_timer = None;
+        // Dismiss any pointer-anchored tooltip immediately and drop its timer.
+        if let Some(hysteresis) = self.tooltip_hysteresis.as_mut() {
+            hysteresis.on_pointer_left();
+        }
+        self.hysteresis_timer = None;
     }
 
     fn set_hover_timer(&mut self, timer_type: HoverTimerType, hover_timer: HoverTimer) {
@@ -254,6 +294,7 @@ impl Hoverable {
             child_max_z_index: None,
             suppress_drag: true,
             defer_events_to_children: false,
+            pointer_hysteresis: false,
         }
     }
 
@@ -385,6 +426,35 @@ impl Hoverable {
         self
     }
 
+    /// Opt this [`Hoverable`] into browser-`title` tooltip hysteresis for a
+    /// pointer-anchored tooltip. `delay` is the single duration `D` reused for
+    /// both showing on rest and dismissing on sustained motion;
+    /// `jitter_threshold` is the pixel radius below which movement counts as
+    /// rest rather than motion.
+    ///
+    /// While this is set, a hover build closure should consult
+    /// [`MouseState::tooltip_hysteresis_state`] (not [`MouseState::is_hovered`])
+    /// to decide whether and where to show the tooltip. The [`Hoverable`] feeds
+    /// the machine every intra-element mouse move and arms notify timers so the
+    /// show/relocate/dismiss transitions fire on schedule without rebuilding on
+    /// every move. This is orthogonal to the plain hover-in/out delays; it does
+    /// not affect [`MouseState::is_hovered`] or `on_hover` callbacks.
+    pub fn with_pointer_hysteresis(mut self, delay: Duration, jitter_threshold: f32) -> Self {
+        self.pointer_hysteresis = true;
+        // Install the machine into the shared state, but only if absent: this
+        // builder runs on *every* rebuild (the view's render closure re-wraps the
+        // element each frame), and the machine carries live show/dismiss state
+        // that must survive rebuilds. Overwriting it here would reset a visible
+        // tooltip back to hidden on the very next frame.
+        {
+            let mut state = self.state.lock().unwrap();
+            if state.tooltip_hysteresis.is_none() {
+                state.tooltip_hysteresis = Some(TooltipHysteresis::new(delay, jitter_threshold));
+            }
+        }
+        self
+    }
+
     /// Skip firing [`Hoverable::on_hover`] when an item is hovered on synthetic mouse events.
     /// Synthetic events are generated by the UI framework when layout changes,
     /// even though the mouse hasn't actually moved.
@@ -473,6 +543,102 @@ impl Hoverable {
         }
     }
 
+    /// Feed a mouse move (or a re-dispatched last-move on redraw) into the
+    /// pointer-hysteresis machine, if this `Hoverable` opted in, and reconcile
+    /// the notify timer that re-evaluates it. Returns `true` if the tooltip's
+    /// visible state changed (so the caller should treat the move as handled and
+    /// let the ensuing rebuild pick up the new [`TooltipState`]).
+    ///
+    /// The machine sees intra-element moves that the hover-state logic ignores;
+    /// its show/relocate/dismiss transitions are driven from a single
+    /// `notify_after` timer armed at the machine's next deadline. On redraw the
+    /// window re-dispatches the last move, which re-enters here and lets a
+    /// matured deadline resolve (see the timer plumbing in `App::dispatch_event`).
+    fn drive_pointer_hysteresis(
+        &mut self,
+        is_over_element: bool,
+        position: Vector2F,
+        ctx: &mut EventContext,
+    ) -> bool {
+        if !self.pointer_hysteresis {
+            return false;
+        }
+
+        // Translate the screen-space sample into the element-relative space the
+        // machine (and the tooltip anchor) work in. Without a paint origin yet we
+        // cannot place the tooltip, so skip until the next frame supplies one.
+        let Some(origin) = self.origin else {
+            return false;
+        };
+        let relative = position - origin.xy();
+        let now = Instant::now();
+
+        let before = self.state().tooltip_hysteresis.as_ref().map(|h| h.state());
+        {
+            let mut state = self.state();
+            let hysteresis = state
+                .tooltip_hysteresis
+                .as_mut()
+                .expect("hysteresis machine installed when pointer_hysteresis is set");
+            if is_over_element {
+                hysteresis.on_pointer_moved(relative, now);
+            } else {
+                hysteresis.on_pointer_left();
+            }
+        }
+
+        // Reconcile the single re-evaluation timer with the machine's next
+        // deadline: clear a stale one, arm a fresh one when a deadline is pending
+        // and none is already scheduled for it.
+        self.reconcile_hysteresis_timer(ctx);
+
+        let after = self.state().tooltip_hysteresis.as_ref().map(|h| h.state());
+        if before != after {
+            ctx.notify();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Clear any armed hysteresis re-evaluation timer whose deadline no longer
+    /// matches the machine, and arm a fresh `notify_after` timer for the current
+    /// pending deadline (show or dismiss) when one is needed.
+    fn reconcile_hysteresis_timer(&mut self, ctx: &mut EventContext) {
+        let deadline = self
+            .state()
+            .tooltip_hysteresis
+            .as_ref()
+            .and_then(|h| h.next_deadline());
+        let existing = self.state().hysteresis_timer.clone();
+
+        match (deadline, existing) {
+            // A deadline is pending and the armed timer already targets it: keep it.
+            (Some(deadline), Some(timer)) if timer.hover_at == deadline => {}
+            // Deadline changed or newly appeared: replace any stale timer.
+            (Some(deadline), existing) => {
+                if let Some(existing) = existing {
+                    ctx.clear_notify_timer(existing.timer_id);
+                }
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                let (timer_id, hover_at) = ctx.notify_after(remaining);
+                // Pin the recorded deadline to the machine's, so the re-dispatch
+                // on the resulting redraw resolves it deterministically even if
+                // `notify_after` rounds the wake time.
+                self.state().hysteresis_timer = Some(HoverTimer {
+                    hover_at: deadline.max(hover_at),
+                    timer_id,
+                });
+            }
+            // No deadline pending: drop any lingering timer.
+            (None, Some(existing)) => {
+                ctx.clear_notify_timer(existing.timer_id);
+                self.state().hysteresis_timer = None;
+            }
+            (None, None) => {}
+        }
+    }
+
     /// The main handler for [`Event::MouseMoved`] events.
     fn handle_mouse_moved(
         &mut self,
@@ -484,6 +650,13 @@ impl Hoverable {
         let was_mouse_over_element = self.state().is_mouse_over_element;
         let is_hovered = self.is_mouse_over_element(ctx, position);
         self.state().is_mouse_over_element = is_hovered;
+
+        // Feed the pointer-hysteresis machine (if opted in) every move, including
+        // intra-element ones the hover-state logic below ignores. It drives its
+        // own show/relocate/dismiss timers and rebuilds independently of the
+        // hover-in/out delays; a visible-state change means the tooltip must be
+        // rebuilt, so treat the move as handled.
+        let hysteresis_changed = self.drive_pointer_hysteresis(is_hovered, position, ctx);
 
         // The type of timer that we might need to set, if there's a corresponding delay.
         let hover_timer_type = if is_hovered {
@@ -513,13 +686,9 @@ impl Hoverable {
         // If there aren't any delays, then we can just handle
         // the mouse movement immediately.
         let Some(hover_delay) = self.hover_delay(is_hovered) else {
-            return self.handle_mouse_moved_without_delay(
-                is_hovered,
-                position,
-                is_synthetic,
-                ctx,
-                app,
-            );
+            let handled =
+                self.handle_mouse_moved_without_delay(is_hovered, position, is_synthetic, ctx, app);
+            return handled || hysteresis_changed;
         };
 
         // If a timer has already been started, then only handle
@@ -528,13 +697,14 @@ impl Hoverable {
         let timer = self.state().hover_timer(hover_timer_type).cloned();
         if let Some(timer) = timer {
             if Instant::now() >= timer.hover_at {
-                return self.handle_mouse_moved_without_delay(
+                let handled = self.handle_mouse_moved_without_delay(
                     is_hovered,
                     position,
                     is_synthetic,
                     ctx,
                     app,
                 );
+                return handled || hysteresis_changed;
             }
         } else {
             // If a timer has not been started, start it now.
@@ -542,7 +712,7 @@ impl Hoverable {
             self.state()
                 .set_hover_timer(hover_timer_type, HoverTimer { hover_at, timer_id });
         }
-        false
+        hysteresis_changed
     }
 
     /// Handles [`Event::MouseMoved`] events when the

--- a/crates/warpui_core/src/elements/gui/hoverable.rs
+++ b/crates/warpui_core/src/elements/gui/hoverable.rs
@@ -182,19 +182,24 @@ impl MouseState {
         self.hover_position
     }
 
-    /// The current browser-`title` tooltip hysteresis outcome, or [`None`] when
-    /// the owning [`Hoverable`] did not opt into pointer hysteresis. A hover
-    /// build closure reads this to decide whether to show a pointer-anchored
-    /// tooltip and at what position, instead of consulting [`Self::is_hovered`].
+    /// The current fade-animated tooltip outcome (position + opacity) at *now*,
+    /// or [`None`] when the owning [`Hoverable`] did not opt into pointer
+    /// hysteresis. A hover build closure reads this to decide whether to show a
+    /// pointer-anchored tooltip, at what position, and at what opacity, instead
+    /// of consulting [`Self::is_hovered`]. Sampled at [`Instant::now`] because
+    /// the opacity animates continuously; the [`Hoverable`] arms redraw timers so
+    /// the closure re-runs while a fade is in progress.
     pub fn tooltip_hysteresis_state(&self) -> Option<TooltipState> {
-        self.tooltip_hysteresis.as_ref().map(|h| h.state())
+        self.tooltip_hysteresis
+            .as_ref()
+            .map(|h| h.state(Instant::now()))
     }
 
     pub fn reset_hover_state(&mut self) {
         self.is_hovered = false;
         self.hover_position = None;
         if let Some(hysteresis) = self.tooltip_hysteresis.as_mut() {
-            hysteresis.on_pointer_left();
+            hysteresis.on_pointer_left(Instant::now());
         }
     }
 
@@ -213,9 +218,10 @@ impl MouseState {
         // Cancel any pending hover timers
         self.hover_in_timer = None;
         self.hover_out_timer = None;
-        // Dismiss any pointer-anchored tooltip immediately and drop its timer.
+        // Fade any pointer-anchored tooltip out (at the exit rate) and drop its
+        // timer. The fade-out still animates; a follow-up frame settles it hidden.
         if let Some(hysteresis) = self.tooltip_hysteresis.as_mut() {
-            hysteresis.on_pointer_left();
+            hysteresis.on_pointer_left(Instant::now());
         }
         self.hysteresis_timer = None;
     }
@@ -545,15 +551,17 @@ impl Hoverable {
 
     /// Feed a mouse move (or a re-dispatched last-move on redraw) into the
     /// pointer-hysteresis machine, if this `Hoverable` opted in, and reconcile
-    /// the notify timer that re-evaluates it. Returns `true` if the tooltip's
-    /// visible state changed (so the caller should treat the move as handled and
-    /// let the ensuing rebuild pick up the new [`TooltipState`]).
+    /// the notify timer that re-samples it during a fade. Returns `true` if the
+    /// tooltip's opacity/position changed since the last sample, or a fade is
+    /// still in progress (so the caller should treat the move as handled and let
+    /// the ensuing rebuild pick up the new [`TooltipState`]).
     ///
     /// The machine sees intra-element moves that the hover-state logic ignores;
-    /// its show/relocate/dismiss transitions are driven from a single
-    /// `notify_after` timer armed at the machine's next deadline. On redraw the
-    /// window re-dispatches the last move, which re-enters here and lets a
-    /// matured deadline resolve (see the timer plumbing in `App::dispatch_event`).
+    /// its opacity animates continuously, so while a fade is running we arm a
+    /// short (~frame-length) `notify_after` timer. On redraw the window
+    /// re-dispatches the last move, which re-enters here, re-samples the opacity,
+    /// and re-arms until the fade settles (see the timer plumbing in
+    /// `App::dispatch_event`).
     fn drive_pointer_hysteresis(
         &mut self,
         is_over_element: bool,
@@ -573,7 +581,11 @@ impl Hoverable {
         let relative = position - origin.xy();
         let now = Instant::now();
 
-        let before = self.state().tooltip_hysteresis.as_ref().map(|h| h.state());
+        let before = self
+            .state()
+            .tooltip_hysteresis
+            .as_ref()
+            .map(|h| h.state(now));
         {
             let mut state = self.state();
             let hysteresis = state
@@ -583,17 +595,28 @@ impl Hoverable {
             if is_over_element {
                 hysteresis.on_pointer_moved(relative, now);
             } else {
-                hysteresis.on_pointer_left();
+                hysteresis.on_pointer_left(now);
             }
         }
 
-        // Reconcile the single re-evaluation timer with the machine's next
-        // deadline: clear a stale one, arm a fresh one when a deadline is pending
-        // and none is already scheduled for it.
-        self.reconcile_hysteresis_timer(ctx);
+        // Reconcile the re-sample timer: while a fade is in progress, keep a
+        // short frame-length timer armed so the opacity re-samples each redraw;
+        // clear it once the fade settles.
+        self.reconcile_hysteresis_timer(ctx, now);
 
-        let after = self.state().tooltip_hysteresis.as_ref().map(|h| h.state());
-        if before != after {
+        let after = self
+            .state()
+            .tooltip_hysteresis
+            .as_ref()
+            .map(|h| h.state(now));
+        // Rebuild if the visible outcome changed, or a fade is still animating
+        // (so the next re-dispatch keeps advancing it toward its target).
+        let animating = self
+            .state()
+            .tooltip_hysteresis
+            .as_ref()
+            .is_some_and(|h| h.is_animating(now));
+        if before != after || animating {
             ctx.notify();
             true
         } else {
@@ -601,41 +624,36 @@ impl Hoverable {
         }
     }
 
-    /// Clear any armed hysteresis re-evaluation timer whose deadline no longer
-    /// matches the machine, and arm a fresh `notify_after` timer for the current
-    /// pending deadline (show or dismiss) when one is needed.
-    fn reconcile_hysteresis_timer(&mut self, ctx: &mut EventContext) {
-        let deadline = self
+    /// The ~frame-length re-sample interval used while a tooltip fade is in
+    /// progress: on each such redraw the window re-dispatches the last move,
+    /// which re-samples the animating opacity. 16 ms ≈ one 60 Hz frame.
+    const HYSTERESIS_FRAME_INTERVAL: Duration = Duration::from_millis(16);
+
+    /// Keep a short re-sample timer armed while the tooltip fade is animating,
+    /// and drop it once the fade settles at its target. Unlike a single
+    /// deadline-at-completion timer, re-sampling every frame lets the build
+    /// closure paint each intermediate opacity, producing a visible fade rather
+    /// than a snap at the end.
+    fn reconcile_hysteresis_timer(&mut self, ctx: &mut EventContext, now: Instant) {
+        let animating = self
             .state()
             .tooltip_hysteresis
             .as_ref()
-            .and_then(|h| h.next_deadline());
+            .is_some_and(|h| h.is_animating(now));
         let existing = self.state().hysteresis_timer.clone();
 
-        match (deadline, existing) {
-            // A deadline is pending and the armed timer already targets it: keep it.
-            (Some(deadline), Some(timer)) if timer.hover_at == deadline => {}
-            // Deadline changed or newly appeared: replace any stale timer.
-            (Some(deadline), existing) => {
-                if let Some(existing) = existing {
-                    ctx.clear_notify_timer(existing.timer_id);
-                }
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                let (timer_id, hover_at) = ctx.notify_after(remaining);
-                // Pin the recorded deadline to the machine's, so the re-dispatch
-                // on the resulting redraw resolves it deterministically even if
-                // `notify_after` rounds the wake time.
-                self.state().hysteresis_timer = Some(HoverTimer {
-                    hover_at: deadline.max(hover_at),
-                    timer_id,
-                });
-            }
-            // No deadline pending: drop any lingering timer.
-            (None, Some(existing)) => {
+        if animating {
+            // Re-arm a fresh frame timer each sample. Clearing the previous one
+            // first avoids leaking timers as the fade re-dispatches frame by frame.
+            if let Some(existing) = existing {
                 ctx.clear_notify_timer(existing.timer_id);
-                self.state().hysteresis_timer = None;
             }
-            (None, None) => {}
+            let (timer_id, hover_at) = ctx.notify_after(Self::HYSTERESIS_FRAME_INTERVAL);
+            self.state().hysteresis_timer = Some(HoverTimer { hover_at, timer_id });
+        } else if let Some(existing) = existing {
+            // Fade settled: stop re-sampling.
+            ctx.clear_notify_timer(existing.timer_id);
+            self.state().hysteresis_timer = None;
         }
     }
 

--- a/crates/warpui_core/src/elements/gui/hoverable.rs
+++ b/crates/warpui_core/src/elements/gui/hoverable.rs
@@ -81,6 +81,18 @@ pub struct MouseState {
     /// This property is _not_ delayed by hover delays.
     is_mouse_over_element: bool,
 
+    /// The cursor position at the moment hover began, expressed relative to the
+    /// element's own top-left origin (so it can be used directly as a
+    /// parent-relative offset when positioning hover affordances at the
+    /// pointer). [`None`] whenever the element is not hovered.
+    ///
+    /// This is a snapshot taken on hover-in, not a live cursor tracker: the
+    /// `Hoverable` only re-runs its build closure on hover-state transitions, so
+    /// intra-element mouse moves do not update it. Affordances that want to sit
+    /// at the pointer (rather than at the element rect) read this in their build
+    /// closure.
+    hover_position: Option<Vector2F>,
+
     /// Keep track of whether the last event changing the hover
     /// state is a synthetic mouse move. If there are two consecutive
     /// events that both want to alter the hover state, we stop the
@@ -138,8 +150,17 @@ impl MouseState {
         self.is_mouse_over_element
     }
 
+    /// The cursor position captured when hover began, relative to the element's
+    /// top-left origin, or [`None`] when the element is not hovered. Usable as a
+    /// parent-relative offset to position a hover affordance at the pointer. See
+    /// the field docs for the snapshot-vs-live-tracking distinction.
+    pub fn hover_position(&self) -> Option<Vector2F> {
+        self.hover_position
+    }
+
     pub fn reset_hover_state(&mut self) {
         self.is_hovered = false;
+        self.hover_position = None;
     }
 
     /// Fully clear interaction state. Useful when a click triggers navigation or focus changes,
@@ -151,6 +172,7 @@ impl MouseState {
         // Clear hover states so hover styles/tooltips don't persist
         self.is_hovered = false;
         self.is_mouse_over_element = false;
+        self.hover_position = None;
         // Treat the next synthetic hover as a no-op (avoids instant re-hover during layout)
         self.last_event_is_synthetic_hover = true;
         // Cancel any pending hover timers
@@ -548,6 +570,18 @@ impl Hoverable {
             return false;
         }
         self.state().is_hovered = is_hovered;
+
+        // Snapshot the pointer for affordances that position at the cursor. Store
+        // it relative to the element's own origin so it can serve as a
+        // parent-relative offset in a hover-built child; clear it on hover-out.
+        // `self.origin` is populated at paint time and shares the event's screen
+        // coordinate space.
+        let hover_position = if is_hovered {
+            self.origin.map(|origin| position - origin.xy())
+        } else {
+            None
+        };
+        self.state().hover_position = hover_position;
 
         // We should only handle this event if not both the previous and current instance of the state change
         // is triggered by a synthetic mouse event. This is to prevent infinite loops when a child element

--- a/crates/warpui_core/src/elements/gui/image_tests.rs
+++ b/crates/warpui_core/src/elements/gui/image_tests.rs
@@ -74,6 +74,23 @@ fn failed_to_load_prefers_failure_element_when_provided() {
 }
 
 #[test]
+fn failed_to_load_uses_failure_element_without_before_load() {
+    let image = test_image().on_load_failure(test_element());
+
+    assert_eq!(
+        image.failed_to_load_backup_element_kind(),
+        Some(BackupElementKind::FailedToLoad)
+    );
+}
+
+#[test]
+fn no_backup_element_when_none_configured() {
+    let image = test_image();
+
+    assert_eq!(image.failed_to_load_backup_element_kind(), None);
+}
+
+#[test]
 fn failed_to_load_falls_back_to_before_load_element() {
     let image = test_image().before_load(test_element());
 

--- a/crates/warpui_core/src/elements/gui/mod.rs
+++ b/crates/warpui_core/src/elements/gui/mod.rs
@@ -31,6 +31,7 @@ mod size_constraint_switch;
 mod stack;
 pub mod table;
 mod text;
+mod tooltip_hysteresis;
 mod uniform_list;
 mod viewported_list;
 
@@ -78,6 +79,7 @@ pub use table::{
     TableVerticalSizing,
 };
 pub use text::*;
+pub use tooltip_hysteresis::*;
 pub use uniform_list::*;
 pub use viewported_list::*;
 

--- a/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
+++ b/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
@@ -927,6 +927,156 @@ fn test_overlay_tooltip_does_not_reserve_layout_space_on_hover() {
     });
 }
 
+/// Below-right nudge applied to the pointer in [`HoverPointerTooltipView`],
+/// mirroring the image alt-text tooltip's `TOOLTIP_POINTER_OFFSET`.
+fn tooltip_pointer_offset() -> Vector2F {
+    vec2f(12., 16.)
+}
+
+/// A view mirroring the `overlay_tool_tip_at_pointer` composition used by the
+/// image alt-text tooltip: a [`Hoverable`] wrapping a [`Stack`] whose in-flow
+/// child is a sized base element, plus — when hovered — a tooltip added via
+/// [`Stack::add_positioned_overlay_child`] anchored at the *pointer* rather than
+/// the base's rect. The pointer-relative offset comes from
+/// [`MouseState::hover_position`], reduced to plain [`Rect`] children so it needs
+/// no theme/appearance setup.
+struct HoverPointerTooltipView {
+    mouse_state: MouseStateHandle,
+}
+
+impl HoverPointerTooltipView {
+    fn new() -> Self {
+        Self {
+            mouse_state: Default::default(),
+        }
+    }
+}
+
+impl Entity for HoverPointerTooltipView {
+    type Event = String;
+}
+
+impl crate::core::View for HoverPointerTooltipView {
+    fn render<'a>(&self, _: &AppContext) -> Box<dyn Element> {
+        Hoverable::new(self.mouse_state.clone(), |state: &MouseState| {
+            let base = ConstrainedBox::new(Rect::new().finish())
+                .with_width(tooltip_base_size().x())
+                .with_height(tooltip_base_size().y())
+                .finish();
+
+            let mut stack = Stack::new().with_child(base);
+
+            if state.is_hovered() {
+                let tooltip = ConstrainedBox::new(Rect::new().finish())
+                    .with_width(tooltip_overlay_size().x())
+                    .with_height(tooltip_overlay_size().y())
+                    .finish();
+                // Position at the captured pointer offset (plus the nudge),
+                // exactly as `overlay_tool_tip_at_pointer` does.
+                let offset = state
+                    .hover_position()
+                    .map(|pointer| pointer + tooltip_pointer_offset())
+                    .unwrap_or_default();
+                stack.add_positioned_overlay_child(
+                    tooltip,
+                    OffsetPositioning::offset_from_parent(
+                        offset,
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::TopLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                );
+            }
+
+            stack.finish()
+        })
+        .finish()
+    }
+
+    fn ui_name() -> &'static str {
+        "HoverPointerTooltipView"
+    }
+}
+
+impl TypedActionView for HoverPointerTooltipView {
+    type Action = ();
+}
+
+/// Pins that the pointer-anchored tooltip lands at the mouse coordinate, not at
+/// the element's rect.
+///
+/// The base sits at the window origin, so `MouseState::hover_position` (the
+/// cursor relative to the element's origin) equals the raw cursor position. A
+/// tooltip anchored at that position must appear at `cursor + nudge` — distinct
+/// from where an element-rect-anchored tooltip (below the base's bottom edge)
+/// would sit. This locks the "derives from mouse coords" contract against a
+/// regression back to element-anchoring.
+#[test]
+fn test_overlay_tooltip_positions_at_mouse_pointer() {
+    App::test((), |mut app| async move {
+        let app = &mut app;
+        app.update(init);
+        let (window_id, _view) = app.add_window(WindowStyle::NotStealFocus, |_| {
+            HoverPointerTooltipView::new()
+        });
+
+        // Frame 1: lay the view out so the Hoverable records a paint origin.
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+
+        // Hover at a point that is inside the base but not at its corner, so the
+        // pointer coordinate is unambiguously distinct from any element-rect
+        // anchor (top/bottom-left corners).
+        let cursor = vec2f(30., 25.);
+        let presenter = app
+            .presenter(window_id)
+            .expect("Test window should have a presenter after the first frame.");
+        app.update(|ctx| {
+            ctx.simulate_window_event(
+                Event::MouseMoved {
+                    position: cursor,
+                    cmd: false,
+                    shift: false,
+                    is_synthetic: false,
+                },
+                window_id,
+                presenter,
+            );
+        });
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+
+        // The tooltip must float in the overlay layer at the cursor plus the
+        // below-right nudge — not at the base's bottom-left.
+        let overlay_bounds = read_scene(app, window_id, |scene| {
+            scene
+                .layers()
+                .skip(scene.layer_count() - scene.overlay_layer_count())
+                .flat_map(|layer| layer.rects.iter().map(|r| r.bounds))
+                .collect::<Vec<RectF>>()
+        });
+
+        let expected_tooltip =
+            RectF::new(cursor + tooltip_pointer_offset(), tooltip_overlay_size());
+        assert!(
+            overlay_bounds.contains(&expected_tooltip),
+            "Tooltip should float at the pointer position {expected_tooltip:?}, \
+             got overlay rects {overlay_bounds:?}"
+        );
+
+        // Guard against silent regression to element-rect anchoring: the
+        // element-anchored position (base bottom-left + gap) must NOT be where
+        // the tooltip landed.
+        let element_anchored = RectF::new(
+            vec2f(0., tooltip_base_size().y() + TOOLTIP_GAP),
+            tooltip_overlay_size(),
+        );
+        assert!(
+            !overlay_bounds.contains(&element_anchored),
+            "Tooltip must not be anchored to the element rect at {element_anchored:?}; \
+             it should track the pointer"
+        );
+    });
+}
+
 /// Read the last-rendered scene for `window_id` and project it with `f`.
 fn read_scene<T>(app: &mut App, window_id: WindowId, f: impl FnOnce(&Scene) -> T) -> T {
     let presenter_ref = app

--- a/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
+++ b/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
@@ -6,9 +6,10 @@ use itertools::Itertools;
 use pathfinder_geometry::rect::RectF;
 
 use super::*;
+use crate::r#async::Timer;
 use crate::elements::{
     Clipped, ConstrainedBox, DispatchEventResult, EventHandler, Hoverable, MouseState,
-    MouseStateHandle, ParentElement, Rect, ZIndex,
+    MouseStateHandle, ParentElement, Rect, TooltipState, ZIndex,
 };
 use crate::platform::WindowStyle;
 use crate::{
@@ -1073,6 +1074,250 @@ fn test_overlay_tooltip_positions_at_mouse_pointer() {
             !overlay_bounds.contains(&element_anchored),
             "Tooltip must not be anchored to the element rect at {element_anchored:?}; \
              it should track the pointer"
+        );
+    });
+}
+
+/// Delay `D` used by the hysteresis scene tests below. Short enough to keep the
+/// real-time waits brief, long enough to be reliably observable across a frame.
+const HYSTERESIS_DELAY: std::time::Duration = std::time::Duration::from_millis(120);
+/// Jitter tolerance (px) for the hysteresis scene tests.
+const HYSTERESIS_JITTER: f32 = 3.0;
+
+/// A view mirroring the real `overlay_tool_tip_at_pointer` composition end to
+/// end: a [`Hoverable`] opted into browser-`title` tooltip hysteresis via
+/// [`Hoverable::with_pointer_hysteresis`], whose build closure shows a
+/// pointer-anchored overlay tooltip iff the machine reports
+/// [`TooltipState::Visible`] — exactly as the image alt-text builder does,
+/// reduced to plain [`Rect`] children so it needs no theme/appearance setup.
+///
+/// Unlike [`HoverPointerTooltipView`] (which reads `hover_position` directly and
+/// so only exercises the Stack overlay primitive), this drives the actual
+/// hysteresis wiring: intra-element moves, timer-armed show/dismiss, and the
+/// redraw re-dispatch that resolves matured deadlines.
+struct HysteresisTooltipView {
+    mouse_state: MouseStateHandle,
+}
+
+impl HysteresisTooltipView {
+    fn new() -> Self {
+        Self {
+            mouse_state: Default::default(),
+        }
+    }
+}
+
+impl Entity for HysteresisTooltipView {
+    type Event = String;
+}
+
+impl crate::core::View for HysteresisTooltipView {
+    fn render<'a>(&self, _: &AppContext) -> Box<dyn Element> {
+        Hoverable::new(self.mouse_state.clone(), |state: &MouseState| {
+            let base = ConstrainedBox::new(Rect::new().finish())
+                .with_width(tooltip_base_size().x())
+                .with_height(tooltip_base_size().y())
+                .finish();
+
+            let mut stack = Stack::new().with_child(base);
+
+            if let Some(TooltipState::Visible { at }) = state.tooltip_hysteresis_state() {
+                let tooltip = ConstrainedBox::new(Rect::new().finish())
+                    .with_width(tooltip_overlay_size().x())
+                    .with_height(tooltip_overlay_size().y())
+                    .finish();
+                stack.add_positioned_overlay_child(
+                    tooltip,
+                    OffsetPositioning::offset_from_parent(
+                        at + tooltip_pointer_offset(),
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::TopLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                );
+            }
+
+            stack.finish()
+        })
+        .with_pointer_hysteresis(HYSTERESIS_DELAY, HYSTERESIS_JITTER)
+        .finish()
+    }
+
+    fn ui_name() -> &'static str {
+        "HysteresisTooltipView"
+    }
+}
+
+impl TypedActionView for HysteresisTooltipView {
+    type Action = ();
+}
+
+/// Bounds of every rect in the scene's floating overlay layers.
+fn overlay_layer_rect_bounds(scene: &Scene) -> Vec<RectF> {
+    scene
+        .layers()
+        .skip(scene.layer_count() - scene.overlay_layer_count())
+        .flat_map(|layer| layer.rects.iter().map(|r| r.bounds))
+        .collect()
+}
+
+/// Dispatch a real (non-synthetic) mouse move and record it as the window's last
+/// move, so the timer-driven redraw re-dispatches it as a synthetic move — the
+/// mechanism that lets a matured show/dismiss deadline resolve on the next frame.
+fn move_mouse(app: &mut App, window_id: WindowId, position: Vector2F) {
+    let presenter = app
+        .presenter(window_id)
+        .expect("Test window should have a presenter after the first frame.");
+    let event = Event::MouseMoved {
+        position,
+        cmd: false,
+        shift: false,
+        is_synthetic: false,
+    };
+    app.update(|ctx| {
+        ctx.simulate_window_event(event.clone(), window_id, presenter);
+        ctx.set_last_mouse_move_event(window_id, event);
+    });
+}
+
+/// Spec point 2: resting the pointer over the element shows the tooltip at the
+/// pointer position after `D`, and not before. Drives the real hysteresis wiring
+/// (Hoverable timer arm → redraw re-dispatch → deadline matures), not just the
+/// pure state machine.
+///
+/// The move-to-dismiss and rest-again-relocate transitions (spec points 3–5) are
+/// exercised exhaustively by the `tooltip_hysteresis` state-machine tests, which
+/// control the clock and pointer motion precisely. They cannot be driven
+/// deterministically here because the harness's only way to advance time is a
+/// real wait, during which the window re-dispatches the *last* mouse position —
+/// which the machine correctly reads as the pointer coming to rest, not as
+/// continued motion. See `test_hysteresis_tooltip_relocates_on_rerest_without_new_delay`
+/// for the relocate path (which the re-dispatch *can* express) and the exit test
+/// for immediate dismissal.
+#[test]
+fn test_hysteresis_tooltip_shows_at_pointer_only_after_rest_delay() {
+    App::test((), |mut app| async move {
+        let app = &mut app;
+        app.update(init);
+        let (window_id, _view) =
+            app.add_window(WindowStyle::NotStealFocus, |_| HysteresisTooltipView::new());
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+
+        // Rest the pointer inside the base. Nothing shows yet (delay unpaid).
+        let rest = vec2f(30., 25.);
+        move_mouse(app, window_id, rest);
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
+        assert!(
+            overlay.is_empty(),
+            "tooltip must not show before the rest delay elapses; got {overlay:?}"
+        );
+
+        // Wait out the show delay; the redraw the notify timer triggers
+        // re-dispatches the held move, which matures the pending-show deadline.
+        Timer::after(HYSTERESIS_DELAY * 3).await;
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
+        let expected = RectF::new(rest + tooltip_pointer_offset(), tooltip_overlay_size());
+        assert!(
+            overlay.contains(&expected),
+            "tooltip should show at the resting pointer {expected:?}; got {overlay:?}"
+        );
+    });
+}
+
+/// Spec point 6: leaving the element dismisses immediately (no delay), driven
+/// through the real wiring.
+#[test]
+fn test_hysteresis_tooltip_dismisses_immediately_on_exit() {
+    App::test((), |mut app| async move {
+        let app = &mut app;
+        app.update(init);
+        let (window_id, _view) =
+            app.add_window(WindowStyle::NotStealFocus, |_| HysteresisTooltipView::new());
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+
+        // Rest and show.
+        let rest = vec2f(30., 25.);
+        move_mouse(app, window_id, rest);
+        Timer::after(HYSTERESIS_DELAY * 3).await;
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        assert!(
+            !read_scene(app, window_id, overlay_layer_rect_bounds).is_empty(),
+            "precondition: tooltip visible after resting"
+        );
+
+        // Move well outside the base (base is 80x60 at the origin). Exit must
+        // dismiss on this very frame, with no delay wait.
+        move_mouse(app, window_id, vec2f(500., 500.));
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
+        assert!(
+            overlay.is_empty(),
+            "tooltip must dismiss immediately on exit; got {overlay:?}"
+        );
+    });
+}
+
+/// Spec point 4: while the tooltip is visible, nudging to a new spot and coming
+/// to rest again before the dismissal fires relocates the still-visible tooltip
+/// to the new pointer position with no additional show delay. Driven through the
+/// real wiring.
+#[test]
+fn test_hysteresis_tooltip_relocates_on_rerest_without_new_delay() {
+    App::test((), |mut app| async move {
+        let app = &mut app;
+        app.update(init);
+        let (window_id, _view) =
+            app.add_window(WindowStyle::NotStealFocus, |_| HysteresisTooltipView::new());
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+
+        // Rest and show at the first spot. Both spots are kept in the top strip
+        // of the base (y small) so the pointer never lands *under* a visible
+        // tooltip (which floats below-right at +16 in y) — a pointer covered by
+        // its own tooltip reads as "left the element" and would dismiss, an
+        // orthogonal hit-testing concern noted in the deliverable.
+        let first = vec2f(15., 8.);
+        move_mouse(app, window_id, first);
+        Timer::after(HYSTERESIS_DELAY * 3).await;
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
+        assert!(
+            overlay.contains(&RectF::new(
+                first + tooltip_pointer_offset(),
+                tooltip_overlay_size()
+            )),
+            "precondition: tooltip visible at first rest spot; got {overlay:?}"
+        );
+
+        // Nudge to a new spot and immediately hold still there. A single move
+        // arms dismissal; holding still (re-dispatched by the redraw) resolves as
+        // a re-rest, which relocates the *still-visible* tooltip with no new show
+        // delay. Check within less than the full delay that it moved and is up.
+        let second = vec2f(55., 8.);
+        move_mouse(app, window_id, second);
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        // Give the relocate (which is immediate on re-rest) a frame to settle,
+        // but far less than a full delay so this can't be confused with a fresh
+        // show-after-delay.
+        Timer::after(HYSTERESIS_DELAY / 4).await;
+        // Hold still: re-dispatch the same position so the machine sees a rest.
+        move_mouse(app, window_id, second);
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
+        assert!(
+            overlay.contains(&RectF::new(
+                second + tooltip_pointer_offset(),
+                tooltip_overlay_size()
+            )),
+            "tooltip should relocate to the new rest spot with no new delay; got {overlay:?}"
+        );
+        assert!(
+            !overlay.contains(&RectF::new(
+                first + tooltip_pointer_offset(),
+                tooltip_overlay_size()
+            )),
+            "tooltip should no longer be at the old spot; got {overlay:?}"
         );
     });
 }

--- a/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
+++ b/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
@@ -1121,7 +1121,12 @@ impl crate::core::View for HysteresisTooltipView {
 
             let mut stack = Stack::new().with_child(base);
 
-            if let Some(TooltipState::Visible { at }) = state.tooltip_hysteresis_state() {
+            // The fade machine reports `Visible` at any opacity > 0. This
+            // reduced view ignores the opacity (its plain `Rect` child carries no
+            // color to fade); the real builder scales the tooltip's colors by it.
+            // What this scene test pins is presence/position/relocation of the
+            // overlay, which are governed by `at`.
+            if let Some(TooltipState::Visible { at, .. }) = state.tooltip_hysteresis_state() {
                 let tooltip = ConstrainedBox::new(Rect::new().finish())
                     .with_width(tooltip_overlay_size().x())
                     .with_height(tooltip_overlay_size().y())
@@ -1180,22 +1185,24 @@ fn move_mouse(app: &mut App, window_id: WindowId, position: Vector2F) {
     });
 }
 
-/// Spec point 2: resting the pointer over the element shows the tooltip at the
-/// pointer position after `D`, and not before. Drives the real hysteresis wiring
-/// (Hoverable timer arm → redraw re-dispatch → deadline matures), not just the
-/// pure state machine.
+/// Fade spec point 1–2: the tooltip is fully faded out before the pointer is
+/// ever seen (no rest sample), and fully faded in at the pointer position once
+/// the pointer has rested for `D`. Drives the real fade wiring (Hoverable arms a
+/// per-frame re-sample timer → redraw re-dispatches the held move → the machine
+/// reads it as rest and advances the fade), not just the pure state machine.
 ///
-/// The move-to-dismiss and rest-again-relocate transitions (spec points 3–5) are
-/// exercised exhaustively by the `tooltip_hysteresis` state-machine tests, which
-/// control the clock and pointer motion precisely. They cannot be driven
-/// deterministically here because the harness's only way to advance time is a
-/// real wait, during which the window re-dispatches the *last* mouse position —
-/// which the machine correctly reads as the pointer coming to rest, not as
-/// continued motion. See `test_hysteresis_tooltip_relocates_on_rerest_without_new_delay`
-/// for the relocate path (which the re-dispatch *can* express) and the exit test
-/// for immediate dismissal.
+/// This reduced view carries no color on its `Rect` child, so it cannot observe
+/// *opacity* — it treats any opacity > 0 as "overlay present". It therefore pins
+/// what it can see at the scene level: no overlay before any pointer sample, and
+/// the overlay present at the settled position after resting for `D`. The
+/// intermediate fade opacities (fade-in curve, `p·D` fade-out, reversal) are
+/// covered precisely by the `tooltip_hysteresis` state-machine tests, which
+/// control the clock and can read the opacity directly. Note that because the
+/// render frame re-dispatches the last move, the machine sees the resting
+/// pointer within a frame and the fade-in begins right away — so this scene test
+/// asserts the *end* of the fade-in, not a "still hidden mid-delay" checkpoint.
 #[test]
-fn test_hysteresis_tooltip_shows_at_pointer_only_after_rest_delay() {
+fn test_hysteresis_tooltip_shows_at_pointer_after_rest_delay() {
     App::test((), |mut app| async move {
         let app = &mut app;
         app.update(init);
@@ -1203,33 +1210,35 @@ fn test_hysteresis_tooltip_shows_at_pointer_only_after_rest_delay() {
             app.add_window(WindowStyle::NotStealFocus, |_| HysteresisTooltipView::new());
         app.update(|ctx| ctx.simulate_render_frame(window_id));
 
-        // Rest the pointer inside the base. Nothing shows yet (delay unpaid).
-        let rest = vec2f(30., 25.);
-        move_mouse(app, window_id, rest);
-        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        // Before any pointer sample, the tooltip is fully faded out.
         let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
         assert!(
             overlay.is_empty(),
-            "tooltip must not show before the rest delay elapses; got {overlay:?}"
+            "tooltip must be fully faded out before the pointer is seen; got {overlay:?}"
         );
 
-        // Wait out the show delay; the redraw the notify timer triggers
-        // re-dispatches the held move, which matures the pending-show deadline.
+        // Rest the pointer, then wait out the fade-in; the per-frame re-sample
+        // timer re-dispatches the held move (read as rest), driving the opacity up
+        // to full over `D`.
+        let rest = vec2f(30., 25.);
+        move_mouse(app, window_id, rest);
         Timer::after(HYSTERESIS_DELAY * 3).await;
         app.update(|ctx| ctx.simulate_render_frame(window_id));
         let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
         let expected = RectF::new(rest + tooltip_pointer_offset(), tooltip_overlay_size());
         assert!(
             overlay.contains(&expected),
-            "tooltip should show at the resting pointer {expected:?}; got {overlay:?}"
+            "tooltip should be faded in at the resting pointer {expected:?}; got {overlay:?}"
         );
     });
 }
 
-/// Spec point 6: leaving the element dismisses immediately (no delay), driven
-/// through the real wiring.
+/// Fade spec point 4 (exit): leaving the element fades the tooltip out (at the
+/// faster exit rate) until it is fully gone, driven through the real wiring.
+/// Unlike an instant snap, the fade takes `D / EXIT_FADE_RATE_MULTIPLIER`; this
+/// test waits that fade out and confirms the overlay is gone once it settles.
 #[test]
-fn test_hysteresis_tooltip_dismisses_immediately_on_exit() {
+fn test_hysteresis_tooltip_fades_out_on_exit() {
     App::test((), |mut app| async move {
         let app = &mut app;
         app.update(init);
@@ -1237,7 +1246,7 @@ fn test_hysteresis_tooltip_dismisses_immediately_on_exit() {
             app.add_window(WindowStyle::NotStealFocus, |_| HysteresisTooltipView::new());
         app.update(|ctx| ctx.simulate_render_frame(window_id));
 
-        // Rest and show.
+        // Rest and fade in.
         let rest = vec2f(30., 25.);
         move_mouse(app, window_id, rest);
         Timer::after(HYSTERESIS_DELAY * 3).await;
@@ -1247,24 +1256,28 @@ fn test_hysteresis_tooltip_dismisses_immediately_on_exit() {
             "precondition: tooltip visible after resting"
         );
 
-        // Move well outside the base (base is 80x60 at the origin). Exit must
-        // dismiss on this very frame, with no delay wait.
+        // Move well outside the base (base is 80x60 at the origin) and wait out
+        // the exit fade. The per-frame re-sample timer re-dispatches the held
+        // outside position (read as "still gone"), driving opacity down to 0.
         move_mouse(app, window_id, vec2f(500., 500.));
+        Timer::after(HYSTERESIS_DELAY * 3).await;
         app.update(|ctx| ctx.simulate_render_frame(window_id));
         let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
         assert!(
             overlay.is_empty(),
-            "tooltip must dismiss immediately on exit; got {overlay:?}"
+            "tooltip must fully fade out after leaving the element; got {overlay:?}"
         );
     });
 }
 
-/// Spec point 4: while the tooltip is visible, nudging to a new spot and coming
-/// to rest again before the dismissal fires relocates the still-visible tooltip
-/// to the new pointer position with no additional show delay. Driven through the
-/// real wiring.
+/// Single-instance relocation (fade spec point 3): moving to a new rest spot
+/// does not slide or crossfade a second instance — the tooltip at the old spot
+/// fades out first, then fades in at the new spot. Driven through the real
+/// wiring, this test pins the *endpoint*: after resting at a new spot long
+/// enough for the old to fade out and the new to fade in, the overlay is at the
+/// new spot and not the old.
 #[test]
-fn test_hysteresis_tooltip_relocates_on_rerest_without_new_delay() {
+fn test_hysteresis_tooltip_relocates_to_new_rest_spot() {
     App::test((), |mut app| async move {
         let app = &mut app;
         app.update(init);
@@ -1272,7 +1285,7 @@ fn test_hysteresis_tooltip_relocates_on_rerest_without_new_delay() {
             app.add_window(WindowStyle::NotStealFocus, |_| HysteresisTooltipView::new());
         app.update(|ctx| ctx.simulate_render_frame(window_id));
 
-        // Rest and show at the first spot. Both spots are kept in the top strip
+        // Rest and fade in at the first spot. Both spots are kept in the top strip
         // of the base (y small) so the pointer never lands *under* a visible
         // tooltip (which floats below-right at +16 in y) — a pointer covered by
         // its own tooltip reads as "left the element" and would dismiss, an
@@ -1290,27 +1303,26 @@ fn test_hysteresis_tooltip_relocates_on_rerest_without_new_delay() {
             "precondition: tooltip visible at first rest spot; got {overlay:?}"
         );
 
-        // Nudge to a new spot and immediately hold still there. A single move
-        // arms dismissal; holding still (re-dispatched by the redraw) resolves as
-        // a re-rest, which relocates the *still-visible* tooltip with no new show
-        // delay. Check within less than the full delay that it moved and is up.
+        // Move to a new spot and hold still there. Under the single-instance
+        // model the old tooltip finishes fading out at `first`, then a fresh
+        // fade-in captures `second`. Wait out both fades (each ≤ D), holding the
+        // pointer still at `second` so the re-dispatch keeps it "at rest".
         let second = vec2f(55., 8.);
         move_mouse(app, window_id, second);
-        app.update(|ctx| ctx.simulate_render_frame(window_id));
-        // Give the relocate (which is immediate on re-rest) a frame to settle,
-        // but far less than a full delay so this can't be confused with a fresh
-        // show-after-delay.
-        Timer::after(HYSTERESIS_DELAY / 4).await;
-        // Hold still: re-dispatch the same position so the machine sees a rest.
-        move_mouse(app, window_id, second);
-        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        // Several settle waits, re-asserting the held position each time so the
+        // machine sees continuous rest at `second` across the fade-out→fade-in.
+        for _ in 0..3 {
+            Timer::after(HYSTERESIS_DELAY).await;
+            move_mouse(app, window_id, second);
+            app.update(|ctx| ctx.simulate_render_frame(window_id));
+        }
         let overlay = read_scene(app, window_id, overlay_layer_rect_bounds);
         assert!(
             overlay.contains(&RectF::new(
                 second + tooltip_pointer_offset(),
                 tooltip_overlay_size()
             )),
-            "tooltip should relocate to the new rest spot with no new delay; got {overlay:?}"
+            "tooltip should end up faded in at the new rest spot; got {overlay:?}"
         );
         assert!(
             !overlay.contains(&RectF::new(

--- a/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
+++ b/crates/warpui_core/src/elements/gui/stack/mod_tests.rs
@@ -7,11 +7,12 @@ use pathfinder_geometry::rect::RectF;
 
 use super::*;
 use crate::elements::{
-    Clipped, ConstrainedBox, DispatchEventResult, EventHandler, ParentElement, Rect, ZIndex,
+    Clipped, ConstrainedBox, DispatchEventResult, EventHandler, Hoverable, MouseState,
+    MouseStateHandle, ParentElement, Rect, ZIndex,
 };
 use crate::platform::WindowStyle;
 use crate::{
-    App, AppContext, Entity, EntityIdSet, Event, Presenter, TypedActionView, ViewContext,
+    App, AppContext, Entity, EntityIdSet, Event, Presenter, Scene, TypedActionView, ViewContext,
     ViewHandle, WindowId, WindowInvalidation,
 };
 
@@ -737,6 +738,205 @@ fn test_relative_positioning_bound_to_missing_anchor() {
             // child, this implicitly tests that we don't panic during layout.
         });
     });
+}
+
+/// Size of the base (in-flow) child in [`HoverOverlayTooltipView`].
+fn tooltip_base_size() -> Vector2F {
+    vec2f(80., 60.)
+}
+/// Size of the floating tooltip child in [`HoverOverlayTooltipView`].
+fn tooltip_overlay_size() -> Vector2F {
+    vec2f(120., 20.)
+}
+/// Vertical gap between the base and the tooltip in [`HoverOverlayTooltipView`].
+const TOOLTIP_GAP: f32 = 4.;
+
+/// A view mirroring the `overlay_tool_tip_on_element` composition used by the
+/// image alt-text tooltip: a [`Hoverable`] wrapping a [`Stack`] whose only
+/// in-flow child is a sized base element, plus — when hovered — a tooltip added
+/// via [`Stack::add_positioned_overlay_child`] anchored below the base.
+///
+/// This is the exact shape produced by
+/// `UiBuilder::overlay_tool_tip_on_element` (overlay = true), reduced to plain
+/// [`Rect`] children so it needs no theme/appearance setup.
+///
+/// The whole thing is wrapped in a [`Clipped`] sized to the base, mirroring the
+/// editor's viewport clip layer (`RichTextElement::paint` starts a bounded clip
+/// layer around all blocks). Because the tooltip is anchored *below* the base —
+/// outside this clip — a tooltip painted in-flow would be clipped away, while a
+/// true floating overlay escapes the clip. This is what makes the test a real
+/// analogue of the editor scenario rather than a bare-Stack check.
+struct HoverOverlayTooltipView {
+    mouse_state: MouseStateHandle,
+}
+
+impl HoverOverlayTooltipView {
+    fn new() -> Self {
+        Self {
+            mouse_state: Default::default(),
+        }
+    }
+}
+
+impl Entity for HoverOverlayTooltipView {
+    type Event = String;
+}
+
+impl crate::core::View for HoverOverlayTooltipView {
+    fn render<'a>(&self, _: &AppContext) -> Box<dyn Element> {
+        let hoverable = Hoverable::new(self.mouse_state.clone(), |state: &MouseState| {
+            let base = ConstrainedBox::new(Rect::new().finish())
+                .with_width(tooltip_base_size().x())
+                .with_height(tooltip_base_size().y())
+                .finish();
+
+            let mut stack = Stack::new().with_child(base);
+
+            if state.is_hovered() {
+                let tooltip = ConstrainedBox::new(Rect::new().finish())
+                    .with_width(tooltip_overlay_size().x())
+                    .with_height(tooltip_overlay_size().y())
+                    .finish();
+                stack.add_positioned_overlay_child(
+                    tooltip,
+                    OffsetPositioning::offset_from_parent(
+                        vec2f(0., TOOLTIP_GAP),
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::BottomLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                );
+            }
+
+            stack.finish()
+        })
+        .finish();
+
+        Clipped::sized(hoverable, tooltip_base_size()).finish()
+    }
+
+    fn ui_name() -> &'static str {
+        "HoverOverlayTooltipView"
+    }
+}
+
+impl TypedActionView for HoverOverlayTooltipView {
+    type Action = ();
+}
+
+/// Collect the bounds of every rect drawn in the scene's normal (in-flow)
+/// layers — i.e. everything that establishes document layout, excluding
+/// floating overlay layers.
+fn normal_layer_rect_bounds(scene: &Scene) -> Vec<RectF> {
+    scene
+        .normal_layers()
+        .flat_map(|layer| layer.rects.iter().map(|r| r.bounds))
+        .collect()
+}
+
+/// Regression test for the image alt-text tooltip reserving layout space.
+///
+/// The tooltip must float in an overlay layer and leave the in-flow content
+/// (the base element) untouched. Before the fix this was structurally
+/// guaranteed by the [`Stack`] excluding positioned children from its size
+/// computation; this test pins that guarantee against the exact composition the
+/// image block uses, so a future refactor of the tooltip helper can't
+/// regress the "zero layout impact on hover" contract.
+#[test]
+fn test_overlay_tooltip_does_not_reserve_layout_space_on_hover() {
+    App::test((), |mut app| async move {
+        let app = &mut app;
+        app.update(init);
+        let (window_id, _view) = app.add_window(WindowStyle::NotStealFocus, |_| {
+            HoverOverlayTooltipView::new()
+        });
+
+        // Frame 1: not hovered. Capture the in-flow layout and confirm no overlay
+        // layer exists yet.
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+        let (unhovered_bounds, unhovered_overlay_count) = read_scene(app, window_id, |scene| {
+            (normal_layer_rect_bounds(scene), scene.overlay_layer_count())
+        });
+        assert_eq!(
+            unhovered_overlay_count, 0,
+            "No overlay layer should exist before hover"
+        );
+        assert!(
+            unhovered_bounds.contains(&RectF::new(Vector2F::zero(), tooltip_base_size())),
+            "Base element should be laid out at its natural size, got {unhovered_bounds:?}"
+        );
+
+        // Move the mouse over the base element to trigger hover, then render the
+        // next frame so the hovered element tree is laid out and painted.
+        let presenter = app
+            .presenter(window_id)
+            .expect("Test window should have a presenter after the first frame.");
+        app.update(|ctx| {
+            ctx.simulate_window_event(
+                Event::MouseMoved {
+                    position: vec2f(10., 10.),
+                    cmd: false,
+                    shift: false,
+                    is_synthetic: false,
+                },
+                window_id,
+                presenter,
+            );
+        });
+        app.update(|ctx| ctx.simulate_render_frame(window_id));
+
+        // Frame 2: hovered. The tooltip must appear in an overlay layer, and the
+        // normal (in-flow) layout must be byte-for-byte identical to the
+        // unhovered frame — the tooltip reserves no document-flow space.
+        let (hovered_bounds, hovered_overlay_count, overlay_bounds) =
+            read_scene(app, window_id, |scene| {
+                let overlay_bounds: Vec<RectF> = scene
+                    .layers()
+                    .skip(scene.layer_count() - scene.overlay_layer_count())
+                    .flat_map(|layer| layer.rects.iter().map(|r| r.bounds))
+                    .collect();
+                (
+                    normal_layer_rect_bounds(scene),
+                    scene.overlay_layer_count(),
+                    overlay_bounds,
+                )
+            });
+
+        assert_eq!(
+            hovered_overlay_count, 1,
+            "Hovering should add exactly one floating overlay layer for the tooltip"
+        );
+        assert_eq!(
+            hovered_bounds, unhovered_bounds,
+            "In-flow layout must be unchanged by hover: the tooltip must not \
+             reserve document-flow space"
+        );
+
+        // The tooltip itself must live in the overlay layer, anchored below the
+        // base (base bottom = 60, plus the 4px gap = y 64), never in the normal
+        // layers.
+        let expected_tooltip = RectF::new(
+            vec2f(0., tooltip_base_size().y() + TOOLTIP_GAP),
+            tooltip_overlay_size(),
+        );
+        assert!(
+            overlay_bounds.contains(&expected_tooltip),
+            "Tooltip should float in the overlay layer at {expected_tooltip:?}, \
+             got overlay rects {overlay_bounds:?}"
+        );
+    });
+}
+
+/// Read the last-rendered scene for `window_id` and project it with `f`.
+fn read_scene<T>(app: &mut App, window_id: WindowId, f: impl FnOnce(&Scene) -> T) -> T {
+    let presenter_ref = app
+        .presenter(window_id)
+        .expect("Test window should have a presenter since a frame was rendered.");
+    let presenter = presenter_ref.borrow();
+    let scene = presenter
+        .scene()
+        .expect("Presenter should have rendered a scene.");
+    f(scene)
 }
 
 /// Positions the second child using the positioning and asserts the child is at bounds

--- a/crates/warpui_core/src/elements/gui/tooltip_hysteresis.rs
+++ b/crates/warpui_core/src/elements/gui/tooltip_hysteresis.rs
@@ -1,0 +1,559 @@
+//! A pure state machine implementing the browser title-tooltip behavior with
+//! symmetric show/dismiss hysteresis, extracted so it can be exhaustively unit
+//! tested with a virtual clock, free of any UI framework or async harness.
+//!
+//! # The model (matching a browser's `title` tooltip)
+//!
+//! Let `D` be a single delay reused for both the show and the dismiss paths.
+//!
+//! - The pointer coming to **rest** over the target (no movement beyond a small
+//!   jitter threshold for `D`) shows the tooltip at the pointer position.
+//! - Once visible, the pointer **moving** starts a dismissal timer of the same
+//!   `D`. If the pointer is still moving when it fires, the tooltip dismisses.
+//! - If the pointer comes to **rest again before** that dismissal fires, the
+//!   dismissal is cancelled and the *visible* tooltip is **relocated** to the
+//!   new pointer position with no additional show delay (it was already paid).
+//! - Resting again *after* a dismissal takes the normal show path (delay `D`,
+//!   appear at the new position).
+//! - The pointer **leaving** the target dismisses immediately, with no delay.
+//!
+//! The word "rest" is load-bearing: this is not "hovered for `D`". The pointer
+//! can sit over the target the entire time and the tooltip still hides while it
+//! keeps moving — exactly like a browser `title` tooltip.
+//!
+//! # Driving the machine
+//!
+//! Callers feed pointer samples in via [`TooltipHysteresis::on_pointer_moved`]
+//! (a move within the target), [`TooltipHysteresis::on_pointer_left`] (exited
+//! the target), and call [`TooltipHysteresis::tick`] whenever the clock may have
+//! advanced far enough to cross a pending deadline (e.g. from a timer callback,
+//! or on the next re-dispatch of the last pointer sample). Every method returns
+//! the current [`TooltipState`] so the caller can rebuild only when it changes.
+//!
+//! The machine holds no real clock: the caller supplies a monotonically
+//! non-decreasing `now` on every call. In production `now` is `Instant::now()`;
+//! in tests it is a virtual clock the test advances by hand.
+
+use std::time::Duration;
+
+use instant::Instant;
+
+use pathfinder_geometry::vector::Vector2F;
+
+/// The framework's tooltip show delay `D`, reused across every hover tooltip so
+/// they feel uniform. Also the dismiss delay for the browser-`title` hysteresis
+/// model (a single `D` governs both the rest-to-show and move-to-dismiss paths).
+/// This matches the hidden-section tooltip's long-standing 500 ms show delay.
+pub const TOOLTIP_SHOW_DELAY: Duration = Duration::from_millis(500);
+
+/// Default jitter tolerance (in pixels) for pointer-hysteresis tooltips: inter-
+/// sample movement at or below this counts as the pointer still being at rest,
+/// so hand tremor neither dismisses nor relocates a visible tooltip.
+pub const TOOLTIP_JITTER_THRESHOLD: f32 = 3.0;
+
+/// The visible outcome of the hysteresis machine, recomputed after every input.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TooltipState {
+    /// The tooltip is not shown.
+    Hidden,
+    /// The tooltip is shown, anchored at this pointer position (relative to the
+    /// target's origin — the same space the samples are fed in).
+    Visible { at: Vector2F },
+}
+
+impl TooltipState {
+    /// Whether the tooltip is currently shown.
+    pub fn is_visible(&self) -> bool {
+        matches!(self, TooltipState::Visible { .. })
+    }
+
+    /// The anchor position if visible.
+    pub fn position(&self) -> Option<Vector2F> {
+        match self {
+            TooltipState::Visible { at } => Some(*at),
+            TooltipState::Hidden => None,
+        }
+    }
+}
+
+/// Internal phase tracking, distinct from the externally observable
+/// [`TooltipState`] because "hidden" splits into "idle" vs "waiting to show" and
+/// "visible" splits into "steady" vs "waiting to dismiss".
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Phase {
+    /// Pointer is over the target but has not yet come to rest, and nothing is
+    /// shown. This is the state after a dismissal while the pointer keeps
+    /// moving, and the initial state.
+    Idle,
+    /// Pointer came to rest at `at`; the tooltip will show when `deadline` is
+    /// reached (provided the pointer has not moved again since).
+    PendingShow { at: Vector2F, deadline: Instant },
+    /// Tooltip is visible and anchored at `at`; the pointer is at rest.
+    Visible { at: Vector2F },
+    /// Tooltip is visible and anchored at `at`, but the pointer has started
+    /// moving; it will dismiss when `deadline` is reached unless the pointer
+    /// comes to rest again first.
+    PendingDismiss { at: Vector2F, deadline: Instant },
+}
+
+/// The browser-`title` tooltip hysteresis state machine. See the module docs.
+#[derive(Clone, Debug)]
+pub struct TooltipHysteresis {
+    /// The single delay `D` reused for the show and dismiss paths.
+    delay: std::time::Duration,
+    /// Movement below this many pixels between two samples is treated as jitter
+    /// (i.e. still "at rest"), not motion.
+    jitter_threshold: f32,
+    phase: Phase,
+    /// The most recent pointer position sampled while over the target, used to
+    /// measure inter-sample movement for jitter rejection. [`None`] before the
+    /// first sample and after the pointer leaves.
+    last_position: Option<Vector2F>,
+}
+
+impl TooltipHysteresis {
+    /// Creates a machine in the [`Phase::Idle`] state.
+    ///
+    /// `delay` is `D` (reused for both show and dismiss). `jitter_threshold` is
+    /// the pixel radius below which movement counts as rest.
+    pub fn new(delay: std::time::Duration, jitter_threshold: f32) -> Self {
+        Self {
+            delay,
+            jitter_threshold,
+            phase: Phase::Idle,
+            last_position: None,
+        }
+    }
+
+    /// The current externally observable state.
+    pub fn state(&self) -> TooltipState {
+        match self.phase {
+            Phase::Idle | Phase::PendingShow { .. } => TooltipState::Hidden,
+            Phase::Visible { at } | Phase::PendingDismiss { at, .. } => {
+                TooltipState::Visible { at }
+            }
+        }
+    }
+
+    /// The next instant at which [`Self::tick`] would change state, if any. A
+    /// caller can use this to schedule a single timer rather than polling.
+    pub fn next_deadline(&self) -> Option<Instant> {
+        match self.phase {
+            Phase::PendingShow { deadline, .. } | Phase::PendingDismiss { deadline, .. } => {
+                Some(deadline)
+            }
+            Phase::Idle | Phase::Visible { .. } => None,
+        }
+    }
+
+    /// Whether `to` is within the jitter threshold of the last sampled position
+    /// (i.e. the pointer is effectively still). The first sample after the
+    /// pointer arrives has no predecessor and so counts as movement, which
+    /// correctly starts the initial rest timer via [`Self::on_pointer_moved`].
+    fn is_jitter(&self, to: Vector2F) -> bool {
+        match self.last_position {
+            Some(from) => (to - from).length() <= self.jitter_threshold,
+            None => false,
+        }
+    }
+
+    /// Feed a pointer sample taken while the pointer is over the target, at
+    /// position `at` (relative to the target's origin) at time `now`.
+    ///
+    /// Movement within the jitter threshold of the previous sample is treated as
+    /// no movement: the pointer is still at rest, so a pending show/relocate is
+    /// left to mature rather than being restarted. Real movement (re)arms the
+    /// rest timer while hidden, and starts/keeps the dismissal timer while
+    /// visible.
+    pub fn on_pointer_moved(&mut self, at: Vector2F, now: Instant) -> TooltipState {
+        // First, let any already-elapsed deadline resolve, so a sample that
+        // arrives after the deadline still shows/dismisses deterministically.
+        self.tick(now);
+
+        let jitter = self.is_jitter(at);
+        let previous = self.last_position;
+        self.last_position = Some(at);
+
+        if jitter {
+            // The pointer held still since the last sample: it has come to rest.
+            // While counting down to dismiss, that re-rest cancels the dismissal
+            // and relocates the still-visible tooltip to the rest position with no
+            // new delay (spec: rest again before dismissal → relocate). This is
+            // how the re-rest is detected in production: the window re-dispatches
+            // the last move on each redraw, and two same-position samples in a row
+            // read as "stopped here".
+            //
+            // A jitter sample with no predecessor cannot happen (`is_jitter` is
+            // false without one), but guard anyway.
+            if previous.is_some()
+                && let Phase::PendingDismiss { .. } = self.phase
+            {
+                self.phase = Phase::Visible { at };
+            }
+            // Otherwise the pointer is still at rest in a phase whose pending
+            // deadline should simply mature (PendingShow) or that is already
+            // steady (Visible/Idle); leave it for `tick`.
+            return self.state();
+        }
+
+        // Real movement.
+        self.phase = match self.phase {
+            // Hidden and moving: (re)start the rest timer. When the pointer next
+            // holds still, `tick` after `delay` will show at that held position.
+            // We keep re-arming to the *latest* position so the tooltip shows
+            // where the pointer actually came to rest.
+            Phase::Idle | Phase::PendingShow { .. } => Phase::PendingShow {
+                at,
+                deadline: now + self.delay,
+            },
+            // Visible and starting/continuing to move: arm (or keep) the
+            // dismissal timer. Keep the anchor pinned where the tooltip is now;
+            // it must not follow the pointer while dismissing.
+            Phase::Visible { at: shown_at } => Phase::PendingDismiss {
+                at: shown_at,
+                deadline: now + self.delay,
+            },
+            // Already counting down to dismiss and still moving: let the
+            // existing deadline stand (do not extend it on every move — a moving
+            // pointer should dismiss `delay` after motion *began*).
+            Phase::PendingDismiss {
+                at: shown_at,
+                deadline,
+            } => Phase::PendingDismiss {
+                at: shown_at,
+                deadline,
+            },
+        };
+        self.state()
+    }
+
+    /// Advance the machine to time `now`, resolving any pending show/dismiss
+    /// whose deadline has been reached. Idempotent and safe to call at any time.
+    ///
+    /// A `PendingShow` that matures becomes `Visible` at its resting position. A
+    /// `PendingDismiss` that matures becomes `Idle` (hidden) — the pointer was
+    /// still moving when the timer fired.
+    pub fn tick(&mut self, now: Instant) -> TooltipState {
+        self.phase = match self.phase {
+            Phase::PendingShow { at, deadline } if now >= deadline => Phase::Visible { at },
+            Phase::PendingDismiss { deadline, .. } if now >= deadline => Phase::Idle,
+            other => other,
+        };
+        self.state()
+    }
+
+    /// Note that the pointer has come to rest at `at` at time `now` (an explicit
+    /// "settled" signal, e.g. from a rest-detection timer). This is a
+    /// convenience over [`Self::on_pointer_moved`] for callers that detect rest
+    /// out-of-band: it relocates a visible tooltip immediately (cancelling any
+    /// dismissal, no new delay) and, if hidden, arms the show timer.
+    pub fn on_pointer_rested(&mut self, at: Vector2F, now: Instant) -> TooltipState {
+        self.tick(now);
+        self.last_position = Some(at);
+        self.phase = match self.phase {
+            // Rest before the dismissal fired: cancel it and relocate the
+            // already-visible tooltip. No new show delay — it was already paid.
+            Phase::PendingDismiss { .. } | Phase::Visible { .. } => Phase::Visible { at },
+            // Hidden: normal show path. Arm the show timer at the resting spot.
+            Phase::Idle | Phase::PendingShow { .. } => Phase::PendingShow {
+                at,
+                deadline: now + self.delay,
+            },
+        };
+        self.state()
+    }
+
+    /// The pointer has left the target entirely: dismiss immediately, with no
+    /// delay, and forget any pending timers and the last sampled position.
+    pub fn on_pointer_left(&mut self) -> TooltipState {
+        self.phase = Phase::Idle;
+        self.last_position = None;
+        self.state()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const D: Duration = Duration::from_millis(500);
+    const JITTER: f32 = 3.0;
+
+    fn machine() -> TooltipHysteresis {
+        TooltipHysteresis::new(D, JITTER)
+    }
+
+    fn at(x: f32, y: f32) -> Vector2F {
+        Vector2F::new(x, y)
+    }
+
+    /// Spec point 2: pointer comes to rest over the target; after D the tooltip
+    /// appears at the pointer position.
+    #[test]
+    fn rest_shows_after_delay_at_pointer() {
+        let mut m = machine();
+        let t0 = Instant::now();
+
+        // Arrival is "movement" (no predecessor) → arms the show timer.
+        assert_eq!(m.on_pointer_moved(at(10., 20.), t0), TooltipState::Hidden);
+        // Held still (jitter) before the deadline: still hidden.
+        assert_eq!(
+            m.on_pointer_moved(at(11., 21.), t0 + Duration::from_millis(100)),
+            TooltipState::Hidden
+        );
+        // Just before the deadline: still hidden.
+        assert_eq!(
+            m.tick(t0 + Duration::from_millis(499)),
+            TooltipState::Hidden
+        );
+        // At the deadline: shows at the resting position.
+        assert_eq!(m.tick(t0 + D), TooltipState::Visible { at: at(10., 20.) });
+    }
+
+    /// The show anchors at where the pointer actually came to rest, not where it
+    /// first entered — re-arming tracks the latest resting spot.
+    #[test]
+    fn show_anchors_at_final_resting_position() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        // Real move to a new spot re-arms the timer at the new position.
+        m.on_pointer_moved(at(50., 60.), t0 + Duration::from_millis(200));
+        // Not yet D since the *second* rest began.
+        assert_eq!(
+            m.tick(t0 + Duration::from_millis(600)),
+            TooltipState::Hidden
+        );
+        assert_eq!(
+            m.tick(t0 + Duration::from_millis(700)),
+            TooltipState::Visible { at: at(50., 60.) }
+        );
+    }
+
+    /// Spec point 4: pointer moves while visible, then comes to rest again
+    /// before the dismissal timer fires → dismissal cancelled and the tooltip
+    /// relocates to the new position with no additional delay.
+    #[test]
+    fn rest_before_dismissal_relocates_without_delay() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        // Show it.
+        m.on_pointer_moved(at(10., 10.), t0);
+        assert!(m.tick(t0 + D).is_visible());
+
+        // Move → arms dismissal at t = D + 300 + D.
+        let t_move = t0 + D + Duration::from_millis(300);
+        assert_eq!(
+            m.on_pointer_moved(at(80., 90.), t_move),
+            TooltipState::Visible { at: at(10., 10.) },
+            "anchor stays pinned while dismissing"
+        );
+
+        // Rest again before the dismissal deadline: relocate immediately.
+        let t_rest = t_move + Duration::from_millis(200);
+        assert_eq!(
+            m.on_pointer_rested(at(80., 90.), t_rest),
+            TooltipState::Visible { at: at(80., 90.) },
+            "relocated with no new delay"
+        );
+        // The prior dismissal deadline must not fire anymore.
+        assert_eq!(
+            m.tick(t_move + D + Duration::from_millis(1)),
+            TooltipState::Visible { at: at(80., 90.) }
+        );
+    }
+
+    /// Spec point 3: pointer keeps moving while visible; the dismissal timer
+    /// completes and the tooltip dismisses.
+    #[test]
+    fn sustained_movement_dismisses_after_delay() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        assert!(m.tick(t0 + D).is_visible());
+
+        // Start moving → arms dismissal D from now.
+        let t_move = t0 + D + Duration::from_millis(100);
+        m.on_pointer_moved(at(40., 40.), t_move);
+        // Keep moving; deadline should not extend on each move.
+        m.on_pointer_moved(at(70., 70.), t_move + Duration::from_millis(200));
+        m.on_pointer_moved(at(100., 100.), t_move + Duration::from_millis(400));
+        // Just before dismissal deadline (t_move + D): still visible.
+        assert!(
+            m.tick(t_move + D - Duration::from_millis(1)).is_visible(),
+            "still visible just before dismissal"
+        );
+        // At the deadline: dismissed.
+        assert_eq!(m.tick(t_move + D), TooltipState::Hidden);
+    }
+
+    /// A dismissal deadline is measured from when motion *began*, not extended by
+    /// each subsequent move — a continuously-moving pointer dismisses on schedule.
+    #[test]
+    fn dismissal_deadline_not_extended_by_continued_motion() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(0., 0.), t0);
+        assert!(m.tick(t0 + D).is_visible());
+
+        let t_move = t0 + D;
+        m.on_pointer_moved(at(20., 0.), t_move);
+        // A later move well before the deadline must not push it out.
+        m.on_pointer_moved(at(40., 0.), t_move + Duration::from_millis(499));
+        assert_eq!(m.tick(t_move + D), TooltipState::Hidden);
+    }
+
+    /// Spec point 6: leaving the target dismisses immediately, no delay, from any
+    /// visible or pending state.
+    #[test]
+    fn leaving_dismisses_immediately() {
+        // From Visible.
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        assert!(m.tick(t0 + D).is_visible());
+        assert_eq!(m.on_pointer_left(), TooltipState::Hidden);
+
+        // From PendingShow.
+        let mut m = machine();
+        m.on_pointer_moved(at(10., 10.), t0);
+        assert_eq!(m.on_pointer_left(), TooltipState::Hidden);
+
+        // From PendingDismiss.
+        let mut m = machine();
+        m.on_pointer_moved(at(10., 10.), t0);
+        m.tick(t0 + D);
+        m.on_pointer_moved(at(40., 40.), t0 + D + Duration::from_millis(50));
+        assert_eq!(m.on_pointer_left(), TooltipState::Hidden);
+    }
+
+    /// Spec point 5: after a dismissal, resting again takes the normal show path
+    /// (full delay D, appears at the new position).
+    #[test]
+    fn rest_after_dismissal_uses_full_show_delay() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        assert!(m.tick(t0 + D).is_visible());
+
+        // Dismiss via sustained movement.
+        let t_move = t0 + D;
+        m.on_pointer_moved(at(40., 40.), t_move);
+        assert_eq!(m.tick(t_move + D), TooltipState::Hidden);
+
+        // Rest at a new spot: must take the full delay again.
+        let t_rest = t_move + D + Duration::from_millis(100);
+        m.on_pointer_moved(at(200., 200.), t_rest);
+        assert_eq!(
+            m.tick(t_rest + D - Duration::from_millis(1)),
+            TooltipState::Hidden,
+            "must pay the full show delay after a dismissal"
+        );
+        assert_eq!(
+            m.tick(t_rest + D),
+            TooltipState::Visible { at: at(200., 200.) }
+        );
+    }
+
+    /// Sub-jitter-threshold movement does not count as motion: a visible tooltip
+    /// stays visible and is not relocated by hand-tremor-scale samples.
+    #[test]
+    fn jitter_does_not_dismiss_or_relocate() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        assert!(m.tick(t0 + D).is_visible());
+
+        // A 2px move (< 3px threshold) is jitter: no dismissal armed, anchor
+        // unchanged.
+        assert_eq!(
+            m.on_pointer_moved(at(12., 10.), t0 + D + Duration::from_millis(100)),
+            TooltipState::Visible { at: at(10., 10.) }
+        );
+        assert_eq!(
+            m.next_deadline(),
+            None,
+            "no dismissal timer armed by jitter"
+        );
+    }
+
+    /// A jitter (hold-still) sample arriving while counting down to dismiss is
+    /// read as the pointer coming to rest again, and relocates the still-visible
+    /// tooltip with no new delay — the production re-rest path, since the window
+    /// re-dispatches the last move on each redraw and two same-spot samples read
+    /// as "stopped here".
+    #[test]
+    fn jitter_sample_during_pending_dismiss_relocates() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        assert!(m.tick(t0 + D).is_visible());
+
+        // Real move → PendingDismiss (anchor still pinned at the old spot).
+        let t_move = t0 + D;
+        assert_eq!(
+            m.on_pointer_moved(at(60., 60.), t_move),
+            TooltipState::Visible { at: at(10., 10.) }
+        );
+        // Hold still near the new spot (within jitter) → re-rest → relocate to the
+        // held position, before the dismissal deadline.
+        assert_eq!(
+            m.on_pointer_moved(at(61., 61.), t_move + Duration::from_millis(50)),
+            TooltipState::Visible { at: at(61., 61.) }
+        );
+        assert_eq!(m.next_deadline(), None, "dismissal cancelled by re-rest");
+    }
+
+    /// `on_pointer_rested` on a hidden machine arms the show timer (does not show
+    /// instantly) — the explicit-rest entry point still honors the show delay
+    /// when nothing is visible yet.
+    #[test]
+    fn explicit_rest_while_hidden_arms_show_timer() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        assert_eq!(m.on_pointer_rested(at(5., 5.), t0), TooltipState::Hidden);
+        assert_eq!(
+            m.tick(t0 + D - Duration::from_millis(1)),
+            TooltipState::Hidden
+        );
+        assert_eq!(m.tick(t0 + D), TooltipState::Visible { at: at(5., 5.) });
+    }
+
+    /// A pointer sample that arrives after its show deadline still resolves to a
+    /// show at that sample time (deadlines are resolved on the next input, not
+    /// only by an external tick).
+    #[test]
+    fn late_sample_resolves_pending_show() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        // Next sample arrives well after the deadline, still at rest (jitter).
+        assert_eq!(
+            m.on_pointer_moved(at(11., 11.), t0 + D + Duration::from_millis(50)),
+            TooltipState::Visible { at: at(10., 10.) }
+        );
+    }
+
+    /// `next_deadline` reports the pending show/dismiss instant and nothing in
+    /// the steady states, so a driver can schedule exactly one timer.
+    #[test]
+    fn next_deadline_tracks_pending_phases() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        assert_eq!(m.next_deadline(), None, "idle has no deadline");
+
+        m.on_pointer_moved(at(0., 0.), t0);
+        assert_eq!(m.next_deadline(), Some(t0 + D), "pending-show deadline");
+
+        m.tick(t0 + D);
+        assert_eq!(m.next_deadline(), None, "visible steady state");
+
+        let t_move = t0 + D + Duration::from_millis(10);
+        m.on_pointer_moved(at(30., 0.), t_move);
+        assert_eq!(
+            m.next_deadline(),
+            Some(t_move + D),
+            "pending-dismiss deadline"
+        );
+    }
+}

--- a/crates/warpui_core/src/elements/gui/tooltip_hysteresis.rs
+++ b/crates/warpui_core/src/elements/gui/tooltip_hysteresis.rs
@@ -75,6 +75,12 @@ use pathfinder_geometry::vector::Vector2F;
 /// hidden-section tooltip's long-standing 500 ms show delay.
 pub const TOOLTIP_SHOW_DELAY: Duration = Duration::from_millis(500);
 
+/// Fade duration for pointer-anchored (at-cursor) tooltips. Tighter than
+/// [`TOOLTIP_SHOW_DELAY`] because a fade that begins the moment the pointer
+/// rests reads sluggish at 500 ms; the hidden-section tooltip keeps the
+/// longer delay since it appears without an animation.
+pub const TOOLTIP_POINTER_FADE_DELAY: Duration = Duration::from_millis(300);
+
 /// Default jitter tolerance (in pixels) for pointer-hysteresis tooltips: inter-
 /// sample movement at or below this counts as the pointer still being at rest,
 /// so hand tremor neither fades out nor relocates a visible tooltip. Raised from

--- a/crates/warpui_core/src/elements/gui/tooltip_hysteresis.rs
+++ b/crates/warpui_core/src/elements/gui/tooltip_hysteresis.rs
@@ -1,34 +1,63 @@
-//! A pure state machine implementing the browser title-tooltip behavior with
-//! symmetric show/dismiss hysteresis, extracted so it can be exhaustively unit
-//! tested with a virtual clock, free of any UI framework or async harness.
+//! A pure state machine implementing the browser title-tooltip behavior as a
+//! *fade animation*, extracted so it can be exhaustively unit tested with a
+//! virtual clock, free of any UI framework or async harness.
 //!
-//! # The model (matching a browser's `title` tooltip)
+//! # The model (a fade-animated browser `title` tooltip)
 //!
-//! Let `D` be a single delay reused for both the show and the dismiss paths.
+//! Let `D` be a single delay reused for both the fade-in and the fade-out paths.
 //!
-//! - The pointer coming to **rest** over the target (no movement beyond a small
-//!   jitter threshold for `D`) shows the tooltip at the pointer position.
-//! - Once visible, the pointer **moving** starts a dismissal timer of the same
-//!   `D`. If the pointer is still moving when it fires, the tooltip dismisses.
-//! - If the pointer comes to **rest again before** that dismissal fires, the
-//!   dismissal is cancelled and the *visible* tooltip is **relocated** to the
-//!   new pointer position with no additional show delay (it was already paid).
-//! - Resting again *after* a dismissal takes the normal show path (delay `D`,
-//!   appear at the new position).
-//! - The pointer **leaving** the target dismisses immediately, with no delay.
+//! The tooltip's opacity continuously animates toward a *target*:
+//!
+//! - `1.0` (fully opaque) while the pointer is **at rest** over the target (no
+//!   movement beyond a small jitter threshold since the last sample).
+//! - `0.0` (fully transparent) while the pointer is **moving** (beyond the
+//!   jitter threshold) or has **left** the target.
+//!
+//! The fade rate is symmetric: a full `0 → 1` fade takes exactly `D` — the
+//! fade-in *is* the rest delay, so it begins the instant the pointer comes to
+//! rest, with no invisible waiting period. A fade-out from opacity `p` takes
+//! `p · D` (same constant rate `1/D`). When the target flips mid-fade, the
+//! animation **reverses from the current opacity**, not from a fixed endpoint:
+//! nudging the pointer while the tooltip is at 30% starts fading it *out* from
+//! 30% (a `0.3 · D` fade-out), and coming to rest again resumes fading *in* from
+//! wherever it had reached.
 //!
 //! The word "rest" is load-bearing: this is not "hovered for `D`". The pointer
-//! can sit over the target the entire time and the tooltip still hides while it
-//! keeps moving — exactly like a browser `title` tooltip.
+//! can sit over the target the entire time and the tooltip still fades away
+//! while it keeps moving — exactly like a browser `title` tooltip.
+//!
+//! # Position
+//!
+//! The anchor position is **captured when a fade-in starts from zero opacity**
+//! (the pointer's rest position). While opacity is `> 0` the position stays
+//! fixed — the tooltip never slides. Only once it has fully faded to `0` is the
+//! position released, so the next fade-in from zero can capture a fresh spot.
+//!
+//! This is the single-tooltip-instance consequence of the framework's overlay
+//! machinery: the build closure emits at most one positioned overlay child from
+//! one [`TooltipState`], so two simultaneously-fading instances at different
+//! positions cannot be expressed. If the pointer comes to rest at a new spot
+//! while the old tooltip is still mid-fade-out, the old one finishes fading to
+//! `0` at its position first, and only then does a fresh fade-in begin at the
+//! new rest position.
+//!
+//! # Exit
+//!
+//! Leaving the target entirely fades out at a **faster** rate than symmetric
+//! (see [`EXIT_FADE_RATE_MULTIPLIER`]) so a dismissed tooltip clears promptly
+//! rather than lingering — snappier than the in-target move-to-dismiss, but
+//! still animated (not an instant snap, which read as janky in the live build).
 //!
 //! # Driving the machine
 //!
 //! Callers feed pointer samples in via [`TooltipHysteresis::on_pointer_moved`]
 //! (a move within the target), [`TooltipHysteresis::on_pointer_left`] (exited
-//! the target), and call [`TooltipHysteresis::tick`] whenever the clock may have
-//! advanced far enough to cross a pending deadline (e.g. from a timer callback,
-//! or on the next re-dispatch of the last pointer sample). Every method returns
-//! the current [`TooltipState`] so the caller can rebuild only when it changes.
+//! the target), and read [`TooltipHysteresis::state`] / the opacity at a given
+//! `now`. Because the opacity animates continuously, a driver re-samples it each
+//! frame while [`TooltipHysteresis::is_animating`] is true (arming a short
+//! ~frame-length timer), and stops re-arming once the opacity settles at its
+//! target. [`TooltipHysteresis::next_deadline`] reports when the current fade
+//! completes, for callers that prefer a single settle timer.
 //!
 //! The machine holds no real clock: the caller supplies a monotonically
 //! non-decreasing `now` on every call. In production `now` is `Instant::now()`;
@@ -40,29 +69,38 @@ use instant::Instant;
 
 use pathfinder_geometry::vector::Vector2F;
 
-/// The framework's tooltip show delay `D`, reused across every hover tooltip so
-/// they feel uniform. Also the dismiss delay for the browser-`title` hysteresis
-/// model (a single `D` governs both the rest-to-show and move-to-dismiss paths).
-/// This matches the hidden-section tooltip's long-standing 500 ms show delay.
+/// The framework's tooltip fade duration `D`, reused across every hover tooltip
+/// so they feel uniform. A full `0 → 1` opacity fade takes exactly this long,
+/// and it doubles as the fade-out span from full opacity. This matches the
+/// hidden-section tooltip's long-standing 500 ms show delay.
 pub const TOOLTIP_SHOW_DELAY: Duration = Duration::from_millis(500);
 
 /// Default jitter tolerance (in pixels) for pointer-hysteresis tooltips: inter-
 /// sample movement at or below this counts as the pointer still being at rest,
-/// so hand tremor neither dismisses nor relocates a visible tooltip.
-pub const TOOLTIP_JITTER_THRESHOLD: f32 = 3.0;
+/// so hand tremor neither fades out nor relocates a visible tooltip. Raised from
+/// the original 3 px to absorb a little more real-hand tremor without the
+/// tooltip flickering toward a fade-out.
+pub const TOOLTIP_JITTER_THRESHOLD: f32 = 6.0;
 
-/// The visible outcome of the hysteresis machine, recomputed after every input.
+/// How much faster than the symmetric rate the tooltip fades when the pointer
+/// leaves the target entirely. Exit should feel snappier than an in-target
+/// move-to-dismiss, but still animate rather than snap. At 3×, a full-opacity
+/// tooltip clears in `D / 3`.
+pub const EXIT_FADE_RATE_MULTIPLIER: f32 = 3.0;
+
+/// The visible outcome of the fade machine, recomputed for a given `now`.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TooltipState {
-    /// The tooltip is not shown.
+    /// The tooltip is fully faded out (opacity 0) and not shown.
     Hidden,
-    /// The tooltip is shown, anchored at this pointer position (relative to the
-    /// target's origin — the same space the samples are fed in).
-    Visible { at: Vector2F },
+    /// The tooltip is shown at `opacity` (in `(0.0, 1.0]`), anchored at `at`
+    /// (relative to the target's origin — the same space samples are fed in).
+    /// The caller scales the tooltip's colors by `opacity`.
+    Visible { at: Vector2F, opacity: f32 },
 }
 
 impl TooltipState {
-    /// Whether the tooltip is currently shown.
+    /// Whether the tooltip is currently shown at all (opacity strictly positive).
     pub fn is_visible(&self) -> bool {
         matches!(self, TooltipState::Visible { .. })
     }
@@ -70,41 +108,51 @@ impl TooltipState {
     /// The anchor position if visible.
     pub fn position(&self) -> Option<Vector2F> {
         match self {
-            TooltipState::Visible { at } => Some(*at),
+            TooltipState::Visible { at, .. } => Some(*at),
             TooltipState::Hidden => None,
+        }
+    }
+
+    /// The current opacity in `[0.0, 1.0]` (0 when hidden).
+    pub fn opacity(&self) -> f32 {
+        match self {
+            TooltipState::Visible { opacity, .. } => *opacity,
+            TooltipState::Hidden => 0.0,
         }
     }
 }
 
-/// Internal phase tracking, distinct from the externally observable
-/// [`TooltipState`] because "hidden" splits into "idle" vs "waiting to show" and
-/// "visible" splits into "steady" vs "waiting to dismiss".
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum Phase {
-    /// Pointer is over the target but has not yet come to rest, and nothing is
-    /// shown. This is the state after a dismissal while the pointer keeps
-    /// moving, and the initial state.
-    Idle,
-    /// Pointer came to rest at `at`; the tooltip will show when `deadline` is
-    /// reached (provided the pointer has not moved again since).
-    PendingShow { at: Vector2F, deadline: Instant },
-    /// Tooltip is visible and anchored at `at`; the pointer is at rest.
-    Visible { at: Vector2F },
-    /// Tooltip is visible and anchored at `at`, but the pointer has started
-    /// moving; it will dismiss when `deadline` is reached unless the pointer
-    /// comes to rest again first.
-    PendingDismiss { at: Vector2F, deadline: Instant },
-}
-
-/// The browser-`title` tooltip hysteresis state machine. See the module docs.
+/// The fade-animated browser-`title` tooltip machine. See the module docs.
+///
+/// Opacity is modeled as a piecewise-linear function of time anchored at
+/// `(anchor_time, anchor_opacity)` and moving at `rate` (opacity units per
+/// second, signed toward `target`). Sampling clamps the linear extrapolation
+/// into `[0, target]` (for a rising fade) or `[target, anchor]` (for a falling
+/// one), so the value never overshoots its target.
 #[derive(Clone, Debug)]
 pub struct TooltipHysteresis {
-    /// The single delay `D` reused for the show and dismiss paths.
-    delay: std::time::Duration,
-    /// Movement below this many pixels between two samples is treated as jitter
-    /// (i.e. still "at rest"), not motion.
+    /// The symmetric fade duration `D`: a full `0 → 1` fade (and a full `1 → 0`
+    /// in-target fade) takes this long.
+    delay: Duration,
+    /// Movement strictly beyond this many pixels between two samples counts as
+    /// motion; at or below it, the pointer is treated as still (jitter).
     jitter_threshold: f32,
-    phase: Phase,
+
+    /// Opacity value at `anchor_time`, the start of the current linear segment.
+    anchor_opacity: f32,
+    /// The instant `anchor_opacity` was captured; the segment's origin.
+    anchor_time: Instant,
+    /// Signed opacity-per-second slope of the current segment (positive fading
+    /// in, negative fading out, zero when settled at the target).
+    rate: f32,
+    /// The opacity the current segment is heading toward (`0.0` or `1.0`).
+    target: f32,
+
+    /// The anchor position, captured when a fade-in began from zero opacity and
+    /// held fixed until the tooltip fully fades out. [`None`] only while fully
+    /// hidden with nothing fading.
+    position: Option<Vector2F>,
+
     /// The most recent pointer position sampled while over the target, used to
     /// measure inter-sample movement for jitter rejection. [`None`] before the
     /// first sample and after the pointer leaves.
@@ -112,44 +160,83 @@ pub struct TooltipHysteresis {
 }
 
 impl TooltipHysteresis {
-    /// Creates a machine in the [`Phase::Idle`] state.
+    /// Creates a machine fully hidden (opacity 0), with no position captured.
     ///
-    /// `delay` is `D` (reused for both show and dismiss). `jitter_threshold` is
-    /// the pixel radius below which movement counts as rest.
-    pub fn new(delay: std::time::Duration, jitter_threshold: f32) -> Self {
+    /// `delay` is `D` (the symmetric fade duration). `jitter_threshold` is the
+    /// pixel radius at/below which inter-sample movement counts as rest.
+    pub fn new(delay: Duration, jitter_threshold: f32) -> Self {
         Self {
             delay,
             jitter_threshold,
-            phase: Phase::Idle,
+            anchor_opacity: 0.0,
+            anchor_time: Instant::now(),
+            rate: 0.0,
+            target: 0.0,
+            position: None,
             last_position: None,
         }
     }
 
-    /// The current externally observable state.
-    pub fn state(&self) -> TooltipState {
-        match self.phase {
-            Phase::Idle | Phase::PendingShow { .. } => TooltipState::Hidden,
-            Phase::Visible { at } | Phase::PendingDismiss { at, .. } => {
-                TooltipState::Visible { at }
-            }
+    /// The symmetric fade rate, in opacity units per second (`1 / D`).
+    fn base_rate(&self) -> f32 {
+        1.0 / self.delay.as_secs_f32()
+    }
+
+    /// The opacity at `now`, clamping the current linear segment so it never
+    /// overshoots its target. Pure: does not mutate the machine.
+    fn opacity_at(&self, now: Instant) -> f32 {
+        let elapsed = now
+            .saturating_duration_since(self.anchor_time)
+            .as_secs_f32();
+        let raw = self.anchor_opacity + self.rate * elapsed;
+        // Clamp into the interval bounded by the anchor and the target, so a
+        // matured fade sits exactly at its target rather than running past it.
+        let (lo, hi) = if self.anchor_opacity <= self.target {
+            (self.anchor_opacity, self.target)
+        } else {
+            (self.target, self.anchor_opacity)
+        };
+        raw.clamp(lo, hi)
+    }
+
+    /// The current externally observable state at `now`.
+    pub fn state(&self, now: Instant) -> TooltipState {
+        let opacity = self.opacity_at(now);
+        match self.position {
+            Some(at) if opacity > 0.0 => TooltipState::Visible { at, opacity },
+            _ => TooltipState::Hidden,
         }
     }
 
-    /// The next instant at which [`Self::tick`] would change state, if any. A
-    /// caller can use this to schedule a single timer rather than polling.
+    /// The current opacity at `now`, in `[0.0, 1.0]`.
+    pub fn opacity(&self, now: Instant) -> f32 {
+        self.opacity_at(now)
+    }
+
+    /// Whether a fade is in progress at `now` (opacity not yet settled at its
+    /// target). A driver re-samples each frame while this is true.
+    pub fn is_animating(&self, now: Instant) -> bool {
+        (self.opacity_at(now) - self.target).abs() > f32::EPSILON
+    }
+
+    /// The instant the current fade completes (opacity reaches its target), if a
+    /// fade is in progress; [`None`] when already settled. A caller can use this
+    /// to schedule a single settle timer instead of polling every frame.
     pub fn next_deadline(&self) -> Option<Instant> {
-        match self.phase {
-            Phase::PendingShow { deadline, .. } | Phase::PendingDismiss { deadline, .. } => {
-                Some(deadline)
-            }
-            Phase::Idle | Phase::Visible { .. } => None,
+        if self.rate == 0.0 || self.anchor_opacity == self.target {
+            return None;
         }
+        let remaining = (self.target - self.anchor_opacity) / self.rate;
+        if remaining <= 0.0 {
+            return None;
+        }
+        Some(self.anchor_time + Duration::from_secs_f32(remaining))
     }
 
     /// Whether `to` is within the jitter threshold of the last sampled position
     /// (i.e. the pointer is effectively still). The first sample after the
-    /// pointer arrives has no predecessor and so counts as movement, which
-    /// correctly starts the initial rest timer via [`Self::on_pointer_moved`].
+    /// pointer arrives has no predecessor and so counts as movement, correctly
+    /// leaving the tooltip faded out until the *next* (resting) sample.
     fn is_jitter(&self, to: Vector2F) -> bool {
         match self.last_position {
             Some(from) => (to - from).length() <= self.jitter_threshold,
@@ -157,118 +244,113 @@ impl TooltipHysteresis {
         }
     }
 
+    /// Re-anchor the animation to the current opacity at `now` and aim it at
+    /// `target` with slope `rate` (magnitude, always positive; sign is derived
+    /// from the direction to the target). A no-op-preserving helper: sampling at
+    /// `now` immediately after yields the same opacity it did just before.
+    fn retarget(&mut self, now: Instant, target: f32, rate_magnitude: f32) {
+        let current = self.opacity_at(now);
+        self.anchor_opacity = current;
+        self.anchor_time = now;
+        self.target = target;
+        self.rate = if target >= current {
+            rate_magnitude
+        } else {
+            -rate_magnitude
+        };
+    }
+
+    /// Release the captured position if the tooltip has fully faded out, so the
+    /// next fade-in from zero can capture a fresh rest position. Called after
+    /// sampling so a matured fade-out drops its anchor.
+    fn release_position_if_hidden(&mut self, now: Instant) {
+        if self.opacity_at(now) <= 0.0 && self.target <= 0.0 {
+            self.position = None;
+        }
+    }
+
     /// Feed a pointer sample taken while the pointer is over the target, at
     /// position `at` (relative to the target's origin) at time `now`.
     ///
-    /// Movement within the jitter threshold of the previous sample is treated as
-    /// no movement: the pointer is still at rest, so a pending show/relocate is
-    /// left to mature rather than being restarted. Real movement (re)arms the
-    /// rest timer while hidden, and starts/keeps the dismissal timer while
-    /// visible.
+    /// Movement at or within the jitter threshold of the previous sample is
+    /// treated as rest: the fade heads toward full opacity. Real movement aims
+    /// the fade toward zero. The animation reverses from the *current* opacity,
+    /// so quick rest/move alternations don't snap.
     pub fn on_pointer_moved(&mut self, at: Vector2F, now: Instant) -> TooltipState {
-        // First, let any already-elapsed deadline resolve, so a sample that
-        // arrives after the deadline still shows/dismisses deterministically.
-        self.tick(now);
-
         let jitter = self.is_jitter(at);
-        let previous = self.last_position;
+        let had_predecessor = self.last_position.is_some();
         self.last_position = Some(at);
 
-        if jitter {
-            // The pointer held still since the last sample: it has come to rest.
-            // While counting down to dismiss, that re-rest cancels the dismissal
-            // and relocates the still-visible tooltip to the rest position with no
-            // new delay (spec: rest again before dismissal → relocate). This is
-            // how the re-rest is detected in production: the window re-dispatches
-            // the last move on each redraw, and two same-position samples in a row
-            // read as "stopped here".
-            //
-            // A jitter sample with no predecessor cannot happen (`is_jitter` is
-            // false without one), but guard anyway.
-            if previous.is_some()
-                && let Phase::PendingDismiss { .. } = self.phase
-            {
-                self.phase = Phase::Visible { at };
-            }
-            // Otherwise the pointer is still at rest in a phase whose pending
-            // deadline should simply mature (PendingShow) or that is already
-            // steady (Visible/Idle); leave it for `tick`.
-            return self.state();
+        // "At rest" = a jitter sample (held still since the last one). The very
+        // first sample after arrival has no predecessor and so is motion, which
+        // keeps the tooltip faded out until the pointer actually holds still.
+        let at_rest = jitter && had_predecessor;
+
+        if at_rest {
+            self.rest_at(at, now);
+        } else {
+            // Real motion (or first-sample arrival): fade toward hidden. Keep the
+            // captured position pinned so the fading-out tooltip does not slide.
+            self.retarget(now, 0.0, self.base_rate());
         }
 
-        // Real movement.
-        self.phase = match self.phase {
-            // Hidden and moving: (re)start the rest timer. When the pointer next
-            // holds still, `tick` after `delay` will show at that held position.
-            // We keep re-arming to the *latest* position so the tooltip shows
-            // where the pointer actually came to rest.
-            Phase::Idle | Phase::PendingShow { .. } => Phase::PendingShow {
-                at,
-                deadline: now + self.delay,
-            },
-            // Visible and starting/continuing to move: arm (or keep) the
-            // dismissal timer. Keep the anchor pinned where the tooltip is now;
-            // it must not follow the pointer while dismissing.
-            Phase::Visible { at: shown_at } => Phase::PendingDismiss {
-                at: shown_at,
-                deadline: now + self.delay,
-            },
-            // Already counting down to dismiss and still moving: let the
-            // existing deadline stand (do not extend it on every move — a moving
-            // pointer should dismiss `delay` after motion *began*).
-            Phase::PendingDismiss {
-                at: shown_at,
-                deadline,
-            } => Phase::PendingDismiss {
-                at: shown_at,
-                deadline,
-            },
-        };
-        self.state()
-    }
-
-    /// Advance the machine to time `now`, resolving any pending show/dismiss
-    /// whose deadline has been reached. Idempotent and safe to call at any time.
-    ///
-    /// A `PendingShow` that matures becomes `Visible` at its resting position. A
-    /// `PendingDismiss` that matures becomes `Idle` (hidden) — the pointer was
-    /// still moving when the timer fired.
-    pub fn tick(&mut self, now: Instant) -> TooltipState {
-        self.phase = match self.phase {
-            Phase::PendingShow { at, deadline } if now >= deadline => Phase::Visible { at },
-            Phase::PendingDismiss { deadline, .. } if now >= deadline => Phase::Idle,
-            other => other,
-        };
-        self.state()
+        self.release_position_if_hidden(now);
+        self.state(now)
     }
 
     /// Note that the pointer has come to rest at `at` at time `now` (an explicit
-    /// "settled" signal, e.g. from a rest-detection timer). This is a
-    /// convenience over [`Self::on_pointer_moved`] for callers that detect rest
-    /// out-of-band: it relocates a visible tooltip immediately (cancelling any
-    /// dismissal, no new delay) and, if hidden, arms the show timer.
+    /// "settled" signal, e.g. from a rest-detection timer). Aims the fade toward
+    /// full opacity when resting at (or near) the captured position, or lets an
+    /// old tooltip finish fading out before capturing a new spot; see [`Self::rest_at`].
     pub fn on_pointer_rested(&mut self, at: Vector2F, now: Instant) -> TooltipState {
-        self.tick(now);
         self.last_position = Some(at);
-        self.phase = match self.phase {
-            // Rest before the dismissal fired: cancel it and relocate the
-            // already-visible tooltip. No new show delay — it was already paid.
-            Phase::PendingDismiss { .. } | Phase::Visible { .. } => Phase::Visible { at },
-            // Hidden: normal show path. Arm the show timer at the resting spot.
-            Phase::Idle | Phase::PendingShow { .. } => Phase::PendingShow {
-                at,
-                deadline: now + self.delay,
-            },
-        };
-        self.state()
+        self.rest_at(at, now);
+        self.release_position_if_hidden(now);
+        self.state(now)
     }
 
-    /// The pointer has left the target entirely: dismiss immediately, with no
-    /// delay, and forget any pending timers and the last sampled position.
-    pub fn on_pointer_left(&mut self) -> TooltipState {
-        self.phase = Phase::Idle;
+    /// Shared "the pointer is at rest at `at`" handling, honoring the
+    /// single-instance relocation rule:
+    ///
+    /// - Fully hidden (opacity 0): capture `at` and fade in from zero.
+    /// - Visible at (or within jitter of) the captured position: reverse toward
+    ///   full opacity in place — this is a re-rest at the same spot.
+    /// - Visible but `at` is a *different* spot: do **not** reverse; keep the
+    ///   fade heading toward zero so the old tooltip finishes fading out at its
+    ///   position, after which a later rest sample (now from zero) captures the
+    ///   new spot. This is the single-tooltip-instance consequence — two
+    ///   simultaneously-visible instances at different positions can't be shown.
+    fn rest_at(&mut self, at: Vector2F, now: Instant) {
+        let opacity = self.opacity_at(now);
+        if opacity <= 0.0 {
+            // Fade in from zero at the fresh rest position.
+            self.position = Some(at);
+            self.retarget(now, 1.0, self.base_rate());
+            return;
+        }
+
+        // Visible: reverse toward full only if resting at the pinned position.
+        let same_spot = self
+            .position
+            .is_some_and(|pinned| (at - pinned).length() <= self.jitter_threshold);
+        if same_spot {
+            self.retarget(now, 1.0, self.base_rate());
+        } else {
+            // Rest at a new spot while the old is still visible: let it finish
+            // fading out first (do not reverse, do not slide).
+            self.retarget(now, 0.0, self.base_rate());
+        }
+    }
+
+    /// The pointer has left the target entirely: fade toward hidden at the faster
+    /// exit rate ([`EXIT_FADE_RATE_MULTIPLIER`]×), reversing from the current
+    /// opacity, and forget the last sampled position. The captured anchor
+    /// position stays pinned until the fade-out completes.
+    pub fn on_pointer_left(&mut self, now: Instant) -> TooltipState {
         self.last_position = None;
-        self.state()
+        self.retarget(now, 0.0, self.base_rate() * EXIT_FADE_RATE_MULTIPLIER);
+        self.release_position_if_hidden(now);
+        self.state(now)
     }
 }
 
@@ -277,7 +359,7 @@ mod tests {
     use super::*;
 
     const D: Duration = Duration::from_millis(500);
-    const JITTER: f32 = 3.0;
+    const JITTER: f32 = 6.0;
 
     fn machine() -> TooltipHysteresis {
         TooltipHysteresis::new(D, JITTER)
@@ -287,273 +369,299 @@ mod tests {
         Vector2F::new(x, y)
     }
 
-    /// Spec point 2: pointer comes to rest over the target; after D the tooltip
-    /// appears at the pointer position.
+    /// Opacity helper: assert two f32s are within a small epsilon. The tolerance
+    /// absorbs the float rounding of `Duration::as_secs_f32` scaled by the rate
+    /// (a 500 ms fade lands within a few thousandths of its target).
+    fn approx(a: f32, b: f32) {
+        assert!((a - b).abs() < 5e-3, "expected {a} ≈ {b}");
+    }
+
+    /// The fade-in *is* the rest delay: opacity rises linearly from 0 the instant
+    /// the pointer comes to rest, reaching full at exactly `D` — no invisible
+    /// waiting period first.
     #[test]
-    fn rest_shows_after_delay_at_pointer() {
+    fn fade_in_is_the_rest_delay_monotonic_from_zero() {
         let mut m = machine();
         let t0 = Instant::now();
 
-        // Arrival is "movement" (no predecessor) → arms the show timer.
+        // Arrival is motion (no predecessor): still hidden, target 0.
         assert_eq!(m.on_pointer_moved(at(10., 20.), t0), TooltipState::Hidden);
-        // Held still (jitter) before the deadline: still hidden.
-        assert_eq!(
-            m.on_pointer_moved(at(11., 21.), t0 + Duration::from_millis(100)),
-            TooltipState::Hidden
-        );
-        // Just before the deadline: still hidden.
-        assert_eq!(
-            m.tick(t0 + Duration::from_millis(499)),
-            TooltipState::Hidden
-        );
-        // At the deadline: shows at the resting position.
-        assert_eq!(m.tick(t0 + D), TooltipState::Visible { at: at(10., 20.) });
-    }
-
-    /// The show anchors at where the pointer actually came to rest, not where it
-    /// first entered — re-arming tracks the latest resting spot.
-    #[test]
-    fn show_anchors_at_final_resting_position() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        m.on_pointer_moved(at(10., 10.), t0);
-        // Real move to a new spot re-arms the timer at the new position.
-        m.on_pointer_moved(at(50., 60.), t0 + Duration::from_millis(200));
-        // Not yet D since the *second* rest began.
-        assert_eq!(
-            m.tick(t0 + Duration::from_millis(600)),
-            TooltipState::Hidden
-        );
-        assert_eq!(
-            m.tick(t0 + Duration::from_millis(700)),
-            TooltipState::Visible { at: at(50., 60.) }
-        );
-    }
-
-    /// Spec point 4: pointer moves while visible, then comes to rest again
-    /// before the dismissal timer fires → dismissal cancelled and the tooltip
-    /// relocates to the new position with no additional delay.
-    #[test]
-    fn rest_before_dismissal_relocates_without_delay() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        // Show it.
-        m.on_pointer_moved(at(10., 10.), t0);
-        assert!(m.tick(t0 + D).is_visible());
-
-        // Move → arms dismissal at t = D + 300 + D.
-        let t_move = t0 + D + Duration::from_millis(300);
-        assert_eq!(
-            m.on_pointer_moved(at(80., 90.), t_move),
-            TooltipState::Visible { at: at(10., 10.) },
-            "anchor stays pinned while dismissing"
-        );
-
-        // Rest again before the dismissal deadline: relocate immediately.
-        let t_rest = t_move + Duration::from_millis(200);
-        assert_eq!(
-            m.on_pointer_rested(at(80., 90.), t_rest),
-            TooltipState::Visible { at: at(80., 90.) },
-            "relocated with no new delay"
-        );
-        // The prior dismissal deadline must not fire anymore.
-        assert_eq!(
-            m.tick(t_move + D + Duration::from_millis(1)),
-            TooltipState::Visible { at: at(80., 90.) }
-        );
-    }
-
-    /// Spec point 3: pointer keeps moving while visible; the dismissal timer
-    /// completes and the tooltip dismisses.
-    #[test]
-    fn sustained_movement_dismisses_after_delay() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        m.on_pointer_moved(at(10., 10.), t0);
-        assert!(m.tick(t0 + D).is_visible());
-
-        // Start moving → arms dismissal D from now.
-        let t_move = t0 + D + Duration::from_millis(100);
-        m.on_pointer_moved(at(40., 40.), t_move);
-        // Keep moving; deadline should not extend on each move.
-        m.on_pointer_moved(at(70., 70.), t_move + Duration::from_millis(200));
-        m.on_pointer_moved(at(100., 100.), t_move + Duration::from_millis(400));
-        // Just before dismissal deadline (t_move + D): still visible.
+        // Hold still: the pointer is now at rest and the fade-in begins at once
+        // (opacity is exactly 0 at the retarget instant, then rises immediately).
+        let t_rest = t0 + Duration::from_millis(1);
+        m.on_pointer_moved(at(11., 21.), t_rest);
+        // A hair after the rest instant, opacity is already positive — no
+        // invisible waiting period before the fade begins.
         assert!(
-            m.tick(t_move + D - Duration::from_millis(1)).is_visible(),
-            "still visible just before dismissal"
+            m.opacity(t_rest + Duration::from_millis(1)) > 0.0,
+            "fade-in begins immediately on rest, not after a delay"
         );
-        // At the deadline: dismissed.
-        assert_eq!(m.tick(t_move + D), TooltipState::Hidden);
+
+        // Monotonically rising toward full over D, measured from the rest instant.
+        approx(m.opacity(t_rest + Duration::from_millis(125)), 0.25);
+        approx(m.opacity(t_rest + Duration::from_millis(250)), 0.50);
+        approx(m.opacity(t_rest + Duration::from_millis(500)), 1.0);
+        // Clamped at full past the deadline.
+        approx(m.opacity(t_rest + Duration::from_millis(900)), 1.0);
+        // The captured anchor is the pointer's rest position (11,21).
+        assert_eq!(
+            m.state(t_rest + Duration::from_millis(500)).position(),
+            Some(at(11., 21.))
+        );
+        approx(m.state(t_rest + Duration::from_millis(500)).opacity(), 1.0);
     }
 
-    /// A dismissal deadline is measured from when motion *began*, not extended by
-    /// each subsequent move — a continuously-moving pointer dismisses on schedule.
+    /// The position is captured at the pointer's rest spot when the fade-in
+    /// starts from zero, and stays fixed while opacity > 0 — no sliding.
     #[test]
-    fn dismissal_deadline_not_extended_by_continued_motion() {
+    fn position_captured_at_zero_start_and_pinned_while_visible() {
         let mut m = machine();
         let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        // Rest: captures the rest-sample position (12,12) as the anchor and begins
+        // fading in (the capture is where the pointer is seen to hold still).
+        let t_rest = t0 + Duration::from_millis(1);
+        m.on_pointer_moved(at(12., 12.), t_rest);
+        approx(m.opacity(t_rest + Duration::from_millis(250)), 0.5);
+        // Another rest sample nearby (within jitter) must NOT move the anchor.
+        let s = m.on_pointer_moved(at(14., 14.), t_rest + Duration::from_millis(300));
+        assert_eq!(
+            s.position(),
+            Some(at(12., 12.)),
+            "anchor pinned while visible"
+        );
+    }
+
+    /// Fade-out from full opacity takes the full `D` (`p·D` with `p = 1`), rising
+    /// then falling symmetrically.
+    #[test]
+    fn fade_out_from_full_takes_full_delay() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        m.on_pointer_moved(at(11., 11.), t0 + Duration::from_millis(1)); // rest → fade in
+        approx(m.opacity(t0 + D), 1.0);
+
+        // Real move at full opacity → fade out begins from 1.0.
+        let t_move = t0 + D;
+        m.on_pointer_moved(at(60., 60.), t_move);
+        approx(m.opacity(t_move + Duration::from_millis(250)), 0.5);
+        approx(m.opacity(t_move + D), 0.0);
+        assert_eq!(m.state(t_move + D), TooltipState::Hidden);
+    }
+
+    /// Fade-out from a *partial* opacity `p` takes `p·D`: moving while the
+    /// tooltip is only 40% faded-in clears it in `0.4·D`, reversing from 0.4 (not
+    /// from 1.0).
+    #[test]
+    fn fade_out_from_partial_takes_p_times_delay_reversing_from_current() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        m.on_pointer_moved(at(11., 11.), t0 + Duration::from_millis(1)); // rest → fade in
+        // At +200ms, opacity ≈ 0.4.
+        let t_move = t0 + Duration::from_millis(201);
+        approx(m.opacity(t_move), 0.4);
+
+        // Move → reverse from 0.4 toward 0 at the same rate: reaches 0 in 0.4·D = 200ms.
+        m.on_pointer_moved(at(80., 80.), t_move);
+        approx(m.opacity(t_move), 0.4);
+        approx(m.opacity(t_move + Duration::from_millis(100)), 0.2);
+        approx(m.opacity(t_move + Duration::from_millis(200)), 0.0);
+        assert_eq!(
+            m.state(t_move + Duration::from_millis(200)),
+            TooltipState::Hidden
+        );
+    }
+
+    /// Re-resting at the *same* captured position mid-fade-out reverses back
+    /// toward full from the current opacity, keeping the pinned position (a
+    /// jitter-scale wobble that resolves as staying put).
+    #[test]
+    fn rest_at_same_spot_mid_fade_out_reverses_from_current() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        // The rest sample (11,11) is captured as the pinned anchor.
+        let t_rest0 = t0 + Duration::from_millis(1);
+        m.on_pointer_moved(at(11., 11.), t_rest0); // rest → fade in
+        approx(m.opacity(t_rest0 + D), 1.0);
+
+        // A brief wobble beyond jitter starts a fade-out (target 0).
+        let t_move = t_rest0 + D;
+        m.on_pointer_moved(at(21., 11.), t_move); // 10px from (11,11) → motion
+        approx(m.opacity(t_move + Duration::from_millis(250)), 0.5);
+
+        // Rest again back at the pinned spot (within jitter of (11,11)) at +250ms
+        // (opacity 0.5) → reverse toward full from 0.5, same position.
+        let t_rest = t_move + Duration::from_millis(250);
+        let s = m.on_pointer_rested(at(11., 11.), t_rest);
+        approx(s.opacity(), 0.5);
+        assert_eq!(
+            s.position(),
+            Some(at(11., 11.)),
+            "position stays pinned while visible"
+        );
+        // Rises back to full over the next 0.5·D = 250ms.
+        approx(m.opacity(t_rest + Duration::from_millis(250)), 1.0);
+    }
+
+    /// Single-instance relocation: resting at a *new* spot while the old tooltip
+    /// is still visible does NOT reverse it in place — the old finishes fading
+    /// out at its position, and only a rest sample taken once fully hidden
+    /// captures the new spot and fades in there.
+    #[test]
+    fn rest_at_new_spot_while_visible_defers_until_faded_out() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        // The rest sample (11,11) is captured as the pinned anchor.
+        let t_rest0 = t0 + Duration::from_millis(1);
+        m.on_pointer_moved(at(11., 11.), t_rest0); // rest at (11,11)
+        approx(m.opacity(t_rest0 + D), 1.0);
+
+        // Move to a far spot, then hold still there while the old is still up.
+        let t_move = t_rest0 + D;
+        m.on_pointer_moved(at(200., 200.), t_move); // motion → fade out from full
+        // Hold still at the new spot mid-fade-out: must NOT reverse (old still
+        // pinned at (11,11)); keeps fading out toward 0.
+        let s = m.on_pointer_moved(at(201., 201.), t_move + Duration::from_millis(100));
+        assert_eq!(
+            s.position(),
+            Some(at(11., 11.)),
+            "old position pinned, not relocated yet"
+        );
+        assert!(s.opacity() < 1.0, "still fading out, not reversed");
+
+        // Let it fully fade out.
+        assert_eq!(m.state(t_move + D), TooltipState::Hidden);
+
+        // Now (fully hidden) a rest sample at the new spot captures it and fades in.
+        let t_new = t_move + D;
+        m.on_pointer_moved(at(202., 202.), t_new + Duration::from_millis(1)); // rest (jitter vs 201) → capture
+        let s = m.state(t_new + Duration::from_millis(2));
+        assert_eq!(
+            s.position(),
+            Some(at(202., 202.)),
+            "new position captured after full fade-out"
+        );
+        assert!(s.opacity() > 0.0, "fading in at the new spot");
+    }
+
+    /// Leaving the target fades out faster than symmetric (3× rate): a
+    /// full-opacity tooltip clears in `D / 3`, still animated (not instant).
+    #[test]
+    fn exit_fades_out_at_faster_rate() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        m.on_pointer_moved(at(11., 11.), t0 + Duration::from_millis(1)); // rest → fade in
+        approx(m.opacity(t0 + D), 1.0);
+
+        // Leave: fade out at 3× → reaches 0 in D/3 ≈ 166.7ms.
+        let t_left = t0 + D;
+        let s = m.on_pointer_left(t_left);
+        approx(s.opacity(), 1.0);
+        approx(m.opacity(t_left + Duration::from_millis(83)), 0.5);
+        approx(m.opacity(t_left + Duration::from_millis(167)), 0.0);
+        assert_eq!(
+            m.state(t_left + Duration::from_millis(167)),
+            TooltipState::Hidden
+        );
+    }
+
+    /// Sub-threshold movement (≤ jitter) counts as rest, so a visible tooltip
+    /// keeps fading toward full and is not relocated by hand-tremor samples. The
+    /// 6px threshold tolerates a larger tremor than the original 3px.
+    #[test]
+    fn jitter_within_six_px_counts_as_rest() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        m.on_pointer_moved(at(10., 10.), t0);
+        // The rest sample (11,11) is captured as the pinned anchor.
+        let t_rest0 = t0 + Duration::from_millis(1);
+        m.on_pointer_moved(at(11., 11.), t_rest0); // rest → fade in
+        approx(m.opacity(t_rest0 + D), 1.0);
+
+        // A ~4.5px move (≤ 6px threshold) is jitter: stays at rest (target 1),
+        // not faded out, anchor unchanged at the pinned (11,11).
+        let s = m.on_pointer_moved(at(15., 13.), t_rest0 + D + Duration::from_millis(50)); // dist=~4.47
+        assert_eq!(s.position(), Some(at(11., 11.)));
+        approx(s.opacity(), 1.0);
+
+        // A ~7px move (> 6px) IS motion: begins a fade-out.
+        let t_move = t_rest0 + D + Duration::from_millis(100);
+        let s = m.on_pointer_moved(at(20., 18.), t_move); // dist from (15,13) = ~7.07
+        approx(s.opacity(), 1.0);
+        assert!(
+            m.opacity(t_move + Duration::from_millis(250)) < 1.0,
+            "fading out after real move"
+        );
+    }
+
+    /// `on_pointer_rested` on a hidden machine begins a fade-in from zero (does
+    /// not snap to full), capturing the rest position.
+    #[test]
+    fn explicit_rest_while_hidden_begins_fade_in() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        let s = m.on_pointer_rested(at(5., 5.), t0);
+        approx(s.opacity(), 0.0);
+        approx(m.opacity(t0 + Duration::from_millis(250)), 0.5);
+        let s = m.state(t0 + D);
+        assert_eq!(
+            s,
+            TooltipState::Visible {
+                at: at(5., 5.),
+                opacity: 1.0
+            }
+        );
+    }
+
+    /// `next_deadline` reports when the current fade completes, and nothing once
+    /// settled at the target, so a driver can schedule exactly one settle timer.
+    #[test]
+    fn next_deadline_reports_fade_completion() {
+        let mut m = machine();
+        let t0 = Instant::now();
+        assert_eq!(m.next_deadline(), None, "settled hidden: no fade");
+
         m.on_pointer_moved(at(0., 0.), t0);
-        assert!(m.tick(t0 + D).is_visible());
-
-        let t_move = t0 + D;
-        m.on_pointer_moved(at(20., 0.), t_move);
-        // A later move well before the deadline must not push it out.
-        m.on_pointer_moved(at(40., 0.), t_move + Duration::from_millis(499));
-        assert_eq!(m.tick(t_move + D), TooltipState::Hidden);
-    }
-
-    /// Spec point 6: leaving the target dismisses immediately, no delay, from any
-    /// visible or pending state.
-    #[test]
-    fn leaving_dismisses_immediately() {
-        // From Visible.
-        let mut m = machine();
-        let t0 = Instant::now();
-        m.on_pointer_moved(at(10., 10.), t0);
-        assert!(m.tick(t0 + D).is_visible());
-        assert_eq!(m.on_pointer_left(), TooltipState::Hidden);
-
-        // From PendingShow.
-        let mut m = machine();
-        m.on_pointer_moved(at(10., 10.), t0);
-        assert_eq!(m.on_pointer_left(), TooltipState::Hidden);
-
-        // From PendingDismiss.
-        let mut m = machine();
-        m.on_pointer_moved(at(10., 10.), t0);
-        m.tick(t0 + D);
-        m.on_pointer_moved(at(40., 40.), t0 + D + Duration::from_millis(50));
-        assert_eq!(m.on_pointer_left(), TooltipState::Hidden);
-    }
-
-    /// Spec point 5: after a dismissal, resting again takes the normal show path
-    /// (full delay D, appears at the new position).
-    #[test]
-    fn rest_after_dismissal_uses_full_show_delay() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        m.on_pointer_moved(at(10., 10.), t0);
-        assert!(m.tick(t0 + D).is_visible());
-
-        // Dismiss via sustained movement.
-        let t_move = t0 + D;
-        m.on_pointer_moved(at(40., 40.), t_move);
-        assert_eq!(m.tick(t_move + D), TooltipState::Hidden);
-
-        // Rest at a new spot: must take the full delay again.
-        let t_rest = t_move + D + Duration::from_millis(100);
-        m.on_pointer_moved(at(200., 200.), t_rest);
-        assert_eq!(
-            m.tick(t_rest + D - Duration::from_millis(1)),
-            TooltipState::Hidden,
-            "must pay the full show delay after a dismissal"
+        let t_rest = t0 + Duration::from_millis(1);
+        m.on_pointer_moved(at(1., 1.), t_rest); // rest → fade in over D
+        let deadline = m.next_deadline().expect("fade in progress");
+        // Completes ~D after the rest sample.
+        let expected = t_rest + D;
+        assert!(
+            deadline.saturating_duration_since(expected) < Duration::from_millis(2)
+                && expected.saturating_duration_since(deadline) < Duration::from_millis(2),
+            "fade-in completion deadline"
         );
-        assert_eq!(
-            m.tick(t_rest + D),
-            TooltipState::Visible { at: at(200., 200.) }
-        );
-    }
 
-    /// Sub-jitter-threshold movement does not count as motion: a visible tooltip
-    /// stays visible and is not relocated by hand-tremor-scale samples.
-    #[test]
-    fn jitter_does_not_dismiss_or_relocate() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        m.on_pointer_moved(at(10., 10.), t0);
-        assert!(m.tick(t0 + D).is_visible());
-
-        // A 2px move (< 3px threshold) is jitter: no dismissal armed, anchor
-        // unchanged.
-        assert_eq!(
-            m.on_pointer_moved(at(12., 10.), t0 + D + Duration::from_millis(100)),
-            TooltipState::Visible { at: at(10., 10.) }
-        );
+        // Once fully faded in, no deadline.
+        // (Sample past the deadline re-anchors nothing; next_deadline is derived
+        // from the segment, which still points at target 1 with anchor < 1 until
+        // re-sampled — so advance via a rest sample at full to settle it.)
+        m.on_pointer_moved(at(2., 2.), t_rest + D); // still rest (jitter) at full
         assert_eq!(
             m.next_deadline(),
             None,
-            "no dismissal timer armed by jitter"
+            "settled at full opacity: no further fade"
         );
     }
 
-    /// A jitter (hold-still) sample arriving while counting down to dismiss is
-    /// read as the pointer coming to rest again, and relocates the still-visible
-    /// tooltip with no new delay — the production re-rest path, since the window
-    /// re-dispatches the last move on each redraw and two same-spot samples read
-    /// as "stopped here".
+    /// `is_animating` is true during a fade and false once settled at the target.
     #[test]
-    fn jitter_sample_during_pending_dismiss_relocates() {
+    fn is_animating_tracks_fade_progress() {
         let mut m = machine();
         let t0 = Instant::now();
-        m.on_pointer_moved(at(10., 10.), t0);
-        assert!(m.tick(t0 + D).is_visible());
-
-        // Real move → PendingDismiss (anchor still pinned at the old spot).
-        let t_move = t0 + D;
-        assert_eq!(
-            m.on_pointer_moved(at(60., 60.), t_move),
-            TooltipState::Visible { at: at(10., 10.) }
-        );
-        // Hold still near the new spot (within jitter) → re-rest → relocate to the
-        // held position, before the dismissal deadline.
-        assert_eq!(
-            m.on_pointer_moved(at(61., 61.), t_move + Duration::from_millis(50)),
-            TooltipState::Visible { at: at(61., 61.) }
-        );
-        assert_eq!(m.next_deadline(), None, "dismissal cancelled by re-rest");
-    }
-
-    /// `on_pointer_rested` on a hidden machine arms the show timer (does not show
-    /// instantly) — the explicit-rest entry point still honors the show delay
-    /// when nothing is visible yet.
-    #[test]
-    fn explicit_rest_while_hidden_arms_show_timer() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        assert_eq!(m.on_pointer_rested(at(5., 5.), t0), TooltipState::Hidden);
-        assert_eq!(
-            m.tick(t0 + D - Duration::from_millis(1)),
-            TooltipState::Hidden
-        );
-        assert_eq!(m.tick(t0 + D), TooltipState::Visible { at: at(5., 5.) });
-    }
-
-    /// A pointer sample that arrives after its show deadline still resolves to a
-    /// show at that sample time (deadlines are resolved on the next input, not
-    /// only by an external tick).
-    #[test]
-    fn late_sample_resolves_pending_show() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        m.on_pointer_moved(at(10., 10.), t0);
-        // Next sample arrives well after the deadline, still at rest (jitter).
-        assert_eq!(
-            m.on_pointer_moved(at(11., 11.), t0 + D + Duration::from_millis(50)),
-            TooltipState::Visible { at: at(10., 10.) }
-        );
-    }
-
-    /// `next_deadline` reports the pending show/dismiss instant and nothing in
-    /// the steady states, so a driver can schedule exactly one timer.
-    #[test]
-    fn next_deadline_tracks_pending_phases() {
-        let mut m = machine();
-        let t0 = Instant::now();
-        assert_eq!(m.next_deadline(), None, "idle has no deadline");
-
         m.on_pointer_moved(at(0., 0.), t0);
-        assert_eq!(m.next_deadline(), Some(t0 + D), "pending-show deadline");
-
-        m.tick(t0 + D);
-        assert_eq!(m.next_deadline(), None, "visible steady state");
-
-        let t_move = t0 + D + Duration::from_millis(10);
-        m.on_pointer_moved(at(30., 0.), t_move);
-        assert_eq!(
-            m.next_deadline(),
-            Some(t_move + D),
-            "pending-dismiss deadline"
+        let t_rest = t0 + Duration::from_millis(1);
+        m.on_pointer_moved(at(1., 1.), t_rest); // fade in
+        assert!(
+            m.is_animating(t_rest + Duration::from_millis(100)),
+            "mid fade-in"
         );
+        assert!(!m.is_animating(t_rest + D), "settled at full");
     }
 }

--- a/crates/warpui_core/src/scene.rs
+++ b/crates/warpui_core/src/scene.rs
@@ -664,6 +664,20 @@ impl Scene {
         self.layers.len() + self.overlay_layers.len()
     }
 
+    /// Get the number of overlay layers. Overlay layers float above the normal
+    /// (in-flow) layers, so a positioned overlay child contributes here rather
+    /// than to the normal layers that establish document flow.
+    #[cfg(test)]
+    pub fn overlay_layer_count(&self) -> usize {
+        self.overlay_layers.len()
+    }
+
+    /// Iterate over just the normal (in-flow) layers, excluding overlay layers.
+    #[cfg(test)]
+    pub fn normal_layers(&self) -> impl Iterator<Item = &Layer> {
+        self.layers.iter()
+    }
+
     pub fn scale_factor(&self) -> f32 {
         self.scale_factor
     }


### PR DESCRIPTION
Closes #13981

## Description

Failed Markdown image loads previously rendered as an invisible empty box: the shared editor image renderer built its `Image` element without configuring the `on_load_failure` fallback the element already supported, so the `FailedToLoad` paint path had nothing to draw. Meanwhile the image's alt text was parsed and carried on `BlockItem::Image` end-to-end — and never consumed anywhere.

This PR makes alt text do its three jobs, per the issue's acceptance criteria:

**Broken-image placeholder.** A failed load renders a broken-image glyph plus the image's alt text, with a generic "Image failed to load" notice when alt is empty or whitespace-only. A themeable `BrokenImageStyle` (mirroring `BrokenLinkStyle`, modeled on [`broken_embedding.rs`](https://github.com/warpdotdev/warp/blob/master/crates/editor/src/render/element/broken_embedding.rs)) carries the glyph and color, using `image-01.svg` so the affordance reads as an image rather than a broken link.

**Alt text as a hover tooltip**, behaving like a browser `title` tooltip with a fade model: opacity eases toward full while the pointer rests over the image (loaded or placeholder) and toward zero while it moves or leaves. The fade-in *is* the rest delay — no invisible waiting period — the rate is symmetric (a fade-out from partial opacity takes proportionally less time, and mid-fade movement reverses from the current opacity instead of popping), position is captured at the pointer per fade-in, and leaving the image fades out at 3× so dismissal feels prompt. A pure, clock-injected `TooltipHysteresis` state machine drives it via short redraw timers, reserving zero document-layout space (pinned by a scene-level layout-invariance test). Timing and jitter tolerance are named constants (`TOOLTIP_POINTER_FADE_DELAY` = 300ms, `TOOLTIP_JITTER_THRESHOLD` = 6px) — open to feedback on how exactly it feels in use.

**Alt text in the accessibility pipeline.** The rich-text editor view (shared by notebooks and the markdown viewer) folds each image's alt text into its `accessibility_contents` announcement, prefixed "Image:" and tagged with the image role, reaching screen readers through Warp's existing focus-driven announcement pipeline. Per browser semantics for decorative images, empty/whitespace alt (`![](src)`) is omitted entirely — the `alt=""` → `role="presentation"` equivalent. Warp's accessibility model is a single per-view announcement rather than a per-element tree, so this is the integration the framework supports today; a per-element accessibility tree is separate, larger framework work.

Raw-HTML `<img>` (#13721) is not yet rendered by the viewer, but its in-progress implementation constructs the same `BlockItem::Image` with `alt_text` populated — when it lands, `<img alt="…">` inherits the placeholder, tooltip, and accessibility behavior automatically.

## Testing

- Unit tests: placeholder label selection (present / trimmed / empty / whitespace); `Image` element failure-fallback selection; announcement construction (included / omitted / no-announcement); tooltip presence conditions; 11 clock-injected `TooltipHysteresis` fade tests (fade-in-is-the-delay, reversal from partial opacity, proportional fade-out, position pinning, jitter tolerance, fast exit).
- Scene-level tests on the real wiring: zero layout-flow impact on hover, positions-at-pointer, shows-after-rest, fades-on-exit, relocates-on-re-rest.
- `cargo nextest run -p warp` (full app suite) plus `warp_editor`/`warpui_core`/`warp_core` suites: all pass. Clippy zero warnings; `cargo fmt --check` clean.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).
- [x] I have manually tested my changes locally with `./script/run` (dev-build verification of placeholder rendering and tooltip feel; captures below)

### Screenshots

<details><summary>Test document used for the captures</summary>

```markdown
# Broken-image placeholder (GH13981)

Should render: failed image loads show a broken-image glyph + the alt text; generic "Image failed to load" when alt is empty.
Currently expect (master): an invisible empty box occupying the image's layout size.

## Alt text present

![A red bicycle](https://example.com/definitely-missing.png)

## Alt text empty (generic fallback)

![](https://example.com/also-missing.png)

## Whitespace-only alt (generic fallback)

![   ](https://example.com/missing-again.png)

## Control: working image (local, no network dependency)

![Local gradient control](control-image.png)

## Broken image mid-document (layout check)

Text before the broken image.

![Diagram of the flux capacitor](https://example.com/flux.png)

Text after the broken image — spacing should look intentional, not like a gap.
```

</details>

Before/after of the test document (broken images with alt text, empty alt, whitespace alt, a working control, and a mid-document broken image):

<img width="1554" height="1470" alt="Screenshot of before/after of the markdown renderer with images that don't load" src="https://github.com/user-attachments/assets/4c3d55b9-dc91-4b78-af40-68605f541d0e" />

Screenshot of the tooltip as rendered
<img width="248" height="187" alt="Local control image tooltip screenshot" src="https://github.com/user-attachments/assets/c0e0ec1c-9149-4fc8-a1b1-fda48fd76057" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Failed image loads in the Markdown viewer now show a broken-image placeholder with the image's alt text; image alt text also appears as a hover tooltip and is announced through accessibility.


