### PR TITLE
eval: authenticate via API key instead of X-Eval-User-ID header

### DIFF
--- a/crates/warp_multi_agent_client/src/lib.rs
+++ b/crates/warp_multi_agent_client/src/lib.rs
@@ -4,8 +4,6 @@ use futures::StreamExt as _;
 use prost::Message as _;
 use tracing_futures::Instrument as _;
 use warp_core::channel::ChannelState;
-#[cfg(feature = "agent_mode_evals")]
-use warp_server_client::base_client::EVAL_USER_ID_HEADER;
 use warp_server_client::base_client::{AmbientHeaderPolicy, BaseClient};
 
 #[derive(Debug, thiserror::Error)]
@@ -69,11 +67,6 @@ pub async fn generate_multi_agent_output(
         .map_err(Error::AmbientHeaders)?
     {
         request_builder = request_builder.header(name, value);
-    }
-
-    #[cfg(feature = "agent_mode_evals")]
-    if let Some(eval_user_id) = client.eval_user_id() {
-        request_builder = request_builder.header(EVAL_USER_ID_HEADER, eval_user_id.to_string());
     }
 
     let raw_stream = client.wrap_eventsource_with_iap_detection(request_builder.eventsource());

--- a/crates/warp_server_client/src/base_client.rs
+++ b/crates/warp_server_client/src/base_client.rs
@@ -8,6 +8,8 @@ use parking_lot::{Mutex, RwLock};
 use warp_graphql::client::RequestOptions;
 use warp_server_auth::auth_state::AuthState;
 use warp_server_auth::credentials::AuthToken;
+#[cfg(feature = "agent_mode_evals")]
+use warp_server_auth::credentials::Credentials;
 
 use crate::auth::{AuthEvent, AuthSession, UserUid};
 
@@ -19,8 +21,6 @@ pub const CLOUD_AGENT_ID_HEADER: &str = "X-Warp-Cloud-Agent-ID";
 
 /// Header used to communicate the source of an agent run.
 pub const AGENT_SOURCE_HEADER: &str = "X-Oz-Api-Source";
-/// Header used to route agent-mode eval requests to a selected eval user.
-pub const EVAL_USER_ID_HEADER: &str = "X-Eval-User-ID";
 
 /// IDs in the staging database that were created specifically for evals.
 ///
@@ -116,8 +116,6 @@ pub struct BaseClient {
     graphql_routing: GraphqlRoutingConfig,
     authenticated_graphql: AuthenticatedGraphqlConfig,
     iap_token_provider: Option<Arc<dyn http_client::iap::IapTokenProvider>>,
-    #[cfg(feature = "agent_mode_evals")]
-    eval_user_id: Option<i32>,
 }
 
 impl BaseClient {
@@ -147,9 +145,16 @@ impl BaseClient {
         };
         #[cfg(feature = "agent_mode_evals")]
         if let Some(eval_user_id) = eval_user_id {
-            authenticated_graphql
-                .headers
-                .insert(EVAL_USER_ID_HEADER.to_string(), eval_user_id.to_string());
+            // Set a deterministic per-user API key so all requests — including
+            // REST endpoints like the SSE event stream — carry a real
+            // Authorization header. The key format mirrors what SeedEvalAPIKeys()
+            // inserts in warp-server at eval startup:
+            // wk-1.<user_id as 64-char zero-padded lowercase hex>.
+            let eval_key = format!("wk-1.{eval_user_id:0>64x}");
+            auth_state.set_credentials(Some(Credentials::ApiKey {
+                key: eval_key,
+                owner_type: None,
+            }));
         }
         let auth_session = Arc::new(AuthSession::new(
             client.clone(),
@@ -167,17 +172,11 @@ impl BaseClient {
             graphql_routing,
             authenticated_graphql,
             iap_token_provider,
-            #[cfg(feature = "agent_mode_evals")]
-            eval_user_id,
         }
     }
 
     /// Returns whether authenticated GraphQL decoration would override BaseClient-owned headers.
     fn is_reserved_authenticated_graphql_header(name: &str) -> bool {
-        #[cfg(feature = "agent_mode_evals")]
-        if name.eq_ignore_ascii_case(EVAL_USER_ID_HEADER) {
-            return true;
-        }
         [
             http::header::AUTHORIZATION.as_str(),
             http::header::CONTENT_TYPE.as_str(),
@@ -211,18 +210,6 @@ impl BaseClient {
 
     pub fn user_id(&self) -> Option<UserUid> {
         self.auth_state.user_id()
-    }
-
-    /// Returns the eval user selected for this client, if eval routing is enabled.
-    pub fn eval_user_id(&self) -> Option<i32> {
-        #[cfg(feature = "agent_mode_evals")]
-        {
-            self.eval_user_id
-        }
-        #[cfg(not(feature = "agent_mode_evals"))]
-        {
-            None
-        }
     }
 
     pub fn access_token_ignoring_validity(&self) -> Option<String> {

--- a/crates/warp_server_client/src/base_client_tests.rs
+++ b/crates/warp_server_client/src/base_client_tests.rs
@@ -9,8 +9,6 @@ use super::{
     AuthenticatedGraphqlConfig, BaseClient, CLOUD_AGENT_ID_HEADER, GraphqlRoutingConfig,
     HeaderOverride,
 };
-#[cfg(feature = "agent_mode_evals")]
-use super::{EVAL_USER_ID_HEADER, EVAL_USER_IDS};
 
 struct StaticIapTokenProvider;
 
@@ -58,26 +56,6 @@ fn iap_proxy_auth_header_uses_configured_provider() {
             http_client::iap::IAP_PROXY_AUTH_HEADER,
             "Bearer iap-token".to_string()
         ))
-    );
-}
-
-#[cfg(feature = "agent_mode_evals")]
-#[test]
-fn eval_user_id_is_selected_once_and_used_for_authenticated_graphql() {
-    let client = client();
-    let eval_user_id = client.eval_user_id().unwrap();
-
-    assert!(EVAL_USER_IDS.contains(&eval_user_id));
-
-    let options = block_on(client.graphql_request_options(None)).unwrap();
-    let eval_user_id = eval_user_id.to_string();
-    assert_eq!(
-        options.headers.get(EVAL_USER_ID_HEADER).map(String::as_str),
-        Some(eval_user_id.as_str())
-    );
-    assert_eq!(
-        client.eval_user_id().map(|id| id.to_string()),
-        Some(eval_user_id)
     );
 }
 
@@ -201,16 +179,6 @@ fn authenticated_graphql_configuration_cannot_override_base_client_owned_headers
             .headers
             .contains_key(&CLOUD_AGENT_ID_HEADER.to_ascii_lowercase())
     );
-    #[cfg(feature = "agent_mode_evals")]
-    {
-        let eval_user_id = client.eval_user_id().unwrap().to_string();
-        assert!(!options.headers.contains_key("x-eval-user-id"));
-        assert_eq!(
-            options.headers.get(EVAL_USER_ID_HEADER).map(String::as_str),
-            Some(eval_user_id.as_str())
-        );
-    }
-    #[cfg(not(feature = "agent_mode_evals"))]
     assert_eq!(
         options.headers.get("x-eval-user-id").map(String::as_str),
         Some("1234")


### PR DESCRIPTION
## Description

Fixes 401 errors on the SSE event-stream endpoint during orchestration evals. The SSE endpoint requires a real Authorization header; REST endpoints received no Authorization header at all (Credentials::Test -> AuthToken::NoAuth), causing 401s for all orchestration event streams.

**Client (this PR):** Each eval client picks a random user from EVAL_USER_IDS and sets Credentials::ApiKey with a deterministic key (wk-1.<user_id as 64-char hex>). Sent as Authorization: Bearer on every request including SSE. EVAL_USER_ID_HEADER / X-Eval-User-ID and eval_user_id field removed from BaseClient — the companion server PR switches eval GraphQL route from SetUserForEvals_InternalOnly to real UserAuth, so the header is no longer needed.

**Server (companion PR):** Seeds one deterministic API key per eval user (2162-2175) at startup when IS_EVALS=true. Eval GraphQL route now uses UserAuth instead of SetUserForEvals_InternalOnly.

One API key per eval user because the SSE endpoint does a ViewAction authz check — the API key owner must match the user who created the runs.

## Linked Issue
- [ ] The linked issue is labeled ready-to-spec or ready-to-implement.
- [ ] Screenshots or video included where appropriate.

## Testing
- [ ] I have manually tested my changes locally with ./script/run

Eval infrastructure only, no UI changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/6195aef0-2e1f-4d48-9ff0-678f3af41744

CHANGELOG-NONE