### PR TITLE
fix: update diesel to resolve GHSA-ggxf-9f6j-w742

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.9"
+version = "2.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
+checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
 dependencies = [
  "chrono",
  "diesel_derives",


### PR DESCRIPTION
## Summary
Resolves the Dependabot alert for the `diesel` crate by bumping it from `2.3.9` to `2.3.10` (the first patched version).

- **Advisory:** [GHSA-ggxf-9f6j-w742](https://github.com/advisories/GHSA-ggxf-9f6j-w742) / [RUSTSEC-2026-0172](https://rustsec.org/advisories/RUSTSEC-2026-0172.html)
- **Severity:** Moderate
- **Issue:** Possible use-after-free when deserializing a SQLite database via `SqliteConnection::deserialize_readonly_database`.
- **Dependabot alert:** https://github.com/warpdotdev/warp/security/dependabot/20

## Changes
- Bumped `diesel` `2.3.9` → `2.3.10` in `Cargo.lock` only.
- No `Cargo.toml` change required: the workspace constraint is `diesel = "2.3.8"` (caret), which already permits `2.3.10`. This is a patch-level bump within the same minor series with an unchanged dependency set.

## Verification
- `cargo update -p diesel --precise 2.3.10` selected `diesel v2.3.9 -> v2.3.10` with no other package changes.
- Re-running the resolve reported no further changes, confirming `Cargo.lock` is consistent with `diesel 2.3.10`.
- The diff is intentionally scoped to the single `diesel` package entry (version + checksum).

Note: `cargo audit` and a full workspace build were not run here because the tool is unavailable and a full build of this large workspace exceeds the CI/sandbox resources for this change; the update is a lockfile-only patch bump verified for lock consistency.

_Conversation: https://staging.warp.dev/conversation/8c6a04f2-d089-4c64-87b4-8dbe6b25e9fc_
_Run: https://oz.staging.warp.dev/runs/019f94da-fa2b-739e-9e55-351b7c5ffaa6_

_This PR was generated with [Oz](https://warp.dev/oz)._
