### PR TITLE
Add shell command tab completions to TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16025,6 +16025,7 @@ dependencies = [
  "vec1",
  "warp",
  "warp_channel_config",
+ "warp_completer",
  "warp_core",
  "warp_editor",
  "warp_errors",

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -132,6 +132,7 @@ pub use crate::code_review::git_repo_model::{
 };
 pub use crate::completer::SessionContext;
 pub use crate::persistence::PersistenceWriter;
+pub use crate::prefix::longest_common_prefix;
 pub use crate::search::slash_command_menu::static_commands::commands::{
     self as slash_commands, COMMAND_REGISTRY,
 };

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -69,6 +69,7 @@ unicode-width.workspace = true
 vec1.workspace = true
 warp = { workspace = true, features = ["image_as_context", "tui"] }
 warp_channel_config.workspace = true
+warp_completer.workspace = true
 warp_core.workspace = true
 warp_errors.workspace = true
 warp_editor.workspace = true

--- a/crates/warp_tui/src/completion_menu.rs
+++ b/crates/warp_tui/src/completion_menu.rs
@@ -1,0 +1,202 @@
+//! Shell-command completion state presented through the shared TUI inline menu.
+
+use std::ops::Range;
+
+use warp_completer::completer::{EngineFileType, MatchedSuggestion};
+use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
+
+use crate::inline_menu::{
+    MAX_INLINE_MENU_ROWS, TuiInlineMenuListState, TuiInlineMenuRow, TuiInlineMenuRowStyle,
+    TuiInlineMenuSnapshot, result_row_capacity,
+};
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
+
+const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, false, false);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TuiCompletionAcceptance {
+    pub(crate) replacement: String,
+    pub(crate) replacement_range: Range<usize>,
+    pub(crate) append_space: bool,
+}
+
+#[derive(Clone, Debug)]
+struct TuiCompletionRow {
+    display: String,
+    description: Option<String>,
+    acceptance: TuiCompletionAcceptance,
+}
+
+#[derive(Clone, Debug, Default)]
+enum TuiCompletionMenuState {
+    #[default]
+    Closed,
+    Open {
+        list: TuiInlineMenuListState<TuiCompletionRow>,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TuiCompletionMenuEvent;
+
+pub(crate) struct TuiCompletionMenuModel {
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+    state: TuiCompletionMenuState,
+}
+
+impl TuiCompletionMenuModel {
+    pub(crate) fn new(suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>) -> Self {
+        Self {
+            suggestions_mode,
+            state: TuiCompletionMenuState::Closed,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+        rows: Vec<(String, TuiCompletionAcceptance)>,
+        selected_index: usize,
+    ) -> Self {
+        let mut list = TuiInlineMenuListState::default();
+        list.replace_rows(
+            rows.into_iter()
+                .map(|(display, acceptance)| TuiCompletionRow {
+                    display,
+                    description: None,
+                    acceptance,
+                })
+                .collect(),
+            false,
+            Some(selected_index),
+            MAX_VISIBLE_ROWS,
+            |_| true,
+        );
+        Self {
+            suggestions_mode,
+            state: TuiCompletionMenuState::Open { list },
+        }
+    }
+
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        matches!(self.state, TuiCompletionMenuState::Open { .. })
+            && self.suggestions_mode.as_ref(ctx).mode()
+                == TuiInputSuggestionsMode::CompletionSuggestions
+    }
+
+    pub(crate) fn show(
+        &mut self,
+        suggestions: Vec<MatchedSuggestion>,
+        replacement_range: Range<usize>,
+        append_space_at_buffer_end: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let did_open = self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::CompletionSuggestions, ctx)
+        });
+        if !did_open {
+            return;
+        }
+
+        let rows = suggestions
+            .into_iter()
+            .map(|suggestion| {
+                let append_space = append_space_at_buffer_end
+                    && suggestion.suggestion.file_type != Some(EngineFileType::Directory);
+                TuiCompletionRow {
+                    display: suggestion.display().to_owned(),
+                    description: suggestion.description(),
+                    acceptance: TuiCompletionAcceptance {
+                        replacement: suggestion.replacement().to_owned(),
+                        replacement_range: replacement_range.clone(),
+                        append_space,
+                    },
+                }
+            })
+            .collect();
+        let mut list = TuiInlineMenuListState::default();
+        list.replace_rows(rows, false, Some(0), MAX_VISIBLE_ROWS, |_| true);
+        self.state = TuiCompletionMenuState::Open { list };
+        ctx.emit(TuiCompletionMenuEvent);
+    }
+
+    pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.is_open(ctx) {
+            self.close(ctx);
+        }
+    }
+
+    pub(crate) fn select_previous(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiCompletionMenuState::Open { list } = &mut self.state else {
+            return;
+        };
+        list.select_previous(MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiCompletionMenuEvent);
+    }
+
+    pub(crate) fn select_next(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiCompletionMenuState::Open { list } = &mut self.state else {
+            return;
+        };
+        list.select_next(MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiCompletionMenuEvent);
+    }
+
+    pub(crate) fn accept_selected(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<TuiCompletionAcceptance> {
+        if !self.is_open(ctx) {
+            return None;
+        }
+        let TuiCompletionMenuState::Open { list } = &self.state else {
+            return None;
+        };
+        let acceptance = list.selected_row()?.acceptance.clone();
+        self.close(ctx);
+        Some(acceptance)
+    }
+
+    pub(crate) fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(ctx) {
+            return None;
+        }
+        let TuiCompletionMenuState::Open { list } = &self.state else {
+            return None;
+        };
+        Some(TuiInlineMenuSnapshot {
+            header: None,
+            rows: list
+                .rows()
+                .iter()
+                .map(|row| TuiInlineMenuRow {
+                    title: row.display.clone(),
+                    description: row.description.clone(),
+                    state_suffix: None,
+                    is_selectable: true,
+                    style: TuiInlineMenuRowStyle::InlineMenuItem,
+                })
+                .collect(),
+            selected_index: list.selected_index(),
+            scroll_offset: list.scroll_offset(),
+            max_visible_rows: MAX_VISIBLE_ROWS,
+            status: None,
+        })
+    }
+
+    fn close(&mut self, ctx: &mut ModelContext<Self>) {
+        self.state = TuiCompletionMenuState::Closed;
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::CompletionSuggestions, ctx);
+        });
+        ctx.emit(TuiCompletionMenuEvent);
+    }
+}
+
+impl Entity for TuiCompletionMenuModel {
+    type Event = TuiCompletionMenuEvent;
+}
+
+#[cfg(test)]
+#[path = "completion_menu_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/completion_menu.rs
+++ b/crates/warp_tui/src/completion_menu.rs
@@ -2,12 +2,13 @@
 
 use std::ops::Range;
 
+use string_offset::CharOffset;
 use warp_completer::completer::{EngineFileType, MatchedSuggestion};
 use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
 
 use crate::inline_menu::{
-    MAX_INLINE_MENU_ROWS, TuiInlineMenuListState, TuiInlineMenuRow, TuiInlineMenuRowStyle,
-    TuiInlineMenuSnapshot, result_row_capacity,
+    MAX_INLINE_MENU_ROWS, TuiInlineMenuAccepted, TuiInlineMenuHandle, TuiInlineMenuListState,
+    TuiInlineMenuRow, TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, result_row_capacity,
 };
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
@@ -193,6 +194,44 @@ impl TuiCompletionMenuModel {
     }
 }
 
+impl TuiInlineMenuHandle for ModelHandle<TuiCompletionMenuModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::CompletionSuggestions
+    }
+
+    fn is_open(&self, ctx: &AppContext) -> bool {
+        self.as_ref(ctx).is_open(ctx)
+    }
+
+    fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
+        None
+    }
+
+    fn input_argument_hint_text(&self, _ctx: &AppContext) -> Option<&'static str> {
+        None
+    }
+
+    fn select_previous(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_previous(ctx));
+    }
+
+    fn select_next(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_next(ctx));
+    }
+
+    fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        self.update(ctx, |model, ctx| model.accept_selected(ctx))
+            .map(TuiInlineMenuAccepted::Completion)
+    }
+
+    fn dismiss(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.dismiss(ctx));
+    }
+
+    fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        self.as_ref(ctx).snapshot(ctx)
+    }
+}
 impl Entity for TuiCompletionMenuModel {
     type Event = TuiCompletionMenuEvent;
 }

