### PR TITLE
[TEST] Compare final TUI Agent failures against pre-#14044

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -48,7 +48,6 @@ use warpui::{Action, AppContext, Element, EventContext, SingletonEntity, View, V
 
 use super::output::LinkActionConstructors;
 use super::{add_highlights_to_rich_text, add_highlights_to_text};
-use crate::ai::AIRequestUsageModel;
 use crate::ai::agent::conversation::AIConversation;
 use crate::ai::agent::icons::red_stop_icon;
 use crate::ai::agent::{
@@ -77,7 +76,9 @@ use crate::ai::blocklist::inline_action::inline_action_icons::{self, icon_size};
 use crate::ai::blocklist::inline_action::requested_action::RenderableAction;
 use crate::ai::blocklist::model::{AIBlockModel, AIBlockModelHelper};
 use crate::ai::blocklist::secret_redaction::{SecretRedactionState, redact_secrets_in_element};
-use crate::ai::blocklist::view_util::error_color;
+use crate::ai::blocklist::view_util::{
+    FailedOutputPresentation, error_color, failed_output_presentation,
+};
 use crate::ai::blocklist::{BlocklistAIActionModel, ShellCommandExecutor, TextLocation};
 use crate::ai::loading::shimmering_warp_loading_text;
 use crate::code::editor::view::CodeEditorView;
@@ -105,9 +106,6 @@ pub const STATUS_ICON_SIZE_DELTA: f32 = 4.;
 pub const STATUS_FOOTER_VERTICAL_PADDING: f32 = 4.;
 pub const WAITING_FOR_USER_INPUT_MESSAGE: &str = "Agent waiting for instructions...";
 const IMAGE_SOURCE_LINK_LINE_INDEX: usize = 1;
-
-const ERROR_APOLOGY_TEXT: &str = "I'm sorry, I couldn't complete that request.";
-const INTERNAL_WARP_ERROR: &str = "Internal Warp error.";
 
 pub const LOAD_OUTPUT_MESSAGE: &str = "Warping...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_ADJUSTING: &str = "Adjusting tasks...";
@@ -3043,92 +3041,44 @@ pub struct FailedOutputProps<'a> {
 
 pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
-
-    // While an automatic retry/resume is still in flight, don't surface the underlying
-    // transport failure at all. These are typically transient and recover on their own,
-    // so showing the alarming "Warp lost connection" banner (plus debug info) for every
-    // blip is noisy and misleading. Render nothing during in-flight recovery; the full
-    // error banner is only shown once recovery has actually failed. Dogfood builds
-    // (Local/Dev) opt out so developers still see every transport failure aggressively.
-    if props.error.should_suppress_during_recovery() {
+    let Some(presentation) = failed_output_presentation(props.error, app) else {
         return Empty::new().finish();
-    }
+    };
 
-    let error_text = match props.error {
-        RenderableAIError::QuotaLimit {
-            user_display_message,
-        } => {
-            if let Some(message) = user_display_message {
-                if should_show_subscribe_cta(app) {
-                    return render_out_of_credits_error(
-                        message,
-                        props.subscribe_button_handle,
-                        props.is_ai_input_enabled,
-                        props.icon_right_margin,
-                        app,
-                    );
-                }
-                format!("{ERROR_APOLOGY_TEXT}\n\n{message}")
-            } else {
-                let ai_request_usage_model = AIRequestUsageModel::as_ref(app);
-                let formatted_next_refresh_time = ai_request_usage_model
-                    .next_refresh_time()
-                    .format("%B %d")
-                    .to_string();
-
-                format!(
-                    "{ERROR_APOLOGY_TEXT}\n\nYou've reached your credit limit. Your credit limit resets on {formatted_next_refresh_time}.",
-                )
-            }
+    let error_text = match presentation {
+        FailedOutputPresentation::Message(message) => message,
+        FailedOutputPresentation::OutOfCredits { title, detail, .. } => {
+            return render_out_of_credits_error(
+                title,
+                detail,
+                props.subscribe_button_handle,
+                props.is_ai_input_enabled,
+                props.icon_right_margin,
+                app,
+            );
         }
-        RenderableAIError::ServerOverloaded => {
-            "Warp is currently overloaded. Please try again later.".to_string()
-        }
-        RenderableAIError::InternalWarpError => {
-            format!("{ERROR_APOLOGY_TEXT}\n\n{INTERNAL_WARP_ERROR}")
-        }
-        RenderableAIError::Other { error_message, .. } => {
-            // A still-recovering `Other` error is handled by the early return above; once we
-            // reach here recovery has failed, so surface the error directly.
-            format!("{ERROR_APOLOGY_TEXT}\n\n{error_message}")
-        }
-        RenderableAIError::AgentExitedShell => {
-            format!("{ERROR_APOLOGY_TEXT}\n\n{}", props.error)
-        }
-        RenderableAIError::TransientNetworkError { .. } => {
-            // Recovering transient errors are handled by the early return above; once we
-            // reach here recovery has failed. These carry their own complete user-facing
-            // copy (plus debug info), so the apology prefix adds nothing.
-            props.error.to_string()
-        }
-        RenderableAIError::InvalidApiKey {
-            provider,
-            model_name,
-        } => {
+        FailedOutputPresentation::InvalidApiKey { title, detail } => {
             return render_invalid_api_key_error(
-                provider,
-                model_name,
+                title,
+                &detail,
                 props.invalid_api_key_button_handle,
                 app,
             );
         }
-        RenderableAIError::ContextWindowExceeded(error) => {
+        FailedOutputPresentation::ContextWindowExceeded { message } => {
             // This is rendered in a different way, like a failed action.
-            return RenderableAction::new(error.as_str(), app)
+            return RenderableAction::new(message.as_str(), app)
                 .with_icon(inline_action_icons::cancelled_icon(appearance).finish())
                 .render(app)
                 .finish();
         }
-        RenderableAIError::AwsBedrockCredentialsExpiredOrInvalid { model_name } => {
+        FailedOutputPresentation::AwsBedrockCredentialsExpiredOrInvalid { fallback_message } => {
             // Use the rich stateful view if it exists, otherwise show a simple error message
             if let Some(view) = props.aws_bedrock_credentials_error_view {
                 return ChildView::new(view).finish();
             }
             // Fallback for contexts that don't have the stateful view (e.g. CLI subagent)
-            format!(
-                "{ERROR_APOLOGY_TEXT}\n\nAWS credentials expired or missing for {model_name}. \
-                 Please refresh your AWS credentials."
-            )
+            fallback_message
         }
     };
 
@@ -3175,15 +3125,6 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
         )
         .finish()
 }
-
-/// Whether to show the out-of-credits CTAs: only for non-paid users. Paid users and the
-/// enterprise spend-limit variant of this message fall back to plain text.
-fn should_show_subscribe_cta(app: &AppContext) -> bool {
-    UserWorkspaces::as_ref(app)
-        .current_workspace()
-        .is_none_or(|workspace| !workspace.billing_metadata.is_user_on_paid_plan())
-}
-
 /// Builds an out-of-credits CTA button, styled like the invalid-API-key error's button.
 fn out_of_credits_cta_button(
     label: &str,
@@ -3218,7 +3159,8 @@ fn out_of_credits_cta_button(
 
 /// Renders the out-of-credits failure: alert icon + message with a Subscribe CTA below.
 fn render_out_of_credits_error(
-    message: &str,
+    title: &str,
+    detail: &str,
     subscribe_button_handle: &MouseStateHandle,
     is_ai_input_enabled: bool,
     icon_right_margin: f32,
@@ -3242,7 +3184,7 @@ fn render_out_of_credits_error(
     .finish();
 
     let text = Text::new(
-        format!("{ERROR_APOLOGY_TEXT}\n\n{message}"),
+        format!("{title}\n\n{detail}"),
         appearance.monospace_font_family(),
         appearance.monospace_font_size(),
     )
@@ -3291,8 +3233,8 @@ fn render_out_of_credits_error(
 }
 
 fn render_invalid_api_key_error(
-    provider: &str,
-    model_name: &str,
+    title: &str,
+    detail: &str,
     state_handle: &MouseStateHandle,
     app: &AppContext,
 ) -> Box<dyn Element> {
@@ -3308,29 +3250,18 @@ fn render_invalid_api_key_error(
     .with_height(icon_size(app))
     .finish();
 
-    let alert_text = Text::new(
-        "Provided API key is not valid",
-        appearance.ui_font_family(),
-        14.,
-    )
-    .with_color(error_color(appearance.theme()))
-    .with_selectable(false)
-    .finish();
+    let alert_text = Text::new(title.to_string(), appearance.ui_font_family(), 14.)
+        .with_color(error_color(appearance.theme()))
+        .with_selectable(false)
+        .finish();
 
-    let detail_text = Text::new(
-        format!(
-            "Failed to authenticate with {provider} when using {model_name}. \
-                     Double-check that your API key is correct."
-        ),
-        appearance.ui_font_family(),
-        14.,
-    )
-    .with_color(blended_colors::text_sub(
-        appearance.theme(),
-        appearance.theme().surface_1(),
-    ))
-    .with_selectable(false)
-    .finish();
+    let detail_text = Text::new(detail.to_string(), appearance.ui_font_family(), 14.)
+        .with_color(blended_colors::text_sub(
+            appearance.theme(),
+            appearance.theme().surface_1(),
+        ))
+        .with_selectable(false)
+        .finish();
 
     let settings_button = appearance
         .ui_builder()

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -77,7 +77,8 @@ use crate::ai::blocklist::inline_action::requested_action::RenderableAction;
 use crate::ai::blocklist::model::{AIBlockModel, AIBlockModelHelper};
 use crate::ai::blocklist::secret_redaction::{SecretRedactionState, redact_secrets_in_element};
 use crate::ai::blocklist::view_util::{
-    FailedOutputPresentation, error_color, failed_output_presentation,
+    FailedOutputPresentation, OUT_OF_CREDITS_SUBSCRIBE_LABEL, error_color,
+    failed_output_presentation,
 };
 use crate::ai::blocklist::{BlocklistAIActionModel, ShellCommandExecutor, TextLocation};
 use crate::ai::loading::shimmering_warp_loading_text;
@@ -3047,10 +3048,9 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
 
     let error_text = match presentation {
         FailedOutputPresentation::Message(message) => message,
-        FailedOutputPresentation::OutOfCredits { title, detail, .. } => {
+        FailedOutputPresentation::OutOfCredits { message } => {
             return render_out_of_credits_error(
-                title,
-                detail,
+                &message,
                 props.subscribe_button_handle,
                 props.is_ai_input_enabled,
                 props.icon_right_margin,
@@ -3159,8 +3159,7 @@ fn out_of_credits_cta_button(
 
 /// Renders the out-of-credits failure: alert icon + message with a Subscribe CTA below.
 fn render_out_of_credits_error(
-    title: &str,
-    detail: &str,
+    message: &str,
     subscribe_button_handle: &MouseStateHandle,
     is_ai_input_enabled: bool,
     icon_right_margin: f32,
@@ -3184,7 +3183,7 @@ fn render_out_of_credits_error(
     .finish();
 
     let text = Text::new(
-        format!("{title}\n\n{detail}"),
+        message.to_owned(),
         appearance.monospace_font_family(),
         appearance.monospace_font_size(),
     )
@@ -3202,7 +3201,7 @@ fn render_out_of_credits_error(
     })
     .finish();
 
-    let subscribe_button = out_of_credits_cta_button("Subscribe", subscribe_button_handle, app)
+    let subscribe_button = out_of_credits_cta_button(OUT_OF_CREDITS_SUBSCRIBE_LABEL, subscribe_button_handle, app)
         .build()
         .on_click(|ctx, _, _| {
             ctx.dispatch_typed_action(WorkspaceAction::ShowUpgrade);

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -3048,7 +3048,7 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
 
     let error_text = match presentation {
         FailedOutputPresentation::Message(message) => message,
-        FailedOutputPresentation::OutOfCredits { message } => {
+        FailedOutputPresentation::OutOfCredits { message, .. } => {
             return render_out_of_credits_error(
                 &message,
                 props.subscribe_button_handle,
@@ -3201,12 +3201,13 @@ fn render_out_of_credits_error(
     })
     .finish();
 
-    let subscribe_button = out_of_credits_cta_button(OUT_OF_CREDITS_SUBSCRIBE_LABEL, subscribe_button_handle, app)
-        .build()
-        .on_click(|ctx, _, _| {
-            ctx.dispatch_typed_action(WorkspaceAction::ShowUpgrade);
-        })
-        .finish();
+    let subscribe_button =
+        out_of_credits_cta_button(OUT_OF_CREDITS_SUBSCRIBE_LABEL, subscribe_button_handle, app)
+            .build()
+            .on_click(|ctx, _, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::ShowUpgrade);
+            })
+            .finish();
 
     Flex::column()
         .with_cross_axis_alignment(CrossAxisAlignment::Start)

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -102,7 +102,7 @@ use crate::ai::blocklist::inline_action::web_search::WebSearchView;
 use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
-use crate::ai::blocklist::view_util::format_credits;
+use crate::ai::blocklist::view_util::{format_credits, should_show_failed_output_usage_notice};
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
 use crate::ai::skills::{
@@ -1252,11 +1252,12 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                 .finish(),
             );
 
-            if props.model.is_latest_visible_exchange_in_root_task(app)
-                && !has_expanded_last_requested_command
-                && !props.model.is_restored()
-                && !error.is_invalid_api_key()
-            {
+            if should_show_failed_output_usage_notice(
+                error,
+                props.model.is_latest_visible_exchange_in_root_task(app),
+                has_expanded_last_requested_command,
+                props.model.is_restored(),
+            ) {
                 output_items.add_child(
                     render_informational_footer(
                         app,

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -102,7 +102,9 @@ use crate::ai::blocklist::inline_action::web_search::WebSearchView;
 use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
-use crate::ai::blocklist::view_util::{format_credits, should_show_failed_output_usage_notice};
+use crate::ai::blocklist::view_util::{
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits, should_show_failed_output_usage_notice,
+};
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
 use crate::ai::skills::{
@@ -1261,7 +1263,7 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                 output_items.add_child(
                     render_informational_footer(
                         app,
-                        "This response won't count towards your usage.".to_string(),
+                        FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_string(),
                     )
                     .with_agent_output_item_spacing(app)
                     .finish(),

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1261,12 +1261,9 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                 props.model.is_restored(),
             ) {
                 output_items.add_child(
-                    render_informational_footer(
-                        app,
-                        FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_string(),
-                    )
-                    .with_agent_output_item_spacing(app)
-                    .finish(),
+                    render_informational_footer(app, FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_string())
+                        .with_agent_output_item_spacing(app)
+                        .finish(),
                 );
 
                 output_items.add_child(

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -15,11 +15,19 @@ use warpui::ui_components::components::{UiComponent, UiComponentStyles};
 use warpui::ui_components::text::Span;
 use warpui::{AppContext, Element, EntityId, EventContext, SingletonEntity};
 
+use crate::ai::AIRequestUsageModel;
+use crate::ai::agent::RenderableAIError;
 use crate::themes::theme::{AnsiColorIdentifier, Fill, WarpTheme};
 use crate::ui_components::icons::Icon;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 
 const PROVIDER_BUTTON_ICON_SIZE: f32 = 14.;
 const PROVIDER_BUTTON_ICON_TEXT_GAP: f32 = 8.;
+const ERROR_APOLOGY_TEXT: &str = "I'm sorry, I couldn't complete that request.";
+const INTERNAL_WARP_ERROR: &str = "Internal Warp error.";
+const OUT_OF_CREDITS_TITLE: &str = "I’m sorry, I couldn’t complete that request.";
+const OUT_OF_CREDITS_DETAIL: &str =
+    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.";
 
 /// Text to use as a label throughout the app for user interactions that will attach selected
 /// block(s) or text selections to a new AI query.
@@ -52,6 +60,126 @@ pub fn error_color(theme: &WarpTheme) -> ColorU {
     AnsiColorIdentifier::Red
         .to_ansi_color(&theme.terminal_colors().normal)
         .into()
+}
+/// Renderer-neutral content for a failed Agent Mode request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FailedOutputPresentation {
+    Message(String),
+    OutOfCredits {
+        title: &'static str,
+        detail: &'static str,
+        can_use_own_api_keys: bool,
+    },
+    InvalidApiKey {
+        title: &'static str,
+        detail: String,
+    },
+    ContextWindowExceeded {
+        message: String,
+    },
+    AwsBedrockCredentialsExpiredOrInvalid {
+        fallback_message: String,
+    },
+}
+
+/// Returns the user-facing presentation for an Agent Mode request failure.
+///
+/// Recovery-pending failures are intentionally suppressed so callers cannot accidentally render
+/// an alarming terminal error while an automatic resume is still in flight.
+pub fn failed_output_presentation(
+    error: &RenderableAIError,
+    app: &AppContext,
+) -> Option<FailedOutputPresentation> {
+    if error.should_suppress_during_recovery() {
+        return None;
+    }
+
+    Some(match error {
+        RenderableAIError::QuotaLimit {
+            user_display_message,
+        } => {
+            if let Some(message) = user_display_message {
+                if should_show_subscribe_cta(app) {
+                    FailedOutputPresentation::OutOfCredits {
+                        title: OUT_OF_CREDITS_TITLE,
+                        detail: OUT_OF_CREDITS_DETAIL,
+                        can_use_own_api_keys: UserWorkspaces::as_ref(app)
+                            .is_byo_api_key_enabled(app),
+                    }
+                } else {
+                    FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{message}"))
+                }
+            } else {
+                let formatted_next_refresh_time = AIRequestUsageModel::as_ref(app)
+                    .next_refresh_time()
+                    .format("%B %d")
+                    .to_string();
+                FailedOutputPresentation::Message(format!(
+                    "{ERROR_APOLOGY_TEXT}\n\nYou've reached your credit limit. Your credit limit resets on {formatted_next_refresh_time}.",
+                ))
+            }
+        }
+        RenderableAIError::ServerOverloaded => FailedOutputPresentation::Message(
+            "Warp is currently overloaded. Please try again later.".to_string(),
+        ),
+        RenderableAIError::InternalWarpError => FailedOutputPresentation::Message(format!(
+            "{ERROR_APOLOGY_TEXT}\n\n{INTERNAL_WARP_ERROR}"
+        )),
+        RenderableAIError::ContextWindowExceeded(message) => {
+            FailedOutputPresentation::ContextWindowExceeded {
+                message: message.clone(),
+            }
+        }
+        RenderableAIError::InvalidApiKey {
+            provider,
+            model_name,
+        } => FailedOutputPresentation::InvalidApiKey {
+            title: "Provided API key is not valid",
+            detail: format!(
+                "Failed to authenticate with {provider} when using {model_name}. \
+                 Double-check that your API key is correct."
+            ),
+        },
+        RenderableAIError::AwsBedrockCredentialsExpiredOrInvalid { model_name } => {
+            FailedOutputPresentation::AwsBedrockCredentialsExpiredOrInvalid {
+                fallback_message: format!(
+                    "{ERROR_APOLOGY_TEXT}\n\nAWS credentials expired or missing for {model_name}. \
+                     Please refresh your AWS credentials."
+                ),
+            }
+        }
+        RenderableAIError::TransientNetworkError { .. } => {
+            FailedOutputPresentation::Message(error.to_string())
+        }
+        RenderableAIError::Other { error_message, .. } => {
+            FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{error_message}"))
+        }
+        RenderableAIError::AgentExitedShell => {
+            FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{error}"))
+        }
+    })
+}
+
+/// Whether a failed Agent Mode response should explain that it will not count towards usage.
+pub fn should_show_failed_output_usage_notice(
+    error: &RenderableAIError,
+    is_latest_visible_exchange_in_root_task: bool,
+    has_expanded_last_requested_command: bool,
+    is_restored: bool,
+) -> bool {
+    !error.should_suppress_during_recovery()
+        && is_latest_visible_exchange_in_root_task
+        && !has_expanded_last_requested_command
+        && !is_restored
+        && !error.is_invalid_api_key()
+}
+
+/// Whether to show the out-of-credits CTA: only for non-paid users. Paid users and the enterprise
+/// spend-limit variant of this message fall back to plain text.
+fn should_show_subscribe_cta(app: &AppContext) -> bool {
+    UserWorkspaces::as_ref(app)
+        .current_workspace()
+        .is_none_or(|workspace| !workspace.billing_metadata.is_user_on_paid_plan())
 }
 
 /// Returns the AI icon element to be rendered in AI output blocks and the terminal input when in

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -25,8 +25,7 @@ const PROVIDER_BUTTON_ICON_SIZE: f32 = 14.;
 const PROVIDER_BUTTON_ICON_TEXT_GAP: f32 = 8.;
 const ERROR_APOLOGY_TEXT: &str = "I'm sorry, I couldn't complete that request.";
 const INTERNAL_WARP_ERROR: &str = "Internal Warp error.";
-pub const FAILED_OUTPUT_USAGE_NOTICE_TEXT: &str =
-    "This response won't count towards your usage.";
+pub const FAILED_OUTPUT_USAGE_NOTICE_TEXT: &str = "This response won't count towards your usage.";
 pub const OUT_OF_CREDITS_SUBSCRIBE_LABEL: &str = "Subscribe";
 
 /// Text to use as a label throughout the app for user interactions that will attach selected
@@ -65,10 +64,20 @@ pub fn error_color(theme: &WarpTheme) -> ColorU {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FailedOutputPresentation {
     Message(String),
-    OutOfCredits { message: String },
-    InvalidApiKey { title: &'static str, detail: String },
-    ContextWindowExceeded { message: String },
-    AwsBedrockCredentialsExpiredOrInvalid { fallback_message: String },
+    OutOfCredits {
+        message: String,
+        can_use_own_api_keys: bool,
+    },
+    InvalidApiKey {
+        title: &'static str,
+        detail: String,
+    },
+    ContextWindowExceeded {
+        message: String,
+    },
+    AwsBedrockCredentialsExpiredOrInvalid {
+        fallback_message: String,
+    },
 }
 
 /// Returns the user-facing presentation for an Agent Mode request failure.
@@ -91,6 +100,8 @@ pub fn failed_output_presentation(
                 if should_show_subscribe_cta(app) {
                     FailedOutputPresentation::OutOfCredits {
                         message: format!("{ERROR_APOLOGY_TEXT}\n\n{message}"),
+                        can_use_own_api_keys: UserWorkspaces::as_ref(app)
+                            .is_byo_api_key_enabled(app),
                     }
                 } else {
                     FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{message}"))

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -25,9 +25,9 @@ const PROVIDER_BUTTON_ICON_SIZE: f32 = 14.;
 const PROVIDER_BUTTON_ICON_TEXT_GAP: f32 = 8.;
 const ERROR_APOLOGY_TEXT: &str = "I'm sorry, I couldn't complete that request.";
 const INTERNAL_WARP_ERROR: &str = "Internal Warp error.";
-const OUT_OF_CREDITS_TITLE: &str = "I’m sorry, I couldn’t complete that request.";
-const OUT_OF_CREDITS_DETAIL: &str =
-    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.";
+pub const FAILED_OUTPUT_USAGE_NOTICE_TEXT: &str =
+    "This response won't count towards your usage.";
+pub const OUT_OF_CREDITS_SUBSCRIBE_LABEL: &str = "Subscribe";
 
 /// Text to use as a label throughout the app for user interactions that will attach selected
 /// block(s) or text selections to a new AI query.
@@ -65,21 +65,10 @@ pub fn error_color(theme: &WarpTheme) -> ColorU {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FailedOutputPresentation {
     Message(String),
-    OutOfCredits {
-        title: &'static str,
-        detail: &'static str,
-        can_use_own_api_keys: bool,
-    },
-    InvalidApiKey {
-        title: &'static str,
-        detail: String,
-    },
-    ContextWindowExceeded {
-        message: String,
-    },
-    AwsBedrockCredentialsExpiredOrInvalid {
-        fallback_message: String,
-    },
+    OutOfCredits { message: String },
+    InvalidApiKey { title: &'static str, detail: String },
+    ContextWindowExceeded { message: String },
+    AwsBedrockCredentialsExpiredOrInvalid { fallback_message: String },
 }
 
 /// Returns the user-facing presentation for an Agent Mode request failure.
@@ -101,10 +90,7 @@ pub fn failed_output_presentation(
             if let Some(message) = user_display_message {
                 if should_show_subscribe_cta(app) {
                     FailedOutputPresentation::OutOfCredits {
-                        title: OUT_OF_CREDITS_TITLE,
-                        detail: OUT_OF_CREDITS_DETAIL,
-                        can_use_own_api_keys: UserWorkspaces::as_ref(app)
-                            .is_byo_api_key_enabled(app),
+                        message: format!("{ERROR_APOLOGY_TEXT}\n\n{message}"),
                     }
                 } else {
                     FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{message}"))

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -49,7 +49,8 @@ pub use crate::ai::blocklist::block::cli_controller::{
     UserTakeOverReason,
 };
 pub use crate::ai::blocklist::block::model::{
-    AIBlockModel, AIBlockModelImpl, AIBlockOutputStatus, AIRequestType, OutputStatusUpdateCallback,
+    AIBlockModel, AIBlockModelHelper, AIBlockModelImpl, AIBlockOutputStatus, AIRequestType,
+    OutputStatusUpdateCallback,
 };
 pub use crate::ai::blocklist::conversation_selection::{
     ConversationSelection, ConversationSelectionEvent, ConversationSelectionHandle,
@@ -73,7 +74,10 @@ pub use crate::ai::blocklist::orchestration_topology::{
     orchestration_root_conversation_id, orchestrator_agent_id_for_conversation,
     resolve_orchestration_participant,
 };
-pub use crate::ai::blocklist::view_util::format_credits;
+pub use crate::ai::blocklist::view_util::{
+    FailedOutputPresentation, failed_output_presentation, format_credits,
+    should_show_failed_output_usage_notice,
+};
 pub use crate::ai::blocklist::{
     AIActionStatus, AskUserQuestionExecutor, AttachmentType, BlocklistAIActionEvent,
     BlocklistAIActionModel, BlocklistAIContextEvent, BlocklistAIContextModel,

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -75,8 +75,8 @@ pub use crate::ai::blocklist::orchestration_topology::{
     resolve_orchestration_participant,
 };
 pub use crate::ai::blocklist::view_util::{
-    FailedOutputPresentation, failed_output_presentation, format_credits,
-    should_show_failed_output_usage_notice,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, OUT_OF_CREDITS_SUBSCRIBE_LABEL,
+    failed_output_presentation, format_credits, should_show_failed_output_usage_notice,
 };
 pub use crate::ai::blocklist::{
     AIActionStatus, AskUserQuestionExecutor, AttachmentType, BlocklistAIActionEvent,

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -17,16 +17,18 @@ use parking_lot::FairMutex;
 use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId,
     AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIAgentTodo, AIBlockModel,
-    AIConversationId, BlockId, BlocklistAIActionEvent, BlocklistAIActionModel,
-    BlocklistAIHistoryModel, CancellationReason, MessageId, ModelEvent, ModelEventDispatcher,
-    ReceivedMessageDisplay, SummarizationType, TerminalModel, TodoOperation, TodoStatus,
+    AIBlockModelHelper, AIBlockOutputStatus, AIConversationId, BlockId, BlocklistAIActionEvent,
+    BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason, FailedOutputPresentation,
+    MessageId, ModelEvent, ModelEventDispatcher, ReceivedMessageDisplay, SummarizationType,
+    TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
+    should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
 use warpui_core::elements::MouseStateHandle;
 use warpui_core::elements::tui::{
     Modifier, TuiBuffer, TuiBufferExt, TuiChildView, TuiConstraint, TuiContainer, TuiElement,
-    TuiFlex, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiParentElement, TuiRect,
-    TuiScreenPosition, TuiSelectionSpan, TuiSize, TuiText,
+    TuiFlex, TuiHoverable, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiParentElement,
+    TuiRect, TuiScreenPosition, TuiSelectionSpan, TuiSize, TuiText,
 };
 use warpui_core::{
     AppContext, Entity, EntityId, EntityIdMap, ModelHandle, TuiView, TypedActionView, ViewContext,
@@ -52,6 +54,9 @@ use crate::tui_markdown::{
 };
 use crate::tui_permission_prompt::TuiPermissionPrompt;
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
+const PLANS_URL: &str = "https://www.warp.dev/pricing";
+const BYOK_DOCS_URL: &str =
+    "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TuiCodeBlockKey {
@@ -122,6 +127,8 @@ enum TuiAIBlockSection {
     },
     /// A message delivered by another agent in the orchestration.
     AgentMessage(ReceivedMessageDisplay),
+    Failure(FailedOutputPresentation),
+    UsageNotice,
 }
 
 /// Per-message UI state for collapsible sections (thinking blocks,
@@ -174,6 +181,127 @@ impl CollapsibleSectionStates {
             .or_default()
             .hover_state
             .clone()
+    }
+}
+
+fn render_failure_section(
+    presentation: &FailedOutputPresentation,
+    compare_plans_hover_state: &MouseStateHandle,
+    byok_hover_state: &MouseStateHandle,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    let error_style = builder.error_text_style();
+    let body_style = builder.muted_text_style();
+    match presentation {
+        FailedOutputPresentation::Message(message)
+        | FailedOutputPresentation::AwsBedrockCredentialsExpiredOrInvalid {
+            fallback_message: message,
+        } => TuiText::from_spans([
+            ("⚠ ".to_owned(), error_style),
+            (message.clone(), body_style),
+        ])
+        .finish(),
+        FailedOutputPresentation::InvalidApiKey { title, detail } => TuiText::from_spans([
+            ("⚠ ".to_owned(), error_style),
+            (
+                (*title).to_owned(),
+                error_style.add_modifier(Modifier::BOLD),
+            ),
+            ("\n  ".to_owned(), body_style),
+            (detail.clone(), body_style),
+        ])
+        .finish(),
+        FailedOutputPresentation::OutOfCredits {
+            title,
+            detail,
+            can_use_own_api_keys,
+        } => {
+            let primary_style = builder.primary_text_style();
+            let link_style = primary_style.add_modifier(Modifier::UNDERLINED);
+            let compare_plans = TuiHoverable::new(
+                compare_plans_hover_state.clone(),
+                TuiText::new("Compare plans")
+                    .with_style(link_style)
+                    .finish(),
+            )
+            .on_click(|_, app| app.open_url(PLANS_URL))
+            .finish();
+            let mut actions = TuiFlex::row()
+                .child(TuiText::new("  ").with_style(primary_style).finish())
+                .child(compare_plans);
+            if *can_use_own_api_keys {
+                actions = actions
+                    .child(
+                        TuiText::new("  or  ")
+                            .with_style(builder.muted_text_style())
+                            .finish(),
+                    )
+                    .child(
+                        TuiHoverable::new(
+                            byok_hover_state.clone(),
+                            TuiText::new("Use your own API keys")
+                                .with_style(link_style)
+                                .finish(),
+                        )
+                        .on_click(|_, app| app.open_url(BYOK_DOCS_URL))
+                        .finish(),
+                    );
+            }
+            TuiFlex::column()
+                .child(
+                    TuiText::from_spans([
+                        ("!".to_owned(), error_style.add_modifier(Modifier::BOLD)),
+                        (" ".to_owned(), primary_style.add_modifier(Modifier::BOLD)),
+                        ((*title).to_owned(), primary_style),
+                    ])
+                    .finish(),
+                )
+                .child(
+                    TuiText::new(format!("  {detail}"))
+                        .with_style(primary_style)
+                        .finish(),
+                )
+                .child(TuiText::new(" ").finish())
+                .child(actions.finish())
+                .finish()
+        }
+        FailedOutputPresentation::ContextWindowExceeded { message } => TuiText::from_spans([
+            ("× ".to_owned(), error_style),
+            (message.clone(), body_style),
+        ])
+        .finish(),
+    }
+}
+
+fn render_usage_notice(app: &AppContext) -> Box<dyn TuiElement> {
+    TuiText::new("This response won't count towards your usage.")
+        .with_style(TuiUiBuilder::from_app(app).muted_text_style())
+        .finish()
+}
+
+fn failure_text(presentation: &FailedOutputPresentation) -> String {
+    match presentation {
+        FailedOutputPresentation::Message(message)
+        | FailedOutputPresentation::AwsBedrockCredentialsExpiredOrInvalid {
+            fallback_message: message,
+        }
+        | FailedOutputPresentation::ContextWindowExceeded { message } => message.clone(),
+        FailedOutputPresentation::OutOfCredits {
+            title,
+            detail,
+            can_use_own_api_keys,
+        } => {
+            let actions = if *can_use_own_api_keys {
+                "Compare plans  or  Use your own API keys"
+            } else {
+                "Compare plans"
+            };
+            format!("{title}\n  {detail}\n\n  {actions}")
+        }
+        FailedOutputPresentation::InvalidApiKey { title, detail } => {
+            format!("{title}\n{detail}")
+        }
     }
 }
 
@@ -258,6 +386,8 @@ pub(super) struct TuiAIBlock {
     /// Per-message UI state for this exchange's collapsible sections
     /// (thinking blocks and task lists).
     collapsible_states: CollapsibleSectionStates,
+    compare_plans_hover_state: MouseStateHandle,
+    byok_hover_state: MouseStateHandle,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -299,6 +429,8 @@ impl TuiAIBlock {
             action_model: action_model.clone(),
             terminal_model,
             collapsible_states: Default::default(),
+            compare_plans_hover_state: MouseStateHandle::default(),
+            byok_hover_state: MouseStateHandle::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
@@ -1079,6 +1211,13 @@ impl TuiAIBlock {
                 )
             }
             TuiAIBlockSection::AgentMessage(_) => return None,
+            TuiAIBlockSection::Failure(presentation) => render_failure_section(
+                presentation,
+                &self.compare_plans_hover_state,
+                &self.byok_hover_state,
+                app,
+            ),
+            TuiAIBlockSection::UsageNotice => render_usage_notice(app),
         })
     }
     fn rich_text_sections(message_id: &MessageId, text: &AIAgentText) -> Vec<TuiRichTextSection> {
@@ -1113,6 +1252,7 @@ impl TuiAIBlock {
     /// preserving message order so reasoning interleaves with plain-text output.
     fn sections(&self, app: &AppContext) -> Vec<TuiAIBlockSection> {
         let mut sections = Vec::new();
+        let status = self.block_model.status(app);
         let input = self
             .block_model
             .inputs_to_render(app)
@@ -1124,7 +1264,7 @@ impl TuiAIBlock {
         }
 
         // Walk output messages in order so tool-call rows interleave with text.
-        if let Some(output) = self.block_model.status(app).output_to_render() {
+        if let Some(output) = status.output_to_render() {
             let output = output.get();
             for message in &output.messages {
                 match &message.message {
@@ -1212,7 +1352,53 @@ impl TuiAIBlock {
             }
         }
 
+        if self.block_model.request_type(app).is_active()
+            && let AIBlockOutputStatus::Failed { error, .. } = &status
+            && let Some(presentation) = failed_output_presentation(error, app)
+        {
+            let is_out_of_credits =
+                matches!(presentation, FailedOutputPresentation::OutOfCredits { .. });
+            sections.push(TuiAIBlockSection::Failure(presentation));
+            if !is_out_of_credits
+                && should_show_failed_output_usage_notice(
+                    error,
+                    self.block_model
+                        .is_latest_visible_exchange_in_root_task(app),
+                    self.has_expanded_last_requested_command(app),
+                    self.block_model.is_restored(),
+                )
+            {
+                sections.push(TuiAIBlockSection::UsageNotice);
+            }
+        }
+
         sections
+    }
+
+    fn has_expanded_last_requested_command(&self, app: &AppContext) -> bool {
+        let status = self.block_model.status(app);
+        let Some(output) = status.output_to_render() else {
+            return false;
+        };
+        let action_id = output.get().messages.iter().rev().find_map(|message| {
+            let AIAgentOutputMessageType::Action(action) = &message.message else {
+                return None;
+            };
+            matches!(
+                &action.action,
+                AIAgentActionType::RequestCommandOutput { .. }
+            )
+            .then(|| action.id.clone())
+        });
+        action_id
+            .and_then(|action_id| self.action_views.get(&action_id))
+            .is_some_and(|view| match view {
+                TuiToolCallView::ShellCommand(view) => view.as_ref(app).is_expanded(),
+                TuiToolCallView::AskQuestion(_)
+                | TuiToolCallView::FileEdits(_)
+                | TuiToolCallView::Plan(_)
+                | TuiToolCallView::OrchestrationBlock(_) => false,
+            })
     }
 
     fn markdown_palette(app: &AppContext, muted: bool) -> TuiMarkdownPalette {
@@ -1408,6 +1594,13 @@ impl TuiAIBlock {
                     self.conversation_id,
                     app,
                 ),
+                TuiAIBlockSection::Failure(presentation) => render_failure_section(
+                    presentation,
+                    &self.compare_plans_hover_state,
+                    &self.byok_hover_state,
+                    app,
+                ),
+                TuiAIBlockSection::UsageNotice => render_usage_notice(app),
             };
 
             // One row of bottom padding separates sections; the last section
@@ -1473,6 +1666,10 @@ fn section_logical_text(section: &TuiAIBlockSection) -> Option<String> {
         | TuiAIBlockSection::TodoList { .. }
         | TuiAIBlockSection::CompletedTodos { .. }
         | TuiAIBlockSection::AgentMessage(_) => None,
+        TuiAIBlockSection::Failure(presentation) => Some(failure_text(presentation)),
+        TuiAIBlockSection::UsageNotice => {
+            Some("This response won't count towards your usage.".to_owned())
+        }
     }
 }
 

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -18,9 +18,10 @@ use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId,
     AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIAgentTodo, AIBlockModel,
     AIBlockModelHelper, AIBlockOutputStatus, AIConversationId, BlockId, BlocklistAIActionEvent,
-    BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason, FailedOutputPresentation,
-    MessageId, ModelEvent, ModelEventDispatcher, ReceivedMessageDisplay, SummarizationType,
-    TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
+    BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, MessageId, ModelEvent,
+    ModelEventDispatcher, OUT_OF_CREDITS_SUBSCRIBE_LABEL, ReceivedMessageDisplay,
+    SummarizationType, TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
     should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
@@ -55,8 +56,7 @@ use crate::tui_markdown::{
 use crate::tui_permission_prompt::TuiPermissionPrompt;
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
 const PLANS_URL: &str = "https://www.warp.dev/pricing";
-const BYOK_DOCS_URL: &str =
-    "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/";
+const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TuiCodeBlockKey {
@@ -186,8 +186,7 @@ impl CollapsibleSectionStates {
 
 fn render_failure_section(
     presentation: &FailedOutputPresentation,
-    compare_plans_hover_state: &MouseStateHandle,
-    byok_hover_state: &MouseStateHandle,
+    subscribe_hover_state: &MouseStateHandle,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
@@ -198,12 +197,12 @@ fn render_failure_section(
         | FailedOutputPresentation::AwsBedrockCredentialsExpiredOrInvalid {
             fallback_message: message,
         } => TuiText::from_spans([
-            ("⚠ ".to_owned(), error_style),
+            (FAILURE_WARNING_PREFIX.to_owned(), error_style),
             (message.clone(), body_style),
         ])
         .finish(),
         FailedOutputPresentation::InvalidApiKey { title, detail } => TuiText::from_spans([
-            ("⚠ ".to_owned(), error_style),
+            (FAILURE_WARNING_PREFIX.to_owned(), error_style),
             (
                 (*title).to_owned(),
                 error_style.add_modifier(Modifier::BOLD),
@@ -212,55 +211,25 @@ fn render_failure_section(
             (detail.clone(), body_style),
         ])
         .finish(),
-        FailedOutputPresentation::OutOfCredits {
-            title,
-            detail,
-            can_use_own_api_keys,
-        } => {
+        FailedOutputPresentation::OutOfCredits { message } => {
             let primary_style = builder.primary_text_style();
             let link_style = primary_style.add_modifier(Modifier::UNDERLINED);
-            let compare_plans = TuiHoverable::new(
-                compare_plans_hover_state.clone(),
-                TuiText::new("Compare plans")
-                    .with_style(link_style)
-                    .finish(),
+            let subscribe = TuiHoverable::new(
+                subscribe_hover_state.clone(),
+            TuiText::new(OUT_OF_CREDITS_SUBSCRIBE_LABEL).with_style(link_style).finish(),
             )
             .on_click(|_, app| app.open_url(PLANS_URL))
             .finish();
-            let mut actions = TuiFlex::row()
+            let actions = TuiFlex::row()
                 .child(TuiText::new("  ").with_style(primary_style).finish())
-                .child(compare_plans);
-            if *can_use_own_api_keys {
-                actions = actions
-                    .child(
-                        TuiText::new("  or  ")
-                            .with_style(builder.muted_text_style())
-                            .finish(),
-                    )
-                    .child(
-                        TuiHoverable::new(
-                            byok_hover_state.clone(),
-                            TuiText::new("Use your own API keys")
-                                .with_style(link_style)
-                                .finish(),
-                        )
-                        .on_click(|_, app| app.open_url(BYOK_DOCS_URL))
-                        .finish(),
-                    );
-            }
+                .child(subscribe);
             TuiFlex::column()
                 .child(
                     TuiText::from_spans([
-                        ("!".to_owned(), error_style.add_modifier(Modifier::BOLD)),
-                        (" ".to_owned(), primary_style.add_modifier(Modifier::BOLD)),
-                        ((*title).to_owned(), primary_style),
+                        (FAILURE_WARNING_PREFIX.to_owned(), error_style),
+                        (message.clone(), primary_style),
                     ])
                     .finish(),
-                )
-                .child(
-                    TuiText::new(format!("  {detail}"))
-                        .with_style(primary_style)
-                        .finish(),
                 )
                 .child(TuiText::new(" ").finish())
                 .child(actions.finish())
@@ -275,7 +244,7 @@ fn render_failure_section(
 }
 
 fn render_usage_notice(app: &AppContext) -> Box<dyn TuiElement> {
-    TuiText::new("This response won't count towards your usage.")
+    TuiText::new(FAILED_OUTPUT_USAGE_NOTICE_TEXT)
         .with_style(TuiUiBuilder::from_app(app).muted_text_style())
         .finish()
 }
@@ -287,17 +256,8 @@ fn failure_text(presentation: &FailedOutputPresentation) -> String {
             fallback_message: message,
         }
         | FailedOutputPresentation::ContextWindowExceeded { message } => message.clone(),
-        FailedOutputPresentation::OutOfCredits {
-            title,
-            detail,
-            can_use_own_api_keys,
-        } => {
-            let actions = if *can_use_own_api_keys {
-                "Compare plans  or  Use your own API keys"
-            } else {
-                "Compare plans"
-            };
-            format!("{title}\n  {detail}\n\n  {actions}")
+        FailedOutputPresentation::OutOfCredits { message } => {
+            format!("{message}\n\nSubscribe")
         }
         FailedOutputPresentation::InvalidApiKey { title, detail } => {
             format!("{title}\n{detail}")
@@ -386,8 +346,7 @@ pub(super) struct TuiAIBlock {
     /// Per-message UI state for this exchange's collapsible sections
     /// (thinking blocks and task lists).
     collapsible_states: CollapsibleSectionStates,
-    compare_plans_hover_state: MouseStateHandle,
-    byok_hover_state: MouseStateHandle,
+    subscribe_hover_state: MouseStateHandle,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -429,8 +388,7 @@ impl TuiAIBlock {
             action_model: action_model.clone(),
             terminal_model,
             collapsible_states: Default::default(),
-            compare_plans_hover_state: MouseStateHandle::default(),
-            byok_hover_state: MouseStateHandle::default(),
+            subscribe_hover_state: MouseStateHandle::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
@@ -1211,12 +1169,9 @@ impl TuiAIBlock {
                 )
             }
             TuiAIBlockSection::AgentMessage(_) => return None,
-            TuiAIBlockSection::Failure(presentation) => render_failure_section(
-                presentation,
-                &self.compare_plans_hover_state,
-                &self.byok_hover_state,
-                app,
-            ),
+            TuiAIBlockSection::Failure(presentation) => {
+                render_failure_section(presentation, &self.subscribe_hover_state, app)
+            }
             TuiAIBlockSection::UsageNotice => render_usage_notice(app),
         })
     }
@@ -1356,18 +1311,14 @@ impl TuiAIBlock {
             && let AIBlockOutputStatus::Failed { error, .. } = &status
             && let Some(presentation) = failed_output_presentation(error, app)
         {
-            let is_out_of_credits =
-                matches!(presentation, FailedOutputPresentation::OutOfCredits { .. });
             sections.push(TuiAIBlockSection::Failure(presentation));
-            if !is_out_of_credits
-                && should_show_failed_output_usage_notice(
-                    error,
-                    self.block_model
-                        .is_latest_visible_exchange_in_root_task(app),
-                    self.has_expanded_last_requested_command(app),
-                    self.block_model.is_restored(),
-                )
-            {
+            if should_show_failed_output_usage_notice(
+                error,
+                self.block_model
+                    .is_latest_visible_exchange_in_root_task(app),
+                self.has_expanded_last_requested_command(app),
+                self.block_model.is_restored(),
+            ) {
                 sections.push(TuiAIBlockSection::UsageNotice);
             }
         }
@@ -1594,12 +1545,9 @@ impl TuiAIBlock {
                     self.conversation_id,
                     app,
                 ),
-                TuiAIBlockSection::Failure(presentation) => render_failure_section(
-                    presentation,
-                    &self.compare_plans_hover_state,
-                    &self.byok_hover_state,
-                    app,
-                ),
+                TuiAIBlockSection::Failure(presentation) => {
+                    render_failure_section(presentation, &self.subscribe_hover_state, app)
+                }
                 TuiAIBlockSection::UsageNotice => render_usage_notice(app),
             };
 

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -20,9 +20,8 @@ use warp::tui_export::{
     AIBlockModelHelper, AIBlockOutputStatus, AIConversationId, BlockId, BlocklistAIActionEvent,
     BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason,
     FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, MessageId, ModelEvent,
-    ModelEventDispatcher, OUT_OF_CREDITS_SUBSCRIBE_LABEL, ReceivedMessageDisplay,
-    SummarizationType, TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
-    should_show_failed_output_usage_notice,
+    ModelEventDispatcher, ReceivedMessageDisplay, SummarizationType, TerminalModel, TodoOperation,
+    TodoStatus, failed_output_presentation, should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
 use warpui_core::elements::MouseStateHandle;
@@ -56,6 +55,10 @@ use crate::tui_markdown::{
 use crate::tui_permission_prompt::TuiPermissionPrompt;
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
 const PLANS_URL: &str = "https://www.warp.dev/pricing";
+const BYOK_DOCS_URL: &str =
+    "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/";
+const COMPARE_PLANS_LABEL: &str = "Compare plans";
+const USE_YOUR_OWN_API_KEYS_LABEL: &str = "Use your own API keys";
 const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -186,7 +189,8 @@ impl CollapsibleSectionStates {
 
 fn render_failure_section(
     presentation: &FailedOutputPresentation,
-    subscribe_hover_state: &MouseStateHandle,
+    compare_plans_hover_state: &MouseStateHandle,
+    byok_hover_state: &MouseStateHandle,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
@@ -211,26 +215,57 @@ fn render_failure_section(
             (detail.clone(), body_style),
         ])
         .finish(),
-        FailedOutputPresentation::OutOfCredits { message } => {
+        FailedOutputPresentation::OutOfCredits {
+            message,
+            can_use_own_api_keys,
+        } => {
             let primary_style = builder.primary_text_style();
             let link_style = primary_style.add_modifier(Modifier::UNDERLINED);
-            let subscribe = TuiHoverable::new(
-                subscribe_hover_state.clone(),
-            TuiText::new(OUT_OF_CREDITS_SUBSCRIBE_LABEL).with_style(link_style).finish(),
+            let (title, detail) = message.split_once("\n\n").unwrap_or((message.as_str(), ""));
+            let compare_plans = TuiHoverable::new(
+                compare_plans_hover_state.clone(),
+                TuiText::new(COMPARE_PLANS_LABEL)
+                    .with_style(link_style)
+                    .finish(),
             )
             .on_click(|_, app| app.open_url(PLANS_URL))
             .finish();
-            let actions = TuiFlex::row()
+            let mut actions = TuiFlex::row()
                 .child(TuiText::new("  ").with_style(primary_style).finish())
-                .child(subscribe);
-            TuiFlex::column()
-                .child(
-                    TuiText::from_spans([
-                        (FAILURE_WARNING_PREFIX.to_owned(), error_style),
-                        (message.clone(), primary_style),
-                    ])
-                    .finish(),
-                )
+                .child(compare_plans);
+            if *can_use_own_api_keys {
+                actions = actions
+                    .child(
+                        TuiText::new("  or  ")
+                            .with_style(builder.muted_text_style())
+                            .finish(),
+                    )
+                    .child(
+                        TuiHoverable::new(
+                            byok_hover_state.clone(),
+                            TuiText::new(USE_YOUR_OWN_API_KEYS_LABEL)
+                                .with_style(link_style)
+                                .finish(),
+                        )
+                        .on_click(|_, app| app.open_url(BYOK_DOCS_URL))
+                        .finish(),
+                    );
+            }
+            let mut content = TuiFlex::column().child(
+                TuiText::from_spans([
+                    (FAILURE_WARNING_PREFIX.to_owned(), error_style),
+                    (title.to_owned(), primary_style),
+                ])
+                .finish(),
+            );
+            if !detail.is_empty() {
+                content = content.child(
+                    TuiText::new(format!("  {detail}"))
+                        .with_style(primary_style)
+                        .finish(),
+                );
+            }
+            content
                 .child(TuiText::new(" ").finish())
                 .child(actions.finish())
                 .finish()
@@ -256,8 +291,16 @@ fn failure_text(presentation: &FailedOutputPresentation) -> String {
             fallback_message: message,
         }
         | FailedOutputPresentation::ContextWindowExceeded { message } => message.clone(),
-        FailedOutputPresentation::OutOfCredits { message } => {
-            format!("{message}\n\nSubscribe")
+        FailedOutputPresentation::OutOfCredits {
+            message,
+            can_use_own_api_keys,
+        } => {
+            let actions = if *can_use_own_api_keys {
+                format!("{COMPARE_PLANS_LABEL}  or  {USE_YOUR_OWN_API_KEYS_LABEL}")
+            } else {
+                COMPARE_PLANS_LABEL.to_owned()
+            };
+            format!("{message}\n\n{actions}")
         }
         FailedOutputPresentation::InvalidApiKey { title, detail } => {
             format!("{title}\n{detail}")
@@ -346,7 +389,8 @@ pub(super) struct TuiAIBlock {
     /// Per-message UI state for this exchange's collapsible sections
     /// (thinking blocks and task lists).
     collapsible_states: CollapsibleSectionStates,
-    subscribe_hover_state: MouseStateHandle,
+    compare_plans_hover_state: MouseStateHandle,
+    byok_hover_state: MouseStateHandle,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -388,7 +432,8 @@ impl TuiAIBlock {
             action_model: action_model.clone(),
             terminal_model,
             collapsible_states: Default::default(),
-            subscribe_hover_state: MouseStateHandle::default(),
+            compare_plans_hover_state: MouseStateHandle::default(),
+            byok_hover_state: MouseStateHandle::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
@@ -1169,9 +1214,12 @@ impl TuiAIBlock {
                 )
             }
             TuiAIBlockSection::AgentMessage(_) => return None,
-            TuiAIBlockSection::Failure(presentation) => {
-                render_failure_section(presentation, &self.subscribe_hover_state, app)
-            }
+            TuiAIBlockSection::Failure(presentation) => render_failure_section(
+                presentation,
+                &self.compare_plans_hover_state,
+                &self.byok_hover_state,
+                app,
+            ),
             TuiAIBlockSection::UsageNotice => render_usage_notice(app),
         })
     }
@@ -1545,9 +1593,12 @@ impl TuiAIBlock {
                     self.conversation_id,
                     app,
                 ),
-                TuiAIBlockSection::Failure(presentation) => {
-                    render_failure_section(presentation, &self.subscribe_hover_state, app)
-                }
+                TuiAIBlockSection::Failure(presentation) => render_failure_section(
+                    presentation,
+                    &self.compare_plans_hover_state,
+                    &self.byok_hover_state,
+                    app,
+                ),
                 TuiAIBlockSection::UsageNotice => render_usage_notice(app),
             };
 
@@ -1615,9 +1666,7 @@ fn section_logical_text(section: &TuiAIBlockSection) -> Option<String> {
         | TuiAIBlockSection::CompletedTodos { .. }
         | TuiAIBlockSection::AgentMessage(_) => None,
         TuiAIBlockSection::Failure(presentation) => Some(failure_text(presentation)),
-        TuiAIBlockSection::UsageNotice => {
-            Some("This response won't count towards your usage.".to_owned())
-        }
+        TuiAIBlockSection::UsageNotice => Some(FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_owned()),
     }
 }
 

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -1395,6 +1395,7 @@ impl TuiAIBlock {
                 TuiToolCallView::ShellCommand(view) => view.as_ref(app).is_expanded(),
                 TuiToolCallView::AskQuestion(_)
                 | TuiToolCallView::FileEdits(_)
+                | TuiToolCallView::Generic(_)
                 | TuiToolCallView::Plan(_)
                 | TuiToolCallView::OrchestrationBlock(_) => false,
             })

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,36 +14,332 @@ use warp::tui_export::{
     AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
     AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIAgentTodo, AIAgentTodoList,
     AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, AgentOutputImage,
-    AgentOutputImageLayout, AgentOutputMermaidDiagram, AgentOutputTable, Appearance, LLMId,
-    MessageId, OutputStatusUpdateCallback, ReceivedMessageDisplay, RequestCommandOutputResult,
-    ServerOutputId, Shared, SummarizationType, TaskId, TerminalModel, TodoOperation, TodoStatus,
-    UserQueryMode,
+    AgentOutputImageLayout, AgentOutputMermaidDiagram, AgentOutputTable, Appearance,
+    FailedOutputPresentation, LLMId, MessageId, OutputStatusUpdateCallback, ReceivedMessageDisplay,
+    RenderableAIError, RequestCommandOutputResult, ServerOutputId, Shared, SummarizationType,
+    TaskId, TerminalModel, TodoOperation, TodoStatus, UserQueryMode,
+    should_show_failed_output_usage_notice,
 };
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill as ThemeFill;
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, SingletonEntity};
-use warpui_core::elements::Fill as CoreFill;
 use warpui_core::elements::tui::{
-    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiEvent, TuiEventContext,
+    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
     TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPoint, TuiRect, TuiScreenPosition,
     TuiSize,
 };
+use warpui_core::elements::{Fill as CoreFill, MouseStateHandle};
 use warpui_core::event::ModifiersState;
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, AppContext, EntityId, EntityIdMap, TuiView, ViewContext, ViewHandle};
 
 use super::{
     CollapsibleSectionStates, TuiAIBlock, TuiAIBlockAction, TuiAIBlockEvent, TuiAIBlockSection,
-    TuiCodeBlockKey, TuiRichTextSection, TuiToolCallView,
+    TuiCodeBlockKey, TuiRichTextSection, TuiToolCallView, render_failure_section,
 };
 use crate::agent_block_sections::{
     completed_todos_label, render_fallback_tool_call_section, render_todo_list_section,
 };
 use crate::agent_message::agent_message_section_id;
 use crate::test_fixtures::{TestHostView, add_test_action_model_and_events};
+use crate::tui_builder::TuiUiBuilder;
 use crate::tui_plan_view::TuiPlanViewAction;
 use crate::tui_shell_command_view::TuiShellCommandViewAction;
+
+#[test]
+fn agent_block_renders_generic_failure_after_partial_output() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: vec![query_input("hello")],
+                status: failed_output(
+                    vec![plain_text_message("message-1", "partial response")],
+                    RenderableAIError::other("backend failed", false),
+                ),
+            },
+        );
+
+        app.read(|ctx| {
+            let lines = render_block_lines(block.as_ref(ctx), 60, ctx);
+            assert_eq!(
+                lines,
+                vec![
+                    "> hello",
+                    "partial response",
+                    "⚠ I'm sorry, I couldn't complete that request.",
+                    "backend failed",
+                ]
+            );
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                block.as_ref(ctx).render_element(ctx),
+                TuiRect::new(0, 0, 60, 9),
+                ctx,
+            );
+            let failure_row = frame
+                .buffer
+                .to_lines()
+                .iter()
+                .position(|line| line.contains("couldn't complete"))
+                .expect("failure row");
+            let red: Color = CoreFill::from(ThemeFill::from(
+                Appearance::as_ref(ctx).theme().terminal_colors().normal.red,
+            ))
+            .into();
+            assert_eq!(frame.buffer[(0, failure_row as u16)].fg, red);
+        });
+    });
+}
+
+#[test]
+fn agent_block_renders_invalid_api_key_detail_without_usage_notice() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: failed_output(
+                    Vec::new(),
+                    RenderableAIError::InvalidApiKey {
+                        provider: "OpenAI".to_owned(),
+                        model_name: "GPT".to_owned(),
+                    },
+                ),
+            },
+        );
+
+        app.read(|ctx| {
+            let lines = render_block_lines(block.as_ref(ctx), 100, ctx);
+            assert_eq!(
+                lines,
+                vec![
+                    "⚠ Provided API key is not valid",
+                    "  Failed to authenticate with OpenAI when using GPT. Double-check that your API key is correct.",
+                ]
+            );
+            assert!(
+                lines
+                    .iter()
+                    .all(|line| !line.contains("won't count towards your usage"))
+            );
+        });
+    });
+}
+
+#[test]
+fn agent_block_suppresses_recovery_pending_failure() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: failed_output(
+                    vec![plain_text_message("message-1", "partial response")],
+                    RenderableAIError::Other {
+                        error_message: "temporary failure".to_owned(),
+                        will_attempt_resume: true,
+                        waiting_for_network: false,
+                        is_user_error: false,
+                    },
+                ),
+            },
+        );
+
+        app.read(|ctx| {
+            assert_eq!(
+                render_block_lines(block.as_ref(ctx), 60, ctx),
+                vec!["partial response"]
+            );
+        });
+    });
+}
+
+#[test]
+fn agent_block_renders_context_window_failure() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: failed_output(
+                    Vec::new(),
+                    RenderableAIError::ContextWindowExceeded(
+                        "The conversation is too long.".to_owned(),
+                    ),
+                ),
+            },
+        );
+
+        app.read(|ctx| {
+            assert_eq!(
+                render_block_lines(block.as_ref(ctx), 60, ctx),
+                vec!["× The conversation is too long."]
+            );
+        });
+    });
+}
+
+#[test]
+fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let opened_urls = Rc::new(RefCell::new(Vec::new()));
+        let opened_urls_for_callback = opened_urls.clone();
+        app.update(|ctx| {
+            ctx.set_before_open_url(move |url, _| {
+                opened_urls_for_callback.borrow_mut().push(url.to_owned());
+                url.to_owned()
+            });
+        });
+
+        app.read(|ctx| {
+            let presentation = FailedOutputPresentation::OutOfCredits {
+                title: "I’m sorry, I couldn’t complete that request.",
+                detail:
+                    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
+                can_use_own_api_keys: true,
+            };
+            let compare_plans_hover_state = MouseStateHandle::default();
+            let byok_hover_state = MouseStateHandle::default();
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 100, 4),
+                ctx,
+            );
+            assert_eq!(
+                frame
+                    .buffer
+                    .to_lines()
+                    .into_iter()
+                    .map(|line| line.trim_end().to_owned())
+                    .collect::<Vec<_>>(),
+                vec![
+                    "! I’m sorry, I couldn’t complete that request.",
+                    "  In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
+                    "",
+                    "  Compare plans  or  Use your own API keys",
+                ]
+            );
+            let builder = TuiUiBuilder::from_app(ctx);
+            let primary_foreground = builder
+                .primary_text_style()
+                .fg
+                .expect("primary foreground");
+            assert_eq!(
+                frame.buffer[(0, 0)].fg,
+                builder.error_text_style().fg.expect("error foreground")
+            );
+            assert_eq!(frame.buffer[(2, 0)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 1)].fg, primary_foreground);
+            assert_eq!(
+                frame.buffer[(17, 3)].fg,
+                builder.muted_text_style().fg.expect("muted foreground")
+            );
+            assert_eq!(frame.buffer[(2, 3)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(21, 3)].fg, primary_foreground);
+            assert!(
+                frame.buffer[(2, 3)]
+                    .modifier
+                    .contains(Modifier::UNDERLINED)
+            );
+            assert!(
+                frame.buffer[(21, 3)]
+                    .modifier
+                    .contains(Modifier::UNDERLINED)
+            );
+
+            dispatch_click_on_text(
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                "Compare plans",
+                100,
+                4,
+                ctx,
+            );
+            dispatch_click_on_text(
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                "Use your own API keys",
+                100,
+                4,
+                ctx,
+            );
+
+            let without_byok = FailedOutputPresentation::OutOfCredits {
+                title: "I’m sorry, I couldn’t complete that request.",
+                detail:
+                    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
+                can_use_own_api_keys: false,
+            };
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_failure_section(
+                    &without_byok,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 100, 4),
+                ctx,
+            );
+            assert_eq!(frame.buffer.to_lines()[3].trim_end(), "  Compare plans");
+        });
+
+        assert_eq!(
+            &*opened_urls.borrow(),
+            &[
+                "https://www.warp.dev/pricing".to_owned(),
+                "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/".to_owned(),
+            ]
+        );
+    });
+}
+
+#[test]
+fn failed_output_usage_notice_matches_gui_conditions() {
+    let error = RenderableAIError::other("failed", false);
+    assert!(should_show_failed_output_usage_notice(
+        &error, true, false, false
+    ));
+    assert!(!should_show_failed_output_usage_notice(
+        &error, false, false, false
+    ));
+    assert!(!should_show_failed_output_usage_notice(
+        &error, true, true, false
+    ));
+    assert!(!should_show_failed_output_usage_notice(
+        &error, true, false, true
+    ));
+    assert!(!should_show_failed_output_usage_notice(
+        &RenderableAIError::InvalidApiKey {
+            provider: "OpenAI".to_owned(),
+            model_name: "GPT".to_owned(),
+        },
+        true,
+        false,
+        false,
+    ));
+}
 
 #[test]
 fn simple_agent_block_reports_full_height_and_renders_content() {
@@ -1831,6 +2127,18 @@ fn complete_output_messages(messages: Vec<AIAgentOutputMessage>) -> AIBlockOutpu
     }
 }
 
+fn failed_output(
+    messages: Vec<AIAgentOutputMessage>,
+    error: RenderableAIError,
+) -> AIBlockOutputStatus {
+    AIBlockOutputStatus::Failed {
+        partial_output: Some(Shared::new(AIAgentOutput {
+            messages,
+            ..Default::default()
+        })),
+        error,
+    }
+}
 /// Builds a text output message from plain-text sections.
 fn text_message(id: &str, sections: Vec<AIAgentTextSection>) -> AIAgentOutputMessage {
     AIAgentOutputMessage {
@@ -2067,6 +2375,70 @@ fn render_block_lines(block: &TuiAIBlock, width: u16, app: &AppContext) -> Vec<S
         .map(|line| line.trim_end().to_owned())
         .filter(|line| !line.is_empty())
         .collect()
+}
+
+fn dispatch_click_on_text(
+    mut element: Box<dyn TuiElement>,
+    label: &str,
+    width: u16,
+    height: u16,
+    app: &AppContext,
+) {
+    let area = TuiRect::new(0, 0, width, height);
+    let mut rendered_views = EntityIdMap::default();
+    let mut layout_ctx = TuiLayoutContext {
+        rendered_views: &mut rendered_views,
+    };
+    element.layout(
+        TuiConstraint::loose(TuiSize::new(width, height)),
+        &mut layout_ctx,
+        app,
+    );
+    let (buffer, scene) = {
+        let mut buffer = TuiBuffer::empty(area);
+        let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+        (buffer, Rc::new(paint_ctx.scene.clone()))
+    };
+    let lines = buffer.to_lines();
+    let (row, byte_index) = lines
+        .iter()
+        .enumerate()
+        .find_map(|(row, line)| line.find(label).map(|byte_index| (row, byte_index)))
+        .expect("rendered element contains target link");
+    let x = lines[row][..byte_index].chars().count() as u16;
+    let position = TuiPoint::new(x, row as u16);
+    let modifiers = ModifiersState::default();
+    let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+    event_ctx.set_origin_view(Some(EntityId::new()));
+    element.dispatch_event(
+        &TuiEvent::MouseMoved {
+            position,
+            modifiers,
+            is_synthetic: false,
+        },
+        &mut event_ctx,
+        app,
+    );
+    element.dispatch_event(
+        &TuiEvent::LeftMouseDown {
+            position,
+            modifiers,
+            click_count: 1,
+            is_first_mouse: false,
+        },
+        &mut event_ctx,
+        app,
+    );
+    element.dispatch_event(
+        &TuiEvent::LeftMouseUp {
+            position,
+            modifiers,
+        },
+        &mut event_ctx,
+        app,
+    );
 }
 
 fn render_tui_view_lines(

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -186,7 +186,7 @@ fn agent_block_renders_context_window_failure() {
 }
 
 #[test]
-fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
+fn out_of_credits_failure_uses_shared_copy_warning_style_and_tui_actions() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let opened_urls = Rc::new(RefCell::new(Vec::new()));
@@ -200,14 +200,21 @@ fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
 
         app.read(|ctx| {
             let presentation = FailedOutputPresentation::OutOfCredits {
-                message: "I'm sorry, I couldn't complete that request.\n\nYou've reached your credit limit."
+                message: "I'm sorry, I couldn't complete that request.\n\nIn order to use Warp's AI features, subscribe to a Warp plan, or bring your own inference."
                     .to_owned(),
+                can_use_own_api_keys: true,
             };
-            let subscribe_hover_state = MouseStateHandle::default();
+            let compare_plans_hover_state = MouseStateHandle::default();
+            let byok_hover_state = MouseStateHandle::default();
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
-                render_failure_section(&presentation, &subscribe_hover_state, ctx),
-                TuiRect::new(0, 0, 100, 5),
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 100, 4),
                 ctx,
             );
             assert_eq!(
@@ -219,10 +226,9 @@ fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
                     .collect::<Vec<_>>(),
                 vec![
                     "⚠ I'm sorry, I couldn't complete that request.",
+                    "  In order to use Warp's AI features, subscribe to a Warp plan, or bring your own inference.",
                     "",
-                    "You've reached your credit limit.",
-                    "",
-                    "  Subscribe",
+                    "  Compare plans  or  Use your own API keys",
                 ]
             );
             let builder = TuiUiBuilder::from_app(ctx);
@@ -235,26 +241,74 @@ fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
                 builder.error_text_style().fg.expect("error foreground")
             );
             assert_eq!(frame.buffer[(2, 0)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(0, 2)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(2, 4)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 1)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 3)].fg, primary_foreground);
+            assert_eq!(
+                frame.buffer[(17, 3)].fg,
+                builder.muted_text_style().fg.expect("muted foreground")
+            );
+            assert_eq!(frame.buffer[(21, 3)].fg, primary_foreground);
             assert!(
-                frame.buffer[(2, 4)]
+                frame.buffer[(2, 3)]
+                    .modifier
+                    .contains(Modifier::UNDERLINED)
+            );
+            assert!(
+                frame.buffer[(21, 3)]
                     .modifier
                     .contains(Modifier::UNDERLINED)
             );
 
             dispatch_click_on_text(
-                render_failure_section(&presentation, &subscribe_hover_state, ctx),
-                "Subscribe",
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                "Compare plans",
                 100,
-                5,
+                4,
                 ctx,
             );
+            dispatch_click_on_text(
+                render_failure_section(
+                    &presentation,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                "Use your own API keys",
+                100,
+                4,
+                ctx,
+            );
+
+            let without_byok = FailedOutputPresentation::OutOfCredits {
+                message: "I'm sorry, I couldn't complete that request.\n\nOut of credits."
+                    .to_owned(),
+                can_use_own_api_keys: false,
+            };
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_failure_section(
+                    &without_byok,
+                    &compare_plans_hover_state,
+                    &byok_hover_state,
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 100, 4),
+                ctx,
+            );
+            assert_eq!(frame.buffer.to_lines()[3].trim_end(), "  Compare plans");
         });
 
         assert_eq!(
             &*opened_urls.borrow(),
-            &["https://www.warp.dev/pricing".to_owned()]
+            &[
+                "https://www.warp.dev/pricing".to_owned(),
+                "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/".to_owned(),
+            ]
         );
     });
 }

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -186,7 +186,7 @@ fn agent_block_renders_context_window_failure() {
 }
 
 #[test]
-fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
+fn out_of_credits_failure_matches_gui_copy_warning_style_and_action() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let opened_urls = Rc::new(RefCell::new(Vec::new()));
@@ -200,22 +200,14 @@ fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
 
         app.read(|ctx| {
             let presentation = FailedOutputPresentation::OutOfCredits {
-                title: "I’m sorry, I couldn’t complete that request.",
-                detail:
-                    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
-                can_use_own_api_keys: true,
+                message: "I'm sorry, I couldn't complete that request.\n\nYou've reached your credit limit."
+                    .to_owned(),
             };
-            let compare_plans_hover_state = MouseStateHandle::default();
-            let byok_hover_state = MouseStateHandle::default();
+            let subscribe_hover_state = MouseStateHandle::default();
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                TuiRect::new(0, 0, 100, 4),
+                render_failure_section(&presentation, &subscribe_hover_state, ctx),
+                TuiRect::new(0, 0, 100, 5),
                 ctx,
             );
             assert_eq!(
@@ -226,10 +218,11 @@ fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
                 vec![
-                    "! I’m sorry, I couldn’t complete that request.",
-                    "  In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
+                    "⚠ I'm sorry, I couldn't complete that request.",
                     "",
-                    "  Compare plans  or  Use your own API keys",
+                    "You've reached your credit limit.",
+                    "",
+                    "  Subscribe",
                 ]
             );
             let builder = TuiUiBuilder::from_app(ctx);
@@ -242,75 +235,26 @@ fn out_of_credits_failure_matches_figma_rows_styles_and_links() {
                 builder.error_text_style().fg.expect("error foreground")
             );
             assert_eq!(frame.buffer[(2, 0)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(2, 1)].fg, primary_foreground);
-            assert_eq!(
-                frame.buffer[(17, 3)].fg,
-                builder.muted_text_style().fg.expect("muted foreground")
-            );
-            assert_eq!(frame.buffer[(2, 3)].fg, primary_foreground);
-            assert_eq!(frame.buffer[(21, 3)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(0, 2)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 4)].fg, primary_foreground);
             assert!(
-                frame.buffer[(2, 3)]
-                    .modifier
-                    .contains(Modifier::UNDERLINED)
-            );
-            assert!(
-                frame.buffer[(21, 3)]
+                frame.buffer[(2, 4)]
                     .modifier
                     .contains(Modifier::UNDERLINED)
             );
 
             dispatch_click_on_text(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                "Compare plans",
+                render_failure_section(&presentation, &subscribe_hover_state, ctx),
+                "Subscribe",
                 100,
-                4,
+                5,
                 ctx,
             );
-            dispatch_click_on_text(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                "Use your own API keys",
-                100,
-                4,
-                ctx,
-            );
-
-            let without_byok = FailedOutputPresentation::OutOfCredits {
-                title: "I’m sorry, I couldn’t complete that request.",
-                detail:
-                    "In order to use Warp’s AI features, subscribe to a Warp plan, or bring your own inference.",
-                can_use_own_api_keys: false,
-            };
-            let mut presenter = TuiPresenter::new();
-            let frame = presenter.present_element(
-                render_failure_section(
-                    &without_byok,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                TuiRect::new(0, 0, 100, 4),
-                ctx,
-            );
-            assert_eq!(frame.buffer.to_lines()[3].trim_end(), "  Compare plans");
         });
 
         assert_eq!(
             &*opened_urls.borrow(),
-            &[
-                "https://www.warp.dev/pricing".to_owned(),
-                "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/".to_owned(),
-            ]
+            &["https://www.warp.dev/pricing".to_owned()]
         );
     });
 }
@@ -320,6 +264,14 @@ fn failed_output_usage_notice_matches_gui_conditions() {
     let error = RenderableAIError::other("failed", false);
     assert!(should_show_failed_output_usage_notice(
         &error, true, false, false
+    ));
+    assert!(should_show_failed_output_usage_notice(
+        &RenderableAIError::QuotaLimit {
+            user_display_message: Some("You've reached your credit limit.".to_owned()),
+        },
+        true,
+        false,
+        false,
     ));
     assert!(!should_show_failed_output_usage_notice(
         &error, false, false, false

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -384,6 +384,25 @@ fn footer_falls_back_to_conversations_callout() {
 }
 
 #[test]
+fn footer_does_not_render_credit_actions() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+
+        let lines = render_session(&mut app, &view, 80, 40);
+        assert!(
+            lines.iter().all(|line| {
+                !line.contains("Out of credits")
+                    && !line.contains("Compare plans")
+                    && !line.contains("Use your own API keys")
+            }),
+            "credit actions belong to the failed transcript block:\n{}",
+            lines.join("\n")
+        );
+    });
+}
+
+#[test]
 fn transient_footer_hint_replaces_conversations_callout() {
     App::test((), |mut app| async move {
         app.update(|ctx| {

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -170,6 +170,9 @@ impl TuiShellCommandView {
     pub(super) fn needs_continuous_height_measurement(&self) -> bool {
         !self.state.is_collapsed() && self.command_running.get()
     }
+    pub(super) fn is_expanded(&self) -> bool {
+        !self.state.is_collapsed()
+    }
 
     /// Resolves the shared terminal block exactly as the GUI requested-command
     /// view does: first by agent action metadata, then by a long-running


### PR DESCRIPTION
> [!WARNING]
> **TEST/COMPARISON PR — DO NOT MERGE.** Both the base and head branches are temporary.

## Description

This comparison PR shows the complete final Agent request-failure implementation relative to commit `995ef1393c`, the commit immediately before #14044.

It contains:
- #14044 (`074e595338`), which introduced TUI Agent request-failure rendering.
- The final follow-up behavior from #14092: preserved original GUI semantics, shared failure policy/copy, warning triangles in the TUI, and Figma-aligned out-of-credits actions/layout.
- A historical-base-only exhaustive match arm and rustfmt adjustment required to build this reconstruction.

The base branch `moira/pre-14044-test-base` is pinned to `995ef1393c`. This PR exists only to make the full before/after diff reviewable; #14092 is the real landing PR.

## Linked Issue

No linked issue; this is a temporary comparison PR for #14092.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- `./script/format`
- `cargo nextest run -p warp_tui --no-fail-fast agent_block` — 54 passed
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run` (not run; this PR is diff-only)

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/69a635c8-cf41-40e3-a612-1e37499fc609

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>