### PR TITLE
move shell edit flow to hint in top right (and fix some focus issues)

### DIFF
--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -12,6 +12,12 @@
 //! through [`TuiOptionSelector::handle_back`].
 use std::collections::{HashMap, HashSet};
 
+use crate::editor_view::{
+    TuiEditorVerticalDirection, TuiEditorView, TuiEditorViewAction, TuiEditorViewEvent,
+};
+use crate::inline_menu::keep_selected_visible;
+use crate::keybindings::TUI_BINDING_GROUP;
+use crate::tui_builder::TuiUiBuilder;
 use warp::tui_export::{OptionBadge, OptionFooter, OptionRow, OptionSnapshot, OptionSourceStatus};
 use warp_search_core::inline_menu::InlineMenuSelection;
 use warpui_core::elements::MouseStateHandle;
@@ -26,11 +32,6 @@ use warpui_core::{
     AppContext, BlurContext, Entity, EntityId, FocusContext, TuiView, TypedActionView, ViewContext,
     ViewHandle,
 };
-
-use crate::editor_view::{TuiEditorView, TuiEditorViewEvent};
-use crate::inline_menu::keep_selected_visible;
-use crate::keybindings::TUI_BINDING_GROUP;
-use crate::tui_builder::TuiUiBuilder;
 
 /// Maximum option rows visible at once; longer lists scroll.
 pub(crate) const MAX_VISIBLE_OPTION_ROWS: usize = 6;
@@ -157,6 +158,16 @@ enum SelectorItem {
     Retry,
     /// The custom-text footer entry point.
     CustomText,
+}
+
+/// The selector zone that currently owns real WarpUI focus.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SelectorFocusZone {
+    List,
+    Search,
+    CustomText,
+    LeadingEditor,
+    None,
 }
 
 /// Editing phase for the custom-text footer.
@@ -378,18 +389,27 @@ impl TuiOptionSelector {
         self.invalidate_layout(ctx);
     }
 
