### PR TITLE
Style shell commands in the TUI

### DIFF
--- a/crates/warp_tui/src/terminal_block.rs
+++ b/crates/warp_tui/src/terminal_block.rs
@@ -17,6 +17,9 @@ use warpui_core::elements::tui::{
 };
 
 use crate::terminal_use::user_controls_running_command;
+use crate::tui_builder::TuiUiBuilder;
+const SHELL_COMMAND_PREFIX: &str = "!";
+const SHELL_COMMAND_PREFIX_WIDTH: u16 = 2;
 
 /// Selects which rows of a terminal block an element paints.
 enum TerminalBlockRows {
@@ -31,6 +34,15 @@ enum TerminalBlockRows {
 struct TerminalBlockPaintBounds {
     origin: TuiScreenPosition,
     size: TuiSize,
+    background: Option<TuiColor>,
+    content_offset: u16,
+    prefix_style: Option<TuiStyle>,
+}
+
+#[derive(Clone, Copy)]
+struct TerminalCommandStyle {
+    background: TuiColor,
+    prefix: TuiStyle,
 }
 
 /// Paints terminal cells from one block using either a pre-clipped transcript
@@ -49,6 +61,7 @@ pub(super) struct TerminalBlockElement {
     rows: TerminalBlockRows,
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
+    command_style: Option<TerminalCommandStyle>,
 }
 
 impl TerminalBlockElement {
@@ -68,6 +81,7 @@ impl TerminalBlockElement {
             },
             size: None,
             origin: None,
+            command_style: None,
         }
     }
     /// Creates an element for all currently displayed command/output rows.
@@ -78,6 +92,7 @@ impl TerminalBlockElement {
             rows: TerminalBlockRows::Content,
             size: None,
             origin: None,
+            command_style: None,
         }
     }
 }
