### PR TITLE
Centralize slash command surface support

### DIFF
--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use warp_core::features::FeatureFlag;
 
-use super::Availability;
+use super::{Availability, SlashCommandKind, SlashCommandSurfaces};
 use crate::search::slash_command_menu::StaticCommand;
 use crate::search::slash_command_menu::static_commands::Argument;
 use crate::ui_components::color_dot;
@@ -13,7 +13,10 @@ use crate::ui_components::color_dot;
 pub static AGENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/agent",
     description: "Start a new conversation",
-    icon_path: "bundled/svg/oz.svg",
+    kind: SlashCommandKind::Agent,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/oz.svg",
+    },
     availability: Availability::AI_ENABLED.union(Availability::NOT_CLOUD_AGENT),
     auto_enter_ai_mode: false,
     argument: Some(Argument::optional().with_execute_on_selection()),
@@ -22,7 +25,10 @@ pub static AGENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub static CLOUD_AGENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/cloud-agent",
     description: "Start a new cloud agent conversation",
-    icon_path: "bundled/svg/oz-cloud.svg",
+    kind: SlashCommandKind::CloudAgent,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/oz-cloud.svg",
+    },
     availability: Availability::AI_ENABLED.union(Availability::NOT_CLOUD_AGENT),
     auto_enter_ai_mode: false,
     argument: Some(Argument::optional().with_execute_on_selection()),
