### PR TITLE
feat: support TUI terminal use for alternate-screen commands

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -956,7 +956,7 @@ impl BlocklistAIActionModel {
 
     /// Installs a front-of-queue confirmation action without preprocessing.
     #[cfg(all(feature = "tui", any(test, feature = "test-util")))]
-    pub(crate) fn queue_confirmation_action(
+    pub fn queue_confirmation_action(
         &mut self,
         action: AIAgentAction,
         conversation_id: AIConversationId,

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -86,6 +86,15 @@ impl TuiBlockingChild {
             Self::Orchestration(view) => view.id(),
         }
     }
+
+    /// Converts the blocking child into its renderable view element.
+    pub(super) fn view_element(self) -> Box<dyn TuiElement> {
+        match self {
+            Self::AskQuestion(view) => TuiChildView::new(&view).finish(),
+            Self::Permission(view) => TuiChildView::new(&view).finish(),
+            Self::Orchestration(view) => TuiChildView::new(&view).finish(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -131,9 +131,13 @@ const CTRL_C_EXIT_HINT: &str = "ctrl-c again to exit";
 const STARTING_SHELL_HINT: &str = "Starting shell...";
 const SESSION_CAN_CANCEL_RESTORE_FLAG: &str = "TuiSessionCanCancelRestore";
 const SESSION_CAN_HAND_BACK_CONTROL_FLAG: &str = "TuiSessionCanHandBackControl";
+const SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG: &str =
+    "TuiSessionCanAcceptBlockedTerminalUseAction";
 pub(crate) const SESSION_COMPOSER_OWNS_INPUT_FLAG: &str = "TuiSessionComposerOwnsInput";
 pub(crate) const PASTE_IMAGE_BINDING_NAME: &str = "tui:session:paste_image";
 pub(crate) const AUTO_APPROVE_TOGGLE_BINDING_NAME: &str = "tui:session:toggle_auto_approve";
+pub(crate) const ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME: &str =
+    "tui:session:accept_blocked_terminal_use_action";
 pub(crate) const VOICE_INPUT_BINDING_NAME: &str = "tui:session:start_voice_input";
 
 /// Events emitted by the TUI terminal session surface.
@@ -491,6 +495,10 @@ pub(crate) enum TuiTerminalSessionAction {
     CancelRestore,
     /// Return a user-controlled terminal-use command to the agent.
     HandBackTerminalUseControl,
+    /// Accept the active terminal-use agent's blocked action.
+    AcceptBlockedTerminalUseAction,
+    /// Reject the active terminal-use agent's blocked action.
+    RejectBlockedTerminalUseAction,
     /// Click on the footer's usage entry: flips the persisted credits⇄cost
     /// display-mode setting.
     ToggleUsageDisplay,
@@ -632,6 +640,17 @@ pub(crate) fn init(app: &mut AppContext) {
         .with_group(TUI_BINDING_GROUP),
     ]);
     app.register_editable_bindings([
+        EditableBinding::new(
+            ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME,
+            "Accept the blocked terminal-use action",
+            TuiTerminalSessionAction::AcceptBlockedTerminalUseAction,
+        )
+        .with_context_predicate(
+            (id!(TuiInputView::ui_name()) | view_context.clone())
+                & id!(SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG),
+        )
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("ctrl-enter"),
         EditableBinding::new(
             AUTO_APPROVE_TOGGLE_BINDING_NAME,
             "Toggle auto approve",
@@ -885,7 +904,7 @@ impl TuiTerminalSessionView {
                     let controller = self.cli_subagent_controller.clone();
                     let action_model = self.ai_action_model.clone();
                     let terminal_model = self.terminal_model.clone();
-                    let view = ctx.add_typed_action_tui_view(|ctx| {
+                    let view = ctx.add_tui_view(|ctx| {
                         TuiCLISubagentView::new(
                             target,
                             controller,
@@ -984,6 +1003,36 @@ impl TuiTerminalSessionView {
             .as_ref(ctx)
             .active_target()
             .filter(|target| target.control_state.is_user_in_control())
+    }
+    fn active_cli_subagent_view(&self, ctx: &AppContext) -> Option<ViewHandle<TuiCLISubagentView>> {
+        let target = self.cli_subagent_controller.as_ref(ctx).active_target()?;
+        self.cli_subagent_views.get(&target.block_id).cloned()
+    }
+
+    fn accept_active_cli_subagent_action(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        let Some(view) = self.active_cli_subagent_view(ctx) else {
+            return false;
+        };
+        if !view.as_ref(ctx).has_blocked_action(ctx) {
+            return false;
+        }
+        view.update(ctx, |view, ctx| {
+            view.accept_blocked_terminal_use_action(ctx)
+        });
+        true
+    }
+
+    fn reject_active_cli_subagent_action(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        let Some(view) = self.active_cli_subagent_view(ctx) else {
+            return false;
+        };
+        if !view.as_ref(ctx).has_blocked_action(ctx) {
+            return false;
+        }
+        view.update(ctx, |view, ctx| {
+            view.reject_blocked_terminal_use_action(ctx)
+        });
+        true
     }
 
     fn send_terminal_use_prompt(&mut self, input: &str, ctx: &mut ViewContext<Self>) -> bool {
@@ -1476,6 +1525,10 @@ impl TuiTerminalSessionView {
                 view.update_process_input_focus(ctx);
                 ctx.notify();
             }
+            ModelEvent::TerminalModeSwapped(_) => {
+                view.update_process_input_focus(ctx);
+                ctx.notify();
+            }
             ModelEvent::Typeahead => view.handle_typeahead_event(ctx),
             ModelEvent::BlockMetadataReceived(_)
             | ModelEvent::BlockWorkingDirectoryUpdated(_)
@@ -1803,6 +1856,74 @@ impl TuiTerminalSessionView {
     /// Footer shown while orchestration tabs own keyboard focus.
     fn render_orchestration_tab_footer(&self, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
         render_orchestration_tab_footer(builder)
+    }
+
+    fn render_input_area(
+        &self,
+        input_target: TuiInputTarget,
+        inline_menu: Option<Box<dyn TuiElement>>,
+        builder: &TuiUiBuilder,
+        ctx: &AppContext,
+    ) -> Box<dyn TuiElement> {
+        let mut content = TuiFlex::column();
+        if let (true, Some(menu)) = (input_target.agent_editor_owns_input(), inline_menu) {
+            content = content.child(
+                TuiConstrainedBox::new(
+                    TuiContainer::new(menu)
+                        .with_padding_top(INLINE_MENU_TOP_PADDING_ROWS)
+                        .finish(),
+                )
+                .with_max_rows(MAX_INLINE_MENU_ROWS + INLINE_MENU_TOP_PADDING_ROWS)
+                .finish(),
+            );
+        }
+        let input = if self.input_view.as_ref(ctx).voice_state(ctx) == TuiVoiceInputState::Listening
+        {
+            let input_view = self.input_view.clone();
+            let builder = builder.clone();
+            let clock = self.input_view.as_ref(ctx).voice_animation_clock(ctx);
+            TuiAnimated::new(VOICE_INPUT_BORDER_REPAINT_INTERVAL, move || {
+                bordered_input(
+                    &input_view,
+                    builder.voice_input_border_style(clock.elapsed()),
+                )
+            })
+            .finish()
+        } else {
+            let border_style = if self.is_shell_mode(ctx) {
+                builder.shell_mode_accent_style()
+            } else {
+                builder.accent_border_style()
+            };
+            bordered_input(&self.input_view, border_style)
+        };
+
+        if self.attachment_bar.as_ref(ctx).should_render(ctx) {
+            content = content.child(
+                TuiConstrainedBox::new(
+                    TuiContainer::new(TuiChildView::new(&self.attachment_bar).finish())
+                        .with_padding_x(1)
+                        .finish(),
+                )
+                .with_max_rows(1)
+                .finish(),
+            );
+        }
+        content = content.child(
+            TuiConstrainedBox::new(input)
+                .with_max_rows(MAX_INPUT_TEXT_ROWS + 2)
+                .finish(),
+        );
+        let footer = if matches!(input_target, TuiInputTarget::Disabled) {
+            self.render_footer(ctx).finish()
+        } else if self.orchestration_tabs_focused {
+            self.render_orchestration_tab_footer(builder)
+        } else {
+            self.render_footer(ctx).finish()
+        };
+        content
+            .child(TuiConstrainedBox::new(footer).with_max_rows(1).finish())
+            .finish()
     }
     /// The active front-of-queue blocking interaction, if any.
     fn active_blocking_child(&self, ctx: &AppContext) -> Option<TuiBlockingChild> {
@@ -2292,10 +2413,10 @@ impl TuiTerminalSessionView {
         self.show_success_hint(COPY_SELECTION_HINT.to_owned(), ctx);
     }
 
-    /// Handles a ctrl-c press: a second press within [`CTRL_C_EXIT_WINDOW`]
-    /// exits the TUI; otherwise one contextual action runs — cancel the running
-    /// conversation if there is one, else clear the input — and the exit
-    /// confirmation is (re-)armed, surfacing [`CTRL_C_EXIT_HINT`] in the footer.
+    /// Handles a ctrl-c press: reject a blocked terminal-use action first, then
+    /// apply terminal-use takeover/interrupt behavior. Otherwise a second press
+    /// within [`CTRL_C_EXIT_WINDOW`] exits the TUI; the first cancels the running
+    /// conversation or clears input and arms the footer confirmation.
     fn handle_interrupt(&mut self, ctx: &mut ViewContext<Self>) {
         if self.cancel_conversation_restore(ctx) {
             return;
@@ -2305,6 +2426,11 @@ impl TuiTerminalSessionView {
             ConversationRestoreState::Failed(_)
         ) {
             ctx.terminate_app(TerminationMode::ForceTerminate, None);
+            return;
+        }
+        if self.reject_active_cli_subagent_action(ctx) {
+            self.exit_confirmation.disarm();
+            ctx.notify();
             return;
         }
         if self.handle_terminal_use_interrupt(ctx) {
@@ -3465,6 +3591,14 @@ impl TuiView for TuiTerminalSessionView {
         if self.active_user_controlled_target(ctx).is_some() {
             context.set.insert(SESSION_CAN_HAND_BACK_CONTROL_FLAG);
         }
+        if self
+            .active_cli_subagent_view(ctx)
+            .is_some_and(|view| view.as_ref(ctx).has_blocked_action(ctx))
+        {
+            context
+                .set
+                .insert(SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG);
+        }
         if self.transcript.as_ref(ctx).has_toggleable_plan(ctx) {
             context.set.insert(PLAN_TOGGLE_AVAILABLE_FLAG);
         }
@@ -3500,25 +3634,16 @@ impl TuiView for TuiTerminalSessionView {
             }
             ConversationRestoreState::Idle => {}
         }
-        // While a full-screen (alt-screen) app is active, hand the whole pane to
-        // it: render its grid and forward input, instead of the block UI.
-        let (alt_screen_active, input_target, user_owns_running_command) = {
+        let (alt_screen_active, input_target, user_owns_running_command, cli_subagent_view) = {
             let terminal_model = self.terminal_model.lock();
+            let active_block = terminal_model.block_list().active_block();
             (
                 terminal_model.is_alt_screen_active(),
                 tui_input_target(&terminal_model),
                 inline_process_owns_input(&terminal_model),
+                self.cli_subagent_views.get(active_block.id()).cloned(),
             )
         };
-        if alt_screen_active {
-            return TuiTerminalContentElement::new(
-                self.terminal_resize_tx.clone(),
-                AltScreenElement::new(self.terminal_model.clone()).finish(),
-            )
-            .with_pty_input(self.terminal_model.clone())
-            .finish();
-        }
-
         let inline_menu = input_target
             .agent_editor_owns_input()
             .then(|| {
@@ -3532,6 +3657,52 @@ impl TuiView for TuiTerminalSessionView {
             .flatten();
         let builder = TuiUiBuilder::from_app(ctx);
         let orchestration_tabs_available = self.orchestration_tab_bar.as_ref(ctx).has_tabs();
+        let blocker_active = self.active_blocking_child(ctx).is_some();
+
+        if alt_screen_active {
+            let terminal_content = TuiTerminalContentElement::new(
+                self.terminal_resize_tx.clone(),
+                AltScreenElement::new(self.terminal_model.clone()).finish(),
+            );
+            let terminal_content = if input_target.pty_owns_input() {
+                terminal_content.with_pty_input(self.terminal_model.clone())
+            } else {
+                terminal_content
+            };
+            let mut content = TuiFlex::column().flex_child(terminal_content.finish());
+            if input_target.agent_editor_owns_input() {
+                let mut agent_area = TuiFlex::column();
+                if let Some(cli_subagent_view) = cli_subagent_view {
+                    agent_area = agent_area.child(TuiChildView::new(&cli_subagent_view).finish());
+                }
+                if let Some(blocker) = self.active_blocking_child(ctx) {
+                    agent_area = agent_area.child(blocker.view_element());
+                } else {
+                    agent_area = agent_area.child(self.render_input_area(
+                        input_target,
+                        inline_menu,
+                        &builder,
+                        ctx,
+                    ));
+                }
+                content = content.child(
+                    TuiContainer::new(agent_area.finish())
+                        .with_padding_x(2)
+                        .with_padding_bottom(1)
+                        .finish(),
+                );
+            }
+
+            let session = content.finish();
+            return if orchestration_tabs_available {
+                TuiFlex::column()
+                    .child(TuiChildView::new(&self.orchestration_tab_bar).finish())
+                    .flex_child(session)
+                    .finish()
+            } else {
+                session
+            };
+        }
 
         // Ctrl-c (cancel/clear/exit) is handled by the keymap pass via the
         // fixed binding registered in [`Self::init`], so no element-level key
@@ -3554,7 +3725,6 @@ impl TuiView for TuiTerminalSessionView {
         // fresh each pass — no stored suppression flag — and the hidden
         // input model is never written to, so its draft/cursor/selection/
         // scroll survive untouched.
-        let blocker_active = self.active_blocking_child(ctx).is_some();
         if !blocker_active && matches!(input_target, TuiInputTarget::Disabled) {
             content = content.child(
                 TuiContainer::new(
@@ -3654,62 +3824,8 @@ impl TuiView for TuiTerminalSessionView {
             && (input_target.agent_editor_owns_input()
                 || matches!(input_target, TuiInputTarget::Disabled))
         {
-            if let (true, Some(menu)) = (input_target.agent_editor_owns_input(), inline_menu) {
-                content = content.child(
-                    TuiConstrainedBox::new(
-                        TuiContainer::new(menu)
-                            .with_padding_top(INLINE_MENU_TOP_PADDING_ROWS)
-                            .finish(),
-                    )
-                    .with_max_rows(MAX_INLINE_MENU_ROWS + INLINE_MENU_TOP_PADDING_ROWS)
-                    .finish(),
-                );
-            }
-            let input =
-                if self.input_view.as_ref(ctx).voice_state(ctx) == TuiVoiceInputState::Listening {
-                    let input_view = self.input_view.clone();
-                    let builder = builder.clone();
-                    let clock = self.input_view.as_ref(ctx).voice_animation_clock(ctx);
-                    TuiAnimated::new(VOICE_INPUT_BORDER_REPAINT_INTERVAL, move || {
-                        bordered_input(
-                            &input_view,
-                            builder.voice_input_border_style(clock.elapsed()),
-                        )
-                    })
-                    .finish()
-                } else {
-                    let border_style = if self.is_shell_mode(ctx) {
-                        builder.shell_mode_accent_style()
-                    } else {
-                        builder.accent_border_style()
-                    };
-                    bordered_input(&self.input_view, border_style)
-                };
-
-            if self.attachment_bar.as_ref(ctx).should_render(ctx) {
-                content = content.child(
-                    TuiConstrainedBox::new(
-                        TuiContainer::new(TuiChildView::new(&self.attachment_bar).finish())
-                            .with_padding_x(1)
-                            .finish(),
-                    )
-                    .with_max_rows(1)
-                    .finish(),
-                );
-            }
-            content = content.child(
-                TuiConstrainedBox::new(input)
-                    .with_max_rows(MAX_INPUT_TEXT_ROWS + 2)
-                    .finish(),
-            );
-            let footer = if matches!(input_target, TuiInputTarget::Disabled) {
-                self.render_footer(ctx).finish()
-            } else if self.orchestration_tabs_focused {
-                self.render_orchestration_tab_footer(&builder)
-            } else {
-                self.render_footer(ctx).finish()
-            };
-            content = content.child(TuiConstrainedBox::new(footer).with_max_rows(1).finish());
+            content =
+                content.child(self.render_input_area(input_target, inline_menu, &builder, ctx));
         }
         let content = content.finish();
         let terminal_content =
@@ -3741,6 +3857,20 @@ impl TuiView for TuiTerminalSessionView {
 }
 
 impl TuiTerminalSessionView {
+    fn forward_user_pty_bytes(&self, bytes: &[u8], ctx: &mut ViewContext<Self>) {
+        let composer_owns_input = self
+            .terminal_model
+            .lock()
+            .block_list()
+            .active_block()
+            .is_agent_in_control_or_tagged_in();
+        if composer_owns_input {
+            return;
+        }
+        ctx.emit(TuiTerminalSessionEvent::WriteUserInput(Cow::Owned(
+            bytes.to_vec(),
+        )));
+    }
     fn handle_typeahead_event(&mut self, ctx: &mut ViewContext<Self>) {
         let typeahead = self.terminal_model.lock().take_typeahead_for_input();
         if let Some((text, previously_inserted)) = typeahead {
@@ -3764,6 +3894,12 @@ impl TypedActionView for TuiTerminalSessionView {
             }
             TuiTerminalSessionAction::HandBackTerminalUseControl => {
                 self.hand_back_terminal_use_control(ctx)
+            }
+            TuiTerminalSessionAction::AcceptBlockedTerminalUseAction => {
+                self.accept_active_cli_subagent_action(ctx);
+            }
+            TuiTerminalSessionAction::RejectBlockedTerminalUseAction => {
+                self.reject_active_cli_subagent_action(ctx);
             }
             TuiTerminalSessionAction::ToggleUsageDisplay => self.toggle_usage_display(ctx),
             TuiTerminalSessionAction::ToggleResponseSummaryVisibility => {
@@ -3790,10 +3926,9 @@ impl TypedActionView for TuiTerminalSessionView {
             }
             TuiTerminalSessionAction::ForwardUserPtyBytes(bytes) => {
                 // Raw passthrough: the bytes are already the app's escape
-                // sequence, so write them to the PTY unmodified.
-                ctx.emit(TuiTerminalSessionEvent::WriteUserInput(Cow::Owned(
-                    bytes.clone(),
-                )));
+                // sequence. Recheck control at the final write boundary in
+                // case the element tree predates an agent takeover.
+                self.forward_user_pty_bytes(bytes, ctx);
             }
             TuiTerminalSessionAction::TogglePlan => {
                 self.transcript

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -5,12 +6,13 @@ use instant::Instant;
 use tempfile::TempDir;
 use warp::appearance::Appearance;
 use warp::settings::{AISettings, TuiUsageDisplayMode, TuiZeroStateObject};
-use warp::terminal::model::ansi::{Handler, InputBufferValue};
+use warp::terminal::model::ansi::{Handler, InputBufferValue, Mode};
 use warp::tui_export::{
-    AIAgentExchangeId, AIConversationAutoexecuteMode, AIConversationId, AgentViewEntryOrigin,
-    BlockPadding, BlocklistAIHistoryModel, ConversationStatus, ConversationUsageTotals, Harness,
-    LLMPreferences, PtyIntent, PtyIntentEvent, SizeInfo, SizeUpdate, TranscriptScope,
-    export_conversation_markdown, register_tui_session_view_test_singletons, slash_commands,
+    AIAgentActionId, AIAgentExchangeId, AIConversationAutoexecuteMode, AIConversationId,
+    AgentViewEntryOrigin, BlockPadding, BlocklistAIHistoryModel, ConversationStatus,
+    ConversationUsageTotals, Harness, LLMPreferences, PtyIntent, PtyIntentEvent, SizeInfo,
+    SizeUpdate, TaskId, TranscriptScope, export_conversation_markdown,
+    register_tui_session_view_test_singletons, slash_commands,
 };
 use warp_core::settings::Setting as _;
 use warp_editor::model::CoreEditorModel;
@@ -31,16 +33,17 @@ use warpui_core::telemetry::{EventPayload, flush_events};
 use warpui_core::{App, AppContext, TuiView, TypedActionView as _, WindowInvalidation};
 
 use super::{
-    AUTO_APPROVE_FEEDBACK_DURATION, AUTO_APPROVE_TOGGLE_BINDING_NAME,
-    COST_CONVERSATION_IN_PROGRESS_HINT, COST_EMPTY_CONVERSATION_HINT,
-    COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT, ConversationRestoreState, FooterSegments,
-    INLINE_MENU_TOP_PADDING_ROWS, LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT,
-    SESSION_COMPOSER_OWNS_INPUT_FLAG, SHELL_MODE_HINT, TuiConversationRestoreOrigin,
-    TuiTerminalSessionAction, TuiTerminalSessionEvent, TuiTerminalSessionView,
-    VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT, attachment_focus_available,
-    cost_command_unavailable_hint, export_file_success_message, log_bundle_success_message,
-    raw_prompt_if_not_blank, render_status_footer_row, voice_argument_is_empty,
-    voice_command_argument,
+    ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME, AUTO_APPROVE_FEEDBACK_DURATION,
+    AUTO_APPROVE_TOGGLE_BINDING_NAME, COST_CONVERSATION_IN_PROGRESS_HINT,
+    COST_EMPTY_CONVERSATION_HINT, COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT,
+    ConversationRestoreState, FooterSegments, INLINE_MENU_TOP_PADDING_ROWS,
+    LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT,
+    SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG, SESSION_COMPOSER_OWNS_INPUT_FLAG,
+    SHELL_MODE_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
+    TuiTerminalSessionEvent, TuiTerminalSessionView, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
+    attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
+    log_bundle_success_message, raw_prompt_if_not_blank, render_status_footer_row,
+    voice_argument_is_empty, voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
@@ -1166,6 +1169,165 @@ fn long_running_command_keeps_input_hidden() {
     });
 }
 
+#[test]
+fn agent_controlled_alt_screen_keeps_output_and_composer_visible() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, _| {
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model.simulate_long_running_block("vim", "");
+            let conversation_id = AIConversationId::new();
+            let task_id = TaskId::new("alt-screen-terminal-use".to_owned());
+            let block = terminal_model.block_list_mut().active_block_mut();
+            block.set_agent_interaction_mode_for_requested_command(
+                AIAgentActionId::from("alt-screen-command".to_owned()),
+                Some(task_id.clone()),
+                conversation_id,
+            );
+            block
+                .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
+                .expect("command should become agent monitored");
+            terminal_model.set_mode(Mode::SwapScreen {
+                save_cursor_and_clear_screen: true,
+            });
+            for character in "ALT SCREEN".chars() {
+                terminal_model.alt_screen_mut().input(character);
+            }
+        });
+
+        assert!(view.read(&app, |view, _| {
+            view.input_target().agent_editor_owns_input()
+        }));
+        let lines = render_session(&mut app, &view, 80, 12);
+        let compact_output = lines
+            .iter()
+            .flat_map(|line| line.chars())
+            .filter(|character| !character.is_whitespace())
+            .collect::<String>();
+        assert!(
+            compact_output.contains("ALTSCREEN"),
+            "alternate-screen output should remain visible:\n{}",
+            lines.join("\n")
+        );
+        let alt_screen_row = lines
+            .iter()
+            .position(|line| line.contains("ALT"))
+            .expect("alternate-screen output should start in the output area");
+        let input_row = lines
+            .iter()
+            .position(|line| line.contains('┌'))
+            .expect("agent-controlled alternate screen should render the composer");
+        assert!(
+            alt_screen_row < input_row,
+            "alternate-screen output should render above the composer:\n{}",
+            lines.join("\n")
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("auto (cost-efficient)")),
+            "the normal agent footer should remain visible:\n{}",
+            lines.join("\n")
+        );
+    });
+}
+
+#[test]
+fn user_controlled_alt_screen_keeps_full_session_input_on_the_pty() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, _| {
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model.simulate_long_running_block("vim", "");
+            terminal_model.set_mode(Mode::SwapScreen {
+                save_cursor_and_clear_screen: true,
+            });
+            for character in "USER ALT SCREEN".chars() {
+                terminal_model.alt_screen_mut().input(character);
+            }
+        });
+
+        assert!(view.read(&app, |view, _| view.input_target().pty_owns_input()));
+        let lines = render_session(&mut app, &view, 80, 12);
+        let compact_output = lines
+            .iter()
+            .flat_map(|line| line.chars())
+            .filter(|character| !character.is_whitespace())
+            .collect::<String>();
+        assert!(
+            compact_output.contains("USERALTSCREEN"),
+            "alternate-screen output should render:\n{}",
+            lines.join("\n")
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.contains('┌') || line.contains("auto (cost-efficient)")),
+            "user-controlled alternate screen should not reserve rows for agent input:\n{}",
+            lines.join("\n")
+        );
+    });
+}
+
+#[test]
+fn stale_user_pty_bytes_are_dropped_after_agent_takes_control_or_is_tagged_in() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let writes = Rc::new(RefCell::new(Vec::new()));
+        let writes_for_events = writes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if let TuiTerminalSessionEvent::WriteUserInput(bytes) = event {
+                    writes_for_events.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(
+                &TuiTerminalSessionAction::ForwardUserPtyBytes(b"user".to_vec()),
+                ctx,
+            );
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model.simulate_long_running_block("vim", "");
+            terminal_model
+                .block_list_mut()
+                .active_block_mut()
+                .set_is_agent_tagged_in(true);
+            drop(terminal_model);
+            view.handle_action(
+                &TuiTerminalSessionAction::ForwardUserPtyBytes(b"tagged".to_vec()),
+                ctx,
+            );
+            let mut terminal_model = view.terminal_model.lock();
+            let conversation_id = AIConversationId::new();
+            let task_id = TaskId::new("stale-pty-write".to_owned());
+            terminal_model
+                .block_list_mut()
+                .active_block_mut()
+                .set_agent_interaction_mode_for_requested_command(
+                    AIAgentActionId::from("stale-pty-command".to_owned()),
+                    Some(task_id.clone()),
+                    conversation_id,
+                );
+            terminal_model
+                .block_list_mut()
+                .active_block_mut()
+                .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
+                .expect("command should become agent monitored");
+            drop(terminal_model);
+            view.handle_action(
+                &TuiTerminalSessionAction::ForwardUserPtyBytes(b"agent".to_vec()),
+                ctx,
+            );
+        });
+
+        assert_eq!(*writes.borrow(), vec![b"user".to_vec()]);
+    });
+}
 /// Visible startup-script execution also routes input to the PTY, but it is
 /// not a user-controlled command: the interrupt hint row must not appear.
 #[test]
@@ -1780,6 +1942,40 @@ fn auto_approve_uses_ctrl_shift_i() {
     });
 }
 
+#[test]
+fn blocked_terminal_use_action_acceptance_uses_ctrl_enter_without_rebinding_submit() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        app.read(|ctx| {
+            let accept = ctx
+                .editable_bindings()
+                .find(|binding| binding.name == ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME)
+                .expect("blocked terminal-use action acceptance binding");
+            assert_eq!(
+                *accept.trigger,
+                Trigger::Keystrokes(vec![Keystroke::parse("ctrl-enter").unwrap()])
+            );
+
+            let mut input_context = Context::default();
+            input_context.set.insert("TuiInputView");
+            assert!(!accept.in_context(&input_context));
+            input_context
+                .set
+                .insert(SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG);
+            assert!(accept.in_context(&input_context));
+
+            let submit = ctx
+                .editable_bindings()
+                .find(|binding| binding.name == "tui:input:submit")
+                .expect("input submit binding");
+            assert_eq!(
+                *submit.trigger,
+                Trigger::Keystrokes(vec![Keystroke::parse("enter").unwrap()])
+            );
+            assert!(submit.in_context(&input_context));
+        });
+    });
+}
 #[test]
 fn voice_input_uses_ctrl_s_only_when_the_composer_owns_input() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/terminal_use.rs
+++ b/crates/warp_tui/src/terminal_use.rs
@@ -69,8 +69,9 @@ fn tui_input_target_for_state(
     startup_script_visible: bool,
     bootstrap_precmd_done: bool,
     inline_process_owns_input: bool,
+    agent_owns_alt_screen_input: bool,
 ) -> TuiInputTarget {
-    if alt_screen_active
+    if (alt_screen_active && !agent_owns_alt_screen_input)
         || (script_execution && startup_script_visible)
         || inline_process_owns_input
     {
@@ -84,14 +85,14 @@ fn tui_input_target_for_state(
 
 pub(super) fn tui_input_target(terminal_model: &TerminalModel) -> TuiInputTarget {
     let block_list = terminal_model.block_list();
+    let active_block = block_list.active_block();
     tui_input_target_for_state(
         terminal_model.is_alt_screen_active(),
         block_list.is_script_execution(),
-        block_list
-            .active_block()
-            .is_visible(block_list.transcript_scope()),
+        active_block.is_visible(block_list.transcript_scope()),
         block_list.is_bootstrapping_precmd_done(),
         inline_process_owns_input(terminal_model),
+        active_block.is_agent_in_control() || active_block.is_agent_tagged_in(),
     )
 }
 

--- a/crates/warp_tui/src/terminal_use_tests.rs
+++ b/crates/warp_tui/src/terminal_use_tests.rs
@@ -52,12 +52,12 @@ fn shell_startup_routes_input_by_bootstrap_stage() {
     model.block_list_mut().reinit_shell();
     assert_eq!(tui_input_target(&model), TuiInputTarget::Disabled);
     assert_eq!(
-        tui_input_target_for_state(false, true, false, false, false),
+        tui_input_target_for_state(false, true, false, false, false, false),
         TuiInputTarget::Disabled,
         "silent startup-script execution should keep the bootstrap editor visible",
     );
     assert_eq!(
-        tui_input_target_for_state(false, true, true, false, false),
+        tui_input_target_for_state(false, true, true, false, false, false),
         TuiInputTarget::Pty,
         "visible startup-script output should accept interactive PTY input",
     );
@@ -66,12 +66,28 @@ fn shell_startup_routes_input_by_bootstrap_stage() {
 #[test]
 fn submit_policy_blocks_bootstrap_but_allows_ready_prompt() {
     assert!(
-        !tui_input_target_for_state(false, false, false, false, false).agent_editor_owns_input(),
+        !tui_input_target_for_state(false, false, false, false, false, false)
+            .agent_editor_owns_input(),
         "bootstrap submission must remain disabled"
     );
     assert!(
-        tui_input_target_for_state(false, false, false, true, false).agent_editor_owns_input(),
+        tui_input_target_for_state(false, false, false, true, false, false)
+            .agent_editor_owns_input(),
         "the normal prompt must accept submission"
+    );
+}
+
+#[test]
+fn alternate_screen_routes_input_to_its_current_owner() {
+    assert_eq!(
+        tui_input_target_for_state(true, false, false, true, false, false),
+        TuiInputTarget::Pty,
+        "a user-controlled alt-screen process should receive PTY input",
+    );
+    assert_eq!(
+        tui_input_target_for_state(true, false, false, true, false, true),
+        TuiInputTarget::AgentEditor,
+        "agent control should keep alt-screen keystrokes in the composer",
     );
 }
 #[test]

--- a/crates/warp_tui/src/test_fixtures.rs
+++ b/crates/warp_tui/src/test_fixtures.rs
@@ -101,7 +101,9 @@ pub(crate) fn add_test_action_model_and_events(
     }
     add_test_semantic_selection(app);
     // Read as a singleton by the action model's executors.
-    app.add_singleton_model(|_| BlocklistAIHistoryModel::default());
+    if !app.read(|ctx| ctx.has_singleton_model::<BlocklistAIHistoryModel>()) {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::default());
+    }
     let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
     let sessions = app.add_model(|_| Sessions::new_for_test());
     let (_tx, model_events_rx) = async_channel::unbounded();

--- a/crates/warp_tui/src/tui_cli_subagent_view.rs
+++ b/crates/warp_tui/src/tui_cli_subagent_view.rs
@@ -7,10 +7,11 @@ use std::time::Duration;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    AIAgentActionType, AIAgentInput, AIBlockModel, AIBlockModelImpl, AIConversationId, BlockId,
-    BlocklistAIActionModel, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
-    CLISubagentController, CLISubagentTarget, LongRunningCommandControlState, ShellCommandDelay,
-    ShellCommandExecutor, TaskId, TerminalModel, UserTakeOverReason,
+    AIAgentAction, AIAgentActionType, AIAgentInput, AIAgentPtyWriteMode, AIBlockModel,
+    AIBlockModelHelper, AIBlockModelImpl, AIConversationId, BlockId, BlocklistAIActionModel,
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, CLISubagentController, CLISubagentTarget,
+    CancellationReason, LongRunningCommandControlState, ShellCommandDelay, ShellCommandExecutor,
+    TaskId, TerminalModel, UserTakeOverReason,
 };
 use warpui::SingletonEntity;
 use warpui_core::r#async::Timer;
@@ -19,10 +20,9 @@ use warpui_core::elements::tui::{
     TuiConstraint, TuiContainer, TuiElement, TuiFlex, TuiHoverable, TuiLayoutContext,
     TuiParentElement, TuiSize, TuiText,
 };
-use warpui_core::{
-    AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext,
-};
+use warpui_core::{AppContext, Entity, EntityId, ModelContext, ModelHandle, TuiView, ViewContext};
 
+use crate::terminal_session_view::TuiTerminalSessionAction;
 use crate::tui_builder::TuiUiBuilder;
 
 pub(super) const TAKE_CONTROL_KEY_BINDING: &str = "ctrl-c";
@@ -39,11 +39,7 @@ fn terminal_use_status_text(
     let (status, key_binding, action) = match control_state {
         LongRunningCommandControlState::Agent {
             is_blocked: true, ..
-        } => (
-            "Agent needs your input",
-            TAKE_CONTROL_KEY_BINDING,
-            "to take control",
-        ),
+        } => return "Agent needs your input".to_owned(),
         LongRunningCommandControlState::Agent { .. } if output_streaming => (
             "Agent is monitoring command",
             TAKE_CONTROL_KEY_BINDING,
@@ -73,6 +69,123 @@ fn terminal_use_status_text(
     format!("{status} · {key_binding} {action}")
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct BlockedActionPresentation {
+    summary: String,
+    detail: Option<String>,
+}
+
+fn display_pty_input(input: &[u8]) -> String {
+    String::from_utf8_lossy(input)
+        .chars()
+        .map(|character| match character {
+            '\n' | '\t' => character.to_string(),
+            '\r' => "<Enter>".to_owned(),
+            '\u{1b}' => "<Esc>".to_owned(),
+            character if character.is_control() => {
+                format!("<0x{:02X}>", u32::from(character))
+            }
+            character => character.to_string(),
+        })
+        .collect()
+}
+
+fn blocked_action_presentation(action: &AIAgentActionType) -> BlockedActionPresentation {
+    let (summary, detail) = match action {
+        AIAgentActionType::WriteToLongRunningShellCommand { input, mode, .. } => {
+            let input_kind = match mode {
+                AIAgentPtyWriteMode::Raw => "Input",
+                AIAgentPtyWriteMode::Line => "Line input",
+                AIAgentPtyWriteMode::Block => "Pasted input",
+            };
+            (
+                "Agent wants to write to the running command".to_owned(),
+                Some(format!("{input_kind}:\n{}", display_pty_input(input))),
+            )
+        }
+        AIAgentActionType::TransferShellCommandControlToUser { reason } => (
+            "Agent wants to hand command control to you".to_owned(),
+            Some(format!("Reason: {reason}")),
+        ),
+        AIAgentActionType::ReadFiles(request) => (
+            "Agent wants to read files".to_owned(),
+            Some(
+                request
+                    .locations
+                    .iter()
+                    .map(|location| location.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            ),
+        ),
+        AIAgentActionType::SearchCodebase(request) => {
+            let mut detail = format!("Query: {}", request.query);
+            if let Some(path) = request.codebase_path.as_deref() {
+                detail.push_str(&format!("\nPath: {path}"));
+            }
+            if let Some(paths) = request
+                .partial_paths
+                .as_ref()
+                .filter(|paths| !paths.is_empty())
+            {
+                detail.push_str(&format!("\nFiles: {}", paths.join(", ")));
+            }
+            (
+                "Agent wants to search the codebase".to_owned(),
+                Some(detail),
+            )
+        }
+        AIAgentActionType::Grep { queries, path } => (
+            "Agent wants to search file contents".to_owned(),
+            Some(format!("Patterns: {}\nPath: {path}", queries.join(", "))),
+        ),
+        AIAgentActionType::FileGlob { patterns, path } => (
+            "Agent wants to find files".to_owned(),
+            Some(format!(
+                "Patterns: {}\nPath: {}",
+                patterns.join(", "),
+                path.as_deref().unwrap_or(".")
+            )),
+        ),
+        AIAgentActionType::FileGlobV2 {
+            patterns,
+            search_dir,
+        } => (
+            "Agent wants to find files".to_owned(),
+            Some(format!(
+                "Patterns: {}\nPath: {}",
+                patterns.join(", "),
+                search_dir.as_deref().unwrap_or(".")
+            )),
+        ),
+        _ => (action.user_friendly_name(), None),
+    };
+    BlockedActionPresentation { summary, detail }
+}
+
+fn execute_blocked_action(
+    action_model: &mut BlocklistAIActionModel,
+    conversation_id: AIConversationId,
+    blocked_action: &AIAgentAction,
+    ctx: &mut ModelContext<BlocklistAIActionModel>,
+) {
+    action_model.execute_action(&blocked_action.id, conversation_id, ctx);
+}
+
+fn cancel_blocked_action(
+    action_model: &mut BlocklistAIActionModel,
+    conversation_id: AIConversationId,
+    blocked_action: &AIAgentAction,
+    ctx: &mut ModelContext<BlocklistAIActionModel>,
+) {
+    action_model.cancel_action_with_id(
+        conversation_id,
+        &blocked_action.id,
+        CancellationReason::ManuallyCancelled,
+        ctx,
+    );
+}
+
 fn resolve_latest_instruction(
     controller_instruction: Option<String>,
     exchange_instruction: Option<String>,
@@ -100,12 +213,6 @@ pub(super) enum TuiCLISubagentViewEvent {
     LayoutChanged,
 }
 
-/// User interactions handled by the terminal-use view.
-#[derive(Clone, Debug)]
-pub(super) enum TuiCLISubagentViewAction {
-    Allow,
-}
-
 /// Compact terminal-use state rendered alongside one command block.
 pub(super) struct TuiCLISubagentView {
     block_id: BlockId,
@@ -117,6 +224,7 @@ pub(super) struct TuiCLISubagentView {
     terminal_model: Arc<FairMutex<TerminalModel>>,
     last_measured_width: Cell<Option<u16>>,
     allow_mouse_state: MouseStateHandle,
+    reject_mouse_state: MouseStateHandle,
 }
 
 impl TuiCLISubagentView {
@@ -189,6 +297,7 @@ impl TuiCLISubagentView {
             terminal_model,
             last_measured_width: Cell::new(None),
             allow_mouse_state: MouseStateHandle::default(),
+            reject_mouse_state: MouseStateHandle::default(),
         };
         view.start_countdown_refresh(ctx);
         view
@@ -280,10 +389,35 @@ impl TuiCLISubagentView {
         self.conversation_id
     }
 
+    fn blocked_action(&self, app: &AppContext) -> Option<AIAgentAction> {
+        self.model.as_ref()?.blocked_action(&self.action_model, app)
+    }
+    pub(super) fn has_blocked_action(&self, app: &AppContext) -> bool {
+        self.blocked_action(app).is_some()
+    }
+
+    pub(super) fn accept_blocked_terminal_use_action(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(blocked_action) = self.blocked_action(ctx) else {
+            return;
+        };
+        self.action_model.update(ctx, |action_model, ctx| {
+            execute_blocked_action(action_model, self.conversation_id, &blocked_action, ctx);
+        });
+    }
+
+    pub(super) fn reject_blocked_terminal_use_action(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(blocked_action) = self.blocked_action(ctx) else {
+            return;
+        };
+        self.action_model.update(ctx, |action_model, ctx| {
+            cancel_blocked_action(action_model, self.conversation_id, &blocked_action, ctx);
+        });
+    }
+
     fn render_action(
         label: &'static str,
         mouse_state: &MouseStateHandle,
-        action: TuiCLISubagentViewAction,
+        action: TuiTerminalSessionAction,
         app: &AppContext,
     ) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(app);
@@ -327,13 +461,43 @@ impl TuiCLISubagentView {
             );
         }
         if target.control_state.is_agent_blocked() {
+            if let Some(action) = self.blocked_action(app) {
+                let presentation = blocked_action_presentation(&action.action);
+                content.add_child(
+                    TuiText::new(presentation.summary)
+                        .with_style(builder.primary_text_style())
+                        .finish(),
+                );
+                if let Some(detail) = presentation.detail {
+                    content.add_child(
+                        TuiContainer::new(
+                            TuiText::new(detail)
+                                .with_style(builder.muted_text_style())
+                                .finish(),
+                        )
+                        .with_padding_left(2)
+                        .finish(),
+                    );
+                }
+            }
             content.add_child(
-                TuiContainer::new(Self::render_action(
-                    "Allow",
-                    &self.allow_mouse_state,
-                    TuiCLISubagentViewAction::Allow,
-                    app,
-                ))
+                TuiContainer::new(
+                    TuiFlex::row()
+                        .child(Self::render_action(
+                            "Allow · Ctrl+Enter",
+                            &self.allow_mouse_state,
+                            TuiTerminalSessionAction::AcceptBlockedTerminalUseAction,
+                            app,
+                        ))
+                        .child(TuiText::new("  ").finish())
+                        .child(Self::render_action(
+                            "Reject · Ctrl+C",
+                            &self.reject_mouse_state,
+                            TuiTerminalSessionAction::RejectBlockedTerminalUseAction,
+                            app,
+                        ))
+                        .finish(),
+                )
                 .finish(),
             );
         }
@@ -394,20 +558,6 @@ impl TuiView for TuiCLISubagentView {
             return TuiFlex::column().finish();
         };
         self.render_content(&target, app)
-    }
-}
-
-impl TypedActionView for TuiCLISubagentView {
-    type Action = TuiCLISubagentViewAction;
-
-    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
-        match action {
-            TuiCLISubagentViewAction::Allow => {
-                self.action_model.update(ctx, |action_model, ctx| {
-                    action_model.execute_next_action_for_user(self.conversation_id, ctx);
-                });
-            }
-        }
     }
 }
 

--- a/crates/warp_tui/src/tui_cli_subagent_view_tests.rs
+++ b/crates/warp_tui/src/tui_cli_subagent_view_tests.rs
@@ -1,11 +1,20 @@
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::time::Duration;
 
-use warp::tui_export::{LongRunningCommandControlState, UserTakeOverReason};
+use warp::tui_export::{
+    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentPtyWriteMode, AIConversationId,
+    BlockId, BlocklistAIActionEvent, CancellationReason, LongRunningCommandControlState, TaskId,
+    UserTakeOverReason, register_tui_session_view_test_singletons,
+};
+use warpui_core::App;
 
 use super::{
-    format_next_check_remaining, remaining_for_fixed_delay, resolve_latest_instruction,
-    terminal_use_status_text,
+    BlockedActionPresentation, blocked_action_presentation, cancel_blocked_action,
+    display_pty_input, execute_blocked_action, format_next_check_remaining,
+    remaining_for_fixed_delay, resolve_latest_instruction, terminal_use_status_text,
 };
+use crate::test_fixtures::add_test_action_model;
 
 #[test]
 fn terminal_use_status_covers_control_and_lifecycle_states() {
@@ -32,7 +41,7 @@ fn terminal_use_status_covers_control_and_lifecycle_states() {
     };
     assert_eq!(
         terminal_use_status_text(&blocked, false, true),
-        "Agent needs your input · ctrl-c to take control"
+        "Agent needs your input"
     );
 
     let manual = LongRunningCommandControlState::User {
@@ -62,6 +71,84 @@ fn terminal_use_status_covers_control_and_lifecycle_states() {
         terminal_use_status_text(&transferred, false, false),
         "Agent handed control to you · ctrl-g to hand back"
     );
+}
+
+fn test_action(id: &str) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from(id.to_owned()),
+        task_id: TaskId::new("terminal-use-task".to_owned()),
+        action: AIAgentActionType::WriteToLongRunningShellCommand {
+            block_id: BlockId::new(),
+            input: b"input".to_vec().into(),
+            mode: AIAgentPtyWriteMode::Raw,
+        },
+        requires_result: true,
+    }
+}
+
+#[test]
+fn allow_executes_the_exact_displayed_action() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        let action_model = add_test_action_model(&mut app);
+        let conversation_id = AIConversationId::new();
+        let first = test_action("first");
+        let displayed = test_action("displayed");
+        let executing_ids = Rc::new(RefCell::new(Vec::new()));
+        let executing_ids_for_event = executing_ids.clone();
+
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&action_model, move |_, event, _| {
+                if let BlocklistAIActionEvent::ExecutingAction(action_id) = event {
+                    executing_ids_for_event.borrow_mut().push(action_id.clone());
+                }
+            });
+            action_model.update(ctx, |action_model, ctx| {
+                action_model.queue_confirmation_action(first, conversation_id, ctx);
+                action_model.queue_confirmation_action(displayed.clone(), conversation_id, ctx);
+                execute_blocked_action(action_model, conversation_id, &displayed, ctx);
+            });
+        });
+
+        assert_eq!(executing_ids.borrow().first(), Some(&displayed.id));
+    });
+}
+
+#[test]
+fn reject_cancels_only_the_exact_displayed_action() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        let action_model = add_test_action_model(&mut app);
+        let conversation_id = AIConversationId::new();
+        let first = test_action("first");
+        let displayed = test_action("displayed");
+        let finished_actions = Rc::new(RefCell::new(Vec::new()));
+        let finished_actions_for_event = finished_actions.clone();
+
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&action_model, move |_, event, _| {
+                if let BlocklistAIActionEvent::FinishedAction {
+                    action_id,
+                    cancellation_reason,
+                    ..
+                } = event
+                {
+                    finished_actions_for_event
+                        .borrow_mut()
+                        .push((action_id.clone(), *cancellation_reason));
+                }
+            });
+            action_model.update(ctx, |action_model, ctx| {
+                action_model.queue_confirmation_action(first, conversation_id, ctx);
+                action_model.queue_confirmation_action(displayed.clone(), conversation_id, ctx);
+                cancel_blocked_action(action_model, conversation_id, &displayed, ctx);
+            });
+        });
+
+        assert!(finished_actions.borrow().iter().any(|(action_id, reason)| {
+            action_id == &displayed.id && *reason == Some(CancellationReason::ManuallyCancelled)
+        }));
+    });
 }
 
 #[test]
@@ -96,5 +183,50 @@ fn next_check_countdown_formats_seconds_and_minutes() {
     assert_eq!(
         format_next_check_remaining(Duration::from_secs(65)),
         " · Check in 1m"
+    );
+}
+
+#[test]
+fn write_action_presentation_shows_input_and_mode_without_internal_ids() {
+    let action = AIAgentActionType::WriteToLongRunningShellCommand {
+        block_id: BlockId::new(),
+        input: b"iRoses\nViolets\x1b".to_vec().into(),
+        mode: AIAgentPtyWriteMode::Raw,
+    };
+
+    let presentation = blocked_action_presentation(&action);
+
+    assert_eq!(
+        presentation,
+        BlockedActionPresentation {
+            summary: "Agent wants to write to the running command".to_owned(),
+            detail: Some("Input:\niRoses\nViolets<Esc>".to_owned()),
+        }
+    );
+    assert!(!presentation.summary.contains("block id"));
+    assert!(!presentation.detail.unwrap().contains("block id"));
+}
+
+#[test]
+fn transfer_action_presentation_shows_the_agents_reason() {
+    let presentation =
+        blocked_action_presentation(&AIAgentActionType::TransferShellCommandControlToUser {
+            reason: "Enter the sudo password".to_owned(),
+        });
+
+    assert_eq!(
+        presentation,
+        BlockedActionPresentation {
+            summary: "Agent wants to hand command control to you".to_owned(),
+            detail: Some("Reason: Enter the sudo password".to_owned()),
+        }
+    );
+}
+
+#[test]
+fn pty_input_display_names_control_bytes_and_preserves_lines() {
+    assert_eq!(
+        display_pty_input(b"first\r\nsecond\x03"),
+        "first<Enter>\nsecond<0x03>"
     );
 }


### PR DESCRIPTION
## Description
- Support terminal use for agent-controlled alternate-screen commands in the headless TUI.
- Render alternate-screen PTY output above the CLI subagent status, blockers, composer, and footer while the agent owns control; keep user-controlled alternate screens PTY-only.
- Route terminal input according to the current owner and drop stale user PTY writes after agent takeover.
- Show details for blocked terminal-use actions and provide clickable Allow/Reject controls.
- Use Ctrl+Enter to allow the displayed action and Ctrl+C to reject it, while preserving Enter for follow-up submission and Shift+Enter for newlines.

## Linked Issue
None.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added render and behavior coverage for agent- and user-controlled alternate screens, PTY ownership transitions, blocked-action presentation, exact action approval/rejection, and the Ctrl+Enter binding.
- `./script/format`
- `cargo nextest run -p warp_tui` (630 passed)
- `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- `git diff --check`
- `./script/run-tui` built, bundled resources, codesigned, and launched successfully.

- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos
Not attached; the change was verified in a live local TUI session.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Agent Mode conversation](https://staging.warp.dev/conversation/e45d1209-475f-4112-b325-ca3c720623a1)

CHANGELOG-IMPROVEMENT: Added terminal-use support for alternate-screen commands in Warp's TUI.
