### PR TITLE
fix: update js-yaml to resolve CVE-2026-59869

### DIFF
--- a/crates/warp_graphql_schema/package.json
+++ b/crates/warp_graphql_schema/package.json
@@ -16,6 +16,7 @@
   "resolutions": {
     "immutable": "3.8.3",
     "lodash": "4.18.1",
-    "@babel/core": "7.29.6"
+    "@babel/core": "7.29.6",
+    "js-yaml": "^4.3.0"
   }
 }

--- a/crates/warp_graphql_schema/yarn.lock
+++ b/crates/warp_graphql_schema/yarn.lock
@@ -1687,10 +1687,10 @@ jose@^5.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.0.0, js-yaml@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@^4.0.0, js-yaml@^4.1.0, js-yaml@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary
Resolves a high-severity DoS vulnerability in the transitive dev dependency `js-yaml`.

- **Advisory:** [GHSA-52cp-r559-cp3m](https://github.com/nodeca/js-yaml/security/advisories/GHSA-52cp-r559-cp3m) / [CVE-2026-59869](https://nvd.nist.gov/vuln/detail/CVE-2026-59869)
- **Severity:** High (CVSS 7.5)
- **Summary:** YAML merge-key chains can force quadratic CPU consumption.
- **Dependabot alert:** https://github.com/warpdotdev/warp/security/dependabot/22

## Change
`js-yaml` is a **transitive, development-scoped** dependency of `crates/warp_graphql_schema` (pulled in via `@graphql-codegen/cli`) that was resolving to the vulnerable `4.2.0`. Added `"js-yaml": "^4.3.0"` to the existing `resolutions` block in `crates/warp_graphql_schema/package.json` and regenerated the lockfile.

- `js-yaml` now resolves to `4.3.0` (the first patched version), which satisfies the existing `^4.0.0` / `^4.1.0` parent constraints.
- The lockfile diff is isolated to the single `js-yaml` entry.

## Verification
`yarn audit` on `crates/warp_graphql_schema` no longer reports the `js-yaml` advisory (remaining advisories — brace-expansion, immutable, shell-quote — are tracked by separate alerts).

---
_Conversation: https://staging.warp.dev/conversation/337479b9-5a45-4a39-9845-ff97f82e6f57_
_Run: https://oz.staging.warp.dev/runs/019f8a8e-4341-7a36-9faf-0ada3234d368_

_This PR was generated with [Oz](https://warp.dev/oz)._
