### PR TITLE
add validation to keep secrets under 128kb

### DIFF
--- a/crates/managed_secrets/src/manager.rs
+++ b/crates/managed_secrets/src/manager.rs
@@ -52,6 +52,9 @@ impl ManagedSecretManager {
             if !FeatureFlag::WarpManagedSecrets.is_enabled() {
                 return Err(anyhow::anyhow!("This feature is not enabled"));
             }
+
+            value.validate_field_sizes(&name)?;
+
             // We retrieve all upload keys on demand. These should potentially be fetched and stored
             // ahead of time instead.
             let configs = client.get_managed_secret_configs().await?;
@@ -112,6 +115,10 @@ impl ManagedSecretManager {
         async move {
             if !FeatureFlag::WarpManagedSecrets.is_enabled() {
                 return Err(anyhow::anyhow!("This feature is not enabled"));
+            }
+
+            if let Some(v) = &value {
+                v.validate_field_sizes(&name)?;
             }
 
             let encrypted_value = if let Some(value) = value {

--- a/crates/managed_secrets/src/secret_value.rs
+++ b/crates/managed_secrets/src/secret_value.rs
@@ -3,6 +3,19 @@ use std::fmt;
 use serde::Serialize;
 use warp_graphql::managed_secrets::ManagedSecretType;
 
+/// Maximum length in bytes of a `KEY=VALUE` env string, one less than Linux's `MAX_ARG_STRLEN`
+/// (128 KiB). The kernel stores each env string NUL-terminated, so the `KEY=VALUE` content must
+/// be strictly shorter than `MAX_ARG_STRLEN` to leave room for the trailing `\0`.
+pub(crate) const MAX_SECRET_FIELD_BYTES: usize = 128 * 1024 - 1;
+
+pub(crate) const ENV_VAR_ANTHROPIC_API_KEY: &str = "ANTHROPIC_API_KEY";
+pub(crate) const ENV_VAR_AWS_BEARER_TOKEN_BEDROCK: &str = "AWS_BEARER_TOKEN_BEDROCK";
+pub(crate) const ENV_VAR_AWS_REGION: &str = "AWS_REGION";
+pub(crate) const ENV_VAR_AWS_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";
+pub(crate) const ENV_VAR_AWS_SECRET_ACCESS_KEY: &str = "AWS_SECRET_ACCESS_KEY";
+pub(crate) const ENV_VAR_AWS_SESSION_TOKEN: &str = "AWS_SESSION_TOKEN";
+pub(crate) const ENV_VAR_OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum ManagedSecretValue {
@@ -75,6 +88,52 @@ impl ManagedSecretValue {
         Self::OpenaiApiKey {
             api_key: api_key.into(),
             base_url,
+        }
+    }
+
+    /// Returns an error if any env var produced by this secret would exceed [`MAX_SECRET_FIELD_BYTES`] bytes.
+    pub fn validate_field_sizes(&self, name: &str) -> anyhow::Result<()> {
+        let check = |env_key: &str, value: &str| -> anyhow::Result<()> {
+            let max_value_len = MAX_SECRET_FIELD_BYTES - env_key.len() - 1 /* '=' */;
+            if value.len() > max_value_len {
+                anyhow::bail!(
+                    "Secret '{env_key}' value is too large to inject as an environment variable \
+                     ({} bytes); the maximum is {max_value_len} bytes. Use a shorter value.",
+                    value.len()
+                );
+            }
+            Ok(())
+        };
+
+        match self {
+            ManagedSecretValue::RawValue { value } => check(name, value),
+            ManagedSecretValue::AnthropicApiKey { api_key } => {
+                check(ENV_VAR_ANTHROPIC_API_KEY, api_key)
+            }
+            ManagedSecretValue::AnthropicBedrockApiKey {
+                aws_bearer_token_bedrock,
+                aws_region,
+            } => {
+                check(ENV_VAR_AWS_BEARER_TOKEN_BEDROCK, aws_bearer_token_bedrock)?;
+                check(ENV_VAR_AWS_REGION, aws_region)
+            }
+            ManagedSecretValue::AnthropicBedrockAccessKey {
+                aws_access_key_id,
+                aws_secret_access_key,
+                aws_session_token,
+                aws_region,
+            } => {
+                check(ENV_VAR_AWS_ACCESS_KEY_ID, aws_access_key_id)?;
+                check(ENV_VAR_AWS_SECRET_ACCESS_KEY, aws_secret_access_key)?;
+                if let Some(token) = aws_session_token {
+                    check(ENV_VAR_AWS_SESSION_TOKEN, token)?;
+                }
+                check(ENV_VAR_AWS_REGION, aws_region)
+            }
+            ManagedSecretValue::OpenaiApiKey { api_key, .. } => {
+                // base_url goes to a config file, not an env var argument.
+                check(ENV_VAR_OPENAI_API_KEY, api_key)
+            }
         }
     }
 

--- a/crates/managed_secrets/src/secret_value.rs
+++ b/crates/managed_secrets/src/secret_value.rs
@@ -94,6 +94,15 @@ impl ManagedSecretValue {
     /// Returns an error if any env var produced by this secret would exceed [`MAX_SECRET_FIELD_BYTES`] bytes.
     pub fn validate_field_sizes(&self, name: &str) -> anyhow::Result<()> {
         let check = |env_key: &str, value: &str| -> anyhow::Result<()> {
+            // Guard against a pathologically long key name causing usize underflow below.
+            if env_key.len() + 1 >= MAX_SECRET_FIELD_BYTES {
+                anyhow::bail!(
+                    "Secret name is too long ({} bytes) to be used as an environment variable \
+                     name; the maximum is {} bytes.",
+                    env_key.len(),
+                    MAX_SECRET_FIELD_BYTES - 2,
+                );
+            }
             let max_value_len = MAX_SECRET_FIELD_BYTES - env_key.len() - 1 /* '=' */;
             if value.len() > max_value_len {
                 anyhow::bail!(

--- a/crates/managed_secrets/src/secret_value_tests.rs
+++ b/crates/managed_secrets/src/secret_value_tests.rs
@@ -161,10 +161,6 @@ mod validate_field_sizes {
 
     const NAME: &str = "my-secret";
 
-    fn oversized_for_name(name: &str) -> String {
-        "x".repeat(MAX_SECRET_FIELD_BYTES - name.len() + 1)
-    }
-
     fn oversized_for_key(env_key: &str) -> String {
         "x".repeat(MAX_SECRET_FIELD_BYTES - env_key.len() + 1)
     }
@@ -187,7 +183,7 @@ mod validate_field_sizes {
 
     #[test]
     fn raw_value_over_limit_is_rejected() {
-        let secret = ManagedSecretValue::raw_value(oversized_for_name(NAME));
+        let secret = ManagedSecretValue::raw_value(oversized_for_key(NAME));
         let err = secret.validate_field_sizes(NAME).unwrap_err();
         assert!(err.to_string().contains(&format!("'{NAME}'")));
     }
@@ -291,7 +287,18 @@ mod validate_field_sizes {
         );
         assert!(secret.validate_field_sizes(NAME).is_ok());
     }
+
+    #[test]
+    fn raw_value_name_at_limit_is_rejected() {
+        // A name this long causes `name.len() + 1 == MAX_SECRET_FIELD_BYTES`, which
+        // would underflow the usize subtraction without the upfront guard.
+        let name = "x".repeat(MAX_SECRET_FIELD_BYTES - 1);
+        let secret = ManagedSecretValue::raw_value("value");
+        assert!(secret.validate_field_sizes(&name).is_err());
+    }
 }
+
+/// Test to ensure that the [`ManagedSecretValue::AnthropicBedrockApiKey`] debug representation does not leak secrets.
 #[test]
 fn test_debug_representation_no_secrets_anthropic_bedrock_api_key() {
     let secret = ManagedSecretValue::AnthropicBedrockApiKey {

--- a/crates/managed_secrets/src/secret_value_tests.rs
+++ b/crates/managed_secrets/src/secret_value_tests.rs
@@ -152,7 +152,146 @@ fn test_debug_representation_no_secrets_anthropic_bedrock_access_key() {
     );
 }
 
-/// Test to ensure that the [`ManagedSecretValue::AnthropicBedrockApiKey`] debug representation does not leak secrets.
+mod validate_field_sizes {
+    use crate::secret_value::{
+        ENV_VAR_ANTHROPIC_API_KEY, ENV_VAR_AWS_ACCESS_KEY_ID, ENV_VAR_AWS_BEARER_TOKEN_BEDROCK,
+        ENV_VAR_AWS_SECRET_ACCESS_KEY, ENV_VAR_AWS_SESSION_TOKEN, ENV_VAR_OPENAI_API_KEY,
+        MAX_SECRET_FIELD_BYTES, ManagedSecretValue,
+    };
+
+    const NAME: &str = "my-secret";
+
+    fn oversized_for_name(name: &str) -> String {
+        "x".repeat(MAX_SECRET_FIELD_BYTES - name.len() + 1)
+    }
+
+    fn oversized_for_key(env_key: &str) -> String {
+        "x".repeat(MAX_SECRET_FIELD_BYTES - env_key.len() + 1)
+    }
+
+    #[test]
+    fn combined_at_limit_is_valid() {
+        let name = "K";
+        let value = "x".repeat(MAX_SECRET_FIELD_BYTES - 2);
+        let secret = ManagedSecretValue::raw_value(value);
+        assert!(secret.validate_field_sizes(name).is_ok());
+    }
+
+    #[test]
+    fn combined_one_over_limit_is_rejected() {
+        let name = "K";
+        let value = "x".repeat(MAX_SECRET_FIELD_BYTES - 1);
+        let secret = ManagedSecretValue::raw_value(value);
+        assert!(secret.validate_field_sizes(name).is_err());
+    }
+
+    #[test]
+    fn raw_value_over_limit_is_rejected() {
+        let secret = ManagedSecretValue::raw_value(oversized_for_name(NAME));
+        let err = secret.validate_field_sizes(NAME).unwrap_err();
+        assert!(err.to_string().contains(&format!("'{NAME}'")));
+    }
+
+    #[test]
+    fn raw_value_combined_name_and_value_over_limit_is_rejected() {
+        let half = MAX_SECRET_FIELD_BYTES / 2;
+        let name = "x".repeat(half + 1);
+        let value = "y".repeat(half);
+        let secret = ManagedSecretValue::raw_value(value);
+        assert!(secret.validate_field_sizes(&name).is_err());
+    }
+
+    #[test]
+    fn anthropic_api_key_over_limit_is_rejected() {
+        let secret =
+            ManagedSecretValue::anthropic_api_key(oversized_for_key(ENV_VAR_ANTHROPIC_API_KEY));
+        let err = secret.validate_field_sizes(NAME).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("'{ENV_VAR_ANTHROPIC_API_KEY}'"))
+        );
+    }
+
+    #[test]
+    fn anthropic_bedrock_api_key_token_over_limit_is_rejected() {
+        let secret = ManagedSecretValue::anthropic_bedrock_api_key(
+            oversized_for_key(ENV_VAR_AWS_BEARER_TOKEN_BEDROCK),
+            "us-east-1",
+        );
+        let err = secret.validate_field_sizes(NAME).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("'{ENV_VAR_AWS_BEARER_TOKEN_BEDROCK}'"))
+        );
+    }
+
+    #[test]
+    fn anthropic_bedrock_access_key_access_key_id_over_limit_is_rejected() {
+        let secret = ManagedSecretValue::anthropic_bedrock_access_key(
+            oversized_for_key(ENV_VAR_AWS_ACCESS_KEY_ID),
+            "secret",
+            None,
+            "us-east-1",
+        );
+        let err = secret.validate_field_sizes(NAME).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("'{ENV_VAR_AWS_ACCESS_KEY_ID}'"))
+        );
+    }
+
+    #[test]
+    fn anthropic_bedrock_access_key_secret_over_limit_is_rejected() {
+        let secret = ManagedSecretValue::anthropic_bedrock_access_key(
+            "AKID",
+            oversized_for_key(ENV_VAR_AWS_SECRET_ACCESS_KEY),
+            None,
+            "us-east-1",
+        );
+        let err = secret.validate_field_sizes(NAME).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("'{ENV_VAR_AWS_SECRET_ACCESS_KEY}'"))
+        );
+    }
+
+    #[test]
+    fn anthropic_bedrock_access_key_session_token_over_limit_is_rejected() {
+        let secret = ManagedSecretValue::anthropic_bedrock_access_key(
+            "AKID",
+            "secret",
+            Some(oversized_for_key(ENV_VAR_AWS_SESSION_TOKEN)),
+            "us-east-1",
+        );
+        let err = secret.validate_field_sizes(NAME).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("'{ENV_VAR_AWS_SESSION_TOKEN}'"))
+        );
+    }
+
+    #[test]
+    fn openai_api_key_over_limit_is_rejected() {
+        let secret =
+            ManagedSecretValue::openai_api_key(oversized_for_key(ENV_VAR_OPENAI_API_KEY), None);
+        let err = secret.validate_field_sizes(NAME).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("'{ENV_VAR_OPENAI_API_KEY}'"))
+        );
+    }
+
+    #[test]
+    fn valid_secret_passes() {
+        let secret = ManagedSecretValue::anthropic_bedrock_access_key(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfi",
+            Some("session-token".to_owned()),
+            "us-east-1",
+        );
+        assert!(secret.validate_field_sizes(NAME).is_ok());
+    }
+}
 #[test]
 fn test_debug_representation_no_secrets_anthropic_bedrock_api_key() {
     let secret = ManagedSecretValue::AnthropicBedrockApiKey {


### PR DESCRIPTION
## Description

Adds validation to `ManagedSecretValue` to ensure secret fields do not exceed Linux's 128 KB `MAX_ARG_STRLEN` limit when formatted as `KEY=VALUE` environment variables.

Currently, injecting oversized secrets into a cloud agent's environment causes `execve` to return `E2BIG`, resulting in a cryptic PTY spawn failure. By validating at create/update time in `ManagedSecretManager`, we can surface a clear error immediately before the secret is saved.

This check applies to all secret types (`RawValue`, `AnthropicApiKey`, `AnthropicBedrockApiKey`, `AnthropicBedrockAccessKey`, and `OpenaiApiKey`), excluding `OpenaiApiKey::base_url` since it is written to a config file rather than passed as a process argument.

## Linked Issue

Fixes [REMOTE-1958](https://linear.app/warp/issue/REMOTE-1958)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Added unit tests in `secret_value_tests.rs` covering:

- **Boundary conditions:** Accepts combined `KEY=VALUE` exactly at the 128 KB limit; rejects at 1 byte over.
- **Combined lengths:** Rejects when the combined name + value exceeds the limit, even if individually under.
- **Type coverage:** Validates proper error messages and env var keys for all typed secrets.
- **Optional fields:** Validates `AWS_SESSION_TOKEN` when present.
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)