### PR TITLE
Fix TUI conversation filtering

### DIFF
--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -166,6 +166,13 @@ pub struct AgentConversationCapabilities {
 }
 
 impl AgentConversationEntry {
+    /// Returns whether this entry represents a cloud agent run.
+    pub fn is_cloud_agent_run(&self) -> bool {
+        matches!(self.provenance, AgentConversationProvenance::AmbientRun)
+            || self.backing.has_ambient_run
+            || self.identity.ambient_agent_task_id.is_some()
+    }
+
     pub(super) fn matches_filters(
         &self,
         filters: &AgentManagementFilters,

--- a/app/src/ui_components/agent_icon.rs
+++ b/app/src/ui_components/agent_icon.rs
@@ -13,8 +13,7 @@ use warpui::{AppContext, SingletonEntity};
 
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent_conversations_model::{
-    AgentConversationEntry, AgentConversationProvenance, AgentConversationsModel,
-    AgentRunDisplayStatus,
+    AgentConversationEntry, AgentConversationsModel, AgentRunDisplayStatus,
 };
 use crate::terminal::CLIAgent;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
@@ -102,13 +101,10 @@ pub(crate) fn agent_conversation_entry_icon_variant(
     entry: &AgentConversationEntry,
 ) -> IconWithStatusVariant {
     let status = entry.display.status.to_conversation_status();
-    let is_ambient = matches!(entry.provenance, AgentConversationProvenance::AmbientRun)
-        || entry.backing.has_ambient_run
-        || entry.identity.ambient_agent_task_id.is_some();
     agent_icon_variant_for_run(
         entry.display.harness.unwrap_or(Harness::Oz),
         status,
-        is_ambient,
+        entry.is_cloud_agent_run(),
     )
 }
 

--- a/app/src/ui_components/agent_icon_tests.rs
+++ b/app/src/ui_components/agent_icon_tests.rs
@@ -438,4 +438,18 @@ fn non_ambient_entry_uses_display_harness() {
             is_ambient: false,
         }
     );
+    assert!(!entry.is_cloud_agent_run());
+
+    let mut cloud_agent_by_provenance = entry.clone();
+    cloud_agent_by_provenance.provenance = AgentConversationProvenance::AmbientRun;
+    assert!(cloud_agent_by_provenance.is_cloud_agent_run());
+
+    let mut cloud_agent_by_backing = entry.clone();
+    cloud_agent_by_backing.backing.has_ambient_run = true;
+    assert!(cloud_agent_by_backing.is_cloud_agent_run());
+
+    let mut cloud_agent_by_task_id = entry;
+    cloud_agent_by_task_id.identity.ambient_agent_task_id =
+        Some("00000000-0000-0000-0000-000000000001".parse().unwrap());
+    assert!(cloud_agent_by_task_id.is_cloud_agent_run());
 }

--- a/crates/warp_tui/src/conversation_selection.rs
+++ b/crates/warp_tui/src/conversation_selection.rs
@@ -151,6 +151,7 @@ impl AgentConversationListPolicy for TuiConversationSelection {
             self.selected_id(),
             entry.identity.local_conversation_id,
             entry.identity.server_conversation_token.is_some(),
+            entry.is_cloud_agent_run(),
             entry.display.harness,
             &entry.display.status,
         )
@@ -161,6 +162,7 @@ fn classify_conversation_list_entry(
     selected_id: Option<AIConversationId>,
     local_conversation_id: Option<AIConversationId>,
     has_server_token: bool,
+    is_cloud_agent_run: bool,
     harness: Option<Harness>,
     status: &AgentRunDisplayStatus,
 ) -> AgentConversationListEntryState {
@@ -188,7 +190,9 @@ fn classify_conversation_list_entry(
         | AgentRunDisplayStatus::ConversationError
         | AgentRunDisplayStatus::ConversationCancelled => true,
     };
-    if has_terminal_status && (local_conversation_id.is_some() || has_server_token) {
+    if (!is_cloud_agent_run || has_terminal_status)
+        && (local_conversation_id.is_some() || has_server_token)
+    {
         AgentConversationListEntryState::Available
     } else {
         AgentConversationListEntryState::Unavailable

--- a/crates/warp_tui/src/conversation_selection.rs
+++ b/crates/warp_tui/src/conversation_selection.rs
@@ -147,25 +147,37 @@ impl AgentConversationListPolicy for TuiConversationSelection {
         entry: &AgentConversationEntry,
         _: &AppContext,
     ) -> AgentConversationListEntryState {
-        classify_conversation_list_entry(
-            self.selected_id(),
-            entry.identity.local_conversation_id,
-            entry.identity.server_conversation_token.is_some(),
-            entry.is_cloud_agent_run(),
-            entry.display.harness,
-            &entry.display.status,
-        )
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: self.selected_id(),
+            local_conversation_id: entry.identity.local_conversation_id,
+            has_server_token: entry.identity.server_conversation_token.is_some(),
+            is_cloud_agent_run: entry.is_cloud_agent_run(),
+            harness: entry.display.harness,
+            status: &entry.display.status,
+        })
     }
 }
 