--- a/crates/warp_tui/src/completion_menu_tests.rs
+++ b/crates/warp_tui/src/completion_menu_tests.rs
@@ -1,0 +1,102 @@
+use warp_completer::completer::{
+    EngineFileType, Match, MatchedSuggestion, Priority, Suggestion, SuggestionType,
+};
+use warpui_core::App;
+
+use super::*;
+
+fn matched_suggestion(
+    display: &str,
+    replacement: &str,
+    file_type: Option<EngineFileType>,
+) -> MatchedSuggestion {
+    let mut suggestion = Suggestion::new(
+        display,
+        replacement,
+        Some(format!("{display} description")),
+        SuggestionType::Argument,
+        Priority::default(),
+    );
+    suggestion.file_type = file_type;
+    MatchedSuggestion::new(
+        suggestion,
+        Match::Prefix {
+            is_case_sensitive: true,
+        },
+    )
+}
+
+#[test]
+fn show_reuses_inline_menu_rows_and_accepts_the_selected_span() {
+    App::test((), |mut app| async move {
+        let suggestions_mode = app.add_model(|_| TuiInputSuggestionsModeModel::new());
+        let menu = app.add_model(|_| TuiCompletionMenuModel::new(suggestions_mode.clone()));
+
+        menu.update(&mut app, |menu, ctx| {
+            menu.show(
+                vec![
+                    matched_suggestion("alpha", "alpha", None),
+                    matched_suggestion("assets", "assets/", Some(EngineFileType::Directory)),
+                ],
+                4..7,
+                true,
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            let snapshot = menu.as_ref(ctx).snapshot(ctx).expect("menu is open");
+            assert_eq!(snapshot.header, None);
+            assert_eq!(snapshot.rows[0].title, "alpha");
+            assert_eq!(
+                snapshot.rows[0].description.as_deref(),
+                Some("alpha description")
+            );
+            assert_eq!(snapshot.selected_index, Some(0));
+        });
+
+        menu.update(&mut app, |menu, ctx| menu.select_next(ctx));
+        let accepted = menu.update(&mut app, |menu, ctx| menu.accept_selected(ctx));
+        assert_eq!(
+            accepted,
+            Some(TuiCompletionAcceptance {
+                replacement: "assets/".to_owned(),
+                replacement_range: 4..7,
+                append_space: false,
+            })
+        );
+        app.read(|ctx| {
+            assert!(!menu.as_ref(ctx).is_open(ctx));
+            assert_eq!(
+                suggestions_mode.as_ref(ctx).mode(),
+                TuiInputSuggestionsMode::Closed
+            );
+        });
+    });
+}
+
+#[test]
+fn show_does_not_replace_an_existing_inline_menu() {
+    App::test((), |mut app| async move {
+        let suggestions_mode = app.add_model(|_| TuiInputSuggestionsModeModel::new());
+        suggestions_mode.update(&mut app, |mode, ctx| {
+            mode.set_mode(TuiInputSuggestionsMode::SlashCommands, ctx);
+        });
+        let menu = app.add_model(|_| TuiCompletionMenuModel::new(suggestions_mode.clone()));
+
+        menu.update(&mut app, |menu, ctx| {
+            menu.show(
+                vec![matched_suggestion("alpha", "alpha", None)],
+                0..1,
+                true,
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            assert!(!menu.as_ref(ctx).is_open(ctx));
+            assert_eq!(
+                suggestions_mode.as_ref(ctx).mode(),
+                TuiInputSuggestionsMode::SlashCommands
+            );
+        });
+    });
+}

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -15,6 +15,7 @@ use warpui_core::elements::tui::{
 };
 use warpui_core::{AppContext, ModelHandle};
 
+use crate::completion_menu::{TuiCompletionAcceptance, TuiCompletionMenuModel};
 use crate::conversation_menu::TuiConversationMenuModel;
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
 use crate::mcp_menu::TuiMcpMenuModel;
@@ -86,6 +87,44 @@ impl TuiInlineMenuHandle for ModelHandle<TuiMcpMenuModel> {
     fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
         self.update(ctx, |model, ctx| model.accept_selected(ctx))
             .map(TuiInlineMenuAccepted::Mcp)
+    }
+
+    fn dismiss(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.dismiss(ctx));
+    }
+
+    fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        self.as_ref(ctx).snapshot(ctx)
+    }
+}
+impl TuiInlineMenuHandle for ModelHandle<TuiCompletionMenuModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::CompletionSuggestions
+    }
+
+    fn is_open(&self, ctx: &AppContext) -> bool {
+        self.as_ref(ctx).is_open(ctx)
+    }
+
+    fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
+        None
+    }
+
+    fn input_argument_hint_text(&self, _ctx: &AppContext) -> Option<&'static str> {
+        None
+    }
+
+    fn select_previous(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_previous(ctx));
+    }
+
+    fn select_next(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_next(ctx));
+    }
+
+    fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        self.update(ctx, |model, ctx| model.accept_selected(ctx))
+            .map(TuiInlineMenuAccepted::Completion)
     }
 
     fn dismiss(&self, ctx: &mut AppContext) {
@@ -274,6 +313,8 @@ pub(crate) enum TuiInlineMenuAccepted {
     Mcp(TuiMcpAction),
     /// The text of a prompt accepted from the up-arrow prompt-history menu.
     PromptHistory(String),
+    /// A shell completion and the exact input span it replaces.
+    Completion(TuiCompletionAcceptance),
 }
 
 /// Type-erased operations shared by TUI inline-menu model handles.

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -15,7 +15,7 @@ use warpui_core::elements::tui::{
 };
 use warpui_core::{AppContext, ModelHandle};
 
-use crate::completion_menu::{TuiCompletionAcceptance, TuiCompletionMenuModel};
+use crate::completion_menu::TuiCompletionAcceptance;
 use crate::conversation_menu::TuiConversationMenuModel;
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
 use crate::mcp_menu::TuiMcpMenuModel;
@@ -87,44 +87,6 @@ impl TuiInlineMenuHandle for ModelHandle<TuiMcpMenuModel> {
     fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
         self.update(ctx, |model, ctx| model.accept_selected(ctx))
             .map(TuiInlineMenuAccepted::Mcp)
-    }
-
-    fn dismiss(&self, ctx: &mut AppContext) {
-        self.update(ctx, |model, ctx| model.dismiss(ctx));
-    }
-
-    fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
-        self.as_ref(ctx).snapshot(ctx)
-    }
-}
-impl TuiInlineMenuHandle for ModelHandle<TuiCompletionMenuModel> {
-    fn mode(&self) -> TuiInputSuggestionsMode {
-        TuiInputSuggestionsMode::CompletionSuggestions
-    }
-
-    fn is_open(&self, ctx: &AppContext) -> bool {
-        self.as_ref(ctx).is_open(ctx)
-    }
-
-    fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
-        None
-    }
-
-    fn input_argument_hint_text(&self, _ctx: &AppContext) -> Option<&'static str> {
-        None
-    }
-
-    fn select_previous(&self, ctx: &mut AppContext) {
-        self.update(ctx, |model, ctx| model.select_previous(ctx));
-    }
-
-    fn select_next(&self, ctx: &mut AppContext) {
-        self.update(ctx, |model, ctx| model.select_next(ctx));
-    }
-
-    fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
-        self.update(ctx, |model, ctx| model.accept_selected(ctx))
-            .map(TuiInlineMenuAccepted::Completion)
     }
 
     fn dismiss(&self, ctx: &mut AppContext) {

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -39,6 +39,7 @@ use warpui_core::{
     ViewContext, ViewHandle,
 };
 
+use crate::completion_menu::TuiCompletionAcceptance;
 use crate::editor_element::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
 use crate::editor_interaction::{
     TuiEditorBehavior, TuiEditorCommand, TuiEditorInteractionOutcome, TuiEditorState,
@@ -61,6 +62,7 @@ use crate::tui_builder::TuiUiBuilder;
 /// order. Inline menus take priority; later input modes should be handled only
 /// after the menu branch.
 const INPUT_HANDLES_ESCAPE_FLAG: &str = "TuiInputHandlesEscape";
+const SHELL_COMPLETION_AVAILABLE_FLAG: &str = "TuiShellCompletionAvailable";
 // ─────────────────────────────────────────────────────────────────────────────
 // Keybindings
 // ─────────────────────────────────────────────────────────────────────────────
@@ -96,6 +98,14 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(id!("TuiInputView") & id!(INPUT_HANDLES_ESCAPE_FLAG))
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("escape"),
+        EditableBinding::new(
+            "tui:input:complete_shell_command",
+            "Complete the shell command",
+            TuiInputAction::Complete,
+        )
+        .with_context_predicate(id!("TuiInputView") & id!(SHELL_COMPLETION_AVAILABLE_FLAG))
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("tab"),
     ]);
 }
 
