### PR TITLE
fix: update shell-quote to resolve CVE-2026-13311

### DIFF
--- a/crates/warp_graphql_schema/package.json
+++ b/crates/warp_graphql_schema/package.json
@@ -16,6 +16,7 @@
   "resolutions": {
     "immutable": "3.8.3",
     "lodash": "4.18.1",
-    "@babel/core": "7.29.6"
+    "@babel/core": "7.29.6",
+    "shell-quote": "^1.9.0"
   }
 }

--- a/crates/warp_graphql_schema/yarn.lock
+++ b/crates/warp_graphql_schema/yarn.lock
@@ -2142,10 +2142,10 @@ setimmediate@^1.0.5:
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
-shell-quote@^1.7.3:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
-  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
+shell-quote@^1.7.3, shell-quote@^1.9.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.10.0.tgz#482033e192e4f5c07151521ffa03400ec71b1b0f"
+  integrity sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==
 
 signal-exit@^3.0.2:
   version "3.0.7"


### PR DESCRIPTION
## Summary
Resolves a high-severity DoS vulnerability in `shell-quote`, a transitive dev dependency in `crates/warp_graphql_schema` (pulled in via `@graphql-codegen/cli`).

- **Advisory:** [GHSA-395f-4hp3-45gv](https://github.com/advisories/GHSA-395f-4hp3-45gv) / [CVE-2026-13311](https://nvd.nist.gov/vuln/detail/CVE-2026-13311)
- **Dependabot alert:** https://github.com/warpdotdev/warp/security/dependabot/23
- **Issue:** Quadratic-complexity Denial of Service in `parse()` (CWE-407)
- **Vulnerable range:** `<= 1.8.4` (was resolving to `1.8.4`)
- **Fixed in:** `1.9.0`

## Changes
- `shell-quote` is a **transitive, development-scoped** dependency. Added a `shell-quote: ^1.9.0` entry to the `resolutions` block in `crates/warp_graphql_schema/package.json` (consistent with the existing resolutions there) and ran `yarn install` to regenerate the lockfile.
- `crates/warp_graphql_schema/yarn.lock` now resolves `shell-quote` to `1.10.0` (satisfies the parent `^1.7.3` constraint and is above the patched `1.9.0`).

## Verification
- Lockfile diff is isolated to the `shell-quote` entry (`1.8.4` -> `1.10.0`); no other packages changed.
- `yarn install` completes successfully.

_Conversation: https://staging.warp.dev/conversation/1b26270e-2c30-4f2a-a978-c0b1ea11f8ed_
_Run: https://oz.staging.warp.dev/runs/019f8567-e927-7331-b7ef-cb3a36ccf204_

_This PR was generated with [Oz](https://warp.dev/oz)._
