### PR TITLE
Refactor TUI question selection state

### DIFF
--- a/crates/ai/src/agent/ask_user_question_session.rs
+++ b/crates/ai/src/agent/ask_user_question_session.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 
@@ -63,13 +63,6 @@ struct AskUserQuestionEditingState {
 }
 
 impl AskUserQuestionEditingState {
-    fn new(draft_count: usize) -> Self {
-        Self {
-            current_question_index: 0,
-            drafts: vec![QuestionDraftState::Unanswered; draft_count],
-        }
-    }
-
     fn current_question_index(&self) -> usize {
         self.current_question_index
     }
@@ -159,12 +152,32 @@ pub struct AskUserQuestionSession {
 }
 
 impl AskUserQuestionSession {
-    pub fn new(mut questions: Vec<AskUserQuestionItem>) -> Self {
+    pub fn new(questions: Vec<AskUserQuestionItem>) -> Self {
+        Self::new_with_drafts(questions, HashMap::new())
+    }
+
+    pub fn new_with_drafts(
+        mut questions: Vec<AskUserQuestionItem>,
+        mut drafts_by_question_id: HashMap<String, QuestionDraft>,
+    ) -> Self {
         // Put multi-select questions before single-select so the last question
         // can auto-submit after a single option toggle.
         questions.sort_by_key(|question| !question.is_multiselect());
+        let drafts = questions
+            .iter()
+            .map(|question| {
+                drafts_by_question_id
+                    .remove(&question.question_id)
+                    .filter(|draft| !draft.is_empty())
+                    .map(QuestionDraftState::Answered)
+                    .unwrap_or(QuestionDraftState::Unanswered)
+            })
+            .collect();
         Self {
-            state: AskUserQuestionState::Editing(AskUserQuestionEditingState::new(questions.len())),
+            state: AskUserQuestionState::Editing(AskUserQuestionEditingState {
+                current_question_index: 0,
+                drafts,
+            }),
             questions,
         }
     }

--- a/crates/ai/src/agent/ask_user_question_session_tests.rs
+++ b/crates/ai/src/agent/ask_user_question_session_tests.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use super::{
     AskUserQuestionAction, AskUserQuestionEffect, AskUserQuestionPhase, AskUserQuestionSession,
     QuestionDraft,
@@ -35,6 +37,32 @@ fn build_session(questions: Vec<AskUserQuestionItem>) -> AskUserQuestionSession 
 
 fn current_draft(session: &AskUserQuestionSession) -> Option<&QuestionDraft> {
     session.current().and_then(|current| current.draft)
+}
+#[test]
+fn initial_drafts_follow_questions_after_multiselect_sorting() {
+    let questions = vec![
+        build_question("single", "Single", false, false, &["One"]),
+        build_question("multi", "Multi", true, false, &["Alpha", "Beta"]),
+    ];
+    let mut drafts = HashMap::new();
+    drafts.insert(
+        "multi".to_owned(),
+        QuestionDraft {
+            selected_option_indices: HashSet::from([1]),
+            ..Default::default()
+        },
+    );
+
+    let session = AskUserQuestionSession::new_with_drafts(questions, drafts);
+
+    assert_eq!(session.questions()[0].question_id, "multi");
+    assert_eq!(
+        session
+            .draft_for_question(0)
+            .map(|draft| &draft.selected_option_indices),
+        Some(&HashSet::from([1]))
+    );
+    assert!(session.draft_for_question(1).is_none());
 }
 
 #[test]

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -121,6 +121,9 @@ pub(crate) enum TuiOptionSelectorEvent {
     /// The selector asked to be dismissed (element-level Escape fallback for
     /// hosts without their own Escape binding).
     Dismissed,
+    /// The host-requested row order changed.
+    #[allow(dead_code)]
+    RowsReordered { ordered_ids: Vec<String> },
     /// The selector's intrinsic height changed. `ctx.notify()` rerenders this
     /// view, but the block list may reuse a stable-width cached rich-content
     /// height. The host forwards this event so the containing rich-content
@@ -150,6 +153,14 @@ pub(crate) enum TuiOptionSelectorAction {
     FocusSearchAndInsert(char),
     /// Handle contextual Escape behavior, falling back to dismissal.
     HandleEscape,
+}
+
+// The next stacked change consumes this row-reordering API.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TuiOptionSelectorMoveDirection {
+    Backward,
+    Forward,
 }
 
 /// One navigable entry in the selector, in display order.
@@ -481,6 +492,83 @@ impl TuiOptionSelector {
             .flatten()
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn ordered_row_ids(&self) -> Vec<String> {
+        self.page
+            .snapshot
+            .rows
+            .iter()
+            .map(|row| row.id.clone())
+            .collect()
+    }
+
+    /// Moves `row_id` one step among the currently filtered rows, while
+    /// updating the full unfiltered catalog and preserving the current
+    /// selection.
+    #[allow(dead_code)]
+    pub(crate) fn move_row(
+        &mut self,
+        row_id: &str,
+        direction: TuiOptionSelectorMoveDirection,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let selected_id = self.selected_row_id();
+        let visible_row_ids = self
+            .items()
+            .into_iter()
+            .filter_map(|item| match item {
+                SelectorItem::Row(index) => {
+                    self.page.snapshot.rows.get(index).map(|row| row.id.clone())
+                }
+                SelectorItem::Retry | SelectorItem::CustomText => None,
+            })
+            .collect::<Vec<_>>();
+        let Some(visible_index) = visible_row_ids.iter().position(|id| id == row_id) else {
+            return false;
+        };
+        let target_visible_index = match direction {
+            TuiOptionSelectorMoveDirection::Backward => visible_index.checked_sub(1),
+            TuiOptionSelectorMoveDirection::Forward => visible_index.checked_add(1),
+        };
+        let Some(target_id) =
+            target_visible_index.and_then(|index| visible_row_ids.get(index).cloned())
+        else {
+            return false;
+        };
+        let Some(source_index) = self
+            .page
+            .snapshot
+            .rows
+            .iter()
+            .position(|row| row.id == row_id)
+        else {
+            return false;
+        };
+        let row = self.page.snapshot.rows.remove(source_index);
+        let Some(target_index) = self
+            .page
+            .snapshot
+            .rows
+            .iter()
+            .position(|row| row.id == target_id)
+        else {
+            self.page.snapshot.rows.insert(source_index, row);
+            return false;
+        };
+        let insertion_index = match direction {
+            TuiOptionSelectorMoveDirection::Backward => target_index,
+            TuiOptionSelectorMoveDirection::Forward => target_index + 1,
+        };
+        self.page.snapshot.rows.insert(insertion_index, row);
+        self.select_id(selected_id);
+        self.sync_after_items_changed();
+        ctx.emit(TuiOptionSelectorEvent::RowsReordered {
+            ordered_ids: self.ordered_row_ids(),
+        });
+        self.invalidate_layout(ctx);
+        true
+    }
+
     /// Whether host shortcuts scoped to the bare option list should be active.
     pub(crate) fn list_is_focused(&self, ctx: &AppContext) -> bool {
         matches!(self.focus_zone(ctx), SelectorFocusZone::List)
@@ -744,7 +832,7 @@ impl TuiOptionSelector {
     }
 
     /// The row id currently selected, when the selection is on a row.
-    fn selected_row_id(&self) -> Option<String> {
+    pub(crate) fn selected_row_id(&self) -> Option<String> {
         let items = self.items();
         match self
             .interaction

--- a/crates/warp_tui/src/option_selector_tests.rs
+++ b/crates/warp_tui/src/option_selector_tests.rs
@@ -18,6 +18,7 @@ use warpui_core::{App, AppContext, TuiView as _, TypedActionView as _, ViewHandl
 use super::{
     OptionSelectorHeader, OptionSelectorPage, SELECTOR_NAVIGATION_ACTIVE, SelectorFocusZone,
     SelectorItem, TuiOptionSelector, TuiOptionSelectorAction, TuiOptionSelectorEvent,
+    TuiOptionSelectorMoveDirection,
 };
 use crate::editor_element::TuiEditorAction;
 use crate::editor_interaction::TuiEditorCommand;
@@ -34,6 +35,60 @@ fn row(id: &str) -> OptionRow {
         badge: None,
         disabled_reason: None,
     }
+}
+
+#[test]
+fn reordering_an_explicit_filtered_row_updates_the_full_catalog_and_preserves_selection() {
+    App::test((), |mut app| async move {
+        let (selector, events) = add_selector(&mut app);
+        set_searchable_page(
+            &mut app,
+            &selector,
+            snapshot(&["alpha", "hidden", "alpine"], Some("alpha")),
+        );
+        selector.update(&mut app, |selector, ctx| {
+            selector.interaction.search_query = "al".to_owned();
+            selector.sync_after_items_changed();
+            ctx.focus_self();
+            assert!(selector.move_row("alpine", TuiOptionSelectorMoveDirection::Backward, ctx));
+        });
+
+        assert_eq!(
+            selector.read(&app, |selector, _| selector.ordered_row_ids()),
+            ["alpine", "alpha", "hidden"]
+        );
+        assert!(selected_line(&app, &selector).contains("alpha"));
+        assert_eq!(
+            primary_events(&events),
+            [TuiOptionSelectorEvent::RowsReordered {
+                ordered_ids: vec!["alpine".to_owned(), "alpha".to_owned(), "hidden".to_owned(),],
+            }]
+        );
+    });
+}
+
+#[test]
+fn moving_a_hidden_or_boundary_row_is_a_noop() {
+    App::test((), |mut app| async move {
+        let (selector, events) = add_selector(&mut app);
+        set_searchable_page(
+            &mut app,
+            &selector,
+            snapshot(&["alpha", "hidden", "alpine"], Some("alpha")),
+        );
+        selector.update(&mut app, |selector, ctx| {
+            selector.interaction.search_query = "al".to_owned();
+            selector.sync_after_items_changed();
+            assert!(!selector.move_row("hidden", TuiOptionSelectorMoveDirection::Forward, ctx));
+            assert!(!selector.move_row("alpha", TuiOptionSelectorMoveDirection::Backward, ctx));
+        });
+
+        assert_eq!(
+            selector.read(&app, |selector, _| selector.ordered_row_ids()),
+            ["alpha", "hidden", "alpine"]
+        );
+        assert!(primary_events(&events).is_empty());
+    });
 }
 
 #[test]

--- a/crates/warp_tui/src/orchestration_block.rs
+++ b/crates/warp_tui/src/orchestration_block.rs
@@ -623,6 +623,7 @@ impl TuiOrchestrationBlock {
             TuiOptionSelectorEvent::LayoutInvalidated => {
                 ctx.emit(TuiOrchestrationBlockEvent::LayoutInvalidated);
             }
+            TuiOptionSelectorEvent::RowsReordered { .. } => {}
         }
     }
 

--- a/crates/warp_tui/src/tui_ask_question_view.rs
+++ b/crates/warp_tui/src/tui_ask_question_view.rs
@@ -335,7 +335,9 @@ impl TuiAskQuestionView {
                 self.handle_effect(effect, ctx);
             }
             TuiOptionSelectorEvent::LayoutInvalidated => self.invalidate_layout(ctx),
-            TuiOptionSelectorEvent::RetryRequested | TuiOptionSelectorEvent::Dismissed => {}
+            TuiOptionSelectorEvent::RetryRequested
+            | TuiOptionSelectorEvent::Dismissed
+            | TuiOptionSelectorEvent::RowsReordered { .. } => {}
         }
     }
 

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -230,6 +230,7 @@ impl TuiPermissionPrompt {
             | TuiOptionSelectorEvent::CustomTextCleared
             | TuiOptionSelectorEvent::CustomTextOpened
             | TuiOptionSelectorEvent::CustomTextClosed => self.invalidate_layout(ctx),
+            TuiOptionSelectorEvent::RowsReordered { .. } => {}
             TuiOptionSelectorEvent::Confirmed { .. } | TuiOptionSelectorEvent::RetryRequested => {}
         }
     }


### PR DESCRIPTION
## Description
Refactors shared Ask User Question state initialization to accept prefilled drafts keyed by question ID, and adds filtered full-catalog row reordering to the reusable TUI option selector. Existing Ask User Question, permission, and orchestration consumers explicitly ignore reorder events, so this PR is behavior-neutral on its own.

## Linked Issue
N/A — stacked prerequisite for #14286.

## Testing
- [x] `cargo nextest run -p ai -E test(ask_user_question_session)` — 19 passed.
- [x] `cargo nextest run -p warp_tui -E test(option_selector)` — 39 passed.
- [x] Formatting and warnings-denied Clippy passed.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>