### PR TITLE
Use Warp Agent CLI download endpoints

### DIFF
--- a/crates/warp_tui/src/autoupdate.rs
+++ b/crates/warp_tui/src/autoupdate.rs
@@ -12,7 +12,7 @@
 //!
 //! and this module keeps that layout fresh: it polls on the same cadence as
 //! the GUI autoupdater (each poll is a single lightweight `/client_version`
-//! request), downloads newer builds from the server's `/download/tui`
+//! request), downloads newer builds from the server's `/download/agent-cli`
 //! endpoint, stages them into `versions/<version>`, and atomically retargets
 //! the `current` symlink. The running session is never touched — the new
 //! version is picked up on the next launch. In particular, the updater never
@@ -548,13 +548,14 @@ fn latest_version_for_channel(versions: &ChannelVersions) -> Result<String> {
     Ok(channel_version.version_info().version)
 }
 
-/// The server's `channel` query parameter for the current channel. Only
-/// channels accepted by [`latest_version_for_channel`] reach this.
-fn download_channel() -> &'static str {
-    match ChannelState::channel() {
-        Channel::Preview => "preview",
-        Channel::Stable => "stable",
-        Channel::Dev | Channel::Local | Channel::Oss | Channel::Integration => "dev",
+/// The Warp Agent CLI artifact endpoint for a release channel.
+fn download_endpoint(channel: Channel) -> &'static str {
+    match channel {
+        Channel::Preview => "/download/agent-cli-preview/artifact",
+        Channel::Stable => "/download/agent-cli/artifact",
+        Channel::Dev | Channel::Local | Channel::Oss | Channel::Integration => {
+            "/download/agent-cli-dev/artifact"
+        }
     }
 }
 
@@ -591,9 +592,9 @@ async fn download_and_stage(
         "x86_64"
     };
     let url = format!(
-        "{}/download/tui?os={os}&arch={arch}&channel={}&version={version}",
+        "{}{}?os={os}&arch={arch}&version={version}",
         ChannelState::server_root_url().trim_end_matches('/'),
-        download_channel(),
+        download_endpoint(ChannelState::channel()),
     );
 
     async_fs::create_dir_all(&layout.versions_dir)

--- a/crates/warp_tui/src/autoupdate_tests.rs
+++ b/crates/warp_tui/src/autoupdate_tests.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::{InstallLayout, InstallLock};
+use warp_core::channel::Channel;
+
+use super::{InstallLayout, InstallLock, download_endpoint};
 
 /// Creates a unique, empty temp directory for a test.
 fn temp_root(name: &str) -> PathBuf {
@@ -46,6 +48,22 @@ fn rejects_unmanaged_exe_paths() {
     assert_eq!(
         InstallLayout::from_canonical_exe_path(Path::new("/repo/target/debug/warp-tui-dev")),
         None
+    );
+}
+
+#[test]
+fn uses_channel_specific_download_endpoints() {
+    assert_eq!(
+        download_endpoint(Channel::Stable),
+        "/download/agent-cli/artifact"
+    );
+    assert_eq!(
+        download_endpoint(Channel::Preview),
+        "/download/agent-cli-preview/artifact"
+    );
+    assert_eq!(
+        download_endpoint(Channel::Dev),
+        "/download/agent-cli-dev/artifact"
     );
 }
 


### PR DESCRIPTION
## Description

Update the Warp Agent CLI auto-updater to download from the newly branded, channel-specific server artifact endpoints. This removes the obsolete `channel` query parameter and ensures stable, preview, and dev builds use the route whose channel is fixed by the server.

Paired server PR: https://github.com/warpdotdev/warp-server/pull/13148

## Linked Issue

No linked issue.

## Testing

- [x] `./script/format --check`
- [x] `cargo clippy -p warp_tui --all-targets --tests -- -D warnings`
- [x] `cargo test -p warp_tui autoupdate` (4 passed)
- [ ] Manual UI testing is not applicable; this changes background download URL construction and adds unit coverage for all published channels.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp Agent Mode

CHANGELOG-NONE

[Agent conversation](https://staging.warp.dev/conversation/12bf958f-72d1-4d80-911c-76c66b7b3a6b)

Co-Authored-By: Warp <agent@warp.dev>