### PR TITLE
ci: verify compilation with the agent_mode_evals feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,11 +814,6 @@ jobs:
           target_os: linux
           is_self_hosted: false
 
-      # Only the library target is checked, because that is all the eval repo
-      # builds: it consumes `warp` as a git dependency, so this crate's own
-      # `#[cfg(test)]` code is never compiled there. Checking `--all-targets`
-      # instead would force unit tests to be `cfg`-gated for a configuration
-      # they are never run in.
       - name: Verify compilation with the agent_mode_evals feature
         run: cargo check --locked -p warp --lib --features agent_mode_evals
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,8 +814,13 @@ jobs:
           target_os: linux
           is_self_hosted: false
 
+      # Only the library target is checked, because that is all the eval repo
+      # builds: it consumes `warp` as a git dependency, so this crate's own
+      # `#[cfg(test)]` code is never compiled there. Checking `--all-targets`
+      # instead would force unit tests to be `cfg`-gated for a configuration
+      # they are never run in.
       - name: Verify compilation with the agent_mode_evals feature
-        run: cargo check --locked -p warp --features agent_mode_evals --all-targets
+        run: cargo check --locked -p warp --lib --features agent_mode_evals
         env:
           # Attach the GitHub auth token so that requests to the GitHub API
           # don't get rate limited during compilation (e.g.: retrieving

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,6 +795,33 @@ jobs:
           # Sentry SDK binary releases).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # The agent-mode-evals repo (warpdotdev/agent-mode-evals) depends on this repo
+  # with the `agent_mode_evals` feature enabled. That feature is not part of any
+  # other CI job's feature set, so code behind `cfg(feature = "agent_mode_evals")`
+  # can silently stop compiling until the eval repo bumps its pinned warp rev.
+  # This job compiles that configuration to catch breakage in the PR that causes it.
+  check-eval-compilation:
+    name: Verify compilation with eval features
+    timeout-minutes: 25
+    # Match the platform used by agent-mode-evals CI.
+    runs-on: ubuntu-latest-large
+    needs: params
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/prepare_environment
+        with:
+          target_os: linux
+          is_self_hosted: false
+
+      - name: Verify compilation with the agent_mode_evals feature
+        run: cargo check --locked -p warp --features agent_mode_evals --all-targets
+        env:
+          # Attach the GitHub auth token so that requests to the GitHub API
+          # don't get rate limited during compilation (e.g.: retrieving
+          # Sentry SDK binary releases).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # A final job that collects the results of all of the parallel CI jobs and
   # makes sure that all of them pass.
   #
@@ -816,6 +843,7 @@ jobs:
       - wasm-lint
       - general-lint
       - check-release-compilation
+      - check-eval-compilation
     steps:
       - name: Check CI results
         run: |


### PR DESCRIPTION
## Description

Adds a `check-eval-compilation` CI job that builds the `warp` library with the `agent_mode_evals` feature.

**Why:** the external [`warpdotdev/agent-mode-evals`](https://github.com/warpdotdev/agent-mode-evals) repo depends on this repo with `agent_mode_evals` enabled, but no CI job here enables that feature — `tests`, `lints`, and `check-release-compilation` all build the default feature set. Code behind `cfg(feature = "agent_mode_evals")` can therefore break on master and stay broken until the eval repo bumps its pinned `warp` rev, at which point the breakage surfaces far from the PR that caused it.

That is exactly what happened with #13886 ("Add TUI-local file-backed execution profiles"), which introduced unconditionally-compiled callers of helpers gated behind `#[cfg(not(feature = "agent_mode_evals"))]`. It passed CI on 2026-07-21 and the eval build stayed broken until #14250 fixed it on 2026-07-24.

**How:** a single job running `cargo check --locked -p warp --lib --features agent_mode_evals` on `ubuntu-latest-large`, matching the platform agent-mode-evals CI uses. It's added to the `ci-result` gather job's `needs` so it's covered by the existing required-check setup rather than needing a new branch protection rule.

### Why `--lib` and not `--all-targets`

The job originally used `--all-targets`, and its first run failed — usefully. `warp (lib test)` does not compile under the feature: `app/src/ai/execution_profiles/profiles_tests.rs` still calls `create_default_from_legacy_settings` and `create_default_for_tui_from_legacy_settings` (imported at line 14, used at 160-161) plus `migrate_settings_profiles` (lines 709, 1004, 1126, 1242), all of which #14250 left gated while fixing the library.

That target is not one the eval repo builds. agent-mode-evals consumes `warp`, `integration`, `warp_cli`, and `warp_core` as git dependencies pinned at a rev, so this crate's own `#[cfg(test)]` code is never compiled there — its `cargo clippy/nextest --workspace --all-targets --all-features` covers only its own `crates/*`. Keeping `--all-targets` here would force warp unit tests to be `cfg`-gated for a configuration they are never run in, an ongoing tax on test authors that protects nobody.

`--lib` still catches the class of breakage the job exists for: #13886 broke `AIExecutionProfilesModel::new` and `migrate_settings_profiles` in the library itself, so this job would have failed on it.

Possible follow-up, deliberately not in this PR: the eval repo also builds the `integration` lib with the feature active via feature unification, which `-p warp` does not cover.

## Linked Issue
N/A — CI hardening follow-up to #14250.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

CI-config-only change; no Rust sources touched, so no `cargo fmt` / `cargo clippy` run is applicable.

- Verified `.github/workflows/ci.yml` parses as valid YAML and that `check-eval-compilation` appears in the job list and in `ci-result`'s `needs`.
- The `--all-targets` run on the first commit confirmed the library target itself is healthy — the log shows `warning: warp (lib) generated 1 warning` (the pre-existing `computer_use_override` dead-field warning) and the failure was isolated to `warp (lib test)`. So the narrowed `--lib` invocation is already known-good on this base.
- The command matches what #14250 validated locally: `cargo check -p warp --lib --features agent_mode_evals`, which failed on pre-fix master and passed after.
- Final validation is this PR's own CI run.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Warp conversation](https://staging.warp.dev/conversation/2c83f2d2-e4a6-4f68-9454-543def52e594)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
CHANGELOG-NONE
-->
