### PR TITLE
Clear shell commands when starting a new TUI conversation

### DIFF
--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1654,6 +1654,10 @@ impl TerminalModel {
     pub fn block_list_mut(&mut self) -> &mut BlockList {
         &mut self.block_list
     }
+    /// Clears all completed blocks and resets the active block's screen.
+    pub fn clear_blocks(&mut self) {
+        self.block_list.clear_screen(ansi::ClearMode::ResetAndClear);
+    }
 
     pub fn remove_image_id_to_metadata_entry(&mut self, image_id: u32) {
         self.image_id_to_metadata.remove(&image_id);

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1654,6 +1654,7 @@ impl TerminalModel {
     pub fn block_list_mut(&mut self) -> &mut BlockList {
         &mut self.block_list
     }
+
     /// Clears all completed blocks and resets the active block's screen.
     pub fn clear_blocks(&mut self) {
         self.block_list.clear_screen(ansi::ClearMode::ResetAndClear);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -2620,6 +2620,9 @@ impl TuiTerminalSessionView {
                 }
                 self.cancel_active_conversation(ctx);
                 let terminal_surface_id = ctx.view_id();
+                self.transcript.update(ctx, |transcript, ctx| {
+                    transcript.clear_for_new_conversation(ctx);
+                });
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
                     history.clear_conversations_for_terminal_surface(terminal_surface_id, ctx);
                 });

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -5,7 +5,9 @@ use warp::tui_export::{
     AIConversationId, AgentViewEntryOrigin, BlockPadding, BlocklistAIHistoryModel,
     ConversationStatus, ConversationUsageTotals, Harness, InputType, PtyIntent, PtyIntentEvent,
     SizeInfo, SizeUpdate, export_conversation_markdown, register_tui_session_view_test_singletons,
+    slash_commands,
 };
+use warp_core::telemetry::testing::MockTelemetryContextProvider;
 use warp_editor::model::CoreEditorModel;
 use warpui::platform::WindowStyle;
 use warpui::{
@@ -90,6 +92,7 @@ fn inline_menu_padding_preserves_result_capacity() {
 
 fn focus_test_fixture(app: &mut App) -> FocusTestFixture {
     register_tui_session_view_test_singletons(app);
+    app.update(MockTelemetryContextProvider::register);
     add_test_semantic_selection(app);
     app.update(TuiAutoupdater::register);
     let (window_id, _) = app.update(|ctx| {
@@ -424,6 +427,46 @@ fn assert_footer_segments_absent(lines: &[String]) {
     );
 }
 
+#[test]
+fn new_slash_command_clears_shell_commands_from_transcript() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, _| {
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model.block_list_mut().set_bootstrapped();
+            terminal_model.simulate_block("echo before-new", "before-new\r\n");
+        });
+
+        view.read(&app, |view, ctx| {
+            assert!(!view.transcript.as_ref(ctx).is_empty());
+            assert!(
+                view.terminal_model
+                    .lock()
+                    .block_list()
+                    .blocks()
+                    .iter()
+                    .any(|block| block.command_to_string() == "echo before-new")
+            );
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.execute_tui_slash_command(&slash_commands::NEW, None, ctx);
+        });
+
+        view.read(&app, |view, ctx| {
+            assert!(
+                view.transcript.as_ref(ctx).is_empty(),
+                "/new should clear both agent and shell transcript blocks"
+            );
+            assert_eq!(
+                view.terminal_model.lock().block_list().blocks().len(),
+                1,
+                "/new should leave only the active prompt block"
+            );
+        });
+    });
+}
 #[test]
 fn orchestration_tab_icon_replaces_identity_only_while_active_or_blocked() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -467,6 +467,7 @@ impl TuiTranscriptView {
         self.clear_agent_blocks(ctx);
         self.viewport.scroll_to_end();
     }
+
     /// Clears agent and terminal blocks before starting a new conversation.
     pub(super) fn clear_for_new_conversation(&mut self, ctx: &mut ViewContext<Self>) {
         self.clear_agent_blocks(ctx);

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -467,6 +467,12 @@ impl TuiTranscriptView {
         self.clear_agent_blocks(ctx);
         self.viewport.scroll_to_end();
     }
+    /// Clears agent and terminal blocks before starting a new conversation.
+    pub(super) fn clear_for_new_conversation(&mut self, ctx: &mut ViewContext<Self>) {
+        self.clear_agent_blocks(ctx);
+        self.model.lock().clear_blocks();
+        self.viewport.scroll_to_end();
+    }
 
     fn mark_exchange_dirty(&mut self, exchange_id: AIAgentExchangeId, ctx: &mut ViewContext<Self>) {
         if let Some(view_id) = self.view_id_for_exchange(exchange_id, ctx) {


### PR DESCRIPTION
## Description

Fixes the TUI `/new` and `/agent` reset path so it clears terminal command blocks as well as agent blocks. The transcript now removes its rich-content registrations, resets the canonical terminal block list to the active prompt, and then starts the new conversation.

Adds a regression test that executes `/new` after a completed shell command and verifies only the active prompt block remains.

## Linked Issue

No linked issue.

## Testing

- [x] I have manually tested my changes locally with the authenticated dev TUI.

## Screenshots/video

https://www.loom.com/share/9d96f4bd250f424fa03b395c2b95b4a0

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/e44bdc67-d90b-43d7-81c8-eab252ee3a85_
_Run: https://oz.staging.warp.dev/runs/019f8523-1e01-7c7e-90a9-e1b4cbc02f59_
_This PR was generated with [Oz](https://warp.dev/oz)._
