### PR TITLE
Bundle Warp TUI for Linux

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -515,8 +515,8 @@ jobs:
     name: Build Release (macOS TUI ${{ matrix.arch }})
     runs-on: macos-26-xlarge
     needs: prepare_release
-    # The Warp TUI is currently a dev-only, macOS-only artifact. Keep this job
-    # scoped to the dev channel; it rides the existing nightly dev cut.
+    # The Warp TUI is currently dev-only. Keep this job scoped to the dev
+    # channel; it rides the existing nightly dev cut.
     if: ${{ inputs.build_macos != false && inputs.channel == 'dev' }}
     timeout-minutes: 60
     strategy:
@@ -600,6 +600,91 @@ jobs:
         with:
           name: release-macos-tui-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
           path: warp-tui-${{ steps.get-config.outputs.channel }}-macos-${{ matrix.arch }}.tar.gz
+
+  release_linux_tui:
+    name: Build Release (Linux TUI ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    needs: prepare_release
+    # Keep Linux TUI artifacts dev-only and workflow-local until the server's
+    # download endpoint and installer accept Linux payloads.
+    if: ${{ inputs.build_linux != false && inputs.channel == 'dev' }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: namespace-profile-ubuntu-20-04
+          - arch: aarch64
+            runner: namespace-profile-ubuntu-20-04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/prepare_environment
+        with:
+          target_os: linux
+          is_self_hosted: false
+          ref: ${{ needs.prepare_release.outputs.release_branch }}
+          install_release_deps: true
+          ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
+
+      # Install gcc 10, as gcc 9.5 has a bug with memcmp that is incompatible
+      # with aws-lc-rs (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189).
+      - name: Install and configure gcc-10
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-10 g++-10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+          gcc --version
+          g++ --version
+
+      - name: Get channel configuration
+        id: get-config
+        uses: ./.github/actions/get_channel_config/
+        with:
+          config_file: ${{ env.CONFIG_FILE }}
+          channel: ${{ inputs.channel }}
+
+      # Namespace's User Bundled Cache persists target/ between jobs on the same profile.
+      - name: Clean stale bundle output
+        run: |
+          if [[ -d target ]]; then
+            find target -path '*/bundle/linux' -type d -prune -exec rm -rf {} +
+          fi
+        shell: bash
+
+      - name: Bundle TUI
+        id: bundle_tui
+        run: script/bundle --channel "$CHANNEL" --artifact tui --arch "${{ matrix.arch }}"
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+
+      - name: Package and validate TUI tarball
+        run: |
+          archive="warp-tui-${CHANNEL}-linux-${{ matrix.arch }}.tar.gz"
+          bundle_dir="$(dirname "${{ steps.bundle_tui.outputs.executable_path }}")"
+          tar czf "$archive" -C "$bundle_dir" "warp-tui-${CHANNEL}" resources
+
+          test -x "$bundle_dir/warp-tui-${CHANNEL}"
+          test -s "$bundle_dir/resources/settings_schema.json"
+          test -s "$bundle_dir/resources/THIRD_PARTY_LICENSES.txt"
+          grep -q "\"warp_version\": \"${GIT_RELEASE_TAG}\"" \
+            "$bundle_dir/resources/bundled/metadata/version.json"
+          tar tzf "$archive" | grep -qx "warp-tui-${CHANNEL}"
+          tar tzf "$archive" | grep -qx "resources/settings_schema.json"
+          tar tzf "$archive" | grep -qx "resources/THIRD_PARTY_LICENSES.txt"
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+
+      - name: Upload TUI as workflow artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: release-linux-tui-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
+          path: warp-tui-${{ steps.get-config.outputs.channel }}-linux-${{ matrix.arch }}.tar.gz
 
   release_linux_x86:
     name: Build Release (Linux x86_64)
@@ -1661,6 +1746,7 @@ jobs:
       - release_macos_universal
       - release_macos_cli
       - release_macos_tui
+      - release_linux_tui
       - release_linux_x86
       - release_linux_arm
       - release_linux_cli_x86
@@ -1686,6 +1772,9 @@ jobs:
           # failure there (it is intentionally skipped elsewhere).
           if [[ ${{ needs.release_macos_tui.result }} != 'success' && ${{ inputs.channel }} == 'dev' ]]; then
             FAILED+=('MacOS TUI')
+          fi
+          if [[ ${{ needs.release_linux_tui.result }} != 'success' && ${{ inputs.channel }} == 'dev' ]]; then
+            FAILED+=('Linux TUI')
           fi
           if [[ ${{ needs.release_linux_x86.result }} != 'success' ]]; then
               FAILED+=("Linux x86_64")

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -85,8 +85,8 @@ while (( "$#" )); do
       ;;
     --artifact)
       if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-        if [[ "$2" != "app" && "$2" != "cli" && "$2" != "warpctrl" ]]; then
-          echo "Error: --artifact must be 'app', 'cli', or 'warpctrl', got '$2'" >&2
+        if [[ "$2" != "app" && "$2" != "cli" && "$2" != "warpctrl" && "$2" != "tui" ]]; then
+          echo "Error: --artifact must be 'app', 'cli', 'warpctrl', or 'tui', got '$2'" >&2
           exit 1
         fi
         ARTIFACT="$2"
@@ -120,6 +120,25 @@ done
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
 
+# TUI Linux bundles use the native GNU target because their clipboard backends
+# link against host Wayland/X11 libraries. Refuse to compile on a different
+# architecture so an x86 binary can never be published under an ARM filename
+# (or vice versa). Packaging-only runs may still stage a prebuilt native binary.
+if [[ "$ARTIFACT" == "tui" && "$BUILD" == "true" ]]; then
+  case "$(uname -m)" in
+    arm64|aarch64) HOST_ARCH="aarch64" ;;
+    x86_64|amd64) HOST_ARCH="x86_64" ;;
+    *)
+      echo "Error: Unsupported native TUI build architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+  if [[ "$BUILD_ARCH" != "$HOST_ARCH" ]]; then
+    echo "Error: TUI bundles must be built natively; requested '$BUILD_ARCH' on '$HOST_ARCH'." >&2
+    exit 1
+  fi
+fi
+
 # Statically compile the CLI and warpctrl artifacts so they can run on older Linux distros.
 if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   TARGET_TRIPLE="${BUILD_ARCH}-unknown-linux-musl"
