### PR TITLE
Move orchestration hint into TUI input

### DIFF
--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -180,8 +180,8 @@ pub struct TuiInputView {
     /// construction always provides this; isolated input tests omit it.
     transcript: Option<ViewHandle<TuiTranscriptView>>,
     keyboard_enhancement_supported: bool,
-    /// Consults the owner live before Shift+Up leaves the first visual row.
-    can_move_focus_up: Rc<dyn Fn(&AppContext) -> bool>,
+    /// Consults the owner live for whether orchestration tabs are available.
+    orchestration_tabs_available: Rc<dyn Fn(&AppContext) -> bool>,
     /// Consults the owner live before an inline-menu Enter can accept an item.
     can_accept_inline_menu: Rc<dyn Fn(&AppContext) -> bool>,
 }
@@ -210,7 +210,7 @@ impl TuiInputView {
         suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         inline_menus: Vec<TuiInlineMenu>,
         transcript: ViewHandle<TuiTranscriptView>,
-        can_move_focus_up: impl Fn(&AppContext) -> bool + 'static,
+        orchestration_tabs_available: impl Fn(&AppContext) -> bool + 'static,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         Self::new_internal(
@@ -219,7 +219,7 @@ impl TuiInputView {
             suggestions_mode,
             inline_menus,
             Some(transcript),
-            can_move_focus_up,
+            orchestration_tabs_available,
             ctx,
         )
     }
@@ -230,7 +230,7 @@ impl TuiInputView {
         input_mode: ModelHandle<BlocklistAIInputModel>,
         suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         inline_menus: Vec<TuiInlineMenu>,
-        can_move_focus_up: impl Fn(&AppContext) -> bool + 'static,
+        orchestration_tabs_available: impl Fn(&AppContext) -> bool + 'static,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         Self::new_internal(
@@ -239,7 +239,7 @@ impl TuiInputView {
             suggestions_mode,
             inline_menus,
             None,
-            can_move_focus_up,
+            orchestration_tabs_available,
             ctx,
         )
     }
@@ -250,7 +250,7 @@ impl TuiInputView {
         suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         inline_menus: Vec<TuiInlineMenu>,
         transcript: Option<ViewHandle<TuiTranscriptView>>,
-        can_move_focus_up: impl Fn(&AppContext) -> bool + 'static,
+        orchestration_tabs_available: impl Fn(&AppContext) -> bool + 'static,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&model, |_, _, event, ctx| {
@@ -273,7 +273,7 @@ impl TuiInputView {
             focused: false,
             transcript,
             keyboard_enhancement_supported: false,
-            can_move_focus_up: Rc::new(can_move_focus_up),
+            orchestration_tabs_available: Rc::new(orchestration_tabs_available),
             can_accept_inline_menu: Rc::new(|_| true),
         }
     }
@@ -364,21 +364,22 @@ impl TuiInputView {
         // state.
         let input_mode = self.input_mode.clone();
         let transcript = self.transcript.clone();
+        let orchestration_tabs_available = self.orchestration_tabs_available.clone();
         element.with_placeholder_ghost_text(move |app| {
             let hint = if input_mode_policy::is_shell_mode(input_mode.as_ref(app)) {
-                input_hints::SHELL_HINT
+                input_hints::SHELL_HINT.to_owned()
             } else {
                 // Inputs constructed without a transcript (isolated tests)
                 // count as zero-state.
                 let transcript_is_empty = transcript
                     .as_ref()
                     .is_none_or(|transcript| transcript.as_ref(app).is_empty());
-                input_hints::agent_input_hint(transcript_is_empty)
+                input_hints::agent_input_hint(
+                    transcript_is_empty,
+                    orchestration_tabs_available(app),
+                )
             };
-            Some((
-                hint.to_owned(),
-                TuiUiBuilder::from_app(app).muted_text_style(),
-            ))
+            Some((hint, TuiUiBuilder::from_app(app).muted_text_style()))
         })
     }
     /// Collapses the current text selection to its head without changing text.
