### PR TITLE
Scope macOS config dirs to WARP_DATA_PROFILE

### DIFF
--- a/crates/warp_core/src/paths.rs
+++ b/crates/warp_core/src/paths.rs
@@ -75,22 +75,40 @@ pub fn warp_home_mcp_config_file_path() -> Option<PathBuf> {
     warp_home_config_dir().map(|warp_config_dir| warp_config_dir.join(".mcp.json"))
 }
 
-/// Returns the macOS config directory name for the current channel.
+/// Returns the macOS config directory name for the current channel and data
+/// profile.
 ///
 /// Stable uses `.warp`, while other channels include a channel suffix
 /// (e.g., `.warp-dev`, `.warp-local`).
+///
+/// Development data profiles append a further `-{profile}` suffix. Without it,
+/// every profile of a channel would share this directory — and with it the
+/// public settings in `settings.toml` — defeating the isolation that profiles
+/// already provide for UserDefaults, Application Support, and the keychain.
 ///
 /// These suffixes are persisted on disk as directory names and must not be
 /// changed once established, or existing user data will be orphaned.
 #[cfg(target_os = "macos")]
 fn macos_config_dir_name() -> String {
-    match ChannelState::channel() {
+    macos_config_dir_name_for(
+        ChannelState::channel(),
+        ChannelState::data_profile().as_deref(),
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn macos_config_dir_name_for(channel: Channel, data_profile: Option<&str>) -> String {
+    let base_dir_name = match channel {
         Channel::Stable => WARP_CONFIG_DIR.to_owned(),
         Channel::Preview => format!("{WARP_CONFIG_DIR}-preview"),
         Channel::Oss => format!("{WARP_CONFIG_DIR}-oss"),
         Channel::Dev => format!("{WARP_CONFIG_DIR}-dev"),
         Channel::Integration => format!("{WARP_CONFIG_DIR}-integration"),
         Channel::Local => format!("{WARP_CONFIG_DIR}-local"),
+    };
+    match data_profile {
+        Some(profile) => format!("{base_dir_name}-{profile}"),
+        None => base_dir_name,
     }
 }
 

--- a/crates/warp_core/src/paths_tests.rs
+++ b/crates/warp_core/src/paths_tests.rs
@@ -36,6 +36,27 @@ fn test_config_local_dir_path() {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn test_macos_config_dir_name_scopes_to_data_profile() {
+    assert_eq!(macos_config_dir_name_for(Channel::Stable, None), ".warp");
+    assert_eq!(
+        macos_config_dir_name_for(Channel::Local, None),
+        ".warp-local"
+    );
+
+    // Each development profile must get its own directory so shared config
+    // (notably settings.toml) cannot leak between profiles.
+    assert_eq!(
+        macos_config_dir_name_for(Channel::Local, Some("myprofile")),
+        ".warp-local-myprofile"
+    );
+    assert_eq!(
+        macos_config_dir_name_for(Channel::Stable, Some("myprofile")),
+        ".warp-myprofile"
+    );
+}
+
 #[test]
 fn test_gui_app_id_maps_oss_tui_to_oss_gui() {
     let gui_app_id = gui_app_id_for_channel(Channel::Oss, AppId::new("dev", "warp", "WarpTui"));


### PR DESCRIPTION
## Description
On macOS, `WARP_DATA_PROFILE` failed to isolate public settings: `config_local_dir()`/`data_dir()` resolved to the un-suffixed channel directory (e.g. `~/.warp-local`), so every development profile of a channel shared one `settings.toml`. Setting the theme (or any public setting) in one profile leaked into every "fresh" profile, breaking first-time-user testing.

This was macOS-only and inconsistent with the rest of the storage stack:
- Private settings (UserDefaults), Application Support/SQLite, and keychain entries are already profile-scoped via `data_domain()`/`project_dirs()`.
- Linux/Windows already scope these directories, since `project_dirs_for_app_id()` appends the `-{profile}` suffix.
- `warp_home_config_dir_name()` (skills, `.mcp.json`) already appends the profile on macOS.

**Fix:** `macos_config_dir_name()` now appends the `-{profile}` suffix, mirroring `warp_home_config_dir_name()`. This transitively scopes `settings.toml`, `themes/`, and the TUI's `.warp_cli*` directory. Extracted a pure `macos_config_dir_name_for(channel, data_profile)` for testability, following the existing pattern in `paths.rs`.

Release builds are unaffected: `ChannelState::data_profile()` returns `None` outside `debug_assertions`. Runs without `WARP_DATA_PROFILE` resolve exactly as before. `gui_config_local_dir()`'s fail-closed behavior under profiles is intentionally unchanged.

## Linked Issue
N/A — dev-tooling bug found while testing account-first onboarding with fresh profiles.

## Testing
- Added `test_macos_config_dir_name_scopes_to_data_profile` unit test covering suffixed and unsuffixed names for Stable/Local channels.
- `cargo nextest run -p warp_core paths`: 14/14 pass.
- `./script/format` and the presubmit clippy suite pass locally (`command-signatures-v2` excluded due to a local Yarn/Corepack env issue; CI runs the full set).
- [ ] I have manually tested my changes locally with `./script/run`

Manual verification steps: run `WARP_DATA_PROFILE=a ./script/run`, change the theme, then run `WARP_DATA_PROFILE=b ./script/run` — profile `b` should get default settings (`~/.warp-local-b/settings.toml`), not profile `a`'s theme.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

---
Conversation: https://staging.warp.dev/conversation/3bcd53de-a063-4c34-8cff-a2ddb77558cb

Co-Authored-By: Oz <oz-agent@warp.dev>
