### PR TITLE
fix extra line after tool calls when there's nothing there

### DIFF
--- a/crates/warp_tui/src/tui_block_list_viewport_source.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source.rs
@@ -169,7 +169,7 @@ impl TuiBlockListViewportSource {
             .filter_map(|view_id| {
                 let height = if let Some(view) = agent_blocks.get(&view_id) {
                     let view = view.as_ref(app);
-                    let height = view.desired_height(width, ctx, app).max(1);
+                    let height = view.desired_height(width, ctx, app);
                     view.record_height_measurement(width);
                     height
                 } else {
@@ -277,8 +277,8 @@ impl TuiBlockListViewportSource {
                     if item.should_hide {
                         None
                     } else if let Some(view) = agent_blocks.get(&item.view_id) {
-                        let height = item.last_laid_out_height.as_f64().ceil().max(1.0) as usize;
-                        Some(TuiBlockListVisibleItem {
+                        let height = item.last_laid_out_height.as_f64().ceil().max(0.0) as usize;
+                        (height > 0).then(|| TuiBlockListVisibleItem {
                             origin_y: item_top,
                             height,
                             kind: TuiBlockListVisibleItemKind::Agent(view.clone()),

--- a/crates/warp_tui/src/tui_block_list_viewport_source.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source.rs
@@ -174,7 +174,7 @@ impl TuiBlockListViewportSource {
                     height
                 } else {
                     let view = cli_subagent_blocks.get(&view_id)?.as_ref(app);
-                    let height = view.desired_height(width, ctx, app).max(1);
+                    let height = view.desired_height(width, ctx, app);
                     view.record_height_measurement(width);
                     height
                 };
@@ -276,22 +276,25 @@ impl TuiBlockListViewportSource {
                 BlockHeightItem::RichContent(item) => {
                     if item.should_hide {
                         None
-                    } else if let Some(view) = agent_blocks.get(&item.view_id) {
-                        let height = item.last_laid_out_height.as_f64().ceil().max(0.0) as usize;
-                        (height > 0).then(|| TuiBlockListVisibleItem {
-                            origin_y: item_top,
-                            height,
-                            kind: TuiBlockListVisibleItemKind::Agent(view.clone()),
-                        })
-                    } else if let Some(view) = cli_subagent_blocks.get(&item.view_id) {
-                        let height = item.last_laid_out_height.as_f64().ceil().max(1.0) as usize;
-                        Some(TuiBlockListVisibleItem {
-                            origin_y: item_top,
-                            height,
-                            kind: TuiBlockListVisibleItemKind::CLISubagent(view.clone()),
-                        })
                     } else {
-                        None
+                        let height = item.last_laid_out_height.as_f64().ceil().max(0.0) as usize;
+                        if height == 0 {
+                            None
+                        } else if let Some(view) = agent_blocks.get(&item.view_id) {
+                            Some(TuiBlockListVisibleItem {
+                                origin_y: item_top,
+                                height,
+                                kind: TuiBlockListVisibleItemKind::Agent(view.clone()),
+                            })
+                        } else {
+                            cli_subagent_blocks.get(&item.view_id).map(|view| {
+                                TuiBlockListVisibleItem {
+                                    origin_y: item_top,
+                                    height,
+                                    kind: TuiBlockListVisibleItemKind::CLISubagent(view.clone()),
+                                }
+                            })
+                        }
                     }
                 }
                 BlockHeightItem::Gap(_)

--- a/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
@@ -15,8 +15,8 @@ use warp::tui_export::{
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, EntityId, EntityIdMap, ViewHandle};
 use warpui_core::elements::tui::{
-    TuiBufferExt, TuiConstraint, TuiGridPoint, TuiLayoutContext, TuiRect, TuiSelectionSpan,
-    TuiSize, TuiViewportContent, TuiViewportWindow, TuiViewportedElement,
+    TuiBufferExt, TuiConstraint, TuiGridPoint, TuiLayoutContext, TuiRect, TuiRowResize,
+    TuiSelectionSpan, TuiSize, TuiViewportContent, TuiViewportWindow, TuiViewportedElement,
 };
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, AppContext, TuiView, TypedActionView, ViewContext};
@@ -146,6 +146,91 @@ fn viewport_layout_reports_original_agent_block_resize() {
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].old_rows, 0..99);
         assert_eq!(changes[0].new_height, expected);
+    });
+}
+
+#[test]
+fn zero_height_agent_block_contributes_no_rows_and_grows_with_content() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (source, model, agent_block, block_model) =
+            updating_agent_block_source(&mut app, AIBlockOutputStatus::Pending);
+
+        let empty_content = request_top_window(&app, &source, 10);
+        assert_eq!(empty_content.content_height, 0);
+        assert!(empty_content.items.is_empty());
+        assert_eq!(rich_content_height(&model, agent_block.id()), Some(0.0));
+        assert_eq!(
+            source.take_selection_row_resizes(),
+            vec![TuiRowResize {
+                old_rows: 0..1,
+                new_height: 0,
+            }]
+        );
+
+        block_model.update_status(
+            completed_markdown_status("Visible response"),
+            &agent_block,
+            &mut app,
+        );
+        let visible_content = request_top_window(&app, &source, 10);
+        assert!(visible_content.content_height > 0);
+        assert_eq!(visible_content.items.len(), 1);
+        assert_eq!(
+            rich_content_height(&model, agent_block.id()),
+            Some(visible_content.content_height as f64)
+        );
+        assert_eq!(
+            source.take_selection_row_resizes(),
+            vec![warpui_core::elements::tui::TuiRowResize {
+                old_rows: 0..0,
+                new_height: visible_content.content_height,
+            }]
+        );
+    });
+}
+
+#[test]
+fn read_only_content_omits_zero_height_agent_after_terminal_block() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let mut terminal_model = TerminalModel::mock(None, None);
+        terminal_model.simulate_block("printf", "terminal row\r\n");
+        let terminal_model = Arc::new(FairMutex::new(terminal_model));
+        let agent_block = add_agent_block_with(
+            &mut app,
+            Vec::new(),
+            AIBlockOutputStatus::Pending,
+            terminal_model.clone(),
+        );
+        let view_id = agent_block.id();
+        {
+            let mut model = terminal_model.lock();
+            model.block_list_mut().append_rich_content(
+                RichContentItem::new(Some(RichContentType::AIBlock), view_id, None, false),
+                false,
+            );
+            model
+                .block_list_mut()
+                .update_rich_content_heights_in_lines(&HashMap::from([(
+                    view_id,
+                    BlockHeight::zero(),
+                )]));
+        }
+        let source = TuiBlockListViewportSource::new(
+            terminal_model,
+            AgentBlockRegistry::new(RefCell::new(HashMap::from([(view_id, agent_block)]))),
+        );
+
+        let content = source.read_only_content(
+            TuiViewportWindow {
+                scroll_top: 0,
+                viewport_height: 100,
+            },
+            80,
+        );
+
+        assert_eq!(content.items.len(), 1);
     });
 }
 

--- a/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
@@ -191,7 +191,7 @@ fn zero_height_agent_block_contributes_no_rows_and_grows_with_content() {
 }
 
 #[test]
-fn read_only_content_omits_zero_height_agent_after_terminal_block() {
+fn read_only_content_omits_zero_height_rich_content_after_terminal_block() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let mut terminal_model = TerminalModel::mock(None, None);


### PR DESCRIPTION
## Description
Slack thread with more context: https://warpdev.slack.com/archives/C0BA99TSDB2/p1784680767186599

Zero height agent blocks were getting rendered with a row, causing what looked like a gap before more text would fill in

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

https://github.com/user-attachments/assets/a739b1ba-7d74-4c93-9492-9fc1f25af65b

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
