### PR TITLE
Add clipboard shortcuts to TUI editors

### DIFF
--- a/crates/warp_tui/src/editor_interaction.rs
+++ b/crates/warp_tui/src/editor_interaction.rs
@@ -278,14 +278,14 @@ const SHARED_EDITOR_BINDINGS: &[EditorBindingSpec] = &[
         input_name: Some("tui:input:copy"),
         editor_name: Some("tui:editor:copy"),
         description: "Copy selected text",
-        keys: &["ctrl-shift-C", "cmd-c"],
+        keys: &["ctrl-shift-C", "alt-w"],
     },
     EditorBindingSpec {
         command: TuiEditorCommand::Cut,
         input_name: Some("tui:input:cut"),
         editor_name: Some("tui:editor:cut"),
         description: "Cut selected text",
-        keys: &["ctrl-x", "cmd-x"],
+        keys: &["ctrl-x"],
     },
     EditorBindingSpec {
         command: TuiEditorCommand::KillToLineEnd,

--- a/crates/warp_tui/src/editor_interaction.rs
+++ b/crates/warp_tui/src/editor_interaction.rs
@@ -8,6 +8,7 @@ use warp_editor::selection::{TextDirection, TextUnit};
 use warpui_core::text::word_boundaries::WordBoundariesPolicy;
 use warpui_core::{AppContext, ModelHandle};
 
+use crate::clipboard::copy_to_clipboard;
 use crate::editor_element::TuiEditorAction;
 
 /// Editing commands shared by TUI text fields.
@@ -33,6 +34,8 @@ pub enum TuiEditorCommand {
     SelectWordLeft,
     SelectWordRight,
     SelectAll,
+    Copy,
+    Cut,
     KillToLineEnd,
     KillToLineStart,
     Yank,
@@ -95,6 +98,14 @@ impl TuiEditorBehavior {
 pub(crate) enum TuiEditorInteractionOutcome {
     FollowCursor,
     PreserveViewport,
+    Clipboard(TuiEditorClipboardAction),
+}
+
+/// Clipboard operation requested by a shared TUI editor command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TuiEditorClipboardAction {
+    Copy,
+    Cut,
 }
 
 /// Selects stable user-configurable names for each binding consumer.
@@ -261,6 +272,20 @@ const SHARED_EDITOR_BINDINGS: &[EditorBindingSpec] = &[
         editor_name: Some("tui:editor:select_all"),
         description: "Select all text",
         keys: &["ctrl-shift-A"],
+    },
+    EditorBindingSpec {
+        command: TuiEditorCommand::Copy,
+        input_name: Some("tui:input:copy"),
+        editor_name: Some("tui:editor:copy"),
+        description: "Copy selected text",
+        keys: &["ctrl-shift-C", "cmd-c"],
+    },
+    EditorBindingSpec {
+        command: TuiEditorCommand::Cut,
+        input_name: Some("tui:input:cut"),
+        editor_name: Some("tui:editor:cut"),
+        description: "Cut selected text",
+        keys: &["ctrl-x", "cmd-x"],
     },
     EditorBindingSpec {
         command: TuiEditorCommand::KillToLineEnd,
@@ -438,6 +463,12 @@ impl TuiEditorState {
             TuiEditorCommand::SelectAll => {
                 model.update(ctx, |model, ctx| model.select_all(ctx));
             }
+            TuiEditorCommand::Copy => {
+                return TuiEditorInteractionOutcome::Clipboard(TuiEditorClipboardAction::Copy);
+            }
+            TuiEditorCommand::Cut => {
+                return TuiEditorInteractionOutcome::Clipboard(TuiEditorClipboardAction::Cut);
+            }
             TuiEditorCommand::KillToLineEnd => {
                 if let Some(killed) = model.update(ctx, |model, ctx| {
                     model.kill_to_char_cell_visual_row_end(ctx)
@@ -470,6 +501,46 @@ impl TuiEditorState {
     }
 }
 
+/// Copies the current editor selection and, for a cut, deletes it only after
+/// the clipboard write succeeds. Returns `false` when there is no selection.
+pub(crate) fn apply_editor_clipboard_action(
+    model: &ModelHandle<CodeEditorModel>,
+    action: TuiEditorClipboardAction,
+    ctx: &mut AppContext,
+) -> anyhow::Result<bool> {
+    apply_editor_clipboard_action_with(model, action, copy_to_clipboard, ctx)
+}
+
+fn apply_editor_clipboard_action_with(
+    model: &ModelHandle<CodeEditorModel>,
+    action: TuiEditorClipboardAction,
+    copy: impl FnOnce(&str) -> anyhow::Result<()>,
+    ctx: &mut AppContext,
+) -> anyhow::Result<bool> {
+    let selected_text = model
+        .as_ref(ctx)
+        .read_selected_text_as_clipboard_content(ctx)
+        .plain_text;
+    if selected_text.is_empty() {
+        return Ok(false);
+    }
+
+    copy(&selected_text)?;
+    if action == TuiEditorClipboardAction::Cut {
+        model.update(ctx, |model, ctx| model.backspace(ctx));
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+pub(crate) fn apply_editor_clipboard_action_for_test(
+    model: &ModelHandle<CodeEditorModel>,
+    action: TuiEditorClipboardAction,
+    copy: impl FnOnce(&str) -> anyhow::Result<()>,
+    ctx: &mut AppContext,
+) -> anyhow::Result<bool> {
+    apply_editor_clipboard_action_with(model, action, copy, ctx)
+}
 /// Applies an element-originated action and reports the required viewport work.
 pub(crate) fn apply_editor_action(
     model: &ModelHandle<CodeEditorModel>,

--- a/crates/warp_tui/src/editor_view.rs
+++ b/crates/warp_tui/src/editor_view.rs
@@ -18,7 +18,7 @@ use warpui_core::{
 use crate::editor_element::{TuiEditorAction, TuiEditorElement};
 use crate::editor_interaction::{
     TuiEditorBehavior, TuiEditorCommand, TuiEditorInteractionOutcome, TuiEditorState,
-    apply_editor_action, follow_editor_cursor,
+    apply_editor_action, apply_editor_clipboard_action, follow_editor_cursor,
 };
 
 #[derive(Clone, Copy)]
@@ -230,6 +230,15 @@ impl TypedActionView for TuiEditorView {
             }
             TuiEditorViewAction::Editor(action) => self.handle_editor_action(action, ctx),
             TuiEditorViewAction::Command(command) => self.handle_command(*command, ctx),
+        };
+        let outcome = match outcome {
+            TuiEditorInteractionOutcome::Clipboard(action) => {
+                if let Err(error) = apply_editor_clipboard_action(&self.model, action, ctx) {
+                    log::error!("Failed to copy TUI editor selection: {error}");
+                }
+                TuiEditorInteractionOutcome::FollowCursor
+            }
+            outcome => outcome,
         };
         if outcome == TuiEditorInteractionOutcome::FollowCursor {
             follow_editor_cursor(&self.model, self.editor_behavior, ctx);

--- a/crates/warp_tui/src/editor_view_tests.rs
+++ b/crates/warp_tui/src/editor_view_tests.rs
@@ -415,10 +415,10 @@ fn keybinding_initializer_registers_line_start_for_input_and_editor() {
                 "alt-enter".to_string(),
             ])
         );
-        let copy = HashSet::from(["ctrl-shift-C".to_string(), "cmd-c".to_string()]);
+        let copy = HashSet::from(["ctrl-shift-C".to_string(), "alt-w".to_string()]);
         assert_eq!(triggers_for("tui:input:copy"), copy);
         assert_eq!(triggers_for("tui:editor:copy"), copy);
-        let cut = HashSet::from(["ctrl-x".to_string(), "cmd-x".to_string()]);
+        let cut = HashSet::from(["ctrl-x".to_string()]);
         assert_eq!(triggers_for("tui:input:cut"), cut);
         assert_eq!(triggers_for("tui:editor:cut"), cut);
         assert!(app.read(|ctx| ctx.get_binding_by_name("tui:editor:move_up").is_none()));

--- a/crates/warp_tui/src/editor_view_tests.rs
+++ b/crates/warp_tui/src/editor_view_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use string_offset::CharOffset;
 use warp::tui_export::Appearance;
-use warp_editor::model::CoreEditorModel;
+use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, EntityIdMap};
 use warpui_core::elements::tui::{
@@ -14,7 +14,9 @@ use warpui_core::{App, TuiView as _, TypedActionView as _};
 
 use super::{TuiEditorView, TuiEditorViewAction};
 use crate::editor_element::TuiEditorAction;
-use crate::editor_interaction::TuiEditorCommand;
+use crate::editor_interaction::{
+    TuiEditorClipboardAction, TuiEditorCommand, apply_editor_clipboard_action_for_test,
+};
 use crate::test_fixtures::TestHostView;
 
 /// Renders an editor view to trimmed lines.
@@ -182,6 +184,133 @@ fn kill_and_yank_are_shared_with_the_generic_editor() {
 }
 
 #[test]
+fn clipboard_actions_copy_and_cut_only_the_selection() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (_, editor) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                TuiEditorView::single_line,
+            )
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.set_text("hello world", ctx);
+            for _ in 0..5 {
+                editor.handle_action(
+                    &TuiEditorViewAction::Command(TuiEditorCommand::SelectLeft),
+                    ctx,
+                );
+            }
+
+            let mut copied = None;
+            assert!(
+                apply_editor_clipboard_action_for_test(
+                    &editor.model,
+                    TuiEditorClipboardAction::Copy,
+                    |text| {
+                        copied = Some(text.to_owned());
+                        Ok(())
+                    },
+                    ctx,
+                )
+                .expect("copy succeeds")
+            );
+            assert_eq!(copied.as_deref(), Some("world"));
+            assert_eq!(editor.text(ctx), "hello world");
+
+            let mut cut = None;
+            assert!(
+                apply_editor_clipboard_action_for_test(
+                    &editor.model,
+                    TuiEditorClipboardAction::Cut,
+                    |text| {
+                        cut = Some(text.to_owned());
+                        Ok(())
+                    },
+                    ctx,
+                )
+                .expect("cut succeeds")
+            );
+            assert_eq!(cut.as_deref(), Some("world"));
+            assert_eq!(editor.text(ctx), "hello ");
+        });
+    });
+}
+
+#[test]
+fn cut_without_a_selection_is_a_noop() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (_, editor) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                TuiEditorView::single_line,
+            )
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.set_text("hello", ctx);
+            assert!(
+                !apply_editor_clipboard_action_for_test(
+                    &editor.model,
+                    TuiEditorClipboardAction::Cut,
+                    |_| panic!("clipboard should not be written without a selection"),
+                    ctx,
+                )
+                .expect("no-selection cut succeeds")
+            );
+            assert_eq!(editor.text(ctx), "hello");
+        });
+    });
+}
+
+#[test]
+fn failed_cut_preserves_the_selection_and_text() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (_, editor) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                TuiEditorView::single_line,
+            )
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.set_text("hello", ctx);
+            editor.handle_action(
+                &TuiEditorViewAction::Command(TuiEditorCommand::SelectLeft),
+                ctx,
+            );
+            let result = apply_editor_clipboard_action_for_test(
+                &editor.model,
+                TuiEditorClipboardAction::Cut,
+                |_| anyhow::bail!("clipboard unavailable"),
+                ctx,
+            );
+            assert!(result.is_err());
+            assert_eq!(editor.text(ctx), "hello");
+            assert_eq!(
+                editor
+                    .model
+                    .as_ref(ctx)
+                    .read_selected_text_as_clipboard_content(ctx)
+                    .plain_text,
+                "o"
+            );
+        });
+    });
+}
+#[test]
 fn editor_follows_cursor_within_its_one_row_viewport() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
