### PR TITLE
Protect running TUI versions during auto-update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15974,6 +15974,7 @@ dependencies = [
  "clap",
  "command",
  "dirs 6.0.0",
+ "fs4",
  "futures",
  "futures-lite 1.13.0",
  "http_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ font-kit = { git = "https://github.com/warpdotdev/font-kit", rev = "a04b225ecb63
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
 futures-lite = "1.13.0"
 futures-util = { version = "0.3", default-features = false }
+fs4 = { version = "0.13.1", features = ["sync"] }
 get-size = { version = "0.1.4", features = ["derive"] }
 globset = "0.4.18"
 gloo = { version = "0.11.0", default-features = false, features = [

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -45,6 +45,7 @@ command.workspace = true
 dirs.workspace = true
 futures.workspace = true
 futures-lite.workspace = true
+fs4.workspace = true
 http_client.workspace = true
 instant.workspace = true
 itertools.workspace = true

--- a/crates/warp_tui/src/autoupdate.rs
+++ b/crates/warp_tui/src/autoupdate.rs
@@ -15,9 +15,9 @@
 //! request), downloads newer builds from the server's `/download/agent-cli`
 //! endpoint, stages them into `versions/<version>`, and atomically retargets
 //! the `current` symlink. The running session is never touched — the new
-//! version is picked up on the next launch. In particular, the updater never
-//! deletes the version directory the current process is executing from
-//! (removing a running binary breaks child-process spawning).
+//! version is picked up on the next launch. Managed processes hold shared
+//! per-version leases for their lifetime, and cleanup only removes inactive
+//! versions whose lease can be locked exclusively.
 //!
 //! Background updates only run for managed installs (i.e. when the running
 //! executable resolves into a `versions/` directory), so `cargo run` builds
@@ -26,16 +26,18 @@
 //! `WARP_TUI_DISABLE_AUTOUPDATE` environment variable; re-running the
 //! install script remains available as a manual escape hatch.
 
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context as _, Result, bail};
 use channel_versions::{ChannelVersions, ParsedVersion};
-use futures::{StreamExt as _, TryStreamExt as _};
+use futures::TryStreamExt as _;
 use warp::settings::TuiAutoupdateSettings;
 use warp_core::channel::{Channel, ChannelState};
-use warp_core::send_telemetry_from_ctx;
+use warp_core::{safe_warn, send_telemetry_from_ctx};
 use warpui::r#async::Timer;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
@@ -51,10 +53,16 @@ const VERSIONS_DIR_NAME: &str = "versions";
 
 /// Name of the symlink under the install root pointing at the active version.
 const CURRENT_LINK_NAME: &str = "current";
+/// Directory under the install root holding stable per-version lease files.
+const VERSION_LEASES_DIR_NAME: &str = "version-leases";
 
-/// Lock file under the install root serializing installs across concurrent
-/// TUI processes.
+/// Atomic directory lock under the install root serializing finalization,
+/// current-pointer changes, and garbage collection across Rust and shell
+/// installers.
 const LOCK_FILE_NAME: &str = ".update.lock";
+
+/// Debug metadata written inside [`LOCK_FILE_NAME`].
+const LOCK_OWNER_FILE_NAME: &str = "owner";
 
 /// How often to check for updates. Mirrors the GUI autoupdater's poll
 /// interval (`AutoupdateState::AUTOUPDATE_POLL`); each check is a single
@@ -71,6 +79,10 @@ const FETCH_VERSIONS_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Timeout for downloading the TUI tarball itself.
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+/// Disambiguates generated staging paths and install-lock owner tokens when
+/// their process ID and timestamp components happen to match.
+static NEXT_UNIQUE_ID: AtomicU64 = AtomicU64::new(0);
+const MAX_STAGING_DIR_ATTEMPTS: usize = 100;
 
 /// The managed, versioned install layout the running binary belongs to.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -92,8 +104,12 @@ impl InstallLayout {
     /// Returns `None` when the binary isn't inside a `versions/<version>/`
     /// directory (e.g. `cargo run` builds or legacy flat installs).
     fn detect() -> Option<Self> {
-        let exe = std::env::current_exe().ok()?.canonicalize().ok()?;
-        Self::from_canonical_exe_path(&exe)
+        let exe = std::env::current_exe().ok()?;
+        // Fall back to the kernel-reported path if canonicalization loses a
+        // startup race with GC. Its `versions/<version>` shape still proves
+        // this is managed, so lease validation must fail closed.
+        let canonical_exe = exe.canonicalize().unwrap_or(exe);
+        Self::from_canonical_exe_path(&canonical_exe)
     }
 
     /// Builds the layout from an already-canonicalized executable path of the
@@ -113,6 +129,71 @@ impl InstallLayout {
             running_version_dir,
             binary_name,
         })
+    }
+}
+
+fn version_lease_path(root: &Path, version: &OsStr) -> PathBuf {
+    let mut lease_name = version.to_os_string();
+    lease_name.push(".lock");
+    root.join(VERSION_LEASES_DIR_NAME).join(lease_name)
+}
+
+fn open_version_lease(root: &Path, version: &OsStr) -> Result<fs::File> {
+    let lease_dir = root.join(VERSION_LEASES_DIR_NAME);
+    fs::create_dir_all(&lease_dir)
+        .with_context(|| format!("failed to create TUI version lease directory {lease_dir:?}"))?;
+    let lease_path = version_lease_path(root, version);
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lease_path)
+        .with_context(|| format!("failed to open TUI version lease {lease_path:?}"))
+}
+
+/// A process-lifetime shared lease protecting one managed version directory
+/// from garbage collection. Dropping the file releases the OS lock.
+pub(crate) struct VersionLease {
+    _file: fs::File,
+}
+
+impl VersionLease {
+    /// Acquires a lease for the version containing the running executable.
+    /// Unmanaged Cargo builds and legacy flat installs do not participate.
+    pub(crate) fn acquire_for_current_process() -> Result<Option<Self>> {
+        InstallLayout::detect()
+            .map(|layout| {
+                Self::acquire(&layout)
+                    .context(
+                        "failed to protect this managed Warp Agent CLI version; retry the \
+                         command, or reinstall Warp Agent CLI if the problem persists",
+                    )
+                    .map(Some)
+            })
+            .unwrap_or(Ok(None))
+    }
+
+    /// Acquires and validates the running version's shared lease.
+    fn acquire(layout: &InstallLayout) -> Result<Self> {
+        let version = layout
+            .running_version_dir
+            .file_name()
+            .context("managed TUI version directory has no version name")?;
+        let lease_path = version_lease_path(&layout.root, version);
+        let file = open_version_lease(&layout.root, version)?;
+        fs4::fs_std::FileExt::lock_shared(&file)
+            .with_context(|| format!("failed to acquire TUI version lease {lease_path:?}"))?;
+
+        if !is_complete_version_dir(layout, &layout.running_version_dir) {
+            bail!(
+                "the managed Warp Agent CLI version at {:?} was retired while this process was \
+                 starting; retry the command, or reinstall Warp Agent CLI if the problem persists",
+                layout.running_version_dir
+            );
+        }
+
+        Ok(Self { _file: file })
     }
 }
 
