### PR TITLE
Expand TUI statusline item catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15994,6 +15994,7 @@ dependencies = [
  "base64 0.22.1",
  "blocking",
  "channel_versions",
+ "chrono",
  "clap",
  "command",
  "dirs 6.0.0",

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -127,9 +127,10 @@ pub(crate) use persistence::PersistedAIInputType;
 pub use persistence::maybe_build_ai_query_upsert_event;
 pub(crate) use persistence::{PersistedAIInput, SerializedBlockListItem};
 pub(crate) use queued_query::{
-    AutofireAction, QueuedQuery, QueuedQueryEvent, QueuedQueryId, QueuedQueryModel,
-    QueuedQueryOrigin, is_lrc_auto_queue_active,
+    AutofireAction, QueuedQuery, QueuedQueryId, QueuedQueryOrigin, is_lrc_auto_queue_active,
 };
+#[cfg_attr(not(feature = "tui"), allow(unused_imports))]
+pub use queued_query::{QueuedQueryEvent, QueuedQueryModel};
 pub use suggestion_chip_view::*;
 pub use view_util::error_color;
 pub(crate) use view_util::{

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -507,7 +507,7 @@ impl GitBranchTrackingStatus {
         })
     }
 
-    pub fn display_text(&self) -> String {
+    pub fn status_text(&self) -> Option<String> {
         let mut parts = Vec::new();
         if self.is_rebased() {
             parts.push("⇅".to_string());
@@ -519,11 +519,13 @@ impl GitBranchTrackingStatus {
                 parts.push(format!("↓{behind}"));
             }
         }
+        (!parts.is_empty()).then(|| parts.join(" "))
+    }
 
-        if parts.is_empty() {
-            self.branch.clone()
-        } else {
-            format!("{} • {}", self.branch, parts.join(" "))
+    pub fn display_text(&self) -> String {
+        match self.status_text() {
+            Some(status) => format!("{} • {status}", self.branch),
+            None => self.branch.clone(),
         }
     }
 

--- a/app/src/context_chips/display_chip_tests.rs
+++ b/app/src/context_chips/display_chip_tests.rs
@@ -56,6 +56,7 @@ fn test_git_branch_tracking_status_displays_ahead_and_behind_when_upstream_exist
     );
 
     assert_eq!(status.display_text(), "feature-a • ↑2 ↓1");
+    assert_eq!(status.status_text().as_deref(), Some("↑2 ↓1"));
 }
 
 #[test]
@@ -68,6 +69,7 @@ fn test_git_branch_tracking_status_hides_zero_counts() {
     );
 
     assert_eq!(status.display_text(), "feature-a • ↑2");
+    assert_eq!(status.status_text().as_deref(), Some("↑2"));
 }
 
 #[test]
@@ -88,6 +90,7 @@ fn test_git_branch_tracking_status_displays_rebased_indicator() {
         GitBranchTrackingStatus::rebased("feature-a".to_string(), "origin/feature-a".to_string());
 
     assert_eq!(status.display_text(), "feature-a • ⇅");
+    assert_eq!(status.status_text().as_deref(), Some("⇅"));
 }
 
 #[test]
@@ -140,6 +143,7 @@ fn test_git_branch_tracking_status_displays_branch_only_without_upstream() {
     let status = GitBranchTrackingStatus::new("feature-a".to_string(), None, 0, 0);
 
     assert_eq!(status.display_text(), "feature-a");
+    assert_eq!(status.status_text(), None);
 }
 
 #[test]
@@ -150,6 +154,7 @@ fn test_git_branch_tracking_status_displays_branch_only_when_counts_are_unavaila
     );
 
     assert_eq!(status.display_text(), "feature-a");
+    assert_eq!(status.status_text(), None);
 }
 
 #[test]

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -45,6 +45,15 @@ pub const ADD_MCP: StaticCommand = StaticCommand {
     auto_enter_ai_mode: false,
     argument: None,
 };
