### PR TITLE
warpctrl: drop shell selection from create APIs and fix Keychain security claims

### DIFF
--- a/app/src/local_control/handlers/app_state.rs
+++ b/app/src/local_control/handlers/app_state.rs
@@ -23,7 +23,7 @@ use warpui::{AppContext, ModelContext, TypedActionView};
 use crate::code::editor_management::CodeSource;
 use crate::local_control::LocalControlBridge;
 use crate::local_control::handlers::ack;
-use crate::local_control::handlers::layout::{create_tab, resolve_shell};
+use crate::local_control::handlers::layout::create_tab;
 use crate::local_control::handlers::metadata::{SurfaceDestination, surface_unavailable_reason};
 use crate::local_control::resolver::{
     activate_target, active_target_pane_group, decode_params, focus_explicit_pane_target,
@@ -246,13 +246,7 @@ fn window_create(
             ));
         }
     }
-    match params.shell.as_deref() {
-        Some(shell_name) => {
-            let shell = resolve_shell(shell_name, ctx)?;
-            ctx.dispatch_global_action("root_view:open_new_with_shell", Some(shell));
-        }
-        None => ctx.dispatch_global_action("root_view:open_new", ()),
-    }
+    ctx.dispatch_global_action("root_view:open_new", ());
     Ok(ack(instance_id, ActionKind::WindowCreate))
 }
 

--- a/app/src/local_control/handlers/layout.rs
+++ b/app/src/local_control/handlers/layout.rs
@@ -5,18 +5,12 @@ mod tests;
 use ::local_control::protocol::{TabCreateParams, TabType, TargetSelector};
 use ::local_control::{ActionKind, ControlError, ErrorCode, InstanceId};
 use serde::Serialize;
-#[cfg(feature = "local_tty")]
-use warpui::SingletonEntity;
 use warpui::{ModelContext, TypedActionView};
 
 use crate::local_control::LocalControlBridge;
 use crate::local_control::resolver::{
     decode_params, target_window_id_for_target, validate_tab_create_target, workspace_for_window,
 };
-use crate::server::telemetry::AddTabWithShellSource;
-use crate::terminal::available_shells::AvailableShell;
-#[cfg(feature = "local_tty")]
-use crate::terminal::available_shells::AvailableShells;
 use crate::workspace::WorkspaceAction;
 #[derive(Serialize)]
 struct TabCreateResponse<'a> {
