### PR TITLE
fix(find): keep async find matches ordered after dirty-range merge

### DIFF
--- a/app/src/terminal/find/model/async_find.rs
+++ b/app/src/terminal/find/model/async_find.rs
@@ -413,11 +413,20 @@ impl BlockFindResults {
 
         matches.splice(replace_range, new_matches);
 
-        // Assert that matches are still in ascending order.
-        debug_assert!(
-            matches.windows(2).all(|w| w[0] <= w[1]),
-            "Matches should be in ascending order after update_dirty_matches"
-        );
+        // The splice window above is computed from row overlap, but
+        // `AbsoluteMatch` orders by full end/start *point* (row *and* column).
+        // A match that spans rows, or shares a row across the dirty-range
+        // boundary, can land out of order at the seam between the spliced-in
+        // and retained matches. That previously tripped an ascending-order
+        // `debug_assert!` here (aborting debug builds) and left release builds
+        // with a mis-ordered list. Restore the ascending invariant that
+        // downstream count/traversal/highlight rendering rely on. Per-block
+        // match counts are bounded and updates are throttled, so the occasional
+        // re-sort is cheap; the already-sorted common case only pays for the
+        // `is_sorted` scan.
+        if !matches.is_sorted() {
+            matches.sort_unstable();
+        }
     }
 }
 

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -660,6 +660,49 @@ fn test_update_dirty_matches_clear_range() {
     assert_eq!(stored[1].start_row(), 25);
 }
 
+#[test]
+fn test_update_dirty_matches_keeps_order_across_row_boundary() {
+    // Regression test for a debug-build abort in `update_dirty_matches`.
+    //
+    // The splice window is chosen by row overlap, but `AbsoluteMatch` orders by
+    // full end/start *point* (row and column). A rescanned match that starts in
+    // the dirty range and extends onto the next row at a *later* column than a
+    // retained match on that same row used to be spliced in ahead of it,
+    // producing a list that was out of order by end column. That tripped the
+    // ascending-order `debug_assert!` and aborted debug builds (SIGABRT).
+    let mut results = BlockFindResults::default();
+    let block_index = BlockIndex(0);
+    let grid_type = GridType::Output;
+
+    // Existing, correctly-ordered matches: one ending on row 9, one on row 11
+    // ending at column 2.
+    results.terminal_matches.insert(
+        (block_index, grid_type),
+        vec![make_match_at(9, 0, 5), make_match_at(11, 0, 2)],
+    );
+
+    // Rescanning dirty row 10 yields a match that starts on row 10 and spans
+    // onto row 11, ending at column 4 — after the retained row-11 match's end
+    // column (2). The row-based splice inserts it between the two existing
+    // matches; without a re-sort the list becomes [row9, span(end 11,4),
+    // row11(end 11,2)], which is out of order.
+    let spanning = AbsoluteMatch {
+        start: AbsolutePoint { row: 10, col: 0 },
+        end: AbsolutePoint { row: 11, col: 4 },
+        is_filtered: false,
+    };
+    results.update_dirty_matches(block_index, grid_type, 10..=10, vec![spanning]);
+
+    let stored = results
+        .terminal_matches
+        .get(&(block_index, grid_type))
+        .unwrap();
+    assert!(
+        stored.windows(2).all(|w| w[0] <= w[1]),
+        "matches must remain in ascending order after update_dirty_matches, got {stored:?}"
+    );
+}
+
 fn assert_async_focused_order_matches_sync(block_sort_direction: BlockSortDirection) {
     App::test((), |mut app| async move {
         initialize_settings_for_tests(&mut app);


### PR DESCRIPTION
## Description

`update_dirty_matches` (async terminal find) merges incremental results using a **row-based** splice window, but `AbsoluteMatch` orders by the full **end/start point** (row *and* column). A rescanned match that spans the dirty-range boundary row — or shares a row with a retained match — could be spliced ahead of a match with a smaller end column, leaving the list out of ascending order.

- **Debug / from-source builds:** the trailing `debug_assert!` fired and aborted the process (`SIGABRT`). Full crash report + backtrace in #14231.
- **Release / Stable builds:** the assert is stripped, so the mis-ordered list persisted, affecting match count, next/previous traversal, and highlight placement.

Fix: restore the ascending invariant right after the splice with a cheap `is_sorted` fast-path + `sort_unstable` (re-sort only when the seam actually broke), instead of asserting it. Per-block match counts are bounded and updates are throttled, so the occasional re-sort is negligible.

## Linked Issue

Fixes #14231

## Testing

- Added `test_update_dirty_matches_keeps_order_across_row_boundary`, which constructs the exact boundary-spanning case (a match starting on row 10 that extends to row 11 col 4, with a retained row-11 match ending at col 2). This produces an out-of-order splice that aborts on the unpatched code and passes with the fix.
- `cargo nextest run -p warp update_dirty_matches` → 13/13 pass.
- `./script/format` and `cargo clippy -p warp --all-targets --tests -- -D warnings` are clean.

- [ ] I have manually tested my changes locally with `./script/run`

> Not checked intentionally: the crash only reproduces after a long streaming-find session (Find open on a block whose output keeps changing), so it isn't reliably reproducible by hand. The change is a data-structure invariant fix covered by a deterministic regression test.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed incorrect find-match ordering (and a debug-build crash) when searching a terminal block whose output was still updating.
