### PR TITLE
Reduce warp-tui release binary size

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -601,6 +601,22 @@ jobs:
           name: release-macos-tui-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
           path: warp-tui-${{ steps.get-config.outputs.channel }}-macos-${{ matrix.arch }}.tar.gz
 
+      - name: Set up Sentry CLI
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b # v2.0.0
+        with:
+          token: ${{ secrets.SENTRY_RELEASE_TOKEN }}
+          organization: warpdotdev
+          project: ${{ steps.get-config.outputs.sentry_project }}
+
+      - name: Upload debugging symbols to Sentry
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        run: |
+          script/sentry_upload_dif.sh
+        shell: bash
+        env:
+          DEBUG_FILE_OR_FOLDER_PATH: ${{ steps.bundle_tui.outputs.dsym_path }}
+
   release_linux_x86:
     name: Build Release (Linux x86_64)
     runs-on: namespace-profile-ubuntu-20-04

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -667,6 +667,13 @@ elif [[ "$ARTIFACT" == "tui" ]]; then
     echo "Copying .dSYM into $OUT_DIR/$WARP_BIN.dSYM"
     cp -HR "target/$DEFAULT_TARGET/$TARGET_PROFILE_DIR/$WARP_BIN.dSYM" "$OUT_DIR/"
   fi
+  # Preserve the dSYM above, then remove local symbols from the distributed
+  # executable before it is signed. This keeps external crash symbolication
+  # intact while substantially reducing both installed and download size.
+  if [[ $DEBUG != true ]]; then
+    echo "Stripping local symbols from $OUT_DIR/$WARP_BIN"
+    strip -x "$OUT_DIR/$WARP_BIN"
+  fi
 
   # Ship bundled skills + settings schema next to the binary. The standalone TUI
   # resolves this `resources/` dir relative to its own executable at runtime.


### PR DESCRIPTION
## Description

The macOS TUI release pipeline preserved local Mach-O symbols in the distributed executable, making the installed binary and compressed release artifact larger than necessary.

This change:
- Copies the TUI dSYM before running `strip -x` on non-debug release artifacts.
- Strips before code signing so the final signature remains valid.
- Leaves `--debug` TUI bundles unstripped.
- Uploads the preserved TUI dSYM to Sentry for external crash symbolication.

Measured against the currently deployed arm64 `warp-tui-dev` binary:
- Raw executable: 320,701,360 → 279,163,968 bytes, saving 39.6 MiB (12.95%).
- Gzip equivalent: 65,844,194 → 59,535,520 bytes, saving 6.0 MiB (9.58%).
- Symbols reported by `nm`: 419,232 → 201,783.

## Testing

- Ran `./script/format`.
- Ran all three clippy configurations from `script/presubmit` with warnings denied.
- Ran `bash -n script/macos/bundle`.
- Parsed `.github/workflows/create_release.yml` as YAML.
- Ran `git diff --check`.
- Copied the deployed `warp-tui-dev` binary to a temporary directory, ran the exact `strip -x` operation, re-signed it ad hoc, and verified it with `codesign --verify --strict`.
- No automated test was added because this changes release scripting rather than runtime behavior; the release operation was exercised directly against a production-built artifact.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>