@@ -50,7 +44,7 @@ pub(crate) fn create_tab(
     validate_tab_create_target(target)?;
     let window_id = target_window_id_for_target(ctx, target, ActionKind::TabCreate)?;
     let workspace = workspace_for_window(window_id, ActionKind::TabCreate, ctx)?;
-    let action = tab_create_action(params, ctx)?;
+    let action = tab_create_action(params)?;
     let (tab_id, previous_tab_count, tab_count, active_tab_index) =
         workspace.update(ctx, |workspace, ctx| {
             let previous_tab_count = workspace.tab_count();
@@ -95,23 +89,8 @@ pub(crate) fn create_tab(
     })
 }
 
-fn tab_create_action(
-    params: &serde_json::Value,
-    ctx: &ModelContext<LocalControlBridge>,
-) -> Result<WorkspaceAction, ControlError> {
+fn tab_create_action(params: &serde_json::Value) -> Result<WorkspaceAction, ControlError> {
     let params = decode_params::<TabCreateParams>(params)?;
-    if let Some(shell_name) = params.shell.as_deref() {
-        if matches!(params.tab_type, Some(TabType::Agent | TabType::CloudAgent)) {
-            return Err(ControlError::new(
-                ErrorCode::InvalidParams,
-                "tab.create cannot combine an agent tab type with a shell",
-            ));
-        }
-        return Ok(WorkspaceAction::AddTabWithShell {
-            shell: resolve_shell(shell_name, ctx)?,
-            source: AddTabWithShellSource::CommandPalette,
-        });
-    }
     match params.tab_type {
         None | Some(TabType::Terminal) => Ok(WorkspaceAction::AddTerminalTab {
             hide_homepage: false,
@@ -123,47 +102,4 @@ fn tab_create_action(
             "tab.create does not support cloud-agent tabs",
         )),
     }
-}
-
-#[cfg_attr(not(feature = "local_tty"), allow(unused_variables))]
-pub(super) fn resolve_shell(
-    name: &str,
-    ctx: &ModelContext<LocalControlBridge>,
-) -> Result<AvailableShell, ControlError> {
-    #[cfg(feature = "local_tty")]
-    {
-        if shell_name_looks_like_path(name) {
-            return Err(ControlError::new(
-                ErrorCode::InvalidParams,
-                format!(
-                    "shell must be a discovered shell command name, not a filesystem path: {name:?}"
-                ),
-            ));
-        }
-        AvailableShells::as_ref(ctx)
-            .find_by_command_name(name)
-            .ok_or_else(|| {
-                ControlError::new(
-                    ErrorCode::InvalidParams,
-                    format!(
-                        "cannot resolve requested shell {name:?}; use a discovered shell command name"
-                    ),
-                )
-            })
-    }
-    #[cfg(not(feature = "local_tty"))]
-    Err(ControlError::new(
-        ErrorCode::UnsupportedAction,
-        format!("shell selection is unavailable for requested shell {name:?}"),
-    ))
-}
-
-/// Returns true when `name` is path-shaped rather than a bare shell command.
-///
-/// Local-control callers must select from shells Warp has already discovered.
-/// Accepting absolute/relative paths would let `tab.create` / `window.create`
-/// spawn an arbitrary same-user binary whose basename looks like a supported
-/// shell (for example `/tmp/evil/zsh`).
-fn shell_name_looks_like_path(name: &str) -> bool {
-    name.contains('/') || name.contains('\\')
 }

--- a/app/src/local_control/handlers/layout.rs
+++ b/app/src/local_control/handlers/layout.rs
@@ -132,13 +132,22 @@ pub(super) fn resolve_shell(
 ) -> Result<AvailableShell, ControlError> {
     #[cfg(feature = "local_tty")]
     {
+        if shell_name_looks_like_path(name) {
+            return Err(ControlError::new(
+                ErrorCode::InvalidParams,
+                format!(
+                    "shell must be a discovered shell command name, not a filesystem path: {name:?}"
+                ),
+            ));
+        }
         AvailableShells::as_ref(ctx)
             .find_by_command_name(name)
-            .or_else(|| AvailableShell::try_from(name).ok())
             .ok_or_else(|| {
                 ControlError::new(
                     ErrorCode::InvalidParams,
-                    format!("cannot resolve requested shell {name:?}"),
+                    format!(
+                        "cannot resolve requested shell {name:?}; use a discovered shell command name"
+                    ),
                 )
             })
     }
@@ -147,4 +156,14 @@ pub(super) fn resolve_shell(
         ErrorCode::UnsupportedAction,
         format!("shell selection is unavailable for requested shell {name:?}"),
     ))
+}
+
+/// Returns true when `name` is path-shaped rather than a bare shell command.
+///
+/// Local-control callers must select from shells Warp has already discovered.
+/// Accepting absolute/relative paths would let `tab.create` / `window.create`
+/// spawn an arbitrary same-user binary whose basename looks like a supported
+/// shell (for example `/tmp/evil/zsh`).
+fn shell_name_looks_like_path(name: &str) -> bool {
+    name.contains('/') || name.contains('\\')
 }

--- a/app/src/local_control/handlers/layout_tests.rs
+++ b/app/src/local_control/handlers/layout_tests.rs
@@ -2,7 +2,7 @@ use ::local_control::protocol::TargetSelector;
 use ::local_control::{ErrorCode, InstanceId};
 use warpui::App;
 
-use super::{create_tab, shell_name_looks_like_path};
+use super::create_tab;
 use crate::local_control::LocalControlBridge;
 use crate::workspace::view::tests::{initialize_app, mock_workspace};
 
@@ -41,20 +41,7 @@ fn tab_create_handler_adds_and_activates_terminal_tab() {
 }
 
 #[test]
-fn shell_name_looks_like_path_detects_unix_and_windows_paths() {
-    assert!(shell_name_looks_like_path("/tmp/evil/zsh"));
-    assert!(shell_name_looks_like_path("./zsh"));
-    assert!(shell_name_looks_like_path("../bin/bash"));
-    assert!(shell_name_looks_like_path(r"C:\evil\zsh.exe"));
-    assert!(shell_name_looks_like_path(r"evil\zsh"));
-    assert!(!shell_name_looks_like_path("zsh"));
-    assert!(!shell_name_looks_like_path("bash"));
-    assert!(!shell_name_looks_like_path("pwsh"));
-    assert!(!shell_name_looks_like_path(""));
-}
-
-#[test]
-fn tab_create_rejects_filesystem_path_shell_parameter() {
+fn tab_create_rejects_shell_parameter() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);
         let _workspace = mock_workspace(&mut app);
@@ -65,18 +52,13 @@ fn tab_create_rejects_filesystem_path_shell_parameter() {
             bridge.set_instance_id(instance_id.clone());
             create_tab(
                 &Some(instance_id.clone()),
-                &serde_json::json!({ "shell": "/tmp/evil/zsh" }),
+                &serde_json::json!({ "shell": "zsh" }),
                 &TargetSelector::default(),
                 ctx,
             )
-            .expect_err("path-shaped shell must be rejected")
+            .expect_err("shell parameter must be rejected")
         });
 
         assert_eq!(err.code, ErrorCode::InvalidParams);
-        assert!(
-            err.message.contains("filesystem path"),
-            "unexpected message: {}",
-            err.message
-        );
     });
 }

--- a/app/src/local_control/handlers/layout_tests.rs
+++ b/app/src/local_control/handlers/layout_tests.rs
@@ -1,8 +1,8 @@
-use ::local_control::InstanceId;
 use ::local_control::protocol::TargetSelector;
+use ::local_control::{ErrorCode, InstanceId};
 use warpui::App;
 
-use super::create_tab;
+use super::{create_tab, shell_name_looks_like_path};
 use crate::local_control::LocalControlBridge;
 use crate::workspace::view::tests::{initialize_app, mock_workspace};
 
@@ -37,5 +37,46 @@ fn tab_create_handler_adds_and_activates_terminal_tab() {
         assert_eq!(response["tab"]["count"], previous_count + 1);
         assert_eq!(response["tab"]["active_index"], previous_count);
         assert!(response["tab"]["id"].is_string());
+    });
+}
+
+#[test]
+fn shell_name_looks_like_path_detects_unix_and_windows_paths() {
+    assert!(shell_name_looks_like_path("/tmp/evil/zsh"));
+    assert!(shell_name_looks_like_path("./zsh"));
+    assert!(shell_name_looks_like_path("../bin/bash"));
+    assert!(shell_name_looks_like_path(r"C:\evil\zsh.exe"));
+    assert!(shell_name_looks_like_path(r"evil\zsh"));
+    assert!(!shell_name_looks_like_path("zsh"));
+    assert!(!shell_name_looks_like_path("bash"));
+    assert!(!shell_name_looks_like_path("pwsh"));
+    assert!(!shell_name_looks_like_path(""));
+}
+
+#[test]
+fn tab_create_rejects_filesystem_path_shell_parameter() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let _workspace = mock_workspace(&mut app);
+        let bridge = app.add_singleton_model(LocalControlBridge::new);
+        let instance_id = InstanceId("inst_test".to_owned());
+
+        let err = bridge.update(&mut app, |bridge, ctx| {
+            bridge.set_instance_id(instance_id.clone());
+            create_tab(
+                &Some(instance_id.clone()),
+                &serde_json::json!({ "shell": "/tmp/evil/zsh" }),
+                &TargetSelector::default(),
+                ctx,
+            )
+            .expect_err("path-shaped shell must be rejected")
+        });
+
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            err.message.contains("filesystem path"),
+            "unexpected message: {}",
+            err.message
+        );
     });
 }

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -164,14 +164,12 @@ pub struct TabCloseParams {
     pub mode: TabCloseMode,
 }
 
-/// Parameters for `tab.create` and `window.create` shell/profile options.
+/// Parameters for `tab.create` and `window.create`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TabCreateParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tab_type: Option<TabType>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub shell: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/local_control/src/protocol_tests.rs
+++ b/crates/local_control/src/protocol_tests.rs
@@ -27,15 +27,21 @@ fn strict_params_serialize_without_synthetic_discriminators() {
         ActionKind::TabCreate,
         TabCreateParams {
             tab_type: Some(TabType::Agent),
-            shell: Some("zsh".to_owned()),
         },
     )
     .expect("tab.create params serialize");
-    assert_eq!(
-        action.params,
-        serde_json::json!({ "tab_type": "agent", "shell": "zsh" })
-    );
+    assert_eq!(action.params, serde_json::json!({ "tab_type": "agent" }));
     assert!(action.params.get("type").is_none());
+    assert!(action.params.get("shell").is_none());
+
+    let action = Action {
+        kind: ActionKind::TabCreate,
+        params: serde_json::json!({ "tab_type": "terminal", "shell": "zsh" }),
+    };
+    let error = action
+        .params_as::<TabCreateParams>()
+        .expect_err("shell is not an accepted tab.create parameter");
+    assert_eq!(error.code, ErrorCode::InvalidParams);
 }
 
 #[test]

--- a/crates/warp_cli/src/local_control/commands.rs
+++ b/crates/warp_cli/src/local_control/commands.rs
@@ -340,7 +340,6 @@ pub(super) fn run_window_command(
             ActionKind::WindowCreate,
             TabCreateParams {
                 tab_type: args.tab_type.map(Into::into),
-                shell: args.shell,
             },
             output_format,
         ),
@@ -369,7 +368,6 @@ pub(super) fn run_tab_command(
             ActionKind::TabCreate,
             TabCreateParams {
                 tab_type: args.tab_type.map(Into::into),
-                shell: args.shell,
             },
             output_format,
         ),

--- a/crates/warp_cli/src/local_control/mod.rs
+++ b/crates/warp_cli/src/local_control/mod.rs
@@ -611,9 +611,6 @@ pub struct TabCreateArgs {
     #[arg(long = "type", value_enum)]
     pub tab_type: Option<CliTabType>,
 
-    #[arg(long = "shell")]
-    pub shell: Option<String>,
-
     #[command(flatten)]
     pub target: TargetArgs,
 }

--- a/crates/warp_cli/src/local_control_tests.rs
+++ b/crates/warp_cli/src/local_control_tests.rs
@@ -14,8 +14,6 @@ fn parses_typed_create_and_setting_list_params() {
         "create",
         "--type",
         "agent",
-        "--shell",
-        "zsh",
         "--session",
         "session_1",
     ])
@@ -24,8 +22,11 @@ fn parses_typed_create_and_setting_list_params() {
         panic!("expected tab create command");
     };
     assert_eq!(args.tab_type, Some(CliTabType::Agent));
-    assert_eq!(args.shell.as_deref(), Some("zsh"));
     assert_eq!(args.target.session.as_deref(), Some("session_1"));
+
+    let err = ControlArgs::try_parse_from(["warpctrl", "tab", "create", "--shell", "zsh"])
+        .expect_err("shell is not an accepted tab create flag");
+    assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
 
     let args =
         ControlArgs::try_parse_from(["warpctrl", "setting", "list", "--namespace", "editor"])

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -118,7 +118,7 @@ The broker authenticates the OS user, not the calling application. Any same-user
 - Short expiry limits the window for credential reuse.
 - Normal Warp close behavior preserves existing warnings for close actions.
 - No `input.run` action exists, so `warpctrl` cannot be used to execute terminal commands.
-- `tab.create` / `window.create` `shell` parameters accept only bare command names of shells Warp has already discovered. Absolute or relative filesystem paths are rejected so local control cannot be used as a same-user process launcher via path basename tricks.
+- `tab.create` / `window.create` do not accept a `shell` parameter. New terminals use the app's default shell selection; local control cannot choose or spawn an arbitrary shell binary.
 - Protected enablement prevents silent activation of the control surface through ordinary config surfaces; it is not a signed-code isolation boundary against same-user Keychain or secret-service access.
 - App-side bridge enforcement re-checks every credential on every request.
 These mitigations route operations through intentional flows. They do not guarantee that arbitrary same-user software cannot cause Warp-visible actions.
@@ -160,6 +160,7 @@ The catalog contains exactly 84 actions. The following families and actions are 
 - The entire Drive family (all `drive.*` actions).
 - The entire History family (`history.list`).
 - `input.get`, `input.clear`, `input.mode.set`, `input.run`, and any form of terminal command execution.
+- `shell` selection on `tab.create` / `window.create`, and any local-control path that spawns a caller-chosen shell binary.
 - `file.list` and any local file content operations beyond the `file.open` app-state intent.
 - Accepted-command submission and agent-prompt submission.
 - Debug, crash, heap-dump, token-copying, and developer-only helpers.

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -58,12 +58,12 @@ Scripting has a single setting:
 - **Enabled** (default on internal dogfood channels): same-user processes may request exact-action credentials and send control requests.
 - **Disabled** (default on Stable, Preview, OSS, and Integration channels): no credentials are issued, no control requests are accepted, discovery records contain no actionable endpoint.
 The authoritative value is stored in the most secure local storage available:
-- **macOS:** Keychain, constrained to Warp-signed code where the platform supports it.
+- **macOS:** Keychain via the platform Security framework generic-password API. This is same-user secret storage that keeps the value out of `settings.toml` and cloud sync; it is **not** currently constrained to Warp-signed code through a Keychain access-control list.
 - **Linux:** Platform secret service where available; owner-only file fallback with the weaker same-user protection explicitly documented.
 The setting is:
 - Local-only: never synced through Settings Sync, Warp Drive, or server-backed preferences.
 - Private: never appears in `settings.toml`, generated schemas, or any user-editable settings surface.
