### PR TITLE
Fix agent_mode_evals build broken by file-backed execution profiles

### DIFF
--- a/app/src/ai/execution_profiles/mod.rs
+++ b/app/src/ai/execution_profiles/mod.rs
@@ -91,6 +91,8 @@ pub fn resolve_cloud_agent_computer_use_state(ctx: &AppContext) -> CloudAgentCom
     }
 }
 
+// Eval builds always use the hard-coded eval profile, so every caller of these helpers is
+// compiled out there (see `AIExecutionProfilesModel::new` and `migrate_settings_profiles`).
 #[cfg(not(feature = "agent_mode_evals"))]
 pub fn create_default_from_legacy_settings(app: &AppContext) -> AIExecutionProfile {
     create_default_from_legacy_settings_with_profile(AIExecutionProfile::default(), app)

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
+// Only the legacy import, which eval builds compile out, materializes an ordered collection.
+#[cfg(not(feature = "agent_mode_evals"))]
 use indexmap::IndexMap;
 use settings::Setting as _;
 use uuid::Uuid;
@@ -19,6 +21,8 @@ use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManagerEvent;
 use crate::auth::AuthStateProvider;
+// The auth-completion trigger for the legacy import is compiled out for eval builds.
+#[cfg(not(feature = "agent_mode_evals"))]
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::cloud_object::model::generic_string_model::GenericStringObjectId;
 use crate::cloud_object::model::persistence::{CloudModelEvent, UpdateSource};
@@ -27,9 +31,10 @@ use crate::drive::CloudObjectTypeAndId;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ClientId, SyncId};
 use crate::settings::cloud_preferences::CloudPreferencesSettings;
-use crate::settings::cloud_preferences_syncer::{
-    CloudPreferencesSyncer, CloudPreferencesSyncerEvent,
-};
+use crate::settings::cloud_preferences_syncer::CloudPreferencesSyncer;
+// The syncer's initial-load trigger for the legacy import is compiled out for eval builds.
+#[cfg(not(feature = "agent_mode_evals"))]
+use crate::settings::cloud_preferences_syncer::CloudPreferencesSyncerEvent;
 use crate::settings::{
     AISettings, AISettingsChangedEvent, AgentModeCommandExecutionPredicate, ExecutionProfiles,
 };
@@ -251,26 +256,34 @@ impl AIExecutionProfilesModel {
         let imports_legacy_profiles = source.imports_legacy_profiles();
 
         // A TUI with no explicit collection seeds its default from the existing
-        // local scalar settings, then uses only the collection.
-        let mut last_settings_profiles = AISettings::as_ref(ctx).execution_profiles.value().clone();
-        if matches!(launch_mode, LaunchMode::Tui { .. })
-            && !AISettings::as_ref(ctx)
-                .execution_profiles
-                .is_value_explicitly_set()
-        {
-            let mut profiles = ExecutionProfilesConfig::default();
-            profiles.insert(
-                ExecutionProfileId::default_profile(),
-                super::create_default_for_tui_from_legacy_settings(ctx),
-            );
-            if let Err(error) = AISettings::handle(ctx).update(ctx, |settings, ctx| {
-                settings.execution_profiles.set_value(profiles.clone(), ctx)
-            }) {
-                report_error!(error.context("Failed to initialize TUI execution profiles"));
-            } else {
-                last_settings_profiles = profiles;
+        // local scalar settings, then uses only the collection. Eval builds never launch the
+        // TUI and never read legacy settings, so this seeding is compiled out for them.
+        #[cfg(not(feature = "agent_mode_evals"))]
+        let last_settings_profiles = {
+            let mut last_settings_profiles =
+                AISettings::as_ref(ctx).execution_profiles.value().clone();
+            if matches!(launch_mode, LaunchMode::Tui { .. })
+                && !AISettings::as_ref(ctx)
+                    .execution_profiles
+                    .is_value_explicitly_set()
+            {
+                let mut profiles = ExecutionProfilesConfig::default();
+                profiles.insert(
+                    ExecutionProfileId::default_profile(),
+                    super::create_default_for_tui_from_legacy_settings(ctx),
+                );
+                if let Err(error) = AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    settings.execution_profiles.set_value(profiles.clone(), ctx)
+                }) {
+                    report_error!(error.context("Failed to initialize TUI execution profiles"));
+                } else {
+                    last_settings_profiles = profiles;
+                }
             }
-        }
+            last_settings_profiles
+        };
+        #[cfg(feature = "agent_mode_evals")]
+        let last_settings_profiles = AISettings::as_ref(ctx).execution_profiles.value().clone();
 
         let settings_profiles_are_explicit = AISettings::as_ref(ctx)
             .execution_profiles
@@ -392,6 +405,8 @@ impl AIExecutionProfilesModel {
                 }
             });
 
