### PR TITLE
Fix TUI clipboard text paste fallback

### DIFF
--- a/crates/warp_tui/src/attachment_bar/image_processing.rs
+++ b/crates/warp_tui/src/attachment_bar/image_processing.rs
@@ -11,6 +11,16 @@ use warp::tui_export::{
 use warpui_core::clipboard::{ClipboardContent, ImageData};
 use warpui_core::clipboard_utils::CLIPBOARD_IMAGE_MIME_TYPES;
 
+pub(super) enum ClipboardPasteContent {
+    Image(ClipboardContent),
+    ImagePaths {
+        paths: Vec<PathBuf>,
+        original_text: String,
+    },
+    Text(String),
+    Empty,
+}
+
 pub(super) fn parse_image_paths(text: &str, cwd: &Path) -> Option<Vec<PathBuf>> {
     let tokens = shell_words::split(text.trim()).ok()?;
     if tokens.is_empty() {
@@ -20,6 +30,48 @@ pub(super) fn parse_image_paths(text: &str, cwd: &Path) -> Option<Vec<PathBuf>> 
         .into_iter()
         .map(|token| resolve_image_path(&token, cwd))
         .collect()
+}
+
+pub(super) fn classify_clipboard_content(
+    content: ClipboardContent,
+    cwd: &Path,
+) -> ClipboardPasteContent {
+    if content.has_image_data() {
+        return ClipboardPasteContent::Image(content);
+    }
+
+    let original_text = if content.plain_text.is_empty() {
+        content
+            .paths
+            .as_ref()
+            .map(|paths| paths.join("\n"))
+            .unwrap_or_default()
+    } else {
+        content.plain_text.clone()
+    };
+    if let Some(paths) = content.paths.as_ref()
+        && !paths.is_empty()
+        && let Some(paths) = paths
+            .iter()
+            .map(|path| resolve_image_path(path, cwd))
+            .collect()
+    {
+        return ClipboardPasteContent::ImagePaths {
+            paths,
+            original_text,
+        };
+    }
+    if let Some(paths) = parse_image_paths(&content.plain_text, cwd) {
+        return ClipboardPasteContent::ImagePaths {
+            paths,
+            original_text,
+        };
+    }
+    if original_text.is_empty() {
+        ClipboardPasteContent::Empty
+    } else {
+        ClipboardPasteContent::Text(original_text)
+    }
 }
 
 fn resolve_image_path(token: &str, cwd: &Path) -> Option<PathBuf> {
@@ -84,20 +136,19 @@ pub(super) async fn process_paths(paths: Vec<PathBuf>) -> Result<Vec<ImageContex
     Ok(images)
 }
 
-pub(super) async fn read_and_process_clipboard_image() -> Result<ImageContext, String> {
-    let content = blocking::unblock(|| -> Result<ClipboardContent, String> {
+pub(super) async fn read_clipboard_content() -> Result<ClipboardContent, String> {
+    blocking::unblock(|| -> Result<ClipboardContent, String> {
         let mut clipboard = warpui::platform::create_system_clipboard()
             .map_err(|_| "The system clipboard is unavailable.".to_owned())?;
         Ok(clipboard.read())
     })
-    .await?;
-    process_clipboard_content(content)
+    .await
 }
 
-fn process_clipboard_content(content: ClipboardContent) -> Result<ImageContext, String> {
+pub(super) fn process_clipboard_content(content: ClipboardContent) -> Result<ImageContext, String> {
     let images = content
         .images
-        .ok_or_else(|| "The clipboard does not contain an image.".to_owned())?;
+        .ok_or_else(|| "Clipboard image data is unavailable.".to_owned())?;
     let image = CLIPBOARD_IMAGE_MIME_TYPES
         .iter()
         .find_map(|mime_type| {

--- a/crates/warp_tui/src/attachment_bar/image_processing_tests.rs
+++ b/crates/warp_tui/src/attachment_bar/image_processing_tests.rs
@@ -5,7 +5,10 @@ use base64::engine::general_purpose;
 use futures_lite::future::block_on;
 use warpui_core::clipboard::{ClipboardContent, ImageData};
 
-use super::{MAX_IMAGE_SIZE_BYTES, parse_image_paths, process_clipboard_content, process_paths};
+use super::{
+    ClipboardPasteContent, MAX_IMAGE_SIZE_BYTES, classify_clipboard_content, parse_image_paths,
+    process_clipboard_content, process_paths,
+};
 
 const ONE_PIXEL_PNG: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
@@ -37,6 +40,56 @@ fn rejects_mixed_or_non_image_pastes() {
     let cwd = Path::new("/workspace");
     assert!(parse_image_paths("one.png notes.txt", cwd).is_none());
     assert!(parse_image_paths("ordinary prompt text", cwd).is_none());
+}
+
+#[test]
+fn classifies_plain_clipboard_text_as_text() {
+    let content = ClipboardContent::plain_text("ordinary prompt text".to_owned());
+
+    let ClipboardPasteContent::Text(text) =
+        classify_clipboard_content(content, Path::new("/workspace"))
+    else {
+        panic!("plain clipboard text should remain text");
+    };
+
+    assert_eq!(text, "ordinary prompt text");
+}
+
+#[test]
+fn classifies_clipboard_image_paths_without_reparsing_spaces() {
+    let content = ClipboardContent {
+        paths: Some(vec!["/workspace/image one.png".to_owned()]),
+        ..Default::default()
+    };
+
+    let ClipboardPasteContent::ImagePaths {
+        paths,
+        original_text,
+    } = classify_clipboard_content(content, Path::new("/other"))
+    else {
+        panic!("an image file path should be classified as an attachment");
+    };
+
+    assert_eq!(paths, [Path::new("/workspace/image one.png")]);
+    assert_eq!(original_text, "/workspace/image one.png");
+}
+
+#[test]
+fn classifies_clipboard_image_data_before_text() {
+    let content = ClipboardContent {
+        plain_text: "image fallback".to_owned(),
+        images: Some(vec![ImageData {
+            data: vec![1, 2, 3],
+            mime_type: "image/png".to_owned(),
+            filename: None,
+        }]),
+        ..Default::default()
+    };
+
+    assert!(matches!(
+        classify_clipboard_content(content, Path::new("/workspace")),
+        ClipboardPasteContent::Image(_)
+    ));
 }
 
 #[test]
@@ -106,9 +159,9 @@ fn processes_clipboard_image_content() {
 }
 
 #[test]
-fn rejects_clipboard_content_without_an_image() {
+fn reports_unavailable_clipboard_image_data() {
     assert_eq!(
         process_clipboard_content(ClipboardContent::plain_text("text".to_owned())).unwrap_err(),
-        "The clipboard does not contain an image."
+        "Clipboard image data is unavailable."
     );
 }

--- a/crates/warp_tui/src/attachment_bar/model.rs
+++ b/crates/warp_tui/src/attachment_bar/model.rs
@@ -9,9 +9,13 @@ use warp::tui_export::{
 use warp_core::features::FeatureFlag;
 use warp_editor::model::CoreEditorModel;
 use warpui_core::r#async::SpawnedFutureHandle;
+use warpui_core::clipboard::ClipboardContent;
 use warpui_core::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity as _};
 
-use super::image_processing::{parse_image_paths, process_paths, read_and_process_clipboard_image};
+use super::image_processing::{
+    ClipboardPasteContent, classify_clipboard_content, parse_image_paths,
+    process_clipboard_content, process_paths, read_clipboard_content,
+};
 use crate::input_mode_policy::AI_LOCKED_CONFIG;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -189,8 +193,20 @@ impl TuiAttachmentModel {
         let Some(paths) = parse_image_paths(&text, &self.current_working_directory(ctx)) else {
             return TuiAttachmentPasteDisposition::NotHandled;
         };
+        self.attach_image_paths(paths, text, ctx)
+    }
+
+    fn attach_image_paths(
+        &mut self,
+        paths: Vec<PathBuf>,
+        original_text: String,
+        ctx: &mut ModelContext<Self>,
+    ) -> TuiAttachmentPasteDisposition {
+        if !FeatureFlag::ImageAsContext.is_enabled() {
+            return TuiAttachmentPasteDisposition::NotHandled;
+        }
         if let Err(error) = self.validate_new_images(paths.len(), ctx) {
-            ctx.emit(TuiAttachmentModelEvent::RestorePastedText(text));
+            ctx.emit(TuiAttachmentModelEvent::RestorePastedText(original_text));
             ctx.emit(TuiAttachmentModelEvent::ShowHint(error));
             return TuiAttachmentPasteDisposition::Handled;
         }
@@ -201,7 +217,6 @@ impl TuiAttachmentModel {
             .map(|file_name| file_name.to_string_lossy().into_owned())
             .unwrap_or_else(|| "image".to_owned());
         self.start_processing(processing_file_name, paths.len(), ctx);
-        let original_text = text;
         self.in_flight = Some(ctx.spawn_abortable(
             process_paths(paths),
             move |model, result, ctx| {
@@ -227,14 +242,49 @@ impl TuiAttachmentModel {
         TuiAttachmentPasteDisposition::Started
     }
 
-    pub(crate) fn paste_image_from_clipboard(&mut self, ctx: &mut ModelContext<Self>) -> bool {
+    pub(crate) fn paste_from_clipboard(&mut self, ctx: &mut ModelContext<Self>) {
+        ctx.spawn(
+            read_clipboard_content(),
+            |model, result, ctx| match result {
+                Ok(content) => {
+                    let cwd = model.current_working_directory(ctx);
+                    match classify_clipboard_content(content, &cwd) {
+                        ClipboardPasteContent::Image(content) => {
+                            model.attach_clipboard_image(content, ctx);
+                        }
+                        ClipboardPasteContent::ImagePaths {
+                            paths,
+                            original_text,
+                        } => {
+                            if model.attach_image_paths(paths, original_text.clone(), ctx)
+                                == TuiAttachmentPasteDisposition::NotHandled
+                            {
+                                ctx.emit(TuiAttachmentModelEvent::RestorePastedText(original_text));
+                            }
+                        }
+                        ClipboardPasteContent::Text(text) => {
+                            ctx.emit(TuiAttachmentModelEvent::RestorePastedText(text));
+                        }
+                        ClipboardPasteContent::Empty => {}
+                    }
+                }
+                Err(error) => ctx.emit(TuiAttachmentModelEvent::ShowHint(error)),
+            },
+        );
+    }
+
+    fn attach_clipboard_image(
+        &mut self,
+        content: ClipboardContent,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
         if let Err(error) = self.validate_new_images(1, ctx) {
             ctx.emit(TuiAttachmentModelEvent::ShowHint(error));
             return false;
         }
         self.start_processing("clipboard-image.png".to_owned(), 1, ctx);
         self.in_flight = Some(ctx.spawn_abortable(
-            read_and_process_clipboard_image(),
+            blocking::unblock(move || process_clipboard_content(content)),
             |model, result, ctx| {
                 model.in_flight = None;
                 model.finish_processing();

--- a/crates/warp_tui/src/attachment_bar/view.rs
+++ b/crates/warp_tui/src/attachment_bar/view.rs
@@ -178,9 +178,9 @@ impl TuiAttachmentBar {
             .update(ctx, |model, ctx| model.try_attach_paste(text, ctx))
     }
 
-    pub(crate) fn paste_image_from_clipboard(&mut self, ctx: &mut ViewContext<Self>) {
+    pub(crate) fn paste_from_clipboard(&mut self, ctx: &mut ViewContext<Self>) {
         self.model
-            .update(ctx, |model, ctx| model.paste_image_from_clipboard(ctx));
+            .update(ctx, |model, ctx| model.paste_from_clipboard(ctx));
     }
 
     pub(crate) fn remove_selected(&mut self, ctx: &mut ViewContext<Self>) {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -385,8 +385,8 @@ pub(crate) enum TuiTerminalSessionAction {
     NavigateOrchestrationTabs(TuiOrchestrationTabNavigationAction),
     /// Move focus from the prompt input into the attachment bar.
     FocusAttachments,
-    /// Read a raw image from the host clipboard and attach it to the next query.
-    PasteImageFromClipboard,
+    /// Paste host clipboard text or attach image data and image paths.
+    PasteFromClipboard,
 }
 
 /// The authenticated terminal/session surface rendered inside [`RootTuiView`].
@@ -513,8 +513,8 @@ pub(crate) fn init(app: &mut AppContext) {
         .with_key_binding("tab"),
         EditableBinding::new(
             PASTE_IMAGE_BINDING_NAME,
-            "Paste an image from the clipboard",
-            TuiTerminalSessionAction::PasteImageFromClipboard,
+            "Paste from the clipboard",
+            TuiTerminalSessionAction::PasteFromClipboard,
         )
         .with_context_predicate(
             (id!(TuiInputView::ui_name()) | id!(TuiTerminalSessionView::ui_name()))
@@ -525,8 +525,8 @@ pub(crate) fn init(app: &mut AppContext) {
         #[cfg(windows)]
         EditableBinding::new(
             PASTE_IMAGE_BINDING_NAME,
-            "Paste an image from the clipboard",
-            TuiTerminalSessionAction::PasteImageFromClipboard,
+            "Paste from the clipboard",
+            TuiTerminalSessionAction::PasteFromClipboard,
         )
         .with_context_predicate(
             (id!(TuiInputView::ui_name()) | id!(TuiTerminalSessionView::ui_name()))
@@ -3282,9 +3282,9 @@ impl TypedActionView for TuiTerminalSessionView {
                     ctx.focus(&self.attachment_bar);
                 }
             }
-            TuiTerminalSessionAction::PasteImageFromClipboard => {
+            TuiTerminalSessionAction::PasteFromClipboard => {
                 self.attachment_bar
-                    .update(ctx, |bar, ctx| bar.paste_image_from_clipboard(ctx));
+                    .update(ctx, |bar, ctx| bar.paste_from_clipboard(ctx));
             }
         }
     }


### PR DESCRIPTION
## Description

Fix Ctrl-V handling in the TUI so clipboard contents are classified before entering the image attachment pipeline. Clipboard image data and image paths are still attached, while ordinary text falls back to raw insertion in the composer instead of showing an image-related hint.

The clipboard classifier preserves native file paths, including image paths containing spaces, and the Ctrl-V binding now describes the general paste behavior.

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Added focused tests covering plain clipboard text, image data precedence, and native image paths containing spaces.
- `cargo nextest run -p warp_tui` (474 passed).
- `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`.
- `./script/run-tui` (built and launched successfully).

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/3781dc2e-abd2-4c58-b4d9-37206df26975

CHANGELOG-BUG-FIX: Fixed Ctrl-V in the TUI to paste text when the clipboard does not contain an image.

Co-Authored-By: Oz <oz-agent@warp.dev>