### PR TITLE
Make zero state animation stacked

### DIFF
--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -1174,6 +1174,15 @@ fn zero_state_renders_with_only_zero_height_bootstrap_blocks() {
             "animation content should use columns beyond the former 48 + 100 column cap:\n{}",
             lines.join("\n")
         );
+        assert!(
+            lines
+                .iter()
+                .take(28)
+                .skip(20)
+                .any(|line| line.chars().take(48).any(|character| character != ' ')),
+            "animation content should paint beneath the status column:\n{}",
+            lines.join("\n")
+        );
     });
 }
 

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -20,7 +20,9 @@ use warp_core::channel::ChannelState;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::SingletonEntity;
 use warpui_core::elements::animation::AnimationClock;
-use warpui_core::elements::tui::{Modifier, TuiConstrainedBox, TuiElement, TuiFlex, TuiText};
+use warpui_core::elements::tui::{
+    Modifier, TuiConstrainedBox, TuiElement, TuiFlex, TuiStack, TuiText,
+};
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 
 use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent};
@@ -34,9 +36,9 @@ use crate::zero_state_animation::{
 /// Cap on "What's new" bullets, mirroring the compact zero-state mock.
 const MAX_CHANGELOG_BULLETS: usize = 3;
 
-/// Fixed width for the text column.  Using a pinned min=max prevents the
-/// animation boundary from shifting as content loads asynchronously at startup
-/// (changelog, MCP status, project context).
+/// Fixed width for the text column. Using a pinned min=max keeps wrapping stable
+/// as content loads asynchronously at startup (changelog, MCP status, project
+/// context) while the animation paints beneath it as a separate stack layer.
 const LEFT_COLUMN_COLS: u16 = 48;
 
 // ---------------------------------------------------------------------------
@@ -144,10 +146,7 @@ impl TuiView for TuiZeroStateView {
             },
         )
         .finish();
-        TuiFlex::row()
-            .child(text_column)
-            .flex_child(animation)
-            .finish()
+        TuiStack::new().child(animation).child(text_column).finish()
     }
 }
 


### PR DESCRIPTION
## Description
Refactor the revamped TUI zero state to use `TuiStack` instead of a horizontal flex row.

The combined rotating-logo and star animation now renders across the full zero-state canvas as the background layer. The fixed 48-column startup/status content renders above it, preserving stable wrapping and preventing animation cells from overwriting status text.

This also adds an end-to-end regression assertion that verifies animation content appears beneath the status column, alongside the existing checks that the foreground title remains readable and the animation extends beyond the former 48 + 100 column layout cap.

## Linked Issue
N/A

## Testing
- `./script/format`
- `cargo nextest run -p warp_tui zero_state_renders_with_only_zero_height_bootstrap_blocks`
- `cargo nextest run -p warp_tui` — 608 tests passed
- `cargo clippy -p warp_tui --all-targets --tests -- -D warnings`
- Manually tested locally with `./script/run-tui`
- Verified the live zero state in a 200×40 tmux pane: foreground status text remained intact, animation rendered within the first 48 columns and across the full width, and decorative cells changed between captured frames

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Agent conversation](https://staging.warp.dev/conversation/0cc02b9b-8983-4791-a102-5044c6f255f4)