@@ -670,7 +671,7 @@ impl TuiInputView {
 
     /// Whether Shift+Up should leave the input instead of extending selection.
     fn can_focus_above(&self, ctx: &AppContext) -> bool {
-        (self.can_move_focus_up)(ctx) && self.single_cursor_on_first_row(ctx)
+        (self.orchestration_tabs_available)(ctx) && self.single_cursor_on_first_row(ctx)
     }
 
     /// Whether the single caret sits on the first visual row of the input with

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -232,8 +232,9 @@ fn agent_mode_placeholder_hint_renders_only_while_empty() {
             let buffer = render_input_buffer(&view, ctx);
             let line = &buffer.to_lines()[0];
             // One pad cell separates the cursor from the hint.
+            let hint = crate::input_hints::agent_input_hint(true, false);
             assert!(
-                line.starts_with(&format!(" {}", crate::input_hints::ZERO_STATE_AGENT_HINT)),
+                line.starts_with(&format!(" {hint}")),
                 "unexpected line: {line:?}"
             );
             let expected = TuiUiBuilder::from_app(ctx)
@@ -247,6 +248,36 @@ fn agent_mode_placeholder_hint_renders_only_while_empty() {
             let line = &buffer.to_lines()[0];
             assert!(line.starts_with('x'), "unexpected line: {line:?}");
             assert!(!line.contains("for conversations"));
+        });
+    });
+}
+#[test]
+fn orchestration_hint_is_ghosted_only_while_tabs_are_available_and_input_is_empty() {
+    App::test((), |mut app| async move {
+        let orchestration_tabs_available = Rc::new(Cell::new(false));
+        let view = app.update(|ctx| {
+            build_view_with_orchestration_tabs(ctx, orchestration_tabs_available.clone())
+        });
+
+        app.read(|ctx| {
+            let line = &render_input_buffer(&view, ctx).to_lines()[0];
+            assert!(!line.contains("Shift + ↑ sub-agents"));
+        });
+
+        orchestration_tabs_available.set(true);
+        app.read(|ctx| {
+            let line = &render_input_buffer(&view, ctx).to_lines()[0];
+            let hint = crate::input_hints::agent_input_hint(true, true);
+            assert!(
+                line.starts_with(&format!(" {hint}")),
+                "unexpected line: {line:?}"
+            );
+        });
+
+        app.update(|ctx| type_str(&view, ctx, "x"));
+        app.read(|ctx| {
+            let line = &render_input_buffer(&view, ctx).to_lines()[0];
+            assert!(!line.contains("Shift + ↑ sub-agents"));
         });
     });
 }
@@ -435,6 +466,13 @@ fn recognized_slash_command_prefix_matches_menu_color_after_menu_closes() {
 }
 
 fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
+    build_view_with_orchestration_tabs(ctx, Rc::new(Cell::new(false)))
+}
+
+fn build_view_with_orchestration_tabs(
+    ctx: &mut AppContext,
+    orchestration_tabs_available: Rc<Cell<bool>>,
+) -> ViewHandle<TuiInputView> {
     // `CodeEditorModel::new_tui` reads syntax colors from the `Appearance`
     // singleton, so register a mock one before constructing the editor.
     ctx.add_singleton_model(|_| Appearance::mock());
@@ -443,6 +481,7 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
     let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
     let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::Closed);
     let prompt_history_menu = add_prompt_history_menu(ctx, &input_model, &suggestions_mode);
+    let orchestration_tabs_available_for_view = orchestration_tabs_available.clone();
     let (_window_id, view) = ctx.add_tui_window(
         AddWindowOptions {
             window_style: WindowStyle::NotStealFocus,
@@ -454,7 +493,7 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
                 input_mode,
                 suggestions_mode,
                 vec![TuiInlineMenu::new(prompt_history_menu)],
-                |_| false,
+                move |_| orchestration_tabs_available_for_view.get(),
                 ctx,
             )
         },
