### PR TITLE
Route account-first onboarding through post-auth outcomes

### DIFF
--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use ai::api_keys::ApiKeyManager;
 use anyhow::Context as _;
 use chrono::{DateTime, Local, Utc};
+use futures::channel::oneshot::{self, Receiver};
 use instant::Instant;
 use serde::{Deserialize, Serialize};
 use warp_core::user_preferences::GetUserPreferences as _;
@@ -248,25 +249,49 @@ impl AIRequestUsageModel {
         self.last_update_time
     }
 
-    /// Spawns a task to refresh the latest AI request usage and bonus grants, fetching from the server.
-    pub fn refresh_request_usage_async(&mut self, ctx: &mut ModelContext<Self>) {
+    /// Refreshes the latest AI request usage and bonus grants from the server.
+    ///
+    /// The receiver resolves to the freshly fetched base request limit. It
+    /// resolves to `None` if the user is logged out or the request fails, so
+    /// callers making entitlement decisions do not fall back to cached data.
+    pub fn refresh_request_usage(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> Receiver<Option<usize>> {
+        let (sender, receiver) = oneshot::channel();
         if !AuthStateProvider::as_ref(ctx).get().is_logged_in() {
-            return;
+            let _ = sender.send(None);
+            return receiver;
         }
 
         let ai_client = self.ai_client.clone();
+        let mut sender = Some(sender);
         ctx.spawn(
             async move { ai_client.get_request_limit_info().await },
-            |model, result, ctx| match result {
-                Ok(usage_info) => {
-                    model.bonus_grants = usage_info.bonus_grants;
-                    model.update_request_limit_info(usage_info.request_limit_info, ctx);
-                }
-                Err(e) => {
-                    log::warn!("Failed to retrieve initial request limit info: {e:#}");
+            move |model, result, ctx| {
+                let request_limit = match result {
+                    Ok(usage_info) => {
+                        let request_limit = usage_info.request_limit_info.limit;
+                        model.bonus_grants = usage_info.bonus_grants;
+                        model.update_request_limit_info(usage_info.request_limit_info, ctx);
+                        Some(request_limit)
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to retrieve request limit info: {e:#}");
+                        None
+                    }
+                };
+                if let Some(sender) = sender.take() {
+                    let _ = sender.send(request_limit);
                 }
             },
         );
+        receiver
+    }
+
+    /// Spawns a task to refresh the latest AI request usage and bonus grants.
+    pub fn refresh_request_usage_async(&mut self, ctx: &mut ModelContext<Self>) {
+        drop(self.refresh_request_usage(ctx));
     }
 
     pub fn update_request_limit_info(

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -45,6 +45,11 @@ fn add_request_usage_model_for_anonymous_users(app: &mut App) -> ModelHandle<AIR
     app.add_singleton_model(|_| AuthStateProvider::new_anonymous_for_test());
     add_request_usage_model_without_auth(app)
 }
+
+fn add_request_usage_model_for_logged_out_users(app: &mut App) -> ModelHandle<AIRequestUsageModel> {
+    app.add_singleton_model(|_| AuthStateProvider::new_logged_out_for_test());
+    add_request_usage_model_without_auth(app)
+}
 fn register_user_preferences_for_tests(app: &mut App) {
     if app
         .models_of_type::<settings::PrivatePreferences>()
@@ -96,6 +101,16 @@ fn enable_auto_reload(workspace: &mut Workspace) {
         .selected_auto_reload_credit_denomination = Some(1000);
 }
 
+#[test]
+fn refresh_request_usage_returns_no_fresh_limit_when_logged_out() {
+    App::test((), |mut app| async move {
+        let request_usage_model = add_request_usage_model_for_logged_out_users(&mut app);
+        let refresh =
+            request_usage_model.update(&mut app, |model, ctx| model.refresh_request_usage(ctx));
+
+        assert_eq!(refresh.await.unwrap(), None);
+    });
+}
 #[test]
 fn test_request_limit_info() {
     App::test((), |mut app| async move {

--- a/app/src/auth/login_slide.rs
+++ b/app/src/auth/login_slide.rs
@@ -319,6 +319,10 @@ impl LoginSlideView {
         matches!(self.step, LoginStep::BrowserOpen) && self.show_auth_token_input
     }
 
+    pub fn is_account_first_onboarding(&self) -> bool {
+        matches!(self.source, LoginSlideSource::AccountFirstOnboarding)
+    }
+
     pub fn new(
         ai_enabled: bool,
         uses_third_party_agents: bool,

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -8,7 +8,8 @@ use cfg_if::cfg_if;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use onboarding::{
-    AgentOnboardingEvent, AgentOnboardingView, OnboardingIntention, SelectedSettings,
+    AgentOnboardingEvent, AgentOnboardingView, OfferVariant, OnboardingEvent, OnboardingIntention,
+    SelectedSettings,
 };
 use parking_lot::Mutex;
 use pathfinder_geometry::rect::RectF;
@@ -36,6 +37,7 @@ use warpui::{
     ViewContext, ViewHandle, WindowId, id,
 };
 
+use crate::ai::AIRequestUsageModel;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::blocklist::SerializedBlockListItem;
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
@@ -77,7 +79,10 @@ use crate::server::telemetry::{LaunchConfigUiLocation, TelemetryEvent};
 use crate::settings::cloud_preferences_syncer::{
     CloudPreferencesSyncer, CloudPreferencesSyncerEvent,
 };
-use crate::settings::{AISettings, QuakeModeSettings, ThemeSettings, apply_onboarding_settings};
+use crate::settings::{
+    AISettings, QuakeModeSettings, ThemeSettings, apply_account_first_onboarding_settings,
+    apply_onboarding_settings,
+};
 use crate::settings_view::mcp_servers_page::MCPServersSettingsPage;
 use crate::settings_view::{OpenTeamsSettingsModalArgs, SettingsSection, flags};
 use crate::terminal::available_shells::AvailableShell;
@@ -99,6 +104,7 @@ use crate::workspace::{PaneViewLocator, Workspace, WorkspaceAction, WorkspaceReg
 use crate::workspaces::team_tester::TeamTesterStatus;
 use crate::workspaces::update_manager::TeamUpdateManager;
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
+use crate::workspaces::workspace::FtueAccountClass;
 use crate::{
     ChannelState, GlobalResourceHandles, GlobalResourceHandlesProvider, UpdateQuakeModeEventArg,
     send_telemetry_from_app_ctx, send_telemetry_from_ctx,
@@ -123,6 +129,14 @@ pub(crate) fn unthemed_window_border() -> Border {
         Border::all(1.).with_border_fill(Fill::black().blend(&Fill::white().with_opacity(15)))
     } else {
         Border::all(1.).with_border_fill(Fill::black().with_opacity(0))
+    }
+}
+
+fn offer_variant_for_account_class(account_class: FtueAccountClass) -> Option<OfferVariant> {
+    match account_class {
+        FtueAccountClass::Paid => None,
+        FtueAccountClass::FreeIcp => Some(OfferVariant::HeadStart),
+        FtueAccountClass::FreeStandard => Some(OfferVariant::ChooseHowToStart),
     }
 }
 
@@ -1611,6 +1625,54 @@ enum AuthOnboardingTarget {
     Terminal(ViewHandle<Workspace>),
 }
 
+#[derive(Clone)]
+struct AccountFirstLoginContext {
+    login_slide_view: ViewHandle<LoginSlideView>,
+    onboarding_view: ViewHandle<AgentOnboardingView>,
+    target: AuthOnboardingTarget,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AccountFirstCompletion {
+    AccountSkipped,
+    PaidTeam,
+    FreeIcpSetupLater,
+    FreeStandardSetupLater,
+    UpgradeCompleted,
+}
+
+impl AccountFirstCompletion {
+    fn completion_type(self) -> &'static str {
+        match self {
+            AccountFirstCompletion::AccountSkipped => "account_skipped",
+            AccountFirstCompletion::PaidTeam => "paid_team",
+            AccountFirstCompletion::FreeIcpSetupLater => "free_icp_setup_later",
+            AccountFirstCompletion::FreeStandardSetupLater => "free_standard_setup_later",
+            AccountFirstCompletion::UpgradeCompleted => "upgrade_completed",
+        }
+    }
+
+    fn account_class(self) -> Option<FtueAccountClass> {
+        match self {
+            AccountFirstCompletion::AccountSkipped => None,
+            AccountFirstCompletion::PaidTeam | AccountFirstCompletion::UpgradeCompleted => {
+                Some(FtueAccountClass::Paid)
+            }
+            AccountFirstCompletion::FreeIcpSetupLater => Some(FtueAccountClass::FreeIcp),
+            AccountFirstCompletion::FreeStandardSetupLater => Some(FtueAccountClass::FreeStandard),
+        }
+    }
+
+    fn starts_tutorial(self) -> bool {
+        matches!(
+            self,
+            AccountFirstCompletion::PaidTeam
+                | AccountFirstCompletion::FreeIcpSetupLater
+                | AccountFirstCompletion::UpgradeCompleted
+        )
+    }
+}
+
 /// User preferences key to track whether the user has completed the onboarding slides locally
 /// (before login). This is needed because the server-side `is_onboarded` flag requires
 /// authentication.
@@ -1651,6 +1713,12 @@ enum AuthOnboardingState {
         onboarding_view: ViewHandle<AgentOnboardingView>,
         target: AuthOnboardingTarget,
     },
+    PostAuthOnboarding {
+        onboarding_view: ViewHandle<AgentOnboardingView>,
+        target: AuthOnboardingTarget,
+        account_class: FtueAccountClass,
+        upgrade_started: bool,
+    },
     Terminal(ViewHandle<Workspace>),
 }
 
@@ -1675,6 +1743,10 @@ pub struct RootView {
     pending_tutorial: Option<OnboardingTutorial>,
     /// settings to apply after a new user login / initial cloud load completes
     pending_post_auth_onboarding_settings: Option<SelectedSettings>,
+    pending_account_first_settings_class: Option<FtueAccountClass>,
+    pending_account_first_tutorial_after_settings: bool,
+    pending_account_first_sso_login: Option<AccountFirstLoginContext>,
+    account_first_refresh_in_flight: bool,
     paste_auth_token_modal: Option<ViewHandle<PasteAuthTokenModalView>>,
 }
 
@@ -1694,6 +1766,10 @@ impl RootView {
 
         ctx.subscribe_to_model(&CloudPreferencesSyncer::handle(ctx), |me, _, event, ctx| {
             me.handle_cloud_preferences_syncer_event(event, ctx);
+        });
+
+        ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), |me, _, event, ctx| {
+            me.handle_account_first_workspaces_event(event, ctx);
         });
 
         let auth_view =
@@ -1778,6 +1854,10 @@ impl RootView {
             window_id: ctx.window_id(),
             pending_tutorial: None,
             pending_post_auth_onboarding_settings: None,
+            pending_account_first_settings_class: None,
+            pending_account_first_tutorial_after_settings: false,
+            pending_account_first_sso_login: None,
+            account_first_refresh_in_flight: false,
             paste_auth_token_modal: None,
         };
 
@@ -1912,6 +1992,10 @@ impl RootView {
 
     // Switch to Auth Screen while destroying Workspace.
     fn log_out(&mut self, _: &(), ctx: &mut ViewContext<Self>) -> bool {
+        self.pending_account_first_settings_class = None;
+        self.pending_account_first_tutorial_after_settings = false;
+        self.pending_account_first_sso_login = None;
+        self.account_first_refresh_in_flight = false;
         self.auth_onboarding_state.log_out(ctx);
         ctx.focus_self();
         ctx.notify();
@@ -1923,7 +2007,11 @@ impl RootView {
             view.set_email(email);
         });
 
-        self.auth_onboarding_state.show_needs_sso_link_view();
+        if let Some(context) = &self.pending_account_first_sso_login {
+            self.auth_onboarding_state = AuthOnboardingState::NeedsSsoLink(context.target.clone());
+        } else {
+            self.auth_onboarding_state.show_needs_sso_link_view();
+        }
         ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
         ctx.notify();
         true
@@ -2087,6 +2175,217 @@ impl RootView {
             })
     }
 
+    fn account_first_login_context(&self, ctx: &AppContext) -> Option<AccountFirstLoginContext> {
+        let AuthOnboardingState::LoginSlide {
+            login_slide_view,
+            onboarding_view,
+            target,
+        } = &self.auth_onboarding_state
+        else {
+            return None;
+        };
+        login_slide_view
+            .as_ref(ctx)
+            .is_account_first_onboarding()
+            .then(|| AccountFirstLoginContext {
+                login_slide_view: login_slide_view.clone(),
+                onboarding_view: onboarding_view.clone(),
+                target: target.clone(),
+            })
+    }
+
+    fn account_first_is_paid(ctx: &AppContext) -> bool {
+        UserWorkspaces::as_ref(ctx)
+            .current_workspace()
+            .is_some_and(|workspace| workspace.billing_metadata.is_user_on_paid_plan())
+    }
+
+    fn account_first_class(is_paid: bool, fresh_request_limit: Option<usize>) -> FtueAccountClass {
+        if is_paid {
+            FtueAccountClass::Paid
+        } else if fresh_request_limit.is_some_and(|request_limit| request_limit > 0) {
+            FtueAccountClass::FreeIcp
+        } else {
+            FtueAccountClass::FreeStandard
+        }
+    }
+
+    fn begin_account_first_post_auth_refresh(
+        &mut self,
+        context: AccountFirstLoginContext,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.account_first_refresh_in_flight {
+            return;
+        }
+        self.auth_onboarding_state = AuthOnboardingState::LoginSlide {
+            login_slide_view: context.login_slide_view,
+            onboarding_view: context.onboarding_view,
+            target: context.target,
+        };
+        self.account_first_refresh_in_flight = true;
+        let workspace_refresh = TeamUpdateManager::handle(ctx)
+            .update(ctx, |manager, ctx| manager.refresh_workspace_metadata(ctx));
+        let request_limit_refresh = AIRequestUsageModel::handle(ctx)
+            .update(ctx, |model, ctx| model.refresh_request_usage(ctx));
+        let _ = ctx.spawn(
+            async move {
+                let _ = workspace_refresh.await;
+                request_limit_refresh.await.unwrap_or(None)
+            },
+            |me, fresh_request_limit, ctx| {
+                me.account_first_refresh_in_flight = false;
+                me.resolve_account_first_post_auth(fresh_request_limit, ctx);
+            },
+        );
+        ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
+        self.focus(ctx);
+        ctx.notify();
+    }
+
+    fn resolve_account_first_post_auth(
+        &mut self,
+        fresh_request_limit: Option<usize>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(context) = self.account_first_login_context(ctx) else {
+            return;
+        };
+        let account_class =
+            Self::account_first_class(Self::account_first_is_paid(ctx), fresh_request_limit);
+        let has_team = UserWorkspaces::as_ref(ctx).has_teams();
+        send_telemetry_from_ctx!(
+            OnboardingEvent::OnboardingAuthCompleted {
+                account_class: account_class.as_str().to_string(),
+                has_team,
+                is_paid: account_class == FtueAccountClass::Paid,
+                team_discovery_outcome: "unknown".to_string(),
+            },
+            ctx
+        );
+
+        match account_class {
+            FtueAccountClass::Paid => {
+                self.complete_account_first(AccountFirstCompletion::PaidTeam, ctx);
+            }
+            FtueAccountClass::FreeIcp | FtueAccountClass::FreeStandard => {
+                let variant = offer_variant_for_account_class(account_class)
+                    .expect("free account classes have an offer");
+                context.onboarding_view.update(ctx, |view, ctx| {
+                    view.show_post_auth_offer(variant, ctx);
+                });
+                self.auth_onboarding_state = AuthOnboardingState::PostAuthOnboarding {
+                    onboarding_view: context.onboarding_view,
+                    target: context.target,
+                    account_class,
+                    upgrade_started: false,
+                };
+                ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
+                self.focus(ctx);
+                ctx.notify();
+            }
+        }
+    }
+
+    fn handle_account_first_workspaces_event(
+        &mut self,
+        event: &UserWorkspacesEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !matches!(event, UserWorkspacesEvent::TeamsChanged) {
+            return;
+        }
+        let (account_class, upgrade_started) = match &self.auth_onboarding_state {
+            AuthOnboardingState::PostAuthOnboarding {
+                account_class,
+                upgrade_started,
+                ..
+            } => (*account_class, *upgrade_started),
+            _ => return,
+        };
+        if !Self::account_first_is_paid(ctx) {
+            return;
+        }
+
+        if upgrade_started {
+            send_telemetry_from_ctx!(
+                OnboardingEvent::OnboardingUpgradeCompleted {
+                    source_slide: match account_class {
+                        FtueAccountClass::FreeIcp => "head_start",
+                        FtueAccountClass::FreeStandard => "choose_how_to_start",
+                        FtueAccountClass::Paid => "unknown",
+                    }
+                    .to_string(),
+                    account_class: account_class.as_str().to_string(),
+                },
+                ctx
+            );
+            self.complete_account_first(AccountFirstCompletion::UpgradeCompleted, ctx);
+        } else {
+            self.complete_account_first(AccountFirstCompletion::PaidTeam, ctx);
+        }
+    }
+
+    fn complete_account_first(
+        &mut self,
+        completion: AccountFirstCompletion,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let target = match &self.auth_onboarding_state {
+            AuthOnboardingState::LoginSlide {
+                login_slide_view,
+                target,
+                ..
+            } if login_slide_view.as_ref(ctx).is_account_first_onboarding() => target.clone(),
+            AuthOnboardingState::PostAuthOnboarding { target, .. } => target.clone(),
+            _ => return,
+        };
+
+        mark_local_onboarding_completed(ctx);
+        if FeatureFlag::HOAOnboardingFlow.is_enabled() {
+            mark_hoa_onboarding_completed(ctx);
+        }
+        if AuthStateProvider::as_ref(ctx).get().is_logged_in() {
+            AuthManager::handle(ctx).update(ctx, |model, ctx| model.set_user_onboarded(ctx));
+        }
+
+        let account_class = completion.account_class();
+        self.pending_account_first_sso_login = None;
+        let cloud_ready = CloudPreferencesSyncer::as_ref(ctx).has_completed_initial_load();
+        let settings_applied = if account_class.is_none() || cloud_ready {
+            self.pending_account_first_settings_class = None;
+            if let Some(selected_settings) = self.pending_post_auth_onboarding_settings.take() {
+                apply_account_first_onboarding_settings(&selected_settings, account_class, ctx);
+            }
+            true
+        } else {
+            self.pending_account_first_settings_class = account_class;
+            false
+        };
+
+        if !completion.starts_tutorial() {
+            self.pending_tutorial = None;
+        }
+        self.pending_account_first_tutorial_after_settings =
+            completion.starts_tutorial() && !settings_applied;
+
+        send_telemetry_from_ctx!(
+            OnboardingEvent::OnboardingCompleted {
+                completion_type: completion.completion_type().to_string(),
+            },
+            ctx
+        );
+
+        self.auth_onboarding_state = AuthOnboardingState::Terminal(target.to_workspace(ctx));
+        ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
+        if completion.starts_tutorial() && settings_applied {
+            self.start_pending_tutorial(ctx);
+        }
+        self.start_autoupdate_polling(ctx);
+        self.focus(ctx);
+        ctx.notify();
+    }
+
     fn handle_login_slide_event(&mut self, event: &LoginSlideEvent, ctx: &mut ViewContext<Self>) {
         match event {
             LoginSlideEvent::BackToOnboarding => {
@@ -2106,11 +2405,17 @@ impl RootView {
                 };
                 self.pending_tutorial = None;
                 self.pending_post_auth_onboarding_settings = None;
+                self.pending_account_first_settings_class = None;
+                self.pending_account_first_tutorial_after_settings = false;
                 ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
                 self.focus(ctx);
                 ctx.notify();
             }
             LoginSlideEvent::LoginLaterConfirmed => {
+                if self.account_first_login_context(ctx).is_some() {
+                    self.complete_account_first(AccountFirstCompletion::AccountSkipped, ctx);
+                    return;
+                }
                 let AuthOnboardingState::LoginSlide { target, .. } = &self.auth_onboarding_state
                 else {
                     return;
@@ -2155,6 +2460,23 @@ impl RootView {
                 });
             }
             AgentOnboardingEvent::OnboardingCompleted(selected_settings) => {
+                if let AuthOnboardingState::PostAuthOnboarding {
+                    onboarding_view,
+                    account_class,
+                    ..
+                } = &self.auth_onboarding_state
+                {
+                    let onboarding_view = onboarding_view.clone();
+                    let account_class = *account_class;
+                    let variant = offer_variant_for_account_class(account_class)
+                        .expect("free account classes have an offer");
+                    onboarding_view.update(ctx, |view, ctx| {
+                        view.show_post_auth_offer(variant, ctx);
+                    });
+                    self.focus(ctx);
+                    ctx.notify();
+                    return;
+                }
                 let AuthOnboardingState::Onboarding {
                     target,
                     onboarding_view,
@@ -2164,10 +2486,12 @@ impl RootView {
                 };
                 let target = target.clone();
                 let onboarding_view = onboarding_view.clone();
-
-                mark_local_onboarding_completed(ctx);
-                if FeatureFlag::HOAOnboardingFlow.is_enabled() {
-                    mark_hoa_onboarding_completed(ctx);
+                let account_first = FeatureFlag::AccountFirstOnboarding.is_enabled();
+                if !account_first {
+                    mark_local_onboarding_completed(ctx);
+                    if FeatureFlag::HOAOnboardingFlow.is_enabled() {
+                        mark_hoa_onboarding_completed(ctx);
+                    }
                 }
 
                 let is_logged_in = AuthStateProvider::as_ref(ctx).get().is_logged_in();
@@ -2176,7 +2500,6 @@ impl RootView {
                 let ai_enabled = selected_settings.is_ai_enabled();
                 let warp_drive_enabled = selected_settings.is_warp_drive_enabled();
                 // With old onboarding, we ask user to log in before onboarding, so don't do it after onboarding completes.
-                let account_first = FeatureFlag::AccountFirstOnboarding.is_enabled();
                 let requires_login =
                     requires_post_onboarding_login(is_logged_in, ai_enabled, warp_drive_enabled);
 
@@ -2285,6 +2608,39 @@ impl RootView {
                 ctx.notify();
             }
             AgentOnboardingEvent::UpgradeRequested => {
+                let upgrade_started = match &mut self.auth_onboarding_state {
+                    AuthOnboardingState::PostAuthOnboarding {
+                        account_class,
+                        upgrade_started,
+                        ..
+                    } if !*upgrade_started => {
+                        *upgrade_started = true;
+                        Some(*account_class)
+                    }
+                    AuthOnboardingState::PostAuthOnboarding { .. }
+                    | AuthOnboardingState::Auth(_)
+                    | AuthOnboardingState::ConfirmIncomingAuth(_)
+                    | AuthOnboardingState::NeedsSsoLink(_)
+                    | AuthOnboardingState::Onboarding { .. }
+                    | AuthOnboardingState::LoginSlide { .. }
+                    | AuthOnboardingState::Terminal(_) => None,
+                    #[cfg(target_family = "wasm")]
+                    AuthOnboardingState::WebImport(_) => None,
+                };
+                if let Some(account_class) = upgrade_started {
+                    send_telemetry_from_ctx!(
+                        OnboardingEvent::OnboardingUpgradeStarted {
+                            source_slide: match account_class {
+                                FtueAccountClass::FreeIcp => "head_start",
+                                FtueAccountClass::FreeStandard => "choose_how_to_start",
+                                FtueAccountClass::Paid => "unknown",
+                            }
+                            .to_string(),
+                            account_class: account_class.as_str().to_string(),
+                        },
+                        ctx
+                    );
+                }
                 let upgrade_url = AuthManager::handle(ctx)
                     .update(ctx, |auth_manager, _| auth_manager.upgrade_url());
                 ctx.open_url(&upgrade_url);
@@ -2420,10 +2776,14 @@ impl RootView {
                 self.focus(ctx);
                 ctx.notify();
             }
-            AgentOnboardingEvent::OfferSetUpLaterSelected { .. } => {
-                // N3 only defines the reusable offer UI. N4 routes this event
-                // through typed entitlement application and final completion.
-            }
+            AgentOnboardingEvent::OfferSetUpLaterSelected { variant } => match variant {
+                OfferVariant::HeadStart => {
+                    self.complete_account_first(AccountFirstCompletion::FreeIcpSetupLater, ctx)
+                }
+                OfferVariant::ChooseHowToStart => {
+                    self.complete_account_first(AccountFirstCompletion::FreeStandardSetupLater, ctx)
+                }
+            },
             AgentOnboardingEvent::AppBecameActive => {
                 // fetch the models / workspace metadata when the user tabs/intents back
                 // into the app during onboarding after potentially upgrading
@@ -2970,21 +3330,47 @@ impl RootView {
         match event {
             AuthManagerEvent::AuthComplete => {
                 self.paste_auth_token_modal = None;
+                let login_context = self.account_first_login_context(ctx);
+                let resumed_sso_context = if matches!(
+                    self.auth_onboarding_state,
+                    AuthOnboardingState::NeedsSsoLink { .. }
+                ) && auth_state.needs_sso_link() == Some(false)
+                {
+                    self.pending_account_first_sso_login.take()
+                } else {
+                    None
+                };
+                let account_first_context = login_context.or(resumed_sso_context);
+                let account_first_auth = account_first_context.is_some()
+                    || self.pending_account_first_sso_login.is_some()
+                    || matches!(
+                        self.auth_onboarding_state,
+                        AuthOnboardingState::PostAuthOnboarding { .. }
+                    );
 
-                // If onboarding was completed pre-login, sync the server-side flag now
-                // that the user is authenticated. This must happen regardless of the
-                // current `auth_onboarding_state` so we also cover users who skipped
-                // login during onboarding and later signed up from a different
-                // entrypoint (i.e. we're already in the `Terminal` state).
-                Self::sync_local_onboarding_to_server(&auth_state, ctx);
+                if !account_first_auth {
+                    Self::sync_local_onboarding_to_server(&auth_state, ctx);
+                }
 
                 // If the user needs SSO after auth is complete, no matter what their current state is,
                 // we need to block their access to the rest of the app.
                 if auth_state.needs_sso_link().unwrap_or(false) {
+                    if let Some(context) = account_first_context.clone() {
+                        self.pending_account_first_sso_login = Some(context);
+                    }
                     self.show_needs_sso_link_view(
                         auth_state.user_email().unwrap_or_default().clone(),
                         ctx,
                     );
+                } else if let Some(context) = account_first_context {
+                    self.begin_account_first_post_auth_refresh(context, ctx);
+                } else if matches!(
+                    self.auth_onboarding_state,
+                    AuthOnboardingState::PostAuthOnboarding { .. }
+                ) {
+                    TeamUpdateManager::handle(ctx).update(ctx, |manager, ctx| {
+                        drop(manager.refresh_workspace_metadata(ctx));
+                    });
                 } else if let AuthOnboardingState::Auth(_)
                 | AuthOnboardingState::ConfirmIncomingAuth(_) =
                     &self.auth_onboarding_state
@@ -3014,7 +3400,9 @@ impl RootView {
                 }
 
                 // Skip onboarding survey if in Variant One.
-                if let Some(BlockOnboarding::VariantOne) = BlockOnboarding::get_group(ctx) {
+                if !account_first_auth
+                    && let Some(BlockOnboarding::VariantOne) = BlockOnboarding::get_group(ctx)
+                {
                     self.auth_onboarding_state
                         .complete_auth_and_create_workspace(ctx);
                 }
@@ -3052,7 +3440,10 @@ impl RootView {
                 UserAuthenticationError::MissingStateParameter => {}
             },
             AuthManagerEvent::SkippedLogin => {
-                if let AuthOnboardingState::Auth(_) | AuthOnboardingState::ConfirmIncomingAuth(_) =
+                if self.account_first_login_context(ctx).is_some() {
+                    self.complete_account_first(AccountFirstCompletion::AccountSkipped, ctx);
+                } else if let AuthOnboardingState::Auth(_)
+                | AuthOnboardingState::ConfirmIncomingAuth(_) =
                     &self.auth_onboarding_state
                 {
                     self.auth_onboarding_state
@@ -3196,6 +3587,11 @@ impl RootView {
             } => {
                 ctx.focus(onboarding_view);
             }
+            AuthOnboardingState::PostAuthOnboarding {
+                onboarding_view, ..
+            } => {
+                ctx.focus(onboarding_view);
+            }
             AuthOnboardingState::LoginSlide {
                 login_slide_view, ..
             } => {
@@ -3263,6 +3659,29 @@ impl RootView {
         ctx: &mut ViewContext<Self>,
     ) {
         if !matches!(event, CloudPreferencesSyncerEvent::InitialLoadCompleted) {
+            return;
+        }
+        if let Some(account_class) = self.pending_account_first_settings_class.take() {
+            if let Some(selected_settings) = self.pending_post_auth_onboarding_settings.take() {
+                apply_account_first_onboarding_settings(
+                    &selected_settings,
+                    Some(account_class),
+                    ctx,
+                );
+            }
+            if self.pending_account_first_tutorial_after_settings {
+                self.pending_account_first_tutorial_after_settings = false;
+                self.start_pending_tutorial(ctx);
+            }
+            return;
+        }
+        if self.account_first_login_context(ctx).is_some()
+            || self.pending_account_first_sso_login.is_some()
+            || matches!(
+                self.auth_onboarding_state,
+                AuthOnboardingState::PostAuthOnboarding { .. }
+            )
+        {
             return;
         }
         let Some(selected_settings) = self.pending_post_auth_onboarding_settings.take() else {
@@ -3336,7 +3755,7 @@ impl View for RootView {
             // Modal is open — focus belongs to the editor inside it.
         } else if matches!(
             self.auth_onboarding_state,
-            AuthOnboardingState::Onboarding { .. }
+            AuthOnboardingState::Onboarding { .. } | AuthOnboardingState::PostAuthOnboarding { .. }
         ) {
             // During onboarding, aggressively redirect focus.
             // This ensures keystrokes (Enter) are handled by the correct view rather
@@ -3366,6 +3785,9 @@ impl View for RootView {
                 ChildView::new(&self.needs_sso_link_view).finish()
             }
             AuthOnboardingState::Onboarding {
+                onboarding_view, ..
+            } => ChildView::new(onboarding_view).finish(),
+            AuthOnboardingState::PostAuthOnboarding {
                 onboarding_view, ..
             } => ChildView::new(onboarding_view).finish(),
             AuthOnboardingState::LoginSlide {
@@ -3555,7 +3977,9 @@ impl AuthOnboardingState {
             AuthOnboardingState::NeedsSsoLink(target) => {
                 *self = AuthOnboardingState::WebImport(target.clone())
             }
-            AuthOnboardingState::Onboarding { .. } | AuthOnboardingState::LoginSlide { .. } => {
+            AuthOnboardingState::Onboarding { .. }
+            | AuthOnboardingState::LoginSlide { .. }
+            | AuthOnboardingState::PostAuthOnboarding { .. } => {
                 // For onboarding/login slide, we don't have a workspace yet, so we can't convert to web import
                 // This case shouldn't normally occur
             }
@@ -3588,7 +4012,9 @@ impl AuthOnboardingState {
                 report_error!("SSO link required after web user import");
             }
             AuthOnboardingState::NeedsSsoLink { .. } => (),
-            AuthOnboardingState::Onboarding { .. } | AuthOnboardingState::LoginSlide { .. } => {
+            AuthOnboardingState::Onboarding { .. }
+            | AuthOnboardingState::LoginSlide { .. }
+            | AuthOnboardingState::PostAuthOnboarding { .. } => {
                 // For onboarding/login slide, we don't have a workspace yet, so we can't convert to SSO link
                 // This case shouldn't normally occur
             }
@@ -3619,7 +4045,9 @@ impl AuthOnboardingState {
                 }
                 AuthOnboardingTarget::Terminal(_) => {}
             },
-            AuthOnboardingState::Onboarding { .. } | AuthOnboardingState::LoginSlide { .. } => {
+            AuthOnboardingState::Onboarding { .. }
+            | AuthOnboardingState::LoginSlide { .. }
+            | AuthOnboardingState::PostAuthOnboarding { .. } => {
                 // No workspace to clean up for onboarding/login slide state
             }
             AuthOnboardingState::Terminal(workspace) => {

--- a/app/src/root_view_tests.rs
+++ b/app/src/root_view_tests.rs
@@ -1,20 +1,50 @@
+use onboarding::OfferVariant;
 use warp_core::features::FeatureFlag;
 use warp_core::user_preferences::GetUserPreferences as _;
 use warpui::{App, SingletonEntity};
 
 use super::{
-    HAS_COMPLETED_ONBOARDING_KEY, RootView, has_completed_local_onboarding,
-    requires_post_onboarding_login,
+    AccountFirstCompletion, HAS_COMPLETED_ONBOARDING_KEY, RootView, has_completed_local_onboarding,
+    offer_variant_for_account_class, requires_post_onboarding_login,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
 use crate::server::server_api::ServerApiProvider;
+use crate::workspaces::workspace::FtueAccountClass;
 
 fn initialize_app(app: &mut App) {
     app.update(crate::settings::init_and_register_user_preferences);
     app.add_singleton_model(|_ctx| ServerApiProvider::new_for_test());
     app.add_singleton_model(|_| AuthStateProvider::new_for_test());
     app.add_singleton_model(AuthManager::new_for_test);
+}
+
+#[test]
+fn account_first_class_uses_paid_status_then_fresh_request_limit() {
+    assert_eq!(
+        RootView::account_first_class(true, Some(0)),
+        FtueAccountClass::Paid
+    );
+    assert_eq!(
+        RootView::account_first_class(true, Some(300)),
+        FtueAccountClass::Paid
+    );
+    assert_eq!(
+        RootView::account_first_class(true, None),
+        FtueAccountClass::Paid
+    );
+    assert_eq!(
+        RootView::account_first_class(false, Some(300)),
+        FtueAccountClass::FreeIcp
+    );
+    assert_eq!(
+        RootView::account_first_class(false, Some(0)),
+        FtueAccountClass::FreeStandard
+    );
+    assert_eq!(
+        RootView::account_first_class(false, None),
+        FtueAccountClass::FreeStandard
+    );
 }
 
 fn set_local_onboarding_completed(app: &mut App, completed: bool) {
@@ -44,6 +74,64 @@ fn fallback_flow_only_requires_login_for_account_backed_settings() {
     assert!(!requires_post_onboarding_login(false, false, false));
     assert!(requires_post_onboarding_login(false, true, false));
     assert!(requires_post_onboarding_login(false, false, true));
+}
+
+#[test]
+fn account_first_classes_route_to_paid_or_the_expected_offer() {
+    assert_eq!(
+        offer_variant_for_account_class(FtueAccountClass::Paid),
+        None
+    );
+    assert_eq!(
+        offer_variant_for_account_class(FtueAccountClass::FreeIcp),
+        Some(OfferVariant::HeadStart)
+    );
+    assert_eq!(
+        offer_variant_for_account_class(FtueAccountClass::FreeStandard),
+        Some(OfferVariant::ChooseHowToStart)
+    );
+}
+
+#[test]
+fn account_first_completion_metadata_matches_terminal_outcomes() {
+    let cases = [
+        (
+            AccountFirstCompletion::AccountSkipped,
+            "account_skipped",
+            None,
+            false,
+        ),
+        (
+            AccountFirstCompletion::PaidTeam,
+            "paid_team",
+            Some(FtueAccountClass::Paid),
+            true,
+        ),
+        (
+            AccountFirstCompletion::FreeIcpSetupLater,
+            "free_icp_setup_later",
+            Some(FtueAccountClass::FreeIcp),
+            true,
+        ),
+        (
+            AccountFirstCompletion::FreeStandardSetupLater,
+            "free_standard_setup_later",
+            Some(FtueAccountClass::FreeStandard),
+            false,
+        ),
+        (
+            AccountFirstCompletion::UpgradeCompleted,
+            "upgrade_completed",
+            Some(FtueAccountClass::Paid),
+            true,
+        ),
+    ];
+
+    for (completion, completion_type, account_class, starts_tutorial) in cases {
+        assert_eq!(completion.completion_type(), completion_type);
+        assert_eq!(completion.account_class(), account_class);
+        assert_eq!(completion.starts_tutorial(), starts_tutorial);
+    }
 }
 
 /// Regression test for the bug fixed by introducing

--- a/app/src/settings/onboarding.rs
+++ b/app/src/settings/onboarding.rs
@@ -12,6 +12,56 @@ use crate::settings::ai::DefaultSessionMode;
 use crate::settings::{AISettings, CodeSettings};
 use crate::workspace::tab_settings::TabSettings;
 use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::workspaces::workspace::FtueAccountClass;
+
+pub fn apply_account_first_onboarding_settings(
+    selected_settings: &SelectedSettings,
+    account_class: Option<FtueAccountClass>,
+    app: &mut AppContext,
+) {
+    let is_ai_enabled = matches!(
+        account_class,
+        Some(FtueAccountClass::Paid | FtueAccountClass::FreeIcp)
+    );
+
+    match selected_settings {
+        SelectedSettings::AgentDrivenDevelopment {
+            agent_settings,
+            ui_customization,
+            ..
+        } => {
+            apply_agent_settings(agent_settings, app);
+            if let Some(ui) = ui_customization {
+                apply_ui_customization_settings(ui, true, app);
+            }
+        }
+        SelectedSettings::Terminal {
+            ui_customization,
+            cli_agent_toolbar_enabled,
+            show_agent_notifications,
+        } => {
+            if let Some(ui) = ui_customization {
+                apply_ui_customization_settings(ui, false, app);
+            }
+            AISettings::handle(app).update(app, |settings, ctx| {
+                report_if_error!(
+                    settings
+                        .should_render_cli_agent_footer
+                        .set_value(*cli_agent_toolbar_enabled, ctx)
+                );
+                report_if_error!(
+                    settings
+                        .show_agent_notifications
+                        .set_value(*show_agent_notifications, ctx)
+                );
+            });
+        }
+    }
+
+    AISettings::handle(app).update(app, |settings, ctx| {
+        report_if_error!(settings.is_any_ai_enabled.set_value(is_ai_enabled, ctx));
+    });
+}
 
 /// Applies onboarding settings based on the user's selected mode.
 ///
@@ -83,7 +133,9 @@ fn apply_ui_customization_settings(
     app: &mut AppContext,
 ) {
     // Customize UI slide should only exist with this flag enabled.
-    if !FeatureFlag::OpenWarpNewSettingsModes.is_enabled() {
+    if !FeatureFlag::AccountFirstOnboarding.is_enabled()
+        && !FeatureFlag::OpenWarpNewSettingsModes.is_enabled()
+    {
         return;
     }
     TabSettings::handle(app).update(app, |settings, ctx| {

--- a/app/src/settings/onboarding_tests.rs
+++ b/app/src/settings/onboarding_tests.rs
@@ -1,7 +1,7 @@
 use ai::LLMId;
 use chrono::{DateTime, Utc};
-use onboarding::SelectedSettings;
 use onboarding::slides::{AgentAutonomy, AgentDevelopmentSettings, ProjectOnboardingSettings};
+use onboarding::{SelectedSettings, UICustomizationSettings};
 use warp_core::features::FeatureFlag;
 use warpui::{App, SingletonEntity};
 
@@ -14,14 +14,20 @@ use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::cloud_object::{Revision, ServerAIExecutionProfile, ServerMetadata, ServerPermissions};
+use crate::drive::settings::WarpDriveSettings;
 use crate::network::NetworkStatus;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::sync_queue::SyncQueue;
-use crate::settings::{AISettings, PrivacySettings, apply_onboarding_settings};
+use crate::settings::{
+    AISettings, CodeSettings, PrivacySettings, apply_account_first_onboarding_settings,
+    apply_onboarding_settings,
+};
 use crate::test_util::settings::initialize_settings_for_tests;
+use crate::workspace::tab_settings::TabSettings;
 use crate::workspaces::team_tester::TeamTesterStatus;
 use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::workspaces::workspace::FtueAccountClass;
 
 fn mock_server_metadata(uid: ServerId) -> ServerMetadata {
     ServerMetadata {
@@ -168,6 +174,65 @@ fn apply_onboarding_settings_preserves_existing_cloud_profile_on_existing_user_l
             );
         });
     })
+}
+
+#[test]
+fn account_first_settings_follow_typed_entitlement_and_always_apply_ui_choices() {
+    let _account_first = FeatureFlag::AccountFirstOnboarding.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+        app.add_singleton_model(PrivacySettings::mock);
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+
+        let selected_settings = SelectedSettings::AgentDrivenDevelopment {
+            agent_settings: AgentDevelopmentSettings {
+                selected_model_id: LLMId::from("auto"),
+                autonomy: None,
+                cli_agent_toolbar_enabled: true,
+                session_default: onboarding::SessionDefault::Agent,
+                disable_oz: false,
+                show_agent_notifications: true,
+            },
+            project_settings: ProjectOnboardingSettings::default(),
+            ui_customization: Some(UICustomizationSettings {
+                use_vertical_tabs: false,
+                show_conversation_history: false,
+                show_project_explorer: true,
+                show_global_search: false,
+                show_warp_drive: false,
+                show_code_review_button: true,
+            }),
+        };
+
+        for (account_class, expected_ai) in [
+            (None, false),
+            (Some(FtueAccountClass::FreeStandard), false),
+            (Some(FtueAccountClass::FreeIcp), true),
+            (Some(FtueAccountClass::Paid), true),
+        ] {
+            app.update(|ctx| {
+                apply_account_first_onboarding_settings(&selected_settings, account_class, ctx);
+            });
+            app.read(|ctx| {
+                assert_eq!(*AISettings::as_ref(ctx).is_any_ai_enabled, expected_ai);
+                assert!(!*TabSettings::as_ref(ctx).use_vertical_tabs);
+                assert!(*TabSettings::as_ref(ctx).show_code_review_button);
+                assert!(!*WarpDriveSettings::as_ref(ctx).enable_warp_drive);
+                assert!(*CodeSettings::as_ref(ctx).show_project_explorer);
+                assert!(!*CodeSettings::as_ref(ctx).show_global_search);
+            });
+        }
+    });
 }
 
 /// Warp's AI features run on a Warp account. For third-party agent intent

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -506,6 +506,26 @@ pub struct BillingMetadata {
     pub ai_overages: Option<AiOverages>,
 }
 
+/// The effective account outcome used to route users after account-first signup.
+///
+/// Paid status and free AI availability are resolved from fresh server-authored
+/// data during post-auth onboarding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FtueAccountClass {
+    Paid,
+    FreeIcp,
+    FreeStandard,
+}
+
+impl FtueAccountClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FtueAccountClass::Paid => "paid",
+            FtueAccountClass::FreeIcp => "free_icp",
+            FtueAccountClass::FreeStandard => "free_standard",
+        }
+    }
+}
 #[derive(Clone, Debug, Default)]
 pub struct BonusGrantsPurchased {
     pub total_credits_purchased: i32,

--- a/app/src/workspaces/workspace_tests.rs
+++ b/app/src/workspaces/workspace_tests.rs
@@ -4,6 +4,12 @@ use crate::server::ids::ServerId;
 // `ServerId::from_string_lossy` requires exactly 22 characters.
 const TEST_WORKSPACE_UID: &str = "workspace_uid123456789";
 
+#[test]
+fn ftue_account_classes_have_stable_telemetry_labels() {
+    assert_eq!(FtueAccountClass::Paid.as_str(), "paid");
+    assert_eq!(FtueAccountClass::FreeIcp.as_str(), "free_icp");
+    assert_eq!(FtueAccountClass::FreeStandard.as_str(), "free_standard");
+}
 fn make_workspace(policy: Option<UsageVisibilityPolicy>) -> Workspace {
     let mut workspace = Workspace::from_local_cache(
         ServerId::from_string_lossy(TEST_WORKSPACE_UID).into(),

--- a/crates/onboarding/src/telemetry.rs
+++ b/crates/onboarding/src/telemetry.rs
@@ -29,9 +29,14 @@ pub enum OnboardingEvent {
     /// The onboarding flow was started.
     OnboardingStarted,
     /// A specific slide was viewed.
-    SlideViewed { slide_name: String },
+    SlideViewed {
+        slide_name: String,
+    },
     /// A setting was changed during onboarding.
-    SettingChanged { setting: String, value: String },
+    SettingChanged {
+        setting: String,
+        value: String,
+    },
     /// The onboarding slides were completed.
     OnboardingSlidesCompleted {
         intention: String,
@@ -49,11 +54,15 @@ pub enum OnboardingEvent {
     /// The user selected a folder.
     FolderSelected,
     /// A callout was displayed.
-    CalloutDisplayed { callout: String },
+    CalloutDisplayed {
+        callout: String,
+    },
     /// The user clicked next on a callout.
     CalloutNext,
     /// The user completed the callout flow.
-    CalloutCompleted { completion_type: String },
+    CalloutCompleted {
+        completion_type: String,
+    },
     /// The user navigated to the next slide.
     SlideNavigatedNext,
     /// The user navigated to the previous slide.
@@ -73,6 +82,23 @@ pub enum OnboardingEvent {
         slide_name: String,
         action: String,
         account_class: Option<String>,
+    },
+    OnboardingAuthCompleted {
+        account_class: String,
+        has_team: bool,
+        is_paid: bool,
+        team_discovery_outcome: String,
+    },
+    OnboardingUpgradeStarted {
+        source_slide: String,
+        account_class: String,
+    },
+    OnboardingUpgradeCompleted {
+        source_slide: String,
+        account_class: String,
+    },
+    OnboardingCompleted {
+        completion_type: String,
     },
 }
 
@@ -97,6 +123,10 @@ impl TelemetryEvent for OnboardingEvent {
             OnboardingEvent::AgentSlideUpgradeClicked => "onboarding_agent_slide_upgrade_clicked",
             OnboardingEvent::WelcomeLoginClicked => "onboarding_welcome_login_clicked",
             OnboardingEvent::OnboardingAction { .. } => "onboarding_action",
+            OnboardingEvent::OnboardingAuthCompleted { .. } => "onboarding_auth_completed",
+            OnboardingEvent::OnboardingUpgradeStarted { .. } => "onboarding_upgrade_started",
+            OnboardingEvent::OnboardingUpgradeCompleted { .. } => "onboarding_upgrade_completed",
+            OnboardingEvent::OnboardingCompleted { .. } => "onboarding_completed",
         }
     }
 
@@ -162,6 +192,38 @@ impl TelemetryEvent for OnboardingEvent {
                 }
                 Some(payload)
             }
+            OnboardingEvent::OnboardingAuthCompleted {
+                account_class,
+                has_team,
+                is_paid,
+                team_discovery_outcome,
+            } => Some(json!({
+                "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+                "account_class": account_class,
+                "has_team": has_team,
+                "is_paid": is_paid,
+                "team_discovery_outcome": team_discovery_outcome,
+            })),
+            OnboardingEvent::OnboardingUpgradeStarted {
+                source_slide,
+                account_class,
+            } => Some(json!({
+                "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+                "source_slide": source_slide,
+                "account_class": account_class,
+            })),
+            OnboardingEvent::OnboardingUpgradeCompleted {
+                source_slide,
+                account_class,
+            } => Some(json!({
+                "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+                "source_slide": source_slide,
+                "account_class": account_class,
+            })),
+            OnboardingEvent::OnboardingCompleted { completion_type } => Some(json!({
+                "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+                "completion_type": completion_type,
+            })),
         }
     }
 
@@ -196,6 +258,18 @@ impl TelemetryEvent for OnboardingEvent {
             }
             OnboardingEvent::OnboardingAction { .. } => {
                 "User performed an action in the account-first onboarding flow"
+            }
+            OnboardingEvent::OnboardingAuthCompleted { .. } => {
+                "User completed account-first browser authentication"
+            }
+            OnboardingEvent::OnboardingUpgradeStarted { .. } => {
+                "User started an upgrade from account-first onboarding"
+            }
+            OnboardingEvent::OnboardingUpgradeCompleted { .. } => {
+                "User completed an upgrade from account-first onboarding"
+            }
+            OnboardingEvent::OnboardingCompleted { .. } => {
+                "User completed account-first onboarding"
             }
         }
     }
@@ -242,6 +316,12 @@ impl TelemetryEventDesc for OnboardingEventDiscriminant {
             }
             OnboardingEventDiscriminant::WelcomeLoginClicked => "onboarding_welcome_login_clicked",
             OnboardingEventDiscriminant::OnboardingAction => "onboarding_action",
+            OnboardingEventDiscriminant::OnboardingAuthCompleted => "onboarding_auth_completed",
+            OnboardingEventDiscriminant::OnboardingUpgradeStarted => "onboarding_upgrade_started",
+            OnboardingEventDiscriminant::OnboardingUpgradeCompleted => {
+                "onboarding_upgrade_completed"
+            }
+            OnboardingEventDiscriminant::OnboardingCompleted => "onboarding_completed",
         }
     }
 
@@ -284,6 +364,18 @@ impl TelemetryEventDesc for OnboardingEventDiscriminant {
             }
             OnboardingEventDiscriminant::OnboardingAction => {
                 "User performed an action in the account-first onboarding flow"
+            }
+            OnboardingEventDiscriminant::OnboardingAuthCompleted => {
+                "User completed account-first browser authentication"
+            }
+            OnboardingEventDiscriminant::OnboardingUpgradeStarted => {
+                "User started an upgrade from account-first onboarding"
+            }
+            OnboardingEventDiscriminant::OnboardingUpgradeCompleted => {
+                "User completed an upgrade from account-first onboarding"
+            }
+            OnboardingEventDiscriminant::OnboardingCompleted => {
+                "User completed account-first onboarding"
             }
         }
     }

--- a/crates/onboarding/src/telemetry_tests.rs
+++ b/crates/onboarding/src/telemetry_tests.rs
@@ -18,6 +18,60 @@ fn account_first_started_payload_includes_flow_metadata() {
 }
 
 #[test]
+fn account_first_lifecycle_payloads_include_flow_and_classification() {
+    assert_eq!(
+        OnboardingEvent::OnboardingAuthCompleted {
+            account_class: "free_icp".to_string(),
+            has_team: true,
+            is_paid: false,
+            team_discovery_outcome: "unknown".to_string(),
+        }
+        .payload(),
+        Some(json!({
+            "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+            "account_class": "free_icp",
+            "has_team": true,
+            "is_paid": false,
+            "team_discovery_outcome": "unknown",
+        }))
+    );
+    assert_eq!(
+        OnboardingEvent::OnboardingUpgradeStarted {
+            source_slide: "head_start".to_string(),
+            account_class: "free_icp".to_string(),
+        }
+        .payload(),
+        Some(json!({
+            "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+            "source_slide": "head_start",
+            "account_class": "free_icp",
+        }))
+    );
+    assert_eq!(
+        OnboardingEvent::OnboardingUpgradeCompleted {
+            source_slide: "head_start".to_string(),
+            account_class: "free_icp".to_string(),
+        }
+        .payload(),
+        Some(json!({
+            "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+            "source_slide": "head_start",
+            "account_class": "free_icp",
+        }))
+    );
+    assert_eq!(
+        OnboardingEvent::OnboardingCompleted {
+            completion_type: "upgrade_completed".to_string(),
+        }
+        .payload(),
+        Some(json!({
+            "flow_version": ACCOUNT_FIRST_FLOW_VERSION,
+            "completion_type": "upgrade_completed",
+        }))
+    );
+}
+
+#[test]
 fn offer_action_payload_includes_account_class() {
     assert_eq!(
         OnboardingEvent::OnboardingAction {


### PR DESCRIPTION
## Description
Adds PR 3 of the account-first onboarding stack: post-auth classification, orchestration, completion, and settings behavior, stacked on #14126.

- Reuses the existing user-level `requestLimitInfo` API; no server or GraphQL schema changes are required.
- Adds an awaitable request-usage refresh that returns only freshly fetched base-plan limits and never classifies from cached/default data.
- Waits for workspace metadata and request-limit refresh after authentication. Paid workspace status wins; otherwise `request_limit > 0` selects the head-start offer and zero/fetch failure selects standard free.
- Correctly handles teamless users because `requestLimitInfo` lives on `User`, outside the filtered placeholder workspace.
- Handles SSO continuation, browser upgrade start/completion, app-focus/workspace refresh, paid bypass, and terminal completion.
- Applies account-first settings after cloud reconciliation and starts the tutorial only for eligible outcomes.
- Adds auth-completion, upgrade, and final-completion telemetry with focused routing/settings tests.

[Implementation plan](https://staging.warp.dev/drive/notebook/gveUFQwEObql0Mi9uJsPgf)

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- `./script/format`
- `cargo nextest run -p onboarding` — 26 passed
- `cargo nextest run -p warp --features account_first_onboarding account_first_` — 6 passed
- `cargo nextest run -p warp --features account_first_onboarding refresh_request_usage_returns_no_fresh_limit_when_logged_out` — 1 passed
- `cargo nextest run -p warp --features account_first_onboarding workspaces::workspace::tests` — 6 passed
- `cargo check -p warp --features account_first_onboarding`
- `cargo clippy -p onboarding --all-targets -- -D warnings`
- `cargo clippy -p warp --features account_first_onboarding --tests -- -D warnings`

- [x] I have manually tested the stacked flow locally with `./script/run`, including non-ICP upgrade and teamless ICP head-start routing

### Screenshots / Videos
- [Non-ICP account-first flow walkthrough](https://www.loom.com/edit/04fe9522a7db4cfd914073aa81aec2dd)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>