-- App-controlled: only the running Warp app through Settings > Scripting can change it. `warpctrl`, shell scripts, config files, registry edits, `defaults write`, and direct protocol requests cannot enable or change it.
+- App-mediated: the supported way to change it is Settings > Scripting in the running Warp app. `warpctrl`, config files, registry edits, `defaults write`, and direct protocol requests cannot enable or change it. Same-user software that can already use the user's Keychain or secret-service session may still be able to read or write the underlying item; that is residual same-user risk, not a hard signed-code boundary.
 - Channel-default: when no valid protected value is available, the mode defaults to enabled on internal dogfood channels (Dev, Local) and disabled on all other channels.
 Disabling Scripting immediately prevents new credential issuance and invalidates outstanding credentials. The control listener rejects all requests with `local_control_disabled`.
 ## Discovery registry
@@ -118,7 +118,8 @@ The broker authenticates the OS user, not the calling application. Any same-user
 - Short expiry limits the window for credential reuse.
 - Normal Warp close behavior preserves existing warnings for close actions.
 - No `input.run` action exists, so `warpctrl` cannot be used to execute terminal commands.
-- Protected enablement prevents silent activation of the control surface.
+- `tab.create` / `window.create` `shell` parameters accept only bare command names of shells Warp has already discovered. Absolute or relative filesystem paths are rejected so local control cannot be used as a same-user process launcher via path basename tricks.
+- Protected enablement prevents silent activation of the control surface through ordinary config surfaces; it is not a signed-code isolation boundary against same-user Keychain or secret-service access.
 - App-side bridge enforcement re-checks every credential on every request.
 These mitigations route operations through intentional flows. They do not guarantee that arbitrary same-user software cannot cause Warp-visible actions.
 ## Transport authentication
@@ -188,7 +189,7 @@ The app never downgrades these failures into broader default actions.
 ## Platform requirements
 ### macOS
 - Discovery directory and records: owner-only permissions.
-- Authoritative Scripting value: Keychain, constrained to Warp-signed code.
+- Authoritative Scripting value: Keychain generic-password item (same-user secret storage; not currently ACL-constrained to Warp-signed code).
 - Broker: Unix-domain socket with peer credential checks.
 ### Linux
 - Discovery directory and records: owner-only permissions (`0700`/`0600`).


### PR DESCRIPTION
## Description

Two launch-critical warpctrl security cleanups from the pre-launch audit:

1. **Remove shell selection from create APIs.** `tab.create` / `window.create` no longer accept a `shell` parameter anywhere in the stack (protocol field, CLI `--shell`, or app handlers). New terminals always use the app default shell. Leftover `shell` values are rejected by strict params / clap as unknown.
2. **Correct Keychain security claims in `SECURITY.md`.** Docs no longer claim a Warp-signed Keychain ACL that is not implemented. Keychain is described as same-user secret storage (kept out of `settings.toml` / cloud sync), with residual same-user risk called out honestly.

### Why

Shell selection via local control was not a requested launch feature. The old path also had a dangerous fallback that could treat path-shaped values like `/tmp/evil/zsh` as a custom shell binary. Instead of keeping a locked-down allowlist, we removed the surface until users ask for it.

### How

- Dropped `TabCreateParams.shell` and the CLI `--shell` flag.
- Simplified `tab.create` / `window.create` handlers and removed `resolve_shell`.
- Added/updated protocol, CLI, and handler tests to assert `shell` is rejected.
- Updated confused-deputy and catalog-boundary language in `specs/warp-control-cli/SECURITY.md`.

## Testing

- [x] `local_control` protocol test rejects `shell` on `tab.create`
- [x] `warp_cli` parse test rejects `--shell`
- [x] `tab_create_rejects_shell_parameter`
- [x] `tab_create_handler_adds_and_activates_terminal_tab`
- [x] `./script/format`
- [x] `cargo clippy -p local_control -p warp_cli -p warp --lib --tests --features local_tty -- -D warnings`

## Screenshots / Videos

N/A — security hardening and docs only; no UI changes.

CHANGELOG-BUG-FIX: Remove shell selection from warpctrl tab/window create so local control cannot spawn caller-chosen shell binaries.
CHANGELOG-IMPROVEMENT:
CHANGELOG-NEW-FEATURE:
CHANGELOG-IMAGE:

Co-Authored-By: Oz <oz-agent@warp.dev>