@@ -904,32 +943,10 @@ fn dispatch(view: &ViewHandle<TuiInputView>, ctx: &mut AppContext, actions: &[Tu
 #[test]
 fn shift_up_requests_focus_above_only_on_first_row_without_selection() {
     App::test((), |mut app| async move {
-        let (view, requests, available) = app.update(|ctx| {
-            ctx.add_singleton_model(|_| Appearance::mock());
-            add_test_semantic_selection(ctx);
-            let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
-            let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::Closed);
-            let available = Rc::new(Cell::new(false));
-            let available_for_view = available.clone();
-            let (_window_id, view) = ctx.add_tui_window(
-                AddWindowOptions {
-                    window_style: WindowStyle::NotStealFocus,
-                    ..Default::default()
-                },
-                move |ctx| {
-                    let model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
-                    let prompt_history_menu =
-                        add_prompt_history_menu(ctx, &model, &suggestions_mode);
-                    TuiInputView::new_for_test(
-                        model,
-                        input_mode,
-                        suggestions_mode,
-                        vec![TuiInlineMenu::new(prompt_history_menu)],
-                        move |_| available_for_view.get(),
-                        ctx,
-                    )
-                },
-            );
+        let (view, requests, orchestration_tabs_available) = app.update(|ctx| {
+            let orchestration_tabs_available = Rc::new(Cell::new(false));
+            let view =
+                build_view_with_orchestration_tabs(ctx, orchestration_tabs_available.clone());
             let requests = Rc::new(RefCell::new(0usize));
             let captured = requests.clone();
             ctx.subscribe_to_view(&view, move |_, event, _| {
@@ -937,7 +954,7 @@ fn shift_up_requests_focus_above_only_on_first_row_without_selection() {
                     *captured.borrow_mut() += 1;
                 }
             });
-            (view, requests, available)
+            (view, requests, orchestration_tabs_available)
         });
 
         app.update(|ctx| {
@@ -949,7 +966,7 @@ fn shift_up_requests_focus_above_only_on_first_row_without_selection() {
         });
         assert_eq!(*requests.borrow(), 0);
 
-        available.set(true);
+        orchestration_tabs_available.set(true);
         app.update(|ctx| {
             dispatch(
                 &view,

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -261,7 +261,7 @@ fn orchestration_hint_is_ghosted_only_while_tabs_are_available_and_input_is_empt
 
         app.read(|ctx| {
             let line = &render_input_buffer(&view, ctx).to_lines()[0];
-            assert!(!line.contains("Shift + ↑ sub-agents"));
+            assert!(!line.contains("Shift + ↑ for other agents"));
         });
 
         orchestration_tabs_available.set(true);
@@ -277,7 +277,7 @@ fn orchestration_hint_is_ghosted_only_while_tabs_are_available_and_input_is_empt
         app.update(|ctx| type_str(&view, ctx, "x"));
         app.read(|ctx| {
             let line = &render_input_buffer(&view, ctx).to_lines()[0];
-            assert!(!line.contains("Shift + ↑ sub-agents"));
+            assert!(!line.contains("Shift + ↑ for other agents"));
         });
     });
 }

--- a/crates/warp_tui/src/input_hints.rs
+++ b/crates/warp_tui/src/input_hints.rs
@@ -1,22 +1,18 @@
 //! Mode-dependent ghosted placeholder hints for the TUI prompt input.
 //!
 //! Content policy for the input's empty-buffer ghost text: keybinding
-//! guidance whose entries adapt to the transcript state. The keys referenced
-//! here are typed characters (`!`, `/`) or fixed navigation keys (`←`), not
-//! remappable bindings, so the strings are static; binding-backed hints must
-//! resolve their keystroke display through the live keymap instead (see
-//! `crate::keybindings::plan_toggle_hint`).
+//! guidance whose entries adapt to the transcript and orchestration state. The
+//! keys referenced here are typed characters (`!`, `/`) or fixed navigation
+//! keys (`←`, `Shift+↑`), not remappable bindings, so the strings are static;
+//! binding-backed hints must resolve their keystroke display through the live
+//! keymap instead (see `crate::keybindings::plan_toggle_hint`).
 
-/// Ghost text for an empty agent-mode input before the transcript has any
-/// visible content. Per design review, the zero state teaches the entry
-/// points instead of pitching an example prompt: slash commands, and the
-/// conversation list (`←` opens it from an empty input).
-pub(crate) const ZERO_STATE_AGENT_HINT: &str = "/ for commands • ← for conversations";
-
-/// Ghost text for an empty agent-mode input once the transcript has content.
-/// The design's `? for shortcuts` segment is intentionally omitted until the
-/// TUI has a shortcuts menu to open.
-pub(crate) const AGENT_HINT: &str = "Ask the agent anything • ! for shell mode • / for commands";
+const ASK_AGENT_HINT: &str = "Ask the agent anything";
+const ORCHESTRATION_HINT: &str = "Shift + ↑ sub-agents";
+const SHELL_MODE_HINT: &str = "! for shell mode";
+const COMMANDS_HINT: &str = "/ for commands";
+const CONVERSATIONS_HINT: &str = "← for conversations";
+const HINT_SEPARATOR: &str = " • ";
 
 /// Ghost text for an empty `!` shell-mode input: how to run and how to get
 /// back to agent mode (esc is the input's contextual escape; backspace on the
@@ -28,13 +24,26 @@ pub(crate) const SHELL_HINT: &str = "Run a shell command • esc for agent mode"
 /// ctrl-c is the reserved interrupt key in both the TUI keymap and the PTY.
 pub(crate) const LONG_RUNNING_COMMAND_HINT: &str = "ctrl-c to interrupt";
 
-/// The agent-mode placeholder hint for the current transcript state.
-pub(crate) fn agent_input_hint(transcript_is_empty: bool) -> &'static str {
+/// The agent-mode placeholder hint for the current transcript and orchestration
+/// state.
+pub(crate) fn agent_input_hint(
+    transcript_is_empty: bool,
+    orchestration_tabs_available: bool,
+) -> String {
+    let mut hints = Vec::with_capacity(4);
     if transcript_is_empty {
-        ZERO_STATE_AGENT_HINT
+        if orchestration_tabs_available {
+            hints.push(ORCHESTRATION_HINT);
+        }
+        hints.extend([COMMANDS_HINT, CONVERSATIONS_HINT]);
     } else {
-        AGENT_HINT
+        hints.push(ASK_AGENT_HINT);
+        if orchestration_tabs_available {
+            hints.push(ORCHESTRATION_HINT);
+        }
+        hints.extend([SHELL_MODE_HINT, COMMANDS_HINT]);
     }
+    hints.join(HINT_SEPARATOR)
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/input_hints.rs
+++ b/crates/warp_tui/src/input_hints.rs
@@ -8,7 +8,7 @@
 //! keymap instead (see `crate::keybindings::plan_toggle_hint`).
 
 const ASK_AGENT_HINT: &str = "Ask the agent anything";
-const ORCHESTRATION_HINT: &str = "Shift + ↑ sub-agents";
+const ORCHESTRATION_HINT: &str = "Shift + ↑ for other agents";
 const SHELL_MODE_HINT: &str = "! for shell mode";
 const COMMANDS_HINT: &str = "/ for commands";
 const CONVERSATIONS_HINT: &str = "← for conversations";

--- a/crates/warp_tui/src/input_hints_tests.rs
+++ b/crates/warp_tui/src/input_hints_tests.rs
@@ -1,20 +1,16 @@
-use super::{AGENT_HINT, ZERO_STATE_AGENT_HINT, agent_input_hint};
+use super::{ASK_AGENT_HINT, COMMANDS_HINT, CONVERSATIONS_HINT, SHELL_MODE_HINT, agent_input_hint};
 
 #[test]
-fn transcript_state_selects_the_hint_variant() {
-    assert_eq!(agent_input_hint(true), ZERO_STATE_AGENT_HINT);
-    assert_eq!(agent_input_hint(false), AGENT_HINT);
-    assert_ne!(agent_input_hint(true), agent_input_hint(false));
-}
+fn transcript_state_selects_the_applicable_hint_segments() {
+    let zero_state = agent_input_hint(true, false);
+    assert!(zero_state.contains(COMMANDS_HINT));
+    assert!(zero_state.contains(CONVERSATIONS_HINT));
+    assert!(!zero_state.contains(ASK_AGENT_HINT));
+    assert!(!zero_state.contains(SHELL_MODE_HINT));
 
-#[test]
-fn zero_state_hint_teaches_commands_and_conversations() {
-    assert!(ZERO_STATE_AGENT_HINT.contains("/ for commands"));
-    assert!(ZERO_STATE_AGENT_HINT.contains("← for conversations"));
-}
-
-#[test]
-fn started_transcript_hint_teaches_shell_mode_and_commands() {
-    assert!(AGENT_HINT.contains("! for shell mode"));
-    assert!(AGENT_HINT.contains("/ for commands"));
+    let started = agent_input_hint(false, false);
+    assert!(started.contains(ASK_AGENT_HINT));
+    assert!(started.contains(SHELL_MODE_HINT));
+    assert!(started.contains(COMMANDS_HINT));
+    assert!(!started.contains(CONVERSATIONS_HINT));
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -2207,18 +2207,16 @@ impl TuiTerminalSessionView {
     /// Builds the status footer under the input box. The row is left-aligned:
     /// in agent mode `[model] [cwd ↬ branch] • [usage] • [+N -M]`, and in shell
     /// mode `[shell mode] [cwd ↬ branch] • [+N -M]` (model and usage hidden).
-    /// A replacing hint — the ctrl-c exit
-    /// confirmation while armed, the conversation-list loading hint, an active
-    /// transient notice, or the `Shift + ↑ sub-agents` orchestration callout
-    /// in agent mode — occupies the whole row instead; shell mode wins over
-    /// the orchestration callout so its indicator keeps leading. Every child
-    /// truncates to a single row, so the row lays out one row tall.
-    fn render_footer(&self, orchestration_tabs_available: bool, ctx: &AppContext) -> TuiFlex {
+    /// A replacing hint — the ctrl-c exit confirmation while armed, the
+    /// conversation-list loading hint, or an active transient notice — occupies
+    /// the whole row instead. Every child truncates to a single row, so the row
+    /// lays out one row tall.
+    fn render_footer(&self, ctx: &AppContext) -> TuiFlex {
         let builder = TuiUiBuilder::from_app(ctx);
         let muted = builder.muted_text_style();
 
         // Replacing hints occupy the entire status row, in the existing
-        // priority order: ctrl-c → loading → transient → orchestration callout.
+        // priority order: ctrl-c → loading → transient.
         if self.exit_confirmation.is_armed() {
             return TuiFlex::row().child(
                 TuiText::new(CTRL_C_EXIT_HINT)
@@ -2253,17 +2251,7 @@ impl TuiTerminalSessionView {
                     .finish(),
             );
         }
-        // The orchestration-tab callout replaces the status row in agent mode;
-        // shell mode wins so its first segment remains the shell indicator.
         let shell_mode = self.is_shell_mode(ctx);
-        if orchestration_tabs_available && !shell_mode {
-            return TuiFlex::row().child(
-                TuiText::new("Shift + ↑ sub-agents")
-                    .with_style(muted)
-                    .truncate()
-                    .finish(),
-            );
-        }
 
         // Normal left-aligned sectioned status row.
         let git_metadata = self.git_status_metadata(ctx);
@@ -3327,13 +3315,11 @@ impl TuiView for TuiTerminalSessionView {
                 .finish(),
             );
             let footer = if matches!(input_target, TuiInputTarget::Disabled) {
-                self.render_footer(orchestration_tabs_available, ctx)
-                    .finish()
+                self.render_footer(ctx).finish()
             } else if self.orchestration_tabs_focused {
                 self.render_orchestration_tab_footer(&builder)
             } else {
-                self.render_footer(orchestration_tabs_available, ctx)
-                    .finish()
+                self.render_footer(ctx).finish()
             };
             content = content.child(TuiConstrainedBox::new(footer).with_max_rows(1).finish());
         }

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -7,9 +7,9 @@ use warp::settings::{AISettings, TuiUsageDisplayMode};
 use warp::terminal::model::ansi::{Handler, InputBufferValue};
 use warp::tui_export::{
     AIConversationAutoexecuteMode, AIConversationId, AgentViewEntryOrigin, BlockPadding,
-    BlocklistAIHistoryModel, ConversationStatus, ConversationUsageTotals, Harness, InputType,
-    LLMPreferences, PtyIntent, PtyIntentEvent, SizeInfo, SizeUpdate, TranscriptScope,
-    export_conversation_markdown, register_tui_session_view_test_singletons, slash_commands,
+    BlocklistAIHistoryModel, ConversationStatus, ConversationUsageTotals, Harness, LLMPreferences,
+    PtyIntent, PtyIntentEvent, SizeInfo, SizeUpdate, TranscriptScope, export_conversation_markdown,
+    register_tui_session_view_test_singletons, slash_commands,
 };
 use warp_core::settings::Setting as _;
 use warp_editor::model::CoreEditorModel;
@@ -1002,14 +1002,10 @@ fn zero_state_transitions_through_bootstrap_lifecycle() {
 fn render_footer_lines(
     app: &mut App,
     view: &ViewHandle<super::TuiTerminalSessionView>,
-    orchestration_tabs_available: bool,
     width: u16,
 ) -> Vec<String> {
     app.update(|ctx| {
-        let footer = view
-            .as_ref(ctx)
-            .render_footer(orchestration_tabs_available, ctx)
-            .finish();
+        let footer = view.as_ref(ctx).render_footer(ctx).finish();
         render_element(footer, ctx, width).to_lines()
     })
 }
@@ -1248,7 +1244,7 @@ fn footer_transient_state_replaces_all_sections() {
         view.update(&mut app, |view, _| {
             view.exit_confirmation.arm(Instant::now());
         });
-        let lines = render_footer_lines(&mut app, &view, false, 80);
+        let lines = render_footer_lines(&mut app, &view, 80);
         assert_eq!(lines, vec![CTRL_C_EXIT_HINT]);
         assert_footer_segments_absent(&lines);
 
@@ -1261,7 +1257,7 @@ fn footer_transient_state_replaces_all_sections() {
                 future: None,
             };
         });
-        let lines = render_footer_lines(&mut app, &view, false, 80);
+        let lines = render_footer_lines(&mut app, &view, 80);
         assert_eq!(lines, vec![LOADING_CONVERSATION_HINT]);
         assert_footer_segments_absent(&lines);
 
@@ -1270,7 +1266,7 @@ fn footer_transient_state_replaces_all_sections() {
             view.conversation_restore_state = ConversationRestoreState::Idle;
             view.show_transient_hint("transient notice".to_owned(), ctx);
         });
-        let lines = render_footer_lines(&mut app, &view, false, 80);
+        let lines = render_footer_lines(&mut app, &view, 80);
         assert_eq!(lines, vec!["transient notice"]);
         assert_footer_segments_absent(&lines);
 
@@ -1285,40 +1281,8 @@ fn footer_transient_state_replaces_all_sections() {
             };
             view.show_transient_hint("transient notice".to_owned(), ctx);
         });
-        let lines = render_footer_lines(&mut app, &view, false, 80);
+        let lines = render_footer_lines(&mut app, &view, 80);
         assert_eq!(lines, vec![CTRL_C_EXIT_HINT]);
-    });
-}
-
-#[test]
-fn footer_orchestration_callout_replaces_sections() {
-    App::test((), |mut app| async move {
-        let fixture = focus_test_fixture(&mut app);
-        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
-
-        // With orchestration tabs available and the session in agent mode, the
-        // callout replaces the entire status row.
-        let lines = render_footer_lines(&mut app, &view, true, 80);
-        assert_eq!(lines, vec!["Shift + ↑ sub-agents"]);
-        assert_footer_segments_absent(&lines);
-
-        // Shell mode wins over the orchestration callout: the bash row leads
-        // with the shell-mode indicator instead.
-        view.update(&mut app, |view, ctx| {
-            view.ai_input_model.update(ctx, |input_mode, ctx| {
-                input_mode.set_input_type(InputType::Shell, None, ctx);
-            });
-        });
-        let lines = render_footer_lines(&mut app, &view, true, 80);
-        let row = lines.join("\n");
-        assert!(
-            row.starts_with(SHELL_MODE_HINT),
-            "shell mode wins over the orchestration callout: {row}"
-        );
-        assert!(
-            !row.contains("Shift + ↑ sub-agents"),
-            "the orchestration callout yields to shell mode: {row}"
-        );
     });
 }
 
@@ -1332,7 +1296,7 @@ fn footer_conversations_callout_no_longer_renders() {
         // left-aligned sectioned row — never the obsolete `← for conversations`
         // callout (render_left_footer_hint and the show_conversations_hint
         // branch are removed, not merely unreachable).
-        let lines = render_footer_lines(&mut app, &view, false, 80);
+        let lines = render_footer_lines(&mut app, &view, 80);
         let row = lines.join("\n");
         assert!(
             !row.contains("← for conversations"),

--- a/specs/code-1822-tui-orchestration-tab-bar/PRODUCT.md
+++ b/specs/code-1822-tui-orchestration-tab-bar/PRODUCT.md
@@ -49,7 +49,7 @@ The Warp TUI shows a tab bar for an orchestration tree so users can see and swit
 12. Reordering never changes the active conversation by itself.
 
 ### Entering and leaving keyboard focus
-13. While an orchestration tab bar is available and the input is focused, the normal footer shows the `Shift + ↑ sub-agents` hint from the design.
+13. While an orchestration tab bar is available, an empty agent-mode input places `Shift + ↑ sub-agents` after the `Ask the agent anything` lead-in and before its ghost-text shortcuts. The normal footer remains available for model, working-directory, usage, and diff status.
 14. `Shift+Up` focuses the tab bar only when:
    - The input cursor is on the first visual row of the wrapped input (display row zero), and
    - The input has no active text selection.

--- a/specs/code-1822-tui-orchestration-tab-bar/PRODUCT.md
+++ b/specs/code-1822-tui-orchestration-tab-bar/PRODUCT.md
@@ -49,7 +49,7 @@ The Warp TUI shows a tab bar for an orchestration tree so users can see and swit
 12. Reordering never changes the active conversation by itself.
 
 ### Entering and leaving keyboard focus
-13. While an orchestration tab bar is available, an empty agent-mode input places `Shift + ↑ sub-agents` after the `Ask the agent anything` lead-in and before its ghost-text shortcuts. The normal footer remains available for model, working-directory, usage, and diff status.
+13. While an orchestration tab bar is available, an empty agent-mode input places `Shift + ↑ for other agents` after the `Ask the agent anything` lead-in and before its ghost-text shortcuts. The normal footer remains available for model, working-directory, usage, and diff status.
 14. `Shift+Up` focuses the tab bar only when:
    - The input cursor is on the first visual row of the wrapped input (display row zero), and
    - The input has no active text selection.

--- a/specs/code-1822-tui-orchestration-tab-bar/TECH.md
+++ b/specs/code-1822-tui-orchestration-tab-bar/TECH.md
@@ -89,7 +89,7 @@ Restructure the normal render tree into:
 
 The alt-screen early return remains unchanged and therefore owns the complete pane. Blocking cards remain inside the normal session column, so the tab bar stays available above them.
 
-When the bar is unfocused, render the normal footer with the conditional `Shift + ↑ sub-agents` hint. When focused, keep the input visible but blurred and replace the normal footer with the PRODUCT (18) navigation footer.
+When the bar is unfocused, place the conditional `Shift + ↑ sub-agents` shortcut after the empty agent input's `Ask the agent anything` lead-in and before its remaining shortcuts, and retain the normal status footer. When focused, keep the input visible but blurred and replace the normal footer with the PRODUCT (18) navigation footer.
 
 Tab and overflow interactions emit semantic child-view events subscribed by `TuiTerminalSessionView`:
 - Tab clicks select immediately. The owner preserves tab focus only if it was already active; otherwise it focuses the target session's normal interaction target.
@@ -110,7 +110,7 @@ Extend `orchestration_model_tests.rs`, `session_registry_tests.rs`, `terminal_se
 - Exact reuse of GUI pin/status/error/active/done-recency/spawn ordering after filtering non-navigable sessions — PRODUCT (4, 9-12).
 - The same root and tabs from orchestrator and child sessions; newly materialized and removed sessions — PRODUCT (1-5, 47-49).
 - Shared active-tree page state, explicit-page persistence, active reveal, and semantic keyboard navigation while the active tab is off-page — PRODUCT (26-27, 39-42).
-- Wrapped-row and selection-aware `Shift+Up` behavior; `Shift+Down` restoration — PRODUCT (13-18).
+- Conditional input ghost text, wrapped-row and selection-aware `Shift+Up` behavior, and `Shift+Down` restoration — PRODUCT (13-18).
 - Wrapped adjacent navigation, child-only first/last jumps, and tab focus preserved across full-session projection — PRODUCT (19-25).
 - Focused and unfocused mouse switches, no-op active clicks, overflow clicks that neither select nor move focus, and blocker precedence — PRODUCT (28-32, 38, 45-46).
 - Tab bar above normal blockers and omitted by alt-screen replacement — PRODUCT (50).

--- a/specs/code-1822-tui-orchestration-tab-bar/TECH.md
+++ b/specs/code-1822-tui-orchestration-tab-bar/TECH.md
@@ -89,7 +89,7 @@ Restructure the normal render tree into:
 
 The alt-screen early return remains unchanged and therefore owns the complete pane. Blocking cards remain inside the normal session column, so the tab bar stays available above them.
 
-When the bar is unfocused, place the conditional `Shift + ↑ sub-agents` shortcut after the empty agent input's `Ask the agent anything` lead-in and before its remaining shortcuts, and retain the normal status footer. When focused, keep the input visible but blurred and replace the normal footer with the PRODUCT (18) navigation footer.
+When the bar is unfocused, place the conditional `Shift + ↑ for other agents` shortcut after the empty agent input's `Ask the agent anything` lead-in and before its remaining shortcuts, and retain the normal status footer. When focused, keep the input visible but blurred and replace the normal footer with the PRODUCT (18) navigation footer.
 
 Tab and overflow interactions emit semantic child-view events subscribed by `TuiTerminalSessionView`:
 - Tab clicks select immediately. The owner preserves tab focus only if it was already active; otherwise it focuses the target session's normal interaction target.


### PR DESCRIPTION
## Description
- Move the conditional `Shift + ↑ sub-agents` hint into empty agent-input ghost text when the orchestration tab bar is visible.
- Keep the normal footer available for model, working-directory, usage, and diff status.
- Align the TUI orchestration product and technical specs with the updated behavior.

## Linked Issue
No linked issue.

## Testing
- [x] Manual live TUI verification (not run per request)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp Agent Mode ([conversation](https://staging.warp.dev/conversation/d4e1633e-cdc6-4548-9772-65bd91bd3b8a))

Co-Authored-By: Oz <oz-agent@warp.dev>