@@ -126,11 +141,19 @@ impl TuiElement for TerminalBlockElement {
         &mut self,
         constraint: TuiConstraint,
         _ctx: &mut TuiLayoutContext,
-        _app: &AppContext,
+        app: &AppContext,
     ) -> TuiSize {
         let rows = match &self.rows {
-            TerminalBlockRows::Visible { rows, .. } => rows.clone(),
+            TerminalBlockRows::Visible { rows, .. } => {
+                let builder = TuiUiBuilder::from_app(app);
+                self.command_style = Some(TerminalCommandStyle {
+                    background: builder.shell_command_background(),
+                    prefix: builder.shell_command_prefix_style(),
+                });
+                rows.clone()
+            }
             TerminalBlockRows::Content => {
+                self.command_style = None;
                 let model = self.model.lock();
                 model
                     .block_list()
@@ -168,14 +191,28 @@ impl TuiElement for TerminalBlockElement {
             TerminalBlockRows::Visible { rows, width } => (rows.clone(), (*width).min(size.width)),
             TerminalBlockRows::Content => (block_content_rows(block), size.width),
         };
-        let cursor = terminal_block_cursor(block, &rows, size);
+        let cursor = terminal_block_cursor(block, &rows, size).and_then(|(column, row)| {
+            let column = if self.command_style.is_some() && block.is_command_grid_active() {
+                column.saturating_add(SHELL_COMMAND_PREFIX_WIDTH)
+            } else {
+                column
+            };
+            (column < size.width).then_some((column, row))
+        });
         render_block_rows(
             block,
             rows,
             width,
-            TerminalBlockPaintBounds { origin, size },
+            TerminalBlockPaintBounds {
+                origin,
+                size,
+                background: None,
+                content_offset: 0,
+                prefix_style: None,
+            },
             surface,
             &colors,
+            self.command_style,
         );
         drop(model);
         if let Some((col, row)) = cursor {
@@ -236,8 +273,18 @@ fn render_block_rows(
     bounds: TerminalBlockPaintBounds,
     surface: &mut TuiPaintSurface<'_>,
     colors: &TerminalColorList,
+    command_style: Option<TerminalCommandStyle>,
 ) {
     if !block.should_hide_command_grid() {
+        let command_bounds = match command_style {
+            Some(style) => TerminalBlockPaintBounds {
+                background: Some(style.background),
+                content_offset: SHELL_COMMAND_PREFIX_WIDTH,
+                prefix_style: Some(style.prefix),
+                ..bounds
+            },
+            None => bounds,
+        };
         render_grid_rows(
             block.prompt_and_command_grid(),
             block
@@ -247,7 +294,7 @@ fn render_block_rows(
                 .max(0.0) as usize,
             visible_rows.clone(),
             max_width,
-            bounds,
+            command_bounds,
             surface,
             colors,
         );
@@ -259,7 +306,12 @@ fn render_block_rows(
             block.output_grid_offset().as_f64().ceil().max(0.0) as usize,
             visible_rows,
             max_width,
-            bounds,
+            TerminalBlockPaintBounds {
+                background: None,
+                content_offset: 0,
+                prefix_style: None,
+                ..bounds
+            },
             surface,
             colors,
         );
@@ -288,6 +340,7 @@ pub(super) fn render_grid_handler(
             origin.offset(0, screen_row as i32),
             surface,
             colors,
+            None,
         );
     }
 }
@@ -323,14 +376,31 @@ fn render_displayed_rows(
         if *y >= bounds.size.height {
             break;
         }
+        let row_origin = bounds.origin.offset(0, i32::from(*y));
+        if let Some(background) = bounds.background {
+            for column in 0..max_width.min(bounds.size.width) {
+                if let Some(cell) = surface.cell_mut(row_origin.offset(i32::from(column), 0)) {
+                    cell.set_style(TuiStyle::default().bg(background));
+                }
+            }
+        }
+        if displayed_row == 0
+            && let Some(prefix_style) = bounds.prefix_style
+            && let Some(cell) = surface.cell_mut(row_origin)
+        {
+            cell.set_symbol(SHELL_COMMAND_PREFIX)
+                .set_style(prefix_style);
+        }
         let original_row = grid.maybe_translate_row_from_displayed_to_original(displayed_row);
+        let content_width = max_width.saturating_sub(bounds.content_offset);
         render_grid_row(
             grid,
             original_row,
-            grid.columns().min(usize::from(max_width)),
-            bounds.origin.offset(0, i32::from(*y)),
+            grid.columns().min(usize::from(content_width)),
+            row_origin.offset(i32::from(bounds.content_offset), 0),
             surface,
             colors,
+            bounds.background,
         );
         *y = (*y).saturating_add(1);
     }
@@ -344,6 +414,7 @@ fn render_grid_row(
     origin: TuiScreenPosition,
     surface: &mut TuiPaintSurface<'_>,
     colors: &TerminalColorList,
+    background: Option<TuiColor>,
 ) {
     let Some(row) = grid.row(row) else {
         return;
@@ -353,9 +424,13 @@ fn render_grid_row(
         if let Some(buffer_cell) =
             surface.cell_mut(origin.offset(i32::try_from(column).unwrap_or(i32::MAX), 0))
         {
+            let mut style = cell_to_style(cell, colors);
+            if let Some(background) = background {
+                style = style.bg(background);
+            }
             buffer_cell
                 .set_symbol(&sanitized_symbol(cell))
-                .set_style(cell_to_style(cell, colors));
+                .set_style(style);
         }
     }
 }

--- a/crates/warp_tui/src/terminal_block_tests.rs
+++ b/crates/warp_tui/src/terminal_block_tests.rs
@@ -1,10 +1,18 @@
-use warp::tui_export::{
-    AIAgentActionId, AIConversationId, AgentInteractionMetadata, BlockId, TerminalModel,
-    TranscriptScope,
-};
-use warpui_core::elements::tui::TuiSize;
+use std::sync::Arc;
 
-use super::{should_render_terminal_block, terminal_block_cursor};
+use parking_lot::FairMutex;
+use warp::tui_export::{
+    AIAgentActionId, AIConversationId, AgentInteractionMetadata, Appearance, BlockId,
+    TerminalModel, TranscriptScope,
+};
+use warpui::App;
+use warpui_core::elements::tui::{Color, Modifier, TuiBufferExt, TuiElement, TuiRect, TuiSize};
+use warpui_core::presenter::tui::TuiPresenter;
+
+use super::{
+    TerminalBlockElement, block_content_rows, should_render_terminal_block, terminal_block_cursor,
+};
+use crate::tui_builder::TuiUiBuilder;
 
 /// Builds a mock model with a single simulated (started + finished) block and
 /// returns the model together with that block's id.
@@ -102,6 +110,122 @@ fn user_command_block_is_rendered_at_top_level() {
 
     assert!(!block.is_agent_requested_command());
     assert!(should_render_terminal_block(block, block_list));
+}
+
+#[test]
+fn top_level_shell_command_row_uses_tinted_background() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (model, block_id) = model_with_finished_block("echo hi");
+        let rows = block_content_rows(
+            model
+                .block_list()
+                .block_with_id(&block_id)
+                .expect("block should exist"),
+        );
+        let model = Arc::new(FairMutex::new(model));
+
+        app.read(|ctx| {
+            let height = rows.end.saturating_sub(rows.start) as u16;
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                TerminalBlockElement::visible_rows(model, block_id, rows, 12).finish(),
+                TuiRect::new(0, 0, 12, height),
+                ctx,
+            );
+            let lines = frame.buffer.to_lines();
+            let command_row = lines
+                .iter()
+                .position(|line| line.contains("echo hi"))
+                .expect("rendered command row");
+            let output_row = lines
+                .iter()
+                .position(|line| line.contains("output"))
+                .expect("rendered output row");
+            assert_eq!(lines[command_row].trim_end(), "! echo hi");
+            assert_eq!(lines[output_row].trim_end(), "output");
+            let builder = TuiUiBuilder::from_app(ctx);
+            let background = builder.shell_command_background();
+            let prefix_style = builder.shell_command_prefix_style();
+
+            for column in 0..12 {
+                assert_eq!(frame.buffer[(column, command_row as u16)].bg, background);
+                assert_eq!(frame.buffer[(column, output_row as u16)].bg, Color::Reset);
+            }
+            let prefix = &frame.buffer[(0, command_row as u16)];
+            assert_eq!(prefix.symbol(), "!");
+            assert_eq!(Some(prefix.fg), prefix_style.fg);
+            assert!(prefix.modifier.contains(Modifier::BOLD));
+            assert_eq!(frame.buffer[(1, command_row as u16)].symbol(), " ");
+            assert_eq!(frame.buffer[(2, command_row as u16)].symbol(), "e");
+            assert_eq!(frame.buffer[(0, output_row as u16)].symbol(), "o");
+        });
+    });
+}
+
+#[test]
+fn inline_shell_command_content_keeps_terminal_background() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (model, block_id) = model_with_finished_block("echo hi");
+        let rows = block_content_rows(
+            model
+                .block_list()
+                .block_with_id(&block_id)
+                .expect("block should exist"),
+        );
+        let height = rows.end.saturating_sub(rows.start) as u16;
+        let model = Arc::new(FairMutex::new(model));
+
+        app.read(|ctx| {
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                TerminalBlockElement::content(model, block_id).finish(),
+                TuiRect::new(0, 0, 12, height),
+                ctx,
+            );
+            let lines = frame.buffer.to_lines();
+            let command_row = lines
+                .iter()
+                .position(|line| line.contains("echo hi"))
+                .expect("rendered command row");
+            assert_eq!(lines[command_row].trim_end(), "echo hi");
+
+            for column in 0..12 {
+                assert_eq!(frame.buffer[(column, command_row as u16)].bg, Color::Reset);
+            }
+        });
+    });
+}
+
+#[test]
+fn shell_command_prefix_handles_single_column_width() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (model, block_id) = model_with_finished_block("echo hi");
+        let rows = block_content_rows(
+            model
+                .block_list()
+                .block_with_id(&block_id)
+                .expect("block should exist"),
+        );
+        let model = Arc::new(FairMutex::new(model));
+
+        app.read(|ctx| {
+            let height = rows.end.saturating_sub(rows.start) as u16;
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                TerminalBlockElement::visible_rows(model, block_id, rows, 1).finish(),
+                TuiRect::new(0, 0, 1, height),
+                ctx,
+            );
+            assert_eq!(frame.buffer.to_lines()[0], "!");
+            assert_eq!(
+                frame.buffer[(0, 0)].bg,
+                TuiUiBuilder::from_app(ctx).shell_command_background()
+            );
+        });
+    });
 }
 
 #[test]

