### PR TITLE
Additional telemetry for build cache setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,6 +2450,7 @@ dependencies = [
  "hex",
  "instant",
  "is_executable",
+ "itertools 0.14.0",
  "log",
  "nix 0.26.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
+ "warp_core",
  "warp_errors",
 ]
 

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -201,6 +201,7 @@ async fn prepare_environment_impl(
 
     #[cfg(feature = "local_fs")]
     if let Some(cache_root) = cache_setup::enabled_cache_root() {
+        log::info!("Configuring build cache");
         let result = setup_events
             .record_result(
                 SetupStep::CacheSetup,
@@ -210,7 +211,10 @@ async fn prepare_environment_impl(
         if let Err(error) = result {
             log::warn!("Build cache setup degraded; continuing environment preparation: {error}");
         }
+    } else {
+        log::info!("Build cache not available");
     }
+
     let has_setup_commands = !setup_commands.is_empty();
     if has_setup_commands {
         setup_events

--- a/crates/build_cache/Cargo.toml
+++ b/crates/build_cache/Cargo.toml
@@ -13,6 +13,7 @@ futures-lite.workspace = true
 hex.workspace = true
 instant.workspace = true
 is_executable = "1.0.1"
+itertools.workspace = true
 log.workspace = true
 nix = { workspace = true, features = ["user"] }
 serde.workspace = true

--- a/crates/build_cache/Cargo.toml
+++ b/crates/build_cache/Cargo.toml
@@ -22,6 +22,7 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+warp_core.workspace = true
 warp_errors.workspace = true
 
 [dev-dependencies]

--- a/crates/build_cache/src/lib.rs
+++ b/crates/build_cache/src/lib.rs
@@ -30,6 +30,7 @@ use command::Stdio;
 use command::r#async::Command;
 use futures_lite::future;
 use is_executable::IsExecutable as _;
+use itertools::Itertools;
 use sha2::{Digest, Sha256};
 use warp_errors::{ErrorExt, register_error};
 
@@ -553,6 +554,7 @@ where
         Ok(Some(plan)) => plan,
         Ok(None) => return report,
         Err(error) => {
+            tracing::error!(error = ?error, "Cache planning failed");
             report.invocations.push(failed_invocation(
                 CacheScope::Global,
                 Vec::new(),
@@ -582,6 +584,11 @@ where
                 Duration::ZERO,
             )
         } else {
+            log::info!(
+                "Mounting cache modes {:?} for {:?}",
+                configuration.modes,
+                configuration.scope
+            );
             run_spacectl_mount(
                 configuration.scope.clone(),
                 configuration.modes.clone(),
@@ -595,6 +602,8 @@ where
         };
 
         if let Some(response) = &invocation.response {
+            tracing::info!(cache_result = ?response.output, modes = ?response.input.modes, scope = ?configuration.scope, "Mounted cache paths");
+
             match &configuration.scope {
                 CacheScope::Repository { .. } => {
                     for (name, value) in &response.output.add_envs {
@@ -660,6 +669,7 @@ where
 /// - `~/.cargo/registry` => `/cache/shared/$HOME/.cargo/registry`
 /// - `/workspace/repo-a/target` => `/cache/<repo-a-key>/target`
 /// - `/workspace/repo-b/target` => `/cache/<repo-b-key>/target`
+#[tracing::instrument(skip_all, fields(tags.cloud_agent = true, additional_global_modes, resolved_modes = tracing::field::Empty))]
 fn construct_plan(
     cache_root: PathBuf,
     mut detections: Vec<DetectedCacheModes>,
@@ -667,6 +677,7 @@ fn construct_plan(
 ) -> Result<Option<CacheSetupPlan>, CacheSetupError> {
     for detection in &mut detections {
         detection.modes = canonical_modes(std::mem::take(&mut detection.modes));
+        tracing::info!(modes = ?detection.modes, repo_key = %detection.key, "Adding detected cache modes");
     }
     let mut global_modes = BTreeSet::new();
     for detection in &detections {
@@ -705,6 +716,7 @@ fn construct_plan(
             .expect("repository configuration")
             .cmp(right.scope.repo_key().expect("repository configuration"))
     });
+    tracing::Span::current().record("resolved_modes", global_modes.iter().join(", "));
     configurations.push(CacheConfiguration {
         scope: CacheScope::Global,
         cwd: scratch,

--- a/crates/build_cache/src/lib.rs
+++ b/crates/build_cache/src/lib.rs
@@ -32,6 +32,7 @@ use futures_lite::future;
 use is_executable::IsExecutable as _;
 use itertools::Itertools;
 use sha2::{Digest, Sha256};
+use warp_core::safe_info;
 use warp_errors::{ErrorExt, register_error};
 
 pub mod spacectl;
@@ -584,10 +585,9 @@ where
                 Duration::ZERO,
             )
         } else {
-            log::info!(
-                "Mounting cache modes {:?} for {:?}",
-                configuration.modes,
-                configuration.scope
+            safe_info!(
+                safe: ("Mounting cache modes {:?} for scope kind '{}'", configuration.modes, configuration.scope.kind()),
+                full: ("Mounting cache modes {:?} for {:?}", configuration.modes, configuration.scope)
             );
             run_spacectl_mount(
                 configuration.scope.clone(),
@@ -669,12 +669,16 @@ where
 /// - `~/.cargo/registry` => `/cache/shared/$HOME/.cargo/registry`
 /// - `/workspace/repo-a/target` => `/cache/<repo-a-key>/target`
 /// - `/workspace/repo-b/target` => `/cache/<repo-b-key>/target`
-#[tracing::instrument(skip_all, fields(tags.cloud_agent = true, additional_global_modes, resolved_modes = tracing::field::Empty))]
+#[tracing::instrument(skip_all, fields(tags.cloud_agent = true, additional_global_modes = tracing::field::Empty, resolved_modes = tracing::field::Empty))]
 fn construct_plan(
     cache_root: PathBuf,
     mut detections: Vec<DetectedCacheModes>,
     additional_global_modes: Vec<String>,
 ) -> Result<Option<CacheSetupPlan>, CacheSetupError> {
+    tracing::Span::current().record(
+        "additional_global_modes",
+        additional_global_modes.iter().join(", "),
+    );
     for detection in &mut detections {
         detection.modes = canonical_modes(std::mem::take(&mut detection.modes));
         tracing::info!(modes = ?detection.modes, repo_key = %detection.key, "Adding detected cache modes");

--- a/crates/build_cache/src/spacectl.rs
+++ b/crates/build_cache/src/spacectl.rs
@@ -125,6 +125,7 @@ where
     } else {
         mount_command(cache_root, cwd, &modes)
     };
+    tracing::info!(?command, "Executing spacectl");
     let started = Instant::now();
     let result = async {
         let bytes = run_command(command).await?;


### PR DESCRIPTION
## Description

This adds extra OTel instrumentation for build cache configuration. While checking some runs, we noticed we were missing useful info such as:
* Which locations were mounted into the cache volume
* How the cache plan was constructed
* The `spacectl` CLI invocation

## Review Feedback Changes

Addressed in a follow-up commit:

1. **`additional_global_modes` span field now populated** — `construct_plan` had `additional_global_modes` declared as a span field but used `#[tracing::instrument(skip_all, ...)]`, which skips all function arguments. The field was therefore always empty in OTel traces. Fixed by adding an explicit `tracing::Span::current().record("additional_global_modes", ...)` call at the top of the function, before the `Vec<String>` is consumed by `extend()`.

2. **`log::info!` → `safe_info!` for CacheScope logging** — The `log::info!` breadcrumb at mount time included the full `Debug` of `CacheScope::Repository { name, key }`, which exposes the repository name in the log file (user-accessible) and cloud-agent sandbox stderr. Replaced with `safe_info!`: the safe variant logs the scope kind and modes only; the full (dogfood) variant retains the original detail. `warp_core` added as a build dependency to access the macro.

3. **`tracing::info!` calls retained as-is** — The reviewer also flagged `tracing::info!(cache_result = ?response.output, ...)` (lib.rs) and `tracing::info!(?command, "Executing spacectl")` (spacectl.rs). Per the requester's explicit instruction, trace detail must not be reduced: these calls write OTel spans to GCP for our own observability and are kept unchanged.

## Testing

Code compiles with `cargo check -p build_cache` and passes `cargo clippy -p build_cache -- -D warnings`. This is a non-user-facing instrumentation change with no observable behavior change. Existing `build_cache` tests pass on CI (Linux runner, which does not have the macOS toolchain timeout issue).

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

CHANGELOG-NONE
-->

Originating thread: https://warpdev.slack.com/archives/C0BDQDW8V5E/p1785235651818479

<!-- factory-agent: {"source":"factory-agent","task_id":"QUALITY-1278","task_source":"linear","task_url":"https://linear.app/warpdotdev/issue/QUALITY-1278/fix-ci-and-address-review-feedback-on-build-cache-otel-instrumentation","oz_run_id":"019fa85e-b7bc-74c1-854e-d2613d5ca601","repo":"warpdotdev/warp","pr_url":"https://github.com/warpdotdev/warp/pull/14235","ci_fix_attempts":1} -->