-    /// Whether the optional search editor currently owns focus.
-    fn search_field_is_focused(&self, ctx: &AppContext) -> bool {
-        self.search_field
+    /// Resolves all selector-owned focus predicates through one exhaustive zone.
+    fn focus_zone(&self, ctx: &AppContext) -> SelectorFocusZone {
+        if self.focused {
+            SelectorFocusZone::List
+        } else if self
+            .search_field
             .as_ref()
             .is_some_and(|field| field.as_ref(ctx).is_focused())
-    }
-
-    /// Whether the host-owned leading editor currently owns focus.
-    fn leading_editor_is_focused(&self, ctx: &AppContext) -> bool {
-        self.leading_editor
+        {
+            SelectorFocusZone::Search
+        } else if self.custom_text.editor.as_ref(ctx).is_focused() {
+            SelectorFocusZone::CustomText
+        } else if self
+            .leading_editor
             .as_ref()
             .is_some_and(|editor| editor.as_ref(ctx).is_focused())
+        {
+            SelectorFocusZone::LeadingEditor
+        } else {
+            SelectorFocusZone::None
+        }
     }
 
     /// The editor that participates in top-of-list focus cycling.
@@ -412,6 +432,7 @@ impl TuiOptionSelector {
 
     /// Resets all transient interaction state for the newly installed page.
     fn reset_interaction_for_page(&mut self, ctx: &mut ViewContext<Self>) {
+        let custom_text_was_focused = matches!(self.focus_zone(ctx), SelectorFocusZone::CustomText);
         self.interaction = SelectorInteractionState::default();
         if let Some(search_field) = self.search_field.as_ref() {
             search_field.update(ctx, |editor, ctx| editor.set_text("", ctx));
@@ -419,6 +440,9 @@ impl TuiOptionSelector {
         self.custom_text.reset_editor(ctx);
         self.select_id(self.page.snapshot.selected_id.clone());
         self.sync_after_items_changed();
+        if custom_text_was_focused {
+            ctx.focus_self();
+        }
     }
 
     /// Replaces the current page and resets its transient interaction state.
@@ -454,9 +478,14 @@ impl TuiOptionSelector {
             .flatten()
     }
 
-    /// Whether keyboard shortcuts for the option list should be active.
-    pub(crate) fn list_is_focused(&self) -> bool {
-        self.focused
+    /// Whether host shortcuts scoped to the bare option list should be active.
+    pub(crate) fn list_is_focused(&self, ctx: &AppContext) -> bool {
+        matches!(self.focus_zone(ctx), SelectorFocusZone::List)
+    }
+
+    /// Whether the host-owned leading editor currently owns focus.
+    pub(crate) fn leading_editor_is_focused(&self, ctx: &AppContext) -> bool {
+        matches!(self.focus_zone(ctx), SelectorFocusZone::LeadingEditor)
     }
 
     /// The highlighted item index, including a trailing custom-text entry.
@@ -470,16 +499,6 @@ impl TuiOptionSelector {
     #[cfg(test)]
     pub(crate) fn search_field_for_test(&self) -> Option<ViewHandle<TuiEditorView>> {
         self.search_field.clone()
-    }
-
-    /// Moves the option highlight upward.
-    pub(crate) fn move_up(&mut self, ctx: &mut ViewContext<Self>) {
-        self.move_selection(false, ctx);
-    }
-
-    /// Moves the option highlight downward.
-    pub(crate) fn move_down(&mut self, ctx: &mut ViewContext<Self>) {
-        self.move_selection(true, ctx);
     }
 
     /// Moves focus and highlight to an item without confirming it.
@@ -539,7 +558,7 @@ impl TuiOptionSelector {
         let target = selected
             .filter(|id| self.page.snapshot.rows.iter().any(|row| &row.id == id))
             .or_else(|| self.page.snapshot.selected_id.clone());
-        if self.search_field_is_focused(ctx) {
+        if matches!(self.focus_zone(ctx), SelectorFocusZone::Search) {
             self.interaction.selection.clear();
         } else {
             self.select_id(target);
@@ -578,7 +597,7 @@ impl TuiOptionSelector {
         if self.custom_text.is_editing() {
             return self.submit_custom_text(ctx);
         }
-        if self.search_field_is_focused(ctx) {
+        if matches!(self.focus_zone(ctx), SelectorFocusZone::Search) {
             if let Some(index) = self.items().iter().position(|item| {
                 matches!(item, SelectorItem::Row(_)) && self.item_is_confirmable(*item)
             }) {
@@ -641,7 +660,9 @@ impl TuiOptionSelector {
     }
     /// Clears focused search text, returning whether it consumed Back.
     fn clear_focused_search(&mut self, ctx: &mut ViewContext<Self>) -> bool {
-        if !self.search_field_is_focused(ctx) || self.interaction.search_query.is_empty() {
+        if !matches!(self.focus_zone(ctx), SelectorFocusZone::Search)
+            || self.interaction.search_query.is_empty()
+        {
             return false;
         }
 
@@ -768,21 +789,37 @@ impl TuiOptionSelector {
 
     /// Moves the selection one step, scrolling to keep it visible.
     fn move_selection(&mut self, forward: bool, ctx: &mut ViewContext<Self>) {
-        if self.custom_text.is_editing() {
-            self.cancel_custom_text_editing(ctx);
-        }
         let items_len = self.items().len();
-        if self.search_field_is_focused(ctx) || self.leading_editor_is_focused(ctx) {
-            if items_len > 0 {
-                let target = if forward { 0 } else { items_len - 1 };
-                self.interaction
-                    .selection
-                    .select(target, items_len, |_| true);
-                ctx.focus_self();
-                self.scroll_to_keep_visible(items_len, target, ctx);
+        match self.focus_zone(ctx) {
+            SelectorFocusZone::CustomText => {
+                self.cancel_custom_text_editing(ctx);
             }
-            ctx.notify();
-            return;
+            SelectorFocusZone::Search => {
+                self.focus_list_boundary(forward, items_len, ctx);
+                return;
+            }
+            SelectorFocusZone::LeadingEditor => {
+                let direction = if forward {
+                    TuiEditorVerticalDirection::Down
+                } else {
+                    TuiEditorVerticalDirection::Up
+                };
+                let moved_within_editor = self.leading_editor.as_ref().is_some_and(|editor| {
+                    if !editor.as_ref(ctx).can_move_vertically(direction, ctx) {
+                        return false;
+                    }
+                    editor.update(ctx, |editor, ctx| {
+                        editor.handle_action(&TuiEditorViewAction::Command(direction.into()), ctx);
+                    });
+                    true
+                });
+                if moved_within_editor {
+                    return;
+                }
+                self.focus_list_boundary(forward, items_len, ctx);
+                return;
+            }
+            SelectorFocusZone::List | SelectorFocusZone::None => {}
         }
         let move_to_editor = self.top_editor().is_some()
             && match (forward, self.interaction.selection.selected_index()) {
@@ -806,6 +843,24 @@ impl TuiOptionSelector {
         }
         if let Some(selected) = self.interaction.selection.selected_index() {
             self.scroll_to_keep_visible(items_len, selected, ctx);
+        }
+        ctx.notify();
+    }
+
+    /// Focuses the first or last item when leaving an editor above the list.
+    fn focus_list_boundary(
+        &mut self,
+        forward: bool,
+        items_len: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if items_len > 0 {
+            let target = if forward { 0 } else { items_len - 1 };
+            self.interaction
+                .selection
+                .select(target, items_len, |_| true);
+            ctx.focus_self();
+            self.scroll_to_keep_visible(items_len, target, ctx);
         }
         ctx.notify();
     }
@@ -1213,10 +1268,13 @@ impl TuiView for TuiOptionSelector {
 
     fn keymap_context(&self, app: &AppContext) -> warpui_core::keymap::Context {
         let mut context = Self::default_keymap_context();
-        if self.focused
-            || self.search_field_is_focused(app)
-            || self.custom_text.editor.as_ref(app).is_focused()
-        {
+        if matches!(
+            self.focus_zone(app),
+            SelectorFocusZone::List
+                | SelectorFocusZone::Search
+                | SelectorFocusZone::CustomText
+                | SelectorFocusZone::LeadingEditor
+        ) {
             context.set.insert(SELECTOR_NAVIGATION_ACTIVE);
         }
         context
@@ -1255,7 +1313,7 @@ impl TuiView for TuiOptionSelector {
         content.add_child(self.render_list(&builder));
         SelectorInputElement {
             child: content.finish(),
-            list_focused: self.focused,
+            list_focused: matches!(self.focus_zone(app), SelectorFocusZone::List),
             searchable: self.page.searchable,
             row_shortcuts: self.page.row_shortcuts.values().copied().collect(),
         }

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -12,12 +12,6 @@
 //! through [`TuiOptionSelector::handle_back`].
 use std::collections::{HashMap, HashSet};
 
-use crate::editor_view::{
-    TuiEditorVerticalDirection, TuiEditorView, TuiEditorViewAction, TuiEditorViewEvent,
-};
-use crate::inline_menu::keep_selected_visible;
-use crate::keybindings::TUI_BINDING_GROUP;
-use crate::tui_builder::TuiUiBuilder;
 use warp::tui_export::{OptionBadge, OptionFooter, OptionRow, OptionSnapshot, OptionSourceStatus};
 use warp_search_core::inline_menu::InlineMenuSelection;
 use warpui_core::elements::MouseStateHandle;
@@ -32,6 +26,13 @@ use warpui_core::{
     AppContext, BlurContext, Entity, EntityId, FocusContext, TuiView, TypedActionView, ViewContext,
     ViewHandle,
 };
+
+use crate::editor_view::{
+    TuiEditorVerticalDirection, TuiEditorView, TuiEditorViewAction, TuiEditorViewEvent,
+};
+use crate::inline_menu::keep_selected_visible;
+use crate::keybindings::TUI_BINDING_GROUP;
+use crate::tui_builder::TuiUiBuilder;
 
 /// Maximum option rows visible at once; longer lists scroll.
 pub(crate) const MAX_VISIBLE_OPTION_ROWS: usize = 6;

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -454,6 +454,11 @@ impl TuiOptionSelector {
             .flatten()
     }
 
+    /// Whether keyboard shortcuts for the option list should be active.
+    pub(crate) fn list_is_focused(&self) -> bool {
+        self.focused
+    }
+
     /// The highlighted item index, including a trailing custom-text entry.
     #[cfg(test)]
     pub(crate) fn highlighted_index(&self) -> Option<usize> {

--- a/crates/warp_tui/src/option_selector_tests.rs
+++ b/crates/warp_tui/src/option_selector_tests.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
+use string_offset::CharOffset;
 
 use warp::tui_export::{
     Appearance, OptionBadge, OptionFooter, OptionRow, OptionSnapshot, OptionSourceStatus,
@@ -14,8 +15,8 @@ use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext, TuiView as _, TypedActionView as _, ViewHandle};
 
 use super::{
-    OptionSelectorHeader, OptionSelectorPage, SELECTOR_NAVIGATION_ACTIVE, SelectorItem,
-    TuiOptionSelector, TuiOptionSelectorAction, TuiOptionSelectorEvent,
+    OptionSelectorHeader, OptionSelectorPage, SELECTOR_NAVIGATION_ACTIVE, SelectorFocusZone,
+    SelectorItem, TuiOptionSelector, TuiOptionSelectorAction, TuiOptionSelectorEvent,
 };
 use crate::editor_element::TuiEditorAction;
 use crate::editor_interaction::TuiEditorCommand;
@@ -32,6 +33,120 @@ fn row(id: &str) -> OptionRow {
         badge: None,
         disabled_reason: None,
     }
+}
+
+#[test]
+fn focus_zone_tracks_each_selector_surface() {
+    App::test((), |mut app| async move {
+        let (selector, _) = add_selector(&mut app);
+        assert_eq!(
+            selector.read(&app, |selector, ctx| selector.focus_zone(ctx)),
+            SelectorFocusZone::None
+        );
+
+        set_page(&mut app, &selector, snapshot(&["a"], Some("a")));
+        selector.update(&mut app, |_, ctx| ctx.focus_self());
+        assert_eq!(
+            selector.read(&app, |selector, ctx| selector.focus_zone(ctx)),
+            SelectorFocusZone::List
+        );
+
+        set_searchable_page(&mut app, &selector, snapshot(&["a"], Some("a")));
+        act(&mut app, &selector, TuiOptionSelectorAction::MoveUp);
+        assert_eq!(
+            selector.read(&app, |selector, ctx| selector.focus_zone(ctx)),
+            SelectorFocusZone::Search
+        );
+        act(&mut app, &selector, TuiOptionSelectorAction::MoveDown);
+
+        let mut with_footer = snapshot(&["a"], Some("a"));
+        with_footer.footer = Some(OptionFooter::CustomText {
+            label: "Other".to_string(),
+        });
+        set_page(&mut app, &selector, with_footer);
+        act(&mut app, &selector, TuiOptionSelectorAction::SelectItem(1));
+        assert_eq!(
+            selector.read(&app, |selector, ctx| selector.focus_zone(ctx)),
+            SelectorFocusZone::CustomText
+        );
+        set_page(&mut app, &selector, snapshot(&["next"], Some("next")));
+        assert_eq!(
+            selector.read(&app, |selector, ctx| selector.focus_zone(ctx)),
+            SelectorFocusZone::List
+        );
+
+        let leading_editor = app.update(|ctx| {
+            ctx.add_typed_action_tui_view(selector.window_id(ctx), |ctx| {
+                TuiEditorView::single_line(ctx)
+            })
+        });
+        selector.update(&mut app, |selector, ctx| {
+            selector.set_leading_editor(leading_editor.clone(), ctx);
+            ctx.focus(&leading_editor);
+        });
+        assert_eq!(
+            selector.read(&app, |selector, ctx| selector.focus_zone(ctx)),
+            SelectorFocusZone::LeadingEditor
+        );
+    });
+}
+
+#[test]
+fn leading_editor_arrows_move_within_multiline_before_list_handoff() {
+    App::test((), |mut app| async move {
+        let (selector, _) = add_selector(&mut app);
+        let leading_editor = app.update(|ctx| {
+            ctx.add_typed_action_tui_view(selector.window_id(ctx), |ctx| {
+                TuiEditorView::multiline(4, ctx)
+            })
+        });
+        leading_editor.update(&mut app, |editor, ctx| {
+            editor.set_text("first\nsecond\nthird", ctx);
+        });
+        selector.update(&mut app, |selector, ctx| {
+            selector.set_leading_editor(leading_editor.clone(), ctx);
+            selector.set_page(page(snapshot(&["a", "b"], Some("a")), false), ctx);
+            ctx.focus(&leading_editor);
+        });
+        leading_editor.update(&mut app, |editor, ctx| {
+            editor.handle_action(
+                &TuiEditorViewAction::Editor(TuiEditorAction::SelectionStartAt {
+                    offset: CharOffset::from(1),
+                }),
+                ctx,
+            );
+        });
+        render_lines(&app, &selector, 60);
+
+        act(&mut app, &selector, TuiOptionSelectorAction::MoveDown);
+        assert!(leading_editor.read(&app, |editor, _| editor.is_focused()));
+        act(&mut app, &selector, TuiOptionSelectorAction::MoveDown);
+        assert!(leading_editor.read(&app, |editor, _| editor.is_focused()));
+        act(&mut app, &selector, TuiOptionSelectorAction::MoveDown);
+        assert_eq!(
+            selector.read(&app, |selector, ctx| selector.focus_zone(ctx)),
+            SelectorFocusZone::List
+        );
+        assert_eq!(
+            selector.read(&app, |selector, _| selector.highlighted_index()),
+            Some(0)
+        );
+
+        leading_editor.update(&mut app, |editor, ctx| {
+            editor.handle_action(
+                &TuiEditorViewAction::Editor(TuiEditorAction::SelectionStartAt {
+                    offset: 1.into(),
+                }),
+                ctx,
+            );
+            ctx.focus_self();
+        });
+        act(&mut app, &selector, TuiOptionSelectorAction::MoveUp);
+        assert_eq!(
+            selector.read(&app, |selector, _| selector.highlighted_index()),
+            Some(1)
+        );
+    });
 }
 
 /// Builds a disabled row carrying `reason`.

--- a/crates/warp_tui/src/option_selector_tests.rs
+++ b/crates/warp_tui/src/option_selector_tests.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
-use string_offset::CharOffset;
 
+use string_offset::CharOffset;
 use warp::tui_export::{
     Appearance, OptionBadge, OptionFooter, OptionRow, OptionSnapshot, OptionSourceStatus,
 };

--- a/crates/warp_tui/src/tui_ask_question_view_tests.rs
+++ b/crates/warp_tui/src/tui_ask_question_view_tests.rs
@@ -1,14 +1,16 @@
 use warp::tui_export::{
-    AIAgentActionId, AIConversationId, Appearance, AskUserQuestionAction,
-    AskUserQuestionAnswerItem, AskUserQuestionItem, AskUserQuestionOption, AskUserQuestionType,
+    AIAgentAction, AIAgentActionId, AIAgentActionType, AIConversationId, Appearance,
+    AskUserQuestionAction, AskUserQuestionAnswerItem, AskUserQuestionItem, AskUserQuestionOption,
+    AskUserQuestionType, TaskId, queue_tui_permission_action,
 };
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, WindowInvalidation};
 use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::keymap::Keystroke;
 use warpui_core::presenter::tui::TuiPresenter;
-use warpui_core::{App, TypedActionView as _, ViewHandle};
+use warpui_core::{App, TuiView as _, TypedActionView as _, ViewHandle};
 
-use super::TuiAskQuestionView;
+use super::{TuiAskQuestionView, TuiAskQuestionViewAction};
 use crate::option_selector::TuiOptionSelectorAction;
 use crate::test_fixtures::add_test_action_model;
 
@@ -77,6 +79,62 @@ fn render_active_lines(app: &mut App, view: &ViewHandle<TuiAskQuestionView>) -> 
             .filter(|line| !line.is_empty())
             .collect()
     })
+}
+
+fn queue_question_action(app: &mut App, view: &ViewHandle<TuiAskQuestionView>) {
+    let (action_model, conversation_id, action) = app.read(|ctx| {
+        let view = view.as_ref(ctx);
+        (
+            view.action_model.clone(),
+            view.conversation_id,
+            AIAgentAction {
+                id: view.action_id.clone(),
+                task_id: TaskId::new("task".to_owned()),
+                action: AIAgentActionType::AskUserQuestion {
+                    questions: view.source_questions.clone(),
+                },
+                requires_result: true,
+            },
+        )
+    });
+    action_model.update(app, |model, ctx| {
+        queue_tui_permission_action(model, action, conversation_id, ctx);
+    });
+}
+
+fn present_active_view(app: &mut App, view: &ViewHandle<TuiAskQuestionView>) {
+    let mut presenter = TuiPresenter::new();
+    app.update(|ctx| {
+        let selector = view.as_ref(ctx).selector.clone();
+        let mut invalidation = WindowInvalidation::default();
+        invalidation.updated.insert(view.id());
+        invalidation.updated.insert(selector.id());
+        invalidation
+            .updated
+            .extend(selector.as_ref(ctx).child_view_ids(ctx));
+        presenter.invalidate(&invalidation, ctx, view.window_id(ctx));
+        presenter.present(ctx, view, TuiRect::new(0, 0, 80, 20));
+    });
+}
+
+fn dispatch_focused_key(app: &mut App, view: &ViewHandle<TuiAskQuestionView>, key: &str) -> bool {
+    let (window_id, responder_chain) = app.read(|ctx| {
+        let window_id = view.window_id(ctx);
+        let focused = ctx
+            .focused_view_id(window_id)
+            .expect("question interaction has a focused view");
+        let responder_chain = ctx.view_ancestors(window_id, focused);
+        assert!(responder_chain.contains(&view.id()));
+        assert!(responder_chain.contains(&view.as_ref(ctx).selector.id()));
+        (window_id, responder_chain)
+    });
+    app.dispatch_keystroke(
+        window_id,
+        &responder_chain,
+        &Keystroke::parse(key).expect("valid keystroke"),
+        false,
+    )
+    .expect("keystroke dispatch succeeds")
 }
 
 #[test]
@@ -271,6 +329,46 @@ fn opening_and_leaving_other_keeps_selector_and_shared_session_in_sync() {
                 Some(0)
             );
         });
+    });
+}
+
+#[test]
+fn submitting_other_restores_question_navigation_focus() {
+    App::test((), |mut app| async move {
+        app.update(super::init);
+        let (_, view) = add_view(
+            &mut app,
+            vec![
+                question("q1", "Target?", true, true, &["Alpha"]),
+                question("q2", "Shell?", false, true, &["Gamma"]),
+            ],
+        );
+        queue_question_action(&mut app, &view);
+        present_active_view(&mut app, &view);
+
+        let selector = app.read(|ctx| view.as_ref(ctx).selector.clone());
+        selector.update(&mut app, |selector, ctx| {
+            selector.handle_action(&TuiOptionSelectorAction::SelectItem(1), ctx);
+            selector.set_active_custom_text_for_test("custom answer", ctx);
+        });
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiAskQuestionViewAction::Enter, ctx);
+            view.abort_auto_advance();
+            let effect = view.session.apply(AskUserQuestionAction::Confirm);
+            view.handle_effect(effect, ctx);
+        });
+        present_active_view(&mut app, &view);
+
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert_eq!(view.session.current_question_index(), 1);
+            assert!(view.selector.as_ref(ctx).list_is_focused(ctx));
+        });
+        assert!(dispatch_focused_key(&mut app, &view, "left"));
+        assert_eq!(
+            app.read(|ctx| view.as_ref(ctx).session.current_question_index()),
+            0
+        );
     });
 }
 

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -1,7 +1,5 @@
 //! Reusable interaction for TUI tool-call permission requests.
 
-use std::collections::HashMap;
-
 use warp::tui_export::{
     AIAgentActionId, BlocklistAIActionEvent, BlocklistAIActionModel, OptionFooter, OptionRow,
     OptionSnapshot, OptionSourceStatus,
@@ -24,13 +22,14 @@ use crate::option_selector::{
 use crate::tui_builder::TuiUiBuilder;
 
 const PERMISSION_PROMPT_ACTIVE: &str = "TuiPermissionPromptActive";
+const PERMISSION_PROMPT_EDITABLE: &str = "TuiPermissionPromptEditable";
 const YES_ID: &str = "yes";
 const NO_ID: &str = "no";
-const EDIT_ID: &str = "edit";
 
 /// Registers controls used while a permission prompt owns focus.
 pub(crate) fn init(app: &mut AppContext) {
     let predicate = id!(TuiPermissionPrompt::ui_name()) & id!(PERMISSION_PROMPT_ACTIVE);
+    let editable_predicate = predicate.clone() & id!(PERMISSION_PROMPT_EDITABLE);
     app.register_fixed_bindings([FixedBinding::new(
         "escape",
         TuiPermissionPromptAction::CancelOrBack,
@@ -64,12 +63,20 @@ pub(crate) fn init(app: &mut AppContext) {
         .with_key_binding("down"),
         EditableBinding::new(
             "tui:permission-prompt:edit",
-            "Edit or save the requested action",
+            "Edit the requested action",
             TuiPermissionPromptAction::EditBody,
         )
-        .with_context_predicate(predicate)
+        .with_context_predicate(editable_predicate.clone())
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("ctrl-e"),
+        EditableBinding::new(
+            "tui:permission-prompt:edit",
+            "Edit the requested action",
+            TuiPermissionPromptAction::EditBody,
+        )
+        .with_context_predicate(editable_predicate)
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("e"),
     ]);
     app.register_tui_binding_validator::<TuiPermissionPrompt>(is_tui_owned_binding);
 }
@@ -124,7 +131,7 @@ impl TuiPermissionPrompt {
             if let Some(body_editor) = body_editor.as_ref() {
                 selector.set_leading_editor(body_editor.clone(), ctx);
             }
-            let mut rows = vec![
+            let rows = vec![
                 OptionRow {
                     id: YES_ID.to_owned(),
                     label: "yes".to_owned(),
@@ -140,15 +147,6 @@ impl TuiPermissionPrompt {
                     disabled_reason: None,
                 },
             ];
-            if body_editor.is_some() {
-                rows.push(OptionRow {
-                    id: EDIT_ID.to_owned(),
-                    label: "edit command".to_owned(),
-                    harness: None,
-                    badge: None,
-                    disabled_reason: None,
-                });
-            }
             selector.set_page(
                 OptionSelectorPage {
                     header: None,
@@ -156,16 +154,12 @@ impl TuiPermissionPrompt {
                         rows,
                         selected_id: Some(YES_ID.to_owned()),
                         status: OptionSourceStatus::Ready,
-                        footer: body_editor.is_none().then(|| OptionFooter::CustomText {
+                        footer: Some(OptionFooter::CustomText {
                             label: "Other".to_owned(),
                         }),
                     },
                     searchable: false,
-                    row_shortcuts: if body_editor.is_some() {
-                        HashMap::from([(EDIT_ID.to_owned(), 'e')])
-                    } else {
-                        Default::default()
-                    },
+                    row_shortcuts: Default::default(),
                 },
                 ctx,
             );
@@ -239,10 +233,6 @@ impl TuiPermissionPrompt {
             TuiOptionSelectorEvent::Confirmed { id } if id == NO_ID => {
                 ctx.emit(TuiPermissionPromptEvent::RejectRequested);
             }
-            TuiOptionSelectorEvent::Confirmed { id } if id == EDIT_ID => {
-                self.selector
-                    .update(ctx, |selector, ctx| selector.focus_leading_editor(ctx));
-            }
             TuiOptionSelectorEvent::CustomTextSubmitted { value } => {
                 ctx.emit(TuiPermissionPromptEvent::ReplacementGuidanceSubmitted(
                     value.clone(),
@@ -292,19 +282,34 @@ pub(crate) fn render_permission_card(
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
-    let header = TuiContainer::new(
-        TuiText::from_spans([
-            ("■ ".to_owned(), builder.attention_glyph_style()),
-            (
-                title.into(),
-                builder.primary_text_style().add_modifier(Modifier::BOLD),
-            ),
-        ])
-        .finish(),
-    )
-    .with_background(builder.permission_header_background())
-    .with_padding_x(1)
+    let title = TuiText::from_spans([
+        ("■ ".to_owned(), builder.attention_glyph_style()),
+        (
+            title.into(),
+            builder.primary_text_style().add_modifier(Modifier::BOLD),
+        ),
+    ])
+    .truncate()
     .finish();
+    let header_content = if prompt.as_ref(app).body_editor.is_some() {
+        TuiFlex::row()
+            .flex_child(title)
+            .child(
+                TuiText::from_spans([
+                    ("e".to_owned(), builder.primary_text_style()),
+                    (" to edit command".to_owned(), builder.muted_text_style()),
+                ])
+                .truncate()
+                .finish(),
+            )
+            .finish()
+    } else {
+        title
+    };
+    let header = TuiContainer::new(header_content)
+        .with_background(builder.permission_header_background())
+        .with_padding_x(1)
+        .finish();
     let mut body_content = TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
     if let Some(body) = body {
         body_content.add_child(body);
@@ -349,6 +354,9 @@ impl TuiView for TuiPermissionPrompt {
             .is_some_and(|editor| editor.as_ref(app).is_focused());
         if self.is_active(app) && !body_editor_focused {
             context.set.insert(PERMISSION_PROMPT_ACTIVE);
+            if self.body_editor.is_some() && self.selector.as_ref(app).list_is_focused() {
+                context.set.insert(PERMISSION_PROMPT_EDITABLE);
+            }
         }
         context
     }

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -46,22 +46,6 @@ pub(crate) fn init(app: &mut AppContext) {
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("enter"),
         EditableBinding::new(
-            "tui:permission-prompt:previous",
-            "Select the previous permission response",
-            TuiPermissionPromptAction::MoveUp,
-        )
-        .with_context_predicate(predicate.clone())
-        .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("up"),
-        EditableBinding::new(
-            "tui:permission-prompt:next",
-            "Select the next permission response",
-            TuiPermissionPromptAction::MoveDown,
-        )
-        .with_context_predicate(predicate.clone())
-        .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("down"),
-        EditableBinding::new(
             "tui:permission-prompt:edit",
             "Edit the requested action",
             TuiPermissionPromptAction::EditBody,
@@ -86,10 +70,6 @@ pub(crate) fn init(app: &mut AppContext) {
 pub(crate) enum TuiPermissionPromptAction {
     /// Confirms the highlighted response.
     Confirm,
-    /// Moves to the previous response, cycling through the optional body editor.
-    MoveUp,
-    /// Moves to the next response, cycling through the optional body editor.
-    MoveDown,
     /// Focuses the optional editable action body.
     EditBody,
     /// Unwinds Other editing, otherwise rejects the request.
@@ -196,6 +176,11 @@ impl TuiPermissionPrompt {
             .as_ref(app)
             .get_action_status(&self.action_id)
             .is_some_and(|status| status.is_blocked())
+    }
+
+    /// Whether the optional action body currently owns focus.
+    pub(crate) fn body_editor_is_focused(&self, app: &AppContext) -> bool {
+        self.selector.as_ref(app).leading_editor_is_focused(app)
     }
 
     /// Focuses the option selector.
@@ -348,13 +333,10 @@ impl TuiView for TuiPermissionPrompt {
 
     fn keymap_context(&self, app: &AppContext) -> warpui_core::keymap::Context {
         let mut context = Self::default_keymap_context();
-        let body_editor_focused = self
-            .body_editor
-            .as_ref()
-            .is_some_and(|editor| editor.as_ref(app).is_focused());
+        let body_editor_focused = self.body_editor_is_focused(app);
         if self.is_active(app) && !body_editor_focused {
             context.set.insert(PERMISSION_PROMPT_ACTIVE);
-            if self.body_editor.is_some() && self.selector.as_ref(app).list_is_focused() {
+            if self.body_editor.is_some() && self.selector.as_ref(app).list_is_focused(app) {
                 context.set.insert(PERMISSION_PROMPT_EDITABLE);
             }
         }
@@ -378,14 +360,6 @@ impl TypedActionView for TuiPermissionPrompt {
                 self.selector.update(ctx, |selector, ctx| {
                     selector.confirm_selected(ctx);
                 });
-            }
-            TuiPermissionPromptAction::MoveUp => {
-                self.selector
-                    .update(ctx, |selector, ctx| selector.move_up(ctx));
-            }
-            TuiPermissionPromptAction::MoveDown => {
-                self.selector
-                    .update(ctx, |selector, ctx| selector.move_down(ctx));
             }
             TuiPermissionPromptAction::EditBody => {
                 self.selector

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -14,7 +14,7 @@ use warpui_core::{TuiView as _, TypedActionView as _, ViewHandle};
 
 use super::{
     PERMISSION_PROMPT_ACTIVE, PERMISSION_PROMPT_EDITABLE, TuiPermissionPrompt,
-    TuiPermissionPromptAction, TuiPermissionPromptEvent, render_permission_card,
+    TuiPermissionPromptEvent, render_permission_card,
 };
 use crate::editor_view::TuiEditorView;
 use crate::option_selector::{TuiOptionSelectorAction, TuiOptionSelectorEvent};
@@ -41,6 +41,44 @@ fn add_prompt(app: &mut App, body_editable: bool) -> ViewHandle<TuiPermissionPro
             )
         })
     })
+}
+
+fn dispatch_focused_key(
+    app: &mut App,
+    prompt: &ViewHandle<TuiPermissionPrompt>,
+    key: &str,
+) -> bool {
+    present_prompt(app, prompt);
+    let (window_id, responder_chain) = app.read(|ctx| {
+        let window_id = prompt.window_id(ctx);
+        let focused = ctx
+            .focused_view_id(window_id)
+            .expect("permission interaction has a focused view");
+        let responder_chain = ctx.view_ancestors(window_id, focused);
+        assert!(responder_chain.contains(&prompt.id()));
+        assert!(responder_chain.contains(&prompt.as_ref(ctx).selector.id()));
+        (window_id, responder_chain)
+    });
+    app.dispatch_keystroke(
+        window_id,
+        &responder_chain,
+        &Keystroke::parse(key).expect("valid keystroke"),
+        false,
+    )
+    .expect("keystroke dispatch succeeds")
+}
+
+fn present_prompt(app: &mut App, prompt: &ViewHandle<TuiPermissionPrompt>) {
+    let mut presenter = TuiPresenter::new();
+    app.update(|ctx| {
+        let mut invalidation = WindowInvalidation::default();
+        invalidation.updated.insert(prompt.id());
+        invalidation
+            .updated
+            .extend(prompt.as_ref(ctx).child_view_ids(ctx));
+        presenter.invalidate(&invalidation, ctx, prompt.window_id(ctx));
+        presenter.present(ctx, prompt, TuiRect::new(0, 0, 80, 12));
+    });
 }
 
 fn render_lines(app: &mut App, prompt: &ViewHandle<TuiPermissionPrompt>) -> Vec<String> {
@@ -100,6 +138,7 @@ fn permission_prompt_defaults_to_yes_and_renders_other() {
 #[test]
 fn leading_editor_participates_in_selector_focus_cycle() {
     App::test((), |mut app| async move {
+        app.update(crate::option_selector::init);
         let prompt = add_prompt(&mut app, true);
         let (action_model, action) = app.read(|ctx| {
             let prompt = prompt.as_ref(ctx);
@@ -108,10 +147,9 @@ fn leading_editor_participates_in_selector_focus_cycle() {
         action_model.update(&mut app, |model, ctx| {
             queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
         });
+        render_lines(&mut app, &prompt);
 
-        prompt.update(&mut app, |prompt, ctx| {
-            prompt.handle_action(&TuiPermissionPromptAction::MoveUp, ctx);
-        });
+        assert!(dispatch_focused_key(&mut app, &prompt, "up"));
 
         app.read(|ctx| {
             let prompt = prompt.as_ref(ctx);
@@ -132,9 +170,7 @@ fn leading_editor_participates_in_selector_focus_cycle() {
             );
         });
 
-        prompt.update(&mut app, |prompt, ctx| {
-            prompt.handle_action(&TuiPermissionPromptAction::MoveUp, ctx);
-        });
+        assert!(dispatch_focused_key(&mut app, &prompt, "up"));
         app.read(|ctx| {
             assert_eq!(
                 prompt.as_ref(ctx).selector.as_ref(ctx).highlighted_index(),
@@ -160,17 +196,8 @@ fn editable_prompt_renders_other_and_e_focuses_the_body_editor() {
         action_model.update(&mut app, |model, ctx| {
             queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
         });
-        let (window_id, selector) =
-            app.read(|ctx| (prompt.window_id(ctx), prompt.as_ref(ctx).selector.clone()));
-        let handled = app
-            .dispatch_keystroke(
-                window_id,
-                &[prompt.id(), selector.id()],
-                &Keystroke::parse("e").expect("valid e keystroke"),
-                false,
-            )
-            .expect("e dispatch succeeds");
-        assert!(handled);
+        let selector = app.read(|ctx| prompt.as_ref(ctx).selector.clone());
+        assert!(dispatch_focused_key(&mut app, &prompt, "e"));
         assert!(app.read(|ctx| {
             prompt
                 .as_ref(ctx)
@@ -204,15 +231,7 @@ fn editable_prompt_renders_other_and_e_focuses_the_body_editor() {
                     .is_focused()
             );
         });
-        let handled = app
-            .dispatch_keystroke(
-                window_id,
-                &[prompt.id(), selector.id()],
-                &Keystroke::parse("e").expect("valid e keystroke"),
-                false,
-            )
-            .expect("e dispatch succeeds");
-        assert!(!handled);
+        assert!(!dispatch_focused_key(&mut app, &prompt, "e"));
         assert!(app.read(|ctx| {
             selector.as_ref(ctx).active_custom_text(ctx).is_some()
                 && !prompt

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -8,12 +8,13 @@ use warp::tui_export::{
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, App, WindowInvalidation};
 use warpui_core::elements::tui::{TuiBufferExt, TuiElement, TuiRect, TuiText};
+use warpui_core::keymap::Keystroke;
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{TuiView as _, TypedActionView as _, ViewHandle};
 
 use super::{
-    PERMISSION_PROMPT_ACTIVE, TuiPermissionPrompt, TuiPermissionPromptAction,
-    TuiPermissionPromptEvent, render_permission_card,
+    PERMISSION_PROMPT_ACTIVE, PERMISSION_PROMPT_EDITABLE, TuiPermissionPrompt,
+    TuiPermissionPromptAction, TuiPermissionPromptEvent, render_permission_card,
 };
 use crate::editor_view::TuiEditorView;
 use crate::option_selector::{TuiOptionSelectorAction, TuiOptionSelectorEvent};
@@ -144,12 +145,13 @@ fn leading_editor_participates_in_selector_focus_cycle() {
 }
 
 #[test]
-fn editable_prompt_uses_edit_option_for_shortcut_and_click() {
+fn editable_prompt_renders_other_and_e_focuses_the_body_editor() {
     App::test((), |mut app| async move {
+        app.update(super::init);
         let prompt = add_prompt(&mut app, true);
         let lines = render_lines(&mut app, &prompt);
-        assert!(lines.iter().any(|line| line == "(e) edit command"));
-        assert!(lines.iter().all(|line| !line.contains("Other")));
+        assert!(lines.iter().any(|line| line.ends_with("e to edit command")));
+        assert!(lines.iter().any(|line| line == "(3) Other"));
 
         let (action_model, action) = app.read(|ctx| {
             let prompt = prompt.as_ref(ctx);
@@ -158,11 +160,17 @@ fn editable_prompt_uses_edit_option_for_shortcut_and_click() {
         action_model.update(&mut app, |model, ctx| {
             queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
         });
-
-        let selector = prompt.read(&app, |prompt, _| prompt.selector.clone());
-        selector.update(&mut app, |selector, ctx| {
-            selector.handle_action(&TuiOptionSelectorAction::SelectShortcut('e'), ctx);
-        });
+        let (window_id, selector) =
+            app.read(|ctx| (prompt.window_id(ctx), prompt.as_ref(ctx).selector.clone()));
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &[prompt.id(), selector.id()],
+                &Keystroke::parse("e").expect("valid e keystroke"),
+                false,
+            )
+            .expect("e dispatch succeeds");
+        assert!(handled);
         assert!(app.read(|ctx| {
             prompt
                 .as_ref(ctx)
@@ -177,14 +185,43 @@ fn editable_prompt_uses_edit_option_for_shortcut_and_click() {
         selector.update(&mut app, |selector, ctx| {
             selector.handle_action(&TuiOptionSelectorAction::SelectItem(2), ctx);
         });
+        app.read(|ctx| {
+            assert!(selector.as_ref(ctx).active_custom_text(ctx).is_some());
+            assert!(
+                !prompt
+                    .as_ref(ctx)
+                    .keymap_context(ctx)
+                    .set
+                    .contains(PERMISSION_PROMPT_EDITABLE)
+            );
+            assert!(
+                !prompt
+                    .as_ref(ctx)
+                    .body_editor
+                    .as_ref()
+                    .expect("editable prompt has a body editor")
+                    .as_ref(ctx)
+                    .is_focused()
+            );
+        });
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &[prompt.id(), selector.id()],
+                &Keystroke::parse("e").expect("valid e keystroke"),
+                false,
+            )
+            .expect("e dispatch succeeds");
+        assert!(!handled);
         assert!(app.read(|ctx| {
-            prompt
-                .as_ref(ctx)
-                .body_editor
-                .as_ref()
-                .expect("editable prompt has a body editor")
-                .as_ref(ctx)
-                .is_focused()
+            selector.as_ref(ctx).active_custom_text(ctx).is_some()
+                && !prompt
+                    .as_ref(ctx)
+                    .body_editor
+                    .as_ref()
+                    .expect("editable prompt has a body editor")
+                    .as_ref(ctx)
+                    .is_focused()
         }));
     });
 }

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -25,9 +25,7 @@ use warpui_core::{
 };
 
 use crate::agent_block_sections::render_fallback_tool_call_section;
-use crate::editor_view::{
-    TuiEditorVerticalDirection, TuiEditorView, TuiEditorViewAction, TuiEditorViewEvent,
-};
+use crate::editor_view::{TuiEditorView, TuiEditorViewEvent};
 use crate::keybindings::{TUI_BINDING_GROUP, is_tui_owned_binding};
 use crate::terminal_block::TerminalBlockElement;
 use crate::terminal_use::user_controls_running_command;
@@ -37,8 +35,7 @@ use crate::tool_call_labels::{
 use crate::tui_builder::TuiUiBuilder;
 use crate::tui_cli_subagent_view::{TuiCLISubagentView, TuiCLISubagentViewEvent};
 use crate::tui_permission_prompt::{
-    TuiPermissionPrompt, TuiPermissionPromptAction, TuiPermissionPromptEvent,
-    render_permission_card,
+    TuiPermissionPrompt, TuiPermissionPromptEvent, render_permission_card,
 };
 const COMMAND_AUTO_EXPAND_DELAY: Duration = Duration::from_secs(3);
 const SHELL_COMMAND_EDITING: &str = "TuiShellCommandEditing";
@@ -73,25 +70,9 @@ pub(crate) fn init(app: &mut AppContext) {
             "Save the edited shell command",
             TuiShellCommandViewAction::SaveCommandEdit,
         )
-        .with_context_predicate(predicate.clone())
-        .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("numpadenter"),
-        EditableBinding::new(
-            "tui:shell-permission:previous",
-            "Move up in the shell command or permission responses",
-            TuiShellCommandViewAction::NavigateUp,
-        )
-        .with_context_predicate(predicate.clone())
-        .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("up"),
-        EditableBinding::new(
-            "tui:shell-permission:next",
-            "Move down in the shell command or permission responses",
-            TuiShellCommandViewAction::NavigateDown,
-        )
         .with_context_predicate(predicate)
         .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("down"),
+        .with_key_binding("numpadenter"),
     ]);
     app.register_tui_binding_validator::<TuiShellCommandView>(is_tui_owned_binding);
 }
@@ -156,8 +137,6 @@ pub(super) enum TuiShellCommandViewEvent {
 #[derive(Clone, Debug)]
 pub(super) enum TuiShellCommandViewAction {
     CancelPermission,
-    NavigateUp,
-    NavigateDown,
     SaveCommandEdit,
     ToggleExpanded,
 }
@@ -265,31 +244,6 @@ impl TuiShellCommandView {
         }
         self.permission_prompt
             .update(ctx, |prompt, ctx| prompt.restore_options_focus(ctx));
-        self.invalidate_layout(ctx);
-    }
-
-    fn navigate_command_editor(
-        &self,
-        direction: TuiEditorVerticalDirection,
-        prompt_action: TuiPermissionPromptAction,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        if !self.command_editor.as_ref(ctx).is_focused() {
-            return;
-        }
-        if self
-            .command_editor
-            .as_ref(ctx)
-            .can_move_vertically(direction, ctx)
-        {
-            self.command_editor.update(ctx, |editor, ctx| {
-                editor.handle_action(&TuiEditorViewAction::Command(direction.into()), ctx);
-            });
-        } else {
-            self.permission_prompt.update(ctx, |prompt, ctx| {
-                prompt.handle_action(&prompt_action, ctx);
-            });
-        }
         self.invalidate_layout(ctx);
     }
 
@@ -461,7 +415,12 @@ impl TuiView for TuiShellCommandView {
             .as_ref(app)
             .get_action_status(&self.action.id)
             .is_some_and(|status| status.is_blocked());
-        if blocked && self.command_editor.as_ref(app).is_focused() {
+        if blocked
+            && self
+                .permission_prompt
+                .as_ref(app)
+                .body_editor_is_focused(app)
+        {
             context.set.insert(SHELL_COMMAND_EDITING);
         }
         context
@@ -532,16 +491,6 @@ impl TypedActionView for TuiShellCommandView {
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
             TuiShellCommandViewAction::CancelPermission => self.reject(ctx),
-            TuiShellCommandViewAction::NavigateUp => self.navigate_command_editor(
-                TuiEditorVerticalDirection::Up,
-                TuiPermissionPromptAction::MoveUp,
-                ctx,
-            ),
-            TuiShellCommandViewAction::NavigateDown => self.navigate_command_editor(
-                TuiEditorVerticalDirection::Down,
-                TuiPermissionPromptAction::MoveDown,
-                ctx,
-            ),
             TuiShellCommandViewAction::SaveCommandEdit => self.save_command_edit(ctx),
             TuiShellCommandViewAction::ToggleExpanded => {
                 if self.user_controls_command() {

--- a/crates/warp_tui/src/tui_shell_command_view_tests.rs
+++ b/crates/warp_tui/src/tui_shell_command_view_tests.rs
@@ -138,33 +138,18 @@ fn finishing_command_editing_selects_yes_without_executing() {
         });
 
         prompt.update(&mut app, |prompt, ctx| {
-            prompt.handle_action(
-                &crate::tui_permission_prompt::TuiPermissionPromptAction::MoveUp,
-                ctx,
-            );
+            prompt.handle_action(&TuiPermissionPromptAction::EditBody, ctx);
         });
         app.read(|ctx| {
             let view = view.as_ref(ctx);
             assert!(view.command_editor.as_ref(ctx).is_focused());
-            assert_eq!(
-                view.permission_prompt.as_ref(ctx).highlighted_index(ctx),
-                None
-            );
         });
         let command_editor = app.read(|ctx| view.as_ref(ctx).command_editor.clone());
         command_editor.update(&mut app, |editor, ctx| {
             editor.set_text("echo edited\necho second", ctx)
         });
-        let window_id = app.read(|ctx| view.window_id(ctx));
-        let handled = app
-            .dispatch_keystroke(
-                window_id,
-                &[view.id(), prompt.id(), command_editor.id()],
-                &Keystroke::parse("enter").expect("valid Enter keystroke"),
-                false,
-            )
-            .expect("Enter dispatch succeeds");
-        assert!(handled);
+        present_shell_view(&mut app, &view);
+        assert!(dispatch_focused_key(&mut app, &view, "enter"));
 
         app.read(|ctx| {
             let view = view.as_ref(ctx);
@@ -222,35 +207,22 @@ fn command_editor_arrows_move_within_multiline_text_then_cycle_at_boundaries() {
             );
         });
 
-        let mut presenter = TuiPresenter::new();
-        app.update(|ctx| {
-            let mut invalidation = WindowInvalidation::default();
-            invalidation.updated.insert(view.id());
-            invalidation.updated.insert(prompt.id());
-            invalidation.updated.insert(command_editor.id());
-            invalidation
-                .updated
-                .extend(prompt.as_ref(ctx).child_view_ids(ctx));
-            presenter.invalidate(&invalidation, ctx, view.window_id(ctx));
-            presenter.present(ctx, &view, TuiRect::new(0, 0, 80, 16));
+        present_shell_view(&mut app, &view);
+        app.read(|ctx| {
+            let window_id = view.window_id(ctx);
+            let focused = ctx
+                .focused_view_id(window_id)
+                .expect("command editor is focused");
+            let responder_chain = ctx.view_ancestors(window_id, focused);
+            let selector_id = prompt.as_ref(ctx).child_view_ids(ctx)[0];
+            assert!(responder_chain.contains(&selector_id));
         });
 
-        let dispatch = |app: &mut App, key: &str| {
-            let window_id = app.read(|ctx| view.window_id(ctx));
-            app.dispatch_keystroke(
-                window_id,
-                &[view.id(), prompt.id(), command_editor.id()],
-                &Keystroke::parse(key).expect("valid keystroke"),
-                false,
-            )
-            .expect("keystroke dispatch succeeds")
-        };
-
-        assert!(dispatch(&mut app, "down"));
+        assert!(dispatch_focused_key(&mut app, &view, "down"));
         assert!(app.read(|ctx| command_editor.as_ref(ctx).is_focused()));
-        assert!(dispatch(&mut app, "down"));
+        assert!(dispatch_focused_key(&mut app, &view, "down"));
         assert!(app.read(|ctx| command_editor.as_ref(ctx).is_focused()));
-        assert!(dispatch(&mut app, "down"));
+        assert!(dispatch_focused_key(&mut app, &view, "down"));
         app.read(|ctx| {
             assert!(!command_editor.as_ref(ctx).is_focused());
             assert_eq!(prompt.as_ref(ctx).highlighted_index(ctx), Some(0));
@@ -267,7 +239,7 @@ fn command_editor_arrows_move_within_multiline_text_then_cycle_at_boundaries() {
                 ctx,
             );
         });
-        assert!(dispatch(&mut app, "up"));
+        assert!(dispatch_focused_key(&mut app, &view, "up"));
         app.read(|ctx| {
             assert!(!command_editor.as_ref(ctx).is_focused());
             assert_eq!(prompt.as_ref(ctx).highlighted_index(ctx), Some(2));
@@ -373,6 +345,40 @@ fn manual_collapse_override_wins_over_auto_expansion() {
     assert!(!state.is_collapsed());
     assert!(state.manual_override);
     assert!(!state.auto_expanded);
+}
+
+fn present_shell_view(app: &mut App, view: &ViewHandle<TuiShellCommandView>) {
+    let mut presenter = TuiPresenter::new();
+    app.update(|ctx| {
+        let view_ref = view.as_ref(ctx);
+        let prompt = &view_ref.permission_prompt;
+        let mut invalidation = WindowInvalidation::default();
+        invalidation.updated.insert(view.id());
+        invalidation.updated.insert(view_ref.command_editor.id());
+        invalidation.updated.insert(prompt.id());
+        invalidation
+            .updated
+            .extend(prompt.as_ref(ctx).child_view_ids(ctx));
+        presenter.invalidate(&invalidation, ctx, view.window_id(ctx));
+        presenter.present(ctx, view, TuiRect::new(0, 0, 80, 16));
+    });
+}
+
+fn dispatch_focused_key(app: &mut App, view: &ViewHandle<TuiShellCommandView>, key: &str) -> bool {
+    let (window_id, responder_chain) = app.read(|ctx| {
+        let window_id = view.window_id(ctx);
+        let focused = ctx
+            .focused_view_id(window_id)
+            .expect("shell permission interaction has a focused view");
+        (window_id, ctx.view_ancestors(window_id, focused))
+    });
+    app.dispatch_keystroke(
+        window_id,
+        &responder_chain,
+        &Keystroke::parse(key).expect("valid keystroke"),
+        false,
+    )
+    .expect("keystroke dispatch succeeds")
 }
 
 fn add_shell_view(

--- a/crates/warp_tui/src/tui_shell_command_view_tests.rs
+++ b/crates/warp_tui/src/tui_shell_command_view_tests.rs
@@ -92,7 +92,13 @@ fn blocked_command_card_matches_permission_layout() {
         let header_row = row_containing("Is it OK if I run this command");
         let command_row = row_containing("echo 1");
         let first_option_row = row_containing("(1) yes");
+        row_containing("(3) Other");
         let footer_row = row_containing("Esc to cancel");
+        assert!(
+            lines[usize::from(header_row)]
+                .trim_end()
+                .ends_with("e to edit command")
+        );
         assert!(first_option_row >= command_row + 2);
 
         let (header_background, surface_background) = app.read(|ctx| {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There was some feedback that the `(e) to edit` option in the shell command card was kind of odd. This PR moves that hint to the header instead (in the top right), and adds back the other option in its place.

This PR also centralizes some scattered focus calculations for the options selector into one shared enum. This helps make it much clearer where focus is (preventing bugs where, say, an other input and an option have 'focus' at the same time).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/bdc58a9a994c4dcfa2d3473f49387794

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode