### PR TITLE
Fix Linux TUI bundling

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -636,6 +636,8 @@ jobs:
     # download endpoint and installer accept Linux payloads.
     if: ${{ inputs.build_linux != false && inputs.channel == 'dev' }}
     timeout-minutes: 180
+    # Experimental TUI failures must not block dev release cuts.
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -699,9 +701,12 @@ jobs:
           test -s "$bundle_dir/resources/THIRD_PARTY_LICENSES.txt"
           grep -q "\"warp_version\": \"${GIT_RELEASE_TAG}\"" \
             "$bundle_dir/resources/bundled/metadata/version.json"
-          tar tzf "$archive" | grep -qx "warp-tui-${CHANNEL}"
-          tar tzf "$archive" | grep -qx "resources/settings_schema.json"
-          tar tzf "$archive" | grep -qx "resources/THIRD_PARTY_LICENSES.txt"
+
+          archive_listing="${RUNNER_TEMP}/warp-tui-${CHANNEL}-linux-${{ matrix.arch }}-contents.txt"
+          tar tzf "$archive" > "$archive_listing"
+          grep -Fqx "warp-tui-${CHANNEL}" "$archive_listing"
+          grep -Fqx "resources/settings_schema.json" "$archive_listing"
+          grep -Fqx "resources/THIRD_PARTY_LICENSES.txt" "$archive_listing"
         shell: bash
         env:
           CHANNEL: ${{ steps.get-config.outputs.channel }}
@@ -712,6 +717,17 @@ jobs:
         with:
           name: release-linux-tui-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
           path: warp-tui-${{ steps.get-config.outputs.channel }}-linux-${{ matrix.arch }}.tar.gz
+
+      - name: Report Linux TUI build failure
+        if: ${{ failure() }}
+        run: |
+          echo "::warning::The experimental Linux TUI ${{ matrix.arch }} release artifact failed to build. This failure will not block the dev release."
+          {
+            echo "## Linux TUI ${{ matrix.arch }} release artifact failed"
+            echo
+            echo "This experimental build failure will not block the dev release. Review the failed step above for details."
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
 
   release_linux_x86:
     name: Build Release (Linux x86_64)


### PR DESCRIPTION
## Description

Fix Linux TUI release packaging after both architecture jobs failed during archive validation even though bundling completed successfully.

The validation used `tar tzf ... | grep -q ...` under Bash with `-o pipefail`. Once `grep -q` found a match, it closed the pipe while `tar` was still writing, causing `tar` to exit with a write error. This change:

- writes the complete archive listing to a temporary file once, then checks required entries with exact fixed-string matches;
- marks the experimental, dev-only Linux TUI matrix as non-blocking so failures cannot prevent a dev release cut; and
- emits an explicit workflow warning and job summary when a Linux TUI build fails, preserving visibility despite `continue-on-error`.

## Linked Issue

None. This fixes the failure observed in [release workflow run 29949383726](https://github.com/warpdotdev/warp-internal/actions/runs/29949383726).

## Testing

- Reproduced the old validation under `bash -e -o pipefail`: exit code `141`.
- Verified the revised validation against the same representative archive: exit code `0`.
- Verified an archive missing a required entry still fails validation: exit code `1`.
- Parsed the workflow YAML with the workspace-pinned `serde_yaml` crate.
- Ran workflow structure assertions and `git diff --check`.

- [ ] I have manually tested my changes locally with `./script/run` (not applicable; workflow-only change)

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
