### PR TITLE
don't invert colors on selection

### DIFF
--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -29,11 +29,13 @@ use warp_editor::render::model::{
     CharCellTemporaryBlock, DisplayLattice, DisplayRow, DisplayRowKind,
 };
 use warpui_core::elements::tui::{
-    Modifier, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiFlex, TuiGridPoint,
-    TuiLayoutContext, TuiLocalPoint, TuiPaintContext, TuiPaintSurface, TuiParentElement,
-    TuiScreenPoint, TuiScreenPosition, TuiSize, TuiStyle, TuiText,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiFlex, TuiGridPoint, TuiLayoutContext,
+    TuiLocalPoint, TuiPaintContext, TuiPaintSurface, TuiParentElement, TuiScreenPoint,
+    TuiScreenPosition, TuiSize, TuiStyle, TuiText,
 };
 use warpui_core::{AppContext, ModelHandle};
+
+use crate::tui_builder::TuiUiBuilder;
 
 /// Display columns between the line-number column and the row content.
 const GUTTER_GAP: u16 = 2;
@@ -85,7 +87,7 @@ pub(crate) struct TuiEditorStyles {
     /// Whole-line overrides by 0-based logical line index; first match wins.
     pub line_overrides: Vec<(Range<usize>, TuiStyle)>,
     /// Character-range style overlays over buffer rows. Applied after the
-    /// row's base style and before selection reversal.
+    /// row's base style and before selection.
     pub text_overrides: Vec<(Range<CharOffset>, TuiStyle)>,
 }
 
@@ -126,6 +128,10 @@ pub(crate) struct TuiEditorElement {
     styles: TuiEditorStyles,
     trailing_ghost_text: Option<(String, TuiStyle)>,
     on_action: Option<TuiEditorActionHandler>,
+
+    /// Solid selection highlight: fg = terminal background, bg = theme
+    /// foreground. Computed once at construction from the active theme.
+    selection_style: TuiStyle,
 
     // ── Built during layout ─────────────────────────────────────────────────
     column: TuiFlex,
@@ -191,6 +197,7 @@ impl TuiEditorElement {
             styles: TuiEditorStyles::default(),
             trailing_ghost_text: None,
             on_action: None,
+            selection_style: TuiUiBuilder::from_app(app).selection_style(),
             column: TuiFlex::column(),
             gutter_cols: 0,
             selected_spans: Vec::new(),
@@ -720,14 +727,14 @@ impl TuiElement for TuiEditorElement {
             }
         }
         if !self.selected_spans.is_empty() {
-            let reversed = TuiStyle::default().add_modifier(Modifier::REVERSED);
+            let selection_style = self.selection_style;
             for &(row_in_view, start_col, end_col) in &self.selected_spans {
                 let width = end_col.saturating_sub(start_col);
                 if row_in_view < size.height && width > 0 {
                     surface.set_style(
                         origin.offset(i32::from(start_col), i32::from(row_in_view)),
                         TuiSize::new(width.min(size.width.saturating_sub(start_col)), 1),
-                        reversed,
+                        selection_style,
                     );
                 }
             }

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -16,9 +16,8 @@ use warpui_core::event::KeyEventDetails;
 use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext, ModelHandle};
 
-use crate::tui_builder::TuiUiBuilder;
-
 use super::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
+use crate::tui_builder::TuiUiBuilder;
 
 /// A char-cell editor model seeded with `text`.
 fn model(ctx: &mut AppContext, text: &str) -> ModelHandle<CodeEditorModel> {

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -8,13 +8,15 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
-    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    Color, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
     TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize,
     TuiStyle,
 };
 use warpui_core::event::KeyEventDetails;
 use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext, ModelHandle};
+
+use crate::tui_builder::TuiUiBuilder;
 
 use super::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
 
