### PR TITLE
fix(cloud-agent): show retry CTA after environment setup failure (REMOTE-2314)

### DIFF
--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -168,7 +168,7 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
             AgentTaskState::Failed,
             TaskStatusUpdate::with_error_code(
                 format!(
-                    "Environment setup failed: {msg}. Check your repository URLs and setup commands."
+                    "Environment setup failed: {msg}. Edit your environment's setup commands in Warp settings to fix the issue, then retry."
                 ),
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -100,14 +100,11 @@ pub(in crate::terminal::view) fn resolve_cloud_conversation_continuation_ui_stat
     if task.has_active_execution() {
         return Err(CloudConversationContinuationError::ActiveTaskExecution);
     }
-    let is_environment_setup_failure = task.state.is_failure_like()
-        && task
-            .status_message
-            .as_ref()
-            .is_some_and(|status_message| status_message.is_environment_setup_failure());
-    if is_environment_setup_failure && task.conversation_id().is_none() {
-        return Ok(CloudConversationContinuationUiState::Tombstone { cta: None });
-    }
+    // If the environment setup failed before a conversation started (setup_command failure,
+    // git-clone failure, etc.) the task will have no conversation_id. We intentionally fall
+    // through to the standard access-check path below so that task owners still receive a
+    // "Continue" CTA that lets them retry after fixing their setup commands.  Non-owners
+    // will reach `Err(MissingConversationToken)` → tombstone with no CTA, which is correct.
     let conversation_token = task
         .conversation_id()
         .map(|token| ServerConversationToken::new(token.to_string()));

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -461,8 +461,49 @@ fn third_party_conversation_with_edit_access_shows_continue_in_cloud_tombstone()
     });
 }
 
+// REMOTE-2314: environment setup failure without a prior conversation (setup command failed
+// before the agent started) — task owner should now get a follow-up input (Oz harness) or
+// a "Continue" CTA (third-party harness) so they can retry after fixing their setup commands.
+
 #[test]
-fn environment_setup_failure_without_conversation_shows_tombstone_without_cta() {
+fn environment_setup_failure_without_conversation_oz_harness_shows_followup_input_for_owner() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::Oz,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            let mut task =
+                ambient_agent_task(task_id, CONVERSATION_TOKEN, AmbientAgentTaskState::Failed);
+            task.conversation_id = None;
+            task.status_message = Some(TaskStatusMessage {
+                message: "Environment setup failed: Failed to run setup command: uv".to_string(),
+                error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
+            });
+            // No agent_config_snapshot → task_harness() returns Oz
+            model.insert_task_for_test(task);
+        });
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::FollowupInput)
+            );
+        });
+    });
+}
+
+#[test]
+fn environment_setup_failure_without_conversation_third_party_harness_shows_continue_cta_for_owner(
+) {
     App::test((), |mut app| async move {
         let TestHandles {
             terminal_view_id,
@@ -475,10 +516,11 @@ fn environment_setup_failure_without_conversation_shows_tombstone_without_cta() 
         );
         AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
             let mut task =
-                ambient_agent_task(task_id, CONVERSATION_TOKEN, AmbientAgentTaskState::Failed);
+                ambient_agent_task(task_id, CONVERSATION_TOKEN, AmbientAgentTaskState::Failed)
+                    .with_harness(Harness::Claude);
             task.conversation_id = None;
             task.status_message = Some(TaskStatusMessage {
-                message: "Environment setup failed: Failed to run setup command: hi".to_string(),
+                message: "Environment setup failed: Failed to run setup command: uv".to_string(),
                 error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
             });
             model.insert_task_for_test(task);
@@ -490,7 +532,45 @@ fn environment_setup_failure_without_conversation_shows_tombstone_without_cta() 
 
             assert_eq!(
                 state,
-                Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
+                Ok(CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+                })
+            );
+        });
+    });
+}
+
+#[test]
+fn environment_setup_failure_without_conversation_shows_tombstone_without_cta_for_non_owner() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::OtherUserOwner,
+        );
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            let mut task =
+                ambient_agent_task(task_id, CONVERSATION_TOKEN, AmbientAgentTaskState::Failed)
+                    .with_creator("other-user");
+            task.conversation_id = None;
+            task.status_message = Some(TaskStatusMessage {
+                message: "Environment setup failed: Failed to run setup command: uv".to_string(),
+                error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
+            });
+            model.insert_task_for_test(task);
+        });
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Err(CloudConversationContinuationError::MissingConversationToken)
             );
         });
     });


### PR DESCRIPTION
## Description

Fixes the case where a cloud agent environment setup command fails (e.g. a `uv` install via `curl`) before the agent starts a conversation — the user was left with no way to continue or retry.

**Root cause:** `resolve_cloud_conversation_continuation_ui_state` had an early return that unconditionally showed a tombstone with no CTA when `is_environment_setup_failure && conversation_id == None`. Since the setup failure happens *before* the agent starts a conversation, `conversation_id` is always `None` in this case, so no CTA was ever shown.

**Fix:** Remove the early return and let the standard access-check path run:
- **Task owner, Oz harness** → `FollowupInput` (editable prompt they can type into to retry).
- **Task owner, third-party harness (Claude Code, Gemini, Codex)** → `Tombstone { cta: ContinueInCloud }` — the existing "Continue" button, now also shown for setup-only failures.
- **Non-owners** → still get a tombstone with no CTA (unchanged, correct behavior).

**Error message** is also improved to tell users they can edit setup commands in Warp settings and retry, rather than the vague "Check your repository URLs and setup commands."

## Linked Issue

- REMOTE-2314

## Testing

- Unit tests updated: removed the old `environment_setup_failure_without_conversation_shows_tombstone_without_cta` test (which asserted the broken behavior) and replaced it with three focused tests:
  1. `environment_setup_failure_without_conversation_oz_harness_shows_followup_input_for_owner` — owner of Oz run now gets editable follow-up input
  2. `environment_setup_failure_without_conversation_third_party_harness_shows_continue_cta_for_owner` — owner of Claude/Gemini/Codex run now gets a "Continue" CTA
  3. `environment_setup_failure_without_conversation_shows_tombstone_without_cta_for_non_owner` — non-owners still get no CTA (no regression)
- `cargo check` passes.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Cloud agent runs that fail during environment setup (git clone, setup commands, etc.) now show a "Continue" or follow-up input option so users can retry after fixing their configuration.
-->

_Conversation: https://staging.warp.dev/conversation/6fa54e3d-e537-482c-9375-8df836d4a59e_
_Run: https://oz.staging.warp.dev/runs/019f95f3-18bb-7892-acae-8c76f8237af6_

_This PR was generated with [Oz](https://warp.dev/oz)._
