### PR TITLE
Add TUI logout slash command

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -314,7 +314,7 @@ use crate::terminal::resizable_data::ResizableData;
 use crate::terminal::view::inline_banner::ByoLlmAuthBannerSessionState;
 use crate::terminal::{AudibleBell, CustomSecretRegexUpdater, History};
 #[cfg(feature = "tui")]
-pub use crate::tui::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
+pub use crate::tui::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase, log_out_tui};
 use crate::undo_close::UndoCloseStack;
 use crate::user_config::WarpConfig;
 use crate::util::bindings::is_binding_cross_platform;

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -94,6 +94,15 @@ pub const EXIT: StaticCommand = StaticCommand {
     argument: None,
 };
 
+pub const LOGOUT: StaticCommand = StaticCommand {
+    name: "/logout",
+    description: "Log out of Warp",
+    icon_path: "bundled/svg/log-out-01.svg",
+    availability: Availability::ALWAYS,
+    auto_enter_ai_mode: false,
+    argument: None,
+};
+
 pub static CREATE_ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/create-environment",
     description: "Create an Oz environment (Docker image + repos) via guided setup",
@@ -702,6 +711,7 @@ fn all_commands(settings_mode: settings::SettingsMode) -> Vec<StaticCommand> {
             AUTO_APPROVE,
             MCP,
             EXIT,
+            LOGOUT,
             VIEW_LOGS,
             ENABLE_NATURAL_LANGUAGE_DETECTION,
             DISABLE_NATURAL_LANGUAGE_DETECTION,

--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -63,6 +63,20 @@ fn auto_approve_command_is_local_agent_action_without_arguments() {
 }
 
 #[test]
+fn logout_command_is_registered_only_for_tui_mode() {
+    assert!(
+        all_commands(settings::SettingsMode::Tui)
+            .iter()
+            .any(|command| command == &LOGOUT)
+    );
+    assert!(
+        !all_commands(settings::SettingsMode::Gui)
+            .iter()
+            .any(|command| command == &LOGOUT)
+    );
+}
+
+#[test]
 fn rename_tab_command_requires_argument() {
     let command = COMMAND_REGISTRY
         .get_command_with_name(RENAME_TAB.name)

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -143,6 +143,7 @@ pub enum TuiSlashCommand {
     AutoApprove,
     Mcp,
     Exit,
+    Logout,
     ViewLogs,
     EnableNaturalLanguageDetection,
     DisableNaturalLanguageDetection,
@@ -165,6 +166,7 @@ impl TuiSlashCommand {
             name if name == commands::AUTO_APPROVE.name => Some(Self::AutoApprove),
             name if name == commands::MCP.name => Some(Self::Mcp),
             name if name == commands::EXIT.name => Some(Self::Exit),
+            name if name == commands::LOGOUT.name => Some(Self::Logout),
             name if name == commands::VIEW_LOGS.name => Some(Self::ViewLogs),
             name if name == commands::ENABLE_NATURAL_LANGUAGE_DETECTION.name => {
                 Some(Self::EnableNaturalLanguageDetection)

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -77,6 +77,7 @@ fn tui_supports_the_selected_low_effort_commands_but_not_cost_or_orchestrate() {
         (&commands::AUTO_APPROVE, TuiSlashCommand::AutoApprove),
         (&commands::MCP, TuiSlashCommand::Mcp),
         (&commands::EXIT, TuiSlashCommand::Exit),
+        (&commands::LOGOUT, TuiSlashCommand::Logout),
         (&commands::VIEW_LOGS, TuiSlashCommand::ViewLogs),
     ] {
         assert_eq!(
@@ -124,6 +125,24 @@ fn exit_command_executes_immediately_and_takes_no_argument() {
     );
     // Available in every session context (gated to the TUI at registry level).
     assert_eq!(commands::EXIT.availability, Availability::ALWAYS);
+}
+
+#[test]
+fn logout_command_executes_immediately_and_takes_no_argument() {
+    use super::{SlashCommandSelectionBehavior, slash_command_selection_behavior};
+
+    assert_eq!(
+        TuiSlashCommand::from_static_command(&commands::LOGOUT),
+        Some(TuiSlashCommand::Logout)
+    );
+    assert!(slash_command_is_supported_in_tui(&commands::LOGOUT));
+    assert!(commands::LOGOUT.argument.is_none());
+    assert!(!slash_command_is_submitted_as_prompt(&commands::LOGOUT));
+    assert_eq!(
+        slash_command_selection_behavior(&commands::LOGOUT),
+        SlashCommandSelectionBehavior::Execute
+    );
+    assert_eq!(commands::LOGOUT.availability, Availability::ALWAYS);
 }
 
 #[test]

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -15,8 +15,8 @@ use warpui::{AppContext, Entity, SingletonEntity};
 
 use crate::TuiMountFn;
 use crate::ai::mcp::FileBasedMCPManager;
-use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::auth::{self, AuthStateProvider};
 
 /// Login state of the headless TUI, observed by the `warp_tui` root view to
 /// decide whether to show the login placeholder or the input UI.
@@ -38,6 +38,8 @@ pub enum TuiLoginPhase {
 pub enum TuiLoginEvent {
     /// Authentication completed and the TUI can create its terminal session.
     LoggedIn,
+    /// The current user logged out and the TUI should return to authentication.
+    LoggedOut,
 }
 
 /// Singleton holding the TUI's [`TuiLoginPhase`]. Updated by [`init`]'s auth
@@ -79,18 +81,8 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
     });
     ctx.add_singleton_model(TuiMcpManager::new);
 
-    // Mount the TUI now so it renders immediately; the root view shows the
-    // login placeholder until the model flips to `LoggedIn`.
-    mount(ctx);
-
-    if logged_in {
-        activate_global_mcp_servers(ctx);
-        return;
-    }
-
-    // Reuses the same device-authorization flow as `oz login` (see
-    // `app/src/ai/agent_sdk/admin.rs`). The browser handles login; control
-    // returns here once the device code is approved.
+    // Keep the auth subscription alive for the full process lifetime so a
+    // logged-in TUI can complete device authorization again after logout.
     ctx.subscribe_to_model(&AuthManager::handle(ctx), |_, event, ctx| match event {
         AuthManagerEvent::ReceivedDeviceAuthorizationCode {
             verification_url,
@@ -122,7 +114,18 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
         ),
         _ => {}
     });
+    // Mount the TUI now so it renders immediately; the root view shows the
+    // login placeholder until the model flips to `LoggedIn`.
+    mount(ctx);
 
+    if logged_in {
+        activate_global_mcp_servers(ctx);
+    } else {
+        authorize_device(ctx);
+    }
+}
+
+fn authorize_device(ctx: &mut AppContext) {
     AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
         auth_manager.authorize_device(ctx);
     });
@@ -131,6 +134,24 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
 fn activate_global_mcp_servers(ctx: &mut AppContext) {
     FileBasedMCPManager::handle(ctx).update(ctx, |manager, ctx| {
         manager.activate_global_warp_servers(ctx);
+    });
+}
+
+/// Logs out the current TUI user and starts a fresh device-authorization flow.
+pub fn log_out_tui(ctx: &mut AppContext) {
+    auth::log_out(ctx);
+    set_logged_out_phase(ctx);
+    authorize_device(ctx);
+}
+
+fn set_logged_out_phase(ctx: &mut AppContext) {
+    TuiLoginModel::handle(ctx).update(ctx, |model, ctx| {
+        model.phase = TuiLoginPhase::AwaitingLogin {
+            verification_uri: None,
+            user_code: None,
+        };
+        ctx.notify();
+        ctx.emit(TuiLoginEvent::LoggedOut);
     });
 }
 

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use warpui::{App, SingletonEntity};
 
-use super::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase, set_login_phase};
+use super::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase, set_logged_out_phase, set_login_phase};
 
 #[test]
 fn emits_logged_in_event_when_login_completes() {
@@ -25,6 +25,7 @@ fn emits_logged_in_event_when_login_completes() {
                         logged_in_events_for_subscription
                             .set(logged_in_events_for_subscription.get() + 1);
                     }
+                    TuiLoginEvent::LoggedOut => {}
                 },
             );
         });