@@ -36,10 +38,14 @@ fn selection_span_uses_grapheme_width() {
             element.sel_char_range = Some(CharOffset::range(1..3));
             let buffer = render_buffer(ctx, element, 10, 1);
 
-            assert!(!buffer[(0, 0)].modifier.contains(Modifier::REVERSED));
-            assert!(buffer[(1, 0)].modifier.contains(Modifier::REVERSED));
-            assert!(buffer[(2, 0)].modifier.contains(Modifier::REVERSED));
-            assert!(!buffer[(3, 0)].modifier.contains(Modifier::REVERSED));
+            // The selection style uses a solid bg color (theme foreground);
+            // verify the highlight covers both display columns of the wide
+            // grapheme and leaves the surrounding cells untouched.
+            let selection_bg = TuiUiBuilder::from_app(ctx).selection_style().bg;
+            assert_ne!(Some(buffer[(0, 0)].bg), selection_bg);
+            assert_eq!(Some(buffer[(1, 0)].bg), selection_bg);
+            assert_eq!(Some(buffer[(2, 0)].bg), selection_bg);
+            assert_ne!(Some(buffer[(3, 0)].bg), selection_bg);
         });
     });
 }

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -27,6 +27,7 @@ use super::terminal_block::{block_content_rows, should_render_terminal_block};
 use super::tui_block_list_viewport_source::{
     AgentBlockRegistry, CLISubagentBlockRegistry, TuiBlockListViewportSource,
 };
+use super::tui_builder::TuiUiBuilder;
 use super::tui_cli_subagent_view::{TuiCLISubagentView, TuiCLISubagentViewEvent};
 
 /// Rows of blank space above every transcript block. Terminal blocks get it
@@ -665,8 +666,12 @@ impl TuiView for TuiTranscriptView {
             self.agent_blocks.clone(),
             self.cli_subagent_blocks.clone(),
         );
-        let viewport = TuiViewportedList::new(self.viewport.clone(), source)
-            .with_vertical_alignment(TuiViewportVerticalAlignment::GrowFromBottom);
+        let viewport = TuiViewportedList::new(
+            self.viewport.clone(),
+            source,
+            TuiUiBuilder::from_app(app).selection_style(),
+        )
+        .with_vertical_alignment(TuiViewportVerticalAlignment::GrowFromBottom);
         let semantic_selection = SemanticSelection::as_ref(app);
         let selectable = TuiSelectable::new(self.selection.clone(), viewport)
             .with_word_boundaries_policy(semantic_selection.word_boundary_policy())

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -25,6 +25,7 @@ use warpui_core::{AppContext, ViewContext, WindowInvalidation};
 use super::TuiTranscriptView;
 use crate::agent_block::TuiAIBlock;
 use crate::test_fixtures::add_test_action_model_and_events;
+use crate::tui_builder::TuiUiBuilder;
 
 #[test]
 fn transcript_view_renders_terminal_blocks_from_canonical_order() {
@@ -672,12 +673,22 @@ fn assert_drag_highlights_text(
     ));
 
     let (selected, scene) = render_retained_element(app, element, rendered_views, area);
+    let selection_style = app.read(|ctx| TuiUiBuilder::from_app(ctx).selection_style());
     for column in start..=end {
+        let cell = &selected[(column, row as u16)];
+        assert_eq!(
+            Some(cell.fg),
+            selection_style.fg,
+            "selected {description} cell at column {column} should use the selection foreground"
+        );
+        assert_eq!(
+            Some(cell.bg),
+            selection_style.bg,
+            "selected {description} cell at column {column} should use the selection background"
+        );
         assert!(
-            selected[(column, row as u16)]
-                .modifier
-                .contains(Modifier::REVERSED),
-            "selected {description} cell at column {column} should be reversed"
+            !cell.modifier.contains(Modifier::REVERSED),
+            "selected {description} cell at column {column} should not use reverse video"
         );
     }
 
@@ -694,11 +705,20 @@ fn assert_drag_highlights_text(
     ));
     let (settled, _) = render_retained_element(app, element, rendered_views, area);
     for column in start..=end {
+        let cell = &settled[(column, row as u16)];
+        assert_eq!(
+            Some(cell.fg),
+            selection_style.fg,
+            "{description} selection foreground should persist after mouse-up"
+        );
+        assert_eq!(
+            Some(cell.bg),
+            selection_style.bg,
+            "{description} selection background should persist after mouse-up"
+        );
         assert!(
-            settled[(column, row as u16)]
-                .modifier
-                .contains(Modifier::REVERSED),
-            "{description} selection should persist after mouse-up"
+            !cell.modifier.contains(Modifier::REVERSED),
+            "{description} selection should not use reverse video after mouse-up"
         );
     }
 }

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -329,6 +329,7 @@ impl TuiUiBuilder {
         TuiStyle::default()
             .fg(cell_color(self.base_background()))
             .bg(cell_color(self.warp_theme.foreground()))
+            .remove_modifier(Modifier::REVERSED)
     }
 
     /// The deterministic agent identity palette for this theme. See

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -321,7 +321,7 @@ impl TuiUiBuilder {
             .bg(self.orchestration_surface_background())
     }
 
