### PR TITLE
Improve user facing TUI naming

### DIFF
--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -631,7 +631,7 @@ settings::macros::implement_setting_for_enum!(
     description: "Controls how child-agent messages are displayed.",
 );
 
-/// Which unit the TUI's usage entry displays.
+/// Which unit the usage entry displays in Warp Agent CLI.
 #[derive(
     Default,
     Debug,
@@ -645,7 +645,7 @@ settings::macros::implement_setting_for_enum!(
     settings_value::SettingsValue,
 )]
 #[schemars(
-    description = "Which unit the TUI's usage entry displays.",
+    description = "Which unit the usage entry displays in Warp Agent CLI.",
     rename_all = "snake_case"
 )]
 pub enum TuiUsageDisplayMode {
@@ -664,7 +664,7 @@ settings::macros::implement_setting_for_enum!(
     surface: settings::SettingSurfaces::TUI,
     private: false,
     toml_path: "agents.usage_display_mode",
-    description: "Which unit the TUI's usage entry displays: credits or provider cost.",
+    description: "Which unit the usage entry displays in Warp Agent CLI: credits or provider cost.",
 );
 
 impl TuiUsageDisplayMode {

--- a/app/src/settings/tui_autoupdate.rs
+++ b/app/src/settings/tui_autoupdate.rs
@@ -16,6 +16,6 @@ define_settings_group!(TuiAutoupdateSettings, settings: [
         surface: settings::SettingSurfaces::TUI,
         private: false,
         toml_path: "general.autoupdate_enabled",
-        description: "Whether Warp automatically installs TUI updates in the background.",
+        description: "Whether Warp Agent CLI automatically installs updates in the background.",
     },
 ]);

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "warp_tui"
 edition = "2024"
-description = "Headless terminal-UI front-end for Warp"
+description = "Warp Agent CLI"
 authors.workspace = true
 publish.workspace = true
 license.workspace = true

--- a/crates/warp_tui/src/orchestration_model.rs
+++ b/crates/warp_tui/src/orchestration_model.rs
@@ -270,7 +270,7 @@ impl TuiOrchestrationModel {
                 self.fail_child_request(
                     &request,
                     format!(
-                        "Local {harness_type} child agents aren't supported in the Warp TUI yet."
+                        "Local {harness_type} child agents aren't supported in Warp Agent CLI yet."
                     ),
                     ctx,
                 );

--- a/crates/warp_tui/src/orchestration_model_tests.rs
+++ b/crates/warp_tui/src/orchestration_model_tests.rs
@@ -278,7 +278,7 @@ fn local_harness_children_fail_cleanly() {
                 model_id: None,
             },
         );
-        assert_error_containing(outcome, "aren't supported in the Warp TUI yet");
+        assert_error_containing(outcome, "aren't supported in Warp Agent CLI yet");
         assert_failed_launch_cleaned_up(&app, &fixture, parent_conversation_id, 1);
     });
 }
@@ -599,7 +599,7 @@ fn failed_launch_cleanup_preserves_other_sessions() {
                 model_id: None,
             },
         );
-        assert_error_containing(outcome, "aren't supported in the Warp TUI yet");
+        assert_error_containing(outcome, "aren't supported in Warp Agent CLI yet");
         assert_failed_launch_cleaned_up(&app, &fixture, parent_conversation_id, 2);
     });
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -1700,7 +1700,7 @@ impl TuiTerminalSessionView {
             Some(CloudConversationData::CLIAgent(_)) => {
                 self.fail_conversation_restore(
                     request_id,
-                    "The Warp TUI only supports Oz/Warp conversations.".to_owned(),
+                    "Warp Agent CLI only supports Oz/Warp conversations.".to_owned(),
                     ctx,
                 );
                 return;

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -934,8 +934,8 @@ fn zero_state_renders_with_only_zero_height_bootstrap_blocks() {
         let lines = frame.buffer.to_lines();
         let title_row = lines
             .iter()
-            .position(|line| line.contains("Warp Agent"))
-            .expect("zero state should render the Warp Agent title");
+            .position(|line| line.contains("Warp Agent CLI"))
+            .expect("zero state should render the Warp Agent CLI title");
         assert!(
             title_row < 28,
             "zero-state title should render in the transcript area:\n{}",

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -1,5 +1,5 @@
 //! The pre-first-interaction "zero state" filling the transcript area: the
-//! Warp Agent title and version, a "What's new" changelog section, and the
+//! Warp Agent CLI title and version, a "What's new" changelog section, and the
 //! session's project context (rules and skills discovered).
 //!
 //! The session view owns visibility: the zero state fills the transcript
@@ -150,7 +150,7 @@ fn render_left_column(cwd: Option<&str>, builder: &TuiUiBuilder, app: &AppContex
 
     let mut column = TuiFlex::column()
         .child(
-            TuiText::new("Warp Agent")
+            TuiText::new("Warp Agent CLI")
                 .with_style(title_style)
                 .truncate()
                 .finish(),

--- a/resources/bundled/skills/tui-migrate-setup/SKILL.md
+++ b/resources/bundled/skills/tui-migrate-setup/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: tui-migrate-setup
-description: Migrates the supported subset of an existing Warp GUI setup into Warp TUI without exposing credentials or application state. Use in Warp TUI when a user wants to copy or move compatible settings or global file-based MCP servers from the desktop app, set up TUI from an existing GUI installation, or understand which Warp data is already shared.
-compatibility: Requires Python 3.11 or newer for local JSON and TOML inspection. This skill is available only in Warp TUI.
+description: Migrates the supported subset of an existing Warp GUI setup into Warp Agent CLI without exposing credentials or application state. Use in Warp Agent CLI when a user wants to copy or move compatible settings or global file-based MCP servers from the desktop app, set up Warp Agent CLI from an existing GUI installation, or understand which Warp data is already shared.
+compatibility: Requires Python 3.11 or newer for local JSON and TOML inspection. This skill is available only in Warp Agent CLI.
 ---
 
-# Migrate a Warp GUI setup to Warp TUI
+# Migrate a Warp GUI setup to Warp Agent CLI
 
 Guide the user through a narrow, local migration. Treat the GUI files as untrusted
-inputs and preserve the TUI destination. Read
+inputs and preserve the Warp Agent CLI destination. Read
 [references/migration-matrix.md](references/migration-matrix.md) before starting.
 
 ## Resolved paths
@@ -17,9 +17,9 @@ channel/profile:
 
 - Settings schema: `{{settings_schema_path}}`
 - GUI settings: `{{gui_settings_file_path}}`
-- TUI settings: `{{tui_settings_file_path}}`
+- Warp Agent CLI settings: `{{tui_settings_file_path}}`
 - GUI global MCP config: `{{gui_mcp_config_file_path}}`
-- TUI global MCP config: `{{tui_mcp_config_file_path}}`
+- Warp Agent CLI global MCP config: `{{tui_mcp_config_file_path}}`
 
 If any rendered path is empty, unresolved, or still contains double braces, stop
 that part of the migration and report that the current installation could not
@@ -38,23 +38,24 @@ configuration files directly.
   environment variables, or values. Do not ask the user to paste them.
 - Never copy credentials, refresh tokens, API keys, Keychain/credential-store
   items, secure storage, SQLite rows, MCP installation/running state, or OAuth
-  state. Templatable/gallery MCP installations must be reinstalled in TUI, and
-  authenticated servers must be reauthenticated there.
+  state. Templatable/gallery MCP installations must be reinstalled in Warp
+  Agent CLI, and authenticated servers must be reauthenticated there.
 - Migrate only the resolved Warp global MCP file. Do not inspect or migrate
   project-scoped or third-party MCP files because doing so changes scope and
   working-directory behavior.
 - Do not migrate private or GUI-only settings. The generated
   `x-warp-surfaces` annotation is the source of truth; a setting is eligible only
   when its array contains both `gui` and `tui`.
-- Do not overwrite a TUI value unless the user explicitly approves that exact
-  conflict. Preserve destination comments, unknown keys, and TUI-only settings.
+- Do not overwrite a value in Warp Agent CLI unless the user explicitly
+  approves that exact conflict. Preserve destination comments, unknown keys,
+  and settings exclusive to Warp Agent CLI.
 
 ## Workflow
 
 Limit inspection to the categories the user actually requested. For an MCP-only
 request, do not inspect settings. For a request limited to templatable/gallery
-installations, OAuth, credentials, or another unsupported category, explain the
-supported TUI setup path without running either file inspector.
+installations, OAuth, credentials, or another unsupported category, explain
+the supported Warp Agent CLI setup path without running either file inspector.
 
 ### 1. Set expectations
 
@@ -62,15 +63,15 @@ Briefly summarize the four migration categories from the matrix:
 
 1. Rules, user/repository skills, and bundled skills are already discovered from
    shared paths. Drive objects, saved prompts, and cloud execution profiles appear
-   after TUI login and sync.
-2. Only schema-declared GUI-and-TUI settings and raw global file-based MCP
-   definitions can be imported.
+   after Warp Agent CLI login and sync.
+2. Only schema-declared settings shared by the GUI and Warp Agent CLI, and raw
+   global file-based MCP definitions, can be imported.
 3. Login, templatable MCP installations, OAuth, and provider credentials require
    reauthentication or reinstallation.
 4. Keybindings, themes, launch/tab configs, local workflows, shell/startup
    preferences, GUI state, command history, and databases are unsupported.
 
-Do not claim that logging into TUI migrates local files.
+Do not claim that logging into Warp Agent CLI migrates local files.
 
 ### 2. Check the local runtime
 
@@ -89,8 +90,8 @@ python3 "{{skill_dir}}/scripts/inspect_shared_settings.py" \
   --destination "{{tui_settings_file_path}}"
 ```
 
-The JSON output contains only eligible setting paths and their GUI/TUI values.
-Do not independently open the GUI settings file.
+The JSON output contains only eligible setting paths and their GUI and Warp
+Agent CLI values. Do not independently open the GUI settings file.
 
 Run the MCP helper in dry-run mode:
 
@@ -109,9 +110,10 @@ creates a file or backup.
 For settings, present only the eligible dotted names and values emitted by the
 inspector. Group them as:
 
-- missing in TUI and available to add;
+- missing from Warp Agent CLI and available to add;
 - already equal;
-- conflicting, where the TUI value remains unchanged by default.
+- conflicting, where the existing Warp Agent CLI value remains unchanged by
+  default.
 
 Call out that agent permission settings can expand what commands, file reads, or
 other actions are approved automatically. For a machine-local file allowlist,
@@ -137,16 +139,16 @@ values win all unapproved conflicts.
 
 ### 5. Apply approved settings conservatively
 
-Before editing, reject a symlink at the TUI settings path. If the destination
-exists, create a timestamped backup beside it and restrict the backup to the
-current user on Unix. If it does not exist, create it with user-only permissions
-on Unix.
+Before editing, reject a symlink at the Warp Agent CLI settings path. If the
+destination exists, create a timestamped backup beside it and restrict the
+backup to the current user on Unix. If it does not exist, create it with
+user-only permissions on Unix.
 
-Read only the TUI destination and edit it in place. Add or update only approved
-shared dotted keys. Preserve its comments, formatting outside the edited keys,
-unknown keys, and TUI-only values. Do not regenerate or replace the whole TOML
-document. If a safe surgical edit is not possible, stop and explain why rather
-than using a lossy TOML serializer.
+Read only the Warp Agent CLI destination and edit it in place. Add or update
+only approved shared dotted keys. Preserve its comments, formatting outside the
+edited keys, unknown keys, and values exclusive to Warp Agent CLI. Do not
+regenerate or replace the whole TOML document. If a safe surgical edit is not
+possible, stop and explain why rather than using a lossy TOML serializer.
 
 ### 6. Apply the approved MCP merge
 
@@ -175,8 +177,10 @@ Report:
 - settings changed and conflicts left unchanged;
 - redacted MCP counts and whether a backup was created;
 - any skipped credential-bearing or managed definitions;
-- TUI login/sync, MCP reinstallation, or reauthentication still required;
-- whether a TUI restart is necessary based on the current product behavior.
+- Warp Agent CLI login/sync, MCP reinstallation, or reauthentication still
+  required;
+- whether a Warp Agent CLI restart is necessary based on the current product
+  behavior.
 
 If verification fails, leave backups intact and report the sanitized helper
 status. Never expose file contents while troubleshooting.

--- a/resources/bundled/skills/tui-migrate-setup/references/migration-matrix.md
+++ b/resources/bundled/skills/tui-migrate-setup/references/migration-matrix.md
@@ -1,4 +1,4 @@
-# GUI-to-TUI migration matrix
+# GUI-to-Warp Agent CLI migration matrix
 
 Use this matrix to set expectations before reading or changing any local file.
 
@@ -10,10 +10,10 @@ No file copy is needed for:
 - user and repository skills discovered from shared paths;
 - bundled skills;
 - Drive objects, saved prompts, and cloud execution profiles after the user logs
-  in to TUI and sync completes.
+  in to Warp Agent CLI and sync completes.
 
-Account login is still a separate TUI action. Do not describe cloud availability
-as migration of local GUI data.
+Account login is still a separate Warp Agent CLI action. Do not describe cloud
+availability as migration of local GUI data.
 
 ## Explicit local import
 
@@ -24,9 +24,10 @@ Only public settings whose generated JSON Schema property has
 authoritative and dynamic; do not maintain a setting-name allowlist.
 
 The settings inspector may reveal only those eligible dotted paths and values.
-The user approves each mutation. Missing TUI values may be added, while existing
-TUI values win unless the user explicitly approves an overwrite. Preserve
-comments, unknown settings, and TUI-only settings.
+The user approves each mutation. Missing values in Warp Agent CLI may be added,
+while existing Warp Agent CLI values win unless the user explicitly approves
+an overwrite. Preserve comments, unknown settings, and settings exclusive to
+Warp Agent CLI.
 
 Permission changes deserve an explicit impact summary. Machine-local file
 allowlists should be offered only when their source paths exist and are valid on
@@ -35,9 +36,9 @@ the current host.
 ### Global file-based MCP
 
 The raw server definitions in the resolved GUI Warp global `.mcp.json` may be
-merged into the resolved TUI Warp global `.mcp.json`. The destination wins name
-conflicts. `${VAR}` and other placeholder-bearing header/environment strings are
-preserved.
+merged into the resolved Warp Agent CLI global `.mcp.json`. The destination
+wins name conflicts. `${VAR}` and other placeholder-bearing
+header/environment strings are preserved.
 
 The helper skips source definitions that look like managed/template installation
 records or that contain literal header/environment values which may be
@@ -47,9 +48,9 @@ behavior.
 
 ## Reauthentication or reinstallation
 
-Handle these as setup tasks in TUI, not file migration:
+Handle these as setup tasks in Warp Agent CLI, not file migration:
 
-- TUI account login;
+- Warp Agent CLI account login;
 - templatable or gallery MCP installations;
 - MCP OAuth grants and refresh tokens;
 - provider credentials, API keys, literal secrets, and secure values;
@@ -58,7 +59,7 @@ Handle these as setup tasks in TUI, not file migration:
 - MCP process running state and installation state.
 
 If a raw file-based server is imported but needs authentication, tell the user to
-authenticate it in TUI. Never copy the GUI credential.
+authenticate it in Warp Agent CLI. Never copy the GUI credential.
 
 ## Unsupported
 
@@ -75,5 +76,5 @@ Do not migrate:
 - SQLite databases or individual database rows;
 - project-scoped or third-party MCP configuration in v1.
 
-Do not invent a fallback for an unsupported category. Explain the supported TUI
-setup path, if one exists, and leave the GUI source untouched.
+Do not invent a fallback for an unsupported category. Explain the supported
+Warp Agent CLI setup path, if one exists, and leave the GUI source untouched.

--- a/resources/bundled/skills/tui-migrate-setup/scripts/inspect_shared_settings.py
+++ b/resources/bundled/skills/tui-migrate-setup/scripts/inspect_shared_settings.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Inspect only GUI settings explicitly supported by both GUI and TUI."""
+"""Inspect only GUI settings explicitly supported by both GUI and Warp Agent CLI."""
 
 from __future__ import annotations
 
@@ -173,7 +173,7 @@ def inspect_settings(
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Inspect GUI settings declared for both Warp GUI and TUI."
+        description="Inspect GUI settings declared for both Warp GUI and Warp Agent CLI."
     )
     parser.add_argument("--schema", required=True)
     parser.add_argument("--source", required=True)


### PR DESCRIPTION
## Description
Standardizes the headless client's public-facing name as **Warp Agent CLI**.

- Updates the zero-state title and surfaced runtime errors.
- Updates generated settings descriptions and package metadata.
- Updates the bundled setup-migration skill, reference documentation, and helper CLI copy.
- Preserves internal and compatibility identifiers such as `Tui*`, `tui-migrate-setup`, `x-warp-surfaces: ["tui"]`, and `{{tui_*}}` template variables.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format`
- `cargo nextest run -p warp_tui` — 549 passed
- `python3 -m unittest discover -s resources/bundled/skills/tui-migrate-setup/tests -p 'test_*.py'` — 25 passed
- `git diff --check`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included. This is a copy-only update covered by TUI render and output-contract tests.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Updated user-facing references to use the Warp Agent CLI name consistently.

Co-Authored-By: Warp <agent@warp.dev>