-fn classify_conversation_list_entry(
+struct ConversationListEntryContext<'a> {
     selected_id: Option<AIConversationId>,
     local_conversation_id: Option<AIConversationId>,
     has_server_token: bool,
     is_cloud_agent_run: bool,
     harness: Option<Harness>,
-    status: &AgentRunDisplayStatus,
+    status: &'a AgentRunDisplayStatus,
+}
+
+fn classify_conversation_list_entry(
+    context: ConversationListEntryContext<'_>,
 ) -> AgentConversationListEntryState {
+    let ConversationListEntryContext {
+        selected_id,
+        local_conversation_id,
+        has_server_token,
+        is_cloud_agent_run,
+        harness,
+        status,
+    } = context;
     if selected_id.is_some_and(|selected_id| local_conversation_id == Some(selected_id)) {
         return AgentConversationListEntryState::Selected;
     }

--- a/crates/warp_tui/src/conversation_selection_tests.rs
+++ b/crates/warp_tui/src/conversation_selection_tests.rs
@@ -10,64 +10,66 @@ use warp::tui_export::{
 use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
 use warpui::{App, EntityId, ModelHandle};
 
-use super::{TuiConversationSelection, classify_conversation_list_entry};
+use super::{
+    ConversationListEntryContext, TuiConversationSelection, classify_conversation_list_entry,
+};
 
 #[test]
 fn tui_list_policy_classifies_selected_terminal_and_unavailable_entries() {
     let selected_id = AIConversationId::new();
     assert_eq!(
-        classify_conversation_list_entry(
-            Some(selected_id),
-            Some(selected_id),
-            true,
-            false,
-            Some(Harness::Oz),
-            &AgentRunDisplayStatus::ConversationSucceeded,
-        ),
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: Some(selected_id),
+            local_conversation_id: Some(selected_id),
+            has_server_token: true,
+            is_cloud_agent_run: false,
+            harness: Some(Harness::Oz),
+            status: &AgentRunDisplayStatus::ConversationSucceeded,
+        },),
         AgentConversationListEntryState::Selected
     );
     assert_eq!(
-        classify_conversation_list_entry(
-            None,
-            Some(AIConversationId::new()),
-            false,
-            false,
-            Some(Harness::Oz),
-            &AgentRunDisplayStatus::ConversationCancelled,
-        ),
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: None,
+            local_conversation_id: Some(AIConversationId::new()),
+            has_server_token: false,
+            is_cloud_agent_run: false,
+            harness: Some(Harness::Oz),
+            status: &AgentRunDisplayStatus::ConversationCancelled,
+        },),
         AgentConversationListEntryState::Available
     );
     assert_eq!(
-        classify_conversation_list_entry(
-            None,
-            None,
-            true,
-            true,
-            Some(Harness::Oz),
-            &AgentRunDisplayStatus::TaskInProgress,
-        ),
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: None,
+            local_conversation_id: None,
+            has_server_token: true,
+            is_cloud_agent_run: true,
+            harness: Some(Harness::Oz),
+            status: &AgentRunDisplayStatus::TaskInProgress,
+        },),
         AgentConversationListEntryState::Unavailable
     );
     assert_eq!(
-        classify_conversation_list_entry(
-            None,
-            None,
-            true,
-            true,
-            Some(Harness::Claude),
-            &AgentRunDisplayStatus::TaskSucceeded,
-        ),
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: None,
+            local_conversation_id: None,
+            has_server_token: true,
+            is_cloud_agent_run: true,
+            harness: Some(Harness::Claude),
+            status: &AgentRunDisplayStatus::TaskSucceeded,
+        },),
         AgentConversationListEntryState::Unavailable
     );
     assert_eq!(
-        classify_conversation_list_entry(
-            None,
-            None,
-            false,
-            true,
-            Some(Harness::Oz),
-            &AgentRunDisplayStatus::TaskSucceeded,
-        ),
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: None,
+            local_conversation_id: None,
+            has_server_token: false,
+            is_cloud_agent_run: true,
+            harness: Some(Harness::Oz),
+            status: &AgentRunDisplayStatus::TaskSucceeded,
+        },),
         AgentConversationListEntryState::Unavailable
     );
 }
@@ -79,14 +81,14 @@ fn tui_list_policy_ignores_status_for_non_cloud_agent_conversations() {
         AgentRunDisplayStatus::TaskInProgress,
     ] {
         assert_eq!(
-            classify_conversation_list_entry(
-                None,
-                Some(AIConversationId::new()),
-                false,
-                false,
-                Some(Harness::Oz),
-                &status,
-            ),
+            classify_conversation_list_entry(ConversationListEntryContext {
+                selected_id: None,
+                local_conversation_id: Some(AIConversationId::new()),
+                has_server_token: false,
+                is_cloud_agent_run: false,
+                harness: Some(Harness::Oz),
+                status: &status,
+            },),
             AgentConversationListEntryState::Available
         );
     }
