### PR TITLE
add overflow arrows to inline menu in the TUI

### DIFF
--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -247,18 +247,14 @@ impl<Row> TuiInlineMenuListState<Row> {
     }
 
     fn keep_selected_visible(&mut self, max_visible_rows: usize) {
-        if let Some(selected_index) = self.selection.selected_index() {
-            keep_selected_visible(
-                self.rows.len(),
-                selected_index,
-                max_visible_rows,
-                &mut self.scroll_offset,
-            );
-        } else {
-            self.scroll_offset = self
-                .scroll_offset
-                .min(self.rows.len().saturating_sub(max_visible_rows));
-        }
+        self.scroll_offset = inline_menu_viewport(
+            self.rows.len(),
+            self.selection.selected_index(),
+            self.scroll_offset,
+            max_visible_rows,
+        )
+        .rows
+        .start;
     }
 }
 
@@ -852,7 +848,7 @@ fn inline_menu_viewport_end(rows_len: usize, start: usize, visible_rows: usize) 
 }
 
 /// Clamps stale scroll offsets and moves the viewport only as far as needed to
-/// keep the selected row within a window of `visible_rows`.
+/// keep the selected row within a window of `visible_rows` result rows.
 pub(crate) fn keep_selected_visible(
     rows_len: usize,
     selected_index: usize,
@@ -864,10 +860,13 @@ pub(crate) fn keep_selected_visible(
         return;
     }
 
-    *scroll_offset =
-        inline_menu_viewport(rows_len, Some(selected_index), *scroll_offset, visible_rows)
-            .rows
-            .start;
+    let max_scroll_offset = rows_len.saturating_sub(visible_rows);
+    *scroll_offset = (*scroll_offset).min(max_scroll_offset);
+    if selected_index < *scroll_offset {
+        *scroll_offset = selected_index;
+    } else if selected_index >= *scroll_offset + visible_rows {
+        *scroll_offset = selected_index + 1 - visible_rows;
+    }
 }
 
 fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -34,6 +34,8 @@ const SLASH_COMMAND_COLUMN_CONSTRAINTS: TuiTwoColumnConstraints = TuiTwoColumnCo
     preferred_maximum_second_columns: 21,
     gap_columns: 1,
 };
+
+pub(crate) const MAX_INLINE_MENU_ROWS: u16 = 10;
 const MIN_REAL_ROWS_WITH_SCROLL_INDICATORS: usize = 3;
 
 #[allow(dead_code)]
@@ -42,6 +44,7 @@ pub(crate) enum TuiInlineMenuRowStyle {
     Default,
     InlineMenuItem,
 }
+
 pub(crate) fn active_inline_menu(
     inline_menus: &[TuiInlineMenu],
     mode: TuiInputSuggestionsMode,
@@ -93,8 +96,6 @@ impl TuiInlineMenuHandle for ModelHandle<TuiMcpMenuModel> {
         self.as_ref(ctx).snapshot(ctx)
     }
 }
-
-pub(crate) const MAX_INLINE_MENU_ROWS: u16 = 10;
 
 /// A presentation-only row in a TUI inline menu.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -34,6 +34,7 @@ const SLASH_COMMAND_COLUMN_CONSTRAINTS: TuiTwoColumnConstraints = TuiTwoColumnCo
     preferred_maximum_second_columns: 21,
     gap_columns: 1,
 };
