### PR TITLE
feat(cli-agents): register Plank as a known CLI agent

### DIFF
--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -466,6 +466,7 @@ pub enum CLIAgentType {
     Hermes,
     Vibe,
     Antigravity,
+    Plank,
     Unknown,
 }
 

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -127,6 +127,14 @@ const HERMES_PURPLE: ColorU = ColorU {
     a: 255,
 };
 
+/// Plank brand color (warm wood brown #8B5A2B)
+const PLANK_COLOR: ColorU = ColorU {
+    r: 139,
+    g: 90,
+    b: 43,
+    a: 255,
+};
+
 /// Mistral brand orange (#FA520F)
 const MISTRAL_ORANGE: ColorU = ColorU {
     r: 250,
@@ -153,6 +161,7 @@ pub enum CLIAgent {
     Hermes,
     Vibe,
     Antigravity,
+    Plank,
     /// Represents an unknown/custom CLI agent matched by user-configured regex patterns.
     Unknown,
 }
@@ -176,6 +185,7 @@ impl CLIAgent {
             CLIAgent::Hermes => "hermes",
             CLIAgent::Vibe => "vibe",
             CLIAgent::Antigravity => "agy",
+            CLIAgent::Plank => "plank",
             CLIAgent::Unknown => "",
         }
     }
@@ -225,6 +235,7 @@ impl CLIAgent {
             CLIAgent::Hermes => "Hermes",
             CLIAgent::Vibe => "Mistral Vibe",
             CLIAgent::Antigravity => "Antigravity",
+            CLIAgent::Plank => "Plank",
             CLIAgent::Unknown => "CLI Agent",
         }
     }
@@ -250,6 +261,9 @@ impl CLIAgent {
             // up in a follow-up once an officially licensed SVG is available.
             CLIAgent::Vibe => None,
             CLIAgent::Antigravity => Some(Icon::AntigravityLogo),
+            // Plank is recognized but ships without a brand asset; the brand
+            // color still drives the toolbar tile.
+            CLIAgent::Plank => None,
             CLIAgent::Unknown => None,
         }
     }
@@ -282,6 +296,7 @@ impl CLIAgent {
             CLIAgent::Hermes => &[SkillProvider::Agents],
             CLIAgent::Vibe => &[SkillProvider::Agents],
             CLIAgent::Antigravity => &[],
+            CLIAgent::Plank => &[],
             CLIAgent::Unknown => &[],
         }
     }
@@ -326,6 +341,7 @@ impl CLIAgent {
             CLIAgent::Hermes => Some(HERMES_PURPLE),
             CLIAgent::Vibe => Some(MISTRAL_ORANGE),
             CLIAgent::Antigravity => Some(ANTIGRAVITY_COLOR),
+            CLIAgent::Plank => Some(PLANK_COLOR),
             CLIAgent::Unknown => None,
         }
     }
@@ -619,6 +635,7 @@ impl From<CLIAgent> for CLIAgentType {
             CLIAgent::Hermes => CLIAgentType::Hermes,
             CLIAgent::Vibe => CLIAgentType::Vibe,
             CLIAgent::Antigravity => CLIAgentType::Antigravity,
+            CLIAgent::Plank => CLIAgentType::Plank,
             CLIAgent::Unknown => CLIAgentType::Unknown,
         }
     }

--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -56,7 +56,8 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         // Auggie and Pi are supported via community-maintained plugins
         // (https://github.com/augmentmoogi/auggie-warp,
         // https://github.com/badlogic/pi-mono). OhMyPi emits these structured
-        // OSC 777 events natively. Droid can be supported by user-configured
+        // OSC 777 events natively, as does Plank
+        // (https://github.com/aovestdipaperino/plank). Droid can be supported by user-configured
         // hooks or future integrations that emit the same events. We don't ship
         // install flows for these agents here — we just listen.
         CLIAgent::Claude
@@ -65,7 +66,8 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         | CLIAgent::Auggie
         | CLIAgent::Droid
         | CLIAgent::Pi
-        | CLIAgent::OhMyPi => Some(Box::new(DefaultSessionListener)),
+        | CLIAgent::OhMyPi
+        | CLIAgent::Plank => Some(Box::new(DefaultSessionListener)),
         CLIAgent::Codex => Some(Box::new(CodexSessionHandler)),
         CLIAgent::Hermes
         | CLIAgent::Amp

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
@@ -299,6 +299,7 @@ pub(crate) fn plugin_manager_for_with_shell(
         | CLIAgent::Goose
         | CLIAgent::Vibe
         | CLIAgent::Antigravity
+        | CLIAgent::Plank
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -266,6 +266,7 @@ fn test_detect_known_agents() {
                 ("vibe", CLIAgent::Vibe),
                 ("agy", CLIAgent::Antigravity),
                 ("omp", CLIAgent::OhMyPi),
+                ("plank", CLIAgent::Plank),
             ] {
                 assert_eq!(
                     CLIAgent::detect(command, None, None, ctx),

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -137,6 +137,7 @@ fn rich_input_submit_strategy(agent: CLIAgent) -> RichInputSubmitStrategy {
         | CLIAgent::Hermes
         | CLIAgent::Vibe
         | CLIAgent::Antigravity
+        | CLIAgent::Plank
         | CLIAgent::Unknown => RichInputSubmitStrategy::Inline,
     }
 }


### PR DESCRIPTION
## Summary

[Plank](https://github.com/aovestdipaperino/plank) is a CLI coding agent that natively emits Warp's structured `warp://cli-agent` OSC 777 events (protocol v1: `{v, agent, event, session_id, cwd, project}`). Without registration, its events resolve to `CLIAgent::Unknown` and get generic treatment.

This PR registers the `plank` slug as a first-class CLI agent, following the pattern used for Hermes/Vibe (recognized, brand color, no icon asset yet):

- `CLIAgent::Plank` variant with command prefix `plank`, display name `Plank`, and a brand color (`#8B5A2B`); `icon()` returns `None` until a brand asset lands
- `CLIAgentType::Plank` telemetry variant
- Session listener: maps to `DefaultSessionListener` (Plank emits the structured events natively, like OhMyPi — no plugin install flow shipped here)
- Plugin manager and rich-input submit strategy: no plugin, `Inline` submit
- Detection test case (`plank` → `CLIAgent::Plank`)

## Testing
- All exhaustive `match`es over `CLIAgent` were located and updated (`cli_agent.rs`, `listener/mod.rs`, `plugin_manager/mod.rs`, `use_agent_footer/mod.rs`, telemetry `From` impl).
- Added `("plank", CLIAgent::Plank)` to the detection table in `cli_agent_tests.rs`.
- Authored from a sparse checkout, so I could not run the full build locally; relying on CI for compile + test verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)