@@ -41,5 +42,42 @@ fn emits_logged_in_event_when_login_completes() {
 
         app.update(|ctx| set_login_phase(ctx, TuiLoginPhase::LoggedIn));
         assert_eq!(logged_in_events.get(), 1);
+    });
+}
+
+#[test]
+fn emits_logged_out_event_and_resets_login_details() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| TuiLoginModel {
+            phase: TuiLoginPhase::LoggedIn,
+        });
+
+        let logged_out_events = Rc::new(Cell::new(0));
+        let logged_out_events_for_subscription = logged_out_events.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(
+                &TuiLoginModel::handle(ctx),
+                move |_, event, _| match event {
+                    TuiLoginEvent::LoggedIn => {}
+                    TuiLoginEvent::LoggedOut => {
+                        logged_out_events_for_subscription
+                            .set(logged_out_events_for_subscription.get() + 1);
+                    }
+                },
+            );
+        });
+
+        app.update(set_logged_out_phase);
+
+        assert_eq!(logged_out_events.get(), 1);
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin {
+                    verification_uri: None,
+                    user_code: None,
+                }
+            ));
+        });
     });
 }

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -199,7 +199,7 @@ pub use crate::themes::default_themes::{dark_theme, light_theme};
 pub use crate::throttle::throttle;
 pub use crate::tui::{
     TuiMcpAction, TuiMcpConfigState, TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerId,
-    TuiMcpServerSnapshot, TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport,
+    TuiMcpServerSnapshot, TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport, log_out_tui,
 };
 #[cfg(any(test, feature = "test-util"))]
 pub use crate::tui_test_support::{

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -54,6 +54,13 @@ impl RootTuiView {
         ctx.notify();
     }
 
+    /// Returns to the authentication gate after the current user logs out.
+    pub(crate) fn show_auth(&mut self, ctx: &mut ViewContext<Self>) {
+        self.state = RootTuiState::Auth;
+        ctx.focus_self();
+        ctx.notify();
+    }
+
     fn focused_session_view(&self, ctx: &AppContext) -> Option<TuiSessionView> {
         if !ctx.has_singleton_model::<TuiSessions>() {
             return None;

--- a/crates/warp_tui/src/root_view_tests.rs
+++ b/crates/warp_tui/src/root_view_tests.rs
@@ -91,5 +91,10 @@ fn root_projects_only_the_focused_retained_session_view() {
             assert_eq!(root.as_ref(ctx).child_view_ids(ctx), vec![cloud_view.id()]);
             assert!(ctx.check_view_or_child_focused(window_id, &cloud_view.id()));
         });
+        root.update(&mut app, |root, ctx| root.show_auth(ctx));
+        app.read(|ctx| {
+            assert!(root.as_ref(ctx).child_view_ids(ctx).is_empty());
+            assert!(ctx.check_view_or_child_focused(window_id, &root.id()));
+        });
     });
 }

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -124,21 +124,21 @@ fn init(
             });
             let orchestration = TuiOrchestrationModel::register(ctx);
             TuiSessions::wire_orchestration(&sessions, &orchestration, ctx);
