### PR TITLE
fix(billing): use the channel's URL scheme for the billing deeplink

### DIFF
--- a/app/src/workspace/view/cloud_agent_capacity_modal/mod.rs
+++ b/app/src/workspace/view/cloud_agent_capacity_modal/mod.rs
@@ -3,6 +3,7 @@ use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use thousands::Separable;
+use warp_core::channel::ChannelState;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::Fill;
 use warp_graphql::billing::StripeSubscriptionPlan;
@@ -32,7 +33,23 @@ const MODAL_HEIGHT: f32 = 532.;
 const COMPACT_MODAL_HEIGHT: f32 = 360.;
 const HEADER_HEIGHT: f32 = 92.;
 const BUTTON_DIAMETER: f32 = 20.;
-const BILLING_AND_USAGE_URL: &str = "warp://settings/billing_and_usage";
+/// Path of the billing-and-usage settings deeplink, appended to the channel's
+/// own URL scheme by [`billing_and_usage_url`].
+const BILLING_AND_USAGE_PATH: &str = "settings/billing_and_usage";
+
+/// The billing-and-usage deeplink for the running channel.
+///
+/// The scheme must come from [`ChannelState::url_scheme`] rather than a
+/// hardcoded `warp://`: only the Stable channel claims `warp://`, so a literal
+/// scheme fails to open on Preview/Dev/Local/OSS builds (macOS reports
+/// `kLSApplicationNotFoundErr`).
+fn billing_and_usage_url() -> String {
+    format!(
+        "{}://{}",
+        ChannelState::url_scheme(),
+        BILLING_AND_USAGE_PATH
+    )
+}
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum CloudAgentCapacityModalVariant {
@@ -116,7 +133,7 @@ impl CloudAgentCapacityModal {
         if Self::can_upgrade(customer_type, self.variant) {
             Self::get_upgrade_url(ctx)
         } else {
-            Some(BILLING_AND_USAGE_URL.to_string())
+            Some(billing_and_usage_url())
         }
     }
 

--- a/app/src/workspace/view/cloud_agent_capacity_modal/mod.rs
+++ b/app/src/workspace/view/cloud_agent_capacity_modal/mod.rs
@@ -33,16 +33,8 @@ const MODAL_HEIGHT: f32 = 532.;
 const COMPACT_MODAL_HEIGHT: f32 = 360.;
 const HEADER_HEIGHT: f32 = 92.;
 const BUTTON_DIAMETER: f32 = 20.;
-/// Path of the billing-and-usage settings deeplink, appended to the channel's
-/// own URL scheme by [`billing_and_usage_url`].
 const BILLING_AND_USAGE_PATH: &str = "settings/billing_and_usage";
 
-/// The billing-and-usage deeplink for the running channel.
-///
-/// The scheme must come from [`ChannelState::url_scheme`] rather than a
-/// hardcoded `warp://`: only the Stable channel claims `warp://`, so a literal
-/// scheme fails to open on Preview/Dev/Local/OSS builds (macOS reports
-/// `kLSApplicationNotFoundErr`).
 fn billing_and_usage_url() -> String {
     format!(
         "{}://{}",


### PR DESCRIPTION
## Description

The cloud-agent capacity modal built its "billing and usage" deeplink from a hardcoded `warp://`, which only the Stable channel claims. On Preview/Dev/Local/OSS builds the link asks macOS to open a scheme no installed app claims, so nothing happens (`kLSApplicationNotFoundErr` / -10814).

Builds the URL from `ChannelState::url_scheme()` instead, matching how `auth_manager` constructs its channel-aware URLs. The path is kept as a separate constant and joined with the scheme at call time.

```rust
- const BILLING_AND_USAGE_URL: &str = "warp://settings/billing_and_usage";
+ const BILLING_AND_USAGE_PATH: &str = "settings/billing_and_usage";
+
+ fn billing_and_usage_url() -> String {
+     format!("{}://{}", ChannelState::url_scheme(), BILLING_AND_USAGE_PATH)
+ }
```

## Linked Issue

Fixes #14316

## Testing

- `cargo check -p warp`, `./script/format`, and `cargo clippy -p warp --all-targets --tests -- -D warnings` are all clean.
- The scheme mapping is covered by `ChannelState::url_scheme()`; this change has no behavior difference on Stable (still `warp://settings/billing_and_usage`) and fixes the link on every other channel.

Not separately unit-tested: the CTA URL is produced inside a `ViewContext`-bound modal method, so exercising it would need a view harness for what is a one-line scheme substitution.

- [ ] I have manually tested my changes locally with `./script/run`

> Reaching the modal requires a cloud-agent capacity/credit-exhausted state I can't induce locally on the OSS channel; the failure mode itself is reproducible with any `warp://` deeplink on a non-Stable build (`open "warp://settings/billing_and_usage"` → `kLSApplicationNotFoundErr`).

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the billing and usage link in the cloud agent capacity dialog not opening on Preview and Dev builds.
