### PR TITLE
Render review comment threads in the TUI

### DIFF
--- a/app/src/code_review/comments/flatten.rs
+++ b/app/src/code_review/comments/flatten.rs
@@ -1,4 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use ai::agent::action::{
+    ReviewCommentThread, format_review_comment_thread, group_review_comment_threads,
+};
 
 use super::comment::{
     AttachedReviewComment, AttachedReviewCommentTarget, CommentId, CommentOrigin,
@@ -18,61 +20,30 @@ pub(crate) fn attach_pending_imported_comments(
         return Vec::new();
     }
 
-    // Build a set of all GitHub comment IDs for orphan detection.
-    let existing_ids: HashSet<&str> = pending_comments
-        .iter()
-        .map(|c| c.github_comment_id())
-        .collect();
-
-    let mut roots: HashMap<&str, &PendingImportedReviewComment> = HashMap::new();
-    let mut parent_to_children: HashMap<&str, Vec<&PendingImportedReviewComment>> = HashMap::new();
-
-    for comment in pending_comments.iter() {
-        match comment.github_parent_comment_id() {
-            Some(parent_id) if existing_ids.contains(parent_id) => {
-                parent_to_children
-                    .entry(parent_id)
-                    .or_default()
-                    .push(comment);
-            }
-            Some(missing_parent_id) => {
-                // Orphaned comment - parent doesn't exist, treat as root.
+    group_review_comment_threads(&pending_comments)
+        .into_iter()
+        .map(|thread| {
+            if let Some(missing_parent_id) = thread.missing_parent_id() {
                 log::warn!(
                     "Importing orphaned comment (ID {:?}) with parent ID {:?}",
-                    comment.github_comment_id(),
+                    thread.root().github_comment_id(),
                     missing_parent_id
                 );
-                roots.insert(comment.github_comment_id(), comment);
             }
-            None => {
-                // Already a root comment.
-                roots.insert(comment.github_comment_id(), comment);
-            }
-        };
-    }
-
-    let mut root_comments: Vec<_> = roots.values().copied().collect();
-    root_comments.sort_by_key(|c| c.github_comment_id());
-
-    root_comments
-        .into_iter()
-        .map(|root| flatten_pending_imported_thread(root, &parent_to_children, repo_path))
+            attach_pending_imported_thread(thread, repo_path)
+        })
         .collect()
 }
 
-fn flatten_pending_imported_thread(
-    root: &PendingImportedReviewComment,
-    children_map: &HashMap<&str, Vec<&PendingImportedReviewComment>>,
+fn attach_pending_imported_thread(
+    thread: ReviewCommentThread<'_, PendingImportedReviewComment>,
     repo_path: &LocalOrRemotePath,
 ) -> AttachedReviewComment {
-    const THREAD_REPLY_DIVIDER: &str = "\n---\n";
-
-    let mut thread_comments = Vec::new();
-    collect_pending_imported_thread_dfs(root, children_map, &mut thread_comments);
-
-    let last_update_time = thread_comments
+    let root = thread.root();
+    let last_update_time = thread
+        .comments()
         .iter()
-        .map(|c| c.last_update_time)
+        .map(|comment| comment.last_update_time)
         .max()
         .unwrap_or(root.last_update_time);
 
@@ -94,46 +65,16 @@ fn flatten_pending_imported_thread(
         PendingImportedReviewCommentTarget::General => AttachedReviewCommentTarget::General,
     };
 
-    let mut combined_body = String::new();
-    for (i, comment) in thread_comments.iter().enumerate() {
-        if i > 0 {
-            combined_body.push_str(THREAD_REPLY_DIVIDER);
-        }
-
-        combined_body.push_str(&format!(
-            "**@{}**:\n{}",
-            comment.author(),
-            comment.body.as_str()
-        ));
-    }
-
     let origin = CommentOrigin::ImportedFromGitHub(root.github_details_without_parent());
 
     AttachedReviewComment {
         id: CommentId::new(),
-        content: combined_body,
+        content: format_review_comment_thread(&thread),
         target,
         last_update_time,
         base: None,
         head: None,
         outdated: false,
         origin,
-    }
-}
-
-fn collect_pending_imported_thread_dfs<'a>(
-    comment: &'a PendingImportedReviewComment,
-    children_map: &HashMap<&str, Vec<&'a PendingImportedReviewComment>>,
-    result: &mut Vec<&'a PendingImportedReviewComment>,
-) {
-    result.push(comment);
-
-    // Get children of this comment.
-    if let Some(children) = children_map.get(comment.github_comment_id()) {
-        let mut sorted_children = children.to_vec();
-        sorted_children.sort_by(|a, b| a.last_update_time.cmp(&b.last_update_time));
-        for child in sorted_children {
-            collect_pending_imported_thread_dfs(child, children_map, result);
-        }
     }
 }

--- a/app/src/code_review/comments/pending_imported.rs
+++ b/app/src/code_review/comments/pending_imported.rs
@@ -1,5 +1,7 @@
+use std::cmp::Ordering;
 use std::path::PathBuf;
 
+use ai::agent::action::ReviewCommentThreadItem;
 use chrono::{DateTime, Local};
 
 use super::comment::{ImportedCommentDetails, LineDiffContent};
@@ -49,6 +51,28 @@ impl PendingImportedReviewComment {
         let mut details = self.github_details.clone();
         details.github_parent_id = None;
         details
+    }
+}
+
+impl ReviewCommentThreadItem for PendingImportedReviewComment {
+    fn comment_id(&self) -> &str {
+        self.github_comment_id()
+    }
+
+    fn parent_comment_id(&self) -> Option<&str> {
+        self.github_parent_comment_id()
+    }
+
+    fn author(&self) -> &str {
+        self.author()
+    }
+
+    fn body(&self) -> &str {
+        &self.body
+    }
+
+    fn compare_last_modified(&self, other: &Self) -> Ordering {
+        self.last_update_time.cmp(&other.last_update_time)
     }
 }
 

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -1,4 +1,5 @@
 mod convert;
