### PR TITLE
Align TUI Agent failure warnings with GUI behavior

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -77,7 +77,8 @@ use crate::ai::blocklist::inline_action::requested_action::RenderableAction;
 use crate::ai::blocklist::model::{AIBlockModel, AIBlockModelHelper};
 use crate::ai::blocklist::secret_redaction::{SecretRedactionState, redact_secrets_in_element};
 use crate::ai::blocklist::view_util::{
-    FailedOutputPresentation, error_color, failed_output_presentation,
+    FailedOutputPresentation, OUT_OF_CREDITS_SUBSCRIBE_LABEL, error_color,
+    failed_output_presentation,
 };
 use crate::ai::blocklist::{BlocklistAIActionModel, ShellCommandExecutor, TextLocation};
 use crate::ai::loading::shimmering_warp_loading_text;
@@ -3047,10 +3048,9 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
 
     let error_text = match presentation {
         FailedOutputPresentation::Message(message) => message,
-        FailedOutputPresentation::OutOfCredits { title, detail, .. } => {
+        FailedOutputPresentation::OutOfCredits { message } => {
             return render_out_of_credits_error(
-                title,
-                detail,
+                &message,
                 props.subscribe_button_handle,
                 props.is_ai_input_enabled,
                 props.icon_right_margin,
@@ -3159,8 +3159,7 @@ fn out_of_credits_cta_button(
 
 /// Renders the out-of-credits failure: alert icon + message with a Subscribe CTA below.
 fn render_out_of_credits_error(
-    title: &str,
-    detail: &str,
+    message: &str,
     subscribe_button_handle: &MouseStateHandle,
     is_ai_input_enabled: bool,
     icon_right_margin: f32,
@@ -3184,7 +3183,7 @@ fn render_out_of_credits_error(
     .finish();
 
     let text = Text::new(
-        format!("{title}\n\n{detail}"),
+        message.to_owned(),
         appearance.monospace_font_family(),
         appearance.monospace_font_size(),
     )
@@ -3202,7 +3201,7 @@ fn render_out_of_credits_error(
     })
     .finish();
 
-    let subscribe_button = out_of_credits_cta_button("Subscribe", subscribe_button_handle, app)
+    let subscribe_button = out_of_credits_cta_button(OUT_OF_CREDITS_SUBSCRIBE_LABEL, subscribe_button_handle, app)
         .build()
         .on_click(|ctx, _, _| {
             ctx.dispatch_typed_action(WorkspaceAction::ShowUpgrade);

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -3048,7 +3048,7 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
 
     let error_text = match presentation {
         FailedOutputPresentation::Message(message) => message,
-        FailedOutputPresentation::OutOfCredits { message } => {
+        FailedOutputPresentation::OutOfCredits { message, .. } => {
             return render_out_of_credits_error(
                 &message,
                 props.subscribe_button_handle,
@@ -3201,12 +3201,13 @@ fn render_out_of_credits_error(
     })
     .finish();
 
-    let subscribe_button = out_of_credits_cta_button(OUT_OF_CREDITS_SUBSCRIBE_LABEL, subscribe_button_handle, app)
-        .build()
-        .on_click(|ctx, _, _| {
-            ctx.dispatch_typed_action(WorkspaceAction::ShowUpgrade);
-        })
-        .finish();
+    let subscribe_button =
+        out_of_credits_cta_button(OUT_OF_CREDITS_SUBSCRIBE_LABEL, subscribe_button_handle, app)
+            .build()
+            .on_click(|ctx, _, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::ShowUpgrade);
+            })
+            .finish();
 
     Flex::column()
         .with_cross_axis_alignment(CrossAxisAlignment::Start)

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -102,7 +102,9 @@ use crate::ai::blocklist::inline_action::web_search::WebSearchView;
 use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
-use crate::ai::blocklist::view_util::{format_credits, should_show_failed_output_usage_notice};
+use crate::ai::blocklist::view_util::{
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits, should_show_failed_output_usage_notice,
+};
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
 use crate::ai::skills::{
@@ -1261,7 +1263,7 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                 output_items.add_child(
                     render_informational_footer(
                         app,
-                        "This response won't count towards your usage.".to_string(),
+                        FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_string(),
                     )
                     .with_agent_output_item_spacing(app)
                     .finish(),

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1261,12 +1261,9 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                 props.model.is_restored(),
             ) {
                 output_items.add_child(
-                    render_informational_footer(
-                        app,
-                        FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_string(),
-                    )
-                    .with_agent_output_item_spacing(app)
-                    .finish(),
+                    render_informational_footer(app, FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_string())
+                        .with_agent_output_item_spacing(app)
+                        .finish(),
                 );
 
                 output_items.add_child(

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -25,8 +25,7 @@ const PROVIDER_BUTTON_ICON_SIZE: f32 = 14.;
 const PROVIDER_BUTTON_ICON_TEXT_GAP: f32 = 8.;
 const ERROR_APOLOGY_TEXT: &str = "I'm sorry, I couldn't complete that request.";
 const INTERNAL_WARP_ERROR: &str = "Internal Warp error.";
-pub const FAILED_OUTPUT_USAGE_NOTICE_TEXT: &str =
-    "This response won't count towards your usage.";
+pub const FAILED_OUTPUT_USAGE_NOTICE_TEXT: &str = "This response won't count towards your usage.";
 pub const OUT_OF_CREDITS_SUBSCRIBE_LABEL: &str = "Subscribe";
 
 /// Text to use as a label throughout the app for user interactions that will attach selected
@@ -65,10 +64,20 @@ pub fn error_color(theme: &WarpTheme) -> ColorU {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FailedOutputPresentation {
     Message(String),
-    OutOfCredits { message: String },
-    InvalidApiKey { title: &'static str, detail: String },
-    ContextWindowExceeded { message: String },
-    AwsBedrockCredentialsExpiredOrInvalid { fallback_message: String },
+    OutOfCredits {
+        message: String,
+        can_use_own_api_keys: bool,
+    },
+    InvalidApiKey {
+        title: &'static str,
+        detail: String,
+    },
+    ContextWindowExceeded {
+        message: String,
+    },
+    AwsBedrockCredentialsExpiredOrInvalid {
+        fallback_message: String,
+    },
 }
 
 /// Returns the user-facing presentation for an Agent Mode request failure.
@@ -91,6 +100,8 @@ pub fn failed_output_presentation(
                 if should_show_subscribe_cta(app) {
                     FailedOutputPresentation::OutOfCredits {
                         message: format!("{ERROR_APOLOGY_TEXT}\n\n{message}"),
+                        can_use_own_api_keys: UserWorkspaces::as_ref(app)
+                            .is_byo_api_key_enabled(app),
                     }
                 } else {
                     FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{message}"))

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -25,9 +25,9 @@ const PROVIDER_BUTTON_ICON_SIZE: f32 = 14.;
 const PROVIDER_BUTTON_ICON_TEXT_GAP: f32 = 8.;
 const ERROR_APOLOGY_TEXT: &str = "I'm sorry, I couldn't complete that request.";
 const INTERNAL_WARP_ERROR: &str = "Internal Warp error.";
-const OUT_OF_CREDITS_TITLE: &str = "I’m sorry, I couldn’t complete that request.";
-const OUT_OF_CREDITS_DETAIL: &str =
-    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.";
+pub const FAILED_OUTPUT_USAGE_NOTICE_TEXT: &str =
+    "This response won't count towards your usage.";
+pub const OUT_OF_CREDITS_SUBSCRIBE_LABEL: &str = "Subscribe";
 
 /// Text to use as a label throughout the app for user interactions that will attach selected
 /// block(s) or text selections to a new AI query.
@@ -65,21 +65,10 @@ pub fn error_color(theme: &WarpTheme) -> ColorU {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FailedOutputPresentation {
     Message(String),
-    OutOfCredits {
-        title: &'static str,
-        detail: &'static str,
-        can_use_own_api_keys: bool,
-    },
-    InvalidApiKey {
-        title: &'static str,
-        detail: String,
-    },
-    ContextWindowExceeded {
-        message: String,
-    },
-    AwsBedrockCredentialsExpiredOrInvalid {
-        fallback_message: String,
-    },
+    OutOfCredits { message: String },
+    InvalidApiKey { title: &'static str, detail: String },
+    ContextWindowExceeded { message: String },
+    AwsBedrockCredentialsExpiredOrInvalid { fallback_message: String },
 }
 
 /// Returns the user-facing presentation for an Agent Mode request failure.
@@ -101,10 +90,7 @@ pub fn failed_output_presentation(
             if let Some(message) = user_display_message {
                 if should_show_subscribe_cta(app) {
                     FailedOutputPresentation::OutOfCredits {
-                        title: OUT_OF_CREDITS_TITLE,
-                        detail: OUT_OF_CREDITS_DETAIL,
-                        can_use_own_api_keys: UserWorkspaces::as_ref(app)
-                            .is_byo_api_key_enabled(app),
+                        message: format!("{ERROR_APOLOGY_TEXT}\n\n{message}"),
                     }
                 } else {
                     FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{message}"))

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -76,8 +76,8 @@ pub use crate::ai::blocklist::orchestration_topology::{
     resolve_orchestration_participant,
 };
 pub use crate::ai::blocklist::view_util::{
-    FailedOutputPresentation, failed_output_presentation, format_credits,
-    should_show_failed_output_usage_notice,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, OUT_OF_CREDITS_SUBSCRIBE_LABEL,
+    failed_output_presentation, format_credits, should_show_failed_output_usage_notice,
 };
 pub use crate::ai::blocklist::{
     AIActionStatus, AskUserQuestionExecutor, AttachmentType, BlocklistAIActionEvent,

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -18,9 +18,10 @@ use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId,
     AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIAgentTodo, AIBlockModel,
     AIBlockModelHelper, AIBlockOutputStatus, AIConversationId, BlockId, BlocklistAIActionEvent,
-    BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason, FailedOutputPresentation,
-    MessageId, ModelEvent, ModelEventDispatcher, ReceivedMessageDisplay, SummarizationType,
-    TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
+    BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, MessageId, ModelEvent,
+    ModelEventDispatcher, OUT_OF_CREDITS_SUBSCRIBE_LABEL, ReceivedMessageDisplay,
+    SummarizationType, TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
     should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
@@ -55,8 +56,7 @@ use crate::tui_markdown::{
 use crate::tui_permission_prompt::TuiPermissionPrompt;
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
 const PLANS_URL: &str = "https://www.warp.dev/pricing";
-const BYOK_DOCS_URL: &str =
-    "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/";
+const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TuiCodeBlockKey {
@@ -186,8 +186,7 @@ impl CollapsibleSectionStates {
 
 fn render_failure_section(
     presentation: &FailedOutputPresentation,
-    compare_plans_hover_state: &MouseStateHandle,
-    byok_hover_state: &MouseStateHandle,
+    subscribe_hover_state: &MouseStateHandle,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
@@ -198,12 +197,12 @@ fn render_failure_section(
         | FailedOutputPresentation::AwsBedrockCredentialsExpiredOrInvalid {
             fallback_message: message,
         } => TuiText::from_spans([
-            ("⚠ ".to_owned(), error_style),
+            (FAILURE_WARNING_PREFIX.to_owned(), error_style),
             (message.clone(), body_style),
         ])
         .finish(),
         FailedOutputPresentation::InvalidApiKey { title, detail } => TuiText::from_spans([
-            ("⚠ ".to_owned(), error_style),
+            (FAILURE_WARNING_PREFIX.to_owned(), error_style),
             (
                 (*title).to_owned(),
                 error_style.add_modifier(Modifier::BOLD),
@@ -212,55 +211,25 @@ fn render_failure_section(
             (detail.clone(), body_style),
         ])
         .finish(),
-        FailedOutputPresentation::OutOfCredits {
-            title,
-            detail,
-            can_use_own_api_keys,
-        } => {
+        FailedOutputPresentation::OutOfCredits { message } => {
             let primary_style = builder.primary_text_style();
             let link_style = primary_style.add_modifier(Modifier::UNDERLINED);
-            let compare_plans = TuiHoverable::new(
-                compare_plans_hover_state.clone(),
-                TuiText::new("Compare plans")
-                    .with_style(link_style)
-                    .finish(),
+            let subscribe = TuiHoverable::new(
+                subscribe_hover_state.clone(),
+            TuiText::new(OUT_OF_CREDITS_SUBSCRIBE_LABEL).with_style(link_style).finish(),
             )
             .on_click(|_, app| app.open_url(PLANS_URL))
             .finish();
-            let mut actions = TuiFlex::row()
+            let actions = TuiFlex::row()
                 .child(TuiText::new("  ").with_style(primary_style).finish())
-                .child(compare_plans);
-            if *can_use_own_api_keys {
-                actions = actions
-                    .child(
-                        TuiText::new("  or  ")
-                            .with_style(builder.muted_text_style())
-                            .finish(),
-                    )
-                    .child(
-                        TuiHoverable::new(
-                            byok_hover_state.clone(),
-                            TuiText::new("Use your own API keys")
-                                .with_style(link_style)
-                                .finish(),
-                        )
-                        .on_click(|_, app| app.open_url(BYOK_DOCS_URL))
-                        .finish(),
-                    );
-            }
+                .child(subscribe);
             TuiFlex::column()
                 .child(
                     TuiText::from_spans([
-                        ("!".to_owned(), error_style.add_modifier(Modifier::BOLD)),
-                        (" ".to_owned(), primary_style.add_modifier(Modifier::BOLD)),
-                        ((*title).to_owned(), primary_style),
+                        (FAILURE_WARNING_PREFIX.to_owned(), error_style),
+                        (message.clone(), primary_style),
                     ])
                     .finish(),
-                )
-                .child(
-                    TuiText::new(format!("  {detail}"))
-                        .with_style(primary_style)
-                        .finish(),
                 )
                 .child(TuiText::new(" ").finish())
                 .child(actions.finish())
@@ -275,7 +244,7 @@ fn render_failure_section(
 }
 
 fn render_usage_notice(app: &AppContext) -> Box<dyn TuiElement> {
-    TuiText::new("This response won't count towards your usage.")
+    TuiText::new(FAILED_OUTPUT_USAGE_NOTICE_TEXT)
         .with_style(TuiUiBuilder::from_app(app).muted_text_style())
         .finish()
 }
@@ -287,17 +256,8 @@ fn failure_text(presentation: &FailedOutputPresentation) -> String {
             fallback_message: message,
         }
         | FailedOutputPresentation::ContextWindowExceeded { message } => message.clone(),
-        FailedOutputPresentation::OutOfCredits {
-            title,
-            detail,
-            can_use_own_api_keys,
-        } => {
-            let actions = if *can_use_own_api_keys {
-                "Compare plans  or  Use your own API keys"
-            } else {
-                "Compare plans"
-            };
-            format!("{title}\n  {detail}\n\n  {actions}")
+        FailedOutputPresentation::OutOfCredits { message } => {
+            format!("{message}\n\nSubscribe")
         }
         FailedOutputPresentation::InvalidApiKey { title, detail } => {
             format!("{title}\n{detail}")
@@ -386,8 +346,7 @@ pub(super) struct TuiAIBlock {
     /// Per-message UI state for this exchange's collapsible sections
     /// (thinking blocks and task lists).
     collapsible_states: CollapsibleSectionStates,
-    compare_plans_hover_state: MouseStateHandle,
-    byok_hover_state: MouseStateHandle,
+    subscribe_hover_state: MouseStateHandle,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -429,8 +388,7 @@ impl TuiAIBlock {
             action_model: action_model.clone(),
             terminal_model,
             collapsible_states: Default::default(),
-            compare_plans_hover_state: MouseStateHandle::default(),
-            byok_hover_state: MouseStateHandle::default(),
+            subscribe_hover_state: MouseStateHandle::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
@@ -1230,12 +1188,9 @@ impl TuiAIBlock {
                 )
             }
             TuiAIBlockSection::AgentMessage(_) => return None,
-            TuiAIBlockSection::Failure(presentation) => render_failure_section(
-                presentation,
-                &self.compare_plans_hover_state,
-                &self.byok_hover_state,
-                app,
-            ),
+            TuiAIBlockSection::Failure(presentation) => {
+                render_failure_section(presentation, &self.subscribe_hover_state, app)
+            }
             TuiAIBlockSection::UsageNotice => render_usage_notice(app),
         })
     }
@@ -1375,18 +1330,14 @@ impl TuiAIBlock {
             && let AIBlockOutputStatus::Failed { error, .. } = &status
             && let Some(presentation) = failed_output_presentation(error, app)
         {
-            let is_out_of_credits =
-                matches!(presentation, FailedOutputPresentation::OutOfCredits { .. });
             sections.push(TuiAIBlockSection::Failure(presentation));
-            if !is_out_of_credits
-                && should_show_failed_output_usage_notice(
-                    error,
-                    self.block_model
-                        .is_latest_visible_exchange_in_root_task(app),
-                    self.has_expanded_last_requested_command(app),
-                    self.block_model.is_restored(),
-                )
-            {
+            if should_show_failed_output_usage_notice(
+                error,
+                self.block_model
+                    .is_latest_visible_exchange_in_root_task(app),
+                self.has_expanded_last_requested_command(app),
+                self.block_model.is_restored(),
+            ) {
                 sections.push(TuiAIBlockSection::UsageNotice);
             }
         }
@@ -1614,12 +1565,9 @@ impl TuiAIBlock {
                     self.conversation_id,
                     app,
                 ),
-                TuiAIBlockSection::Failure(presentation) => render_failure_section(
-                    presentation,
-                    &self.compare_plans_hover_state,
-                    &self.byok_hover_state,
-                    app,
-                ),
+                TuiAIBlockSection::Failure(presentation) => {
+                    render_failure_section(presentation, &self.subscribe_hover_state, app)
+                }
                 TuiAIBlockSection::UsageNotice => render_usage_notice(app),
             };
 

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -20,9 +20,8 @@ use warp::tui_export::{
     AIBlockModelHelper, AIBlockOutputStatus, AIConversationId, BlockId, BlocklistAIActionEvent,
     BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason,
     FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, MessageId, ModelEvent,
-    ModelEventDispatcher, OUT_OF_CREDITS_SUBSCRIBE_LABEL, ReceivedMessageDisplay,
-    SummarizationType, TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
-    should_show_failed_output_usage_notice,
+    ModelEventDispatcher, ReceivedMessageDisplay, SummarizationType, TerminalModel, TodoOperation,
+    TodoStatus, failed_output_presentation, should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
 use warpui_core::elements::MouseStateHandle;
@@ -56,6 +55,10 @@ use crate::tui_markdown::{
 use crate::tui_permission_prompt::TuiPermissionPrompt;
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
 const PLANS_URL: &str = "https://www.warp.dev/pricing";
+const BYOK_DOCS_URL: &str =
+    "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/";
+const COMPARE_PLANS_LABEL: &str = "Compare plans";
+const USE_YOUR_OWN_API_KEYS_LABEL: &str = "Use your own API keys";
 const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -186,7 +189,8 @@ impl CollapsibleSectionStates {
 
 fn render_failure_section(
     presentation: &FailedOutputPresentation,
-    subscribe_hover_state: &MouseStateHandle,
+    compare_plans_hover_state: &MouseStateHandle,
+    byok_hover_state: &MouseStateHandle,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
@@ -211,26 +215,57 @@ fn render_failure_section(
             (detail.clone(), body_style),
         ])
         .finish(),
-        FailedOutputPresentation::OutOfCredits { message } => {
+        FailedOutputPresentation::OutOfCredits {
+            message,
+            can_use_own_api_keys,
+        } => {
             let primary_style = builder.primary_text_style();
             let link_style = primary_style.add_modifier(Modifier::UNDERLINED);
-            let subscribe = TuiHoverable::new(
-                subscribe_hover_state.clone(),
-            TuiText::new(OUT_OF_CREDITS_SUBSCRIBE_LABEL).with_style(link_style).finish(),
+            let (title, detail) = message.split_once("\n\n").unwrap_or((message.as_str(), ""));
+            let compare_plans = TuiHoverable::new(
+                compare_plans_hover_state.clone(),
+                TuiText::new(COMPARE_PLANS_LABEL)
+                    .with_style(link_style)
+                    .finish(),
             )
             .on_click(|_, app| app.open_url(PLANS_URL))
             .finish();
-            let actions = TuiFlex::row()
+            let mut actions = TuiFlex::row()
                 .child(TuiText::new("  ").with_style(primary_style).finish())
-                .child(subscribe);
-            TuiFlex::column()
-                .child(
-                    TuiText::from_spans([
-                        (FAILURE_WARNING_PREFIX.to_owned(), error_style),
-                        (message.clone(), primary_style),
-                    ])
-                    .finish(),
-                )
+                .child(compare_plans);
+            if *can_use_own_api_keys {
+                actions = actions
+                    .child(
+                        TuiText::new("  or  ")
+                            .with_style(builder.muted_text_style())
+                            .finish(),
+                    )
+                    .child(
+                        TuiHoverable::new(
+                            byok_hover_state.clone(),
+                            TuiText::new(USE_YOUR_OWN_API_KEYS_LABEL)
+                                .with_style(link_style)
+                                .finish(),
+                        )
+                        .on_click(|_, app| app.open_url(BYOK_DOCS_URL))
+                        .finish(),
+                    );
+            }
+            let mut content = TuiFlex::column().child(
+                TuiText::from_spans([
+                    (FAILURE_WARNING_PREFIX.to_owned(), error_style),
+                    (title.to_owned(), primary_style),
+                ])
+                .finish(),
+            );
+            if !detail.is_empty() {
+                content = content.child(
+                    TuiText::new(format!("  {detail}"))
+                        .with_style(primary_style)
+                        .finish(),
+                );
+            }
+            content
                 .child(TuiText::new(" ").finish())
                 .child(actions.finish())
                 .finish()
@@ -256,8 +291,16 @@ fn failure_text(presentation: &FailedOutputPresentation) -> String {
             fallback_message: message,
         }
         | FailedOutputPresentation::ContextWindowExceeded { message } => message.clone(),
-        FailedOutputPresentation::OutOfCredits { message } => {
-            format!("{message}\n\nSubscribe")
+        FailedOutputPresentation::OutOfCredits {
+            message,
+            can_use_own_api_keys,
+        } => {
+            let actions = if *can_use_own_api_keys {
+                format!("{COMPARE_PLANS_LABEL}  or  {USE_YOUR_OWN_API_KEYS_LABEL}")
+            } else {
+                COMPARE_PLANS_LABEL.to_owned()
+            };
+            format!("{message}\n\n{actions}")
         }
         FailedOutputPresentation::InvalidApiKey { title, detail } => {
             format!("{title}\n{detail}")
@@ -346,7 +389,8 @@ pub(super) struct TuiAIBlock {
     /// Per-message UI state for this exchange's collapsible sections
     /// (thinking blocks and task lists).
     collapsible_states: CollapsibleSectionStates,
-    subscribe_hover_state: MouseStateHandle,
+    compare_plans_hover_state: MouseStateHandle,
+    byok_hover_state: MouseStateHandle,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -388,7 +432,8 @@ impl TuiAIBlock {
             action_model: action_model.clone(),
             terminal_model,
             collapsible_states: Default::default(),
-            subscribe_hover_state: MouseStateHandle::default(),
+            compare_plans_hover_state: MouseStateHandle::default(),
+            byok_hover_state: MouseStateHandle::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
@@ -1188,9 +1233,12 @@ impl TuiAIBlock {
                 )
             }
             TuiAIBlockSection::AgentMessage(_) => return None,
-            TuiAIBlockSection::Failure(presentation) => {
-                render_failure_section(presentation, &self.subscribe_hover_state, app)
-            }
+            TuiAIBlockSection::Failure(presentation) => render_failure_section(
+                presentation,
+                &self.compare_plans_hover_state,
+                &self.byok_hover_state,
+                app,
+            ),
             TuiAIBlockSection::UsageNotice => render_usage_notice(app),
         })
     }
@@ -1565,9 +1613,12 @@ impl TuiAIBlock {
                     self.conversation_id,
                     app,
                 ),
-                TuiAIBlockSection::Failure(presentation) => {
-                    render_failure_section(presentation, &self.subscribe_hover_state, app)
-                }
+                TuiAIBlockSection::Failure(presentation) => render_failure_section(
+                    presentation,
+                    &self.compare_plans_hover_state,
+                    &self.byok_hover_state,
+                    app,
+                ),
                 TuiAIBlockSection::UsageNotice => render_usage_notice(app),
             };
 
@@ -1635,9 +1686,7 @@ fn section_logical_text(section: &TuiAIBlockSection) -> Option<String> {
         | TuiAIBlockSection::CompletedTodos { .. }
         | TuiAIBlockSection::AgentMessage(_) => None,
         TuiAIBlockSection::Failure(presentation) => Some(failure_text(presentation)),
-        TuiAIBlockSection::UsageNotice => {
-            Some("This response won't count towards your usage.".to_owned())
-        }
+        TuiAIBlockSection::UsageNotice => Some(FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_owned()),
     }
 }
 

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -186,7 +186,7 @@ fn agent_block_renders_context_window_failure() {
 }
 
 #[test]
-fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
+fn out_of_credits_failure_uses_shared_copy_warning_style_and_tui_actions() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let opened_urls = Rc::new(RefCell::new(Vec::new()));
@@ -200,14 +200,21 @@ fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
 
         app.read(|ctx| {
             let presentation = FailedOutputPresentation::OutOfCredits {
-                message: "I'm sorry, I couldn't complete that request.\n\nYou've reached your credit limit."
+                message: "I'm sorry, I couldn't complete that request.\n\nIn order to use Warp's AI features, subscribe to a Warp plan, or bring your own inference."
                     .to_owned(),
+                can_use_own_api_keys: true,
             };
-            let subscribe_hover_state = MouseStateHandle::default();
+            let compare_plans_hover_state = MouseStateHandle::default();
+            let byok_hover_state = MouseStateHandle::default();
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
-                render_failure_section(&presentation, &subscribe_hover_state, ctx),
-                TuiRect::new(0, 0, 100, 5),
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 100, 4),
                 ctx,
             );
             assert_eq!(
@@ -219,10 +226,9 @@ fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
                     .collect::<Vec<_>>(),
                 vec![
                     "⚠ I'm sorry, I couldn't complete that request.",
+                    "  In order to use Warp's AI features, subscribe to a Warp plan, or bring your own inference.",
                     "",
-                    "You've reached your credit limit.",
-                    "",
-                    "  Subscribe",
+                    "  Compare plans  or  Use your own API keys",
                 ]
             );
             let builder = TuiUiBuilder::from_app(ctx);
@@ -235,26 +241,74 @@ fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
                 builder.error_text_style().fg.expect("error foreground")
             );
             assert_eq!(frame.buffer[(2, 0)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(0, 2)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(2, 4)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 1)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 3)].fg, primary_foreground);
+            assert_eq!(
+                frame.buffer[(17, 3)].fg,
+                builder.muted_text_style().fg.expect("muted foreground")
+            );
+            assert_eq!(frame.buffer[(21, 3)].fg, primary_foreground);
             assert!(
-                frame.buffer[(2, 4)]
+                frame.buffer[(2, 3)]
+                    .modifier
+                    .contains(Modifier::UNDERLINED)
+            );
+            assert!(
+                frame.buffer[(21, 3)]
                     .modifier
                     .contains(Modifier::UNDERLINED)
             );
 
             dispatch_click_on_text(
-                render_failure_section(&presentation, &subscribe_hover_state, ctx),
-                "Subscribe",
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                "Compare plans",
                 100,
-                5,
+                4,
                 ctx,
             );
+            dispatch_click_on_text(
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                "Use your own API keys",
+                100,
+                4,
+                ctx,
+            );
+
+            let without_byok = FailedOutputPresentation::OutOfCredits {
+                message: "I'm sorry, I couldn't complete that request.\n\nOut of credits."
+                    .to_owned(),
+                can_use_own_api_keys: false,
+            };
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_failure_section(
+                    &without_byok,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 100, 4),
+                ctx,
+            );
+            assert_eq!(frame.buffer.to_lines()[3].trim_end(), "  Compare plans");
         });
 
         assert_eq!(
             &*opened_urls.borrow(),
-            &["https://www.warp.dev/pricing".to_owned()]
+            &[
+                "https://www.warp.dev/pricing".to_owned(),
+                "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/".to_owned(),
+            ]
         );
     });
 }

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -186,7 +186,7 @@ fn agent_block_renders_context_window_failure() {
 }
 
 #[test]
-fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
+fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let opened_urls = Rc::new(RefCell::new(Vec::new()));
@@ -200,22 +200,14 @@ fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
 
         app.read(|ctx| {
             let presentation = FailedOutputPresentation::OutOfCredits {
-                title: "I’m sorry, I couldn’t complete that request.",
-                detail:
-                    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
-                can_use_own_api_keys: true,
+                message: "I'm sorry, I couldn't complete that request.\n\nYou've reached your credit limit."
+                    .to_owned(),
             };
-            let compare_plans_hover_state = MouseStateHandle::default();
-            let byok_hover_state = MouseStateHandle::default();
+            let subscribe_hover_state = MouseStateHandle::default();
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                TuiRect::new(0, 0, 100, 4),
+                render_failure_section(&presentation, &subscribe_hover_state, ctx),
+                TuiRect::new(0, 0, 100, 5),
                 ctx,
             );
             assert_eq!(
@@ -226,10 +218,11 @@ fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
                 vec![
-                    "! I’m sorry, I couldn’t complete that request.",
-                    "  In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
+                    "⚠ I'm sorry, I couldn't complete that request.",
                     "",
-                    "  Compare plans  or  Use your own API keys",
+                    "You've reached your credit limit.",
+                    "",
+                    "  Subscribe",
                 ]
             );
             let builder = TuiUiBuilder::from_app(ctx);
@@ -242,75 +235,26 @@ fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
                 builder.error_text_style().fg.expect("error foreground")
             );
             assert_eq!(frame.buffer[(2, 0)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(2, 1)].fg, primary_foreground);
-            assert_eq!(
-                frame.buffer[(17, 3)].fg,
-                builder.muted_text_style().fg.expect("muted foreground")
-            );
-            assert_eq!(frame.buffer[(2, 3)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(21, 3)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(0, 2)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 4)].fg, primary_foreground);
             assert!(
-                frame.buffer[(2, 3)]
-                    .modifier
-                    .contains(Modifier::UNDERLINED)
-            );
-            assert!(
-                frame.buffer[(21, 3)]
+                frame.buffer[(2, 4)]
                     .modifier
                     .contains(Modifier::UNDERLINED)
             );
 
             dispatch_click_on_text(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                "Compare plans",
+                render_failure_section(&presentation, &subscribe_hover_state, ctx),
+                "Subscribe",
                 100,
-                4,
+                5,
                 ctx,
             );
-            dispatch_click_on_text(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                "Use your own API keys",
-                100,
-                4,
-                ctx,
-            );
-
-            let without_byok = FailedOutputPresentation::OutOfCredits {
-                title: "I’m sorry, I couldn’t complete that request.",
-                detail:
-                    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
-                can_use_own_api_keys: false,
-            };
-            let mut presenter = TuiPresenter::new();
-            let frame = presenter.present_element(
-                render_failure_section(
-                    &without_byok,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                TuiRect::new(0, 0, 100, 4),
-                ctx,
-            );
-            assert_eq!(frame.buffer.to_lines()[3].trim_end(), "  Compare plans");
         });
 
         assert_eq!(
             &*opened_urls.borrow(),
-            &[
-                "https://www.warp.dev/pricing".to_owned(),
-                "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/".to_owned(),
-            ]
+            &["https://www.warp.dev/pricing".to_owned()]
         );
     });
 }
@@ -320,6 +264,14 @@ fn failed_output_usage_notice_matches_gui_conditions() {
     let error = RenderableAIError::other("failed", false);
     assert!(should_show_failed_output_usage_notice(
         &error, true, false, false
+    ));
+    assert!(should_show_failed_output_usage_notice(
+        &RenderableAIError::QuotaLimit {
+            user_display_message: Some("You've reached your credit limit.".to_owned()),
+        },
+        true,
+        false,
+        false,
     ));
     assert!(!should_show_failed_output_usage_notice(
         &error, false, false, false


### PR DESCRIPTION
Updating to use the same GUI triangle alert after Slack discussion https://warpdev.slack.com/archives/C0BA99TSDB2/p1784652815749719?thread_ts=1784572310.801899&cid=C0BA99TSDB2

## Description
Align Agent request failure rendering in the headless TUI with the original GUI behavior while preserving TUI-specific presentation.

- Centralizes failed-output copy and policy so the GUI and TUI share error classification, server-provided out-of-credits messaging, CTA eligibility, and usage-notice behavior.
- Uses the warning triangle for TUI warning-class failures, matching the GUI's alert-triangle semantics; context-window failures retain the cancellation `×` marker.
- Restores the TUI-specific “Compare plans” and conditional “Use your own API keys” actions from the [Figma design](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1267-23012&m=dev).
- Composes out-of-credits copy into the compact TUI row layout without changing the shared message or GUI rendering.

Investigation and implementation context: https://staging.warp.dev/conversation/69a635c8-cf41-40e3-a612-1e37499fc609

## Linked Issue
N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<img width="1114" height="298" alt="Screenshot 2026-07-21 at 12 54 22 PM" src="https://github.com/user-attachments/assets/61e61b86-e397-4dc8-8dc2-e9a8c5c48bbb" />

- `cargo nextest run -p warp_tui --no-fail-fast agent_block` — 54 passed.
- `./script/presubmit` — formatting, all three clippy configurations, clang-format, and wgslfmt passed. The workspace integration phase was blocked by unrelated local environment failures in SSH tests: non-interactive gcloud reauthentication and a port 9281 collision.
- [x] Manually tested in the headless TUI with `./script/run-tui`.

### Screenshots / Videos
See the conversation link above for the before/after TUI screenshots and the linked Figma frame.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Agent request failures in the TUI now use consistent warning styling and out-of-credits actions.

Co-Authored-By: Oz <oz-agent@warp.dev>
