### PR TITLE
feat(tui): add local-to-cloud handoff

### DIFF
--- a/app/src/ai/blocklist/handoff/mod.rs
+++ b/app/src/ai/blocklist/handoff/mod.rs
@@ -41,6 +41,9 @@ pub use pipeline::{
 #[cfg(feature = "local_fs")]
 #[cfg_attr(not(feature = "tui"), allow(unused_imports))]
 pub use snapshot::SnapshotUploadTarget;
+#[cfg(feature = "local_fs")]
+#[cfg_attr(not(feature = "tui"), allow(unused_imports))]
+pub use touched_repos::suggest_handoff_environment;
 
 /// Prompt attachments represented for both cloud submission and local restoration.
 #[cfg_attr(target_family = "wasm", allow(dead_code))]

--- a/app/src/ai/blocklist/handoff/pipeline.rs
+++ b/app/src/ai/blocklist/handoff/pipeline.rs
@@ -339,7 +339,11 @@ impl PendingHandoff {
         self.config.model_id = Some(model_id);
     }
 
-    fn set_valid_environment_ids(&mut self, valid_environment_ids: HashSet<SyncId>) {
+    /// Replaces the environment catalog used by [`Self::validate`].
+    ///
+    /// Frontends call this when their environment projection changes while
+    /// retaining an editable pending handoff.
+    pub fn set_valid_environment_ids(&mut self, valid_environment_ids: HashSet<SyncId>) {
         self.valid_environment_ids = valid_environment_ids;
     }
 

--- a/app/src/ai/blocklist/handoff/touched_repos.rs
+++ b/app/src/ai/blocklist/handoff/touched_repos.rs
@@ -26,6 +26,7 @@ use command::r#async::Command;
 use futures::future::join_all;
 use tokio::fs as tokio_fs;
 use warp_util::standardized_path::StandardizedPath;
+use warpui::AppContext;
 use warpui::r#async::FutureExt as _;
 
 use crate::ai::agent::conversation::AIConversation;
@@ -33,6 +34,7 @@ use crate::ai::agent::{AIAgentAction, AIAgentActionType, AIAgentOutputMessageTyp
 use crate::ai::cloud_environments::{
     CloudAmbientAgentEnvironment, GithubRepo, sort_environments_by_recency,
 };
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::server::ids::SyncId;
 
 /// Cap on how many of the conversation's action results we scan for paths,
@@ -200,6 +202,25 @@ pub(crate) async fn resolve_repo_for_path(path: &Path) -> Option<TouchedRepo> {
         .as_deref()
         .and_then(parse_github_repo);
     Some(TouchedRepo { git_root, repo_id })
+}
+
+/// Suggests the available environment whose configured repositories overlap
+/// the Git repository containing `path`.
+pub fn suggest_handoff_environment(
+    path: PathBuf,
+    ctx: &AppContext,
+) -> impl std::future::Future<Output = Option<SyncId>> + Send + 'static {
+    let environments = CloudAmbientAgentEnvironment::get_all(ctx);
+    async move {
+        let touched_repo = resolve_repo_for_path(&path).await?;
+        pick_handoff_overlap_env(
+            &TouchedWorkspace {
+                repos: vec![touched_repo],
+                orphan_files: Vec::new(),
+            },
+            environments,
+        )
+    }
 }
 
 /// Pick the env that has the most overlap with the touched repos, breaking ties by

--- a/app/src/ai/cloud_environments/catalog.rs
+++ b/app/src/ai/cloud_environments/catalog.rs
@@ -9,6 +9,7 @@ use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::cloud_object::CloudObjectLookup as _;
 use crate::cloud_object::model::generic_string_model::StringModel as _;
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
+#[cfg(feature = "tui")]
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::SyncId;
 
@@ -99,7 +100,7 @@ impl CloudEnvironmentCatalog {
     }
 
     /// Requests an out-of-band refresh of cloud objects from the server.
-    #[allow(dead_code)]
+    #[cfg(feature = "tui")]
     pub fn refresh_from_server(&self, ctx: &mut ModelContext<Self>) {
         UpdateManager::handle(ctx).update(ctx, |manager, ctx| {
             manager.refresh_updated_objects(ctx);

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -2,6 +2,8 @@ mod catalog;
 pub use catalog::CloudEnvironmentCatalog;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 pub(crate) use catalog::sort_environments_by_recency;
+#[cfg(feature = "tui")]
+pub use catalog::{CloudEnvironment, CloudEnvironmentCatalogEvent};
 #[cfg_attr(target_family = "wasm", expect(unused_imports))]
 pub use cloud_object_models::{
     AmbientAgentEnvironment, AwsProviderConfig, BaseImage, CloudAmbientAgentEnvironment,
@@ -19,6 +21,10 @@ use crate::cloud_object::{
 };
 use crate::server::sync_queue::QueueItem;
 use crate::workspaces::user_workspaces::UserWorkspaces;
+
+/// Oz web app page for viewing and creating cloud environments.
+#[cfg(feature = "tui")]
+pub const OZ_ENVIRONMENTS_URL: &str = "https://oz.warp.dev/environments";
 
 impl StringModel for AmbientAgentEnvironment {
     type CloudObjectType = CloudAmbientAgentEnvironment;

--- a/app/src/ai/orchestration/mod.rs
+++ b/app/src/ai/orchestration/mod.rs
@@ -36,6 +36,8 @@ pub use remote_child::{
 pub(crate) use snapshots::AUTH_SECRET_INHERIT_LABEL;
 #[cfg_attr(not(feature = "tui"), allow(unused_imports))]
 pub use snapshots::location_snapshot;
+#[cfg_attr(not(feature = "tui"), allow(unused_imports))]
+pub use snapshots::oz_model_snapshot;
 pub use snapshots::{
     OptionBadge, OptionFooter, OptionRow, OptionSnapshot, OptionSourceStatus, api_key_snapshot,
     build_runner_snapshot, environment_snapshot, harness_snapshot, host_snapshot, model_snapshot,

--- a/app/src/ai/orchestration/snapshots.rs
+++ b/app/src/ai/orchestration/snapshots.rs
@@ -287,32 +287,7 @@ pub fn model_snapshot(state: &OrchestrationConfigState, ctx: &AppContext) -> Opt
     let is_local = !state.execution_mode.is_remote();
     let harness = Harness::parse_orchestration_harness(&state.harness_type);
     match harness {
-        Some(Harness::Oz) | None => {
-            // Oz / unset: Warp LLM catalog. Custom models excluded for
-            // cloud runs (not supported by remote workers).
-            // Order: auto models first, then custom models, then other models.
-            let llm_prefs = LLMPreferences::as_ref(ctx);
-            let (auto_models, rest): (Vec<_>, Vec<_>) =
-                get_base_model_choices(llm_prefs, ctx, is_local)
-                    .partition(|llm| llm.id.as_str().starts_with("auto"));
-            let (custom_models, other_models): (Vec<_>, Vec<_>) = rest
-                .into_iter()
-                .partition(|llm| llm_prefs.custom_llm_info_for_id(&llm.id).is_some());
-            let choices: Vec<ModelChoiceInput> = auto_models
-                .into_iter()
-                .chain(custom_models)
-                .chain(other_models)
-                .map(|llm| ModelChoiceInput {
-                    id: llm.id.to_string(),
-                    label: llm.menu_display_name(),
-                    disabled_reason: llm
-                        .disable_reason
-                        .as_ref()
-                        .map(|reason| reason.tooltip_text().to_string()),
-                })
-                .collect();
-            build_oz_model_snapshot(choices, &state.model_id)
-        }
+        Some(Harness::Oz) | None => oz_model_snapshot(&state.model_id, is_local, ctx),
         Some(Harness::Codex) if is_local => {
             // Local Codex: only "Default model" entry.
             OptionSnapshot::ready(
@@ -336,6 +311,39 @@ pub fn model_snapshot(state: &OrchestrationConfigState, ctx: &AppContext) -> Opt
             build_non_oz_model_snapshot(models, &state.model_id)
         }
     }
+}
+
+/// Builds the Oz model options available for the requested execution location.
+///
+/// Local execution includes custom models backed by local endpoints. Cloud
+/// execution excludes them because remote workers cannot reach those endpoints.
+pub fn oz_model_snapshot(
+    selected_model_id: &str,
+    is_local: bool,
+    ctx: &AppContext,
+) -> OptionSnapshot {
+    // Oz / unset: Warp LLM catalog. Custom models are excluded for cloud
+    // execution because remote workers cannot use local custom endpoints.
+    let llm_prefs = LLMPreferences::as_ref(ctx);
+    let (auto_models, rest): (Vec<_>, Vec<_>) = get_base_model_choices(llm_prefs, ctx, is_local)
+        .partition(|llm| llm.id.as_str().starts_with("auto"));
+    let (custom_models, other_models): (Vec<_>, Vec<_>) = rest
+        .into_iter()
+        .partition(|llm| llm_prefs.custom_llm_info_for_id(&llm.id).is_some());
+    let choices = auto_models
+        .into_iter()
+        .chain(custom_models)
+        .chain(other_models)
+        .map(|llm| ModelChoiceInput {
+            id: llm.id.to_string(),
+            label: llm.menu_display_name(),
+            disabled_reason: llm
+                .disable_reason
+                .as_ref()
+                .map(|reason| reason.tooltip_text().to_string()),
+        })
+        .collect();
+    build_oz_model_snapshot(choices, selected_model_id)
 }
 
 /// Pure core for the Oz / unset branch of [`model_snapshot`].

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -319,7 +319,7 @@ pub static MOVE_TO_CLOUD: LazyLock<StaticCommand> = LazyLock::new(|| StaticComma
     name: "/handoff",
     description: "Hand off this conversation to a cloud agent",
     kind: SlashCommandKind::MoveToCloud,
-    supported_surfaces: SlashCommandSurfaces::GuiOnly {
+    supported_surfaces: SlashCommandSurfaces::GuiAndTui {
         icon_path: "bundled/svg/upload-cloud-01.svg",
     },
     availability: Availability::AGENT_VIEW

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -166,11 +166,9 @@ use crate::ai::blocklist::block::cli_controller::{CLISubagentController, CLISuba
 use crate::ai::blocklist::block::status_bar::BlocklistAIStatusBar;
 use crate::ai::blocklist::conversation_selection::ConversationSelectionHandle;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::handoff::touched_repos::{
-    TouchedWorkspace, pick_handoff_overlap_env, resolve_repo_for_path,
+use crate::ai::blocklist::handoff::{
+    HandoffLaunchAttachments, PendingCloudLaunch, suggest_handoff_environment,
 };
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
 use crate::ai::blocklist::telemetry_banner::should_collect_ai_ugc_telemetry;
 use crate::ai::blocklist::{
@@ -185,8 +183,6 @@ use crate::ai::blocklist::{
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::cloud_environments::sort_environments_by_recency;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::conversation_export::export_conversation_markdown;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentVersion};
@@ -4295,29 +4291,19 @@ impl Input {
         };
 
         let handoff_compose_state = self.handoff_compose_state.clone();
+        let suggestion = suggest_handoff_environment(pwd, ctx);
         ctx.spawn(
             async move {
-                resolve_repo_for_path(&pwd)
+                suggestion
                     .with_timeout(Duration::from_secs(5))
                     .await
                     .ok()
                     .flatten()
             },
-            move |_input, touched_repo, ctx| {
-                use crate::cloud_object::CloudObjectLookup as _;
-
-                let Some(touched_repo) = touched_repo else {
-                    return;
-                };
-                let workspace = TouchedWorkspace {
-                    repos: vec![touched_repo],
-                    orphan_files: vec![],
-                };
-                let mut envs = CloudAmbientAgentEnvironment::get_all(ctx);
-                sort_environments_by_recency(&mut envs);
-                if let Some(overlap_env) = pick_handoff_overlap_env(&workspace, envs) {
+            move |_input, environment_id, ctx| {
+                if let Some(environment_id) = environment_id {
                     handoff_compose_state.update(ctx, |state, ctx| {
-                        state.set_environment_id(Some(overlap_env), false, ctx);
+                        state.set_environment_id(Some(environment_id), false, ctx);
                     });
                 }
             },

--- a/app/src/terminal/input/slash_commands/data_source/core.rs
+++ b/app/src/terminal/input/slash_commands/data_source/core.rs
@@ -21,7 +21,9 @@ use crate::ai::skills::{SkillDescriptor, SkillManager};
 use crate::search::slash_command_menu::fuzzy_match::SlashCommandFuzzyMatchResult;
 use crate::search::slash_command_menu::static_commands::{Availability, commands};
 use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
-use crate::settings::{AISettings, AISettingsChangedEvent};
+use crate::settings::{
+    AISettings, AISettingsChangedEvent, PrivacySettings, PrivacySettingsChangedEvent,
+};
 use crate::terminal::cli_agent_sessions::{
     CLIAgentInputState, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
 };
@@ -95,6 +97,14 @@ pub(super) fn subscribe_to_shared_dependencies<T>(
             AISettingsChangedEvent::IsAnyAIEnabled { .. }
                 | AISettingsChangedEvent::ShouldForceDisableCloudHandoff { .. }
                 | AISettingsChangedEvent::AIAutoDetectionEnabled { .. }
+        ) {
+            recompute_active_commands(me, ctx);
+        }
+    });
+    ctx.subscribe_to_model(&PrivacySettings::handle(ctx), move |me, _, event, ctx| {
+        if matches!(
+            event,
+            PrivacySettingsChangedEvent::UpdateIsCloudConversationStorageEnabled { .. }
         ) {
             recompute_active_commands(me, ctx);
         }

--- a/app/src/terminal/input/slash_commands/data_source/tui.rs
+++ b/app/src/terminal/input/slash_commands/data_source/tui.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use parking_lot::FairMutex;
 #[cfg(feature = "voice_input")]
-use warpui::SingletonEntity;
+use warpui::SingletonEntity as _;
 use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle};
 
 use super::core::subscribe_to_shared_dependencies;

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -79,6 +79,7 @@ fn tui_commands_have_typed_identities_and_explicit_surface_support() {
             SlashCommandKind::ExportToClipboard,
         ),
         (&*commands::EXPORT_TO_FILE, SlashCommandKind::ExportToFile),
+        (&*commands::MOVE_TO_CLOUD, SlashCommandKind::MoveToCloud),
         (&commands::AUTO_APPROVE, SlashCommandKind::AutoApprove),
         (&commands::MCP, SlashCommandKind::Mcp),
         (&commands::EXIT, SlashCommandKind::Exit),

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -72,7 +72,7 @@ pub use crate::ai::blocklist::handoff::{
     HandoffCommitFailure, HandoffCommitOutcome, HandoffCreated, HandoffLaunchAttachments,
     HandoffPrepareError, HandoffPrepareInput, HandoffPresentationSnapshot, HandoffRestoration,
     HandoffTargetMaterialization, MaterializeHandoffTarget, PendingCloudLaunch, PendingHandoff,
-    SnapshotUploadTarget, execute_handoff, prepare_handoff,
+    SnapshotUploadTarget, execute_handoff, prepare_handoff, suggest_handoff_environment,
 };
 pub use crate::ai::blocklist::history_model::{
     AIQueryHistory, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, CloudConversationData,
@@ -108,6 +108,9 @@ pub use crate::ai::blocklist::{
 pub use crate::ai::blocklist::{
     PreparedLocalOzChildLaunch, apply_child_agent_model_override, prepare_local_oz_child_launch,
 };
+pub use crate::ai::cloud_environments::{
+    CloudEnvironment, CloudEnvironmentCatalog, CloudEnvironmentCatalogEvent, OZ_ENVIRONMENTS_URL,
+};
 pub use crate::ai::connected_self_hosted_workers::{
     ConnectedSelfHostedWorkersEvent, ConnectedSelfHostedWorkersModel,
 };
@@ -129,8 +132,8 @@ pub use crate::ai::orchestration::{
     PreparedRemoteChildLaunch, RemoteChildLaunchConfig, accept_disabled_reason_with_auth,
     api_key_snapshot, auth_secret_selection_required, classify_cloud_agent_startup_error,
     empty_env_recommendation_message, environment_snapshot, harness_is_selectable,
-    harness_snapshot, host_snapshot, location_snapshot, model_snapshot, oz_run_url,
-    persist_environment_selection, persist_host_selection, prepare_remote_child_launch,
+    harness_snapshot, host_snapshot, location_snapshot, model_snapshot, oz_model_snapshot,
+    oz_run_url, persist_environment_selection, persist_host_selection, prepare_remote_child_launch,
     resolve_auth_secret_selection_for_harness, resolve_default_environment_id,
     resolve_default_host_slug, should_show_auth_secret_picker,
 };
@@ -156,11 +159,12 @@ pub use crate::search::slash_command_menu::static_commands::{
     SlashCommandKind, SlashCommandSurfaces,
 };
 pub use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
+pub use crate::server::ids::SyncId;
 pub use crate::server::server_api::ServerApiProvider;
 #[cfg(feature = "voice_input")]
 pub use crate::server::server_api::TranscribeError;
 pub use crate::server::server_api::ai::{
-    AIClient, AgentConfigSnapshot, SpawnAgentRequest, SpawnAgentResponse,
+    AIClient, AgentConfigSnapshot, AttachmentInput, SpawnAgentRequest, SpawnAgentResponse,
 };
 pub use crate::settings::AISettingsChangedEvent;
 pub use crate::terminal::alt_screen::{should_intercept_mouse, should_intercept_scroll};
@@ -236,7 +240,7 @@ pub use crate::util::repo_detection::{RepoDetectionSessionType, detect_possible_
 pub use crate::util::time_format::format_elapsed_seconds;
 #[cfg(feature = "voice_input")]
 pub use crate::voice::transcriber::{Transcriber, VoiceTranscriber};
-pub use crate::workspaces::user_workspaces::UserWorkspaces;
+pub use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 
 /// Builds the live-shell completion context used to parse TUI input for NLD.
 pub fn tui_completion_session_context(

--- a/crates/warp_tui/src/handoff/block.rs
+++ b/crates/warp_tui/src/handoff/block.rs
@@ -1,0 +1,676 @@
+//! TUI card for presenting and configuring a local-to-cloud handoff.
+//!
+//! The card renders each handoff phase, from initial acceptance and the
+//! environment/model selectors through launch progress and the created cloud
+//! run. It owns keyboard actions, focus transitions, selector coordination,
+//! links, and layout invalidation for the embedded transcript surface.
+//!
+//! Handoff state, validation, environment-catalog updates, and asynchronous
+//! execution remain in [`super::model::TuiHandoffModel`]. This module
+//! translates that model state into terminal elements and forwards user intent
+//! back to the model.
+
+use std::cell::Cell;
+
+use warp::tui_export::{AIConversationId, OZ_ENVIRONMENTS_URL};
+use warpui_core::elements::CrossAxisAlignment;
+use warpui_core::elements::tui::{
+    TuiChildView, TuiConstraint, TuiContainer, TuiElement, TuiFlex, TuiLayoutContext, TuiSize,
+    TuiText,
+};
+use warpui_core::keymap::macros::*;
+use warpui_core::keymap::{self, FixedBinding};
+use warpui_core::{
+    AppContext, Entity, EntityId, FocusContext, ModelHandle, TuiView, TypedActionView, ViewContext,
+    ViewHandle,
+};
+
+use super::model::{
+    TuiHandoffModel, TuiHandoffModelEvent, TuiHandoffPhase, TuiHandoffSelectorKind,
+};
+use crate::keybindings::TUI_BINDING_GROUP;
+use crate::link::TuiLink;
+use crate::option_selector::{
+    OptionSelectorHeader, OptionSelectorPage, TuiOptionSelector, TuiOptionSelectorEvent,
+};
+use crate::transcript_view::BLOCK_TOP_PADDING_ROWS;
+use crate::tui_ask_question_view::PageNavigationDirection;
+use crate::tui_builder::TuiUiBuilder;
+
+const HANDOFF_TITLE: &str = "Hand off to cloud";
+const HANDOFF_PAGE_SEQUENCE: [TuiHandoffSelectorKind; 2] = [
+    TuiHandoffSelectorKind::Environment,
+    TuiHandoffSelectorKind::Model,
+];
+const ACCEPTANCE_CONTEXT_FLAG: &str = "TuiHandoffBlockAcceptance";
+const CONFIGURING_CONTEXT_FLAG: &str = "TuiHandoffBlockConfiguring";
+const NO_ENVIRONMENT_CONTEXT_FLAG: &str = "TuiHandoffBlockNoEnvironment";
+const COMMITTED_CONTEXT_FLAG: &str = "TuiHandoffBlockCommitted";
+const CREATED_CONTEXT_FLAG: &str = "TuiHandoffBlockCreated";
+
+pub(crate) fn init(app: &mut AppContext) {
+    let card = || id!(TuiHandoffBlock::ui_name());
+    let acceptance = || card() & id!(ACCEPTANCE_CONTEXT_FLAG);
+    let configuring = || card() & id!(CONFIGURING_CONTEXT_FLAG);
+    let no_environment = || card() & id!(NO_ENVIRONMENT_CONTEXT_FLAG);
+    let committed = || card() & id!(COMMITTED_CONTEXT_FLAG);
+    let created = || card() & id!(CREATED_CONTEXT_FLAG);
+    app.register_fixed_bindings([
+        FixedBinding::new("enter", TuiHandoffBlockAction::Confirm, acceptance())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("numpadenter", TuiHandoffBlockAction::Confirm, acceptance())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("ctrl-e", TuiHandoffBlockAction::Configure, acceptance())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "enter",
+            TuiHandoffBlockAction::OpenEnvironments,
+            no_environment(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "numpadenter",
+            TuiHandoffBlockAction::OpenEnvironments,
+            no_environment(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "r",
+            TuiHandoffBlockAction::RefreshEnvironments,
+            no_environment(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("escape", TuiHandoffBlockAction::Back, configuring())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "left",
+            TuiHandoffBlockAction::CommitAndPreviousPage,
+            configuring(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "right",
+            TuiHandoffBlockAction::CommitAndNextPage,
+            configuring(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("tab", TuiHandoffBlockAction::NextPage, configuring())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "ctrl-c",
+            TuiHandoffBlockAction::Cancel,
+            acceptance() | configuring() | no_environment(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "ctrl-c",
+            TuiHandoffBlockAction::ConsumeInterrupt,
+            committed(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("enter", TuiHandoffBlockAction::OpenRun, created())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("numpadenter", TuiHandoffBlockAction::OpenRun, created())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("c", TuiHandoffBlockAction::ContinueLocally, created())
+            .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("n", TuiHandoffBlockAction::StartNewConversation, created())
+            .with_group(TUI_BINDING_GROUP),
+    ]);
+}
+
+/// Events owned by the view rather than the handoff model.
+#[derive(Clone)]
+pub(crate) enum TuiHandoffBlockEvent {
+    LayoutInvalidated,
+}
+
+/// Keyboard actions supported by the handoff card.
+#[derive(Clone, Debug)]
+pub(crate) enum TuiHandoffBlockAction {
+    Confirm,
+    Configure,
+    CommitAndPreviousPage,
+    CommitAndNextPage,
+    NextPage,
+    OpenEnvironments,
+    RefreshEnvironments,
+    Back,
+    Cancel,
+    ConsumeInterrupt,
+    OpenRun,
+    ContinueLocally,
+    StartNewConversation,
+}
+
+/// Keyboard-focused presentation for a [`TuiHandoffModel`].
+pub(crate) struct TuiHandoffBlock {
+    model: ModelHandle<TuiHandoffModel>,
+    selector: ViewHandle<TuiOptionSelector>,
+    pending_page_navigation: Option<PageNavigationDirection>,
+    link: TuiLink,
+    last_measured_width: Cell<Option<u16>>,
+}
+
+impl TuiHandoffBlock {
+    pub(crate) fn new(model: ModelHandle<TuiHandoffModel>, ctx: &mut ViewContext<Self>) -> Self {
+        let selector = ctx.add_typed_action_tui_view(TuiOptionSelector::new);
+        ctx.subscribe_to_view(&selector, |block, _, event, ctx| {
+            block.handle_selector_event(event, ctx);
+        });
+        ctx.subscribe_to_model(&model, |block, _, event, ctx| {
+            block.handle_model_event(event, ctx);
+        });
+        Self {
+            model,
+            selector,
+            pending_page_navigation: None,
+            link: TuiLink::default(),
+            last_measured_width: Cell::new(None),
+        }
+    }
+
+    pub(crate) fn is_active(&self, ctx: &AppContext) -> bool {
+        self.model.as_ref(ctx).is_active()
+    }
+
+    pub(crate) fn source_conversation_id(&self, ctx: &AppContext) -> Option<AIConversationId> {
+        self.model.as_ref(ctx).source_conversation_id()
+    }
+
+    fn handle_model_event(&mut self, event: &TuiHandoffModelEvent, ctx: &mut ViewContext<Self>) {
+        if let TuiHandoffModelEvent::Changed { focus_block } = event {
+            self.refresh_selector(ctx);
+            if *focus_block {
+                ctx.focus_self();
+            }
+            ctx.notify();
+        }
+    }
+
+    fn finish_page_confirmation(
+        &mut self,
+        page: TuiHandoffSelectorKind,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let sequence = HANDOFF_PAGE_SEQUENCE;
+        let Some(index) = sequence.iter().position(|candidate| *candidate == page) else {
+            self.return_to_acceptance(ctx);
+            return;
+        };
+        let navigation = self.pending_page_navigation.take();
+        let target = match navigation {
+            Some(PageNavigationDirection::Previous) => {
+                index.checked_sub(1).and_then(|index| sequence.get(index))
+            }
+            Some(PageNavigationDirection::Next) | None => sequence.get(index + 1),
+        };
+        match target.copied() {
+            Some(target) => self.open_page(target, ctx),
+            None if navigation.is_some() => self.open_page(page, ctx),
+            None => self.return_to_acceptance(ctx),
+        }
+    }
+
+    fn navigate_page(&mut self, direction: PageNavigationDirection, ctx: &mut ViewContext<Self>) {
+        let TuiHandoffPhase::Configuring { page } = self.model.as_ref(ctx).phase() else {
+            return;
+        };
+        let page = *page;
+        let sequence = HANDOFF_PAGE_SEQUENCE;
+        let Some(index) = sequence.iter().position(|candidate| *candidate == page) else {
+            return;
+        };
+        let target = match direction {
+            PageNavigationDirection::Previous => {
+                index.checked_sub(1).and_then(|index| sequence.get(index))
+            }
+            PageNavigationDirection::Next => sequence.get(index + 1),
+        };
+        if let Some(target) = target.copied() {
+            self.open_page(target, ctx);
+        }
+    }
+
+    fn handle_configure(&mut self, ctx: &mut ViewContext<Self>) {
+        if matches!(self.model.as_ref(ctx).phase(), TuiHandoffPhase::Acceptance)
+            && !self.model.as_ref(ctx).no_environments(ctx)
+        {
+            self.open_page(TuiHandoffSelectorKind::Environment, ctx);
+        }
+    }
+
+    fn handle_arrow_navigation(
+        &mut self,
+        navigation: PageNavigationDirection,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.pending_page_navigation = Some(navigation);
+        let confirmation_started = self
+            .selector
+            .update(ctx, |selector, ctx| selector.confirm_selected(ctx));
+        if !confirmation_started {
+            self.pending_page_navigation = None;
+            self.navigate_page(navigation, ctx);
+        }
+    }
+
+    fn open_page(&mut self, page: TuiHandoffSelectorKind, ctx: &mut ViewContext<Self>) {
+        let opened = self
+            .model
+            .update(ctx, |model, ctx| model.open_page(page, ctx));
+        if !opened {
+            return;
+        }
+        let snapshot = self.model.as_ref(ctx).selector_snapshot(page, ctx);
+        let sequence = HANDOFF_PAGE_SEQUENCE;
+        let position = sequence
+            .iter()
+            .position(|candidate| *candidate == page)
+            .unwrap_or(0)
+            + 1;
+        self.selector.update(ctx, |selector, ctx| {
+            selector.set_page(
+                OptionSelectorPage {
+                    header: Some(OptionSelectorHeader {
+                        field_label: "Edit handoff configuration".to_owned(),
+                        position: (position, sequence.len()),
+                        prompt: page.question().to_owned(),
+                    }),
+                    snapshot,
+                    searchable: true,
+                    row_shortcuts: Default::default(),
+                },
+                ctx,
+            );
+        });
+        ctx.focus(&self.selector);
+        ctx.notify();
+    }
+
+    fn return_to_acceptance(&mut self, ctx: &mut ViewContext<Self>) {
+        self.model.update(ctx, |model, ctx| {
+            model.return_to_acceptance(ctx);
+        });
+        self.pending_page_navigation = None;
+        ctx.focus_self();
+        ctx.notify();
+    }
+
+    fn refresh_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        let TuiHandoffPhase::Configuring { page } = self.model.as_ref(ctx).phase() else {
+            return;
+        };
+        let snapshot = self.model.as_ref(ctx).selector_snapshot(*page, ctx);
+        self.selector.update(ctx, |selector, ctx| {
+            selector.refresh_snapshot(snapshot, ctx);
+        });
+    }
+
+    fn handle_selector_event(
+        &mut self,
+        event: &TuiOptionSelectorEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            TuiOptionSelectorEvent::Confirmed { id } => {
+                let TuiHandoffPhase::Configuring { page } = self.model.as_ref(ctx).phase() else {
+                    return;
+                };
+                let page = *page;
+                let applied = self
+                    .model
+                    .update(ctx, |model, ctx| model.apply_selection(page, id, ctx));
+                if applied {
+                    self.finish_page_confirmation(page, ctx);
+                }
+            }
+            TuiOptionSelectorEvent::Dismissed => self.return_to_acceptance(ctx),
+            TuiOptionSelectorEvent::CustomTextSubmitted { .. }
+            | TuiOptionSelectorEvent::RowsReordered { .. }
+            | TuiOptionSelectorEvent::CustomTextCleared
+            | TuiOptionSelectorEvent::CustomTextOpened
+            | TuiOptionSelectorEvent::CustomTextClosed
+            | TuiOptionSelectorEvent::RetryRequested => {}
+            TuiOptionSelectorEvent::LayoutInvalidated => {
+                ctx.emit(TuiHandoffBlockEvent::LayoutInvalidated);
+            }
+        }
+    }
+
+    fn confirm(&mut self, ctx: &mut ViewContext<Self>) {
+        self.model.update(ctx, |model, ctx| model.confirm(ctx));
+        if matches!(
+            self.model.as_ref(ctx).phase(),
+            TuiHandoffPhase::Committed { .. }
+        ) {
+            ctx.focus_self();
+        }
+        ctx.notify();
+    }
+
+    fn handle_back(&mut self, ctx: &mut ViewContext<Self>) {
+        self.pending_page_navigation = None;
+        let handled = self
+            .selector
+            .update(ctx, |selector, ctx| selector.handle_back(ctx));
+        if !handled {
+            self.return_to_acceptance(ctx);
+        }
+    }
+
+    fn render_configuration(
+        &self,
+        ctx: &AppContext,
+        builder: &TuiUiBuilder,
+    ) -> Box<dyn TuiElement> {
+        let model = self.model.as_ref(ctx);
+        if model.no_environments(ctx) {
+            return TuiFlex::column()
+                .child(
+                    TuiText::new("A cloud environment is required to hand off this conversation.")
+                        .with_style(builder.primary_text_style())
+                        .finish(),
+                )
+                .child(
+                    TuiText::new("Create one in Oz, then refresh this card.")
+                        .with_style(builder.muted_text_style())
+                        .finish(),
+                )
+                .finish();
+        }
+        let mut content = TuiFlex::column()
+            .child(
+                TuiText::from_spans([
+                    ("Environment: ".to_owned(), builder.primary_text_style()),
+                    (
+                        model.environment_label(ctx),
+                        builder.orchestration_selected_value_style(),
+                    ),
+                ])
+                .finish(),
+            )
+            .child(
+                TuiText::from_spans([
+                    ("Model: ".to_owned(), builder.primary_text_style()),
+                    (
+                        model.model_label(ctx),
+                        builder.orchestration_selected_value_style(),
+                    ),
+                ])
+                .finish(),
+            );
+        if let Some(error) = model.validation_error() {
+            content = content.child(
+                TuiText::new(error.to_owned())
+                    .with_style(builder.error_text_style())
+                    .finish(),
+            );
+        }
+        content.finish()
+    }
+
+    fn render_body(&self, ctx: &AppContext, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
+        match self.model.as_ref(ctx).phase() {
+            TuiHandoffPhase::Acceptance => self.render_configuration(ctx, builder),
+            TuiHandoffPhase::Configuring { .. } => TuiChildView::new(&self.selector).finish(),
+            TuiHandoffPhase::Committed { .. } => TuiText::new("Creating cloud run…")
+                .with_style(builder.primary_text_style())
+                .finish(),
+            TuiHandoffPhase::Created { url } => TuiFlex::column()
+                .child(
+                    TuiText::new("Cloud run created.")
+                        .with_style(builder.primary_text_style())
+                        .finish(),
+                )
+                .child(self.link.render(url.clone(), ctx, move |event_ctx, _| {
+                    event_ctx.dispatch_typed_action(TuiHandoffBlockAction::OpenRun);
+                }))
+                .finish(),
+            TuiHandoffPhase::Persisted { .. } => TuiFlex::column().finish(),
+        }
+    }
+
+    fn render_footer(&self, ctx: &AppContext, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
+        let model = self.model.as_ref(ctx);
+        let spans = match model.phase() {
+            TuiHandoffPhase::Acceptance if model.no_environments(ctx) => vec![
+                ("Enter ".to_owned(), builder.primary_text_style()),
+                ("open environments  ".to_owned(), builder.muted_text_style()),
+                ("R ".to_owned(), builder.primary_text_style()),
+                ("refresh  ".to_owned(), builder.muted_text_style()),
+                ("Ctrl + C".to_owned(), builder.primary_text_style()),
+                (" to cancel".to_owned(), builder.muted_text_style()),
+            ],
+            TuiHandoffPhase::Acceptance => vec![
+                ("Enter ".to_owned(), builder.primary_text_style()),
+                ("to hand off  ".to_owned(), builder.muted_text_style()),
+                ("Ctrl + E".to_owned(), builder.primary_text_style()),
+                (" to edit  ".to_owned(), builder.muted_text_style()),
+                ("Ctrl + C".to_owned(), builder.primary_text_style()),
+                (" to cancel".to_owned(), builder.muted_text_style()),
+            ],
+            TuiHandoffPhase::Configuring { .. } => vec![
+                ("Enter ".to_owned(), builder.primary_text_style()),
+                ("to accept  ".to_owned(), builder.muted_text_style()),
+                ("Tab or ← →".to_owned(), builder.primary_text_style()),
+                (" to navigate  ".to_owned(), builder.muted_text_style()),
+                ("Esc ".to_owned(), builder.primary_text_style()),
+                ("to go back".to_owned(), builder.muted_text_style()),
+            ],
+            TuiHandoffPhase::Committed { .. } => vec![(
+                "Handoff is in progress…".to_owned(),
+                builder.muted_text_style(),
+            )],
+            TuiHandoffPhase::Created { .. } => {
+                let mut spans = vec![
+                    ("Enter ".to_owned(), builder.primary_text_style()),
+                    ("open cloud run  ".to_owned(), builder.muted_text_style()),
+                ];
+                if model.forked_existing_conversation() {
+                    spans.extend([
+                        ("C ".to_owned(), builder.primary_text_style()),
+                        ("continue locally  ".to_owned(), builder.muted_text_style()),
+                    ]);
+                }
+                spans.extend([
+                    ("N ".to_owned(), builder.primary_text_style()),
+                    ("new conversation".to_owned(), builder.muted_text_style()),
+                ]);
+                spans
+            }
+            TuiHandoffPhase::Persisted { .. } => Vec::new(),
+        };
+        TuiText::from_spans(spans).finish()
+    }
+
+    fn render_completed(&self, url: &str, ctx: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(ctx);
+        let content = TuiFlex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .child(
+                TuiText::from_spans([
+                    ("■ ".to_owned(), builder.option_selector_selected_style()),
+                    (
+                        "Conversation forked to cloud; continuing locally".to_owned(),
+                        builder.primary_text_style(),
+                    ),
+                ])
+                .finish(),
+            )
+            .child(self.link.render(url.to_owned(), ctx, move |event_ctx, _| {
+                event_ctx.dispatch_typed_action(TuiHandoffBlockAction::OpenRun);
+            }))
+            .finish();
+        let banner = TuiContainer::new(content)
+            .with_background(builder.orchestration_header_background())
+            .with_padding_x(1)
+            .finish();
+        TuiContainer::new(banner)
+            .with_padding_top(BLOCK_TOP_PADDING_ROWS)
+            .finish()
+    }
+
+    pub(crate) fn needs_height_measurement(&self, width: u16) -> bool {
+        self.last_measured_width.get() != Some(width)
+    }
+
+    pub(crate) fn record_height_measurement(&self, width: u16) {
+        self.last_measured_width.set(Some(width));
+    }
+
+    pub(crate) fn desired_height(
+        &self,
+        width: u16,
+        ctx: &mut TuiLayoutContext,
+        app: &AppContext,
+    ) -> usize {
+        let mut element = self.render(app);
+        usize::from(
+            element
+                .layout(
+                    TuiConstraint::loose(TuiSize::new(width, u16::MAX)),
+                    ctx,
+                    app,
+                )
+                .height,
+        )
+    }
+}
+
+impl Entity for TuiHandoffBlock {
+    type Event = TuiHandoffBlockEvent;
+}
+
+impl TuiView for TuiHandoffBlock {
+    fn ui_name() -> &'static str {
+        "TuiHandoffBlock"
+    }
+
+    fn child_view_ids(&self, _ctx: &AppContext) -> Vec<EntityId> {
+        vec![self.selector.id()]
+    }
+
+    fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
+        if focus_ctx.is_self_focused()
+            && matches!(
+                self.model.as_ref(ctx).phase(),
+                TuiHandoffPhase::Configuring { .. }
+            )
+        {
+            ctx.focus(&self.selector);
+        }
+    }
+
+    fn keymap_context(&self, ctx: &AppContext) -> keymap::Context {
+        let mut context = keymap::Context::default();
+        context.set.insert(Self::ui_name());
+        let model = self.model.as_ref(ctx);
+        match model.phase() {
+            TuiHandoffPhase::Acceptance if model.no_environments(ctx) => {
+                context.set.insert(NO_ENVIRONMENT_CONTEXT_FLAG);
+            }
+            TuiHandoffPhase::Acceptance => {
+                context.set.insert(ACCEPTANCE_CONTEXT_FLAG);
+            }
+            TuiHandoffPhase::Configuring { .. } => {
+                context.set.insert(CONFIGURING_CONTEXT_FLAG);
+            }
+            TuiHandoffPhase::Committed { .. } => {
+                context.set.insert(COMMITTED_CONTEXT_FLAG);
+            }
+            TuiHandoffPhase::Created { .. } => {
+                context.set.insert(CREATED_CONTEXT_FLAG);
+            }
+            TuiHandoffPhase::Persisted { .. } => {}
+        }
+        context
+    }
+
+    fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
+        if let TuiHandoffPhase::Persisted { url } = self.model.as_ref(ctx).phase() {
+            return self.render_completed(url, ctx);
+        }
+        let builder = TuiUiBuilder::from_app(ctx);
+        let header = TuiContainer::new(
+            TuiText::from_spans([
+                ("■ ".to_owned(), builder.option_selector_selected_style()),
+                (HANDOFF_TITLE.to_owned(), builder.primary_text_style()),
+            ])
+            .finish(),
+        )
+        .with_background(builder.orchestration_header_background())
+        .with_padding_x(1)
+        .finish();
+        let body = TuiContainer::new(self.render_body(ctx, &builder))
+            .with_background(builder.orchestration_surface_background())
+            .with_padding_x(3)
+            .with_padding_y(1)
+            .finish();
+        TuiContainer::new(
+            TuiFlex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .child(header)
+                .child(body)
+                .child(
+                    TuiContainer::new(self.render_footer(ctx, &builder))
+                        .with_padding_top(1)
+                        .finish(),
+                )
+                .finish(),
+        )
+        .with_padding_top(BLOCK_TOP_PADDING_ROWS)
+        .finish()
+    }
+}
+
+impl TypedActionView for TuiHandoffBlock {
+    type Action = TuiHandoffBlockAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            TuiHandoffBlockAction::Confirm => self.confirm(ctx),
+            TuiHandoffBlockAction::Configure => self.handle_configure(ctx),
+            TuiHandoffBlockAction::CommitAndPreviousPage => {
+                self.handle_arrow_navigation(PageNavigationDirection::Previous, ctx)
+            }
+            TuiHandoffBlockAction::CommitAndNextPage => {
+                self.handle_arrow_navigation(PageNavigationDirection::Next, ctx)
+            }
+            TuiHandoffBlockAction::NextPage => {
+                self.navigate_page(PageNavigationDirection::Next, ctx)
+            }
+            TuiHandoffBlockAction::OpenEnvironments => ctx.open_url(OZ_ENVIRONMENTS_URL),
+            TuiHandoffBlockAction::RefreshEnvironments => {
+                self.model
+                    .update(ctx, |model, ctx| model.refresh_environments(ctx));
+            }
+            TuiHandoffBlockAction::Back => self.handle_back(ctx),
+            TuiHandoffBlockAction::Cancel => {
+                self.model.update(ctx, |model, ctx| model.cancel(ctx));
+            }
+            TuiHandoffBlockAction::ConsumeInterrupt => {}
+            TuiHandoffBlockAction::OpenRun => {
+                if let Some(url) = self.model.as_ref(ctx).url() {
+                    ctx.open_url(url);
+                }
+            }
+            TuiHandoffBlockAction::ContinueLocally => {
+                self.model
+                    .update(ctx, |model, ctx| model.continue_locally(ctx));
+                if matches!(
+                    self.model.as_ref(ctx).phase(),
+                    TuiHandoffPhase::Persisted { .. }
+                ) {
+                    self.last_measured_width.set(None);
+                    ctx.emit(TuiHandoffBlockEvent::LayoutInvalidated);
+                    ctx.notify();
+                }
+            }
+            TuiHandoffBlockAction::StartNewConversation => {
+                self.model
+                    .update(ctx, |model, ctx| model.start_new_conversation(ctx));
+            }
+        }
+    }
+}

--- a/crates/warp_tui/src/handoff/block.rs
+++ b/crates/warp_tui/src/handoff/block.rs
@@ -26,7 +26,8 @@ use warpui_core::{
 };
 
 use super::model::{
-    TuiHandoffModel, TuiHandoffModelEvent, TuiHandoffPhase, TuiHandoffSelectorKind,
+    TuiHandoffEditableState, TuiHandoffModel, TuiHandoffModelEvent, TuiHandoffPhase,
+    TuiHandoffSelectorKind,
 };
 use crate::keybindings::TUI_BINDING_GROUP;
 use crate::link::TuiLink;
@@ -213,7 +214,11 @@ impl TuiHandoffBlock {
     }
 
     fn navigate_page(&mut self, direction: PageNavigationDirection, ctx: &mut ViewContext<Self>) {
-        let TuiHandoffPhase::Configuring { page } = self.model.as_ref(ctx).phase() else {
+        let TuiHandoffPhase::Editable {
+            state: TuiHandoffEditableState::Configuring { page },
+            ..
+        } = self.model.as_ref(ctx).phase()
+        else {
             return;
         };
         let page = *page;
@@ -233,8 +238,13 @@ impl TuiHandoffBlock {
     }
 
     fn handle_configure(&mut self, ctx: &mut ViewContext<Self>) {
-        if matches!(self.model.as_ref(ctx).phase(), TuiHandoffPhase::Acceptance)
-            && !self.model.as_ref(ctx).no_environments(ctx)
+        if matches!(
+            self.model.as_ref(ctx).phase(),
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { .. },
+                ..
+            }
+        ) && !self.model.as_ref(ctx).no_environments(ctx)
         {
             self.open_page(TuiHandoffSelectorKind::Environment, ctx);
         }
@@ -298,7 +308,11 @@ impl TuiHandoffBlock {
     }
 
     fn refresh_selector(&mut self, ctx: &mut ViewContext<Self>) {
-        let TuiHandoffPhase::Configuring { page } = self.model.as_ref(ctx).phase() else {
+        let TuiHandoffPhase::Editable {
+            state: TuiHandoffEditableState::Configuring { page },
+            ..
+        } = self.model.as_ref(ctx).phase()
+        else {
             return;
         };
         let snapshot = self.model.as_ref(ctx).selector_snapshot(*page, ctx);
@@ -314,7 +328,11 @@ impl TuiHandoffBlock {
     ) {
         match event {
             TuiOptionSelectorEvent::Confirmed { id } => {
-                let TuiHandoffPhase::Configuring { page } = self.model.as_ref(ctx).phase() else {
+                let TuiHandoffPhase::Editable {
+                    state: TuiHandoffEditableState::Configuring { page },
+                    ..
+                } = self.model.as_ref(ctx).phase()
+                else {
                     return;
                 };
                 let page = *page;
@@ -412,8 +430,14 @@ impl TuiHandoffBlock {
 
     fn render_body(&self, ctx: &AppContext, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
         match self.model.as_ref(ctx).phase() {
-            TuiHandoffPhase::Acceptance => self.render_configuration(ctx, builder),
-            TuiHandoffPhase::Configuring { .. } => TuiChildView::new(&self.selector).finish(),
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { .. },
+                ..
+            } => self.render_configuration(ctx, builder),
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Configuring { .. },
+                ..
+            } => TuiChildView::new(&self.selector).finish(),
             TuiHandoffPhase::Committed { .. } => TuiText::new("Creating cloud run…")
                 .with_style(builder.primary_text_style())
                 .finish(),
@@ -434,7 +458,10 @@ impl TuiHandoffBlock {
     fn render_footer(&self, ctx: &AppContext, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
         let model = self.model.as_ref(ctx);
         let spans = match model.phase() {
-            TuiHandoffPhase::Acceptance if model.no_environments(ctx) => vec![
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { .. },
+                ..
+            } if model.no_environments(ctx) => vec![
                 ("Enter ".to_owned(), builder.primary_text_style()),
                 ("open environments  ".to_owned(), builder.muted_text_style()),
                 ("R ".to_owned(), builder.primary_text_style()),
@@ -442,7 +469,10 @@ impl TuiHandoffBlock {
                 ("Ctrl + C".to_owned(), builder.primary_text_style()),
                 (" to cancel".to_owned(), builder.muted_text_style()),
             ],
-            TuiHandoffPhase::Acceptance => vec![
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { .. },
+                ..
+            } => vec![
                 ("Enter ".to_owned(), builder.primary_text_style()),
                 ("to hand off  ".to_owned(), builder.muted_text_style()),
                 ("Ctrl + E".to_owned(), builder.primary_text_style()),
@@ -450,7 +480,10 @@ impl TuiHandoffBlock {
                 ("Ctrl + C".to_owned(), builder.primary_text_style()),
                 (" to cancel".to_owned(), builder.muted_text_style()),
             ],
-            TuiHandoffPhase::Configuring { .. } => vec![
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Configuring { .. },
+                ..
+            } => vec![
                 ("Enter ".to_owned(), builder.primary_text_style()),
                 ("to accept  ".to_owned(), builder.muted_text_style()),
                 ("Tab or ← →".to_owned(), builder.primary_text_style()),
@@ -555,7 +588,10 @@ impl TuiView for TuiHandoffBlock {
         if focus_ctx.is_self_focused()
             && matches!(
                 self.model.as_ref(ctx).phase(),
-                TuiHandoffPhase::Configuring { .. }
+                TuiHandoffPhase::Editable {
+                    state: TuiHandoffEditableState::Configuring { .. },
+                    ..
+                }
             )
         {
             ctx.focus(&self.selector);
@@ -567,13 +603,22 @@ impl TuiView for TuiHandoffBlock {
         context.set.insert(Self::ui_name());
         let model = self.model.as_ref(ctx);
         match model.phase() {
-            TuiHandoffPhase::Acceptance if model.no_environments(ctx) => {
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { .. },
+                ..
+            } if model.no_environments(ctx) => {
                 context.set.insert(NO_ENVIRONMENT_CONTEXT_FLAG);
             }
-            TuiHandoffPhase::Acceptance => {
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { .. },
+                ..
+            } => {
                 context.set.insert(ACCEPTANCE_CONTEXT_FLAG);
             }
-            TuiHandoffPhase::Configuring { .. } => {
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Configuring { .. },
+                ..
+            } => {
                 context.set.insert(CONFIGURING_CONTEXT_FLAG);
             }
             TuiHandoffPhase::Committed { .. } => {

--- a/crates/warp_tui/src/handoff/block.rs
+++ b/crates/warp_tui/src/handoff/block.rs
@@ -531,9 +531,13 @@ impl TuiHandoffBlock {
                 ])
                 .finish(),
             )
-            .child(self.link.render(url.to_owned(), ctx, move |event_ctx, _| {
-                event_ctx.dispatch_typed_action(TuiHandoffBlockAction::OpenRun);
-            }))
+            .child(
+                TuiFlex::row()
+                    .child(self.link.render(url.to_owned(), ctx, move |event_ctx, _| {
+                        event_ctx.dispatch_typed_action(TuiHandoffBlockAction::OpenRun);
+                    }))
+                    .finish(),
+            )
             .finish();
         let banner = TuiContainer::new(content)
             .with_background(builder.orchestration_header_background())

--- a/crates/warp_tui/src/handoff/mod.rs
+++ b/crates/warp_tui/src/handoff/mod.rs
@@ -1,0 +1,7 @@
+//! TUI local-to-cloud handoff state, presentation, and session integration.
+
+mod block;
+mod model;
+
+pub(crate) use block::{TuiHandoffBlock, TuiHandoffBlockEvent, init};
+pub(crate) use model::{TuiHandoffModel, TuiHandoffModelEvent};

--- a/crates/warp_tui/src/handoff/model.rs
+++ b/crates/warp_tui/src/handoff/model.rs
@@ -39,14 +39,28 @@ impl TuiHandoffSelectorKind {
     }
 }
 
-/// Model-owned lifecycle state for one handoff.
-#[derive(Debug)]
-pub(crate) enum TuiHandoffPhase {
-    Acceptance,
+/// Editable presentation state for a prepared handoff.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TuiHandoffEditableState {
+    Acceptance { validation_error: Option<String> },
     Configuring { page: TuiHandoffSelectorKind },
-    Committed { operation_id: u64 },
-    Created { url: String },
-    Persisted { url: String },
+}
+
+/// Model-owned lifecycle state for one handoff.
+pub(crate) enum TuiHandoffPhase {
+    Editable {
+        state: TuiHandoffEditableState,
+        pending: PendingHandoff,
+    },
+    Committed {
+        operation_id: u64,
+    },
+    Created {
+        url: String,
+    },
+    Persisted {
+        url: String,
+    },
 }
 
 /// Outcomes that require the owning terminal session to change surfaces.
@@ -80,11 +94,9 @@ impl TuiHandoffPreparationFailure {
 /// Model backing one TUI handoff card.
 pub(crate) struct TuiHandoffModel {
     source_conversation_id: Option<AIConversationId>,
-    pending: Option<PendingHandoff>,
     phase: TuiHandoffPhase,
     environments: ModelHandle<CloudEnvironmentCatalog>,
     forked_existing_conversation: bool,
-    validation_error: Option<String>,
     next_operation_id: u64,
     dismissed: bool,
 }
@@ -203,11 +215,14 @@ impl TuiHandoffModel {
                 pending.presentation_snapshot().forked_existing_conversation;
             let mut model = Self {
                 source_conversation_id,
-                pending: Some(pending),
-                phase: TuiHandoffPhase::Acceptance,
+                phase: TuiHandoffPhase::Editable {
+                    state: TuiHandoffEditableState::Acceptance {
+                        validation_error: None,
+                    },
+                    pending,
+                },
                 environments,
                 forked_existing_conversation,
-                validation_error: None,
                 next_operation_id: 0,
                 dismissed: false,
             };
@@ -220,7 +235,7 @@ impl TuiHandoffModel {
                         return;
                     }
                     if let Some(environment_id) = environment_id
-                        && let Some(pending) = model.pending.as_mut()
+                        && let Some(pending) = model.pending_mut()
                     {
                         pending.set_environment_id(Some(environment_id), false);
                         ctx.emit(TuiHandoffModelEvent::Changed { focus_block: false });
@@ -332,10 +347,7 @@ impl TuiHandoffModel {
     }
 
     pub(crate) fn is_editable(&self) -> bool {
-        matches!(
-            self.phase,
-            TuiHandoffPhase::Acceptance | TuiHandoffPhase::Configuring { .. }
-        )
+        matches!(self.phase, TuiHandoffPhase::Editable { .. })
     }
 
     pub(crate) fn no_environments(&self, ctx: &AppContext) -> bool {
@@ -347,15 +359,43 @@ impl TuiHandoffModel {
     }
 
     pub(crate) fn validation_error(&self) -> Option<&str> {
-        self.validation_error.as_deref()
+        match &self.phase {
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { validation_error },
+                ..
+            } => validation_error.as_deref(),
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Configuring { .. },
+                ..
+            }
+            | TuiHandoffPhase::Committed { .. }
+            | TuiHandoffPhase::Created { .. }
+            | TuiHandoffPhase::Persisted { .. } => None,
+        }
     }
 
     pub(crate) fn url(&self) -> Option<&str> {
         match &self.phase {
             TuiHandoffPhase::Created { url } | TuiHandoffPhase::Persisted { url } => Some(url),
-            TuiHandoffPhase::Acceptance
-            | TuiHandoffPhase::Configuring { .. }
-            | TuiHandoffPhase::Committed { .. } => None,
+            TuiHandoffPhase::Editable { .. } | TuiHandoffPhase::Committed { .. } => None,
+        }
+    }
+
+    fn pending(&self) -> Option<&PendingHandoff> {
+        match &self.phase {
+            TuiHandoffPhase::Editable { pending, .. } => Some(pending),
+            TuiHandoffPhase::Committed { .. }
+            | TuiHandoffPhase::Created { .. }
+            | TuiHandoffPhase::Persisted { .. } => None,
+        }
+    }
+
+    fn pending_mut(&mut self) -> Option<&mut PendingHandoff> {
+        match &mut self.phase {
+            TuiHandoffPhase::Editable { pending, .. } => Some(pending),
+            TuiHandoffPhase::Committed { .. }
+            | TuiHandoffPhase::Created { .. }
+            | TuiHandoffPhase::Persisted { .. } => None,
         }
     }
 
@@ -372,8 +412,7 @@ impl TuiHandoffModel {
 
     fn environment_snapshot(&self, ctx: &AppContext) -> OptionSnapshot {
         let selected_id = self
-            .pending
-            .as_ref()
+            .pending()
             .and_then(|pending| pending.presentation_snapshot().environment_id)
             .map(|id| id.to_string());
         let rows = self
@@ -407,8 +446,7 @@ impl TuiHandoffModel {
 
     fn model_snapshot(&self, ctx: &AppContext) -> OptionSnapshot {
         let selected_model_id = self
-            .pending
-            .as_ref()
+            .pending()
             .expect("editable handoff has pending state")
             .presentation_snapshot()
             .model_id;
@@ -417,8 +455,7 @@ impl TuiHandoffModel {
 
     pub(crate) fn environment_label(&self, ctx: &AppContext) -> String {
         let selected = self
-            .pending
-            .as_ref()
+            .pending()
             .and_then(|pending| pending.presentation_snapshot().environment_id);
         selected
             .and_then(|selected| {
@@ -433,7 +470,7 @@ impl TuiHandoffModel {
     }
 
     pub(crate) fn model_label(&self, ctx: &AppContext) -> String {
-        let Some(pending) = self.pending.as_ref() else {
+        let Some(pending) = self.pending() else {
             return String::new();
         };
         let presentation = pending.presentation_snapshot();
@@ -463,14 +500,21 @@ impl TuiHandoffModel {
         {
             return false;
         }
-        self.phase = TuiHandoffPhase::Configuring { page };
-        self.validation_error = None;
+        let TuiHandoffPhase::Editable { state, .. } = &mut self.phase else {
+            return false;
+        };
+        *state = TuiHandoffEditableState::Configuring { page };
         ctx.notify();
         true
     }
 
     pub(crate) fn return_to_acceptance(&mut self, ctx: &mut ModelContext<Self>) {
-        self.phase = TuiHandoffPhase::Acceptance;
+        let TuiHandoffPhase::Editable { state, .. } = &mut self.phase else {
+            return;
+        };
+        *state = TuiHandoffEditableState::Acceptance {
+            validation_error: None,
+        };
         ctx.notify();
     }
 
@@ -480,9 +524,6 @@ impl TuiHandoffModel {
         id: &str,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
-        let Some(pending) = self.pending.as_mut() else {
-            return false;
-        };
         match page {
             TuiHandoffSelectorKind::Environment => {
                 let environment_id = self
@@ -495,12 +536,18 @@ impl TuiHandoffModel {
                 let Some(environment_id) = environment_id else {
                     return false;
                 };
+                let Some(pending) = self.pending_mut() else {
+                    return false;
+                };
                 pending.set_environment_id(Some(environment_id), true);
                 self.environments.update(ctx, |catalog, ctx| {
                     catalog.persist_selection(environment_id, ctx);
                 });
             }
             TuiHandoffSelectorKind::Model => {
+                let Some(pending) = self.pending_mut() else {
+                    return false;
+                };
                 pending.set_model_id(id.to_owned(), true, ctx);
             }
         }
@@ -509,29 +556,38 @@ impl TuiHandoffModel {
     }
 
     pub(crate) fn confirm(&mut self, ctx: &mut ModelContext<Self>) {
-        if !matches!(self.phase, TuiHandoffPhase::Acceptance) || self.no_environments(ctx) {
+        if !matches!(
+            self.phase,
+            TuiHandoffPhase::Editable {
+                state: TuiHandoffEditableState::Acceptance { .. },
+                ..
+            }
+        ) || self.no_environments(ctx)
+        {
             return;
         }
         let validation = self
-            .pending
-            .as_ref()
-            .expect("configuring handoff has pending state")
+            .pending()
+            .expect("editable handoff has pending state")
             .validate();
         if let Err(error) = validation {
-            self.validation_error = Some(Self::validation_message(&error).to_owned());
+            let TuiHandoffPhase::Editable { state, .. } = &mut self.phase else {
+                unreachable!("validated handoff is editable");
+            };
+            *state = TuiHandoffEditableState::Acceptance {
+                validation_error: Some(Self::validation_message(&error).to_owned()),
+            };
             ctx.emit(TuiHandoffModelEvent::Changed { focus_block: false });
             ctx.notify();
             return;
         }
-
-        let pending = self
-            .pending
-            .take()
-            .expect("configuring handoff has pending state");
         self.next_operation_id = self.next_operation_id.wrapping_add(1);
         let operation_id = self.next_operation_id;
-        self.phase = TuiHandoffPhase::Committed { operation_id };
-        self.validation_error = None;
+        let editable =
+            std::mem::replace(&mut self.phase, TuiHandoffPhase::Committed { operation_id });
+        let TuiHandoffPhase::Editable { pending, .. } = editable else {
+            unreachable!("confirmed handoff is editable");
+        };
         ctx.notify();
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
@@ -548,9 +604,12 @@ impl TuiHandoffModel {
             }
             match outcome {
                 HandoffCommitOutcome::Rejected { pending, error } => {
-                    model.pending = Some(*pending);
-                    model.phase = TuiHandoffPhase::Acceptance;
-                    model.validation_error = Some(Self::validation_message(&error).to_owned());
+                    model.phase = TuiHandoffPhase::Editable {
+                        state: TuiHandoffEditableState::Acceptance {
+                            validation_error: Some(Self::validation_message(&error).to_owned()),
+                        },
+                        pending: *pending,
+                    };
                     model.refresh_pending_environments(ctx);
                     ctx.emit(TuiHandoffModelEvent::Changed { focus_block: true });
                     ctx.notify();
@@ -584,8 +643,7 @@ impl TuiHandoffModel {
             return;
         }
         let restoration = self
-            .pending
-            .as_mut()
+            .pending_mut()
             .and_then(PendingHandoff::take_restoration);
         self.dismissed = true;
         ctx.emit(TuiHandoffModelEvent::Cancelled(restoration));
@@ -627,12 +685,13 @@ impl TuiHandoffModel {
             .iter()
             .map(|environment| environment.id)
             .collect::<HashSet<_>>();
-        let Some(pending) = self.pending.as_mut() else {
+        let default_environment_id = self.environments.as_ref(ctx).default_environment_id(ctx);
+        let Some(pending) = self.pending_mut() else {
             return;
         };
         pending.set_valid_environment_ids(valid_ids);
         if pending.presentation_snapshot().environment_id.is_none()
-            && let Some(environment_id) = self.environments.as_ref(ctx).default_environment_id(ctx)
+            && let Some(environment_id) = default_environment_id
         {
             pending.set_environment_id(Some(environment_id), false);
         }

--- a/crates/warp_tui/src/handoff/model.rs
+++ b/crates/warp_tui/src/handoff/model.rs
@@ -1,0 +1,657 @@
+//! State and execution model for the TUI local-to-cloud handoff flow.
+//!
+//! The terminal session supplies its concrete terminal/controller handles once
+//! at preparation time. After that, this model owns handoff data, catalog
+//! subscriptions, validation, asynchronous execution, and lifecycle outcomes.
+//! [`super::block::TuiHandoffBlock`] only presents and edits this state.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::FairMutex;
+use warp::settings::{AISettings, PrivacySettings, PrivacySettingsChangedEvent};
+use warp::tui_export::{
+    AIConversationId, AISettingsChangedEvent, AttachmentInput, BlocklistAIContextModel,
+    BlocklistAIController, BlocklistAIHistoryModel, CloudEnvironmentCatalog, HandoffCommitOutcome,
+    HandoffEntryPoint, HandoffLaunchAttachments, HandoffPrepareError, HandoffPrepareInput,
+    HandoffRestoration, HandoffSurface, LLMId, LLMPreferences, LLMPreferencesEvent, OptionRow,
+    OptionSnapshot, OptionSourceStatus, PendingCloudLaunch, PendingHandoff, ServerApiProvider,
+    SnapshotUploadTarget, TerminalModel, UserWorkspaces, UserWorkspacesEvent, execute_handoff,
+    oz_model_snapshot, prepare_handoff, suggest_handoff_environment,
+};
+use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity as _};
+
+/// Editable selector pages in their handoff configuration order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TuiHandoffSelectorKind {
+    Environment,
+    Model,
+}
+
+impl TuiHandoffSelectorKind {
+    /// User-facing question shown above this selector page.
+    pub(crate) fn question(self) -> &'static str {
+        match self {
+            Self::Environment => "Which environment should run this conversation?",
+            Self::Model => "Which model should run this conversation?",
+        }
+    }
+}
+
+/// Model-owned lifecycle state for one handoff.
+#[derive(Debug)]
+pub(crate) enum TuiHandoffPhase {
+    Acceptance,
+    Configuring { page: TuiHandoffSelectorKind },
+    Committed { operation_id: u64 },
+    Created { url: String },
+    Persisted { url: String },
+}
+
+/// Outcomes that require the owning terminal session to change surfaces.
+#[derive(Clone)]
+pub(crate) enum TuiHandoffModelEvent {
+    Changed {
+        focus_block: bool,
+    },
+    Cancelled(Option<HandoffRestoration>),
+    Failed {
+        restoration: Option<HandoffRestoration>,
+        message: String,
+    },
+    ContinueLocally,
+    StartNewConversation,
+}
+
+/// Preparation failure already reduced to the local input and message the TUI
+/// should display.
+pub(crate) struct TuiHandoffPreparationFailure {
+    replacement_input: Option<String>,
+    message: String,
+}
+
+impl TuiHandoffPreparationFailure {
+    pub(crate) fn into_parts(self) -> (Option<String>, String) {
+        (self.replacement_input, self.message)
+    }
+}
+
+/// Model backing one TUI handoff card.
+pub(crate) struct TuiHandoffModel {
+    source_conversation_id: Option<AIConversationId>,
+    pending: Option<PendingHandoff>,
+    phase: TuiHandoffPhase,
+    environments: ModelHandle<CloudEnvironmentCatalog>,
+    forked_existing_conversation: bool,
+    validation_error: Option<String>,
+    next_operation_id: u64,
+    dismissed: bool,
+}
+
+impl TuiHandoffModel {
+    /// Prepares a handoff and registers its retained model.
+    pub(crate) fn new(
+        terminal_surface_id: EntityId,
+        terminal_model: Arc<FairMutex<TerminalModel>>,
+        controller: ModelHandle<BlocklistAIController>,
+        context: ModelHandle<BlocklistAIContextModel>,
+        current_working_directory: Option<String>,
+        argument: Option<String>,
+        ctx: &mut AppContext,
+    ) -> Result<ModelHandle<Self>, TuiHandoffPreparationFailure> {
+        if !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx) {
+            return Err(TuiHandoffPreparationFailure {
+                replacement_input: None,
+                message: "Cloud handoff is unavailable.".to_owned(),
+            });
+        }
+
+        let history = BlocklistAIHistoryModel::handle(ctx);
+        let selected_conversation = history.as_ref(ctx).active_conversation(terminal_surface_id);
+        let source_model_id = selected_conversation
+            .and_then(|conversation| conversation.latest_exchange())
+            .map(|exchange| exchange.model_id.to_string());
+        let source_conversation_id = selected_conversation.map(|conversation| conversation.id());
+        let source_was_active = selected_conversation.is_some_and(|conversation| {
+            conversation.status().is_in_progress() || conversation.status().is_blocked()
+        });
+        let has_long_running_command = terminal_model
+            .lock()
+            .block_list()
+            .active_block()
+            .is_active_and_long_running();
+        if has_long_running_command {
+            return Err(Self::preparation_failure(
+                HandoffPrepareError::LongRunningCommand,
+                source_was_active,
+                argument.as_ref(),
+            ));
+        }
+
+        let launch = PendingCloudLaunch {
+            prompt: argument.clone().unwrap_or_default(),
+            attachments: Self::collect_attachments(&context, ctx),
+        };
+        let provider = ServerApiProvider::as_ref(ctx);
+        let pending = prepare_handoff(
+            HandoffPrepareInput::new(
+                terminal_surface_id,
+                history,
+                controller,
+                context,
+                SnapshotUploadTarget::Local {
+                    ai_client: provider.get_ai_client(),
+                    http: provider.get_http_client(),
+                },
+                HandoffEntryPoint::SlashCommand,
+                HandoffSurface::Tui,
+            )
+            .with_expected_conversation_id(source_conversation_id)
+            .with_current_working_directory(current_working_directory.clone())
+            .with_long_running_command(has_long_running_command)
+            .with_launch(Some(launch))
+            .with_environment_required(true),
+            ctx,
+        )
+        .map_err(|error| Self::preparation_failure(error, source_was_active, argument.as_ref()))?;
+        let mut pending = pending;
+        if let Some(source_model_id) = source_model_id {
+            pending.set_model_id(source_model_id, false, ctx);
+        }
+
+        Ok(ctx.add_model(move |ctx: &mut ModelContext<Self>| {
+            let environments = CloudEnvironmentCatalog::handle(ctx);
+            ctx.subscribe_to_model(&environments, |model, _, _, ctx| {
+                model.handle_environment_change(ctx);
+            });
+            ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |_, _, event, ctx| {
+                if matches!(event, LLMPreferencesEvent::UpdatedAvailableLLMs) {
+                    ctx.emit(TuiHandoffModelEvent::Changed { focus_block: false });
+                    ctx.notify();
+                }
+            });
+            ctx.subscribe_to_model(
+                &AISettings::handle(ctx),
+                |model, _, _: &AISettingsChangedEvent, ctx| {
+                    if model.is_editable() && !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx)
+                    {
+                        model.cancel(ctx);
+                    }
+                },
+            );
+            ctx.subscribe_to_model(&PrivacySettings::handle(ctx), |model, _, event, ctx| {
+                if matches!(
+                    event,
+                    PrivacySettingsChangedEvent::UpdateIsCloudConversationStorageEnabled { .. }
+                ) && model.is_editable()
+                    && !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx)
+                {
+                    model.cancel(ctx);
+                }
+            });
+            ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), |model, _, event, ctx| {
+                if matches!(event, UserWorkspacesEvent::TeamsChanged)
+                    && model.is_editable()
+                    && !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx)
+                {
+                    model.cancel(ctx);
+                }
+            });
+
+            let forked_existing_conversation =
+                pending.presentation_snapshot().forked_existing_conversation;
+            let mut model = Self {
+                source_conversation_id,
+                pending: Some(pending),
+                phase: TuiHandoffPhase::Acceptance,
+                environments,
+                forked_existing_conversation,
+                validation_error: None,
+                next_operation_id: 0,
+                dismissed: false,
+            };
+            model.refresh_pending_environments(ctx);
+
+            if let Some(path) = current_working_directory.map(PathBuf::from) {
+                let suggestion = suggest_handoff_environment(path, ctx);
+                ctx.spawn(suggestion, |model, environment_id, ctx| {
+                    if !model.is_editable() || model.dismissed {
+                        return;
+                    }
+                    if let Some(environment_id) = environment_id
+                        && let Some(pending) = model.pending.as_mut()
+                    {
+                        pending.set_environment_id(Some(environment_id), false);
+                        ctx.emit(TuiHandoffModelEvent::Changed { focus_block: false });
+                        ctx.notify();
+                    }
+                });
+            }
+            model
+        }))
+    }
+
+    fn collect_attachments(
+        context: &ModelHandle<BlocklistAIContextModel>,
+        ctx: &AppContext,
+    ) -> HandoffLaunchAttachments {
+        let context = context.as_ref(ctx);
+        let request_attachments = context
+            .pending_images()
+            .into_iter()
+            .map(|image| AttachmentInput {
+                file_name: image.file_name.clone(),
+                mime_type: image.mime_type.clone(),
+                data: image.data.clone(),
+            })
+            .collect();
+        HandoffLaunchAttachments {
+            request_attachments,
+            display_attachments: context.pending_attachments().to_vec(),
+        }
+    }
+
+    fn preparation_failure(
+        error: HandoffPrepareError,
+        source_was_active: bool,
+        argument: Option<&String>,
+    ) -> TuiHandoffPreparationFailure {
+        let replacement_input = (source_was_active
+            && matches!(error, HandoffPrepareError::MissingServerConversationToken))
+        .then(|| {
+            argument
+                .map(|argument| argument.trim())
+                .unwrap_or_default()
+                .to_owned()
+        });
+        TuiHandoffPreparationFailure {
+            replacement_input,
+            message: Self::prepare_error_message(&error).to_owned(),
+        }
+    }
+
+    fn prepare_error_message(error: &HandoffPrepareError) -> &'static str {
+        match error {
+            HandoffPrepareError::LongRunningCommand => {
+                "Can't hand off while a command is running. Cancel it or wait for it to finish."
+            }
+            HandoffPrepareError::ActiveOrBlockedChild => {
+                "Can't hand off while child work is active or waiting for input."
+            }
+            HandoffPrepareError::EmptySourceAndPrompt => {
+                "Nothing to hand off — start a conversation or add a prompt."
+            }
+            HandoffPrepareError::MissingServerConversationToken => {
+                "This conversation hasn't synced yet. Send another message, then try again."
+            }
+            HandoffPrepareError::InvalidModel => "The selected model can't run in Oz cloud.",
+            HandoffPrepareError::SourceConversationChanged
+            | HandoffPrepareError::SourceNotInProgress
+            | HandoffPrepareError::HandoffDisabled
+            | HandoffPrepareError::MissingRequiredEnvironment
+            | HandoffPrepareError::InvalidEnvironment => {
+                "Couldn't start the handoff. Check the current conversation and try again."
+            }
+        }
+    }
+
+    fn validation_message(error: &HandoffPrepareError) -> &'static str {
+        match error {
+            HandoffPrepareError::MissingRequiredEnvironment => {
+                "Select an environment before starting the handoff."
+            }
+            HandoffPrepareError::InvalidEnvironment => {
+                "The selected environment is no longer available."
+            }
+            HandoffPrepareError::InvalidModel => {
+                "The selected model cannot run in Oz cloud. Choose a compatible model."
+            }
+            HandoffPrepareError::HandoffDisabled => "Cloud handoff is no longer available.",
+            HandoffPrepareError::SourceConversationChanged
+            | HandoffPrepareError::EmptySourceAndPrompt
+            | HandoffPrepareError::SourceNotInProgress
+            | HandoffPrepareError::LongRunningCommand
+            | HandoffPrepareError::ActiveOrBlockedChild
+            | HandoffPrepareError::MissingServerConversationToken => {
+                "The handoff can no longer start. Return to local input and try again."
+            }
+        }
+    }
+
+    pub(crate) fn phase(&self) -> &TuiHandoffPhase {
+        &self.phase
+    }
+
+    pub(crate) fn source_conversation_id(&self) -> Option<AIConversationId> {
+        self.source_conversation_id
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        !self.dismissed && !matches!(self.phase, TuiHandoffPhase::Persisted { .. })
+    }
+
+    pub(crate) fn is_editable(&self) -> bool {
+        matches!(
+            self.phase,
+            TuiHandoffPhase::Acceptance | TuiHandoffPhase::Configuring { .. }
+        )
+    }
+
+    pub(crate) fn no_environments(&self, ctx: &AppContext) -> bool {
+        self.environments.as_ref(ctx).environments().is_empty()
+    }
+
+    pub(crate) fn forked_existing_conversation(&self) -> bool {
+        self.forked_existing_conversation
+    }
+
+    pub(crate) fn validation_error(&self) -> Option<&str> {
+        self.validation_error.as_deref()
+    }
+
+    pub(crate) fn url(&self) -> Option<&str> {
+        match &self.phase {
+            TuiHandoffPhase::Created { url } | TuiHandoffPhase::Persisted { url } => Some(url),
+            TuiHandoffPhase::Acceptance
+            | TuiHandoffPhase::Configuring { .. }
+            | TuiHandoffPhase::Committed { .. } => None,
+        }
+    }
+
+    pub(crate) fn selector_snapshot(
+        &self,
+        page: TuiHandoffSelectorKind,
+        ctx: &AppContext,
+    ) -> OptionSnapshot {
+        match page {
+            TuiHandoffSelectorKind::Environment => self.environment_snapshot(ctx),
+            TuiHandoffSelectorKind::Model => self.model_snapshot(ctx),
+        }
+    }
+
+    fn environment_snapshot(&self, ctx: &AppContext) -> OptionSnapshot {
+        let selected_id = self
+            .pending
+            .as_ref()
+            .and_then(|pending| pending.presentation_snapshot().environment_id)
+            .map(|id| id.to_string());
+        let rows = self
+            .environments
+            .as_ref(ctx)
+            .environments()
+            .iter()
+            .map(|environment| OptionRow {
+                id: environment.id.to_string(),
+                label: environment.name.clone(),
+                harness: None,
+                badge: None,
+                disabled_reason: None,
+            })
+            .collect::<Vec<_>>();
+        let selected_id =
+            selected_id.filter(|selected_id| rows.iter().any(|row| row.id == *selected_id));
+        OptionSnapshot {
+            status: if rows.is_empty() {
+                OptionSourceStatus::Empty {
+                    message: "No cloud environments available".to_owned(),
+                }
+            } else {
+                OptionSourceStatus::Ready
+            },
+            rows,
+            selected_id,
+            footer: None,
+        }
+    }
+
+    fn model_snapshot(&self, ctx: &AppContext) -> OptionSnapshot {
+        let selected_model_id = self
+            .pending
+            .as_ref()
+            .expect("editable handoff has pending state")
+            .presentation_snapshot()
+            .model_id;
+        oz_model_snapshot(&selected_model_id, false, ctx)
+    }
+
+    pub(crate) fn environment_label(&self, ctx: &AppContext) -> String {
+        let selected = self
+            .pending
+            .as_ref()
+            .and_then(|pending| pending.presentation_snapshot().environment_id);
+        selected
+            .and_then(|selected| {
+                self.environments
+                    .as_ref(ctx)
+                    .environments()
+                    .iter()
+                    .find(|environment| environment.id == selected)
+                    .map(|environment| environment.name.clone())
+            })
+            .unwrap_or_else(|| "Select an environment".to_owned())
+    }
+
+    pub(crate) fn model_label(&self, ctx: &AppContext) -> String {
+        let Some(pending) = self.pending.as_ref() else {
+            return String::new();
+        };
+        let presentation = pending.presentation_snapshot();
+        let snapshot = self.model_snapshot(ctx);
+        let label = snapshot
+            .rows
+            .iter()
+            .find(|row| row.id == presentation.model_id)
+            .map(|row| row.label.clone())
+            .unwrap_or_else(|| presentation.model_id.clone());
+        if !LLMPreferences::as_ref(ctx)
+            .is_cloud_runnable_oz_model_id(&LLMId::from(presentation.model_id.as_str()))
+        {
+            format!("{label} (incompatible)")
+        } else {
+            label
+        }
+    }
+
+    pub(crate) fn open_page(
+        &mut self,
+        page: TuiHandoffSelectorKind,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        if !self.is_editable()
+            || (page == TuiHandoffSelectorKind::Environment && self.no_environments(ctx))
+        {
+            return false;
+        }
+        self.phase = TuiHandoffPhase::Configuring { page };
+        self.validation_error = None;
+        ctx.notify();
+        true
+    }
+
+    pub(crate) fn return_to_acceptance(&mut self, ctx: &mut ModelContext<Self>) {
+        self.phase = TuiHandoffPhase::Acceptance;
+        ctx.notify();
+    }
+
+    pub(crate) fn apply_selection(
+        &mut self,
+        page: TuiHandoffSelectorKind,
+        id: &str,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let Some(pending) = self.pending.as_mut() else {
+            return false;
+        };
+        match page {
+            TuiHandoffSelectorKind::Environment => {
+                let environment_id = self
+                    .environments
+                    .as_ref(ctx)
+                    .environments()
+                    .iter()
+                    .find(|environment| environment.id.to_string() == id)
+                    .map(|environment| environment.id);
+                let Some(environment_id) = environment_id else {
+                    return false;
+                };
+                pending.set_environment_id(Some(environment_id), true);
+                self.environments.update(ctx, |catalog, ctx| {
+                    catalog.persist_selection(environment_id, ctx);
+                });
+            }
+            TuiHandoffSelectorKind::Model => {
+                pending.set_model_id(id.to_owned(), true, ctx);
+            }
+        }
+        ctx.notify();
+        true
+    }
+
+    pub(crate) fn confirm(&mut self, ctx: &mut ModelContext<Self>) {
+        if !matches!(self.phase, TuiHandoffPhase::Acceptance) || self.no_environments(ctx) {
+            return;
+        }
+        let validation = self
+            .pending
+            .as_ref()
+            .expect("configuring handoff has pending state")
+            .validate();
+        if let Err(error) = validation {
+            self.validation_error = Some(Self::validation_message(&error).to_owned());
+            ctx.emit(TuiHandoffModelEvent::Changed { focus_block: false });
+            ctx.notify();
+            return;
+        }
+
+        let pending = self
+            .pending
+            .take()
+            .expect("configuring handoff has pending state");
+        self.next_operation_id = self.next_operation_id.wrapping_add(1);
+        let operation_id = self.next_operation_id;
+        self.phase = TuiHandoffPhase::Committed { operation_id };
+        self.validation_error = None;
+        ctx.notify();
+
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let execution = execute_handoff(pending, ai_client, None, ctx);
+        ctx.spawn(execution, move |model, outcome, ctx| {
+            if !matches!(
+                model.phase,
+                TuiHandoffPhase::Committed {
+                    operation_id: active_operation_id
+                } if active_operation_id == operation_id
+            ) || model.dismissed
+            {
+                return;
+            }
+            match outcome {
+                HandoffCommitOutcome::Rejected { pending, error } => {
+                    model.pending = Some(*pending);
+                    model.phase = TuiHandoffPhase::Acceptance;
+                    model.validation_error = Some(Self::validation_message(&error).to_owned());
+                    model.refresh_pending_environments(ctx);
+                    ctx.emit(TuiHandoffModelEvent::Changed { focus_block: true });
+                    ctx.notify();
+                }
+                HandoffCommitOutcome::Failed(failure) => {
+                    model.dismissed = true;
+                    ctx.emit(TuiHandoffModelEvent::Failed {
+                        restoration: failure.restoration,
+                        message:
+                            "Couldn't start the handoff. Check your network connection and try again."
+                                .to_owned(),
+                    });
+                    ctx.notify();
+                }
+                HandoffCommitOutcome::Cancelled => {
+                    model.dismissed = true;
+                    ctx.emit(TuiHandoffModelEvent::Cancelled(None));
+                    ctx.notify();
+                }
+                HandoffCommitOutcome::Created(created) => {
+                    model.phase = TuiHandoffPhase::Created { url: created.url };
+                    ctx.emit(TuiHandoffModelEvent::Changed { focus_block: true });
+                    ctx.notify();
+                }
+            }
+        });
+    }
+
+    pub(crate) fn cancel(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_editable() || self.dismissed {
+            return;
+        }
+        let restoration = self
+            .pending
+            .as_mut()
+            .and_then(PendingHandoff::take_restoration);
+        self.dismissed = true;
+        ctx.emit(TuiHandoffModelEvent::Cancelled(restoration));
+        ctx.notify();
+    }
+
+    pub(crate) fn continue_locally(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiHandoffPhase::Created { url } = &self.phase else {
+            return;
+        };
+        if !self.forked_existing_conversation || self.dismissed {
+            return;
+        }
+        self.phase = TuiHandoffPhase::Persisted { url: url.clone() };
+        ctx.emit(TuiHandoffModelEvent::ContinueLocally);
+        ctx.notify();
+    }
+
+    pub(crate) fn start_new_conversation(&mut self, ctx: &mut ModelContext<Self>) {
+        if !matches!(self.phase, TuiHandoffPhase::Created { .. }) || self.dismissed {
+            return;
+        }
+        self.dismissed = true;
+        ctx.emit(TuiHandoffModelEvent::StartNewConversation);
+        ctx.notify();
+    }
+
+    pub(crate) fn refresh_environments(&self, ctx: &mut ModelContext<Self>) {
+        self.environments.update(ctx, |catalog, ctx| {
+            catalog.refresh_from_server(ctx);
+        });
+    }
+
+    fn refresh_pending_environments(&mut self, ctx: &AppContext) {
+        let valid_ids = self
+            .environments
+            .as_ref(ctx)
+            .environments()
+            .iter()
+            .map(|environment| environment.id)
+            .collect::<HashSet<_>>();
+        let Some(pending) = self.pending.as_mut() else {
+            return;
+        };
+        pending.set_valid_environment_ids(valid_ids);
+        if pending.presentation_snapshot().environment_id.is_none()
+            && let Some(environment_id) = self.environments.as_ref(ctx).default_environment_id(ctx)
+        {
+            pending.set_environment_id(Some(environment_id), false);
+        }
+    }
+
+    fn handle_environment_change(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_editable() {
+            return;
+        }
+        self.refresh_pending_environments(ctx);
+        ctx.emit(TuiHandoffModelEvent::Changed { focus_block: false });
+        ctx.notify();
+    }
+}
+
+impl Entity for TuiHandoffModel {
+    type Event = TuiHandoffModelEvent;
+}
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/handoff/model.rs
+++ b/crates/warp_tui/src/handoff/model.rs
@@ -50,7 +50,7 @@ pub(crate) enum TuiHandoffEditableState {
 pub(crate) enum TuiHandoffPhase {
     Editable {
         state: TuiHandoffEditableState,
-        pending: PendingHandoff,
+        pending: Box<PendingHandoff>,
     },
     Committed {
         operation_id: u64,
@@ -219,7 +219,7 @@ impl TuiHandoffModel {
                     state: TuiHandoffEditableState::Acceptance {
                         validation_error: None,
                     },
-                    pending,
+                    pending: Box::new(pending),
                 },
                 environments,
                 forked_existing_conversation,
@@ -383,7 +383,7 @@ impl TuiHandoffModel {
 
     fn pending(&self) -> Option<&PendingHandoff> {
         match &self.phase {
-            TuiHandoffPhase::Editable { pending, .. } => Some(pending),
+            TuiHandoffPhase::Editable { pending, .. } => Some(pending.as_ref()),
             TuiHandoffPhase::Committed { .. }
             | TuiHandoffPhase::Created { .. }
             | TuiHandoffPhase::Persisted { .. } => None,
@@ -392,7 +392,7 @@ impl TuiHandoffModel {
 
     fn pending_mut(&mut self) -> Option<&mut PendingHandoff> {
         match &mut self.phase {
-            TuiHandoffPhase::Editable { pending, .. } => Some(pending),
+            TuiHandoffPhase::Editable { pending, .. } => Some(pending.as_mut()),
             TuiHandoffPhase::Committed { .. }
             | TuiHandoffPhase::Created { .. }
             | TuiHandoffPhase::Persisted { .. } => None,
@@ -591,7 +591,7 @@ impl TuiHandoffModel {
         ctx.notify();
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        let execution = execute_handoff(pending, ai_client, None, ctx);
+        let execution = execute_handoff(*pending, ai_client, None, ctx);
         ctx.spawn(execution, move |model, outcome, ctx| {
             if !matches!(
                 model.phase,
@@ -608,7 +608,7 @@ impl TuiHandoffModel {
                         state: TuiHandoffEditableState::Acceptance {
                             validation_error: Some(Self::validation_message(&error).to_owned()),
                         },
-                        pending: *pending,
+                        pending,
                     };
                     model.refresh_pending_environments(ctx);
                     ctx.emit(TuiHandoffModelEvent::Changed { focus_block: true });

--- a/crates/warp_tui/src/handoff/model_tests.rs
+++ b/crates/warp_tui/src/handoff/model_tests.rs
@@ -1,56 +1,6 @@
-use warp::tui_export::{
-    CloudEnvironmentCatalog, HandoffPrepareError, register_tui_session_view_test_singletons,
-};
-use warpui::platform::WindowStyle;
-use warpui::{AddWindowOptions, App, SingletonEntity as _, TuiView as _};
+use warp::tui_export::HandoffPrepareError;
 
-use super::{TuiHandoffModel, TuiHandoffPhase};
-use crate::handoff::TuiHandoffBlock;
-use crate::test_fixtures::TestHostView;
-
-#[test]
-fn focusing_a_configuring_block_delegates_to_the_selector() {
-    App::test((), |mut app| async move {
-        register_tui_session_view_test_singletons(&mut app);
-        let model = app.add_model(|ctx| TuiHandoffModel {
-            source_conversation_id: None,
-            pending: None,
-            phase: TuiHandoffPhase::Configuring {
-                page: super::TuiHandoffSelectorKind::Model,
-            },
-            environments: CloudEnvironmentCatalog::handle(ctx),
-            forked_existing_conversation: false,
-            validation_error: None,
-            next_operation_id: 0,
-            dismissed: false,
-        });
-        let block = app.update(|ctx| {
-            let (window_id, _) = ctx.add_tui_window(
-                AddWindowOptions {
-                    window_style: WindowStyle::NotStealFocus,
-                    ..Default::default()
-                },
-                |_| TestHostView,
-            );
-            ctx.add_typed_action_tui_view(window_id, |ctx| TuiHandoffBlock::new(model, ctx))
-        });
-        let (window_id, selector_id) = app.read(|ctx| {
-            (
-                block.window_id(ctx),
-                block
-                    .as_ref(ctx)
-                    .child_view_ids(ctx)
-                    .into_iter()
-                    .next()
-                    .expect("handoff block has a selector"),
-            )
-        });
-
-        block.update(&mut app, |_, ctx| ctx.focus_self());
-
-        assert_eq!(app.focused_view_id(window_id), Some(selector_id));
-    });
-}
+use super::TuiHandoffModel;
 
 #[test]
 fn missing_token_after_eager_cancellation_restores_only_trimmed_argument() {

--- a/crates/warp_tui/src/handoff/model_tests.rs
+++ b/crates/warp_tui/src/handoff/model_tests.rs
@@ -1,0 +1,95 @@
+use warp::tui_export::{
+    CloudEnvironmentCatalog, HandoffPrepareError, register_tui_session_view_test_singletons,
+};
+use warpui::platform::WindowStyle;
+use warpui::{AddWindowOptions, App, SingletonEntity as _, TuiView as _};
+
+use super::{TuiHandoffModel, TuiHandoffPhase};
+use crate::handoff::TuiHandoffBlock;
+use crate::test_fixtures::TestHostView;
+
+#[test]
+fn focusing_a_configuring_block_delegates_to_the_selector() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        let model = app.add_model(|ctx| TuiHandoffModel {
+            source_conversation_id: None,
+            pending: None,
+            phase: TuiHandoffPhase::Configuring {
+                page: super::TuiHandoffSelectorKind::Model,
+            },
+            environments: CloudEnvironmentCatalog::handle(ctx),
+            forked_existing_conversation: false,
+            validation_error: None,
+            next_operation_id: 0,
+            dismissed: false,
+        });
+        let block = app.update(|ctx| {
+            let (window_id, _) = ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |_| TestHostView,
+            );
+            ctx.add_typed_action_tui_view(window_id, |ctx| TuiHandoffBlock::new(model, ctx))
+        });
+        let (window_id, selector_id) = app.read(|ctx| {
+            (
+                block.window_id(ctx),
+                block
+                    .as_ref(ctx)
+                    .child_view_ids(ctx)
+                    .into_iter()
+                    .next()
+                    .expect("handoff block has a selector"),
+            )
+        });
+
+        block.update(&mut app, |_, ctx| ctx.focus_self());
+
+        assert_eq!(app.focused_view_id(window_id), Some(selector_id));
+    });
+}
+
+#[test]
+fn missing_token_after_eager_cancellation_restores_only_trimmed_argument() {
+    let argument = "  keep this prompt  ".to_owned();
+    let (replacement, _) = TuiHandoffModel::preparation_failure(
+        HandoffPrepareError::MissingServerConversationToken,
+        true,
+        Some(&argument),
+    )
+    .into_parts();
+    assert_eq!(replacement.as_deref(), Some("keep this prompt"));
+
+    let (replacement, _) = TuiHandoffModel::preparation_failure(
+        HandoffPrepareError::MissingServerConversationToken,
+        true,
+        None,
+    )
+    .into_parts();
+    assert_eq!(replacement.as_deref(), Some(""));
+
+    let (replacement, _) = TuiHandoffModel::preparation_failure(
+        HandoffPrepareError::LongRunningCommand,
+        true,
+        Some(&argument),
+    )
+    .into_parts();
+    assert!(
+        replacement.is_none(),
+        "pre-cancellation guard failures keep the full slash command draft"
+    );
+
+    let (replacement, _) = TuiHandoffModel::preparation_failure(
+        HandoffPrepareError::MissingServerConversationToken,
+        false,
+        Some(&argument),
+    )
+    .into_parts();
+    assert!(
+        replacement.is_none(),
+        "idle missing-token failures did not eagerly cancel the source"
+    );
+}

--- a/crates/warp_tui/src/handoff/session.rs
+++ b/crates/warp_tui/src/handoff/session.rs
@@ -1,0 +1,124 @@
+//! Local-to-cloud handoff coordination for a TUI terminal session.
+//!
+//! [`TuiHandoffModel`] owns handoff state and execution. This module owns the
+//! active card's lifetime within the session surface and applies
+//! session-specific outcomes such as restoring input or persisting the
+//! completed card into the transcript.
+
+use warp::tui_export::{HandoffRestoration, record_static_slash_command_accepted};
+use warpui_core::{AppContext, ViewContext, ViewHandle};
+
+use super::TuiTerminalSessionView;
+use crate::handoff::{
+    TuiHandoffBlock, TuiHandoffBlockEvent, TuiHandoffModel, TuiHandoffModelEvent,
+};
+
+impl TuiTerminalSessionView {
+    pub(super) fn active_handoff(&self, ctx: &AppContext) -> Option<ViewHandle<TuiHandoffBlock>> {
+        let handoff = self.handoff.as_ref()?;
+        handoff.as_ref(ctx).is_active(ctx).then(|| handoff.clone())
+    }
+
+    pub(super) fn start_handoff(&mut self, argument: Option<&String>, ctx: &mut ViewContext<Self>) {
+        if self
+            .session_state(ctx)
+            .is_ok_and(|state| state.has_blocking_interaction())
+        {
+            return;
+        }
+        let current_working_directory = self.current_working_directory(ctx);
+        let model = match TuiHandoffModel::new(
+            self.terminal_surface_id,
+            self.terminal_model.clone(),
+            self.ai_controller.clone(),
+            self.ai_context_model.clone(),
+            current_working_directory,
+            argument.cloned(),
+            ctx,
+        ) {
+            Ok(model) => model,
+            Err(failure) => {
+                let (replacement_input, message) = failure.into_parts();
+                if let Some(input) = replacement_input {
+                    self.input_view.update(ctx, |input_view, ctx| {
+                        input_view.set_text(&input, ctx);
+                    });
+                }
+                self.show_transient_hint(message, ctx);
+                return;
+            }
+        };
+
+        self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+        let model_for_view = model.clone();
+        let handoff_block =
+            ctx.add_typed_action_tui_view(move |ctx| TuiHandoffBlock::new(model_for_view, ctx));
+        let handoff_block_for_events = handoff_block.clone();
+        ctx.subscribe_to_model(&model, move |view, _, event, ctx| {
+            view.handle_handoff_model_event(&handoff_block_for_events, event, ctx);
+        });
+        ctx.subscribe_to_view(&handoff_block, |_, _, event, ctx| match event {
+            TuiHandoffBlockEvent::LayoutInvalidated => ctx.notify(),
+        });
+        self.handoff = Some(handoff_block);
+        self.refresh_input_focus(ctx);
+        record_static_slash_command_accepted("/handoff", true, ctx);
+    }
+
+    fn restore_handoff_input(
+        &mut self,
+        restoration: &HandoffRestoration,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.input_view.update(ctx, |input, ctx| {
+            input.set_text(&restoration.prompt, ctx);
+        });
+        if !restoration.attachments.is_empty() {
+            self.ai_context_model.update(ctx, |context, ctx| {
+                context.append_pending_attachments(restoration.attachments.clone(), ctx);
+            });
+        }
+    }
+
+    fn clear_handoff_interaction(&mut self) {
+        self.handoff = None;
+    }
+
+    fn handle_handoff_model_event(
+        &mut self,
+        handoff_block: &ViewHandle<TuiHandoffBlock>,
+        event: &TuiHandoffModelEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            TuiHandoffModelEvent::Changed { .. } => return,
+            TuiHandoffModelEvent::Cancelled(restoration) => {
+                self.clear_handoff_interaction();
+                if let Some(restoration) = restoration {
+                    self.restore_handoff_input(restoration, ctx);
+                }
+            }
+            TuiHandoffModelEvent::Failed {
+                restoration,
+                message,
+            } => {
+                self.clear_handoff_interaction();
+                if let Some(restoration) = restoration {
+                    self.restore_handoff_input(restoration, ctx);
+                }
+                self.show_transient_hint(message.clone(), ctx);
+            }
+            TuiHandoffModelEvent::ContinueLocally => {
+                self.clear_handoff_interaction();
+                self.transcript.update(ctx, |transcript, ctx| {
+                    transcript.attach_handoff(handoff_block.clone(), ctx);
+                });
+            }
+            TuiHandoffModelEvent::StartNewConversation => {
+                self.clear_handoff_interaction();
+                self.start_new_conversation(None, ctx);
+            }
+        }
+        self.refresh_input_focus(ctx);
+    }
+}

--- a/crates/warp_tui/src/handoff/tests.rs
+++ b/crates/warp_tui/src/handoff/tests.rs
@@ -1,0 +1,311 @@
+use warp::settings::AISettings;
+use warp::tui_export::{
+    ImageContext, ParsedSlashCommandInput, PendingAttachment, SlashCommandDataSource as _,
+    register_tui_session_view_test_singletons, slash_commands,
+};
+use warp_core::features::FeatureFlag;
+use warp_core::settings::Setting as _;
+use warp_editor::model::CoreEditorModel;
+use warpui::platform::WindowStyle;
+use warpui::{
+    AddWindowOptions, App, SingletonEntity, TuiView as _, ViewHandle, WindowInvalidation,
+};
+use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::keymap::Keystroke;
+use warpui_core::presenter::tui::TuiPresenter;
+
+use super::TuiTerminalSessionView;
+use crate::autoupdate::TuiAutoupdater;
+use crate::handoff::TuiHandoffBlock;
+use crate::orchestration_model::TuiOrchestrationModel;
+use crate::root_view::RootTuiView;
+use crate::session_registry::TuiSessions;
+use crate::test_fixtures::{add_test_semantic_selection, add_test_terminal_session};
+
+struct Fixture {
+    view: ViewHandle<TuiTerminalSessionView>,
+    window_id: warpui_core::WindowId,
+}
+
+fn fixture(app: &mut App) -> Fixture {
+    register_tui_session_view_test_singletons(app);
+    add_test_semantic_selection(app);
+    app.update(TuiAutoupdater::register);
+    app.update(crate::keybindings::init);
+    let (window_id, _) = app.update(|ctx| {
+        ctx.add_tui_window(
+            AddWindowOptions {
+                window_style: WindowStyle::NotStealFocus,
+                ..Default::default()
+            },
+            |_| RootTuiView::new(),
+        )
+    });
+    let sessions = app.add_singleton_model(|_| TuiSessions::new_for_test());
+    let orchestration = app.update(TuiOrchestrationModel::register);
+    app.update(|ctx| TuiSessions::wire_orchestration(&sessions, &orchestration, ctx));
+    let (view, manager) = add_test_terminal_session(app, window_id);
+    app.update(|ctx| {
+        TuiSessions::register_session(&sessions, view.clone(), manager, true, ctx);
+    });
+    Fixture { view, window_id }
+}
+
+fn dispatch(
+    app: &mut App,
+    window_id: warpui_core::WindowId,
+    path: &[warpui_core::EntityId],
+    key: &str,
+) -> bool {
+    app.dispatch_keystroke(
+        window_id,
+        path,
+        &Keystroke::parse(key).expect("valid keystroke"),
+        false,
+    )
+    .expect("keystroke dispatch succeeds")
+}
+
+fn submit_handoff(app: &mut App, fixture: &Fixture, text: &str) -> ViewHandle<TuiHandoffBlock> {
+    fixture.view.update(app, |view, ctx| {
+        view.input_view.update(ctx, |input, ctx| {
+            input.set_text(text, ctx);
+        });
+        ctx.focus(&view.input_view);
+    });
+    let input_id = fixture.view.read(app, |view, _| view.input_view.id());
+    assert!(dispatch(
+        app,
+        fixture.window_id,
+        &[fixture.view.id(), input_id],
+        "enter",
+    ));
+    fixture.view.read(app, |view, ctx| {
+        view.active_handoff(ctx).expect("handoff card is installed")
+    })
+}
+
+fn input_text(app: &App, fixture: &Fixture) -> String {
+    fixture.view.read(app, |view, ctx| {
+        view.input_view
+            .as_ref(ctx)
+            .model()
+            .as_ref(ctx)
+            .content()
+            .as_ref(ctx)
+            .text()
+            .into_string()
+    })
+}
+
+fn render_session(app: &mut App, fixture: &Fixture) -> Vec<String> {
+    let mut presenter = TuiPresenter::new();
+    app.update(|ctx| {
+        let mut invalidation = WindowInvalidation::default();
+        invalidation.updated.insert(fixture.view.id());
+        let session = fixture.view.as_ref(ctx);
+        invalidation.updated.extend(session.child_view_ids(ctx));
+        invalidation
+            .updated
+            .extend(session.transcript.as_ref(ctx).child_view_ids(ctx));
+        if let Some(handoff) = session.active_handoff(ctx) {
+            invalidation
+                .updated
+                .extend(handoff.as_ref(ctx).child_view_ids(ctx));
+        }
+        presenter.invalidate(&invalidation, ctx, fixture.window_id);
+        presenter
+            .present(ctx, &fixture.view, TuiRect::new(0, 0, 100, 40))
+            .buffer
+            .to_lines()
+    })
+}
+
+#[test]
+fn slash_menu_selection_inserts_handoff_for_optional_prompt_composition() {
+    let _oz_handoff = FeatureFlag::OzHandoff.override_enabled(true);
+    let _local_cloud = FeatureFlag::HandoffLocalCloud.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = fixture(&mut app);
+        fixture.view.update(&mut app, |view, ctx| {
+            view.select_tui_slash_command(&slash_commands::MOVE_TO_CLOUD, ctx);
+        });
+        assert_eq!(input_text(&app, &fixture), "/handoff ");
+    });
+}
+
+#[test]
+fn no_environment_card_has_top_padding_and_ctrl_c_restores_prompt_and_images() {
+    let _oz_handoff = FeatureFlag::OzHandoff.override_enabled(true);
+    let _local_cloud = FeatureFlag::HandoffLocalCloud.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = fixture(&mut app);
+        fixture.view.update(&mut app, |view, ctx| {
+            view.ai_context_model.update(ctx, |context, ctx| {
+                context.append_pending_attachments(
+                    vec![PendingAttachment::Image(ImageContext {
+                        data: "aW1hZ2U=".to_owned(),
+                        mime_type: "image/png".to_owned(),
+                        file_name: "context.png".to_owned(),
+                        is_figma: false,
+                    })],
+                    ctx,
+                );
+            });
+        });
+        let handoff = submit_handoff(&mut app, &fixture, "/handoff finish the task");
+
+        assert_eq!(input_text(&app, &fixture), "");
+        fixture.view.read(&app, |view, ctx| {
+            assert!(
+                view.ai_context_model
+                    .as_ref(ctx)
+                    .pending_attachments()
+                    .is_empty()
+            );
+        });
+        let lines = render_session(&mut app, &fixture).join("\n");
+        assert!(lines.contains("Hand off to cloud"), "{lines}");
+        assert!(lines.contains("A cloud environment is required"), "{lines}");
+        assert!(lines.contains("Enter open environments"), "{lines}");
+        assert!(!lines.contains("finish the task"), "{lines}");
+        let title_row = lines
+            .lines()
+            .position(|line| line.contains("Hand off to cloud"))
+            .expect("handoff title renders");
+        assert!(
+            lines
+                .lines()
+                .nth(title_row.saturating_sub(1))
+                .is_some_and(|line| line.trim().is_empty()),
+            "the handoff card has a blank row above it:\n{lines}"
+        );
+
+        assert!(dispatch(
+            &mut app,
+            fixture.window_id,
+            &[fixture.view.id(), handoff.id()],
+            "ctrl-c",
+        ));
+        assert_eq!(input_text(&app, &fixture), "finish the task");
+        fixture.view.read(&app, |view, ctx| {
+            assert_eq!(
+                view.ai_context_model
+                    .as_ref(ctx)
+                    .pending_attachments()
+                    .len(),
+                1
+            );
+            assert!(
+                view.terminal_model
+                    .lock()
+                    .block_list()
+                    .rich_content_row_range(handoff.id())
+                    .is_none()
+            );
+            assert!(view.active_handoff(ctx).is_none());
+            assert!(
+                !view
+                    .session_state(ctx)
+                    .expect("session state resolves")
+                    .has_blocking_interaction()
+            );
+        });
+    });
+}
+
+#[test]
+fn settings_invalidation_restores_the_draft_and_repeated_submission_keeps_one_card() {
+    let _oz_handoff = FeatureFlag::OzHandoff.override_enabled(true);
+    let _local_cloud = FeatureFlag::HandoffLocalCloud.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = fixture(&mut app);
+        let handoff = submit_handoff(&mut app, &fixture, "/handoff preserve me");
+        fixture.view.update(&mut app, |view, ctx| {
+            view.execute_tui_slash_command(
+                &slash_commands::MOVE_TO_CLOUD,
+                Some(&"second".to_owned()),
+                ctx,
+            );
+        });
+        fixture.view.read(&app, |view, ctx| {
+            assert_eq!(
+                view.active_handoff(ctx).map(|view| view.id()),
+                Some(handoff.id())
+            );
+        });
+
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .should_force_disable_cloud_handoff
+                .set_value(true, ctx)
+                .expect("test setting persists");
+        });
+        assert_eq!(input_text(&app, &fixture), "preserve me");
+        fixture.view.read(&app, |view, ctx| {
+            assert!(view.active_handoff(ctx).is_none());
+        });
+    });
+}
+
+#[test]
+fn privacy_invalidation_restores_the_draft_and_removes_handoff_from_commands() {
+    let _oz_handoff = FeatureFlag::OzHandoff.override_enabled(true);
+    let _local_cloud = FeatureFlag::HandoffLocalCloud.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = fixture(&mut app);
+        submit_handoff(&mut app, &fixture, "/handoff preserve privacy draft");
+
+        warp::settings::PrivacySettings::handle(&app).update(&mut app, |privacy_settings, ctx| {
+            privacy_settings.is_cloud_conversation_storage_enabled = false;
+            ctx.emit(
+                warp::settings::PrivacySettingsChangedEvent::UpdateIsCloudConversationStorageEnabled {
+                    old_value: true,
+                    new_value: false,
+                },
+            );
+        });
+
+        assert_eq!(input_text(&app, &fixture), "preserve privacy draft");
+        fixture.view.read(&app, |view, ctx| {
+            assert!(view.active_handoff(ctx).is_none());
+            assert!(!matches!(
+                view.slash_commands_source
+                    .as_ref(ctx)
+                    .parse_input("/handoff another", ctx),
+                ParsedSlashCommandInput::SlashCommand(_)
+            ));
+        });
+    });
+}
+
+#[test]
+fn long_running_command_rejection_preserves_the_full_local_draft() {
+    let _oz_handoff = FeatureFlag::OzHandoff.override_enabled(true);
+    let _local_cloud = FeatureFlag::HandoffLocalCloud.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = fixture(&mut app);
+        fixture.view.update(&mut app, |view, ctx| {
+            view.terminal_model
+                .lock()
+                .simulate_long_running_block("sleep 30", "");
+            view.input_view.update(ctx, |input, ctx| {
+                input.set_text("/handoff keep this prompt", ctx);
+            });
+            view.execute_tui_slash_command(
+                &slash_commands::MOVE_TO_CLOUD,
+                Some(&"keep this prompt".to_owned()),
+                ctx,
+            );
+        });
+        assert_eq!(input_text(&app, &fixture), "/handoff keep this prompt");
+        fixture.view.read(&app, |view, ctx| {
+            assert!(view.active_handoff(ctx).is_none());
+            assert!(
+                view.transient_hint
+                    .current()
+                    .is_some_and(|(message, _)| message.contains("command is running"))
+            );
+        });
+    });
+}

--- a/crates/warp_tui/src/keybindings.rs
+++ b/crates/warp_tui/src/keybindings.rs
@@ -29,6 +29,7 @@ use crate::attachment_bar::TuiAttachmentBar;
 use crate::cloud_run_view::TuiCloudRunView;
 use crate::editor_interaction::{TuiEditorBindingTarget, TuiEditorCommand, editor_binding_specs};
 use crate::editor_view::{TuiEditorView, TuiEditorViewAction};
+use crate::handoff::TuiHandoffBlock;
 use crate::input::TuiInputView;
 use crate::input::view::TuiInputAction;
 use crate::option_selector::TuiOptionSelector;
@@ -90,6 +91,7 @@ pub(crate) fn init(app: &mut AppContext) {
         TuiEditorViewAction::Command,
     );
     crate::orchestration_block::init(app);
+    crate::handoff::init(app);
     crate::tui_ask_question_view::init(app);
     crate::tui_permission_prompt::init(app);
     crate::tui_shell_command_view::init(app);
@@ -150,6 +152,7 @@ fn register_binding_validators(app: &mut AppContext) {
     app.register_tui_binding_validator::<TuiEditorView>(is_tui_owned_binding);
     app.register_tui_binding_validator::<TuiTranscriptView>(is_tui_owned_binding);
     app.register_tui_binding_validator::<TuiOrchestrationBlock>(is_tui_owned_binding);
+    app.register_tui_binding_validator::<TuiHandoffBlock>(is_tui_owned_binding);
     app.register_tui_binding_validator::<TuiOptionSelector>(is_tui_owned_binding);
 }
 

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -31,6 +31,7 @@ mod editor_element;
 mod editor_interaction;
 mod editor_view;
 mod exit_confirmation;
+mod handoff;
 mod inline_menu;
 mod input_hints;
 mod input_mode_policy;

--- a/crates/warp_tui/src/link_tests.rs
+++ b/crates/warp_tui/src/link_tests.rs
@@ -1,6 +1,7 @@
 use warp::tui_export::Appearance;
 use warpui_core::App;
-use warpui_core::elements::tui::{Modifier, TuiBufferExt, TuiRect};
+use warpui_core::elements::CrossAxisAlignment;
+use warpui_core::elements::tui::{Modifier, TuiBufferExt, TuiElement, TuiFlex, TuiRect};
 use warpui_core::presenter::tui::TuiPresenter;
 
 use super::TuiLink;
@@ -10,15 +11,44 @@ fn link_renders_visible_underlined_text() {
     App::test((), |app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         app.read(|ctx| {
+            let label = "https://example.com/run";
             let link = TuiLink::default();
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
-                link.render("https://example.com/run", ctx, |_, _| {}),
+                link.render(label, ctx, |_, _| {}),
                 TuiRect::new(0, 0, 40, 1),
                 ctx,
             );
-            assert!(frame.buffer.to_lines()[0].starts_with("https://example.com/run"));
+            assert!(frame.buffer.to_lines()[0].starts_with(label));
             assert!(frame.buffer[(0, 0)].modifier.contains(Modifier::UNDERLINED));
+        });
+    });
+}
+
+#[test]
+fn link_row_in_stretched_banner_only_underlines_the_link_text() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|ctx| {
+            let label = "https://example.com/run";
+            let link = TuiLink::default();
+            let banner_content = TuiFlex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .child(
+                    TuiFlex::row()
+                        .child(link.render(label, ctx, |_, _| {}))
+                        .finish(),
+                )
+                .finish();
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(banner_content, TuiRect::new(0, 0, 40, 1), ctx);
+
+            assert!(frame.buffer[(0, 0)].modifier.contains(Modifier::UNDERLINED));
+            assert!(
+                !frame.buffer[(label.len() as u16, 0)]
+                    .modifier
+                    .contains(Modifier::UNDERLINED)
+            );
         });
     });
 }

--- a/crates/warp_tui/src/orchestration_block.rs
+++ b/crates/warp_tui/src/orchestration_block.rs
@@ -43,6 +43,7 @@ use crate::option_selector::{
     OptionSelectorHeader, OptionSelectorPage, TuiOptionSelector, TuiOptionSelectorEvent,
 };
 use crate::orchestrated_agent_identity_styling::AgentIdentity;
+use crate::tui_ask_question_view::PageNavigationDirection;
 use crate::tui_builder::TuiUiBuilder;
 
 const ORCHESTRATION_BLOCK_TITLE: &str = "Can I start additional agents for this task?";
@@ -103,14 +104,6 @@ enum CardMode {
     Configuring { page: ConfigPage },
 }
 
-/// Direction to navigate after the selector confirms the current page.
-/// Arrow actions retain this until the selector emits its confirmation event.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PageConfirmationNavigation {
-    Previous,
-    Next,
-}
-
 /// Events emitted to the owning agent block.
 #[derive(Clone, Debug)]
 pub(crate) enum TuiOrchestrationBlockEvent {
@@ -157,7 +150,7 @@ pub(crate) struct TuiOrchestrationBlock {
     mode: CardMode,
     selector: ViewHandle<TuiOptionSelector>,
     /// Arrow direction awaiting the selector's confirmation event.
-    pending_page_navigation: Option<PageConfirmationNavigation>,
+    pending_page_navigation: Option<PageNavigationDirection>,
     /// Validation reason shown inline after a blocked Accept.
     accept_error: Option<String>,
 
@@ -544,11 +537,11 @@ impl TuiOrchestrationBlock {
         };
         let navigation = self.pending_page_navigation.take();
         let target = match navigation {
-            Some(PageConfirmationNavigation::Previous) => index
+            Some(PageNavigationDirection::Previous) => index
                 .checked_sub(1)
                 .and_then(|index| sequence.get(index))
                 .copied(),
-            Some(PageConfirmationNavigation::Next) | None => sequence.get(index + 1).copied(),
+            Some(PageNavigationDirection::Next) | None => sequence.get(index + 1).copied(),
         };
         match target {
             Some(target) => self.open_page(target, ctx),
@@ -709,7 +702,7 @@ impl TuiOrchestrationBlock {
     /// Confirms the selection, then applies the requested arrow navigation.
     fn handle_arrow_navigation(
         &mut self,
-        navigation: PageConfirmationNavigation,
+        navigation: PageNavigationDirection,
         ctx: &mut ViewContext<Self>,
     ) {
         self.pending_page_navigation = Some(navigation);
@@ -764,10 +757,10 @@ impl TypedActionView for TuiOrchestrationBlock {
             TuiOrchestrationBlockAction::Accept => self.handle_accept(ctx),
             TuiOrchestrationBlockAction::Configure => self.handle_configure(ctx),
             TuiOrchestrationBlockAction::CommitAndPreviousPage => {
-                self.handle_arrow_navigation(PageConfirmationNavigation::Previous, ctx)
+                self.handle_arrow_navigation(PageNavigationDirection::Previous, ctx)
             }
             TuiOrchestrationBlockAction::CommitAndNextPage => {
-                self.handle_arrow_navigation(PageConfirmationNavigation::Next, ctx)
+                self.handle_arrow_navigation(PageNavigationDirection::Next, ctx)
             }
             TuiOrchestrationBlockAction::NextPage => self.navigate_page(true, ctx),
             TuiOrchestrationBlockAction::Back => self.handle_back(ctx),

--- a/crates/warp_tui/src/orchestration_block/configuration.rs
+++ b/crates/warp_tui/src/orchestration_block/configuration.rs
@@ -69,7 +69,7 @@ impl ConfigPage {
 
     /// Whether this page opts into the selector's pinned search editor.
     pub(super) fn is_searchable(self) -> bool {
-        matches!(self, Self::Model)
+        matches!(self, Self::Environment | Self::Model)
     }
 }
 

--- a/crates/warp_tui/src/orchestration_block_tests.rs
+++ b/crates/warp_tui/src/orchestration_block_tests.rs
@@ -46,14 +46,30 @@ fn request(harness: &str, execution_mode: RunAgentsExecutionMode) -> RunAgentsRe
 }
 
 #[test]
-fn only_the_model_page_is_searchable() {
+fn environment_selector_is_searchable() {
+    App::test((), |mut app| async move {
+        let (block, _) = test_block(&mut app, &request("oz", remote("env-1", "warp")));
+        block.update(&mut app, |block, ctx| {
+            block.open_page(ConfigPage::Environment, ctx);
+        });
+        let selector = app.read(|ctx| block.as_ref(ctx).selector.clone());
+        assert!(
+            selector
+                .read(&app, |selector, _| selector.search_field_for_test())
+                .is_some()
+        );
+    });
+}
+
+#[test]
+fn environment_and_model_pages_are_searchable() {
+    assert!(ConfigPage::Environment.is_searchable());
     assert!(ConfigPage::Model.is_searchable());
     for page in [
         ConfigPage::Location,
         ConfigPage::Harness,
         ConfigPage::ApiKey,
         ConfigPage::Host,
-        ConfigPage::Environment,
     ] {
         assert!(!page.is_searchable(), "{page:?}");
     }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -68,6 +68,7 @@ use crate::conversation_menu::{TuiConversationMenuEvent, TuiConversationMenuMode
 use crate::conversation_selection::TuiConversationSelection;
 use crate::editor_interaction::TuiEditorCommand;
 use crate::exit_confirmation::{CTRL_C_EXIT_WINDOW, ExitConfirmation};
+use crate::handoff::TuiHandoffBlock;
 use crate::inline_menu::{MAX_INLINE_MENU_ROWS, TuiInlineMenu, active_inline_menu};
 use crate::input::view::TuiInputAction;
 use crate::input::{TuiInputView, TuiInputViewEvent};
@@ -116,10 +117,12 @@ use crate::zero_state_animation::{
     ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent, ZeroStateAnimationLoadFailure,
 };
 mod completions;
+
+#[path = "handoff/session.rs"]
+mod handoff_session;
 mod input_detection;
 mod shortcuts;
 pub(crate) mod state;
-
 use self::completions::CompletionRequestState;
 use self::input_detection::InputDetectionState;
 use self::state::{
@@ -158,6 +161,8 @@ pub(super) enum BlockingInputSource {
     Permission(ViewHandle<TuiPermissionPrompt>),
     /// The specialized orchestration configuration request.
     Orchestration(ViewHandle<TuiOrchestrationBlock>),
+    /// A local-to-cloud handoff configuration or result card.
+    Handoff(ViewHandle<TuiHandoffBlock>),
 }
 
 impl BlockingInputSource {
@@ -171,10 +176,10 @@ impl BlockingInputSource {
             Self::AskQuestion(view) => Some(TuiChildView::new(&view).finish()),
             Self::Permission(view) => Some(TuiChildView::new(&view).finish()),
             Self::Orchestration(view) => Some(TuiChildView::new(&view).finish()),
+            Self::Handoff(view) => Some(TuiChildView::new(&view).finish()),
         }
     }
 }
-
 /// Events emitted by the TUI terminal session surface.
 pub(crate) enum TuiTerminalSessionEvent {
     ExecuteCommand(Box<ExecuteCommandEvent>),
@@ -645,6 +650,7 @@ pub(crate) struct TuiTerminalSessionView {
     conversation_restore_state: ConversationRestoreState,
     next_restore_request_id: u64,
     exit_summary: TuiExitSummaryHandle,
+    handoff: Option<ViewHandle<TuiHandoffBlock>>,
     orchestration_tab_bar: ViewHandle<TuiTabBarView>,
     orchestration_tabs_focused: bool,
     zero_state_view: ViewHandle<TuiZeroStateView>,
@@ -823,7 +829,12 @@ impl TuiTerminalSessionView {
         &self,
         ctx: &AppContext,
     ) -> Result<TuiTerminalSessionState, TuiTerminalSessionStateResolveError> {
-        self.session_state.as_ref(ctx).resolve(ctx)
+        let state = self.session_state.as_ref(ctx).resolve(ctx)?;
+        Ok(if let Some(handoff) = self.active_handoff(ctx) {
+            state.with_blocking_input_source(BlockingInputSource::Handoff(handoff))
+        } else {
+            state
+        })
     }
 
     fn update_process_input_focus(&mut self, ctx: &mut ViewContext<Self>) {
@@ -841,6 +852,7 @@ impl TuiTerminalSessionView {
             BlockingInputSource::AskQuestion(view) => ctx.focus(&view),
             BlockingInputSource::Permission(view) => ctx.focus(&view),
             BlockingInputSource::Orchestration(view) => ctx.focus(&view),
+            BlockingInputSource::Handoff(view) => ctx.focus(&view),
         }
     }
 
@@ -1759,6 +1771,7 @@ impl TuiTerminalSessionView {
             conversation_restore_state: ConversationRestoreState::Idle,
             next_restore_request_id: 0,
             exit_summary,
+            handoff: None,
             orchestration_tab_bar,
             orchestration_tabs_focused: false,
             zero_state_view,
@@ -3259,6 +3272,13 @@ impl TuiTerminalSessionView {
     }
 
     fn select_tui_slash_command(&mut self, command: &StaticCommand, ctx: &mut ViewContext<Self>) {
+        if command.kind == SlashCommandKind::MoveToCloud {
+            self.input_view.update(ctx, |input, ctx| {
+                input.set_text("/handoff ", ctx);
+            });
+            ctx.notify();
+            return;
+        }
         match slash_command_selection_behavior(command) {
             SlashCommandSelectionBehavior::InsertCommandText(text) => {
                 self.input_view.update(ctx, |input, ctx| {
@@ -3269,6 +3289,40 @@ impl TuiTerminalSessionView {
                 self.execute_tui_slash_command(command, None, ctx);
             }
         }
+    }
+
+    fn start_new_conversation(
+        &mut self,
+        prompt: Option<&String>,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        if !self
+            .ai_context_model
+            .as_ref(ctx)
+            .can_start_new_conversation()
+        {
+            self.show_transient_hint(NEW_CONVERSATION_COMMAND_RUNNING_HINT.to_owned(), ctx);
+            return false;
+        }
+        self.cancel_active_conversation(ctx);
+        let terminal_surface_id = ctx.view_id();
+        self.transcript.update(ctx, |transcript, ctx| {
+            transcript.clear_for_new_conversation(ctx);
+        });
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+            history.clear_conversations_for_terminal_surface(terminal_surface_id, ctx);
+        });
+        self.conversation_selection.update(ctx, |selection, ctx| {
+            selection.select_new_conversation(AgentViewEntryOrigin::Tui, ctx);
+        });
+        if let Some(prompt) = prompt
+            .map(|argument| argument.trim())
+            .filter(|argument| !argument.is_empty())
+        {
+            self.send_prompt(prompt.to_owned(), ctx);
+        }
+        self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+        true
     }
 
     fn execute_tui_slash_command(
@@ -3287,38 +3341,17 @@ impl TuiTerminalSessionView {
 
         match command.kind {
             SlashCommandKind::Agent | SlashCommandKind::New => {
-                if !self
-                    .ai_context_model
-                    .as_ref(ctx)
-                    .can_start_new_conversation()
-                {
-                    self.show_transient_hint(NEW_CONVERSATION_COMMAND_RUNNING_HINT.to_owned(), ctx);
-                    return;
+                if self.start_new_conversation(argument, ctx) {
+                    record_static_slash_command_accepted(command.name, true, ctx);
                 }
-                self.cancel_active_conversation(ctx);
-                let terminal_surface_id = ctx.view_id();
-                self.transcript.update(ctx, |transcript, ctx| {
-                    transcript.clear_for_new_conversation(ctx);
-                });
-                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-                    history.clear_conversations_for_terminal_surface(terminal_surface_id, ctx);
-                });
-                self.conversation_selection.update(ctx, |selection, ctx| {
-                    selection.select_new_conversation(AgentViewEntryOrigin::Tui, ctx);
-                });
-                if let Some(prompt) = argument
-                    .map(|argument| argument.trim())
-                    .filter(|argument| !argument.is_empty())
-                {
-                    self.send_prompt(prompt.to_owned(), ctx);
-                }
-                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-                record_static_slash_command_accepted(command.name, true, ctx);
             }
             SlashCommandKind::Conversations => {
                 self.conversation_menu
                     .update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
+            }
+            SlashCommandKind::MoveToCloud => {
+                self.start_handoff(argument, ctx);
             }
             SlashCommandKind::AutoApprove => {
                 self.toggle_auto_approve(true, ctx);
@@ -3517,7 +3550,6 @@ impl TuiTerminalSessionView {
             | SlashCommandKind::RenameConversation
             | SlashCommandKind::SetTabColor
             | SlashCommandKind::Fork
-            | SlashCommandKind::MoveToCloud
             | SlashCommandKind::OpenCodeReview
             | SlashCommandKind::Index
             | SlashCommandKind::Init
@@ -3697,14 +3729,18 @@ impl TuiView for TuiTerminalSessionView {
         "TuiTerminalSessionView"
     }
 
-    fn child_view_ids(&self, _ctx: &AppContext) -> Vec<EntityId> {
-        vec![
+    fn child_view_ids(&self, ctx: &AppContext) -> Vec<EntityId> {
+        let mut view_ids = vec![
             self.transcript.id(),
             self.input_view.id(),
             self.orchestration_tab_bar.id(),
             self.attachment_bar.id(),
             self.zero_state_view.id(),
-        ]
+        ];
+        if let Some(handoff) = self.active_handoff(ctx) {
+            view_ids.push(handoff.id());
+        }
+        view_ids
     }
 
     fn keymap_context(&self, ctx: &AppContext) -> keymap::Context {
@@ -3960,6 +3996,9 @@ impl TuiView for TuiTerminalSessionView {
                 .finish(),
             );
         }
+        if let Some(BlockingInputSource::Handoff(handoff)) = state.blocking_input_source() {
+            content = content.child(TuiChildView::new(handoff).finish());
+        }
         if !blocker_active
             && (input_target.agent_editor_owns_input()
                 || matches!(input_target, TuiInputTarget::Disabled))
@@ -4106,6 +4145,9 @@ impl TerminalSurface for TuiTerminalSessionView {
     }
 }
 
+#[cfg(test)]
+#[path = "handoff/tests.rs"]
+mod handoff_tests;
 #[cfg(test)]
 #[path = "terminal_session_view_tests.rs"]
 mod tests;

--- a/crates/warp_tui/src/terminal_session_view/state.rs
+++ b/crates/warp_tui/src/terminal_session_view/state.rs
@@ -310,6 +310,13 @@ pub(crate) struct TuiShortcutSection {
 }
 
 impl TuiTerminalSessionState {
+    pub(super) fn with_blocking_input_source(mut self, source: BlockingInputSource) -> Self {
+        let state = match &mut self {
+            Self::AltScreen { state, .. } | Self::Block(state) => state,
+        };
+        state.interaction = TuiInteractionState::Blocking(source);
+        self
+    }
     fn state(&self) -> &TuiBlockSessionState {
         match self {
             Self::AltScreen { state, .. } | Self::Block(state) => state,
@@ -373,7 +380,8 @@ impl TuiTerminalSessionState {
                     BlockingInputSource::LongRunningCommand => TuiInputTarget::Pty,
                     BlockingInputSource::AskQuestion(_)
                     | BlockingInputSource::Permission(_)
-                    | BlockingInputSource::Orchestration(_) => TuiInputTarget::Disabled,
+                    | BlockingInputSource::Orchestration(_)
+                    | BlockingInputSource::Handoff(_) => TuiInputTarget::Disabled,
                 },
                 TuiInteractionState::StartingShell => TuiInputTarget::Disabled,
                 TuiInteractionState::Composer(_) => TuiInputTarget::AgentEditor,
@@ -463,7 +471,8 @@ impl TuiTerminalSessionState {
             TuiInteractionState::Blocking(
                 BlockingInputSource::AskQuestion(_)
                 | BlockingInputSource::Permission(_)
-                | BlockingInputSource::Orchestration(_),
+                | BlockingInputSource::Orchestration(_)
+                | BlockingInputSource::Handoff(_),
             )
             | TuiInteractionState::StartingShell
             | TuiInteractionState::Pty(TuiPtyState::Process) => return Vec::new(),

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -23,10 +23,11 @@ use warpui_core::{
 };
 
 use super::agent_block::{TuiAIBlock, TuiAIBlockEvent};
+use super::handoff::{TuiHandoffBlock, TuiHandoffBlockEvent};
 use super::terminal_block::{block_content_rows, should_render_terminal_block};
 use super::terminal_session_view::BlockingInputSource;
 use super::tui_block_list_viewport_source::{
-    AgentBlockRegistry, CLISubagentBlockRegistry, TuiBlockListViewportSource,
+    AgentBlockRegistry, CLISubagentBlockRegistry, HandoffBlockRegistry, TuiBlockListViewportSource,
 };
 use super::tui_builder::TuiUiBuilder;
 use super::tui_cli_subagent_view::{TuiCLISubagentView, TuiCLISubagentViewEvent};
@@ -83,11 +84,40 @@ pub(super) struct TuiTranscriptView {
     model_events: ModelHandle<ModelEventDispatcher>,
     agent_blocks: AgentBlockRegistry,
     cli_subagent_blocks: CLISubagentBlockRegistry,
+    handoff_blocks: HandoffBlockRegistry,
     viewport: TuiViewportedListState,
     selection: TuiSelectionHandle,
 }
 
 impl TuiTranscriptView {
+    pub(super) fn attach_handoff(
+        &mut self,
+        view: ViewHandle<TuiHandoffBlock>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let view_id = view.id();
+        if self.handoff_blocks.borrow().contains_key(&view_id) {
+            return;
+        }
+        ctx.subscribe_to_view(&view, move |transcript, _, event, ctx| match event {
+            TuiHandoffBlockEvent::LayoutInvalidated => {
+                transcript.mark_agent_block_dirty(view_id, ctx);
+            }
+        });
+        self.handoff_blocks.borrow_mut().insert(view_id, view);
+        {
+            let mut model = self.model.lock();
+            let block_list = model.block_list_mut();
+            block_list.append_rich_content(
+                RichContentItem::new(Some(RichContentType::AIBlock), view_id, None, false),
+                false,
+            );
+            block_list.mark_rich_content_dirty(view_id);
+        }
+        self.viewport.scroll_to_end();
+        ctx.notify();
+    }
+
     /// Creates a transcript view for one terminal surface.
     pub(super) fn new(
         terminal_surface_id: EntityId,
@@ -108,6 +138,7 @@ impl TuiTranscriptView {
             model_events: model_events.clone(),
             agent_blocks: Rc::new(RefCell::new(HashMap::new())),
             cli_subagent_blocks: Rc::new(RefCell::new(HashMap::new())),
+            handoff_blocks: Rc::new(RefCell::new(HashMap::new())),
             viewport: TuiViewportedListState::new_at_end(),
             selection: TuiSelectionHandle::default(),
         }
@@ -306,7 +337,10 @@ impl TuiTranscriptView {
     /// the zero state. The session view fills the transcript slot with the zero
     /// state exactly while this holds.
     pub(super) fn is_empty(&self) -> bool {
-        if !self.agent_blocks.borrow().is_empty() || !self.cli_subagent_blocks.borrow().is_empty() {
+        if !self.agent_blocks.borrow().is_empty()
+            || !self.cli_subagent_blocks.borrow().is_empty()
+            || !self.handoff_blocks.borrow().is_empty()
+        {
             return false;
         }
         let model = self.model.lock();
@@ -584,6 +618,15 @@ impl TuiTranscriptView {
                     (view.as_ref(ctx).conversation_id() == conversation_id).then_some(*view_id)
                 }),
         );
+        view_ids.extend(
+            self.handoff_blocks
+                .borrow()
+                .iter()
+                .filter_map(|(view_id, view)| {
+                    (view.as_ref(ctx).source_conversation_id(ctx) == Some(conversation_id))
+                        .then_some(*view_id)
+                }),
+        );
         for view_id in view_ids {
             let rows = {
                 let model = self.model.lock();
@@ -597,6 +640,7 @@ impl TuiTranscriptView {
             }
             self.agent_blocks.borrow_mut().remove(&view_id);
             self.cli_subagent_blocks.borrow_mut().remove(&view_id);
+            self.handoff_blocks.borrow_mut().remove(&view_id);
             self.model
                 .lock()
                 .block_list_mut()
@@ -633,8 +677,10 @@ impl TuiTranscriptView {
             .copied()
             .collect::<Vec<_>>();
         view_ids.extend(self.cli_subagent_blocks.borrow().keys().copied());
+        view_ids.extend(self.handoff_blocks.borrow().keys().copied());
         self.agent_blocks.borrow_mut().clear();
         self.cli_subagent_blocks.borrow_mut().clear();
+        self.handoff_blocks.borrow_mut().clear();
         self.selection.clear();
         let mut model = self.model.lock();
         for view_id in view_ids {
@@ -661,14 +707,16 @@ impl TuiView for TuiTranscriptView {
             .copied()
             .collect::<Vec<_>>();
         ids.extend(self.cli_subagent_blocks.borrow().keys().copied());
+        ids.extend(self.handoff_blocks.borrow().keys().copied());
         ids
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
-        let source = TuiBlockListViewportSource::new_with_cli_subagents(
+        let source = TuiBlockListViewportSource::new_with_rich_content(
             self.model.clone(),
             self.agent_blocks.clone(),
             self.cli_subagent_blocks.clone(),
+            self.handoff_blocks.clone(),
         );
         let viewport = TuiViewportedList::new(
             self.viewport.clone(),

--- a/crates/warp_tui/src/tui_ask_question_view.rs
+++ b/crates/warp_tui/src/tui_ask_question_view.rs
@@ -60,7 +60,7 @@ pub(crate) fn init(app: &mut AppContext) {
         EditableBinding::new(
             "tui:ask-question:previous",
             "Show the previous question",
-            TuiAskQuestionViewAction::Previous,
+            TuiAskQuestionViewAction::Navigate(PageNavigationDirection::Previous),
         )
         .with_context_predicate(predicate.clone())
         .with_group(TUI_BINDING_GROUP)
@@ -68,7 +68,7 @@ pub(crate) fn init(app: &mut AppContext) {
         EditableBinding::new(
             "tui:ask-question:next",
             "Show the next question",
-            TuiAskQuestionViewAction::Next,
+            TuiAskQuestionViewAction::Navigate(PageNavigationDirection::Next),
         )
         .with_context_predicate(predicate.clone())
         .with_group(TUI_BINDING_GROUP)
@@ -76,7 +76,7 @@ pub(crate) fn init(app: &mut AppContext) {
         EditableBinding::new(
             "tui:ask-question:next",
             "Show the next question",
-            TuiAskQuestionViewAction::Next,
+            TuiAskQuestionViewAction::Navigate(PageNavigationDirection::Next),
         )
         .with_context_predicate(predicate)
         .with_group(TUI_BINDING_GROUP)
@@ -85,12 +85,18 @@ pub(crate) fn init(app: &mut AppContext) {
     app.register_tui_binding_validator::<TuiAskQuestionView>(is_tui_owned_binding);
 }
 
+/// Direction through a sequence of interactive card pages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PageNavigationDirection {
+    Previous,
+    Next,
+}
+
 #[derive(Clone, Debug)]
 pub(super) enum TuiAskQuestionViewAction {
     Enter,
     AdvanceMultiselect,
-    Previous,
-    Next,
+    Navigate(PageNavigationDirection),
     SkipAll,
 }
 
@@ -711,14 +717,13 @@ impl TypedActionView for TuiAskQuestionView {
                 let effect = self.session.apply(AskUserQuestionAction::Confirm);
                 self.handle_effect(effect, ctx);
             }
-            TuiAskQuestionViewAction::Previous => {
+            TuiAskQuestionViewAction::Navigate(direction) => {
                 self.commit_active_other_text(ctx);
-                let effect = self.session.apply(AskUserQuestionAction::NavigatePrev);
-                self.handle_effect(effect, ctx);
-            }
-            TuiAskQuestionViewAction::Next => {
-                self.commit_active_other_text(ctx);
-                let effect = self.session.apply(AskUserQuestionAction::NavigateNext);
+                let action = match direction {
+                    PageNavigationDirection::Previous => AskUserQuestionAction::NavigatePrev,
+                    PageNavigationDirection::Next => AskUserQuestionAction::NavigateNext,
+                };
+                let effect = self.session.apply(action);
                 self.handle_effect(effect, ctx);
             }
             TuiAskQuestionViewAction::SkipAll => {

--- a/crates/warp_tui/src/tui_block_list_viewport_source.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source.rs
@@ -19,12 +19,14 @@ use warpui_core::elements::tui::{
 };
 
 use super::agent_block::TuiAIBlock;
+use super::handoff::TuiHandoffBlock;
 use super::terminal_block::{TerminalBlockElement, should_render_terminal_block};
 use super::tui_cli_subagent_view::TuiCLISubagentView;
 
 pub(super) type AgentBlockRegistry = Rc<RefCell<HashMap<EntityId, ViewHandle<TuiAIBlock>>>>;
 pub(super) type CLISubagentBlockRegistry =
     Rc<RefCell<HashMap<EntityId, ViewHandle<TuiCLISubagentView>>>>;
+pub(super) type HandoffBlockRegistry = Rc<RefCell<HashMap<EntityId, ViewHandle<TuiHandoffBlock>>>>;
 
 /// Extra rows above and below the viewport whose non-dirty agent blocks are
 /// re-measured each frame, so near-off-screen reflow (e.g. a width change) is
@@ -38,6 +40,7 @@ pub(super) enum TuiBlockListViewportItemId {
     Terminal(BlockId),
     Agent(EntityId),
     CLISubagent(EntityId),
+    Handoff(EntityId),
 }
 
 struct TuiBlockListVisibleItem {
@@ -51,6 +54,7 @@ enum TuiBlockListVisibleItemKind {
     Terminal(BlockId),
     Agent(ViewHandle<TuiAIBlock>),
     CLISubagent(ViewHandle<TuiCLISubagentView>),
+    Handoff(ViewHandle<TuiHandoffBlock>),
 }
 
 /// Adapts a terminal model's canonical block-list order for TUI viewporting.
@@ -58,6 +62,7 @@ pub(super) struct TuiBlockListViewportSource {
     model: Arc<FairMutex<TerminalModel>>,
     agent_blocks: AgentBlockRegistry,
     cli_subagent_blocks: CLISubagentBlockRegistry,
+    handoff_blocks: HandoffBlockRegistry,
     height_changes: RefCell<Vec<TuiRowResize>>,
 }
 
@@ -72,19 +77,21 @@ impl TuiBlockListViewportSource {
             model,
             agent_blocks,
             cli_subagent_blocks: Rc::new(RefCell::new(HashMap::new())),
+            handoff_blocks: Rc::new(RefCell::new(HashMap::new())),
             height_changes: RefCell::new(Vec::new()),
         }
     }
-
-    pub(super) fn new_with_cli_subagents(
+    pub(super) fn new_with_rich_content(
         model: Arc<FairMutex<TerminalModel>>,
         agent_blocks: AgentBlockRegistry,
         cli_subagent_blocks: CLISubagentBlockRegistry,
+        handoff_blocks: HandoffBlockRegistry,
     ) -> Self {
         Self {
             model,
             agent_blocks,
             cli_subagent_blocks,
+            handoff_blocks,
             height_changes: RefCell::new(Vec::new()),
         }
     }
@@ -113,6 +120,7 @@ impl TuiBlockListViewportSource {
 
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
+        let handoff_blocks = self.handoff_blocks.borrow();
         let block_list = model.block_list();
         let band_top = window.scroll_top.saturating_sub(OVERHANG_ROWS);
         let band_bottom = window
@@ -146,6 +154,10 @@ impl TuiBlockListViewportSource {
                         .needs_height_measurement(available_width, app)
                 {
                     view_ids.insert(rich_content.view_id);
+                } else if let Some(view) = handoff_blocks.get(&rich_content.view_id)
+                    && view.as_ref(app).needs_height_measurement(available_width)
+                {
+                    view_ids.insert(rich_content.view_id);
                 }
             }
             cursor.next();
@@ -164,6 +176,7 @@ impl TuiBlockListViewportSource {
     ) -> HashMap<EntityId, BlockHeight> {
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
+        let handoff_blocks = self.handoff_blocks.borrow();
         view_ids
             .into_iter()
             .filter_map(|view_id| {
@@ -172,8 +185,13 @@ impl TuiBlockListViewportSource {
                     let height = view.desired_height(width, ctx, app);
                     view.record_height_measurement(width);
                     height
+                } else if let Some(view) = cli_subagent_blocks.get(&view_id) {
+                    let view = view.as_ref(app);
+                    let height = view.desired_height(width, ctx, app);
+                    view.record_height_measurement(width);
+                    height
                 } else {
-                    let view = cli_subagent_blocks.get(&view_id)?.as_ref(app);
+                    let view = handoff_blocks.get(&view_id)?.as_ref(app);
                     let height = view.desired_height(width, ctx, app);
                     view.record_height_measurement(width);
                     height
@@ -230,6 +248,7 @@ impl TuiBlockListViewportSource {
         let block_list = model.block_list();
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
+        let handoff_blocks = self.handoff_blocks.borrow();
         let viewport_bottom = window
             .scroll_top
             .saturating_add(usize::from(window.viewport_height));
@@ -286,14 +305,20 @@ impl TuiBlockListViewportSource {
                                 height,
                                 kind: TuiBlockListVisibleItemKind::Agent(view.clone()),
                             })
+                        } else if let Some(view) = cli_subagent_blocks.get(&item.view_id) {
+                            Some(TuiBlockListVisibleItem {
+                                origin_y: item_top,
+                                height,
+                                kind: TuiBlockListVisibleItemKind::CLISubagent(view.clone()),
+                            })
                         } else {
-                            cli_subagent_blocks.get(&item.view_id).map(|view| {
-                                TuiBlockListVisibleItem {
+                            handoff_blocks
+                                .get(&item.view_id)
+                                .map(|view| TuiBlockListVisibleItem {
                                     origin_y: item_top,
                                     height,
-                                    kind: TuiBlockListVisibleItemKind::CLISubagent(view.clone()),
-                                }
-                            })
+                                    kind: TuiBlockListVisibleItemKind::Handoff(view.clone()),
+                                })
                         }
                     }
                 }
@@ -344,6 +369,7 @@ impl TuiBlockListViewportSource {
         let block_list = model.block_list();
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
+        let handoff_blocks = self.handoff_blocks.borrow();
         let mut item_ids = Vec::new();
         let mut cursor = block_list
             .block_heights()
@@ -369,6 +395,11 @@ impl TuiBlockListViewportSource {
                     if !item.should_hide && cli_subagent_blocks.contains_key(&item.view_id) =>
                 {
                     item_ids.push(TuiBlockListViewportItemId::CLISubagent(item.view_id));
+                }
+                BlockHeightItem::RichContent(item)
+                    if !item.should_hide && handoff_blocks.contains_key(&item.view_id) =>
+                {
+                    item_ids.push(TuiBlockListViewportItemId::Handoff(item.view_id));
                 }
                 BlockHeightItem::RichContent(_)
                 | BlockHeightItem::Gap(_)
@@ -494,9 +525,9 @@ impl TuiBlockListVisibleItem {
             TuiBlockListVisibleItemKind::Terminal(_) => {
                 self.origin_y.saturating_add(visible_rows.start)
             }
-            TuiBlockListVisibleItemKind::Agent(_) | TuiBlockListVisibleItemKind::CLISubagent(_) => {
-                self.origin_y
-            }
+            TuiBlockListVisibleItemKind::Agent(_)
+            | TuiBlockListVisibleItemKind::CLISubagent(_)
+            | TuiBlockListVisibleItemKind::Handoff(_) => self.origin_y,
         };
         TuiVisibleViewportItem {
             origin_y,
@@ -518,6 +549,7 @@ impl TuiBlockListVisibleItem {
             }
             TuiBlockListVisibleItemKind::Agent(view) => TuiChildView::new(&view).finish(),
             TuiBlockListVisibleItemKind::CLISubagent(view) => TuiChildView::new(&view).finish(),
+            TuiBlockListVisibleItemKind::Handoff(view) => TuiChildView::new(&view).finish(),
         }
     }
 }

--- a/specs/CODE-1827/PRODUCT.md
+++ b/specs/CODE-1827/PRODUCT.md
@@ -1,0 +1,250 @@
+# CODE-1827: TUI Local-to-Cloud Handoff
+
+## Summary
+
+Warp’s headless TUI lets users fork a local Oz conversation into an Oz cloud run with `/handoff [prompt]`. Handoff preserves the local transcript, gathers the required cloud configuration in a blocking card, transfers applicable local context, and leaves the user with explicit choices to open the cloud run, continue locally, or start a new conversation.
+
+## Problem
+
+TUI users can run local agents and launch cloud agents, but they cannot move an existing local conversation and workspace state into a cloud run. Replacing the current TUI conversation with a cloud view would also hide the local transcript and make the forked nature of handoff unclear.
+
+## Goals
+
+- Provide a keyboard-first local-to-cloud handoff flow for Oz conversations.
+- Preserve the local conversation and make local continuation explicit.
+- Match the established GUI handoff semantics for conversation forking, continuation prompts, environment suggestion, snapshots, and guardrails.
+- Keep cloud environment creation and cloud-run inspection outside the TUI.
+
+## Non-goals
+
+- Adding an `&` prefix entrypoint to the TUI.
+- Adding a TUI environment-creation form.
+- Turning the local TUI session into a cloud session or embedding a cloud-run viewer.
+- Supporting a selectable harness, execution location, worker host, or API key.
+- Moving an entire orchestration tree into cloud.
+- Adding in-card retry after a fatal handoff failure.
+- Adding cloud-to-local or cloud-to-cloud handoff behavior.
+
+## Figma
+
+Figma: none provided. The existing TUI orchestration card is the structural and copy-style reference. The GUI `&` handoff affordance is the accent-color reference.
+
+## Behavior
+
+### Availability and command composition
+
+1. `/handoff` is available only in a local Oz conversation when the existing local-to-cloud handoff settings, account policy, privacy policy, AI availability, and native-platform requirements permit handoff.
+
+2. `/handoff` is not available from a cloud-agent conversation.
+
+3. Selecting `/handoff` in the slash-command menu inserts `/handoff ` into the input instead of executing it immediately.
+
+4. While `/handoff ` is in the input with no argument, ghost text communicates that adding a prompt is optional.
+
+5. The user may submit either:
+   - `/handoff`, to hand off with no explicit prompt.
+   - `/handoff <prompt>`, to provide the cloud run’s initial prompt.
+
+6. Leading and trailing whitespace is trimmed from a non-empty prompt argument. The remaining prompt text is preserved for the cloud run, apart from the same query-mode parsing that applies to normal agent prompts.
+
+7. If the selected local conversation has no content:
+   - `/handoff` with no prompt is rejected with a transient bottom-row message explaining that there is nothing to hand off.
+   - `/handoff <prompt>` enters the same configuration flow and creates a fresh cloud run rather than forking a conversation.
+
+### Eligibility and cancellation
+
+8. Before cancelling local generation, Warp checks whether a long-running command is active. If one is active:
+   - Handoff is rejected.
+   - The command and agent conversation remain untouched.
+   - The prompt argument and pending images remain in local input.
+   - A transient bottom-row message tells the user to cancel the command or wait for it to finish.
+
+9. Before cancelling an orchestrator conversation, Warp checks every loaded child conversation. An in-progress or blocked child prevents handoff.
+
+10. When a child prevents handoff:
+   - The parent and children remain untouched.
+   - The prompt argument and pending images remain in local input.
+   - A transient bottom-row message explains that active child work must finish or be cancelled first.
+
+11. Finished, failed, and cancelled child conversations do not prevent parent handoff.
+
+12. After the command and orchestration guardrails pass, submitting `/handoff` immediately cancels an in-progress or blocked source response before showing the handoff card.
+
+13. The source’s active state is captured before cancellation. Later prompt synthesis uses that captured state; cancellation must not cause the cloud run to forget that it interrupted active work.
+
+14. Eager cancellation also occurs when configuration is subsequently blocked by no available environment or an incompatible model. The agent must never continue streaming behind the blocking handoff card.
+
+15. Eager cancellation does not itself fork the conversation, upload a snapshot, or create a cloud run.
+
+### Blocking card and focus
+
+16. After preparation succeeds, a handoff card replaces the local input area. The existing transcript remains visible and unchanged.
+
+17. The handoff card belongs to the source TUI session. If another session becomes focused through existing session navigation, the handoff state does not move to that session; returning to the source session restores its card and state.
+
+18. While the handoff card is active:
+   - Normal input, image attachments, inline menus, footer content, and response-summary/warping rows are hidden.
+   - Keyboard focus belongs to the handoff card or its active selector.
+   - The hidden local input’s cursor and editing state are not mutated.
+
+19. The card follows the TUI orchestration card’s visual hierarchy:
+   - One blank row above the card.
+   - A tinted title row.
+   - A tinted body containing configuration or status.
+   - A separate key-hint row.
+   - Inline attention and error presentation consistent with orchestration.
+
+20. The card uses the active theme’s normal ANSI magenta—the same themed color source as the GUI `&` handoff indicator. Color is not the only indicator of card state or action availability.
+
+### Environment and model configuration
+
+21. The configuration card displays exactly two editable values:
+   - Environment.
+   - Model.
+
+22. Execution is always remote and the harness is always Oz. Location, harness, worker host, and API-key choices are not shown.
+
+23. The initial environment is the user’s saved/recent environment when one remains available.
+
+24. While the card is open, Warp asynchronously inspects the current working directory’s Git repository. If an available environment contains that repository, Warp may replace the default suggestion with the most-recent matching environment.
+
+25. A repository-based suggestion never overwrites a selection the user explicitly made.
+
+26. Environment discovery does not delay showing the card or prevent the user from interacting with it.
+
+27. The configuration summary uses the same interaction model as the TUI orchestration card:
+   - Enter confirms the handoff.
+   - Ctrl-E opens configuration editing.
+   - Ctrl-C cancels handoff.
+
+28. Configuration editing contains two searchable selector pages in order: environment, then model.
+   - Up and Down navigate within a page, including its search field.
+   - Enter applies the selected value and advances to the next page or returns to the summary after the last page.
+   - Left and Right apply the current selection and navigate between pages. If there is no confirmable selection, they still navigate without changing the current value.
+   - Tab advances without applying the current selection.
+   - Escape returns to the summary without applying the current page’s highlighted change.
+
+29. The model initially matches the local conversation’s model when that model can run in Oz cloud.
+
+30. If the local model cannot run in Oz cloud:
+   - The card identifies the model as incompatible.
+   - Handoff confirmation remains unavailable.
+   - The user must explicitly choose a compatible model.
+   - Warp never silently substitutes `auto` or another model.
+
+31. Enter confirms handoff only when the selected environment still exists and the selected model remains compatible.
+
+### No-environment state
+
+32. If the user has no cloud environments, the card explains that an environment is required and does not offer an in-TUI creation form.
+
+33. In the no-environment state:
+   - Enter opens `https://oz.warp.dev/environments`, where the user can create an environment.
+   - `R` refreshes cloud environments.
+   - Ctrl-C cancels handoff.
+
+34. The card automatically observes environment changes. When an environment becomes available, the same card transitions to normal configuration without losing the prompt, images, or captured source state.
+
+35. Manual refresh and automatic environment updates must not create a separate handoff flow or duplicate the card.
+
+### Prompt and image ownership
+
+36. Pending TUI images move with the handoff prompt when the card opens:
+   - They disappear from the normal local attachment bar.
+   - They remain associated with the pending handoff.
+   - They are included in the cloud run if handoff succeeds.
+
+37. If pre-confirmation handoff is cancelled or handoff later fails fatally, the prompt argument and images return to local input.
+
+38. After successful handoff, the prompt and images are considered consumed. Choosing **Continue locally** reopens clean local input; choosing **Start new conversation** opens a clean new conversation.
+
+### Pre-confirmation cancellation
+
+39. Before confirmation, Ctrl-C cancels from either the summary or an editing page. Escape from an editing page returns to the summary.
+
+40. Cancelling before confirmation:
+   - Creates no server conversation fork.
+   - Uploads no snapshot.
+   - Creates no cloud run.
+   - Reopens local input.
+   - Restores only the optional prompt argument, without restoring `/handoff`.
+   - Restores pending images.
+
+41. Cancelling pre-confirmation does not automatically resume a response that was eagerly cancelled.
+
+### Commitment and progress
+
+42. Enter on a valid configuration commits the handoff. Confirmation is the point of no return.
+
+43. After confirmation:
+   - Configuration and cancellation actions disappear.
+   - The card displays handoff progress.
+   - Ctrl-C is consumed without cancelling handoff or exiting the TUI.
+   - The local input remains blocked until a cloud run is created or handoff fails.
+
+44. The committed operation revalidates environment, model, and handoff availability before external work begins. If revalidation fails, the card returns to editable configuration without creating a fork or cloud run.
+
+45. For a non-empty source conversation, handoff creates an independent cloud fork. The original local conversation and transcript remain available and do not synchronize with subsequent cloud changes.
+
+46. For an empty source conversation with an explicit prompt, handoff creates a fresh cloud run without a conversation fork.
+
+47. A permitted orchestrator handoff forks only the selected conversation. The local orchestration tree remains available locally, and the cloud run receives the context necessary to understand that it came from an orchestration handoff.
+
+48. Snapshot collection for a permitted orchestrator includes workspace changes represented by completed child conversations as well as the selected parent conversation.
+
+49. Handoff waits for local workspace snapshot preparation to settle before creating the cloud run.
+
+50. Snapshot derivation or upload failure is non-fatal:
+   - The failure is not displayed in the card.
+   - Handoff continues without the missing snapshot.
+   - Conversation history is still handed off.
+
+51. An explicit user prompt is sent unchanged even when local generation was interrupted or a snapshot exists.
+
+52. With no explicit user prompt, the cloud run receives:
+   - Interrupted source with snapshot content: `Continue. Apply the workspace changes from my previous session.`
+   - Interrupted source without snapshot content: `Continue`.
+   - Idle source with snapshot content: `Apply the workspace changes from my previous session.`
+   - Idle source without snapshot content: no initial prompt.
+
+### Successful handoff
+
+53. Handoff is considered created when Warp receives a cloud run identifier.
+
+54. The blocking card becomes a static created card. It does not continue tracking queued, setup, running, completed, cancelled, or failed cloud-task state.
+
+55. For a forked conversation, the created card provides:
+   - Enter: open the cloud run.
+   - `C`: continue locally.
+   - `N`: start a new conversation.
+
+56. For a fresh cloud launch with no source conversation, the created card omits **Continue locally** and provides only:
+   - Enter: open the cloud run.
+   - `N`: start a new conversation.
+
+57. Opening the cloud run launches its Oz URL in the system browser.
+
+58. Opening the cloud run does not dismiss the created card, replace the TUI transcript, switch to a cloud-run view, or unblock local input.
+
+59. **Continue locally** moves the created card into the canonical transcript block list as a compact linked banner at the handoff location, then reopens clean local input. The banner has the same blank row above it as surrounding transcript blocks, states `Conversation forked to cloud; continuing locally`, and renders the cloud-run link on the next row. It remains while the user continues locally and follows normal transcript scrolling and clearing behavior.
+
+60. **Start new conversation** removes the created card and performs the TUI’s existing new-conversation behavior without installing the compact transcript banner.
+
+### Failures and state changes
+
+61. Fatal handoff failure after confirmation:
+   - Removes the blocking card.
+   - Reopens local input.
+   - Restores the optional prompt argument and pending images.
+   - Shows a transient bottom-row error.
+   - Does not offer in-card retry.
+
+62. A user may submit `/handoff` again after a fatal failure.
+
+63. If handoff becomes unavailable while the card is still editable—for example, because account policy or privacy settings change—the card closes, local input is restored, and no external handoff work begins.
+
+64. Once confirmation has committed the operation, later focus changes or card re-renders must not start a second fork, snapshot upload, or cloud run.
+
+65. Delayed environment suggestions, refresh results, or other asynchronous pre-confirmation updates must be ignored after the card is cancelled, replaced, or committed.
+
+66. The TUI must never show two handoff cards for the same session at once.

--- a/specs/CODE-1827/TECH.md
+++ b/specs/CODE-1827/TECH.md
@@ -1,0 +1,199 @@
+# CODE-1827 PR 3: TUI Local-to-Cloud Handoff
+
+## Context
+
+This top PR implements [`PRODUCT.md`](PRODUCT.md) using three downstack foundations:
+
+1. `code-1827-blocking-interactions` centralizes TUI blocking/focus/render placement.
+2. `code-1827-shared-handoff-pipeline` provides `prepare_handoff`, `PendingHandoff`, `execute_handoff`, shared startup classification, and GUI-proven behavior.
+3. `code-1827-shared-environment-catalog` provides the live cloud-environment catalog shared by GUI and TUI consumers.
+
+This PR leaves the GUI handoff pipeline and existing blocker architecture intact. It moves the GUI compose surface onto the same repository-aware environment suggestion helper used by the TUI, so both frontends share that policy.
+
+Relevant TUI references at warp commit `c4cc7be9477897c75c34bdc75c1a324c25b12f27`:
+
+- [`app/src/terminal/input/slash_commands/mod.rs (103-186)`](https://github.com/warpdotdev/warp/blob/c4cc7be9477897c75c34bdc75c1a324c25b12f27/app/src/terminal/input/slash_commands/mod.rs#L103-L186) owns TUI command selection/allowlisting.
+- [`crates/warp_tui/src/terminal_session_view.rs (2569-2810)`](https://github.com/warpdotdev/warp/blob/c4cc7be9477897c75c34bdc75c1a324c25b12f27/crates/warp_tui/src/terminal_session_view.rs#L2569-L2810) dispatches TUI slash commands.
+- [`crates/warp_tui/src/orchestration_block/configuration.rs (47-207)`](https://github.com/warpdotdev/warp/blob/c4cc7be9477897c75c34bdc75c1a324c25b12f27/crates/warp_tui/src/orchestration_block/configuration.rs#L47-L207) shows selector integration.
+- [`crates/warp_tui/src/orchestration_block/render.rs (85-267)`](https://github.com/warpdotdev/warp/blob/c4cc7be9477897c75c34bdc75c1a324c25b12f27/crates/warp_tui/src/orchestration_block/render.rs#L85-L267) is the card structure/copy reference.
+- [`crates/warp_tui/src/attachment_bar/model.rs (52-443)`](https://github.com/warpdotdev/warp/blob/c4cc7be9477897c75c34bdc75c1a324c25b12f27/crates/warp_tui/src/attachment_bar/model.rs#L52-L443) projects pending images from shared input context.
+- [`crates/warp_tui/src/orchestration_model.rs (316-440)`](https://github.com/warpdotdev/warp/blob/c4cc7be9477897c75c34bdc75c1a324c25b12f27/crates/warp_tui/src/orchestration_model.rs#L316-L440) demonstrates direct cloud-run creation and static URL state.
+
+## Proposed changes
+
+### Slash command
+
+- Add the existing `/handoff` static command to the TUI allowlist and exhaustive execution match.
+- Preserve insert-on-selection behavior and optional argument ghost text.
+- Gate availability and execution through existing handoff enablement; add no new feature flag.
+- On submission, gather concrete session/controller/context inputs and call downstack `prepare_handoff`.
+- Show transient bottom-row errors for long-running commands, active/blocked children, empty source without prompt, and other preparation failures.
+
+### Environment and model options
+
+Keep handoff independent of orchestration-card state while reusing lower-level providers:
+
+- Reuse compatible Oz model catalog filtering and validation.
+- Build environment rows without “Empty environment.”
+- Reuse saved/recent environment selection and persistence.
+- Start current-directory repository suggestion after preparation; apply it only while selection is non-explicit.
+
+Consume the downstack `CloudEnvironmentCatalog` singleton through `app/src/tui_export.rs`:
+
+- Build rows and valid IDs from its recency-ordered environment summaries.
+- Subscribe to its creation/deletion/update events.
+- Use its saved/default selection and persistence operations.
+- Trigger its existing out-of-band refresh operation for `R`.
+
+Keep repository-overlap suggestion in the shared handoff domain. `suggest_handoff_environment` resolves the current directory’s repository and applies the shared overlap/recency policy for both GUI compose and TUI handoff. Do not export cloud-object persistence internals or add card-owned polling.
+
+### Handoff card
+
+Keep the TUI handoff feature under `crates/warp_tui/src/handoff/`:
+
+- `model.rs` owns handoff state and execution.
+- `block.rs` owns presentation and input handling.
+- `session.rs` owns the active card’s session integration.
+- `model_tests.rs` and `tests.rs` cover model and session behavior.
+
+`TuiHandoffModel` owns:
+
+- Acceptance summary with `PendingHandoff`.
+- Two-page environment/model configuration flow.
+- No-environment state.
+- Committed progress.
+- Static created decision.
+- Compact persisted result after local continuation.
+- Preparation errors and restoration outcomes.
+- Environment/model subscriptions, validation, and handoff execution.
+
+`TuiHandoffBlock` owns selector navigation, focus, keybindings, rendering, and layout measurement.
+
+Session-specific coordination lives in the terminal session’s `handoff/session.rs` child module: it constructs the model and block, installs the active view in `BlockingInputSource`, restores prompt/images, transfers a completed card into the transcript, or starts a new conversation in response to model outcomes. `TuiTerminalSessionView` retains the enum-owned active view without a parallel interaction wrapper.
+
+The session owns the handoff view and projects it as a concrete `TuiSessionBlockingChild`. The live `TuiTerminalSessionState` is overlaid as blocked while the card is active, so the transcript stays visible while the normal input, attachments, menus, footer, and response-status rows are suppressed.
+
+Embed `TuiOptionSelector` for environment/model selection. Both pages use its existing search editor. Follow the orchestration card’s acceptance/configuration split, page header and position treatment, tinted header/body, metadata hierarchy, inline attention/error treatment, spacing, and key-hint grammar. Add one blank row above the active card. Reuse theme recipes based on `terminal_colors().normal.magenta`, matching GUI `ai_brand_color(theme)`; do not hard-code RGB values.
+
+Register phase-scoped fixed bindings:
+
+- Acceptance: Enter, Ctrl-E, Ctrl-C.
+- Configuration pages: Enter, Left, Right, Tab, Escape, Ctrl-C.
+- No environment: Enter, `R`, Ctrl-C.
+- Committed progress: consume Ctrl-C without cancellation.
+- Created: Enter, `C`, `N`.
+
+### Prompt and image ownership
+
+- On successful preparation, transfer pending images from shared input context into `PendingHandoff`.
+- On pre-confirmation cancellation or fatal outcome, restore prompt/images exactly once.
+- On successful creation, consume them. Local input remains blocked until the user chooses Continue locally or Start new conversation.
+- Never manipulate image ownership through `TuiAttachmentModel` view state.
+
+### Commit and outcomes
+
+On valid Enter:
+
+1. Consume pending card state into `execute_handoff`.
+2. Pass no `materialize_handoff_target` callback.
+3. Keep the blocker installed in non-cancellable progress state.
+4. Ignore late callbacks after the card/session is removed.
+
+On created outcome:
+
+- Store the run URL and whether a source conversation existed.
+- Do not create `TuiCloudRunView` or task-status subscriptions.
+- Keep the static created card installed as the session-owned blocking interaction.
+- Enter opens the URL without dismissing the card.
+- For a forked conversation, `C` transitions the same view to compact persisted presentation, removes the blocker, registers it as canonical transcript rich content, and focuses existing local input.
+- `N` removes the blocker and invokes existing new-conversation behavior without registering transcript rich content.
+- Omit `C` for a fresh launch with no source conversation.
+
+On fatal outcome:
+
+- Remove the interaction.
+- Restore prompt/images.
+- Focus local input.
+- Show a transient error.
+- Offer no in-card retry.
+
+### No environment
+
+- Render setup-required state with no creation form.
+- Enter opens `https://oz.warp.dev/environments`.
+- `R` invokes shared refresh.
+- Automatically transition when `CloudEnvironmentCatalog` reports an environment.
+
+### Telemetry
+
+- Emit the downstack initiation event with TUI surface and slash-command entry point.
+- Reuse snapshot-prepared and dispatch-failure behavior.
+- Add no card-action telemetry.
+
+### End-to-end flow
+
+```mermaid
+flowchart LR
+  Submit["/handoff"] --> Prepare["prepare_handoff"]
+  Prepare -->|rejected| Input["Local input + transient error"]
+  Prepare -->|pending| Card["TUI handoff card"]
+  Card -->|cancel| Restore["Restore prompt/images"]
+  Card -->|confirm| Commit["execute_handoff"]
+  Commit -->|failed| Restore
+  Commit -->|created| Created["Created decision card"]
+  Created --> Browser["Enter: open Oz"]
+  Created --> Continue["C: continue locally"]
+  Created --> New["N: new conversation"]
+  Continue --> Static["Compact transcript banner"]
+  Static --> Local["Local input reopens"]
+```
+
+## Testing and validation
+
+Add `handoff/model_tests.rs` plus session-level render and interaction tests in `handoff/tests.rs`.
+
+Map [`PRODUCT.md`](PRODUCT.md) invariants:
+
+- 1-7: command availability, insertion, ghost argument, parsing, fresh launch.
+- 8-15: guard errors, eager cancellation, and source-state capture through the shared API.
+- 16-20: input-area placement, focus, hidden-input preservation, and magenta theme.
+- 21-35: metadata, Ctrl-E editing, searchable environment/model pages, page navigation, no-environment creation-link/refresh, automatic environment transition, incompatible model.
+- 36-41: image transfer/restoration and pre-confirmation cancellation.
+- 42-52: progress state, point of no return, shared execution integration, snapshot degradation, prompt semantics.
+- 53-60: created decision card, URL open without dismissal, `C` persistence and local continuation, fresh-launch behavior, and `N` new-conversation behavior.
+- 61-66: fatal cleanup, single-card invariant, settings changes, and stale callbacks.
+
+Use real `App::dispatch_keystroke` paths and render-to-lines assertions.
+
+Run:
+
+- `./script/format`
+- Focused `cargo nextest run -p warp_tui` tests.
+- Focused downstack shared-pipeline regression tests if integration changes require them.
+- The applicable `warp_tui` clippy command from `./script/presubmit`.
+
+Run `./script/run-tui` in a real terminal and verify:
+
+1. Existing and fresh conversations, with and without prompt.
+2. Active-response cancellation.
+3. Environment/model selection and no-environment recovery.
+4. Image transfer/cancellation restoration.
+5. Long-running command and active-child rejection.
+6. Snapshot success and induced snapshot failure.
+7. Browser open, persistent completed banner, local continuation, and new conversation.
+8. Narrow terminal plus light and dark themes.
+
+Do not use GUI integration tests for the TUI card.
+
+## Risks and mitigations
+
+- Keep the PR limited to TUI product behavior; do not redesign downstack APIs without approval.
+- Consume pending state once and ignore stale completions to prevent duplicate runs.
+- Restore images idempotently.
+- Use `TuiTerminalSessionState` as the sole semantic focus/suppression source; keep concrete blocker handles only for rendering and focus transfer.
+- Use the shared `CloudEnvironmentCatalog` plus explicit refresh.
+- Derive accent styles from themed normal magenta.
+
+## Parallelization
+
+Do not parallelize implementation. The command, card, shared-pipeline integration, focus behavior, and tests form one tightly coupled product slice.


### PR DESCRIPTION
## Description

Adds keyboard-first local-to-cloud handoff to the headless TUI with `/handoff [prompt]`. The flow forks an existing local Oz conversation—or starts a fresh cloud run when there is only a prompt—while preserving the local transcript and making the next local action explicit.

This is the behavior-changing PR in the stack. It builds on the downstack blocking-interaction model, shared handoff pipeline, and shared cloud-environment catalog.

### What changed

- Makes `/handoff` available in eligible TUI Oz conversations. Selecting it inserts `/handoff ` so the user can optionally add a prompt before submitting.
- Adds `TuiHandoffModel`, which owns preparation, environment/model state, validation, shared pipeline execution, settings invalidation, and lifecycle outcomes.
- Adds `TuiHandoffBlock`, which owns rendering, focus, keybindings, and the two searchable environment/model selector pages.
- Adds `TuiHandoffInteraction`, which owns the active card handle and keeps it synchronized with the session’s `TuiBlockingInteractionModel` identity.
- Reuses `prepare_handoff`/`execute_handoff`, including long-running-command and orchestration-child guardrails, eager source cancellation, snapshot behavior, prompt substitution, and exactly-once prompt/image restoration.
- Reuses `CloudEnvironmentCatalog` for live environment rows, defaults, persistence, manual refresh, and no-environment recovery. Repository overlap can update an implicit default but never an explicit user selection.
- Blocks normal input, attachments, menus, footer, and warping/summary rows while the card owns the session.
- Treats confirmation as the point of no return: Ctrl-C cancels before commit and is consumed after commit.
- After creation, Enter opens the cloud run, `C` continues locally with a compact linked transcript banner, and `N` starts a clean conversation. Fresh launches omit `C`.
- Extends the canonical transcript/viewport rich-content path so the completed handoff banner scrolls, reflows, clears, and participates in selection resizing like other transcript blocks.
- Shares searchable environment pages and page-navigation behavior with the existing TUI orchestration selector.

### Architecture

```mermaid
flowchart TD
    Session["TuiTerminalSessionView"] --> Interaction["TuiHandoffInteraction"]
    Interaction -->|owns active ViewHandle| Block["TuiHandoffBlock"]
    Interaction -->|syncs blocker identity| Blocker["TuiBlockingInteractionModel"]

    Block -->|ModelHandle| Model["TuiHandoffModel"]
    Block -->|ViewHandle| Selector["TuiOptionSelector"]

    Model --> Phase["TuiHandoffPhase"]
    Model --> Pending["PendingHandoff"]
    Model --> Catalog["CloudEnvironmentCatalog"]
    Model --> Pipeline["prepare_handoff / execute_handoff"]

    Model -->|state updates| Block
    Model -->|outcome events| Session

    Session --> Transcript["TuiTranscriptView"]
    Transcript -->|retains completed block| Block
    Viewport["TuiBlockListViewportSource"] -->|measures + renders| Block
```

### Review guide

#### Read closely

- `crates/warp_tui/src/handoff/model.rs`:
  - `TuiHandoffPhase` and `TuiHandoffModelEvent` define the state machine and the events sent back to the session.
  - `TuiHandoffModel::new` prepares the shared `PendingHandoff`, subscribes to settings/catalog changes, and installs the retained model.
  - `selector_snapshot` and `apply_selection` own environment/model picker data and mutations.
  - `confirm` owns validation, the committed operation ID, `execute_handoff`, and handling rejected/failed/created outcomes.
  - `cancel`, `continue_locally`, and `start_new_conversation` are the three user exits from the card.
  - `refresh_pending_environments` and `handle_environment_change` keep pending validation synchronized with `CloudEnvironmentCatalog`.
- `crates/warp_tui/src/handoff/block.rs`:
  - `init` defines every phase-scoped keybinding.
  - `TuiHandoffBlock::new` wires the selector and model subscriptions.
  - `finish_page_confirmation`, `navigate_page`, `open_page`, and `handle_selector_event` implement the two-page environment/model editor.
  - `confirm` hands confirmation to the model and moves focus into committed state.
  - `render_configuration`, `render_body`, `render_footer`, and `render_completed` are the card’s phase-specific presentation.
  - `TypedActionView::handle_action` is the complete mapping from keyboard actions to model/view behavior.
- `crates/warp_tui/src/handoff/session.rs`:
  - `TuiHandoffInteraction::activate`, `deactivate`, and `active` keep the concrete `TuiHandoffBlock` handle synchronized with `TuiBlockingInteractionModel`.
  - `TuiTerminalSessionView::start_handoff` constructs the model/block and installs the interaction.
  - `restore_handoff_input`, `clear_handoff_interaction`, and `handle_handoff_model_event` route cancellation, failure, continue-local, and new-conversation outcomes back into the session.
- `crates/warp_tui/src/transcript_view.rs`:
  - `attach_handoff` inserts the completed card into canonical transcript rich content.
  - `remove_conversation` and `clear_agent_blocks` remove persisted handoff cards with the rest of their conversation/transcript state.
- `crates/warp_tui/src/tui_block_list_viewport_source.rs`:
  - `agent_heights_to_measure` and `measured_agent_heights` include handoff cards in rich-content measurement.
  - `visible_items_in_window` and `TuiBlockListVisibleItem::render_element` resolve/render the new `Handoff` variant.
- `crates/warp_tui/src/terminal_session_view.rs` — review only the `handoff_interaction` field and its use from `focus_current_owner`, `sync_blocker_state`, and `render`. The actual handoff logic lives in `handoff/session.rs`.

IMO, the rest is either skimable or skipable. The app-side changes are mostly slash-command/export/model-catalog adapters, the orchestration changes reuse existing selector navigation/search behavior, and all test files can be skipped.

## Testing

- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos

https://www.loom.com/share/1bab653f40524d89a3c2ecacdb35727f

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp&#39;s AI Agent Mode



