### PR TITLE
Tag Warp Agent CLI device auth URLs

### DIFF
--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -11,6 +11,7 @@ pub use mcp::{
     TuiMcpAction, TuiMcpConfigState, TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerId,
     TuiMcpServerSnapshot, TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport,
 };
+use url::Url;
 use warpui::{AppContext, Entity, SingletonEntity};
 
 use crate::TuiMountFn;
@@ -93,11 +94,12 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
             let url_to_open = verification_url_complete
                 .as_deref()
                 .unwrap_or(verification_url.as_str());
-            ctx.open_url(url_to_open);
+            let url_to_open = tui_verification_url(url_to_open);
+            ctx.open_url(&url_to_open);
             set_login_phase(
                 ctx,
                 TuiLoginPhase::AwaitingLogin {
-                    verification_uri: Some(url_to_open.to_owned()),
+                    verification_uri: Some(url_to_open),
                     user_code: Some(user_code.clone()),
                 },
             );
@@ -129,6 +131,15 @@ fn authorize_device(ctx: &mut AppContext) {
     AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
         auth_manager.authorize_device(ctx);
     });
+}
+fn tui_verification_url(verification_url: &str) -> String {
+    let Ok(mut verification_url) = Url::parse(verification_url) else {
+        return verification_url.to_owned();
+    };
+    verification_url
+        .query_pairs_mut()
+        .append_pair("source", "warp-agent-cli");
+    verification_url.into()
 }
 
 fn activate_global_mcp_servers(ctx: &mut AppContext) {

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -3,7 +3,33 @@ use std::rc::Rc;
 
 use warpui::{App, SingletonEntity};
 
-use super::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase, set_logged_out_phase, set_login_phase};
+use super::{
+    TuiLoginEvent, TuiLoginModel, TuiLoginPhase, set_logged_out_phase, set_login_phase,
+    tui_verification_url,
+};
+
+#[test]
+fn tags_tui_verification_url_without_losing_existing_query_parameters() {
+    let url = tui_verification_url(
+        "https://app.warp.dev/device?user_code=ABCD-EFGH&existing=value#fragment",
+    );
+    let url = url::Url::parse(&url).unwrap();
+
+    assert_eq!(url.fragment(), Some("fragment"));
+    assert_eq!(
+        url.query_pairs().collect::<Vec<_>>(),
+        vec![
+            ("user_code".into(), "ABCD-EFGH".into()),
+            ("existing".into(), "value".into()),
+            ("source".into(), "warp-agent-cli".into()),
+        ]
+    );
+}
+
+#[test]
+fn leaves_invalid_verification_url_unchanged() {
+    assert_eq!(tui_verification_url("not a URL"), "not a URL".to_owned());
+}
 
 #[test]
 fn emits_logged_in_event_when_login_completes() {


### PR DESCRIPTION
## Description

Tag device-auth verification URLs opened by the Warp Agent CLI with `source=warp-agent-cli`.

This lets the browser authorization page distinguish TUI-started login from other consumers of the shared OAuth device flow. The marker is presentation-only: it does not affect authorization, token issuance, or trust decisions. Existing query parameters, including the pre-filled user code, are preserved; malformed URLs fall back unchanged.

The companion server PR uses this marker to hide the confusing Open/Download Warp CTA only for Warp Agent CLI login and reduces the device polling interval from 5 seconds to 2 seconds:

- https://github.com/warpdotdev/warp-server/pull/13146

## Linked Issue

No linked issue.

## Testing

- [x] Added unit coverage for preserving existing query parameters while appending `source=warp-agent-cli`
- [x] Added unit coverage for leaving malformed verification URLs unchanged
- [x] `cargo nextest run -p warp --features tui -E 'test(tui_verification_url)'`
- [x] `cargo nextest run -p warp --features tui -E 'test(leaves_invalid_verification_url_unchanged)'`
- [x] `./script/format`
- [ ] I have manually tested my changes locally with `./script/run`

Full workspace clippy is currently blocked by five pre-existing lints in the untouched `warp_completer` crate on `master`; the changed TUI code and focused tests pass.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Plan: https://staging.warp.dev/drive/notebook/b8oQ2ECjmmcYHxVK4qpwzK
Conversation: https://staging.warp.dev/conversation/57de0c3c-e089-4edb-95ac-e4c2f6be74ff

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>