-    /// Solid selection background for text selection in editor elements.
+    /// Solid selection style shared by editors and transcript viewports.
     /// Uses the theme foreground as the selection background and the
     /// terminal background as the selection foreground, giving a consistent
     /// solid highlight instead of per-cell reversal.

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -321,6 +321,16 @@ impl TuiUiBuilder {
             .bg(self.orchestration_surface_background())
     }
 
+    /// Solid selection background for text selection in editor elements.
+    /// Uses the theme foreground as the selection background and the
+    /// terminal background as the selection foreground, giving a consistent
+    /// solid highlight instead of per-cell reversal.
+    pub(crate) fn selection_style(&self) -> TuiStyle {
+        TuiStyle::default()
+            .fg(cell_color(self.base_background()))
+            .bg(cell_color(self.warp_theme.foreground()))
+    }
+
     /// The deterministic agent identity palette for this theme. See
     /// [`crate::orchestrated_agent_identity_styling`].
     pub(crate) fn agent_identity_palette(&self) -> Vec<AgentIdentity> {

--- a/crates/warp_tui/src/tui_builder_tests.rs
+++ b/crates/warp_tui/src/tui_builder_tests.rs
@@ -52,4 +52,11 @@ fn text_styles_follow_light_theme_foreground() {
     assert_eq!(selection_style.fg, Some(selection_foreground));
     assert_eq!(selection_style.bg, Some(selection_background));
     assert!(selection_style.add_modifier.contains(Modifier::BOLD));
+
+    let text_selection_style = builder.selection_style();
+    assert!(
+        text_selection_style
+            .sub_modifier
+            .contains(Modifier::REVERSED)
+    );
 }

--- a/crates/warpui_core/src/elements/tui/viewported_list.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list.rs
@@ -14,7 +14,7 @@ use super::{
     TuiBuffer, TuiClipped, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiGridPoint,
     TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPresentationContext, TuiRect,
     TuiRowResize, TuiScreenPoint, TuiScreenPosition, TuiScrollableElement, TuiSelectableElement,
-    TuiSelectionSpan, TuiSize,
+    TuiSelectionSpan, TuiSize, TuiStyle,
 };
 use crate::AppContext;
 
@@ -199,7 +199,7 @@ where
             }
         }
         for (origin, size) in selection_rects {
-            toggle_selection_reverse(surface, origin, size);
+            surface.set_style(origin, size, self.selection_style);
         }
     }
 
@@ -401,26 +401,6 @@ fn render_viewport_content(
     buffer
 }
 
-/// Toggles reverse video over selected absolute bounds.
-fn toggle_selection_reverse(
-    surface: &mut TuiPaintSurface<'_>,
-    origin: TuiScreenPosition,
-    size: TuiSize,
-) {
-    for row in 0..size.height {
-        for col in 0..size.width {
-            let Some(cell) = surface.cell_mut(origin.offset(i32::from(col), i32::from(row))) else {
-                continue;
-            };
-            if cell.modifier.contains(super::Modifier::REVERSED) {
-                cell.modifier.remove(super::Modifier::REVERSED);
-            } else {
-                cell.modifier.insert(super::Modifier::REVERSED);
-            }
-        }
-    }
-}
-
 /// A variable-height viewport that delegates content slicing to its source.
 pub struct TuiViewportedList<Content>
 where
@@ -433,6 +413,7 @@ where
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
     vertical_alignment: TuiViewportVerticalAlignment,
+    selection_style: TuiStyle,
     selection_snapshot: RefCell<Option<(TuiResolvedViewport, TuiBuffer)>>,
 }
 