--- a/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
@@ -51,6 +51,7 @@ fn tui_block_list_viewport_source_uses_canonical_block_list_order() {
 #[test]
 fn tui_block_list_viewport_source_slices_terminal_blocks_to_visible_rows() {
     App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
         app.read(|app| {
             let mut model = TerminalModel::mock(None, None);
             model.simulate_block("printf", "one\r\ntwo\r\nthree\r\n");

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -193,6 +193,26 @@ impl TuiUiBuilder {
                 .blend(&accent.with_opacity(10)),
         )
     }
+
+    /// Pale-green overlay behind shell command rows in the transcript.
+    /// Pre-blended because terminal cells cannot preserve alpha.
+    pub(crate) fn shell_command_background(&self) -> Color {
+        let accent = ThemeFill::from(self.warp_theme.terminal_colors().bright.green);
+        cell_color(self.base_background().blend(&accent.with_opacity(10)))
+    }
+
+    /// Bold pale-green `!` marker for a shell command row, over the same
+    /// [`Self::shell_command_background`] the rest of the row uses. Mirrors the
+    /// shell-mode `!` affordance the input shows before submission, which is
+    /// stripped from the command sent to the PTY.
+    pub(crate) fn shell_command_prefix_style(&self) -> TuiStyle {
+        TuiStyle::default()
+            .fg(cell_color(ThemeFill::from(
+                self.warp_theme.terminal_colors().bright.green,
+            )))
+            .bg(self.shell_command_background())
+            .add_modifier(Modifier::BOLD)
+    }
     /// Blue-overlay background for inline plan bodies, matching the TUI
     /// design's `blue_overlay_1` treatment.
     pub(crate) fn plan_background(&self) -> Color {

--- a/crates/warp_tui/src/tui_builder_tests.rs
+++ b/crates/warp_tui/src/tui_builder_tests.rs
@@ -48,6 +48,28 @@ fn text_styles_follow_light_theme_foreground() {
         builder.slash_command_selection_background(),
         selection_background
     );
+    let shell_command_fill = ThemeFill::from(theme.terminal_colors().bright.green);
+    let shell_command_background: Color = CoreFill::from(
+        theme
+            .background()
+            .blend(&shell_command_fill.with_opacity(10)),
+    )
+    .into();
+    assert_eq!(builder.shell_command_background(), shell_command_background);
+    let shell_command_prefix_style = builder.shell_command_prefix_style();
+    assert_eq!(
+        shell_command_prefix_style.fg,
+        Some(CoreFill::from(shell_command_fill).into())
+    );
+    assert_eq!(
+        shell_command_prefix_style.bg,
+        Some(shell_command_background)
+    );
+    assert!(
+        shell_command_prefix_style
+            .add_modifier
+            .contains(Modifier::BOLD)
+    );
     let selection_style = builder.slash_command_selection_text_style();
     assert_eq!(selection_style.fg, Some(selection_foreground));
     assert_eq!(selection_style.bg, Some(selection_background));


### PR DESCRIPTION
## Description

Styles top-level shell commands in the TUI with a tinted background and a bold `!` prefix so commands are visually distinct from surrounding agent output. The terminal block layout, rendering, and cursor calculations now reserve space for the prefix while inline shell-command content keeps the terminal background.

## Linked Issue

N/A

## Testing
<img width="701" height="384" alt="Screenshot 2026-07-21 at 1 32 46 PM" src="https://github.com/user-attachments/assets/70e025b4-3a95-4c3a-954f-6522e3632d08" />


- [x] Manually built and launched with `./script/run-tui`
- [x] Ran `./script/format`
- [x] Ran `cargo nextest run -p warp_tui` (487 tests passed)
- [ ] Workspace Clippy (skipped at request)

### Screenshots / Videos

Not attached.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/2e2de95c-89ce-4064-ba2a-fb2b1ae10db7

CHANGELOG-IMPROVEMENT: Improved TUI shell-command readability with distinct command styling.

Co-Authored-By: Oz <oz-agent@warp.dev>