@@ -298,16 +379,11 @@ impl TuiAutoupdater {
                 Ok(CheckDecision::Settled(outcome)) => {
                     me.finish_check(Ok(outcome), fallback_status, layout, ctx);
                 }
-                Ok(CheckDecision::NeedsInstall {
-                    latest_version,
-                    already_staged,
-                }) => {
+                Ok(CheckDecision::NeedsInstall { latest_version }) => {
                     me.set_status(TuiAutoupdateStatus::Updating, ctx);
                     let install_layout = layout.clone();
                     ctx.spawn(
-                        async move {
-                            install_update(install_layout, latest_version, already_staged).await
-                        },
+                        async move { install_update(install_layout, latest_version).await },
                         move |me, result, ctx| {
                             me.finish_check(result, fallback_status, layout, ctx);
                         },
@@ -389,12 +465,7 @@ enum CheckDecision {
     /// Nothing to install; the pass is complete with this outcome.
     Settled(UpdateOutcome),
     /// A newer version needs the install phase ([`install_update`]).
-    NeedsInstall {
-        latest_version: String,
-        /// A previous check already staged this version's directory; only
-        /// the `current` symlink still needs retargeting.
-        already_staged: bool,
-    },
+    NeedsInstall { latest_version: String },
 }
 
 /// Performs the check phase of an update pass: a single lightweight
@@ -431,47 +502,103 @@ async fn check_for_update(layout: InstallLayout) -> Result<CheckDecision> {
         bail!("refusing to overwrite the running version directory {version_dir:?}");
     }
 
-    // If a previous check already staged this version and pointed `current`
-    // at it, there is nothing left to do until the user restarts. Like the
-    // staging validation, don't treat a symlinked binary as staged.
-    let already_staged = fs::symlink_metadata(version_dir.join(&layout.binary_name))
-        .is_ok_and(|metadata| metadata.file_type().is_file());
-    if already_staged && current_points_at(&layout, &latest_version) {
-        return Ok(CheckDecision::Settled(UpdateOutcome::PendingRestart {
-            version: latest_version,
-        }));
+    // Errors from this check abort only the current background update pass.
+    // `finish_check` restores the previous status and schedules the next poll.
+    match version_dir_state(&layout, &version_dir)? {
+        VersionDirState::Complete if current_points_at(&layout, &latest_version) => {
+            return Ok(CheckDecision::Settled(UpdateOutcome::PendingRestart {
+                version: latest_version,
+            }));
+        }
+        VersionDirState::Invalid => {
+            bail!(
+                "refusing to replace incomplete or invalid installed TUI version at \
+                 {version_dir:?}; remove that directory or reinstall Warp Agent CLI, then retry"
+            );
+        }
+        VersionDirState::Complete | VersionDirState::Missing => {}
     }
 
-    Ok(CheckDecision::NeedsInstall {
-        latest_version,
-        already_staged,
-    })
+    Ok(CheckDecision::NeedsInstall { latest_version })
 }
 
-/// Performs the install phase of an update pass: downloads and stages
-/// `latest_version` (unless already staged) and retargets `current` at it.
-async fn install_update(
-    layout: InstallLayout,
-    latest_version: String,
-    already_staged: bool,
-) -> Result<UpdateOutcome> {
-    // Serialize installs across concurrent TUI processes.
-    let Some(_lock) = InstallLock::acquire(&layout.root)? else {
-        return Ok(UpdateOutcome::Locked);
+/// Performs the install phase of an update pass. Download and extraction
+/// happen without the global install lock; only immutable finalization,
+/// activation, and garbage collection are serialized.
+async fn install_update(layout: InstallLayout, latest_version: String) -> Result<UpdateOutcome> {
+    let version_dir = layout.versions_dir.join(&latest_version);
+    let staged = match version_dir_state(&layout, &version_dir)? {
+        VersionDirState::Complete => None,
+        VersionDirState::Missing => {
+            let client = http_client::Client::new();
+            Some(download_update(&layout, &client, &latest_version).await?)
+        }
+        VersionDirState::Invalid => {
+            bail!(
+                "refusing to replace incomplete or invalid installed TUI version at \
+                 {version_dir:?}; remove that directory or reinstall Warp Agent CLI, then retry"
+            );
+        }
     };
+    blocking::unblock(move || {
+        let Some(_lock) = InstallLock::acquire(&layout.root)? else {
+            return Ok(UpdateOutcome::Locked);
+        };
+        // Another installer may have completed this exact immutable version
+        // while this process downloaded, so recheck under the install lock.
+        match version_dir_state(&layout, &version_dir)? {
+            VersionDirState::Complete => {}
+            VersionDirState::Missing => {
+                let staged = staged.context(
+                    "the completed TUI version disappeared before activation; retry the update",
+                )?;
+                finalize_staged_version(&layout, &latest_version, staged, &version_dir)?;
+            }
+            VersionDirState::Invalid => {
+                bail!(
+                    "refusing to replace incomplete or invalid installed TUI version at \
+                     {version_dir:?}; remove that directory or reinstall Warp Agent CLI, then retry"
+                );
+            }
+        }
 
-    if !already_staged {
-        let client = http_client::Client::new();
-        let version_dir = layout.versions_dir.join(&latest_version);
-        download_and_stage(&layout, &client, &latest_version, &version_dir).await?;
-    }
+        point_current_at(&layout, &latest_version)?;
+        prune_old_versions(&layout, &latest_version);
 
-    point_current_at(&layout, &latest_version)?;
-    prune_old_versions(&layout, &latest_version).await;
-
-    Ok(UpdateOutcome::Installed {
-        version: latest_version,
+        Ok(UpdateOutcome::Installed {
+            version: latest_version,
+        })
     })
+    .await
+}
+
+/// State of an immutable final version path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VersionDirState {
+    Missing,
+    Complete,
+    Invalid,
+}
+
+/// A complete version is a real directory containing the expected regular
+/// binary and a real `resources/` directory. Symlinks never satisfy these
+/// checks.
+fn is_complete_version_dir(layout: &InstallLayout, version_dir: &Path) -> bool {
+    fs::symlink_metadata(version_dir).is_ok_and(|metadata| metadata.file_type().is_dir())
+        && fs::symlink_metadata(version_dir.join(&layout.binary_name))
+            .is_ok_and(|metadata| metadata.file_type().is_file())
+        && fs::symlink_metadata(version_dir.join("resources"))
+            .is_ok_and(|metadata| metadata.file_type().is_dir())
+}
+
+fn version_dir_state(layout: &InstallLayout, version_dir: &Path) -> Result<VersionDirState> {
+    match fs::symlink_metadata(version_dir) {
+        Ok(_) if is_complete_version_dir(layout, version_dir) => Ok(VersionDirState::Complete),
+        Ok(_) => Ok(VersionDirState::Invalid),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(VersionDirState::Missing),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to inspect TUI version directory {version_dir:?}")),
+    }
 }
 
 /// Whether the `current` symlink points at `versions/<version>`.
@@ -574,17 +701,80 @@ fn download_os() -> Option<&'static str> {
     }
 }
 
-/// Downloads and stages `version` into `version_dir`: stream the tarball into
-/// a staging directory next to `versions/`, extract and validate it, then
-/// atomically rename it into place. The staging directory lives on the same
-/// filesystem so the final move is a cheap rename, and it is cleaned up on
-/// any failure.
-async fn download_and_stage(
+/// A validated update payload staged next to the final version directories.
+/// Its staging tree is removed on every exit path.
+struct StagedUpdate {
+    staging_dir: PathBuf,
+    payload_dir: PathBuf,
+}
+
+impl StagedUpdate {
+    /// Atomically publishes this payload at a previously missing immutable
+    /// version path.
+    fn finalize(self, version_dir: &Path) -> Result<()> {
+        fs::rename(&self.payload_dir, version_dir)
+            .with_context(|| format!("failed to move the staged TUI update into {version_dir:?}"))
+    }
+}
+
+fn finalize_staged_version(
+    layout: &InstallLayout,
+    version: &str,
+    staged: StagedUpdate,
+    version_dir: &Path,
+) -> Result<()> {
+    staged.finalize(version_dir)?;
+    open_version_lease(&layout.root, OsStr::new(version))
+        .context("failed to mark the finalized TUI version as lease-aware")?;
+    Ok(())
+}
+
+impl Drop for StagedUpdate {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.staging_dir);
+    }
+}
+
+async fn create_unique_staging_dir(versions_dir: &Path, version: &str) -> Result<PathBuf> {
+    create_unique_staging_dir_with(|| {
+        let staging_id = NEXT_UNIQUE_ID.fetch_add(1, Ordering::Relaxed);
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        versions_dir.join(format!(
+            ".staging-{version}-{}-{timestamp}-{staging_id}",
+            std::process::id()
+        ))
+    })
+    .await
+}
+
+async fn create_unique_staging_dir_with(
+    mut next_candidate: impl FnMut() -> PathBuf,
+) -> Result<PathBuf> {
+    for _ in 0..MAX_STAGING_DIR_ATTEMPTS {
+        let staging_dir = next_candidate();
+        match async_fs::create_dir(&staging_dir).await {
+            Ok(()) => return Ok(staging_dir),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to create staging dir {staging_dir:?}"));
+            }
+        }
+    }
+    bail!("failed to allocate a unique TUI update staging directory")
+}
+
+/// Downloads, extracts, and validates `version` without holding the install
+/// lock. The returned payload remains in a unique hidden staging directory on
+/// the same filesystem so locked finalization is a cheap atomic rename.
+async fn download_update(
     layout: &InstallLayout,
     client: &http_client::Client,
     version: &str,
-    version_dir: &Path,
-) -> Result<()> {
+) -> Result<StagedUpdate> {
     let os = download_os().context("no TUI release artifacts exist for this platform")?;
     let arch = if cfg!(target_arch = "aarch64") {
         "aarch64"
@@ -600,15 +790,8 @@ async fn download_and_stage(
     async_fs::create_dir_all(&layout.versions_dir)
         .await
         .with_context(|| format!("failed to create {:?}", layout.versions_dir))?;
-    let staging_dir = layout
-        .versions_dir
-        .join(format!(".staging-{version}-{}", std::process::id()));
+    let staging_dir = create_unique_staging_dir(&layout.versions_dir, version).await?;
     let _cleanup = RemoveDirOnDrop(staging_dir.clone());
-    // Clear any leftovers from a previous crashed attempt by this same pid.
-    let _ = async_fs::remove_dir_all(&staging_dir).await;
-    async_fs::create_dir_all(&staging_dir)
-        .await
-        .with_context(|| format!("failed to create staging dir {staging_dir:?}"))?;
 
     // Stream the tarball straight to disk instead of buffering it in memory
     // (the artifact is tens of MBs), mirroring the GUI's DMG download.
@@ -696,15 +879,11 @@ async fn download_and_stage(
             .await;
     }
 
-    // Move the validated payload into place. `version_dir` can only already
-    // exist as a partial install (the validity check above failed for it), so
-    // replacing it is safe — and it's never the running version's directory.
-    let _ = async_fs::remove_dir_all(version_dir).await;
-    async_fs::rename(&payload_dir, version_dir)
-        .await
-        .with_context(|| format!("failed to move the staged TUI update into {version_dir:?}"))?;
-
-    Ok(())
+    std::mem::forget(_cleanup);
+    Ok(StagedUpdate {
+        staging_dir,
+        payload_dir,
+    })
 }
 
 /// Atomically points the `current` symlink at `versions/<version>` by staging
@@ -726,79 +905,242 @@ fn point_current_at(_layout: &InstallLayout, _version: &str) -> Result<()> {
     bail!("TUI auto-update is only supported on unix platforms")
 }
 
-/// Removes stale version directories, keeping the newly installed version,
-/// the version the running binary is executing from, and whatever `current`
-/// points at. Deleting a running version's directory would break its child
-/// process spawning, so this errs on the side of keeping things.
-async fn prune_old_versions(layout: &InstallLayout, new_version: &str) {
-    let current_target = fs::read_link(&layout.current_link)
-        .ok()
-        .and_then(|target| target.file_name().map(|name| name.to_owned()));
+/// Removes inactive, lease-aware versions while the caller holds the global
+/// install lock. Unmarked versions predate this protocol and are retained.
+fn prune_old_versions(layout: &InstallLayout, new_version: &str) {
     let running_version = layout
         .running_version_dir
         .file_name()
         .map(ToOwned::to_owned);
-
-    let Ok(mut entries) = async_fs::read_dir(&layout.versions_dir).await else {
-        return;
+    let entries = match fs::read_dir(&layout.versions_dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            safe_warn!(
+                safe: ("TUI autoupdate: failed to inspect installed versions: {error}"),
+                full: (
+                    "TUI autoupdate: failed to inspect installed versions at {:?}: {error}",
+                    layout.versions_dir
+                )
+            );
+            return;
+        }
     };
-    while let Some(Ok(entry)) = entries.next().await {
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                log::warn!("TUI autoupdate: failed to inspect installed version: {error}");
+                continue;
+            }
+        };
         let name = entry.file_name();
-        // Skip staging dirs / lock leftovers, the new install, the running
-        // version, and the current target.
         if name.to_string_lossy().starts_with('.')
             || name == *new_version
             || Some(&name) == running_version.as_ref()
-            || Some(&name) == current_target.as_ref()
         {
             continue;
         }
-        if entry
-            .file_type()
-            .await
-            .is_ok_and(|file_type| file_type.is_dir())
-        {
-            log::info!("TUI autoupdate: pruning old version {name:?}");
-            if let Err(error) = async_fs::remove_dir_all(entry.path()).await {
-                log::warn!("TUI autoupdate: failed to prune {name:?}: {error}");
+        let is_dir = match entry.file_type() {
+            Ok(file_type) => file_type.is_dir(),
+            Err(error) => {
+                log::warn!("TUI autoupdate: retaining {name:?}; inspection failed: {error}");
+                continue;
             }
+        };
+        if !is_dir || !is_complete_version_dir(layout, &entry.path()) {
+            log::info!(
+                "TUI autoupdate: retaining {name:?}; it is not a completed version directory"
+            );
+            continue;
+        }
+
+        let mut lease_name = name.clone();
+        lease_name.push(".lock");
+        let lease_path = layout.root.join(VERSION_LEASES_DIR_NAME).join(lease_name);
+        let lease_is_file = match fs::symlink_metadata(&lease_path) {
+            Ok(metadata) => metadata.file_type().is_file(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                log::info!("TUI autoupdate: retaining unmarked version {name:?}");
+                continue;
+            }
+            Err(error) => {
+                safe_warn!(
+                    safe: (
+                        "TUI autoupdate: retaining {name:?}; failed to inspect its lease: {error}"
+                    ),
+                    full: (
+                        "TUI autoupdate: retaining {name:?}; failed to inspect lease \
+                         {lease_path:?}: {error}"
+                    )
+                );
+                continue;
+            }
+        };
+        if !lease_is_file {
+            safe_warn!(
+                safe: (
+                    "TUI autoupdate: retaining {name:?}; its lease path is not a regular file"
+                ),
+                full: (
+                    "TUI autoupdate: retaining {name:?}; lease path is not a regular file: \
+                     {lease_path:?}"
+                )
+            );
+            continue;
+        }
+        let lease = match fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&lease_path)
+        {
+            Ok(lease) => lease,
+            Err(error) => {
+                safe_warn!(
+                    safe: (
+                        "TUI autoupdate: retaining {name:?}; failed to open its lease: {error}"
+                    ),
+                    full: (
+                        "TUI autoupdate: retaining {name:?}; failed to open lease \
+                         {lease_path:?}: {error}"
+                    )
+                );
+                continue;
+            }
+        };
+        match fs4::fs_std::FileExt::try_lock_exclusive(&lease) {
+            Ok(true) => {}
+            Ok(false) => {
+                log::info!("TUI autoupdate: retaining live version {name:?}");
+                continue;
+            }
+            Err(error) => {
+                safe_warn!(
+                    safe: (
+                        "TUI autoupdate: retaining {name:?}; failed to lock its lease: {error}"
+                    ),
+                    full: (
+                        "TUI autoupdate: retaining {name:?}; failed to lock lease \
+                         {lease_path:?}: {error}"
+                    )
+                );
+                continue;
+            }
+        }
+
+        // `current` may have changed while the lease was being acquired.
+        // Re-read it immediately before deletion.
+        match fs::read_link(&layout.current_link) {
+            Ok(target) if target.file_name() == Some(name.as_os_str()) => {
+                log::info!("TUI autoupdate: retaining current version {name:?}");
+                continue;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                safe_warn!(
+                    safe: (
+                        "TUI autoupdate: retaining {name:?}; failed to inspect current symlink: \
+                         {error}"
+                    ),
+                    full: (
+                        "TUI autoupdate: retaining {name:?}; failed to inspect current symlink \
+                         {:?}: {error}",
+                        layout.current_link
+                    )
+                );
+                continue;
+            }
+        }
+        log::info!("TUI autoupdate: pruning inactive version {name:?}");
+        if let Err(error) = fs::remove_dir_all(entry.path()) {
+            log::warn!("TUI autoupdate: failed to prune {name:?}: {error}");
         }
     }
 }
 
-/// An exclusive advisory lock over the install, backed by an `O_EXCL`-style
-/// lock file under the install root. Removed on drop; locks older than
-/// [`STALE_LOCK_AGE`] are assumed abandoned and broken.
+/// An exclusive install lock backed by an atomically created directory. The
+/// owner token prevents a stale guard from removing a successor's lock.
+/// Fresh legacy lock files are treated as contention and stale files are
+/// migrated using the same one-retry policy as lock directories.
 struct InstallLock {
     path: PathBuf,
+    owner: String,
 }
 
 impl InstallLock {
     /// Attempts to take the lock. Returns `Ok(None)` when another live
     /// process holds it.
     fn acquire(root: &Path) -> Result<Option<Self>> {
+        Self::acquire_with_stale_age(root, STALE_LOCK_AGE)
+    }
+
+    fn acquire_with_stale_age(root: &Path, stale_age: Duration) -> Result<Option<Self>> {
         let path = root.join(LOCK_FILE_NAME);
+        let owner = format!(
+            "{}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos(),
+            NEXT_UNIQUE_ID.fetch_add(1, Ordering::Relaxed)
+        );
         for attempt in 0..2 {
-            match fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&path)
-            {
-                Ok(_) => return Ok(Some(Self { path })),
+            match fs::create_dir(&path) {
+                Ok(()) => {
+                    let owner_path = path.join(LOCK_OWNER_FILE_NAME);
+                    if let Err(error) = fs::write(&owner_path, &owner) {
+                        let _ = fs::remove_dir_all(&path);
+                        return Err(error)
+                            .with_context(|| format!("failed to write lock owner {owner_path:?}"));
+                    }
+                    return Ok(Some(Self {
+                        path,
+                        owner: owner.clone(),
+                    }));
+                }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    let is_stale = fs::metadata(&path)
-                        .and_then(|metadata| metadata.modified())
+                    let metadata = match fs::symlink_metadata(&path) {
+                        Ok(metadata) => metadata,
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                        Err(error) => {
+                            return Err(error).with_context(|| {
+                                format!("failed to inspect install lock {path:?}")
+                            });
+                        }
+                    };
+                    let is_stale = metadata
+                        .modified()
                         .ok()
                         .and_then(|modified| modified.elapsed().ok())
-                        .is_some_and(|age| age > STALE_LOCK_AGE);
+                        .is_some_and(|age| age > stale_age);
                     if !is_stale || attempt > 0 {
                         return Ok(None);
                     }
-                    log::warn!("TUI autoupdate: breaking stale install lock at {path:?}");
-                    let _ = fs::remove_file(&path);
+                    safe_warn!(
+                        safe: ("TUI autoupdate: breaking stale install lock"),
+                        full: ("TUI autoupdate: breaking stale install lock at {path:?}")
+                    );
+                    let remove_result = if metadata.file_type().is_dir() {
+                        fs::remove_dir_all(&path)
+                    } else {
+                        fs::remove_file(&path)
+                    };
+                    if let Err(error) = remove_result
+                        && error.kind() != std::io::ErrorKind::NotFound
+                    {
+                        safe_warn!(
+                            safe: ("TUI autoupdate: failed to break stale install lock: {error}"),
+                            full: (
+                                "TUI autoupdate: failed to break stale install lock at \
+                                 {path:?}: {error}"
+                            )
+                        );
+                        return Ok(None);
+                    }
                 }
                 Err(error) => {
-                    return Err(error).context(format!("failed to create lock file {path:?}"));
+                    return Err(error)
+                        .with_context(|| format!("failed to create lock directory {path:?}"));
                 }
             }
         }
@@ -808,7 +1150,18 @@ impl InstallLock {
 
 impl Drop for InstallLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        let owner_path = self.path.join(LOCK_OWNER_FILE_NAME);
+        if fs::read_to_string(&owner_path).is_ok_and(|owner| owner == self.owner)
+            && let Err(error) = fs::remove_dir_all(&self.path)
+        {
+            safe_warn!(
+                safe: ("TUI autoupdate: failed to release install lock: {error}"),
+                full: (
+                    "TUI autoupdate: failed to release install lock at {:?}: {error}",
+                    self.path
+                )
+            );
+        }
     }
 }
 

--- a/crates/warp_tui/src/autoupdate_tests.rs
+++ b/crates/warp_tui/src/autoupdate_tests.rs
@@ -1,19 +1,96 @@
-use std::fs;
 use std::path::{Path, PathBuf};
+#[allow(clippy::disallowed_types)]
+use std::process::Child;
+use std::time::Duration;
+use std::{fs, thread};
 
+use command::blocking::Command;
+use instant::Instant;
 use warp_core::channel::Channel;
 
-use super::{InstallLayout, InstallLock, download_endpoint};
+use super::{
+    CURRENT_LINK_NAME, InstallLayout, InstallLock, LOCK_FILE_NAME, LOCK_OWNER_FILE_NAME,
+    VERSION_LEASES_DIR_NAME, VersionDirState, VersionLease, create_unique_staging_dir_with,
+    download_endpoint, is_complete_version_dir, version_dir_state,
+};
+#[cfg(unix)]
+use super::{
+    StagedUpdate, finalize_staged_version, install_update, point_current_at, prune_old_versions,
+};
 
-/// Creates a unique, empty temp directory for a test.
-fn temp_root(name: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "warp-tui-autoupdate-test-{name}-{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    fs::create_dir_all(&dir).unwrap();
-    dir
+const BINARY_NAME: &str = "warp-tui-dev";
+const HELPER_MODE_ENV: &str = "WARP_TUI_AUTOUPDATE_HELPER_MODE";
+const HELPER_ROOT_ENV: &str = "WARP_TUI_AUTOUPDATE_HELPER_ROOT";
+const HELPER_VERSION_ENV: &str = "WARP_TUI_AUTOUPDATE_HELPER_VERSION";
+const HELPER_READY_ENV: &str = "WARP_TUI_AUTOUPDATE_HELPER_READY";
+const HELPER_RELEASE_ENV: &str = "WARP_TUI_AUTOUPDATE_HELPER_RELEASE";
+
+fn temp_root(name: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("warp-tui-autoupdate-{name}-"))
+        .tempdir()
+        .unwrap()
+}
+
+fn layout(root: &Path, running_version: &str) -> InstallLayout {
+    InstallLayout {
+        root: root.to_path_buf(),
+        versions_dir: root.join("versions"),
+        current_link: root.join(CURRENT_LINK_NAME),
+        running_version_dir: root.join("versions").join(running_version),
+        binary_name: BINARY_NAME.to_owned(),
+    }
+}
+
+fn create_complete_version(root: &Path, version: &str, contents: &str) -> PathBuf {
+    let version_dir = root.join("versions").join(version);
+    fs::create_dir_all(version_dir.join("resources")).unwrap();
+    fs::write(version_dir.join(BINARY_NAME), contents).unwrap();
+    fs::write(version_dir.join("resources").join("marker"), contents).unwrap();
+    version_dir
+}
+
+fn lease_path(root: &Path, version: &str) -> PathBuf {
+    root.join(VERSION_LEASES_DIR_NAME)
+        .join(format!("{version}.lock"))
+}
+
+fn wait_for_contents(path: &Path, expected: &str, child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if fs::read_to_string(path).is_ok_and(|contents| contents == expected) {
+            return;
+        }
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!("helper exited before writing {expected:?} to {path:?}: {status}");
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {expected:?} in {path:?}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn spawn_helper(
+    mode: &str,
+    root: &Path,
+    version: &str,
+    ready: &Path,
+    release: Option<&Path>,
+) -> Child {
+    let mut command = Command::new(std::env::current_exe().unwrap());
+    command
+        .arg("lease_process_helper")
+        .arg("--nocapture")
+        .env(HELPER_MODE_ENV, mode)
+        .env(HELPER_ROOT_ENV, root)
+        .env(HELPER_VERSION_ENV, version)
+        .env(HELPER_READY_ENV, ready);
+    if let Some(release) = release {
+        command.env(HELPER_RELEASE_ENV, release);
+    }
+    command.spawn().unwrap()
 }
 
 #[test]
@@ -34,20 +111,23 @@ fn detects_managed_install_layout() {
         layout.running_version_dir,
         Path::new("/home/user/.warp/tui/versions/v0.2026.01.01.00.00.dev_00")
     );
-    assert_eq!(layout.binary_name, "warp-tui-dev");
+    assert_eq!(layout.binary_name, BINARY_NAME);
 }
 
 #[test]
 fn rejects_unmanaged_exe_paths() {
-    // Legacy flat install: the binary sits directly under the install root.
     assert_eq!(
         InstallLayout::from_canonical_exe_path(Path::new("/home/user/.warp/tui/warp-tui-dev")),
         None
     );
-    // A plain cargo build in target/.
     assert_eq!(
         InstallLayout::from_canonical_exe_path(Path::new("/repo/target/debug/warp-tui-dev")),
         None
+    );
+    assert!(
+        VersionLease::acquire_for_current_process()
+            .unwrap()
+            .is_none()
     );
 }
 
@@ -68,18 +148,297 @@ fn uses_channel_specific_download_endpoints() {
 }
 
 #[test]
-fn install_lock_is_exclusive_and_released_on_drop() {
-    let root = temp_root("lock");
+fn complete_versions_require_real_binary_and_resources() {
+    let root = temp_root("complete");
+    let layout = layout(root.path(), "A");
+    let version_dir = create_complete_version(root.path(), "A", "original");
+    assert!(is_complete_version_dir(&layout, &version_dir));
+    assert_eq!(
+        version_dir_state(&layout, &version_dir).unwrap(),
+        VersionDirState::Complete
+    );
 
-    let lock = InstallLock::acquire(&root).unwrap();
-    assert!(lock.is_some());
+    fs::remove_dir_all(version_dir.join("resources")).unwrap();
+    assert_eq!(
+        version_dir_state(&layout, &version_dir).unwrap(),
+        VersionDirState::Invalid
+    );
+    assert_eq!(
+        fs::read_to_string(version_dir.join(BINARY_NAME)).unwrap(),
+        "original"
+    );
+}
 
-    // A second acquisition fails while the lock is held.
-    assert!(InstallLock::acquire(&root).unwrap().is_none());
+#[test]
+fn staging_allocation_skips_existing_directory_without_reusing_it() {
+    let root = temp_root("staging-collision");
+    let versions_dir = root.path().join("versions");
+    fs::create_dir(&versions_dir).unwrap();
+    let stale = versions_dir.join(".staging-stale");
+    let fresh = versions_dir.join(".staging-fresh");
+    fs::create_dir(&stale).unwrap();
+    fs::write(stale.join("marker"), "stale").unwrap();
+    let mut candidates = [stale.clone(), fresh.clone()].into_iter();
 
-    // Dropping the lock releases it.
+    let allocated = futures::executor::block_on(create_unique_staging_dir_with(|| {
+        candidates.next().unwrap()
+    }))
+    .unwrap();
+
+    assert_eq!(allocated, fresh);
+    assert_eq!(fs::read_to_string(stale.join("marker")).unwrap(), "stale");
+    assert!(allocated.is_dir());
+}
+
+#[test]
+fn managed_version_lease_creates_stable_marker() {
+    let root = temp_root("lease");
+    let version = "v0.2026.07.22.18.00.dev_00";
+    let layout = layout(root.path(), version);
+    create_complete_version(root.path(), version, "A");
+
+    let lease = VersionLease::acquire(&layout).unwrap();
+    assert!(lease_path(root.path(), version).is_file());
+    assert!(layout.running_version_dir.is_dir());
+    drop(lease);
+    assert!(lease_path(root.path(), version).is_file());
+}
+
+#[cfg(unix)]
+#[test]
+fn finalized_unlaunched_version_is_marked_and_reclaimed() {
+    let root = temp_root("finalized-marker");
+    let layout = layout(root.path(), "A");
+    create_complete_version(root.path(), "A", "A");
+    point_current_at(&layout, "A").unwrap();
+
+    let staging_dir = root.path().join("versions/.staging-B");
+    let payload_dir = staging_dir.join("payload");
+    fs::create_dir_all(payload_dir.join("resources")).unwrap();
+    fs::write(payload_dir.join(BINARY_NAME), "B").unwrap();
+    fs::write(payload_dir.join("resources/marker"), "B").unwrap();
+    let staged = StagedUpdate {
+        staging_dir,
+        payload_dir,
+    };
+    let version_dir = root.path().join("versions/B");
+
+    finalize_staged_version(&layout, "B", staged, &version_dir).unwrap();
+    assert!(lease_path(root.path(), "B").is_file());
+
+    create_complete_version(root.path(), "C", "C");
+    point_current_at(&layout, "C").unwrap();
+    prune_old_versions(&layout, "C");
+    assert!(!version_dir.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn completed_version_is_reused_and_invalid_version_is_not_replaced() {
+    let root = temp_root("immutable");
+    create_complete_version(root.path(), "A", "running");
+    let target = create_complete_version(root.path(), "C", "original");
+    let layout = layout(root.path(), "A");
+    point_current_at(&layout, "A").unwrap();
+
+    futures::executor::block_on(install_update(layout.clone(), "C".to_owned())).unwrap();
+    assert_eq!(
+        fs::read_to_string(target.join(BINARY_NAME)).unwrap(),
+        "original"
+    );
+    assert_eq!(
+        fs::read_to_string(target.join("resources/marker")).unwrap(),
+        "original"
+    );
+
+    fs::remove_dir_all(&target).unwrap();
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join(BINARY_NAME), "partial").unwrap();
+    point_current_at(&layout, "A").unwrap();
+    let error =
+        futures::executor::block_on(install_update(layout.clone(), "C".to_owned())).unwrap_err();
+    assert!(format!("{error:#}").contains("refusing to replace incomplete or invalid"));
+    assert_eq!(
+        fs::read_to_string(target.join(BINARY_NAME)).unwrap(),
+        "partial"
+    );
+    assert!(super::current_points_at(&layout, "A"));
+}
+
+#[cfg(unix)]
+#[test]
+fn live_versions_are_retained_and_reclaimed_after_exit() {
+    let root = temp_root("gc");
+    create_complete_version(root.path(), "A", "A");
+    create_complete_version(root.path(), "B", "B");
+    create_complete_version(root.path(), "C", "C");
+    create_complete_version(root.path(), "legacy", "legacy");
+    let layout = layout(root.path(), "C");
+    point_current_at(&layout, "C").unwrap();
+
+    let a_ready = root.path().join("a-ready");
+    let a_release = root.path().join("a-release");
+    let b_ready = root.path().join("b-ready");
+    let b_release = root.path().join("b-release");
+    let mut a = spawn_helper("hold-lease", root.path(), "A", &a_ready, Some(&a_release));
+    let mut b = spawn_helper("hold-lease", root.path(), "B", &b_ready, Some(&b_release));
+    wait_for_contents(&a_ready, "locked", &mut a);
+    wait_for_contents(&b_ready, "locked", &mut b);
+
+    prune_old_versions(&layout, "C");
+    assert!(root.path().join("versions/A").is_dir());
+    assert!(root.path().join("versions/B").is_dir());
+    assert!(root.path().join("versions/C").is_dir());
+    assert!(root.path().join("versions/legacy").is_dir());
+
+    fs::write(&a_release, "").unwrap();
+    assert!(a.wait().unwrap().success());
+    prune_old_versions(&layout, "C");
+    assert!(!root.path().join("versions/A").exists());
+    assert!(lease_path(root.path(), "A").is_file());
+    assert!(root.path().join("versions/B").is_dir());
+
+    fs::write(&b_release, "").unwrap();
+    assert!(b.wait().unwrap().success());
+    prune_old_versions(&layout, "C");
+    assert!(!root.path().join("versions/B").exists());
+    assert!(root.path().join("versions/C").is_dir());
+    assert!(root.path().join("versions/legacy").is_dir());
+}
+
+#[cfg(unix)]
+#[test]
+fn current_version_is_rechecked_before_gc_deletion() {
+    let root = temp_root("gc-current");
+    create_complete_version(root.path(), "A", "A");
+    create_complete_version(root.path(), "C", "C");
+    fs::create_dir_all(root.path().join(VERSION_LEASES_DIR_NAME)).unwrap();
+    fs::write(lease_path(root.path(), "A"), "").unwrap();
+    let layout = layout(root.path(), "C");
+    point_current_at(&layout, "A").unwrap();
+
+    prune_old_versions(&layout, "C");
+    assert!(root.path().join("versions/A").is_dir());
+}
+
+#[test]
+fn startup_fails_closed_if_gc_wins_the_lease_race() {
+    let root = temp_root("gc-wins");
+    let version_dir = create_complete_version(root.path(), "A", "A");
+    fs::create_dir_all(root.path().join(VERSION_LEASES_DIR_NAME)).unwrap();
+    let lease_path = lease_path(root.path(), "A");
+    let lease = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lease_path)
+        .unwrap();
+    fs4::fs_std::FileExt::lock_exclusive(&lease).unwrap();
+
+    let ready = root.path().join("race-result");
+    let mut child = spawn_helper("attempt-lease", root.path(), "A", &ready, None);
+    wait_for_contents(&ready, "starting", &mut child);
+    fs::remove_dir_all(version_dir).unwrap();
+    fs4::fs_std::FileExt::unlock(&lease).unwrap();
+    drop(lease);
+
+    wait_for_contents(&ready, "error", &mut child);
+    assert!(child.wait().unwrap().success());
+}
+
+#[test]
+fn directory_install_lock_is_cross_process_and_token_owned() {
+    let root = temp_root("install-lock");
+    let ready = root.path().join("lock-ready");
+    let release = root.path().join("lock-release");
+    let mut child = spawn_helper(
+        "hold-install-lock",
+        root.path(),
+        "unused",
+        &ready,
+        Some(&release),
+    );
+    wait_for_contents(&ready, "locked", &mut child);
+    assert!(InstallLock::acquire(root.path()).unwrap().is_none());
+
+    fs::write(&release, "").unwrap();
+    assert!(child.wait().unwrap().success());
+    let lock = InstallLock::acquire(root.path()).unwrap().unwrap();
+    fs::write(
+        root.path().join(LOCK_FILE_NAME).join(LOCK_OWNER_FILE_NAME),
+        "successor",
+    )
+    .unwrap();
     drop(lock);
-    assert!(InstallLock::acquire(&root).unwrap().is_some());
+    assert!(root.path().join(LOCK_FILE_NAME).is_dir());
+}
 
-    let _ = fs::remove_dir_all(&root);
+#[test]
+fn install_lock_migrates_stale_legacy_file_and_directory() {
+    for representation in ["file", "directory"] {
+        let root = temp_root(representation);
+        let lock_path = root.path().join(LOCK_FILE_NAME);
+        if representation == "file" {
+            fs::write(&lock_path, "legacy").unwrap();
+        } else {
+            fs::create_dir(&lock_path).unwrap();
+            fs::write(lock_path.join(LOCK_OWNER_FILE_NAME), "stale").unwrap();
+        }
+
+        let lock = InstallLock::acquire_with_stale_age(root.path(), Duration::ZERO)
+            .unwrap()
+            .unwrap();
+        assert!(lock_path.is_dir());
+        assert_ne!(
+            fs::read_to_string(lock_path.join(LOCK_OWNER_FILE_NAME)).unwrap(),
+            "stale"
+        );
+        drop(lock);
+        assert!(!lock_path.exists());
+    }
+}
+
+#[test]
+fn fresh_legacy_install_lock_is_contention() {
+    let root = temp_root("fresh-legacy-lock");
+    fs::write(root.path().join(LOCK_FILE_NAME), "legacy").unwrap();
+    assert!(InstallLock::acquire(root.path()).unwrap().is_none());
+}
+
+#[test]
+fn lease_process_helper() {
+    let Ok(mode) = std::env::var(HELPER_MODE_ENV) else {
+        return;
+    };
+    let root = PathBuf::from(std::env::var_os(HELPER_ROOT_ENV).unwrap());
+    let version = std::env::var(HELPER_VERSION_ENV).unwrap();
+    let ready = PathBuf::from(std::env::var_os(HELPER_READY_ENV).unwrap());
+
+    match mode.as_str() {
+        "hold-lease" => {
+            let lease = VersionLease::acquire(&layout(&root, &version)).unwrap();
+            fs::write(&ready, "locked").unwrap();
+            let release = PathBuf::from(std::env::var_os(HELPER_RELEASE_ENV).unwrap());
+            while !release.exists() {
+                thread::sleep(Duration::from_millis(10));
+            }
+            drop(lease);
+        }
+        "attempt-lease" => {
+            fs::write(&ready, "starting").unwrap();
+            let result = VersionLease::acquire(&layout(&root, &version));
+            fs::write(&ready, if result.is_ok() { "acquired" } else { "error" }).unwrap();
+        }
+        "hold-install-lock" => {
+            let lock = InstallLock::acquire(&root).unwrap().unwrap();
+            fs::write(&ready, "locked").unwrap();
+            let release = PathBuf::from(std::env::var_os(HELPER_RELEASE_ENV).unwrap());
+            while !release.exists() {
+                thread::sleep(Duration::from_millis(10));
+            }
+            drop(lock);
+        }
+        mode => panic!("unknown helper mode {mode}"),
+    }
 }

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -45,6 +45,9 @@ fn parse_resume_token(token: String) -> Result<ServerConversationToken> {
 
 /// Boots the headless Warp app and mounts the transcript-capable TUI session.
 pub fn run() -> Result<()> {
+    // Protect this managed version before any worker dispatch or resource
+    // access. The guard stays alive until this process exits.
+    let _version_lease = crate::autoupdate::VersionLease::acquire_for_current_process()?;
     // If this process was re-exec'd as a Warp worker (e.g. the terminal
     // server), dispatch that instead of starting another TUI — otherwise the
     // worker re-exec would recursively launch TUIs.


### PR DESCRIPTION
## Description

### Root problem

Warp Agent CLI releases are installed as self-contained version roots:

`versions/<version>/{warp-tui-<channel>, resources/}`

The `current` symlink selects the version used by new launches. Existing processes continue running the version they started from, which is intentional: updating `current` should not interrupt an active session.

Before this PR, every successful in-process update eagerly pruned old version directories. The updater preserved only:

1. the newly installed version,
2. the version currently selected by `current`, and
3. the version running the process that happened to perform this update.

That is not the same as preserving every live version. For example:

1. Process A starts from version A.
2. B is installed and a second process starts from version B; A remains open.
3. C is installed while A and B are both still running.
4. The process installing C preserves itself and C, but can delete the other live process's version root.

The global install lock does not prevent this. It serializes update transactions, but a live TUI process that is not currently updating does not hold that lock and is therefore invisible to garbage collection.

### Risk

On Unix, deleting a running executable does not necessarily terminate the process because the executable image may remain mapped. That makes this failure latent rather than safe.

Warp still needs the backing version directory after startup:

- bundled resources are resolved relative to the running executable,
- worker processes are dispatched before normal app startup and may re-execute the versioned binary,
- later child-process launches can use the running executable path.

After eager pruning, the existing process may appear healthy until it reads a bundled asset or spawns a child. It can then fail because `current_exe()` no longer canonicalizes, `resources/` no longer exists, or the executable path used for re-exec has been removed.

Replacing an existing same-version directory has the same class of bug: a live process can still depend on that exact directory even when a new archive has the same version string.

### Prior art

| Updater | Storage and activation model | Cleanup behavior | Applicability to Warp |
| --- | --- | --- | --- |
| Codex standalone | Self-contained `releases/<version>-<target>` roots selected through a `current` symlink/junction | Completed releases are retained; only staging artifacts are cleaned | Safe for live processes and bundled assets, but completed versions can accumulate indefinitely |
| Claude Code native | Version directories selected through a launcher | Cleanup exists, but its retention count/timing and liveness guarantees are not documented; custom launchers can cause all versions to be retained | The layout is similar, but there is no documented cleanup contract we can rely on |
| Amp direct installer | One mostly self-contained executable atomically renamed over a fixed path; Windows temporarily uses `.old.exe` | No long-lived version roots on Unix; the OS keeps the old executable inode available to an existing process | Works for a single-file payload, but does not protect Warp's sibling `resources/` tree or versioned re-exec path |
| Warp before this PR | Self-contained version roots selected through `current` | Eagerly removes every version except new/current/updater-self | Bounds disk usage, but is unsafe when three or more versions overlap in time |

This PR keeps the useful parts of the versioned Codex-style model—self-contained immutable release roots and atomic activation—while adding explicit process liveness so completed releases do not need to accumulate forever.

Keeping only `current` plus N predecessors would reduce the probability of deletion but would not establish a correctness bound: any fixed N can be exceeded by long-running sessions. PID scanning has similar race and portability problems. The process itself needs to hold the proof that its version is active.

### Proposed protocol

#### 1. Treat completed versions as immutable

- Downloads are extracted into a unique hidden staging directory.
- After taking the install lock, the updater rechecks `versions/<version>`.
- A complete existing version is reused.
- An incomplete, symlinked, or otherwise invalid existing target is rejected rather than replaced.
- A new payload is finalized with a same-filesystem rename, then `current` is atomically retargeted.

#### 2. Give every managed process a lifetime lease

- Lease files live outside deletable version roots at `version-leases/<version>.lock`.
- A managed TUI opens its version's lease file and acquires a shared advisory lock at the beginning of `session::run`, before worker dispatch or resource access.
- After acquiring the lease, startup verifies that the canonical version root, executable, and resources still exist.
- The guard remains alive for the process lifetime; process exit or a crash releases the OS lock automatically.

Unmanaged development binaries do not acquire a lease.

#### 3. Garbage-collect only versions proven inactive

- GC runs while holding the global install lock.
- It always preserves the newly installed version and re-reads/preserves `current`.
- Versions without a lease marker are retained because they may have been started before the lease protocol existed.
- For a marked older version, GC must acquire its lease file exclusively without blocking. A shared holder means the version is live and must be retained.
- After winning the exclusive lock, GC rechecks `current` before deleting the version root.
- Inspection, locking, or deletion errors fail safe by retaining the candidate.

This closes both sides of the startup/GC race:

- If startup gets the shared lease first, GC cannot delete the version.
- If GC gets the exclusive lease first, startup waits, then detects that its payload disappeared and exits with an actionable error instead of running from a partially missing installation.

#### 4. Share one installer lock across Rust and shell

`.update.lock` is a shared path with two compatible representations:

- The Rust updater atomically creates a directory and writes owner metadata inside it.
- The shell installer atomically creates a regular file with Bash noclobber and stores its owner token in that file. Keeping the shell side file-based preserves compatibility with already-deployed clients that only know how to recover regular-file locks.

Both writers contend on the same path, treat either fresh representation as contention, recognize stale files and directories, and only release locks they still own. Network download and archive validation stay outside the critical section. Immutable-version finalization, the `current` swap, and client-side GC happen inside it.

### Cross-repository rollout

The companion server change is [warpdotdev/warp-server#13171](https://github.com/warpdotdev/warp-server/pull/13171). It makes manual installs follow the same immutability and install-lock contract and stops installer-side completed-version cleanup.

The server change should land and deploy first. Otherwise, an older shell installer could still bypass the new protocol and prune a backing directory while a lease-aware client is running. The client remains conservative during rollout by never automatically deleting an unmarked pre-protocol version.

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo nextest run -p warp_tui autoupdate`: 15/15 tests passed.
  - Managed and unmanaged lease acquisition.
  - Concurrent live-version retention and post-exit reclamation.
  - Startup/GC ordering in both directions.
  - Rechecking `current` after exclusive lease acquisition.
  - Retaining unmarked pre-protocol versions.
  - Marking newly finalized, never-launched versions so they can later be reclaimed.
  - Immutable-version reuse and invalid-target rejection.
  - Cross-process install-lock exclusion, legacy/stale lock migration, and unique staging paths.
- `./script/presubmit`: Rust formatting, Clippy, clang-format, and WGSL formatting passed. The complete command could not pass locally because PowerShell `Invoke-ScriptAnalyzer` is unavailable and the SSH integration suite requires interactive `gcloud` reauthentication.
- Launched the headless TUI under tmux and verified normal startup and rendering.

### Manual real-process A/B/C validation

- Built the real standalone `warp-tui-dev` with `GIT_RELEASE_TAG=v0.2026.07.22.22.00.dev_00`, staged the production bundled-resource tree, and ran an isolated managed install against a local HTTP release endpoint. Because the TUI entry point does not apply the shared CLI parser's runtime server override, the dev wrapper was temporarily pointed at that endpoint for packaging; that one-line harness change was reverted before validation completed, and the lease/updater/worker implementation was unmodified.
- Started real tmux-backed TUI processes from A and B. `lsof` showed both parent TUIs and their automatically re-execed `terminal-server` workers holding shared `version-leases/A.lock` and `B.lock`.
- B's in-process Rust updater fetched `/client_version`, followed the real artifact redirect, downloaded/extracted C, atomically changed `current` to C, and retained the live A/B roots. A, B, and C each retained a readable version-specific marker inside the real `resources/` tree.
- After C activation, launched protocol-valid `terminal-server` workers from the original A and B executables using the same inherited Unix socket FD contract as production. Both remained running from their original version paths and held the corresponding A/B leases.
- Ran the server PR's rendered shell installer to download and activate D. It changed `current` to D, left A/B/C intact and readable, kept both TUI sessions alive, and released its regular-file `.update.lock`.
- After A exited, a real D→E Rust update reclaimed inactive marked A and C while retaining live B, running D, and current E. After B and D exited, E→F reclaimed B and D while retaining running E, current F, and a complete legacy root with no lease marker.
- Terminated the final TUI and local release server. No test process or lease holder remained, `.update.lock` was absent, and the last-GC filesystem state was current F plus running-at-that-GC E and the intentionally retained unmarked legacy root.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Agent Mode conversation](https://staging.warp.dev/conversation/c27e9dec-07d1-440a-adb4-f783eb13520b)
- [Implementation plan](https://staging.warp.dev/drive/notebook/csGSrTvjpK0vogt7QJPTfr)

CHANGELOG-NONE