@@ -441,7 +422,7 @@ where
     Content: TuiViewportedElement,
 {
     /// Creates a generalized viewport over `content`.
-    pub fn new(state: TuiViewportedListState, content: Content) -> Self {
+    pub fn new(state: TuiViewportedListState, content: Content, selection_style: TuiStyle) -> Self {
         Self {
             state,
             content,
@@ -450,6 +431,7 @@ where
             size: None,
             origin: None,
             vertical_alignment: TuiViewportVerticalAlignment::Top,
+            selection_style,
             selection_snapshot: RefCell::new(None),
         }
     }

--- a/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
@@ -8,10 +8,10 @@ use super::{
     TuiViewportedElement, TuiViewportedList, TuiViewportedListState, TuiVisibleViewportItem,
 };
 use crate::elements::tui::{
-    Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiContainer, TuiElement, TuiEvent,
+    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiContainer, TuiElement, TuiEvent,
     TuiEventContext, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPoint, TuiRect,
     TuiScreenPoint, TuiScreenPosition, TuiScrollable, TuiScrollableElement, TuiSelectable,
-    TuiSelectionHandle, TuiSelectionSpan, TuiSize, TuiText,
+    TuiSelectionHandle, TuiSelectionSpan, TuiSize, TuiStyle, TuiText,
 };
 use crate::event::ModifiersState;
 use crate::presenter::tui::TuiPresenter;
@@ -215,7 +215,11 @@ fn viewport_with_state(
     state: TuiViewportedListState,
     content: FakeContent,
 ) -> TuiViewportedList<FakeContent> {
-    TuiViewportedList::new(state, content)
+    TuiViewportedList::new(state, content, viewport_selection_style())
+}
+
+fn viewport_selection_style() -> TuiStyle {
+    TuiStyle::default().fg(Color::Black).bg(Color::White)
 }
 
 /// Verifies viewport geometry is unavailable until layout establishes it.
@@ -395,6 +399,7 @@ fn bottom_clipped_item_is_laid_out_once() {
             LayoutCountingContent {
                 layout_count: layout_count.clone(),
             },
+            viewport_selection_style(),
         );
 
         render_viewport(&app, &mut viewport, TuiSize::new(8, 2));
@@ -539,7 +544,8 @@ fn scrolling_up_clamps_to_the_top_without_snapping_to_bottom() {
 fn scrolling_up_works_over_opaque_content_in_a_clipped_layer() {
     App::test((), |app| async move {
         let state = TuiViewportedListState::new_at_end();
-        let viewport = TuiViewportedList::new(state.clone(), OpaqueContent);
+        let viewport =
+            TuiViewportedList::new(state.clone(), OpaqueContent, viewport_selection_style());
         let mut scrollable = TuiScrollable::new(viewport.finish_scrollable());
         let size = TuiSize::new(10, 3);
 
@@ -586,6 +592,7 @@ fn selectable_viewport_highlights_and_copies_linear_rows() {
     App::test((), |app| async move {
         let content = FakeContent::new(vec![fake_item(1, 3)]);
         let state = TuiViewportedListState::new_at_end();
+        let selection_style = viewport_selection_style();
         let viewport = viewport_with_state(state.clone(), content);
         let copies = Rc::new(RefCell::new(Vec::new()));
         let copies_for_callback = copies.clone();
@@ -613,8 +620,12 @@ fn selectable_viewport_highlights_and_copies_linear_rows() {
             }
             buffer
         });
-        assert!(buffer[(0, 0)].modifier.contains(Modifier::REVERSED));
-        assert!(buffer[(2, 1)].modifier.contains(Modifier::REVERSED));
+        for position in [(0, 0), (2, 1)] {
+            let cell = &buffer[position];
+            assert_eq!(Some(cell.fg), selection_style.fg);
+            assert_eq!(Some(cell.bg), selection_style.bg);
+            assert!(!cell.modifier.contains(Modifier::REVERSED));
+        }
         assert!(mouse(&app, &mut element, size, left_up(2, 1)));
         assert_eq!(copies.borrow().as_slice(), ["1:0\n1:1"]);
         assert!(selection.range().is_some());
@@ -754,19 +765,6 @@ fn selectable_prefers_smart_selection_over_word_boundaries() {
 
         assert_eq!(copies.borrow().as_slice(), ["foo-bar"]);
     });
-}
-
-#[test]
-fn selection_reverse_toggles_existing_modifier() {
-    let area = TuiRect::new(0, 0, 2, 1);
-    let mut buffer = TuiBuffer::empty(area);
-    buffer[(0, 0)].modifier.insert(Modifier::REVERSED);
-    {
-        let mut surface = TuiPaintSurface::new(&mut buffer);
-        super::toggle_selection_reverse(&mut surface, TuiScreenPosition::new(0, 0), area.as_size());
-    }
-    assert!(!buffer[(0, 0)].modifier.contains(Modifier::REVERSED));
-    assert!(buffer[(1, 0)].modifier.contains(Modifier::REVERSED));
 }
 
 /// Verifies wheel scrolling preserves persistent selection anchors.
@@ -923,7 +921,7 @@ fn drag_past_edge_preserves_selection_when_scroll_changes_a_visible_glyph() {
         let content = ScrollSensitiveContent { row_count: 10 };
         let state = TuiViewportedListState::new_at_end();
         state.scroll_to_rows_from_top(5);
-        let viewport = TuiViewportedList::new(state.clone(), content);
+        let viewport = TuiViewportedList::new(state.clone(), content, viewport_selection_style());
         let selection = TuiSelectionHandle::default();
         let selectable = TuiSelectable::new(selection.clone(), viewport);
         let mut element = TuiScrollable::new(selectable.finish_scrollable());
@@ -1012,7 +1010,7 @@ fn repaint_after_mouse_up_preserves_selection_on_glyph_change() {
         };
         let state = TuiViewportedListState::new_at_end();
         state.scroll_to_rows_from_top(0);
-        let viewport = TuiViewportedList::new(state, content);
+        let viewport = TuiViewportedList::new(state, content, viewport_selection_style());
         let selection = TuiSelectionHandle::default();
         let selectable = TuiSelectable::new(selection.clone(), viewport);
         let mut element = TuiScrollable::new(selectable.finish_scrollable());
@@ -1295,6 +1293,7 @@ fn single_element_viewport(
         SingleElementContent {
             element: RefCell::new(Some(element)),
         },
+        viewport_selection_style(),
     )
 }
 

--- a/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
@@ -35,6 +35,7 @@ struct FakeContent {
     logical_text: Rc<RefCell<Option<String>>>,
     /// Selection spans passed to `selection_logical_text`, for assertions.
     logical_requests: Rc<RefCell<Vec<TuiSelectionSpan>>>,
+    style: TuiStyle,
 }
 
 impl FakeContent {
@@ -45,6 +46,7 @@ impl FakeContent {
             widths: Rc::new(RefCell::new(Vec::new())),
             logical_text: Rc::new(RefCell::new(None)),
             logical_requests: Rc::new(RefCell::new(Vec::new())),
+            style: TuiStyle::default(),
         }
     }
 
@@ -52,6 +54,11 @@ impl FakeContent {
     /// selection (the logical-sourcing path), instead of the per-row fallback.
     fn with_logical_text(self, text: impl Into<String>) -> Self {
         *self.logical_text.borrow_mut() = Some(text.into());
+        self
+    }
+
+    fn with_style(mut self, style: TuiStyle) -> Self {
+        self.style = style;
         self
     }
 
@@ -70,7 +77,11 @@ impl FakeContent {
             if item_bottom > window.scroll_top && item_top < viewport_bottom {
                 visible_items.push(TuiVisibleViewportItem {
                     origin_y: item_top,
-                    element: Box::new(TuiText::new(item.lines.join("\n")).truncate()),
+                    element: Box::new(
+                        TuiText::new(item.lines.join("\n"))
+                            .with_style(self.style)
+                            .truncate(),
+                    ),
                 });
             }
             origin_y = item_bottom;
@@ -219,7 +230,10 @@ fn viewport_with_state(
 }
 
 fn viewport_selection_style() -> TuiStyle {
-    TuiStyle::default().fg(Color::Black).bg(Color::White)
+    TuiStyle::default()
+        .fg(Color::Black)
+        .bg(Color::White)
+        .remove_modifier(Modifier::REVERSED)
 }
 
 /// Verifies viewport geometry is unavailable until layout establishes it.
@@ -590,7 +604,8 @@ fn scrolling_down_pins_to_bottom_without_overscrolling() {
 #[test]
 fn selectable_viewport_highlights_and_copies_linear_rows() {
     App::test((), |app| async move {
-        let content = FakeContent::new(vec![fake_item(1, 3)]);
+        let content = FakeContent::new(vec![fake_item(1, 3)])
+            .with_style(TuiStyle::default().add_modifier(Modifier::REVERSED));
         let state = TuiViewportedListState::new_at_end();
         let selection_style = viewport_selection_style();
         let viewport = viewport_with_state(state.clone(), content);


### PR DESCRIPTION
## Description
Replace `Modifier::REVERSED` selection highlighting in the TUI editor element with a consistent solid background. Previously, selection inverted each cell's fg/bg individually, producing inconsistent highlight colors across spans with different styles (syntax highlighting, muted text, etc.). Now all selected cells get a uniform bg derived from the theme foreground color, with the terminal background as the text color.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/f062e56a6d4348d28d2bd3f51c419ec1

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
