### PR TITLE
Don't block startup on D-Bus Secret Service activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16291,6 +16291,7 @@ dependencies = [
  "windows 0.62.2",
  "windows-registry 0.2.0",
  "windows-result 0.2.0",
+ "zbus",
 ]
 
 [[package]]

--- a/crates/warpui_extras/Cargo.toml
+++ b/crates/warpui_extras/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [features]
 default = ["secure_storage", "user_preferences", "user_preferences-file"]
-secure_storage = ["dep:security-framework", "dep:secret-service", "dep:ouroboros"]
+secure_storage = ["dep:security-framework", "dep:secret-service", "dep:ouroboros", "dep:zbus"]
 test-util = []
 user_preferences = ["dep:objc2", "dep:objc2-foundation", "dep:gloo-storage"]
 user_preferences-file = ["user_preferences", "dep:serde", "dep:serde_json"]
@@ -44,6 +44,7 @@ ouroboros = { version = "0.18", optional = true }
 rand = "0.8.5"
 ring = "0.17.13"
 secret-service = {version = "5.0.0", features = ["rt-async-io-crypto-rust"], optional = true}
+zbus = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 gloo-storage = { version = "0.3.0", optional = true }

--- a/crates/warpui_extras/src/secure_storage/linux.rs
+++ b/crates/warpui_extras/src/secure_storage/linux.rs
@@ -103,13 +103,14 @@ impl SecureStorage {
             // fail. See https://github.com/warpdotdev/warp/issues/13978.
             let timeout = SECRET_SERVICE_ACTIVATION_TIMEOUT;
             match secret_service_availability(timeout) {
-                ServiceAvailability::TimedOut => {
+                ServiceAvailability::Indeterminate => {
                     log::info!(
-                        "Secret Service activation did not complete within {timeout:?}; \
-                         falling back to encrypted file storage for now"
+                        "Could not determine Secret Service availability within {timeout:?} \
+                         (timed out or hit a D-Bus error); falling back to encrypted file \
+                         storage for now"
                     );
                     return Err(Error::Unknown(anyhow!(
-                        "Secret Service activation timed out"
+                        "Could not determine Secret Service availability"
                     )));
                 }
                 ServiceAvailability::Unavailable => {
@@ -425,67 +426,70 @@ enum ServiceAvailability {
     /// A Secret Service provider is running (or was just activated) and
     /// ready to be connected to.
     Available,
-    /// There is no Secret Service provider installed, and none can be
-    /// activated. This is a stable answer that is safe to cache.
+    /// The bus was reachable and confirmed there is no Secret Service
+    /// provider installed, and none can be activated. This is a stable
+    /// answer that is safe to cache.
     Unavailable,
-    /// The probe did not finish within the allotted timeout. This is
-    /// deliberately distinct from [`Self::Unavailable`]: the provider may
-    /// simply be slow to activate, so callers should not treat this as a
-    /// permanent answer.
-    TimedOut,
+    /// The probe either did not finish within the allotted timeout, or hit a
+    /// D-Bus/proxy/listing error while talking to the bus. Both are
+    /// transient conditions: the provider may simply be slow to activate, or
+    /// the bus call may succeed on a later attempt. Callers should not treat
+    /// this as a permanent answer.
+    Indeterminate,
 }
 
 fn secret_service_availability(timeout: Duration) -> ServiceAvailability {
     match run_with_timeout("secret-service-probe", timeout, probe_secret_service) {
-        Some(true) => ServiceAvailability::Available,
-        Some(false) => ServiceAvailability::Unavailable,
-        None => ServiceAvailability::TimedOut,
+        Some(Some(true)) => ServiceAvailability::Available,
+        Some(Some(false)) => ServiceAvailability::Unavailable,
+        Some(None) | None => ServiceAvailability::Indeterminate,
     }
 }
 
 /// Asks the session bus for a running Secret Service provider, requesting
 /// activation of one if it is not already running.
 ///
+/// Returns [`None`] if a D-Bus/proxy/listing error prevents us from reaching
+/// a confirmed answer; that is distinct from confirming there is no provider
+/// to talk to, and callers must not treat it as such (see
+/// [`ServiceAvailability::Indeterminate`]).
+///
 /// This may block for as long as the session bus's activation timeout, so it
 /// is expected to be called via [`run_with_timeout`].
-fn probe_secret_service() -> bool {
-    let Ok(connection) = Connection::session() else {
-        // No session bus at all (headless sessions, containers, some remote
-        // shells): there is nothing to talk to.
-        return false;
-    };
-    let Ok(dbus) = DBusProxy::new(&connection) else {
-        return false;
-    };
-    let Ok(bus_name) = WellKnownName::try_from(SECRET_SERVICE_BUS_NAME) else {
-        return false;
-    };
+fn probe_secret_service() -> Option<bool> {
+    // No session bus at all (headless sessions, containers, some remote
+    // shells) or a proxy/name-parsing failure: these are transport-level
+    // errors, not a confirmation that no provider exists, so they must not
+    // be cached as `Unavailable`.
+    let connection = Connection::session().ok()?;
+    let dbus = DBusProxy::new(&connection).ok()?;
+    let bus_name = WellKnownName::try_from(SECRET_SERVICE_BUS_NAME).ok()?;
 
     // A provider is already running, so connecting will not block on activation.
     if dbus
         .name_has_owner(BusName::from(bus_name.clone()))
         .unwrap_or(false)
     {
-        return true;
+        return Some(true);
     }
 
-    // Nothing owns the name and the bus has no activation entry for it, so no
-    // provider is installed and asking for one would only waste time.
+    // Nothing owns the name; ask the bus whether it has an activation entry
+    // for it. A failure here is a listing error, not a confirmation that no
+    // provider is installed, so it must also be left indeterminate.
     let is_activatable = dbus
         .list_activatable_names()
-        .map(|names| {
-            names
-                .iter()
-                .any(|name| name.as_str() == SECRET_SERVICE_BUS_NAME)
-        })
-        .unwrap_or(false);
+        .ok()?
+        .iter()
+        .any(|name| name.as_str() == SECRET_SERVICE_BUS_NAME);
     if !is_activatable {
-        return false;
+        // The bus positively confirmed there is no activation entry: no
+        // provider is installed and asking for one would only waste time.
+        return Some(false);
     }
 
     // The name is activatable but nothing owns it yet. This is the call that
     // hangs when a provider is installed but cannot start.
-    dbus.start_service_by_name(bus_name, 0).is_ok()
+    Some(dbus.start_service_by_name(bus_name, 0).is_ok())
 }
 
 /// Runs `operation` on a worker thread, returning its result if it completes

--- a/crates/warpui_extras/src/secure_storage/linux.rs
+++ b/crates/warpui_extras/src/secure_storage/linux.rs
@@ -469,7 +469,10 @@ fn run_with_timeout<T: Send + 'static>(
             let _ = sender.send(operation());
         });
     if let Err(err) = spawned {
-        report_error!(anyhow!("Failed to spawn {thread_name} thread: {err}"));
+        report_error!(
+            anyhow::Error::new(err).context("Failed to spawn worker thread"),
+            extra: { "thread_name" => %thread_name }
+        );
         return None;
     }
 

--- a/crates/warpui_extras/src/secure_storage/linux.rs
+++ b/crates/warpui_extras/src/secure_storage/linux.rs
@@ -90,31 +90,53 @@ impl SecureStorage {
     /// or instead only store the collection on a successful connection and
     /// return the error on an initialization failure.
     fn collection(&self) -> Result<&secret_service::blocking::Collection<'_>, Error> {
-        self.collection
-            .get_or_init(|| {
-                // Probing the bus first keeps a missing or broken Secret
-                // Service provider from blocking on D-Bus activation, which
-                // can take up to `service_start_timeout` (120s by default) to
-                // fail. See https://github.com/warpdotdev/warp/issues/13978.
-                let timeout = SECRET_SERVICE_ACTIVATION_TIMEOUT;
-                if !secret_service_is_available(timeout) {
+        // If we already have a definitive answer (a collection, or a
+        // confirmed absence of a provider), use it. Otherwise fall through
+        // to probe again: a prior attempt may have merely timed out, which
+        // is deliberately *not* cached below so a slow-to-activate provider
+        // gets retried instead of being written off for the rest of the
+        // process.
+        if self.collection.get().is_none() {
+            // Probing the bus first keeps a missing or broken Secret
+            // Service provider from blocking on D-Bus activation, which
+            // can take up to `service_start_timeout` (120s by default) to
+            // fail. See https://github.com/warpdotdev/warp/issues/13978.
+            let timeout = SECRET_SERVICE_ACTIVATION_TIMEOUT;
+            match secret_service_availability(timeout) {
+                ServiceAvailability::TimedOut => {
+                    log::info!(
+                        "Secret Service activation did not complete within {timeout:?}; \
+                         falling back to encrypted file storage for now"
+                    );
+                    return Err(Error::Unknown(anyhow!(
+                        "Secret Service activation timed out"
+                    )));
+                }
+                ServiceAvailability::Unavailable => {
                     log::info!(
                         "No Secret Service provider available after {timeout:?}; \
                          falling back to encrypted file storage"
                     );
-                    return None;
+                    let _ = self.collection.set(None);
                 }
+                ServiceAvailability::Available => {
+                    let collection = match Collection::open_default_collection()
+                        .context("Failed to acquire default Secret Service collection")
+                    {
+                        Ok(collection) => Some(collection),
+                        Err(err) => {
+                            report_error!(err);
+                            None
+                        }
+                    };
+                    let _ = self.collection.set(collection);
+                }
+            }
+        }
 
-                match Collection::open_default_collection()
-                    .context("Failed to acquire default Secret Service collection")
-                {
-                    Ok(collection) => Some(collection),
-                    Err(err) => {
-                        report_error!(err);
-                        None
-                    }
-                }
-            })
+        self.collection
+            .get()
+            .expect("collection was just initialized above")
             .as_ref()
             .ok_or_else(|| {
                 Error::Unknown(anyhow!("Failed to initialize Secret Service connection"))
@@ -399,8 +421,26 @@ impl From<ring::error::Unspecified> for Error {
 /// (120 seconds by default). Bounding the wait here keeps startup fast on
 /// systems without a working keyring, at the cost of falling back to encrypted
 /// file storage for the rest of the session.
-fn secret_service_is_available(timeout: Duration) -> bool {
-    run_with_timeout("secret-service-probe", timeout, probe_secret_service).unwrap_or(false)
+enum ServiceAvailability {
+    /// A Secret Service provider is running (or was just activated) and
+    /// ready to be connected to.
+    Available,
+    /// There is no Secret Service provider installed, and none can be
+    /// activated. This is a stable answer that is safe to cache.
+    Unavailable,
+    /// The probe did not finish within the allotted timeout. This is
+    /// deliberately distinct from [`Self::Unavailable`]: the provider may
+    /// simply be slow to activate, so callers should not treat this as a
+    /// permanent answer.
+    TimedOut,
+}
+
+fn secret_service_availability(timeout: Duration) -> ServiceAvailability {
+    match run_with_timeout("secret-service-probe", timeout, probe_secret_service) {
+        Some(true) => ServiceAvailability::Available,
+        Some(false) => ServiceAvailability::Unavailable,
+        None => ServiceAvailability::TimedOut,
+    }
 }
 
 /// Asks the session bus for a running Secret Service provider, requesting

--- a/crates/warpui_extras/src/secure_storage/linux.rs
+++ b/crates/warpui_extras/src/secure_storage/linux.rs
@@ -6,6 +6,9 @@ use std::fs::OpenOptions;
 use std::io::Write as _;
 use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, anyhow};
 use rand::RngCore;
@@ -13,8 +16,25 @@ use ring::aead;
 use secret_service::EncryptionType;
 use secret_service::blocking::{Item, SecretService};
 use warp_errors::report_error;
+use zbus::blocking::Connection;
+use zbus::blocking::fdo::DBusProxy;
+use zbus::names::{BusName, WellKnownName};
 
 use super::Error;
+
+/// The well-known D-Bus name that a Secret Service API provider (GNOME
+/// Keyring, KWallet, KeePassXC, ...) takes ownership of.
+const SECRET_SERVICE_BUS_NAME: &str = "org.freedesktop.secrets";
+
+/// How long we are willing to wait for a Secret Service provider to become
+/// available on the session bus before falling back to file-based storage.
+///
+/// D-Bus applies its own, far more generous, activation timeout
+/// (`service_start_timeout`, 120 seconds by default). A provider that is
+/// installed but broken makes every connection attempt block for that entire
+/// window, which stalls application startup, so we impose a much shorter bound
+/// of our own.
+const SECRET_SERVICE_ACTIVATION_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Implementation of the SecureStorage service using the Secret Service API.
 pub struct SecureStorage {
@@ -72,6 +92,19 @@ impl SecureStorage {
     fn collection(&self) -> Result<&secret_service::blocking::Collection<'_>, Error> {
         self.collection
             .get_or_init(|| {
+                // Probing the bus first keeps a missing or broken Secret
+                // Service provider from blocking on D-Bus activation, which
+                // can take up to `service_start_timeout` (120s by default) to
+                // fail. See https://github.com/warpdotdev/warp/issues/13978.
+                let timeout = SECRET_SERVICE_ACTIVATION_TIMEOUT;
+                if !secret_service_is_available(timeout) {
+                    log::info!(
+                        "No Secret Service provider available after {timeout:?}; \
+                         falling back to encrypted file storage"
+                    );
+                    return None;
+                }
+
                 match Collection::open_default_collection()
                     .context("Failed to acquire default Secret Service collection")
                 {
@@ -355,6 +388,92 @@ impl From<ring::error::Unspecified> for Error {
     fn from(value: ring::error::Unspecified) -> Self {
         Error::Unknown(anyhow!(value))
     }
+}
+
+/// Returns whether a Secret Service provider can be reached on the D-Bus
+/// session bus within `timeout`, activating one if the bus knows how to.
+///
+/// This exists because `SecretService::connect` triggers D-Bus activation of
+/// [`SECRET_SERVICE_BUS_NAME`], and activation of a missing or misconfigured
+/// provider only fails once the bus hits its own `service_start_timeout`
+/// (120 seconds by default). Bounding the wait here keeps startup fast on
+/// systems without a working keyring, at the cost of falling back to encrypted
+/// file storage for the rest of the session.
+fn secret_service_is_available(timeout: Duration) -> bool {
+    run_with_timeout("secret-service-probe", timeout, probe_secret_service).unwrap_or(false)
+}
+
+/// Asks the session bus for a running Secret Service provider, requesting
+/// activation of one if it is not already running.
+///
+/// This may block for as long as the session bus's activation timeout, so it
+/// is expected to be called via [`run_with_timeout`].
+fn probe_secret_service() -> bool {
+    let Ok(connection) = Connection::session() else {
+        // No session bus at all (headless sessions, containers, some remote
+        // shells): there is nothing to talk to.
+        return false;
+    };
+    let Ok(dbus) = DBusProxy::new(&connection) else {
+        return false;
+    };
+    let Ok(bus_name) = WellKnownName::try_from(SECRET_SERVICE_BUS_NAME) else {
+        return false;
+    };
+
+    // A provider is already running, so connecting will not block on activation.
+    if dbus
+        .name_has_owner(BusName::from(bus_name.clone()))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    // Nothing owns the name and the bus has no activation entry for it, so no
+    // provider is installed and asking for one would only waste time.
+    let is_activatable = dbus
+        .list_activatable_names()
+        .map(|names| {
+            names
+                .iter()
+                .any(|name| name.as_str() == SECRET_SERVICE_BUS_NAME)
+        })
+        .unwrap_or(false);
+    if !is_activatable {
+        return false;
+    }
+
+    // The name is activatable but nothing owns it yet. This is the call that
+    // hangs when a provider is installed but cannot start.
+    dbus.start_service_by_name(bus_name, 0).is_ok()
+}
+
+/// Runs `operation` on a worker thread, returning its result if it completes
+/// within `timeout` and [`None`] otherwise.
+///
+/// The worker thread is deliberately detached rather than joined: a blocked
+/// D-Bus call cannot be cancelled, so waiting for the thread to unwind would
+/// reintroduce exactly the stall this is meant to avoid. The thread finishes on
+/// its own once the underlying call returns.
+fn run_with_timeout<T: Send + 'static>(
+    thread_name: &str,
+    timeout: Duration,
+    operation: impl FnOnce() -> T + Send + 'static,
+) -> Option<T> {
+    let (sender, receiver) = mpsc::channel();
+    let spawned = thread::Builder::new()
+        .name(thread_name.to_owned())
+        .spawn(move || {
+            // A send error means the caller already timed out and went away,
+            // which is expected and requires no handling here.
+            let _ = sender.send(operation());
+        });
+    if let Err(err) = spawned {
+        report_error!(anyhow!("Failed to spawn {thread_name} thread: {err}"));
+        return None;
+    }
+
+    receiver.recv_timeout(timeout).ok()
 }
 
 /// A helper structure that maintains access to the default collection.

--- a/crates/warpui_extras/src/secure_storage/linux_tests.rs
+++ b/crates/warpui_extras/src/secure_storage/linux_tests.rs
@@ -1,4 +1,6 @@
-use super::{Error, SecureStorage};
+use std::time::{Duration, Instant};
+
+use super::{Error, SecureStorage, run_with_timeout};
 
 #[test]
 fn test_encrypt_decrypt_returns_same_value() {
@@ -76,4 +78,31 @@ fn default_fallback_does_not_create_missing_directory() {
 
     assert!(storage.write_fallback_value("key", "value").is_err());
     assert!(!fallback_dir.exists());
+}
+
+#[test]
+fn run_with_timeout_returns_result_of_fast_operations() {
+    let result = run_with_timeout("test-fast-operation", Duration::from_secs(30), || 42);
+
+    assert_eq!(result, Some(42));
+}
+
+#[test]
+fn run_with_timeout_gives_up_on_slow_operations() {
+    let timeout = Duration::from_millis(50);
+    let started_at = Instant::now();
+
+    // Stands in for a D-Bus activation request against a provider that never
+    // comes up, which the session bus only abandons after two minutes.
+    let result = run_with_timeout("test-slow-operation", timeout, || {
+        std::thread::sleep(Duration::from_secs(120));
+        true
+    });
+    let elapsed = started_at.elapsed();
+
+    assert_eq!(result, None);
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "expected to give up promptly after {timeout:?}, but waited {elapsed:?}"
+    );
 }


### PR DESCRIPTION
## Description

On Linux, the first read from secure storage calls `SecretService::connect`, which triggers D-Bus activation of `org.freedesktop.secrets`. If no Secret Service provider is installed — or one is installed but fails to start — that call blocks until the session bus abandons activation. `service_start_timeout` defaults to 120 seconds, so Warp stalls during startup before the existing encrypted-file fallback is ever reached.

This adds a bounded probe of the session bus before connecting:

- If `org.freedesktop.secrets` already has an owner, connect directly (no behavior change for working keyrings).
- If the name is only activatable, request activation on a worker thread with a 2 second budget. A provider that starts normally is well inside that budget; a broken one no longer holds up startup.
- If nothing owns the name and the bus has no activation entry for it, skip the Secret Service entirely.

In every failing case we fall through to the existing encrypted-file fallback, which is the same end state as today — just reached in ~2s instead of up to 120s. The probe thread is detached rather than joined, since a blocked D-Bus call can't be cancelled and joining would reintroduce the stall.

This also removes a spurious error report on machines that simply have no keyring installed; that case is now an `info` log instead.

## Linked Issue

Fixes #13978

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

<!-- Note: #13978 is triaged as a bug but has not been given a readiness label yet. Happy to hold this PR until a maintainer applies one. -->

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Automated: added unit tests for the timeout wrapper in `crates/warpui_extras/src/secure_storage/linux_tests.rs`, covering both a fast operation (result returned) and an operation that outlives its budget (gives up promptly instead of waiting out the full call). The slow case stands in for the D-Bus activation request that never returns.

<!--
CHANGELOG-BUG-FIX: Fixed a startup delay on Linux when no working D-Bus Secret Service provider is available.
-->
