### PR TITLE
fix ask question tool focus

### DIFF
--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -695,7 +695,7 @@ impl AskUserQuestionView {
             AskUserQuestionEffect::RefreshCurrent => {
                 self.rebuild_current_question(AskUserQuestionRebuildMode::PreserveSelection, ctx);
             }
-            AskUserQuestionEffect::FocusOtherInput => {
+            AskUserQuestionEffect::FocusCustomAnswerInput => {
                 self.rebuild_current_question(AskUserQuestionRebuildMode::PreserveSelection, ctx);
                 if let Some(text_input) = &self.text_input {
                     ctx.focus(text_input);
@@ -1246,7 +1246,9 @@ impl TypedActionView for AskUserQuestionView {
             }
             AskUserQuestionViewAction::OtherSelected => {
                 self.abort_auto_advance();
-                let effect = self.session.apply(AskUserQuestionAction::OpenOtherInput);
+                let effect = self
+                    .session
+                    .apply(AskUserQuestionAction::EnterCustomAnswerEditing);
                 self.handle_session_effect(effect, ctx);
             }
             AskUserQuestionViewAction::NavigateNext => {

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view_tests.rs
@@ -32,7 +32,7 @@ fn view_state_shows_other_input_only_for_the_current_question() {
         }
     );
 
-    session.apply(AskUserQuestionAction::OpenOtherInput);
+    session.apply(AskUserQuestionAction::EnterCustomAnswerEditing);
     assert_eq!(
         ask_user_question_view_state(session.current()),
         AskUserQuestionViewState {

--- a/crates/ai/src/agent/ask_user_question_session.rs
+++ b/crates/ai/src/agent/ask_user_question_session.rs
@@ -124,7 +124,10 @@ pub enum AskUserQuestionAction {
     ToggleOption {
         option_index: usize,
     },
-    OpenOtherInput,
+    /// Enters the inline editor for a free-form answer outside the listed choices.
+    EnterCustomAnswerEditing,
+    /// Leaves custom-answer editing without changing saved text or advancing.
+    ExitCustomAnswerEditing,
     SaveOtherText {
         text: Option<String>,
     },
@@ -142,7 +145,8 @@ pub enum AskUserQuestionAction {
 pub enum AskUserQuestionEffect {
     Noop,
     RefreshCurrent,
-    FocusOtherInput,
+    /// Requests focus for the inline free-form answer editor.
+    FocusCustomAnswerInput,
     ShowQuestion,
     ScheduleAutoAdvance,
     Submit(Vec<AskUserQuestionAnswerItem>),
@@ -229,7 +233,8 @@ impl AskUserQuestionSession {
             AskUserQuestionAction::ToggleOption { option_index } => {
                 self.toggle_option(option_index)
             }
-            AskUserQuestionAction::OpenOtherInput => self.open_other_input(),
+            AskUserQuestionAction::EnterCustomAnswerEditing => self.enter_custom_answer_editing(),
+            AskUserQuestionAction::ExitCustomAnswerEditing => self.exit_custom_answer_editing(),
             AskUserQuestionAction::SaveOtherText { text } => self.save_other_text(text),
             AskUserQuestionAction::NavigatePrev => self.navigate_prev(),
             AskUserQuestionAction::NavigateNext => self.navigate_next(),
@@ -296,7 +301,8 @@ impl AskUserQuestionSession {
         }
     }
 
-    fn open_other_input(&mut self) -> AskUserQuestionEffect {
+    /// Activates the inline free-form answer editor for the current question.
+    fn enter_custom_answer_editing(&mut self) -> AskUserQuestionEffect {
         let Some(is_multiselect) = self
             .current()
             .map(|current| current.question.is_multiselect())
@@ -314,7 +320,21 @@ impl AskUserQuestionSession {
             }
             draft.is_other_input_active = true;
         });
-        AskUserQuestionEffect::FocusOtherInput
+        AskUserQuestionEffect::FocusCustomAnswerInput
+    }
+
+    /// Clears only the custom-answer input's active editing state.
+    ///
+    /// Previously saved custom text remains part of the draft, and returning
+    /// to the option list does not trigger questionnaire auto-advance.
+    fn exit_custom_answer_editing(&mut self) -> AskUserQuestionEffect {
+        let Some(editing) = self.editing_state_mut() else {
+            return AskUserQuestionEffect::Noop;
+        };
+        editing.update_current_draft(|draft| {
+            draft.is_other_input_active = false;
+        });
+        AskUserQuestionEffect::RefreshCurrent
     }
 
     fn save_other_text(&mut self, text: Option<String>) -> AskUserQuestionEffect {
@@ -391,7 +411,7 @@ impl AskUserQuestionSession {
         };
 
         if supports_other && highlighted_index == Some(option_count) {
-            return self.open_other_input();
+            return self.enter_custom_answer_editing();
         }
 
         if let Some(option_index) = highlighted_index.filter(|index| *index < option_count) {

--- a/crates/ai/src/agent/ask_user_question_session_tests.rs
+++ b/crates/ai/src/agent/ask_user_question_session_tests.rs
@@ -46,7 +46,7 @@ fn submitting_the_other_row_focuses_the_other_input() {
             highlighted_index: Some(1),
             active_other_text: None,
         }),
-        AskUserQuestionEffect::FocusOtherInput
+        AskUserQuestionEffect::FocusCustomAnswerInput
     );
 }
 
@@ -100,8 +100,8 @@ fn submitting_blank_other_input_submits_the_last_question_immediately() {
     let mut session = build_session(vec![build_question("q1", "Only", false, true, &["Stable"])]);
 
     assert_eq!(
-        session.apply(AskUserQuestionAction::OpenOtherInput),
-        AskUserQuestionEffect::FocusOtherInput
+        session.apply(AskUserQuestionAction::EnterCustomAnswerEditing),
+        AskUserQuestionEffect::FocusCustomAnswerInput
     );
 
     assert_eq!(
@@ -120,8 +120,8 @@ fn submitting_active_other_text_schedules_auto_advance() {
     let mut session = build_session(vec![build_question("q1", "Only", false, true, &["Stable"])]);
 
     assert_eq!(
-        session.apply(AskUserQuestionAction::OpenOtherInput),
-        AskUserQuestionEffect::FocusOtherInput
+        session.apply(AskUserQuestionAction::EnterCustomAnswerEditing),
+        AskUserQuestionEffect::FocusCustomAnswerInput
     );
     assert_eq!(
         session.apply(AskUserQuestionAction::SubmitAnswer {
@@ -136,6 +136,22 @@ fn submitting_active_other_text_schedules_auto_advance() {
     );
 }
 
+#[test]
+fn exiting_custom_answer_editing_preserves_the_draft_without_auto_advancing() {
+    let mut session = build_session(vec![build_question("q1", "Only", false, true, &["Stable"])]);
+    session.apply(AskUserQuestionAction::SaveOtherText {
+        text: Some("nightly".to_string()),
+    });
+    session.apply(AskUserQuestionAction::EnterCustomAnswerEditing);
+
+    assert_eq!(
+        session.apply(AskUserQuestionAction::ExitCustomAnswerEditing),
+        AskUserQuestionEffect::RefreshCurrent
+    );
+    let draft = current_draft(&session).expect("draft should remain");
+    assert_eq!(draft.other_text.as_deref(), Some("nightly"));
+    assert!(!draft.is_other_input_active);
+}
 #[test]
 fn submitting_single_select_option_toggles_it_and_schedules_auto_advance() {
     let mut session = build_session(vec![build_question(
@@ -308,8 +324,8 @@ fn drafts_survive_navigation_and_submit_skips_only_unanswered_questions() {
         AskUserQuestionEffect::ShowQuestion
     );
     assert_eq!(
-        session.apply(AskUserQuestionAction::OpenOtherInput),
-        AskUserQuestionEffect::FocusOtherInput
+        session.apply(AskUserQuestionAction::EnterCustomAnswerEditing),
+        AskUserQuestionEffect::FocusCustomAnswerInput
     );
     assert_eq!(
         session.apply(AskUserQuestionAction::SaveOtherText {
@@ -352,8 +368,8 @@ fn multi_select_other_text_does_not_auto_advance_before_last_question() {
     ]);
 
     assert_eq!(
-        session.apply(AskUserQuestionAction::OpenOtherInput),
-        AskUserQuestionEffect::FocusOtherInput
+        session.apply(AskUserQuestionAction::EnterCustomAnswerEditing),
+        AskUserQuestionEffect::FocusCustomAnswerInput
     );
     assert_eq!(
         session.apply(AskUserQuestionAction::SaveOtherText {
@@ -377,7 +393,7 @@ fn skip_all_moves_session_to_completed_with_skipped_answers() {
 
     session.apply(AskUserQuestionAction::ToggleOption { option_index: 0 });
     session.apply(AskUserQuestionAction::NavigateNext);
-    session.apply(AskUserQuestionAction::OpenOtherInput);
+    session.apply(AskUserQuestionAction::EnterCustomAnswerEditing);
     session.apply(AskUserQuestionAction::SaveOtherText {
         text: Some("nightly".to_string()),
     });
@@ -406,8 +422,8 @@ fn other_text_submission_exits_input_and_submits_last_question() {
     let mut session = build_session(vec![build_question("q1", "Only", false, true, &["Stable"])]);
 
     assert_eq!(
-        session.apply(AskUserQuestionAction::OpenOtherInput),
-        AskUserQuestionEffect::FocusOtherInput
+        session.apply(AskUserQuestionAction::EnterCustomAnswerEditing),
+        AskUserQuestionEffect::FocusCustomAnswerInput
     );
     assert!(current_draft(&session).is_some_and(|draft| draft.is_other_input_active));
 

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -69,6 +69,8 @@ struct TuiCodeBlockKey {
 
 /// The focused child view for the front-of-queue blocking interaction.
 pub(super) enum TuiBlockingChild {
+    /// An ask-user-question questionnaire.
+    AskQuestion(ViewHandle<TuiAskQuestionView>),
     /// A standard Yes/No/Other permission request.
     Permission(ViewHandle<TuiPermissionPrompt>),
     /// The specialized orchestration configuration request.
@@ -79,6 +81,7 @@ impl TuiBlockingChild {
     /// Returns the view identity used to detect blocker focus transitions.
     pub(super) fn id(&self) -> EntityId {
         match self {
+            Self::AskQuestion(view) => view.id(),
             Self::Permission(view) => view.id(),
             Self::Orchestration(view) => view.id(),
         }
@@ -453,6 +456,7 @@ impl TuiAIBlock {
                     ) {
                         me.sync_action_views(&action_model, ctx);
                     }
+                    ctx.emit(TuiAIBlockEvent::BlockingStateChanged);
                     me.invalidate_action(event.action_id(), ctx);
                 }
             },
@@ -804,6 +808,10 @@ impl TuiAIBlock {
             return None;
         }
         match self.action_views.get(&action_id)? {
+            TuiToolCallView::AskQuestion(view) => view
+                .as_ref(ctx)
+                .is_awaiting_answers(ctx)
+                .then(|| TuiBlockingChild::AskQuestion(view.clone())),
             TuiToolCallView::OrchestrationBlock(view) => view
                 .as_ref(ctx)
                 .is_awaiting_confirmation(ctx)
@@ -820,8 +828,8 @@ impl TuiAIBlock {
                 .as_ref(ctx)
                 .active_permission_prompt(ctx)
                 .map(TuiBlockingChild::Permission),
-            // These tool views render inline and never replace the input.
-            TuiToolCallView::AskQuestion(_) | TuiToolCallView::Plan(_) => None,
+            // Plan tool views render inline and never replace the input.
+            TuiToolCallView::Plan(_) => None,
         }
     }
 

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -110,6 +110,8 @@ pub(crate) enum TuiOptionSelectorEvent {
     CustomTextSubmitted { value: String },
     /// The question-card Other editor was opened.
     CustomTextOpened,
+    /// The custom-text editor was left without submitting a new value.
+    CustomTextClosed,
     /// The Retry affordance of a `Failed` catalog was activated.
     RetryRequested,
     /// The selector asked to be dismissed (element-level Escape fallback for
@@ -592,6 +594,7 @@ impl TuiOptionSelector {
         };
 
         ctx.focus_self();
+        ctx.emit(TuiOptionSelectorEvent::CustomTextClosed);
         if layout_changed {
             self.invalidate_layout(ctx);
         } else {
@@ -761,7 +764,7 @@ impl TuiOptionSelector {
     /// Moves the selection one step, scrolling to keep it visible.
     fn move_selection(&mut self, forward: bool, ctx: &mut ViewContext<Self>) {
         if self.custom_text.is_editing() {
-            return;
+            self.cancel_custom_text_editing(ctx);
         }
         let items_len = self.items().len();
         if self.search_field_is_focused(ctx) || self.leading_editor_is_focused(ctx) {
@@ -1205,7 +1208,10 @@ impl TuiView for TuiOptionSelector {
 
     fn keymap_context(&self, app: &AppContext) -> warpui_core::keymap::Context {
         let mut context = Self::default_keymap_context();
-        if self.focused || self.search_field_is_focused(app) {
+        if self.focused
+            || self.search_field_is_focused(app)
+            || self.custom_text.editor.as_ref(app).is_focused()
+        {
             context.set.insert(SELECTOR_NAVIGATION_ACTIVE);
         }
         context

--- a/crates/warp_tui/src/option_selector_tests.rs
+++ b/crates/warp_tui/src/option_selector_tests.rs
@@ -14,8 +14,8 @@ use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext, TuiView as _, TypedActionView as _, ViewHandle};
 
 use super::{
-    OptionSelectorHeader, OptionSelectorPage, SelectorItem, TuiOptionSelector,
-    TuiOptionSelectorAction, TuiOptionSelectorEvent,
+    OptionSelectorHeader, OptionSelectorPage, SELECTOR_NAVIGATION_ACTIVE, SelectorItem,
+    TuiOptionSelector, TuiOptionSelectorAction, TuiOptionSelectorEvent,
 };
 use crate::editor_element::TuiEditorAction;
 use crate::editor_interaction::TuiEditorCommand;
@@ -913,9 +913,8 @@ fn back_cancels_custom_text_editing_before_leaving_the_page() {
     });
 }
 
-/// Arrow navigation leaves list state untouched while custom text owns focus.
 #[test]
-fn arrows_do_not_navigate_the_list_while_editing_custom_text() {
+fn arrows_leave_custom_text_and_navigate_adjacent_options() {
     App::test((), |mut app| async move {
         let (selector, _) = add_selector(&mut app);
         let mut with_footer = snapshot(&["a", "b", "c", "d", "e", "f", "g", "h"], Some("a"));
@@ -924,33 +923,28 @@ fn arrows_do_not_navigate_the_list_while_editing_custom_text() {
         });
         set_page(&mut app, &selector, with_footer);
         let custom_text_index = 8;
-
-        for action in [
-            TuiOptionSelectorAction::MoveUp,
-            TuiOptionSelectorAction::MoveDown,
+        for (action, expected_index) in [
+            (TuiOptionSelectorAction::MoveUp, 7),
+            (TuiOptionSelectorAction::MoveDown, 0),
         ] {
             act(
                 &mut app,
                 &selector,
                 TuiOptionSelectorAction::SelectItem(custom_text_index),
             );
-            let before = selector.read(&app, |selector, _| {
-                (
-                    selector.interaction.selection.selected_index(),
-                    selector.interaction.scroll_offset,
-                )
-            });
+            assert!(selector.read(&app, |selector, ctx| {
+                selector
+                    .keymap_context(ctx)
+                    .set
+                    .contains(SELECTOR_NAVIGATION_ACTIVE)
+            }));
 
             act(&mut app, &selector, action);
-
-            let after = selector.read(&app, |selector, _| {
-                (
-                    selector.interaction.selection.selected_index(),
-                    selector.interaction.scroll_offset,
-                )
-            });
-            assert_eq!(after, before);
-            assert!(custom_text_field(&app, &selector).read(&app, |field, _| field.is_focused()));
+            assert_eq!(
+                selector.read(&app, |selector, _| selector.highlighted_index()),
+                Some(expected_index)
+            );
+            assert!(!custom_text_field(&app, &selector).read(&app, |field, _| field.is_focused()));
         }
     });
 }

--- a/crates/warp_tui/src/orchestration_block.rs
+++ b/crates/warp_tui/src/orchestration_block.rs
@@ -608,7 +608,8 @@ impl TuiOrchestrationBlock {
                     self.finish_page_confirmation(ConfigPage::Host, ctx);
                 }
             }
-            TuiOptionSelectorEvent::CustomTextOpened => {}
+            TuiOptionSelectorEvent::CustomTextOpened | TuiOptionSelectorEvent::CustomTextClosed => {
+            }
             TuiOptionSelectorEvent::RetryRequested => {
                 self.pending_page_navigation = None;
                 self.ensure_auth_secrets_fetched(ctx);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -603,6 +603,9 @@ impl TuiTerminalSessionView {
 
     fn focus_blocking_child(blocker: TuiBlockingChild, ctx: &mut ViewContext<Self>) {
         match blocker {
+            TuiBlockingChild::AskQuestion(view) => {
+                view.update(ctx, |view, ctx| view.focus(ctx));
+            }
             TuiBlockingChild::Permission(view) => {
                 view.update(ctx, |view, ctx| view.focus(ctx));
             }

--- a/crates/warp_tui/src/tui_ask_question_view.rs
+++ b/crates/warp_tui/src/tui_ask_question_view.rs
@@ -151,6 +151,14 @@ impl TuiAskQuestionView {
             .is_some_and(|status| status.is_blocked())
     }
 
+    pub(super) fn is_awaiting_answers(&self, app: &AppContext) -> bool {
+        self.session.is_editing() && self.is_waiting_on_answers(app)
+    }
+
+    pub(super) fn focus(&self, ctx: &mut ViewContext<Self>) {
+        ctx.focus(&self.selector);
+    }
+
     pub(super) fn matches_action(
         &self,
         action_id: &AIAgentActionId,
@@ -281,8 +289,17 @@ impl TuiAskQuestionView {
             }
             TuiOptionSelectorEvent::CustomTextOpened => {
                 self.abort_auto_advance();
-                let _ = self.session.apply(AskUserQuestionAction::OpenOtherInput);
+                let _ = self
+                    .session
+                    .apply(AskUserQuestionAction::EnterCustomAnswerEditing);
                 self.invalidate_layout(ctx);
+            }
+            TuiOptionSelectorEvent::CustomTextClosed => {
+                self.abort_auto_advance();
+                let effect = self
+                    .session
+                    .apply(AskUserQuestionAction::ExitCustomAnswerEditing);
+                self.handle_effect(effect, ctx);
             }
             TuiOptionSelectorEvent::LayoutInvalidated => self.invalidate_layout(ctx),
             TuiOptionSelectorEvent::RetryRequested | TuiOptionSelectorEvent::Dismissed => {}
@@ -337,7 +354,7 @@ impl TuiAskQuestionView {
         match effect {
             AskUserQuestionEffect::Noop => {}
             AskUserQuestionEffect::RefreshCurrent => self.refresh_selection(ctx),
-            AskUserQuestionEffect::FocusOtherInput => {
+            AskUserQuestionEffect::FocusCustomAnswerInput => {
                 self.selector
                     .update(ctx, |selector, ctx| selector.confirm_selected(ctx));
             }

--- a/crates/warp_tui/src/tui_ask_question_view_tests.rs
+++ b/crates/warp_tui/src/tui_ask_question_view_tests.rs
@@ -233,7 +233,7 @@ fn navigation_restores_multi_selection_and_other_text() {
 }
 
 #[test]
-fn opening_other_keeps_selector_and_shared_session_in_sync() {
+fn opening_and_leaving_other_keeps_selector_and_shared_session_in_sync() {
     App::test((), |mut app| async move {
         let (_, view) = add_view(
             &mut app,
@@ -253,6 +253,23 @@ fn opening_other_keeps_selector_and_shared_session_in_sync() {
                     .is_some_and(|draft| draft.is_other_input_active)
             );
             assert_eq!(view.selector.as_ref(ctx).highlighted_question_index(), None);
+        });
+
+        selector.update(&mut app, |selector, ctx| {
+            selector.handle_action(&TuiOptionSelectorAction::MoveUp, ctx);
+        });
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(
+                view.session
+                    .current()
+                    .and_then(|current| current.draft)
+                    .is_none_or(|draft| !draft.is_other_input_active)
+            );
+            assert_eq!(
+                view.selector.as_ref(ctx).highlighted_question_index(),
+                Some(0)
+            );
         });
     });
 }
@@ -275,7 +292,9 @@ fn navigating_away_from_a_cleared_other_editor_removes_the_previous_answer() {
             view.handle_effect(effect, ctx);
             view.show_current_question(ctx);
 
-            let effect = view.session.apply(AskUserQuestionAction::OpenOtherInput);
+            let effect = view
+                .session
+                .apply(AskUserQuestionAction::EnterCustomAnswerEditing);
             view.handle_effect(effect, ctx);
             view.selector.update(ctx, |selector, ctx| {
                 selector.set_active_custom_text_for_test("", ctx);

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -252,7 +252,8 @@ impl TuiPermissionPrompt {
                 ctx.emit(TuiPermissionPromptEvent::RejectRequested);
             }
             TuiOptionSelectorEvent::LayoutInvalidated
-            | TuiOptionSelectorEvent::CustomTextOpened => self.invalidate_layout(ctx),
+            | TuiOptionSelectorEvent::CustomTextOpened
+            | TuiOptionSelectorEvent::CustomTextClosed => self.invalidate_layout(ctx),
             TuiOptionSelectorEvent::Confirmed { .. } | TuiOptionSelectorEvent::RetryRequested => {}
         }
     }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There was a bug w/ the ask question tool where it wouldn't hide the input/take focus when it was running, so you couldn't actually interact with the card. This PR fixes that.

It also fixes an issue I noticed where, if you selected the other option, you couldn't use the arrow keys to get out of the option.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/2e069b607d884560beabc2296fe9c1fc

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode