### PR TITLE
fix: update immutable to 4.3.9 to resolve CVE-2026-59879 and CVE-2026-59880

### DIFF
--- a/crates/warp_graphql_schema/package.json
+++ b/crates/warp_graphql_schema/package.json
@@ -14,7 +14,7 @@
     "typescript": "^5.4.3"
   },
   "resolutions": {
-    "immutable": "3.8.3",
+    "immutable": "4.3.9",
     "lodash": "4.18.1",
     "@babel/core": "7.29.6"
   }

--- a/crates/warp_graphql_schema/yarn.lock
+++ b/crates/warp_graphql_schema/yarn.lock
@@ -1528,10 +1528,10 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-immutable@3.8.3, immutable@~3.7.6:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
-  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
+immutable@4.3.9, immutable@~3.7.6:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
+  integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
 
 import-fresh@^3.3.0:
   version "3.3.1"


### PR DESCRIPTION
## Summary
Updates the `immutable` dependency in `crates/warp_graphql_schema` from **3.8.3** to **4.3.9** to resolve two high-severity Dependabot alerts.

Resolves:
- https://github.com/warpdotdev/warp/security/dependabot/24 — [CVE-2026-59879](https://github.com/immutable-js/immutable-js/security/advisories/GHSA-v56q-mh7h-f735): Immutable.js `List` 32-bit trie overflow → unrecoverable DoS
- https://github.com/warpdotdev/warp/security/dependabot/25 — [CVE-2026-59880](https://github.com/immutable-js/immutable-js/security/advisories/GHSA-xvcm-6775-5m9r): Hash-collision algorithmic complexity DoS in Immutable.Map/Set

## Details
- **Dependency:** `immutable` (npm), transitive / development-scoped, pulled in via `@graphql-codegen/cli` → `@ardatan/relay-compiler` (`immutable "~3.7.6"`).
- **Manifest:** `crates/warp_graphql_schema/yarn.lock`
- **Change:** The existing `resolutions` block in `crates/warp_graphql_schema/package.json` pinned `immutable` to the vulnerable `3.8.3`. That pin is why Dependabot reported `update_not_possible` ("One or more other dependencies require a version that is incompatible with this update"). Bumped the resolution to `4.3.9` (the first patched version) and regenerated the lockfile with `yarn install`. The lockfile now resolves `immutable` to `4.3.9`.

## Why bumping to v4 is safe here
`@ardatan/relay-compiler` is the only consumer requesting `immutable ~3.7.6` (v3 API), but it is never executed in this crate's codegen path — `graphql.config.js` only runs the `schema-ast` plugin to generate `api/schema.graphql`. It is a dev-only transitive dependency.

## Verification
- `yarn install` succeeds; diff is isolated to the `immutable` entry in `package.json` and `yarn.lock`.
- `yarn audit` no longer reports `immutable` (remaining entries are unrelated alerts tracked separately).
- Sanity load check passes: `require('immutable')` (v4 `List` available) and `require('@graphql-codegen/cli')` both load without error.

_Conversation: https://staging.warp.dev/conversation/905b2527-ca95-462f-8e0b-8409a1b35dce_

_Run: https://oz.staging.warp.dev/runs/019f8fb4-9da4-72db-9e07-f227b1d35a0b_

_This PR was generated with [Oz](https://warp.dev/oz)._
