### PR TITLE
Add TUI statusline configuration picker

### DIFF
--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -666,6 +666,115 @@ settings::macros::implement_setting_for_enum!(
     toml_path: "agents.usage_display_mode",
     description: "Which unit the usage entry displays in Warp Agent CLI: credits or provider cost.",
 );
+/// One configurable item in the Warp Agent CLI statusline.
+#[derive(
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    Hash,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+#[schemars(
+    description = "A configurable item in the Warp Agent CLI statusline.",
+    rename_all = "snake_case"
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TuiStatuslineItem {
+    AutoApprove,
+    AutoQueue,
+    Model,
+    WorkingDirectory,
+    GitBranch,
+    GitDiffStatus,
+    CreditUsage,
+    ContextWindowUsage,
+}
+
+impl TuiStatuslineItem {
+    pub const ALL: [Self; 8] = [
+        Self::AutoApprove,
+        Self::AutoQueue,
+        Self::Model,
+        Self::WorkingDirectory,
+        Self::GitBranch,
+        Self::GitDiffStatus,
+        Self::CreditUsage,
+        Self::ContextWindowUsage,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::AutoApprove => "Auto-approve indicator",
+            Self::AutoQueue => "Auto-queue next prompt indicator",
+            Self::Model => "Model",
+            Self::WorkingDirectory => "Working directory",
+            Self::GitBranch => "Git branch",
+            Self::GitDiffStatus => "Git diff status",
+            Self::CreditUsage => "Credit usage",
+            Self::ContextWindowUsage => "Context window usage",
+        }
+    }
+}
+
+/// Ordered and enabled items in the Warp Agent CLI statusline.
+#[derive(
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+pub struct TuiStatuslineConfig {
+    pub order: Vec<TuiStatuslineItem>,
+    pub enabled: Vec<TuiStatuslineItem>,
+}
+
+impl Default for TuiStatuslineConfig {
+    fn default() -> Self {
+        Self {
+            order: TuiStatuslineItem::ALL.to_vec(),
+            enabled: vec![
+                TuiStatuslineItem::Model,
+                TuiStatuslineItem::WorkingDirectory,
+                TuiStatuslineItem::GitBranch,
+                TuiStatuslineItem::GitDiffStatus,
+            ],
+        }
+    }
+}
+
+impl TuiStatuslineConfig {
+    /// Returns a complete, duplicate-free catalog and a valid enabled subset.
+    pub fn normalized(&self) -> Self {
+        let mut order = Vec::with_capacity(TuiStatuslineItem::ALL.len());
+        for item in self.order.iter().copied().chain(TuiStatuslineItem::ALL) {
+            if !order.contains(&item) {
+                order.push(item);
+            }
+        }
+
+        let mut enabled = Vec::with_capacity(self.enabled.len());
+        for item in self.enabled.iter().copied() {
+            if order.contains(&item) && !enabled.contains(&item) {
+                enabled.push(item);
+            }
+        }
+
+        Self { order, enabled }
+    }
+
+    pub fn is_enabled(&self, item: TuiStatuslineItem) -> bool {
+        self.enabled.contains(&item)
+    }
+}
 
 impl TuiUsageDisplayMode {
     /// The other unit — clicking the usage entry flips to this.
@@ -1324,6 +1433,18 @@ define_settings_group!(AISettings, settings: [
     //
     // TUI-only and file-backed so the choice persists across TUI sessions.
     usage_display_mode: TuiUsageDisplayMode,
+    // Ordered visibility configuration for the TUI's bottom statusline.
+    // TUI-only and local so separate devices can use different terminal layouts.
+    tui_statusline: TuiStatusline {
+        type: TuiStatuslineConfig,
+        default: TuiStatuslineConfig::default(),
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Never,
+        surface: settings::SettingSurfaces::TUI,
+        private: false,
+        toml_path: "agents.statusline",
+        description: "Controls the order and visibility of Warp Agent CLI statusline items.",
+    },
     // Whether or not the profile-level command autoexecution speedbump has been shown.
     //
     // Not a user-visible setting - we model it as a setting so we can track how often

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -36,6 +36,58 @@ fn add_ai_enablement_dependencies_for_test(app: &mut App) {
     app.add_singleton_model(UserWorkspaces::default_mock);
 }
 
+#[test]
+fn tui_statusline_default_matches_figma() {
+    let config = TuiStatuslineConfig::default();
+    assert_eq!(config.order, TuiStatuslineItem::ALL);
+    assert_eq!(
+        config.enabled,
+        vec![
+            TuiStatuslineItem::Model,
+            TuiStatuslineItem::WorkingDirectory,
+            TuiStatuslineItem::GitBranch,
+            TuiStatuslineItem::GitDiffStatus,
+        ]
+    );
+}
+
+#[test]
+fn tui_statusline_normalization_preserves_custom_order_and_appends_missing_items() {
+    let config = TuiStatuslineConfig {
+        order: vec![
+            TuiStatuslineItem::GitBranch,
+            TuiStatuslineItem::Model,
+            TuiStatuslineItem::GitBranch,
+        ],
+        enabled: vec![
+            TuiStatuslineItem::Model,
+            TuiStatuslineItem::Model,
+            TuiStatuslineItem::ContextWindowUsage,
+        ],
+    }
+    .normalized();
+
+    assert_eq!(
+        config.order,
+        vec![
+            TuiStatuslineItem::GitBranch,
+            TuiStatuslineItem::Model,
+            TuiStatuslineItem::AutoApprove,
+            TuiStatuslineItem::AutoQueue,
+            TuiStatuslineItem::WorkingDirectory,
+            TuiStatuslineItem::GitDiffStatus,
+            TuiStatuslineItem::CreditUsage,
+            TuiStatuslineItem::ContextWindowUsage,
+        ]
+    );
+    assert_eq!(
+        config.enabled,
+        vec![
+            TuiStatuslineItem::Model,
+            TuiStatuslineItem::ContextWindowUsage,
+        ]
+    );
+}
 // FocusedTerminalInfo Tests
 
 #[test]

--- a/crates/warp_tui/src/keybindings.rs
+++ b/crates/warp_tui/src/keybindings.rs
@@ -88,6 +88,7 @@ pub(crate) fn init(app: &mut AppContext) {
     );
     crate::orchestration_block::init(app);
     crate::tui_ask_question_view::init(app);
+    crate::statusline_config_view::init(app);
     crate::tui_permission_prompt::init(app);
     crate::tui_shell_command_view::init(app);
 

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -50,6 +50,7 @@ mod resume;
 mod session_registry;
 mod skills_menu;
 mod slash_commands;
+mod statusline_config_view;
 pub mod tab_bar;
 mod terminal_background;
 mod terminal_block;

--- a/crates/warp_tui/src/statusline_config_view.rs
+++ b/crates/warp_tui/src/statusline_config_view.rs
@@ -1,0 +1,364 @@
+//! Local TUI questionnaire for configuring the bottom statusline.
+
+use std::collections::{HashMap, HashSet};
+
+use warp::settings::{TuiStatuslineConfig, TuiStatuslineItem};
+use warp::tui_export::{
+    AskUserQuestionAction, AskUserQuestionItem, AskUserQuestionOption, AskUserQuestionSession,
+    AskUserQuestionType, OptionRow, OptionSnapshot, OptionSourceStatus, QuestionDraft,
+};
+use warpui_core::elements::tui::{
+    Modifier, TuiChildView, TuiContainer, TuiElement, TuiFlex, TuiText,
+};
+use warpui_core::keymap::macros::*;
+use warpui_core::keymap::{EditableBinding, FixedBinding};
+use warpui_core::{
+    AppContext, Entity, EntityId, TuiView, TypedActionView, ViewContext, ViewHandle,
+};
+
+use crate::keybindings::{TUI_BINDING_GROUP, is_tui_owned_binding};
+use crate::option_selector::{
+    OptionSelectorPage, TuiOptionSelector, TuiOptionSelectorEvent, TuiOptionSelectorMoveDirection,
+};
+use crate::tui_builder::TuiUiBuilder;
+
+const STATUSLINE_CONFIG_ACTIVE: &str = "TuiStatuslineConfigActive";
+const STATUSLINE_REORDER_ACTIVE: &str = "TuiStatuslineReorderActive";
+// The next stacked change mounts the picker and consumes this identifier.
+#[allow(dead_code)]
+const STATUSLINE_QUESTION_ID: &str = "statusline-items";
+
+pub(crate) fn init(app: &mut AppContext) {
+    let active = id!(TuiStatuslineConfigView::ui_name()) & id!(STATUSLINE_CONFIG_ACTIVE);
+    let reorder = active.clone() & id!(STATUSLINE_REORDER_ACTIVE);
+    app.register_fixed_bindings([FixedBinding::new(
+        "ctrl-c",
+        TuiStatuslineConfigAction::Cancel,
+        active.clone(),
+    )
+    .with_group(TUI_BINDING_GROUP)]);
+    app.register_editable_bindings([
+        EditableBinding::new(
+            "tui:statusline:toggle",
+            "Toggle the highlighted statusline item",
+            TuiStatuslineConfigAction::Toggle,
+        )
+        .with_context_predicate(active.clone())
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("enter"),
+        EditableBinding::new(
+            "tui:statusline:save",
+            "Save and close the statusline configuration",
+            TuiStatuslineConfigAction::Save,
+        )
+        .with_context_predicate(active)
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("escape"),
+        EditableBinding::new(
+            "tui:statusline:move_left",
+            "Move the highlighted statusline item left",
+            TuiStatuslineConfigAction::MoveBackward,
+        )
+        .with_context_predicate(reorder.clone())
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("left"),
+        EditableBinding::new(
+            "tui:statusline:move_right",
+            "Move the highlighted statusline item right",
+            TuiStatuslineConfigAction::MoveForward,
+        )
+        .with_context_predicate(reorder)
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("right"),
+    ]);
+    app.register_tui_binding_validator::<TuiStatuslineConfigView>(is_tui_owned_binding);
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum TuiStatuslineConfigAction {
+    Toggle,
+    Save,
+    Cancel,
+    MoveBackward,
+    MoveForward,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TuiStatuslineConfigEvent {
+    Saved(TuiStatuslineConfig),
+    Cancelled,
+    // The next stacked change mounts the picker and handles layout updates.
+    #[allow(dead_code)]
+    LayoutChanged,
+}
+
+pub(crate) struct TuiStatuslineConfigView {
+    session: AskUserQuestionSession,
+    selector: ViewHandle<TuiOptionSelector>,
+}
+
+// The next stacked change mounts the picker and consumes these lifecycle helpers.
+#[allow(dead_code)]
+impl TuiStatuslineConfigView {
+    pub(crate) fn new(config: TuiStatuslineConfig, ctx: &mut ViewContext<Self>) -> Self {
+        let config = config.normalized();
+        let question = statusline_question();
+        let selected_option_indices = config
+            .enabled
+            .iter()
+            .filter_map(|item| {
+                TuiStatuslineItem::ALL
+                    .iter()
+                    .position(|candidate| candidate == item)
+            })
+            .collect();
+        let drafts = HashMap::from([(
+            STATUSLINE_QUESTION_ID.to_owned(),
+            QuestionDraft {
+                selected_option_indices,
+                ..Default::default()
+            },
+        )]);
+        let session = AskUserQuestionSession::new_with_drafts(vec![question], drafts);
+        let selector = ctx.add_typed_action_tui_view(TuiOptionSelector::new);
+        let mut view = Self {
+            session,
+            selector: selector.clone(),
+        };
+        view.show_options(&config.order, ctx);
+        ctx.subscribe_to_view(&selector, |view, _, event, ctx| {
+            view.handle_selector_event(event, ctx);
+        });
+        ctx.focus(&selector);
+        view
+    }
+
+    pub(crate) fn focus(&self, ctx: &mut ViewContext<Self>) {
+        ctx.focus(&self.selector);
+    }
+
+    fn show_options(&mut self, order: &[TuiStatuslineItem], ctx: &mut ViewContext<Self>) {
+        let rows = order
+            .iter()
+            .filter_map(|item| {
+                TuiStatuslineItem::ALL
+                    .iter()
+                    .position(|candidate| candidate == item)
+                    .map(|index| OptionRow {
+                        id: index.to_string(),
+                        label: item.label().to_owned(),
+                        harness: None,
+                        badge: None,
+                        disabled_reason: None,
+                    })
+            })
+            .collect::<Vec<_>>();
+        let selected_id = rows.first().map(|row| row.id.clone());
+        self.selector.update(ctx, |selector, ctx| {
+            selector.set_page(
+                OptionSelectorPage {
+                    header: None,
+                    snapshot: OptionSnapshot {
+                        rows,
+                        selected_id,
+                        status: OptionSourceStatus::Ready,
+                        footer: None,
+                    },
+                    searchable: true,
+                    row_shortcuts: Default::default(),
+                },
+                ctx,
+            );
+        });
+        self.refresh_selection(ctx);
+    }
+
+    fn refresh_selection(&self, ctx: &mut ViewContext<Self>) {
+        let selected_ids = self
+            .session
+            .draft_for_question(0)
+            .map(|draft| {
+                draft
+                    .selected_option_indices
+                    .iter()
+                    .map(usize::to_string)
+                    .collect::<HashSet<_>>()
+            })
+            .unwrap_or_default();
+        self.selector.update(ctx, |selector, ctx| {
+            selector.set_question_state(selected_ids, true, ctx);
+        });
+    }
+
+    fn handle_selector_event(
+        &mut self,
+        event: &TuiOptionSelectorEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            TuiOptionSelectorEvent::Confirmed { id } => {
+                let Ok(option_index) = id.parse::<usize>() else {
+                    return;
+                };
+                let _ = self
+                    .session
+                    .apply(AskUserQuestionAction::ToggleOption { option_index });
+                self.refresh_selection(ctx);
+            }
+            TuiOptionSelectorEvent::LayoutInvalidated
+            | TuiOptionSelectorEvent::RowsReordered { .. } => {
+                ctx.emit(TuiStatuslineConfigEvent::LayoutChanged);
+                ctx.notify();
+            }
+            TuiOptionSelectorEvent::Dismissed => {
+                ctx.emit(TuiStatuslineConfigEvent::Cancelled);
+            }
+            TuiOptionSelectorEvent::CustomTextSubmitted { .. }
+            | TuiOptionSelectorEvent::CustomTextCleared
+            | TuiOptionSelectorEvent::CustomTextOpened
+            | TuiOptionSelectorEvent::CustomTextClosed
+            | TuiOptionSelectorEvent::RetryRequested => {}
+        }
+    }
+
+    fn current_config(&self, ctx: &AppContext) -> TuiStatuslineConfig {
+        let order = self
+            .selector
+            .as_ref(ctx)
+            .ordered_row_ids()
+            .into_iter()
+            .filter_map(|id| id.parse::<usize>().ok())
+            .filter_map(|index| TuiStatuslineItem::ALL.get(index).copied())
+            .collect::<Vec<_>>();
+        let enabled_indices = self
+            .session
+            .draft_for_question(0)
+            .map(|draft| &draft.selected_option_indices);
+        let enabled = order
+            .iter()
+            .copied()
+            .filter(|item| {
+                TuiStatuslineItem::ALL
+                    .iter()
+                    .position(|candidate| candidate == item)
+                    .is_some_and(|index| {
+                        enabled_indices.is_some_and(|indices| indices.contains(&index))
+                    })
+            })
+            .collect();
+        TuiStatuslineConfig { order, enabled }.normalized()
+    }
+
+    fn render_footer(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(app);
+        TuiText::from_spans([
+            ("Enter ".to_owned(), builder.primary_text_style()),
+            ("to toggle  ".to_owned(), builder.muted_text_style()),
+            ("Esc ".to_owned(), builder.primary_text_style()),
+            ("to save and close  ".to_owned(), builder.muted_text_style()),
+            ("← → ".to_owned(), builder.primary_text_style()),
+            ("to reorder".to_owned(), builder.muted_text_style()),
+        ])
+        .truncate()
+        .finish()
+    }
+}
+
+// The next stacked change mounts the picker and builds this question.
+#[allow(dead_code)]
+fn statusline_question() -> AskUserQuestionItem {
+    AskUserQuestionItem {
+        question_id: STATUSLINE_QUESTION_ID.to_owned(),
+        question: "Configure statusline".to_owned(),
+        question_type: AskUserQuestionType::MultipleChoice {
+            is_multiselect: true,
+            options: TuiStatuslineItem::ALL
+                .iter()
+                .map(|item| AskUserQuestionOption {
+                    label: item.label().to_owned(),
+                    recommended: false,
+                })
+                .collect(),
+            supports_other: false,
+        },
+    }
+}
+
+impl Entity for TuiStatuslineConfigView {
+    type Event = TuiStatuslineConfigEvent;
+}
+
+impl TuiView for TuiStatuslineConfigView {
+    fn ui_name() -> &'static str {
+        "TuiStatuslineConfigView"
+    }
+
+    fn child_view_ids(&self, _app: &AppContext) -> Vec<EntityId> {
+        vec![self.selector.id()]
+    }
+
+    fn keymap_context(&self, app: &AppContext) -> warpui_core::keymap::Context {
+        let mut context = Self::default_keymap_context();
+        context.set.insert(STATUSLINE_CONFIG_ACTIVE);
+        if self.selector.as_ref(app).list_is_focused(app) {
+            context.set.insert(STATUSLINE_REORDER_ACTIVE);
+        }
+        context
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(app);
+        let title = TuiText::new("Configure statusline")
+            .with_style(builder.primary_text_style().add_modifier(Modifier::BOLD))
+            .finish();
+        let body = TuiFlex::column()
+            .child(title)
+            .child(TuiChildView::new(&self.selector).finish())
+            .child(TuiText::new(" ").finish())
+            .child(self.render_footer(app))
+            .finish();
+        TuiContainer::new(body)
+            .with_padding(1)
+            .with_background(builder.question_surface_background())
+            .finish()
+    }
+}
+
+impl TypedActionView for TuiStatuslineConfigView {
+    type Action = TuiStatuslineConfigAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            TuiStatuslineConfigAction::Toggle => {
+                self.selector
+                    .update(ctx, |selector, ctx| selector.confirm_selected(ctx));
+            }
+            TuiStatuslineConfigAction::Save => {
+                ctx.emit(TuiStatuslineConfigEvent::Saved(self.current_config(ctx)));
+            }
+            TuiStatuslineConfigAction::Cancel => {
+                ctx.emit(TuiStatuslineConfigEvent::Cancelled);
+            }
+            TuiStatuslineConfigAction::MoveBackward => {
+                self.selector.update(ctx, |selector, ctx| {
+                    let Some(row_id) = selector.selected_row_id() else {
+                        return;
+                    };
+                    selector.move_row(&row_id, TuiOptionSelectorMoveDirection::Backward, ctx);
+                });
+            }
+            TuiStatuslineConfigAction::MoveForward => {
+                self.selector.update(ctx, |selector, ctx| {
+                    let Some(row_id) = selector.selected_row_id() else {
+                        return;
+                    };
+                    selector.move_row(&row_id, TuiOptionSelectorMoveDirection::Forward, ctx);
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "statusline_config_view_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/statusline_config_view_tests.rs
+++ b/crates/warp_tui/src/statusline_config_view_tests.rs
@@ -1,0 +1,100 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use warp::settings::{TuiStatuslineConfig, TuiStatuslineItem};
+use warp::tui_export::Appearance;
+use warpui::platform::WindowStyle;
+use warpui::{AddWindowOptions, App};
+use warpui_core::TypedActionView as _;
+
+use super::{TuiStatuslineConfigAction, TuiStatuslineConfigEvent, TuiStatuslineConfigView};
+
+#[test]
+fn default_picker_preserves_figma_selection_and_full_catalog_order() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let view = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |ctx| TuiStatuslineConfigView::new(TuiStatuslineConfig::default(), ctx),
+            )
+            .1
+        });
+
+        assert_eq!(
+            app.read(|ctx| view.as_ref(ctx).current_config(ctx)),
+            TuiStatuslineConfig::default()
+        );
+    });
+}
+
+#[test]
+fn toggle_and_reorder_are_reflected_in_saved_config() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let view = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |ctx| TuiStatuslineConfigView::new(TuiStatuslineConfig::default(), ctx),
+            )
+            .1
+        });
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let events_for_subscription = events.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                events_for_subscription.borrow_mut().push(event.clone());
+            });
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiStatuslineConfigAction::Toggle, ctx);
+        });
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiStatuslineConfigAction::MoveForward, ctx);
+        });
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiStatuslineConfigAction::Save, ctx);
+        });
+
+        let saved = events
+            .borrow()
+            .iter()
+            .find_map(|event| match event {
+                TuiStatuslineConfigEvent::Saved(config) => Some(config.clone()),
+                TuiStatuslineConfigEvent::Cancelled | TuiStatuslineConfigEvent::LayoutChanged => {
+                    None
+                }
+            })
+            .expect("save emits a config");
+        assert_eq!(
+            saved.order,
+            [
+                TuiStatuslineItem::AutoQueue,
+                TuiStatuslineItem::AutoApprove,
+                TuiStatuslineItem::Model,
+                TuiStatuslineItem::WorkingDirectory,
+                TuiStatuslineItem::GitBranch,
+                TuiStatuslineItem::GitDiffStatus,
+                TuiStatuslineItem::CreditUsage,
+                TuiStatuslineItem::ContextWindowUsage,
+            ]
+        );
+        assert_eq!(
+            saved.enabled,
+            [
+                TuiStatuslineItem::AutoApprove,
+                TuiStatuslineItem::Model,
+                TuiStatuslineItem::WorkingDirectory,
+                TuiStatuslineItem::GitBranch,
+                TuiStatuslineItem::GitDiffStatus,
+            ]
+        );
+    });
+}


### PR DESCRIPTION
## Description
Adds the local-only TUI statusline settings model and an Ask User Question-style searchable multiselect for toggling and reordering statusline items. The picker and keybindings compile and are tested, but this PR deliberately does not register `/statusline`, mount the picker in a session, or render the configuration, so it is behavior-neutral until #14253.

- [Figma](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1232-21908&m=dev)
- [Implementation plan](https://staging.warp.dev/drive/notebook/7AF2ymkhaGMxoqY0etazX5)

## Linked Issue
N/A — stacked parent for #14253.

## Testing
- [x] `cargo nextest run -p warp tui_statusline` — 2 passed.
- [x] `cargo nextest run -p warp_tui statusline_config_view` — 2 passed.
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`.
- [x] Not manually testable in isolation; #14253 mounts the picker and user-visible behavior.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>