### PR TITLE
Hide agent footer for renamed Warp TUI executables

### DIFF
--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -421,8 +421,8 @@ impl CLIAgent {
     }
 
     /// Returns whether `command` launches Warp's own headless TUI (`warp_tui`) —
-    /// e.g. `warp`, the legacy `warp-tui` alias, `warp-tui-oss`, an
-    /// absolute/relative path to one of those, or the `./script/run-tui` dev
+    /// e.g. `warp`, `warp-preview`, `warp-dev`, the legacy `warp-tui` aliases,
+    /// an absolute/relative path to one of those, or the `./script/run-tui` dev
     /// launcher.
     ///
     /// This mirrors [`Self::detect`] (which decides when to show the CLI agent
@@ -438,7 +438,10 @@ impl CLIAgent {
         // Match on the executable's file name so absolute/relative paths work
         // (e.g. `/path/to/warp-tui`, `./target/debug/warp-tui`).
         let basename = first_word.rsplit(['/', '\\']).next().unwrap_or(&first_word);
-        matches!(basename, "warp" | "warp-tui" | "warp-tui-oss" | "run-tui")
+        matches!(
+            basename,
+            "warp" | "warp-preview" | "warp-dev" | "warp-tui" | "warp-tui-oss" | "run-tui"
+        )
     }
 }
 

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -579,6 +579,8 @@ fn test_oh_my_pi_supports_bash_mode() {
 fn test_command_is_warp_tui_matches_binaries_and_launchers() {
     // Direct binary names.
     assert!(CLIAgent::command_is_warp_tui("warp", None));
+    assert!(CLIAgent::command_is_warp_tui("warp-preview", None));
+    assert!(CLIAgent::command_is_warp_tui("warp-dev", None));
     assert!(CLIAgent::command_is_warp_tui("warp-tui", None));
     assert!(CLIAgent::command_is_warp_tui("warp-tui-oss", None));
     // The dev launcher script.
@@ -592,6 +594,10 @@ fn test_command_is_warp_tui_matches_binaries_and_launchers() {
     assert!(CLIAgent::command_is_warp_tui(
         "./target/debug/warp-tui",
         None
+    ));
+    assert!(CLIAgent::command_is_warp_tui(
+        "/Applications/WarpPreview.app/Contents/MacOS/warp-preview --resume abc",
+        None,
     ));
     // With arguments and leading whitespace.
     assert!(CLIAgent::command_is_warp_tui("  warp --resume abc", None));
@@ -613,6 +619,8 @@ fn test_command_is_warp_tui_negatives() {
     assert!(!CLIAgent::command_is_warp_tui("htop", None));
     assert!(!CLIAgent::command_is_warp_tui("claude", None));
     // Lookalikes / substrings should not match.
+    assert!(!CLIAgent::command_is_warp_tui("warp-preview-wrapper", None));
+    assert!(!CLIAgent::command_is_warp_tui("mywarp-dev", None));
     assert!(!CLIAgent::command_is_warp_tui("warp-tui-wrapper", None));
     assert!(!CLIAgent::command_is_warp_tui("mywarp-tui", None));
     assert!(!CLIAgent::command_is_warp_tui("", None));


### PR DESCRIPTION
## Description

Recognizes the packaged `warp-preview` and `warp-dev` executable names as Warp's headless TUI so the enclosing Warp pane does not show the redundant Use Agent footer or outer agent input bar.

The command classifier continues to use exact basename matching and preserves the existing `warp`, `warp-tui`, `warp-tui-oss`, and `run-tui` launch names for stable, source, and local-development workflows. Regression coverage includes the renamed binaries, bundled paths with arguments, and lookalike commands that must not match.

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] Ran `./script/format`
- [x] Ran `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] Ran `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] Ran `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] Ran `cargo nextest run -p warp command_is_warp_tui` (3 passed)
- [x] Added focused unit regression coverage; GUI integration coverage was intentionally not added for this exact-name classifier change
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/f1ca3db0-77ef-499c-acff-d04b8e324713

CHANGELOG-BUG-FIX: Fixed the redundant Agent footer appearing when Warp Preview or Dev TUI runs inside Warp.

Co-Authored-By: Oz <oz-agent@warp.dev>