### PR TITLE
add version command

### DIFF
--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -109,6 +109,16 @@ pub const EXIT: StaticCommand = StaticCommand {
     argument: None,
 };
 
+pub const VERSION: StaticCommand = StaticCommand {
+    name: "/version",
+    description: "Show the Warp version",
+    kind: SlashCommandKind::Version,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
+    availability: Availability::ALWAYS,
+    auto_enter_ai_mode: false,
+    argument: None,
+};
+
 pub const LOGOUT: StaticCommand = StaticCommand {
     name: "/logout",
     description: "Log out of Warp",
@@ -858,6 +868,7 @@ fn all_commands(settings_mode: settings::SettingsMode) -> Vec<StaticCommand> {
         CONVERSATIONS,
         EXPORT_TO_CLIPBOARD,
         MODEL.clone(),
+        VERSION,
         VIEW_LOGS,
     ];
 

--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -133,6 +133,20 @@ fn logout_command_is_registered_only_for_tui_mode() {
 }
 
 #[test]
+fn version_command_is_registered_only_for_tui_mode() {
+    assert!(
+        all_commands(settings::SettingsMode::Tui)
+            .iter()
+            .any(|command| command == &VERSION)
+    );
+    assert!(
+        !all_commands(settings::SettingsMode::Gui)
+            .iter()
+            .any(|command| command == &VERSION)
+    );
+}
+
+#[test]
 fn rename_tab_command_requires_argument() {
     let command = COMMAND_REGISTRY
         .get_command_with_name(RENAME_TAB.name)

--- a/app/src/search/slash_command_menu/static_commands/mod.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod.rs
@@ -61,6 +61,7 @@ pub enum SlashCommandKind {
     DisableNaturalLanguageDetection,
     Exit,
     Logout,
+    Version,
     CreateEnvironment,
     CreateDockerSandbox,
     CreateNewProject,

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1260,7 +1260,8 @@ impl Input {
             | SlashCommandKind::EnableNaturalLanguageDetection
             | SlashCommandKind::DisableNaturalLanguageDetection
             | SlashCommandKind::Exit
-            | SlashCommandKind::Logout => {
+            | SlashCommandKind::Logout
+            | SlashCommandKind::Version => {
                 debug_assert!(
                     false,
                     "Attempted to execute TUI-only slash command in the GUI: {}",

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -68,6 +68,7 @@ fn tui_commands_have_typed_identities_and_explicit_surface_support() {
         (&commands::MCP, SlashCommandKind::Mcp),
         (&commands::EXIT, SlashCommandKind::Exit),
         (&commands::LOGOUT, SlashCommandKind::Logout),
+        (&commands::VERSION, SlashCommandKind::Version),
         (&commands::VIEW_LOGS, SlashCommandKind::ViewLogs),
     ] {
         assert_eq!(
@@ -116,6 +117,21 @@ fn logout_command_executes_immediately_and_takes_no_argument() {
         SlashCommandSelectionBehavior::Execute
     );
     assert_eq!(commands::LOGOUT.availability, Availability::ALWAYS);
+}
+
+#[test]
+fn version_command_executes_immediately_and_takes_no_argument() {
+    use super::{SlashCommandSelectionBehavior, slash_command_selection_behavior};
+
+    assert_eq!(commands::VERSION.kind, SlashCommandKind::Version);
+    assert!(commands::VERSION.argument.is_none());
+    assert!(!slash_command_is_submitted_as_prompt(&commands::VERSION));
+    assert_eq!(
+        slash_command_selection_behavior(&commands::VERSION),
+        SlashCommandSelectionBehavior::Execute
+    );
+    assert_eq!(commands::VERSION.availability, Availability::ALWAYS);
+    assert!(commands::VERSION.supports_surface(settings::SettingsMode::Tui));
 }
 
 #[test]

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -24,8 +24,15 @@ use crate::telemetry::TuiStartupTelemetryEvent;
 use crate::terminal_background::probe_and_select_theme;
 use crate::terminal_session_view::{TuiConversationRestoreOrigin, TuiConversationRestoreTarget};
 
-#[derive(Parser)]
-#[command(name = "warp")]
+/// Version string printed by `--version`. Release builds get `GIT_RELEASE_TAG`;
+/// local cargo builds fall back to a numeric placeholder.
+const CLI_VERSION: &str = match option_env!("GIT_RELEASE_TAG") {
+    Some(version) => version,
+    None => "v0.0.0.0.0.0",
+};
+
+#[derive(Debug, Parser)]
+#[command(name = "warp", version = CLI_VERSION)]
 struct TuiArgs {
     /// Resume an Oz/Warp conversation by server token.
     #[arg(long)]
@@ -53,12 +60,12 @@ pub fn run() -> Result<()> {
     }
     let args = match TuiArgs::try_parse() {
         Ok(args) => args,
-        Err(error)
-            if matches!(
-                error.kind(),
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
-            ) =>
-        {
+        // Match the zero-state version line: bare tag/version, no binary name prefix.
+        Err(error) if error.kind() == ErrorKind::DisplayVersion => {
+            println!("{CLI_VERSION}");
+            return Ok(());
+        }
+        Err(error) if error.kind() == ErrorKind::DisplayHelp => {
             error.print()?;
             return Ok(());
         }

--- a/crates/warp_tui/src/session_tests.rs
+++ b/crates/warp_tui/src/session_tests.rs
@@ -43,3 +43,17 @@ fn accepts_startup_without_resume() {
     assert_eq!(args.resume, None);
     assert_eq!(args.api_key, None);
 }
+
+#[test]
+fn version_flag_prints_cli_version() {
+    let error = TuiArgs::try_parse_from(["warp", "--version"])
+        .expect_err("--version should short-circuit clap parsing");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+    // `run()` prints only CLI_VERSION (no binary-name precursor). Clap's
+    // DisplayVersion payload still contains the configured version string.
+    assert!(
+        error.to_string().contains(super::CLI_VERSION),
+        "--version should be backed by the configured CLI version"
+    );
+}

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -37,6 +37,7 @@ use warp::tui_export::{
     record_static_slash_command_accepted, saved_prompt_text_for_id,
     slash_command_selection_behavior, throttle,
 };
+use warp_core::channel::{Channel, ChannelState};
 use warp_core::features::FeatureFlag;
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
@@ -193,6 +194,27 @@ const COST_CONVERSATION_IN_PROGRESS_HINT: &str =
 
 fn log_bundle_success_message(path: &Path) -> String {
     format!("Log bundle saved to {}", path.display())
+}
+
+/// User-facing CLI binary name for the current channel.
+///
+/// Installed builds expose `warp`, `warp-dev`, `warp-preview`, etc. Local cargo
+/// builds don't ship a versioned `warp` binary on PATH, so they intentionally
+/// target `warp-dev` (the dogfood channel name).
+fn tui_cli_binary_name(channel: Channel) -> &'static str {
+    match channel {
+        Channel::Stable => "warp",
+        Channel::Dev | Channel::Local => "warp-dev",
+        Channel::Preview => "warp-preview",
+        Channel::Oss => "warp-oss",
+        Channel::Integration => "warp-integration",
+    }
+}
+
+/// Shell command used by `/version` to print the binary version as a normal
+/// transcript block.
+fn version_shell_command(channel: Channel) -> String {
+    format!("{} --version", tui_cli_binary_name(channel))
 }
 
 fn raw_prompt_if_not_blank(input: &str) -> Option<&str> {
@@ -2902,6 +2924,13 @@ impl TuiTerminalSessionView {
             SlashCommandKind::Logout => {
                 record_static_slash_command_accepted(command.name, true, ctx);
                 log_out_tui(ctx);
+            }
+            SlashCommandKind::Version => {
+                // Run as a normal user shell command so version output lands in
+                // the transcript as a regular shell block.
+                let command_text = version_shell_command(ChannelState::channel());
+                self.execute_user_command(&command_text, ctx);
+                record_static_slash_command_accepted(command.name, true, ctx);
             }
             SlashCommandKind::ViewLogs => {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -1997,3 +1997,33 @@ fn escape_with_root_selected_clears_tab_focus_without_switching() {
         });
     });
 }
+
+#[test]
+fn version_shell_command_uses_channel_cli_names() {
+    use warp_core::channel::Channel;
+
+    assert_eq!(
+        super::version_shell_command(Channel::Stable),
+        "warp --version"
+    );
+    assert_eq!(
+        super::version_shell_command(Channel::Dev),
+        "warp-dev --version"
+    );
+    assert_eq!(
+        super::version_shell_command(Channel::Local),
+        "warp-dev --version"
+    );
+    assert_eq!(
+        super::version_shell_command(Channel::Preview),
+        "warp-preview --version"
+    );
+    assert_eq!(
+        super::version_shell_command(Channel::Oss),
+        "warp-oss --version"
+    );
+    assert_eq!(
+        super::version_shell_command(Channel::Integration),
+        "warp-integration --version"
+    );
+}


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

WISOTT. Adds a `/version` command to the tui, and a `--version` argument that you can use in the TUI to print its version. The `/version` command just runs `warp --version` (or warp dev for dev and preview for preview). Running warp locally doesn't have a version, so `/version` just runs warp dev as well.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/b10d6f59d2b34508a45a433ce8350a37

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode