### PR TITLE
Retry git credential bootstrap on transient failures (REMOTE-2312)

### DIFF
--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -6,6 +6,7 @@ use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use ai::api_keys::{ApiKeyManager, AwsCredentialsRefreshStrategy};
 use anyhow::Context;
@@ -906,22 +907,45 @@ impl AgentDriverRunner {
             })
             .await?;
 
-        let credentials = match Self::fetch_task_git_credentials(task_id_str, ai_client).await {
-            Ok(credentials) => credentials,
-            Err(err)
-                if err
-                    .downcast_ref::<IsolationPlatformError>()
-                    .is_some_and(|err| {
-                        matches!(err, IsolationPlatformError::NoIsolationPlatformDetected)
-                    }) =>
-            {
-                log::debug!("Skipping git credentials bootstrap: {err}");
-                return Ok(());
-            }
-            Err(err) => {
-                return Err(AgentDriverError::SkillResolutionFailed(format!(
-                    "Failed to fetch git credentials before skill resolution: {err:#}"
-                )));
+        // Retry the credential fetch to handle transient failures (e.g. a race
+        // condition where the task is not yet fully "in progress" on the server
+        // when the worker first contacts it).
+        const GIT_CRED_BOOTSTRAP_RETRY_DELAYS: [Duration; 3] = [
+            Duration::from_secs(2),
+            Duration::from_secs(4),
+            Duration::from_secs(8),
+        ];
+        let mut attempt = 0usize;
+        let credentials = loop {
+            let result =
+                Self::fetch_task_git_credentials(task_id_str.clone(), ai_client.clone()).await;
+            match result {
+                Ok(creds) => break creds,
+                Err(err)
+                    if err
+                        .downcast_ref::<IsolationPlatformError>()
+                        .is_some_and(|e| {
+                            matches!(e, IsolationPlatformError::NoIsolationPlatformDetected)
+                        }) =>
+                {
+                    log::debug!("Skipping git credentials bootstrap: {err}");
+                    return Ok(());
+                }
+                Err(err) if attempt < GIT_CRED_BOOTSTRAP_RETRY_DELAYS.len() => {
+                    let delay = GIT_CRED_BOOTSTRAP_RETRY_DELAYS[attempt];
+                    log::warn!(
+                        "Git credentials bootstrap failed (attempt {}): {err:#}; retrying in {}s",
+                        attempt + 1,
+                        delay.as_secs()
+                    );
+                    warpui::r#async::Timer::after(delay).await;
+                    attempt += 1;
+                }
+                Err(err) => {
+                    return Err(AgentDriverError::SkillResolutionFailed(format!(
+                        "Failed to fetch git credentials before skill resolution: {err:#}"
+                    )));
+                }
             }
         };
         if credentials.is_empty() {


### PR DESCRIPTION
## Description

Adds retry logic with exponential backoff to `bootstrap_git_credentials_for_task` to handle intermittent failures where the task's git credentials cannot be fetched before skill resolution.

**Root Cause:** There is a race condition where the worker container starts executing and immediately calls `bootstrap_git_credentials_for_task`, but the task hasn't yet been fully transitioned to "in progress" state on the server. The server-side `GetTaskGitCredentials` checks `GetLiveAgentRunForTask` and returns `"task %s is not in progress"` when there is no active worker ID yet. This error propagates to the client as the generic `"Unable to access task git credentials"` message, which was being treated as an immediate fatal failure (no retries).

**Fix:** Replace the single-attempt credential fetch with a retry loop (up to 3 retries with 2s/4s/8s exponential backoff). This gives the server time to fully register the active execution before giving up. The existing fatal error path is preserved after all retries are exhausted.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Related Linear: REMOTE-2312

## Testing

This is an infrastructure-level race condition fix. Manual testing of the happy path is straightforward (git credentials still work when available), but the intermittent failure is timing-dependent and difficult to reproduce reliably on demand.

- [ ] I have manually tested my changes locally with `./script/run`

The change is minimal and targeted: only `bootstrap_git_credentials_for_task` is modified, and only to wrap the existing `fetch_task_git_credentials` call in a bounded retry loop. The logic after credential fetch (writing credentials to disk, returning `Ok(())` on empty credentials) is unchanged.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/b623a258-f962-4a23-934c-deef29c75045_
_Run: https://oz.staging.warp.dev/runs/019f95f2-be5f-7ee8-ba9c-4e2f4e77c87b_

_This PR was generated with [Oz](https://warp.dev/oz)._
