### PR TITLE
Fix TUI Linux panick

### DIFF
--- a/crates/warp_tui/src/editor_interaction.rs
+++ b/crates/warp_tui/src/editor_interaction.rs
@@ -292,10 +292,7 @@ const SHARED_EDITOR_BINDINGS: &[EditorBindingSpec] = &[
         input_name: Some("tui:input:kill_to_line_end"),
         editor_name: Some("tui:editor:kill_to_line_end"),
         description: "Delete to end of line",
-        // `cmd-delete` mirrors the GUI's `editor_view:delete_all_right`
-        // (cmd-delete on macOS, a.k.a. delete-all-right). `ctrl-k` keeps the
-        // Emacs/readline binding that terminals and shell prompts expect.
-        keys: &["ctrl-k", "cmd-delete"],
+        keys: &["ctrl-k"],
     },
     EditorBindingSpec {
         command: TuiEditorCommand::KillToLineStart,

--- a/crates/warp_tui/src/editor_view_tests.rs
+++ b/crates/warp_tui/src/editor_view_tests.rs
@@ -393,7 +393,7 @@ fn keybinding_initializer_registers_line_start_for_input_and_editor() {
         let expected = HashSet::from(["home".to_string(), "ctrl-a".to_string()]);
         assert_eq!(triggers_for("tui:input:move_to_line_start"), expected);
         assert_eq!(triggers_for("tui:editor:move_to_line_start"), expected);
-        let kill_to_line_end = HashSet::from(["ctrl-k".to_string(), "cmd-delete".to_string()]);
+        let kill_to_line_end = HashSet::from(["ctrl-k".to_string()]);
         assert_eq!(triggers_for("tui:input:kill_to_line_end"), kill_to_line_end);
         assert_eq!(
             triggers_for("tui:editor:kill_to_line_end"),
@@ -425,12 +425,10 @@ fn keybinding_initializer_registers_line_start_for_input_and_editor() {
     });
 }
 
-/// Regression for APP-4915: `cmd-delete` must bind to `KillToLineEnd` (delete to
-/// end of line) in both the TUI input editor and the standalone editor view,
-/// matching the GUI's `cmd-delete` / delete-all-right convention. `alt-delete`
-/// must remain bound to `DeleteWordForward` (option+delete deletes a word).
+/// `cmd-delete` is not portable terminal input and must not be registered on
+/// either TUI editor surface. `alt-delete` remains a forward-word deletion.
 #[test]
-fn cmd_delete_binds_kill_to_line_end_and_alt_delete_binds_delete_word_forward() {
+fn cmd_delete_is_unbound_and_alt_delete_binds_delete_word_forward() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);
 
@@ -445,26 +443,16 @@ fn cmd_delete_binds_kill_to_line_end_and_alt_delete_binds_delete_word_forward() 
                     .collect::<HashSet<_>>()
             })
         };
-
-        // `cmd-delete` deletes to end of line in both editor surfaces.
-        assert!(
-            triggers_for("tui:input:kill_to_line_end").contains("cmd-delete"),
-            "cmd-delete must bind tui:input:kill_to_line_end"
-        );
-        assert!(
-            triggers_for("tui:editor:kill_to_line_end").contains("cmd-delete"),
-            "cmd-delete must bind tui:editor:kill_to_line_end"
-        );
-
-        // `alt-delete` keeps deleting the next word (option+delete -> DeleteWordForward).
-        assert!(
-            triggers_for("tui:input:delete_word_forward").contains("alt-delete"),
-            "alt-delete must remain bound to tui:input:delete_word_forward"
-        );
-        assert!(
-            triggers_for("tui:editor:delete_word_forward").contains("alt-delete"),
-            "alt-delete must remain bound to tui:editor:delete_word_forward"
-        );
+        for target in ["input", "editor"] {
+            assert!(
+                !triggers_for(&format!("tui:{target}:kill_to_line_end")).contains("cmd-delete"),
+                "cmd-delete must not be registered for the TUI {target} editor"
+            );
+            assert!(
+                triggers_for(&format!("tui:{target}:delete_word_forward")).contains("alt-delete"),
+                "alt-delete must remain registered for the TUI {target} editor"
+            );
+        }
     });
 }
 

--- a/crates/warp_tui/src/keybindings_tests.rs
+++ b/crates/warp_tui/src/keybindings_tests.rs
@@ -34,6 +34,17 @@ fn tui_binding_registration_passes_the_cross_surface_validators() {
         app.update(super::init);
     });
 }
+
+#[test]
+fn tui_binding_registration_passes_the_app_cross_platform_validator() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.set_default_binding_validator(warp::util::bindings::is_binding_cross_platform);
+            super::init(ctx);
+        });
+    });
+}
+
 #[test]
 fn attachment_bindings_are_scoped_to_available_and_focused_contexts() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