@@ -126,6 +136,8 @@ pub enum TuiInputViewEvent {
     /// The user accepted a prompt from the up-arrow prompt-history menu. Carries
     /// the prompt text to fill into the input and submit.
     AcceptedPromptHistory(String),
+    /// Tab requested shell completion for the current input snapshot.
+    RequestShellCompletion,
     /// Selected prompt text was copied to the host clipboard.
     ClipboardCopySucceeded,
     /// Selected prompt text could not be copied to the host clipboard.
@@ -147,11 +159,19 @@ pub enum TuiInputAction {
     Submit,
     /// Handle contextual input Escape behavior, prioritizing an open inline menu.
     HandleEscape,
+    /// Request or advance shell-command completion.
+    Complete,
     /// Apply an editing command shared with generic TUI editors.
     EditorCommand(TuiEditorCommand),
     /// Place the cursor at `offset` without starting a drag selection
     /// (the prompt gutter click).
     SetCursor { offset: CharOffset },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TuiCompletionInputSnapshot {
+    pub(crate) buffer_text: String,
+    pub(crate) cursor_byte_offset: usize,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -479,6 +499,7 @@ impl TuiView for TuiInputView {
             self.active_inline_menu(ctx).is_some() || self.is_shell_mode(ctx),
             self.plan_toggle_available(ctx),
             self.keyboard_enhancement_supported,
+            self.is_shell_mode(ctx),
         )
     }
 
@@ -501,6 +522,7 @@ fn input_keymap_context(
     input_handles_escape: bool,
     plan_toggle_available: bool,
     keyboard_enhancement_supported: bool,
+    shell_completion_available: bool,
 ) -> keymap::Context {
     let mut context = keymap::Context::default();
     context.set.insert(TuiInputView::ui_name());
@@ -512,6 +534,9 @@ fn input_keymap_context(
     }
     if keyboard_enhancement_supported {
         context.set.insert(KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG);
+    }
+    if shell_completion_available {
+        context.set.insert(SHELL_COMPLETION_AVAILABLE_FLAG);
     }
     context
 }
@@ -551,6 +576,12 @@ impl TypedActionView for TuiInputView {
             TuiInputAction::HandleEscape => {
                 self.handle_escape(ctx);
                 TuiEditorInteractionOutcome::FollowCursor
+            }
+            TuiInputAction::Complete => {
+                if self.is_shell_mode(ctx) {
+                    ctx.emit(TuiInputViewEvent::RequestShellCompletion);
+                }
+                TuiEditorInteractionOutcome::PreserveViewport
             }
             TuiInputAction::EditorCommand(command) => {
                 if matches!(*command, TuiEditorCommand::SelectUp) && self.can_focus_above(ctx) {
@@ -645,6 +676,55 @@ impl TuiInputView {
             return String::new();
         }
         buffer.text().into_string()
+    }
+
+    pub(crate) fn completion_snapshot(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<TuiCompletionInputSnapshot> {
+        if !self.is_shell_mode(ctx) || !self.model.as_ref(ctx).selection_is_single_cursor(ctx) {
+            return None;
+        }
+        let buffer_text = self.plain_text(ctx);
+        let cursor_char_offset = self
+            .model
+            .as_ref(ctx)
+            .buffer_selection_model()
+            .as_ref(ctx)
+            .first_selection_head()
+            .as_usize()
+            .saturating_sub(1);
+        let cursor_byte_offset = byte_offset_for_char_offset(&buffer_text, cursor_char_offset)?;
+        Some(TuiCompletionInputSnapshot {
+            buffer_text,
+            cursor_byte_offset,
+        })
+    }
+
+    pub(crate) fn apply_shell_completion(
+        &mut self,
+        acceptance: TuiCompletionAcceptance,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let buffer_text = self.plain_text(ctx);
+        let Some(selection_range) =
+            char_range_for_byte_range(&buffer_text, acceptance.replacement_range)
+        else {
+            return false;
+        };
+        let mut replacement = acceptance.replacement;
+        if acceptance.append_space {
+            replacement.push(' ');
+        }
+        self.model.update(ctx, |model, ctx| {
+            model.select_at(selection_range.start, false, ctx);
+            model.set_last_selection_head(selection_range.end, ctx);
+            model.end_selection(ctx);
+            model.user_insert(&replacement, ctx);
+        });
+        self.follow_cursor(ctx);
+        ctx.notify();
+        true
     }
 
     fn cursor_offset(&self, ctx: &AppContext) -> CharOffset {
@@ -780,6 +860,7 @@ impl TuiInputView {
             TuiInputAction::EditorCommand(TuiEditorCommand::MoveUp | TuiEditorCommand::MoveDown)
                 | TuiInputAction::Submit
                 | TuiInputAction::HandleEscape
+                | TuiInputAction::Complete
         ) {
             return false;
         }
@@ -791,6 +872,13 @@ impl TuiInputView {
             // bootstrapping. Consume Enter without accepting a hidden menu item;
             // otherwise the accepted-menu event bypasses the session's normal
             // submission guard and can execute or clear the draft.
+            return true;
+        }
+        if matches!(action, TuiInputAction::Complete) {
+            if inline_menu.mode() == TuiInputSuggestionsMode::CompletionSuggestions {
+                inline_menu.select_next(ctx);
+                ctx.notify();
+            }
             return true;
         }
 
@@ -818,6 +906,9 @@ impl TuiInputView {
                         }
                         TuiInlineMenuAccepted::PromptHistory(text) => {
                             ctx.emit(TuiInputViewEvent::AcceptedPromptHistory(text));
+                        }
+                        TuiInlineMenuAccepted::Completion(acceptance) => {
+                            self.apply_shell_completion(acceptance, ctx);
                         }
                     }
                 }
@@ -853,6 +944,28 @@ impl TuiInputView {
             ctx,
         )
     }
+}
+
+fn byte_offset_for_char_offset(text: &str, char_offset: usize) -> Option<usize> {
+    if char_offset == text.chars().count() {
+        return Some(text.len());
+    }
+    text.char_indices()
+        .nth(char_offset)
+        .map(|(byte_offset, _)| byte_offset)
+}
+
+fn char_range_for_byte_range(text: &str, byte_range: Range<usize>) -> Option<Range<CharOffset>> {
+    if byte_range.start > byte_range.end
+        || byte_range.end > text.len()
+        || !text.is_char_boundary(byte_range.start)
+        || !text.is_char_boundary(byte_range.end)
+    {
+        return None;
+    }
+    let start = text[..byte_range.start].chars().count() + 1;
+    let end = text[..byte_range.end].chars().count() + 1;
+    Some(CharOffset::from(start)..CharOffset::from(end))
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -23,7 +23,7 @@
 use std::ops::Range;
 use std::rc::Rc;
 
-use string_offset::CharOffset;
+use string_offset::{ByteOffset, CharOffset};
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::tui_export::{
     AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, InputType,
@@ -34,6 +34,7 @@ use warpui_core::elements::MouseStateHandle;
 use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiHoverable, TuiText};
 use warpui_core::keymap::macros::*;
 use warpui_core::keymap::{self, EditableBinding};
+use warpui_core::text::{byte_offset_for_char_offset, count_chars_up_to_byte};
 use warpui_core::{
     AppContext, BlurContext, Entity, FocusContext, ModelHandle, TuiView, TypedActionView,
     ViewContext, ViewHandle,
@@ -495,12 +496,12 @@ impl TuiView for TuiInputView {
     }
 
     fn keymap_context(&self, ctx: &AppContext) -> keymap::Context {
-        input_keymap_context(
-            self.active_inline_menu(ctx).is_some() || self.is_shell_mode(ctx),
-            self.plan_toggle_available(ctx),
-            self.keyboard_enhancement_supported,
-            self.is_shell_mode(ctx),
-        )
+        input_keymap_context(InputKeymapContextConfig {
+            input_handles_escape: self.active_inline_menu(ctx).is_some() || self.is_shell_mode(ctx),
+            plan_toggle_available: self.plan_toggle_available(ctx),
+            keyboard_enhancement_supported: self.keyboard_enhancement_supported,
+            shell_completion_available: self.is_shell_mode(ctx),
+        })
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
@@ -518,24 +519,27 @@ impl TuiView for TuiInputView {
     }
 }
 
-fn input_keymap_context(
+#[derive(Clone, Copy, Debug, Default)]
+struct InputKeymapContextConfig {
     input_handles_escape: bool,
     plan_toggle_available: bool,
     keyboard_enhancement_supported: bool,
     shell_completion_available: bool,
-) -> keymap::Context {
+}
+
+fn input_keymap_context(config: InputKeymapContextConfig) -> keymap::Context {
     let mut context = keymap::Context::default();
     context.set.insert(TuiInputView::ui_name());
-    if input_handles_escape {
+    if config.input_handles_escape {
         context.set.insert(INPUT_HANDLES_ESCAPE_FLAG);
     }
-    if plan_toggle_available {
+    if config.plan_toggle_available {
         context.set.insert(PLAN_TOGGLE_AVAILABLE_FLAG);
     }
-    if keyboard_enhancement_supported {
+    if config.keyboard_enhancement_supported {
         context.set.insert(KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG);
     }
-    if shell_completion_available {
+    if config.shell_completion_available {
         context.set.insert(SHELL_COMPLETION_AVAILABLE_FLAG);
     }
     context
@@ -694,7 +698,9 @@ impl TuiInputView {
             .first_selection_head()
             .as_usize()
             .saturating_sub(1);
-        let cursor_byte_offset = byte_offset_for_char_offset(&buffer_text, cursor_char_offset)?;
+        let cursor_byte_offset =
+            byte_offset_for_char_offset(&buffer_text, CharOffset::from(cursor_char_offset))?
+                .as_usize();
         Some(TuiCompletionInputSnapshot {
             buffer_text,
             cursor_byte_offset,
@@ -707,11 +713,21 @@ impl TuiInputView {
         ctx: &mut ViewContext<Self>,
     ) -> bool {
         let buffer_text = self.plain_text(ctx);
-        let Some(selection_range) =
-            char_range_for_byte_range(&buffer_text, acceptance.replacement_range)
+        let replacement_range = acceptance.replacement_range;
+        if replacement_range.start > replacement_range.end {
+            return false;
+        }
+        let Some(replacement_start) =
+            count_chars_up_to_byte(&buffer_text, ByteOffset::from(replacement_range.start))
         else {
             return false;
         };
+        let Some(replacement_end) =
+            count_chars_up_to_byte(&buffer_text, ByteOffset::from(replacement_range.end))
+        else {
+            return false;
+        };
+        let selection_range = replacement_start + 1..replacement_end + 1;
         let mut replacement = acceptance.replacement;
         if acceptance.append_space {
             replacement.push(' ');
@@ -944,28 +960,6 @@ impl TuiInputView {
             ctx,
         )
     }
-}
-
-fn byte_offset_for_char_offset(text: &str, char_offset: usize) -> Option<usize> {
-    if char_offset == text.chars().count() {
-        return Some(text.len());
-    }
-    text.char_indices()
-        .nth(char_offset)
-        .map(|(byte_offset, _)| byte_offset)
-}
-
-fn char_range_for_byte_range(text: &str, byte_range: Range<usize>) -> Option<Range<CharOffset>> {
-    if byte_range.start > byte_range.end
-        || byte_range.end > text.len()
-        || !text.is_char_boundary(byte_range.start)
-        || !text.is_char_boundary(byte_range.end)
-    {
-        return None;
-    }
-    let start = text[..byte_range.start].chars().count() + 1;
-    let end = text[..byte_range.end].chars().count() + 1;
-    Some(CharOffset::from(start)..CharOffset::from(end))
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -32,8 +32,8 @@ use warpui_core::{
 };
 
 use super::{
-    INPUT_HANDLES_ESCAPE_FLAG, SHELL_COMPLETION_AVAILABLE_FLAG, TuiInputAction, TuiInputView,
-    TuiInputViewEvent, input_keymap_context,
+    INPUT_HANDLES_ESCAPE_FLAG, InputKeymapContextConfig, SHELL_COMPLETION_AVAILABLE_FLAG,
+    TuiInputAction, TuiInputView, TuiInputViewEvent, input_keymap_context,
 };
 use crate::completion_menu::{TuiCompletionAcceptance, TuiCompletionMenuModel};
 use crate::editor_element::{TuiEditorAction, TuiEditorElement};
@@ -265,7 +265,7 @@ fn completion_can_append_a_space_at_buffer_end() {
 
 #[test]
 fn input_escape_context_is_present_only_while_escape_is_handled() {
-    let closed = input_keymap_context(false, false, false, false);
+    let closed = input_keymap_context(InputKeymapContextConfig::default());
     assert!(closed.set.contains("TuiInputView"));
     assert!(!closed.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
     assert!(
@@ -279,7 +279,12 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
             .contains(crate::keybindings::KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG)
     );
 
-    let open = input_keymap_context(true, true, true, true);
+    let open = input_keymap_context(InputKeymapContextConfig {
+        input_handles_escape: true,
+        plan_toggle_available: true,
+        keyboard_enhancement_supported: true,
+        shell_completion_available: true,
+    });
     assert!(open.set.contains("TuiInputView"));
     assert!(open.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
     assert!(
@@ -2509,13 +2514,17 @@ fn keymap_context_flags_shell_mode() {
             let view = build_view(ctx);
             assert_eq!(
                 view.as_ref(ctx).keymap_context(ctx),
-                input_keymap_context(false, false, false, false)
+                input_keymap_context(InputKeymapContextConfig::default())
             );
 
             type_str(&view, ctx, "!");
             assert_eq!(
                 view.as_ref(ctx).keymap_context(ctx),
-                input_keymap_context(true, false, false, true)
+                input_keymap_context(InputKeymapContextConfig {
+                    input_handles_escape: true,
+                    shell_completion_available: true,
+                    ..Default::default()
+                })
             );
         });
     });

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -32,9 +32,10 @@ use warpui_core::{
 };
 
 use super::{
-    INPUT_HANDLES_ESCAPE_FLAG, TuiInputAction, TuiInputView, TuiInputViewEvent,
-    input_keymap_context,
+    INPUT_HANDLES_ESCAPE_FLAG, SHELL_COMPLETION_AVAILABLE_FLAG, TuiInputAction, TuiInputView,
+    TuiInputViewEvent, input_keymap_context,
 };
+use crate::completion_menu::{TuiCompletionAcceptance, TuiCompletionMenuModel};
 use crate::editor_element::{TuiEditorAction, TuiEditorElement};
 use crate::editor_interaction::TuiEditorCommand;
 use crate::inline_menu::{
@@ -87,8 +88,184 @@ impl InputModePolicy for TestInputModePolicy {
 }
 
 #[test]
+fn tab_cycles_open_completion_menu_and_enter_applies_selection() {
+    App::test((), |mut app| async move {
+        let (view, menu, completion_requests) = app.update(|ctx| {
+            let (view, menu) = build_view_with_completion_menu(ctx);
+            type_str(&view, ctx, "!");
+            view.update(ctx, |view, ctx| view.set_text("ec", ctx));
+            let completion_requests = Rc::new(Cell::new(0));
+            let completion_requests_for_subscription = completion_requests.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiInputViewEvent::RequestShellCompletion) {
+                    completion_requests_for_subscription
+                        .set(completion_requests_for_subscription.get() + 1);
+                }
+            });
+            (view, menu, completion_requests)
+        });
+
+        app.update(|ctx| {
+            dispatch(
+                &view,
+                ctx,
+                &[TuiInputAction::Complete, TuiInputAction::Submit],
+            );
+        });
+        assert_eq!(completion_requests.get(), 0);
+        app.read(|ctx| {
+            assert_eq!(text(&view, ctx), "eclair ");
+            assert!(!menu.as_ref(ctx).is_open(ctx));
+        });
+    });
+}
+
+#[test]
+fn tab_requests_completion_for_detected_shell_input() {
+    App::test((), |mut app| async move {
+        let (view, completion_requests) = app.update(|ctx| {
+            let view = build_view(ctx);
+            let input_mode = view.as_ref(ctx).input_mode.clone();
+            input_mode.update(ctx, |input_mode, ctx| {
+                input_mode.enable_autodetection(InputType::Shell, ctx);
+            });
+            view.update(ctx, |view, ctx| view.set_text("git che", ctx));
+            let completion_requests = Rc::new(Cell::new(0));
+            let completion_requests_for_subscription = completion_requests.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiInputViewEvent::RequestShellCompletion) {
+                    completion_requests_for_subscription
+                        .set(completion_requests_for_subscription.get() + 1);
+                }
+            });
+            (view, completion_requests)
+        });
+
+        app.update(|ctx| dispatch(&view, ctx, &[TuiInputAction::Complete]));
+        assert_eq!(completion_requests.get(), 1);
+        app.read(|ctx| {
+            assert!(view.as_ref(ctx).is_shell_mode(ctx));
+            assert_eq!(
+                view.as_ref(ctx).completion_snapshot(ctx),
+                Some(super::TuiCompletionInputSnapshot {
+                    buffer_text: "git che".to_owned(),
+                    cursor_byte_offset: 7,
+                })
+            );
+        });
+    });
+}
+
+#[test]
+fn tab_requests_completion_only_in_shell_mode_without_submitting() {
+    App::test((), |mut app| async move {
+        let (view, completion_requests, submitted) = app.update(|ctx| {
+            let view = build_view(ctx);
+            let completion_requests = Rc::new(Cell::new(0));
+            let completion_requests_for_subscription = completion_requests.clone();
+            let submitted = Rc::new(RefCell::new(Vec::new()));
+            let submitted_for_subscription = submitted.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| match event {
+                TuiInputViewEvent::RequestShellCompletion => {
+                    completion_requests_for_subscription
+                        .set(completion_requests_for_subscription.get() + 1);
+                }
+                TuiInputViewEvent::Submitted(text) => {
+                    submitted_for_subscription.borrow_mut().push(text.clone());
+                }
+                _ => {}
+            });
+            (view, completion_requests, submitted)
+        });
+
+        app.update(|ctx| {
+            dispatch(&view, ctx, &[TuiInputAction::Complete]);
+            type_str(&view, ctx, "!git che");
+            dispatch(&view, ctx, &[TuiInputAction::Complete]);
+        });
+        assert_eq!(completion_requests.get(), 1);
+        assert!(submitted.borrow().is_empty());
+        app.read(|ctx| assert_eq!(text(&view, ctx), "git che"));
+    });
+}
+
+#[test]
+fn tab_is_consumed_by_an_existing_non_completion_menu() {
+    App::test((), |mut app| async move {
+        let (view, menu, completion_requests) = app.update(|ctx| {
+            let (view, menu, _) = build_view_with_inline_menu(ctx);
+            type_str(&view, ctx, "!");
+            let completion_requests = Rc::new(Cell::new(0));
+            let completion_requests_for_subscription = completion_requests.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiInputViewEvent::RequestShellCompletion) {
+                    completion_requests_for_subscription
+                        .set(completion_requests_for_subscription.get() + 1);
+                }
+            });
+            (view, menu, completion_requests)
+        });
+
+        app.update(|ctx| dispatch(&view, ctx, &[TuiInputAction::Complete]));
+        assert_eq!(completion_requests.get(), 0);
+        app.read(|ctx| assert!(menu.as_ref(ctx).is_open(ctx)));
+    });
+}
+
+#[test]
+fn completion_replaces_utf8_byte_span_and_preserves_following_text() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "!");
+            view.update(ctx, |view, ctx| view.set_text("écho --fi tail", ctx));
+            let input = text(&view, ctx);
+            let start = input.find("--fi").expect("test token exists");
+            let end = start + "--fi".len();
+
+            let applied = view.update(ctx, |view, ctx| {
+                view.apply_shell_completion(
+                    TuiCompletionAcceptance {
+                        replacement: "--file".to_owned(),
+                        replacement_range: start..end,
+                        append_space: false,
+                    },
+                    ctx,
+                )
+            });
+
+            assert!(applied);
+            assert_eq!(text(&view, ctx), "écho --file tail");
+        });
+    });
+}
+
+#[test]
+fn completion_can_append_a_space_at_buffer_end() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "!ec");
+            let applied = view.update(ctx, |view, ctx| {
+                view.apply_shell_completion(
+                    TuiCompletionAcceptance {
+                        replacement: "echo".to_owned(),
+                        replacement_range: 0..2,
+                        append_space: true,
+                    },
+                    ctx,
+                )
+            });
+
+            assert!(applied);
+            assert_eq!(text(&view, ctx), "echo ");
+        });
+    });
+}
+
+#[test]
 fn input_escape_context_is_present_only_while_escape_is_handled() {
-    let closed = input_keymap_context(false, false, false);
+    let closed = input_keymap_context(false, false, false, false);
     assert!(closed.set.contains("TuiInputView"));
     assert!(!closed.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
     assert!(
@@ -102,7 +279,7 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
             .contains(crate::keybindings::KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG)
     );
 
-    let open = input_keymap_context(true, true, true);
+    let open = input_keymap_context(true, true, true, true);
     assert!(open.set.contains("TuiInputView"));
     assert!(open.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
     assert!(
@@ -113,6 +290,7 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
         open.set
             .contains(crate::keybindings::KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG)
     );
+    assert!(open.set.contains(SHELL_COMPLETION_AVAILABLE_FLAG));
 }
 
 fn add_suggestions_mode(
@@ -533,6 +711,62 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
     build_view_with_orchestration_tabs(ctx, Rc::new(Cell::new(false)))
 }
 
+fn build_view_with_completion_menu(
+    ctx: &mut AppContext,
+) -> (
+    ViewHandle<TuiInputView>,
+    ModelHandle<TuiCompletionMenuModel>,
+) {
+    ctx.add_singleton_model(|_| Appearance::mock());
+    add_test_semantic_selection(ctx);
+    let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
+    let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
+    let suggestions_mode =
+        add_suggestions_mode(ctx, TuiInputSuggestionsMode::CompletionSuggestions);
+    let completion_menu = ctx.add_model(|_| {
+        TuiCompletionMenuModel::new_for_test(
+            suggestions_mode.clone(),
+            vec![
+                (
+                    "echo".to_owned(),
+                    TuiCompletionAcceptance {
+                        replacement: "echo".to_owned(),
+                        replacement_range: 0..2,
+                        append_space: true,
+                    },
+                ),
+                (
+                    "eclair".to_owned(),
+                    TuiCompletionAcceptance {
+                        replacement: "eclair".to_owned(),
+                        replacement_range: 0..2,
+                        append_space: true,
+                    },
+                ),
+            ],
+            0,
+        )
+    });
+    let menu_for_return = completion_menu.clone();
+    let (_window_id, view) = ctx.add_tui_window(
+        AddWindowOptions {
+            window_style: WindowStyle::NotStealFocus,
+            ..Default::default()
+        },
+        move |ctx| {
+            TuiInputView::new_for_test(
+                input_model,
+                input_mode,
+                suggestions_mode,
+                vec![TuiInlineMenu::new(completion_menu)],
+                |_| false,
+                ctx,
+            )
+        },
+    );
+    (view, menu_for_return)
+}
+
 fn build_view_with_orchestration_tabs(
     ctx: &mut AppContext,
     orchestration_tabs_available: Rc<Cell<bool>>,
@@ -927,6 +1161,7 @@ fn multiline_paste_emits_once_and_fallback_inserts_without_submitting() {
                 | TuiInputViewEvent::AcceptedModel(_)
                 | TuiInputViewEvent::AcceptedMcp(_)
                 | TuiInputViewEvent::AcceptedPromptHistory(_)
+                | TuiInputViewEvent::RequestShellCompletion
                 | TuiInputViewEvent::BackspaceAtEmptyInput
                 | TuiInputViewEvent::MoveFocusUp
                 | TuiInputViewEvent::ClipboardCopySucceeded
@@ -2274,13 +2509,13 @@ fn keymap_context_flags_shell_mode() {
             let view = build_view(ctx);
             assert_eq!(
                 view.as_ref(ctx).keymap_context(ctx),
-                input_keymap_context(false, false, false)
+                input_keymap_context(false, false, false, false)
             );
 
             type_str(&view, ctx, "!");
             assert_eq!(
                 view.as_ref(ctx).keymap_context(ctx),
-                input_keymap_context(true, false, false)
+                input_keymap_context(true, false, false, true)
             );
         });
     });

--- a/crates/warp_tui/src/input_suggestions_mode.rs
+++ b/crates/warp_tui/src/input_suggestions_mode.rs
@@ -16,6 +16,7 @@ pub(crate) enum TuiInputSuggestionsMode {
     SkillMenu,
     Mcp,
     PromptHistory,
+    CompletionSuggestions,
 }
 
 impl TuiInputSuggestionsMode {
@@ -73,7 +74,8 @@ impl TuiInputSuggestionsModeModel {
             | TuiInputSuggestionsMode::ModelSelector
             | TuiInputSuggestionsMode::SkillMenu
             | TuiInputSuggestionsMode::Mcp
-            | TuiInputSuggestionsMode::PromptHistory => false,
+            | TuiInputSuggestionsMode::PromptHistory
+            | TuiInputSuggestionsMode::CompletionSuggestions => false,
         }
     }
 

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -24,6 +24,7 @@ mod tui_ask_question_view;
 mod tui_builder;
 mod ui;
 
+mod completion_menu;
 mod conversation_menu;
 mod conversation_selection;
 mod editor_element;

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -25,8 +25,8 @@ use warp::tui_export::{
     GitStatusMetadata, LLMId, LLMPreferences, LLMPreferencesEvent,
     LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, ModelEvent, ParsedSlashCommandInput,
     PersistenceWriter, PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
-    ServerConversationToken, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
-    SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
+    ServerConversationToken, Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate,
+    SkillReference, SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
     StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TerminalModel, TerminalSurface,
     TerminalSurfaceInit, TranscriptScope, TuiMcpAction, TuiMcpManager, TuiSlashCommandDataSource,
     TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource, UserTakeOverReason,
@@ -63,6 +63,7 @@ use crate::attachment_bar::{
     TuiAttachmentPasteDisposition,
 };
 use crate::clipboard::copy_to_clipboard;
+use crate::completion_menu::TuiCompletionMenuModel;
 use crate::conversation_menu::{TuiConversationMenuEvent, TuiConversationMenuModel};
 use crate::conversation_selection::TuiConversationSelection;
 use crate::editor_interaction::TuiEditorCommand;
@@ -107,8 +108,10 @@ use crate::ui::{compact_footer_path, conversation_restore_failed, conversation_r
 use crate::usage::UsageToggle;
 use crate::warping_indicator::{render_response_summary, render_warping_indicator_row};
 use crate::zero_state::TuiZeroStateView;
+mod completions;
 mod input_detection;
 
+use self::completions::CompletionRequestState;
 use self::input_detection::InputDetectionState;
 
 /// Width used before the first layout pass pushes the real terminal width into the editor.
@@ -207,6 +210,10 @@ fn cost_command_unavailable_hint(
         Some((false, false)) => Some(COST_CONVERSATION_IN_PROGRESS_HINT),
         Some((false, true)) => None,
     }
+}
+
+fn attachment_focus_available(is_shell_mode: bool, attachments_should_render: bool) -> bool {
+    !is_shell_mode && attachments_should_render
 }
 
 /// Resolved segments for the footer's left-aligned sectioned status row.
@@ -421,6 +428,7 @@ pub(crate) struct TuiTerminalSessionView {
     model_menu: ModelHandle<TuiModelMenuModel>,
     skills_menu: ModelHandle<TuiSkillMenuModel>,
     mcp_menu: ModelHandle<TuiMcpMenuModel>,
+    completion_menu: ModelHandle<TuiCompletionMenuModel>,
     slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
     conversation_selection: ConversationSelectionHandle,
     ai_action_model: ModelHandle<BlocklistAIActionModel>,
@@ -429,6 +437,7 @@ pub(crate) struct TuiTerminalSessionView {
     cli_subagent_views: HashMap<BlockId, ViewHandle<TuiCLISubagentView>>,
     /// Read by the footer for the active session's working directory.
     active_session: ModelHandle<ActiveSession>,
+    sessions: ModelHandle<Sessions>,
     /// Repository currently containing the active session's working directory.
     current_repo_path: Option<LocalOrRemotePath>,
     /// Watcher-backed branch and uncommitted diff metadata for the footer.
@@ -453,6 +462,7 @@ pub(crate) struct TuiTerminalSessionView {
     ai_context_model: ModelHandle<BlocklistAIContextModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
     input_detection: InputDetectionState,
+    completion_request: CompletionRequestState,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     /// Last dimensions applied to the terminal model and PTY.
     size_info: SizeInfo,
@@ -922,7 +932,7 @@ impl TuiTerminalSessionView {
         });
         let context_model = ctx.add_model(|ctx| {
             BlocklistAIContextModel::new(
-                sessions,
+                sessions.clone(),
                 &model_events,
                 model.clone(),
                 terminal_surface_id,
@@ -1091,6 +1101,9 @@ impl TuiTerminalSessionView {
             let TuiPromptHistoryMenuEvent::Updated = event;
             ctx.notify();
         });
+        let completion_menu =
+            ctx.add_model(|_| TuiCompletionMenuModel::new(suggestions_mode.clone()));
+        ctx.subscribe_to_model(&completion_menu, |_, _, _, ctx| ctx.notify());
         // The footer's conversations callout depends on whether the input is
         // empty, so content changes must invalidate this parent view as well as
         // the input child. Typing after ctrl-c also disarms the pending exit
@@ -1115,10 +1128,11 @@ impl TuiTerminalSessionView {
 
         let editor_for_selection = input_editor_model.clone();
         let transcript_for_selection = transcript.clone();
-        ctx.subscribe_to_model(&input_editor_model, move |_, _, event, ctx| {
+        ctx.subscribe_to_model(&input_editor_model, move |view, _, event, ctx| {
             if !matches!(event, CodeEditorModelEvent::SelectionChanged) {
                 return;
             }
+            view.handle_completion_editor_changed(ctx);
 
             let has_selection = !editor_for_selection
                 .as_ref(ctx)
@@ -1140,6 +1154,7 @@ impl TuiTerminalSessionView {
             TuiInlineMenu::new(skills_menu.clone()),
             TuiInlineMenu::new(mcp_menu.clone()),
             TuiInlineMenu::new(prompt_history_menu.clone()),
+            TuiInlineMenu::new(completion_menu.clone()),
         ];
         let inline_menus_for_input = inline_menus.clone();
         let suggestions_mode_for_input = suggestions_mode.clone();
@@ -1232,6 +1247,9 @@ impl TuiTerminalSessionView {
             TuiInputViewEvent::AcceptedPromptHistory(text) => {
                 view.handle_accepted_prompt_history(text.clone(), ctx);
             }
+            TuiInputViewEvent::RequestShellCompletion => {
+                view.request_shell_completion(ctx);
+            }
             TuiInputViewEvent::ClipboardCopySucceeded => view.show_copy_hint(ctx),
             TuiInputViewEvent::ClipboardCopyFailed => {
                 view.show_transient_hint(COPY_FAILED_HINT.to_owned(), ctx);
@@ -1273,7 +1291,10 @@ impl TuiTerminalSessionView {
         });
         // The input box border color and the footer's shell-mode hint depend
         // on the input mode.
-        ctx.subscribe_to_model(&ai_input_model, |_, _, _, ctx| ctx.notify());
+        ctx.subscribe_to_model(&ai_input_model, |view, _, _, ctx| {
+            view.handle_completion_editor_changed(ctx);
+            ctx.notify();
+        });
         ctx.subscribe_to_model(&suggestions_mode, |_, _, _, ctx| ctx.notify());
         // The warping indicator between the transcript and the input box
         // tracks the selected conversation: re-render when its status changes
@@ -1352,6 +1373,7 @@ impl TuiTerminalSessionView {
         });
         ctx.subscribe_to_model(&active_session, |view, _, event, ctx| match event {
             ActiveSessionEvent::UpdatedPwd => {
+                view.abort_shell_completion(ctx);
                 // Run repo detection so project rules and skills follow the
                 // session's working directory (the GUI's equivalent lives in
                 // `TerminalView::apply_block_metadata_update`). The first
@@ -1391,7 +1413,7 @@ impl TuiTerminalSessionView {
                 });
                 ctx.notify();
             }
-            ActiveSessionEvent::Bootstrapped => {}
+            ActiveSessionEvent::Bootstrapped => view.abort_shell_completion(ctx),
         });
         // The footer's usage entry shows the selected conversation's token/cost
         // totals: re-render when that conversation's usage metadata updates.
@@ -1440,6 +1462,7 @@ impl TuiTerminalSessionView {
             model_menu,
             skills_menu,
             mcp_menu,
+            completion_menu,
             slash_commands_source,
             conversation_selection,
             ai_action_model: action_model,
@@ -1447,6 +1470,7 @@ impl TuiTerminalSessionView {
             cli_subagent_controller,
             cli_subagent_views: HashMap::new(),
             active_session,
+            sessions,
             current_repo_path: None,
             git_repo_status: None,
             terminal_surface_id,
@@ -1458,6 +1482,7 @@ impl TuiTerminalSessionView {
             ai_context_model: context_model,
             ai_input_model,
             input_detection: InputDetectionState::default(),
+            completion_request: CompletionRequestState::default(),
             terminal_model: model,
             size_info,
             terminal_resize_tx,
@@ -3230,7 +3255,10 @@ impl TuiView for TuiTerminalSessionView {
             && !self.suggestions_mode.as_ref(ctx).mode().is_visible()
         {
             context.set.insert(SESSION_COMPOSER_OWNS_INPUT_FLAG);
-            if self.attachment_bar.as_ref(ctx).should_render(ctx) {
+            if attachment_focus_available(
+                self.is_shell_mode(ctx),
+                self.attachment_bar.as_ref(ctx).should_render(ctx),
+            ) {
                 context.set.insert(ATTACHMENTS_AVAILABLE_FLAG);
             }
         }

--- a/crates/warp_tui/src/terminal_session_view/completions.rs
+++ b/crates/warp_tui/src/terminal_session_view/completions.rs
@@ -1,0 +1,261 @@
+//! Asynchronous shell-command completion coordination for the TUI composer.
+
+use warp::tui_export::{longest_common_prefix, tui_completion_session_context};
+use warp_completer::completer::{
+    CompleterOptions, EngineFileType, Match, SuggestionResults, suggestions,
+};
+use warp_core::SessionId;
+use warpui_core::r#async::SpawnedFutureHandle;
+use warpui_core::{AppContext, ViewContext};
+
+use super::TuiTerminalSessionView;
+use crate::completion_menu::TuiCompletionAcceptance;
+use crate::inline_menu::active_inline_menu;
+use crate::input::view::TuiCompletionInputSnapshot;
+
+#[derive(Default)]
+pub(super) struct CompletionRequestState {
+    future: Option<SpawnedFutureHandle>,
+    generation: u64,
+    menu_snapshot: Option<TuiCompletionInputSnapshot>,
+}
+
+#[derive(Clone, Debug)]
+struct CompletionRequestSnapshot {
+    input: TuiCompletionInputSnapshot,
+    session_id: SessionId,
+    current_working_directory: String,
+    generation: u64,
+}
+
+impl TuiTerminalSessionView {
+    pub(super) fn request_shell_completion(&mut self, ctx: &mut ViewContext<Self>) {
+        if active_inline_menu(
+            &self.inline_menus,
+            self.suggestions_mode.as_ref(ctx).mode(),
+            ctx,
+        )
+        .is_some()
+        {
+            return;
+        }
+        let Some(input) = self.input_view.as_ref(ctx).completion_snapshot(ctx) else {
+            return;
+        };
+        let Some(current_working_directory) = self.current_working_directory(ctx) else {
+            return;
+        };
+        let Some(session) = self.active_session.as_ref(ctx).session(ctx) else {
+            return;
+        };
+        let session_id = session.id();
+        let Some(completion_context) = tui_completion_session_context(
+            self.active_session.as_ref(ctx),
+            current_working_directory.clone(),
+            ctx,
+        ) else {
+            return;
+        };
+        let session_env_vars = self
+            .sessions
+            .as_ref(ctx)
+            .get_env_vars_for_session(session_id);
+        self.abort_input_detection(ctx);
+
+        self.abort_shell_completion(ctx);
+        self.completion_request.generation = self.completion_request.generation.wrapping_add(1);
+        let generation = self.completion_request.generation;
+        let request = CompletionRequestSnapshot {
+            input,
+            session_id,
+            current_working_directory,
+            generation,
+        };
+        let line = request.input.buffer_text[..request.input.cursor_byte_offset].to_owned();
+        let cursor_byte_offset = request.input.cursor_byte_offset;
+        let completion_session = completion_context.session.clone();
+        self.completion_request.future = Some(ctx.spawn_abortable(
+            async move {
+                let results = suggestions(
+                    &line,
+                    cursor_byte_offset,
+                    session_env_vars.as_ref(),
+                    CompleterOptions::default(),
+                    &completion_context,
+                )
+                .await;
+                (request, results)
+            },
+            |view, (request, results), ctx| {
+                view.handle_shell_completion_results(request, results, ctx);
+            },
+            move |_, _| completion_session.cancel_active_commands(),
+        ));
+    }
+
+    pub(super) fn abort_shell_completion(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(future) = self.completion_request.future.take() {
+            future.abort();
+        }
+        self.completion_request.generation = self.completion_request.generation.wrapping_add(1);
+        self.completion_request.menu_snapshot = None;
+        self.completion_menu
+            .update(ctx, |menu, ctx| menu.dismiss(ctx));
+    }
+
+    pub(super) fn handle_completion_editor_changed(&mut self, ctx: &mut ViewContext<Self>) {
+        let current_snapshot = self.input_view.as_ref(ctx).completion_snapshot(ctx);
+        let preserves_open_menu = self.completion_menu.as_ref(ctx).is_open(ctx)
+            && current_snapshot.as_ref() == self.completion_request.menu_snapshot.as_ref();
+        if !preserves_open_menu {
+            self.abort_shell_completion(ctx);
+        }
+    }
+
+    fn handle_shell_completion_results(
+        &mut self,
+        request: CompletionRequestSnapshot,
+        results: Option<SuggestionResults>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.completion_request.generation == request.generation {
+            self.completion_request.future = None;
+        }
+        if !self.completion_result_is_applicable(&request, ctx) {
+            return;
+        }
+        let Some(results) = results.filter(|results| !results.suggestions.is_empty()) else {
+            return;
+        };
+        let replacement_range = results.replacement_span.start()..results.replacement_span.end();
+        let append_space_at_buffer_end =
+            request.input.cursor_byte_offset == request.input.buffer_text.len();
+
+        if let Some(suggestion) = results.single_prefix_suggestion() {
+            let acceptance = TuiCompletionAcceptance {
+                replacement: suggestion.replacement().to_owned(),
+                replacement_range,
+                append_space: append_space_at_buffer_end
+                    && suggestion.suggestion.file_type != Some(EngineFileType::Directory),
+            };
+            self.input_view.update(ctx, |input, ctx| {
+                input.apply_shell_completion(acceptance, ctx)
+            });
+            return;
+        }
+
+        let common_prefix = longest_common_prefix(
+            results
+                .suggestions
+                .iter()
+                .filter(|suggestion| {
+                    matches!(
+                        suggestion.match_type,
+                        Match::Prefix {
+                            is_case_sensitive: true
+                        } | Match::Exact {
+                            is_case_sensitive: true
+                        }
+                    )
+                })
+                .map(|suggestion| suggestion.replacement()),
+        )
+        .map(str::to_owned);
+        let menu_input = common_prefix
+            .filter(|prefix| {
+                should_insert_common_prefix(
+                    prefix,
+                    &request.input,
+                    results.replacement_span.start(),
+                    results.replacement_span.distance(),
+                )
+            })
+            .and_then(|prefix| {
+                let acceptance = TuiCompletionAcceptance {
+                    replacement: prefix,
+                    replacement_range: replacement_range.clone(),
+                    append_space: false,
+                };
+                let did_apply = self.input_view.update(ctx, |input, ctx| {
+                    input.apply_shell_completion(acceptance, ctx)
+                });
+                did_apply.then(|| self.input_view.as_ref(ctx).completion_snapshot(ctx))?
+            })
+            .unwrap_or_else(|| request.input.clone());
+        let menu_replacement_range =
+            results.replacement_span.start()..menu_input.cursor_byte_offset;
+        let append_space_at_buffer_end =
+            menu_input.cursor_byte_offset == menu_input.buffer_text.len();
+        self.completion_request.menu_snapshot = Some(menu_input);
+        self.completion_menu.update(ctx, |menu, ctx| {
+            menu.show(
+                results.suggestions,
+                menu_replacement_range,
+                append_space_at_buffer_end,
+                ctx,
+            );
+        });
+    }
+
+    fn completion_result_is_applicable(
+        &self,
+        request: &CompletionRequestSnapshot,
+        ctx: &AppContext,
+    ) -> bool {
+        let current_input = self.input_view.as_ref(ctx).completion_snapshot(ctx);
+        let current_session_id = self
+            .active_session
+            .as_ref(ctx)
+            .session(ctx)
+            .map(|session| session.id());
+        let current_working_directory = self.current_working_directory(ctx);
+        let has_active_inline_menu = active_inline_menu(
+            &self.inline_menus,
+            self.suggestions_mode.as_ref(ctx).mode(),
+            ctx,
+        )
+        .is_some();
+        completion_request_is_current(
+            request,
+            self.completion_request.generation,
+            current_input.as_ref(),
+            current_session_id,
+            current_working_directory.as_deref(),
+            has_active_inline_menu,
+        )
+    }
+}
+
+fn completion_request_is_current(
+    request: &CompletionRequestSnapshot,
+    current_generation: u64,
+    current_input: Option<&TuiCompletionInputSnapshot>,
+    current_session_id: Option<SessionId>,
+    current_working_directory: Option<&str>,
+    has_active_inline_menu: bool,
+) -> bool {
+    current_generation == request.generation
+        && current_input == Some(&request.input)
+        && current_session_id == Some(request.session_id)
+        && current_working_directory == Some(request.current_working_directory.as_str())
+        && !has_active_inline_menu
+}
+
+fn should_insert_common_prefix(
+    common_prefix: &str,
+    input: &TuiCompletionInputSnapshot,
+    replacement_start: usize,
+    replacement_distance: usize,
+) -> bool {
+    let Some(current_word) = input
+        .buffer_text
+        .get(replacement_start..input.cursor_byte_offset)
+    else {
+        return false;
+    };
+    common_prefix.len() > replacement_distance && common_prefix.starts_with(current_word)
+}
+
+#[cfg(test)]
+#[path = "completions_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/terminal_session_view/completions_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view/completions_tests.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+fn snapshot(buffer_text: &str, cursor_byte_offset: usize) -> TuiCompletionInputSnapshot {
+    TuiCompletionInputSnapshot {
+        buffer_text: buffer_text.to_owned(),
+        cursor_byte_offset,
+    }
+}
+
+#[test]
+fn common_prefix_extends_only_the_current_backend_span() {
+    assert!(should_insert_common_prefix(
+        "checkout",
+        &snapshot("git che", 7),
+        4,
+        3,
+    ));
+    assert!(!should_insert_common_prefix(
+        "branch",
+        &snapshot("git che", 7),
+        4,
+        3,
+    ));
+    assert!(!should_insert_common_prefix(
+        "che",
+        &snapshot("git che", 7),
+        4,
+        3,
+    ));
+}
+
+#[test]
+fn completion_requests_reject_every_stale_snapshot_dimension() {
+    let input = snapshot("git che", 7);
+    let request = CompletionRequestSnapshot {
+        input: input.clone(),
+        session_id: SessionId::from(42),
+        current_working_directory: "/repo".to_owned(),
+        generation: 7,
+    };
+    assert!(completion_request_is_current(
+        &request,
+        7,
+        Some(&input),
+        Some(SessionId::from(42)),
+        Some("/repo"),
+        false,
+    ));
+
+    let changed_input = snapshot("git checkout", 12);
+    for is_current in [
+        completion_request_is_current(
+            &request,
+            8,
+            Some(&input),
+            Some(SessionId::from(42)),
+            Some("/repo"),
+            false,
+        ),
+        completion_request_is_current(
+            &request,
+            7,
+            Some(&changed_input),
+            Some(SessionId::from(42)),
+            Some("/repo"),
+            false,
+        ),
+        completion_request_is_current(
+            &request,
+            7,
+            Some(&input),
+            Some(SessionId::from(43)),
+            Some("/repo"),
+            false,
+        ),
+        completion_request_is_current(
+            &request,
+            7,
+            Some(&input),
+            Some(SessionId::from(42)),
+            Some("/other"),
+            false,
+        ),
+        completion_request_is_current(
+            &request,
+            7,
+            Some(&input),
+            Some(SessionId::from(42)),
+            Some("/repo"),
+            true,
+        ),
+    ] {
+        assert!(!is_current);
+    }
+}
+
+#[test]
+fn common_prefix_rejects_invalid_utf8_or_out_of_bounds_spans() {
+    assert!(!should_insert_common_prefix(
+        "éclair",
+        &snapshot("é", "é".len()),
+        1,
+        1,
+    ));
+    assert!(!should_insert_common_prefix(
+        "echo",
+        &snapshot("ec", 2),
+        3,
+        1,
+    ));
+}

--- a/crates/warp_tui/src/terminal_session_view/input_detection.rs
+++ b/crates/warp_tui/src/terminal_session_view/input_detection.rs
@@ -98,6 +98,7 @@ impl TuiTerminalSessionView {
         is_user_edit: bool,
         ctx: &mut ViewContext<Self>,
     ) {
+        self.handle_completion_editor_changed(ctx);
         self.abort_input_detection(ctx);
         if is_user_edit {
             self.schedule_input_detection(ctx);

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -35,9 +35,9 @@ use super::{
     COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT, ConversationRestoreState, FooterSegments,
     INLINE_MENU_TOP_PADDING_ROWS, LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT,
     SHELL_MODE_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
-    TuiTerminalSessionEvent, TuiTerminalSessionView, cost_command_unavailable_hint,
-    export_file_success_message, log_bundle_success_message, raw_prompt_if_not_blank,
-    render_status_footer_row,
+    TuiTerminalSessionEvent, TuiTerminalSessionView, attachment_focus_available,
+    cost_command_unavailable_hint, export_file_success_message, log_bundle_success_message,
+    raw_prompt_if_not_blank, render_status_footer_row,
 };
 use crate::autoupdate::TuiAutoupdater;
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
@@ -62,6 +62,13 @@ use crate::usage::UsageToggle;
 struct FocusTestFixture {
     window_id: warpui_core::WindowId,
     sessions: ModelHandle<TuiSessions>,
+}
+
+#[test]
+fn shell_mode_reserves_tab_even_when_attachments_render() {
+    assert!(attachment_focus_available(false, true));
+    assert!(!attachment_focus_available(true, true));
+    assert!(!attachment_focus_available(false, false));
 }
 
 #[test]

--- a/crates/warpui_core/src/text/mod.rs
+++ b/crates/warpui_core/src/text/mod.rs
@@ -358,6 +358,14 @@ pub fn char_slice(s: &str, start: usize, end: usize) -> Option<&str> {
     s.get(start_index..end_index)
 }
 
+pub fn byte_offset_for_char_offset(text: &str, char_offset: CharOffset) -> Option<ByteOffset> {
+    if char_offset.as_usize() == text.chars().count() {
+        return Some(ByteOffset::from(text.len()));
+    }
+    text.char_indices()
+        .nth(char_offset.as_usize())
+        .map(|(byte_offset, _)| ByteOffset::from(byte_offset))
+}
 pub fn count_chars_up_to_byte(text: &str, byte_offset: ByteOffset) -> Option<CharOffset> {
     if byte_offset.as_usize() == text.len() {
         return Some(CharOffset::from(text.chars().count()));

--- a/crates/warpui_core/src/text/mod_tests.rs
+++ b/crates/warpui_core/src/text/mod_tests.rs
@@ -1,5 +1,8 @@
 use super::point::Point;
-use super::{BufferIndex, TextBuffer, char_slice, count_chars_up_to_byte, str_to_byte_vec};
+use super::{
+    BufferIndex, TextBuffer, byte_offset_for_char_offset, char_slice, count_chars_up_to_byte,
+    str_to_byte_vec,
+};
 
 #[test]
 fn test_str_to_byte_vec() {
@@ -42,6 +45,23 @@ fn test_char_slice() {
     assert_eq!(char_slice("The end: 🫥??", 10, 12), Some("??"));
 
     assert_eq!(char_slice("🫥", 0, 0), Some(""));
+}
+#[test]
+fn test_byte_offset_for_char_offset() {
+    let text = "abc🔥abc☄️abc😬";
+    assert_eq!(byte_offset_for_char_offset(text, 0.into()), Some(0.into()));
+    assert_eq!(
+        byte_offset_for_char_offset(text, 4.into()),
+        Some("abc🔥".len().into())
+    );
+    assert_eq!(
+        byte_offset_for_char_offset(text, text.chars().count().into()),
+        Some(text.len().into())
+    );
+    assert_eq!(
+        byte_offset_for_char_offset(text, (text.chars().count() + 1).into()),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Adds Tab-triggered shell command completion to the headless TUI for detected shell input and explicit `!` mode.

This reuses the shared `warp_completer` backend and the TUI's existing inline-menu infrastructure. Completion requests are cancellable and reject stale results; accepted suggestions use UTF-8-safe backend replacement spans, preserve suffix text, insert safe common prefixes, and avoid trailing spaces for directories.

## Linked Issue

No linked issue.

## Testing

https://www.loom.com/share/cbb4e4be9710463ebfa36ab4e16e92a3

- `./script/format`
- `cargo test -p warp_tui --lib` — 560 passed
- `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- `git diff --check`
- [x] Manually tested locally with `./script/run-tui`
    - Verified Tab opens and cycles the inline completion menu in explicit shell mode.
    - Verified Enter accepts without submitting and Escape dismisses.
    - Verified directory completions do not append a trailing space.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added Tab completion for shell commands in the TUI.

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)