+            let sessions_for_login = sessions.clone();
+            let root_for_login = root.clone();
+            let login_model = TuiLoginModel::handle(ctx);
+            ctx.subscribe_to_model(&login_model, move |_, event, ctx| match event {
+                TuiLoginEvent::LoggedIn => {
+                    create_terminal_session_after_login(&sessions_for_login, &root_for_login, ctx)
+                }
+                TuiLoginEvent::LoggedOut => {
+                    root_for_login.update(ctx, |root, ctx| root.show_auth(ctx));
+                    sessions_for_login.update(ctx, |sessions, ctx| sessions.clear(ctx));
+                }
+            });
             if matches!(TuiLoginModel::as_ref(ctx).phase(), TuiLoginPhase::LoggedIn) {
                 // Already authenticated at mount: create the first session now.
                 create_terminal_session_after_login(&sessions, &root, ctx);
-            } else {
-                // Otherwise wait for login to complete and create it then.
-                let sessions_for_login = sessions.clone();
-                let root_for_login = root.clone();
-                let login_model = TuiLoginModel::handle(ctx);
-                ctx.subscribe_to_model(&login_model, move |_, event, ctx| match event {
-                    TuiLoginEvent::LoggedIn => create_terminal_session_after_login(
-                        &sessions_for_login,
-                        &root_for_login,
-                        ctx,
-                    ),
-                });
             }
         }
         Err(error) => {

--- a/crates/warp_tui/src/session_registry.rs
+++ b/crates/warp_tui/src/session_registry.rs
@@ -461,6 +461,28 @@ impl TuiSessions {
         }
         ctx.notify();
     }