@@ -144,13 +163,13 @@ elif [[ $RELEASE_CHANNEL = "local" || $RELEASE_CHANNEL = "dev" ]]; then
   # For dev bundles, we want to enable debug assertions to
   # catch violations that would otherwise silently pass in
   # a normal release build (e.g. in stable).
-  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
+  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" || "$ARTIFACT" == "tui" ]]; then
     CARGO_PROFILE="release-cli-debug_assertions"
   else
     CARGO_PROFILE="release-lto-debug_assertions"
   fi
 else
-  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
+  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" || "$ARTIFACT" == "tui" ]]; then
     CARGO_PROFILE="release-cli"
   else
     CARGO_PROFILE="release-lto"
@@ -220,6 +239,14 @@ if [[ "$ARTIFACT" == "cli" ]]; then
 elif [[ "$ARTIFACT" == "warpctrl" ]]; then
   BINARY_NAME="warpctrl"
   PACKAGES=()
+elif [[ "$ARTIFACT" == "tui" ]]; then
+  case "$RELEASE_CHANNEL" in
+    local) WARP_BIN="warp-tui" ;;
+    oss) WARP_BIN="warp-tui-oss" ;;
+    *) WARP_BIN="warp-tui-$RELEASE_CHANNEL" ;;
+  esac
+  BINARY_NAME="$WARP_BIN"
+  PACKAGES=()
 fi
 
 # Artifact-specific configuration
@@ -228,12 +255,24 @@ if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   if [[ "$ARTIFACT" == "warpctrl" ]]; then
     FEATURES="$FEATURES,warp_control_cli"
   fi
+elif [[ "$ARTIFACT" == "tui" ]]; then
+  # The TUI is a separate console crate with its own per-channel bins and a
+  # minimal feature set. It uses the native GNU target so the Linux clipboard
+  # backends can link against the host's Wayland/X11 libraries.
+  WARP_TUI_FEATURES="release_bundle,standalone"
+  if [[ "$RELEASE_CHANNEL" != "oss" ]]; then
+    WARP_TUI_FEATURES="$WARP_TUI_FEATURES,crash_reporting"
+  fi
 elif [[ "$ARTIFACT" == "app" ]]; then
   # All channels ship the v3 classifier and v2 heuristic.
   FEATURES="$FEATURES,gui,nld_classifier_v3,nld_heuristic_v2"
 fi
 if [[ -n "$EXTRA_FEATURES" ]]; then
-  FEATURES="$FEATURES,$EXTRA_FEATURES"
+  if [[ "$ARTIFACT" == "tui" ]]; then
+    WARP_TUI_FEATURES="$WARP_TUI_FEATURES,$EXTRA_FEATURES"
+  else
+    FEATURES="$FEATURES,$EXTRA_FEATURES"
+  fi
 fi
 
 BUNDLE_ID="dev.warp.$APP_NAME"
@@ -249,14 +288,22 @@ export APPIMAGE_NAME="$APP_NAME-$BUILD_ARCH.AppImage"
 # then exit.  We use this script to invoke `cargo check` to ensure that we are
 # using the same feature flags and profile that we would be using in production.
 if [[ "$CHECK_ONLY" == "true" ]]; then