+            // Eval builds never import legacy cloud profiles into settings.
+            #[cfg(not(feature = "agent_mode_evals"))]
             if imports_legacy_profiles {
                 if ctx.has_singleton_model::<AuthManager>() {
                     ctx.subscribe_to_model(&AuthManager::handle(ctx), |me, _, event, ctx| {
@@ -494,13 +509,16 @@ impl AIExecutionProfilesModel {
 
         if !uses_file_backed_profiles {
             model.maybe_inherit_from_legacy_settings(ctx);
-        } else if imports_legacy_profiles
+        }
+        // The syncer may finish before this model is registered. In that case its one-shot event
+        // cannot reach this subscription, so run migration from the already-completed state.
+        // Eval builds never import legacy cloud profiles into settings.
+        #[cfg(not(feature = "agent_mode_evals"))]
+        if uses_file_backed_profiles
+            && imports_legacy_profiles
             && ctx.has_singleton_model::<CloudPreferencesSyncer>()
             && CloudPreferencesSyncer::as_ref(ctx).has_completed_initial_load()
         {
-            // The syncer may finish before this model is registered. In that
-            // case its one-shot event cannot reach this subscription, so run
-            // migration from the already-completed state.
             model.migrate_settings_profiles(ctx);
         }
         model
@@ -633,6 +651,9 @@ impl AIExecutionProfilesModel {
     /// An explicit collection is reconciled with cloud preferences after their initial-load
     /// direction is known. Otherwise, owned legacy cloud objects are imported once all have server
     /// IDs. Missing prerequisites leave the migration pending so a later readiness event can retry.
+    ///
+    /// Eval builds never import legacy profiles, so this is compiled out for them.
+    #[cfg(not(feature = "agent_mode_evals"))]
     pub(crate) fn migrate_settings_profiles(&mut self, ctx: &mut ModelContext<Self>) {
         if !self.source.imports_legacy_profiles()
             || self.settings_migration_state == SettingsMigrationState::Complete
@@ -754,6 +775,9 @@ impl AIExecutionProfilesModel {
         }
     }
     /// Uploads an explicit local collection after the deferred migration check.
+    ///
+    /// Only the legacy import calls this, so eval builds compile it out.
+    #[cfg(not(feature = "agent_mode_evals"))]
     fn sync_explicit_settings_collection(ctx: &mut ModelContext<Self>) {
         if !ctx.has_singleton_model::<CloudPreferencesSyncer>() {
             return;


### PR DESCRIPTION
## Description

The `agent_mode_evals` build of the `warp` crate no longer compiles on master.

**Breaking PR:** https://github.com/warpdotdev/warp/pull/13886 ("Add TUI-local file-backed execution profiles")

The legacy-settings helpers in `app/src/ai/execution_profiles/mod.rs` (`create_default_from_legacy_settings`, `create_default_for_tui_from_legacy_settings`, `create_default_from_legacy_settings_with_profile`) are gated behind `#[cfg(not(feature = "agent_mode_evals"))]`, because eval builds always use the hard-coded eval profile (`AIExecutionProfile::create_agent_mode_eval_profile()`) and never read legacy scalar AI settings. #13886 introduced new callers of those helpers in code that is compiled unconditionally — the TUI default seeding in `AIExecutionProfilesModel::new` and the legacy → settings import in `migrate_settings_profiles` — so eval builds failed with unresolved-function errors.

**Mitigation in this PR:** rather than removing the gates (which would pull legacy-settings profile logic into eval builds and re-introduce dead code there), the helpers stay gated and their callers are compiled out for eval builds:

- `AIExecutionProfilesModel::new`: the TUI seeding block that writes a default profile into `AISettings::execution_profiles` is gated, with eval builds simply reading the current settings value for `last_settings_profiles`.
- `AIExecutionProfilesModel::new`: the `imports_legacy_profiles` subscriptions (auth, cloud preferences syncer, cloud model) and the post-construction migration kick are gated. The latter was restructured out of an `else if` chain so it can carry a `cfg` attribute.
- `migrate_settings_profiles` itself is gated, which removes the remaining references to `create_default_from_legacy_settings`.

Behavior for GUI/TUI/CLI builds is unchanged: every gated branch was already unreachable for eval builds at runtime (evals never launch the TUI and override the default profile state with the eval profile).

## Linked Issue
N/A — build fix.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Compile-only change; verified the previously broken configuration and the normal configurations:

- `cargo check -p warp --lib --features agent_mode_evals` — now succeeds (fails on master). Only remaining warning is the pre-existing `computer_use_override` dead-field warning for eval builds.
- `cargo check -p warp --lib` and `cargo check -p warp --lib --tests` — pass.
- `cargo clippy -p warp --all-targets --tests -- -D warnings` (the presubmit invocation) — passes.
- `./script/format` — clean.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