+mod review_comments;
 
 use std::fmt::Display;
 use std::ops::Range;
@@ -6,6 +7,10 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use itertools::Itertools as _;
+pub use review_comments::{
+    ReviewCommentThread, ReviewCommentThreadItem, format_review_comment_thread,
+    group_review_comment_threads,
+};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumDiscriminants;
 use uuid::Uuid;

--- a/crates/ai/src/agent/action/review_comments.rs
+++ b/crates/ai/src/agent/action/review_comments.rs
@@ -1,0 +1,145 @@
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+use chrono::DateTime;
+
+use super::InsertReviewComment;
+
+const THREAD_REPLY_DIVIDER: &str = "\n---\n";
+
+/// Presentation-neutral data needed to reconstruct provider review comment threads.
+pub trait ReviewCommentThreadItem {
+    fn comment_id(&self) -> &str;
+    fn parent_comment_id(&self) -> Option<&str>;
+    fn author(&self) -> &str;
+    fn body(&self) -> &str;
+    fn compare_last_modified(&self, other: &Self) -> Ordering;
+}
+
+/// One root review comment and its replies in display order.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReviewCommentThread<'a, T> {
+    comments: Vec<&'a T>,
+    missing_parent_id: Option<&'a str>,
+}
+
+impl<'a, T> ReviewCommentThread<'a, T> {
+    pub fn root(&self) -> &'a T {
+        self.comments[0]
+    }
+
+    pub fn comments(&self) -> &[&'a T] {
+        &self.comments
+    }
+
+    pub fn missing_parent_id(&self) -> Option<&'a str> {
+        self.missing_parent_id
+    }
+}
+
+/// Groups review comments into deterministic, depth-first provider threads.
+///
+/// Roots are ordered by comment ID. Replies are stably ordered by their
+/// last-modified value. A comment whose parent is absent is retained as a root
+/// and exposes that missing parent ID.
+pub fn group_review_comment_threads<T: ReviewCommentThreadItem>(
+    comments: &[T],
+) -> Vec<ReviewCommentThread<'_, T>> {
+    if comments.is_empty() {
+        return Vec::new();
+    }
+
+    let existing_ids: HashSet<&str> = comments.iter().map(T::comment_id).collect();
+    let mut roots: HashMap<&str, (&T, Option<&str>)> = HashMap::new();
+    let mut parent_to_children: HashMap<&str, Vec<&T>> = HashMap::new();
+
+    for comment in comments {
+        match comment.parent_comment_id() {
+            Some(parent_id) if existing_ids.contains(parent_id) => {
+                parent_to_children
+                    .entry(parent_id)
+                    .or_default()
+                    .push(comment);
+            }
+            missing_parent_id => {
+                roots.insert(comment.comment_id(), (comment, missing_parent_id));
+            }
+        }
+    }
+
+    let mut roots: Vec<_> = roots.into_values().collect();
+    roots.sort_by(|(a, _), (b, _)| a.comment_id().cmp(b.comment_id()));
+    roots
+        .into_iter()
+        .map(|(root, missing_parent_id)| {
+            let mut thread_comments = Vec::new();
+            collect_review_comment_thread(root, &parent_to_children, &mut thread_comments);
+            ReviewCommentThread {
+                comments: thread_comments,
+                missing_parent_id,
+            }
+        })
+        .collect()
+}
+
+/// Formats a provider thread using the Markdown representation shared by clients.
+pub fn format_review_comment_thread<T: ReviewCommentThreadItem>(
+    thread: &ReviewCommentThread<'_, T>,
+) -> String {
+    thread
+        .comments()
+        .iter()
+        .map(|comment| format!("**@{}**:\n{}", comment.author(), comment.body()))
+        .collect::<Vec<_>>()
+        .join(THREAD_REPLY_DIVIDER)
+}
+
+fn collect_review_comment_thread<'a, T: ReviewCommentThreadItem>(
+    comment: &'a T,
+    children_map: &HashMap<&str, Vec<&'a T>>,
+    result: &mut Vec<&'a T>,
+) {
+    result.push(comment);
+
+    if let Some(children) = children_map.get(comment.comment_id()) {
+        let mut sorted_children = children.to_vec();
+        sorted_children.sort_by(|a, b| a.compare_last_modified(b));
+        for child in sorted_children {
+            collect_review_comment_thread(child, children_map, result);
+        }
+    }
+}
+
+impl ReviewCommentThreadItem for InsertReviewComment {
+    fn comment_id(&self) -> &str {
+        &self.comment_id
+    }
+
+    fn parent_comment_id(&self) -> Option<&str> {
+        self.parent_comment_id.as_deref()
+    }
+
+    fn author(&self) -> &str {
+        &self.author
+    }
+
+    fn body(&self) -> &str {
+        &self.comment_body
+    }
+
+    fn compare_last_modified(&self, other: &Self) -> Ordering {
+        match (
+            DateTime::parse_from_rfc3339(&self.last_modified_timestamp),
+            DateTime::parse_from_rfc3339(&other.last_modified_timestamp),
+        ) {
+            (Ok(this), Ok(other)) => this.cmp(&other),
+            _ => self
+                .last_modified_timestamp
+                .cmp(&other.last_modified_timestamp),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "review_comments_tests.rs"]
+mod tests;

--- a/crates/ai/src/agent/action/review_comments_tests.rs
+++ b/crates/ai/src/agent/action/review_comments_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+fn comment(
+    id: &str,
+    author: &str,
+    body: &str,
+    parent_id: Option<&str>,
+    timestamp: &str,
+) -> InsertReviewComment {
+    InsertReviewComment {
+        comment_id: id.to_owned(),
+        author: author.to_owned(),
+        last_modified_timestamp: timestamp.to_owned(),
+        comment_body: body.to_owned(),
+        parent_comment_id: parent_id.map(str::to_owned),
+        comment_location: None,
+        html_url: None,
+    }
+}
+
+#[test]
+fn groups_roots_and_depth_first_replies_deterministically() {
+    let comments = vec![
+        comment("4", "dana", "Early", Some("1"), "2024-01-01T00:30:00Z"),
+        comment("2", "bob", "Later", Some("1"), "2024-01-01T01:00:00Z"),
+        comment("3", "charlie", "Nested", Some("2"), "2024-01-01T02:00:00Z"),
+        comment("5", "eve", "Second root", None, "2024-01-01T00:00:00Z"),
+        comment("1", "alice", "Root", None, "2024-01-01T00:00:00Z"),
+    ];
+
+    let threads = group_review_comment_threads(&comments);
+
+    assert_eq!(threads.len(), 2);
+    assert_eq!(
+        threads[0]
+            .comments()
+            .iter()
+            .map(|comment| comment.comment_id())
+            .collect::<Vec<_>>(),
+        vec!["1", "4", "2", "3"]
+    );
+    assert_eq!(threads[1].root().comment_id(), "5");
+    assert_eq!(
+        format_review_comment_thread(&threads[0]),
+        "**@alice**:\nRoot\n---\n**@dana**:\nEarly\n---\n**@bob**:\nLater\n---\n**@charlie**:\nNested"
+    );
+}
+
+#[test]
+fn retains_orphaned_replies_as_roots() {
+    let comments = vec![comment(
+        "2",
+        "bob",
+        "Orphan",
+        Some("missing"),
+        "2024-01-01T00:00:00Z",
+    )];
+
+    let threads = group_review_comment_threads(&comments);
+
+    assert_eq!(threads.len(), 1);
+    assert_eq!(threads[0].root().comment_id(), "2");
+    assert_eq!(threads[0].missing_parent_id(), Some("missing"));
+}

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -62,17 +62,6 @@ const COMPARE_PLANS_LABEL: &str = "Compare plans";
 const USE_YOUR_OWN_API_KEYS_LABEL: &str = "Use your own API keys";
 const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
-fn render_stateless_tool_call_section(
-    action: &AIAgentAction,
-    status: Option<&AIActionStatus>,
-    output_streaming: bool,
-    app: &AppContext,
-) -> Box<dyn TuiElement> {
-    render_review_comments_tool_call(action, status, output_streaming, app).unwrap_or_else(|| {
-        render_fallback_tool_call_section(action, status, output_streaming, None, app)
-    })
-}
-
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TuiCodeBlockKey {
     message_id: MessageId,
@@ -1189,20 +1178,40 @@ impl TuiAIBlock {
                 self.render_rich_text_section(section, false, app)
             }
             TuiAIBlockSection::ToolCall(action) => {
-                if let Some(view) = self.action_views.get(&action.id) {
-                    match view {
-                        TuiToolCallView::Generic(view)
-                            if view.as_ref(app).active_permission_prompt(app).is_none() => {}
-                        TuiToolCallView::AskQuestion(_)
-                        | TuiToolCallView::FileEdits(_)
-                        | TuiToolCallView::Generic(_)
-                        | TuiToolCallView::Plan(_)
-                        | TuiToolCallView::ShellCommand(_)
-                        | TuiToolCallView::OrchestrationBlock(_) => return None,
+                let status = self.action_model.as_ref(app).get_action_status(&action.id);
+                match &action.action {
+                    AIAgentActionType::InsertCodeReviewComments { comments, .. } => {
+                        render_review_comments_tool_call(
+                            action,
+                            comments,
+                            status.as_ref(),
+                            output_streaming,
+                            app,
+                        )
+                    }
+                    _ => {
+                        if let Some(view) = self.action_views.get(&action.id) {
+                            match view {
+                                TuiToolCallView::Generic(view)
+                                    if view.as_ref(app).active_permission_prompt(app).is_none() => {
+                                }
+                                TuiToolCallView::AskQuestion(_)
+                                | TuiToolCallView::FileEdits(_)
+                                | TuiToolCallView::Generic(_)
+                                | TuiToolCallView::Plan(_)
+                                | TuiToolCallView::ShellCommand(_)
+                                | TuiToolCallView::OrchestrationBlock(_) => return None,
+                            }
+                        }
+                        render_fallback_tool_call_section(
+                            action,
+                            status.as_ref(),
+                            output_streaming,
+                            None,
+                            app,
+                        )
                     }
                 }
-                let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                render_stateless_tool_call_section(action, status.as_ref(), output_streaming, app)
             }
             TuiAIBlockSection::Thinking {
                 message_id,
@@ -1532,37 +1541,57 @@ impl TuiAIBlock {
                 }
                 // Stateful tool calls render their registered child view; every
                 // other tool call stays a pure render fn.
-                TuiAIBlockSection::ToolCall(action) => match self.action_views.get(&action.id) {
-                    Some(TuiToolCallView::Plan(view)) if !view.as_ref(app).renders_rich_body() => {
+                TuiAIBlockSection::ToolCall(action) => match &action.action {
+                    AIAgentActionType::InsertCodeReviewComments { comments, .. } => {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        render_stateless_tool_call_section(
+                        render_review_comments_tool_call(
                             action,
+                            comments,
                             status.as_ref(),
                             output_streaming,
                             app,
                         )
                     }
-                    Some(TuiToolCallView::Generic(view))
-                        if view.as_ref(app).active_permission_prompt(app).is_none() =>
-                    {
-                        let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        render_stateless_tool_call_section(
-                            action,
-                            status.as_ref(),
-                            output_streaming,
-                            app,
-                        )
-                    }
-                    Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
-                    None => {
-                        let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        render_stateless_tool_call_section(
-                            action,
-                            status.as_ref(),
-                            output_streaming,
-                            app,
-                        )
-                    }
+                    _ => match self.action_views.get(&action.id) {
+                        Some(TuiToolCallView::Plan(view))
+                            if !view.as_ref(app).renders_rich_body() =>
+                        {
+                            let status =
+                                self.action_model.as_ref(app).get_action_status(&action.id);
+                            render_fallback_tool_call_section(
+                                action,
+                                status.as_ref(),
+                                output_streaming,
+                                None,
+                                app,
+                            )
+                        }
+                        Some(TuiToolCallView::Generic(view))
+                            if view.as_ref(app).active_permission_prompt(app).is_none() =>
+                        {
+                            let status =
+                                self.action_model.as_ref(app).get_action_status(&action.id);
+                            render_fallback_tool_call_section(
+                                action,
+                                status.as_ref(),
+                                output_streaming,
+                                None,
+                                app,
+                            )
+                        }
+                        Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
+                        None => {
+                            let status =
+                                self.action_model.as_ref(app).get_action_status(&action.id);
+                            render_fallback_tool_call_section(
+                                action,
+                                status.as_ref(),
+                                output_streaming,
+                                None,
+                                app,
+                            )
+                        }
+                    },
                 },
                 TuiAIBlockSection::Thinking {
                     message_id,

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -54,12 +54,24 @@ use crate::tui_markdown::{
     TuiMarkdownBlockHooks, TuiMarkdownPalette, render_formatted_table, render_formatted_text,
 };
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
+use crate::tui_review_comments::render_review_comments_tool_call;
 const PLANS_URL: &str = "https://www.warp.dev/pricing";
 const BYOK_DOCS_URL: &str =
     "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/";
 const COMPARE_PLANS_LABEL: &str = "Compare plans";
 const USE_YOUR_OWN_API_KEYS_LABEL: &str = "Use your own API keys";
 const FAILURE_WARNING_PREFIX: &str = "⚠ ";
+
+fn render_stateless_tool_call_section(
+    action: &AIAgentAction,
+    status: Option<&AIActionStatus>,
+    output_streaming: bool,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    render_review_comments_tool_call(action, status, output_streaming, app).unwrap_or_else(|| {
+        render_fallback_tool_call_section(action, status, output_streaming, None, app)
+    })
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TuiCodeBlockKey {
@@ -1190,13 +1202,7 @@ impl TuiAIBlock {
                     }
                 }
                 let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                render_fallback_tool_call_section(
-                    action,
-                    status.as_ref(),
-                    output_streaming,
-                    None,
-                    app,
-                )
+                render_stateless_tool_call_section(action, status.as_ref(), output_streaming, app)
             }
             TuiAIBlockSection::Thinking {
                 message_id,
@@ -1529,11 +1535,10 @@ impl TuiAIBlock {
                 TuiAIBlockSection::ToolCall(action) => match self.action_views.get(&action.id) {
                     Some(TuiToolCallView::Plan(view)) if !view.as_ref(app).renders_rich_body() => {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        render_fallback_tool_call_section(
+                        render_stateless_tool_call_section(
                             action,
                             status.as_ref(),
                             output_streaming,
-                            None,
                             app,
                         )
                     }
@@ -1541,22 +1546,20 @@ impl TuiAIBlock {
                         if view.as_ref(app).active_permission_prompt(app).is_none() =>
                     {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        render_fallback_tool_call_section(
+                        render_stateless_tool_call_section(
                             action,
                             status.as_ref(),
                             output_streaming,
-                            None,
                             app,
                         )
                     }
                     Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
                     None => {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        render_fallback_tool_call_section(
+                        render_stateless_tool_call_section(
                             action,
                             status.as_ref(),
                             output_streaming,
-                            None,
                             app,
                         )
                     }

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -73,6 +73,7 @@ mod tui_generic_tool_call_view;
 mod tui_markdown;
 mod tui_permission_prompt;
 mod tui_plan_view;
+mod tui_review_comments;
 mod tui_shell_command_view;
 mod usage;
 mod voice_input;

--- a/crates/warp_tui/src/tui_review_comments.rs
+++ b/crates/warp_tui/src/tui_review_comments.rs
@@ -1,0 +1,101 @@
+use ai::agent::action::{
+    AIAgentActionType, CommentSide, InsertReviewComment, InsertedCommentLocation,
+    format_review_comment_thread, group_review_comment_threads,
+};
+use markdown_parser::parse_markdown;
+use warp::tui_export::{AIActionStatus, AIAgentAction};
+use warpui_core::AppContext;
+use warpui_core::elements::tui::{Modifier, TuiContainer, TuiElement, TuiFlex, TuiText};
+
+use crate::agent_block_sections::render_fallback_tool_call_section;
+use crate::tui_builder::TuiUiBuilder;
+use crate::tui_markdown::{TuiMarkdownBlockHooks, TuiMarkdownPalette, render_formatted_text};
+
+pub(crate) fn render_review_comments_tool_call(
+    action: &AIAgentAction,
+    status: Option<&AIActionStatus>,
+    output_streaming: bool,
+    app: &AppContext,
+) -> Option<Box<dyn TuiElement>> {
+    let AIAgentActionType::InsertCodeReviewComments { comments, .. } = &action.action else {
+        return None;
+    };
+
+    let status_row = render_fallback_tool_call_section(action, status, output_streaming, None, app);
+    if !status.is_some_and(AIActionStatus::is_success) || comments.is_empty() {
+        return Some(status_row);
+    }
+
+    let builder = TuiUiBuilder::from_app(app);
+    let palette = TuiMarkdownPalette::from_builder(&builder);
+    let mut column = TuiFlex::column().child(status_row);
+    for thread in group_review_comment_threads(comments) {
+        let root = thread.root();
+        let body = format_review_comment_thread(&thread);
+        let rendered_body = match parse_markdown(&body) {
+            Ok(formatted) => {
+                render_formatted_text(&formatted, palette, &TuiMarkdownBlockHooks::default())
+            }
+            Err(_) => TuiText::new(body).with_style(palette.body).finish(),
+        };
+
+        let mut comment = TuiFlex::column()
+            .child(
+                TuiText::new(format_comment_target(root))
+                    .with_style(builder.muted_text_style().add_modifier(Modifier::BOLD))
+                    .finish(),
+            )
+            .child(rendered_body);
+        if let Some(url) = &root.html_url {
+            comment = comment.child(
+                TuiText::new(url.clone())
+                    .with_style(
+                        builder
+                            .accent_text_style()
+                            .add_modifier(Modifier::UNDERLINED),
+                    )
+                    .finish(),
+            );
+        }
+
+        column = column.child(
+            TuiContainer::new(comment.finish())
+                .with_padding_top(1)
+                .with_padding_left(2)
+                .finish(),
+        );
+    }
+
+    Some(column.finish())
+}
+
+fn format_comment_target(comment: &InsertReviewComment) -> String {
+    let Some(location) = &comment.comment_location else {
+        return "Pull request".to_owned();
+    };
+    format_location(location)
+}
+
+fn format_location(location: &InsertedCommentLocation) -> String {
+    let Some(line) = &location.line else {
+        return location.relative_file_path.clone();
+    };
+    let range = &line.comment_line_range;
+    let line_label = if range.start == 0 {
+        range.end.to_string()
+    } else if range.end == 0 || range.start == range.end {
+        range.start.to_string()
+    } else {
+        format!("{}-{}", range.start, range.end)
+    };
+    let side = match line.side {
+        Some(CommentSide::Right) => "new",
+        Some(CommentSide::Left) => "old",
+        None => "diff",
+    };
+    format!("{}:{line_label} ({side})", location.relative_file_path)
+}
+
+#[cfg(test)]
+#[path = "tui_review_comments_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/tui_review_comments.rs
+++ b/crates/warp_tui/src/tui_review_comments.rs
@@ -1,6 +1,6 @@
 use ai::agent::action::{
-    AIAgentActionType, CommentSide, InsertReviewComment, InsertedCommentLocation,
-    format_review_comment_thread, group_review_comment_threads,
+    CommentSide, InsertReviewComment, InsertedCommentLocation, format_review_comment_thread,
+    group_review_comment_threads,
 };
 use markdown_parser::parse_markdown;
 use warp::tui_export::{AIActionStatus, AIAgentAction};
@@ -13,17 +13,14 @@ use crate::tui_markdown::{TuiMarkdownBlockHooks, TuiMarkdownPalette, render_form
 
 pub(crate) fn render_review_comments_tool_call(
     action: &AIAgentAction,
+    comments: &[InsertReviewComment],
     status: Option<&AIActionStatus>,
     output_streaming: bool,
     app: &AppContext,
-) -> Option<Box<dyn TuiElement>> {
-    let AIAgentActionType::InsertCodeReviewComments { comments, .. } = &action.action else {
-        return None;
-    };
-
+) -> Box<dyn TuiElement> {
     let status_row = render_fallback_tool_call_section(action, status, output_streaming, None, app);
     if !status.is_some_and(AIActionStatus::is_success) || comments.is_empty() {
-        return Some(status_row);
+        return status_row;
     }
 
     let builder = TuiUiBuilder::from_app(app);
@@ -66,7 +63,7 @@ pub(crate) fn render_review_comments_tool_call(
         );
     }
 
-    Some(column.finish())
+    column.finish()
 }
 
 fn format_comment_target(comment: &InsertReviewComment) -> String {

--- a/crates/warp_tui/src/tui_review_comments_tests.rs
+++ b/crates/warp_tui/src/tui_review_comments_tests.rs
@@ -1,0 +1,206 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ai::agent::action::{
+    CommentSide, InsertReviewComment, InsertedCommentLine, InsertedCommentLocation,
+};
+use ai::agent::action_result::InsertReviewCommentsResult;
+use warp::tui_export::{
+    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
+    AIAgentActionType, Appearance, TaskId,
+};
+use warpui_core::App;
+use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::presenter::tui::TuiPresenter;
+
+use super::{format_comment_target, render_review_comments_tool_call};
+
+fn comment(
+    id: &str,
+    author: &str,
+    body: &str,
+    parent_id: Option<&str>,
+    location: Option<InsertedCommentLocation>,
+) -> InsertReviewComment {
+    InsertReviewComment {
+        comment_id: id.to_owned(),
+        author: author.to_owned(),
+        last_modified_timestamp: format!("2024-01-01T00:00:0{id}Z"),
+        comment_body: body.to_owned(),
+        parent_comment_id: parent_id.map(str::to_owned),
+        comment_location: location,
+        html_url: Some(format!("https://github.com/warp/warp/pull/1#comment-{id}")),
+    }
+}
+
+fn action(comments: Vec<InsertReviewComment>) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from("comments-action".to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        action: AIAgentActionType::InsertCodeReviewComments {
+            repo_path: PathBuf::from("/repo"),
+            comments,
+            base_branch: Some("master".to_owned()),
+        },
+        requires_result: true,
+    }
+}
+
+fn finished_status(action: &AIAgentAction, result: InsertReviewCommentsResult) -> AIActionStatus {
+    AIActionStatus::Finished(Arc::new(AIAgentActionResult {
+        id: action.id.clone(),
+        task_id: action.task_id.clone(),
+        result: AIAgentActionResultType::InsertReviewComments(result),
+    }))
+}
+
+#[test]
+fn formats_pull_request_file_and_line_targets() {
+    assert_eq!(
+        format_comment_target(&comment("1", "alice", "body", None, None)),
+        "Pull request"
+    );
+    assert_eq!(
+        format_comment_target(&comment(
+            "1",
+            "alice",
+            "body",
+            None,
+            Some(InsertedCommentLocation {
+                relative_file_path: "src/main.rs".to_owned(),
+                line: None,
+            }),
+        )),
+        "src/main.rs"
+    );
+    assert_eq!(
+        format_comment_target(&comment(
+            "1",
+            "alice",
+            "body",
+            None,
+            Some(InsertedCommentLocation {
+                relative_file_path: "src/main.rs".to_owned(),
+                line: Some(InsertedCommentLine {
+                    comment_line_range: 10..12,
+                    diff_hunk_line_range: 8..14,
+                    diff_hunk_text: String::new(),
+                    side: Some(CommentSide::Right),
+                }),
+            }),
+        )),
+        "src/main.rs:10-12 (new)"
+    );
+    assert_eq!(
+        format_comment_target(&comment(
+            "1",
+            "alice",
+            "body",
+            None,
+            Some(InsertedCommentLocation {
+                relative_file_path: "src/main.rs".to_owned(),
+                line: Some(InsertedCommentLine {
+                    comment_line_range: 15..15,
+                    diff_hunk_line_range: 15..15,
+                    diff_hunk_text: String::new(),
+                    side: Some(CommentSide::Left),
+                }),
+            }),
+        )),
+        "src/main.rs:15 (old)"
+    );
+}
+
+#[test]
+fn renders_shared_markdown_thread_only_after_success() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let action = action(vec![
+            comment("1", "alice", "**Root**", None, None),
+            comment("2", "bob", "Reply", Some("1"), None),
+        ]);
+        app.read(|ctx| {
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_review_comments_tool_call(
+                    &action,
+                    Some(&finished_status(
+                        &action,
+                        InsertReviewCommentsResult::Success {
+                            repo_path: "/repo".to_owned(),
+                        },
+                    )),
+                    false,
+                    ctx,
+                )
+                .expect("review comment action should render"),
+                TuiRect::new(0, 0, 80, 20),
+                ctx,
+            );
+            let lines = frame
+                .buffer
+                .to_lines()
+                .into_iter()
+                .map(|line| line.trim_end().to_owned())
+                .filter(|line| !line.is_empty())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                lines,
+                vec![
+                    "✓ Inserted 2 review comments",
+                    "  Pull request",
+                    "  @alice:",
+                    "  Root",
+                    "  ──────────────────────────────────────────────────────────────────────────────",
+                    "  @bob:",
+                    "  Reply",
+                    "  https://github.com/warp/warp/pull/1#comment-1",
+                ]
+            );
+
+            let mut presenter = TuiPresenter::new();
+            let pending = presenter.present_element(
+                render_review_comments_tool_call(&action, None, false, ctx)
+                    .expect("review comment action should render"),
+                TuiRect::new(0, 0, 80, 4),
+                ctx,
+            );
+            assert_eq!(
+                pending.buffer.to_lines()[0].trim_end(),
+                "○ Insert 2 review comments"
+            );
+
+            for (result, expected) in [
+                (
+                    InsertReviewCommentsResult::Error {
+                        repo_path: "/repo".to_owned(),
+                        message: "failed".to_owned(),
+                    },
+                    "× Failed to insert review comments",
+                ),
+                (
+                    InsertReviewCommentsResult::Cancelled,
+                    "■ Insert review comments cancelled",
+                ),
+            ] {
+                let mut presenter = TuiPresenter::new();
+                let status = finished_status(&action, result);
+                let frame = presenter.present_element(
+                    render_review_comments_tool_call(&action, Some(&status), false, ctx)
+                        .expect("review comment action should render"),
+                    TuiRect::new(0, 0, 80, 4),
+                    ctx,
+                );
+                assert_eq!(frame.buffer.to_lines()[0].trim_end(), expected);
+                assert!(
+                    frame
+                        .buffer
+                        .to_lines()
+                        .iter()
+                        .skip(1)
+                        .all(|line| line.trim().is_empty())
+                );
+            }
+        });
+    });
+}

--- a/crates/warp_tui/src/tui_review_comments_tests.rs
+++ b/crates/warp_tui/src/tui_review_comments_tests.rs
@@ -119,11 +119,15 @@ fn renders_shared_markdown_thread_only_after_success() {
             comment("1", "alice", "**Root**", None, None),
             comment("2", "bob", "Reply", Some("1"), None),
         ]);
+        let AIAgentActionType::InsertCodeReviewComments { comments, .. } = &action.action else {
+            unreachable!("expected review comment action");
+        };
         app.read(|ctx| {
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
                 render_review_comments_tool_call(
                     &action,
+                    comments,
                     Some(&finished_status(
                         &action,
                         InsertReviewCommentsResult::Success {
@@ -132,8 +136,7 @@ fn renders_shared_markdown_thread_only_after_success() {
                     )),
                     false,
                     ctx,
-                )
-                .expect("review comment action should render"),
+                ),
                 TuiRect::new(0, 0, 80, 20),
                 ctx,
             );
@@ -160,8 +163,7 @@ fn renders_shared_markdown_thread_only_after_success() {
 
             let mut presenter = TuiPresenter::new();
             let pending = presenter.present_element(
-                render_review_comments_tool_call(&action, None, false, ctx)
-                    .expect("review comment action should render"),
+                render_review_comments_tool_call(&action, comments, None, false, ctx),
                 TuiRect::new(0, 0, 80, 4),
                 ctx,
             );
@@ -186,8 +188,13 @@ fn renders_shared_markdown_thread_only_after_success() {
                 let mut presenter = TuiPresenter::new();
                 let status = finished_status(&action, result);
                 let frame = presenter.present_element(
-                    render_review_comments_tool_call(&action, Some(&status), false, ctx)
-                        .expect("review comment action should render"),
+                    render_review_comments_tool_call(
+                        &action,
+                        comments,
+                        Some(&status),
+                        false,
+                        ctx,
+                    ),
                     TuiRect::new(0, 0, 80, 4),
                     ctx,
                 );


### PR DESCRIPTION
## Description

Render imported code review comments as structured Markdown threads in the headless TUI while sharing thread grouping and formatting with the GUI implementation.

- Centralizes review-comment thread grouping and Markdown formatting in `crates/ai`.
- Reuses the shared helpers when the GUI attaches pending imported review comments.
- Adds TUI-specific rendering for comment targets, locations, authors, and reply threads.
- Preserves the existing generic tool-call rendering as a fallback when review-comment payloads cannot be parsed.

### GUI/TUI architecture boundaries

```mermaid
flowchart TB
    Shared["Shared model and application core"]

    Shared --> Core["warp_core<br/>App, Entity, AppContext<br/>actions, appearance, feature flags"]
    Shared --> Main["app/<br/>terminal, AI, Drive, auth,<br/>settings, workspaces"]
    Shared --> UIShared["warpui / warpui_core<br/>shared entities, handles,<br/>state and mouse tracking"]

    Core --> GUI
    Main --> GUI
    UIShared --> GUI

    Core --> TUI
    Main --> TUI
    UIShared --> TUI

    subgraph GUI["GUI-specific boundary"]
        direction TB
        GUIApp["app GUI frontend"]
        GUIElements["WarpUI Element / View layout"]
        GPURendering["GPU rendering<br/>WGSL, pixels, terminal themes"]
        GUIInput["Native keyboard and mouse input"]
        GUIValidation["crates/integration<br/>screenshots and visual verification"]

        GUIApp --> GUIElements --> GPURendering
        GUIElements --> GUIInput
        GPURendering --> GUIValidation
    end

    subgraph TUI["TUI-specific boundary"]
        direction TB
        TUIApp["crates/warp_tui"]
        TUIElements["warpui_core::elements::tui<br/>TuiElement"]
        CellRendering["Cell-grid rendering<br/>TuiBuffer"]
        TUIInput["crossterm input<br/>TuiEvent"]
        TUIValidation["Render-to-lines unit tests<br/>and ./script/run-tui"]

        TUIApp --> TUIElements --> CellRendering
        TUIElements --> TUIInput
        CellRendering --> TUIValidation
    end

    GUI -. "does not use" .-> CellRendering
    TUI -. "does not use" .-> GPURendering
```

## Linked Issue

No linked issue.

## Testing

![Screenshot 2026-07-23 at 12.20.48 PM.png](https://app.graphite.com/user-attachments/assets/1c7b7880-ea8e-475f-b378-e858548a0059.png)



- `./script/format --check`
- `./script/check_no_inline_test_modules`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo nextest run -p ai -p warp_tui` — 906 passed
- `./script/run-tui` — built and launched successfully
- [x] I have manually tested my changes locally with `./script/run-tui`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Improved rendering of code review comment threads in the headless TUI.

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)