@@ -286,6 +415,12 @@ fn keybinding_initializer_registers_line_start_for_input_and_editor() {
                 "alt-enter".to_string(),
             ])
         );
+        let copy = HashSet::from(["ctrl-shift-C".to_string(), "cmd-c".to_string()]);
+        assert_eq!(triggers_for("tui:input:copy"), copy);
+        assert_eq!(triggers_for("tui:editor:copy"), copy);
+        let cut = HashSet::from(["ctrl-x".to_string(), "cmd-x".to_string()]);
+        assert_eq!(triggers_for("tui:input:cut"), cut);
+        assert_eq!(triggers_for("tui:editor:cut"), cut);
         assert!(app.read(|ctx| ctx.get_binding_by_name("tui:editor:move_up").is_none()));
     });
 }

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -42,7 +42,7 @@ use warpui_core::{
 use crate::editor_element::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
 use crate::editor_interaction::{
     TuiEditorBehavior, TuiEditorCommand, TuiEditorInteractionOutcome, TuiEditorState,
-    apply_editor_action, follow_editor_cursor,
+    apply_editor_action, apply_editor_clipboard_action, follow_editor_cursor,
 };
 use crate::inline_menu::{TuiInlineMenu, TuiInlineMenuAccepted, active_inline_menu};
 use crate::input_hints;
@@ -125,6 +125,10 @@ pub enum TuiInputViewEvent {
     /// The user accepted a prompt from the up-arrow prompt-history menu. Carries
     /// the prompt text to fill into the input and submit.
     AcceptedPromptHistory(String),
+    /// Selected prompt text was copied to the host clipboard.
+    ClipboardCopySucceeded,
+    /// Selected prompt text could not be copied to the host clipboard.
+    ClipboardCopyFailed,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -606,6 +610,20 @@ impl TypedActionView for TuiInputView {
                 });
                 TuiEditorInteractionOutcome::FollowCursor
             }
