### PR TITLE
Fix Rich Input UX issues with Claude Code harness: approval friction and Enter behavior after agent stops (REMOTE-2313)

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13362,11 +13362,30 @@ impl TerminalView {
                 match status {
                     CLIAgentSessionStatus::Blocked { .. } => {
                         // Auto-close rich input when the agent is blocked
-                        // (it requires direct keyboard interaction in the terminal).
-                        self.close_cli_agent_rich_input(
-                            CLIAgentRichInputCloseReason::AutoToggle,
-                            ctx,
-                        );
+                        // (awaiting keyboard approval/response) ONLY if the
+                        // rich input was auto-opened by the system. If the user
+                        // manually opened rich input (Ctrl-G / footer button),
+                        // keep it open so they can type approval responses
+                        // (e.g. 'y' or 'n') directly through rich input.
+                        let was_auto_opened = CLIAgentSessionsModel::as_ref(ctx)
+                            .session(self.view_id)
+                            .and_then(|s| match s.input_state {
+                                CLIAgentInputState::Open { entrypoint, .. } => Some(entrypoint),
+                                CLIAgentInputState::Closed => None,
+                            })
+                            .is_some_and(|e| {
+                                matches!(
+                                    e,
+                                    CLIAgentInputEntrypoint::AutoShow
+                                        | CLIAgentInputEntrypoint::SharedSessionSync
+                                )
+                            });
+                        if was_auto_opened {
+                            self.close_cli_agent_rich_input(
+                                CLIAgentRichInputCloseReason::AutoToggle,
+                                ctx,
+                            );
+                        }
                     }
                     CLIAgentSessionStatus::InProgress
                     | CLIAgentSessionStatus::Success

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -57,7 +57,7 @@ use crate::settings::{
 };
 pub use crate::terminal::CLIAgent;
 use crate::terminal::TerminalModel;
-use crate::terminal::cli_agent_sessions::CLIAgentRichInputCloseReason;
+use crate::terminal::cli_agent_sessions::{CLIAgentRichInputCloseReason, CLIAgentSessionStatus};
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
@@ -113,6 +113,11 @@ enum RichInputSubmitStrategy {
     /// For agents that don't respond to `\r` when it arrives in the same
     /// buffer as the text and don't support bracketed paste reliably.
     DelayedEnter,
+    /// Send text first, then `\r` after a longer delay (300 ms).
+    /// Used when the agent's TUI is transitioning between states (e.g. Claude
+    /// Code returning to its idle prompt after finishing a task) and needs
+    /// more time to settle before it will treat `\r` as a submit keystroke.
+    DelayedEnterLong,
     /// Wrap text in bracketed paste (reliable buffer insertion), then send
     /// `\r` after a delay. For agents like Copilot that need bracketed paste
     /// for reliable text delivery but also need a separate delayed Enter.
@@ -138,6 +143,31 @@ fn rich_input_submit_strategy(agent: CLIAgent) -> RichInputSubmitStrategy {
         | CLIAgent::Vibe
         | CLIAgent::Antigravity
         | CLIAgent::Unknown => RichInputSubmitStrategy::Inline,
+    }
+}
+
+/// Returns the submit strategy for a CLI agent taking its current session
+/// status into account.
+///
+/// For agents that use `DelayedEnter`, when the agent is in an idle state
+/// (Success or Failed) rather than actively running (InProgress / Blocked),
+/// its TUI needs extra time after a batch PTY write before the trailing `\r`
+/// is interpreted as a submit rather than a newline.  `DelayedEnterLong` gives
+/// it that breathing room without changing any other agent's strategy.
+fn rich_input_submit_strategy_for_session(
+    agent: CLIAgent,
+    status: &CLIAgentSessionStatus,
+) -> RichInputSubmitStrategy {
+    let base = rich_input_submit_strategy(agent);
+    if base == RichInputSubmitStrategy::DelayedEnter
+        && matches!(
+            status,
+            CLIAgentSessionStatus::Success | CLIAgentSessionStatus::Failed { .. }
+        )
+    {
+        RichInputSubmitStrategy::DelayedEnterLong
+    } else {
+        base
     }
 }
 
@@ -674,9 +704,12 @@ impl TerminalView {
             sessions_model.clear_draft(view_id);
         });
 
+        // Use the status-aware strategy so that Claude Code in its idle
+        // (Success / Failed) state gets a longer Enter delay, giving the TUI
+        // time to settle before the submit keystroke arrives.
         let strategy = CLIAgentSessionsModel::as_ref(ctx)
             .session(self.view_id)
-            .map(|s| rich_input_submit_strategy(s.agent))
+            .map(|s| rich_input_submit_strategy_for_session(s.agent, &s.status))
             .unwrap_or(RichInputSubmitStrategy::Inline);
 
         let text_bytes = text.into_bytes();
@@ -981,6 +1014,20 @@ impl TerminalView {
                 self.write_user_bytes_to_pty(text_bytes, ctx);
                 ctx.spawn(
                     Timer::after(CLI_AGENT_PTY_WRITE_DELAY),
+                    move |me, _, ctx| {
+                        me.write_user_bytes_to_pty(b"\r".to_vec(), ctx);
+                        me.maybe_close_rich_input_after_submit(ctx);
+                    },
+                );
+            }
+            RichInputSubmitStrategy::DelayedEnterLong => {
+                // Same as DelayedEnter but with a longer delay so that the
+                // agent's TUI (e.g. Claude Code transitioning from task-complete
+                // back to its idle prompt) has enough time to settle before the
+                // submit keystroke arrives.
+                self.write_user_bytes_to_pty(text_bytes, ctx);
+                ctx.spawn(
+                    Timer::after(CLI_AGENT_BRACKETED_PASTE_ENTER_DELAY),
                     move |me, _, ctx| {
                         me.write_user_bytes_to_pty(b"\r".to_vec(), ctx);
                         me.maybe_close_rich_input_after_submit(ctx);


### PR DESCRIPTION
## Description

Two UX fixes for the Claude Code harness Rich Input, addressing user-reported friction from Christian Cygnus (REMOTE-2313).

### Fix 1 — Approval friction (Issue #1)

When the auto-toggle setting is enabled and the agent enters a `Blocked` state (permission/approval request), Rich Input was unconditionally auto-closed, forcing users to disable it entirely to approve commands. Now the auto-close only applies when Rich Input was **system-opened** (`AutoShow` / `SharedSessionSync` entrypoint). When the user manually opened Rich Input via Ctrl-G or the footer button, it stays open so they can type approval responses (e.g. `y` or `n`) directly through it.

File: `app/src/terminal/view.rs` — `handle_cli_agent_sessions_event`

### Fix 2 — Enter acts as Shift-Enter after agent stops (Issue #2)

After Claude Code finishes a task and transitions back to its idle prompt (`Success` / `Failed` status), the 50 ms `DelayedEnter` delay was too short — the TUI had not yet settled before the trailing `\r` arrived, so it was treated as a newline (Shift+Enter) rather than a submit. A new `DelayedEnterLong` strategy reuses the existing 300 ms `CLI_AGENT_BRACKETED_PASTE_ENTER_DELAY` constant to give the TUI enough time to reach its ready state. This longer delay is selected automatically for agents using `DelayedEnter` (Claude Code, OpenCode, Gemini, Auggie, CursorCli) when their session status is `Success` or `Failed`, with no change to `InProgress` or `Blocked` submissions.

File: `app/src/terminal/view/use_agent_footer/mod.rs`

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Linear: [REMOTE-2313](https://linear.app/warp/issue/REMOTE-2313)

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

These changes are in the PTY write / auto-toggle paths which require a live Claude Code session. Both branches preserve existing behaviour for non-Claude agents and for the `InProgress`/`Blocked` states that worked before.

Automated: `cargo check --package warp` and `cargo clippy --package warp -- -D warnings` both pass.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed Rich Input approval friction with Claude Code: when the user manually opened Rich Input, it now stays open when the agent requests command approval so responses can be sent without toggling Rich Input off.
CHANGELOG-BUG-FIX: Fixed Enter acting as Shift-Enter in Rich Input after Claude Code finishes a task, by using a longer submit delay when the agent is in its idle state.
-->

_Conversation: https://staging.warp.dev/conversation/bebf09d3-db37-4aa5-af5c-13d32326123b_
_Run: https://oz.staging.warp.dev/runs/019f95f3-0725-7a02-91f5-a168d0b6a9cf_

_This PR was generated with [Oz](https://warp.dev/oz)._
