### PR TITLE
Fix local task-backed conversations disappearing from the TUI

### DIFF
--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -12,7 +12,9 @@ use super::{
 use crate::ai::active_agent_views_model::{ActiveAgentViewsModel, ConversationOrTaskId};
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::ambient_agents::{AgentSource, AmbientAgentTask, AmbientAgentTaskId};
+use crate::ai::ambient_agents::{
+    AgentSource, AmbientAgentTask, AmbientAgentTaskId, ExecutionLocation,
+};
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
 use crate::ai::conversation_navigation::ConversationNavigationData;
@@ -71,6 +73,7 @@ pub struct AgentConversationEntry {
     pub id: AgentConversationEntryId,
     pub identity: AgentConversationIdentity,
     pub provenance: AgentConversationProvenance,
+    pub execution_location: Option<ExecutionLocation>,
     pub display: AgentConversationDisplayData,
     pub backing: AgentConversationBackingData,
     pub capabilities: AgentConversationCapabilities,
@@ -168,9 +171,15 @@ pub struct AgentConversationCapabilities {
 impl AgentConversationEntry {
     /// Returns whether this entry represents a cloud agent run.
     pub fn is_cloud_agent_run(&self) -> bool {
-        matches!(self.provenance, AgentConversationProvenance::AmbientRun)
-            || self.backing.has_ambient_run
-            || self.identity.ambient_agent_task_id.is_some()
+        match self.execution_location {
+            Some(ExecutionLocation::Local) => false,
+            Some(ExecutionLocation::Remote) => true,
+            None => {
+                matches!(self.provenance, AgentConversationProvenance::AmbientRun)
+                    || self.backing.has_ambient_run
+                    || self.identity.ambient_agent_task_id.is_some()
+            }
+        }
     }
 
     pub(super) fn matches_filters(
@@ -494,6 +503,7 @@ pub(super) fn entry_for_task(
             session_id: task_session_id(task),
         },
         provenance: AgentConversationProvenance::AmbientRun,
+        execution_location: task.execution_location,
         display: AgentConversationDisplayData {
             title: task.title.clone(),
             initial_query: Some(task.prompt.clone()),
@@ -615,6 +625,7 @@ fn entry_for_conversation_parts(
             session_id: None,
         },
         provenance,
+        execution_location: None,
         display: AgentConversationDisplayData {
             title: conversation_title(&metadata, history_model),
             initial_query: metadata.nav_data.initial_query.clone(),

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -30,6 +30,7 @@ use crate::ai::agent::conversation::{
 use crate::ai::ambient_agents::task::{HarnessConfig, TaskPrincipalInfo, TaskStatusMessage};
 use crate::ai::ambient_agents::{
     AgentConfigSnapshot, AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState,
+    ExecutionLocation,
 };
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{
@@ -62,6 +63,7 @@ fn create_test_task(
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: Some(TaskPrincipalInfo {
@@ -960,8 +962,82 @@ fn test_get_entries_includes_task_only_entry() {
             assert_eq!(entry.identity.local_conversation_id, None);
             assert_eq!(entry.provenance, AgentConversationProvenance::AmbientRun);
             assert_eq!(entry.display.run_time.as_deref(), Some("2.00 min"));
+            assert_eq!(entry.execution_location, None);
             assert!(entry.backing.has_ambient_run);
             assert!(!entry.backing.has_loaded_conversation);
+            assert!(entry.is_cloud_agent_run());
+        });
+    });
+}
+
+#[test]
+fn test_task_entry_preserves_execution_location_independently_of_task_backing() {
+    App::test((), |mut app| async move {
+        add_entry_projection_test_models(&mut app);
+
+        let mut model = create_test_model();
+        let mut local_task = create_test_task(&make_uuid(8101), "user-a", Utc::now());
+        local_task.execution_location = Some(ExecutionLocation::Local);
+        let mut remote_task = create_test_task(&make_uuid(8102), "user-a", Utc::now());
+        remote_task.execution_location = Some(ExecutionLocation::Remote);
+        model.tasks.insert(local_task.task_id, local_task);
+        model.tasks.insert(remote_task.task_id, remote_task);
+
+        app.update(|ctx| {
+            let entries = model.get_entries(&all_owner_filters(), ctx);
+            let local_entry = entries
+                .iter()
+                .find(|entry| entry.execution_location == Some(ExecutionLocation::Local))
+                .expect("local task entry");
+            let remote_entry = entries
+                .iter()
+                .find(|entry| entry.execution_location == Some(ExecutionLocation::Remote))
+                .expect("remote task entry");
+
+            assert!(local_entry.backing.has_ambient_run);
+            assert!(local_entry.identity.ambient_agent_task_id.is_some());
+            assert!(!local_entry.is_cloud_agent_run());
+            assert!(remote_entry.backing.has_ambient_run);
+            assert!(remote_entry.identity.ambient_agent_task_id.is_some());
+            assert!(remote_entry.is_cloud_agent_run());
+        });
+    });
+}
+
+#[test]
+fn test_ambient_conversation_without_task_preserves_cloud_classification() {
+    App::test((), |mut app| async move {
+        let ambient_task_id = make_uuid(8103).parse().unwrap();
+        let server_token = "ambient-conversation-token";
+        add_entry_projection_test_models(&mut app);
+        let mut conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        conversation.set_server_conversation_token(server_token.to_string());
+        let server_metadata = create_server_conversation_metadata(
+            "Ambient conversation",
+            server_token,
+            Some(ambient_task_id),
+        );
+        BlocklistAIHistoryModel::handle(&app).update(&mut app, |model, ctx| {
+            model.restore_conversations(EntityId::new(), vec![conversation], ctx);
+            model.merge_cloud_conversation_metadata(vec![server_metadata]);
+        });
+
+        let mut model = create_test_model();
+        model.conversations.insert(
+            conversation_id,
+            create_test_conversation_metadata(conversation_id, "Ambient conversation"),
+        );
+
+        app.update(|ctx| {
+            let entries = model.get_entries(&all_owner_filters(), ctx);
+
+            assert_eq!(entries.len(), 1);
+            let entry = &entries[0];
+            assert_eq!(entry.identity.ambient_agent_task_id, Some(ambient_task_id));
+            assert_eq!(entry.execution_location, None);
+            assert!(entry.backing.has_ambient_run);
+            assert!(entry.is_cloud_agent_run());
         });
     });
 }

--- a/app/src/ai/ambient_agents/mod.rs
+++ b/app/src/ai/ambient_agents/mod.rs
@@ -18,7 +18,8 @@ pub mod telemetry;
 
 pub use task::{
     AgentConfigSnapshot, AgentSource, AmbientAgentLiveSessionState, AmbientAgentTask,
-    AmbientAgentTaskState, TaskStatusMessage, cancel_task_silently, cancel_task_with_toast,
+    AmbientAgentTaskState, ExecutionLocation, TaskStatusMessage, cancel_task_silently,
+    cancel_task_with_toast,
 };
 pub const OUT_OF_CREDITS_TASK_FAILURE_MESSAGE: &str =
     "Out of credits. Upgrade your Warp plan to continue running cloud agents.";

--- a/app/src/ai/ambient_agents/spawn_tests.rs
+++ b/app/src/ai/ambient_agents/spawn_tests.rs
@@ -30,6 +30,7 @@ fn task_with(
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id,
         session_link,
         creator: None,

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -116,6 +116,23 @@ impl AgentSource {
     }
 }
 
+/// Where the server executed an agent run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ExecutionLocation {
+    Local,
+    Remote,
+}
+
+impl ExecutionLocation {
+    pub(crate) fn as_query_param(self) -> &'static str {
+        match self {
+            ExecutionLocation::Local => "LOCAL",
+            ExecutionLocation::Remote => "REMOTE",
+        }
+    }
+}
+
 fn deserialize_ambient_agent_source<'de, D>(
     deserializer: D,
 ) -> Result<Option<AgentSource>, D::Error>
@@ -160,6 +177,8 @@ pub struct AmbientAgentTask {
     pub status_message: Option<TaskStatusMessage>,
     #[serde(default, deserialize_with = "deserialize_ambient_agent_source")]
     pub source: Option<AgentSource>,
+    #[serde(default)]
+    pub execution_location: Option<ExecutionLocation>,
     pub session_id: Option<String>,
     pub session_link: Option<String>,
     pub creator: Option<TaskPrincipalInfo>,

--- a/app/src/ai/ambient_agents/task_tests.rs
+++ b/app/src/ai/ambient_agents/task_tests.rs
@@ -2,8 +2,8 @@ use chrono::{Duration, Utc};
 use serde_json::{Value, json};
 
 use super::{
-    AgentConfigSnapshot, AgentSource, AmbientAgentTask, AmbientAgentTaskState, TaskStatusErrorCode,
-    TaskStatusMessage,
+    AgentConfigSnapshot, AgentSource, AmbientAgentTask, AmbientAgentTaskState, ExecutionLocation,
+    TaskStatusErrorCode, TaskStatusMessage,
 };
 
 fn make_task(snapshot_name: Option<&str>, title: &str) -> AmbientAgentTask {
@@ -24,6 +24,7 @@ fn make_task(snapshot_name: Option<&str>, title: &str) -> AmbientAgentTask {
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: None,
@@ -49,6 +50,7 @@ fn task_json_with_run_time(run_time_key: &str, run_time: Value) -> Value {
         "started_at": now,
         "updated_at": now,
         "status_message": null,
+        "execution_location": "LOCAL",
         "session_id": null,
         "session_link": null,
         "creator": null,
@@ -142,6 +144,7 @@ fn ambient_agent_task_deserializes_run_time_iso8601() {
         serde_json::from_value(task_json_with_run_time("run_time", json!("PT2M30S"))).unwrap();
 
     assert_eq!(task.run_time(), Some(Duration::seconds(150)));
+    assert_eq!(task.execution_location, Some(ExecutionLocation::Local));
 }
 
 #[test]

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -195,6 +195,7 @@ fn make_ambient_task_with_event_seq(
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: None,

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -33,6 +33,7 @@ fn create_test_task(task_id: &str) -> AmbientAgentTask {
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: Some(TaskPrincipalInfo {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -299,6 +299,7 @@ fn ambient_agent_task_for_current_user(task_id: AmbientAgentTaskId) -> AmbientAg
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: Some(AgentSource::CloudMode),
+        execution_location: None,
         session_id: None,
         session_link: None,
         executor: None,

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -127,7 +127,8 @@ use crate::ai::agent::conversation::{
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 // Re-export ambient agent types for backwards compatibility
 pub use crate::ai::ambient_agents::{
-    AgentConfigSnapshot, AgentSource, AmbientAgentTask, AmbientAgentTaskState, TaskStatusMessage,
+    AgentConfigSnapshot, AgentSource, AmbientAgentTask, AmbientAgentTaskState, ExecutionLocation,
+    TaskStatusMessage,
     task::{AttachmentInput, TaskAttachment},
 };
 use crate::ai::artifacts::Artifact;
@@ -706,22 +707,6 @@ pub struct TaskListFilter {
     pub sort_by: Option<RunSortBy>,
     pub sort_order: Option<RunSortOrder>,
     pub cursor: Option<String>,
-}
-
-/// Execution location filter values accepted by the public API.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ExecutionLocation {
-    Local,
-    Remote,
-}
-
-impl ExecutionLocation {
-    pub fn as_query_param(&self) -> &'static str {
-        match self {
-            ExecutionLocation::Local => "LOCAL",
-            ExecutionLocation::Remote => "REMOTE",
-        }
-    }
 }
 
 /// Artifact type filter values accepted by the public API.

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -130,6 +130,7 @@ fn make_task_with_name(
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: session_id.map(String::from),
         session_link: None,
         creator: None,

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -178,6 +178,7 @@ fn ambient_agent_task(
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: Some(TaskPrincipalInfo {

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -24,6 +24,7 @@ fn task_with_run_time_and_credits() -> AmbientAgentTask {
         run_time: Some("PT42S".parse().unwrap()),
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: Some(TaskPrincipalInfo {

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -690,6 +690,7 @@ fn create_cloud_mode_task_for_user(creator_uid: &str) -> AmbientAgentTask {
         run_time: Some("PT1S".parse().unwrap()),
         status_message: None,
         source: Some(AgentSource::CloudMode),
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: Some(TaskPrincipalInfo {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -118,6 +118,7 @@ fn owned_resumable_oz_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
         run_time: None,
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: Some(TaskPrincipalInfo {

--- a/app/src/ui_components/agent_icon_tests.rs
+++ b/app/src/ui_components/agent_icon_tests.rs
@@ -26,6 +26,7 @@ use crate::ai::agent_conversations_model::{
     AgentConversationEntry, AgentConversationEntryId, AgentConversationProvenance,
     AgentRunDisplayStatus,
 };
+use crate::ai::ambient_agents::ExecutionLocation;
 use crate::terminal::CLIAgent;
 use crate::ui_components::icon_with_status::IconWithStatusVariant;
 
@@ -384,7 +385,7 @@ fn local_claude_vs_cloud_claude_differ_only_by_is_ambient() {
 }
 
 #[test]
-fn non_ambient_entry_uses_display_harness() {
+fn entry_icon_uses_harness_and_execution_location() {
     let conversation_id = AIConversationId::new();
     let entry = AgentConversationEntry {
         id: AgentConversationEntryId::Conversation(conversation_id),
@@ -395,6 +396,7 @@ fn non_ambient_entry_uses_display_harness() {
             session_id: None,
         },
         provenance: AgentConversationProvenance::CloudSyncedConversation,
+        execution_location: None,
         display: AgentConversationDisplayData {
             title: "Codex conversation".to_string(),
             initial_query: None,
@@ -440,16 +442,21 @@ fn non_ambient_entry_uses_display_harness() {
     );
     assert!(!entry.is_cloud_agent_run());
 
-    let mut cloud_agent_by_provenance = entry.clone();
-    cloud_agent_by_provenance.provenance = AgentConversationProvenance::AmbientRun;
-    assert!(cloud_agent_by_provenance.is_cloud_agent_run());
-
-    let mut cloud_agent_by_backing = entry.clone();
-    cloud_agent_by_backing.backing.has_ambient_run = true;
-    assert!(cloud_agent_by_backing.is_cloud_agent_run());
-
-    let mut cloud_agent_by_task_id = entry;
-    cloud_agent_by_task_id.identity.ambient_agent_task_id =
+    let mut task_backed_local = entry.clone();
+    task_backed_local.provenance = AgentConversationProvenance::AmbientRun;
+    task_backed_local.backing.has_ambient_run = true;
+    task_backed_local.identity.ambient_agent_task_id =
         Some("00000000-0000-0000-0000-000000000001".parse().unwrap());
-    assert!(cloud_agent_by_task_id.is_cloud_agent_run());
+    assert!(task_backed_local.is_cloud_agent_run());
+
+    task_backed_local.execution_location = Some(ExecutionLocation::Local);
+    let variant = agent_conversation_entry_icon_variant(&task_backed_local);
+    assert!(!AgentIconFields::from_variant(&variant).unwrap().is_ambient);
+    assert!(!task_backed_local.is_cloud_agent_run());
+
+    let mut remote_task = task_backed_local;
+    remote_task.execution_location = Some(ExecutionLocation::Remote);
+    let variant = agent_conversation_entry_icon_variant(&remote_task);
+    assert!(AgentIconFields::from_variant(&variant).unwrap().is_ambient);
+    assert!(remote_task.is_cloud_agent_run());
 }

--- a/crates/warp_tui/src/conversation_selection_tests.rs
+++ b/crates/warp_tui/src/conversation_selection_tests.rs
@@ -75,7 +75,7 @@ fn tui_list_policy_classifies_selected_terminal_and_unavailable_entries() {
 }
 
 #[test]
-fn tui_list_policy_ignores_status_for_non_cloud_agent_conversations() {
+fn tui_list_policy_ignores_status_for_local_task_backed_conversations() {
     for status in [
         AgentRunDisplayStatus::ConversationInProgress,
         AgentRunDisplayStatus::TaskInProgress,
@@ -95,7 +95,7 @@ fn tui_list_policy_ignores_status_for_non_cloud_agent_conversations() {
 }
 
 #[test]
-fn tui_list_policy_requires_terminal_status_for_cloud_agent_runs() {
+fn tui_list_policy_requires_terminal_status_for_remote_agent_runs() {
     assert_eq!(
         classify_conversation_list_entry(ConversationListEntryContext {
             selected_id: None,


### PR DESCRIPTION
## Description

Task-backed conversations were classified as cloud agent runs based on task provenance and task ID presence. Local agent runs can also have task IDs, so an in-progress local conversation could initially appear in the TUI conversation list and then disappear when asynchronous task metadata replaced the conversation-only entry.

This change deserializes the server's authoritative execution location, carries it through ambient tasks and normalized conversation entries, and makes `is_cloud_agent_run` depend only on remote execution. Task provenance and backing remain separate metadata. The GUI agent icon also uses execution location so local task-backed runs retain local treatment.

## Linked Issue

N/A

## Testing

- Added regression coverage for local and remote task-backed classification, TUI filtering, task deserialization, and GUI icon selection.
- `cargo nextest run -p warp -p warp_tui -E 'test(ambient_agent_task_deserializes_run_time_iso8601) | test(test_task_entry_preserves_execution_location_independently_of_task_backing) | test(entry_icon_uses_display_harness_and_execution_location) | test(tui_list_policy)'`
- `cargo clippy -p warp -p warp_tui --all-targets --tests -- -D warnings`
- `./script/format`
- Manually verified with `./script/run-tui` that local, task-backed in-progress conversations remain visible after task metadata loads.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed local task-backed conversations disappearing from the TUI conversation list after task metadata loaded.

Co-Authored-By: Oz <oz-agent@warp.dev>