### PR TITLE
Enable account-first onboarding for dogfood

### DIFF
--- a/crates/warp_features/src/features_tests.rs
+++ b/crates/warp_features/src/features_tests.rs
@@ -20,10 +20,10 @@ fn local_child_harnesses_are_local_only_by_default() {
 }
 
 #[test]
-fn account_first_onboarding_is_disabled_for_all_rollout_channels() {
+fn account_first_onboarding_is_dogfood_only() {
     assert!(!LOCAL_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
     assert!(!DEBUG_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
-    assert!(!DOGFOOD_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
+    assert!(DOGFOOD_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
     assert!(!PREVIEW_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
     assert!(!RELEASE_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -999,6 +999,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::GeminiEnterprise,
     FeatureFlag::BoxDrawingGlyphs,
+    FeatureFlag::AccountFirstOnboarding,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Enables the merged account-first onboarding flow (#14075) for internal dogfood/Dev builds so the team can bug-bash the packaged experience before any Preview or Stable rollout.

- Adds `FeatureFlag::AccountFirstOnboarding` to `DOGFOOD_FLAGS`.
- Keeps the flag disabled for Local, Debug, Preview, and Release builds.
- Replaces the all-channels-off regression test with a dogfood-only scope assertion.

This is a rollout-only change; it does not modify the onboarding implementation. The branch is based on latest `master`, including merged #14075 and #14175.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- `./script/format`
- `cargo nextest run -p warp_features account_first_onboarding_is_dogfood_only` — 1 passed
- `cargo clippy -p warp_features --all-targets --tests -- -D warnings`
- `git diff --check`

No new GUI integration test was added because this PR only changes the channel rollout array; the account-first UI and routing tests landed with #14075.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>