### PR TITLE
Promote account-first onboarding to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -613,6 +613,7 @@ default = [
     "agent_tips",
     "pluggable_notifications",
     "agent_onboarding",
+    "account_first_onboarding",
     "global_search",
     "cloud_conversations",
     "list_skills",

--- a/crates/warp_features/src/features_tests.rs
+++ b/crates/warp_features/src/features_tests.rs
@@ -18,12 +18,3 @@ fn local_child_harnesses_are_local_only_by_default() {
     assert!(!DEBUG_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
     assert!(!DOGFOOD_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
 }
-
-#[test]
-fn account_first_onboarding_is_dogfood_only() {
-    assert!(!LOCAL_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
-    assert!(!DEBUG_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
-    assert!(DOGFOOD_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
-    assert!(!PREVIEW_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
-    assert!(!RELEASE_FLAGS.contains(&FeatureFlag::AccountFirstOnboarding));
-}

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -999,7 +999,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::GeminiEnterprise,
     FeatureFlag::BoxDrawingGlyphs,
-    FeatureFlag::AccountFirstOnboarding,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Promotes account-first onboarding from internal dogfood (#14212) to Stable after the core flow (#14075) and account-backed toolbelt availability follow-up (#14175) landed.

- Enables the existing `account_first_onboarding` Cargo feature by default.
- Removes `FeatureFlag::AccountFirstOnboarding` from `DOGFOOD_FLAGS` because the default feature now enables it across app builds.
- Removes the obsolete dogfood-only rollout guard test.

This is a rollout-only change; it does not modify the onboarding implementation. Keeping the runtime feature flag and Cargo bridge in place preserves a one-line rollback path while the Stable rollout settles.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format --check`
- `cargo nextest run -p warp_features` — 1 passed, 1 intentionally skipped
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `git diff --check origin/master...HEAD`

No new GUI integration test was added because this PR only changes rollout plumbing; the account-first UI, routing, telemetry, and classification coverage landed with #14075.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