@@ -95,25 +97,25 @@ fn tui_list_policy_ignores_status_for_non_cloud_agent_conversations() {
 #[test]
 fn tui_list_policy_requires_terminal_status_for_cloud_agent_runs() {
     assert_eq!(
-        classify_conversation_list_entry(
-            None,
-            Some(AIConversationId::new()),
-            true,
-            true,
-            Some(Harness::Oz),
-            &AgentRunDisplayStatus::TaskInProgress,
-        ),
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: None,
+            local_conversation_id: Some(AIConversationId::new()),
+            has_server_token: true,
+            is_cloud_agent_run: true,
+            harness: Some(Harness::Oz),
+            status: &AgentRunDisplayStatus::TaskInProgress,
+        },),
         AgentConversationListEntryState::Unavailable
     );
     assert_eq!(
-        classify_conversation_list_entry(
-            None,
-            Some(AIConversationId::new()),
-            true,
-            true,
-            Some(Harness::Oz),
-            &AgentRunDisplayStatus::TaskSucceeded,
-        ),
+        classify_conversation_list_entry(ConversationListEntryContext {
+            selected_id: None,
+            local_conversation_id: Some(AIConversationId::new()),
+            has_server_token: true,
+            is_cloud_agent_run: true,
+            harness: Some(Harness::Oz),
+            status: &AgentRunDisplayStatus::TaskSucceeded,
+        },),
         AgentConversationListEntryState::Available
     );
 }

--- a/crates/warp_tui/src/conversation_selection_tests.rs
+++ b/crates/warp_tui/src/conversation_selection_tests.rs
@@ -20,6 +20,7 @@ fn tui_list_policy_classifies_selected_terminal_and_unavailable_entries() {
             Some(selected_id),
             Some(selected_id),
             true,
+            false,
             Some(Harness::Oz),
             &AgentRunDisplayStatus::ConversationSucceeded,
         ),
@@ -29,6 +30,7 @@ fn tui_list_policy_classifies_selected_terminal_and_unavailable_entries() {
         classify_conversation_list_entry(
             None,
             Some(AIConversationId::new()),
+            false,
             false,
             Some(Harness::Oz),
             &AgentRunDisplayStatus::ConversationCancelled,
@@ -40,6 +42,7 @@ fn tui_list_policy_classifies_selected_terminal_and_unavailable_entries() {
             None,
             None,
             true,
+            true,
             Some(Harness::Oz),
             &AgentRunDisplayStatus::TaskInProgress,
         ),
@@ -49,6 +52,7 @@ fn tui_list_policy_classifies_selected_terminal_and_unavailable_entries() {
         classify_conversation_list_entry(
             None,
             None,
+            true,
             true,
             Some(Harness::Claude),
             &AgentRunDisplayStatus::TaskSucceeded,
@@ -60,10 +64,57 @@ fn tui_list_policy_classifies_selected_terminal_and_unavailable_entries() {
             None,
             None,
             false,
+            true,
             Some(Harness::Oz),
             &AgentRunDisplayStatus::TaskSucceeded,
         ),
         AgentConversationListEntryState::Unavailable
+    );
+}
+
+#[test]
+fn tui_list_policy_ignores_status_for_non_cloud_agent_conversations() {
+    for status in [
+        AgentRunDisplayStatus::ConversationInProgress,
+        AgentRunDisplayStatus::TaskInProgress,
+    ] {
+        assert_eq!(
+            classify_conversation_list_entry(
+                None,
+                Some(AIConversationId::new()),
+                false,
+                false,
+                Some(Harness::Oz),
+                &status,
+            ),
+            AgentConversationListEntryState::Available
+        );
+    }
+}
+
+#[test]
+fn tui_list_policy_requires_terminal_status_for_cloud_agent_runs() {
+    assert_eq!(
+        classify_conversation_list_entry(
+            None,
+            Some(AIConversationId::new()),
+            true,
+            true,
+            Some(Harness::Oz),
+            &AgentRunDisplayStatus::TaskInProgress,
+        ),
+        AgentConversationListEntryState::Unavailable
+    );
+    assert_eq!(
+        classify_conversation_list_entry(
+            None,
+            Some(AIConversationId::new()),
+            true,
+            true,
+            Some(Harness::Oz),
+            &AgentRunDisplayStatus::TaskSucceeded,
+        ),
+        AgentConversationListEntryState::Available
     );
 }
 


### PR DESCRIPTION
## Description

Fixes local conversations disappearing from the TUI conversation menu after cloud metadata loads.

The shared conversation entry now exposes the same semantic cloud-agent classification used by GUI conversation-list icons. The TUI requires terminal lifecycle status only for actual cloud-agent runs; ordinary conversations remain searchable and restorable regardless of their displayed lifecycle status.


## Testing

- [x] Manually tested with `./script/run-tui`: opened `/conversations` and confirmed the populated list remained stable after cloud loading settled.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/10cde148-18e5-4b21-b9b7-eed28f33144a

Co-Authored-By: Oz <oz-agent@warp.dev>
