### PR TITLE
Revamp TUI zero state animation

### DIFF
--- a/app/src/settings/init.rs
+++ b/app/src/settings/init.rs
@@ -19,7 +19,7 @@ use super::{
     FontSettings, FontSettingsChangedEvent, GPUSettings, InputBoxType, InputModeSettings,
     InputSettings, LocalControlSettings, PaneSettings, SameLinePromptBlockSettings, ScrollSettings,
     SelectionSettings, SharedObjectLimitBannerSettings, SshSettings, ThemeSettings,
-    TuiAutoupdateSettings, VimBannerSettings, WarpDrivePrivacySettings,
+    TuiAutoupdateSettings, TuiZeroStateSettings, VimBannerSettings, WarpDrivePrivacySettings,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::appearance;
@@ -80,6 +80,7 @@ pub fn register_all_settings(ctx: &mut AppContext) {
     InputModeSettings::register(ctx);
     ThemeSettings::register(ctx);
     TuiAutoupdateSettings::register(ctx);
+    TuiZeroStateSettings::register(ctx);
     AccessibilitySettings::register(ctx);
     NativePreferenceSettings::register(ctx);
     CloudPreferencesSettings::register(ctx);

--- a/app/src/settings/mod.rs
+++ b/app/src/settings/mod.rs
@@ -34,6 +34,7 @@ mod shared_object_limit_banner;
 mod ssh;
 mod theme;
 mod tui_autoupdate;
+mod tui_zero_state;
 mod vim_banner;
 
 #[cfg(test)]
@@ -69,6 +70,7 @@ pub use shared_object_limit_banner::*;
 pub use ssh::*;
 pub use theme::*;
 pub use tui_autoupdate::*;
+pub use tui_zero_state::*;
 pub use vim_banner::*;
 use warp_core::user_preferences::GetUserPreferences as _;
 

--- a/app/src/settings/tui_zero_state.rs
+++ b/app/src/settings/tui_zero_state.rs
@@ -141,7 +141,7 @@ define_settings_group!(TuiZeroStateSettings, settings: [
         private: false,
         toml_path: "appearance.zero_state.object",
         max_table_depth: 0,
-        description: "The object rotated in the TUI zero state. Use built_in or an ascii_file path relative to the TUI settings directory.",
+        description: "The object rotated in the Warp Agent CLI zero state. Use built_in or an ascii_file path relative to the Warp Agent CLI settings directory. Changing this setting reloads the object; editing the linked file requires a restart.",
     },
     rotation_period_seconds: TuiZeroStateRotationPeriodSecondsSetting {
         type: TuiZeroStateRotationPeriodSeconds,
@@ -151,7 +151,7 @@ define_settings_group!(TuiZeroStateSettings, settings: [
         surface: settings::SettingSurfaces::TUI,
         private: false,
         toml_path: "appearance.zero_state.rotation_period_seconds",
-        description: "Seconds per TUI zero-state object rotation, from 1 through 60.",
+        description: "Seconds per Warp Agent CLI zero-state object rotation, from 1 through 60.",
     },
     extrusion_depth: TuiZeroStateExtrusionDepthSetting {
         type: TuiZeroStateExtrusionDepth,
@@ -161,7 +161,7 @@ define_settings_group!(TuiZeroStateSettings, settings: [
         surface: settings::SettingSurfaces::TUI,
         private: false,
         toml_path: "appearance.zero_state.extrusion_depth",
-        description: "Normalized half-depth of the extruded TUI zero-state object, from 0.02 through 0.5.",
+        description: "Normalized half-depth of the extruded Warp Agent CLI zero-state object, from 0.02 through 0.5.",
     },
 ]);
 

--- a/app/src/settings/tui_zero_state.rs
+++ b/app/src/settings/tui_zero_state.rs
@@ -1,0 +1,170 @@
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Deserializer, Serialize};
+use settings::macros::define_settings_group;
+use settings::{SupportedPlatforms, SyncToCloud};
+
+pub const DEFAULT_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS: f64 = 5.0;
+pub const MIN_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS: f64 = 1.0;
+pub const MAX_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS: f64 = 60.0;
+pub const DEFAULT_TUI_ZERO_STATE_EXTRUSION_DEPTH: f64 = 0.18;
+pub const MIN_TUI_ZERO_STATE_EXTRUSION_DEPTH: f64 = 0.02;
+pub const MAX_TUI_ZERO_STATE_EXTRUSION_DEPTH: f64 = 0.5;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TuiZeroStateObject {
+    #[default]
+    BuiltIn,
+    AsciiFile {
+        path: PathBuf,
+    },
+}
+
+impl settings_value::SettingsValue for TuiZeroStateObject {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, schemars::JsonSchema)]
+#[serde(transparent)]
+#[schemars(transparent)]
+pub struct TuiZeroStateRotationPeriodSeconds(f64);
+
+impl TuiZeroStateRotationPeriodSeconds {
+    pub fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl Default for TuiZeroStateRotationPeriodSeconds {
+    fn default() -> Self {
+        Self(DEFAULT_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS)
+    }
+}
+
+impl<'de> Deserialize<'de> for TuiZeroStateRotationPeriodSeconds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_bounded_f64(
+            deserializer,
+            "rotation period",
+            MIN_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
+            MAX_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
+        )
+        .map(Self)
+    }
+}
+
+impl settings_value::SettingsValue for TuiZeroStateRotationPeriodSeconds {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, schemars::JsonSchema)]
+#[serde(transparent)]
+#[schemars(transparent)]
+pub struct TuiZeroStateExtrusionDepth(f64);
+
+impl TuiZeroStateExtrusionDepth {
+    pub fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl Default for TuiZeroStateExtrusionDepth {
+    fn default() -> Self {
+        Self(DEFAULT_TUI_ZERO_STATE_EXTRUSION_DEPTH)
+    }
+}
+
+impl<'de> Deserialize<'de> for TuiZeroStateExtrusionDepth {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_bounded_f64(
+            deserializer,
+            "extrusion depth",
+            MIN_TUI_ZERO_STATE_EXTRUSION_DEPTH,
+            MAX_TUI_ZERO_STATE_EXTRUSION_DEPTH,
+        )
+        .map(Self)
+    }
+}
+
+impl settings_value::SettingsValue for TuiZeroStateExtrusionDepth {}
+
+fn deserialize_bounded_f64<'de, D>(
+    deserializer: D,
+    name: &'static str,
+    min: f64,
+    max: f64,
+) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = f64::deserialize(deserializer)?;
+    if value.is_finite() && (min..=max).contains(&value) {
+        Ok(value)
+    } else {
+        Err(serde::de::Error::custom(BoundedFloatError {
+            name,
+            value,
+            min,
+            max,
+        }))
+    }
+}
+
+struct BoundedFloatError {
+    name: &'static str,
+    value: f64,
+    min: f64,
+    max: f64,
+}
+
+impl fmt::Display for BoundedFloatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} must be finite and between {} and {}, got {}",
+            self.name, self.min, self.max, self.value
+        )
+    }
+}
+
+define_settings_group!(TuiZeroStateSettings, settings: [
+    object: TuiZeroStateObjectSetting {
+        type: TuiZeroStateObject,
+        default: TuiZeroStateObject::default(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        surface: settings::SettingSurfaces::TUI,
+        private: false,
+        toml_path: "appearance.zero_state.object",
+        max_table_depth: 0,
+        description: "The object rotated in the TUI zero state. Use built_in or an ascii_file path relative to the TUI settings directory.",
+    },
+    rotation_period_seconds: TuiZeroStateRotationPeriodSecondsSetting {
+        type: TuiZeroStateRotationPeriodSeconds,
+        default: TuiZeroStateRotationPeriodSeconds::default(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        surface: settings::SettingSurfaces::TUI,
+        private: false,
+        toml_path: "appearance.zero_state.rotation_period_seconds",
+        description: "Seconds per TUI zero-state object rotation, from 1 through 60.",
+    },
+    extrusion_depth: TuiZeroStateExtrusionDepthSetting {
+        type: TuiZeroStateExtrusionDepth,
+        default: TuiZeroStateExtrusionDepth::default(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        surface: settings::SettingSurfaces::TUI,
+        private: false,
+        toml_path: "appearance.zero_state.extrusion_depth",
+        description: "Normalized half-depth of the extruded TUI zero-state object, from 0.02 through 0.5.",
+    },
+]);
+
+#[cfg(test)]
+#[path = "tui_zero_state_tests.rs"]
+mod tests;

--- a/app/src/settings/tui_zero_state_tests.rs
+++ b/app/src/settings/tui_zero_state_tests.rs
@@ -1,0 +1,123 @@
+use std::path::PathBuf;
+
+use serde::Deserialize as _;
+use settings::schema::SettingSchemaEntry;
+use settings::{Setting, SettingSurfaces, SettingsMode, SyncToCloud};
+use settings_value::SettingsValue;
+
+use super::{
+    MAX_TUI_ZERO_STATE_EXTRUSION_DEPTH, MAX_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
+    MIN_TUI_ZERO_STATE_EXTRUSION_DEPTH, MIN_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
+    TuiZeroStateExtrusionDepth, TuiZeroStateExtrusionDepthSetting, TuiZeroStateObject,
+    TuiZeroStateObjectSetting, TuiZeroStateRotationPeriodSeconds,
+    TuiZeroStateRotationPeriodSecondsSetting,
+};
+
+#[test]
+fn object_source_uses_tagged_file_representation() {
+    let value = serde_json::json!({
+        "type": "ascii_file",
+        "path": "logos/rocket.txt",
+    });
+
+    assert_eq!(
+        TuiZeroStateObject::from_file_value(&value),
+        Some(TuiZeroStateObject::AsciiFile {
+            path: PathBuf::from("logos/rocket.txt"),
+        })
+    );
+    assert_eq!(
+        TuiZeroStateObject::BuiltIn.to_file_value(),
+        serde_json::json!({ "type": "built_in" })
+    );
+}
+
+#[test]
+fn numeric_settings_accept_inclusive_bounds() {
+    for value in [
+        MIN_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
+        MAX_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
+    ] {
+        let parsed =
+            serde_json::from_value::<TuiZeroStateRotationPeriodSeconds>(serde_json::json!(value))
+                .unwrap();
+        assert_eq!(parsed.get(), value);
+    }
+    for value in [
+        MIN_TUI_ZERO_STATE_EXTRUSION_DEPTH,
+        MAX_TUI_ZERO_STATE_EXTRUSION_DEPTH,
+    ] {
+        let parsed =
+            serde_json::from_value::<TuiZeroStateExtrusionDepth>(serde_json::json!(value)).unwrap();
+        assert_eq!(parsed.get(), value);
+    }
+}
+
+#[test]
+fn numeric_settings_reject_out_of_range_values() {
+    for value in [
+        MIN_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS - 0.1,
+        MAX_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS + 0.1,
+    ] {
+        assert!(
+            serde_json::from_value::<TuiZeroStateRotationPeriodSeconds>(serde_json::json!(value))
+                .is_err()
+        );
+    }
+    for value in [
+        MIN_TUI_ZERO_STATE_EXTRUSION_DEPTH - 0.01,
+        MAX_TUI_ZERO_STATE_EXTRUSION_DEPTH + 0.01,
+    ] {
+        assert!(
+            serde_json::from_value::<TuiZeroStateExtrusionDepth>(serde_json::json!(value)).is_err()
+        );
+    }
+    let nan = serde::de::value::F64Deserializer::<serde::de::value::Error>::new(f64::NAN);
+    assert!(TuiZeroStateRotationPeriodSeconds::deserialize(nan).is_err());
+    let infinity = serde::de::value::F64Deserializer::<serde::de::value::Error>::new(f64::INFINITY);
+    assert!(TuiZeroStateExtrusionDepth::deserialize(infinity).is_err());
+}
+
+#[test]
+fn zero_state_settings_are_tui_local_file_settings() {
+    assert_eq!(
+        TuiZeroStateObjectSetting::toml_path(),
+        Some("appearance.zero_state.object")
+    );
+    assert_eq!(
+        TuiZeroStateRotationPeriodSecondsSetting::toml_path(),
+        Some("appearance.zero_state.rotation_period_seconds")
+    );
+    assert_eq!(
+        TuiZeroStateExtrusionDepthSetting::toml_path(),
+        Some("appearance.zero_state.extrusion_depth")
+    );
+    assert_eq!(
+        TuiZeroStateObjectSetting::sync_to_cloud(),
+        SyncToCloud::Never
+    );
+    assert_eq!(
+        TuiZeroStateRotationPeriodSecondsSetting::sync_to_cloud(),
+        SyncToCloud::Never
+    );
+    assert_eq!(
+        TuiZeroStateExtrusionDepthSetting::sync_to_cloud(),
+        SyncToCloud::Never
+    );
+    assert_eq!(TuiZeroStateObjectSetting::max_table_depth(), Some(0));
+}
+
+#[test]
+fn zero_state_schema_entries_are_tui_only() {
+    let zero_state_entries = inventory::iter::<SettingSchemaEntry>
+        .into_iter()
+        .filter(|entry| entry.hierarchy == Some("appearance.zero_state"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(zero_state_entries.len(), 3);
+    for entry in zero_state_entries {
+        let surfaces: SettingSurfaces = (entry.surfaces_fn)();
+        assert!(surfaces.includes(SettingsMode::Tui));
+        assert!(!surfaces.includes(SettingsMode::Gui));
+    }
+}

--- a/app/src/settings/tui_zero_state_tests.rs
+++ b/app/src/settings/tui_zero_state_tests.rs
@@ -116,6 +116,8 @@ fn zero_state_schema_entries_are_tui_only() {
 
     assert_eq!(zero_state_entries.len(), 3);
     for entry in zero_state_entries {
+        assert!(entry.description.contains("Warp Agent CLI"));
+        assert!(!entry.description.contains("TUI"));
         let surfaces: SettingSurfaces = (entry.surfaces_fn)();
         assert!(surfaces.includes(SettingsMode::Tui));
         assert!(!surfaces.includes(SettingsMode::Gui));

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -99,6 +99,7 @@ fn init(
     // release builds installed via the managed versioned layout; see the
     // `autoupdate` module docs).
     crate::autoupdate::TuiAutoupdater::register(ctx);
+    crate::zero_state_animation::ZeroStateAnimationConfig::register(ctx);
 
     // Theme the transcript to match the host terminal. Keep this scoped to
     // the TUI process by overriding the already-initialized Appearance theme at

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -108,6 +108,9 @@ use crate::ui::{compact_footer_path, conversation_restore_failed, conversation_r
 use crate::usage::UsageToggle;
 use crate::warping_indicator::{render_response_summary, render_warping_indicator_row};
 use crate::zero_state::TuiZeroStateView;
+use crate::zero_state_animation::{
+    ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent, ZeroStateAnimationLoadFailure,
+};
 mod completions;
 mod input_detection;
 
@@ -164,6 +167,13 @@ impl PtyIntentEvent for TuiTerminalSessionEvent {
     }
 }
 
+fn zero_state_ascii_load_failure_hint(failure: ZeroStateAnimationLoadFailure) -> &'static str {
+    match failure {
+        ZeroStateAnimationLoadFailure::InitialLoad => ZERO_STATE_ASCII_INITIAL_LOAD_FAILED_HINT,
+        ZeroStateAnimationLoadFailure::Reload => ZERO_STATE_ASCII_RELOAD_FAILED_HINT,
+    }
+}
+
 /// Transient hint shown when a shell command is rejected because the PTY is
 /// already running a command.
 const COMMAND_ALREADY_RUNNING_HINT: &str = "cannot run — command already running";
@@ -188,6 +198,10 @@ const LOG_BUNDLE_FAILED_HINT: &str = "Failed to create log bundle (check logs)";
 const NLD_ENABLED_HINT: &str = "Natural language detection enabled.";
 const NLD_DISABLED_HINT: &str = "Natural language detection disabled.";
 const NLD_PERSISTENCE_FAILED_HINT: &str = "Could not save the natural language detection setting.";
+const ZERO_STATE_ASCII_INITIAL_LOAD_FAILED_HINT: &str =
+    "Could not load custom ASCII art. Using the built-in Warp logo.";
+const ZERO_STATE_ASCII_RELOAD_FAILED_HINT: &str =
+    "Could not reload custom ASCII art. Keeping the current object.";
 const COST_NO_ACTIVE_CONVERSATION_HINT: &str =
     "Cannot show conversation cost: no active conversation";
 const COST_EMPTY_CONVERSATION_HINT: &str = "Cannot show conversation cost: conversation is empty";
@@ -922,6 +936,18 @@ impl TuiTerminalSessionView {
         let terminal_surface_id: EntityId = ctx.view_id();
         let active_session =
             ctx.add_model(|ctx| ActiveSession::new(sessions.clone(), model_events.clone(), ctx));
+        let zero_state_animation_config = ZeroStateAnimationConfig::handle(ctx);
+        let initial_zero_state_load_failure =
+            zero_state_animation_config.as_ref(ctx).load_failure();
+        ctx.subscribe_to_model(
+            &zero_state_animation_config,
+            |view, _, event, ctx| match event {
+                ZeroStateAnimationConfigEvent::Updated => {}
+                ZeroStateAnimationConfigEvent::LoadFailed(failure) => {
+                    view.show_zero_state_ascii_load_failure(*failure, ctx);
+                }
+            },
+        );
         let model_for_conversation_selection = model.clone();
         let conversation_selection = ctx.add_model(|ctx| {
             Box::new(TuiConversationSelection::new(
@@ -1452,7 +1478,7 @@ impl TuiTerminalSessionView {
         ctx.spawn_stream_local(terminal_resize_rx, Self::handle_terminal_resize, |_, _| {});
         let zero_state_view =
             ctx.add_tui_view(|ctx| TuiZeroStateView::new(active_session.clone(), ctx));
-        Self {
+        let mut view = Self {
             transcript,
             input_view,
             attachment_bar,
@@ -1497,7 +1523,11 @@ impl TuiTerminalSessionView {
             orchestration_tab_bar,
             orchestration_tabs_focused: false,
             zero_state_view,
+        };
+        if let Some(failure) = initial_zero_state_load_failure {
+            view.show_zero_state_ascii_load_failure(failure, ctx);
         }
+        view
     }
 
     /// Starts the first request for a child conversation hosted by this
@@ -2133,6 +2163,20 @@ impl TuiTerminalSessionView {
             .show_success(text, ctx, |view| &mut view.transient_hint);
     }
 
+    /// Displays error-colored feedback in the transient footer slot.
+    fn show_error_hint(&mut self, text: String, ctx: &mut ViewContext<Self>) {
+        self.transient_hint
+            .show_error(text, ctx, |view| &mut view.transient_hint);
+    }
+
+    fn show_zero_state_ascii_load_failure(
+        &mut self,
+        failure: ZeroStateAnimationLoadFailure,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.show_error_hint(zero_state_ascii_load_failure_hint(failure).to_owned(), ctx);
+    }
+
     /// Displays success-colored feedback in the transient footer slot.
     fn show_copy_hint(&mut self, ctx: &mut ViewContext<Self>) {
         self.show_success_hint(COPY_SELECTION_HINT.to_owned(), ctx);
@@ -2305,6 +2349,7 @@ impl TuiTerminalSessionView {
             let style = match tone {
                 TransientHintTone::Muted => muted,
                 TransientHintTone::Success => builder.success_glyph_style(),
+                TransientHintTone::Error => builder.error_text_style(),
             };
             return TuiFlex::row().child(
                 TuiText::new(transient)

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -2,8 +2,9 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use instant::Instant;
+use tempfile::TempDir;
 use warp::appearance::Appearance;
-use warp::settings::{AISettings, TuiUsageDisplayMode};
+use warp::settings::{AISettings, TuiUsageDisplayMode, TuiZeroStateObject};
 use warp::terminal::model::ansi::{Handler, InputBufferValue};
 use warp::tui_export::{
     AIAgentExchangeId, AIConversationAutoexecuteMode, AIConversationId, AgentViewEntryOrigin,
@@ -58,6 +59,9 @@ use crate::test_fixtures::{add_test_semantic_selection, add_test_terminal_sessio
 use crate::transcript_view::TRANSCRIPT_BLOCK_SPACING;
 use crate::tui_builder::TuiUiBuilder;
 use crate::usage::UsageToggle;
+use crate::zero_state_animation::{
+    ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent, ZeroStateAnimationLoadFailure,
+};
 
 struct FocusTestFixture {
     window_id: warpui_core::WindowId,
@@ -116,6 +120,79 @@ fn inline_menu_padding_preserves_result_capacity() {
     });
 }
 
+#[test]
+fn zero_state_reload_failure_renders_as_an_error_footer_hint() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+
+        app.update(|ctx| {
+            ZeroStateAnimationConfig::handle(ctx).update(ctx, |_, ctx| {
+                ctx.emit(ZeroStateAnimationConfigEvent::LoadFailed(
+                    ZeroStateAnimationLoadFailure::Reload,
+                ));
+            });
+        });
+
+        assert_eq!(
+            view.read(&app, |view, _| {
+                view.transient_hint
+                    .current()
+                    .map(|(text, tone)| (text.to_owned(), tone))
+            }),
+            Some((
+                super::ZERO_STATE_ASCII_RELOAD_FAILED_HINT.to_owned(),
+                super::TransientHintTone::Error
+            ))
+        );
+
+        app.read(|ctx| {
+            let footer = view.as_ref(ctx).render_footer(ctx).finish();
+            let buffer = render_element(footer, ctx, 120);
+            assert_eq!(
+                buffer.to_lines(),
+                vec![super::ZERO_STATE_ASCII_RELOAD_FAILED_HINT.to_owned()]
+            );
+            assert_eq!(
+                buffer[(0, 0)].fg,
+                TuiUiBuilder::from_app(ctx)
+                    .error_text_style()
+                    .fg
+                    .expect("error text style should have a foreground")
+            );
+        });
+    });
+}
+
+#[test]
+fn zero_state_initial_load_failure_shows_an_error_footer_hint() {
+    App::test((), |mut app| async move {
+        let temp_dir = TempDir::new().unwrap();
+        let config = ZeroStateAnimationConfig::load(
+            &TuiZeroStateObject::AsciiFile {
+                path: "missing.txt".into(),
+            },
+            5.0,
+            0.18,
+            temp_dir.path(),
+        );
+        app.add_singleton_model(move |_| config);
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+
+        assert_eq!(
+            view.read(&app, |view, _| {
+                view.transient_hint
+                    .current()
+                    .map(|(text, tone)| (text.to_owned(), tone))
+            }),
+            Some((
+                super::ZERO_STATE_ASCII_INITIAL_LOAD_FAILED_HINT.to_owned(),
+                super::TransientHintTone::Error
+            ))
+        );
+    });
+}
 fn mouse_moved(x: u16, y: u16) -> TuiEvent {
     TuiEvent::MouseMoved {
         position: TuiPoint::new(x, y),
@@ -1077,7 +1154,7 @@ fn zero_state_renders_with_only_zero_height_bootstrap_blocks() {
                 .updated
                 .extend(view.as_ref(ctx).child_view_ids(ctx));
             presenter.invalidate(&invalidation, ctx, fixture.window_id);
-            presenter.present(ctx, &view, TuiRect::new(0, 0, 120, 40))
+            presenter.present(ctx, &view, TuiRect::new(0, 0, 200, 40))
         });
         let lines = frame.buffer.to_lines();
         let title_row = lines
@@ -1087,6 +1164,14 @@ fn zero_state_renders_with_only_zero_height_bootstrap_blocks() {
         assert!(
             title_row < 28,
             "zero-state title should render in the transcript area:\n{}",
+            lines.join("\n")
+        );
+        assert!(
+            lines
+                .iter()
+                .take(28)
+                .any(|line| line.chars().skip(148).any(|character| character != ' ')),
+            "animation content should use columns beyond the former 48 + 100 column cap:\n{}",
             lines.join("\n")
         );
     });

--- a/crates/warp_tui/src/test_fixtures.rs
+++ b/crates/warp_tui/src/test_fixtures.rs
@@ -18,6 +18,7 @@ use warpui_core::{AppContext, Entity, TuiView, TypedActionView, ViewHandle, Wind
 use crate::conversation_selection::TuiConversationSelection;
 use crate::resume::TuiExitSummaryHandle;
 use crate::terminal_session_view::TuiTerminalSessionView;
+use crate::zero_state_animation::ZeroStateAnimationConfig;
 
 struct TestTerminalManager(Arc<FairMutex<TerminalModel>>);
 
@@ -134,6 +135,9 @@ pub(crate) fn add_test_terminal_session(
     ModelHandle<Box<dyn TerminalManagerTrait>>,
 ) {
     app.update(|ctx| {
+        if !ctx.has_singleton_model::<ZeroStateAnimationConfig>() {
+            ctx.add_singleton_model(|_| ZeroStateAnimationConfig::default());
+        }
         let surface_init = TerminalSurfaceInit::new_for_test(ctx);
         let terminal_model = surface_init.model.clone();
         let view = ctx.add_typed_action_tui_view(window_id, |ctx| {

--- a/crates/warp_tui/src/transient_hint.rs
+++ b/crates/warp_tui/src/transient_hint.rs
@@ -30,6 +30,7 @@ pub(crate) struct TransientHint {
 pub(crate) enum TransientHintTone {
     Muted,
     Success,
+    Error,
 }
 
 #[derive(Debug)]
@@ -61,6 +62,15 @@ impl TransientHint {
         transient_hint: impl Fn(&mut V) -> &mut TransientHint + 'static,
     ) {
         self.show_with_tone(text, TransientHintTone::Success, ctx, transient_hint);
+    }
+    /// Displays error feedback in the shared transient footer slot.
+    pub(crate) fn show_error<V: Entity>(
+        &mut self,
+        text: String,
+        ctx: &mut ViewContext<V>,
+        transient_hint: impl Fn(&mut V) -> &mut TransientHint + 'static,
+    ) {
+        self.show_with_tone(text, TransientHintTone::Error, ctx, transient_hint);
     }
 
     fn show_with_tone<V: Entity>(

--- a/crates/warp_tui/src/transient_hint_tests.rs
+++ b/crates/warp_tui/src/transient_hint_tests.rs
@@ -86,6 +86,22 @@ fn success_hint_uses_success_tone() {
 }
 
 #[test]
+fn error_hint_uses_error_tone() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            view.update(ctx, |view, ctx| {
+                view.hint
+                    .show_error("failed".to_owned(), ctx, |view| &mut view.hint);
+            });
+            assert_eq!(
+                view.as_ref(ctx).hint.current(),
+                Some(("failed", TransientHintTone::Error))
+            );
+        });
+    });
+}
+#[test]
 fn show_supersedes_the_earlier_notice() {
     App::test((), |mut app| async move {
         app.update(|ctx| {

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -8,6 +8,7 @@
 //! transcript empties out again.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use ai::project_context::model::{ProjectContextModel, ProjectContextModelEvent};
@@ -25,7 +26,9 @@ use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent};
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
-use crate::zero_state_animation::{WarpLogoStyles, ZeroStateAnimationElement};
+use crate::zero_state_animation::{
+    WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationElement,
+};
 
 /// Cap on "What's new" bullets, mirroring the compact zero-state mock.
 const MAX_CHANGELOG_BULLETS: usize = 3;
@@ -49,6 +52,7 @@ const MAX_ANIMATION_COLS: u16 = 100;
 /// view re-renders (e.g. when MCP connects or a changelog loads).
 pub(crate) struct TuiZeroStateView {
     clock: AnimationClock,
+    animation_config: Arc<ZeroStateAnimationConfig>,
     active_session: ModelHandle<ActiveSession>,
 }
 
@@ -92,6 +96,7 @@ impl TuiZeroStateView {
 
         Self {
             clock: AnimationClock::starting_at(Duration::ZERO),
+            animation_config: Arc::new(ZeroStateAnimationConfig::as_ref(ctx).clone()),
             active_session,
         }
     }
@@ -122,6 +127,7 @@ impl TuiView for TuiZeroStateView {
         let animation = TuiConstrainedBox::new(
             ZeroStateAnimationElement::new(
                 self.clock,
+                self.animation_config.clone(),
                 WarpLogoStyles {
                     front: builder.accent_text_style(),
                     back: builder.primary_text_style(),

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -27,7 +27,8 @@ use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
 use crate::zero_state_animation::{
-    WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationElement,
+    WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent,
+    ZeroStateAnimationElement,
 };
 
 /// Cap on "What's new" bullets, mirroring the compact zero-state mock.
@@ -37,10 +38,6 @@ const MAX_CHANGELOG_BULLETS: usize = 3;
 /// animation boundary from shifting as content loads asynchronously at startup
 /// (changelog, MCP status, project context).
 const LEFT_COLUMN_COLS: u16 = 48;
-
-/// Maximum width of the logo animation panel. On wide terminals the
-/// animation stays at this width and excess space becomes blank background.
-const MAX_ANIMATION_COLS: u16 = 100;
 
 // ---------------------------------------------------------------------------
 // TuiZeroStateView
@@ -93,10 +90,22 @@ impl TuiZeroStateView {
             };
             ctx.notify();
         });
+        let animation_config = ZeroStateAnimationConfig::handle(ctx);
+        let animation_config_snapshot = Arc::new(animation_config.as_ref(ctx).clone());
+        ctx.subscribe_to_model(
+            &animation_config,
+            |view, animation_config, event, ctx| match event {
+                ZeroStateAnimationConfigEvent::Updated => {
+                    view.animation_config = Arc::new(animation_config.as_ref(ctx).clone());
+                    ctx.notify();
+                }
+                ZeroStateAnimationConfigEvent::LoadFailed(_) => {}
+            },
+        );
 
         Self {
             clock: AnimationClock::starting_at(Duration::ZERO),
-            animation_config: Arc::new(ZeroStateAnimationConfig::as_ref(ctx).clone()),
+            animation_config: animation_config_snapshot,
             active_session,
         }
     }
@@ -124,20 +133,16 @@ impl TuiView for TuiZeroStateView {
                 .with_min_cols(LEFT_COLUMN_COLS)
                 .with_max_cols(LEFT_COLUMN_COLS)
                 .finish();
-        let animation = TuiConstrainedBox::new(
-            ZeroStateAnimationElement::new(
-                self.clock,
-                self.animation_config.clone(),
-                WarpLogoStyles {
-                    front: builder.accent_text_style(),
-                    back: builder.primary_text_style(),
-                    side: builder.dim_text_style(),
-                    background: builder.muted_text_style(),
-                },
-            )
-            .finish(),
+        let animation = ZeroStateAnimationElement::new(
+            self.clock,
+            self.animation_config.clone(),
+            WarpLogoStyles {
+                front: builder.accent_text_style(),
+                back: builder.primary_text_style(),
+                side: builder.dim_text_style(),
+                background: builder.muted_text_style(),
+            },
         )
-        .with_max_cols(MAX_ANIMATION_COLS)
         .finish();
         TuiFlex::row()
             .child(text_column)

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -7,9 +7,7 @@
 //! the first accepted submission produces a block and returns whenever the
 //! transcript empties out again.
 
-use std::cell::RefCell;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use ai::project_context::model::{ProjectContextModel, ProjectContextModelEvent};
@@ -27,7 +25,7 @@ use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent};
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
-use crate::zero_state_animation::{StarfieldState, ZeroStateAnimationElement};
+use crate::zero_state_animation::{WarpLogoStyles, ZeroStateAnimationElement};
 
 /// Cap on "What's new" bullets, mirroring the compact zero-state mock.
 const MAX_CHANGELOG_BULLETS: usize = 3;
@@ -37,7 +35,7 @@ const MAX_CHANGELOG_BULLETS: usize = 3;
 /// (changelog, MCP status, project context).
 const LEFT_COLUMN_COLS: u16 = 48;
 
-/// Maximum width of the starfield animation panel.  On wide terminals the
+/// Maximum width of the logo animation panel. On wide terminals the
 /// animation stays at this width and excess space becomes blank background.
 const MAX_ANIMATION_COLS: u16 = 100;
 
@@ -47,12 +45,9 @@ const MAX_ANIMATION_COLS: u16 = 100;
 
 /// The zero-state view: displayed when the transcript is empty.
 ///
-/// Owns the starfield animation state so it persists across view re-renders
-/// (e.g. when MCP connects or a changelog loads).  The animation element
-/// receives an `Rc<RefCell<StarfieldState>>` clone on each render, keeping
-/// the star positions continuous through paint-only animation repaints.
+/// Owns the animation clock so the logo's rotation remains continuous across
+/// view re-renders (e.g. when MCP connects or a changelog loads).
 pub(crate) struct TuiZeroStateView {
-    starfield: Rc<RefCell<StarfieldState>>,
     clock: AnimationClock,
     active_session: ModelHandle<ActiveSession>,
 }
@@ -96,7 +91,6 @@ impl TuiZeroStateView {
         });
 
         Self {
-            starfield: Rc::new(RefCell::new(StarfieldState::new())),
             clock: AnimationClock::starting_at(Duration::ZERO),
             active_session,
         }
@@ -127,9 +121,13 @@ impl TuiView for TuiZeroStateView {
                 .finish();
         let animation = TuiConstrainedBox::new(
             ZeroStateAnimationElement::new(
-                Rc::clone(&self.starfield),
                 self.clock,
-                builder.accent_color(),
+                WarpLogoStyles {
+                    front: builder.accent_text_style(),
+                    back: builder.primary_text_style(),
+                    side: builder.dim_text_style(),
+                    background: builder.muted_text_style(),
+                },
             )
             .finish(),
         )

--- a/crates/warp_tui/src/zero_state_animation.rs
+++ b/crates/warp_tui/src/zero_state_animation.rs
@@ -1,10 +1,12 @@
-//! Rotating Warp logo animation for the TUI zero state.
+//! Rotating object animation for the TUI zero state.
 //!
-//! The two faces from the Warp mark are sampled into a shallow, ghosted
-//! wireframe, rotated around its vertical axis, and projected back onto terminal
-//! cells. A tiny z-buffer keeps the front-most sample for each cell, while
-//! directional ASCII edges and sparse stippling retain depth without a solid fill.
+//! The built-in Warp mark or a user-provided ASCII silhouette is sampled into a
+//! shallow, ghosted wireframe, rotated around its vertical axis, and projected
+//! back onto terminal cells. A tiny z-buffer keeps the front-most sample for
+//! each cell, while directional ASCII edges and sparse stippling retain depth
+//! without a solid fill.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use warpui_core::AppContext;
@@ -14,16 +16,22 @@ use warpui_core::elements::tui::{
     TuiScreenPosition, TuiSize, TuiStyle,
 };
 
+#[path = "zero_state_animation_config.rs"]
+mod config;
+
+pub(crate) use config::ZeroStateAnimationConfig;
+use config::ZeroStateShape;
+
 /// A terminal does not need a 30 fps repaint for this deliberately slow motion.
 const REPAINT_INTERVAL: Duration = Duration::from_millis(66);
-const REVOLUTION_SECS: f64 = 5.0;
 
 const MIN_ANIMATION_COLS: u16 = 18;
 const MIN_ANIMATION_ROWS: u16 = 7;
 const MAX_LOGO_COLS: u16 = 42;
 const MAX_LOGO_ROWS: u16 = 17;
-const LOGO_CELL_ASPECT_RATIO: f64 = 2.5;
-const LOGO_DEPTH: f64 = 0.18;
+const MIN_OBJECT_COLS: u16 = 5;
+const MIN_OBJECT_ROWS: u16 = 5;
+const BUILT_IN_LOGO_CELL_ASPECT_RATIO: f64 = 2.5;
 const SURFACE_SAMPLES: usize = 3;
 const DEPTH_SAMPLES: usize = 6;
 const GHOST_STIPPLE_MODULUS: usize = 97;
@@ -33,6 +41,9 @@ const STARFIELD_REFERENCE_COUNT: usize = 36;
 const STARFIELD_MIN_COUNT: usize = 18;
 const STARFIELD_MAX_COUNT: usize = 48;
 const STAR_TRAVEL_SECS: f64 = 7.0;
+const MAX_ASCII_ART_BYTES: u64 = 64 * 1024;
+const MAX_ASCII_ART_COLS: usize = 128;
+const MAX_ASCII_ART_ROWS: usize = 64;
 
 /// Approximate visible bounds of the bundled Warp logo SVG.
 const SVG_MIN_X: f64 = 35.0;
@@ -159,15 +170,21 @@ impl LogoFrame {
 
 pub struct ZeroStateAnimationElement {
     clock: AnimationClock,
+    config: Arc<ZeroStateAnimationConfig>,
     styles: WarpLogoStyles,
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
 }
 
 impl ZeroStateAnimationElement {
-    pub(crate) fn new(clock: AnimationClock, styles: WarpLogoStyles) -> Self {
+    pub(crate) fn new(
+        clock: AnimationClock,
+        config: Arc<ZeroStateAnimationConfig>,
+        styles: WarpLogoStyles,
+    ) -> Self {
         Self {
             clock,
+            config,
             styles,
             size: None,
             origin: None,
@@ -201,7 +218,7 @@ impl TuiElement for ZeroStateAnimationElement {
     ) {
         self.origin = Some(ctx.scene_point(origin));
         let Some(size) = self.size else { return };
-        let Some(frame) = logo_frame_at(self.clock.elapsed(), size) else {
+        let Some(frame) = object_frame_at(self.clock.elapsed(), size, &self.config) else {
             return;
         };
 
@@ -229,9 +246,20 @@ impl TuiElement for ZeroStateAnimationElement {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn logo_frame_at(elapsed: Duration, size: TuiSize) -> Option<LogoFrame> {
-    let (logo_cols, logo_rows) = fitted_logo_size(size)?;
-    let angle = (elapsed.as_secs_f64() % REVOLUTION_SECS) / REVOLUTION_SECS * std::f64::consts::TAU;
+    object_frame_at(elapsed, size, &ZeroStateAnimationConfig::default())
+}
+
+fn object_frame_at(
+    elapsed: Duration,
+    size: TuiSize,
+    config: &ZeroStateAnimationConfig,
+) -> Option<LogoFrame> {
+    let cell_aspect_ratio = config.shape.cell_aspect_ratio();
+    let (logo_cols, logo_rows) = fitted_logo_size(size, cell_aspect_ratio)?;
+    let revolution_secs = config.rotation_period.as_secs_f64();
+    let angle = (elapsed.as_secs_f64() % revolution_secs) / revolution_secs * std::f64::consts::TAU;
     let (sin, cos) = angle.sin_cos();
     let mut frame = LogoFrame::new(size);
     draw_background_stars(&mut frame, elapsed);
@@ -248,10 +276,18 @@ pub(crate) fn logo_frame_at(elapsed: Duration, size: TuiSize) -> Option<LogoFram
         let model_y = sample_coordinate(source_y, source_rows);
         for source_x in 0..source_cols {
             let model_x = sample_coordinate(source_x, source_cols);
-            if !warp_logo_contains(model_x, model_y) {
+            if !config.shape.contains(model_x, model_y) {
                 continue;
             }
-            let outline_glyph = logo_outline_glyph(model_x, model_y, source_cols, source_rows, cos);
+            let outline_glyph = logo_outline_glyph(
+                config.shape.as_ref(),
+                model_x,
+                model_y,
+                source_cols,
+                source_rows,
+                cos,
+                cell_aspect_ratio,
+            );
             let is_ghost_sample = (source_x * 17 + source_y * 31) % GHOST_STIPPLE_MODULUS == 0;
             let is_side_stitch = (source_x * 13 + source_y * 7) % SIDE_STITCH_MODULUS == 0;
             if outline_glyph.is_none() && !is_ghost_sample {
@@ -263,8 +299,8 @@ pub(crate) fn logo_frame_at(elapsed: Duration, size: TuiSize) -> Option<LogoFram
                 if !is_face && (outline_glyph.is_none() || !is_side_stitch) {
                     continue;
                 }
-                let model_z =
-                    -LOGO_DEPTH + 2.0 * LOGO_DEPTH * depth_index as f64 / DEPTH_SAMPLES as f64;
+                let model_z = -config.extrusion_depth
+                    + 2.0 * config.extrusion_depth * depth_index as f64 / DEPTH_SAMPLES as f64;
                 let rotated_x = model_x * cos + model_z * sin;
                 let rotated_depth = -model_x * sin + model_z * cos;
                 let projected_x = (center_x + rotated_x * scale_x).round() as i32;
@@ -373,7 +409,7 @@ fn unit_random(seed: u64) -> f64 {
     ((value ^ (value >> 31)) >> 11) as f64 / (1_u64 << 53) as f64
 }
 
-fn fitted_logo_size(size: TuiSize) -> Option<(u16, u16)> {
+fn fitted_logo_size(size: TuiSize, cell_aspect_ratio: f64) -> Option<(u16, u16)> {
     if size.width < MIN_ANIMATION_COLS || size.height < MIN_ANIMATION_ROWS {
         return None;
     }
@@ -381,38 +417,40 @@ fn fitted_logo_size(size: TuiSize) -> Option<(u16, u16)> {
     let available_cols = size.width.saturating_sub(2);
     let available_rows = size.height.saturating_sub(2);
     let mut rows = available_rows.min(MAX_LOGO_ROWS);
-    let mut cols = ((f64::from(rows) * LOGO_CELL_ASPECT_RATIO).round() as u16)
+    let mut cols = ((f64::from(rows) * cell_aspect_ratio).round() as u16)
         .min(available_cols)
         .min(MAX_LOGO_COLS);
-    rows = rows.min((f64::from(cols) / LOGO_CELL_ASPECT_RATIO).round() as u16);
-    cols = ((f64::from(rows) * LOGO_CELL_ASPECT_RATIO).round() as u16).min(cols);
+    rows = rows.min((f64::from(cols) / cell_aspect_ratio).round() as u16);
+    cols = ((f64::from(rows) * cell_aspect_ratio).round() as u16).min(cols);
 
-    (cols >= 16 && rows >= 5).then_some((cols, rows))
+    (cols >= MIN_OBJECT_COLS && rows >= MIN_OBJECT_ROWS).then_some((cols, rows))
 }
 
 fn sample_coordinate(index: usize, sample_count: usize) -> f64 {
     ((index as f64 + 0.5) / sample_count as f64) * 2.0 - 1.0
 }
 fn logo_outline_glyph(
+    shape: &ZeroStateShape,
     x: f64,
     y: f64,
     source_cols: usize,
     source_rows: usize,
     rotation_cos: f64,
+    cell_aspect_ratio: f64,
 ) -> Option<LogoGlyph> {
     let dx = 2.0 / source_cols as f64;
     let dy = 2.0 / source_rows as f64;
-    let left = warp_logo_contains(x - dx, y);
-    let right = warp_logo_contains(x + dx, y);
-    let above = warp_logo_contains(x, y - dy);
-    let below = warp_logo_contains(x, y + dy);
+    let left = shape.contains(x - dx, y);
+    let right = shape.contains(x + dx, y);
+    let above = shape.contains(x, y - dy);
+    let below = shape.contains(x, y + dy);
     if left && right && above && below {
         return None;
     }
 
     let normal_x = bool_as_scalar(left) - bool_as_scalar(right);
     let normal_y = bool_as_scalar(above) - bool_as_scalar(below);
-    let tangent_x = -normal_y * rotation_cos * LOGO_CELL_ASPECT_RATIO;
+    let tangent_x = -normal_y * rotation_cos * cell_aspect_ratio;
     let tangent_y = normal_x;
     if tangent_x.abs() > tangent_y.abs() * 1.8 {
         Some(LogoGlyph::Horizontal)

--- a/crates/warp_tui/src/zero_state_animation.rs
+++ b/crates/warp_tui/src/zero_state_animation.rs
@@ -19,15 +19,16 @@ use warpui_core::elements::tui::{
 #[path = "zero_state_animation_config.rs"]
 mod config;
 
-pub(crate) use config::ZeroStateAnimationConfig;
 use config::ZeroStateShape;
+pub(crate) use config::{
+    ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent, ZeroStateAnimationLoadFailure,
+};
 
 /// A terminal does not need a 30 fps repaint for this deliberately slow motion.
 const REPAINT_INTERVAL: Duration = Duration::from_millis(66);
 
 const MIN_ANIMATION_COLS: u16 = 18;
 const MIN_ANIMATION_ROWS: u16 = 7;
-const MAX_LOGO_COLS: u16 = 42;
 const MAX_LOGO_ROWS: u16 = 17;
 const MIN_OBJECT_COLS: u16 = 5;
 const MIN_OBJECT_ROWS: u16 = 5;
@@ -39,7 +40,10 @@ const SIDE_STITCH_MODULUS: usize = 29;
 const STARFIELD_REFERENCE_AREA: usize = 52 * 20;
 const STARFIELD_REFERENCE_COUNT: usize = 36;
 const STARFIELD_MIN_COUNT: usize = 18;
-const STARFIELD_MAX_COUNT: usize = 48;
+/// Bounds per-frame work for synthetic or otherwise impractical terminal sizes.
+/// Ordinary terminal dimensions remain below this budget and retain full
+/// area-proportional star density.
+const STARFIELD_CANDIDATE_BUDGET: usize = 8_192;
 const STAR_TRAVEL_SECS: f64 = 7.0;
 const MAX_ASCII_ART_BYTES: u64 = 64 * 1024;
 const MAX_ASCII_ART_COLS: usize = 128;
@@ -360,8 +364,7 @@ fn object_frame_at(
 fn draw_background_stars(frame: &mut LogoFrame, elapsed: Duration) {
     let width = usize::from(frame.size.width);
     let height = usize::from(frame.size.height);
-    let star_count = (width * height * STARFIELD_REFERENCE_COUNT / STARFIELD_REFERENCE_AREA)
-        .clamp(STARFIELD_MIN_COUNT, STARFIELD_MAX_COUNT);
+    let star_count = star_count_for_size(frame.size);
     let center_x = (f64::from(frame.size.width) - 1.0) / 2.0;
     let center_y = (f64::from(frame.size.height) - 1.0) / 2.0;
     let elapsed = elapsed.as_secs_f64();
@@ -402,6 +405,13 @@ fn draw_background_stars(frame: &mut LogoFrame, elapsed: Duration) {
     }
 }
 
+fn star_count_for_size(size: TuiSize) -> usize {
+    let area = u64::from(size.width) * u64::from(size.height);
+    let scaled_count = area * STARFIELD_REFERENCE_COUNT as u64 / STARFIELD_REFERENCE_AREA as u64;
+    usize::try_from(scaled_count)
+        .expect("u16 terminal dimensions produce a star count that fits usize")
+        .clamp(STARFIELD_MIN_COUNT, STARFIELD_CANDIDATE_BUDGET)
+}
 fn unit_random(seed: u64) -> f64 {
     let mut value = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
     value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
@@ -416,14 +426,25 @@ fn fitted_logo_size(size: TuiSize, cell_aspect_ratio: f64) -> Option<(u16, u16)>
 
     let available_cols = size.width.saturating_sub(2);
     let available_rows = size.height.saturating_sub(2);
-    let mut rows = available_rows.min(MAX_LOGO_ROWS);
-    let mut cols = ((f64::from(rows) * cell_aspect_ratio).round() as u16)
-        .min(available_cols)
-        .min(MAX_LOGO_COLS);
-    rows = rows.min((f64::from(cols) / cell_aspect_ratio).round() as u16);
-    cols = ((f64::from(rows) * cell_aspect_ratio).round() as u16).min(cols);
+    let max_rows = available_rows.min(MAX_LOGO_ROWS);
+    let natural_cols = (f64::from(max_rows) * cell_aspect_ratio).round() as u16;
+    if natural_cols <= available_cols {
+        return Some((natural_cols.max(MIN_OBJECT_COLS), max_rows));
+    }
 
-    (cols >= MIN_OBJECT_COLS && rows >= MIN_OBJECT_ROWS).then_some((cols, rows))
+    let cols = available_cols;
+    let fitted_rows = (f64::from(cols) / cell_aspect_ratio).round() as u16;
+    if fitted_rows < MIN_OBJECT_ROWS {
+        // Preserve visibility when an extreme horizontal aspect ratio would
+        // otherwise round the height to zero.
+        return Some((cols, MIN_OBJECT_ROWS));
+    }
+
+    let rows = fitted_rows.min(max_rows);
+    let cols = ((f64::from(rows) * cell_aspect_ratio).round() as u16)
+        .min(cols)
+        .max(MIN_OBJECT_COLS);
+    Some((cols, rows))
 }
 
 fn sample_coordinate(index: usize, sample_count: usize) -> f64 {

--- a/crates/warp_tui/src/zero_state_animation.rs
+++ b/crates/warp_tui/src/zero_state_animation.rs
@@ -1,219 +1,174 @@
-//! Starfield animation for the TUI zero state.
+//! Rotating Warp logo animation for the TUI zero state.
 //!
-//! 220 stars radiate outward from the terminal centre, streaking as they
-//! accelerate toward the screen edge — a "warp speed" effect driven by an
-//! analytically-computed spring-based speed ramp.
-//!
-//! Animation state ([`StarfieldState`]) is owned by [`super::TuiZeroStateView`]
-//! and shared with [`ZeroStateAnimationElement`] via an `Rc<RefCell<…>>`, so
-//! the animation continues uninterrupted across view re-renders (e.g. when MCP
-//! connects or a changelog loads).
+//! The two faces from the Warp mark are sampled into a shallow, ghosted
+//! wireframe, rotated around its vertical axis, and projected back onto terminal
+//! cells. A tiny z-buffer keeps the front-most sample for each cell, while
+//! directional ASCII edges and sparse stippling retain depth without a solid fill.
 
-use std::cell::RefCell;
-use std::rc::Rc;
 use std::time::Duration;
 
 use warpui_core::AppContext;
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{
-    Color, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
-    TuiScreenPoint, TuiScreenPosition, TuiSize, TuiStyle,
+    TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiScreenPoint,
+    TuiScreenPosition, TuiSize, TuiStyle,
 };
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
+/// A terminal does not need a 30 fps repaint for this deliberately slow motion.
+const REPAINT_INTERVAL: Duration = Duration::from_millis(66);
+const REVOLUTION_SECS: f64 = 5.0;
 
-/// Target repaint cadence (~30 fps — smooth and low-CPU for a background FX).
-const REPAINT_INTERVAL: Duration = Duration::from_millis(33);
+const MIN_ANIMATION_COLS: u16 = 18;
+const MIN_ANIMATION_ROWS: u16 = 7;
+const MAX_LOGO_COLS: u16 = 42;
+const MAX_LOGO_ROWS: u16 = 17;
+const LOGO_CELL_ASPECT_RATIO: f64 = 2.5;
+const LOGO_DEPTH: f64 = 0.18;
+const SURFACE_SAMPLES: usize = 3;
+const DEPTH_SAMPLES: usize = 6;
+const GHOST_STIPPLE_MODULUS: usize = 97;
+const SIDE_STITCH_MODULUS: usize = 29;
+const STARFIELD_REFERENCE_AREA: usize = 52 * 20;
+const STARFIELD_REFERENCE_COUNT: usize = 36;
+const STARFIELD_MIN_COUNT: usize = 18;
+const STARFIELD_MAX_COUNT: usize = 48;
+const STAR_TRAVEL_SECS: f64 = 7.0;
 
-/// Simulation step rate: advance stars this many times per elapsed second.
-const SIM_FPS: f64 = 60.0;
+/// Approximate visible bounds of the bundled Warp logo SVG.
+const SVG_MIN_X: f64 = 35.0;
+const SVG_MAX_X: f64 = 216.155;
+const SVG_MIN_Y: f64 = 25.5701;
+const SVG_MAX_Y: f64 = 170.489;
 
-/// Number of stars in the field.
-pub(crate) const NUM_STARS: usize = 220;
+/// The upper-right and lower-left faces from `warp-logo-light.svg`.
+///
+/// Rounded corners are intentionally squared off: at terminal-cell resolution,
+/// preserving the diagonal cut and offset silhouette contributes much more to
+/// recognition than sub-cell corner curvature.
+const UPPER_FACE: &[(f64, f64)] = &[
+    (127.725, 25.5701),
+    (196.111, 25.5701),
+    (216.155, 46.2824),
+    (216.155, 126.695),
+    (196.111, 147.407),
+    (98.2486, 147.407),
+];
+const LOWER_FACE: &[(f64, f64)] = &[
+    (109.963, 48.652),
+    (54.8733, 48.652),
+    (35.0, 69.3643),
+    (35.0, 149.777),
+    (54.8733, 170.489),
+    (122.676, 170.489),
+    (125.395, 159.154),
+    (83.4561, 159.154),
+];
 
-/// ASCII glyph ramp: dim near centre, bright near the edge.
-const STAR_GLYPHS: &[u8] = b".:-=+*#@";
-
-/// Warp factor the spring starts at.
-pub(crate) const WARP_INITIAL: f64 = 0.15;
-
-/// Warp factor the spring converges to.
-pub(crate) const WARP_TARGET: f64 = 0.85;
-
-/// Minimum width / height for the animation to render.
-const MIN_ANIMATION_COLS: u16 = 4;
-const MIN_ANIMATION_ROWS: u16 = 2;
-
-// ---------------------------------------------------------------------------
-// Warp spring (analytical solution)
-// ---------------------------------------------------------------------------
-// Underdamped spring with ζ = 0.8, ω = 1.0:
-//   ωd = ω · √(1 − ζ²) = √0.36 = 0.6
-//
-//   warp(t) = target + e^(−ζωt) · [ Δ·cos(ωd·t) + (ζω·Δ/ωd)·sin(ωd·t) ]
-// where Δ = initial − target = 0.15 − 0.85 = −0.7
-
-const SPRING_ZETA: f64 = 0.8;
-const SPRING_OMEGA: f64 = 1.0;
-const SPRING_OMEGA_D: f64 = 0.6;
-const SPRING_DELTA: f64 = WARP_INITIAL - WARP_TARGET; // −0.7
-
-pub(crate) fn warp_at(t: f64) -> f64 {
-    let envelope = (-SPRING_ZETA * SPRING_OMEGA * t).exp();
-    let cos_term = SPRING_DELTA * (SPRING_OMEGA_D * t).cos();
-    let sin_term =
-        (SPRING_ZETA * SPRING_OMEGA * SPRING_DELTA / SPRING_OMEGA_D) * (SPRING_OMEGA_D * t).sin();
-    (WARP_TARGET + envelope * (cos_term + sin_term)).clamp(WARP_INITIAL - 0.01, WARP_TARGET + 0.1)
+#[derive(Clone, Copy)]
+pub(crate) struct WarpLogoStyles {
+    pub(crate) front: TuiStyle,
+    pub(crate) back: TuiStyle,
+    pub(crate) side: TuiStyle,
+    pub(crate) background: TuiStyle,
 }
 
-// ---------------------------------------------------------------------------
-// Minimal deterministic PRNG (xorshift64)
-// ---------------------------------------------------------------------------
-
-pub(crate) fn xorshift64(s: &mut u64) -> u64 {
-    *s ^= *s << 13;
-    *s ^= *s >> 7;
-    *s ^= *s << 17;
-    *s
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LogoSurface {
+    Front,
+    Back,
+    Side,
+    Ghost,
+    Background,
 }
 
-pub(crate) fn xorshift_f64(s: &mut u64) -> f64 {
-    (xorshift64(s) >> 11) as f64 / ((1u64 << 53) as f64)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LogoGlyph {
+    Horizontal,
+    Vertical,
+    ForwardSlash,
+    Backslash,
+    Dot,
+    Plus,
+    Star,
 }
 
-// ---------------------------------------------------------------------------
-// Star
-// ---------------------------------------------------------------------------
-
-pub(crate) struct Star {
-    pub(crate) angle: f64, // radians, direction from centre
-    pub(crate) r: f64,     // current radius from centre
-    pub(crate) r_prev: f64,
-    pub(crate) speed: f64, // per-star speed multiplier in [0.5, 1.5]
-    glow: bool,            // lavender highlight
-}
-
-fn new_star(rng: &mut u64, max_r: f64) -> Star {
-    let angle = xorshift_f64(rng) * std::f64::consts::TAU;
-    let r = xorshift_f64(rng) * max_r * 0.15;
-    Star {
-        angle,
-        r,
-        r_prev: r,
-        speed: 0.5 + xorshift_f64(rng) * 1.0,
-        glow: xorshift_f64(rng) < 0.35,
+impl LogoGlyph {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Horizontal => "-",
+            Self::Vertical => "|",
+            Self::ForwardSlash => "/",
+            Self::Backslash => "\\",
+            Self::Dot => ".",
+            Self::Plus => "+",
+            Self::Star => "*",
+        }
     }
 }
-
-// ---------------------------------------------------------------------------
-// StarfieldState — owned by TuiZeroStateView, shared with the element
-// ---------------------------------------------------------------------------
-
-pub(crate) struct StarfieldState {
-    pub(crate) stars: Vec<Star>,
-    rng: u64,
-    sim_secs: f64,
-    max_r: f64,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LogoCell {
+    surface: LogoSurface,
+    glyph: LogoGlyph,
 }
 
-impl StarfieldState {
-    pub(crate) fn new() -> Self {
-        let mut rng: u64 = 0xDEAD_BEEF_CAFE_1234;
-        // Typical 80×24 maxR for initial placement; updated on first render.
-        let init_max_r = 62.5_f64;
-        let stars = (0..NUM_STARS)
-            .map(|_| new_star(&mut rng, init_max_r))
-            .collect();
+#[derive(Clone, Copy)]
+struct ProjectedSample {
+    depth: f64,
+    cell: LogoCell,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct LogoFrame {
+    size: TuiSize,
+    cells: Vec<Option<LogoCell>>,
+}
+
+impl LogoFrame {
+    fn new(size: TuiSize) -> Self {
         Self {
-            stars,
-            rng,
-            sim_secs: 0.0,
-            max_r: init_max_r,
+            size,
+            cells: vec![None; usize::from(size.width) * usize::from(size.height)],
         }
     }
 
-    /// Advances simulation by one 1/60s step.
-    fn advance_one_step(&mut self, warp: f64) {
-        // Normalize base velocity to panel size so crossing time is consistent
-        // across all terminal widths (~4.5s at reference max_r=43).
-        let a = 0.12 * (self.max_r / 43.0).clamp(0.5, 3.0);
-        for star in &mut self.stars {
-            star.r_prev = star.r;
-            star.r += (a + star.r * 0.012) * star.speed * warp;
-            // ~2% chance per step to toggle glow.
-            if xorshift_f64(&mut self.rng) < 0.02 {
-                star.glow = !star.glow;
-            }
-            if star.r >= self.max_r {
-                *star = new_star(&mut self.rng, self.max_r);
-            }
-        }
+    fn set(&mut self, x: usize, y: usize, cell: LogoCell) {
+        self.cells[y * usize::from(self.size.width) + x] = Some(cell);
     }
 
-    /// Simulates up to `target_secs` in 1/60s increments.
-    pub(crate) fn simulate_to(&mut self, target_secs: f64) {
-        let step = 1.0 / SIM_FPS;
-        // Cap at 2 seconds worth of steps to avoid stalls after long pauses.
-        let max_steps = (SIM_FPS * 2.0) as usize;
-        let mut steps = 0;
-        while self.sim_secs + step <= target_secs && steps < max_steps {
-            let warp = warp_at(self.sim_secs);
-            self.advance_one_step(warp);
-            self.sim_secs += step;
-            steps += 1;
-        }
-        self.sim_secs = target_secs;
+    fn iter_cells(&self) -> impl Iterator<Item = (usize, usize, LogoCell)> + '_ {
+        let width = usize::from(self.size.width);
+        self.cells
+            .iter()
+            .enumerate()
+            .filter_map(move |(index, cell)| cell.map(|cell| (index % width, index / width, cell)))
     }
 
-    /// Updates the panel geometry and adjusts the star count to match the new size.
-    pub(crate) fn set_dimensions(&mut self, max_r: f64, num_stars: usize) {
-        self.max_r = max_r;
-        while self.stars.len() < num_stars {
-            self.stars.push(new_star(&mut self.rng, self.max_r));
-        }
-        self.stars.truncate(num_stars);
+    #[cfg(test)]
+    fn to_lines(&self) -> Vec<String> {
+        let width = usize::from(self.size.width);
+        self.cells
+            .chunks(width)
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.map_or(" ", |cell| cell.glyph.as_str()))
+                    .collect()
+            })
+            .collect()
     }
-}
-
-/// Returns the number of stars appropriate for the panel's max_r, keeping
-/// density consistent across terminal sizes (reference: 220 stars at max_r=43).
-pub(crate) fn star_count_for_max_r(max_r: f64) -> usize {
-    ((220.0_f64 * (max_r / 43.0).powf(1.5)).round() as usize).clamp(50, 500)
-}
-
-// ---------------------------------------------------------------------------
-// TuiElement
-// ---------------------------------------------------------------------------
-
-/// Per-render geometry cache — avoids threading 5 scalars through every call.
-struct GridGeometry {
-    cx: f64,
-    cy: f64,
-    max_r: f64,
-    cols: usize,
-    rows: usize,
 }
 
 pub struct ZeroStateAnimationElement {
-    state: Rc<RefCell<StarfieldState>>,
     clock: AnimationClock,
-    glow_color: Color,
+    styles: WarpLogoStyles,
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
 }
 
 impl ZeroStateAnimationElement {
-    pub(crate) fn new(
-        state: Rc<RefCell<StarfieldState>>,
-        clock: AnimationClock,
-        glow_color: Color,
-    ) -> Self {
+    pub(crate) fn new(clock: AnimationClock, styles: WarpLogoStyles) -> Self {
         Self {
-            state,
             clock,
-            glow_color,
+            styles,
             size: None,
             origin: None,
         }
@@ -246,34 +201,20 @@ impl TuiElement for ZeroStateAnimationElement {
     ) {
         self.origin = Some(ctx.scene_point(origin));
         let Some(size) = self.size else { return };
-        if size.width < MIN_ANIMATION_COLS || size.height < MIN_ANIMATION_ROWS {
+        let Some(frame) = logo_frame_at(self.clock.elapsed(), size) else {
             return;
-        }
-
-        let cols = usize::from(size.width);
-        let rows = usize::from(size.height);
-        let elapsed = self.clock.elapsed().as_secs_f64();
-
-        let cx = cols as f64 / 2.0;
-        let cy = rows as f64 / 2.0;
-        // Aspect correction: terminal cells ~2× taller than wide.
-        let max_r = cx.hypot(cy * 2.0);
-
-        let mut sf = self.state.borrow_mut();
-        let num_stars = star_count_for_max_r(max_r);
-        sf.set_dimensions(max_r, num_stars);
-        sf.simulate_to(elapsed);
-
-        let geo = GridGeometry {
-            cx,
-            cy,
-            max_r,
-            cols,
-            rows,
         };
-        let glow_color = self.glow_color;
-        for star in &sf.stars {
-            draw_star_streak(surface, origin, star, &geo, glow_color);
+
+        for (x, y, logo_cell) in frame.iter_cells() {
+            let style = match logo_cell.surface {
+                LogoSurface::Front => self.styles.front,
+                LogoSurface::Back => self.styles.back,
+                LogoSurface::Side | LogoSurface::Ghost => self.styles.side,
+                LogoSurface::Background => self.styles.background,
+            };
+            if let Some(cell) = surface.cell_mut(origin.offset(x as i32, y as i32)) {
+                cell.set_symbol(logo_cell.glyph.as_str()).set_style(style);
+            }
         }
 
         ctx.repaint_after(REPAINT_INTERVAL);
@@ -288,48 +229,226 @@ impl TuiElement for ZeroStateAnimationElement {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Star streak renderer
-// ---------------------------------------------------------------------------
+pub(crate) fn logo_frame_at(elapsed: Duration, size: TuiSize) -> Option<LogoFrame> {
+    let (logo_cols, logo_rows) = fitted_logo_size(size)?;
+    let angle = (elapsed.as_secs_f64() % REVOLUTION_SECS) / REVOLUTION_SECS * std::f64::consts::TAU;
+    let (sin, cos) = angle.sin_cos();
+    let mut frame = LogoFrame::new(size);
+    draw_background_stars(&mut frame, elapsed);
+    let mut z_buffer = vec![None; usize::from(size.width) * usize::from(size.height)];
 
-fn draw_star_streak(
-    surface: &mut TuiPaintSurface<'_>,
-    origin: TuiScreenPosition,
-    star: &Star,
-    geo: &GridGeometry,
-    glow_color: Color,
-) {
-    if star.r <= 0.0 || geo.max_r <= 0.0 {
-        return;
+    let source_cols = usize::from(logo_cols) * SURFACE_SAMPLES;
+    let source_rows = usize::from(logo_rows) * SURFACE_SAMPLES;
+    let center_x = (f64::from(size.width) - 1.0) / 2.0;
+    let center_y = (f64::from(size.height) - 1.0) / 2.0;
+    let scale_x = (f64::from(logo_cols) - 1.0) / 2.0;
+    let scale_y = (f64::from(logo_rows) - 1.0) / 2.0;
+
+    for source_y in 0..source_rows {
+        let model_y = sample_coordinate(source_y, source_rows);
+        for source_x in 0..source_cols {
+            let model_x = sample_coordinate(source_x, source_cols);
+            if !warp_logo_contains(model_x, model_y) {
+                continue;
+            }
+            let outline_glyph = logo_outline_glyph(model_x, model_y, source_cols, source_rows, cos);
+            let is_ghost_sample = (source_x * 17 + source_y * 31) % GHOST_STIPPLE_MODULUS == 0;
+            let is_side_stitch = (source_x * 13 + source_y * 7) % SIDE_STITCH_MODULUS == 0;
+            if outline_glyph.is_none() && !is_ghost_sample {
+                continue;
+            }
+
+            for depth_index in 0..=DEPTH_SAMPLES {
+                let is_face = depth_index == 0 || depth_index == DEPTH_SAMPLES;
+                if !is_face && (outline_glyph.is_none() || !is_side_stitch) {
+                    continue;
+                }
+                let model_z =
+                    -LOGO_DEPTH + 2.0 * LOGO_DEPTH * depth_index as f64 / DEPTH_SAMPLES as f64;
+                let rotated_x = model_x * cos + model_z * sin;
+                let rotated_depth = -model_x * sin + model_z * cos;
+                let projected_x = (center_x + rotated_x * scale_x).round() as i32;
+                let projected_y = (center_y + model_y * scale_y).round() as i32;
+                if projected_x < 0
+                    || projected_y < 0
+                    || projected_x >= i32::from(size.width)
+                    || projected_y >= i32::from(size.height)
+                {
+                    continue;
+                }
+
+                let cell = if !is_face {
+                    LogoCell {
+                        surface: LogoSurface::Side,
+                        glyph: LogoGlyph::Dot,
+                    }
+                } else if let Some(glyph) = outline_glyph {
+                    let surface = if depth_index == DEPTH_SAMPLES {
+                        LogoSurface::Front
+                    } else {
+                        LogoSurface::Back
+                    };
+                    LogoCell { surface, glyph }
+                } else {
+                    LogoCell {
+                        surface: LogoSurface::Ghost,
+                        glyph: LogoGlyph::Dot,
+                    }
+                };
+                let index = projected_y as usize * usize::from(size.width) + projected_x as usize;
+                let sample = ProjectedSample {
+                    depth: rotated_depth,
+                    cell,
+                };
+                if z_buffer[index]
+                    .is_none_or(|current: ProjectedSample| sample.depth > current.depth)
+                {
+                    z_buffer[index] = Some(sample);
+                }
+            }
+        }
     }
-    let (dir_x, dir_y) = (star.angle.cos(), star.angle.sin());
-    let length = star.r - star.r_prev;
-    let steps = (length as usize).max(1);
 
-    let color = if star.glow {
-        glow_color
-    } else {
-        Color::Rgb(255, 255, 255)
-    };
-    let style = TuiStyle::default().fg(color);
+    for (index, sample) in z_buffer.into_iter().enumerate() {
+        if let Some(sample) = sample {
+            frame.set(
+                index % usize::from(size.width),
+                index / usize::from(size.width),
+                sample.cell,
+            );
+        }
+    }
+    Some(frame)
+}
 
-    for st in 0..=steps {
-        let rr = star.r_prev + length * st as f64 / steps as f64;
-        // Y halved for aspect correction.
-        let px = (geo.cx + dir_x * rr).round() as i32;
-        let py = (geo.cy + dir_y * rr / 2.0).round() as i32;
-        if px < 0 || py < 0 || px as usize >= geo.cols || py as usize >= geo.rows {
+fn draw_background_stars(frame: &mut LogoFrame, elapsed: Duration) {
+    let width = usize::from(frame.size.width);
+    let height = usize::from(frame.size.height);
+    let star_count = (width * height * STARFIELD_REFERENCE_COUNT / STARFIELD_REFERENCE_AREA)
+        .clamp(STARFIELD_MIN_COUNT, STARFIELD_MAX_COUNT);
+    let center_x = (f64::from(frame.size.width) - 1.0) / 2.0;
+    let center_y = (f64::from(frame.size.height) - 1.0) / 2.0;
+    let elapsed = elapsed.as_secs_f64();
+
+    for index in 0..star_count {
+        let seed = index as u64 ^ 0xA5A5_6C8E_9CF5_703B;
+        let angle = unit_random(seed) * std::f64::consts::TAU;
+        let phase = unit_random(seed ^ 0x6E62_4EB7_F3A1_92D1);
+        let speed = 0.75 + unit_random(seed ^ 0xD1B5_4A32_D192_ED03) * 0.5;
+        let progress = (phase + elapsed / STAR_TRAVEL_SECS * speed).fract();
+        let direction_x = angle.cos();
+        let direction_y = angle.sin();
+        let radius_x = center_x / direction_x.abs().max(0.001);
+        let radius_y = center_y * 2.0 / direction_y.abs().max(0.001);
+        let max_radius = radius_x.min(radius_y);
+        let radius = 1.0 + progress.powf(1.4) * (max_radius - 1.0).max(0.0);
+        let x = (center_x + direction_x * radius).round() as usize;
+        let y = (center_y + direction_y * radius / 2.0).round() as usize;
+        if x >= width || y >= height {
             continue;
         }
-        let gi = ((rr / geo.max_r).powf(0.65) * (STAR_GLYPHS.len() - 1) as f64) as usize;
-        let gi = gi.min(STAR_GLYPHS.len() - 1);
-        let glyph = STAR_GLYPHS[gi];
-        let buf = [glyph];
-        let s = std::str::from_utf8(&buf).unwrap_or(".");
-        if let Some(c) = surface.cell_mut(origin.offset(px, py)) {
-            c.set_symbol(s).set_style(style);
-        }
+
+        let glyph = if progress < 0.7 {
+            LogoGlyph::Dot
+        } else if progress < 0.9 {
+            LogoGlyph::Plus
+        } else {
+            LogoGlyph::Star
+        };
+        frame.set(
+            x,
+            y,
+            LogoCell {
+                surface: LogoSurface::Background,
+                glyph,
+            },
+        );
     }
+}
+
+fn unit_random(seed: u64) -> f64 {
+    let mut value = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    ((value ^ (value >> 31)) >> 11) as f64 / (1_u64 << 53) as f64
+}
+
+fn fitted_logo_size(size: TuiSize) -> Option<(u16, u16)> {
+    if size.width < MIN_ANIMATION_COLS || size.height < MIN_ANIMATION_ROWS {
+        return None;
+    }
+
+    let available_cols = size.width.saturating_sub(2);
+    let available_rows = size.height.saturating_sub(2);
+    let mut rows = available_rows.min(MAX_LOGO_ROWS);
+    let mut cols = ((f64::from(rows) * LOGO_CELL_ASPECT_RATIO).round() as u16)
+        .min(available_cols)
+        .min(MAX_LOGO_COLS);
+    rows = rows.min((f64::from(cols) / LOGO_CELL_ASPECT_RATIO).round() as u16);
+    cols = ((f64::from(rows) * LOGO_CELL_ASPECT_RATIO).round() as u16).min(cols);
+
+    (cols >= 16 && rows >= 5).then_some((cols, rows))
+}
+
+fn sample_coordinate(index: usize, sample_count: usize) -> f64 {
+    ((index as f64 + 0.5) / sample_count as f64) * 2.0 - 1.0
+}
+fn logo_outline_glyph(
+    x: f64,
+    y: f64,
+    source_cols: usize,
+    source_rows: usize,
+    rotation_cos: f64,
+) -> Option<LogoGlyph> {
+    let dx = 2.0 / source_cols as f64;
+    let dy = 2.0 / source_rows as f64;
+    let left = warp_logo_contains(x - dx, y);
+    let right = warp_logo_contains(x + dx, y);
+    let above = warp_logo_contains(x, y - dy);
+    let below = warp_logo_contains(x, y + dy);
+    if left && right && above && below {
+        return None;
+    }
+
+    let normal_x = bool_as_scalar(left) - bool_as_scalar(right);
+    let normal_y = bool_as_scalar(above) - bool_as_scalar(below);
+    let tangent_x = -normal_y * rotation_cos * LOGO_CELL_ASPECT_RATIO;
+    let tangent_y = normal_x;
+    if tangent_x.abs() > tangent_y.abs() * 1.8 {
+        Some(LogoGlyph::Horizontal)
+    } else if tangent_y.abs() > tangent_x.abs() * 1.8 {
+        Some(LogoGlyph::Vertical)
+    } else if tangent_x.signum() == tangent_y.signum() {
+        Some(LogoGlyph::Backslash)
+    } else {
+        Some(LogoGlyph::ForwardSlash)
+    }
+}
+
+fn bool_as_scalar(value: bool) -> f64 {
+    if value { 1.0 } else { 0.0 }
+}
+
+fn warp_logo_contains(x: f64, y: f64) -> bool {
+    let svg_x = SVG_MIN_X + (x + 1.0) * 0.5 * (SVG_MAX_X - SVG_MIN_X);
+    let svg_y = SVG_MIN_Y + (y + 1.0) * 0.5 * (SVG_MAX_Y - SVG_MIN_Y);
+    point_in_polygon(svg_x, svg_y, UPPER_FACE) || point_in_polygon(svg_x, svg_y, LOWER_FACE)
+}
+
+fn point_in_polygon(x: f64, y: f64, polygon: &[(f64, f64)]) -> bool {
+    let mut inside = false;
+    let mut previous = polygon.len() - 1;
+    for current in 0..polygon.len() {
+        let (current_x, current_y) = polygon[current];
+        let (previous_x, previous_y) = polygon[previous];
+        if ((current_y > y) != (previous_y > y))
+            && x < (previous_x - current_x) * (y - current_y) / (previous_y - current_y) + current_x
+        {
+            inside = !inside;
+        }
+        previous = current;
+    }
+    inside
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/zero_state_animation_config.rs
+++ b/crates/warp_tui/src/zero_state_animation_config.rs
@@ -1,0 +1,275 @@
+use std::fmt;
+use std::fs::File;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use warp::settings::{TuiZeroStateObject, TuiZeroStateSettings};
+use warp_core::safe_warn;
+use warp_core::settings::Setting;
+use warpui::SingletonEntity;
+use warpui_core::{AppContext, Entity};
+
+use super::{
+    BUILT_IN_LOGO_CELL_ASPECT_RATIO, MAX_ASCII_ART_BYTES, MAX_ASCII_ART_COLS, MAX_ASCII_ART_ROWS,
+    warp_logo_contains,
+};
+
+#[derive(Clone, Debug)]
+pub(super) enum ZeroStateShape {
+    BuiltInWarp,
+    Ascii(AsciiArtMask),
+}
+
+impl ZeroStateShape {
+    pub(super) fn contains(&self, x: f64, y: f64) -> bool {
+        match self {
+            Self::BuiltInWarp => warp_logo_contains(x, y),
+            Self::Ascii(mask) => mask.contains(x, y),
+        }
+    }
+
+    pub(super) fn cell_aspect_ratio(&self) -> f64 {
+        match self {
+            Self::BuiltInWarp => BUILT_IN_LOGO_CELL_ASPECT_RATIO,
+            Self::Ascii(mask) => mask.cell_aspect_ratio(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct AsciiArtMask {
+    width: usize,
+    height: usize,
+    cells: Vec<bool>,
+}
+
+impl AsciiArtMask {
+    pub(super) fn parse(source: &str) -> Result<Self, AsciiArtError> {
+        if source.len() as u64 > MAX_ASCII_ART_BYTES {
+            return Err(AsciiArtError::TooLarge {
+                bytes: source.len() as u64,
+            });
+        }
+
+        let normalized = source.replace("\r\n", "\n");
+        if normalized.contains('\r') {
+            return Err(AsciiArtError::InvalidCharacter);
+        }
+        let mut rows = normalized.split('\n').collect::<Vec<_>>();
+        if rows.last() == Some(&"") {
+            rows.pop();
+        }
+        if rows.len() > MAX_ASCII_ART_ROWS {
+            return Err(AsciiArtError::TooManyRows { rows: rows.len() });
+        }
+
+        let mut min_x = usize::MAX;
+        let mut max_x = 0;
+        let mut min_y = usize::MAX;
+        let mut max_y = 0;
+        let mut found_occupied = false;
+        for (y, row) in rows.iter().enumerate() {
+            if row.len() > MAX_ASCII_ART_COLS {
+                return Err(AsciiArtError::TooManyColumns { columns: row.len() });
+            }
+            for (x, byte) in row.bytes().enumerate() {
+                if !(b' '..=b'~').contains(&byte) {
+                    return Err(AsciiArtError::InvalidCharacter);
+                }
+                if byte != b' ' {
+                    found_occupied = true;
+                    min_x = min_x.min(x);
+                    max_x = max_x.max(x);
+                    min_y = min_y.min(y);
+                    max_y = max_y.max(y);
+                }
+            }
+        }
+        if !found_occupied {
+            return Err(AsciiArtError::Empty);
+        }
+
+        let width = max_x - min_x + 1;
+        let height = max_y - min_y + 1;
+        let mut cells = vec![false; width * height];
+        for source_y in min_y..=max_y {
+            let row = rows[source_y].as_bytes();
+            for source_x in min_x..=max_x {
+                cells[(source_y - min_y) * width + source_x - min_x] =
+                    row.get(source_x).is_some_and(|byte| *byte != b' ');
+            }
+        }
+        Ok(Self {
+            width,
+            height,
+            cells,
+        })
+    }
+
+    fn contains(&self, x: f64, y: f64) -> bool {
+        if !(-1.0..=1.0).contains(&x) || !(-1.0..=1.0).contains(&y) {
+            return false;
+        }
+        let column = (((x + 1.0) * 0.5 * self.width as f64).floor() as usize).min(self.width - 1);
+        let row = (((y + 1.0) * 0.5 * self.height as f64).floor() as usize).min(self.height - 1);
+        self.cells[row * self.width + column]
+    }
+
+    fn cell_aspect_ratio(&self) -> f64 {
+        self.width as f64 / self.height as f64
+    }
+
+    #[cfg(test)]
+    pub(super) fn size(&self) -> (usize, usize) {
+        (self.width, self.height)
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum AsciiArtError {
+    Io(std::io::Error),
+    NotAFile,
+    TooLarge { bytes: u64 },
+    TooManyColumns { columns: usize },
+    TooManyRows { rows: usize },
+    InvalidCharacter,
+    Empty,
+}
+
+impl fmt::Display for AsciiArtError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "{error}"),
+            Self::NotAFile => write!(f, "path is not a regular file"),
+            Self::TooLarge { bytes } => {
+                write!(f, "file is {bytes} bytes; limit is {MAX_ASCII_ART_BYTES}")
+            }
+            Self::TooManyColumns { columns } => {
+                write!(
+                    f,
+                    "art has {columns} columns; limit is {MAX_ASCII_ART_COLS}"
+                )
+            }
+            Self::TooManyRows { rows } => {
+                write!(f, "art has {rows} rows; limit is {MAX_ASCII_ART_ROWS}")
+            }
+            Self::InvalidCharacter => {
+                write!(f, "art must contain only printable ASCII and newlines")
+            }
+            Self::Empty => write!(f, "art does not contain any occupied cells"),
+        }
+    }
+}
+
+impl From<std::io::Error> for AsciiArtError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ZeroStateAnimationConfig {
+    pub(super) shape: Arc<ZeroStateShape>,
+    pub(super) rotation_period: Duration,
+    pub(super) extrusion_depth: f64,
+}
+
+impl Default for ZeroStateAnimationConfig {
+    fn default() -> Self {
+        Self {
+            shape: Arc::new(ZeroStateShape::BuiltInWarp),
+            rotation_period: Duration::from_secs_f64(
+                warp::settings::DEFAULT_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
+            ),
+            extrusion_depth: warp::settings::DEFAULT_TUI_ZERO_STATE_EXTRUSION_DEPTH,
+        }
+    }
+}
+
+impl Entity for ZeroStateAnimationConfig {
+    type Event = ();
+}
+
+impl SingletonEntity for ZeroStateAnimationConfig {}
+
+impl ZeroStateAnimationConfig {
+    pub(crate) fn register(ctx: &mut AppContext) {
+        let (object, rotation_period, extrusion_depth) = {
+            let settings = TuiZeroStateSettings::as_ref(ctx);
+            (
+                settings.object.value().clone(),
+                settings.rotation_period_seconds.value().get(),
+                settings.extrusion_depth.value().get(),
+            )
+        };
+        let config = Self::load(
+            &object,
+            rotation_period,
+            extrusion_depth,
+            &warp_core::paths::tui_config_local_dir(),
+        );
+        ctx.add_singleton_model(move |_| config);
+    }
+
+    pub(super) fn load(
+        object: &TuiZeroStateObject,
+        rotation_period_seconds: f64,
+        extrusion_depth: f64,
+        config_dir: &Path,
+    ) -> Self {
+        let shape = match object {
+            TuiZeroStateObject::BuiltIn => ZeroStateShape::BuiltInWarp,
+            TuiZeroStateObject::AsciiFile { path } => {
+                let path = resolve_ascii_art_path(path, config_dir);
+                match load_ascii_art(&path) {
+                    Ok(mask) => ZeroStateShape::Ascii(mask),
+                    Err(error) => {
+                        safe_warn!(
+                            safe: (
+                                "Could not load custom TUI zero-state ASCII art; using the built-in Warp logo"
+                            ),
+                            full: (
+                                "Could not load custom TUI zero-state ASCII art; using the built-in Warp logo: path={} error={error}",
+                                path.display()
+                            )
+                        );
+                        ZeroStateShape::BuiltInWarp
+                    }
+                }
+            }
+        };
+        Self {
+            shape: Arc::new(shape),
+            rotation_period: Duration::from_secs_f64(rotation_period_seconds),
+            extrusion_depth,
+        }
+    }
+}
+
+pub(super) fn resolve_ascii_art_path(path: &Path, config_dir: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_owned()
+    } else {
+        config_dir.join(path)
+    }
+}
+
+fn load_ascii_art(path: &Path) -> Result<AsciiArtMask, AsciiArtError> {
+    let mut file = File::open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(AsciiArtError::NotAFile);
+    }
+    if metadata.len() > MAX_ASCII_ART_BYTES {
+        return Err(AsciiArtError::TooLarge {
+            bytes: metadata.len(),
+        });
+    }
+    let mut source = String::new();
+    (&mut file)
+        .take(MAX_ASCII_ART_BYTES + 1)
+        .read_to_string(&mut source)?;
+    AsciiArtMask::parse(&source)
+}

--- a/crates/warp_tui/src/zero_state_animation_config.rs
+++ b/crates/warp_tui/src/zero_state_animation_config.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use warp::settings::{TuiZeroStateObject, TuiZeroStateSettings};
+use warp::settings::{TuiZeroStateObject, TuiZeroStateSettings, TuiZeroStateSettingsChangedEvent};
 use warp_core::safe_warn;
 use warp_core::settings::Setting;
 use warpui::SingletonEntity;
@@ -171,31 +171,55 @@ impl From<std::io::Error> for AsciiArtError {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ZeroStateAnimationConfig {
+    pub(super) active_object: TuiZeroStateObject,
     pub(super) shape: Arc<ZeroStateShape>,
     pub(super) rotation_period: Duration,
     pub(super) extrusion_depth: f64,
+    pub(super) load_failure: Option<ZeroStateAnimationLoadFailure>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ZeroStateAnimationLoadFailure {
+    InitialLoad,
+    Reload,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ZeroStateAnimationConfigEvent {
+    Updated,
+    LoadFailed(ZeroStateAnimationLoadFailure),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ReloadObjectOutcome {
+    Unchanged,
+    Reloaded,
+    Failed,
 }
 
 impl Default for ZeroStateAnimationConfig {
     fn default() -> Self {
         Self {
+            active_object: TuiZeroStateObject::BuiltIn,
             shape: Arc::new(ZeroStateShape::BuiltInWarp),
             rotation_period: Duration::from_secs_f64(
                 warp::settings::DEFAULT_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
             ),
             extrusion_depth: warp::settings::DEFAULT_TUI_ZERO_STATE_EXTRUSION_DEPTH,
+            load_failure: None,
         }
     }
 }
 
 impl Entity for ZeroStateAnimationConfig {
-    type Event = ();
+    type Event = ZeroStateAnimationConfigEvent;
 }
 
 impl SingletonEntity for ZeroStateAnimationConfig {}
 
 impl ZeroStateAnimationConfig {
     pub(crate) fn register(ctx: &mut AppContext) {
+        let config_dir = warp_core::paths::tui_config_local_dir();
         let (object, rotation_period, extrusion_depth) = {
             let settings = TuiZeroStateSettings::as_ref(ctx);
             (
@@ -204,46 +228,101 @@ impl ZeroStateAnimationConfig {
                 settings.extrusion_depth.value().get(),
             )
         };
-        let config = Self::load(
-            &object,
-            rotation_period,
-            extrusion_depth,
-            &warp_core::paths::tui_config_local_dir(),
+        let config = Self::load(&object, rotation_period, extrusion_depth, &config_dir);
+        let config = ctx.add_singleton_model(move |_| config);
+        ctx.subscribe_to_model(
+            &TuiZeroStateSettings::handle(ctx),
+            move |settings, event, ctx| {
+                let TuiZeroStateSettingsChangedEvent::TuiZeroStateObjectSetting { .. } = event
+                else {
+                    return;
+                };
+                let object = settings.as_ref(ctx).object.value().clone();
+                config.update(ctx, |config, ctx| {
+                    match config.reload_object(&object, &config_dir) {
+                        ReloadObjectOutcome::Unchanged => {}
+                        ReloadObjectOutcome::Reloaded => {
+                            ctx.emit(ZeroStateAnimationConfigEvent::Updated);
+                        }
+                        ReloadObjectOutcome::Failed => {
+                            ctx.emit(ZeroStateAnimationConfigEvent::LoadFailed(
+                                ZeroStateAnimationLoadFailure::Reload,
+                            ));
+                        }
+                    }
+                });
+            },
         );
-        ctx.add_singleton_model(move |_| config);
     }
 
-    pub(super) fn load(
+    pub(crate) fn load(
         object: &TuiZeroStateObject,
         rotation_period_seconds: f64,
         extrusion_depth: f64,
         config_dir: &Path,
     ) -> Self {
-        let shape = match object {
-            TuiZeroStateObject::BuiltIn => ZeroStateShape::BuiltInWarp,
-            TuiZeroStateObject::AsciiFile { path } => {
-                let path = resolve_ascii_art_path(path, config_dir);
-                match load_ascii_art(&path) {
-                    Ok(mask) => ZeroStateShape::Ascii(mask),
-                    Err(error) => {
-                        safe_warn!(
-                            safe: (
-                                "Could not load custom TUI zero-state ASCII art; using the built-in Warp logo"
-                            ),
-                            full: (
-                                "Could not load custom TUI zero-state ASCII art; using the built-in Warp logo: path={} error={error}",
-                                path.display()
-                            )
-                        );
-                        ZeroStateShape::BuiltInWarp
-                    }
-                }
+        let (active_object, shape, load_failure) = match load_object_shape(object, config_dir) {
+            Ok(shape) => (object.clone(), shape, None),
+            Err((path, error)) => {
+                safe_warn!(
+                    safe: (
+                        "Could not load custom Warp Agent CLI zero-state ASCII art; using the built-in Warp logo"
+                    ),
+                    full: (
+                        "Could not load custom Warp Agent CLI zero-state ASCII art; using the built-in Warp logo: path={} error={error}",
+                        path.display()
+                    )
+                );
+                (
+                    TuiZeroStateObject::BuiltIn,
+                    ZeroStateShape::BuiltInWarp,
+                    Some(ZeroStateAnimationLoadFailure::InitialLoad),
+                )
             }
         };
         Self {
+            active_object,
             shape: Arc::new(shape),
             rotation_period: Duration::from_secs_f64(rotation_period_seconds),
             extrusion_depth,
+            load_failure,
+        }
+    }
+
+    pub(crate) fn load_failure(&self) -> Option<ZeroStateAnimationLoadFailure> {
+        self.load_failure
+    }
+
+    pub(super) fn reload_object(
+        &mut self,
+        object: &TuiZeroStateObject,
+        config_dir: &Path,
+    ) -> ReloadObjectOutcome {
+        if &self.active_object == object {
+            self.load_failure = None;
+            return ReloadObjectOutcome::Unchanged;
+        }
+
+        match load_object_shape(object, config_dir) {
+            Ok(shape) => {
+                self.active_object = object.clone();
+                self.shape = Arc::new(shape);
+                self.load_failure = None;
+                ReloadObjectOutcome::Reloaded
+            }
+            Err((path, error)) => {
+                safe_warn!(
+                    safe: (
+                        "Could not reload custom Warp Agent CLI zero-state ASCII art; keeping the current object"
+                    ),
+                    full: (
+                        "Could not reload custom Warp Agent CLI zero-state ASCII art; keeping the current object: path={} error={error}",
+                        path.display()
+                    )
+                );
+                self.load_failure = Some(ZeroStateAnimationLoadFailure::Reload);
+                ReloadObjectOutcome::Failed
+            }
         }
     }
 }
@@ -256,6 +335,20 @@ pub(super) fn resolve_ascii_art_path(path: &Path, config_dir: &Path) -> PathBuf 
     }
 }
 
+fn load_object_shape(
+    object: &TuiZeroStateObject,
+    config_dir: &Path,
+) -> Result<ZeroStateShape, (PathBuf, AsciiArtError)> {
+    match object {
+        TuiZeroStateObject::BuiltIn => Ok(ZeroStateShape::BuiltInWarp),
+        TuiZeroStateObject::AsciiFile { path } => {
+            let path = resolve_ascii_art_path(path, config_dir);
+            load_ascii_art(&path)
+                .map(ZeroStateShape::Ascii)
+                .map_err(|error| (path, error))
+        }
+    }
+}
 fn load_ascii_art(path: &Path) -> Result<AsciiArtMask, AsciiArtError> {
     let mut file = File::open(path)?;
     let metadata = file.metadata()?;

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -3,19 +3,26 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tempfile::TempDir;
-use warp::settings::TuiZeroStateObject;
+use warp::settings::{
+    TuiZeroStateExtrusionDepthSetting, TuiZeroStateObject, TuiZeroStateObjectSetting,
+    TuiZeroStateRotationPeriodSeconds, TuiZeroStateRotationPeriodSecondsSetting,
+    TuiZeroStateSettings,
+};
+use warp_core::settings::Setting as _;
+use warpui::SingletonEntity as _;
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{TuiBufferExt, TuiElement, TuiRect, TuiSize, TuiStyle};
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{AddWindowOptions, App, AppContext, Entity, TuiView, TypedActionView};
 
 use super::config::{
-    AsciiArtError, AsciiArtMask, ZeroStateAnimationConfig, ZeroStateShape, resolve_ascii_art_path,
+    AsciiArtError, AsciiArtMask, ReloadObjectOutcome, ZeroStateAnimationConfig,
+    ZeroStateAnimationLoadFailure, ZeroStateShape, resolve_ascii_art_path,
 };
 use super::{
     BUILT_IN_LOGO_CELL_ASPECT_RATIO, LogoCell, LogoSurface, WarpLogoStyles,
     ZeroStateAnimationElement, fitted_logo_size, logo_frame_at, object_frame_at,
-    warp_logo_contains,
+    star_count_for_size, warp_logo_contains,
 };
 
 const PANEL_SIZE: TuiSize = TuiSize::new(52, 20);
@@ -29,10 +36,21 @@ fn custom_config(
     extrusion_depth: f64,
 ) -> ZeroStateAnimationConfig {
     ZeroStateAnimationConfig {
+        active_object: TuiZeroStateObject::BuiltIn,
         shape: Arc::new(ZeroStateShape::Ascii(AsciiArtMask::parse(art).unwrap())),
         rotation_period: Duration::from_secs_f64(rotation_period_secs),
         extrusion_depth,
+        load_failure: None,
     }
+}
+#[test]
+fn starfield_density_scales_with_the_full_panel_area() {
+    assert_eq!(star_count_for_size(TuiSize::new(18, 7)), 18);
+    assert_eq!(star_count_for_size(PANEL_SIZE), 36);
+    assert_eq!(star_count_for_size(TuiSize::new(104, 20)), 72);
+    assert_eq!(star_count_for_size(TuiSize::new(1_000, 200)), 6_923);
+    assert_eq!(star_count_for_size(TuiSize::new(2_000, 200)), 8_192);
+    assert_eq!(star_count_for_size(TuiSize::new(u16::MAX, u16::MAX)), 8_192);
 }
 
 fn logo_cells(frame: &super::LogoFrame) -> Vec<(usize, usize, LogoCell)> {
@@ -185,12 +203,13 @@ fn one_revolution_returns_to_the_initial_frame() {
 fn logo_scales_down_while_preserving_cell_aspect() {
     assert_eq!(
         fitted_logo_size(TuiSize::new(100, 40), BUILT_IN_LOGO_CELL_ASPECT_RATIO),
-        Some((42, 17))
+        Some((43, 17))
     );
     assert_eq!(
         fitted_logo_size(TuiSize::new(30, 12), BUILT_IN_LOGO_CELL_ASPECT_RATIO),
         Some((25, 10))
     );
+    assert_eq!(fitted_logo_size(TuiSize::new(100, 40), 4.0), Some((68, 17)));
 }
 
 #[test]
@@ -274,6 +293,7 @@ fn startup_loader_reads_relative_ascii_art_and_retains_motion_settings() {
 
     assert_eq!(config.rotation_period, Duration::from_secs_f64(3.5));
     assert_eq!(config.extrusion_depth, 0.3);
+    assert_eq!(config.load_failure(), None);
     let ZeroStateShape::Ascii(mask) = config.shape.as_ref() else {
         panic!("valid custom art should produce an ASCII shape");
     };
@@ -297,7 +317,140 @@ fn startup_loader_falls_back_for_missing_or_invalid_art_only() {
         assert!(matches!(config.shape.as_ref(), ZeroStateShape::BuiltInWarp));
         assert_eq!(config.rotation_period, Duration::from_secs(7));
         assert_eq!(config.extrusion_depth, 0.4);
+        assert_eq!(
+            config.load_failure(),
+            Some(ZeroStateAnimationLoadFailure::InitialLoad)
+        );
     }
+}
+
+#[test]
+fn object_path_change_reloads_shape_without_changing_motion_settings() {
+    let temp_dir = TempDir::new().unwrap();
+    write_art(temp_dir.path(), "diamond.txt", DIAMOND_ART);
+    write_art(temp_dir.path(), "rocket.txt", ROCKET_ART);
+    let diamond = TuiZeroStateObject::AsciiFile {
+        path: PathBuf::from("diamond.txt"),
+    };
+    let rocket = TuiZeroStateObject::AsciiFile {
+        path: PathBuf::from("rocket.txt"),
+    };
+    let mut config = ZeroStateAnimationConfig::load(&diamond, 3.5, 0.3, temp_dir.path());
+    let initial = object_frame_at(Duration::ZERO, PANEL_SIZE, &config).unwrap();
+
+    assert_eq!(
+        config.reload_object(&rocket, temp_dir.path()),
+        ReloadObjectOutcome::Reloaded
+    );
+    assert_eq!(config.load_failure(), None);
+    assert_eq!(config.rotation_period, Duration::from_secs_f64(3.5));
+    assert_eq!(config.extrusion_depth, 0.3);
+    let ZeroStateShape::Ascii(mask) = config.shape.as_ref() else {
+        panic!("valid replacement art should produce an ASCII shape");
+    };
+    assert_eq!(mask.size(), (5, 6));
+    let reloaded = object_frame_at(Duration::ZERO, PANEL_SIZE, &config).unwrap();
+    assert_ne!(logo_cells(&initial), logo_cells(&reloaded));
+}
+
+#[test]
+fn linked_file_content_change_is_ignored_when_object_path_is_unchanged() {
+    let temp_dir = TempDir::new().unwrap();
+    write_art(temp_dir.path(), "active.txt", DIAMOND_ART);
+    let object = TuiZeroStateObject::AsciiFile {
+        path: PathBuf::from("active.txt"),
+    };
+    let mut config = ZeroStateAnimationConfig::load(&object, 4.0, 0.18, temp_dir.path());
+
+    write_art(temp_dir.path(), "active.txt", ROCKET_ART);
+
+    assert_eq!(
+        config.reload_object(&object, temp_dir.path()),
+        ReloadObjectOutcome::Unchanged
+    );
+    let ZeroStateShape::Ascii(mask) = config.shape.as_ref() else {
+        panic!("unchanged path should retain the loaded ASCII shape");
+    };
+    assert_eq!(mask.size(), (5, 5));
+}
+
+#[test]
+fn invalid_object_path_change_keeps_last_valid_shape() {
+    let temp_dir = TempDir::new().unwrap();
+    write_art(temp_dir.path(), "diamond.txt", DIAMOND_ART);
+    let diamond = TuiZeroStateObject::AsciiFile {
+        path: PathBuf::from("diamond.txt"),
+    };
+    let missing = TuiZeroStateObject::AsciiFile {
+        path: PathBuf::from("missing.txt"),
+    };
+    let mut config = ZeroStateAnimationConfig::load(&diamond, 4.0, 0.18, temp_dir.path());
+
+    assert_eq!(
+        config.reload_object(&missing, temp_dir.path()),
+        ReloadObjectOutcome::Failed
+    );
+    assert_eq!(
+        config.load_failure(),
+        Some(ZeroStateAnimationLoadFailure::Reload)
+    );
+    let ZeroStateShape::Ascii(mask) = config.shape.as_ref() else {
+        panic!("invalid replacement path should retain the previous ASCII shape");
+    };
+    assert_eq!(mask.size(), (5, 5));
+}
+
+#[test]
+fn settings_model_reloads_only_object_changes() {
+    let temp_dir = TempDir::new().unwrap();
+    let diamond_path = write_art(temp_dir.path(), "diamond.txt", DIAMOND_ART);
+    let rocket_path = write_art(temp_dir.path(), "rocket.txt", ROCKET_ART);
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| TuiZeroStateSettings {
+                object: TuiZeroStateObjectSetting::new(Some(TuiZeroStateObject::AsciiFile {
+                    path: diamond_path,
+                })),
+                rotation_period_seconds: TuiZeroStateRotationPeriodSecondsSetting::new(None),
+                extrusion_depth: TuiZeroStateExtrusionDepthSetting::new(None),
+            });
+            ZeroStateAnimationConfig::register(ctx);
+        });
+
+        let initial_period = app.read(|ctx| ZeroStateAnimationConfig::as_ref(ctx).rotation_period);
+        app.update(|ctx| {
+            TuiZeroStateSettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .object
+                    .load_value(
+                        TuiZeroStateObject::AsciiFile { path: rocket_path },
+                        true,
+                        ctx,
+                    )
+                    .unwrap();
+                settings
+                    .rotation_period_seconds
+                    .load_value(
+                        serde_json::from_value::<TuiZeroStateRotationPeriodSeconds>(
+                            serde_json::json!(12.0),
+                        )
+                        .unwrap(),
+                        true,
+                        ctx,
+                    )
+                    .unwrap();
+            });
+        });
+
+        app.read(|ctx| {
+            let config = ZeroStateAnimationConfig::as_ref(ctx);
+            assert_eq!(config.rotation_period, initial_period);
+            let ZeroStateShape::Ascii(mask) = config.shape.as_ref() else {
+                panic!("object setting event should reload the replacement ASCII shape");
+            };
+            assert_eq!(mask.size(), (5, 6));
+        });
+    });
 }
 
 #[test]
@@ -363,6 +516,19 @@ fn configured_depth_changes_edge_on_width() {
 fn custom_shapes_preserve_their_authored_cell_aspect() {
     assert_eq!(fitted_logo_size(PANEL_SIZE, 1.0), Some((17, 17)));
     assert_eq!(fitted_logo_size(PANEL_SIZE, 9.0 / 5.0), Some((31, 17)));
+}
+
+#[test]
+fn extreme_ascii_aspect_ratios_clamp_to_a_visible_minimum() {
+    let wide = custom_config(&"#".repeat(128), 4.0, 0.18);
+    let tall = custom_config(&"#\n".repeat(64), 4.0, 0.18);
+
+    assert_eq!(fitted_logo_size(PANEL_SIZE, 128.0), Some((50, 5)));
+    assert_eq!(fitted_logo_size(PANEL_SIZE, 1.0 / 64.0), Some((5, 17)));
+    for config in [wide, tall] {
+        let frame = object_frame_at(Duration::ZERO, PANEL_SIZE, &config).unwrap();
+        assert!(!logo_cells(&frame).is_empty());
+    }
 }
 
 #[test]

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -1,10 +1,86 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
-use warpui_core::elements::tui::TuiSize;
+use tempfile::TempDir;
+use warp::settings::TuiZeroStateObject;
+use warpui_core::elements::animation::AnimationClock;
+use warpui_core::elements::tui::{TuiBufferExt, TuiElement, TuiRect, TuiSize, TuiStyle};
+use warpui_core::presenter::tui::TuiPresenter;
+use warpui_core::{AddWindowOptions, App, AppContext, Entity, TuiView, TypedActionView};
 
-use super::{LogoSurface, fitted_logo_size, logo_frame_at, warp_logo_contains};
+use super::config::{
+    AsciiArtError, AsciiArtMask, ZeroStateAnimationConfig, ZeroStateShape, resolve_ascii_art_path,
+};
+use super::{
+    BUILT_IN_LOGO_CELL_ASPECT_RATIO, LogoCell, LogoSurface, WarpLogoStyles,
+    ZeroStateAnimationElement, fitted_logo_size, logo_frame_at, object_frame_at,
+    warp_logo_contains,
+};
 
 const PANEL_SIZE: TuiSize = TuiSize::new(52, 20);
+const DIAMOND_ART: &str = "   #\n  ###\n #####\n  ###\n   #\n";
+const ROCKET_ART: &str = "    #\n   ###\n  ####\n #####\n   ###\n  #  #\n";
+const WARP_W_ART: &str = "#       #\n#       #\n#   #   #\n#  # #  #\n ##   ##\n";
+
+fn custom_config(
+    art: &str,
+    rotation_period_secs: f64,
+    extrusion_depth: f64,
+) -> ZeroStateAnimationConfig {
+    ZeroStateAnimationConfig {
+        shape: Arc::new(ZeroStateShape::Ascii(AsciiArtMask::parse(art).unwrap())),
+        rotation_period: Duration::from_secs_f64(rotation_period_secs),
+        extrusion_depth,
+    }
+}
+
+fn logo_cells(frame: &super::LogoFrame) -> Vec<(usize, usize, LogoCell)> {
+    frame
+        .iter_cells()
+        .filter(|(_, _, cell)| cell.surface != LogoSurface::Background)
+        .collect()
+}
+
+fn write_art(config_dir: &Path, relative_path: &str, art: &str) -> PathBuf {
+    let path = config_dir.join(relative_path);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, art).unwrap();
+    path
+}
+
+struct AnimationTestView {
+    config: Arc<ZeroStateAnimationConfig>,
+}
+
+impl Entity for AnimationTestView {
+    type Event = ();
+}
+
+impl TypedActionView for AnimationTestView {
+    type Action = ();
+}
+
+impl TuiView for AnimationTestView {
+    fn ui_name() -> &'static str {
+        "AnimationTestView"
+    }
+
+    fn render(&self, _ctx: &AppContext) -> Box<dyn TuiElement> {
+        let style = TuiStyle::default();
+        ZeroStateAnimationElement::new(
+            AnimationClock::starting_at(Duration::ZERO),
+            self.config.clone(),
+            WarpLogoStyles {
+                front: style,
+                back: style,
+                side: style,
+                background: style,
+            },
+        )
+        .finish()
+    }
+}
 
 #[test]
 fn logo_mask_preserves_the_offset_warp_faces() {
@@ -107,12 +183,213 @@ fn one_revolution_returns_to_the_initial_frame() {
 
 #[test]
 fn logo_scales_down_while_preserving_cell_aspect() {
-    assert_eq!(fitted_logo_size(TuiSize::new(100, 40)), Some((42, 17)));
-    assert_eq!(fitted_logo_size(TuiSize::new(30, 12)), Some((25, 10)));
+    assert_eq!(
+        fitted_logo_size(TuiSize::new(100, 40), BUILT_IN_LOGO_CELL_ASPECT_RATIO),
+        Some((42, 17))
+    );
+    assert_eq!(
+        fitted_logo_size(TuiSize::new(30, 12), BUILT_IN_LOGO_CELL_ASPECT_RATIO),
+        Some((25, 10))
+    );
 }
 
 #[test]
 fn animation_is_hidden_when_the_panel_is_too_small() {
     assert!(logo_frame_at(Duration::ZERO, TuiSize::new(17, 20)).is_none());
     assert!(logo_frame_at(Duration::ZERO, TuiSize::new(30, 6)).is_none());
+}
+
+#[test]
+fn ascii_parser_normalizes_crlf_trims_borders_and_pads_ragged_rows() {
+    let mask =
+        AsciiArtMask::parse("\r\n     \r\n   #\r\n  ###\r\n #####\r\n  ##\r\n     \r\n").unwrap();
+
+    assert_eq!(mask.size(), (5, 4));
+    let shape = ZeroStateShape::Ascii(mask);
+    assert!(shape.contains(0.0, -1.0));
+    assert!(shape.contains(-0.5, 0.5));
+    assert!(!shape.contains(1.0, 1.0));
+}
+
+#[test]
+fn representative_ascii_fixtures_have_distinct_dimensions() {
+    assert_eq!(AsciiArtMask::parse(DIAMOND_ART).unwrap().size(), (5, 5));
+    assert_eq!(AsciiArtMask::parse(ROCKET_ART).unwrap().size(), (5, 6));
+    assert_eq!(AsciiArtMask::parse(WARP_W_ART).unwrap().size(), (9, 5));
+}
+
+#[test]
+fn ascii_parser_rejects_invalid_empty_and_oversized_input() {
+    assert!(matches!(
+        AsciiArtMask::parse("\t#"),
+        Err(AsciiArtError::InvalidCharacter)
+    ));
+    assert!(matches!(
+        AsciiArtMask::parse("é"),
+        Err(AsciiArtError::InvalidCharacter)
+    ));
+    assert!(matches!(
+        AsciiArtMask::parse("  \n  \n"),
+        Err(AsciiArtError::Empty)
+    ));
+    assert!(matches!(
+        AsciiArtMask::parse(&"#".repeat(129)),
+        Err(AsciiArtError::TooManyColumns { .. })
+    ));
+    assert!(matches!(
+        AsciiArtMask::parse(&"#\n".repeat(65)),
+        Err(AsciiArtError::TooManyRows { .. })
+    ));
+    assert!(matches!(
+        AsciiArtMask::parse(&" ".repeat(65 * 1024)),
+        Err(AsciiArtError::TooLarge { .. })
+    ));
+}
+
+#[test]
+fn relative_ascii_paths_resolve_from_the_tui_config_directory() {
+    let config_dir = Path::new("/tmp/warp-tui-config");
+    assert_eq!(
+        resolve_ascii_art_path(Path::new("logos/diamond.txt"), config_dir),
+        config_dir.join("logos/diamond.txt")
+    );
+    assert_eq!(
+        resolve_ascii_art_path(Path::new("/tmp/rocket.txt"), config_dir),
+        PathBuf::from("/tmp/rocket.txt")
+    );
+}
+
+#[test]
+fn startup_loader_reads_relative_ascii_art_and_retains_motion_settings() {
+    let temp_dir = TempDir::new().unwrap();
+    write_art(temp_dir.path(), "logos/rocket.txt", ROCKET_ART);
+    let config = ZeroStateAnimationConfig::load(
+        &TuiZeroStateObject::AsciiFile {
+            path: PathBuf::from("logos/rocket.txt"),
+        },
+        3.5,
+        0.3,
+        temp_dir.path(),
+    );
+
+    assert_eq!(config.rotation_period, Duration::from_secs_f64(3.5));
+    assert_eq!(config.extrusion_depth, 0.3);
+    let ZeroStateShape::Ascii(mask) = config.shape.as_ref() else {
+        panic!("valid custom art should produce an ASCII shape");
+    };
+    assert_eq!(mask.size(), (5, 6));
+}
+
+#[test]
+fn startup_loader_falls_back_for_missing_or_invalid_art_only() {
+    let temp_dir = TempDir::new().unwrap();
+    write_art(temp_dir.path(), "invalid.txt", "\tinvalid");
+    for path in ["missing.txt", "invalid.txt"] {
+        let config = ZeroStateAnimationConfig::load(
+            &TuiZeroStateObject::AsciiFile {
+                path: PathBuf::from(path),
+            },
+            7.0,
+            0.4,
+            temp_dir.path(),
+        );
+
+        assert!(matches!(config.shape.as_ref(), ZeroStateShape::BuiltInWarp));
+        assert_eq!(config.rotation_period, Duration::from_secs(7));
+        assert_eq!(config.extrusion_depth, 0.4);
+    }
+}
+
+#[test]
+fn representative_ascii_shapes_rotate_through_front_side_and_back() {
+    for art in [DIAMOND_ART, ROCKET_ART, WARP_W_ART] {
+        let config = custom_config(art, 4.0, 0.18);
+        let face = object_frame_at(Duration::ZERO, PANEL_SIZE, &config).unwrap();
+        let edge = object_frame_at(Duration::from_secs(1), PANEL_SIZE, &config).unwrap();
+        let back = object_frame_at(Duration::from_secs(2), PANEL_SIZE, &config).unwrap();
+
+        assert!(logo_cells(&face).len() > 20);
+        assert!(
+            edge.iter_cells()
+                .any(|(_, _, cell)| cell.surface == LogoSurface::Side)
+        );
+        assert!(
+            back.iter_cells()
+                .all(|(_, _, cell)| cell.surface != LogoSurface::Front)
+        );
+        assert!(
+            back.iter_cells()
+                .any(|(_, _, cell)| cell.surface == LogoSurface::Back)
+        );
+        assert_ne!(logo_cells(&face), logo_cells(&edge));
+    }
+}
+
+#[test]
+fn configured_period_controls_phase_and_repeats_exactly() {
+    let four_seconds = custom_config(ROCKET_ART, 4.0, 0.18);
+    let eight_seconds = custom_config(ROCKET_ART, 8.0, 0.18);
+    let four_second_quarter =
+        object_frame_at(Duration::from_secs(1), PANEL_SIZE, &four_seconds).unwrap();
+    let eight_second_quarter =
+        object_frame_at(Duration::from_secs(2), PANEL_SIZE, &eight_seconds).unwrap();
+    let revolved = object_frame_at(Duration::from_secs(4), PANEL_SIZE, &four_seconds).unwrap();
+    let initial = object_frame_at(Duration::ZERO, PANEL_SIZE, &four_seconds).unwrap();
+
+    assert_eq!(
+        logo_cells(&four_second_quarter),
+        logo_cells(&eight_second_quarter)
+    );
+    assert_eq!(logo_cells(&initial), logo_cells(&revolved));
+}
+
+#[test]
+fn configured_depth_changes_edge_on_width() {
+    let shallow = custom_config(DIAMOND_ART, 4.0, 0.02);
+    let deep = custom_config(DIAMOND_ART, 4.0, 0.5);
+    let shallow = object_frame_at(Duration::from_secs(1), PANEL_SIZE, &shallow).unwrap();
+    let deep = object_frame_at(Duration::from_secs(1), PANEL_SIZE, &deep).unwrap();
+    let horizontal_span = |frame: &super::LogoFrame| {
+        let cells = logo_cells(frame);
+        let min = cells.iter().map(|(x, _, _)| *x).min().unwrap();
+        let max = cells.iter().map(|(x, _, _)| *x).max().unwrap();
+        max - min + 1
+    };
+
+    assert!(horizontal_span(&deep) > horizontal_span(&shallow));
+}
+
+#[test]
+fn custom_shapes_preserve_their_authored_cell_aspect() {
+    assert_eq!(fitted_logo_size(PANEL_SIZE, 1.0), Some((17, 17)));
+    assert_eq!(fitted_logo_size(PANEL_SIZE, 9.0 / 5.0), Some((31, 17)));
+}
+
+#[test]
+fn custom_animation_element_paints_and_requests_another_frame() {
+    App::test((), |mut app| async move {
+        let config = Arc::new(custom_config(WARP_W_ART, 4.0, 0.18));
+        let (_, view) = app.update(|ctx| {
+            ctx.add_tui_window(AddWindowOptions::default(), move |_| AnimationTestView {
+                config,
+            })
+        });
+        let mut presenter = TuiPresenter::new();
+        let frame = app.update(|ctx| {
+            presenter.present(
+                ctx,
+                &view,
+                TuiRect::new(0, 0, PANEL_SIZE.width, PANEL_SIZE.height),
+            )
+        });
+
+        assert!(
+            frame
+                .buffer
+                .to_lines()
+                .iter()
+                .any(|line| line.chars().any(|character| character != ' '))
+        );
+        assert!(frame.repaint_at.is_some());
+    });
 }

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -1,174 +1,118 @@
-use super::{
-    StarfieldState, WARP_INITIAL, WARP_TARGET, star_count_for_max_r, warp_at, xorshift_f64,
-    xorshift64,
-};
+use std::time::Duration;
 
-// ---------------------------------------------------------------------------
-// xorshift64 PRNG
-// ---------------------------------------------------------------------------
+use warpui_core::elements::tui::TuiSize;
+
+use super::{LogoSurface, fitted_logo_size, logo_frame_at, warp_logo_contains};
+
+const PANEL_SIZE: TuiSize = TuiSize::new(52, 20);
 
 #[test]
-fn xorshift64_is_deterministic() {
-    let mut s = 0xDEAD_BEEF_CAFE_1234_u64;
-    let a = xorshift64(&mut s);
-    let mut s2 = 0xDEAD_BEEF_CAFE_1234_u64;
-    let b = xorshift64(&mut s2);
-    assert_eq!(a, b);
+fn logo_mask_preserves_the_offset_warp_faces() {
+    assert!(warp_logo_contains(0.25, -0.65));
+    assert!(warp_logo_contains(-0.55, 0.45));
+    assert!(!warp_logo_contains(-0.85, -0.85));
+    assert!(!warp_logo_contains(0.0, 0.9));
 }
 
 #[test]
-fn xorshift64_produces_different_values_sequentially() {
-    let mut s = 12345_u64;
-    let a = xorshift64(&mut s);
-    let b = xorshift64(&mut s);
-    assert_ne!(a, b, "sequential xorshift64 calls should differ");
-}
+fn full_face_frame_is_recognizable_and_centered() {
+    let frame = logo_frame_at(Duration::ZERO, PANEL_SIZE).unwrap();
+    let lines = frame.to_lines();
+    let occupied = frame.iter_cells().count();
 
-#[test]
-fn xorshift_f64_stays_in_unit_interval() {
-    let mut s = 0xABCD_EF01_u64;
-    for _ in 0..10_000 {
-        let v = xorshift_f64(&mut s);
-        assert!((0.0..1.0).contains(&v), "xorshift_f64 out of [0,1): {v}");
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Warp spring (analytical solution)
-// ---------------------------------------------------------------------------
-
-#[test]
-fn warp_at_zero_equals_initial() {
-    // At t=0 the spring has not moved yet.
-    let w = warp_at(0.0);
     assert!(
-        (w - WARP_INITIAL).abs() < 1e-9,
-        "warp_at(0) = {w}, expected {WARP_INITIAL}"
+        (90..220).contains(&occupied),
+        "expected a sparse logo outline, got {occupied} cells"
     );
-}
-
-#[test]
-fn warp_at_large_t_converges_to_target() {
-    // After 30 seconds the spring is essentially settled.
-    let w = warp_at(30.0);
     assert!(
-        (w - WARP_TARGET).abs() < 1e-4,
-        "warp_at(30) = {w}, should be ≈ {WARP_TARGET}"
+        frame
+            .iter_cells()
+            .filter(|(_, _, cell)| cell.surface != LogoSurface::Background)
+            .all(|(_, y, _)| y > 0 && y < usize::from(PANEL_SIZE.height) - 1)
     );
+    assert!(lines.iter().any(|line| line.contains("------")));
+    assert!(lines.iter().any(|line| line.contains('.')));
+    assert!(lines.iter().all(|line| !line.contains(['█', '▓', '▒'])));
 }
-
 #[test]
-fn warp_increases_monotonically_through_ramp() {
-    // Sample at 0.5s intervals; warp should be strictly increasing during
-    // the ramp phase (first ~5 seconds).
-    let mut prev = warp_at(0.0);
-    for i in 1..10 {
-        let t = i as f64 * 0.5;
-        let w = warp_at(t);
-        assert!(
-            w > prev,
-            "warp should increase: warp_at({t}) = {w} ≤ prev {prev}"
-        );
-        prev = w;
-    }
-}
-
-#[test]
-fn warp_stays_above_initial_and_below_ceiling() {
-    for i in 0..1000 {
-        let t = i as f64 * 0.05;
-        let w = warp_at(t);
-        assert!(
-            ((WARP_INITIAL - 0.01)..=(WARP_TARGET + 0.1)).contains(&w),
-            "warp_at({t}) = {w} out of allowed range"
-        );
-    }
-}
-
-// ---------------------------------------------------------------------------
-// StarfieldState
-// ---------------------------------------------------------------------------
-
-#[test]
-fn starfield_state_initializes_with_correct_star_count() {
-    let sf = StarfieldState::new();
-    assert_eq!(sf.stars.len(), super::NUM_STARS);
-}
-
-#[test]
-fn starfield_state_stars_start_near_centre() {
-    let sf = StarfieldState::new();
-    let init_max_r = 62.5_f64;
-    for (i, star) in sf.stars.iter().enumerate() {
-        assert!(
-            star.r <= init_max_r * 0.15 + 1e-9,
-            "star[{i}].r = {} exceeds init range",
-            star.r
-        );
-    }
-}
-
-#[test]
-fn starfield_state_star_speeds_in_range() {
-    let sf = StarfieldState::new();
-    for (i, star) in sf.stars.iter().enumerate() {
-        assert!(
-            star.speed >= 0.5 && star.speed <= 1.5,
-            "star[{i}].speed = {} out of [0.5, 1.5]",
-            star.speed
-        );
-    }
-}
-
-#[test]
-fn starfield_simulate_advances_stars_outward() {
-    let mut sf = StarfieldState::new();
-    let initial_r: Vec<f64> = sf.stars.iter().map(|s| s.r).collect();
-    sf.simulate_to(1.0); // 1 real second → ~60 sim steps
-    let advanced = sf
-        .stars
-        .iter()
-        .zip(&initial_r)
-        .filter(|(star, r0)| star.r > **r0)
+fn background_starfield_stays_low_density() {
+    let frame = logo_frame_at(Duration::ZERO, PANEL_SIZE).unwrap();
+    let stars = frame
+        .iter_cells()
+        .filter(|(_, _, cell)| cell.surface == LogoSurface::Background)
         .count();
-    // At least 90% of stars should have moved outward.
+
     assert!(
-        advanced > super::NUM_STARS * 9 / 10,
-        "only {advanced}/{} stars moved outward",
-        super::NUM_STARS
+        (12..=36).contains(&stars),
+        "expected a subtle background starfield, got {stars} visible stars"
     );
 }
 
 #[test]
-fn starfield_stars_reset_when_they_leave_screen() {
-    let mut sf = StarfieldState::new();
-    // Override max_r to something tiny so stars leave immediately.
-    let tiny_max_r = 5.0;
-    sf.set_dimensions(tiny_max_r, star_count_for_max_r(tiny_max_r));
-    sf.simulate_to(5.0); // 5 seconds
-    // All stars should be back near centre (r < tiny_max_r).
-    for (i, star) in sf.stars.iter().enumerate() {
-        assert!(
-            star.r < tiny_max_r,
-            "star[{i}].r = {} should be < max_r = {tiny_max_r}",
-            star.r,
-        );
-    }
+fn background_stars_move_between_frames() {
+    let initial = logo_frame_at(Duration::ZERO, PANEL_SIZE).unwrap();
+    let advanced = logo_frame_at(Duration::from_millis(700), PANEL_SIZE).unwrap();
+    let star_positions = |frame: &super::LogoFrame| {
+        frame
+            .iter_cells()
+            .filter_map(|(x, y, cell)| (cell.surface == LogoSurface::Background).then_some((x, y)))
+            .collect::<Vec<_>>()
+    };
+
+    assert_ne!(star_positions(&initial), star_positions(&advanced));
 }
 
 #[test]
-fn starfield_simulate_is_deterministic_for_same_duration() {
-    // Two independent state machines simulated to the same target should agree.
-    let mut sf1 = StarfieldState::new();
-    let mut sf2 = StarfieldState::new();
-    sf1.simulate_to(2.0);
-    sf2.simulate_to(2.0);
-    for (i, (s1, s2)) in sf1.stars.iter().zip(sf2.stars.iter()).enumerate() {
-        assert!(
-            (s1.r - s2.r).abs() < 1e-9,
-            "star[{i}].r diverged: {:.6} vs {:.6}",
-            s1.r,
-            s2.r
-        );
-    }
+fn quarter_turn_is_narrower_and_exposes_the_side() {
+    let face = logo_frame_at(Duration::ZERO, PANEL_SIZE).unwrap();
+    let edge = logo_frame_at(Duration::from_millis(1250), PANEL_SIZE).unwrap();
+
+    assert!(edge.iter_cells().count() < face.iter_cells().count());
+    assert!(
+        edge.iter_cells()
+            .any(|(_, _, cell)| cell.surface == LogoSurface::Side)
+    );
+    assert_ne!(face.to_lines(), edge.to_lines());
+}
+
+#[test]
+fn half_turn_exposes_the_back_face() {
+    let frame = logo_frame_at(Duration::from_millis(2500), PANEL_SIZE).unwrap();
+
+    assert!(
+        frame
+            .iter_cells()
+            .all(|(_, _, cell)| cell.surface != LogoSurface::Front)
+    );
+    assert!(
+        frame
+            .iter_cells()
+            .any(|(_, _, cell)| cell.surface == LogoSurface::Back)
+    );
+}
+
+#[test]
+fn one_revolution_returns_to_the_initial_frame() {
+    let initial = logo_frame_at(Duration::ZERO, PANEL_SIZE).unwrap();
+    let revolved = logo_frame_at(Duration::from_secs(5), PANEL_SIZE).unwrap();
+    let logo_cells = |frame: &super::LogoFrame| {
+        frame
+            .iter_cells()
+            .filter(|(_, _, cell)| cell.surface != LogoSurface::Background)
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(logo_cells(&initial), logo_cells(&revolved));
+}
+
+#[test]
+fn logo_scales_down_while_preserving_cell_aspect() {
+    assert_eq!(fitted_logo_size(TuiSize::new(100, 40)), Some((42, 17)));
+    assert_eq!(fitted_logo_size(TuiSize::new(30, 12)), Some((25, 10)));
+}
+
+#[test]
+fn animation_is_hidden_when_the_panel_is_too_small() {
+    assert!(logo_frame_at(Duration::ZERO, TuiSize::new(17, 20)).is_none());
+    assert!(logo_frame_at(Duration::ZERO, TuiSize::new(30, 6)).is_none());
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Revamps the Warp Agent CLI zero state with a responsive, customizable ASCII animation.

### Animation

- Renders the built-in Warp logo as a ghosted 3D wireframe with deterministic front, back, side, and stipple layers over a moving starfield.
- Keeps animation state paint-only so rotation remains continuous across rerenders, resizes, and object changes.
- Uses the full available terminal width instead of stopping at a fixed panel/object cap.
- Scales star density with the full panel area using overflow-safe arithmetic while retaining a subtle minimum density on small terminals.
- Preserves each custom object’s authored aspect ratio and applies configurable extrusion depth.

### Customization

Adds local, non-synced settings under `appearance.zero_state` in the Warp Agent CLI settings file:

- `object`: use the built-in Warp logo or load an ASCII-art file.
- `rotation_period_seconds`: configure a 1–60 second revolution period.
- `extrusion_depth`: configure normalized half-depth from 0.02–0.5.

Relative art paths resolve from the Warp Agent CLI settings directory. Input is limited to printable ASCII/newlines, 128 columns, 64 rows, and 64 KiB, and must contain at least one occupied cell.

For the initial hot-reload scope, changing `object`/`object.path` reloads the shape without resetting rotation phase. Editing the currently linked file or changing motion settings still requires restarting Warp Agent CLI.

### Failure handling

- Invalid startup art falls back to the built-in Warp logo.
- Invalid replacement art retains the last valid object.
- Load and reload failures show a temporary error-colored footer message.
- Detailed paths and parser/I/O errors remain in safe logs rather than user-facing text.

## Linked Issue

None; this is a Warp Agent CLI visual customization prototype.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] Manually tested custom cat, rocket, and profile art with `./script/run-tui`.
- [x] Rebuilt the Warp Agent CLI, generated its 209-setting schema, prepared bundled resources, and codesigned the local binary with `./script/run-tui` after the final iteration.
- [x] `cargo nextest run -p warp_tui` — 592 tests passed.
- [x] Focused zero-state and transient-footer tests — 35 tests passed.
- [x] Added a 200-column render regression covering the former width cap.
- [x] Added startup- and reload-failure footer state/color coverage.
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`.
- [x] `./script/format` and `git diff --check`.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Visual iterations and local demo validation are documented in the [Warp Agent conversation](https://staging.warp.dev/conversation/ed5b6602-e17d-44ed-bfa6-18904ca1a518).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a customizable rotating ASCII zero state with responsive starfield rendering to Warp Agent CLI.

Co-Authored-By: Warp <agent@warp.dev>
