### PR TITLE
refactor: share cloud environment catalog across frontends

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -2,11 +2,9 @@ use std::sync::Arc;
 
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
-use settings::Setting;
 use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill;
-use warp_errors::report_if_error;
 use warpui::elements::{
     ChildAnchor, ChildView, ConstrainedBox, OffsetPositioning, ParentAnchor, ParentElement,
     ParentOffsetBounds, Stack,
@@ -18,12 +16,8 @@ use warpui::{
 
 use super::{AgentInputButtonTheme, AmbientAgentViewModel};
 use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
-use crate::ai::cloud_agent_settings::CloudAgentSettings;
-use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
+use crate::ai::cloud_environments::CloudEnvironmentCatalog;
 use crate::appearance::Appearance;
-use crate::cloud_object::CloudObjectLookup as _;
-use crate::cloud_object::model::generic_string_model::StringModel;
-use crate::cloud_object::model::persistence::CloudModel;
 use crate::context_chips::display_menu::{
     ChipMenuType, DisplayChipMenu, FixedFooter, GenericMenuItem, PromptDisplayMenuEvent,
 };
@@ -101,6 +95,7 @@ impl EnvironmentSelectorTarget {
 pub struct EnvironmentSelector {
     button: ViewHandle<ActionButton>,
     dropdown: ViewHandle<DisplayChipMenu>,
+    environments: ModelHandle<CloudEnvironmentCatalog>,
     is_menu_open: bool,
     menu_positioning_provider: Arc<dyn MenuPositioningProvider>,
     target: EnvironmentSelectorTarget,
@@ -180,22 +175,6 @@ impl GenericMenuItem for NewEnvironmentMenuItem {
     }
 }
 
-pub(crate) fn sort_environments_by_recency(environments: &mut [CloudAmbientAgentEnvironment]) {
-    environments.sort_by(|a, b| {
-        // Sort by last-used timestamp descending (most recent first), then by display name ascending
-        b.metadata
-            .last_task_run_ts
-            .cmp(&a.metadata.last_task_run_ts)
-            .then_with(|| {
-                a.model()
-                    .string_model
-                    .name
-                    .to_lowercase()
-                    .cmp(&b.model().string_model.name.to_lowercase())
-            })
-    });
-}
-
 impl EnvironmentSelector {
     pub fn new(
         menu_positioning_provider: Arc<dyn MenuPositioningProvider>,
@@ -254,8 +233,9 @@ impl EnvironmentSelector {
                     );
                     if me.is_configuring(ctx) {
                         me.target.set_environment_id(Some(env_item.id), true, ctx);
-                        // Persist the selection to settings for next time.
-                        me.save_selected_environment_to_settings(env_item.id, ctx);
+                        me.environments.update(ctx, |catalog, ctx| {
+                            catalog.persist_selection(env_item.id, ctx);
+                        });
                     }
                     me.set_menu_visibility(false, ctx);
                 }
@@ -265,8 +245,8 @@ impl EnvironmentSelector {
             }
         });
 
-        // Subscribe to CloudModel to refresh when environments are added/removed.
-        ctx.subscribe_to_model(&CloudModel::handle(ctx), |me, _, _, ctx| {
+        let environments = CloudEnvironmentCatalog::handle(ctx);
+        ctx.subscribe_to_model(&environments, |me, _, _, ctx| {
             me.ensure_default_selection(ctx);
             me.refresh_menu(ctx);
             me.refresh_button(ctx);
@@ -303,6 +283,7 @@ impl EnvironmentSelector {
         let mut me = Self {
             button,
             dropdown,
+            environments,
             is_menu_open: false,
             menu_positioning_provider,
             target,
@@ -333,9 +314,13 @@ impl EnvironmentSelector {
             return;
         };
 
-        let mut environments = CloudAmbientAgentEnvironment::get_all(ctx);
-        sort_environments_by_recency(&mut environments);
-        let Some(index) = environments.iter().position(|env| env.id == selected_id) else {
+        let Some(index) = self
+            .environments
+            .as_ref(ctx)
+            .environments()
+            .iter()
+            .position(|environment| environment.id == selected_id)
+        else {
             return;
         };
 
@@ -366,58 +351,28 @@ impl EnvironmentSelector {
             return;
         }
 
-        // First, try to restore the user's last selected environment from settings.
-        if let Some(env_id) = self.get_saved_environment_from_settings(ctx) {
-            // Verify the environment still exists.
-            if CloudAmbientAgentEnvironment::get_by_id(&env_id, ctx).is_some() {
-                self.target.ensure_default_environment_id(env_id, ctx);
-                return;
-            }
+        if let Some(environment_id) = self.environments.as_ref(ctx).default_environment_id(ctx) {
+            self.target
+                .ensure_default_environment_id(environment_id, ctx);
         }
-
-        // Fall back to auto-selecting the most recently used environment.
-        let mut environments = CloudAmbientAgentEnvironment::get_all(ctx);
-        sort_environments_by_recency(&mut environments);
-        if let Some(first_env) = environments.first() {
-            self.target.ensure_default_environment_id(first_env.id, ctx);
-        }
-    }
-
-    /// Retrieves the last selected environment ID from settings.
-    fn get_saved_environment_from_settings(&self, ctx: &ViewContext<Self>) -> Option<SyncId> {
-        *CloudAgentSettings::as_ref(ctx)
-            .last_selected_environment_id
-            .value()
-    }
-
-    /// Saves the selected environment ID to settings.
-    fn save_selected_environment_to_settings(&self, env_id: SyncId, ctx: &mut ViewContext<Self>) {
-        CloudAgentSettings::handle(ctx).update(ctx, |settings, ctx| {
-            report_if_error!(
-                settings
-                    .last_selected_environment_id
-                    .set_value(Some(env_id), ctx)
-            );
-        });
     }
 
     fn refresh_menu(&mut self, ctx: &mut ViewContext<Self>) {
-        let mut environments = CloudAmbientAgentEnvironment::get_all(ctx);
-        sort_environments_by_recency(&mut environments);
-
         let selected_id = self.target.selected_environment_id(ctx);
-
-        let menu_items: Vec<EnvironmentMenuItem> = environments
+        let menu_items = self
+            .environments
+            .as_ref(ctx)
+            .environments()
             .iter()
-            .map(|env| {
-                let is_selected = selected_id.as_ref() == Some(&env.id);
+            .map(|environment| {
+                let is_selected = selected_id == Some(environment.id);
                 EnvironmentMenuItem {
-                    id: env.id,
-                    name: env.model().string_model.display_name(),
+                    id: environment.id,
+                    name: environment.name.clone(),
                     is_selected,
                 }
             })
-            .collect();
+            .collect::<Vec<_>>();
 
         self.dropdown.update(ctx, |menu, ctx| {
             menu.update_menu_items(menu_items, ctx);
@@ -430,8 +385,10 @@ impl EnvironmentSelector {
 
     fn refresh_button(&mut self, ctx: &mut ViewContext<Self>) {
         let label = if let Some(id) = self.target.selected_environment_id(ctx) {
-            CloudAmbientAgentEnvironment::get_by_id(&id, ctx)
-                .map(|env| env.model().string_model.display_name())
+            self.environments
+                .as_ref(ctx)
+                .environment(id)
+                .map(|environment| environment.name.clone())
                 .unwrap_or_else(|| "New environment".to_string())
         } else {
             "New environment".to_string()

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -48,8 +48,6 @@ use warpui::{
     ViewHandle,
 };
 
-#[cfg(feature = "local_fs")]
-pub(crate) use self::environment_selector::sort_environments_by_recency;
 pub(crate) use self::environment_selector::{
     EnvironmentSelector, EnvironmentSelectorEvent, EnvironmentSelectorTarget,
 };

--- a/app/src/ai/blocklist/handoff/touched_repos.rs
+++ b/app/src/ai/blocklist/handoff/touched_repos.rs
@@ -30,8 +30,9 @@ use warpui::r#async::FutureExt as _;
 
 use crate::ai::agent::conversation::AIConversation;
 use crate::ai::agent::{AIAgentAction, AIAgentActionType, AIAgentOutputMessageType};
-use crate::ai::blocklist::agent_view::agent_input_footer::sort_environments_by_recency;
-use crate::ai::cloud_environments::{CloudAmbientAgentEnvironment, GithubRepo};
+use crate::ai::cloud_environments::{
+    CloudAmbientAgentEnvironment, GithubRepo, sort_environments_by_recency,
+};
 use crate::server::ids::SyncId;
 
 /// Cap on how many of the conversation's action results we scan for paths,

--- a/app/src/ai/cloud_environments/catalog.rs
+++ b/app/src/ai/cloud_environments/catalog.rs
@@ -99,7 +99,7 @@ impl CloudEnvironmentCatalog {
     }
 
     /// Requests an out-of-band refresh of cloud objects from the server.
-    #[cfg_attr(not(feature = "tui"), allow(dead_code))]
+    #[allow(dead_code)]
     pub fn refresh_from_server(&self, ctx: &mut ModelContext<Self>) {
         UpdateManager::handle(ctx).update(ctx, |manager, ctx| {
             manager.refresh_updated_objects(ctx);

--- a/app/src/ai/cloud_environments/catalog.rs
+++ b/app/src/ai/cloud_environments/catalog.rs
@@ -26,6 +26,7 @@ pub struct CloudEnvironmentCatalogEvent;
 /// Canonical, recency-ordered cloud-environment projection shared by frontends.
 pub struct CloudEnvironmentCatalog {
     environments: Vec<CloudEnvironment>,
+    orchestration_default_environment_id: Option<SyncId>,
 }
 
 impl CloudEnvironmentCatalog {
@@ -38,6 +39,7 @@ impl CloudEnvironmentCatalog {
                     ctx.spawn(async {}, |catalog, (), ctx| catalog.refresh(ctx));
                 }
                 CloudModelEvent::InitialLoadCompleted
+                | CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated
                 | CloudModelEvent::ObjectMoved { .. }
                 | CloudModelEvent::ObjectUpdated { .. }
                 | CloudModelEvent::ObjectTrashed { .. }
@@ -49,8 +51,10 @@ impl CloudEnvironmentCatalog {
                 | CloudModelEvent::ObjectSynced { .. } => catalog.refresh(ctx),
             }
         });
+        let (environments, orchestration_default_environment_id) = Self::current_environments(ctx);
         Self {
-            environments: Self::current_environments(ctx),
+            environments,
+            orchestration_default_environment_id,
         }
     }
 
@@ -69,12 +73,15 @@ impl CloudEnvironmentCatalog {
     /// Returns the saved environment when it still exists, otherwise the
     /// most-recent environment.
     pub fn default_environment_id(&self, ctx: &AppContext) -> Option<SyncId> {
-        let saved = *CloudAgentSettings::as_ref(ctx)
-            .last_selected_environment_id
-            .value();
-        saved
-            .filter(|id| self.environment(*id).is_some())
+        self.saved_environment_id(ctx)
             .or_else(|| self.environments.first().map(|environment| environment.id))
+    }
+
+    /// Returns the saved environment when it still exists, otherwise the
+    /// orchestration GUI's case-sensitive name fallback.
+    pub fn orchestration_default_environment_id(&self, ctx: &AppContext) -> Option<SyncId> {
+        self.saved_environment_id(ctx)
+            .or(self.orchestration_default_environment_id)
     }
 
     /// Persists a valid environment selection for future default resolution.
@@ -100,24 +107,42 @@ impl CloudEnvironmentCatalog {
     }
 
     fn refresh(&mut self, ctx: &mut ModelContext<Self>) {
-        let environments = Self::current_environments(ctx);
-        if environments != self.environments {
+        let (environments, orchestration_default_environment_id) = Self::current_environments(ctx);
+        if environments != self.environments
+            || orchestration_default_environment_id != self.orchestration_default_environment_id
+        {
             self.environments = environments;
+            self.orchestration_default_environment_id = orchestration_default_environment_id;
             ctx.emit(CloudEnvironmentCatalogEvent);
             ctx.notify();
         }
     }
 
-    fn current_environments(ctx: &AppContext) -> Vec<CloudEnvironment> {
+    fn saved_environment_id(&self, ctx: &AppContext) -> Option<SyncId> {
+        (*CloudAgentSettings::as_ref(ctx)
+            .last_selected_environment_id
+            .value())
+        .filter(|id| self.environment(*id).is_some())
+    }
+
+    fn current_environments(ctx: &AppContext) -> (Vec<CloudEnvironment>, Option<SyncId>) {
         let mut environments = CloudAmbientAgentEnvironment::get_all(ctx);
+        let orchestration_default_environment_id = {
+            let mut orchestration_environments = environments.clone();
+            sort_environments_for_orchestration_default(&mut orchestration_environments);
+            orchestration_environments
+                .first()
+                .map(|environment| environment.id)
+        };
         sort_environments_by_recency(&mut environments);
-        environments
+        let environments = environments
             .into_iter()
             .map(|environment| CloudEnvironment {
                 id: environment.id,
                 name: environment.model().string_model.display_name(),
             })
-            .collect()
+            .collect();
+        (environments, orchestration_default_environment_id)
     }
 }
 
@@ -138,6 +163,20 @@ pub(crate) fn sort_environments_by_recency(environments: &mut [CloudAmbientAgent
                     .name
                     .to_lowercase()
                     .cmp(&b.model().string_model.name.to_lowercase())
+            })
+    });
+}
+
+fn sort_environments_for_orchestration_default(environments: &mut [CloudAmbientAgentEnvironment]) {
+    environments.sort_by(|a, b| {
+        b.metadata
+            .last_task_run_ts
+            .cmp(&a.metadata.last_task_run_ts)
+            .then_with(|| {
+                a.model()
+                    .string_model
+                    .name
+                    .cmp(&b.model().string_model.name)
             })
     });
 }

--- a/app/src/ai/cloud_environments/catalog.rs
+++ b/app/src/ai/cloud_environments/catalog.rs
@@ -1,0 +1,147 @@
+//! Shared projection of cloud environments for GUI and TUI consumers.
+
+use settings::Setting as _;
+use warp_errors::report_if_error;
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity as _};
+
+use super::CloudAmbientAgentEnvironment;
+use crate::ai::cloud_agent_settings::CloudAgentSettings;
+use crate::cloud_object::CloudObjectLookup as _;
+use crate::cloud_object::model::generic_string_model::StringModel as _;
+use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
+use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::ids::SyncId;
+
+/// Environment identity and display data consumed by frontend selectors.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CloudEnvironment {
+    pub id: SyncId,
+    pub name: String,
+}
+
+/// Emitted when the projected environment catalog changes.
+#[derive(Clone, Copy, Debug)]
+pub struct CloudEnvironmentCatalogEvent;
+
+/// Canonical, recency-ordered cloud-environment projection shared by frontends.
+pub struct CloudEnvironmentCatalog {
+    environments: Vec<CloudEnvironment>,
+}
+
+impl CloudEnvironmentCatalog {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        ctx.subscribe_to_model(&CloudModel::handle(ctx), |catalog, _, event, ctx| {
+            match event {
+                // `CloudModel::create_object` emits before inserting. Defer the
+                // projection lookup until the source update and event flush finish.
+                CloudModelEvent::ObjectCreated { .. } => {
+                    ctx.spawn(async {}, |catalog, (), ctx| catalog.refresh(ctx));
+                }
+                CloudModelEvent::InitialLoadCompleted
+                | CloudModelEvent::ObjectMoved { .. }
+                | CloudModelEvent::ObjectUpdated { .. }
+                | CloudModelEvent::ObjectTrashed { .. }
+                | CloudModelEvent::ObjectUntrashed { .. }
+                | CloudModelEvent::NotebookEditorChangedFromServer { .. }
+                | CloudModelEvent::ObjectDeleted { .. }
+                | CloudModelEvent::ObjectPermissionsUpdated { .. }
+                | CloudModelEvent::ObjectForceExpanded { .. }
+                | CloudModelEvent::ObjectSynced { .. } => catalog.refresh(ctx),
+            }
+        });
+        Self {
+            environments: Self::current_environments(ctx),
+        }
+    }
+
+    /// Current environments ordered by most-recent use, then display name.
+    pub fn environments(&self) -> &[CloudEnvironment] {
+        &self.environments
+    }
+
+    /// Returns the projected environment with `id`.
+    pub fn environment(&self, id: SyncId) -> Option<&CloudEnvironment> {
+        self.environments
+            .iter()
+            .find(|environment| environment.id == id)
+    }
+
+    /// Returns the saved environment when it still exists, otherwise the
+    /// most-recent environment.
+    pub fn default_environment_id(&self, ctx: &AppContext) -> Option<SyncId> {
+        let saved = *CloudAgentSettings::as_ref(ctx)
+            .last_selected_environment_id
+            .value();
+        saved
+            .filter(|id| self.environment(*id).is_some())
+            .or_else(|| self.environments.first().map(|environment| environment.id))
+    }
+
+    /// Persists a valid environment selection for future default resolution.
+    pub fn persist_selection(&self, environment_id: SyncId, ctx: &mut ModelContext<Self>) {
+        if self.environment(environment_id).is_none() {
+            return;
+        }
+        CloudAgentSettings::handle(ctx).update(ctx, |settings, ctx| {
+            report_if_error!(
+                settings
+                    .last_selected_environment_id
+                    .set_value(Some(environment_id), ctx)
+            );
+        });
+    }
+
+    /// Requests an out-of-band refresh of cloud objects from the server.
+    #[cfg_attr(not(feature = "tui"), allow(dead_code))]
+    pub fn refresh_from_server(&self, ctx: &mut ModelContext<Self>) {
+        UpdateManager::handle(ctx).update(ctx, |manager, ctx| {
+            manager.refresh_updated_objects(ctx);
+        });
+    }
+
+    fn refresh(&mut self, ctx: &mut ModelContext<Self>) {
+        let environments = Self::current_environments(ctx);
+        if environments != self.environments {
+            self.environments = environments;
+            ctx.emit(CloudEnvironmentCatalogEvent);
+            ctx.notify();
+        }
+    }
+
+    fn current_environments(ctx: &AppContext) -> Vec<CloudEnvironment> {
+        let mut environments = CloudAmbientAgentEnvironment::get_all(ctx);
+        sort_environments_by_recency(&mut environments);
+        environments
+            .into_iter()
+            .map(|environment| CloudEnvironment {
+                id: environment.id,
+                name: environment.model().string_model.display_name(),
+            })
+            .collect()
+    }
+}
+
+impl Entity for CloudEnvironmentCatalog {
+    type Event = CloudEnvironmentCatalogEvent;
+}
+
+impl warpui::SingletonEntity for CloudEnvironmentCatalog {}
+
+pub(crate) fn sort_environments_by_recency(environments: &mut [CloudAmbientAgentEnvironment]) {
+    environments.sort_by(|a, b| {
+        b.metadata
+            .last_task_run_ts
+            .cmp(&a.metadata.last_task_run_ts)
+            .then_with(|| {
+                a.model()
+                    .string_model
+                    .name
+                    .to_lowercase()
+                    .cmp(&b.model().string_model.name.to_lowercase())
+            })
+    });
+}
+
+#[cfg(test)]
+#[path = "catalog_tests.rs"]
+mod tests;

--- a/app/src/ai/cloud_environments/catalog_tests.rs
+++ b/app/src/ai/cloud_environments/catalog_tests.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
 
 use chrono::{Duration, Utc};
@@ -33,8 +34,15 @@ fn environment_creation_refreshes_after_cloud_model_inserts_the_object() {
         let catalog = app.add_singleton_model(CloudEnvironmentCatalog::new);
         let sync_id = SyncId::ClientId(ClientId::new());
         let object = environment(sync_id, "Created environment");
+        let (refresh_tx, refresh_rx) = futures::channel::oneshot::channel();
+        let refresh_tx = RefCell::new(Some(refresh_tx));
 
         app.update(|ctx| {
+            ctx.subscribe_to_model(&catalog, move |_, _, _| {
+                if let Some(tx) = refresh_tx.borrow_mut().take() {
+                    let _ = tx.send(());
+                }
+            });
             CloudModel::handle(ctx).update(ctx, |model, ctx| {
                 model.create_object(sync_id, object, ctx);
             });
@@ -44,12 +52,9 @@ fn environment_creation_refreshes_after_cloud_model_inserts_the_object() {
             );
         });
 
-        for _ in 0..10 {
-            if catalog.read(&app, |catalog, _| !catalog.environments().is_empty()) {
-                break;
-            }
-            futures_lite::future::yield_now().await;
-        }
+        refresh_rx
+            .await
+            .expect("environment creation should refresh the catalog");
         assert_eq!(
             catalog.read(&app, |catalog, _| catalog.environments().to_vec()),
             vec![CloudEnvironment {

--- a/app/src/ai/cloud_environments/catalog_tests.rs
+++ b/app/src/ai/cloud_environments/catalog_tests.rs
@@ -1,0 +1,53 @@
+use warpui::{App, SingletonEntity as _};
+
+use super::*;
+use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironmentModel};
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::{CloudObjectMetadata, CloudObjectPermissions};
+use crate::server::ids::{ClientId, SyncId};
+
+#[test]
+fn environment_creation_refreshes_after_cloud_model_inserts_the_object() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(CloudModel::mock);
+        let catalog = app.add_singleton_model(CloudEnvironmentCatalog::new);
+        let sync_id = SyncId::ClientId(ClientId::new());
+        let environment = AmbientAgentEnvironment::new(
+            "Created environment".to_owned(),
+            None,
+            Vec::new(),
+            "ubuntu:latest".to_owned(),
+            Vec::new(),
+        );
+        let object = CloudAmbientAgentEnvironment::new(
+            sync_id,
+            CloudAmbientAgentEnvironmentModel::new(environment),
+            CloudObjectMetadata::mock(),
+            CloudObjectPermissions::mock_personal(),
+        );
+
+        app.update(|ctx| {
+            CloudModel::handle(ctx).update(ctx, |model, ctx| {
+                model.create_object(sync_id, object, ctx);
+            });
+            assert!(
+                catalog.as_ref(ctx).environments().is_empty(),
+                "create event fires before CloudModel inserts the object"
+            );
+        });
+
+        for _ in 0..10 {
+            if catalog.read(&app, |catalog, _| !catalog.environments().is_empty()) {
+                break;
+            }
+            futures_lite::future::yield_now().await;
+        }
+        assert_eq!(
+            catalog.read(&app, |catalog, _| catalog.environments().to_vec()),
+            vec![CloudEnvironment {
+                id: sync_id,
+                name: "Created environment".to_owned(),
+            }]
+        );
+    });
+}

--- a/app/src/ai/cloud_environments/catalog_tests.rs
+++ b/app/src/ai/cloud_environments/catalog_tests.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+
+use chrono::{Duration, Utc};
 use warpui::{App, SingletonEntity as _};
 
 use super::*;
@@ -5,6 +8,23 @@ use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEn
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::{CloudObjectMetadata, CloudObjectPermissions};
 use crate::server::ids::{ClientId, SyncId};
+use crate::test_util::settings::initialize_settings_for_tests;
+
+fn environment(sync_id: SyncId, name: &str) -> CloudAmbientAgentEnvironment {
+    let environment = AmbientAgentEnvironment::new(
+        name.to_owned(),
+        None,
+        Vec::new(),
+        "ubuntu:latest".to_owned(),
+        Vec::new(),
+    );
+    CloudAmbientAgentEnvironment::new(
+        sync_id,
+        CloudAmbientAgentEnvironmentModel::new(environment),
+        CloudObjectMetadata::mock(),
+        CloudObjectPermissions::mock_personal(),
+    )
+}
 
 #[test]
 fn environment_creation_refreshes_after_cloud_model_inserts_the_object() {
@@ -12,19 +32,7 @@ fn environment_creation_refreshes_after_cloud_model_inserts_the_object() {
         app.add_singleton_model(CloudModel::mock);
         let catalog = app.add_singleton_model(CloudEnvironmentCatalog::new);
         let sync_id = SyncId::ClientId(ClientId::new());
-        let environment = AmbientAgentEnvironment::new(
-            "Created environment".to_owned(),
-            None,
-            Vec::new(),
-            "ubuntu:latest".to_owned(),
-            Vec::new(),
-        );
-        let object = CloudAmbientAgentEnvironment::new(
-            sync_id,
-            CloudAmbientAgentEnvironmentModel::new(environment),
-            CloudObjectMetadata::mock(),
-            CloudObjectPermissions::mock_personal(),
-        );
+        let object = environment(sync_id, "Created environment");
 
         app.update(|ctx| {
             CloudModel::handle(ctx).update(ctx, |model, ctx| {
@@ -49,5 +57,80 @@ fn environment_creation_refreshes_after_cloud_model_inserts_the_object() {
                 name: "Created environment".to_owned(),
             }]
         );
+    });
+}
+
+#[test]
+fn environment_timestamp_updates_refresh_recency_order() {
+    App::test((), |mut app| async move {
+        let cloud_model = app.add_singleton_model(CloudModel::mock);
+        let older_id = SyncId::ClientId(ClientId::new());
+        let newer_id = SyncId::ClientId(ClientId::new());
+        app.update(|ctx| {
+            cloud_model.update(ctx, |model, ctx| {
+                model.create_object(older_id, environment(older_id, "Alpha"), ctx);
+                model.create_object(newer_id, environment(newer_id, "Zulu"), ctx);
+            });
+        });
+        let catalog = app.add_singleton_model(CloudEnvironmentCatalog::new);
+        assert_eq!(
+            catalog.read(&app, |catalog, _| {
+                catalog
+                    .environments()
+                    .iter()
+                    .map(|environment| environment.id)
+                    .collect::<Vec<_>>()
+            }),
+            vec![older_id, newer_id]
+        );
+
+        let now = Utc::now();
+        app.update(|ctx| {
+            cloud_model.update(ctx, |model, ctx| {
+                model.update_environment_last_task_run_timestamps(
+                    HashMap::from([
+                        (older_id.uid(), now - Duration::hours(1)),
+                        (newer_id.uid(), now),
+                    ]),
+                    ctx,
+                );
+            });
+        });
+
+        assert_eq!(
+            catalog.read(&app, |catalog, _| {
+                catalog
+                    .environments()
+                    .iter()
+                    .map(|environment| environment.id)
+                    .collect::<Vec<_>>()
+            }),
+            vec![newer_id, older_id]
+        );
+    });
+}
+
+#[test]
+fn default_resolution_preserves_each_gui_consumer_name_tie_breaker() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let cloud_model = app.add_singleton_model(CloudModel::mock);
+        let lowercase_id = SyncId::ClientId(ClientId::new());
+        let uppercase_id = SyncId::ClientId(ClientId::new());
+        app.update(|ctx| {
+            cloud_model.update(ctx, |model, ctx| {
+                model.create_object(lowercase_id, environment(lowercase_id, "alpha"), ctx);
+                model.create_object(uppercase_id, environment(uppercase_id, "Beta"), ctx);
+            });
+        });
+        let catalog = app.add_singleton_model(CloudEnvironmentCatalog::new);
+
+        catalog.read(&app, |catalog, ctx| {
+            assert_eq!(catalog.default_environment_id(ctx), Some(lowercase_id));
+            assert_eq!(
+                catalog.orchestration_default_environment_id(ctx),
+                Some(uppercase_id)
+            );
+        });
     });
 }

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -1,11 +1,7 @@
 mod catalog;
-// Some of these re-exported types aren't used in the wasm build, so we suppress this
-// warning.
 pub use catalog::CloudEnvironmentCatalog;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 pub(crate) use catalog::sort_environments_by_recency;
-#[cfg_attr(not(feature = "tui"), allow(unused_imports))]
-pub use catalog::{CloudEnvironment, CloudEnvironmentCatalogEvent};
 #[cfg_attr(target_family = "wasm", expect(unused_imports))]
 pub use cloud_object_models::{
     AmbientAgentEnvironment, AwsProviderConfig, BaseImage, CloudAmbientAgentEnvironment,

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -1,5 +1,10 @@
+mod catalog;
 // Some of these re-exported types aren't used in the wasm build, so we suppress this
 // warning.
+pub use catalog::CloudEnvironmentCatalog;
+pub(crate) use catalog::sort_environments_by_recency;
+#[cfg_attr(not(feature = "tui"), allow(unused_imports))]
+pub use catalog::{CloudEnvironment, CloudEnvironmentCatalogEvent};
 #[cfg_attr(target_family = "wasm", expect(unused_imports))]
 pub use cloud_object_models::{
     AmbientAgentEnvironment, AwsProviderConfig, BaseImage, CloudAmbientAgentEnvironment,

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -2,6 +2,7 @@ mod catalog;
 // Some of these re-exported types aren't used in the wasm build, so we suppress this
 // warning.
 pub use catalog::CloudEnvironmentCatalog;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 pub(crate) use catalog::sort_environments_by_recency;
 #[cfg_attr(not(feature = "tui"), allow(unused_imports))]
 pub use catalog::{CloudEnvironment, CloudEnvironmentCatalogEvent};

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -418,7 +418,8 @@ impl AIDocumentModel {
             | CloudModelEvent::ObjectPermissionsUpdated { .. }
             | CloudModelEvent::ObjectForceExpanded { .. }
             | CloudModelEvent::ObjectCreated { .. }
-            | CloudModelEvent::NotebookEditorChangedFromServer { .. } => {}
+            | CloudModelEvent::NotebookEditorChangedFromServer { .. }
+            | CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated => {}
         }
     }
     /// Reconciles one server-backed notebook with its loaded AI document.

--- a/app/src/ai/orchestration/providers.rs
+++ b/app/src/ai/orchestration/providers.rs
@@ -10,12 +10,11 @@ use warpui::{AppContext, SingletonEntity};
 use crate::LLMPreferences;
 use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
-use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
+use crate::ai::cloud_environments::CloudEnvironmentCatalog;
 use crate::ai::connected_self_hosted_workers::WARP_WORKER_HOST;
 use crate::ai::harness_availability::{AuthSecretFetchState, HarnessAvailabilityModel};
 use crate::ai::llms::LLMInfo;
 use crate::ai::orchestration::config_state::AuthSecretSelection;
-use crate::cloud_object::CloudObjectLookup as _;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
 /// Env var override for the workspace default host (developer testing).
@@ -149,26 +148,9 @@ pub fn harness_save_key(harness_type: &str) -> &str {
 /// last-selected environment from settings, then falls back to the
 /// most recently used environment.
 pub fn resolve_default_environment_id(ctx: &AppContext) -> Option<String> {
-    if let Some(env_id) = *CloudAgentSettings::as_ref(ctx)
-        .last_selected_environment_id
-        .value()
-        && CloudAmbientAgentEnvironment::get_by_id(&env_id, ctx).is_some()
-    {
-        return Some(env_id.uid());
-    }
-    let mut envs = CloudAmbientAgentEnvironment::get_all(ctx);
-    envs.sort_by(|a, b| {
-        b.metadata
-            .last_task_run_ts
-            .cmp(&a.metadata.last_task_run_ts)
-            .then_with(|| {
-                a.model()
-                    .string_model
-                    .name
-                    .cmp(&b.model().string_model.name)
-            })
-    });
-    envs.first().map(|e| e.id.uid())
+    CloudEnvironmentCatalog::as_ref(ctx)
+        .default_environment_id(ctx)
+        .map(|id| id.uid())
 }
 
 /// Persists the user's environment selection to settings so it can
@@ -178,16 +160,15 @@ pub fn persist_environment_selection(environment_id: &str, ctx: &mut AppContext)
     if environment_id.is_empty() {
         return;
     }
-    let all_envs = CloudAmbientAgentEnvironment::get_all(ctx);
-    if let Some(env) = all_envs.iter().find(|e| e.id.uid() == environment_id) {
-        let sync_id = env.id;
-        CloudAgentSettings::handle(ctx).update(ctx, |settings, ctx| {
-            if let Err(e) = settings
-                .last_selected_environment_id
-                .set_value(Some(sync_id), ctx)
-            {
-                log::warn!("Failed to persist environment selection: {e:?}");
-            }
+    let catalog = CloudEnvironmentCatalog::handle(ctx);
+    let environment_id = catalog
+        .as_ref(ctx)
+        .environments()
+        .iter()
+        .find_map(|environment| (environment.id.uid() == environment_id).then_some(environment.id));
+    if let Some(environment_id) = environment_id {
+        catalog.update(ctx, |catalog, ctx| {
+            catalog.persist_selection(environment_id, ctx);
         });
     }
 }

--- a/app/src/ai/orchestration/providers.rs
+++ b/app/src/ai/orchestration/providers.rs
@@ -143,13 +143,12 @@ pub fn harness_save_key(harness_type: &str) -> &str {
     }
 }
 
-/// Resolves a default environment ID using the same logic as the
-/// `/cloud-agent` environment selector: first tries the user's
-/// last-selected environment from settings, then falls back to the
-/// most recently used environment.
+/// Resolves the orchestration GUI's default environment: first tries the
+/// user's last-selected environment, then preserves its existing
+/// most-recent-use and case-sensitive-name fallback.
 pub fn resolve_default_environment_id(ctx: &AppContext) -> Option<String> {
     CloudEnvironmentCatalog::as_ref(ctx)
-        .default_environment_id(ctx)
+        .orchestration_default_environment_id(ctx)
         .map(|id| id.uid())
 }
 

--- a/app/src/cloud_object/model/persistence.rs
+++ b/app/src/cloud_object/model/persistence.rs
@@ -96,6 +96,8 @@ pub enum CloudModelEvent {
     },
     /// The initial bulk load of cloud objects from the server has completed.
     InitialLoadCompleted,
+    /// Environment last-task timestamps fetched outside the generic cloud-object sync were merged.
+    EnvironmentLastTaskRunTimestampsUpdated,
 }
 
 enum FolderOpenState {
@@ -771,6 +773,7 @@ impl CloudModel {
                 object.metadata_mut().last_task_run_ts = Some(timestamp.into());
             }
         }
+        ctx.emit(CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated);
         ctx.notify();
     }
 

--- a/app/src/cloud_object/model/view.rs
+++ b/app/src/cloud_object/model/view.rs
@@ -362,7 +362,8 @@ impl CloudViewModel {
             CloudModelEvent::NotebookEditorChangedFromServer { .. }
             | CloudModelEvent::ObjectForceExpanded { .. }
             | CloudModelEvent::ObjectSynced { .. }
-            | CloudModelEvent::InitialLoadCompleted => (),
+            | CloudModelEvent::InitialLoadCompleted
+            | CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated => (),
         }
     }
 

--- a/app/src/drive/index.rs
+++ b/app/src/drive/index.rs
@@ -1234,7 +1234,8 @@ impl DriveIndex {
             | CloudModelEvent::ObjectPermissionsUpdated { .. }
             | CloudModelEvent::NotebookEditorChangedFromServer { .. }
             | CloudModelEvent::ObjectSynced { .. }
-            | CloudModelEvent::InitialLoadCompleted => {}
+            | CloudModelEvent::InitialLoadCompleted
+            | CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated => {}
         }
     }
 

--- a/app/src/drive/sharing/dialog/mod.rs
+++ b/app/src/drive/sharing/dialog/mod.rs
@@ -328,9 +328,9 @@ impl SharingDialog {
                 CloudModelEvent::ObjectPermissionsUpdated { type_and_id, .. } => type_and_id,
                 CloudModelEvent::ObjectDeleted { .. } => return,
                 CloudModelEvent::ObjectForceExpanded { .. } => return,
-                CloudModelEvent::ObjectSynced { .. } | CloudModelEvent::InitialLoadCompleted => {
-                    return;
-                }
+                CloudModelEvent::ObjectSynced { .. }
+                | CloudModelEvent::InitialLoadCompleted
+                | CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated => return,
             };
 
             if event_object_id.sync_id().into_server() == Some(target_server_id) {

--- a/app/src/drive/workflows/modal.rs
+++ b/app/src/drive/workflows/modal.rs
@@ -925,7 +925,8 @@ impl WorkflowModal {
             | CloudModelEvent::ObjectDeleted { .. }
             | CloudModelEvent::ObjectForceExpanded { .. }
             | CloudModelEvent::ObjectSynced { .. }
-            | CloudModelEvent::InitialLoadCompleted => {}
+            | CloudModelEvent::InitialLoadCompleted
+            | CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated => {}
         }
     }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2048,6 +2048,7 @@ pub(crate) fn initialize_app(
             time_of_next_force_object_refresh,
         )
     });
+    ctx.add_singleton_model(ai::cloud_environments::CloudEnvironmentCatalog::new);
 
     let unsynced_actions: Vec<(CloudObjectTypeAndId, ObjectAction)> = object_actions
         .iter()

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -50,6 +50,7 @@ use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStream
 use crate::ai::blocklist::orchestration_events::OrchestrationEventService;
 use crate::ai::blocklist::orchestration_topology::descendant_conversation_ids_in_spawn_order;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, QueuedQueryModel};
+use crate::ai::cloud_environments::CloudEnvironmentCatalog;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::harness_availability::HarnessAvailabilityModel;
@@ -132,6 +133,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(|_| SystemStats::new());
     app.add_singleton_model(SyncQueue::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(CloudEnvironmentCatalog::new);
     app.add_singleton_model(UserWorkspaces::default_mock);
     app.add_singleton_model(TeamTesterStatus::mock);
     app.add_singleton_model(TeamUpdateManager::mock);

--- a/app/src/settings_view/environments_page.rs
+++ b/app/src/settings_view/environments_page.rs
@@ -355,7 +355,8 @@ impl EnvironmentsPageView {
                 CloudModelEvent::ObjectUpdated { .. }
                 | CloudModelEvent::ObjectMoved { .. }
                 | CloudModelEvent::ObjectPermissionsUpdated { .. }
-                | CloudModelEvent::ObjectSynced { .. } => {}
+                | CloudModelEvent::ObjectSynced { .. }
+                | CloudModelEvent::EnvironmentLastTaskRunTimestampsUpdated => {}
                 // Events that never affect environments — skip entirely.
                 CloudModelEvent::NotebookEditorChangedFromServer { .. }
                 | CloudModelEvent::ObjectForceExpanded { .. } => return,

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -157,8 +157,6 @@ use crate::ai::agent_conversations_model::{
 use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
 use crate::ai::attachment_utils::MAX_ATTACHMENT_SIZE_BYTES;
 use crate::ai::block_context::BlockContext;
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::agent_view::agent_input_footer::sort_environments_by_recency;
 use crate::ai::blocklist::agent_view::shortcuts::AgentShortcutViewModel;
 use crate::ai::blocklist::agent_view::{
     AgentInputFooter, AgentInputFooterEvent, AgentViewController, AgentViewEntryOrigin,
@@ -186,7 +184,7 @@ use crate::ai::blocklist::{
     render_ai_agent_mode_icon, render_ai_follow_up_icon,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
-use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
+use crate::ai::cloud_environments::{CloudAmbientAgentEnvironment, sort_environments_by_recency};
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::conversation_export::export_conversation_markdown;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentVersion};

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -184,7 +184,9 @@ use crate::ai::blocklist::{
     render_ai_agent_mode_icon, render_ai_follow_up_icon,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
-use crate::ai::cloud_environments::{CloudAmbientAgentEnvironment, sort_environments_by_recency};
+use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::cloud_environments::sort_environments_by_recency;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::conversation_export::export_conversation_markdown;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentVersion};

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -228,6 +228,7 @@ pub fn initialize_app(app: &mut App) {
     app.add_singleton_model(|_| Prompt::mock());
     app.add_singleton_model(SyncQueue::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(crate::ai::cloud_environments::CloudEnvironmentCatalog::new);
     app.add_singleton_model(ImportedConfigModel::new);
     app.add_singleton_model(UserWorkspaces::default_mock);
     app.add_singleton_model(TeamTesterStatus::mock);

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -24,6 +24,7 @@ use crate::ai::blocklist::orchestration_events::OrchestrationEventService;
 use crate::ai::blocklist::{
     BlocklistAIHistoryModel, BlocklistAIPermissions, QueuedQueryModel, SerializedBlockListItem,
 };
+use crate::ai::cloud_environments::CloudEnvironmentCatalog;
 use crate::ai::connected_self_hosted_workers::ConnectedSelfHostedWorkersModel;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
@@ -92,6 +93,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(|_| Prompt::mock());
     app.add_singleton_model(SyncQueue::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(CloudEnvironmentCatalog::new);
     app.add_singleton_model(UserWorkspaces::default_mock);
     app.add_singleton_model(TeamTesterStatus::mock);
     app.add_singleton_model(TeamUpdateManager::mock);

--- a/app/src/tui_test_support.rs
+++ b/app/src/tui_test_support.rs
@@ -23,6 +23,7 @@ use crate::ai::blocklist::{
     PersistedAIInputType, QueuedQueryModel,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
+use crate::ai::cloud_environments::CloudEnvironmentCatalog;
 use crate::ai::connected_self_hosted_workers::ConnectedSelfHostedWorkersModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::harness_availability::HarnessAvailabilityModel;
@@ -113,6 +114,7 @@ pub fn register_tui_session_view_test_singletons(app: &mut warpui::App) {
     });
     app.add_singleton_model(SyncQueue::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(CloudEnvironmentCatalog::new);
     app.add_singleton_model(|_| crate::appearance::Appearance::mock());
 
     app.add_singleton_model(|_| TemplatableMCPServerManager::default());

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -29,6 +29,7 @@ use crate::ai::agent_tips::AITipModel;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
 use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::OrchestrationPillBarModel;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
+use crate::ai::cloud_environments::CloudEnvironmentCatalog;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::facts::manager::AIFactManager;
@@ -104,6 +105,7 @@ pub(crate) fn initialize_app(app: &mut App) {
     app.add_singleton_model(|_| SystemStats::new());
     app.add_singleton_model(SyncQueue::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(CloudEnvironmentCatalog::new);
     app.add_singleton_model(UserWorkspaces::default_mock);
     app.add_singleton_model(|_ctx| UserProfiles::new(Vec::new()));
     app.add_singleton_model(TeamTesterStatus::mock);

--- a/specs/cloud-environment-catalog/TECH.md
+++ b/specs/cloud-environment-catalog/TECH.md
@@ -18,8 +18,10 @@ The catalog:
 - Subscribes once to `CloudModel`.
 - Stores frontend-safe `CloudEnvironment` summaries containing only `SyncId` and display name.
 - Orders summaries by most-recent task use, then case-insensitive display name, matching the existing GUI selector.
+- Separately retains the orchestration GUI's existing most-recent, then case-sensitive-name fallback ID so sharing the catalog does not change either GUI consumer's default selection.
 - Emits `CloudEnvironmentCatalogEvent` only when the projected catalog changes.
 - Defers `ObjectCreated` refresh by one app task because `CloudModel` emits that event before inserting the object.
+- Refreshes when the separately fetched environment last-task timestamps are merged into `CloudModel`.
 - Resolves the saved environment only while it remains in the catalog, otherwise falling back to the first recency-ordered environment.
 - Persists only IDs that remain present in the catalog.
 - Exposes the existing out-of-band `UpdateManager` refresh operation for frontends that offer explicit refresh.
@@ -32,7 +34,7 @@ Menu rows, selected-row highlighting, default selection, labels, live updates, a
 
 Move the full-object recency sorting helper into the cloud-environment module so repository-overlap code can retain its pure full-object scoring without depending on a GUI view module.
 ### Shared provider migration
-Update orchestration environment default and persistence providers to use `CloudEnvironmentCatalog`. This keeps orchestration cards and frontend selectors on the same validity and fallback rules.
+Update orchestration environment default and persistence providers to use `CloudEnvironmentCatalog`. This keeps validity and recency state shared while preserving the orchestration GUI's existing case-sensitive name tie-break.
 ### TUI consumption
 Export the catalog summary, event, and model through `app/src/tui_export.rs` on the TUI handoff branch.
 
@@ -46,6 +48,7 @@ Export the catalog summary, event, and model through `app/src/tui_export.rs` on 
 Repository-overlap suggestion remains asynchronous and applies through `PendingHandoff::set_environment_id(..., false)`, preserving explicit-selection precedence.
 ## Testing and validation
 - Add catalog unit coverage proving an `ObjectCreated` event refreshes only after `CloudModel` inserts the new object.
+- Add catalog unit coverage for last-task timestamp reordering and both existing GUI name tie-break policies.
 - Run focused `CloudEnvironmentCatalog`, environment selector, orchestration provider, and handoff pipeline tests.
 - Run the complete `warp_tui` test suite after the TUI branch consumes the catalog.
 - Run `./script/format`.

--- a/specs/cloud-environment-catalog/TECH.md
+++ b/specs/cloud-environment-catalog/TECH.md
@@ -1,0 +1,65 @@
+# Shared Cloud Environment Catalog
+## Context
+Cloud environments are persisted in `CloudModel`, but frontend consumers currently project that persistence state independently.
+
+- [`app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs (175-421) @ 8be97b2cb`](https://github.com/warpdotdev/warp/blob/8be97b2cb7967e3ee89f8ac1977be87f1f4d137c/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs#L175-L421) subscribes directly to `CloudModel`, repeatedly reads `CloudAmbientAgentEnvironment`, sorts it, resolves defaults, and persists selection from the GUI view.
+- [`app/src/ai/orchestration/providers.rs (142-193) @ 8be97b2cb`](https://github.com/warpdotdev/warp/blob/8be97b2cb7967e3ee89f8ac1977be87f1f4d137c/app/src/ai/orchestration/providers.rs#L142-L193) independently reads the same cloud objects for orchestration defaults and persistence.
+- [`app/src/lib.rs (2037-2055) @ 8be97b2cb`](https://github.com/warpdotdev/warp/blob/8be97b2cb7967e3ee89f8ac1977be87f1f4d137c/app/src/lib.rs#L2037-L2055) registers `CloudModel`, which is the source of truth for cloud-object persistence.
+
+The GUI and headless TUI use different view frameworks, so they cannot share selector views. They can share a single model that projects environment identity, display data, ordering, updates, defaults, persistence, and refresh behavior from `CloudModel`.
+
+This is an internal state-ownership refactor. Environment selection behavior and cloud-object persistence semantics remain unchanged.
+## Proposed changes
+### Shared catalog
+Add `CloudEnvironmentCatalog` under `app/src/ai/cloud_environments/` and register it as a singleton immediately after `CloudModel`.
+
+The catalog:
+
+- Subscribes once to `CloudModel`.
+- Stores frontend-safe `CloudEnvironment` summaries containing only `SyncId` and display name.
+- Orders summaries by most-recent task use, then case-insensitive display name, matching the existing GUI selector.
+- Emits `CloudEnvironmentCatalogEvent` only when the projected catalog changes.
+- Defers `ObjectCreated` refresh by one app task because `CloudModel` emits that event before inserting the object.
+- Resolves the saved environment only while it remains in the catalog, otherwise falling back to the first recency-ordered environment.
+- Persists only IDs that remain present in the catalog.
+- Exposes the existing out-of-band `UpdateManager` refresh operation for frontends that offer explicit refresh.
+
+`CloudModel` remains the persistence source of truth. The catalog owns no network or database state and does not expose cloud-object model internals.
+### GUI migration
+Update `EnvironmentSelector` to retain and subscribe to `ModelHandle<CloudEnvironmentCatalog>`.
+
+Menu rows, selected-row highlighting, default selection, labels, live updates, and selection persistence read through the catalog. The view continues to own menu visibility, focus, telemetry, and target-specific selection mutation.
+
+Move the full-object recency sorting helper into the cloud-environment module so repository-overlap code can retain its pure full-object scoring without depending on a GUI view module.
+### Shared provider migration
+Update orchestration environment default and persistence providers to use `CloudEnvironmentCatalog`. This keeps orchestration cards and frontend selectors on the same validity and fallback rules.
+### TUI consumption
+Export the catalog summary, event, and model through `app/src/tui_export.rs` on the TUI handoff branch.
+
+`TuiHandoffModel` will subscribe to the singleton catalog rather than creating a TUI-specific projection. It will continue to own pending-handoff selection state and will use catalog methods for:
+
+- Current environment rows and valid IDs.
+- Default selection.
+- Manual refresh.
+- Live transition from the no-environment state.
+
+Repository-overlap suggestion remains asynchronous and applies through `PendingHandoff::set_environment_id(..., false)`, preserving explicit-selection precedence.
+## Testing and validation
+- Add catalog unit coverage proving an `ObjectCreated` event refreshes only after `CloudModel` inserts the new object.
+- Run focused `CloudEnvironmentCatalog`, environment selector, orchestration provider, and handoff pipeline tests.
+- Run the complete `warp_tui` test suite after the TUI branch consumes the catalog.
+- Run `./script/format`.
+- Run the applicable `warp` and `warp_tui` clippy commands with warnings denied.
+- Manually verify the GUI environment selector still:
+  - Restores a valid saved environment.
+  - Falls back to the most-recent environment.
+  - Updates after environment creation or deletion.
+  - Persists explicit selection.
+- Manually verify the TUI handoff card transitions from no environments to configuration and preserves explicit selection during repository suggestion.
+## Risks and mitigations
+- **Registration ordering:** register the catalog after `CloudModel` in production and shared test initializers.
+- **Premature create events:** defer projection refresh for `ObjectCreated`.
+- **Ordering drift:** centralize recency ordering in the cloud-environment module and test consumer-visible order.
+- **Cross-frontend coupling:** expose summaries and catalog operations only; keep GUI/TUI interaction state in their respective view or handoff models.
+## Parallelization
+Do not parallelize this migration. Catalog shape, registration, GUI migration, shared provider migration, and upstack TUI consumption touch one tightly coupled API boundary and must land sequentially across the Graphite stack.


### PR DESCRIPTION
## Description

This PR adds one shared, frontend-neutral projection of cloud environments and migrates the existing GUI environment selector and orchestration providers to use it. `CloudModel` stays the persistence source of truth; the new catalog owns the small piece of derived state that every frontend actually needs.

This is an internal ownership refactor. Environment ordering, default selection, persistence, and GUI behavior should stay the same. The upstack TUI PR will consume this same catalog instead of introducing its own projection.

### What changed

- Adds the singleton `CloudEnvironmentCatalog`, which subscribes once to `CloudModel` and exposes recency-ordered `CloudEnvironment { id, name }` summaries.
- Adds `CloudEnvironmentCatalogEvent`, emitted only when the projected catalog actually changes.
- Keeps saved/default environment resolution and selection persistence behind the catalog, so GUI and future TUI consumers use the same validity and fallback rules.
- Defers `ObjectCreated` refresh by one app task because `CloudModel` emits that event before inserting the new object.
- Exposes the existing `UpdateManager` refresh path for surfaces that offer manual refresh.
- Migrates the GUI `EnvironmentSelector` from direct `CloudModel`/`CloudAmbientAgentEnvironment` reads to `ModelHandle<CloudEnvironmentCatalog>`.
- Migrates orchestration’s environment default and persistence helpers to the same catalog.
- Moves the full-object recency sorter out of the GUI view module so repository-overlap code no longer depends on GUI code.

## Testing

- [x] I have manually tested my changes locally with `./script/run`
Again, no behavior changes yet.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp&#39;s AI Agent Mode