-  cargo check -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" ${TARGET_TRIPLE:+--target $TARGET_TRIPLE}
+  if [[ "$ARTIFACT" == "tui" ]]; then
+    cargo check -p warp_tui --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$WARP_TUI_FEATURES"
+  else
+    cargo check -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" ${TARGET_TRIPLE:+--target $TARGET_TRIPLE}
+  fi
   exit 0
 fi
 
 # Build the binary.
 if [[ "$BUILD" == "true" ]]; then
   echo "Building and bundling Warp for channel $RELEASE_CHANNEL and bundle id $BUNDLE_ID"
-  cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" ${TARGET_TRIPLE:+--target $TARGET_TRIPLE}
+  if [[ "$ARTIFACT" == "tui" ]]; then
+    cargo build -p warp_tui --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$WARP_TUI_FEATURES"
+  else
+    cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" ${TARGET_TRIPLE:+--target $TARGET_TRIPLE}
+  fi
 
   echo "Making debug copy of '$EXECUTABLE_PATH' at '$DEBUG_EXECUTABLE_PATH'"
   cp "$EXECUTABLE_PATH" "$DEBUG_EXECUTABLE_PATH"
@@ -290,11 +337,15 @@ fi
 BINARY_PATH="$EXECUTABLE_PATH"
 if [[ "$ARTIFACT" == "warpctrl" ]]; then
   BINARY_PATH="$WARPCTRL_SCRIPT_PATH"
+elif [[ "$ARTIFACT" == "tui" ]]; then
+  echo "Copying TUI binary into $OUT_DIR/$WARP_BIN"
+  cp "$EXECUTABLE_PATH" "$OUT_DIR/$WARP_BIN"
+  BINARY_PATH="$OUT_DIR/$WARP_BIN"
 fi
 
-# Prepare bundled resources for CLI builds.
-if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
-  echo "Preparing CLI resources directory"
+# Prepare bundled resources for standalone builds.
+if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" || "$ARTIFACT" == "tui" ]]; then
+  echo "Preparing standalone resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
   "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 fi


### PR DESCRIPTION
## Description

Bundles the headless Warp TUI for Linux on both x86_64 and aarch64.

- Adds `--artifact tui` support to `script/linux/bundle`, using the TUI's release CLI profile and `release_bundle`, `standalone`, and `crash_reporting` features.
- Packages the channel-specific binary with sibling bundled resources, settings schema, license attribution, version metadata, and a separate debug-symbol copy.
- Builds natively on GNU/Linux so the clipboard stack can link against the host Wayland/X11 libraries.
- Rejects requested TUI architectures that do not match the build host, preventing mislabeled x86/ARM artifacts.
- Adds a dev-only release matrix for x86_64 and aarch64. For now, both tarballs are retained as workflow artifacts rather than published to GitHub Releases or GCS; server download/installer support will follow separately.

Implementation plan: https://staging.warp.dev/drive/notebook/k5kMDkTBglJ5joCz2NjaWz

Agent conversation: https://staging.warp.dev/conversation/98637f8f-c7d5-4be4-8e2a-f991f1e49d8e

## Linked Issue

None.

## Testing

Automated validation:

- `script/linux/test_bundle_warpctrl`
- `actionlint` on `.github/workflows/create_release.yml` (ignoring the repository's expected custom runner-label warnings)
- `./script/format`
- All clippy invocations from `./script/presubmit`
- `git diff --check`

Manual x86_64 artifact validation:

- Built the dev-channel release bundle with the production feature/profile tuple.
- Verified the 64 MiB tarball layout, executable permissions, ELF architecture, dynamic dependencies, bundled resources, settings schema, licenses, and version metadata.
- Extracted the tarball outside the checkout and launched it in a real Linux PTY.
- Authenticated with an API key and exercised prompt submission, response streaming, permission approval, shell execution, file creation/readback, multi-turn context, conversation navigation, clean double-Ctrl-C exit, and resume handoff generation.
- Independently verified the tool-created file had the exact expected bytes and newline.

The aarch64 job is configured for the existing native `namespace-profile-ubuntu-20-04-arm` runner. It cannot be compiled or runtime-tested on the x86_64 devbox because the bundler intentionally rejects cross-architecture native GNU artifacts.

Full presubmit was attempted from a clean 119 GiB target reset. Formatting, clippy, clang-format, WGSL checks, and focused integration coverage passed. The broader integration suite remains blocked by devbox environment dependencies unrelated to this patch: unavailable gcloud authentication, invalid/missing runtime display state without Xvfb, occupied integration-test ports, and unavailable test backend endpoints. The initially failing display-dependent integration test passed when rerun under Xvfb.

- [ ] I have manually tested my changes locally with `./script/run` (not applicable; this changes the headless TUI release path)

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
