### PR TITLE
Improve starfield animation scaling across terminal sizes

### DIFF
--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -35,6 +35,10 @@ const MAX_CHANGELOG_BULLETS: usize = 3;
 /// Width cap on the text column so bullets wrap like the mock.
 const LEFT_COLUMN_MAX_COLS: u16 = 48;
 
+/// Maximum width of the starfield animation panel.  On wide terminals the
+/// animation stays at this width and excess space becomes blank background.
+const MAX_ANIMATION_COLS: u16 = 100;
+
 // ---------------------------------------------------------------------------
 // TuiZeroStateView
 // ---------------------------------------------------------------------------
@@ -118,11 +122,15 @@ impl TuiView for TuiZeroStateView {
             TuiConstrainedBox::new(render_left_column(cwd.as_deref(), &builder, ctx).finish())
                 .with_max_cols(LEFT_COLUMN_MAX_COLS)
                 .finish();
-        let animation = ZeroStateAnimationElement::new(
-            Rc::clone(&self.starfield),
-            self.clock,
-            builder.accent_color(),
+        let animation = TuiConstrainedBox::new(
+            ZeroStateAnimationElement::new(
+                Rc::clone(&self.starfield),
+                self.clock,
+                builder.accent_color(),
+            )
+            .finish(),
         )
+        .with_max_cols(MAX_ANIMATION_COLS)
         .finish();
         TuiFlex::row()
             .child(text_column)

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -32,8 +32,10 @@ use crate::zero_state_animation::{StarfieldState, ZeroStateAnimationElement};
 /// Cap on "What's new" bullets, mirroring the compact zero-state mock.
 const MAX_CHANGELOG_BULLETS: usize = 3;
 
-/// Width cap on the text column so bullets wrap like the mock.
-const LEFT_COLUMN_MAX_COLS: u16 = 48;
+/// Fixed width for the text column.  Using a pinned min=max prevents the
+/// animation boundary from shifting as content loads asynchronously at startup
+/// (changelog, MCP status, project context).
+const LEFT_COLUMN_COLS: u16 = 48;
 
 /// Maximum width of the starfield animation panel.  On wide terminals the
 /// animation stays at this width and excess space becomes blank background.
@@ -120,7 +122,8 @@ impl TuiView for TuiZeroStateView {
         });
         let text_column =
             TuiConstrainedBox::new(render_left_column(cwd.as_deref(), &builder, ctx).finish())
-                .with_max_cols(LEFT_COLUMN_MAX_COLS)
+                .with_min_cols(LEFT_COLUMN_COLS)
+                .with_max_cols(LEFT_COLUMN_COLS)
                 .finish();
         let animation = TuiConstrainedBox::new(
             ZeroStateAnimationElement::new(

--- a/crates/warp_tui/src/zero_state_animation.rs
+++ b/crates/warp_tui/src/zero_state_animation.rs
@@ -136,9 +136,12 @@ impl StarfieldState {
 
     /// Advances simulation by one 1/60s step.
     fn advance_one_step(&mut self, warp: f64) {
+        // Normalize base velocity to panel size so crossing time is consistent
+        // across all terminal widths (~4.5s at reference max_r=43).
+        let a = 0.12 * (self.max_r / 43.0).clamp(0.5, 3.0);
         for star in &mut self.stars {
             star.r_prev = star.r;
-            star.r += (0.12 + star.r * 0.012) * star.speed * warp;
+            star.r += (a + star.r * 0.012) * star.speed * warp;
             // ~2% chance per step to toggle glow.
             if xorshift_f64(&mut self.rng) < 0.02 {
                 star.glow = !star.glow;
@@ -164,9 +167,20 @@ impl StarfieldState {
         self.sim_secs = target_secs;
     }
 
-    pub(crate) fn set_max_r(&mut self, max_r: f64) {
+    /// Updates the panel geometry and adjusts the star count to match the new size.
+    pub(crate) fn set_dimensions(&mut self, max_r: f64, num_stars: usize) {
         self.max_r = max_r;
+        while self.stars.len() < num_stars {
+            self.stars.push(new_star(&mut self.rng, self.max_r));
+        }
+        self.stars.truncate(num_stars);
     }
+}
+
+/// Returns the number of stars appropriate for the panel's max_r, keeping
+/// density consistent across terminal sizes (reference: 220 stars at max_r=43).
+pub(crate) fn star_count_for_max_r(max_r: f64) -> usize {
+    ((220.0_f64 * (max_r / 43.0).powf(1.5)).round() as usize).clamp(50, 500)
 }
 
 // ---------------------------------------------------------------------------
@@ -246,7 +260,8 @@ impl TuiElement for ZeroStateAnimationElement {
         let max_r = cx.hypot(cy * 2.0);
 
         let mut sf = self.state.borrow_mut();
-        sf.set_max_r(max_r);
+        let num_stars = star_count_for_max_r(max_r);
+        sf.set_dimensions(max_r, num_stars);
         sf.simulate_to(elapsed);
 
         let geo = GridGeometry {
@@ -306,7 +321,7 @@ fn draw_star_streak(
         if px < 0 || py < 0 || px as usize >= geo.cols || py as usize >= geo.rows {
             continue;
         }
-        let gi = ((rr / geo.max_r) * (STAR_GLYPHS.len() - 1) as f64) as usize;
+        let gi = ((rr / geo.max_r).powf(0.65) * (STAR_GLYPHS.len() - 1) as f64) as usize;
         let gi = gi.min(STAR_GLYPHS.len() - 1);
         let glyph = STAR_GLYPHS[gi];
         let buf = [glyph];

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -1,4 +1,7 @@
-use super::{StarfieldState, WARP_INITIAL, WARP_TARGET, warp_at, xorshift_f64, xorshift64};
+use super::{
+    StarfieldState, WARP_INITIAL, WARP_TARGET, star_count_for_max_r, warp_at, xorshift_f64,
+    xorshift64,
+};
 
 // ---------------------------------------------------------------------------
 // xorshift64 PRNG
@@ -141,7 +144,7 @@ fn starfield_stars_reset_when_they_leave_screen() {
     let mut sf = StarfieldState::new();
     // Override max_r to something tiny so stars leave immediately.
     let tiny_max_r = 5.0;
-    sf.set_max_r(tiny_max_r);
+    sf.set_dimensions(tiny_max_r, star_count_for_max_r(tiny_max_r));
     sf.simulate_to(5.0); // 5 seconds
     // All stars should be back near centre (r < tiny_max_r).
     for (i, star) in sf.stars.iter().enumerate() {

--- a/crates/warpui_core/src/elements/tui/constrained_box.rs
+++ b/crates/warpui_core/src/elements/tui/constrained_box.rs
@@ -1,10 +1,10 @@
-//! [`TuiConstrainedBox`]: caps a single child's size on either axis.
+//! [`TuiConstrainedBox`]: constrains a single child's size on either axis.
 //!
 //! # Construction
-//! Wrap a child with [`TuiConstrainedBox::new`] and cap either axis with
-//! [`with_max_rows`](TuiConstrainedBox::with_max_rows) (height) and
-//! [`with_max_cols`](TuiConstrainedBox::with_max_cols) (width). Either cap may
-//! be left unset, in which case that axis passes through unchanged.
+//! Wrap a child with [`TuiConstrainedBox::new`] and constrain either axis with
+//! the `with_min_*` / `with_max_*` setters. Either bound may be left unset, in
+//! which case that bound passes through from the parent. Setting `min == max`
+//! on an axis pins the child to exactly that size.
 //!
 //! # Layout policy
 //! The box is otherwise transparent: it measures and paints its child within the
@@ -21,6 +21,7 @@ use crate::AppContext;
 
 pub struct TuiConstrainedBox {
     child: Box<dyn TuiElement>,
+    min_cols: Option<u16>,
     max_rows: Option<u16>,
     max_cols: Option<u16>,
 }
@@ -29,9 +30,18 @@ impl TuiConstrainedBox {
     pub fn new(child: Box<dyn TuiElement>) -> Self {
         Self {
             child,
+            min_cols: None,
             max_rows: None,
             max_cols: None,
         }
+    }
+
+    /// Floors the child's width to `cols` cells. When combined with
+    /// [`with_max_cols`](Self::with_max_cols) set to the same value the child
+    /// is pinned to exactly that width.
+    pub fn with_min_cols(mut self, cols: u16) -> Self {
+        self.min_cols = Some(cols);
+        self
     }
 
     /// Caps the child's height to `rows` cells.
@@ -55,10 +65,13 @@ impl TuiConstrainedBox {
         let max_height = self.max_rows.map_or(constraint.max.height, |rows| {
             constraint.max.height.min(rows)
         });
-        let min = TuiSize::new(
-            constraint.min.width.min(max_width),
-            constraint.min.height.min(max_height),
-        );
+        // Apply min_cols: the child must be at least this wide, clamped to
+        // max_width so it degrades gracefully on terminals narrower than the
+        // requested minimum.
+        let min_width = self.min_cols.map_or(constraint.min.width, |cols| {
+            cols.min(max_width).max(constraint.min.width)
+        });
+        let min = TuiSize::new(min_width, constraint.min.height.min(max_height));
         TuiConstraint::new(min, TuiSize::new(max_width, max_height))
     }
 }

--- a/crates/warpui_core/src/elements/tui/constrained_box.rs
+++ b/crates/warpui_core/src/elements/tui/constrained_box.rs
@@ -65,12 +65,13 @@ impl TuiConstrainedBox {
         let max_height = self.max_rows.map_or(constraint.max.height, |rows| {
             constraint.max.height.min(rows)
         });
-        // Apply min_cols: the child must be at least this wide, clamped to
-        // max_width so it degrades gracefully on terminals narrower than the
-        // requested minimum.
-        let min_width = self.min_cols.map_or(constraint.min.width, |cols| {
-            cols.min(max_width).max(constraint.min.width)
-        });
+        // Apply min_cols: floor the child's width to `min_cols`, taking the
+        // larger of `min_cols` and the parent's existing min, then clamp to
+        // max_width so the constraint invariant (min ≤ max) is always upheld.
+        let min_width = match self.min_cols {
+            None => constraint.min.width.min(max_width),
+            Some(cols) => cols.max(constraint.min.width).min(max_width),
+        };
         let min = TuiSize::new(min_width, constraint.min.height.min(max_height));
         TuiConstraint::new(min, TuiSize::new(max_width, max_height))
     }

--- a/crates/warpui_core/src/elements/tui/constrained_box_tests.rs
+++ b/crates/warpui_core/src/elements/tui/constrained_box_tests.rs
@@ -42,3 +42,73 @@ fn passes_through_when_uncapped() {
         });
     });
 }
+
+#[test]
+fn min_cols_floors_narrow_child_to_minimum_width() {
+    // A text child whose natural width (1 char) is less than min_cols (10);
+    // the box should force it to the minimum.
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let mut boxed = TuiConstrainedBox::new(TuiText::new("A").finish()).with_min_cols(10);
+            let mut rendered_views = EntityIdMap::default();
+            let mut ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            let size = boxed.layout(
+                TuiConstraint::loose(TuiSize::new(80, 24)),
+                &mut ctx,
+                app_ctx,
+            );
+            assert_eq!(size.width, 10, "min_cols should floor narrow child to 10");
+        });
+    });
+}
+
+#[test]
+fn min_and_max_cols_pin_child_to_fixed_width() {
+    // Setting min == max == 48 produces a fixed-width column regardless of
+    // content width — the primary use-case for the zero-state text column.
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let mut boxed = TuiConstrainedBox::new(TuiText::new("short").finish())
+                .with_min_cols(48)
+                .with_max_cols(48);
+            let mut rendered_views = EntityIdMap::default();
+            let mut ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            let size = boxed.layout(
+                TuiConstraint::loose(TuiSize::new(200, 24)),
+                &mut ctx,
+                app_ctx,
+            );
+            assert_eq!(size.width, 48, "min=max=48 should pin width to exactly 48");
+        });
+    });
+}
+
+#[test]
+fn min_cols_clamps_gracefully_on_narrow_terminal() {
+    // When the parent only offers 20 cols and min_cols=48, the box should
+    // clamp the min to the available space (20) and not panic.
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let mut boxed = TuiConstrainedBox::new(TuiText::new("short").finish())
+                .with_min_cols(48)
+                .with_max_cols(48);
+            let mut rendered_views = EntityIdMap::default();
+            let mut ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            let size = boxed.layout(
+                TuiConstraint::loose(TuiSize::new(20, 24)),
+                &mut ctx,
+                app_ctx,
+            );
+            assert_eq!(
+                size.width, 20,
+                "should clamp to available 20 cols on a narrow terminal"
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Description

Four improvements to the TUI zero-state starfield animation that make it look consistent at any terminal width:

1. **Speed normalization** (): Base star velocity now scales with  so stars cross the panel in a consistent ~4.5s regardless of terminal size, instead of the crossing time varying 2× between narrow and wide terminals.

2. **Dynamic star density** (): Replaces the fixed 220-star count with  which scales density with  (clamped 50–500). This keeps the field from looking overcrowded on narrow terminals or invisible on wide ones. Replaces  with  to manage both geometry and star count together.

3. **Glyph brightness ramp** (): Applies  to the radial fraction before mapping to the glyph ramp, so stars appear in brighter characters sooner instead of spending most of their life as dim dots near the center.

4. **Animation width cap** (): Wraps the animation element in a  with  so ultra-wide terminals don't spread the field too thin.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Ran `cargo nextest run -p warp_tui zero_state` — 19 tests, all passed.
- Ran `./script/format` and `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings` — clean.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>