+
+    /// Removes every retained session without focusing an intermediate fallback.
+    pub(crate) fn clear(&mut self, ctx: &mut ModelContext<Self>) {
+        let removed_ids = self
+            .sessions
+            .iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>();
+        self.focused_session_id = None;
+        self.sessions.clear();
+        if ctx.has_singleton_model::<TuiOrchestrationModel>() {
+            for id in &removed_ids {
+                TuiOrchestrationModel::handle(ctx).update(ctx, |orchestration, ctx| {
+                    orchestration.handle_session_removed(*id, ctx);
+                });
+            }
+        }
+        for id in removed_ids {
+            ctx.emit(TuiSessionsEvent::SessionRemoved(id));
+        }
+        ctx.notify();
+    }
     /// Focuses a registered session. Returns whether focus changed.
     pub(crate) fn focus_session(&mut self, id: TuiSessionId, ctx: &mut ModelContext<Self>) -> bool {
         if self.focused_session_id == Some(id) || self.session(id).is_none() {

--- a/crates/warp_tui/src/session_registry_tests.rs
+++ b/crates/warp_tui/src/session_registry_tests.rs
@@ -98,5 +98,19 @@ fn focus_drives_events() {
             std::mem::take(&mut *events.borrow_mut()),
             vec![TuiSessionsEvent::FocusChanged(first_id)],
         );
+
+        app.update_model(&sessions, |sessions, ctx| sessions.clear(ctx));
+        assert_eq!(app.read_model(&sessions, |sessions, _| sessions.len()), 0);
+        assert_eq!(
+            app.read_model(&sessions, |sessions, _| sessions.focused_session_id()),
+            None
+        );
+        assert_eq!(
+            std::mem::take(&mut *events.borrow_mut()),
+            vec![
+                TuiSessionsEvent::SessionRemoved(first_id),
+                TuiSessionsEvent::SessionRemoved(second_id),
+            ],
+        );
     });
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -32,9 +32,10 @@ use warp::tui_export::{
     TranscriptScope, TuiMcpAction, TuiMcpManager, TuiSlashCommand, TuiSlashCommandDataSource,
     TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource, UserTakeOverReason,
     WAKEUP_THROTTLE_PERIOD, block_context_from_terminal_model, build_slash_command_mixer,
-    detect_possible_git_repo, export_conversation_markdown, maybe_build_ai_query_upsert_event,
-    prepare_conversation_block_restoration, record_autodetection_toggle_from_slash_command,
-    record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
+    detect_possible_git_repo, export_conversation_markdown, log_out_tui,
+    maybe_build_ai_query_upsert_event, prepare_conversation_block_restoration,
+    record_autodetection_toggle_from_slash_command, record_saved_prompt_accepted,
+    record_static_slash_command_accepted, saved_prompt_text_for_id,
     slash_command_selection_behavior, throttle,
 };
 use warp_core::features::FeatureFlag;
@@ -2851,6 +2852,10 @@ impl TuiTerminalSessionView {
             TuiSlashCommand::Exit => {
                 record_static_slash_command_accepted(command.name, true, ctx);
                 ctx.terminate_app(TerminationMode::ForceTerminate, None);
+            }
+            TuiSlashCommand::Logout => {
+                record_static_slash_command_accepted(command.name, true, ctx);
+                log_out_tui(ctx);
             }
             TuiSlashCommand::ViewLogs => {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));


### PR DESCRIPTION
## Description
Adds a TUI-only `/logout` slash command that performs Warp's full shared logout cleanup, tears down retained TUI sessions and orchestration state, returns to the existing authentication screen, and starts a fresh device-authorization flow. The command is excluded from the GUI registry.

## Linked Issue
No linked issue.

## Testing
https://www.loom.com/share/57b944f826834d4790bf35ed822a20b9
- [x] `./script/format`
- [x] `cargo clippy -p warp_tui --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p warp_tui` — 517 tests passed
- [x] Focused app tests for TUI-only registration, immediate execution semantics, and login lifecycle events — 4 tests passed
- [ ] Manual logout was not run because it would delete the current local TUI credential and launch the browser authorization flow

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/598cacea-9598-4ea8-bdc2-ef6cab991d23

CHANGELOG-IMPROVEMENT: Added a `/logout` command to the Warp TUI.

Co-Authored-By: Oz <oz-agent@warp.dev>