### PR TITLE
Fix file-backed execution profile migration on restart

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -3046,7 +3046,7 @@ impl AgentDriver {
                 .map_err(|_| AgentDriverError::ProfileError(profile.clone()))?;
             let sync_id = SyncId::ServerId(server_id);
             AIExecutionProfilesModel::handle(ctx).update(ctx, |model, ctx| {
-                if let Some(profile_id) = model.get_profile_id_by_sync_id(&sync_id) {
+                if let Some(profile_id) = model.get_profile_id_by_sync_id(&sync_id, ctx) {
                     model.set_active_profile(terminal_id, profile_id, ctx);
                 } else {
                     return Err(AgentDriverError::ProfileError(profile.clone()));

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -19,12 +19,14 @@ use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManagerEvent;
 use crate::auth::AuthStateProvider;
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::cloud_object::model::generic_string_model::GenericStringObjectId;
 use crate::cloud_object::model::persistence::{CloudModelEvent, UpdateSource};
 use crate::cloud_object::{CloudObject as _, GenericStringObjectFormat, JsonObjectType};
 use crate::drive::CloudObjectTypeAndId;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ClientId, SyncId};
+use crate::settings::cloud_preferences::CloudPreferencesSettings;
 use crate::settings::cloud_preferences_syncer::{
     CloudPreferencesSyncer, CloudPreferencesSyncerEvent,
 };
@@ -100,19 +102,79 @@ impl ProfileSource {
         }
     }
 
-    /// Returns whether profiles are read from the file-backed collection.
-    fn uses_settings_backend(self) -> bool {
+    /// Returns whether this source stores profiles in the settings collection.
+    fn is_settings_collection(self) -> bool {
         matches!(self, Self::SettingsCollection { .. })
     }
 
     /// Returns whether this launch performs the one-way legacy import.
-    fn migrates_legacy_cloud_profiles(self) -> bool {
+    fn imports_legacy_profiles(self) -> bool {
         matches!(
             self,
             Self::SettingsCollection {
                 migrates_legacy_cloud_profiles: true
             }
         )
+    }
+
+    /// Returns the stable key for a default profile read from the selected source.
+    fn default_profile_id(self) -> ExecutionProfileId {
+        if self.imports_legacy_profiles() {
+            ExecutionProfileId::default_profile()
+        } else {
+            ExecutionProfileId::new()
+        }
+    }
+
+    /// Derives the stable collection key assigned to a legacy cloud object.
+    ///
+    /// Synced non-default profiles derive their key from the server ID so independent clients
+    /// produce the same mapping. A profile that still has only a client ID receives a generated
+    /// key until the server ID arrives.
+    fn legacy_profile_id(self, sync_id: SyncId, is_default_profile: bool) -> ExecutionProfileId {
+        if is_default_profile {
+            return self.default_profile_id();
+        }
+        if !self.imports_legacy_profiles() {
+            return ExecutionProfileId::new();
+        }
+        sync_id
+            .into_server()
+            .map(ExecutionProfileId::from_legacy_server_id)
+            .unwrap_or_else(ExecutionProfileId::new)
+    }
+}
+
+/// Tracks which profile source is authoritative while the settings collection is initialized.
+///
+/// This state is process-local. An explicit [`ExecutionProfiles`] value is the durable signal
+/// that a collection was materialized on a previous launch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SettingsMigrationState {
+    /// No explicit collection is available, so reads continue using owned legacy cloud objects.
+    PendingLegacyImport,
+    /// The settings collection is authoritative, but its initial cloud reconciliation is pending.
+    PendingExplicitSync,
+    /// The collection needs no further migration work during this process.
+    Complete,
+}
+
+impl SettingsMigrationState {
+    /// Selects the initial authority state for a profile source.
+    fn for_launch(source: ProfileSource, settings_profiles_are_explicit: bool) -> Self {
+        match (
+            source.imports_legacy_profiles(),
+            settings_profiles_are_explicit,
+        ) {
+            (true, true) => Self::PendingExplicitSync,
+            (true, false) => Self::PendingLegacyImport,
+            (false, _) => Self::Complete,
+        }
+    }
+
+    /// Returns whether this state permits reads and writes through [`AISettings`].
+    fn settings_are_authoritative(self) -> bool {
+        !matches!(self, Self::PendingLegacyImport)
     }
 }
 
@@ -158,6 +220,8 @@ impl DefaultProfileState {
 pub struct AIExecutionProfilesModel {
     /// Authoritative persistence backend selected for this launch.
     source: ProfileSource,
+    /// State of the one-time import into the settings collection.
+    settings_migration_state: SettingsMigrationState,
     /// Whether post-auth onboarding must preserve the materialized default profile.
     preserve_profile_onboarding_overrides: bool,
     /// Previous settings snapshot used only to classify collection change events.
@@ -183,8 +247,8 @@ impl AIExecutionProfilesModel {
     pub(crate) fn new(launch_mode: &LaunchMode, ctx: &mut ModelContext<Self>) -> Self {
         // Resolve the persistence backend before constructing any source-specific state.
         let source = ProfileSource::for_launch_mode(launch_mode);
-        let uses_file_backed_profiles = source.uses_settings_backend();
-        let should_migrate_legacy_cloud_profiles = source.migrates_legacy_cloud_profiles();
+        let uses_file_backed_profiles = source.is_settings_collection();
+        let imports_legacy_profiles = source.imports_legacy_profiles();
 
         // A TUI with no explicit collection seeds its default from the existing
         // local scalar settings, then uses only the collection.
@@ -208,6 +272,16 @@ impl AIExecutionProfilesModel {
             }
         }
 
+        let settings_profiles_are_explicit = AISettings::as_ref(ctx)
+            .execution_profiles
+            .is_value_explicitly_set();
+        // Existing collections are authoritative immediately. A migration-capable launch without
+        // one keeps reading legacy objects until the import has materialized the settings value.
+        let settings_migration_state =
+            SettingsMigrationState::for_launch(source, settings_profiles_are_explicit);
+        let settings_are_authoritative =
+            uses_file_backed_profiles && settings_migration_state.settings_are_authoritative();
+
         // Build the source-specific legacy state. The settings backend does not
         // need cloud IDs; all effective reads still come directly from AISettings.
         cfg_if::cfg_if! {
@@ -223,7 +297,7 @@ impl AIExecutionProfilesModel {
                     default_profile_state,
                     profile_id_to_sync_id,
                     active_profiles_per_session,
-                ) = if uses_file_backed_profiles {
+                ) = if settings_are_authoritative {
                     (
                         DefaultProfileState::Unsynced {
                             id: ExecutionProfileId::default_profile(),
@@ -251,7 +325,7 @@ impl AIExecutionProfilesModel {
 
                     // Insert all non-default profiles from the cloud
                     for cloud_profile in all_profiles_from_cloud.iter().filter(|p| !p.model().string_model.is_default_profile) {
-                        let profile_id = ExecutionProfileId::new();
+                        let profile_id = source.legacy_profile_id(cloud_profile.id, false);
                         profile_id_to_sync_id.insert(profile_id, cloud_profile.id);
                     }
 
@@ -260,14 +334,15 @@ impl AIExecutionProfilesModel {
                         | LaunchMode::Test { .. } => {
                             match default_profile_from_cloud {
                                 Some(p) => {
-                                    let execution_profile_id = ExecutionProfileId::new();
+                                    let execution_profile_id =
+                                        source.legacy_profile_id(p.id, true);
                                     profile_id_to_sync_id.insert(execution_profile_id.clone(), p.id);
                                     DefaultProfileState::Synced {
                                         id: execution_profile_id,
                                     }
                                 }
                                 None => DefaultProfileState::Unsynced {
-                                    id: ExecutionProfileId::new(),
+                                    id: source.default_profile_id(),
                                     profile: super::create_default_from_legacy_settings(ctx),
                                 },
                             }
@@ -317,7 +392,15 @@ impl AIExecutionProfilesModel {
                 }
             });
 
-            if should_migrate_legacy_cloud_profiles {
+            if imports_legacy_profiles {
+                if ctx.has_singleton_model::<AuthManager>() {
+                    ctx.subscribe_to_model(&AuthManager::handle(ctx), |me, _, event, ctx| {
+                        if matches!(event, AuthManagerEvent::AuthComplete) {
+                            me.migrate_settings_profiles(ctx);
+                        }
+                    });
+                }
+
                 if ctx.has_singleton_model::<CloudPreferencesSyncer>() {
                     ctx.subscribe_to_model(
                         &CloudPreferencesSyncer::handle(ctx),
@@ -329,18 +412,29 @@ impl AIExecutionProfilesModel {
                     );
                 }
                 ctx.subscribe_to_model(&CloudModel::handle(ctx), |me, _, event, ctx| {
-                    if matches!(
-                        event,
-                        CloudModelEvent::ObjectSynced {
-                            type_and_id: CloudObjectTypeAndId::GenericStringObject {
-                                object_type: GenericStringObjectFormat::Json(
-                                    JsonObjectType::AIExecutionProfile
-                                ),
+                    if !me.settings_are_authoritative() {
+                        me.handle_cloud_model_event(event, ctx);
+                    }
+                    if let CloudModelEvent::ObjectSynced {
+                        type_and_id:
+                            CloudObjectTypeAndId::GenericStringObject {
+                                object_type:
+                                    GenericStringObjectFormat::Json(
+                                        JsonObjectType::AIExecutionProfile,
+                                    ),
                                 ..
                             },
-                            ..
-                        }
-                    ) {
+                        client_id,
+                        server_id,
+                    } = event
+                    {
+                        me.replace_client_id_with_server_id(
+                            SyncId::ServerId(*server_id),
+                            SyncId::ClientId(*client_id),
+                            ctx,
+                        );
+                        me.migrate_settings_profiles(ctx);
+                    } else if matches!(event, CloudModelEvent::InitialLoadCompleted) {
                         me.migrate_settings_profiles(ctx);
                     }
                 });
@@ -379,7 +473,7 @@ impl AIExecutionProfilesModel {
                     log::info!(
                         "Resetting execution profile model because default profile was deleted."
                     );
-                    me.reset();
+                    me.reset(false);
                 }
             });
         }
@@ -390,7 +484,8 @@ impl AIExecutionProfilesModel {
 
         let mut model = Self {
             source,
-            preserve_profile_onboarding_overrides: false,
+            settings_migration_state,
+            preserve_profile_onboarding_overrides: settings_profiles_are_explicit,
             last_settings_profiles,
             default_profile_state,
             profile_id_to_sync_id,
@@ -399,7 +494,7 @@ impl AIExecutionProfilesModel {
 
         if !uses_file_backed_profiles {
             model.maybe_inherit_from_legacy_settings(ctx);
-        } else if should_migrate_legacy_cloud_profiles
+        } else if imports_legacy_profiles
             && ctx.has_singleton_model::<CloudPreferencesSyncer>()
             && CloudPreferencesSyncer::as_ref(ctx).has_completed_initial_load()
         {
@@ -419,6 +514,81 @@ impl AIExecutionProfilesModel {
         UserWorkspaces::as_ref(ctx)
             .personal_drive(ctx)
             .is_some_and(|owner| profile.permissions().owner == owner)
+    }
+
+    /// Returns whether the settings collection is currently authoritative for profile operations.
+    fn settings_are_authoritative(&self) -> bool {
+        self.source.is_settings_collection()
+            && self.settings_migration_state.settings_are_authoritative()
+    }
+
+    /// Snapshots the currently visible legacy-backed profiles into a settings collection.
+    ///
+    /// Local edits use this snapshot to become file-backed without exposing the empty implicit
+    /// settings default.
+    fn pending_legacy_profiles(&self, ctx: &AppContext) -> ExecutionProfilesConfig {
+        let mut profiles = ExecutionProfilesConfig::default();
+        for profile_id in self.get_all_profile_ids() {
+            if let Some(profile) = self.get_profile_by_id(&profile_id, ctx) {
+                profiles.insert(profile_id, profile.data);
+            }
+        }
+        profiles
+    }
+
+    fn cloud_collection_exists(ctx: &AppContext) -> bool {
+        CloudModel::as_ref(ctx)
+            .get_all_cloud_preferences_by_storage_key()
+            .contains_key(ExecutionProfiles::storage_key())
+    }
+
+    /// Returns whether settings sync must apply an existing cloud collection before local changes.
+    ///
+    /// Deferring in this state prevents stale legacy or local values from overwriting a newer
+    /// collection received from another client.
+    fn cloud_collection_awaiting_reconciliation(ctx: &AppContext) -> bool {
+        *CloudPreferencesSettings::as_ref(ctx)
+            .settings_sync_enabled
+            .value()
+            && Self::cloud_collection_exists(ctx)
+            && ctx.has_singleton_model::<CloudPreferencesSyncer>()
+            && !CloudPreferencesSyncer::as_ref(ctx).has_completed_initial_load()
+    }
+
+    /// Makes a locally edited pending collection authoritative in [`AISettings`].
+    ///
+    /// Returns `false` without changing authority when cloud reconciliation must run first or when
+    /// the collection cannot be persisted.
+    fn activate_pending_settings_collection(
+        &mut self,
+        profiles: ExecutionProfilesConfig,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        if AuthStateProvider::as_ref(ctx).get().user_id().is_some()
+            && !UpdateManager::as_ref(ctx).has_completed_initial_load()
+        {
+            return false;
+        }
+
+        if Self::cloud_collection_awaiting_reconciliation(ctx) {
+            return false;
+        }
+        let update_result = AISettings::handle(ctx).update(ctx, |settings, ctx| {
+            settings.execution_profiles.set_value(profiles, ctx)
+        });
+        match update_result {
+            Ok(()) => {
+                self.settings_migration_state = SettingsMigrationState::PendingExplicitSync;
+                self.preserve_profile_onboarding_overrides = true;
+                true
+            }
+            Err(error) => {
+                report_error!(
+                    error.context("Failed to materialize pending execution profiles in settings")
+                );
+                false
+            }
+        }
     }
 
     /// Classifies a collection update into profile events and removes stale selections.
@@ -448,14 +618,32 @@ impl AIExecutionProfilesModel {
         self.active_profiles_per_session
             .retain(|_, id| current_ids.contains(id));
         self.last_settings_profiles = current;
+        if self.settings_migration_state == SettingsMigrationState::PendingLegacyImport
+            && AISettings::as_ref(ctx)
+                .execution_profiles
+                .is_value_explicitly_set()
+        {
+            self.settings_migration_state = SettingsMigrationState::PendingExplicitSync;
+            self.preserve_profile_onboarding_overrides = true;
+        }
     }
 
-    /// Materializes the account's execution profiles into the file-backed collection.
+    /// Attempts to make the account's file-backed execution-profile collection authoritative.
+    ///
+    /// An explicit collection is reconciled with cloud preferences after their initial-load
+    /// direction is known. Otherwise, owned legacy cloud objects are imported once all have server
+    /// IDs. Missing prerequisites leave the migration pending so a later readiness event can retry.
     pub(crate) fn migrate_settings_profiles(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.source.migrates_legacy_cloud_profiles() {
+        if !self.source.imports_legacy_profiles()
+            || self.settings_migration_state == SettingsMigrationState::Complete
+        {
             return;
         }
         if AuthStateProvider::as_ref(ctx).get().user_id().is_none() {
+            return;
+        }
+
+        if !UpdateManager::as_ref(ctx).has_completed_initial_load() {
             return;
         }
 
@@ -463,9 +651,28 @@ impl AIExecutionProfilesModel {
             .execution_profiles
             .is_value_explicitly_set()
         {
+            if ctx.has_singleton_model::<CloudPreferencesSyncer>()
+                && !CloudPreferencesSyncer::as_ref(ctx).has_completed_initial_load()
+            {
+                return;
+            }
             self.preserve_profile_onboarding_overrides = true;
             Self::sync_explicit_settings_collection(ctx);
+            self.settings_migration_state = SettingsMigrationState::Complete;
             return;
+        }
+        if Self::cloud_collection_awaiting_reconciliation(ctx) {
+            return;
+        }
+
+        if *CloudPreferencesSettings::as_ref(ctx)
+            .settings_sync_enabled
+            .value()
+            && Self::cloud_collection_exists(ctx)
+        {
+            log::error!(
+                "Failed to apply cloud execution profiles; recovering from legacy profiles"
+            );
         }
 
         let owned_legacy_profiles = CloudModel::as_ref(ctx)
@@ -500,8 +707,7 @@ impl AIExecutionProfilesModel {
             .collect::<Vec<_>>();
         legacy_profiles.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
 
-        let profiles = if legacy_profiles.is_empty() {
-            self.preserve_profile_onboarding_overrides = false;
+        let (profiles, preserve_profile_onboarding_overrides) = if legacy_profiles.is_empty() {
             let mut profile = super::create_default_from_legacy_settings(ctx);
             if let Some(base_llm_id) = ctx
                 .private_user_preferences()
@@ -515,9 +721,8 @@ impl AIExecutionProfilesModel {
             }
             let mut profiles = ExecutionProfilesConfig::default();
             profiles.insert(ExecutionProfileId::default_profile(), profile);
-            profiles
+            (profiles, false)
         } else {
-            self.preserve_profile_onboarding_overrides = true;
             if !legacy_profiles.iter().any(|(id, _)| id.is_default()) {
                 legacy_profiles.insert(
                     0,
@@ -527,15 +732,25 @@ impl AIExecutionProfilesModel {
                     ),
                 );
             }
-            ExecutionProfilesConfig::from_profiles(IndexMap::from_iter(legacy_profiles))
-                .expect("legacy migration inserts a default profile")
+            (
+                ExecutionProfilesConfig::from_profiles(IndexMap::from_iter(legacy_profiles))
+                    .expect("legacy migration inserts a default profile"),
+                true,
+            )
         };
 
         let update_result = AISettings::handle(ctx).update(ctx, |settings, ctx| {
             settings.execution_profiles.set_value(profiles, ctx)
         });
-        if let Err(error) = update_result {
-            report_error!(error.context("Failed to migrate execution profiles to settings"));
+        match update_result {
+            Ok(()) => {
+                self.preserve_profile_onboarding_overrides = preserve_profile_onboarding_overrides;
+                self.settings_migration_state = SettingsMigrationState::Complete;
+                log::info!("Migrated legacy execution profiles to the settings collection");
+            }
+            Err(error) => {
+                report_error!(error.context("Failed to migrate execution profiles to settings"));
+            }
         }
     }
     /// Uploads an explicit local collection after the deferred migration check.
@@ -553,7 +768,7 @@ impl AIExecutionProfilesModel {
 
     /// Returns whether onboarding must leave the existing default profile unchanged.
     pub fn should_preserve_onboarding_profile(&self, ctx: &AppContext) -> bool {
-        if self.source.uses_settings_backend() {
+        if self.settings_are_authoritative() {
             self.preserve_profile_onboarding_overrides
         } else {
             self.default_profile(ctx).sync_id().is_some()
@@ -597,8 +812,21 @@ impl AIExecutionProfilesModel {
 
     pub fn create_profile(&mut self, ctx: &mut ModelContext<Self>) -> Option<ExecutionProfileId> {
         let profile_id = ExecutionProfileId::new();
+        if self.settings_migration_state == SettingsMigrationState::PendingLegacyImport {
+            let mut profiles = self.pending_legacy_profiles(ctx);
+            let mut new_profile = self.default_profile(ctx).data().clone();
+            new_profile.name = String::new();
+            new_profile.is_default_profile = false;
+            new_profile.autosync_plans_to_warp_drive = true;
+            profiles.insert(profile_id.clone(), new_profile);
+            if !self.activate_pending_settings_collection(profiles, ctx) {
+                return None;
+            }
+            send_telemetry_from_ctx!(TelemetryEvent::AIExecutionProfileCreated, ctx);
+            return Some(profile_id);
+        }
 
-        if self.source.uses_settings_backend() {
+        if self.settings_are_authoritative() {
             let mut profiles = AISettings::as_ref(ctx).execution_profiles.value().clone();
             let mut new_profile = self.default_profile(ctx).data().clone();
             new_profile.name = String::new();
@@ -646,7 +874,24 @@ impl AIExecutionProfilesModel {
         profile_id: &ExecutionProfileId,
         ctx: &mut ModelContext<Self>,
     ) {
-        if self.source.uses_settings_backend() {
+        if self.settings_migration_state == SettingsMigrationState::PendingLegacyImport {
+            if profile_id == &self.default_profile_state.id() {
+                log::warn!("Attempted to delete default profile (id: {profile_id})");
+                return;
+            }
+            let mut profiles = self.pending_legacy_profiles(ctx);
+            if profiles.remove(profile_id).is_none() {
+                return;
+            }
+            if !self.activate_pending_settings_collection(profiles, ctx) {
+                return;
+            }
+            self.active_profiles_per_session
+                .retain(|_, active_profile_id| active_profile_id != profile_id);
+            send_telemetry_from_ctx!(TelemetryEvent::AIExecutionProfileDeleted, ctx);
+            return;
+        }
+        if self.settings_are_authoritative() {
             if profile_id.is_default() {
                 log::warn!("Attempted to delete default profile (id: {profile_id})");
                 return;
@@ -692,8 +937,22 @@ impl AIExecutionProfilesModel {
     }
 
     // On logout, we need to clear any existing profile state.
-    pub fn reset(&mut self) {
-        if self.source.uses_settings_backend() {
+    pub fn reset(&mut self, settings_profiles_are_explicit: bool) {
+        if self.source.is_settings_collection() {
+            if self.source.imports_legacy_profiles() {
+                self.settings_migration_state =
+                    SettingsMigrationState::for_launch(self.source, settings_profiles_are_explicit);
+                self.preserve_profile_onboarding_overrides = settings_profiles_are_explicit;
+                self.default_profile_state = DefaultProfileState::Unsynced {
+                    id: ExecutionProfileId::default_profile(),
+                    profile: AIExecutionProfile {
+                        name: "Default".to_string(),
+                        is_default_profile: true,
+                        ..Default::default()
+                    },
+                };
+                self.profile_id_to_sync_id.clear();
+            }
             self.active_profiles_per_session.clear();
             return;
         }
@@ -724,14 +983,14 @@ impl AIExecutionProfilesModel {
     }
 
     pub fn default_profile_id(&self) -> ExecutionProfileId {
-        if self.source.uses_settings_backend() {
+        if self.settings_are_authoritative() {
             return ExecutionProfileId::default_profile();
         }
         self.default_profile_state.id()
     }
 
     pub fn default_profile(&self, ctx: &AppContext) -> AIExecutionProfileInfo {
-        if self.source.uses_settings_backend() {
+        if self.settings_are_authoritative() {
             let id = ExecutionProfileId::default_profile();
             let data = AISettings::as_ref(ctx)
                 .execution_profiles
@@ -811,7 +1070,7 @@ impl AIExecutionProfilesModel {
         profile_id: &ExecutionProfileId,
         ctx: &AppContext,
     ) -> Option<AIExecutionProfileInfo> {
-        if self.source.uses_settings_backend() {
+        if self.settings_are_authoritative() {
             return AISettings::as_ref(ctx)
                 .execution_profiles
                 .value()
@@ -854,7 +1113,7 @@ impl AIExecutionProfilesModel {
     }
 
     pub fn get_all_profile_ids(&self) -> Vec<ExecutionProfileId> {
-        if self.source.uses_settings_backend() {
+        if self.settings_are_authoritative() {
             return self.last_settings_profiles.profile_ids().cloned().collect();
         }
         let default_profile_id = self.default_profile_state.id();
@@ -870,11 +1129,47 @@ impl AIExecutionProfilesModel {
             .collect()
     }
 
-    /// Look up a local client profile ID from its cloud sync ID.
+    /// Resolves a legacy cloud sync ID to the profile key used by the active backend.
+    ///
+    /// Legacy backends consult their in-memory ID map. Migration-capable settings backends retain
+    /// mappings from the current process, then derive deterministic keys for profiles restored on
+    /// a later launch. Non-migrating settings backends, such as the TUI, have no legacy sync-ID
+    /// mapping.
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
-    pub fn get_profile_id_by_sync_id(&self, sync_id: &SyncId) -> Option<ExecutionProfileId> {
-        if self.source.uses_settings_backend() {
-            return None;
+    pub fn get_profile_id_by_sync_id(
+        &self,
+        sync_id: &SyncId,
+        ctx: &AppContext,
+    ) -> Option<ExecutionProfileId> {
+        if self.settings_are_authoritative() {
+            if !self.source.imports_legacy_profiles() {
+                return None;
+            }
+            let profiles = AISettings::as_ref(ctx).execution_profiles.value();
+            if let Some(profile_id) =
+                self.profile_id_to_sync_id
+                    .iter()
+                    .find_map(|(profile_id, candidate_sync_id)| {
+                        (candidate_sync_id == sync_id).then(|| profile_id.clone())
+                    })
+                && profiles.profile(&profile_id).is_some()
+            {
+                return Some(profile_id);
+            }
+            let server_id = sync_id.into_server()?;
+            let legacy_profile = CloudModel::as_ref(ctx)
+                .get_object_of_type::<GenericStringObjectId, CloudAIExecutionProfileModel>(sync_id);
+            let profile_id = if legacy_profile
+                .is_some_and(|profile| profile.model().string_model.is_default_profile)
+            {
+                ExecutionProfileId::default_profile()
+            } else {
+                ExecutionProfileId::from_legacy_server_id(server_id)
+            };
+            return profiles
+                .profile(&profile_id)
+                .is_some()
+                .then_some(profile_id);
         }
         self.profile_id_to_sync_id
             .iter()
@@ -888,7 +1183,7 @@ impl AIExecutionProfilesModel {
     }
 
     pub fn has_multiple_profiles(&self) -> bool {
-        if self.source.uses_settings_backend() {
+        if self.settings_are_authoritative() {
             return self.last_settings_profiles.profile_ids().nth(1).is_some();
         }
         let default_profile_id = self.default_profile_state.id();
@@ -1651,7 +1946,17 @@ impl AIExecutionProfilesModel {
         edit_fn: impl FnOnce(&mut AIExecutionProfile) -> bool,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
-        if self.source.uses_settings_backend() {
+        if self.settings_migration_state == SettingsMigrationState::PendingLegacyImport {
+            let mut profiles = self.pending_legacy_profiles(ctx);
+            let Some(profile) = profiles.profile_mut(profile_id) else {
+                return false;
+            };
+            if !edit_fn(profile) {
+                return false;
+            }
+            return self.activate_pending_settings_collection(profiles, ctx);
+        }
+        if self.settings_are_authoritative() {
             let mut profiles = AISettings::as_ref(ctx).execution_profiles.value().clone();
             let Some(profile) = profiles.profile_mut(profile_id) else {
                 return false;
@@ -1861,7 +2166,7 @@ impl AIExecutionProfilesModel {
                 continue;
             }
             if !self.profile_id_to_sync_id.values().any(|s| *s == sync_id) {
-                let profile_id = ExecutionProfileId::new();
+                let profile_id = self.source.legacy_profile_id(sync_id, false);
                 self.profile_id_to_sync_id.insert(profile_id, sync_id);
                 log::info!(
                     "Registered existing cloud execution profile after initial load: {sync_id:?}"
@@ -1938,7 +2243,7 @@ impl AIExecutionProfilesModel {
         // For non-default profiles, add to the map if not already present
         let profile_exists = self.profile_id_to_sync_id.values().any(|id| *id == sync_id);
         if !profile_exists {
-            let profile_id = ExecutionProfileId::new();
+            let profile_id = self.source.legacy_profile_id(sync_id, false);
             self.profile_id_to_sync_id.insert(profile_id, sync_id);
             log::info!("Added new execution profile to map: {sync_id:?}");
             ctx.emit(AIExecutionProfilesModelEvent::ProfileCreated);
@@ -2003,7 +2308,7 @@ impl AIExecutionProfilesModel {
         }
 
         // Find the client profile ID for this sync ID
-        let profile_id = self.get_profile_id_by_sync_id(&sync_id);
+        let profile_id = self.get_profile_id_by_sync_id(&sync_id, ctx);
 
         if let Some(profile_id) = profile_id {
             log::info!("Execution profile updated from server: {sync_id:?}");
@@ -2034,15 +2339,66 @@ impl AIExecutionProfilesModel {
         }
     }
 
-    // We don't want stale client ids in our map. We won't be able to find the backing cloud object when
-    // an edit occurs.
-    pub fn replace_client_id_with_server_id(&mut self, server_id: SyncId, client_id: SyncId) {
-        for (_, sync_id) in self.profile_id_to_sync_id.iter_mut() {
-            if *sync_id == client_id {
-                *sync_id = server_id;
-                log::info!("Updated profile id mapping after creating a new execution profile");
+    /// Replaces a temporary client sync ID with the server ID assigned after object creation.
+    ///
+    /// Migration-capable sources also replace generated profile keys with their deterministic
+    /// migrated keys in settings and active/default references.
+    pub fn replace_client_id_with_server_id(
+        &mut self,
+        server_id: SyncId,
+        client_id: SyncId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(profile_id) = self
+            .profile_id_to_sync_id
+            .iter()
+            .find_map(|(profile_id, sync_id)| (*sync_id == client_id).then(|| profile_id.clone()))
+        else {
+            return;
+        };
+        let is_default_profile = profile_id == self.default_profile_state.id();
+        let migrated_profile_id = if self.source.imports_legacy_profiles() {
+            self.source.legacy_profile_id(server_id, is_default_profile)
+        } else {
+            profile_id.clone()
+        };
+
+        self.profile_id_to_sync_id.remove(&profile_id);
+        self.profile_id_to_sync_id
+            .insert(migrated_profile_id.clone(), server_id);
+        if migrated_profile_id != profile_id {
+            if self.settings_are_authoritative() {
+                let mut profiles = AISettings::as_ref(ctx).execution_profiles.value().clone();
+                if let Some(profile) = profiles.remove(&profile_id) {
+                    profiles.insert(migrated_profile_id.clone(), profile);
+                    if let Err(error) = AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                        settings.execution_profiles.set_value(profiles, ctx)
+                    }) {
+                        report_error!(
+                            error.context("Failed to re-key migrated execution profile settings")
+                        );
+                    }
+                }
+            }
+            for active_profile_id in self.active_profiles_per_session.values_mut() {
+                if *active_profile_id == profile_id {
+                    active_profile_id.clone_from(&migrated_profile_id);
+                }
+            }
+            match &mut self.default_profile_state {
+                DefaultProfileState::Unsynced { id, .. }
+                | DefaultProfileState::Synced { id }
+                | DefaultProfileState::Cli { id, .. }
+                    if *id == profile_id =>
+                {
+                    id.clone_from(&migrated_profile_id);
+                }
+                DefaultProfileState::Unsynced { .. }
+                | DefaultProfileState::Synced { .. }
+                | DefaultProfileState::Cli { .. } => {}
             }
         }
+        log::info!("Updated profile id mapping after creating a new execution profile");
     }
 
     /// Replaces the given profile's data with CLI defaults for the given sandboxed state.

--- a/app/src/ai/execution_profiles/profiles_tests.rs
+++ b/app/src/ai/execution_profiles/profiles_tests.rs
@@ -14,21 +14,27 @@ use crate::ai::execution_profiles::{
     WriteToPtyPermission, create_default_for_tui_from_legacy_settings,
     create_default_from_legacy_settings,
 };
+use crate::ai::llms::LLMId;
 use crate::ai::mcp::TemplatableMCPServerManager;
-use crate::auth::user::TEST_USER_UID;
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::auth::user::{TEST_USER_UID, User};
 use crate::auth::{AuthStateProvider, UserUid};
+use crate::cloud_object::model::actions::ObjectActions;
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::cloud_object::{
     ObjectIdType, Owner, Revision, ServerAIExecutionProfile, ServerCreationInfo,
-    ServerGuestSubject, ServerMetadata, ServerObjectGuest, ServerPermissions,
+    ServerGuestSubject, ServerMetadata, ServerObjectGuest, ServerPermissions, ServerPreference,
 };
 use crate::network::NetworkStatus;
-use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::cloud_objects::update_manager::{InitialLoadResponse, UpdateManager};
 use crate::server::ids::{ServerId, ServerIdAndType, SyncId};
+use crate::server::server_api::ServerApiProvider;
 use crate::server::sync_queue::SyncQueue;
+use crate::settings::cloud_preferences::{CloudPreferenceModel, CloudPreferencesSettings};
 use crate::settings::{AISettings, AgentModeCommandExecutionPredicate, PrivacySettings};
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::workspaces::team_tester::TeamTesterStatus;
+use crate::workspaces::user_profiles::UserProfiles;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
 fn mock_server_metadata(uid: ServerId) -> ServerMetadata {
@@ -54,6 +60,19 @@ fn owned_legacy_profile(
         sync_id,
         CloudAIExecutionProfileModel::new(profile),
         mock_server_metadata(metadata_id),
+        ServerPermissions::mock_personal(),
+    )
+}
+
+/// Creates the minimal cloud preference needed to model a previously migrated account.
+fn cloud_execution_profiles_preference(server_id: ServerId) -> ServerPreference {
+    ServerPreference::new(
+        SyncId::ServerId(server_id),
+        CloudPreferenceModel::deserialize_owned(
+            r#"{"storage_key":"ExecutionProfiles","value":{},"platform":"Global"}"#,
+        )
+        .expect("execution profiles preference should deserialize"),
+        mock_server_metadata(server_id),
         ServerPermissions::mock_personal(),
     )
 }
@@ -103,9 +122,17 @@ fn install_singletons(app: &mut App, auth_state: AuthStateProvider) {
     app.add_singleton_model(TeamTesterStatus::mock);
     app.add_singleton_model(UpdateManager::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(|_| ObjectActions::new(Vec::new()));
     app.add_singleton_model(|_| TemplatableMCPServerManager::default());
     app.add_singleton_model(PrivacySettings::mock);
+    app.add_singleton_model(|_| UserProfiles::new(Vec::new()));
     app.add_singleton_model(UserWorkspaces::default_mock);
+}
+
+fn complete_cloud_initial_load(app: &mut App) {
+    UpdateManager::handle(app).update(app, |update_manager, ctx| {
+        update_manager.mock_initial_load(InitialLoadResponse::default(), ctx);
+    });
 }
 
 fn collection_with_profile(
@@ -349,9 +376,7 @@ fn explicit_local_collection_is_preserved_from_onboarding() {
         let profile_model = app.add_singleton_model(|ctx| {
             AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
         });
-        profile_model.update(&mut app, |model, ctx| {
-            model.migrate_settings_profiles(ctx);
-        });
+        complete_cloud_initial_load(&mut app);
 
         profile_model.read(&app, |model, ctx| {
             assert!(model.should_preserve_onboarding_profile(ctx));
@@ -392,9 +417,23 @@ fn migration_retries_after_pending_legacy_profile_receives_server_id() {
         let profile_model = app.add_singleton_model(|ctx| {
             AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
         });
-        profile_model.update(&mut app, |model, ctx| {
-            model.migrate_settings_profiles(ctx);
+        let terminal_id = profile_model.id();
+        let pending_profile_id = profile_model.read(&app, |model, _| {
+            model
+                .get_all_profile_ids()
+                .into_iter()
+                .find(|id| id != &model.default_profile_id())
+                .expect("pending non-default profile should be available")
         });
+        profile_model.update(&mut app, |model, ctx| {
+            model.set_active_profile(terminal_id, pending_profile_id, ctx);
+            model.replace_client_id_with_server_id(
+                SyncId::ServerId(server_id),
+                SyncId::ClientId(client_id),
+                ctx,
+            );
+        });
+        complete_cloud_initial_load(&mut app);
         app.read(|ctx| {
             assert_eq!(
                 AISettings::as_ref(ctx)
@@ -430,6 +469,261 @@ fn migration_retries_after_pending_legacy_profile_receives_server_id() {
                     .profile(&migrated_key)
                     .map(|profile| profile.read_files),
                 Some(ActionPermission::AlwaysAllow)
+            );
+        });
+        profile_model.read(&app, |model, ctx| {
+            let active_profile = model.active_profile(Some(terminal_id), ctx);
+            assert_eq!(active_profile.id(), &migrated_key);
+            assert_eq!(active_profile.data().name, "Pending");
+        });
+    });
+}
+
+#[test]
+fn materialized_pending_profile_is_rekeyed_after_server_id_arrives() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        let client_id = crate::server::ids::ClientId::new();
+        let server_id = ServerId::from(517);
+        let pending_profile = owned_legacy_profile(
+            SyncId::ClientId(client_id),
+            server_id,
+            AIExecutionProfile {
+                name: "Pending".to_string(),
+                read_files: ActionPermission::AlwaysAllow,
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(pending_profile, ctx);
+        });
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let pending_profile_id = profile_model.read(&app, |model, _| {
+            model
+                .get_all_profile_ids()
+                .into_iter()
+                .find(|id| id != &model.default_profile_id())
+                .expect("pending non-default profile should be available")
+        });
+        complete_cloud_initial_load(&mut app);
+
+        let default_profile_id = profile_model.read(&app, |model, _| model.default_profile_id());
+        profile_model.update(&mut app, |model, ctx| {
+            model.set_base_model(
+                &default_profile_id,
+                Some(LLMId::from("gpt-5-6-sol-high")),
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            assert!(
+                AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .value()
+                    .profile(&pending_profile_id)
+                    .is_some()
+            );
+        });
+
+        profile_model.update(&mut app, |model, ctx| {
+            model.replace_client_id_with_server_id(
+                SyncId::ServerId(server_id),
+                SyncId::ClientId(client_id),
+                ctx,
+            );
+        });
+
+        let migrated_key = ExecutionProfileId::from_legacy_server_id(server_id);
+        app.read(|ctx| {
+            let profiles = AISettings::as_ref(ctx).execution_profiles.value();
+            assert!(profiles.profile(&pending_profile_id).is_none());
+            assert_eq!(
+                profiles
+                    .profile(&migrated_key)
+                    .map(|profile| profile.read_files),
+                Some(ActionPermission::AlwaysAllow)
+            );
+        });
+        let restored_model = app
+            .add_model(|ctx| AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx));
+        restored_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.get_profile_id_by_sync_id(&SyncId::ServerId(server_id), ctx),
+                Some(migrated_key)
+            );
+        });
+    });
+}
+
+#[test]
+fn migration_retries_after_auth_completes() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_logged_out_for_test());
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+
+        let server_id = ServerId::from(504);
+        let legacy_profile = owned_legacy_profile(
+            SyncId::ServerId(server_id),
+            server_id,
+            AIExecutionProfile {
+                name: "Migrated after auth".to_string(),
+                read_files: ActionPermission::AlwaysAllow,
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(legacy_profile, ctx);
+        });
+
+        let _profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        complete_cloud_initial_load(&mut app);
+        app.read(|ctx| {
+            assert!(
+                !AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+
+        AuthManager::handle(&app).update(&mut app, |_auth_manager, ctx| {
+            AuthStateProvider::as_ref(ctx)
+                .get()
+                .set_user(Some(User::test()));
+            ctx.emit(AuthManagerEvent::AuthComplete);
+        });
+
+        let migrated_key = ExecutionProfileId::from_legacy_server_id(server_id);
+        app.read(|ctx| {
+            assert_eq!(
+                AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .value()
+                    .profile(&migrated_key)
+                    .map(|profile| profile.read_files),
+                Some(ActionPermission::AlwaysAllow)
+            );
+        });
+    });
+}
+
+#[test]
+fn auth_completion_waits_for_cloud_initial_load_before_migrating() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_logged_out_for_test());
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        AuthManager::handle(&app).update(&mut app, |_auth_manager, ctx| {
+            AuthStateProvider::as_ref(ctx)
+                .get()
+                .set_user(Some(User::test()));
+            ctx.emit(AuthManagerEvent::AuthComplete);
+        });
+
+        app.read(|ctx| {
+            assert!(
+                !AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+
+        let server_id = ServerId::from(516);
+        let legacy_profile = owned_legacy_profile(
+            SyncId::ServerId(server_id),
+            server_id,
+            AIExecutionProfile {
+                name: "Loaded after auth".to_string(),
+                read_files: ActionPermission::AlwaysAllow,
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.update_objects_from_initial_load(vec![legacy_profile], false, false, ctx);
+        });
+        complete_cloud_initial_load(&mut app);
+
+        let migrated_key = ExecutionProfileId::from_legacy_server_id(server_id);
+        app.read(|ctx| {
+            assert_eq!(
+                AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .value()
+                    .profile(&migrated_key)
+                    .map(|profile| profile.read_files),
+                Some(ActionPermission::AlwaysAllow)
+            );
+        });
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model
+                    .get_profile_by_id(&migrated_key, ctx)
+                    .map(|profile| profile.data().name.clone()),
+                Some("Loaded after auth".to_string())
+            );
+        });
+    });
+}
+
+#[test]
+fn feature_disabled_keeps_legacy_backend_behavior() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(false);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        let server_id = ServerId::from(511);
+        let legacy_model = LLMId::from("gpt-5-6-sol-high");
+        let legacy_default = owned_legacy_profile(
+            SyncId::ServerId(server_id),
+            server_id,
+            AIExecutionProfile {
+                name: "Legacy default".to_string(),
+                is_default_profile: true,
+                base_model: Some(legacy_model.clone()),
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(legacy_default, ctx);
+        });
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        profile_model.update(&mut app, |model, ctx| {
+            model.migrate_settings_profiles(ctx);
+        });
+
+        profile_model.read(&app, |model, ctx| {
+            let default_profile = model.default_profile(ctx);
+            assert_ne!(default_profile.id(), &ExecutionProfileId::default_profile());
+            assert_eq!(default_profile.data().base_model, Some(legacy_model));
+            assert_eq!(default_profile.sync_id(), Some(SyncId::ServerId(server_id)));
+            assert_eq!(
+                model.get_profile_id_by_sync_id(&SyncId::ServerId(server_id), ctx),
+                Some(default_profile.id().clone())
+            );
+        });
+        app.read(|ctx| {
+            assert!(
+                !AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
             );
         });
     });
@@ -468,12 +762,10 @@ fn migration_imports_owned_legacy_profiles_with_deterministic_keys() {
             cloud_model.upsert_from_server_object(custom_profile, ctx);
         });
 
-        let profile_model = app.add_singleton_model(|ctx| {
+        app.add_singleton_model(|ctx| {
             AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
         });
-        profile_model.update(&mut app, |model, ctx| {
-            model.migrate_settings_profiles(ctx);
-        });
+        complete_cloud_initial_load(&mut app);
 
         let custom_key = ExecutionProfileId::from_legacy_server_id(custom_server_id);
         app.read(|ctx| {
@@ -498,6 +790,411 @@ fn migration_imports_owned_legacy_profiles_with_deterministic_keys() {
                     >()
                     .count(),
                 2
+            );
+        });
+    });
+}
+
+#[test]
+fn pending_migration_keeps_legacy_default_model_until_import_succeeds() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        let server_id = ServerId::from(507);
+        let legacy_model = LLMId::from("gpt-5-6-sol-high");
+        let legacy_default = owned_legacy_profile(
+            SyncId::ServerId(server_id),
+            server_id,
+            AIExecutionProfile {
+                name: "Default".to_string(),
+                is_default_profile: true,
+                base_model: Some(legacy_model.clone()),
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(legacy_default, ctx);
+        });
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+
+        profile_model.read(&app, |model, ctx| {
+            let default_profile = model.default_profile(ctx);
+            assert_eq!(
+                default_profile.data().base_model,
+                Some(legacy_model.clone())
+            );
+            assert_eq!(default_profile.sync_id(), Some(SyncId::ServerId(server_id)));
+            assert_eq!(default_profile.id(), &ExecutionProfileId::default_profile());
+        });
+        app.read(|ctx| {
+            assert!(
+                !AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+        complete_cloud_initial_load(&mut app);
+
+        profile_model.read(&app, |model, ctx| {
+            let default_profile = model.default_profile(ctx);
+            assert_eq!(default_profile.data().base_model, Some(legacy_model));
+            assert_eq!(default_profile.sync_id(), None);
+        });
+        app.read(|ctx| {
+            assert!(
+                AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+    });
+}
+
+#[test]
+fn malformed_cloud_collection_falls_back_to_legacy_import() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        app.update(|ctx| {
+            CloudPreferencesSettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings.settings_sync_enabled.set_value(true, ctx).unwrap();
+            });
+        });
+        let legacy_server_id = ServerId::from(512);
+        let preference_server_id = ServerId::from(513);
+        let legacy_default = owned_legacy_profile(
+            SyncId::ServerId(legacy_server_id),
+            legacy_server_id,
+            AIExecutionProfile {
+                name: "Default".to_string(),
+                is_default_profile: true,
+                base_model: Some(LLMId::from("auto-genius")),
+                ..Default::default()
+            },
+        );
+        let cloud_preference = cloud_execution_profiles_preference(preference_server_id);
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(legacy_default, ctx);
+            cloud_model.upsert_from_server_object(cloud_preference, ctx);
+        });
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        complete_cloud_initial_load(&mut app);
+
+        app.read(|ctx| {
+            assert!(
+                AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.default_profile(ctx).data().base_model,
+                Some(LLMId::from("auto-genius"))
+            );
+            assert_eq!(model.default_profile(ctx).sync_id(), None);
+        });
+    });
+}
+
+#[test]
+fn malformed_cloud_collection_without_legacy_profiles_materializes_default() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        app.update(|ctx| {
+            CloudPreferencesSettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings.settings_sync_enabled.set_value(true, ctx).unwrap();
+            });
+        });
+        let cloud_preference = cloud_execution_profiles_preference(ServerId::from(519));
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(cloud_preference, ctx);
+        });
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        complete_cloud_initial_load(&mut app);
+
+        app.read(|ctx| {
+            let profiles = &AISettings::as_ref(ctx).execution_profiles;
+            assert!(profiles.is_value_explicitly_set());
+            assert!(
+                profiles
+                    .value()
+                    .profile(&ExecutionProfileId::default_profile())
+                    .is_some()
+            );
+        });
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(model.default_profile(ctx).data().name, "Default");
+        });
+    });
+}
+
+#[test]
+fn settings_sync_disabled_imports_legacy_profiles() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        let legacy_server_id = ServerId::from(514);
+        let preference_server_id = ServerId::from(515);
+        let legacy_default = owned_legacy_profile(
+            SyncId::ServerId(legacy_server_id),
+            legacy_server_id,
+            AIExecutionProfile {
+                name: "Default".to_string(),
+                is_default_profile: true,
+                base_model: Some(LLMId::from("gpt-5-6-sol-high")),
+                ..Default::default()
+            },
+        );
+        let cloud_preference = cloud_execution_profiles_preference(preference_server_id);
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(legacy_default, ctx);
+            cloud_model.upsert_from_server_object(cloud_preference, ctx);
+        });
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        complete_cloud_initial_load(&mut app);
+
+        app.read(|ctx| {
+            assert!(
+                AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.default_profile(ctx).data().base_model,
+                Some(LLMId::from("gpt-5-6-sol-high"))
+            );
+            assert_eq!(model.default_profile(ctx).sync_id(), None);
+        });
+    });
+}
+
+#[test]
+fn pre_login_edit_materializes_the_pending_collection() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_logged_out_for_test());
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let default_profile_id = profile_model.read(&app, |model, _| model.default_profile_id());
+
+        profile_model.update(&mut app, |model, ctx| {
+            model.set_apply_code_diffs(&default_profile_id, &ActionPermission::AlwaysAllow, ctx);
+            model.migrate_settings_profiles(ctx);
+        });
+
+        app.read(|ctx| {
+            let settings = AISettings::as_ref(ctx);
+            assert!(settings.execution_profiles.is_value_explicitly_set());
+            assert_eq!(
+                settings
+                    .execution_profiles
+                    .value()
+                    .profile(&ExecutionProfileId::default_profile())
+                    .map(|profile| profile.apply_code_diffs),
+                Some(ActionPermission::AlwaysAllow)
+            );
+        });
+        let restored_model = app
+            .add_model(|ctx| AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx));
+        restored_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.default_profile(ctx).data().apply_code_diffs,
+                ActionPermission::AlwaysAllow
+            );
+        });
+    });
+}
+
+#[test]
+fn cloud_initial_load_retries_pending_migration() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let server_id = ServerId::from(508);
+        let legacy_model = LLMId::from("gpt-5-6-sol-high");
+        let legacy_default = owned_legacy_profile(
+            SyncId::ServerId(server_id),
+            server_id,
+            AIExecutionProfile {
+                name: "Default".to_string(),
+                is_default_profile: true,
+                base_model: Some(legacy_model.clone()),
+                ..Default::default()
+            },
+        );
+
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.update_objects_from_initial_load(vec![legacy_default], false, false, ctx);
+        });
+        complete_cloud_initial_load(&mut app);
+
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.default_profile(ctx).data().base_model,
+                Some(legacy_model)
+            );
+            assert_eq!(model.default_profile(ctx).sync_id(), None);
+        });
+        app.read(|ctx| {
+            assert!(
+                AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+    });
+}
+
+#[test]
+fn completed_migration_is_not_reapplied_and_legacy_ids_restore_after_restart() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        let default_server_id = ServerId::from(509);
+        let custom_server_id = ServerId::from(510);
+        let migrated_model = LLMId::from("gpt-5-6-sol-high");
+        let default_profile = owned_legacy_profile(
+            SyncId::ServerId(default_server_id),
+            default_server_id,
+            AIExecutionProfile {
+                name: "Default".to_string(),
+                is_default_profile: true,
+                base_model: Some(migrated_model.clone()),
+                ..Default::default()
+            },
+        );
+        let custom_profile = owned_legacy_profile(
+            SyncId::ServerId(custom_server_id),
+            custom_server_id,
+            AIExecutionProfile {
+                name: "Review".to_string(),
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(default_profile, ctx);
+            cloud_model.upsert_from_server_object(custom_profile, ctx);
+        });
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        complete_cloud_initial_load(&mut app);
+
+        let changed_legacy_default = owned_legacy_profile(
+            SyncId::ServerId(default_server_id),
+            default_server_id,
+            AIExecutionProfile {
+                name: "Default".to_string(),
+                is_default_profile: true,
+                base_model: Some(LLMId::from("auto-genius")),
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(changed_legacy_default, ctx);
+            ctx.emit(CloudModelEvent::InitialLoadCompleted);
+        });
+        profile_model.update(&mut app, |model, ctx| {
+            model.migrate_settings_profiles(ctx);
+        });
+
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.default_profile(ctx).data().base_model,
+                Some(migrated_model)
+            );
+        });
+
+        let restored_model = app
+            .add_model(|ctx| AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx));
+        restored_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.get_profile_id_by_sync_id(&SyncId::ServerId(default_server_id), ctx,),
+                Some(ExecutionProfileId::default_profile())
+            );
+            assert_eq!(
+                model.get_profile_id_by_sync_id(&SyncId::ServerId(custom_server_id), ctx),
+                Some(ExecutionProfileId::from_legacy_server_id(custom_server_id))
+            );
+        });
+    });
+}
+
+#[test]
+fn reset_without_explicit_collection_reimports_the_next_accounts_legacy_profile() {
+    let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_for_test());
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        profile_model.update(&mut app, |model, _| model.reset(false));
+
+        let default_profile_id = profile_model.read(&app, |model, _| model.default_profile_id());
+        profile_model.update(&mut app, |model, ctx| {
+            model.set_base_model(
+                &default_profile_id,
+                Some(LLMId::from("gpt-5-6-sol-high")),
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            assert!(
+                !AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            );
+        });
+
+        let server_id = ServerId::from(518);
+        let legacy_default = owned_legacy_profile(
+            SyncId::ServerId(server_id),
+            server_id,
+            AIExecutionProfile {
+                name: "Default".to_string(),
+                is_default_profile: true,
+                base_model: Some(LLMId::from("auto-genius")),
+                ..Default::default()
+            },
+        );
+        CloudModel::handle(&app).update(&mut app, |cloud_model, ctx| {
+            cloud_model.upsert_from_server_object(legacy_default, ctx);
+        });
+        complete_cloud_initial_load(&mut app);
+
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.default_profile(ctx).data().base_model,
+                Some(LLMId::from("auto-genius"))
             );
         });
     });
@@ -586,6 +1283,10 @@ fn profile_sources_preserve_state_across_migration_and_rollout() {
         restored_settings_model.read(&app, |model, ctx| {
             assert_eq!(model.default_profile(ctx).data().name, "Settings default");
         });
+        restored_settings_model.update(&mut app, |model, _| model.reset(true));
+        restored_settings_model.read(&app, |model, ctx| {
+            assert_eq!(model.default_profile(ctx).data().name, "Settings default");
+        });
 
         let tui_model = {
             let _guard = FeatureFlag::FileBackedExecutionProfiles.override_enabled(false);
@@ -601,6 +1302,10 @@ fn profile_sources_preserve_state_across_migration_and_rollout() {
         };
         tui_model.read(&app, |model, ctx| {
             assert_eq!(model.default_profile(ctx).data().name, "Settings default");
+            assert_eq!(
+                model.get_profile_id_by_sync_id(&SyncId::ServerId(server_id), ctx),
+                None
+            );
         });
 
         let cli_model = {

--- a/app/src/auth/mod.rs
+++ b/app/src/auth/mod.rs
@@ -41,7 +41,7 @@ use crate::server::sync_queue::SyncQueue;
 use crate::server::telemetry::{PaletteSource, TelemetryEvent};
 use crate::session_management::{RunningSessionSummary, SessionNavigationData};
 use crate::settings::{
-    CRASH_REPORTING_ENABLED_DEFAULTS_KEY, CloudPreferencesSettings, PrivacySettings,
+    AISettings, CRASH_REPORTING_ENABLED_DEFAULTS_KEY, CloudPreferencesSettings, PrivacySettings,
     TELEMETRY_ENABLED_DEFAULTS_KEY,
 };
 use crate::terminal::general_settings::GeneralSettings;
@@ -223,9 +223,6 @@ pub fn log_out(app: &mut AppContext) {
     AuthManager::handle(app).update(app, |auth_manager, ctx| {
         auth_manager.log_out(ctx);
     });
-    AIExecutionProfilesModel::handle(app).update(app, |ai_execution_profiles_model, _| {
-        ai_execution_profiles_model.reset();
-    });
     BlocklistAIHistoryModel::handle(app).update(app, |history_model, _| {
         history_model.reset();
     });
@@ -251,6 +248,14 @@ pub fn log_out(app: &mut AppContext) {
         manager.stop_polling_for_workspace_metadata_updates();
     });
     remove_cloud_persisted_settings(app);
+
+    let settings_profiles_are_explicit = AISettings::as_ref(app)
+        .execution_profiles
+        .is_value_explicitly_set();
+    AIExecutionProfilesModel::handle(app).update(app, |profiles, _| {
+        profiles.reset(settings_profiles_are_explicit);
+    });
+
     NotebookManager::handle(app).update(app, |manager, _| manager.reset());
     EnvVarCollectionManager::handle(app).update(app, |manager, _| manager.reset());
     WorkflowManager::handle(app).update(app, |manager, _| manager.reset());

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1312,17 +1312,23 @@ fn refresh_user_after_iap_access(ctx: &mut AppContext) {
     }
 
     let mut refresh_started = false;
-    ctx.subscribe_to_model(&iap_manager, move |iap_manager, event, ctx| {
-        if refresh_started
-            || !matches!(event, IapManagerEvent::StateChanged)
-            || !iap_manager.as_ref(ctx).has_valid_token()
-        {
-            return;
+    ctx.subscribe_to_model(&iap_manager, move |iap_manager, event, ctx| match event {
+        IapManagerEvent::StateChanged => {
+            if refresh_started || !iap_manager.as_ref(ctx).has_valid_token() {
+                return;
+            }
+            refresh_started = true;
+            AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
+                auth_manager.refresh_user(ctx);
+            });
         }
-        refresh_started = true;
-        AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
-            auth_manager.refresh_user(ctx);
-        });
+        IapManagerEvent::AccessUnavailable => {
+            report_error!("Staging IAP access unavailable before startup user refresh");
+        }
+        IapManagerEvent::RefreshFailed {
+            message: _,
+            is_first_failure_of_streak: _,
+        } => {}
     });
     iap_manager.update(ctx, |manager, ctx| manager.ensure_access(ctx));
 }

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -1716,7 +1716,7 @@ impl PaneGroup {
                     let profiles_model = AIExecutionProfilesModel::as_ref(ctx);
 
                     if let Some(profile_id) =
-                        profiles_model.get_profile_id_by_sync_id(active_profile_sync_id)
+                        profiles_model.get_profile_id_by_sync_id(active_profile_sync_id, ctx)
                     {
                         AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles_model, ctx| {
                             profiles_model.set_active_profile(

--- a/app/src/server/cloud_objects/update_manager.rs
+++ b/app/src/server/cloud_objects/update_manager.rs
@@ -406,8 +406,8 @@ impl UpdateManager {
                                     }
                                 });
                         } else if cloud_model.get_ai_execution_profile(&server_id).is_some() {
-                            AIExecutionProfilesModel::handle(ctx).update(ctx, |model, _| {
-                                model.replace_client_id_with_server_id(server_id, client_id);
+                            AIExecutionProfilesModel::handle(ctx).update(ctx, |model, ctx| {
+                                model.replace_client_id_with_server_id(server_id, client_id, ctx);
                             });
                         }
                     }
@@ -1231,6 +1231,11 @@ impl UpdateManager {
     pub fn initial_load_complete(&self) -> impl Future<Output = ()> + use<> {
         // We're not using `async fn` here so that the returned Future doesn't borrow self.
         self.has_initial_load.wait()
+    }
+
+    /// Returns whether the current account's initial cloud-object load has completed.
+    pub(crate) fn has_completed_initial_load(&self) -> bool {
+        self.has_initial_load.is_set()
     }
 
     /// Reset the initial-load condition so that subsequent callers of


### PR DESCRIPTION
## Description

The dogfood rollout of file-backed execution profiles switched GUI reads to the settings collection before the first migration had necessarily materialized it. When startup authentication or cloud-preference initialization was delayed, the implicit default profile had no `base_model`, so Warp fell back to the server default (Auto Genius). Restored terminals also could not resolve legacy profile sync IDs after the backend switch.

This PR makes the transition atomic and retryable:

- Separates backend capability from current authority. Until a file-backed `ExecutionProfiles` value exists, the GUI continues reading known-good legacy profile objects.
- Makes an explicit local or cloud-synced `ExecutionProfiles` collection permanently authoritative over legacy objects.
- Waits for cloud-preference initial-load direction before reconciling explicit local data, preventing stale legacy or local values from overwriting a newer file-backed collection from another client.
- Preserves the intentional settings-sync behavior: synced collections reconcile through cloud preferences when settings sync is enabled; when disabled, legacy profiles migrate into a device-local file-backed collection.
- Materializes pre-login/local edits into the new collection so onboarding, model, permission, create, and delete changes are not lost during migration.
- Retries migration after cloud-object load, cloud-preference load, and pending profile client-to-server ID conversion. Successful migration is idempotent for the rest of the process.
- Uses deterministic keys for migrated legacy profiles and re-keys active/default references when a pending object receives its server ID. Old terminal snapshots can resolve their legacy sync IDs into the migrated collection.
- Resets account-specific runtime mappings and migration readiness on logout without hiding an explicit device-local collection.
- Reports staging IAP startup unavailability instead of silently leaving startup user refresh pending.

Execution-profile behavior is gated by `FileBackedExecutionProfiles` for GUI/Test launches. Feature-disabled GUI, CLI, remote-server, and TUI behavior are covered as unchanged. The IAP diagnostic is independent and staging-only.

## Linked Issue

N/A — fixes a dogfood regression reconstructed from client logs.

## Testing

- [x] I have manually tested my changes locally with `./script/run`.

The migration is covered at the model/event-ordering level; per author direction, no additional GUI integration test was added.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