+        };
+        let outcome = match outcome {
+            TuiEditorInteractionOutcome::Clipboard(action) => {
+                match apply_editor_clipboard_action(&self.model, action, ctx) {
+                    Ok(true) => ctx.emit(TuiInputViewEvent::ClipboardCopySucceeded),
+                    Ok(false) => {}
+                    Err(error) => {
+                        log::error!("Failed to copy TUI input selection: {error}");
+                        ctx.emit(TuiInputViewEvent::ClipboardCopyFailed);
+                    }
+                }
+                TuiEditorInteractionOutcome::FollowCursor
+            }
+            outcome => outcome,
         };
         if outcome == TuiEditorInteractionOutcome::FollowCursor {
             self.follow_cursor(ctx);

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -864,7 +864,9 @@ fn multiline_paste_emits_once_and_fallback_inserts_without_submitting() {
                 | TuiInputViewEvent::AcceptedMcp(_)
                 | TuiInputViewEvent::AcceptedPromptHistory(_)
                 | TuiInputViewEvent::BackspaceAtEmptyInput
-                | TuiInputViewEvent::MoveFocusUp => {}
+                | TuiInputViewEvent::MoveFocusUp
+                | TuiInputViewEvent::ClipboardCopySucceeded
+                | TuiInputViewEvent::ClipboardCopyFailed => {}
             });
             (view, pasted, submitted)
         });