+const MIN_REAL_ROWS_WITH_SCROLL_INDICATORS: usize = 3;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -559,11 +560,12 @@ pub(crate) fn render_inline_menu(
     snapshot: &TuiInlineMenuSnapshot,
     builder: &TuiUiBuilder,
 ) -> Box<dyn TuiElement> {
-    Box::new(TuiInlineMenuElement {
+    TuiInlineMenuElement {
         snapshot: snapshot.clone(),
         builder: builder.clone(),
         content: None,
-    })
+    }
+    .finish()
 }
 
 struct TuiInlineMenuElement {
@@ -712,23 +714,23 @@ fn build_inline_menu(
         }
     } else {
         let visible_rows = visible_result_capacity(snapshot, allocated_height);
-        let mut scroll_offset = snapshot.scroll_offset;
-        if let Some(selected_index) = snapshot.selected_index {
-            keep_selected_visible(
-                snapshot.rows.len(),
-                selected_index,
-                visible_rows,
-                &mut scroll_offset,
-            );
-        } else {
-            scroll_offset = scroll_offset.min(snapshot.rows.len().saturating_sub(visible_rows));
+        let viewport = inline_menu_viewport(
+            snapshot.rows.len(),
+            snapshot.selected_index,
+            snapshot.scroll_offset,
+            visible_rows,
+        );
+
+        if viewport.has_more_above {
+            column = column.child(menu_scroll_indicator_row("↑", builder));
         }
+
         for (index, row) in snapshot
             .rows
             .iter()
             .enumerate()
-            .skip(scroll_offset)
-            .take(visible_rows)
+            .skip(viewport.rows.start)
+            .take(viewport.rows.len())
         {
             column = column.child(menu_result_row(
                 row,
@@ -736,6 +738,10 @@ fn build_inline_menu(
                 slash_command_columns,
                 builder,
             ));
+        }
+
+        if viewport.has_more_below {
+            column = column.child(menu_scroll_indicator_row("↓", builder));
         }
     }
 
@@ -747,6 +753,101 @@ fn menu_header_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
         .with_style(builder.dim_text_style())
         .truncate()
         .finish()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TuiInlineMenuViewport {
+    rows: Range<usize>,
+    has_more_above: bool,
+    has_more_below: bool,
+}
+
+fn inline_menu_viewport(
+    rows_len: usize,
+    selected_index: Option<usize>,
+    scroll_offset: usize,
+    visible_rows: usize,
+) -> TuiInlineMenuViewport {
+    if rows_len == 0 || visible_rows == 0 {
+        return TuiInlineMenuViewport {
+            rows: 0..0,
+            has_more_above: false,
+            has_more_below: false,
+        };
+    }
+    if rows_len <= visible_rows {
+        return TuiInlineMenuViewport {
+            rows: 0..rows_len,
+            has_more_above: false,
+            has_more_below: false,
+        };
+    }
+    if visible_rows <= MIN_REAL_ROWS_WITH_SCROLL_INDICATORS {
+        return inline_menu_viewport_without_indicators(
+            rows_len,
+            selected_index,
+            scroll_offset,
+            visible_rows,
+        );
+    }
+
+    let bottom_start = rows_len.saturating_sub(visible_rows - 1);
+    let mut start = scroll_offset.min(bottom_start);
+    let mut end = inline_menu_viewport_end(rows_len, start, visible_rows);
+    if let Some(selected_index) = selected_index.filter(|index| *index < rows_len) {
+        if selected_index < start {
+            start = selected_index;
+        } else if selected_index >= end {
+            start = (selected_index + 1 - (visible_rows - 2)).min(bottom_start);
+        }
+        end = inline_menu_viewport_end(rows_len, start, visible_rows);
+    }
+
+    let viewport = TuiInlineMenuViewport {
+        rows: start..end,
+        has_more_above: start > 0,
+        has_more_below: end < rows_len,
+    };
+    if viewport.rows.len() < MIN_REAL_ROWS_WITH_SCROLL_INDICATORS {
+        return inline_menu_viewport_without_indicators(
+            rows_len,
+            selected_index,
+            scroll_offset,
+            visible_rows,
+        );
+    }
+    viewport
+}
+
+fn inline_menu_viewport_without_indicators(
+    rows_len: usize,
+    selected_index: Option<usize>,
+    scroll_offset: usize,
+    visible_rows: usize,
+) -> TuiInlineMenuViewport {
+    let mut start = scroll_offset.min(rows_len.saturating_sub(visible_rows));
+    if let Some(selected_index) = selected_index.filter(|index| *index < rows_len) {
+        if selected_index < start {
+            start = selected_index;
+        } else if selected_index >= start + visible_rows {
+            start = selected_index + 1 - visible_rows;
+        }
+    }
+    TuiInlineMenuViewport {
+        rows: start..(start + visible_rows).min(rows_len),
+        has_more_above: false,
+        has_more_below: false,
+    }
+}
+
+fn inline_menu_viewport_end(rows_len: usize, start: usize, visible_rows: usize) -> usize {
+    let upper_indicator_rows = usize::from(start > 0);
+    let rows_without_lower_indicator = visible_rows - upper_indicator_rows;
+    let reaches_end = start.saturating_add(rows_without_lower_indicator) >= rows_len;
+    let lower_indicator_rows = usize::from(!reaches_end);
+    start
+        .saturating_add(visible_rows - upper_indicator_rows - lower_indicator_rows)
+        .min(rows_len)
 }
 
 /// Clamps stale scroll offsets and moves the viewport only as far as needed to
@@ -762,13 +863,10 @@ pub(crate) fn keep_selected_visible(
         return;
     }
 
-    let max_scroll_offset = rows_len.saturating_sub(visible_rows);
-    *scroll_offset = (*scroll_offset).min(max_scroll_offset);
-    if selected_index < *scroll_offset {
-        *scroll_offset = selected_index;
-    } else if selected_index >= *scroll_offset + visible_rows {
-        *scroll_offset = selected_index + 1 - visible_rows;
-    }
+    *scroll_offset =
+        inline_menu_viewport(rows_len, Some(selected_index), *scroll_offset, visible_rows)
+            .rows
+            .start;
 }
 
 fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
@@ -781,6 +879,12 @@ fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
     .with_padding_left(1)
     .with_padding_right(1)
     .finish()
+}
+
+fn menu_scroll_indicator_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
+    TuiText::new(label)
+        .with_style(builder.dim_text_style())
+        .finish()
 }
 
 fn menu_result_row(

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -106,6 +106,13 @@ pub(crate) struct TuiInlineMenuRow {
     pub(crate) is_selectable: bool,
     pub(crate) style: TuiInlineMenuRowStyle,
 }
+/// Returns a single-line menu title while leaving the source text unchanged.
+pub(crate) fn single_line_menu_title(text: &str) -> String {
+    let Some((first_line, _)) = text.split_once('\n') else {
+        return text.to_owned();
+    };
+    format!("{}...", first_line.strip_suffix('\r').unwrap_or(first_line))
+}
 
 /// A presentation-only tab in a TUI inline-menu header.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -915,10 +922,11 @@ fn menu_result_row(
     } else {
         slash_command_columns.available_columns
     };
+    let single_line_title = single_line_menu_title(&row.title);
     let title = match row.style {
-        TuiInlineMenuRowStyle::Default => row.title.clone(),
+        TuiInlineMenuRowStyle::Default => single_line_title,
         TuiInlineMenuRowStyle::InlineMenuItem => format_tui_first_column(
-            &row.title,
+            &single_line_title,
             slash_command_columns.with_second_visible(show_description),
         ),
     };

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -30,6 +30,40 @@ fn render_at_height(snapshot: TuiInlineMenuSnapshot, height: u16) -> Vec<String>
 fn render(snapshot: TuiInlineMenuSnapshot) -> Vec<String> {
     render_at_height(snapshot, 12)
 }
+fn rendered_labels(snapshot: TuiInlineMenuSnapshot, height: u16) -> Vec<String> {
+    let mut lines = render_at_height(snapshot, height)
+        .into_iter()
+        .map(|line| line.trim_end().to_owned())
+        .collect::<Vec<_>>();
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    lines
+}
+
+fn rows_snapshot(
+    row_count: usize,
+    selected_index: usize,
+    scroll_offset: usize,
+    max_visible_rows: usize,
+) -> TuiInlineMenuSnapshot {
+    TuiInlineMenuSnapshot {
+        header: None,
+        rows: (0..row_count)
+            .map(|index| TuiInlineMenuRow {
+                title: format!("Conversation {index}"),
+                description: None,
+                state_suffix: None,
+                is_selectable: true,
+                style: TuiInlineMenuRowStyle::Default,
+            })
+            .collect(),
+        selected_index: Some(selected_index),
+        scroll_offset,
+        max_visible_rows,
+        status: None,
+    }
+}
 
 fn status_snapshot(status: TuiInlineMenuStatus) -> TuiInlineMenuSnapshot {
     TuiInlineMenuSnapshot {
@@ -65,27 +99,61 @@ fn renders_loading_and_empty_statuses() {
 
 #[test]
 fn renders_only_the_visible_row_window() {
-    let lines = render(TuiInlineMenuSnapshot {
-        header: None,
-        rows: (0..5)
-            .map(|index| TuiInlineMenuRow {
-                title: format!("Conversation {index}"),
-                description: None,
-                state_suffix: None,
-                is_selectable: true,
-                style: TuiInlineMenuRowStyle::Default,
-            })
-            .collect(),
-        selected_index: Some(3),
-        scroll_offset: 2,
-        max_visible_rows: 2,
-        status: None,
-    });
-    let rendered = lines.join("\n");
-    assert!(!rendered.contains("Conversation 1"));
-    assert!(rendered.contains("Conversation 2"));
-    assert!(rendered.contains("Conversation 3"));
-    assert!(!rendered.contains("Conversation 4"));
+    assert_eq!(
+        rendered_labels(rows_snapshot(5, 3, 2, 2), 12),
+        vec!["Conversation 2", "Conversation 3"]
+    );
+}
+
+#[test]
+fn fitting_rows_render_without_overflow_indicators() {
+    assert_eq!(
+        rendered_labels(rows_snapshot(3, 1, 0, 4), 4),
+        vec!["Conversation 0", "Conversation 1", "Conversation 2"]
+    );
+}
+
+#[test]
+fn lower_overflow_renders_a_down_arrow_as_the_last_row() {
+    assert_eq!(
+        rendered_labels(rows_snapshot(5, 1, 0, 4), 4),
+        vec!["Conversation 0", "Conversation 1", "Conversation 2", "↓"]
+    );
+}
+
+#[test]
+fn upper_overflow_renders_an_up_arrow_as_the_first_row() {
+    assert_eq!(
+        rendered_labels(rows_snapshot(5, 4, 3, 4), 4),
+        vec!["↑", "Conversation 2", "Conversation 3", "Conversation 4"]
+    );
+}
+
+#[test]
+fn overflow_in_both_directions_renders_both_arrows_and_keeps_selection_visible() {
+    assert_eq!(
+        rendered_labels(rows_snapshot(7, 4, 0, 5), 5),
+        vec![
+            "↑",
+            "Conversation 2",
+            "Conversation 3",
+            "Conversation 4",
+            "↓"
+        ]
+    );
+}
+
+#[test]
+fn short_viewport_prioritizes_three_real_rows_over_scroll_indicators() {
+    assert_eq!(
+        rendered_labels(rows_snapshot(7, 3, 0, 4), 4),
+        vec![
+            "Conversation 0",
+            "Conversation 1",
+            "Conversation 2",
+            "Conversation 3"
+        ]
+    );
 }
 
 #[test]

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -465,6 +465,16 @@ fn shared_list_navigation_wraps_skips_disabled_rows_and_scrolls() {
 }
 
 #[test]
+fn shared_list_reserves_space_for_scroll_indicators() {
+    let mut list = TuiInlineMenuListState::default();
+
+    list.replace_rows(vec![(); 11], false, Some(10), 10, |_| true);
+
+    assert_eq!(list.selected_index(), Some(10));
+    assert_eq!(list.scroll_offset(), 2);
+}
+
+#[test]
 fn shared_list_preserves_ready_rows_while_a_mixer_query_loads() {
     let mut list = TuiInlineMenuListState::default();
     list.replace_rows(vec!["ready"], false, Some(0), 2, |_| true);

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -120,6 +120,16 @@ fn lower_overflow_renders_a_down_arrow_as_the_last_row() {
         vec!["Conversation 0", "Conversation 1", "Conversation 2", "↓"]
     );
 }
+#[test]
+fn multiline_conversation_title_is_ellipsized_without_hiding_lower_overflow() {
+    let mut snapshot = rows_snapshot(5, 0, 0, 4);
+    snapshot.rows[0].title = "Conversation 0\ncontinued title".to_owned();
+
+    assert_eq!(
+        rendered_labels(snapshot, 4),
+        vec!["Conversation 0...", "Conversation 1", "Conversation 2", "↓"]
+    );
+}
 
 #[test]
 fn upper_overflow_renders_an_up_arrow_as_the_first_row() {

--- a/crates/warp_tui/src/prompt_history_menu.rs
+++ b/crates/warp_tui/src/prompt_history_menu.rs
@@ -20,6 +20,7 @@ use warpui_core::{AppContext, Entity, EntityId, ModelContext, ModelHandle, Singl
 use crate::inline_menu::{
     MAX_INLINE_MENU_ROWS, TuiInlineMenuHeader, TuiInlineMenuListState, TuiInlineMenuRow,
     TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, result_row_capacity,
+    single_line_menu_title,
 };
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
@@ -223,7 +224,7 @@ impl TuiPromptHistoryMenuModel {
                 .rows()
                 .iter()
                 .map(|row| TuiInlineMenuRow {
-                    title: prompt_history_title(&row.text),
+                    title: single_line_menu_title(&row.text),
                     description: None,
                     state_suffix: None,
                     is_selectable: true,
@@ -331,15 +332,6 @@ impl TuiPromptHistoryMenuModel {
                 .update(ctx, |buffer, _| buffer.reset_undo_stack());
         });
     }
-}
-
-/// Returns a single-line menu title while leaving the full prompt available for
-/// preview and acceptance.
-fn prompt_history_title(text: &str) -> String {
-    let Some((first_line, _)) = text.split_once('\n') else {
-        return text.to_owned();
-    };
-    format!("{}...", first_line.strip_suffix('\r').unwrap_or(first_line))
 }
 
 /// Preserves selection by prompt text, falling back to the nearest previous

--- a/crates/warp_tui/src/prompt_history_menu_tests.rs
+++ b/crates/warp_tui/src/prompt_history_menu_tests.rs
@@ -9,11 +9,8 @@ use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, AppContext, EntityId, ModelHandle};
 
-use super::{
-    TuiPromptHistoryMenuModel, TuiPromptHistoryRow, prompt_history_title,
-    reconciled_selection_index,
-};
-use crate::inline_menu::render_inline_menu;
+use super::{TuiPromptHistoryMenuModel, TuiPromptHistoryRow, reconciled_selection_index};
+use crate::inline_menu::{render_inline_menu, single_line_menu_title};
 use crate::input_suggestions_mode::TuiInputSuggestionsModeModel;
 use crate::tui_builder::TuiUiBuilder;
 
@@ -183,7 +180,7 @@ fn multiline_prompt_uses_single_line_title_without_changing_prompt_text() {
 #[test]
 fn prompt_history_title_handles_windows_line_endings() {
     assert_eq!(
-        prompt_history_title("deploy the app\r\nthen verify it"),
+        single_line_menu_title("deploy the app\r\nthen verify it"),
         "deploy the app..."
     );
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR adds up/down arrows to the inline menu when there are more options hidden above or below, as otherwise it's not very clear that there are more options available.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/302eee0bb7d040f48e8260ff7816f038

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode