### PR TITLE
Add per-profile subagent model picker and plumb into MAA requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,7 +4506,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7134,7 +7134,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7328,7 +7328,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9756,7 +9756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -10572,7 +10572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph",
@@ -10591,7 +10591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11831,7 +11831,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11899,7 +11899,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13589,7 +13589,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15792,7 +15792,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=9ce5da6fd67694acd6ceace0a44f8824203e3c19#9ce5da6fd67694acd6ceace0a44f8824203e3c19"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=ccea78599336c89e94cd3344886807eba13dfd58#ccea78599336c89e94cd3344886807eba13dfd58"
 dependencies = [
  "prost",
  "prost-reflect",
@@ -16978,7 +16978,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "9ce5da6fd67694acd6ceace0a44f8824203e3c19" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "ccea78599336c89e94cd3344886807eba13dfd58" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -105,6 +105,8 @@ pub struct RequestParams {
     pub coding_model: LLMId,
     pub cli_agent_model: LLMId,
     pub computer_use_model: LLMId,
+    /// Model override for subagents. `None` means subagents use the base model.
+    pub subagent_model: Option<LLMId>,
     pub is_memory_enabled: bool,
     pub warp_drive_context_enabled: bool,
     pub context_window_limit: Option<u32>,
@@ -173,6 +175,7 @@ impl RequestParams {
             coding_model: LLMId::from("test-model"),
             cli_agent_model: LLMId::from("test-model"),
             computer_use_model: LLMId::from("test-model"),
+            subagent_model: None,
             is_memory_enabled: false,
             warp_drive_context_enabled: false,
             context_window_limit: None,
@@ -366,6 +369,9 @@ impl RequestParams {
             coding_model: request_input.coding_model_id.clone(),
             cli_agent_model: request_input.cli_agent_model_id.clone(),
             computer_use_model: request_input.computer_use_model_id.clone(),
+            subagent_model: LLMPreferences::as_ref(app)
+                .get_active_subagent_model(app, terminal_view_id)
+                .map(|info| info.id.clone()),
             is_memory_enabled,
             warp_drive_context_enabled,
             mcp_context,

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -68,6 +68,7 @@ pub async fn generate_multi_agent_output(
                 base: params.model.into(),
                 cli_agent: params.cli_agent_model.into(),
                 computer_use_agent: params.computer_use_model.into(),
+                subagent: params.subagent_model.map(Into::into).unwrap_or_default(),
                 base_model_context_window_limit: params.context_window_limit.unwrap_or(0),
                 ..Default::default()
             }),

--- a/app/src/ai/agent/api/impl_tests.rs
+++ b/app/src/ai/agent/api/impl_tests.rs
@@ -27,6 +27,7 @@ fn request_params_with_ask_user_question_enabled(ask_user_question_enabled: bool
         coding_model: model.clone(),
         cli_agent_model: model.clone(),
         computer_use_model: model,
+        subagent_model: None,
         is_memory_enabled: false,
         warp_drive_context_enabled: false,
         context_window_limit: None,

--- a/app/src/ai/blocklist/permissions.rs
+++ b/app/src/ai/blocklist/permissions.rs
@@ -207,6 +207,7 @@ impl BlocklistAIPermissions {
             coding_model: profile_data.coding_model.clone(),
             cli_agent_model: profile_data.cli_agent_model.clone(),
             computer_use_model: profile_data.computer_use_model.clone(),
+            subagent_model: profile_data.subagent_model.clone(),
             context_window_limit: profile_data.context_window_limit,
             autosync_plans_to_warp_drive: profile_data.autosync_plans_to_warp_drive,
             web_search_enabled: profile_data.web_search_enabled,

--- a/app/src/ai/execution_profiles/config.rs
+++ b/app/src/ai/execution_profiles/config.rs
@@ -474,6 +474,10 @@ struct ExecutionProfileFile {
     cli_agent_model: Option<String>,
     #[schemars(description = "Optional computer-use model override.")]
     computer_use_model: Option<String>,
+    #[schemars(
+        description = "Optional subagent-model override; unset means subagents use the base model."
+    )]
+    subagent_model: Option<String>,
     #[schemars(description = "Optional maximum context window in tokens.")]
     context_window_limit: Option<u32>,
     #[schemars(description = "Whether plans are automatically synced to Warp Drive.")]
@@ -525,6 +529,7 @@ impl From<&AIExecutionProfile> for ExecutionProfileFile {
             coding_model: profile.coding_model.clone().map(Into::into),
             cli_agent_model: profile.cli_agent_model.clone().map(Into::into),
             computer_use_model: profile.computer_use_model.clone().map(Into::into),
+            subagent_model: profile.subagent_model.clone().map(Into::into),
             context_window_limit: profile.context_window_limit,
             autosync_plans_to_warp_drive: profile.autosync_plans_to_warp_drive,
             web_search_enabled: profile.web_search_enabled,
@@ -576,6 +581,7 @@ impl TryFrom<ExecutionProfileFile> for AIExecutionProfile {
             coding_model: file.coding_model.map(LLMId::from),
             cli_agent_model: file.cli_agent_model.map(LLMId::from),
             computer_use_model: file.computer_use_model.map(LLMId::from),
+            subagent_model: file.subagent_model.map(LLMId::from),
             context_window_limit: file.context_window_limit,
             autosync_plans_to_warp_drive: file.autosync_plans_to_warp_drive,
             web_search_enabled: file.web_search_enabled,

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -170,6 +170,9 @@ pub enum ExecutionProfileEditorViewAction {
     SetComputerUseModel {
         id: LLMId,
     },
+    SetSubagentModel {
+        id: LLMId,
+    },
 
     SetApplyCodeDiffs {
         permission: ActionPermission,
@@ -249,6 +252,7 @@ pub struct ExecutionProfileEditorView {
     full_terminal_use_model_dropdown:
         ViewHandle<FilterableDropdown<ExecutionProfileEditorViewAction>>,
     computer_use_model_dropdown: ViewHandle<FilterableDropdown<ExecutionProfileEditorViewAction>>,
+    subagent_model_dropdown: ViewHandle<FilterableDropdown<ExecutionProfileEditorViewAction>>,
     apply_code_diffs_dropdown: ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
     read_files_dropdown: ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
     execute_commands_dropdown: ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
@@ -572,6 +576,11 @@ impl ExecutionProfileEditorView {
             dropdown.set_menu_width(MODEL_MENU_WIDTH, ctx);
             dropdown
         });
+        let subagent_model_dropdown = ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = FilterableDropdown::new(ctx);
+            dropdown.set_menu_width(MODEL_MENU_WIDTH, ctx);
+            dropdown
+        });
         let command_allowlist_editor = ctx.add_typed_action_view(|ctx| {
             let mut input =
                 SubmittableTextInput::new(ctx).validate_on_edit(|s| Regex::new(s).is_ok());
@@ -655,6 +664,7 @@ impl ExecutionProfileEditorView {
             coding_model_dropdown,
             full_terminal_use_model_dropdown,
             computer_use_model_dropdown,
+            subagent_model_dropdown,
             apply_code_diffs_dropdown,
             read_files_dropdown,
             execute_commands_dropdown,
@@ -781,6 +791,21 @@ impl ExecutionProfileEditorView {
                         |prefs, _| prefs.get_computer_use_llm_choices().collect_vec(),
                         |id| ExecutionProfileEditorViewAction::SetComputerUseModel { id },
                         |prefs, app| prefs.get_default_computer_use_model(app).id.clone(),
+                        &me.upgrade_footer_mouse_state,
+                        ctx,
+                    );
+                    Self::refresh_filterable_model_dropdown(
+                        &me.subagent_model_dropdown,
+                        current_permissions.subagent_model.clone(),
+                        |prefs, app| prefs.get_base_llm_choices_for_agent_mode(app).collect_vec(),
+                        |id| ExecutionProfileEditorViewAction::SetSubagentModel { id },
+                        {
+                            let profile_base_model = current_permissions.base_model.clone();
+                            move |prefs, app| {
+                                profile_base_model
+                                    .unwrap_or_else(|| prefs.get_default_base_model(app).id.clone())
+                            }
+                        },
                         &me.upgrade_footer_mouse_state,
                         ctx,
                     );
@@ -960,6 +985,21 @@ impl ExecutionProfileEditorView {
             |prefs, _| prefs.get_computer_use_llm_choices().collect_vec(),
             |id| ExecutionProfileEditorViewAction::SetComputerUseModel { id },
             |prefs, app| prefs.get_default_computer_use_model(app).id.clone(),
+            &self.upgrade_footer_mouse_state,
+            ctx,
+        );
+        Self::refresh_filterable_model_dropdown(
+            &self.subagent_model_dropdown,
+            current_permissions.subagent_model.clone(),
+            |prefs, app| prefs.get_base_llm_choices_for_agent_mode(app).collect_vec(),
+            |id| ExecutionProfileEditorViewAction::SetSubagentModel { id },
+            {
+                let profile_base_model = current_permissions.base_model.clone();
+                move |prefs, app| {
+                    profile_base_model
+                        .unwrap_or_else(|| prefs.get_default_base_model(app).id.clone())
+                }
+            },
             &self.upgrade_footer_mouse_state,
             ctx,
         );
@@ -1621,6 +1661,12 @@ impl TypedActionView for ExecutionProfileEditorView {
             ExecutionProfileEditorViewAction::SetComputerUseModel { id } => {
                 AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles_model, ctx| {
                     profiles_model.set_computer_use_model(&self.profile_id, Some(id.clone()), ctx);
+                });
+                ctx.notify();
+            }
+            ExecutionProfileEditorViewAction::SetSubagentModel { id } => {
+                AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles_model, ctx| {
+                    profiles_model.set_subagent_model(&self.profile_id, Some(id.clone()), ctx);
                 });
                 ctx.notify();
             }

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -282,6 +282,13 @@ pub fn render_models_section(
         &view.full_terminal_use_model_dropdown,
     ));
 
+    column = column.with_child(render_filterable_dropdown_row(
+        appearance,
+        "Subagent model",
+        "The model used by subagents that the agent launches to work on delegated tasks. When not set, subagents use the base model.",
+        &view.subagent_model_dropdown,
+    ));
+
     if FeatureFlag::LocalComputerUse.is_enabled() {
         column.add_child(render_filterable_dropdown_row(
             appearance,

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -1309,6 +1309,35 @@ impl AIExecutionProfilesModel {
         }
     }
 
+    pub fn set_subagent_model(
+        &mut self,
+        profile_id: &ExecutionProfileId,
+        model_id: Option<LLMId>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.edit_profile_internal(
+            profile_id,
+            |profile| {
+                if profile.subagent_model != model_id {
+                    profile.subagent_model = model_id.clone();
+                    return true;
+                }
+                false
+            },
+            ctx,
+        );
+
+        if let Some(model_id) = &model_id {
+            send_telemetry_from_ctx!(
+                TelemetryEvent::AIExecutionProfileModelSelected {
+                    model_type: "subagent".to_string(),
+                    model_value: model_id.to_string(),
+                },
+                ctx
+            );
+        }
+    }
+
     pub fn set_context_window_limit(
         &mut self,
         profile_id: &ExecutionProfileId,

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -1064,6 +1064,22 @@ impl LLMPreferences {
             .unwrap_or_else(|| DEFAULT.get_or_init(default_computer_use_llms))
     }
 
+    /// Returns the `LLMInfo` for the subagent model override on the active
+    /// profile. `None` means subagents use the base model.
+    pub fn get_active_subagent_model<'a>(
+        &'a self,
+        app: &'a AppContext,
+        terminal_view_id: Option<EntityId>,
+    ) -> Option<&'a LLMInfo> {
+        let profile = AIExecutionProfilesModel::as_ref(app).active_profile(terminal_view_id, app);
+
+        profile
+            .data()
+            .subagent_model
+            .clone()
+            .and_then(|id| self.model_info_for_id(&self.models_by_feature.agent_mode, &id, app))
+    }
+
     /// Returns metadata about an LLM, if the client knows about it.
     /// Falls back to the user's custom-endpoint LLMs when the id isn't a server-known model
     /// id (e.g. when it's a `config_key` UUID).

--- a/app/src/settings_view/execution_profile_view.rs
+++ b/app/src/settings_view/execution_profile_view.rs
@@ -137,6 +137,14 @@ impl View for ExecutionProfileView {
                     .clone()
             });
 
+        // Subagents fall back to the base model when no override is set.
+        let subagent_model = profile
+            .subagent_model
+            .as_ref()
+            .and_then(|id| llm_preferences.get_llm_info(id))
+            .map(|info| info.display_name.clone())
+            .unwrap_or_else(|| base_model.clone());
+
         Container::new(
             Flex::column()
                 .with_child(
@@ -182,6 +190,15 @@ impl View for ExecutionProfileView {
                             Icon::Terminal,
                             "Full terminal use:",
                             cli_agent_model,
+                            appearance,
+                            is_any_ai_enabled,
+                        ),
+                    ));
+                    model_flex.add_child(with_standard_vertical_margin(
+                        render_model_line_with_icon(
+                            Icon::Workflow,
+                            "Subagents:",
+                            subagent_model,
                             appearance,
                             is_any_ai_enabled,
                         ),

--- a/crates/cloud_object_models/src/ai_execution_profile.rs
+++ b/crates/cloud_object_models/src/ai_execution_profile.rs
@@ -381,6 +381,9 @@ pub struct AIExecutionProfile {
     pub coding_model: Option<LLMId>,
     pub cli_agent_model: Option<LLMId>,
     pub computer_use_model: Option<LLMId>,
+    /// Model override for subagents spawned by the agent. `None` means
+    /// subagents use the base model.
+    pub subagent_model: Option<LLMId>,
 
     pub context_window_limit: Option<u32>,
 
@@ -413,6 +416,7 @@ impl Default for AIExecutionProfile {
             coding_model: None,
             cli_agent_model: None,
             computer_use_model: None,
+            subagent_model: None,
             context_window_limit: None,
             autosync_plans_to_warp_drive: true,
             web_search_enabled: true,
@@ -452,6 +456,7 @@ impl AIExecutionProfile {
             coding_model: None,
             cli_agent_model: None,
             computer_use_model: None,
+            subagent_model: None,
             context_window_limit: None,
             autosync_plans_to_warp_drive: false,
             web_search_enabled: true,
@@ -508,6 +513,7 @@ impl AIExecutionProfile {
             coding_model: None,
             cli_agent_model: None,
             computer_use_model: None,
+            subagent_model: None,
             context_window_limit: None,
             autosync_plans_to_warp_drive: FeatureFlag::SyncAmbientPlans.is_enabled(),
             web_search_enabled: true,


### PR DESCRIPTION
## Description

Adds a new optional **"Subagent model"** picker to agent (execution) profile settings and plumbs the selection into the outgoing multi-agent API request via the new `ModelConfig.subagent` proto field.

> **⚠️ Dependency:** This PR depends on warpdotdev/warp-proto-apis#346 and **must not merge before it**. The `warp_multi_agent_api` dependency is pinned to that PR's head commit (`ccea78599336c89e94cd3344886807eba13dfd58`); once #346 merges, the pin should be updated to the merged mainline commit.

**What / How** (mirrors the existing `cli_agent_model` / `computer_use_model` pattern end-to-end):
- **Proto dep**: bump `warp_multi_agent_api` rev in the root `Cargo.toml` to the head of warp-proto-apis#346, which adds `ModelConfig.subagent` ("LLM of preference for subagents; unset means use the base model").
- **Storage**: `subagent_model: Option<LLMId>` on `AIExecutionProfile` (defaults to `None`), included in the enterprise-permissions overlay (`BlocklistAIPermissions::permissions_profile_for_id`) and the user-editable `ExecutionProfileFile` schema + conversions.
- **Model plumbing**: `AIExecutionProfilesModel::set_subagent_model` (with `AIExecutionProfileModelSelected` telemetry, `model_type: "subagent"`) and `LLMPreferences::get_active_subagent_model`, which resolves the stored id against the agent-mode model list and returns `None` when unset (= use base model).
- **Settings UI**: new "Subagent model" `FilterableDropdown` in the profile editor (choices match the base-model picker; when no override is set the dropdown displays the profile's base model) and a "Subagents:" summary line in the settings profile card.
- **Request**: `RequestParams.subagent_model: Option<LLMId>` populated from the active profile, then `ModelConfig.subagent` set on the outgoing MAA request (empty string when unset, per proto convention).

## Linked Issue
N/A — implements the client side of the subagent model preference introduced in warpdotdev/warp-proto-apis#346.

## Testing

- `cargo check -p cloud_object_models -p warp` — passes
- `cargo clippy -p cloud_object_models -p warp --all-targets --tests -- -D warnings` — clean
- `./script/format` — applied
- `cargo nextest run --no-fail-fast -p warp -p cloud_object_models execution_profiles ai_execution_profile agent::api` — 84 passed, 0 failed

The new field flows through the existing `ExecutionProfileFile` round-trip conversions covered by `config_tests.rs`; no new test surface beyond the existing patterns (the neighboring optional model pickers have no dedicated per-field tests either).

- [ ] I have manually tested my changes locally with `./script/run` (not yet — draft; UI verification pending)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Agent profiles now support an optional "Subagent model" picker, letting you choose which model subagents use (defaults to the base model).

Co-Authored-By: Oz <oz-agent@warp.dev>