--- a/crates/warp_tui/src/keybindings_tests.rs
+++ b/crates/warp_tui/src/keybindings_tests.rs
@@ -1,4 +1,6 @@
-use warpui_core::keymap::Context;
+use std::collections::HashSet;
+
+use warpui_core::keymap::{Context, Trigger};
 use warpui_core::{App, TuiView};
 
 use super::{ATTACHMENTS_AVAILABLE_FLAG, TUI_BINDING_GROUP, is_tui_owned};
@@ -84,17 +86,39 @@ fn attachment_bindings_are_scoped_to_available_and_focused_contexts() {
                     .all(|binding| !binding.in_context(&plain_input))
             );
 
-            let paste_image = ctx
+            let paste_bindings = ctx
                 .editable_bindings()
-                .find(|binding| binding.name == PASTE_IMAGE_BINDING_NAME)
-                .expect("clipboard image binding");
+                .filter(|binding| binding.name == PASTE_IMAGE_BINDING_NAME)
+                .collect::<Vec<_>>();
+            assert!(!paste_bindings.is_empty());
             let mut composer_context = plain_input.clone();
             composer_context
                 .set
                 .insert(SESSION_COMPOSER_OWNS_INPUT_FLAG);
-            assert!(paste_image.in_context(&composer_context));
-            assert!(!paste_image.in_context(&plain_input));
-            assert!(!paste_image.in_context(&bar_context));
+            assert!(
+                paste_bindings
+                    .iter()
+                    .all(|binding| binding.in_context(&composer_context))
+            );
+            assert!(
+                paste_bindings
+                    .iter()
+                    .all(|binding| !binding.in_context(&plain_input))
+            );
+            assert!(
+                paste_bindings
+                    .iter()
+                    .all(|binding| !binding.in_context(&bar_context))
+            );
+            let paste_triggers = paste_bindings
+                .iter()
+                .filter_map(|binding| match binding.trigger {
+                    Trigger::Keystrokes(keys) => keys.first().map(|key| key.normalized()),
+                    Trigger::Empty | Trigger::Standard(_) | Trigger::Custom(_) => None,
+                })
+                .collect::<HashSet<_>>();
+            assert!(paste_triggers.contains("ctrl-v"));
+            assert!(paste_triggers.contains("ctrl-shift-V"));
         });
     });
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -565,6 +565,17 @@ pub(crate) fn init(app: &mut AppContext) {
         )
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("ctrl-v"),
+        EditableBinding::new(
+            PASTE_IMAGE_BINDING_NAME,
+            "Paste from the clipboard",
+            TuiTerminalSessionAction::PasteFromClipboard,
+        )
+        .with_context_predicate(
+            (id!(TuiInputView::ui_name()) | id!(TuiTerminalSessionView::ui_name()))
+                & id!(SESSION_COMPOSER_OWNS_INPUT_FLAG),
+        )
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("ctrl-shift-V"),
         #[cfg(windows)]
         EditableBinding::new(
             PASTE_IMAGE_BINDING_NAME,
@@ -1220,6 +1231,10 @@ impl TuiTerminalSessionView {
             }
             TuiInputViewEvent::AcceptedPromptHistory(text) => {
                 view.handle_accepted_prompt_history(text.clone(), ctx);
+            }
+            TuiInputViewEvent::ClipboardCopySucceeded => view.show_copy_hint(ctx),
+            TuiInputViewEvent::ClipboardCopyFailed => {
+                view.show_transient_hint(COPY_FAILED_HINT.to_owned(), ctx);
             }
             TuiInputViewEvent::MoveFocusUp => {
                 view.focus_orchestration_tabs(ctx);


### PR DESCRIPTION
## Description

Adds selection-aware clipboard shortcuts to Warp TUI editors:

- `Ctrl-X` cuts the active selection.
- `Ctrl-Shift-C` or readline-style `Alt-W` copies the active selection.
- `Ctrl-Shift-V` provides a terminal-standard paste alias alongside `Ctrl-V`.
- Cut is a no-op without a selection and only deletes text after a successful clipboard write.
- Prompt copy/cut operations surface success or failure feedback without changing `Ctrl-C` cancellation behavior.

The implementation reuses the TUI's existing native/OSC 52 clipboard transport and applies the behavior to both the prompt editor and reusable TUI editor fields.

## Linked Issue

None.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] `./script/format`
- [x] `cargo nextest run -p warp_tui` — 559 tests passed
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- [x] Built `warp-tui-oss` and manually verified the real TUI under tmux:
  - Selecting `world` in `hello world` and pressing `Ctrl-X` cut the selection and showed clipboard feedback.
  - Pressing `Ctrl-V` restored `hello world` from the host clipboard.
  - Pressing `Ctrl-X` without a selection left the prompt unchanged.
  - Selecting `world` and pressing `Alt-W` showed clipboard feedback, and `pbpaste` returned `world`.
- [ ] Full `./script/presubmit` was not run, per request.

Agent conversation: https://staging.warp.dev/conversation/cfb694de-da9c-478c-93cd-28adefea284a

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added clipboard shortcuts for copying, cutting, and pasting selected text in Warp TUI.

Co-Authored-By: Warp <agent@warp.dev>
