### PR TITLE
Keep selected account-backed toolbelt entries visible

### DIFF
--- a/app/src/auth/auth_view_modal.rs
+++ b/app/src/auth/auth_view_modal.rs
@@ -21,7 +21,7 @@ use warpui::{
 
 use super::UserUid;
 use super::auth_manager::{AuthManager, AuthManagerEvent};
-use super::auth_view_body::{AuthStep, AuthViewBodyEvent};
+use super::auth_view_body::{AuthStep, AuthViewBodyAction, AuthViewBodyEvent};
 use super::credentials::RefreshToken;
 use super::login_failure_notification::{self, LoginFailureReason};
 use crate::appearance::Appearance;
@@ -213,6 +213,12 @@ impl AuthView {
 
     pub fn skip_to_browser_open_step(&mut self, ctx: &mut ViewContext<Self>) {
         self.set_auth_step(ctx, AuthStep::BrowserOpen);
+    }
+
+    pub fn start_sign_in(&mut self, ctx: &mut ViewContext<Self>) {
+        self.update_auth_body(ctx, |body, ctx| {
+            body.handle_action(&AuthViewBodyAction::Login, ctx);
+        });
     }
 
     fn focus(&self, ctx: &mut ViewContext<Self>) {

--- a/app/src/drive/settings.rs
+++ b/app/src/drive/settings.rs
@@ -39,15 +39,24 @@ define_settings_group!(WarpDriveSettings, settings: [
 ]);
 
 impl WarpDriveSettings {
+    /// Returns whether Warp Drive is available for the current auth state.
+    ///
+    /// This is intentionally separate from the stored `enable_warp_drive`
+    /// preference. Logged-out and anonymous users can retain their onboarding
+    /// preference so Warp Drive appears automatically after signup, while the
+    /// feature remains unavailable until then.
+    pub fn is_warp_drive_available(app: &warpui::AppContext) -> bool {
+        use warpui::SingletonEntity as _;
+        !FeatureFlag::SkipFirebaseAnonymousUser.is_enabled()
+            || !crate::auth::AuthStateProvider::as_ref(app)
+                .get()
+                .is_anonymous_or_logged_out()
+    }
     /// Returns whether Warp Drive should be considered enabled.
     /// Returns `false` when the user is anonymous or fully logged out,
     /// regardless of the user setting.
     pub fn is_warp_drive_enabled(app: &warpui::AppContext) -> bool {
         use warpui::SingletonEntity as _;
-        let is_anonymous_or_logged_out = FeatureFlag::SkipFirebaseAnonymousUser.is_enabled()
-            && crate::auth::AuthStateProvider::as_ref(app)
-                .get()
-                .is_anonymous_or_logged_out();
-        *Self::as_ref(app).enable_warp_drive && !is_anonymous_or_logged_out
+        *Self::as_ref(app).enable_warp_drive && Self::is_warp_drive_available(app)
     }
 }

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -2013,6 +2013,22 @@ impl AISettings {
             && !self.is_ai_disabled_due_to_remote_session_org_policy(app)
     }
 
+    /// Returns whether conversation history is available for the current
+    /// account and AI state.
+    ///
+    /// The stored `show_conversation_history` preference is kept separately so
+    /// an onboarding choice can take effect automatically after signup and AI
+    /// enablement without asking the user to toggle the setting again.
+    pub fn is_conversation_history_available(&self, app: &AppContext) -> bool {
+        self.is_any_ai_enabled(app)
+    }
+
+    /// Returns whether conversation history should currently appear in the
+    /// tools panel.
+    pub fn is_conversation_history_enabled(&self, app: &AppContext) -> bool {
+        *self.show_conversation_history && self.is_conversation_history_available(app)
+    }
+
     pub fn default_session_mode(&self, app: &AppContext) -> DefaultSessionMode {
         let mode = *self.default_session_mode_internal.value();
         match mode {

--- a/app/src/settings_view/warp_drive_page.rs
+++ b/app/src/settings_view/warp_drive_page.rs
@@ -23,6 +23,7 @@ use super::{
 };
 use crate::appearance::Appearance;
 use crate::auth::AuthStateProvider;
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::drive::settings::WarpDriveSettings;
 
 #[derive(Debug, Clone)]
@@ -65,7 +66,12 @@ pub struct WarpDriveSettingsPageView {
 }
 
 impl WarpDriveSettingsPageView {
-    pub fn new(_ctx: &mut ViewContext<Self>) -> Self {
+    pub fn new(ctx: &mut ViewContext<Self>) -> Self {
+        ctx.subscribe_to_model(&AuthManager::handle(ctx), |_, _, event, ctx| {
+            if matches!(event, AuthManagerEvent::AuthComplete) {
+                ctx.notify();
+            }
+        });
         Self {
             page: PageType::new_uncategorized(
                 vec![
@@ -236,6 +242,10 @@ impl SettingsWidget for WarpDriveToggleWidget {
         "warp drive tools panel command palette search workflows prompts notebooks environment variables"
     }
 
+    fn should_render(&self, app: &AppContext) -> bool {
+        WarpDriveSettings::is_warp_drive_available(app)
+    }
+
     fn render(
         &self,
         _view: &Self::View,
@@ -243,10 +253,6 @@ impl SettingsWidget for WarpDriveToggleWidget {
         app: &AppContext,
     ) -> Box<dyn Element> {
         let settings = WarpDriveSettings::as_ref(app);
-        let is_anonymous_or_logged_out = FeatureFlag::SkipFirebaseAnonymousUser.is_enabled()
-            && AuthStateProvider::as_ref(app)
-                .get()
-                .is_anonymous_or_logged_out();
 
         render_body_item::<WarpDriveSettingsPageAction>(
             "Warp Drive".into(),
@@ -259,24 +265,15 @@ impl SettingsWidget for WarpDriveToggleWidget {
                 tooltip_override_text: None,
             }),
             LocalOnlyIconState::Hidden,
-            if is_anonymous_or_logged_out {
-                ToggleState::Disabled
-            } else {
-                ToggleState::Enabled
-            },
+            ToggleState::Enabled,
             appearance,
             appearance
                 .ui_builder()
                 .switch(self.switch_state.clone())
-                .check(*settings.enable_warp_drive && !is_anonymous_or_logged_out)
-                .with_disabled(is_anonymous_or_logged_out)
+                .check(*settings.enable_warp_drive)
                 .build()
-                .on_click(move |ctx, _, _| {
-                    if !is_anonymous_or_logged_out {
-                        ctx.dispatch_typed_action(
-                            WarpDriveSettingsPageAction::ToggleShowWarpDrive,
-                        );
-                    }
+                .on_click(|ctx, _, _| {
+                    ctx.dispatch_typed_action(WarpDriveSettingsPageAction::ToggleShowWarpDrive);
                 })
                 .finish(),
             Some("Warp Drive is a workspace in your terminal where you can save Workflows, Notebooks, Prompts, and Environment Variables for personal use or to share with a team.".into()),

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6423,6 +6423,12 @@ impl Workspace {
                     ctx,
                 );
             }
+            LeftPanelEvent::SignInRequested => {
+                self.open_require_login_modal(AuthViewVariant::RequireLoginCloseable, ctx);
+                self.require_login_modal.update(ctx, |modal, ctx| {
+                    modal.start_sign_in(ctx);
+                });
+            }
         }
     }
 
@@ -11389,6 +11395,13 @@ impl Workspace {
                 self.open_auth_override_warning_modal(interrupted_auth_payload.clone(), ctx);
             }
             AuthManagerEvent::AuthComplete => {
+                // This workspace can survive an anonymous user signing up from
+                // inside the app. Refresh the cached auth state and recompute
+                // effective toolbelt availability so onboarding preferences
+                // (for example, Warp Drive and conversation history) take
+                // effect without requiring an off/on toggle.
+                self.auth_state = AuthStateProvider::as_ref(ctx).get().clone();
+                self.update_left_panel_available_views(ctx);
                 // Only show the telemetry banner if the user is an existing user. The new user flow
                 // for this is handled in the onboarding flow.
                 if self.auth_state.is_onboarded().unwrap_or_default() {
@@ -11396,6 +11409,7 @@ impl Workspace {
                     // to make sure we don't show the banner if the user is an enterprise user.
                     self.check_and_trigger_telemetry_banner_for_existing_users(ctx);
                 }
+                ctx.notify();
             }
             _ => {
                 ctx.notify();
@@ -23685,7 +23699,6 @@ impl Workspace {
             views.push(ToolPanelView::ProjectExplorer);
         }
         if FeatureFlag::AgentViewConversationListView.is_enabled()
-            && AISettings::as_ref(ctx).is_any_ai_enabled(ctx)
             && *AISettings::as_ref(ctx).show_conversation_history
         {
             views.push(ToolPanelView::ConversationListView);
@@ -23698,7 +23711,7 @@ impl Workspace {
                 entry_focus: GlobalSearchEntryFocus::Results,
             });
         }
-        if WarpDriveSettings::is_warp_drive_enabled(ctx) {
+        if *WarpDriveSettings::as_ref(ctx).enable_warp_drive {
             views.push(ToolPanelView::WarpDrive);
         }
         views
@@ -26311,9 +26324,7 @@ impl View for Workspace {
             context.set.insert(flags::ENABLE_WARP_DRIVE);
         }
 
-        if AISettings::as_ref(app).is_any_ai_enabled(app)
-            && *AISettings::as_ref(app).show_conversation_history
-        {
+        if AISettings::as_ref(app).is_conversation_history_enabled(app) {
             context.set.insert(flags::SHOW_CONVERSATION_HISTORY);
         }
 

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -7,11 +7,13 @@ use warp_core::ui::theme::color::internal_colors;
 use warp_errors::report_error;
 use warp_util::path::LineAndColumnArg;
 use warpui::elements::{
-    ChildView, ConstrainedBox, Container, CrossAxisAlignment, DragBarSide, Element, Empty, Flex,
-    MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Resizable,
+    Align, ChildView, ConstrainedBox, Container, CrossAxisAlignment, DragBarSide, Element, Empty,
+    Flex, MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Resizable,
     ResizableStateHandle, Shrinkable, resizable_state_handle,
 };
+use warpui::fonts::Weight;
 use warpui::platform::Cursor;
+use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
     AppContext, Entity, FocusContext, ModelHandle, SingletonEntity, TypedActionView, View,
@@ -22,6 +24,7 @@ use crate::TelemetryEvent;
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::appearance::Appearance;
+use crate::auth::AuthStateProvider;
 use crate::code::buffer_location::LocalOrRemotePath;
 #[cfg(feature = "local_fs")]
 use crate::code::file_tree::FileTreeEvent;
@@ -30,6 +33,7 @@ use crate::coding_panel_enablement_state::CodingPanelEnablementState;
 use crate::drive::panel::{
     DrivePanel, DrivePanelEvent, MAX_SIDEBAR_WIDTH_RATIO, MIN_SIDEBAR_WIDTH,
 };
+use crate::drive::settings::WarpDriveSettings;
 use crate::pane_group::pane::view::header::PANE_HEADER_HEIGHT;
 use crate::pane_group::pane::view::header::components::HEADER_EDGE_PADDING;
 use crate::pane_group::working_directories::WorkingDirectory;
@@ -39,6 +43,7 @@ use crate::pane_group::{
 #[cfg(feature = "local_fs")]
 use crate::server::telemetry::CodePanelsFileOpenEntrypoint;
 use crate::server::telemetry::{FileTreeSource, WarpDriveSource};
+use crate::settings::AISettings;
 use crate::settings_view::keybindings::{KeybindingChangedEvent, KeybindingChangedNotifier};
 use crate::terminal::resizable_data::{ModalType, ResizableData};
 use crate::ui_components::buttons::{icon_button, icon_button_with_color};
@@ -71,6 +76,7 @@ struct MouseStateHandles {
     conversation_list_view_button: MouseStateHandle,
     global_search_button: MouseStateHandle,
     warp_drive_button: MouseStateHandle,
+    sign_in_button: MouseStateHandle,
 }
 
 #[derive(Clone, Debug)]
@@ -79,6 +85,43 @@ pub enum LeftPanelAction {
     GlobalSearch { entry_focus: GlobalSearchEntryFocus },
     WarpDrive,
     ConversationListView,
+    SignIn,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ToolPanelAvailability {
+    Available,
+    RequiresAccount,
+    RequiresAi,
+}
+
+impl ToolPanelView {
+    fn availability(self, app: &AppContext) -> ToolPanelAvailability {
+        match self {
+            ToolPanelView::ProjectExplorer | ToolPanelView::GlobalSearch { .. } => {
+                ToolPanelAvailability::Available
+            }
+            ToolPanelView::WarpDrive => {
+                if WarpDriveSettings::is_warp_drive_available(app) {
+                    ToolPanelAvailability::Available
+                } else {
+                    ToolPanelAvailability::RequiresAccount
+                }
+            }
+            ToolPanelView::ConversationListView => {
+                if AuthStateProvider::as_ref(app)
+                    .get()
+                    .is_anonymous_or_logged_out()
+                {
+                    ToolPanelAvailability::RequiresAccount
+                } else if AISettings::as_ref(app).is_conversation_history_available(app) {
+                    ToolPanelAvailability::Available
+                } else {
+                    ToolPanelAvailability::RequiresAi
+                }
+            }
+        }
+    }
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -98,6 +141,7 @@ pub enum LeftPanelEvent {
         conversation_title: String,
         terminal_view_id: Option<warpui::EntityId>,
     },
+    SignInRequested,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -199,6 +243,97 @@ fn toolbelt_tooltip_keybinding(binding_names: &[&'static str], app: &AppContext)
 }
 
 impl LeftPanelView {
+    pub(crate) fn active_view_availability(&self, app: &AppContext) -> ToolPanelAvailability {
+        self.active_view.get().availability(app)
+    }
+
+    fn render_unavailable_panel(
+        &self,
+        appearance: &Appearance,
+        view: ToolPanelView,
+        availability: ToolPanelAvailability,
+    ) -> Box<dyn Element> {
+        let (title, description) = match (view, availability) {
+            (ToolPanelView::WarpDrive, ToolPanelAvailability::RequiresAccount) => (
+                "Sign in to access Warp Drive",
+                "Create an account to save and share workflows, notebooks, prompts, and more.",
+            ),
+            (ToolPanelView::ConversationListView, ToolPanelAvailability::RequiresAccount) => (
+                "Sign in to access Agent conversations",
+                "Create an account and enable AI to access your conversation history.",
+            ),
+            (ToolPanelView::ConversationListView, ToolPanelAvailability::RequiresAi) => (
+                "Turn on AI to access Agent conversations",
+                "Enable Warp AI to access your conversation history.",
+            ),
+            (
+                ToolPanelView::ProjectExplorer
+                | ToolPanelView::GlobalSearch { .. }
+                | ToolPanelView::WarpDrive,
+                ToolPanelAvailability::RequiresAi,
+            )
+            | (
+                ToolPanelView::ProjectExplorer | ToolPanelView::GlobalSearch { .. },
+                ToolPanelAvailability::RequiresAccount,
+            )
+            | (_, ToolPanelAvailability::Available) => {
+                debug_assert!(false, "unexpected locked tool-panel state");
+                (
+                    "Feature unavailable",
+                    "This feature is currently unavailable.",
+                )
+            }
+        };
+        let theme = appearance.theme();
+        let title = appearance
+            .ui_builder()
+            .paragraph(title)
+            .with_style(UiComponentStyles {
+                font_size: Some(16.),
+                font_weight: Some(Weight::Semibold),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+        let description = appearance
+            .ui_builder()
+            .paragraph(description)
+            .with_style(UiComponentStyles {
+                font_size: Some(13.),
+                font_color: Some(internal_colors::text_sub(
+                    theme,
+                    theme.background().into_solid(),
+                )),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+        let mut content = Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(title)
+            .with_child(Container::new(description).with_margin_top(8.).finish());
+        if availability == ToolPanelAvailability::RequiresAccount {
+            let sign_in = appearance
+                .ui_builder()
+                .button(
+                    ButtonVariant::Accent,
+                    self.mouse_state_handles.sign_in_button.clone(),
+                )
+                .with_text_label("Sign in".to_string())
+                .build()
+                .on_click(|ctx, _, _| {
+                    ctx.dispatch_typed_action(LeftPanelAction::SignIn);
+                })
+                .finish();
+            content = content.with_child(Container::new(sign_in).with_margin_top(16.).finish());
+        }
+        let content = ConstrainedBox::new(content.finish())
+            .with_max_width(280.)
+            .finish();
+
+        Align::new(Container::new(content).with_uniform_padding(24.).finish()).finish()
+    }
     pub fn new(
         working_directories_model: ModelHandle<WorkingDirectoriesModel>,
         views: Vec<ToolPanelView>,
@@ -389,6 +524,16 @@ impl LeftPanelView {
         } else {
             self.update_button_active_states();
         }
+        // The selected tab can remain the same while its account/AI
+        // availability changes. Reconcile the real conversation view's open
+        // registration so a locked placeholder never polls, and enabling AI
+        // while the panel is open starts polling without another click.
+        let is_left_panel_open = self
+            .active_pane_group
+            .as_ref()
+            .and_then(|pane_group| pane_group.upgrade(ctx))
+            .is_some_and(|pane_group| pane_group.as_ref(ctx).left_panel_open);
+        self.on_conversation_list_view_visibility_changed(is_left_panel_open, ctx);
 
         ctx.notify();
     }
@@ -689,6 +834,10 @@ impl LeftPanelView {
     }
 
     pub fn focus_active_view_on_entry(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.active_view_availability(ctx) != ToolPanelAvailability::Available {
+            ctx.focus_self();
+            return;
+        }
         match self.active_view.get() {
             ToolPanelView::ProjectExplorer => {
                 if let Some(file_tree_view) = self.active_file_tree_view(ctx) {
@@ -890,6 +1039,7 @@ impl LeftPanelView {
                 LeftPanelAction::ConversationListView => {
                     self.active_view.get() == ToolPanelView::ConversationListView
                 }
+                LeftPanelAction::SignIn => false,
             };
         }
     }
@@ -1009,27 +1159,34 @@ impl LeftPanelView {
             }
             LeftPanelAction::WarpDrive => {
                 active_view_state::set(self, ToolPanelView::WarpDrive, ctx);
-                if force_open {
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::WarpDriveOpened {
-                            source: WarpDriveSource::ForceOpened,
-                            is_code_mode_v2: true
-                        },
-                        ctx
-                    );
-                } else {
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::WarpDriveOpened {
-                            source: WarpDriveSource::LeftPanelToolbelt,
-                            is_code_mode_v2: true
-                        },
-                        ctx
-                    );
+                if self.active_view_availability(ctx) == ToolPanelAvailability::Available {
+                    if force_open {
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::WarpDriveOpened {
+                                source: WarpDriveSource::ForceOpened,
+                                is_code_mode_v2: true
+                            },
+                            ctx
+                        );
+                    } else {
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::WarpDriveOpened {
+                                source: WarpDriveSource::LeftPanelToolbelt,
+                                is_code_mode_v2: true
+                            },
+                            ctx
+                        );
+                    }
                 }
             }
             LeftPanelAction::ConversationListView => {
                 active_view_state::set(self, ToolPanelView::ConversationListView, ctx);
-                send_telemetry_from_ctx!(TelemetryEvent::ConversationListViewOpened, ctx);
+                if self.active_view_availability(ctx) == ToolPanelAvailability::Available {
+                    send_telemetry_from_ctx!(TelemetryEvent::ConversationListViewOpened, ctx);
+                }
+            }
+            LeftPanelAction::SignIn => {
+                ctx.emit(LeftPanelEvent::SignInRequested);
             }
         }
     }
@@ -1089,10 +1246,12 @@ impl LeftPanelView {
         is_now_open: bool,
         ctx: &mut ViewContext<Self>,
     ) {
+        let is_available = self.active_view.get() == ToolPanelView::ConversationListView
+            && self.active_view_availability(ctx) == ToolPanelAvailability::Available;
         let window_id = ctx.window_id();
         let view_id = self.conversation_list_view.id();
         AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-            if is_now_open {
+            if is_now_open && is_available {
                 model.register_view_open(window_id, view_id, ctx);
             } else {
                 model.register_view_closed(window_id, view_id, ctx);
@@ -1116,7 +1275,9 @@ impl View for LeftPanelView {
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
         // Focus the active tool panel view on-left-panel-focus.
-        if focus_ctx.is_self_focused() {
+        if focus_ctx.is_self_focused()
+            && self.active_view_availability(ctx) == ToolPanelAvailability::Available
+        {
             match self.active_view.get() {
                 ToolPanelView::ProjectExplorer => {
                     if let Some(view) = self.active_file_tree_view(ctx) {
@@ -1165,36 +1326,49 @@ impl View for LeftPanelView {
             None
         };
 
-        let content_area: Box<dyn Element> = match self.active_view.get() {
-            ToolPanelView::ProjectExplorer => match self.active_file_tree_view(app) {
-                Some(file_tree_view) => Shrinkable::new(
+        let active_view = self.active_view.get();
+        let availability = self.active_view_availability(app);
+        let content_area: Box<dyn Element> = if availability != ToolPanelAvailability::Available {
+            Shrinkable::new(
+                1.0,
+                self.render_unavailable_panel(appearance, active_view, availability),
+            )
+            .finish()
+        } else {
+            match active_view {
+                ToolPanelView::ProjectExplorer => match self.active_file_tree_view(app) {
+                    Some(file_tree_view) => Shrinkable::new(
+                        1.0,
+                        Container::new(ChildView::new(&file_tree_view).finish())
+                            .with_padding_left(2.)
+                            .with_padding_right(2.)
+                            .finish(),
+                    )
+                    .finish(),
+                    _ => Shrinkable::new(1.0, Container::new(Empty::new().finish()).finish())
+                        .finish(),
+                },
+                ToolPanelView::GlobalSearch { .. } => match self.active_global_search_view(app) {
+                    Some(global_search_view) => Shrinkable::new(
+                        1.0,
+                        Container::new(ChildView::new(&global_search_view).finish()).finish(),
+                    )
+                    .finish(),
+                    _ => Shrinkable::new(1.0, Container::new(Empty::new().finish()).finish())
+                        .finish(),
+                },
+                ToolPanelView::WarpDrive => Shrinkable::new(
                     1.0,
-                    Container::new(ChildView::new(&file_tree_view).finish())
+                    Container::new(ChildView::new(&self.warp_drive_view).finish())
                         .with_padding_left(2.)
                         .with_padding_right(2.)
                         .finish(),
                 )
                 .finish(),
-                _ => Shrinkable::new(1.0, Container::new(Empty::new().finish()).finish()).finish(),
-            },
-            ToolPanelView::GlobalSearch { .. } => match self.active_global_search_view(app) {
-                Some(global_search_view) => Shrinkable::new(
-                    1.0,
-                    Container::new(ChildView::new(&global_search_view).finish()).finish(),
-                )
-                .finish(),
-                _ => Shrinkable::new(1.0, Container::new(Empty::new().finish()).finish()).finish(),
-            },
-            ToolPanelView::WarpDrive => Shrinkable::new(
-                1.0,
-                Container::new(ChildView::new(&self.warp_drive_view).finish())
-                    .with_padding_left(2.)
-                    .with_padding_right(2.)
-                    .finish(),
-            )
-            .finish(),
-            ToolPanelView::ConversationListView => {
-                Shrinkable::new(1.0, ChildView::new(&self.conversation_list_view).finish()).finish()
+                ToolPanelView::ConversationListView => {
+                    Shrinkable::new(1.0, ChildView::new(&self.conversation_list_view).finish())
+                        .finish()
+                }
             }
         };
 

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -357,6 +357,203 @@ fn test_theme_chooser_does_not_suppress_tab_bar_traffic_light_padding() {
     });
 }
 
+/// Regression for account-first onboarding users who select Warp Drive and
+/// conversation history, skip signup, and create an account later. The stored
+/// preferences should remain true while unavailable, then take effect
+/// automatically as account and AI availability change—without an off/on
+/// toggle.
+#[test]
+fn test_tools_panel_preferences_activate_after_signup_and_ai_enablement() {
+    let _skip_anon_guard = FeatureFlag::SkipFirebaseAnonymousUser.override_enabled(true);
+    let _conversation_list_guard =
+        FeatureFlag::AgentViewConversationListView.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        // Preserve the user's onboarding intent while starting logged out with
+        // AI disabled (the account-skipped account-first completion state).
+        app.update(|ctx| {
+            WarpDriveSettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .enable_warp_drive
+                    .set_value(true, ctx)
+                    .expect("remember Warp Drive preference");
+            });
+            AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .show_conversation_history
+                    .set_value(true, ctx)
+                    .expect("remember conversation-history preference");
+                settings
+                    .is_any_ai_enabled
+                    .set_value(false, ctx)
+                    .expect("AI remains disabled after skipped signup");
+            });
+            let auth_state = AuthStateProvider::as_ref(ctx).get();
+            auth_state.set_user(None);
+            auth_state.set_credentials(None);
+        });
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            assert!(
+                workspace
+                    .left_panel_views
+                    .contains(&ToolPanelView::WarpDrive),
+                "the stored preference should keep the locked Warp Drive entry visible"
+            );
+            assert!(
+                workspace
+                    .left_panel_views
+                    .contains(&ToolPanelView::ConversationListView),
+                "the stored preference should keep the locked conversations entry visible"
+            );
+            workspace.left_panel_view.update(ctx, |left_panel, ctx| {
+                left_panel.handle_action_with_force_open(&LeftPanelAction::WarpDrive, false, ctx);
+                assert_eq!(
+                    left_panel.active_view_availability(ctx),
+                    left_panel::ToolPanelAvailability::RequiresAccount
+                );
+                drop(left_panel.render(ctx));
+
+                left_panel.handle_action_with_force_open(
+                    &LeftPanelAction::ConversationListView,
+                    false,
+                    ctx,
+                );
+                assert_eq!(
+                    left_panel.active_view_availability(ctx),
+                    left_panel::ToolPanelAvailability::RequiresAccount
+                );
+                drop(left_panel.render(ctx));
+            });
+            workspace.handle_left_panel_event(&LeftPanelEvent::SignInRequested, ctx);
+            assert!(
+                workspace
+                    .current_workspace_state
+                    .is_require_login_modal_open,
+                "locked-panel Sign in should open the existing auth modal"
+            );
+            // Keep the remainder of this state-transition test focused on the
+            // tool panel rather than modal rendering.
+            workspace
+                .current_workspace_state
+                .is_require_login_modal_open = false;
+        });
+        app.read(|ctx| {
+            // Availability must not erase the raw onboarding preferences.
+            assert!(*WarpDriveSettings::as_ref(ctx).enable_warp_drive);
+            assert!(*AISettings::as_ref(ctx).show_conversation_history);
+            assert!(!WarpDriveSettings::is_warp_drive_available(ctx));
+            assert!(!WarpDriveSettings::is_warp_drive_enabled(ctx));
+            assert!(!AISettings::as_ref(ctx).is_conversation_history_available(ctx));
+            assert!(!AISettings::as_ref(ctx).is_conversation_history_enabled(ctx));
+        });
+
+        // Signing up makes account-backed features available. AuthComplete
+        // must refresh the existing workspace even though no setting changed.
+        app.update(|ctx| {
+            AuthStateProvider::as_ref(ctx)
+                .get()
+                .apply_remote_server_auth_context(
+                    "test-token".to_string(),
+                    "test-user".to_string(),
+                    "test@warp.dev".to_string(),
+                );
+        });
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.handle_auth_manager_event(
+                AuthManager::handle(ctx),
+                &AuthManagerEvent::AuthComplete,
+                ctx,
+            );
+            assert!(
+                workspace
+                    .left_panel_views
+                    .contains(&ToolPanelView::WarpDrive),
+                "Drive entry remains visible and unlocks after signup"
+            );
+            assert!(
+                workspace
+                    .left_panel_views
+                    .contains(&ToolPanelView::ConversationListView),
+                "conversation entry remains visible while waiting for AI"
+            );
+            assert!(!workspace.auth_state.is_anonymous_or_logged_out());
+            assert!(WarpDriveSettings::is_warp_drive_enabled(ctx));
+            assert!(!AISettings::as_ref(ctx).is_conversation_history_enabled(ctx));
+            workspace.left_panel_view.update(ctx, |left_panel, ctx| {
+                left_panel.handle_action_with_force_open(&LeftPanelAction::WarpDrive, false, ctx);
+                assert_eq!(
+                    left_panel.active_view_availability(ctx),
+                    left_panel::ToolPanelAvailability::Available
+                );
+
+                left_panel.handle_action_with_force_open(
+                    &LeftPanelAction::ConversationListView,
+                    false,
+                    ctx,
+                );
+                assert_eq!(
+                    left_panel.active_view_availability(ctx),
+                    left_panel::ToolPanelAvailability::RequiresAi
+                );
+                drop(left_panel.render(ctx));
+            });
+        });
+
+        // Enabling AI later should make the preserved conversation-history
+        // preference effective through the existing AI-settings subscription.
+        app.update(|ctx| {
+            AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .is_any_ai_enabled
+                    .set_value(true, ctx)
+                    .expect("enable AI");
+            });
+        });
+        workspace.update(&mut app, |workspace, ctx| {
+            assert!(
+                workspace
+                    .left_panel_views
+                    .contains(&ToolPanelView::ConversationListView)
+            );
+            workspace.left_panel_view.update(ctx, |left_panel, ctx| {
+                left_panel.handle_action_with_force_open(
+                    &LeftPanelAction::ConversationListView,
+                    false,
+                    ctx,
+                );
+                assert_eq!(
+                    left_panel.active_view_availability(ctx),
+                    left_panel::ToolPanelAvailability::Available
+                );
+            });
+        });
+        app.read(|ctx| {
+            assert!(AISettings::as_ref(ctx).is_conversation_history_enabled(ctx));
+        });
+
+        // The raw setting still controls whether the toolbelt entry exists.
+        app.update(|ctx| {
+            AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .show_conversation_history
+                    .set_value(false, ctx)
+                    .expect("hide conversation history");
+            });
+        });
+        workspace.read(&app, |workspace, _| {
+            assert!(
+                !workspace
+                    .left_panel_views
+                    .contains(&ToolPanelView::ConversationListView)
+            );
+        });
+    });
+}
+
 fn assert_vertical_tabs_tools_panel_preserves_padding(config: HeaderToolbarChipSelection) {
     App::test((), |mut app| async move {
         initialize_app(&mut app);


### PR DESCRIPTION
## Description
Stacked on #14075.

Loom: https://www.loom.com/share/90bc436bc9714bc0ba69659e36402de0 (we now have a button to sign in directly on the panel)

Account-first onboarding lets users choose Warp Drive and Agent conversations before creating an account. If they skipped signup, those preferences were stored but the tabs disappeared from the toolbelt, making Settings and the running product feel inconsistent.

This PR keeps selected account-backed tabs visible while separating toolbelt preference from feature availability:

- Builds the toolbelt icon list from the stored Warp Drive and Agent conversations preferences.
- Shows locked panels when prerequisites are missing:
  - `Sign in to access Warp Drive` with a **Sign in** CTA
  - `Sign in to access Agent conversations` with a **Sign in** CTA
  - `Turn on AI to access Agent conversations` (text-only)
- Keeps Appearance switches tied to the raw “show this tab” preference, so users can hide locked entries.
- Hides the dedicated Warp Drive feature toggle while logged out, leaving its existing signup prompt.
- Routes the Sign in CTA through the existing closeable auth modal and browser/token fallback flow.
- Refreshes the existing workspace after signup so locked panels unlock without an off/on toggle.
- Prevents locked child views from receiving focus, starting conversation polling, or emitting real feature-opened telemetry.
- Reconciles conversation polling when AI becomes available while the panel is already open.
- Adds regression coverage for logged out → signed in with AI off → AI enabled → raw preference disabled.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- `./script/format`
- `cargo check -p warp --features account_first_onboarding`
- `cargo nextest run -p warp --features account_first_onboarding tools_panel` — 3 passed
- `cargo nextest run -p warp --features account_first_onboarding account_first_settings_enable_agent_for_authenticated_users_and_apply_ui_choices` — 1 passed
- `cargo clippy -p warp --features account_first_onboarding --all-targets --tests -- -D warnings`
- Presubmit clippy sequence:
  - `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
  - `cargo clippy -p warp --all-targets --tests -- -D warnings`
  - `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

