### PR TITLE
Add should_persist to stop_recording (client)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15792,7 +15792,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=03c30e9d5708ff3d9f60df4526b4649a8e251f0e#03c30e9d5708ff3d9f60df4526b4649a8e251f0e"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=ba4ab14cf25987568414be89b7ec25b37a040bb6#ba4ab14cf25987568414be89b7ec25b37a040bb6"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15792,7 +15792,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=9ce5da6fd67694acd6ceace0a44f8824203e3c19#9ce5da6fd67694acd6ceace0a44f8824203e3c19"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=03c30e9d5708ff3d9f60df4526b4649a8e251f0e#03c30e9d5708ff3d9f60df4526b4649a8e251f0e"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "9ce5da6fd67694acd6ceace0a44f8824203e3c19" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "03c30e9d5708ff3d9f60df4526b4649a8e251f0e" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "03c30e9d5708ff3d9f60df4526b4649a8e251f0e" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "ba4ab14cf25987568414be89b7ec25b37a040bb6" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1696,6 +1696,9 @@ pub(crate) fn convert_tool_call_result_to_input(
                 Some(api::stop_recording_result::Result::Error(error)) => {
                     StopRecordingResult::Error(error.message.clone())
                 }
+                Some(api::stop_recording_result::Result::Discarded(_)) => {
+                    StopRecordingResult::Discarded
+                }
                 None => StopRecordingResult::Cancelled,
             };
             Some(AIAgentInput::ActionResult {

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1829,7 +1829,7 @@ impl AIConversation {
                             buffered_action_ids.push(action.id.clone());
                         }
                     }
-                    AIAgentActionType::StopRecording { recording_id } => {
+                    AIAgentActionType::StopRecording { recording_id, .. } => {
                         let Some(span) = active_span.as_ref() else {
                             continue;
                         };
@@ -1852,7 +1852,9 @@ impl AIConversation {
                                 active_span = None;
                             }
                             Some(AIAgentActionResultType::StopRecording(
-                                StopRecordingResult::Error(_) | StopRecordingResult::Cancelled,
+                                StopRecordingResult::Error(_)
+                                | StopRecordingResult::Cancelled
+                                | StopRecordingResult::Discarded,
                             )) => {
                                 // The stop saved no recording, so the buffered
                                 // rows must not be labeled as captured.

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -163,7 +163,7 @@ fn use_computer_tool_call(summary: &str) -> api::message::tool_call::Tool {
 fn stop_recording_tool_call(recording_id: &str) -> api::message::tool_call::Tool {
     api::message::tool_call::Tool::StopRecording(api::message::tool_call::StopRecording {
         recording_id: recording_id.to_string(),
-        should_persist_value: None,
+        discard: false,
     })
 }
 

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -163,6 +163,7 @@ fn use_computer_tool_call(summary: &str) -> api::message::tool_call::Tool {
 fn stop_recording_tool_call(recording_id: &str) -> api::message::tool_call::Tool {
     api::message::tool_call::Tool::StopRecording(api::message::tool_call::StopRecording {
         recording_id: recording_id.to_string(),
+        should_persist_value: None,
     })
 }
 

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -411,8 +411,15 @@ pub mod text {
                     AIAgentActionType::StartRecording { .. } => {
                         writeln!(w, "Starting recording")?;
                     }
-                    AIAgentActionType::StopRecording { recording_id, .. } => {
-                        writeln!(w, "Stopping recording {recording_id}")?;
+                    AIAgentActionType::StopRecording {
+                        recording_id,
+                        should_persist,
+                    } => {
+                        if *should_persist {
+                            writeln!(w, "Stopping recording {recording_id}")?;
+                        } else {
+                            writeln!(w, "Stopping recording {recording_id} and discarding result")?;
+                        }
                     }
                     AIAgentActionType::ReadSkill(request) => {
                         writeln!(w, "Reading skill: {}", request.skill)?;

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -411,7 +411,7 @@ pub mod text {
                     AIAgentActionType::StartRecording { .. } => {
                         writeln!(w, "Starting recording")?;
                     }
-                    AIAgentActionType::StopRecording { recording_id } => {
+                    AIAgentActionType::StopRecording { recording_id, .. } => {
                         writeln!(w, "Stopping recording {recording_id}")?;
                     }
                     AIAgentActionType::ReadSkill(request) => {

--- a/app/src/ai/blocklist/action_model/execute/stop_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/stop_recording.rs
@@ -62,15 +62,16 @@ impl StopRecordingExecutor {
             else {
                 return ActionExecution::<()>::InvalidAction.into();
             };
-            // Explicit stop remains retry-safe while the conversation is
+            // A persisting stop remains retry-safe while the conversation is
             // syncing: do not claim the handle until it can be associated with
-            // the conversation. Automatic terminal paths may instead use the
-            // ambient run association so they can upload before teardown.
+            // the conversation for upload. A discard needs no upload
+            // association or server token, so it proceeds regardless of sync
+            // state.
             let conversation_is_synced = BlocklistAIHistoryModel::as_ref(ctx)
                 .conversation(&conversation_id)
                 .and_then(|conversation| conversation.server_conversation_token())
                 .is_some();
-            if !conversation_is_synced {
+            if *should_persist && !conversation_is_synced {
                 return ActionExecution::<()>::Sync(AIAgentActionResultType::StopRecording(
                     StopRecordingResult::Error(
                         StopRecordingControllerError::ConversationNotSynced.to_string(),

--- a/app/src/ai/blocklist/action_model/execute/stop_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/stop_recording.rs
@@ -55,7 +55,11 @@ impl StopRecordingExecutor {
                 action,
                 conversation_id,
             } = input;
-            let AIAgentActionType::StopRecording { recording_id } = &action.action else {
+            let AIAgentActionType::StopRecording {
+                recording_id,
+                should_persist,
+            } = &action.action
+            else {
                 return ActionExecution::<()>::InvalidAction.into();
             };
             // Explicit stop remains retry-safe while the conversation is
@@ -78,18 +82,20 @@ impl StopRecordingExecutor {
             // Atomically claim an active recording, join an upload another
             // terminal path already started, or read the retained result. The
             // controller owns the actual stop/upload task in every case.
-            let finalization =
-                match finalize_recording_by_id(recording_id, FinalizeReason::StoppedByAgent, ctx) {
-                    Ok(finalization) => finalization,
-                    Err(error) => {
-                        return ActionExecution::<()>::Sync(
-                            AIAgentActionResultType::StopRecording(StopRecordingResult::Error(
-                                error.to_string(),
-                            )),
-                        )
-                        .into();
-                    }
-                };
+            let finalization = match finalize_recording_by_id(
+                recording_id,
+                FinalizeReason::StoppedByAgent,
+                *should_persist,
+                ctx,
+            ) {
+                Ok(finalization) => finalization,
+                Err(error) => {
+                    return ActionExecution::<()>::Sync(AIAgentActionResultType::StopRecording(
+                        StopRecordingResult::Error(error.to_string()),
+                    ))
+                    .into();
+                }
+            };
             let recording_id = recording_id.clone();
 
             // Consume `Finalized` only from the completion callback, after the

--- a/app/src/ai/blocklist/action_model/recording_finalize.rs
+++ b/app/src/ai/blocklist/action_model/recording_finalize.rs
@@ -96,16 +96,18 @@ async fn finalize_recording(
     uploader: FileArtifactUploader,
     server_conversation_token: Option<crate::ai::agent::api::ServerConversationToken>,
 ) -> StopRecordingResult {
-    // Both early exits discard the recording without uploading. They share the
-    // same mechanism — dropping the whole `ActiveRecording` struct, which
-    // kill-on-drops ffmpeg and removes the partial capture — but return
-    // different results to distinguish a user-initiated cancellation from a
-    // genuine finalization error. The cancellation check intentionally comes
-    // first so its `Cancelled` contract holds even when no action group was
-    // committed.
+    // A no-upload finalization discards the recording without publishing: it
+    // drops the whole `ActiveRecording` (kill-on-drops ffmpeg, removes the
+    // partial capture). The reason distinguishes an agent-requested discard
+    // (`Discarded`) from a conversation cancellation (`Cancelled`), which the
+    // agent turn treats differently. This check comes first so it holds even
+    // when no action group was committed.
     if !should_upload {
         drop(recording);
-        return StopRecordingResult::Cancelled;
+        return match reason {
+            FinalizeReason::StoppedByAgent => StopRecordingResult::Discarded,
+            _ => StopRecordingResult::Cancelled,
+        };
     }
     if recording.actions.is_empty() {
         drop(recording);
@@ -275,12 +277,13 @@ fn start_or_join_finalization<T: Entity>(
 pub(crate) fn finalize_recording_by_id<T: Entity>(
     recording_id: &str,
     reason: FinalizeReason,
+    should_persist: bool,
     ctx: &mut ModelContext<T>,
 ) -> Result<RecordingFinalization, StopRecordingControllerError> {
     let claim = RecordingController::handle(ctx).update(ctx, |controller, _| {
         controller.claim_finalization_by_id(recording_id)
     });
-    start_or_join_finalization(claim, reason, true, ctx).ok_or_else(|| {
+    start_or_join_finalization(claim, reason, should_persist, ctx).ok_or_else(|| {
         StopRecordingControllerError::RecordingNotFound {
             recording_id: recording_id.to_string(),
         }

--- a/app/src/ai/blocklist/action_model/recording_finalize_tests.rs
+++ b/app/src/ai/blocklist/action_model/recording_finalize_tests.rs
@@ -43,6 +43,48 @@ fn cancellation_finalization_skips_upload_even_without_actions() {
     });
 }
 
+/// An agent-initiated stop with `should_persist=false` discards the recording:
+/// it kills ffmpeg (by dropping the handle) and resolves as `Discarded` without
+/// touching the uploader, so the agent's turn continues.
+#[test]
+fn agent_discard_finalization_skips_upload() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let uploader = app.update(|ctx| {
+            FileArtifactUploader::new(
+                ServerApiProvider::as_ref(ctx).get_ai_client(),
+                ServerApiProvider::as_ref(ctx).get(),
+            )
+        });
+
+        let (handle, _exit_state) = RecordingHandle::new_test(1, 1);
+        let recording = ActiveRecording {
+            id: "recording".to_string(),
+            conversation_id: AIConversationId::new(),
+            handle,
+            started_at: Instant::now(),
+            frame_rate: 15,
+            target: computer_use::Target::Screen,
+            actions: Vec::new(),
+            summary: None,
+            description: None,
+            pending_group: None,
+        };
+
+        let result = finalize_recording(
+            recording,
+            FinalizeReason::StoppedByAgent,
+            false,
+            uploader,
+            None,
+        )
+        .await;
+
+        assert_eq!(result, StopRecordingResult::Discarded);
+    });
+}
+
 /// A recording with no committed meaningful action group is an explicit
 /// finalization error: it is not uploaded, and the handle is dropped (which
 /// kill-on-drops ffmpeg and removes the partial capture). This returns before

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3047,6 +3047,10 @@ fn stop_recording_card_text(result: Option<&StopRecordingResult>) -> RecordingCa
                 subtext: None,
             }
         }
+        Some(StopRecordingResult::Discarded) => RecordingCardText {
+            primary: "Recording discarded".to_string(),
+            subtext: None,
+        },
         None => RecordingCardText {
             primary: "Saving recording".to_string(),
             subtext: None,

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -30,8 +30,8 @@ pub use crate::ai::agent::{
     FileGlobV2Result, GrepResult, ImageContext, MessageId, ReceivedMessageDisplay,
     RenderableAIError, RequestCommandOutputResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
     SearchCodebaseFailureReason, SearchCodebaseResult, ServerOutputId, Shared, ShellCommandDelay,
-    StartAgentExecutionMode, SuggestNewConversationResult, SummarizationType, TodoOperation,
-    UserQueryMode,
+    StartAgentExecutionMode, StopRecordingResult, SuggestNewConversationResult, SummarizationType,
+    TodoOperation, UserQueryMode,
 };
 pub use crate::ai::agent_conversations_model::{
     AgentConversationEntry, AgentConversationEntryId, AgentConversationListEntryState,

--- a/crates/ai/src/agent/action/convert.rs
+++ b/crates/ai/src/agent/action/convert.rs
@@ -534,6 +534,11 @@ impl From<api::message::tool_call::StopRecording> for AIAgentActionType {
     fn from(value: api::message::tool_call::StopRecording) -> Self {
         AIAgentActionType::StopRecording {
             recording_id: value.recording_id,
+            should_persist: value.should_persist_value.is_none_or(
+                |api::message::tool_call::stop_recording::ShouldPersistValue::ShouldPersist(
+                    should_persist,
+                )| should_persist,
+            ),
         }
     }
 }

--- a/crates/ai/src/agent/action/convert.rs
+++ b/crates/ai/src/agent/action/convert.rs
@@ -534,11 +534,9 @@ impl From<api::message::tool_call::StopRecording> for AIAgentActionType {
     fn from(value: api::message::tool_call::StopRecording) -> Self {
         AIAgentActionType::StopRecording {
             recording_id: value.recording_id,
-            should_persist: value.should_persist_value.is_none_or(
-                |api::message::tool_call::stop_recording::ShouldPersistValue::ShouldPersist(
-                    should_persist,
-                )| should_persist,
-            ),
+            // Normalize the wire's `discard` polarity to the internal
+            // `should_persist`; unset `discard` defaults to persist.
+            should_persist: !value.discard,
         }
     }
 }

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -158,9 +158,12 @@ pub enum AIAgentActionType {
         window: Option<computer_use::Target>,
     },
 
-    /// AI requested to stop an in-progress recording and publish the video.
+    /// AI requested to stop an in-progress recording. When `should_persist` is
+    /// false the recording is discarded instead of uploaded; an unset proto
+    /// field defaults to `true` (persist).
     StopRecording {
         recording_id: String,
+        should_persist: bool,
     },
 
     // AI requested to read a skill.
@@ -608,8 +611,14 @@ impl Display for AIAgentActionType {
             AIAgentActionType::StartRecording { .. } => {
                 write!(f, "StartRecording")
             }
-            AIAgentActionType::StopRecording { recording_id } => {
-                write!(f, "StopRecording: {recording_id}")
+            AIAgentActionType::StopRecording {
+                recording_id,
+                should_persist,
+            } => {
+                write!(
+                    f,
+                    "StopRecording: {recording_id} (persist: {should_persist})"
+                )
             }
             AIAgentActionType::ReadSkill(req) => {
                 write!(f, "ReadSkill: {}", req.skill)

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -1493,6 +1493,15 @@ impl TryFrom<StopRecordingResult> for api::request::input::tool_call_result::Res
                     },
                 ),
             ),
+            StopRecordingResult::Discarded => Ok(
+                api::request::input::tool_call_result::Result::StopRecording(
+                    api::StopRecordingResult {
+                        result: Some(api::stop_recording_result::Result::Discarded(
+                            api::stop_recording_result::Discarded {},
+                        )),
+                    },
+                ),
+            ),
             StopRecordingResult::Cancelled => Err(ConvertToAPITypeError::Ignore),
         }
     }

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -823,7 +823,9 @@ impl AIAgentActionResultType {
             | Self::InsertReviewComments(InsertReviewCommentsResult::Success { .. })
             | Self::RequestComputerUse(RequestComputerUseResult::Approved { .. })
             | Self::StartRecording(StartRecordingResult::Success(_))
-            | Self::StopRecording(StopRecordingResult::Success(_))
+            | Self::StopRecording(
+                StopRecordingResult::Success(_) | StopRecordingResult::Discarded,
+            )
             | Self::OpenCodeReview
             | Self::ReadSkill(ReadSkillResult::Success { .. })
             | Self::FetchConversation(FetchConversationResult::Success { .. })
@@ -1264,6 +1266,10 @@ pub enum StopRecordingResult {
     Success(RecordingStopped),
     Error(String),
     Cancelled,
+    /// The agent opted not to persist the recording (`should_persist=false`), so
+    /// it was discarded without uploading. Distinct from `Cancelled` so the
+    /// agent's turn continues.
+    Discarded,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1287,6 +1293,7 @@ impl Display for StopRecordingResult {
             ),
             StopRecordingResult::Error(error) => write!(f, "Stop recording error: {error}"),
             StopRecordingResult::Cancelled => write!(f, "Stop recording cancelled"),
+            StopRecordingResult::Discarded => write!(f, "Recording discarded"),
         }
     }
 }

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -8,7 +8,7 @@ use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionResultType, AIAgentActionType,
     AskUserQuestionResult, FileGlobV2Result, GrepResult, RequestCommandOutputResult,
     RunAgentsAgentOutcomeKind, RunAgentsResult, SearchCodebaseFailureReason, SearchCodebaseResult,
-    SuggestNewConversationResult,
+    StopRecordingResult, SuggestNewConversationResult,
 };
 use warp_core::command::ExitCode;
 use warpui_core::elements::tui::TuiStyle;
@@ -446,7 +446,12 @@ fn label_for_action(
         AIAgentActionType::StopRecording { .. } => match state {
             State::Pending | State::Blocked => "Stop recording".to_owned(),
             State::Constructing | State::Running => "Stopping recording…".to_owned(),
-            State::Succeeded => "Saved screen recording".to_owned(),
+            State::Succeeded => match result {
+                Some(AIAgentActionResultType::StopRecording(StopRecordingResult::Discarded)) => {
+                    "Discarded screen recording".to_owned()
+                }
+                _ => "Saved screen recording".to_owned(),
+            },
             State::Failed => "Failed to save recording".to_owned(),
             State::Cancelled => "Stop recording cancelled".to_owned(),
         },


### PR DESCRIPTION
## Description
Adds a `should_persist` parameter to the `stop_recording` computer-use tool so an agent can throw a recording away instead of always uploading it, without introducing a new server tool.

- When `should_persist=false`, the client discards the recording via the existing finalization discard path (kill-on-drop ffmpeg + delete of the partial capture) that conversation cancellation already uses.
- A discard returns a new `StopRecordingResult::Discarded` result — a real, non-cancelled wire result — so the agent's turn continues normally. This is intentionally distinct from `Cancelled`, which is dropped on the wire and halts the turn.
- The field is oneof-wrapped in the proto; an unset value defaults to persist, preserving today's behavior (backward compatible with older servers).

Depends on the proto contract in warpdotdev/warp-proto-apis#347 (adds the `should_persist` oneof on `StopRecording` and the `Discarded` case on `StopRecordingResult`). This PR pins `warp_multi_agent_api` to the merged proto rev.

## Linked Issue
N/A — companion client change for warp-proto-apis#347.

## Testing
- Added a focused unit test `agent_discard_finalization_skips_upload`: an agent-initiated stop with `should_upload=false` (reason `StoppedByAgent`) returns `Discarded` without touching the uploader. The existing cancellation test still asserts `Cancelled`.
- Validated: `cargo check -p ai`, `cargo check -p warp`, `cargo nextest run -p warp -E 'test(recording_finalize)'` (3 passed), `cargo fmt -- --check`, and `cargo clippy -p ai -p warp --all-targets --tests -- -D warnings` (clean).

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Plan: https://staging.warp.dev/drive/notebook/iZxISDERKfQVzAHmWvehXd
Conversation: https://staging.warp.dev/conversation/07815c7a-a04c-49da-afe6-df1fa487fe95

CHANGELOG-NONE
