### PR TITLE
Fix TUI multi-select question controls

### DIFF
--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -110,6 +110,8 @@ pub(crate) enum TuiOptionSelectorEvent {
     Confirmed { id: String },
     /// The custom-text footer editor was submitted with a valid value.
     CustomTextSubmitted { value: String },
+    /// A checked question-card Other value was selected again and cleared.
+    CustomTextCleared,
     /// The question-card Other editor was opened.
     CustomTextOpened,
     /// The custom-text editor was left without submitting a new value.
@@ -659,6 +661,25 @@ impl TuiOptionSelector {
             ctx.notify();
         }
     }
+
+    /// Clears a committed question-card Other value without opening its editor.
+    fn clear_custom_text(&mut self, ctx: &mut ViewContext<Self>) {
+        self.custom_text.committed_value = None;
+        self.custom_text.editing = CustomTextEditingState::Inactive;
+        self.custom_text
+            .editor
+            .update(ctx, |editor, ctx| editor.set_text("", ctx));
+        self.page.snapshot.selected_id = self
+            .page
+            .snapshot
+            .rows
+            .iter()
+            .find(|row| self.selected_ids.contains(&row.id))
+            .map(|row| row.id.clone());
+        ctx.focus_self();
+        ctx.emit(TuiOptionSelectorEvent::CustomTextCleared);
+        ctx.notify();
+    }
     /// Clears focused search text, returning whether it consumed Back.
     fn clear_focused_search(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         if !matches!(self.focus_zone(ctx), SelectorFocusZone::Search)
@@ -889,6 +910,10 @@ impl TuiOptionSelector {
             }
             SelectorItem::Retry => ctx.emit(TuiOptionSelectorEvent::RetryRequested),
             SelectorItem::CustomText => {
+                if self.show_selection_markers && self.custom_text.committed_value.is_some() {
+                    self.clear_custom_text(ctx);
+                    return true;
+                }
                 self.begin_custom_text_editing(ctx);
                 return true;
             }
@@ -1042,11 +1067,11 @@ impl TuiOptionSelector {
         let mut spans = vec![(shortcut_prefix, detail_style)];
         if self.show_selection_markers {
             spans.push((
-                if is_selected { "✓ " } else { "  " }.to_string(),
+                if is_selected { "[✓] " } else { "[ ] " }.to_string(),
                 if is_selected {
                     builder.success_glyph_style()
                 } else {
-                    builder.muted_text_style()
+                    builder.primary_text_style()
                 },
             ));
         }
@@ -1072,15 +1097,25 @@ impl TuiOptionSelector {
         text: String,
         digit: Option<usize>,
         is_highlighted: bool,
+        selection_marker: Option<bool>,
         style: TuiStyle,
         builder: &TuiUiBuilder,
     ) -> Box<dyn TuiElement> {
-        let style = if is_highlighted {
-            if self.question_style {
-                builder.question_option_selected_style()
-            } else {
-                builder.option_selector_selected_style()
-            }
+        let is_selected = selection_marker == Some(true);
+        let selected_style = if self.question_style {
+            builder.question_option_selected_style()
+        } else {
+            builder.option_selector_selected_style()
+        };
+        let label_style = if is_highlighted || is_selected {
+            selected_style
+        } else {
+            style
+        };
+        let detail_style = if is_highlighted {
+            selected_style
+        } else if selection_marker.is_some() {
+            builder.muted_text_style()
         } else {
             style
         };
@@ -1088,9 +1123,19 @@ impl TuiOptionSelector {
             Some(digit) => format!("({digit}) "),
             None => "    ".to_string(),
         };
-        TuiText::from_spans([(format!("{digit_prefix}{text}"), style)])
-            .truncate()
-            .finish()
+        let mut spans = vec![(digit_prefix, detail_style)];
+        if let Some(is_selected) = selection_marker {
+            spans.push((
+                if is_selected { "[✓] " } else { "[ ] " }.to_string(),
+                if is_selected {
+                    builder.success_glyph_style()
+                } else {
+                    builder.primary_text_style()
+                },
+            ));
+        }
+        spans.push((text, label_style));
+        TuiText::from_spans(spans).truncate().finish()
     }
 
     /// Renders selector-owned label/error chrome around a generic editor view.
@@ -1100,12 +1145,22 @@ impl TuiOptionSelector {
         label: &str,
         editor: &ViewHandle<TuiEditorView>,
         error: Option<&str>,
+        selection_marker: Option<bool>,
         builder: &TuiUiBuilder,
     ) -> Box<dyn TuiElement> {
-        let label = TuiText::new(format!("{prefix}{label}: "))
-            .with_style(builder.muted_text_style())
-            .truncate()
-            .finish();
+        let mut spans = vec![(prefix, builder.muted_text_style())];
+        if let Some(is_selected) = selection_marker {
+            spans.push((
+                if is_selected { "[✓] " } else { "[ ] " }.to_string(),
+                if is_selected {
+                    builder.success_glyph_style()
+                } else {
+                    builder.primary_text_style()
+                },
+            ));
+        }
+        spans.push((format!("{label}: "), builder.muted_text_style()));
+        let label = TuiText::from_spans(spans).truncate().finish();
         let row = TuiFlex::row()
             .child(label)
             .flex_child(TuiChildView::new(editor).finish())
@@ -1157,55 +1212,62 @@ impl TuiOptionSelector {
             let digit = (position < 9).then_some(position + 1);
             let is_selected = !self.custom_text.is_editing()
                 && self.interaction.selection.selected_index() == Some(index);
-            let element =
-                match item {
-                    SelectorItem::Row(row_index) => {
-                        let Some(row) = self.page.snapshot.rows.get(row_index) else {
-                            continue;
-                        };
-                        let shortcut =
-                            self.page.row_shortcuts.get(&row.id).copied().or_else(|| {
-                                digit.and_then(|digit| char::from_digit(digit as u32, 10))
-                            });
-                        self.render_row(row, shortcut, is_selected, builder)
-                    }
-                    SelectorItem::Retry => self.render_virtual_row(
-                        "↻ Retry".to_string(),
-                        digit,
-                        is_selected,
-                        builder.error_text_style(),
-                        builder,
-                    ),
-                    SelectorItem::CustomText => {
-                        match (&self.page.snapshot.footer, self.custom_text.is_editing()) {
-                            (Some(OptionFooter::CustomText { label }), true) => self
-                                .render_editor_field(
-                                    digit.map_or_else(
-                                        || "    ".to_string(),
-                                        |digit| format!("({digit}) "),
-                                    ),
-                                    label,
-                                    &self.custom_text.editor,
-                                    self.custom_text
-                                        .error_is_visible()
-                                        .then_some(CUSTOM_TEXT_EMPTY_ERROR),
-                                    builder,
+            let element = match item {
+                SelectorItem::Row(row_index) => {
+                    let Some(row) = self.page.snapshot.rows.get(row_index) else {
+                        continue;
+                    };
+                    let shortcut = self
+                        .page
+                        .row_shortcuts
+                        .get(&row.id)
+                        .copied()
+                        .or_else(|| digit.and_then(|digit| char::from_digit(digit as u32, 10)));
+                    self.render_row(row, shortcut, is_selected, builder)
+                }
+                SelectorItem::Retry => self.render_virtual_row(
+                    "↻ Retry".to_string(),
+                    digit,
+                    is_selected,
+                    None,
+                    builder.error_text_style(),
+                    builder,
+                ),
+                SelectorItem::CustomText => {
+                    match (&self.page.snapshot.footer, self.custom_text.is_editing()) {
+                        (Some(OptionFooter::CustomText { label }), true) => self
+                            .render_editor_field(
+                                digit.map_or_else(
+                                    || "    ".to_string(),
+                                    |digit| format!("({digit}) "),
                                 ),
-                            (Some(OptionFooter::CustomText { label }), false) => self
-                                .render_virtual_row(
-                                    self.custom_text
-                                        .committed_value
-                                        .clone()
-                                        .unwrap_or_else(|| label.clone()),
-                                    digit,
-                                    is_selected,
-                                    builder.primary_text_style(),
-                                    builder,
-                                ),
-                            (Some(OptionFooter::CreateNewAuthSecret) | None, _) => continue,
+                                label,
+                                &self.custom_text.editor,
+                                self.custom_text
+                                    .error_is_visible()
+                                    .then_some(CUSTOM_TEXT_EMPTY_ERROR),
+                                self.show_selection_markers
+                                    .then_some(self.custom_text.committed_value.is_some()),
+                                builder,
+                            ),
+                        (Some(OptionFooter::CustomText { label }), false) => {
+                            let custom_text_selected = self.custom_text.committed_value.is_some();
+                            self.render_virtual_row(
+                                self.custom_text
+                                    .committed_value
+                                    .clone()
+                                    .unwrap_or_else(|| label.clone()),
+                                digit,
+                                is_selected,
+                                self.show_selection_markers.then_some(custom_text_selected),
+                                builder.primary_text_style(),
+                                builder,
+                            )
                         }
+                        (Some(OptionFooter::CreateNewAuthSecret) | None, _) => continue,
                     }
-                };
+                }
+            };
             // Each visible row is clickable through its own persistent
             // mouse-state handle.
             let element = match self.item_mouse_states.get(index) {
@@ -1307,6 +1369,7 @@ impl TuiView for TuiOptionSelector {
                 String::new(),
                 "Search",
                 search_field,
+                None,
                 None,
                 &builder,
             ));

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -680,6 +680,7 @@ impl TuiOptionSelector {
         ctx.emit(TuiOptionSelectorEvent::CustomTextCleared);
         ctx.notify();
     }
+
     /// Clears focused search text, returning whether it consumed Back.
     fn clear_focused_search(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         if !matches!(self.focus_zone(ctx), SelectorFocusZone::Search)
@@ -1102,16 +1103,19 @@ impl TuiOptionSelector {
         builder: &TuiUiBuilder,
     ) -> Box<dyn TuiElement> {
         let is_selected = selection_marker == Some(true);
+
         let selected_style = if self.question_style {
             builder.question_option_selected_style()
         } else {
             builder.option_selector_selected_style()
         };
+
         let label_style = if is_highlighted || is_selected {
             selected_style
         } else {
             style
         };
+
         let detail_style = if is_highlighted {
             selected_style
         } else if selection_marker.is_some() {
@@ -1119,6 +1123,7 @@ impl TuiOptionSelector {
         } else {
             style
         };
+
         let digit_prefix = match digit {
             Some(digit) => format!("({digit}) "),
             None => "    ".to_string(),

--- a/crates/warp_tui/src/option_selector_tests.rs
+++ b/crates/warp_tui/src/option_selector_tests.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use string_offset::CharOffset;
@@ -711,6 +712,45 @@ fn normal_selector_selected_row_does_not_depend_on_question_selected_ids() {
             assert_eq!(cell.fg, selected_fg);
             assert!(cell.modifier.contains(Modifier::BOLD));
         }
+    });
+}
+
+#[test]
+fn selected_custom_answer_number_is_not_highlighted_after_the_cursor_moves_away() {
+    App::test((), |mut app| async move {
+        let (selector, _) = add_selector(&mut app);
+        let mut with_selected_other = snapshot(&["a", "b"], Some("Canary"));
+        with_selected_other.footer = Some(OptionFooter::CustomText {
+            label: "Other".to_string(),
+        });
+        set_page(&mut app, &selector, with_selected_other);
+        selector.update(&mut app, |selector, ctx| {
+            selector.set_question_state(HashSet::new(), true, ctx);
+            selector.select_item_without_confirm(0, ctx);
+        });
+
+        let buffer = render_buffer(&app, &selector, 60);
+        let builder = app.read(TuiUiBuilder::from_app);
+        let number = &buffer[(0, 5)];
+        let label = &buffer[(8, 5)];
+        assert_eq!(number.symbol(), "(");
+        assert_eq!(label.symbol(), "C");
+        assert_eq!(
+            number.fg,
+            builder
+                .muted_text_style()
+                .fg
+                .expect("muted text has a foreground")
+        );
+        assert_eq!(
+            label.fg,
+            builder
+                .question_option_selected_style()
+                .fg
+                .expect("selected question options have a foreground")
+        );
+        assert!(!number.modifier.contains(Modifier::BOLD));
+        assert!(label.modifier.contains(Modifier::BOLD));
     });
 }
 

--- a/crates/warp_tui/src/orchestration_block.rs
+++ b/crates/warp_tui/src/orchestration_block.rs
@@ -608,8 +608,9 @@ impl TuiOrchestrationBlock {
                     self.finish_page_confirmation(ConfigPage::Host, ctx);
                 }
             }
-            TuiOptionSelectorEvent::CustomTextOpened | TuiOptionSelectorEvent::CustomTextClosed => {
-            }
+            TuiOptionSelectorEvent::CustomTextCleared
+            | TuiOptionSelectorEvent::CustomTextOpened
+            | TuiOptionSelectorEvent::CustomTextClosed => {}
             TuiOptionSelectorEvent::RetryRequested => {
                 self.pending_page_navigation = None;
                 self.ensure_auth_secrets_fetched(ctx);

--- a/crates/warp_tui/src/tui_ask_question_view.rs
+++ b/crates/warp_tui/src/tui_ask_question_view.rs
@@ -26,6 +26,7 @@ use crate::option_selector::{OptionSelectorPage, TuiOptionSelector, TuiOptionSel
 use crate::tui_builder::TuiUiBuilder;
 
 const ASK_QUESTION_ACTIVE: &str = "TuiAskQuestionActive";
+const ASK_QUESTION_MULTISELECT_ACTIVE: &str = "TuiAskQuestionMultiselectActive";
 const AUTO_ADVANCE_DELAY: Duration = Duration::from_millis(300);
 
 /// Registers controls that must win over the surrounding terminal session
@@ -47,6 +48,14 @@ pub(crate) fn init(app: &mut AppContext) {
         .with_context_predicate(predicate.clone())
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("enter"),
+        EditableBinding::new(
+            "tui:ask-question:advance-multiselect",
+            "Advance after selecting multiple answers",
+            TuiAskQuestionViewAction::AdvanceMultiselect,
+        )
+        .with_context_predicate(predicate.clone() & id!(ASK_QUESTION_MULTISELECT_ACTIVE))
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("shift-enter"),
         EditableBinding::new(
             "tui:ask-question:previous",
             "Show the previous question",
@@ -78,6 +87,7 @@ pub(crate) fn init(app: &mut AppContext) {
 #[derive(Clone, Debug)]
 pub(super) enum TuiAskQuestionViewAction {
     Enter,
+    AdvanceMultiselect,
     Previous,
     Next,
     SkipAll,
@@ -275,16 +285,39 @@ impl TuiAskQuestionView {
                     return;
                 };
                 self.abort_auto_advance();
+                let is_multiselect = self
+                    .session
+                    .current()
+                    .is_some_and(|current| current.question.is_multiselect());
                 let effect = self
                     .session
                     .apply(AskUserQuestionAction::ToggleOption { option_index });
-                self.handle_effect(effect, ctx);
+                if is_multiselect {
+                    self.handle_effect(AskUserQuestionEffect::RefreshCurrent, ctx);
+                } else {
+                    self.handle_effect(effect, ctx);
+                }
             }
             TuiOptionSelectorEvent::CustomTextSubmitted { value } => {
                 self.abort_auto_advance();
                 let effect = self.session.apply(AskUserQuestionAction::SaveOtherText {
                     text: Some(value.clone()),
                 });
+                if self
+                    .session
+                    .current()
+                    .is_some_and(|current| current.question.is_multiselect())
+                {
+                    self.handle_effect(AskUserQuestionEffect::RefreshCurrent, ctx);
+                } else {
+                    self.handle_effect(effect, ctx);
+                }
+            }
+            TuiOptionSelectorEvent::CustomTextCleared => {
+                self.abort_auto_advance();
+                let effect = self
+                    .session
+                    .apply(AskUserQuestionAction::SaveOtherText { text: None });
                 self.handle_effect(effect, ctx);
             }
             TuiOptionSelectorEvent::CustomTextOpened => {
@@ -421,6 +454,29 @@ impl TuiAskQuestionView {
         if current.question.is_multiselect() {
             question.push_str(" (select all that apply)");
         }
+        let footer = if current.question.is_multiselect() {
+            TuiText::from_spans([
+                ("Shift + Enter ".to_owned(), builder.primary_text_style()),
+                ("to advance ".to_owned(), builder.muted_text_style()),
+                ("Enter or number ".to_owned(), builder.primary_text_style()),
+                ("to select ".to_owned(), builder.muted_text_style()),
+                ("Ctrl + C ".to_owned(), builder.primary_text_style()),
+                ("to cancel question".to_owned(), builder.muted_text_style()),
+            ])
+            .truncate()
+            .finish()
+        } else {
+            TuiText::from_spans([
+                ("Enter or number ".to_owned(), builder.primary_text_style()),
+                ("to select ".to_owned(), builder.muted_text_style()),
+                ("Tab or ← → ".to_owned(), builder.primary_text_style()),
+                ("to navigate ".to_owned(), builder.muted_text_style()),
+                ("Ctrl + C ".to_owned(), builder.primary_text_style()),
+                ("to cancel question".to_owned(), builder.muted_text_style()),
+            ])
+            .truncate()
+            .finish()
+        };
         let body = TuiFlex::column()
             .child(header)
             .child(TuiText::new(" ").finish())
@@ -431,18 +487,7 @@ impl TuiAskQuestionView {
             )
             .child(TuiChildView::new(&self.selector).finish())
             .child(TuiText::new(" ").finish())
-            .child(
-                TuiText::from_spans([
-                    ("Enter or number ".to_owned(), builder.primary_text_style()),
-                    ("to select ".to_owned(), builder.muted_text_style()),
-                    ("Tab or ← → ".to_owned(), builder.primary_text_style()),
-                    ("to navigate ".to_owned(), builder.muted_text_style()),
-                    ("Ctrl + C ".to_owned(), builder.primary_text_style()),
-                    ("to cancel question".to_owned(), builder.muted_text_style()),
-                ])
-                .truncate()
-                .finish(),
-            )
+            .child(footer)
             .finish();
         TuiContainer::new(body)
             .with_padding(1)
@@ -575,6 +620,13 @@ impl TuiView for TuiAskQuestionView {
             && self.is_waiting_on_answers(app)
         {
             context.set.insert(ASK_QUESTION_ACTIVE);
+            if self
+                .session
+                .current()
+                .is_some_and(|current| current.question.is_multiselect())
+            {
+                context.set.insert(ASK_QUESTION_MULTISELECT_ACTIVE);
+            }
         }
         context
     }
@@ -620,6 +672,15 @@ impl TypedActionView for TuiAskQuestionView {
         self.abort_auto_advance();
         match action {
             TuiAskQuestionViewAction::Enter => {
+                if self
+                    .session
+                    .current()
+                    .is_some_and(|current| current.question.is_multiselect())
+                {
+                    self.selector
+                        .update(ctx, |selector, ctx| selector.confirm_selected(ctx));
+                    return;
+                }
                 let (highlighted_index, active_other_text) =
                     self.selector.read(ctx, |selector, ctx| {
                         (
@@ -631,6 +692,18 @@ impl TypedActionView for TuiAskQuestionView {
                     highlighted_index,
                     active_other_text,
                 });
+                self.handle_effect(effect, ctx);
+            }
+            TuiAskQuestionViewAction::AdvanceMultiselect => {
+                if !self
+                    .session
+                    .current()
+                    .is_some_and(|current| current.question.is_multiselect())
+                {
+                    return;
+                }
+                self.commit_active_other_text(ctx);
+                let effect = self.session.apply(AskUserQuestionAction::Confirm);
                 self.handle_effect(effect, ctx);
             }
             TuiAskQuestionViewAction::Previous => {

--- a/crates/warp_tui/src/tui_ask_question_view_tests.rs
+++ b/crates/warp_tui/src/tui_ask_question_view_tests.rs
@@ -163,15 +163,160 @@ fn active_card_matches_question_panel_structure() {
                 "│ ■ Agent questions                                                 ← 1 of 2 → │",
                 "│                                                                              │",
                 "│ Which targets should be tested? (select all that apply)                      │",
-                "│ (1)   Stable                                                                 │",
-                "│ (2)   Nightly                                                                │",
-                "│ (3) Other…                                                                   │",
+                "│ (1) [ ] Stable                                                               │",
+                "│ (2) [ ] Nightly                                                              │",
+                "│ (3) [ ] Other…                                                               │",
                 "│                                                                              │",
-                "│ Enter or number to select Tab or ← → to navigate Ctrl + C to cancel question │",
+                "│ Shift + Enter to advance Enter or number to select Ctrl + C to cancel questi │",
                 "│                                                                              │",
                 "└──────────────────────────────────────────────────────────────────────────────┘",
             ]
         );
+    });
+}
+
+#[test]
+fn enter_selects_options_and_other_before_shift_enter_advances_multiselect() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        let (_, view) = add_view(
+            &mut app,
+            vec![
+                question(
+                    "multi",
+                    "Which targets?",
+                    true,
+                    true,
+                    &["Stable", "Nightly"],
+                ),
+                question("single", "Which shell?", false, false, &["zsh"]),
+            ],
+        );
+        queue_question_action(&mut app, &view);
+        present_active_view(&mut app, &view);
+
+        assert!(dispatch_focused_key(&mut app, &view, "enter"));
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert_eq!(view.session.current_question_index(), 0);
+            assert!(view.auto_advance.is_none());
+            assert!(
+                view.session
+                    .draft_for_question(0)
+                    .is_some_and(|draft| draft.selected_option_indices.contains(&0))
+            );
+        });
+        assert!(
+            render_active_lines(&mut app, &view)
+                .iter()
+                .any(|line| line.contains("(1) [✓] Stable"))
+        );
+
+        let selector = app.read(|ctx| view.as_ref(ctx).selector.clone());
+        selector.update(&mut app, |selector, ctx| {
+            selector.handle_action(&TuiOptionSelectorAction::SelectItem(2), ctx);
+            selector.set_active_custom_text_for_test("Canary", ctx);
+        });
+        assert!(dispatch_focused_key(&mut app, &view, "enter"));
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert_eq!(view.session.current_question_index(), 0);
+            assert!(view.auto_advance.is_none());
+            let draft = view
+                .session
+                .draft_for_question(0)
+                .expect("multi-select draft exists");
+            assert!(draft.selected_option_indices.contains(&0));
+            assert_eq!(draft.other_text.as_deref(), Some("Canary"));
+        });
+        assert!(
+            render_active_lines(&mut app, &view)
+                .iter()
+                .any(|line| line.contains("(3) [✓] Canary"))
+        );
+        assert!(dispatch_focused_key(&mut app, &view, "enter"));
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            let draft = view
+                .session
+                .draft_for_question(0)
+                .expect("regular multi-select option remains selected");
+            assert!(draft.selected_option_indices.contains(&0));
+            assert!(draft.other_text.is_none());
+        });
+        assert!(
+            render_active_lines(&mut app, &view)
+                .iter()
+                .any(|line| line.contains("(3) [ ] Other…"))
+        );
+
+        assert!(dispatch_focused_key(&mut app, &view, "shift-enter"));
+        assert_eq!(
+            app.read(|ctx| view.as_ref(ctx).session.current_question_index()),
+            1
+        );
+    });
+}
+
+#[test]
+fn enter_keeps_single_select_auto_advance_behavior() {
+    App::test((), |mut app| async move {
+        app.update(super::init);
+        let (_, view) = add_view(
+            &mut app,
+            vec![question(
+                "single",
+                "Which shell?",
+                false,
+                false,
+                &["zsh", "fish"],
+            )],
+        );
+        queue_question_action(&mut app, &view);
+        present_active_view(&mut app, &view);
+
+        assert!(dispatch_focused_key(&mut app, &view, "enter"));
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(view.auto_advance.is_some());
+            assert!(
+                view.session
+                    .draft_for_question(0)
+                    .is_some_and(|draft| draft.selected_option_indices.contains(&0))
+            );
+        });
+    });
+}
+
+#[test]
+fn enter_does_not_submit_a_final_multiselect_question() {
+    App::test((), |mut app| async move {
+        app.update(super::init);
+        let (_, view) = add_view(
+            &mut app,
+            vec![question(
+                "multi",
+                "Which targets?",
+                true,
+                true,
+                &["Stable", "Nightly"],
+            )],
+        );
+        queue_question_action(&mut app, &view);
+        present_active_view(&mut app, &view);
+
+        assert!(dispatch_focused_key(&mut app, &view, "enter"));
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(view.session.is_editing());
+            assert_eq!(view.session.current_question_index(), 0);
+            assert!(view.auto_advance.is_none());
+            assert!(
+                view.session
+                    .draft_for_question(0)
+                    .is_some_and(|draft| draft.selected_option_indices.contains(&0))
+            );
+        });
     });
 }
 
@@ -285,8 +430,8 @@ fn navigation_restores_multi_selection_and_other_text() {
         });
 
         let lines = render_active_lines(&mut app, &view);
-        assert!(lines.iter().any(|line| line.contains("✓ Nightly")));
-        assert!(lines.iter().any(|line| line.contains("Canary")));
+        assert!(lines.iter().any(|line| line.contains("[✓] Nightly")));
+        assert!(lines.iter().any(|line| line.contains("[✓] Canary")));
     });
 }
 
@@ -378,7 +523,7 @@ fn navigating_away_from_a_cleared_other_editor_removes_the_previous_answer() {
         let (_, view) = add_view(
             &mut app,
             vec![
-                question("q1", "Targets?", true, true, &["Stable"]),
+                question("q1", "Target?", false, true, &["Stable"]),
                 question("q2", "Shell?", false, false, &["zsh"]),
             ],
         );

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -227,6 +227,7 @@ impl TuiPermissionPrompt {
                 ctx.emit(TuiPermissionPromptEvent::RejectRequested);
             }
             TuiOptionSelectorEvent::LayoutInvalidated
+            | TuiOptionSelectorEvent::CustomTextCleared
             | TuiOptionSelectorEvent::CustomTextOpened
             | TuiOptionSelectorEvent::CustomTextClosed => self.invalidate_layout(ctx),
             TuiOptionSelectorEvent::Confirmed { .. } | TuiOptionSelectorEvent::RetryRequested => {}


### PR DESCRIPTION
## Description
Fix TUI ask-question multi-select interactions so Enter toggles the highlighted option without advancing, while Shift+Enter advances to the next question or submits the questionnaire. This applies when the multi-select is the final question as well. Single-select questions retain their existing Enter behavior.

Render every multi-select choice, including Other, with the specified inline `[✓]` and `[ ]` markers. Custom Other text remains combinable with regular selected options, can be unchecked without clearing the other selections, and does not advance until Shift+Enter. The footer presents Shift+Enter as the first hint.

## Testing
- [x] Manual TUI verification

## Screenshots/Video

https://www.loom.com/share/1b29fb0acc7b43e0aaecfbde2711b4c6

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Agent conversation](https://staging.warp.dev/conversation/0e3de91f-29b2-4766-b46f-81aa9c883675)

Co-Authored-By: Oz <oz-agent@warp.dev>