+pub const STATUSLINE: StaticCommand = StaticCommand {
+    name: "/statusline",
+    description: "Configure the statusline",
+    kind: SlashCommandKind::Statusline,
+    supported_surfaces: SlashCommandSurfaces::TuiOnly,
+    availability: Availability::ALWAYS,
+    auto_enter_ai_mode: false,
+    argument: None,
+};
 
 pub const AUTO_APPROVE: StaticCommand = StaticCommand {
     name: "/auto-approve",
@@ -876,6 +885,7 @@ fn all_commands(settings_mode: settings::SettingsMode) -> Vec<StaticCommand> {
         RENAME_CONVERSATION.clone(),
         RENAME_TAB.clone(),
         SET_TAB_COLOR.clone(),
+        STATUSLINE,
         NATURAL_LANGUAGE_DETECTION,
         THEME,
         USAGE,

--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -135,6 +135,23 @@ fn auto_approve_command_is_local_agent_action_without_arguments() {
 }
 
 #[test]
+fn statusline_command_is_always_available_only_in_tui_mode() {
+    let command = all_commands(settings::SettingsMode::Tui)
+        .into_iter()
+        .find(|command| command.kind == SlashCommandKind::Statusline)
+        .expect("expected /statusline to be registered in TUI mode");
+    assert_eq!(command, STATUSLINE);
+    assert_eq!(command.availability, Availability::ALWAYS);
+    assert_eq!(command.supported_surfaces, SlashCommandSurfaces::TuiOnly);
+    assert!(!command.auto_enter_ai_mode);
+    assert!(command.argument.is_none());
+    assert!(
+        all_commands(settings::SettingsMode::Gui)
+            .iter()
+            .all(|command| command.kind != SlashCommandKind::Statusline)
+    );
+}
+#[test]
 fn logout_command_is_registered_only_for_tui_mode() {
     assert!(
         all_commands(settings::SettingsMode::Tui)

--- a/app/src/search/slash_command_menu/static_commands/mod.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod.rs
@@ -55,6 +55,7 @@ pub enum SlashCommandKind {
     CloudAgent,
     AddMcp,
     AutoApprove,
+    Statusline,
     Mcp,
     ViewLogs,
     Voice,

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -690,21 +690,31 @@ pub enum TuiStatuslineItem {
     Model,
     WorkingDirectory,
     GitBranch,
+    GitBranchStatus,
     GitDiffStatus,
     CreditUsage,
     ContextWindowUsage,
+    Date,
+    Time12Hour,
+    Time24Hour,
+    AgentTodoList,
 }
 
 impl TuiStatuslineItem {
-    pub const ALL: [Self; 8] = [
+    pub const ALL: [Self; 13] = [
         Self::AutoApprove,
         Self::AutoQueue,
         Self::Model,
         Self::WorkingDirectory,
         Self::GitBranch,
+        Self::GitBranchStatus,
         Self::GitDiffStatus,
         Self::CreditUsage,
         Self::ContextWindowUsage,
+        Self::Date,
+        Self::Time12Hour,
+        Self::Time24Hour,
+        Self::AgentTodoList,
     ];
 
     pub fn label(self) -> &'static str {
@@ -714,9 +724,14 @@ impl TuiStatuslineItem {
             Self::Model => "Model",
             Self::WorkingDirectory => "Working directory",
             Self::GitBranch => "Git branch",
+            Self::GitBranchStatus => "Git branch status",
             Self::GitDiffStatus => "Git diff status",
             Self::CreditUsage => "Credit usage",
             Self::ContextWindowUsage => "Context window usage",
+            Self::Date => "Date",
+            Self::Time12Hour => "Time (12 hour format)",
+            Self::Time24Hour => "Time (24 hour format)",
+            Self::AgentTodoList => "Agent to-do list",
         }
     }
 }

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -695,13 +695,16 @@ pub enum TuiStatuslineItem {
     CreditUsage,
     ContextWindowUsage,
     Date,
+    #[schemars(rename = "time_12_hour")]
     Time12Hour,
+    #[schemars(rename = "time_24_hour")]
     Time24Hour,
     AgentTodoList,
+    VoiceInput,
 }
 
 impl TuiStatuslineItem {
-    pub const ALL: [Self; 13] = [
+    pub const ALL: [Self; 14] = [
         Self::AutoApprove,
         Self::AutoQueue,
         Self::Model,
@@ -715,6 +718,7 @@ impl TuiStatuslineItem {
         Self::Time12Hour,
         Self::Time24Hour,
         Self::AgentTodoList,
+        Self::VoiceInput,
     ];
 
     pub fn label(self) -> &'static str {
@@ -732,6 +736,7 @@ impl TuiStatuslineItem {
             Self::Time12Hour => "Time (12 hour format)",
             Self::Time24Hour => "Time (24 hour format)",
             Self::AgentTodoList => "Agent to-do list",
+            Self::VoiceInput => "Voice input",
         }
     }
 }

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -83,6 +83,7 @@ fn tui_statusline_normalization_preserves_custom_order_and_appends_missing_items
             TuiStatuslineItem::Time12Hour,
             TuiStatuslineItem::Time24Hour,
             TuiStatuslineItem::AgentTodoList,
+            TuiStatuslineItem::VoiceInput,
         ]
     );
     assert_eq!(

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -75,9 +75,14 @@ fn tui_statusline_normalization_preserves_custom_order_and_appends_missing_items
             TuiStatuslineItem::AutoApprove,
             TuiStatuslineItem::AutoQueue,
             TuiStatuslineItem::WorkingDirectory,
+            TuiStatuslineItem::GitBranchStatus,
             TuiStatuslineItem::GitDiffStatus,
             TuiStatuslineItem::CreditUsage,
             TuiStatuslineItem::ContextWindowUsage,
+            TuiStatuslineItem::Date,
+            TuiStatuslineItem::Time12Hour,
+            TuiStatuslineItem::Time24Hour,
+            TuiStatuslineItem::AgentTodoList,
         ]
     );
     assert_eq!(

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1255,6 +1255,7 @@ impl Input {
                 return false;
             }
             SlashCommandKind::AutoApprove
+            | SlashCommandKind::Statusline
             | SlashCommandKind::ViewLogs
             | SlashCommandKind::Voice
             | SlashCommandKind::NaturalLanguageDetection

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -98,10 +98,11 @@ pub use crate::ai::blocklist::{
     BlocklistAIActionModel, BlocklistAIContextEvent, BlocklistAIContextModel,
     BlocklistAIController, BlocklistAIInputModel, InputConfig, InputModePolicy,
     InputModePolicyHandle, InputType, InputTypeAutoDetectionSource, NewConversationDecision,
-    PendingAttachment, PendingAttachmentSummary, PolicyConfigUpdate, RequestFileEditsExecutor,
-    RunAgentsExecutor, RunAgentsExecutorEvent, RunAgentsSpawningSnapshot, ShellCommandExecutor,
-    ShellCommandExecutorEvent, StartAgentExecutor, StartAgentExecutorEvent, StartAgentOutcome,
-    StartAgentRequest, StartAgentRequestId, block_context_from_terminal_model,
+    PendingAttachment, PendingAttachmentSummary, PolicyConfigUpdate, QueuedQueryEvent,
+    QueuedQueryModel,
+    RequestFileEditsExecutor, RunAgentsExecutor, RunAgentsExecutorEvent, RunAgentsSpawningSnapshot,
+    ShellCommandExecutor, ShellCommandExecutorEvent, StartAgentExecutor, StartAgentExecutorEvent,
+    StartAgentOutcome, StartAgentRequest, StartAgentRequestId, block_context_from_terminal_model,
     inherit_child_agent_settings, maybe_build_ai_query_upsert_event,
 };
 #[cfg(not(target_family = "wasm"))]

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -99,11 +99,11 @@ pub use crate::ai::blocklist::{
     BlocklistAIController, BlocklistAIInputModel, InputConfig, InputModePolicy,
     InputModePolicyHandle, InputType, InputTypeAutoDetectionSource, NewConversationDecision,
     PendingAttachment, PendingAttachmentSummary, PolicyConfigUpdate, QueuedQueryEvent,
-    QueuedQueryModel,
-    RequestFileEditsExecutor, RunAgentsExecutor, RunAgentsExecutorEvent, RunAgentsSpawningSnapshot,
-    ShellCommandExecutor, ShellCommandExecutorEvent, StartAgentExecutor, StartAgentExecutorEvent,
-    StartAgentOutcome, StartAgentRequest, StartAgentRequestId, block_context_from_terminal_model,
-    inherit_child_agent_settings, maybe_build_ai_query_upsert_event,
+    QueuedQueryModel, RequestFileEditsExecutor, RunAgentsExecutor, RunAgentsExecutorEvent,
+    RunAgentsSpawningSnapshot, ShellCommandExecutor, ShellCommandExecutorEvent, StartAgentExecutor,
+    StartAgentExecutorEvent, StartAgentOutcome, StartAgentRequest, StartAgentRequestId,
+    block_context_from_terminal_model, inherit_child_agent_settings,
+    maybe_build_ai_query_upsert_event,
 };
 #[cfg(not(target_family = "wasm"))]
 pub use crate::ai::blocklist::{

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -40,6 +40,7 @@ async-fs.workspace = true
 base64.workspace = true
 blocking.workspace = true
 channel_versions.workspace = true
+chrono.workspace = true
 clap.workspace = true
 command.workspace = true
 dirs.workspace = true

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -363,6 +363,11 @@ impl TuiInputView {
         })
     }
 
+    pub(crate) fn stop_voice_input(&mut self, ctx: &mut ViewContext<Self>) {
+        self.voice_input
+            .update(ctx, |voice_input, ctx| voice_input.stop(ctx));
+    }
+
     /// Returns a handle to the backing [`CodeEditorModel`].
     pub fn model(&self) -> &ModelHandle<CodeEditorModel> {
         &self.model

--- a/crates/warp_tui/src/statusline_config_view_tests.rs
+++ b/crates/warp_tui/src/statusline_config_view_tests.rs
@@ -89,6 +89,7 @@ fn toggle_and_reorder_are_reflected_in_saved_config() {
                 TuiStatuslineItem::Time12Hour,
                 TuiStatuslineItem::Time24Hour,
                 TuiStatuslineItem::AgentTodoList,
+                TuiStatuslineItem::VoiceInput,
             ]
         );
         assert_eq!(

--- a/crates/warp_tui/src/statusline_config_view_tests.rs
+++ b/crates/warp_tui/src/statusline_config_view_tests.rs
@@ -81,9 +81,14 @@ fn toggle_and_reorder_are_reflected_in_saved_config() {
                 TuiStatuslineItem::Model,
                 TuiStatuslineItem::WorkingDirectory,
                 TuiStatuslineItem::GitBranch,
+                TuiStatuslineItem::GitBranchStatus,
                 TuiStatuslineItem::GitDiffStatus,
                 TuiStatuslineItem::CreditUsage,
                 TuiStatuslineItem::ContextWindowUsage,
+                TuiStatuslineItem::Date,
+                TuiStatuslineItem::Time12Hour,
+                TuiStatuslineItem::Time24Hour,
+                TuiStatuslineItem::AgentTodoList,
             ]
         );
         assert_eq!(

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -139,6 +139,7 @@ const INITIAL_INPUT_WIDTH: u16 = 80;
 const INLINE_MENU_TOP_PADDING_ROWS: u16 = 1;
 const MAX_INPUT_TEXT_ROWS: u16 = 6;
 const AUTO_APPROVE_FEEDBACK_DURATION: Duration = Duration::from_secs(3);
+const STATUSLINE_DATETIME_REPAINT_INTERVAL: Duration = Duration::from_secs(60);
 const VOICE_INPUT_BORDER_REPAINT_INTERVAL: Duration = Duration::from_millis(33);
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
@@ -356,6 +357,18 @@ fn format_statusline_time_12_hour(now: NaiveDateTime) -> String {
 fn format_statusline_time_24_hour(now: NaiveDateTime) -> String {
     now.format("%H:%M").to_string()
 }
+fn render_statusline_datetime(
+    formatter: fn(NaiveDateTime) -> String,
+    style: TuiStyle,
+) -> Box<dyn TuiElement> {
+    TuiAnimated::new(STATUSLINE_DATETIME_REPAINT_INTERVAL, move || {
+        TuiText::new(formatter(Local::now().naive_local()))
+            .with_style(style)
+            .truncate()
+            .finish()
+    })
+    .finish()
+}
 fn format_todo_progress(completed: usize, total: usize, finished: bool) -> String {
     let marker = if finished { "✓" } else { "❒" };
     format!("{marker} {completed}/{total}")
@@ -409,8 +422,9 @@ enum FooterSegment {
     ContextWindowUsage(String),
     GitDiff { additions: usize, deletions: usize },
     GitBranchStatus(String),
-    DateTime(String),
+    DateTime(Box<dyn TuiElement>),
     AgentTodoList(String),
+    VoiceInput(Box<dyn TuiElement>),
 }
 
 impl FooterSegment {
@@ -418,10 +432,7 @@ impl FooterSegment {
         match (self, next) {
             (Self::ShellMode | Self::Model(_), Self::WorkingDirectory(_)) => " ",
             (Self::WorkingDirectory(_), Self::GitBranch(_)) => " ↬ ",
-            (
-                Self::ActiveIndicator(_),
-                Self::ActiveIndicator(_),
-            ) => " • ",
+            (Self::ActiveIndicator(_), Self::ActiveIndicator(_)) => " • ",
             (
                 Self::WorkingDirectory(_) | Self::GitBranch(_),
                 Self::WorkingDirectory(_) | Self::GitBranch(_),
@@ -439,7 +450,8 @@ impl FooterSegment {
                 | Self::GitDiff { .. }
                 | Self::GitBranchStatus(_)
                 | Self::DateTime(_)
-                | Self::AgentTodoList(_),
+                | Self::AgentTodoList(_)
+                | Self::VoiceInput(_),
                 Self::ActiveIndicator(_)
                 | Self::Model(_)
                 | Self::WorkingDirectory(_)
@@ -449,7 +461,8 @@ impl FooterSegment {
                 | Self::GitDiff { .. }
                 | Self::GitBranchStatus(_)
                 | Self::DateTime(_)
-                | Self::AgentTodoList(_),
+                | Self::AgentTodoList(_)
+                | Self::VoiceInput(_),
             ) => " | ",
         }
     }
@@ -459,12 +472,11 @@ impl FooterSegment {
 struct FooterSegments {
     ordered: Vec<FooterSegment>,
 }
-
 /// Builds the status row from resolved segments. Working directory follows a
-/// leading shell-mode label with a plain space; an immediately following
-/// branch uses the existing ` ↬ ` relationship marker. Items in different
-/// Figma groups use ` | `; other adjacent pairs use ` • `. The first item never
-/// receives a separator.
+/// leading shell-mode or model label with a plain space; an immediately
+/// following branch uses the existing ` ↬ ` relationship marker. Items in
+/// different Figma groups use ` | `; other adjacent pairs use ` • `. The first
+/// item never receives a separator.
 fn render_status_footer_row(segments: FooterSegments, builder: &TuiUiBuilder) -> TuiFlex {
     let muted = builder.muted_text_style();
     let mut row = TuiFlex::row();
@@ -488,8 +500,11 @@ fn render_status_footer_row(segments: FooterSegments, builder: &TuiUiBuilder) ->
                         .finish(),
                 );
             }
-            FooterSegment::Model(model) | FooterSegment::CreditUsage(model) => {
-                row = row.child(model);
+            FooterSegment::Model(element)
+            | FooterSegment::CreditUsage(element)
+            | FooterSegment::DateTime(element)
+            | FooterSegment::VoiceInput(element) => {
+                row = row.child(element);
             }
             FooterSegment::WorkingDirectory(cwd) | FooterSegment::GitBranch(cwd) => {
                 row = row.child(TuiText::new(cwd).with_style(muted).truncate().finish());
@@ -497,9 +512,7 @@ fn render_status_footer_row(segments: FooterSegments, builder: &TuiUiBuilder) ->
             FooterSegment::ContextWindowUsage(usage) => {
                 row = row.child(TuiText::new(usage).with_style(muted).truncate().finish());
             }
-            FooterSegment::GitBranchStatus(value)
-            | FooterSegment::DateTime(value)
-            | FooterSegment::AgentTodoList(value) => {
+            FooterSegment::GitBranchStatus(value) | FooterSegment::AgentTodoList(value) => {
                 row = row.child(TuiText::new(value).with_style(muted).truncate().finish());
             }
             FooterSegment::GitDiff {
@@ -631,6 +644,8 @@ pub(crate) enum TuiTerminalSessionAction {
     PasteFromClipboard,
     /// Start recording voice input from the session composer.
     StartVoiceInput,
+    /// Start or stop voice input from the configured statusline control.
+    ToggleVoiceInput,
 }
 
 /// The authenticated terminal/session surface rendered inside [`RootTuiView`].
@@ -676,6 +691,8 @@ pub(crate) struct TuiTerminalSessionView {
     /// (not created inline during render) so it survives element-tree rebuilds
     /// — the same `MouseStateHandle` pattern as [`UsageToggle`].
     model_label_hover: MouseStateHandle,
+    /// Hover and click state for the configured Voice statusline control.
+    voice_input_mouse: MouseStateHandle,
     keyboard_enhancement_supported: bool,
     ai_context_model: ModelHandle<BlocklistAIContextModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
@@ -1717,6 +1734,7 @@ impl TuiTerminalSessionView {
                 event,
                 AISettingsChangedEvent::TuiUsageDisplayMode { .. }
                     | AISettingsChangedEvent::TuiStatusline { .. }
+                    | AISettingsChangedEvent::VoiceInputEnabled { .. }
             ) {
                 ctx.notify();
             }
@@ -1841,6 +1859,7 @@ impl TuiTerminalSessionView {
             usage_toggle: UsageToggle::default(),
             hidden_response_summary_exchange_ids: HashSet::new(),
             model_label_hover: MouseStateHandle::default(),
+            voice_input_mouse: MouseStateHandle::default(),
             keyboard_enhancement_supported,
             ai_context_model: context_model,
             ai_input_model,
@@ -2730,7 +2749,11 @@ impl TuiTerminalSessionView {
 
     /// Selects the single message that replaces the normal footer, preserving
     /// the priority order between competing session states.
-    fn footer_hint(&self, ctx: &AppContext) -> Option<FooterHint<'_>> {
+    fn footer_hint(
+        &self,
+        voice_statusline_visible: bool,
+        ctx: &AppContext,
+    ) -> Option<FooterHint<'_>> {
         if self.exit_confirmation.is_armed() {
             return Some(FooterHint::muted(CTRL_C_EXIT_HINT));
         }
@@ -2750,6 +2773,9 @@ impl TuiTerminalSessionView {
                 TransientHintTone::Error => FooterHintStyle::Error,
             };
             return Some(FooterHint { text, style });
+        }
+        if voice_statusline_visible {
+            return None;
         }
         match self.input_view.as_ref(ctx).voice_state(ctx) {
             TuiVoiceInputState::Listening => {
@@ -2773,13 +2799,14 @@ impl TuiTerminalSessionView {
     /// the whole row instead. An empty resolved configuration consumes no row.
     fn render_footer(&self, ctx: &AppContext) -> TuiFlex {
         let builder = TuiUiBuilder::from_app(ctx);
-        if let Some(hint) = self.footer_hint(ctx) {
-            return hint.render(&builder);
-        }
         let shell_mode = self.is_shell_mode(ctx);
         let config = AISettings::as_ref(ctx).tui_statusline.normalized();
+        let voice_statusline_visible = config.is_enabled(TuiStatuslineItem::VoiceInput)
+            && self.voice_statusline_is_available(shell_mode, ctx);
+        if let Some(hint) = self.footer_hint(voice_statusline_visible, ctx) {
+            return hint.render(&builder);
+        }
         let git_metadata = self.git_status_metadata(ctx);
-        let local_now = Local::now().naive_local();
         let mut ordered = Vec::new();
         if shell_mode {
             ordered.push(FooterSegment::ShellMode);
@@ -2832,8 +2859,11 @@ impl TuiTerminalSessionView {
                     .map(|cwd| FooterSegment::WorkingDirectory(compact_footer_path(&cwd))),
                 TuiStatuslineItem::GitBranch => git_metadata
                     .map(|metadata| FooterSegment::GitBranch(metadata.current_branch_name.clone())),
-                TuiStatuslineItem::GitBranchStatus => git_metadata.map(|metadata| {
-                    FooterSegment::GitBranchStatus(metadata.branch_tracking_status.display_text())
+                TuiStatuslineItem::GitBranchStatus => git_metadata.and_then(|metadata| {
+                    metadata
+                        .branch_tracking_status
+                        .status_text()
+                        .map(FooterSegment::GitBranchStatus)
                 }),
                 TuiStatuslineItem::GitDiffStatus => git_metadata.and_then(|metadata| {
                     let stats = metadata.stats_against_head;
@@ -2872,15 +2902,21 @@ impl TuiTerminalSessionView {
                             conversation.context_window_usage(),
                         ))
                     }),
-                TuiStatuslineItem::Date => {
-                    Some(FooterSegment::DateTime(format_statusline_date(local_now)))
+                TuiStatuslineItem::Date => Some(FooterSegment::DateTime(
+                    render_statusline_datetime(format_statusline_date, builder.muted_text_style()),
+                )),
+                TuiStatuslineItem::Time12Hour => {
+                    Some(FooterSegment::DateTime(render_statusline_datetime(
+                        format_statusline_time_12_hour,
+                        builder.muted_text_style(),
+                    )))
                 }
-                TuiStatuslineItem::Time12Hour => Some(FooterSegment::DateTime(
-                    format_statusline_time_12_hour(local_now),
-                )),
-                TuiStatuslineItem::Time24Hour => Some(FooterSegment::DateTime(
-                    format_statusline_time_24_hour(local_now),
-                )),
+                TuiStatuslineItem::Time24Hour => {
+                    Some(FooterSegment::DateTime(render_statusline_datetime(
+                        format_statusline_time_24_hour,
+                        builder.muted_text_style(),
+                    )))
+                }
                 TuiStatuslineItem::AgentTodoList => (!shell_mode)
                     .then(|| {
                         self.conversation_selection
@@ -2897,12 +2933,56 @@ impl TuiTerminalSessionView {
                             todo_list.is_finished(),
                         ))
                     }),
+                TuiStatuslineItem::VoiceInput => voice_statusline_visible.then(|| {
+                    FooterSegment::VoiceInput(self.render_voice_statusline(&builder, ctx))
+                }),
             };
             if let Some(segment) = segment {
                 ordered.push(segment);
             }
         }
         render_status_footer_row(FooterSegments { ordered }, &builder)
+    }
+
+    fn voice_statusline_is_available(&self, shell_mode: bool, ctx: &AppContext) -> bool {
+        !shell_mode && AISettings::as_ref(ctx).is_voice_input_enabled(ctx)
+    }
+
+    fn render_voice_statusline(
+        &self,
+        builder: &TuiUiBuilder,
+        ctx: &AppContext,
+    ) -> Box<dyn TuiElement> {
+        let state = self.input_view.as_ref(ctx).voice_state(ctx);
+        let hovered = self
+            .voice_input_mouse
+            .lock()
+            .is_ok_and(|state| state.is_hovered());
+        let (label, style) = match state {
+            TuiVoiceInputState::Idle => (
+                "Voice",
+                if hovered {
+                    builder.primary_text_style()
+                } else {
+                    builder.muted_text_style()
+                },
+            ),
+            TuiVoiceInputState::Listening => ("■ Listening", builder.error_text_style()),
+            TuiVoiceInputState::Transcribing => {
+                return TuiText::new("… Transcribing")
+                    .with_style(builder.voice_input_status_style())
+                    .truncate()
+                    .finish();
+            }
+        };
+        TuiHoverable::new(
+            self.voice_input_mouse.clone(),
+            TuiText::new(label).with_style(style).truncate().finish(),
+        )
+        .on_click(|event_ctx, _| {
+            event_ctx.dispatch_typed_action(TuiTerminalSessionAction::ToggleVoiceInput);
+        })
+        .finish()
     }
 
     fn is_auto_queue_enabled(&self, ctx: &AppContext) -> bool {
@@ -3204,6 +3284,18 @@ impl TuiTerminalSessionView {
         });
         if started && matches!(source, VoiceInputStartSource::SlashCommand) {
             record_static_slash_command_accepted("/voice", true, ctx);
+        }
+    }
+    fn toggle_voice_input(&mut self, ctx: &mut ViewContext<Self>) {
+        match self.input_view.as_ref(ctx).voice_state(ctx) {
+            TuiVoiceInputState::Idle => {
+                self.start_voice_input(VoiceInputStartSource::Button, ctx);
+            }
+            TuiVoiceInputState::Listening => {
+                self.input_view
+                    .update(ctx, |input, ctx| input.stop_voice_input(ctx));
+            }
+            TuiVoiceInputState::Transcribing => {}
         }
     }
 
@@ -4354,6 +4446,7 @@ impl TypedActionView for TuiTerminalSessionView {
             TuiTerminalSessionAction::StartVoiceInput => {
                 self.start_voice_input(VoiceInputStartSource::Keybinding, ctx);
             }
+            TuiTerminalSessionAction::ToggleVoiceInput => self.toggle_voice_input(ctx),
         }
     }
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -10,7 +10,10 @@ use async_channel::Sender;
 use instant::Instant;
 use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
-use warp::settings::{AISettings, AISettingsChangedEvent, TuiTheme, TuiThemeSettings};
+use warp::settings::{
+    AISettings, AISettingsChangedEvent, TuiStatuslineConfig, TuiStatuslineItem, TuiTheme,
+    TuiThemeSettings,
+};
 use warp::tui_export::{
     AIAgentActionId, AIAgentActionResultType, AIAgentContext, AIAgentExchangeId,
     AIAgentPtyWriteMode, AIConversation, AIConversationId, AcceptSlashCommandOrSavedPrompt,
@@ -24,17 +27,17 @@ use warp::tui_export::{
     ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels, GitRepoStatusModel,
     GitStatusMetadata, LLMId, LLMPreferences, LLMPreferencesEvent,
     LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, ModelEvent, ParsedSlashCommandInput,
-    PersistenceWriter, PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
-    ServerConversationToken, Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate,
-    SkillReference, SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
-    StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TerminalModel, TerminalSurface,
-    TerminalSurfaceInit, TranscriptScope, TuiMcpAction, TuiMcpManager, TuiSlashCommandDataSource,
-    TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource, UserTakeOverReason,
-    WAKEUP_THROTTLE_PERIOD, block_context_from_terminal_model, build_slash_command_mixer,
-    detect_possible_git_repo, export_conversation_markdown, log_out_tui,
-    maybe_build_ai_query_upsert_event, prepare_conversation_block_restoration,
-    record_autodetection_toggle_from_slash_command, record_saved_prompt_accepted,
-    record_static_slash_command_accepted, saved_prompt_text_for_id,
+    PersistenceWriter, PtyIntent, PtyIntentEvent, QueuedQueryEvent, QueuedQueryModel,
+    RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken, Sessions,
+    ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference, SlashCommandDataSource as _,
+    SlashCommandKind, SlashCommandSelectionBehavior, StartAgentExecutorEvent, StartAgentRequest,
+    StaticCommand, TerminalModel, TerminalSurface, TerminalSurfaceInit, TranscriptScope,
+    TuiMcpAction, TuiMcpManager, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
+    TuiZeroStateDataSource, UserTakeOverReason, WAKEUP_THROTTLE_PERIOD,
+    block_context_from_terminal_model, build_slash_command_mixer, detect_possible_git_repo,
+    export_conversation_markdown, log_out_tui, maybe_build_ai_query_upsert_event,
+    prepare_conversation_block_restoration, record_autodetection_toggle_from_slash_command,
+    record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
     slash_command_selection_behavior, slash_commands, throttle,
 };
 use warp_core::channel::{Channel, ChannelState};
@@ -95,6 +98,7 @@ use crate::resume::TuiExitSummaryHandle;
 use crate::session_registry::TuiSessions;
 use crate::skills_menu::{TuiSkillMenuEvent, TuiSkillMenuModel};
 use crate::slash_commands::TuiSlashCommandModel;
+use crate::statusline_config_view::{TuiStatuslineConfigEvent, TuiStatuslineConfigView};
 use crate::tab_bar::{TuiTabBarConfig, TuiTabBarEvent, TuiTabBarView};
 use crate::terminal_background::probed_colors;
 use crate::terminal_content_element::TuiTerminalContentElement;
@@ -255,6 +259,8 @@ const ZERO_STATE_ASCII_RELOAD_FAILED_HINT: &str =
 const VOICE_USAGE_HINT: &str = "Usage: /voice (no arguments)";
 const AUTO_APPROVE_ENABLED_HINT: &str = "Auto approve on";
 const AUTO_APPROVE_DISABLED_HINT: &str = "Auto approve off";
+const STATUSLINE_SAVED_HINT: &str = "Statusline configuration saved.";
+const STATUSLINE_PERSISTENCE_FAILED_HINT: &str = "Could not save the statusline configuration.";
 const COST_NO_ACTIVE_CONVERSATION_HINT: &str =
     "Cannot show conversation cost: no active conversation";
 const COST_EMPTY_CONVERSATION_HINT: &str = "Cannot show conversation cost: conversation is empty";
@@ -337,6 +343,9 @@ fn version_shell_command(channel: Channel) -> String {
 fn raw_prompt_if_not_blank(input: &str) -> Option<&str> {
     (!input.trim().is_empty()).then_some(input)
 }
+fn format_context_window_usage(usage: f32) -> String {
+    format!("{:.0}% context used", usage * 100.0)
+}
 fn cost_command_unavailable_hint(
     selected_conversation: Option<(bool, bool)>,
 ) -> Option<&'static str> {
@@ -375,112 +384,115 @@ fn bordered_input(
         .finish()
 }
 
-/// Resolved segments for the footer's left-aligned sectioned status row.
-/// [`TuiTerminalSessionView::render_footer`] builds this from view state and
-/// delegates to [`render_status_footer_row`]; keeping the row layout separate
-/// makes the left alignment, section order, and shell-mode omissions directly
-/// render-to-lines testable without view-state plumbing.
-struct FooterSegments {
-    /// Whether the input is in `!` shell mode: the shell-mode indicator leads
-    /// the row and the model/usage segments are hidden.
-    shell_mode: bool,
-    /// The clickable active-model label. Hidden in shell mode.
-    model_label: Option<Box<dyn TuiElement>>,
-    /// The session's compacted working directory. Part of the combined
-    /// cwd/branch section.
-    cwd: Option<String>,
-    /// The current branch name, appended to the cwd segment as ` ↬ branch`.
-    branch: Option<String>,
-    /// The clickable usage entry. Hidden in shell mode.
-    usage: Option<Box<dyn TuiElement>>,
-    /// Uncommitted diff additions; rendered as `+N` when > 0.
-    diff_additions: usize,
-    /// Uncommitted diff deletions; rendered as `-M` when > 0.
-    diff_deletions: usize,
+/// One resolved item in the footer's configured presentation order.
+enum FooterSegment {
+    ShellMode,
+    ActiveIndicator(&'static str),
+    Model(Box<dyn TuiElement>),
+    WorkingDirectory(String),
+    GitBranch(String),
+    CreditUsage(Box<dyn TuiElement>),
+    ContextWindowUsage(String),
+    GitDiff { additions: usize, deletions: usize },
 }
 
-/// Builds the left-aligned sectioned status row from resolved segments.
-///
-/// Agent mode orders the sections `[model] [cwd ↬ branch] • [usage] •
-/// [+N -M]`; shell mode leads with the shell-mode indicator and hides the
-/// model and usage segments, yielding `[Shell mode] [cwd ↬ branch] •
-/// [+N -M]`. A plain space separates the model from cwd/branch; a ` • `
-/// separator precedes usage and diff. Absent metadata never leaves a stray
-/// separator. Every child truncates to a single row, so the row lays out one
-/// row tall.
+impl FooterSegment {
+    fn separator_to(&self, next: &Self) -> &'static str {
+        match (self, next) {
+            (Self::ShellMode | Self::Model(_), Self::WorkingDirectory(_)) => " ",
+            (Self::WorkingDirectory(_), Self::GitBranch(_)) => " ↬ ",
+            (
+                Self::ShellMode
+                | Self::ActiveIndicator(_)
+                | Self::Model(_)
+                | Self::WorkingDirectory(_)
+                | Self::GitBranch(_)
+                | Self::CreditUsage(_)
+                | Self::ContextWindowUsage(_)
+                | Self::GitDiff { .. },
+                Self::ShellMode
+                | Self::ActiveIndicator(_)
+                | Self::Model(_)
+                | Self::WorkingDirectory(_)
+                | Self::GitBranch(_)
+                | Self::CreditUsage(_)
+                | Self::ContextWindowUsage(_)
+                | Self::GitDiff { .. },
+            ) => " • ",
+        }
+    }
+}
+
+/// Resolved segments for the footer's left-aligned status row.
+struct FooterSegments {
+    ordered: Vec<FooterSegment>,
+}
+
+/// Builds the status row from resolved segments. Working directory follows a
+/// leading model or shell-mode label with a plain space; an immediately
+/// following branch uses the existing ` ↬ ` relationship marker. Every other
+/// adjacent pair uses ` • `, and the first item never receives a separator.
 fn render_status_footer_row(segments: FooterSegments, builder: &TuiUiBuilder) -> TuiFlex {
     let muted = builder.muted_text_style();
     let mut row = TuiFlex::row();
-    let mut has_segment = false;
-
-    // First segment: the shell-mode indicator (Shell mode) or the clickable
-    // model label (agent mode). Shell mode hides the model segment so the
-    // indicator leads.
-    if segments.shell_mode {
-        row = row.child(
-            TuiText::new(SHELL_MODE_HINT)
-                .with_style(builder.shell_command_accent_style())
-                .truncate()
-                .finish(),
-        );
-        has_segment = true;
-    } else if let Some(model_label) = segments.model_label {
-        row = row.child(model_label);
-        has_segment = true;
-    }
-
-    // Combined cwd/branch section: the branch stays contextual to its path.
-    // A plain space separates this from the leading model/shell-mode segment,
-    // matching master's layout where model and cwd run together without a dot.
-    if segments.cwd.is_some() || segments.branch.is_some() {
-        if has_segment {
-            row = row.child(TuiText::new(" ").truncate().finish());
-        }
-        if let Some(cwd) = segments.cwd {
-            row = row.child(TuiText::new(cwd).with_style(muted).truncate().finish());
-        }
-        if let Some(branch) = segments.branch {
-            row = row.child(
-                TuiText::new(format!(" ↬ {branch}"))
-                    .with_style(muted)
-                    .truncate()
-                    .finish(),
-            );
-        }
-        has_segment = true;
-    }
-
-    // Usage entry (agent mode only): the clickable credits/cost toggle.
-    if !segments.shell_mode
-        && let Some(usage) = segments.usage
-    {
-        if has_segment {
-            row = row.child(TuiText::new(" • ").with_style(muted).truncate().finish());
-        }
-        row = row.child(usage);
-        has_segment = true;
-    }
-
-    // Diff counts retain their existing added/removed styles.
-    if segments.diff_additions > 0 || segments.diff_deletions > 0 {
-        if has_segment {
-            row = row.child(TuiText::new(" • ").with_style(muted).truncate().finish());
-        }
-        if segments.diff_additions > 0 {
-            row = row.child(
-                TuiText::new(format!("+{}", segments.diff_additions))
-                    .with_style(builder.diff_added_style())
-                    .truncate()
-                    .finish(),
-            );
-        }
-        if segments.diff_deletions > 0 {
-            if segments.diff_additions > 0 {
-                row = row.child(TuiText::new(" ").truncate().finish());
+    let mut segments = segments.ordered.into_iter().peekable();
+    while let Some(segment) = segments.next() {
+        let separator = segments.peek().map(|next| segment.separator_to(next));
+        match segment {
+            FooterSegment::ShellMode => {
+                row = row.child(
+                    TuiText::new(SHELL_MODE_HINT)
+                        .with_style(builder.shell_command_accent_style())
+                        .truncate()
+                        .finish(),
+                );
             }
+            FooterSegment::ActiveIndicator(label) => {
+                row = row.child(
+                    TuiText::new(label)
+                        .with_style(builder.success_glyph_style())
+                        .truncate()
+                        .finish(),
+                );
+            }
+            FooterSegment::Model(model) | FooterSegment::CreditUsage(model) => {
+                row = row.child(model);
+            }
+            FooterSegment::WorkingDirectory(cwd) | FooterSegment::GitBranch(cwd) => {
+                row = row.child(TuiText::new(cwd).with_style(muted).truncate().finish());
+            }
+            FooterSegment::ContextWindowUsage(usage) => {
+                row = row.child(TuiText::new(usage).with_style(muted).truncate().finish());
+            }
+            FooterSegment::GitDiff {
+                additions,
+                deletions,
+            } => {
+                if additions > 0 {
+                    row = row.child(
+                        TuiText::new(format!("+{additions}"))
+                            .with_style(builder.diff_added_style())
+                            .truncate()
+                            .finish(),
+                    );
+                }
+                if deletions > 0 {
+                    if additions > 0 {
+                        row = row.child(TuiText::new(" ").truncate().finish());
+                    }
+                    row = row.child(
+                        TuiText::new(format!("-{deletions}"))
+                            .with_style(builder.diff_removed_style())
+                            .truncate()
+                            .finish(),
+                    );
+                }
+            }
+        }
+        if let Some(separator) = separator {
             row = row.child(
-                TuiText::new(format!("-{}", segments.diff_deletions))
-                    .with_style(builder.diff_removed_style())
+                TuiText::new(separator)
+                    .with_style(muted)
                     .truncate()
                     .finish(),
             );
@@ -651,6 +663,7 @@ pub(crate) struct TuiTerminalSessionView {
     next_restore_request_id: u64,
     exit_summary: TuiExitSummaryHandle,
     handoff: Option<ViewHandle<TuiHandoffBlock>>,
+    statusline_config_view: Option<ViewHandle<TuiStatuslineConfigView>>,
     orchestration_tab_bar: ViewHandle<TuiTabBarView>,
     orchestration_tabs_focused: bool,
     zero_state_view: ViewHandle<TuiZeroStateView>,
@@ -866,6 +879,9 @@ impl TuiTerminalSessionView {
                 if let Some(source) = blocking_input_source {
                     self.orchestration_tabs_focused = false;
                     Self::focus_blocking_input_source(source, ctx);
+                } else if let Some(statusline_config_view) = self.statusline_config_view.as_ref() {
+                    self.orchestration_tabs_focused = false;
+                    statusline_config_view.update(ctx, |view, ctx| view.focus(ctx));
                 } else if self.orchestration_tabs_focused {
                     ctx.focus_self();
                 } else {
@@ -880,6 +896,9 @@ impl TuiTerminalSessionView {
                 if let Some(source) = blocking_input_source {
                     self.orchestration_tabs_focused = false;
                     Self::focus_blocking_input_source(source, ctx);
+                } else if let Some(statusline_config_view) = self.statusline_config_view.as_ref() {
+                    self.orchestration_tabs_focused = false;
+                    statusline_config_view.update(ctx, |view, ctx| view.focus(ctx));
                 } else if self.orchestration_tabs_focused {
                     ctx.focus_self();
                 } else {
@@ -1583,6 +1602,30 @@ impl TuiTerminalSessionView {
                 view.refresh_orchestration_tab_state(ctx);
             }
         });
+        ctx.subscribe_to_model(
+            &QueuedQueryModel::handle(ctx),
+            |view, _, event, ctx| match event {
+                QueuedQueryEvent::QueueNextPromptToggled { conversation_id } => {
+                    if view
+                        .conversation_selection
+                        .as_ref(ctx)
+                        .selected_conversation_id(ctx)
+                        == Some(*conversation_id)
+                    {
+                        ctx.notify();
+                    }
+                }
+                QueuedQueryEvent::DefaultModeChanged => ctx.notify(),
+                QueuedQueryEvent::Appended { .. }
+                | QueuedQueryEvent::RowUnlocked { .. }
+                | QueuedQueryEvent::Removed { .. }
+                | QueuedQueryEvent::Reordered { .. }
+                | QueuedQueryEvent::EditEntered { .. }
+                | QueuedQueryEvent::EditCommitted { .. }
+                | QueuedQueryEvent::EditCancelled { .. }
+                | QueuedQueryEvent::Cleared { .. } => {}
+            },
+        );
 
         // Trigger the changelog fetch once at startup so `TuiZeroStateView`
         // has data to display.  The re-render subscription lives in the view.
@@ -1627,12 +1670,16 @@ impl TuiTerminalSessionView {
             | ModelEvent::FinishUpdate(_) => ctx.notify(),
             _ => {}
         });
-        // The footer shows the active model, working directory, and usage
-        // entry: re-render when the usage-display-mode setting changes (click
-        // or settings-file hot reload), when the active model or its display
-        // name changes, or when the session's working directory changes.
+        // Re-render when the configured statusline or usage-display mode
+        // changes (click or settings-file hot reload). Model, working
+        // directory, git, queue, and conversation subscriptions below cover
+        // changes in the configured items' live values.
         ctx.subscribe_to_model(&AISettings::handle(ctx), |view, _, event, ctx| {
-            if matches!(event, AISettingsChangedEvent::TuiUsageDisplayMode { .. }) {
+            if matches!(
+                event,
+                AISettingsChangedEvent::TuiUsageDisplayMode { .. }
+                    | AISettingsChangedEvent::TuiStatusline { .. }
+            ) {
                 ctx.notify();
             }
             if matches!(event, AISettingsChangedEvent::AIAutoDetectionEnabled { .. }) {
@@ -1772,6 +1819,7 @@ impl TuiTerminalSessionView {
             next_restore_request_id: 0,
             exit_summary,
             handoff: None,
+            statusline_config_view: None,
             orchestration_tab_bar,
             orchestration_tabs_focused: false,
             zero_state_view,
@@ -2678,104 +2726,136 @@ impl TuiTerminalSessionView {
         }
         None
     }
-    /// Builds the status footer under the input box. The row is left-aligned:
-    /// in agent mode `[model] [cwd ↬ branch] • [usage] • [+N -M]`, and in shell
-    /// mode `[shell mode] [cwd ↬ branch] • [+N -M]` (model and usage hidden).
-    /// A replacing hint — the ctrl-c exit confirmation while armed, the
+
+    /// Builds the configured statusline under the input box. Normal mode uses
+    /// the persisted item order and visibility; shell mode always leads with
+    /// its mode label and only resolves configured working-directory and git
+    /// items. A replacing hint — the ctrl-c exit confirmation while armed, the
     /// conversation-list loading hint, or an active transient notice — occupies
-    /// the whole row instead. Every child truncates to a single row, so the row
-    /// lays out one row tall.
+    /// the whole row instead. An empty resolved configuration consumes no row.
     fn render_footer(&self, ctx: &AppContext) -> TuiFlex {
         let builder = TuiUiBuilder::from_app(ctx);
         if let Some(hint) = self.footer_hint(ctx) {
             return hint.render(&builder);
         }
-
-        // Normal left-aligned sectioned status row.
         let shell_mode = self.is_shell_mode(ctx);
+        let config = AISettings::as_ref(ctx).tui_statusline.normalized();
         let git_metadata = self.git_status_metadata(ctx);
-        let model_label = if shell_mode {
-            None
-        } else {
-            let model_name = LLMPreferences::as_ref(ctx)
-                .get_active_base_model(ctx, Some(self.terminal_surface_id))
-                .display_name
-                .clone();
-            // The active-model label is clickable: a left click toggles the
-            // inline model picker (the same menu `/model` surfaces). The hover
-            // state lives on a retained [`MouseStateHandle`] so it survives
-            // element-tree rebuilds, and the click dispatches a typed action
-            // since the element pass only has an immutable [`AppContext`] —
-            // mirroring the usage entry.
-            let model_label_hovered = self
-                .model_label_hover
-                .lock()
-                .is_ok_and(|state| state.is_hovered());
-            let model_label_style = if model_label_hovered {
-                builder.primary_text_style()
-            } else {
-                builder.muted_text_style()
-            };
-            Some(
-                TuiHoverable::new(
-                    self.model_label_hover.clone(),
-                    TuiText::new(model_name)
-                        .with_style(model_label_style)
-                        .truncate()
+        let mut ordered = Vec::new();
+        if shell_mode {
+            ordered.push(FooterSegment::ShellMode);
+        }
+        for item in config.order.iter().copied() {
+            if !config.is_enabled(item) {
+                continue;
+            }
+            let segment = match item {
+                TuiStatuslineItem::AutoApprove => (!shell_mode
+                    && self
+                        .conversation_selection
+                        .as_ref(ctx)
+                        .pending_query_autoexecute_override(ctx)
+                        .is_autoexecute_any_action())
+                .then_some(FooterSegment::ActiveIndicator("Auto-approve")),
+                TuiStatuslineItem::AutoQueue => (!shell_mode && self.is_auto_queue_enabled(ctx))
+                    .then_some(FooterSegment::ActiveIndicator("Auto-queue")),
+                TuiStatuslineItem::Model => (!shell_mode).then(|| {
+                    let model_name = LLMPreferences::as_ref(ctx)
+                        .get_active_base_model(ctx, Some(self.terminal_surface_id))
+                        .display_name
+                        .clone();
+                    let model_label_hovered = self
+                        .model_label_hover
+                        .lock()
+                        .is_ok_and(|state| state.is_hovered());
+                    let model_label_style = if model_label_hovered {
+                        builder.primary_text_style()
+                    } else {
+                        builder.muted_text_style()
+                    };
+                    FooterSegment::Model(
+                        TuiHoverable::new(
+                            self.model_label_hover.clone(),
+                            TuiText::new(model_name)
+                                .with_style(model_label_style)
+                                .truncate()
+                                .finish(),
+                        )
+                        .on_click(|event_ctx, _| {
+                            event_ctx
+                                .dispatch_typed_action(TuiTerminalSessionAction::ToggleModelMenu);
+                        })
                         .finish(),
-                )
-                .on_click(|event_ctx, _| {
-                    event_ctx.dispatch_typed_action(TuiTerminalSessionAction::ToggleModelMenu);
-                })
-                .finish(),
-            )
-        };
-        let cwd = self
-            .current_working_directory(ctx)
-            .map(|cwd| compact_footer_path(&cwd));
-        let branch = git_metadata.map(|metadata| metadata.current_branch_name.clone());
-        // Usage entry: the selected conversation's credits/cost totals, hidden
-        // until any usage has been reported (and hidden in shell mode, where it
-        // is stale AI-conversation metadata). The displayed unit is the
-        // persisted `agents.usage_display_mode` setting; a click dispatches the
-        // toggle action (the element pass cannot write settings directly).
-        let usage = if shell_mode {
-            None
-        } else {
-            self.selected_conversation_usage_totals(ctx).map(|totals| {
-                let mode = AISettings::as_ref(ctx).usage_display_mode;
-                self.usage_toggle
-                    .render_entry(mode, totals, ctx, |event_ctx, _| {
-                        event_ctx
-                            .dispatch_typed_action(TuiTerminalSessionAction::ToggleUsageDisplay);
+                    )
+                }),
+                TuiStatuslineItem::WorkingDirectory => self
+                    .current_working_directory(ctx)
+                    .map(|cwd| FooterSegment::WorkingDirectory(compact_footer_path(&cwd))),
+                TuiStatuslineItem::GitBranch => git_metadata
+                    .map(|metadata| FooterSegment::GitBranch(metadata.current_branch_name.clone())),
+                TuiStatuslineItem::GitDiffStatus => git_metadata.and_then(|metadata| {
+                    let stats = metadata.stats_against_head;
+                    (stats.total_additions > 0 || stats.total_deletions > 0).then_some(
+                        FooterSegment::GitDiff {
+                            additions: stats.total_additions,
+                            deletions: stats.total_deletions,
+                        },
+                    )
+                }),
+                TuiStatuslineItem::CreditUsage => (!shell_mode)
+                    .then(|| self.selected_conversation_usage_totals(ctx))
+                    .flatten()
+                    .map(|totals| {
+                        let mode = AISettings::as_ref(ctx).usage_display_mode;
+                        FooterSegment::CreditUsage(self.usage_toggle.render_entry(
+                            mode,
+                            totals,
+                            ctx,
+                            |event_ctx, _| {
+                                event_ctx.dispatch_typed_action(
+                                    TuiTerminalSessionAction::ToggleUsageDisplay,
+                                );
+                            },
+                        ))
+                    }),
+                TuiStatuslineItem::ContextWindowUsage => (!shell_mode)
+                    .then(|| {
+                        self.conversation_selection
+                            .as_ref(ctx)
+                            .selected_conversation(ctx)
                     })
-            })
-        };
-        let (diff_additions, diff_deletions) = git_metadata
-            .filter(|metadata| {
-                let stats = metadata.stats_against_head;
-                stats.total_additions > 0 || stats.total_deletions > 0
-            })
-            .map(|metadata| {
-                let stats = metadata.stats_against_head;
-                (stats.total_additions, stats.total_deletions)
-            })
-            .unwrap_or_default();
-
-        render_status_footer_row(
-            FooterSegments {
-                shell_mode,
-                model_label,
-                cwd,
-                branch,
-                usage,
-                diff_additions,
-                diff_deletions,
-            },
-            &builder,
-        )
+                    .flatten()
+                    .map(|conversation| {
+                        FooterSegment::ContextWindowUsage(format_context_window_usage(
+                            conversation.context_window_usage(),
+                        ))
+                    }),
+            };
+            if let Some(segment) = segment {
+                ordered.push(segment);
+            }
+        }
+        render_status_footer_row(FooterSegments { ordered }, &builder)
     }
 
+    fn is_auto_queue_enabled(&self, ctx: &AppContext) -> bool {
+        if !FeatureFlag::QueueSlashCommand.is_enabled() {
+            return false;
+        }
+        let Some(conversation_id) = self
+            .conversation_selection
+            .as_ref(ctx)
+            .selected_conversation_id(ctx)
+        else {
+            return false;
+        };
+        let terminal_model = self.terminal_model.lock();
+        QueuedQueryModel::as_ref(ctx).is_queue_next_prompt_enabled(
+            conversation_id,
+            terminal_model.block_list().active_block(),
+            ctx,
+        )
+    }
     /// Updates the watcher-backed git-status subscription after repository
     /// detection completes for the active working directory.
     fn update_git_status_subscription(
@@ -3358,6 +3438,9 @@ impl TuiTerminalSessionView {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
+            SlashCommandKind::Statusline => {
+                self.open_statusline_config(command.name, ctx);
+            }
             SlashCommandKind::Cost => {
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 ctx.dispatch_typed_action_deferred(
@@ -3583,6 +3666,63 @@ impl TuiTerminalSessionView {
         }
     }
 
+    fn open_statusline_config(&mut self, command_name: &'static str, ctx: &mut ViewContext<Self>) {
+        let Ok(state) = self.session_state(ctx) else {
+            return;
+        };
+        if state.blocking_input_source().is_some() || self.statusline_config_view.is_some() {
+            return;
+        }
+        let config = AISettings::as_ref(ctx).tui_statusline.normalized();
+        let statusline_config_view =
+            ctx.add_typed_action_tui_view(|ctx| TuiStatuslineConfigView::new(config, ctx));
+        ctx.subscribe_to_view(&statusline_config_view, |view, _, event, ctx| {
+            view.handle_statusline_config_event(event, ctx);
+        });
+        self.statusline_config_view = Some(statusline_config_view);
+        self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+        self.orchestration_tabs_focused = false;
+        self.focus_current_owner_if_active(ctx);
+        record_static_slash_command_accepted(command_name, true, ctx);
+        ctx.notify();
+    }
+
+    fn handle_statusline_config_event(
+        &mut self,
+        event: &TuiStatuslineConfigEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            TuiStatuslineConfigEvent::Saved(config) => {
+                self.persist_statusline_config(config.clone(), ctx);
+            }
+            TuiStatuslineConfigEvent::Cancelled => {
+                self.statusline_config_view = None;
+                self.focus_current_owner_if_active(ctx);
+                ctx.notify();
+            }
+            TuiStatuslineConfigEvent::LayoutChanged => ctx.notify(),
+        }
+    }
+
+    fn persist_statusline_config(
+        &mut self,
+        config: TuiStatuslineConfig,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let result = AISettings::handle(ctx).update(ctx, |settings, ctx| {
+            settings.tui_statusline.set_value(config.normalized(), ctx)
+        });
+        self.statusline_config_view = None;
+        self.focus_current_owner_if_active(ctx);
+        match result {
+            Ok(()) => self.show_success_hint(STATUSLINE_SAVED_HINT.to_owned(), ctx),
+            Err(error) => {
+                report_error!("failed to persist the TUI statusline config: {error:#}");
+                self.show_transient_hint(STATUSLINE_PERSISTENCE_FAILED_HINT.to_owned(), ctx);
+            }
+        }
+    }
     /// Toggles and persists natural-language detection (NLD), reports the change
     /// via telemetry, and surfaces a confirmation hint.
     fn toggle_nld(&mut self, command_name: &'static str, ctx: &mut ViewContext<Self>) {
@@ -3739,6 +3879,9 @@ impl TuiView for TuiTerminalSessionView {
         ];
         if let Some(handoff) = self.active_handoff(ctx) {
             view_ids.push(handoff.id());
+        }
+        if let Some(statusline_config_view) = self.statusline_config_view.as_ref() {
+            view_ids.push(statusline_config_view.id());
         }
         view_ids
     }
@@ -3929,7 +4072,11 @@ impl TuiView for TuiTerminalSessionView {
             .and_then(|conversation_id| {
                 BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
             })
-            .filter(|_| !blocker_active && input_target.agent_editor_owns_input());
+            .filter(|_| {
+                !blocker_active
+                    && self.statusline_config_view.is_none()
+                    && input_target.agent_editor_owns_input()
+            });
         if let Some(conversation) = selected_conversation {
             if conversation.status().is_in_progress() {
                 let warping_elapsed = conversation
@@ -4000,6 +4147,16 @@ impl TuiView for TuiTerminalSessionView {
             content = content.child(TuiChildView::new(handoff).finish());
         }
         if !blocker_active
+            && let Some(statusline_config_view) = self.statusline_config_view.as_ref()
+        {
+            content = content.child(
+                TuiContainer::new(TuiChildView::new(statusline_config_view).finish())
+                    .with_padding_top(1)
+                    .finish(),
+            );
+        }
+        if !blocker_active
+            && self.statusline_config_view.is_none()
             && (input_target.agent_editor_owns_input()
                 || matches!(input_target, TuiInputTarget::Disabled))
         {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_channel::Sender;
+use chrono::{Local, NaiveDateTime};
 use instant::Instant;
 use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
@@ -346,6 +347,19 @@ fn raw_prompt_if_not_blank(input: &str) -> Option<&str> {
 fn format_context_window_usage(usage: f32) -> String {
     format!("{:.0}% context used", usage * 100.0)
 }
+fn format_statusline_date(now: NaiveDateTime) -> String {
+    now.format("%B %-d, %Y").to_string()
+}
+fn format_statusline_time_12_hour(now: NaiveDateTime) -> String {
+    now.format("%-I:%M%P").to_string()
+}
+fn format_statusline_time_24_hour(now: NaiveDateTime) -> String {
+    now.format("%H:%M").to_string()
+}
+fn format_todo_progress(completed: usize, total: usize, finished: bool) -> String {
+    let marker = if finished { "✓" } else { "❒" };
+    format!("{marker} {completed}/{total}")
+}
 fn cost_command_unavailable_hint(
     selected_conversation: Option<(bool, bool)>,
 ) -> Option<&'static str> {
@@ -394,6 +408,9 @@ enum FooterSegment {
     CreditUsage(Box<dyn TuiElement>),
     ContextWindowUsage(String),
     GitDiff { additions: usize, deletions: usize },
+    GitBranchStatus(String),
+    DateTime(String),
+    AgentTodoList(String),
 }
 
 impl FooterSegment {
@@ -402,23 +419,38 @@ impl FooterSegment {
             (Self::ShellMode | Self::Model(_), Self::WorkingDirectory(_)) => " ",
             (Self::WorkingDirectory(_), Self::GitBranch(_)) => " ↬ ",
             (
-                Self::ShellMode
-                | Self::ActiveIndicator(_)
-                | Self::Model(_)
-                | Self::WorkingDirectory(_)
-                | Self::GitBranch(_)
-                | Self::CreditUsage(_)
-                | Self::ContextWindowUsage(_)
-                | Self::GitDiff { .. },
-                Self::ShellMode
-                | Self::ActiveIndicator(_)
-                | Self::Model(_)
-                | Self::WorkingDirectory(_)
-                | Self::GitBranch(_)
-                | Self::CreditUsage(_)
-                | Self::ContextWindowUsage(_)
-                | Self::GitDiff { .. },
+                Self::ActiveIndicator(_),
+                Self::ActiveIndicator(_),
             ) => " • ",
+            (
+                Self::WorkingDirectory(_) | Self::GitBranch(_),
+                Self::WorkingDirectory(_) | Self::GitBranch(_),
+            )
+            | (Self::DateTime(_), Self::DateTime(_))
+            | (Self::ShellMode, _)
+            | (_, Self::ShellMode) => " • ",
+            (
+                Self::ActiveIndicator(_)
+                | Self::Model(_)
+                | Self::WorkingDirectory(_)
+                | Self::GitBranch(_)
+                | Self::CreditUsage(_)
+                | Self::ContextWindowUsage(_)
+                | Self::GitDiff { .. }
+                | Self::GitBranchStatus(_)
+                | Self::DateTime(_)
+                | Self::AgentTodoList(_),
+                Self::ActiveIndicator(_)
+                | Self::Model(_)
+                | Self::WorkingDirectory(_)
+                | Self::GitBranch(_)
+                | Self::CreditUsage(_)
+                | Self::ContextWindowUsage(_)
+                | Self::GitDiff { .. }
+                | Self::GitBranchStatus(_)
+                | Self::DateTime(_)
+                | Self::AgentTodoList(_),
+            ) => " | ",
         }
     }
 }
@@ -429,9 +461,10 @@ struct FooterSegments {
 }
 
 /// Builds the status row from resolved segments. Working directory follows a
-/// leading model or shell-mode label with a plain space; an immediately
-/// following branch uses the existing ` ↬ ` relationship marker. Every other
-/// adjacent pair uses ` • `, and the first item never receives a separator.
+/// leading shell-mode label with a plain space; an immediately following
+/// branch uses the existing ` ↬ ` relationship marker. Items in different
+/// Figma groups use ` | `; other adjacent pairs use ` • `. The first item never
+/// receives a separator.
 fn render_status_footer_row(segments: FooterSegments, builder: &TuiUiBuilder) -> TuiFlex {
     let muted = builder.muted_text_style();
     let mut row = TuiFlex::row();
@@ -463,6 +496,11 @@ fn render_status_footer_row(segments: FooterSegments, builder: &TuiUiBuilder) ->
             }
             FooterSegment::ContextWindowUsage(usage) => {
                 row = row.child(TuiText::new(usage).with_style(muted).truncate().finish());
+            }
+            FooterSegment::GitBranchStatus(value)
+            | FooterSegment::DateTime(value)
+            | FooterSegment::AgentTodoList(value) => {
+                row = row.child(TuiText::new(value).with_style(muted).truncate().finish());
             }
             FooterSegment::GitDiff {
                 additions,
@@ -2729,8 +2767,8 @@ impl TuiTerminalSessionView {
 
     /// Builds the configured statusline under the input box. Normal mode uses
     /// the persisted item order and visibility; shell mode always leads with
-    /// its mode label and only resolves configured working-directory and git
-    /// items. A replacing hint — the ctrl-c exit confirmation while armed, the
+    /// its mode label and resolves configured shell-relevant metadata. A
+    /// replacing hint — the ctrl-c exit confirmation while armed, the
     /// conversation-list loading hint, or an active transient notice — occupies
     /// the whole row instead. An empty resolved configuration consumes no row.
     fn render_footer(&self, ctx: &AppContext) -> TuiFlex {
@@ -2741,6 +2779,7 @@ impl TuiTerminalSessionView {
         let shell_mode = self.is_shell_mode(ctx);
         let config = AISettings::as_ref(ctx).tui_statusline.normalized();
         let git_metadata = self.git_status_metadata(ctx);
+        let local_now = Local::now().naive_local();
         let mut ordered = Vec::new();
         if shell_mode {
             ordered.push(FooterSegment::ShellMode);
@@ -2793,6 +2832,9 @@ impl TuiTerminalSessionView {
                     .map(|cwd| FooterSegment::WorkingDirectory(compact_footer_path(&cwd))),
                 TuiStatuslineItem::GitBranch => git_metadata
                     .map(|metadata| FooterSegment::GitBranch(metadata.current_branch_name.clone())),
+                TuiStatuslineItem::GitBranchStatus => git_metadata.map(|metadata| {
+                    FooterSegment::GitBranchStatus(metadata.branch_tracking_status.display_text())
+                }),
                 TuiStatuslineItem::GitDiffStatus => git_metadata.and_then(|metadata| {
                     let stats = metadata.stats_against_head;
                     (stats.total_additions > 0 || stats.total_deletions > 0).then_some(
@@ -2828,6 +2870,31 @@ impl TuiTerminalSessionView {
                     .map(|conversation| {
                         FooterSegment::ContextWindowUsage(format_context_window_usage(
                             conversation.context_window_usage(),
+                        ))
+                    }),
+                TuiStatuslineItem::Date => {
+                    Some(FooterSegment::DateTime(format_statusline_date(local_now)))
+                }
+                TuiStatuslineItem::Time12Hour => Some(FooterSegment::DateTime(
+                    format_statusline_time_12_hour(local_now),
+                )),
+                TuiStatuslineItem::Time24Hour => Some(FooterSegment::DateTime(
+                    format_statusline_time_24_hour(local_now),
+                )),
+                TuiStatuslineItem::AgentTodoList => (!shell_mode)
+                    .then(|| {
+                        self.conversation_selection
+                            .as_ref(ctx)
+                            .selected_conversation(ctx)
+                    })
+                    .flatten()
+                    .and_then(|conversation| conversation.active_todo_list())
+                    .filter(|todo_list| !todo_list.is_empty())
+                    .map(|todo_list| {
+                        FooterSegment::AgentTodoList(format_todo_progress(
+                            todo_list.completed_items().len(),
+                            todo_list.len(),
+                            todo_list.is_finished(),
                         ))
                     }),
             };

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
+use chrono::NaiveDate;
 use instant::Instant;
 use tempfile::TempDir;
 use warp::appearance::Appearance;
@@ -47,8 +48,10 @@ use super::{
     SHELL_MODE_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
     TuiTerminalSessionEvent, TuiTerminalSessionView, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
     attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
-    format_context_window_usage, log_bundle_success_message, raw_prompt_if_not_blank,
-    render_status_footer_row, voice_argument_is_empty, voice_command_argument,
+    format_context_window_usage, format_statusline_date, format_statusline_time_12_hour,
+    format_statusline_time_24_hour, format_todo_progress, log_bundle_success_message,
+    raw_prompt_if_not_blank, render_status_footer_row, voice_argument_is_empty,
+    voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
@@ -83,7 +86,19 @@ struct FocusTestFixture {
 }
 
 #[test]
-fn footer_supports_arbitrary_order_and_branch_without_a_leading_arrow() {
+fn figma_statusline_metadata_formats_are_stable() {
+    let now = NaiveDate::from_ymd_opt(2026, 7, 20)
+        .unwrap()
+        .and_hms_opt(13, 8, 0)
+        .unwrap();
+    assert_eq!(format_statusline_date(now), "July 20, 2026");
+    assert_eq!(format_statusline_time_12_hour(now), "1:08pm");
+    assert_eq!(format_statusline_time_24_hour(now), "13:08");
+    assert_eq!(format_todo_progress(1, 10, false), "❒ 1/10");
+    assert_eq!(format_todo_progress(10, 10, true), "✓ 10/10");
+}
+#[test]
+fn footer_supports_arbitrary_order_and_figma_group_dividers() {
     App::test((), |mut app| async move {
         app.update(|ctx| {
             ctx.add_singleton_model(|_| Appearance::mock());
@@ -95,6 +110,7 @@ fn footer_supports_arbitrary_order_and_branch_without_a_leading_arrow() {
                         FooterSegment::GitBranch("feature/statusline".to_owned()),
                         FooterSegment::ActiveIndicator("Auto-queue"),
                         FooterSegment::WorkingDirectory("/tmp/warp".to_owned()),
+                        FooterSegment::DateTime("July 20, 2026".to_owned()),
                     ],
                 },
                 &builder,
@@ -102,7 +118,10 @@ fn footer_supports_arbitrary_order_and_branch_without_a_leading_arrow() {
             .finish();
             assert_eq!(
                 render_element(row, ctx, 120).to_lines(),
-                vec!["43% context used • feature/statusline • Auto-queue • /tmp/warp".to_owned()],
+                vec![
+                    "43% context used | feature/statusline | Auto-queue | /tmp/warp | July 20, 2026"
+                        .to_owned()
+                ],
             );
 
             let branch_only = render_status_footer_row(
@@ -120,6 +139,45 @@ fn footer_supports_arbitrary_order_and_branch_without_a_leading_arrow() {
     });
 }
 
+#[test]
+fn footer_uses_pipes_between_figma_groups_and_preserves_within_group_separators() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let builder = TuiUiBuilder::from_app(ctx);
+            let row = render_status_footer_row(
+                FooterSegments {
+                    ordered: vec![
+                        FooterSegment::ActiveIndicator("Auto-approve"),
+                        FooterSegment::ActiveIndicator("Auto-queue"),
+                        FooterSegment::Model(TuiText::new("model").finish()),
+                        FooterSegment::WorkingDirectory("/tmp/warp".to_owned()),
+                        FooterSegment::GitBranch("main".to_owned()),
+                        FooterSegment::GitBranchStatus("↑1 ↓2".to_owned()),
+                        FooterSegment::GitDiff {
+                            additions: 31,
+                            deletions: 12,
+                        },
+                        FooterSegment::CreditUsage(TuiText::new("40 credits").finish()),
+                        FooterSegment::ContextWindowUsage("43% context used".to_owned()),
+                        FooterSegment::DateTime("July 20, 2026".to_owned()),
+                        FooterSegment::DateTime("1:08pm".to_owned()),
+                        FooterSegment::AgentTodoList("❒ 1/10".to_owned()),
+                    ],
+                },
+                &builder,
+            )
+            .finish();
+            assert_eq!(
+                render_element(row, ctx, 160).to_lines(),
+                vec![
+                    "Auto-approve • Auto-queue | model | /tmp/warp ↬ main | ↑1 ↓2 | +31 -12 | 40 credits | 43% context used | July 20, 2026 • 1:08pm | ❒ 1/10"
+                        .to_owned()
+                ],
+            );
+        });
+    });
+}
 #[test]
 fn empty_configurable_footer_has_zero_height() {
     App::test((), |mut app| async move {
@@ -1997,6 +2055,10 @@ fn assert_footer_segments_absent(lines: &[String]) {
         "a replacing hint should occupy the whole row with no sections: {row}"
     );
     assert!(
+        !row.contains(" | "),
+        "a replacing hint should contain no statusline group dividers: {row}"
+    );
+    assert!(
         !row.contains(" ↬ "),
         "the cwd/branch section is absent: {row}"
     );
@@ -2127,7 +2189,7 @@ fn footer_renders_agent_sections_left_aligned() {
 
             assert_eq!(
                 lines,
-                vec!["TestModel /home/user/warp ↬ main • 2.5 credits • +3 -1"],
+                vec!["TestModel | /home/user/warp ↬ main | 2.5 credits | +3 -1"],
                 "agent footer is left-aligned in order model → cwd/branch → usage → diff"
             );
             assert!(
@@ -2192,7 +2254,7 @@ fn footer_renders_shell_mode_sections_without_model_or_usage() {
 
             assert_eq!(
                 lines,
-                vec![format!("{SHELL_MODE_HINT} /home/user/warp ↬ main • +3 -1")],
+                vec![format!("{SHELL_MODE_HINT} /home/user/warp ↬ main | +3 -1")],
                 "shell footer leads with the shell-mode indicator and hides model/usage"
             );
             assert!(

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -16,8 +16,8 @@ use warp::tui_export::{
     AgentViewEntryOrigin, BlockPadding, BlocklistAIHistoryModel, ConversationStatus,
     ConversationUsageTotals, Harness, LLMPreferences, LongRunningCommandControlState, PtyIntent,
     PtyIntentEvent, QueuedQueryModel, SizeInfo, SizeUpdate, TaskId, TranscriptScope,
-    UserTakeOverReason, export_conversation_markdown,
-    register_tui_session_view_test_singletons, slash_commands,
+    UserTakeOverReason, export_conversation_markdown, register_tui_session_view_test_singletons,
+    slash_commands,
 };
 use warp_core::settings::Setting as _;
 use warp_editor::model::CoreEditorModel;
@@ -42,15 +42,15 @@ use super::{
     AUTO_APPROVE_ENABLED_HINT, AUTO_APPROVE_FEEDBACK_DURATION, AUTO_APPROVE_TOGGLE_BINDING_NAME,
     BlockingInputSource, COST_CONVERSATION_IN_PROGRESS_HINT, COST_EMPTY_CONVERSATION_HINT,
     COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT, ConversationRestoreState, FooterSegment,
-    FooterSegments, INLINE_MENU_TOP_PADDING_ROWS,
-    LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT,
-    SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG, SESSION_COMPOSER_OWNS_INPUT_FLAG,
-    SHELL_MODE_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
-    TuiTerminalSessionEvent, TuiTerminalSessionView, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
-    attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
-    format_context_window_usage, format_statusline_date, format_statusline_time_12_hour,
-    format_statusline_time_24_hour, format_todo_progress, log_bundle_success_message,
-    raw_prompt_if_not_blank, render_status_footer_row, voice_argument_is_empty,
+    FooterSegments, INLINE_MENU_TOP_PADDING_ROWS, LOADING_CONVERSATION_HINT,
+    LOG_BUNDLE_FAILED_HINT, SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG,
+    SESSION_COMPOSER_OWNS_INPUT_FLAG, SHELL_MODE_HINT, TuiConversationRestoreOrigin,
+    TuiTerminalSessionAction, TuiTerminalSessionEvent, TuiTerminalSessionView,
+    VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT, attachment_focus_available,
+    cost_command_unavailable_hint, export_file_success_message, format_context_window_usage,
+    format_statusline_date, format_statusline_time_12_hour, format_statusline_time_24_hour,
+    format_todo_progress, log_bundle_success_message, raw_prompt_if_not_blank,
+    render_status_footer_row, render_statusline_datetime, voice_argument_is_empty,
     voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
@@ -97,6 +97,22 @@ fn figma_statusline_metadata_formats_are_stable() {
     assert_eq!(format_todo_progress(1, 10, false), "❒ 1/10");
     assert_eq!(format_todo_progress(10, 10, true), "✓ 10/10");
 }
+
+#[test]
+fn statusline_datetime_requests_a_periodic_repaint() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let datetime =
+                render_statusline_datetime(format_statusline_time_24_hour, TuiStyle::default());
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(datetime, TuiRect::new(0, 0, 5, 1), ctx);
+            assert!(
+                frame.repaint_at.is_some(),
+                "visible date/time items must repaint so their value cannot freeze"
+            );
+        });
+    });
+}
 #[test]
 fn footer_supports_arbitrary_order_and_figma_group_dividers() {
     App::test((), |mut app| async move {
@@ -110,7 +126,7 @@ fn footer_supports_arbitrary_order_and_figma_group_dividers() {
                         FooterSegment::GitBranch("feature/statusline".to_owned()),
                         FooterSegment::ActiveIndicator("Auto-queue"),
                         FooterSegment::WorkingDirectory("/tmp/warp".to_owned()),
-                        FooterSegment::DateTime("July 20, 2026".to_owned()),
+                        FooterSegment::DateTime(TuiText::new("July 20, 2026").finish()),
                     ],
                 },
                 &builder,
@@ -160,9 +176,10 @@ fn footer_uses_pipes_between_figma_groups_and_preserves_within_group_separators(
                         },
                         FooterSegment::CreditUsage(TuiText::new("40 credits").finish()),
                         FooterSegment::ContextWindowUsage("43% context used".to_owned()),
-                        FooterSegment::DateTime("July 20, 2026".to_owned()),
-                        FooterSegment::DateTime("1:08pm".to_owned()),
+                        FooterSegment::DateTime(TuiText::new("July 20, 2026").finish()),
+                        FooterSegment::DateTime(TuiText::new("1:08pm").finish()),
                         FooterSegment::AgentTodoList("❒ 1/10".to_owned()),
+                        FooterSegment::VoiceInput(TuiText::new("Voice").finish()),
                     ],
                 },
                 &builder,
@@ -171,7 +188,7 @@ fn footer_uses_pipes_between_figma_groups_and_preserves_within_group_separators(
             assert_eq!(
                 render_element(row, ctx, 160).to_lines(),
                 vec![
-                    "Auto-approve • Auto-queue | model | /tmp/warp ↬ main | ↑1 ↓2 | +31 -12 | 40 credits | 43% context used | July 20, 2026 • 1:08pm | ❒ 1/10"
+                    "Auto-approve • Auto-queue | model /tmp/warp ↬ main | ↑1 ↓2 | +31 -12 | 40 credits | 43% context used | July 20, 2026 • 1:08pm | ❒ 1/10 | Voice"
                         .to_owned()
                 ],
             );
@@ -674,20 +691,20 @@ fn dispatch_session_event(
     })
 }
 
-/// Locates the footer's active-model label in the rendered buffer, returning
-/// the (column, row) of its first cell. Counts chars (not bytes) so multi-byte
-/// glyphs earlier in the footer row don't shift the column.
-fn model_label_position(buffer: &TuiBuffer, model_name: &str) -> (u16, u16) {
+/// Locates a label in the rendered footer, returning the (column, row) of its
+/// first cell. Counts chars (not bytes) so multi-byte glyphs earlier in the
+/// footer row don't shift the column.
+fn footer_label_position(buffer: &TuiBuffer, label: &str) -> (u16, u16) {
     let lines = buffer.to_lines();
     for (row, line) in lines.iter().enumerate() {
-        if let Some(byte_offset) = line.find(model_name) {
+        if let Some(byte_offset) = line.find(label) {
             let col = line[..byte_offset].chars().count() as u16;
             return (col, row as u16);
         }
     }
     panic!(
-        "model label {:?} not found in rendered footer:\n{}",
-        model_name,
+        "label {:?} not found in rendered footer:\n{}",
+        label,
         lines.join("\n")
     );
 }
@@ -1139,7 +1156,7 @@ fn footer_model_label_is_a_bounded_click_target() {
                 .clone()
         });
         let (mut element, scene, buffer) = render_retained_session(&app, &view, 80, 40);
-        let (label_col, label_row) = model_label_position(&buffer, &model_name);
+        let (label_col, label_row) = footer_label_position(&buffer, &model_name);
         let inside = (label_col + 1, label_row);
         let outside = (0, label_row);
 
@@ -2005,9 +2022,26 @@ fn render_footer(
         render_element(footer, ctx, width)
     })
 }
+fn set_enabled_statusline_items(app: &mut App, items: Vec<TuiStatuslineItem>) {
+    app.update(|ctx| {
+        AISettings::handle(ctx).update(ctx, |settings, ctx| {
+            settings
+                .tui_statusline
+                .set_value(
+                    TuiStatuslineConfig {
+                        order: items.clone(),
+                        enabled: items,
+                    }
+                    .normalized(),
+                    ctx,
+                )
+                .expect("statusline setting should persist");
+        });
+    });
+}
 
 #[test]
-fn footer_renders_voice_listening_and_transcribing_states() {
+fn footer_falls_back_to_replacing_voice_hints_when_voice_item_is_disabled() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
@@ -2046,6 +2080,164 @@ fn footer_renders_voice_listening_and_transcribing_states() {
     });
 }
 
+#[test]
+fn configured_voice_item_renders_idle_listening_and_transcribing_states() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        set_enabled_statusline_items(&mut app, vec![TuiStatuslineItem::VoiceInput]);
+        assert!(view.read(&app, |view, ctx| {
+            view.voice_statusline_is_available(false, ctx)
+                && !view.voice_statusline_is_available(true, ctx)
+        }));
+
+        let idle_footer = render_footer(&mut app, &view, 80);
+        assert_eq!(idle_footer.to_lines(), vec!["Voice"]);
+
+        view.update(&mut app, |view, ctx| {
+            let voice_input = view.input_view.as_ref(ctx).voice_input_model().clone();
+            voice_input.update(ctx, |voice, ctx| {
+                voice.set_state_for_test(TuiVoiceInputState::Listening, ctx);
+            });
+        });
+        let listening_footer = render_footer(&mut app, &view, 80);
+        assert_eq!(listening_footer.to_lines(), vec!["■ Listening"]);
+        assert_eq!(
+            listening_footer[(0, 0)].fg,
+            app.read(|ctx| {
+                TuiUiBuilder::from_app(ctx)
+                    .error_text_style()
+                    .fg
+                    .expect("error text style should have a foreground")
+            })
+        );
+
+        view.update(&mut app, |view, ctx| {
+            let voice_input = view.input_view.as_ref(ctx).voice_input_model().clone();
+            voice_input.update(ctx, |voice, ctx| {
+                voice.set_state_for_test(TuiVoiceInputState::Transcribing, ctx);
+            });
+        });
+        let transcribing_footer = render_footer(&mut app, &view, 80);
+        assert_eq!(transcribing_footer.to_lines(), vec!["… Transcribing"]);
+        assert_eq!(
+            transcribing_footer[(0, 0)].fg,
+            app.read(|ctx| {
+                TuiUiBuilder::from_app(ctx)
+                    .voice_input_status_style()
+                    .fg
+                    .expect("voice input status should have a foreground")
+            })
+        );
+
+        view.update(&mut app, |view, ctx| {
+            let voice_input = view.input_view.as_ref(ctx).voice_input_model().clone();
+            voice_input.update(ctx, |voice, ctx| {
+                voice.set_state_for_test(TuiVoiceInputState::Idle, ctx);
+            });
+            AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .voice_input_enabled_internal
+                    .set_value(false, ctx)
+                    .expect("voice setting should persist");
+            });
+        });
+        assert!(render_footer(&mut app, &view, 80).to_lines().is_empty());
+    });
+}
+
+#[test]
+fn voice_click_is_interactive_only_within_the_segment_bounds() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        set_enabled_statusline_items(&mut app, vec![TuiStatuslineItem::VoiceInput]);
+        let (mut element, scene, buffer) = render_retained_session(&app, &view, 20, 20);
+        let (voice_col, voice_row) = footer_label_position(&buffer, "Voice");
+        let inside = (voice_col + 1, voice_row);
+        let outside = (voice_col + 5, voice_row);
+
+        dispatch_session_event(
+            &app,
+            &view,
+            &mut element,
+            scene.clone(),
+            &mouse_moved(inside.0, inside.1),
+        );
+        assert!(view.read(&app, |view, _| {
+            view.voice_input_mouse.lock().unwrap().is_hovered()
+        }));
+        assert!(dispatch_session_event(
+            &app,
+            &view,
+            &mut element,
+            scene.clone(),
+            &left_mouse_down(inside.0, inside.1),
+        ));
+        assert!(view.read(&app, |view, _| {
+            view.voice_input_mouse.lock().unwrap().is_clicked()
+        }));
+        assert!(dispatch_session_event(
+            &app,
+            &view,
+            &mut element,
+            scene.clone(),
+            &left_mouse_up(inside.0, inside.1),
+        ));
+        assert!(!view.read(&app, |view, _| {
+            view.voice_input_mouse.lock().unwrap().is_clicked()
+        }));
+
+        dispatch_session_event(
+            &app,
+            &view,
+            &mut element,
+            scene.clone(),
+            &mouse_moved(outside.0, outside.1),
+        );
+        assert!(!view.read(&app, |view, _| {
+            view.voice_input_mouse.lock().unwrap().is_hovered()
+        }));
+        assert!(!dispatch_session_event(
+            &app,
+            &view,
+            &mut element,
+            scene,
+            &left_mouse_down(outside.0, outside.1),
+        ));
+    });
+}
+
+#[test]
+fn voice_toggle_stops_listening_and_ignores_transcribing() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, ctx| {
+            let voice_input = view.input_view.as_ref(ctx).voice_input_model().clone();
+            voice_input.update(ctx, |voice, ctx| {
+                voice.set_state_for_test(TuiVoiceInputState::Listening, ctx);
+            });
+            view.handle_action(&TuiTerminalSessionAction::ToggleVoiceInput, ctx);
+        });
+        view.read(&app, |view, ctx| {
+            assert_eq!(
+                view.input_view.as_ref(ctx).voice_state(ctx),
+                TuiVoiceInputState::Transcribing
+            );
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiTerminalSessionAction::ToggleVoiceInput, ctx);
+        });
+        view.read(&app, |view, ctx| {
+            assert_eq!(
+                view.input_view.as_ref(ctx).voice_state(ctx),
+                TuiVoiceInputState::Transcribing
+            );
+        });
+    });
+}
 /// A replacing hint occupies the whole status row, so no section separators,
 /// branch arrows, or usage text should appear alongside it.
 fn assert_footer_segments_absent(lines: &[String]) {
@@ -2189,7 +2381,7 @@ fn footer_renders_agent_sections_left_aligned() {
 
             assert_eq!(
                 lines,
-                vec!["TestModel | /home/user/warp ↬ main | 2.5 credits | +3 -1"],
+                vec!["TestModel /home/user/warp ↬ main | 2.5 credits | +3 -1"],
                 "agent footer is left-aligned in order model → cwd/branch → usage → diff"
             );
             assert!(

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -6,15 +6,17 @@ use instant::Instant;
 use tempfile::TempDir;
 use warp::appearance::Appearance;
 use warp::settings::{
-    AISettings, TuiTheme, TuiThemeSettings, TuiUsageDisplayMode, TuiZeroStateObject,
+    AISettings, TuiStatuslineConfig, TuiStatuslineItem, TuiTheme, TuiThemeSettings,
+    TuiUsageDisplayMode, TuiZeroStateObject,
 };
 use warp::terminal::model::ansi::{Handler, InputBufferValue, Mode};
 use warp::tui_export::{
     AIAgentActionId, AIAgentExchangeId, AIConversationAutoexecuteMode, AIConversationId,
     AgentViewEntryOrigin, BlockPadding, BlocklistAIHistoryModel, ConversationStatus,
     ConversationUsageTotals, Harness, LLMPreferences, LongRunningCommandControlState, PtyIntent,
-    PtyIntentEvent, SizeInfo, SizeUpdate, TaskId, TranscriptScope, UserTakeOverReason,
-    export_conversation_markdown, register_tui_session_view_test_singletons, slash_commands,
+    PtyIntentEvent, QueuedQueryModel, SizeInfo, SizeUpdate, TaskId, TranscriptScope,
+    UserTakeOverReason, export_conversation_markdown,
+    register_tui_session_view_test_singletons, slash_commands,
 };
 use warp_core::settings::Setting as _;
 use warp_editor::model::CoreEditorModel;
@@ -38,14 +40,15 @@ use super::{
     ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME, AUTO_APPROVE_DISABLED_HINT,
     AUTO_APPROVE_ENABLED_HINT, AUTO_APPROVE_FEEDBACK_DURATION, AUTO_APPROVE_TOGGLE_BINDING_NAME,
     BlockingInputSource, COST_CONVERSATION_IN_PROGRESS_HINT, COST_EMPTY_CONVERSATION_HINT,
-    COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT, ConversationRestoreState, FooterSegments,
-    INLINE_MENU_TOP_PADDING_ROWS, LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT,
+    COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT, ConversationRestoreState, FooterSegment,
+    FooterSegments, INLINE_MENU_TOP_PADDING_ROWS,
+    LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT,
     SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG, SESSION_COMPOSER_OWNS_INPUT_FLAG,
     SHELL_MODE_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
     TuiTerminalSessionEvent, TuiTerminalSessionView, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
     attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
-    log_bundle_success_message, raw_prompt_if_not_blank, render_status_footer_row,
-    voice_argument_is_empty, voice_command_argument,
+    format_context_window_usage, log_bundle_success_message, raw_prompt_if_not_blank,
+    render_status_footer_row, voice_argument_is_empty, voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
@@ -62,6 +65,7 @@ use crate::orchestration_tab_bar::{
 };
 use crate::root_view::RootTuiView;
 use crate::session_registry::{TuiSessionId, TuiSessions};
+use crate::statusline_config_view::TuiStatuslineConfigEvent;
 use crate::terminal_block::{block_content_rows, should_render_terminal_block};
 use crate::terminal_use::TuiInputTarget;
 use crate::test_fixtures::{add_test_semantic_selection, add_test_terminal_session};
@@ -76,6 +80,120 @@ use crate::zero_state_animation::{
 struct FocusTestFixture {
     window_id: warpui_core::WindowId,
     sessions: ModelHandle<TuiSessions>,
+}
+
+#[test]
+fn footer_supports_arbitrary_order_and_branch_without_a_leading_arrow() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let builder = TuiUiBuilder::from_app(ctx);
+            let row = render_status_footer_row(
+                FooterSegments {
+                    ordered: vec![
+                        FooterSegment::ContextWindowUsage(format_context_window_usage(0.426)),
+                        FooterSegment::GitBranch("feature/statusline".to_owned()),
+                        FooterSegment::ActiveIndicator("Auto-queue"),
+                        FooterSegment::WorkingDirectory("/tmp/warp".to_owned()),
+                    ],
+                },
+                &builder,
+            )
+            .finish();
+            assert_eq!(
+                render_element(row, ctx, 120).to_lines(),
+                vec!["43% context used • feature/statusline • Auto-queue • /tmp/warp".to_owned()],
+            );
+
+            let branch_only = render_status_footer_row(
+                FooterSegments {
+                    ordered: vec![FooterSegment::GitBranch("main".to_owned())],
+                },
+                &builder,
+            )
+            .finish();
+            assert_eq!(
+                render_element(branch_only, ctx, 80).to_lines(),
+                vec!["main".to_owned()],
+            );
+        });
+    });
+}
+
+#[test]
+fn empty_configurable_footer_has_zero_height() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let builder = TuiUiBuilder::from_app(ctx);
+            let row = render_status_footer_row(
+                FooterSegments {
+                    ordered: Vec::new(),
+                },
+                &builder,
+            )
+            .finish();
+            assert!(render_element(row, ctx, 80).to_lines().is_empty());
+        });
+    });
+}
+
+#[test]
+fn enabled_auto_indicators_render_only_while_their_effective_states_are_on() {
+    App::test((), |mut app| async move {
+        let _queue_flag =
+            warp_core::features::FeatureFlag::QueueSlashCommand.override_enabled(true);
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let conversation_id = view.update(&mut app, |view, ctx| {
+            let conversation_id = view.conversation_selection.update(ctx, |selection, ctx| {
+                selection
+                    .try_start_new_conversation(AgentViewEntryOrigin::Tui, ctx)
+                    .expect("test conversation should start")
+            });
+            view.conversation_selection.update(ctx, |selection, ctx| {
+                selection.toggle_pending_query_autoexecute(ctx);
+            });
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.toggle_queue_next_prompt(conversation_id, ctx);
+            });
+            AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .tui_statusline
+                    .set_value(
+                        TuiStatuslineConfig {
+                            order: vec![
+                                TuiStatuslineItem::AutoApprove,
+                                TuiStatuslineItem::AutoQueue,
+                            ],
+                            enabled: vec![
+                                TuiStatuslineItem::AutoApprove,
+                                TuiStatuslineItem::AutoQueue,
+                            ],
+                        }
+                        .normalized(),
+                        ctx,
+                    )
+                    .expect("statusline setting should persist");
+            });
+            conversation_id
+        });
+
+        assert_eq!(
+            render_footer_lines(&mut app, &view, 80),
+            vec!["Auto-approve • Auto-queue".to_owned()],
+        );
+
+        view.update(&mut app, |view, ctx| {
+            view.conversation_selection.update(ctx, |selection, ctx| {
+                selection.toggle_pending_query_autoexecute(ctx);
+            });
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.toggle_queue_next_prompt(conversation_id, ctx);
+            });
+        });
+        assert!(render_footer_lines(&mut app, &view, 80).is_empty());
+    });
 }
 
 #[test]
@@ -665,6 +783,95 @@ fn theme_slash_command_rejects_a_missing_argument() {
 }
 
 #[test]
+fn statusline_slash_command_clears_input_focuses_one_picker_and_cancels_cleanly() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, ctx| {
+            view.input_view.update(ctx, |input, ctx| {
+                input.set_text("/statusline", ctx);
+            });
+            view.execute_tui_slash_command(&slash_commands::STATUSLINE, None, ctx);
+        });
+
+        let picker_id = view.read(&app, |view, ctx| {
+            let picker = view
+                .statusline_config_view
+                .as_ref()
+                .expect("statusline picker should be open");
+            assert_eq!(
+                view.input_view
+                    .as_ref(ctx)
+                    .model()
+                    .as_ref(ctx)
+                    .content()
+                    .as_ref(ctx)
+                    .text()
+                    .into_string(),
+                ""
+            );
+            assert!(ctx.check_view_or_child_focused(fixture.window_id, &picker.id()));
+            picker.id()
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.execute_tui_slash_command(&slash_commands::STATUSLINE, None, ctx);
+        });
+        assert_eq!(
+            view.read(&app, |view, _| {
+                view.statusline_config_view.as_ref().map(ViewHandle::id)
+            }),
+            Some(picker_id),
+        );
+
+        view.update(&mut app, |view, ctx| {
+            view.handle_statusline_config_event(&TuiStatuslineConfigEvent::Cancelled, ctx);
+        });
+        view.read(&app, |view, ctx| {
+            assert!(view.statusline_config_view.is_none());
+            assert!(ctx.check_view_or_child_focused(fixture.window_id, &view.input_view.id()));
+        });
+    });
+}
+
+#[test]
+fn saving_statusline_configuration_persists_and_restores_input_focus() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let config = TuiStatuslineConfig {
+            order: vec![
+                TuiStatuslineItem::ContextWindowUsage,
+                TuiStatuslineItem::CreditUsage,
+            ],
+            enabled: Vec::new(),
+        }
+        .normalized();
+
+        view.update(&mut app, |view, ctx| {
+            view.execute_tui_slash_command(&slash_commands::STATUSLINE, None, ctx);
+            view.handle_statusline_config_event(
+                &TuiStatuslineConfigEvent::Saved(config.clone()),
+                ctx,
+            );
+        });
+
+        assert_eq!(
+            app.read(|ctx| AISettings::as_ref(ctx).tui_statusline.normalized()),
+            config,
+        );
+        view.read(&app, |view, ctx| {
+            assert!(view.statusline_config_view.is_none());
+            assert!(ctx.check_view_or_child_focused(fixture.window_id, &view.input_view.id()));
+            assert_eq!(
+                view.transient_hint.current().map(|(text, _)| text),
+                Some(super::STATUSLINE_SAVED_HINT),
+            );
+        });
+    });
+}
+
+#[test]
 fn cost_slash_command_rejects_an_empty_conversation_like_the_gui() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -717,18 +924,15 @@ fn render_usage_footer_row(app: &mut App, totals: ConversationUsageTotals) -> Ve
         let usage = UsageToggle::default().render_entry(mode, totals, ctx, |_, _| {});
         let row = render_status_footer_row(
             FooterSegments {
-                shell_mode: false,
-                model_label: Some(
-                    TuiText::new("TestModel")
-                        .with_style(builder.primary_text_style())
-                        .truncate()
-                        .finish(),
-                ),
-                cwd: None,
-                branch: None,
-                usage: Some(usage),
-                diff_additions: 0,
-                diff_deletions: 0,
+                ordered: vec![
+                    FooterSegment::Model(
+                        TuiText::new("TestModel")
+                            .with_style(builder.primary_text_style())
+                            .truncate()
+                            .finish(),
+                    ),
+                    FooterSegment::CreditUsage(usage),
+                ],
             },
             &builder,
         )
@@ -1899,18 +2103,21 @@ fn footer_renders_agent_sections_left_aligned() {
             );
             let row = render_status_footer_row(
                 FooterSegments {
-                    shell_mode: false,
-                    model_label: Some(
-                        TuiText::new("TestModel")
-                            .with_style(builder.primary_text_style())
-                            .truncate()
-                            .finish(),
-                    ),
-                    cwd: Some("/home/user/warp".to_owned()),
-                    branch: Some("main".to_owned()),
-                    usage: Some(usage),
-                    diff_additions: 3,
-                    diff_deletions: 1,
+                    ordered: vec![
+                        FooterSegment::Model(
+                            TuiText::new("TestModel")
+                                .with_style(builder.primary_text_style())
+                                .truncate()
+                                .finish(),
+                        ),
+                        FooterSegment::WorkingDirectory("/home/user/warp".to_owned()),
+                        FooterSegment::GitBranch("main".to_owned()),
+                        FooterSegment::CreditUsage(usage),
+                        FooterSegment::GitDiff {
+                            additions: 3,
+                            deletions: 1,
+                        },
+                    ],
                 },
                 &builder,
             )
@@ -1957,29 +2164,17 @@ fn footer_renders_shell_mode_sections_without_model_or_usage() {
         app.update(|ctx| {
             ctx.add_singleton_model(|_| Appearance::mock());
             let builder = TuiUiBuilder::from_app(ctx);
-            let usage = UsageToggle::default().render_entry(
-                TuiUsageDisplayMode::default(),
-                ConversationUsageTotals {
-                    credits_spent: 2.5,
-                    cost_in_cents: 0.0,
-                },
-                ctx,
-                |_, _| {},
-            );
             let row = render_status_footer_row(
                 FooterSegments {
-                    shell_mode: true,
-                    model_label: Some(
-                        TuiText::new("TestModel")
-                            .with_style(builder.primary_text_style())
-                            .truncate()
-                            .finish(),
-                    ),
-                    cwd: Some("/home/user/warp".to_owned()),
-                    branch: Some("main".to_owned()),
-                    usage: Some(usage),
-                    diff_additions: 3,
-                    diff_deletions: 1,
+                    ordered: vec![
+                        FooterSegment::ShellMode,
+                        FooterSegment::WorkingDirectory("/home/user/warp".to_owned()),
+                        FooterSegment::GitBranch("main".to_owned()),
+                        FooterSegment::GitDiff {
+                            additions: 3,
+                            deletions: 1,
+                        },
+                    ],
                 },
                 &builder,
             )

--- a/crates/warp_tui/src/voice_input.rs
+++ b/crates/warp_tui/src/voice_input.rs
@@ -26,6 +26,7 @@ pub(crate) enum TuiVoiceInputEvent {
 pub(crate) enum VoiceInputStartSource {
     SlashCommand,
     Keybinding,
+    Button,
 }
 
 impl VoiceInputStartSource {
@@ -35,7 +36,7 @@ impl VoiceInputStartSource {
 
     fn toggled_from(self) -> VoiceInputToggledFrom {
         match self {
-            Self::SlashCommand => VoiceInputToggledFrom::Button,
+            Self::SlashCommand | Self::Button => VoiceInputToggledFrom::Button,
             Self::Keybinding => VoiceInputToggledFrom::Key {
                 state: KeyState::Pressed,
             },


### PR DESCRIPTION
## Description
Expands `/statusline` with five items from the latest design that already have authoritative TUI state: Git branch status, Agent to-do list progress, Date, Time (12 hour), and Time (24 hour). New items append disabled, preserving existing defaults and persisted configurations. Unsupported voice, user/host, SVN, pull-request, and language-environment entries are intentionally omitted rather than stubbed.

Statusline items follow the Figma catalog order, with Agent to-do list after date/time. Adjacent rendered items separated by dividers in Figma use ` | `, while items within the same Figma group retain ` • ` and working directory followed by Git branch retains ` ↬ `. Grouping is semantic and not persisted, and unavailable or disabled items cannot leave stray separators.

[Figma catalog](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1246-22478&m=dev)

## Linked Issue
N/A — stacked on #14253.

## Testing
- [x] Full stack-tip `cargo nextest run --manifest-path crates/warp_tui/Cargo.toml` — 642 passed.
- [x] Deterministic settings, picker, metadata-format, and footer tests, including Figma group dividers and preserved within-group separators.
- [x] `./script/format --check` and warnings-denied Clippy for `ai`, `warp`, and `warp_tui` passed.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add branch tracking, todo progress, date, and time options to the configurable TUI statusline.

Co-Authored-By: Oz <oz-agent@warp.dev>