### PR TITLE
fix: bound PTY spawn to prevent silent 6-hour hangs on GHA Blacksmith runners (REMOTE-2318)

### DIFF
--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -259,8 +259,43 @@ impl PtySpawner {
     ) -> Result<(PtySpawnResult, Box<dyn PtyHandle>)> {
         use crate::terminal::local_tty::server::ServerOwnedPtyHandle;
 
+        // Run the IPC call in a background thread with a timeout. The blocking
+        // `receive_message` inside `spawn_pty` runs on a Unix domain socket and
+        // normally completes in milliseconds. If the terminal server subprocess
+        // hangs (e.g. during user resolution via a slow NSS backend, or during
+        // PTY allocation), the receive never returns. Because `spawn_pty_via_server`
+        // is called on the UI thread inside `AgentDriver::new`, an indefinite
+        // block here freezes the entire Warp event loop: no async timers can
+        // fire, no bootstrap timeout can trigger, and the agent hangs silently
+        // for the GHA job ceiling (observed as 6-hour hangs on Blacksmith
+        // runners; see REMOTE-2318).
+        //
+        // On timeout the call falls back to `spawn_pty_directly`. The background
+        // thread is intentionally left running: it will eventually unblock when
+        // the terminal server responds (result discarded) or when the terminal
+        // server subprocess is killed on process exit.
+        const TERMINAL_SERVER_SPAWN_TIMEOUT: std::time::Duration =
+            std::time::Duration::from_secs(30);
+
         let client = server.client().clone();
-        let result = client.spawn_pty(options)?;
+        let client_for_thread = client.clone();
+        let (tx, rx) = std::sync::mpsc::channel::<anyhow::Result<PtySpawnResult>>();
+        std::thread::spawn(move || {
+            let _ = tx.send(client_for_thread.spawn_pty(options));
+        });
+
+        let result = match rx.recv_timeout(TERMINAL_SERVER_SPAWN_TIMEOUT) {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                anyhow::bail!(
+                    "Terminal server did not respond to PTY spawn request within {}s; \
+                     the server subprocess may be unresponsive. \
+                     Falling back to direct PTY spawn.",
+                    TERMINAL_SERVER_SPAWN_TIMEOUT.as_secs()
+                );
+            }
+        };
+
         let handle = Box::new(ServerOwnedPtyHandle {
             pid: result.pid,
             client,

--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -9,10 +9,12 @@ use std::mem::MaybeUninit;
 use std::os::unix::fs::DirBuilderExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::{io, ptr};
 
 use anyhow::{Context as _, Error, Result};
 use command::blocking::Command;
+use instant::Instant;
 use itertools::Itertools;
 use libc::{self, TIOCSCTTY, c_int, winsize};
 use mio::Interest;
@@ -154,12 +156,46 @@ fn current_user_via_getpwuid(uid: nix::unistd::Uid) -> Option<CurrentUser> {
 /// `getent` is the host's own (typically glibc-dynamic) binary, so it consults
 /// the host's full NSS configuration — including SSSD/LDAP/AD — which a
 /// static/musl Warp binary cannot do in-process.
+///
+/// The subprocess is killed if it does not complete within a short deadline.
+/// `getent` is normally instantaneous for local `/etc/passwd` lookups, but can
+/// hang indefinitely when the NSS stack contacts a slow or unreachable network
+/// service (LDAP/SSSD/AD). Without the timeout the hang would propagate to the
+/// terminal server, leaving the oz CLI's UI thread blocked and the agent
+/// silently stalled (see REMOTE-2318).
 fn current_user_via_getent(uid: u32) -> Option<CurrentUser> {
-    let output = Command::new("getent")
+    // 5 seconds is generous for a local passwd lookup and still short enough
+    // to avoid a long-lived silent stall if the NSS backend is misconfigured.
+    const GETENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+    let mut child = Command::new("getent")
         .arg("passwd")
         .arg(uid.to_string())
-        .output()
+        .stdout(std::process::Stdio::piped())
+        .spawn()
         .ok()?;
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if start.elapsed() > GETENT_TIMEOUT {
+                    log::warn!(
+                        "getent timed out after {}s looking up uid {uid}; \
+                         skipping NSS-delegated user resolution",
+                        GETENT_TIMEOUT.as_secs()
+                    );
+                    let _ = child.kill();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => return None,
+        }
+    }
+
+    let output = child.wait_with_output().ok()?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
## Description

Fixes silent 6-hour hangs in `oz agent run` on GHA Blacksmith runners (REMOTE-2318).

### Root Cause

When the terminal server subprocess fails to respond to a PTY spawn request, the blocking `receive_message` call on its Unix domain socket waits forever. Because `spawn_pty_via_server` runs on the oz CLI's UI thread (inside `AgentDriver::new` → `ctx.add_singleton_model`), this freezes the entire Warp event loop — no async timers can fire, no 60-second bootstrap timeout can trigger, and the agent hangs silently. This explains the observed pattern: "Run ID" is printed (task created successfully), then complete silence until the 6-hour GHA job ceiling cancels the run and reaps an orphaned `oz` process.

The terminal server's event loop hangs most likely because `resolve_current_user()` calls `getent passwd <uid>` via a blocking `Command::output()` call. On systems where the NSS stack contacts a slow or unreachable LDAP/SSSD service, this subprocess never exits.

### Fix

**`app/src/terminal/local_tty/spawner.rs`** — `spawn_pty_via_server` timeout:
- Run `client.spawn_pty` in a background thread and receive its result via an `mpsc::channel` with a 30-second timeout.
- On timeout, return `Err` to trigger the existing fallback to `spawn_pty_directly`.
- The background thread is left running; it unblocks naturally when the terminal server eventually responds or the process exits.

**`app/src/terminal/local_tty/unix.rs`** — `current_user_via_getent` timeout:
- Replace the blocking `Command::output()` call with `spawn()` + a polling `try_wait()` loop that kills the subprocess and returns `None` after 5 seconds.
- Bounds the hang in both the terminal server event loop and the direct-spawn fallback path.

## Linked Issue
- [REMOTE-2318](https://linear.app/warp/issue/REMOTE-2318/pnpm-oz-cloud-agent-jobs-hang-silently-on-blacksmith-gha-runners-8-39)
- [pnpm/pnpm#13249](https://github.com/pnpm/pnpm/pull/13249) — short-term mitigation (step timeout) already merged upstream

## Testing

- `cargo check` and `cargo clippy -- -D warnings` pass with no errors.
- `./script/format` runs cleanly.
- Normal PTY spawn is unaffected: the 30-second terminal server timeout is well above the typical millisecond response time. The fallback-to-direct path already existed and is exercised in CI via the `PtySpawnMode::FallbackToDirect` telemetry path.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

---

_Conversation: https://staging.warp.dev/conversation/37213020-beb8-44ff-8c1c-96b956f526e5_
_Run: https://oz.staging.warp.dev/runs/019f95f3-0503-7d9a-91d0-6547a488c5d1_

_This PR was generated with [Oz](https://warp.dev/oz)._
