### PR TITLE
Enable gemini_enterprise for prod

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -697,6 +697,7 @@ default = [
     "solo_user_byok",
     "custom_model_routers",
     "supergrok",
+    "gemini_enterprise",
     "billing_and_usage_page_v2",
     "remote_code_review",
     "git_operations_in_code_review",


### PR DESCRIPTION
## Description

Adds `gemini_enterprise` to the `default` features in `app/Cargo.toml` to enable it for all stable/prod builds.

This is the client-side counterpart to warpdotdev/warp-server#13282, which enables the `gemini_enterprise` flag in `config/prod.yaml`.

Co-Authored-By: Oz <oz-agent@warp.dev>