@@ -31,7 +37,10 @@ pub static CLOUD_AGENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand
 pub const ADD_MCP: StaticCommand = StaticCommand {
     name: "/add-mcp",
     description: "Add a new MCP server via the MCP settings page",
-    icon_path: "bundled/svg/dataflow.svg",
+    kind: SlashCommandKind::AddMcp,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/dataflow.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -40,7 +49,8 @@ pub const ADD_MCP: StaticCommand = StaticCommand {
 pub const AUTO_APPROVE: StaticCommand = StaticCommand {
     name: "/auto-approve",
     description: "Toggle auto approve",
-    icon_path: "bundled/svg/fast-forward.svg",
+    kind: SlashCommandKind::AutoApprove,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
     availability: Availability::AGENT_VIEW
         .union(Availability::ACTIVE_CONVERSATION)
         .union(Availability::AI_ENABLED)
@@ -52,7 +62,8 @@ pub const AUTO_APPROVE: StaticCommand = StaticCommand {
 pub const MCP: StaticCommand = StaticCommand {
     name: "/mcp",
     description: "View and manage MCP servers",
-    icon_path: "bundled/svg/dataflow.svg",
+    kind: SlashCommandKind::Mcp,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -61,7 +72,8 @@ pub const MCP: StaticCommand = StaticCommand {
 pub const VIEW_LOGS: StaticCommand = StaticCommand {
     name: "/view-logs",
     description: "Bundle your logs into a zip archive",
-    icon_path: "bundled/svg/download-01.svg",
+    kind: SlashCommandKind::ViewLogs,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: None,
@@ -70,7 +82,8 @@ pub const VIEW_LOGS: StaticCommand = StaticCommand {
 pub const ENABLE_NATURAL_LANGUAGE_DETECTION: StaticCommand = StaticCommand {
     name: "/enable-natural-language-detection",
     description: "Turn on natural language detection in the input",
-    icon_path: "bundled/svg/eye.svg",
+    kind: SlashCommandKind::EnableNaturalLanguageDetection,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -79,7 +92,8 @@ pub const ENABLE_NATURAL_LANGUAGE_DETECTION: StaticCommand = StaticCommand {
 pub const DISABLE_NATURAL_LANGUAGE_DETECTION: StaticCommand = StaticCommand {
     name: "/disable-natural-language-detection",
     description: "Turn off natural language detection in the input",
-    icon_path: "bundled/svg/eye.svg",
+    kind: SlashCommandKind::DisableNaturalLanguageDetection,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -88,7 +102,8 @@ pub const DISABLE_NATURAL_LANGUAGE_DETECTION: StaticCommand = StaticCommand {
 pub const EXIT: StaticCommand = StaticCommand {
     name: "/exit",
     description: "Exit Warp",
-    icon_path: "bundled/svg/log-out-01.svg",
+    kind: SlashCommandKind::Exit,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: None,
@@ -97,7 +112,8 @@ pub const EXIT: StaticCommand = StaticCommand {
 pub const LOGOUT: StaticCommand = StaticCommand {
     name: "/logout",
     description: "Log out of Warp",
-    icon_path: "bundled/svg/log-out-01.svg",
+    kind: SlashCommandKind::Logout,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: None,
@@ -106,7 +122,10 @@ pub const LOGOUT: StaticCommand = StaticCommand {
 pub static CREATE_ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/create-environment",
     description: "Create an Oz environment (Docker image + repos) via guided setup",
-    icon_path: "bundled/svg/dataflow.svg",
+    kind: SlashCommandKind::CreateEnvironment,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/dataflow.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: Some(
@@ -119,7 +138,10 @@ pub static CREATE_ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| Static
 pub const CREATE_DOCKER_SANDBOX: StaticCommand = StaticCommand {
     name: "/docker-sandbox",
     description: "Create a new docker sandbox terminal session",
-    icon_path: "bundled/svg/docker.svg",
+    kind: SlashCommandKind::CreateDockerSandbox,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/docker.svg",
+    },
     availability: Availability::LOCAL.union(Availability::AI_ENABLED),
     auto_enter_ai_mode: false,
     argument: None,
@@ -128,7 +150,10 @@ pub const CREATE_DOCKER_SANDBOX: StaticCommand = StaticCommand {
 pub static CREATE_NEW_PROJECT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/create-new-project",
     description: "Have Oz walk you through creating a new coding project",
-    icon_path: "bundled/svg/plus.svg",
+    kind: SlashCommandKind::CreateNewProject,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/plus.svg",
+    },
     availability: Availability::LOCAL | Availability::AI_ENABLED,
     auto_enter_ai_mode: true,
     argument: Some(Argument::required().with_hint_text("<describe what you want to build>")),
@@ -137,7 +162,10 @@ pub static CREATE_NEW_PROJECT: LazyLock<StaticCommand> = LazyLock::new(|| Static
 pub static EDIT_SKILL: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/open-skill",
     description: "Open a skill's markdown file in Warp's built-in editor",
-    icon_path: "bundled/svg/file-code-02.svg",
+    kind: SlashCommandKind::EditSkill,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/file-code-02.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -146,7 +174,10 @@ pub static EDIT_SKILL: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand 
 pub static INVOKE_SKILL: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/skills",
     description: "Invoke a skill",
-    icon_path: "bundled/svg/stars-01.svg",
+    kind: SlashCommandKind::InvokeSkill,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/stars-01.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -155,10 +186,13 @@ pub static INVOKE_SKILL: LazyLock<StaticCommand> = LazyLock::new(|| StaticComman
 pub static ADD_PROMPT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/add-prompt",
     description: "Add new Agent prompt",
-    icon_path: if FeatureFlag::AgentView.is_enabled() {
-        "bundled/svg/prompt.svg"
-    } else {
-        "bundled/svg/agentmode.svg"
+    kind: SlashCommandKind::AddPrompt,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: if FeatureFlag::AgentView.is_enabled() {
+            "bundled/svg/prompt.svg"
+        } else {
+            "bundled/svg/agentmode.svg"
+        },
     },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
@@ -168,7 +202,10 @@ pub static ADD_PROMPT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand 
 pub const ADD_RULE: StaticCommand = StaticCommand {
     name: "/add-rule",
     description: "Add a new global rule for the agent",
-    icon_path: "bundled/svg/book-open.svg",
+    kind: SlashCommandKind::AddRule,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/book-open.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -177,7 +214,10 @@ pub const ADD_RULE: StaticCommand = StaticCommand {
 pub static EDIT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/open-file",
     description: "Open a file in Warp's code editor",
-    icon_path: "bundled/svg/file-code-02.svg",
+    kind: SlashCommandKind::Edit,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/file-code-02.svg",
+    },
     availability: Availability::LOCAL,
     auto_enter_ai_mode: false,
     argument: Some(
@@ -188,7 +228,10 @@ pub static EDIT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub static RENAME_TAB: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/rename-tab",
     description: "Rename the current tab",
-    icon_path: "bundled/svg/pencil-line.svg",
+    kind: SlashCommandKind::RenameTab,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/pencil-line.svg",
+    },
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: Some(Argument::required().with_hint_text("<tab name>")),
@@ -197,7 +240,10 @@ pub static RENAME_TAB: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand 
 pub static RENAME_CONVERSATION: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/rename-conversation",
     description: "Rename the current conversation",
-    icon_path: "bundled/svg/pencil-line.svg",
+    kind: SlashCommandKind::RenameConversation,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/pencil-line.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::ACTIVE_CONVERSATION
         | Availability::AI_ENABLED,
@@ -218,7 +264,10 @@ static SET_TAB_COLOR_HINT: LazyLock<String> = LazyLock::new(|| {
 pub static SET_TAB_COLOR: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/set-tab-color",
     description: "Set the color of the current tab",
-    icon_path: "bundled/svg/ellipse.svg",
+    kind: SlashCommandKind::SetTabColor,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/ellipse.svg",
+    },
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: Some(Argument::required().with_hint_text(SET_TAB_COLOR_HINT.as_str())),
@@ -229,7 +278,10 @@ pub static FORK: LazyLock<StaticCommand> = LazyLock::new(|| {
     StaticCommand {
         name: "/fork",
         description: "Fork the current conversation in a new pane or a new tab",
-        icon_path: "bundled/svg/arrow-split.svg",
+        kind: SlashCommandKind::Fork,
+        supported_surfaces: SlashCommandSurfaces::GuiOnly {
+            icon_path: "bundled/svg/arrow-split.svg",
+        },
         availability: Availability::AGENT_VIEW
             | Availability::ACTIVE_CONVERSATION
             | Availability::NO_LRC_CONTROL
@@ -242,7 +294,10 @@ pub static FORK: LazyLock<StaticCommand> = LazyLock::new(|| {
 pub static MOVE_TO_CLOUD: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/handoff",
     description: "Hand off this conversation to a cloud agent",
-    icon_path: "bundled/svg/upload-cloud-01.svg",
+    kind: SlashCommandKind::MoveToCloud,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/upload-cloud-01.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::ACTIVE_CONVERSATION
         | Availability::AI_ENABLED
@@ -258,7 +313,10 @@ pub static MOVE_TO_CLOUD: LazyLock<StaticCommand> = LazyLock::new(|| StaticComma
 pub const OPEN_CODE_REVIEW: StaticCommand = StaticCommand {
     name: "/open-code-review",
     description: "Open code review",
-    icon_path: "bundled/svg/diff.svg",
+    kind: SlashCommandKind::OpenCodeReview,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/diff.svg",
+    },
     availability: Availability::REPOSITORY,
     auto_enter_ai_mode: false,
     argument: None,
@@ -267,7 +325,10 @@ pub const OPEN_CODE_REVIEW: StaticCommand = StaticCommand {
 pub const INDEX: StaticCommand = StaticCommand {
     name: "/index",
     description: "Index this codebase",
-    icon_path: "bundled/svg/find-all.svg",
+    kind: SlashCommandKind::Index,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/find-all.svg",
+    },
     availability: Availability::REPOSITORY
         .union(Availability::CODEBASE_CONTEXT)
         .union(Availability::AI_ENABLED),
@@ -278,7 +339,10 @@ pub const INDEX: StaticCommand = StaticCommand {
 pub const INIT: StaticCommand = StaticCommand {
     name: "/init",
     description: "Index this codebase and generate an AGENTS.md file",
-    icon_path: "bundled/svg/warp-2.svg",
+    kind: SlashCommandKind::Init,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/warp-2.svg",
+    },
     availability: Availability::REPOSITORY
         .union(Availability::AGENT_VIEW)
         .union(Availability::AI_ENABLED),
@@ -289,7 +353,10 @@ pub const INIT: StaticCommand = StaticCommand {
 pub const OPEN_PROJECT_RULES: StaticCommand = StaticCommand {
     name: "/open-project-rules",
     description: "Open the project rules file (AGENTS.md)",
-    icon_path: "bundled/svg/file-code-02.svg",
+    kind: SlashCommandKind::OpenProjectRules,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/file-code-02.svg",
+    },
     availability: Availability::REPOSITORY.union(Availability::AI_ENABLED),
     auto_enter_ai_mode: false,
     argument: None,
@@ -298,7 +365,10 @@ pub const OPEN_PROJECT_RULES: StaticCommand = StaticCommand {
 pub const OPEN_MCP_SERVERS: StaticCommand = StaticCommand {
     name: "/open-mcp-servers",
     description: "Open MCP servers",
-    icon_path: "bundled/svg/dataflow.svg",
+    kind: SlashCommandKind::OpenMcpServers,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/dataflow.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -307,7 +377,10 @@ pub const OPEN_MCP_SERVERS: StaticCommand = StaticCommand {
 pub const OPEN_SETTINGS_FILE: StaticCommand = StaticCommand {
     name: "/open-settings-file",
     description: "Open settings file (TOML)",
-    icon_path: "bundled/svg/file-code-02.svg",
+    kind: SlashCommandKind::OpenSettingsFile,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/file-code-02.svg",
+    },
     availability: Availability::LOCAL,
     auto_enter_ai_mode: false,
     argument: None,
@@ -316,7 +389,10 @@ pub const OPEN_SETTINGS_FILE: StaticCommand = StaticCommand {
 pub const CHANGELOG: StaticCommand = StaticCommand {
     name: "/changelog",
     description: "Open the latest changelog",
-    icon_path: "bundled/svg/book-open.svg",
+    kind: SlashCommandKind::Changelog,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/book-open.svg",
+    },
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: None,
@@ -328,7 +404,10 @@ pub const CHANGELOG: StaticCommand = StaticCommand {
 pub static FEEDBACK: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/feedback",
     description: "Send feedback",
-    icon_path: "bundled/svg/feedback.svg",
+    kind: SlashCommandKind::Feedback,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/feedback.svg",
+    },
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: Some(Argument::optional().with_execute_on_selection()),
@@ -337,7 +416,10 @@ pub static FEEDBACK: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub const OPEN_REPO: StaticCommand = StaticCommand {
     name: "/open-repo",
     description: "Switch to another indexed repository",
-    icon_path: "bundled/svg/folder.svg",
+    kind: SlashCommandKind::OpenRepo,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/folder.svg",
+    },
     availability: Availability::LOCAL.union(Availability::AI_ENABLED),
     auto_enter_ai_mode: false,
     argument: None,
@@ -346,7 +428,10 @@ pub const OPEN_REPO: StaticCommand = StaticCommand {
 pub const OPEN_RULES: StaticCommand = StaticCommand {
     name: "/open-rules",
     description: "View all of your global and project rules",
-    icon_path: "bundled/svg/book-open.svg",
+    kind: SlashCommandKind::OpenRules,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/book-open.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -355,7 +440,10 @@ pub const OPEN_RULES: StaticCommand = StaticCommand {
 pub static NEW: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/new",
     description: "Start a new conversation (alias for /agent)",
-    icon_path: "bundled/svg/new-conversation.svg",
+    kind: SlashCommandKind::New,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/new-conversation.svg",
+    },
     availability: Availability::NO_LRC_CONTROL
         | Availability::AI_ENABLED
         | Availability::NOT_CLOUD_AGENT,
@@ -366,7 +454,10 @@ pub static NEW: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub static MODEL: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/model",
     description: "Switch the base agent model",
-    icon_path: "bundled/svg/oz.svg",
+    kind: SlashCommandKind::Model,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/oz.svg",
+    },
     availability: Availability::AGENT_VIEW | Availability::AI_ENABLED,
     auto_enter_ai_mode: true,
     argument: None,
@@ -375,7 +466,10 @@ pub static MODEL: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub static HOST: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/host",
     description: "Switch the cloud agent execution host",
-    icon_path: "bundled/svg/oz-cloud.svg",
+    kind: SlashCommandKind::Host,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/oz-cloud.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
         | Availability::CLOUD_MODE_V2_COMPOSER,
@@ -386,7 +480,10 @@ pub static HOST: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub static HARNESS: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/harness",
     description: "Switch the cloud agent harness",
-    icon_path: "bundled/svg/oz.svg",
+    kind: SlashCommandKind::Harness,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/oz.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
         | Availability::CLOUD_MODE_V2_COMPOSER,
@@ -397,7 +494,10 @@ pub static HARNESS: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub static ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/environment",
     description: "Switch the cloud agent environment",
-    icon_path: "bundled/svg/globe-04.svg",
+    kind: SlashCommandKind::Environment,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/globe-04.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
         | Availability::CLOUD_MODE_V2_COMPOSER,
@@ -408,7 +508,10 @@ pub static ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand
 pub static PROFILE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/profile",
     description: "Switch the active execution profile",
-    icon_path: "bundled/svg/psychology.svg",
+    kind: SlashCommandKind::Profile,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/psychology.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
         | Availability::NOT_CLOUD_AGENT,
@@ -421,7 +524,10 @@ pub const PLAN_NAME: &str = "/plan";
 pub static PLAN: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: PLAN_NAME,
     description: "Prompt the agent to do some research and create a plan for a task",
-    icon_path: "bundled/svg/file-06.svg",
+    kind: SlashCommandKind::Plan,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/file-06.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: true,
     argument: Some(Argument::optional().with_hint_text("<describe your task>")),
@@ -432,7 +538,10 @@ pub const ORCHESTRATE_NAME: &str = "/orchestrate";
 pub static ORCHESTRATE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: ORCHESTRATE_NAME,
     description: "Break a task into subtasks and run them in parallel with multiple agents",
-    icon_path: "bundled/svg/oz.svg",
+    kind: SlashCommandKind::Orchestrate,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/oz.svg",
+    },
     availability: Availability::LOCAL | Availability::AI_ENABLED,
     auto_enter_ai_mode: true,
     argument: Some(Argument::optional().with_hint_text("<describe your task>")),
@@ -450,7 +559,10 @@ pub fn strip_command_prefix(query: &str, name: &str) -> Option<String> {
 pub static COMPACT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/compact",
     description: "Free up context by summarizing convo history",
-    icon_path: "bundled/svg/collapse_content.svg",
+    kind: SlashCommandKind::Compact,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/collapse_content.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::ACTIVE_CONVERSATION
         | Availability::NO_LRC_CONTROL
@@ -465,7 +577,10 @@ pub static COMPACT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub static COMPACT_AND: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/compact-and",
     description: "Compact conversation and then send a follow-up prompt",
-    icon_path: "bundled/svg/collapse_content.svg",
+    kind: SlashCommandKind::CompactAnd,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/collapse_content.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::ACTIVE_CONVERSATION
         | Availability::NO_LRC_CONTROL
@@ -478,7 +593,10 @@ pub static COMPACT_AND: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand
 pub static QUEUE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/queue",
     description: "Queue a prompt to send after the agent finishes responding",
-    icon_path: "bundled/svg/clock-plus.svg",
+    kind: SlashCommandKind::Queue,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/clock-plus.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::ACTIVE_CONVERSATION
         | Availability::AI_ENABLED
@@ -492,7 +610,10 @@ pub static FORK_AND_COMPACT: LazyLock<StaticCommand> = LazyLock::new(|| {
     StaticCommand {
         name: "/fork-and-compact",
         description: "Fork current conversation and compact it in the forked copy",
-        icon_path: "bundled/svg/fork_and_compact.svg",
+        kind: SlashCommandKind::ForkAndCompact,
+        supported_surfaces: SlashCommandSurfaces::GuiOnly {
+            icon_path: "bundled/svg/fork_and_compact.svg",
+        },
         availability: Availability::AGENT_VIEW
             | Availability::ACTIVE_CONVERSATION
             | Availability::NO_LRC_CONTROL
@@ -506,7 +627,10 @@ pub static FORK_AND_COMPACT: LazyLock<StaticCommand> = LazyLock::new(|| {
 pub const FORK_FROM: StaticCommand = StaticCommand {
     name: "/fork-from",
     description: "Fork conversation from a specific query",
-    icon_path: "bundled/svg/arrow-split.svg",
+    kind: SlashCommandKind::ForkFrom,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/arrow-split.svg",
+    },
     availability: Availability::AGENT_VIEW
         .union(Availability::NO_LRC_CONTROL)
         .union(Availability::AI_ENABLED)
@@ -520,7 +644,10 @@ pub static CONTINUE_LOCALLY: LazyLock<StaticCommand> = LazyLock::new(|| {
     StaticCommand {
         name: "/continue-locally",
         description: "Continue this cloud conversation locally",
-        icon_path: "bundled/svg/arrow-split.svg",
+        kind: SlashCommandKind::ContinueLocally,
+        supported_surfaces: SlashCommandSurfaces::GuiOnly {
+            icon_path: "bundled/svg/arrow-split.svg",
+        },
         availability: Availability::AGENT_VIEW
             | Availability::ACTIVE_CONVERSATION
             | Availability::AI_ENABLED
@@ -533,7 +660,10 @@ pub static CONTINUE_LOCALLY: LazyLock<StaticCommand> = LazyLock::new(|| {
 pub const USAGE: StaticCommand = StaticCommand {
     name: "/usage",
     description: "Open billing and usage settings",
-    icon_path: "bundled/svg/bar-chart-04.svg",
+    kind: SlashCommandKind::Usage,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/bar-chart-04.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -542,7 +672,10 @@ pub const USAGE: StaticCommand = StaticCommand {
 pub const REMOTE_CONTROL: StaticCommand = StaticCommand {
     name: "/remote-control",
     description: "Start remote control for this session",
-    icon_path: "bundled/svg/phone-01.svg",
+    kind: SlashCommandKind::RemoteControl,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/phone-01.svg",
+    },
     availability: Availability::AI_ENABLED.union(Availability::NOT_CLOUD_AGENT),
     auto_enter_ai_mode: false,
     argument: None,
@@ -551,7 +684,10 @@ pub const REMOTE_CONTROL: StaticCommand = StaticCommand {
 pub const COST: StaticCommand = StaticCommand {
     name: "/cost",
     description: "Toggle credit usage details",
-    icon_path: "bundled/svg/bar-chart-04.svg",
+    kind: SlashCommandKind::Cost,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/bar-chart-04.svg",
+    },
     availability: Availability::AGENT_VIEW
         .union(Availability::AI_ENABLED)
         .union(Availability::NOT_CLOUD_AGENT),
@@ -562,7 +698,10 @@ pub const COST: StaticCommand = StaticCommand {
 pub const CONVERSATIONS: StaticCommand = StaticCommand {
     name: "/conversations",
     description: "Open conversation history",
-    icon_path: "bundled/svg/conversation.svg",
+    kind: SlashCommandKind::Conversations,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/conversation.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -571,7 +710,10 @@ pub const CONVERSATIONS: StaticCommand = StaticCommand {
 pub static PROMPTS: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/prompts",
     description: "Search saved prompts",
-    icon_path: "bundled/svg/prompt.svg",
+    kind: SlashCommandKind::Prompts,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/prompt.svg",
+    },
     availability: Availability::AI_ENABLED,
     auto_enter_ai_mode: false,
     argument: None,
@@ -580,7 +722,10 @@ pub static PROMPTS: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
 pub const REWIND: StaticCommand = StaticCommand {
     name: "/rewind",
     description: "Rewind to a previous point in the conversation",
-    icon_path: "bundled/svg/clock-rewind.svg",
+    kind: SlashCommandKind::Rewind,
+    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        icon_path: "bundled/svg/clock-rewind.svg",
+    },
     availability: Availability::AGENT_VIEW
         .union(Availability::AI_ENABLED)
         .union(Availability::NOT_CLOUD_AGENT),
@@ -591,7 +736,10 @@ pub const REWIND: StaticCommand = StaticCommand {
 pub const EXPORT_TO_CLIPBOARD: StaticCommand = StaticCommand {
     name: "/export-to-clipboard",
     description: "Export current conversation to clipboard in markdown format",
-    icon_path: "bundled/svg/copy.svg",
+    kind: SlashCommandKind::ExportToClipboard,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/copy.svg",
+    },
     availability: Availability::AGENT_VIEW
         .union(Availability::AI_ENABLED)
         .union(Availability::NOT_CLOUD_AGENT),
@@ -602,7 +750,10 @@ pub const EXPORT_TO_CLIPBOARD: StaticCommand = StaticCommand {
 pub static EXPORT_TO_FILE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/export-to-file",
     description: "Export current conversation to a markdown file",
-    icon_path: "bundled/svg/download-01.svg",
+    kind: SlashCommandKind::ExportToFile,
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
+        icon_path: "bundled/svg/download-01.svg",
+    },
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
         | Availability::NOT_CLOUD_AGENT,
@@ -684,10 +835,16 @@ fn all_commands(settings_mode: settings::SettingsMode) -> Vec<StaticCommand> {
         ADD_MCP,
         ADD_PROMPT.clone(),
         ADD_RULE,
+        AUTO_APPROVE,
         COST,
+        DISABLE_NATURAL_LANGUAGE_DETECTION,
+        ENABLE_NATURAL_LANGUAGE_DETECTION,
+        EXIT,
         FEEDBACK.clone(),
         INDEX,
         INIT,
+        LOGOUT,
+        MCP,
         OPEN_PROJECT_RULES,
         OPEN_MCP_SERVERS,
         OPEN_RULES,
@@ -701,21 +858,11 @@ fn all_commands(settings_mode: settings::SettingsMode) -> Vec<StaticCommand> {
         CONVERSATIONS,
         EXPORT_TO_CLIPBOARD,
         MODEL.clone(),
+        VIEW_LOGS,
     ];
 
     if FeatureFlag::LocalDockerSandbox.is_enabled() {
         commands.push(CREATE_DOCKER_SANDBOX);
-    }
-    if settings_mode == settings::SettingsMode::Tui {
-        commands.extend([
-            AUTO_APPROVE,
-            MCP,
-            EXIT,
-            LOGOUT,
-            VIEW_LOGS,
-            ENABLE_NATURAL_LANGUAGE_DETECTION,
-            DISABLE_NATURAL_LANGUAGE_DETECTION,
-        ]);
     }
 
     if FeatureFlag::CreatingSharedSessions.is_enabled()
@@ -807,6 +954,7 @@ fn all_commands(settings_mode: settings::SettingsMode) -> Vec<StaticCommand> {
         commands.push(HARNESS.clone());
         commands.push(ENVIRONMENT.clone());
     }
+    commands.retain(|command| command.supports_surface(settings_mode));
 
     commands
 }

--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -3,12 +3,68 @@ use std::collections::HashSet;
 use super::*;
 
 #[test]
-fn command_names_are_unique() {
-    let names = COMMAND_REGISTRY.all_commands().map(|command| command.name);
-    let mut seen = HashSet::new();
-    for name in names {
-        assert!(seen.insert(name), "duplicate slash command name: {name}");
+fn command_names_and_kinds_are_unique_per_surface() {
+    for settings_mode in [settings::SettingsMode::Gui, settings::SettingsMode::Tui] {
+        let mut names = HashSet::new();
+        let mut kinds = HashSet::new();
+        for command in all_commands(settings_mode) {
+            assert!(
+                names.insert(command.name),
+                "duplicate slash command name on {settings_mode:?}: {}",
+                command.name
+            );
+            assert!(
+                kinds.insert(command.kind),
+                "duplicate slash command kind on {settings_mode:?}: {:?}",
+                command.kind
+            );
+        }
     }
+}
+
+#[test]
+fn gui_icon_metadata_matches_surface_support() {
+    let mut checked_kinds = HashSet::new();
+    for settings_mode in [settings::SettingsMode::Gui, settings::SettingsMode::Tui] {
+        for command in all_commands(settings_mode) {
+            if checked_kinds.insert(command.kind) {
+                assert_eq!(
+                    command.supported_surfaces.gui_icon_path().is_some(),
+                    command.supports_gui(),
+                    "{} has inconsistent GUI icon metadata",
+                    command.name
+                );
+            }
+        }
+    }
+}
+#[test]
+fn command_registry_filters_explicit_surface_metadata() {
+    for settings_mode in [settings::SettingsMode::Gui, settings::SettingsMode::Tui] {
+        for command in all_commands(settings_mode) {
+            assert!(
+                command.supports_surface(settings_mode),
+                "{} should support {settings_mode:?}",
+                command.name
+            );
+        }
+    }
+    assert_eq!(COST.kind, SlashCommandKind::Cost);
+    assert!(matches!(
+        COST.supported_surfaces,
+        SlashCommandSurfaces::GuiAndTui {
+            icon_path: "bundled/svg/bar-chart-04.svg"
+        }
+    ));
+    assert_eq!(EXIT.kind, SlashCommandKind::Exit);
+    assert_eq!(EXIT.supported_surfaces, SlashCommandSurfaces::TuiOnly);
+    assert_eq!(ADD_MCP.kind, SlashCommandKind::AddMcp);
+    assert!(matches!(
+        ADD_MCP.supported_surfaces,
+        SlashCommandSurfaces::GuiOnly {
+            icon_path: "bundled/svg/dataflow.svg"
+        }
+    ));
 }
 #[test]
 fn view_logs_command_is_registered_only_for_tui_mode() {
@@ -38,7 +94,7 @@ fn auto_approve_command_is_local_agent_action_without_arguments() {
     );
 
     assert_eq!(command.description, "Toggle auto approve");
-    assert_eq!(command.icon_path, "bundled/svg/fast-forward.svg");
+    assert_eq!(command.supported_surfaces.gui_icon_path(), None);
     assert!(!command.auto_enter_ai_mode);
     assert_eq!(
         command.availability,
@@ -102,7 +158,10 @@ fn rename_conversation_command_is_active_conversation_scoped_and_requires_argume
         .expect("expected /rename-conversation to require an argument");
 
     assert_eq!(command.name, "/rename-conversation");
-    assert_eq!(command.icon_path, "bundled/svg/pencil-line.svg");
+    assert_eq!(
+        command.supported_surfaces.gui_icon_path(),
+        Some("bundled/svg/pencil-line.svg")
+    );
     assert!(!command.auto_enter_ai_mode);
     assert_eq!(
         command.availability,
@@ -121,7 +180,10 @@ fn continue_locally_command_is_registered() {
         .expect("expected /continue-locally to be registered");
 
     assert_eq!(command.name, "/continue-locally");
-    assert_eq!(command.icon_path, "bundled/svg/arrow-split.svg");
+    assert_eq!(
+        command.supported_surfaces.gui_icon_path(),
+        Some("bundled/svg/arrow-split.svg")
+    );
     assert!(command.auto_enter_ai_mode);
     assert_eq!(
         command.availability,

--- a/app/src/search/slash_command_menu/static_commands/mod.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod.rs
@@ -3,6 +3,7 @@ pub mod commands;
 
 use bitflags::bitflags;
 pub use commands::SlashCommandId;
+use settings::SettingsMode;
 
 bitflags! {
     /// Specifies the requirements for a slash command to be available.
@@ -43,6 +44,102 @@ bitflags! {
         /// is enabled. Commands that require this bit are hidden everywhere except the V2
         /// cloud-mode composing input.
         const CLOUD_MODE_V2_COMPOSER = 1 << 10;
+    }
+}
+/// Stable identity for a static slash command.
+///
+/// Front-ends dispatch on this value instead of matching command-name strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SlashCommandKind {
+    Agent,
+    CloudAgent,
+    AddMcp,
+    AutoApprove,
+    Mcp,
+    ViewLogs,
+    EnableNaturalLanguageDetection,
+    DisableNaturalLanguageDetection,
+    Exit,
+    Logout,
+    CreateEnvironment,
+    CreateDockerSandbox,
+    CreateNewProject,
+    EditSkill,
+    InvokeSkill,
+    AddPrompt,
+    AddRule,
+    Edit,
+    RenameTab,
+    RenameConversation,
+    SetTabColor,
+    Fork,
+    MoveToCloud,
+    OpenCodeReview,
+    Index,
+    Init,
+    OpenProjectRules,
+    OpenMcpServers,
+    OpenSettingsFile,
+    Changelog,
+    Feedback,
+    OpenRepo,
+    OpenRules,
+    New,
+    Model,
+    Host,
+    Harness,
+    Environment,
+    Profile,
+    Plan,
+    Orchestrate,
+    Compact,
+    CompactAnd,
+    Queue,
+    ForkAndCompact,
+    ForkFrom,
+    ContinueLocally,
+    Usage,
+    RemoteControl,
+    Cost,
+    Conversations,
+    Prompts,
+    Rewind,
+    ExportToClipboard,
+    ExportToFile,
+}
+
+/// The application surfaces on which a static slash command is implemented.
+///
+/// This field is required on every [`StaticCommand`] so new commands must explicitly declare
+/// whether they are GUI-only, TUI-only, or shared by both front-ends. GUI-capable variants also
+/// require the icon path used to render the command in GUI menus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashCommandSurfaces {
+    GuiOnly { icon_path: &'static str },
+    TuiOnly,
+    GuiAndTui { icon_path: &'static str },
+}
+
+impl SlashCommandSurfaces {
+    pub fn supports_gui(self) -> bool {
+        matches!(self, Self::GuiOnly { .. } | Self::GuiAndTui { .. })
+    }
+
+    pub fn supports_tui(self) -> bool {
+        matches!(self, Self::TuiOnly | Self::GuiAndTui { .. })
+    }
+
+    pub fn gui_icon_path(self) -> Option<&'static str> {
+        match self {
+            Self::GuiOnly { icon_path } | Self::GuiAndTui { icon_path } => Some(icon_path),
+            Self::TuiOnly => None,
+        }
+    }
+    pub fn includes(self, settings_mode: SettingsMode) -> bool {
+        match settings_mode {
+            SettingsMode::Gui => self.supports_gui(),
+            SettingsMode::Tui => self.supports_tui(),
+        }
     }
 }
 
@@ -89,9 +186,10 @@ impl Argument {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StaticCommand {
+    pub kind: SlashCommandKind,
     pub name: &'static str,
     pub description: &'static str,
-    pub icon_path: &'static str,
+    pub supported_surfaces: SlashCommandSurfaces,
     /// Specifies the requirements for this command to be available. See [`Availability`].
     pub availability: Availability,
     /// Whether this command requires AI mode when executed.
@@ -106,6 +204,17 @@ pub struct SlashCommandArgumentHint {
 }
 
 impl StaticCommand {
+    pub fn supports_gui(&self) -> bool {
+        self.supported_surfaces.supports_gui()
+    }
+
+    pub fn supports_tui(&self) -> bool {
+        self.supported_surfaces.supports_tui()
+    }
+    pub fn supports_surface(&self, settings_mode: SettingsMode) -> bool {
+        self.supported_surfaces.includes(settings_mode)
+    }
+
     pub fn matches_filter(&self, filter_text: &str) -> bool {
         if filter_text.is_empty() {
             return true;

--- a/app/src/terminal/input/slash_commands/data_source/core.rs
+++ b/app/src/terminal/input/slash_commands/data_source/core.rs
@@ -645,7 +645,7 @@ fn prefix_match_bonus(query: &str, name: &str) -> f64 {
 #[derive(Debug, Clone)]
 pub struct InlineItem {
     pub action: AcceptSlashCommandOrSavedPrompt,
-    pub icon_path: &'static str,
+    pub icon_path: Option<&'static str>,
     pub name: String,
     pub description: Option<String>,
     pub font_family: FamilyId,
@@ -664,7 +664,7 @@ impl InlineItem {
         let appearance = Appearance::as_ref(app);
         Self {
             action: AcceptSlashCommandOrSavedPrompt::SlashCommand { id: *command_id },
-            icon_path: command.icon_path,
+            icon_path: command.supported_surfaces.gui_icon_path(),
             name: command.name.to_owned(),
             description: Some(command.description.to_owned()),
             font_family: appearance.monospace_font_family(),
@@ -684,7 +684,7 @@ impl InlineItem {
             action: AcceptSlashCommandOrSavedPrompt::SavedPrompt {
                 id: saved_prompt.id,
             },
-            icon_path: "bundled/svg/prompt.svg",
+            icon_path: Some("bundled/svg/prompt.svg"),
             name: saved_prompt.model().data.name().to_owned(),
             description: None,
             font_family: appearance.ui_font_family(),
@@ -717,7 +717,7 @@ impl InlineItem {
                 reference: skill.reference.clone(),
                 name: skill.name.clone(),
             },
-            icon_path: icon.into(),
+            icon_path: Some(icon.into()),
             name: format!("/{}", &skill.name),
             description: Some(skill.description.clone()),
             font_family: appearance.monospace_font_family(),

--- a/app/src/terminal/input/slash_commands/data_source/saved_prompts.rs
+++ b/app/src/terminal/input/slash_commands/data_source/saved_prompts.rs
@@ -106,7 +106,7 @@ pub(crate) fn fuzzy_match_saved_prompts(
                             action: AcceptSlashCommandOrSavedPrompt::SavedPrompt {
                                 id: candidate.id,
                             },
-                            icon_path: "bundled/svg/prompt.svg",
+                            icon_path: Some("bundled/svg/prompt.svg"),
                             name: candidate.model.data.name().to_owned(),
                             description: None,
                             font_family: snapshot.font_family,
@@ -136,7 +136,7 @@ pub(crate) fn fuzzy_match_saved_prompts(
                             action: AcceptSlashCommandOrSavedPrompt::SavedPrompt {
                                 id: candidate.id,
                             },
-                            icon_path: "bundled/svg/prompt.svg",
+                            icon_path: Some("bundled/svg/prompt.svg"),
                             name: candidate.model.data.name().to_owned(),
                             description: None,
                             font_family: snapshot.font_family,

--- a/app/src/terminal/input/slash_commands/data_source/tui.rs
+++ b/app/src/terminal/input/slash_commands/data_source/tui.rs
@@ -16,9 +16,7 @@ use crate::search::mixer::DataSourceRunErrorWrapper;
 use crate::search::slash_command_menu::static_commands::Availability;
 use crate::search::slash_command_menu::static_commands::commands::COMMAND_REGISTRY;
 use crate::terminal::TerminalModel;
-use crate::terminal::input::slash_commands::{
-    AcceptSlashCommandOrSavedPrompt, slash_command_is_supported_in_tui,
-};
+use crate::terminal::input::slash_commands::AcceptSlashCommandOrSavedPrompt;
 use crate::terminal::model::session::active_session::ActiveSession;
 use crate::terminal::view::resolve_ai_query_routing;
 
@@ -88,8 +86,7 @@ impl TuiSlashCommandDataSource {
             COMMAND_REGISTRY
                 .all_commands_by_id()
                 .filter(|(_, command)| {
-                    slash_command_is_supported_in_tui(command)
-                        && self.command_passes_common_gates(command, availability, &gates)
+                    self.command_passes_common_gates(command, availability, &gates)
                 })
                 .map(|(id, command)| (id, command.clone())),
         );

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -44,7 +44,9 @@ use crate::ai::blocklist::{
 use crate::ai::conversation_rename::rename_conversation;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
-use crate::search::slash_command_menu::static_commands::commands::{self, COMMAND_REGISTRY};
+#[cfg(not(target_family = "wasm"))]
+use crate::search::slash_command_menu::static_commands::commands;
+use crate::search::slash_command_menu::static_commands::commands::COMMAND_REGISTRY;
 use crate::search::slash_command_menu::static_commands::{Availability, SlashCommandKind};
 use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
 use crate::server::ids::SyncId;

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -44,8 +44,8 @@ use crate::ai::blocklist::{
 use crate::ai::conversation_rename::rename_conversation;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
-use crate::search::slash_command_menu::static_commands::Availability;
 use crate::search::slash_command_menu::static_commands::commands::{self, COMMAND_REGISTRY};
+use crate::search::slash_command_menu::static_commands::{Availability, SlashCommandKind};
 use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
 use crate::server::ids::SyncId;
 use crate::server::telemetry::{AgentModeAutoDetectionSettingOrigin, SlashCommandAcceptedDetails};
@@ -122,71 +122,6 @@ pub fn should_close_slash_command_menu_for_exact_match(
     argument_started: bool,
 ) -> bool {
     result_count < 2 || argument_started
-}
-
-/// Static slash commands that the TUI can execute.
-///
-/// Converting a registry command to this enum centralizes the supported-command policy and lets
-/// the TUI execution path match every supported command exhaustively.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TuiSlashCommand {
-    Agent,
-    New,
-    Compact,
-    Cost,
-    Plan,
-    Conversations,
-    Model,
-    Skills,
-    CreateNewProject,
-    ExportToClipboard,
-    ExportToFile,
-    AutoApprove,
-    Mcp,
-    Exit,
-    Logout,
-    ViewLogs,
-    EnableNaturalLanguageDetection,
-    DisableNaturalLanguageDetection,
-}
-
-impl TuiSlashCommand {
-    /// Classifies a registry command when the TUI supports it.
-    pub fn from_static_command(command: &StaticCommand) -> Option<Self> {
-        match command.name {
-            name if name == commands::AGENT.name => Some(Self::Agent),
-            name if name == commands::NEW.name => Some(Self::New),
-            name if name == commands::COMPACT.name => Some(Self::Compact),
-            name if name == commands::COST.name => Some(Self::Cost),
-            name if name == commands::PLAN.name => Some(Self::Plan),
-            name if name == commands::CONVERSATIONS.name => Some(Self::Conversations),
-            name if name == commands::MODEL.name => Some(Self::Model),
-            name if name == commands::INVOKE_SKILL.name => Some(Self::Skills),
-            name if name == commands::CREATE_NEW_PROJECT.name => Some(Self::CreateNewProject),
-            name if name == commands::EXPORT_TO_CLIPBOARD.name => Some(Self::ExportToClipboard),
-            name if name == commands::EXPORT_TO_FILE.name => Some(Self::ExportToFile),
-            name if name == commands::AUTO_APPROVE.name => Some(Self::AutoApprove),
-            name if name == commands::MCP.name => Some(Self::Mcp),
-            name if name == commands::EXIT.name => Some(Self::Exit),
-            name if name == commands::LOGOUT.name => Some(Self::Logout),
-            name if name == commands::VIEW_LOGS.name => Some(Self::ViewLogs),
-            name if name == commands::ENABLE_NATURAL_LANGUAGE_DETECTION.name => {
-                Some(Self::EnableNaturalLanguageDetection)
-            }
-            name if name == commands::DISABLE_NATURAL_LANGUAGE_DETECTION.name => {
-                Some(Self::DisableNaturalLanguageDetection)
-            }
-            _ => None,
-        }
-    }
-}
-
-/// Returns whether TUI can execute or otherwise handle the static slash command today.
-///
-/// GUI-only actions such as opening settings panes or inline menus should stay hidden until the
-/// TUI has equivalent flows.
-pub fn slash_command_is_supported_in_tui(command: &StaticCommand) -> bool {
-    TuiSlashCommand::from_static_command(command).is_some()
 }
 
 /// Records a static slash command accepted from either the GUI or TUI surface.
@@ -422,7 +357,7 @@ impl Input {
                     self.enter_ai_mode(Some(InputTypeAutoDetectionSource::SlashCommand), ctx);
                 }
 
-                if detected_command.command.name == commands::EDIT.name
+                if detected_command.command.kind == SlashCommandKind::Edit
                     && detected_command
                         .argument
                         .as_ref()
@@ -547,19 +482,17 @@ impl Input {
         }
 
         // Handle the slash command action based on its kind
-        match command.name {
-            _add_mcp if command.name == commands::ADD_MCP.name => {
+        match command.kind {
+            SlashCommandKind::AddMcp => {
                 ctx.dispatch_typed_action(&TerminalAction::OpenAddMCPPane);
             }
-            _add_prompt if command.name == commands::ADD_PROMPT.name => {
+            SlashCommandKind::AddPrompt => {
                 ctx.dispatch_typed_action(&TerminalAction::OpenAddPromptPane);
             }
-            _add_rule if command.name == commands::ADD_RULE.name => {
+            SlashCommandKind::AddRule => {
                 ctx.dispatch_typed_action(&TerminalAction::OpenAddRulePane);
             }
-            _agent_or_new
-                if command.name == commands::NEW.name || command.name == commands::AGENT.name =>
-            {
+            SlashCommandKind::Agent | SlashCommandKind::New => {
                 if !self
                     .ai_context_model
                     .as_ref(ctx)
@@ -612,7 +545,7 @@ impl Input {
                     origin: AgentViewEntryOrigin::SlashCommand { trigger },
                 });
             }
-            _cloud_agent if command.name == commands::CLOUD_AGENT.name => {
+            SlashCommandKind::CloudAgent => {
                 let prompt = argument.and_then(|argument| {
                     let trimmed = argument.trim();
                     if trimmed.is_empty() {
@@ -626,10 +559,10 @@ impl Input {
                     initial_prompt: prompt,
                 });
             }
-            _create_docker_sandbox if command.name == commands::CREATE_DOCKER_SANDBOX.name => {
+            SlashCommandKind::CreateDockerSandbox => {
                 ctx.emit(Event::CreateDockerSandbox);
             }
-            _conversations if command.name == commands::CONVERSATIONS.name => {
+            SlashCommandKind::Conversations => {
                 if self.is_cloud_mode_input_v2_composing(ctx) {
                     self.suggestions_mode_model.update(ctx, |model, ctx| {
                         model.set_mode(InputSuggestionsMode::Closed, ctx);
@@ -648,7 +581,7 @@ impl Input {
                     ctx.dispatch_typed_action(&TerminalAction::OpenConversationsPalette);
                 }
             }
-            _rename_tab if command.name == commands::RENAME_TAB.name => {
+            SlashCommandKind::RenameTab => {
                 let Some(name) = argument
                     .map(|name| name.trim())
                     .filter(|name| !name.is_empty())
@@ -662,7 +595,7 @@ impl Input {
 
                 ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabName(name.to_owned()));
             }
-            _ if command.name == commands::RENAME_CONVERSATION.name => {
+            SlashCommandKind::RenameConversation => {
                 let Some(conversation_id) = self
                     .ai_context_model
                     .as_ref(ctx)
@@ -676,7 +609,7 @@ impl Input {
                 };
                 rename_conversation(conversation_id, argument.cloned().unwrap_or_default(), ctx);
             }
-            _set_tab_color if command.name == commands::SET_TAB_COLOR.name => {
+            SlashCommandKind::SetTabColor => {
                 let supported_options = || {
                     color_dot::TAB_COLOR_OPTIONS
                         .iter()
@@ -724,7 +657,7 @@ impl Input {
 
                 ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabColor(color));
             }
-            _create_env if command.name == commands::CREATE_ENVIRONMENT.name => {
+            SlashCommandKind::CreateEnvironment => {
                 // If the user included args after the slash command, treat them as repo paths/URLs.
                 let repos = argument
                     .map(|arg| {
@@ -737,7 +670,7 @@ impl Input {
 
                 ctx.emit(Event::TriggerEnvironmentSetup { repos });
             }
-            _create_project if command.name == commands::CREATE_NEW_PROJECT.name => {
+            SlashCommandKind::CreateNewProject => {
                 if argument.is_none_or(|args| args.is_empty()) {
                     show_error_toast(
                         "Please describe the project you want to create after /create-new-project"
@@ -750,7 +683,7 @@ impl Input {
                 let args = argument.expect("args are Some()");
                 self.initiate_create_new_project(args.to_owned(), ctx);
             }
-            _edit if command.name == commands::EDIT.name => {
+            SlashCommandKind::Edit => {
                 #[cfg(feature = "local_fs")]
                 match argument {
                     Some(args) if !args.is_empty() => {
@@ -834,7 +767,7 @@ impl Input {
                     return true;
                 }
             }
-            _export_to_clipboard if command.name == commands::EXPORT_TO_CLIPBOARD.name => {
+            SlashCommandKind::ExportToClipboard => {
                 let history = BlocklistAIHistoryModel::handle(ctx);
                 let Some(conversation) = history
                     .as_ref(ctx)
@@ -859,7 +792,7 @@ impl Input {
                     toast_stack.add_ephemeral_toast(toast, window_id, ctx);
                 });
             }
-            _export_to_file if command.name == commands::EXPORT_TO_FILE.name => {
+            SlashCommandKind::ExportToFile => {
                 #[cfg(not(target_family = "wasm"))]
                 {
                     self.export_conversation_to_file(
@@ -876,52 +809,49 @@ impl Input {
                     return true;
                 }
             }
-            _index if command.name == commands::INDEX.name => {
+            SlashCommandKind::Index => {
                 ctx.dispatch_typed_action(&TerminalAction::IndexProjectSpeedbump);
             }
-            _init if command.name == commands::INIT.name => {
+            SlashCommandKind::Init => {
                 ctx.dispatch_typed_action(&TerminalAction::InitProject);
             }
-            _changelog if command.name == commands::CHANGELOG.name => {
+            SlashCommandKind::Changelog => {
                 if !FeatureFlag::Changelog.is_enabled() {
                     return false;
                 }
                 ctx.dispatch_typed_action(&WorkspaceAction::ViewLatestChangelog);
             }
-            _feedback if command.name == commands::FEEDBACK.name => {
+            SlashCommandKind::Feedback => {
                 ctx.dispatch_typed_action(&WorkspaceAction::SendFeedback);
             }
-            _open_code_review if command.name == commands::OPEN_CODE_REVIEW.name => {
+            SlashCommandKind::OpenCodeReview => {
                 ctx.dispatch_typed_action(&TerminalAction::ToggleCodeReviewPane {
                     entrypoint: CodeReviewPaneEntrypoint::SlashCommand,
                 });
             }
-            _open_mcp_servers
-                if command.name == commands::OPEN_MCP_SERVERS.name
-                    || command.name == commands::MCP.name =>
-            {
+            SlashCommandKind::OpenMcpServers | SlashCommandKind::Mcp => {
                 ctx.dispatch_typed_action(&TerminalAction::OpenViewMCPPane);
             }
-            _open_settings_file if command.name == commands::OPEN_SETTINGS_FILE.name => {
+            SlashCommandKind::OpenSettingsFile => {
                 if !FeatureFlag::SettingsFile.is_enabled() || !cfg!(feature = "local_fs") {
                     return false;
                 }
                 ctx.dispatch_typed_action(&WorkspaceAction::OpenSettingsFile);
             }
-            _open_project_rules if command.name == commands::OPEN_PROJECT_RULES.name => {
+            SlashCommandKind::OpenProjectRules => {
                 ctx.dispatch_typed_action(&TerminalAction::OpenProjectRulesPane);
             }
-            _open_rules if command.name == commands::OPEN_RULES.name => {
+            SlashCommandKind::OpenRules => {
                 ctx.dispatch_typed_action(&TerminalAction::OpenRulesPane);
             }
-            _edit_skill if command.name == commands::EDIT_SKILL.name => {
+            SlashCommandKind::EditSkill => {
                 if !FeatureFlag::ListSkills.is_enabled() {
                     return false;
                 }
                 // Open the skill selector menu - user will select a skill from the inline menu
                 self.open_skill_selector(ctx);
             }
-            _invoke_skill if command.name == commands::INVOKE_SKILL.name => {
+            SlashCommandKind::InvokeSkill => {
                 if !FeatureFlag::ListSkills.is_enabled() {
                     return false;
                 }
@@ -932,7 +862,7 @@ impl Input {
                 // Open the skill selector menu for invocation - skill command will be inserted into buffer
                 self.open_invoke_skill_selector(ctx);
             }
-            _host if command.name == commands::HOST.name => {
+            SlashCommandKind::Host => {
                 if !self.is_cloud_mode_input_v2_composing(ctx) {
                     return false;
                 }
@@ -950,7 +880,7 @@ impl Input {
                 self.open_v2_host_selector(ctx);
                 return true;
             }
-            _harness if command.name == commands::HARNESS.name => {
+            SlashCommandKind::Harness => {
                 if !self.is_cloud_mode_input_v2_composing(ctx) {
                     // Defensive: the command is registered only when the V2 flag is on and its
                     // availability requires CLOUD_MODE_V2_COMPOSER, so this branch should be unreachable.
@@ -963,7 +893,7 @@ impl Input {
                 self.open_v2_harness_selector(ctx);
                 return true;
             }
-            _environment if command.name == commands::ENVIRONMENT.name => {
+            SlashCommandKind::Environment => {
                 if !self.is_cloud_mode_input_v2_composing(ctx) {
                     return false;
                 }
@@ -974,7 +904,7 @@ impl Input {
                 self.open_v2_environment_selector(ctx);
                 return true;
             }
-            _models if command.name == commands::MODEL.name => {
+            SlashCommandKind::Model => {
                 if self.is_cloud_mode_input_v2_composing(ctx) {
                     self.suggestions_mode_model.update(ctx, |model, ctx| {
                         model.set_mode(InputSuggestionsMode::Closed, ctx);
@@ -1002,14 +932,14 @@ impl Input {
                     ctx.notify();
                 }
             }
-            _profiles if command.name == commands::PROFILE.name => {
+            SlashCommandKind::Profile => {
                 if !FeatureFlag::InlineProfileSelector.is_enabled() {
                     return false;
                 }
 
                 self.open_profile_selector(ctx);
             }
-            _prompts if command.name == commands::PROMPTS.name => {
+            SlashCommandKind::Prompts => {
                 if self.is_cloud_mode_input_v2_composing(ctx) {
                     self.apply_v2_slash_section_filter(CloudModeV2Section::Prompts, ctx);
                     return true;
@@ -1020,13 +950,13 @@ impl Input {
                     return false;
                 }
             }
-            _rewind if command.name == commands::REWIND.name => {
+            SlashCommandKind::Rewind => {
                 self.open_rewind_menu(ctx);
             }
-            _usage if command.name == commands::USAGE.name => {
+            SlashCommandKind::Usage => {
                 ctx.dispatch_typed_action(&TerminalAction::OpenBillingAndUsagePane);
             }
-            _remote_control if command.name == commands::REMOTE_CONTROL.name => {
+            SlashCommandKind::RemoteControl => {
                 if !FeatureFlag::CreatingSharedSessions.is_enabled()
                     || !FeatureFlag::HOARemoteControl.is_enabled()
                 {
@@ -1043,7 +973,7 @@ impl Input {
                 }
                 ctx.emit(Event::StartRemoteControl);
             }
-            _cost if command.name == commands::COST.name => {
+            SlashCommandKind::Cost => {
                 let history = BlocklistAIHistoryModel::handle(ctx);
                 let conversation = history
                     .as_ref(ctx)
@@ -1068,7 +998,7 @@ impl Input {
                 }
             }
             #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-            _move_to_cloud if command.name == commands::MOVE_TO_CLOUD.name => {
+            SlashCommandKind::MoveToCloud => {
                 if !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx) {
                     return false;
                 }
@@ -1116,7 +1046,7 @@ impl Input {
                     );
                 }
             }
-            _fork if command.name == commands::FORK.name => {
+            SlashCommandKind::Fork => {
                 let Some(conversation_id) = self
                     .ai_context_model
                     .as_ref(ctx)
@@ -1146,12 +1076,12 @@ impl Input {
                     destination,
                 });
             }
-            _fork_from if command.name == commands::FORK_FROM.name => {
+            SlashCommandKind::ForkFrom => {
                 self.open_user_query_menu(UserQueryMenuAction::ForkFrom, ctx);
                 return true;
             }
             #[cfg(not(target_family = "wasm"))]
-            _continue_locally if command.name == commands::CONTINUE_LOCALLY.name => {
+            SlashCommandKind::ContinueLocally => {
                 let Some(conversation_id) = self
                     .ai_context_model
                     .as_ref(ctx)
@@ -1198,7 +1128,7 @@ impl Input {
                     destination,
                 });
             }
-            _fork_and_compact if command.name == commands::FORK_AND_COMPACT.name => {
+            SlashCommandKind::ForkAndCompact => {
                 let Some(conversation_id) = self
                     .ai_context_model
                     .as_ref(ctx)
@@ -1224,7 +1154,7 @@ impl Input {
                     destination,
                 });
             }
-            _compact_and if command.name == commands::COMPACT_AND.name => {
+            SlashCommandKind::CompactAnd => {
                 let conversation_id = if is_queued_prompt {
                     let Some(conversation_id) = queued_conversation_id else {
                         report_error!("Queued /compact-and missing conversation id");
@@ -1265,7 +1195,7 @@ impl Input {
                     ctx.dispatch_typed_action(&summarize);
                 }
             }
-            _queue if command.name == commands::QUEUE.name => {
+            SlashCommandKind::Queue => {
                 let Some(conversation_id) = self
                     .ai_context_model
                     .as_ref(ctx)
@@ -1311,28 +1241,35 @@ impl Input {
                     self.submit_user_query_now(prompt, ctx);
                 }
             }
-            _open_repo if command.name == commands::OPEN_REPO.name => {
+            SlashCommandKind::OpenRepo => {
                 if !FeatureFlag::InlineRepoMenu.is_enabled() {
                     return false;
                 }
                 self.open_repos_menu(ctx);
             }
-            _command_that_just_sends_ai_request_with_prefix
-                if slash_command_is_submitted_as_prompt(command) =>
-            {
+            SlashCommandKind::Compact | SlashCommandKind::Plan | SlashCommandKind::Orchestrate => {
                 // These slash commands just send AI requests with the slash command text as a
                 // prefix, and special handling is done downstream as an implementation detail
                 // of handling user queries with specific slash command prefixes.
                 return false;
             }
-            _ => {
+            SlashCommandKind::AutoApprove
+            | SlashCommandKind::ViewLogs
+            | SlashCommandKind::EnableNaturalLanguageDetection
+            | SlashCommandKind::DisableNaturalLanguageDetection
+            | SlashCommandKind::Exit
+            | SlashCommandKind::Logout => {
                 debug_assert!(
                     false,
-                    "Attempted to execute slash command with no handler: {}",
+                    "Attempted to execute TUI-only slash command in the GUI: {}",
                     command.name
                 );
                 return false;
             }
+            #[cfg(any(not(feature = "local_fs"), target_family = "wasm"))]
+            SlashCommandKind::MoveToCloud => return false,
+            #[cfg(target_family = "wasm")]
+            SlashCommandKind::ContinueLocally => return false,
         }
 
         // Leave the buffer alone when re-sending a queued prompt (the user may have typed
@@ -1588,9 +1525,10 @@ impl Input {
 /// menu, etc.), so callers gating prompt queuing or shared-session forwarding should treat those
 /// as "run now".
 pub fn slash_command_is_submitted_as_prompt(command: &StaticCommand) -> bool {
-    command.name == commands::COMPACT.name
-        || command.name == commands::PLAN.name
-        || command.name == commands::ORCHESTRATE.name
+    matches!(
+        command.kind,
+        SlashCommandKind::Compact | SlashCommandKind::Plan | SlashCommandKind::Orchestrate
+    )
 }
 
 /// Returns true when the conversation with `conversation_id` is associated with an Oz

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -1,8 +1,9 @@
-use super::{
-    TuiSlashCommand, slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui,
-};
+use super::slash_command_is_submitted_as_prompt;
 use crate::features::FeatureFlag;
-use crate::search::slash_command_menu::static_commands::{Availability, commands};
+use crate::search::slash_command_menu::static_commands::{
+    Availability, SlashCommandKind, commands,
+};
+
 const BASELINE_AVAILABILITY: Availability = Availability::AGENT_VIEW
     .union(Availability::AI_ENABLED)
     .union(Availability::NO_LRC_CONTROL);
@@ -12,44 +13,32 @@ const BASELINE_AVAILABILITY: Availability = Availability::AGENT_VIEW
 /// and must be treated as "run now" by the prompt-queue gate and the shared-session viewer path.
 #[test]
 fn slash_command_is_submitted_as_prompt_only_for_prompt_commands() {
-    // Prompt-submitting commands reiterate their text into the conversation.
     assert!(slash_command_is_submitted_as_prompt(&commands::COMPACT));
     assert!(slash_command_is_submitted_as_prompt(&commands::PLAN));
     assert!(slash_command_is_submitted_as_prompt(&commands::ORCHESTRATE));
 
-    // Action-emitting commands run immediately and are never queued / forwarded as prompts.
-    assert!(!slash_command_is_submitted_as_prompt(&commands::FORK));
-    assert!(!slash_command_is_submitted_as_prompt(
-        &commands::FORK_AND_COMPACT
-    ));
-    assert!(!slash_command_is_submitted_as_prompt(&commands::FORK_FROM));
-    assert!(!slash_command_is_submitted_as_prompt(
-        &commands::CONTINUE_LOCALLY
-    ));
-    assert!(!slash_command_is_submitted_as_prompt(
-        &commands::COMPACT_AND
-    ));
-    assert!(!slash_command_is_submitted_as_prompt(&commands::MODEL));
-    assert!(!slash_command_is_submitted_as_prompt(
-        &commands::AUTO_APPROVE
-    ));
-    assert!(!slash_command_is_submitted_as_prompt(&commands::REWIND));
-    assert!(!slash_command_is_submitted_as_prompt(
-        &commands::CONVERSATIONS
-    ));
-    assert!(!slash_command_is_submitted_as_prompt(&commands::QUEUE));
-    assert!(!slash_command_is_submitted_as_prompt(&commands::MCP));
+    for command in [
+        &*commands::FORK,
+        &*commands::FORK_AND_COMPACT,
+        &commands::FORK_FROM,
+        &*commands::CONTINUE_LOCALLY,
+        &*commands::COMPACT_AND,
+        &*commands::MODEL,
+        &commands::AUTO_APPROVE,
+        &commands::REWIND,
+        &commands::CONVERSATIONS,
+        &*commands::QUEUE,
+        &commands::MCP,
+    ] {
+        assert!(!slash_command_is_submitted_as_prompt(command));
+    }
 }
 
 #[test]
 fn auto_approve_is_an_exact_no_argument_command() {
     use super::{SlashCommandSelectionBehavior, slash_command_selection_behavior};
 
-    assert_eq!(
-        TuiSlashCommand::from_static_command(&commands::AUTO_APPROVE),
-        Some(TuiSlashCommand::AutoApprove)
-    );
-    assert!(slash_command_is_supported_in_tui(&commands::AUTO_APPROVE));
+    assert_eq!(commands::AUTO_APPROVE.kind, SlashCommandKind::AutoApprove);
     assert_eq!(
         slash_command_selection_behavior(&commands::AUTO_APPROVE),
         SlashCommandSelectionBehavior::Execute
@@ -58,50 +47,45 @@ fn auto_approve_is_an_exact_no_argument_command() {
 }
 
 #[test]
-fn tui_supports_the_selected_low_effort_commands_but_not_orchestrate() {
+fn tui_commands_have_typed_identities_and_explicit_surface_support() {
     for (command, expected) in [
-        (&*commands::AGENT, TuiSlashCommand::Agent),
-        (&*commands::NEW, TuiSlashCommand::New),
-        (&*commands::COMPACT, TuiSlashCommand::Compact),
-        (&commands::COST, TuiSlashCommand::Cost),
-        (&*commands::PLAN, TuiSlashCommand::Plan),
-        (&commands::MODEL, TuiSlashCommand::Model),
+        (&*commands::AGENT, SlashCommandKind::Agent),
+        (&*commands::NEW, SlashCommandKind::New),
+        (&*commands::COMPACT, SlashCommandKind::Compact),
+        (&commands::COST, SlashCommandKind::Cost),
+        (&*commands::PLAN, SlashCommandKind::Plan),
+        (&*commands::MODEL, SlashCommandKind::Model),
         (
             &*commands::CREATE_NEW_PROJECT,
-            TuiSlashCommand::CreateNewProject,
+            SlashCommandKind::CreateNewProject,
         ),
         (
             &commands::EXPORT_TO_CLIPBOARD,
-            TuiSlashCommand::ExportToClipboard,
+            SlashCommandKind::ExportToClipboard,
         ),
-        (&*commands::EXPORT_TO_FILE, TuiSlashCommand::ExportToFile),
-        (&commands::AUTO_APPROVE, TuiSlashCommand::AutoApprove),
-        (&commands::MCP, TuiSlashCommand::Mcp),
-        (&commands::EXIT, TuiSlashCommand::Exit),
-        (&commands::LOGOUT, TuiSlashCommand::Logout),
-        (&commands::VIEW_LOGS, TuiSlashCommand::ViewLogs),
+        (&*commands::EXPORT_TO_FILE, SlashCommandKind::ExportToFile),
+        (&commands::AUTO_APPROVE, SlashCommandKind::AutoApprove),
+        (&commands::MCP, SlashCommandKind::Mcp),
+        (&commands::EXIT, SlashCommandKind::Exit),
+        (&commands::LOGOUT, SlashCommandKind::Logout),
+        (&commands::VIEW_LOGS, SlashCommandKind::ViewLogs),
     ] {
         assert_eq!(
-            TuiSlashCommand::from_static_command(command),
-            Some(expected),
-            "{} should map to its TUI command",
+            command.kind, expected,
+            "{} should have its typed command identity",
             command.name
         );
-        assert!(
-            slash_command_is_supported_in_tui(command),
-            "{} should be supported in TUI",
-            command.name
-        );
+        assert!(command.supports_surface(settings::SettingsMode::Tui));
     }
 
     let command = &*commands::ORCHESTRATE;
-    assert_eq!(TuiSlashCommand::from_static_command(command), None);
-    assert!(!slash_command_is_supported_in_tui(command));
+    assert_eq!(command.kind, SlashCommandKind::Orchestrate);
+    assert!(!command.supports_surface(settings::SettingsMode::Tui));
 }
 
 #[test]
 fn model_command_is_supported_in_tui_without_becoming_a_prompt_command() {
-    assert!(slash_command_is_supported_in_tui(&commands::MODEL));
+    assert_eq!(commands::MODEL.kind, SlashCommandKind::Model);
     assert!(!slash_command_is_submitted_as_prompt(&commands::MODEL));
     assert!(commands::MODEL.argument.is_none());
 }
@@ -110,20 +94,13 @@ fn model_command_is_supported_in_tui_without_becoming_a_prompt_command() {
 fn exit_command_executes_immediately_and_takes_no_argument() {
     use super::{SlashCommandSelectionBehavior, slash_command_selection_behavior};
 
-    assert_eq!(
-        TuiSlashCommand::from_static_command(&commands::EXIT),
-        Some(TuiSlashCommand::Exit)
-    );
-    assert!(slash_command_is_supported_in_tui(&commands::EXIT));
-    // No argument, and it is never reiterated into the conversation as a prompt.
+    assert_eq!(commands::EXIT.kind, SlashCommandKind::Exit);
     assert!(commands::EXIT.argument.is_none());
     assert!(!slash_command_is_submitted_as_prompt(&commands::EXIT));
-    // With no argument, accepting the command from the menu runs it immediately.
     assert_eq!(
         slash_command_selection_behavior(&commands::EXIT),
         SlashCommandSelectionBehavior::Execute
     );
-    // Available in every session context (gated to the TUI at registry level).
     assert_eq!(commands::EXIT.availability, Availability::ALWAYS);
 }
 
@@ -131,11 +108,7 @@ fn exit_command_executes_immediately_and_takes_no_argument() {
 fn logout_command_executes_immediately_and_takes_no_argument() {
     use super::{SlashCommandSelectionBehavior, slash_command_selection_behavior};
 
-    assert_eq!(
-        TuiSlashCommand::from_static_command(&commands::LOGOUT),
-        Some(TuiSlashCommand::Logout)
-    );
-    assert!(slash_command_is_supported_in_tui(&commands::LOGOUT));
+    assert_eq!(commands::LOGOUT.kind, SlashCommandKind::Logout);
     assert!(commands::LOGOUT.argument.is_none());
     assert!(!slash_command_is_submitted_as_prompt(&commands::LOGOUT));
     assert_eq!(
@@ -178,25 +151,19 @@ fn natural_language_detection_commands_are_supported_in_tui() {
     for (command, expected) in [
         (
             &commands::ENABLE_NATURAL_LANGUAGE_DETECTION,
-            TuiSlashCommand::EnableNaturalLanguageDetection,
+            SlashCommandKind::EnableNaturalLanguageDetection,
         ),
         (
             &commands::DISABLE_NATURAL_LANGUAGE_DETECTION,
-            TuiSlashCommand::DisableNaturalLanguageDetection,
+            SlashCommandKind::DisableNaturalLanguageDetection,
         ),
     ] {
         assert_eq!(
-            TuiSlashCommand::from_static_command(command),
-            Some(expected),
-            "{} should map to its TUI command",
+            command.kind, expected,
+            "{} should have its typed command identity",
             command.name
         );
-        assert!(
-            slash_command_is_supported_in_tui(command),
-            "{} should be supported in TUI",
-            command.name
-        );
-        // The toggle commands run immediately and are never reiterated as a prompt.
+        assert!(command.supports_surface(settings::SettingsMode::Tui));
         assert!(command.argument.is_none());
         assert!(!slash_command_is_submitted_as_prompt(command));
     }

--- a/app/src/terminal/input/slash_commands/search_item.rs
+++ b/app/src/terminal/input/slash_commands/search_item.rs
@@ -41,9 +41,12 @@ impl SearchItem for InlineItem {
     ) -> Box<dyn Element> {
         let icon_color = inline_styles::icon_color(appearance);
         let icon_size = inline_styles::font_size(appearance);
+        let icon_path = self
+            .icon_path
+            .expect("items rendered in the GUI slash command menu must have an icon");
 
         Container::new(
-            ConstrainedBox::new(Icon::new(self.icon_path, icon_color.into_solid()).finish())
+            ConstrainedBox::new(Icon::new(icon_path, icon_color.into_solid()).finish())
                 .with_width(icon_size)
                 .with_height(icon_size)
                 .finish(),

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -135,6 +135,9 @@ pub use crate::persistence::PersistenceWriter;
 pub use crate::search::slash_command_menu::static_commands::commands::{
     self as slash_commands, COMMAND_REGISTRY,
 };
+pub use crate::search::slash_command_menu::static_commands::{
+    SlashCommandKind, SlashCommandSurfaces,
+};
 pub use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
 pub use crate::server::server_api::ServerApiProvider;
 pub use crate::server::server_api::ai::{
@@ -162,11 +165,11 @@ pub use crate::terminal::input::slash_command_model::{
 pub use crate::terminal::input::slash_commands::{
     AcceptSlashCommandOrSavedPrompt, InlineItem, SlashCommandDataSource, SlashCommandMixer,
     SlashCommandSelectionBehavior, TuiDataSourceArgs as TuiSlashCommandDataSourceArgs,
-    TuiSlashCommand, TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
+    TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
     build_slash_command_mixer, record_autodetection_toggle_from_slash_command,
     record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
     should_close_slash_command_menu_for_exact_match, slash_command_is_submitted_as_prompt,
-    slash_command_is_supported_in_tui, slash_command_query, slash_command_selection_behavior,
+    slash_command_query, slash_command_selection_behavior,
 };
 pub use crate::terminal::local_tty::{
     TerminalManager as LocalTtyTerminalManager, TerminalManagerInit, TerminalSurfaceInit,

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -26,9 +26,9 @@ use warp::tui_export::{
     LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, ModelEvent, ParsedSlashCommandInput,
     PersistenceWriter, PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
     ServerConversationToken, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
-    SlashCommandDataSource as _, SlashCommandSelectionBehavior, StartAgentExecutorEvent,
-    StartAgentRequest, StaticCommand, TerminalModel, TerminalSurface, TerminalSurfaceInit,
-    TranscriptScope, TuiMcpAction, TuiMcpManager, TuiSlashCommand, TuiSlashCommandDataSource,
+    SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
+    StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TerminalModel, TerminalSurface,
+    TerminalSurfaceInit, TranscriptScope, TuiMcpAction, TuiMcpManager, TuiSlashCommandDataSource,
     TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource, UserTakeOverReason,
     WAKEUP_THROTTLE_PERIOD, block_context_from_terminal_model, build_slash_command_mixer,
     detect_possible_git_repo, export_conversation_markdown, log_out_tui,
@@ -2824,16 +2824,16 @@ impl TuiTerminalSessionView {
         argument: Option<&String>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let Some(tui_command) = TuiSlashCommand::from_static_command(command) else {
+        if !command.supports_tui() {
             log::debug!(
                 "TUI slash command selection is not supported yet: {}",
                 command.name
             );
             return;
-        };
+        }
 
-        match tui_command {
-            TuiSlashCommand::Agent | TuiSlashCommand::New => {
+        match command.kind {
+            SlashCommandKind::Agent | SlashCommandKind::New => {
                 if !self
                     .ai_context_model
                     .as_ref(ctx)
@@ -2862,48 +2862,48 @@ impl TuiTerminalSessionView {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::Conversations => {
+            SlashCommandKind::Conversations => {
                 self.conversation_menu
                     .update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::AutoApprove => {
+            SlashCommandKind::AutoApprove => {
                 self.toggle_auto_approve(true, ctx);
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::Cost => {
+            SlashCommandKind::Cost => {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 ctx.dispatch_typed_action_deferred(
                     TuiTerminalSessionAction::ToggleResponseSummaryVisibility,
                 );
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::Model => {
+            SlashCommandKind::Model => {
                 self.model_menu.update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::Skills => {
+            SlashCommandKind::InvokeSkill => {
                 if !FeatureFlag::ListSkills.is_enabled() {
                     return;
                 }
                 self.skills_menu.update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::Mcp => {
+            SlashCommandKind::Mcp => {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 self.mcp_menu.update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::Exit => {
+            SlashCommandKind::Exit => {
                 record_static_slash_command_accepted(command.name, true, ctx);
                 ctx.terminate_app(TerminationMode::ForceTerminate, None);
             }
-            TuiSlashCommand::Logout => {
+            SlashCommandKind::Logout => {
                 record_static_slash_command_accepted(command.name, true, ctx);
                 log_out_tui(ctx);
             }
-            TuiSlashCommand::ViewLogs => {
+            SlashCommandKind::ViewLogs => {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 ctx.spawn(
                     async move {
@@ -2932,7 +2932,7 @@ impl TuiTerminalSessionView {
                 );
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::CreateNewProject => {
+            SlashCommandKind::CreateNewProject => {
                 let Some(query) = argument
                     .map(|argument| argument.trim())
                     .filter(|argument| !argument.is_empty())
@@ -2950,7 +2950,7 @@ impl TuiTerminalSessionView {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::ExportToClipboard => {
+            SlashCommandKind::ExportToClipboard => {
                 if let Some(conversation) = self
                     .conversation_selection
                     .as_ref(ctx)
@@ -2976,7 +2976,7 @@ impl TuiTerminalSessionView {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::ExportToFile => {
+            SlashCommandKind::ExportToFile => {
                 let Some(conversation) = self
                     .conversation_selection
                     .as_ref(ctx)
@@ -3016,7 +3016,7 @@ impl TuiTerminalSessionView {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
-            TuiSlashCommand::Compact | TuiSlashCommand::Plan => {
+            SlashCommandKind::Compact | SlashCommandKind::Plan => {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 let command_name = command.name;
                 let prompt = argument
@@ -3031,11 +3031,54 @@ impl TuiTerminalSessionView {
                 self.send_prompt(prompt, ctx);
                 record_static_slash_command_accepted(command_name, true, ctx);
             }
-            TuiSlashCommand::EnableNaturalLanguageDetection => {
+            SlashCommandKind::EnableNaturalLanguageDetection => {
                 self.set_nld_enabled(true, command.name, ctx);
             }
-            TuiSlashCommand::DisableNaturalLanguageDetection => {
+            SlashCommandKind::DisableNaturalLanguageDetection => {
                 self.set_nld_enabled(false, command.name, ctx);
+            }
+            SlashCommandKind::CloudAgent
+            | SlashCommandKind::AddMcp
+            | SlashCommandKind::CreateEnvironment
+            | SlashCommandKind::CreateDockerSandbox
+            | SlashCommandKind::EditSkill
+            | SlashCommandKind::AddPrompt
+            | SlashCommandKind::AddRule
+            | SlashCommandKind::Edit
+            | SlashCommandKind::RenameTab
+            | SlashCommandKind::RenameConversation
+            | SlashCommandKind::SetTabColor
+            | SlashCommandKind::Fork
+            | SlashCommandKind::MoveToCloud
+            | SlashCommandKind::OpenCodeReview
+            | SlashCommandKind::Index
+            | SlashCommandKind::Init
+            | SlashCommandKind::OpenProjectRules
+            | SlashCommandKind::OpenMcpServers
+            | SlashCommandKind::OpenSettingsFile
+            | SlashCommandKind::Changelog
+            | SlashCommandKind::Feedback
+            | SlashCommandKind::OpenRepo
+            | SlashCommandKind::OpenRules
+            | SlashCommandKind::Host
+            | SlashCommandKind::Harness
+            | SlashCommandKind::Environment
+            | SlashCommandKind::Profile
+            | SlashCommandKind::Orchestrate
+            | SlashCommandKind::CompactAnd
+            | SlashCommandKind::Queue
+            | SlashCommandKind::ForkAndCompact
+            | SlashCommandKind::ForkFrom
+            | SlashCommandKind::ContinueLocally
+            | SlashCommandKind::Usage
+            | SlashCommandKind::RemoteControl
+            | SlashCommandKind::Prompts
+            | SlashCommandKind::Rewind => {
+                debug_assert!(
+                    false,
+                    "Attempted to execute GUI-only slash command in the TUI: {}",
+                    command.name
+                );
             }
         }
     }


### PR DESCRIPTION
## Description

Centralizes static slash-command identity and frontend support metadata.

Every `StaticCommand` now declares a unique `SlashCommandKind` and one payload-free surface value: GUI-only, TUI-only, or shared. Registry construction filters commands by the active frontend, and both GUI and TUI execution dispatch on the typed command kind instead of maintaining name-based frontend allowlists.

This makes frontend support an explicit decision when adding a command and prevents registry visibility from drifting away from execution support.

## Linked Issue

Stacked on #14120.

## Testing

- `./script/format --check`
- All clippy invocations defined by `script/presubmit`
- Focused command identity, uniqueness, and surface filtering tests — 5 passed
- `cargo nextest run -p warp_tui` — 551 passed

- [x] I have manually verified the existing TUI `/cost` flow through the parent PR

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Run: https://staging.warp.dev/conversation/12d19735-3184-4a7e-9b28-78ec61f65d0c

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
