### PR TITLE
Strip debuginfo from bundling profile

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -567,6 +567,33 @@ jobs:
           WARP_NOTARIZATION_APPLE_ID: ${{ secrets.WARP_NOTARIZATION_APPLE_ID }}
           WARP_NOTARIZATION_PASSWORD: ${{ secrets.WARP_NOTARIZATION_PASSWORD }}
 
+      - name: Set up Sentry CLI
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b # v2.0.0
+        with:
+          token: ${{ secrets.SENTRY_RELEASE_TOKEN }}
+          organization: warpdotdev
+          project: ${{ steps.get-config.outputs.sentry_project }}
+
+      - name: Verify and upload TUI debugging symbols to Sentry
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        run: |
+          binary_path="${{ steps.bundle_tui.outputs.binary_path }}"
+          dsym_path="${{ steps.bundle_tui.outputs.dsym_path }}"
+          test -n "$dsym_path"
+          test -d "$dsym_path"
+
+          binary_uuid="$(dwarfdump --uuid "$binary_path" | awk '{print $2}')"
+          dsym_uuid="$(dwarfdump --uuid "$dsym_path" | awk '{print $2}')"
+          test -n "$binary_uuid"
+          test "$binary_uuid" = "$dsym_uuid"
+
+          dsym_dwarf_path="$(find "$dsym_path/Contents/Resources/DWARF" -type f -print -quit)"
+          test -n "$dsym_dwarf_path"
+          sentry-cli debug-files check "$dsym_dwarf_path"
+          sentry-cli upload-dif "$dsym_path"
+        shell: bash
+
       - name: Package TUI binary
         run: |
           mv ${{ steps.bundle_tui.outputs.binary_path }} warp-tui-${{ steps.get-config.outputs.channel }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,6 +512,17 @@ codegen-units = 1
 inherits = "release-cli"
 debug-assertions = true
 
+# Release profile for the standalone TUI. Strip debug-map entries while
+# retaining function symbols so local backtraces and profiles remain readable.
+[profile.release-tui]
+inherits = "release-cli"
+strip = "debuginfo"
+
+# Packaged local/dev TUI builds retain the release profile's debug assertions.
+[profile.release-tui-debug-assertions]
+inherits = "release-tui"
+debug-assertions = true
+
 [profile.release-wasm]
 inherits = "release"
 opt-level = "s"

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -250,13 +250,17 @@ elif [[ $RELEASE_CHANNEL = "local" || $RELEASE_CHANNEL = "dev" ]]; then
   # For dev bundles, we want to enable debug assertions to
   # catch violations that would otherwise silently pass in
   # a normal release build (e.g. in stable).
-  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" || "$ARTIFACT" == "tui" ]]; then
+  if [[ "$ARTIFACT" == "tui" ]]; then
+    CARGO_PROFILE="release-tui-debug-assertions"
+  elif [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
     CARGO_PROFILE="release-cli-debug_assertions"
   else
     CARGO_PROFILE="release-lto-debug_assertions"
   fi
 else
-  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" || "$ARTIFACT" == "tui" ]]; then
+  if [[ "$ARTIFACT" == "tui" ]]; then
+    CARGO_PROFILE="release-tui"
+  elif [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
     CARGO_PROFILE="release-cli"
   else
     CARGO_PROFILE="release-lto"


### PR DESCRIPTION
## Description

Reduce the size of packaged macOS Warp TUI binaries without degrading local function-name stack traces or profiling:

- Add dedicated `release-tui` profiles that inherit the existing size-optimized CLI profile and use debug-only stripping (`strip = "debuginfo"`).
- Keep ordinary local `script/run-tui` builds unchanged and unstripped.
- Route packaged TUI builds through the new profiles while preserving debug assertions for local/dev channels.
- Require the release workflow to verify that the binary and dSYM UUIDs match, validate the dSYM with Sentry CLI, and upload it before packaging/publishing the binary.

Debug-only stripping removes debug-map entries while retaining runtime-visible function symbols. Local backtraces should therefore remain as readable as today, while Sentry can use the uploaded dSYM for server-side file/line symbolification.

A prior strip experiment on the installed arm64 TUI measured an expected reduction of approximately **17.85 MiB raw** and **3.26 MiB packaged**. This PR intentionally does not use `strip = "symbols"`, which would save more space but make local panic stacks and the current profiling paths substantially less useful.

## Linked Issue

No linked issue; this is an internal release and binary-size improvement.

## Testing

- `script/macos/bundle --check-only --channel dev --arch aarch64 --artifact tui --nosign`
  - Completed successfully using the `release-tui-debug-assertions` profile and packaged TUI feature set.
- `bash -n script/macos/bundle`
- `cargo metadata --no-deps --format-version 1`
- Parsed `.github/workflows/create_release.yml` with the system YAML parser.
- Verified local Sentry CLI supports `debug-files check` and `upload-dif`.
- `git diff --check`

No new automated test was added because this changes Cargo profiles and release workflow configuration rather than runtime behavior. Exact binary-size validation requires a full release build; the release workflow now validates the generated dSYM before publishing.

- [ ] I have manually tested my changes locally with `./script/run` — not applicable; no GUI or runtime behavior changed.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
