### PR TITLE
fix(winit): apply the shaper's GPOS offsets when converting shaped glyphs

### DIFF
--- a/crates/warpui/src/windowing/winit/fonts/text_layout.rs
+++ b/crates/warpui/src/windowing/winit/fonts/text_layout.rs
@@ -82,9 +82,19 @@ impl<'a> RunBuilder<'a> {
             .char_index(glyph.start)
             .unwrap_or_else(|| self.str_index_map.num_chars());
 
+        // `glyph.x` / `glyph.y` are the pen position — where the glyph's cell starts after
+        // accumulating advances. The shaper's GPOS placement lives separately in
+        // `x_offset` / `y_offset`, expressed in em units, and must be folded in or every
+        // zero-advance combining mark lands at the pen instead of on its base. That is what
+        // made Thai stack wrong: in "พี่" both ◌ี and ◌้ came back at x = the base's advance
+        // and y = 0, i.e. side by side after the consonant rather than stacked above it.
+        // Sign convention and the font_size scaling follow `LayoutGlyph::physical` upstream.
+        let gpos_x_offset = glyph.font_size * glyph.x_offset;
+        let gpos_y_offset = glyph.font_size * glyph.y_offset;
+
         self.glyphs_in_current_run.push(Glyph {
             id: glyph.glyph_id as u32,
-            position_along_baseline: vec2f(glyph.x, glyph.y),
+            position_along_baseline: vec2f(glyph.x + gpos_x_offset, glyph.y - gpos_y_offset),
             index: glyph_char_index,
             width: glyph.w,
         });

--- a/crates/warpui/src/windowing/winit/text_layout_tests.rs
+++ b/crates/warpui/src/windowing/winit/text_layout_tests.rs
@@ -583,6 +583,121 @@ fn test_layout_text_first_line_indent_large_bidirectional() -> Result<()> {
     Ok(())
 }
 
+/// Combining marks must be placed with the shaper's GPOS offsets, not with the pen position.
+///
+/// [`cosmic_text::LayoutGlyph`] reports the shaped placement of a glyph in `x_offset` / `y_offset`
+/// (em units, to be scaled by `font_size`), separately from `x` / `y`, which are the pen position
+/// after advance accumulation. Ignoring the offsets draws every zero-advance combining mark at the
+/// pen instead of on its base.
+///
+/// This is invisible with a single mark — most fonts draw mark glyphs extending left of their
+/// origin, so a mark placed at the pen happens to land over its base — and only becomes visible
+/// once two marks stack, since both then get identical coordinates.
+#[test]
+fn test_combining_marks_are_placed_with_gpos_offsets() -> Result<()> {
+    use std::path::PathBuf;
+
+    let (mut font_db, _roboto) = init_fonts();
+
+    // The bundled Roboto-Regular doesn't cover COMBINING DIAERESIS, and carries no mark anchors
+    // for COMBINING ACUTE ACCENT either, so it can't exercise GPOS mark positioning. RobotoFlex,
+    // also bundled, has both marks plus mark-to-base and mark-to-mark anchors.
+    let font_path: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "..",
+        "..",
+        "app",
+        "assets",
+        "bundled",
+        "fonts",
+        "roboto",
+        "RobotoFlex-Semibold.ttf",
+    ]
+    .iter()
+    .collect();
+    let roboto_flex = font_db
+        .load_from_bytes(
+            "RobotoFlex",
+            vec![std::fs::read(font_path).expect("should be able to read the bundled RobotoFlex")],
+        )
+        .expect("should be able to load RobotoFlex for test");
+
+    // `b` has no precomposed form with either mark, so the shaper cannot compose them away and
+    // emits three glyphs: the base, then two stacked zero-advance marks.
+    let text = "b\u{0301}\u{0308}"; // b + COMBINING ACUTE ACCENT + COMBINING DIAERESIS
+
+    let line = font_db.text_layout_system().layout_line(
+        text,
+        LineStyle {
+            font_size: FONT_SIZE,
+            line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+            baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+            fixed_width_tab_size: None,
+        },
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(roboto_flex, Properties::default(), TextStyle::new()),
+        )],
+        f32::MAX,
+        crate::text_layout::ClipConfig::default(),
+    );
+
+    let glyphs = line
+        .runs
+        .iter()
+        .flat_map(|run| run.glyphs.iter())
+        .collect_vec();
+    assert_eq!(
+        glyphs.len(),
+        3,
+        "expected a base glyph followed by two combining marks, got {glyphs:?}"
+    );
+
+    let base = glyphs[0];
+    let (acute, diaeresis) = (glyphs[1], glyphs[2]);
+
+    assert!(base.width > 0., "the base glyph should advance the pen");
+    assert_eq!(
+        (
+            base.position_along_baseline.x(),
+            base.position_along_baseline.y()
+        ),
+        (0., 0.),
+        "the base glyph starts at the origin"
+    );
+
+    for mark in [acute, diaeresis] {
+        assert_eq!(mark.width, 0., "combining marks have no advance");
+        // Without the GPOS offsets a mark keeps the pen position it inherited from the base's
+        // advance, which places it after the base instead of over it.
+        assert!(
+            mark.position_along_baseline.x() < base.width,
+            "mark should be pulled back over its base by its GPOS x offset, got x = {} with a \
+             base advance of {}",
+            mark.position_along_baseline.x(),
+            base.width
+        );
+        // Screen coordinates grow downwards, so a mark rendered above the baseline has a negative
+        // y. Without the GPOS offsets every mark stays on the baseline.
+        assert!(
+            mark.position_along_baseline.y() < 0.,
+            "mark should be raised above the baseline by its GPOS y offset, got y = {}",
+            mark.position_along_baseline.y()
+        );
+    }
+
+    // The point of the fix: stacked marks must not collapse onto one another. The diaeresis is
+    // attached to the acute by the font's mark-to-mark anchors, so it sits strictly higher.
+    assert!(
+        diaeresis.position_along_baseline.y() < acute.position_along_baseline.y(),
+        "the second mark should stack above the first, but they are at y = {} and y = {}",
+        diaeresis.position_along_baseline.y(),
+        acute.position_along_baseline.y()
+    );
+
+    Ok(())
+}
+
 /// Checks that the head indent and first line's width don't exceed the frame's width.
 fn first_line_bounded(frame: &TextFrame, first_line_indent: f32, frame_width: f32) -> bool {
     let first_line_width = frame.lines().first().unwrap().width;


### PR DESCRIPTION
Closes #14323

## Problem

On the winit platforms, combining marks are drawn at the pen position instead of on their base. With
a single mark that is usually invisible, which is why it has gone unnoticed; with two stacked marks
both land at identical coordinates and the text becomes unreadable.

Thai is where it shows up worst — `พี่`, `ที่`, `เก้าอี้`, `ก๋วยเตี๋ยว` all lose a mark — but this
is not Thai-specific. It affects any script that relies on GPOS mark positioning, and it sits below
the terminal, so it applies to all text `warpui` lays out.

## Root cause

`RunBuilder::push_glyph` built each glyph's position from `LayoutGlyph::x` / `y` alone:

```rust
position_along_baseline: vec2f(glyph.x, glyph.y),
```

Those are the pen position after advance accumulation. cosmic-text keeps the shaped placement in the
separate `x_offset` / `y_offset` fields (em units, to be scaled by `font_size`) — see
`LayoutGlyph::physical` upstream — and nothing in `warpui` or `warpui_core` ever read them. So every
zero-advance combining mark was drawn at the pen rather than on its base.

## Fix

```rust
let gpos_x_offset = glyph.font_size * glyph.x_offset;
let gpos_y_offset = glyph.font_size * glyph.y_offset;
position_along_baseline: vec2f(glyph.x + gpos_x_offset, glyph.y - gpos_y_offset),
```

Scaling and sign mirror `LayoutGlyph::physical`.

macOS is unaffected — `platform/mac/text_layout.rs` gets final positions from CoreText, which is
also why this never showed up in testing on a Mac.

## Test

`test_combining_marks_are_placed_with_gpos_offsets` in
`crates/warpui/src/windowing/winit/text_layout_tests.rs` shapes `b` + COMBINING ACUTE ACCENT +
COMBINING DIAERESIS and asserts that both marks are pulled back over the base and stacked at
different heights.

It uses the bundled `RobotoFlex-Semibold.ttf` rather than the `Roboto-Regular` the neighbouring tests
use, and that is deliberate: Roboto-Regular has no COMBINING DIAERESIS (it shapes to `.notdef`) and
returns a zero offset for the acute, so it cannot exercise mark positioning at all. RobotoFlex
carries both mark-to-base and mark-to-mark anchors, which is what makes the stacked case meaningful.

Fail-before / pass-after — with the fix reverted to `master`:

```
mark should be pulled back over its base by its GPOS x offset,
got x = 9.5 with a base advance of 9.5
test result: FAILED. 0 passed; 1 failed
```

The mark sitting at exactly the base's advance is the bug itself.

With the fix, `cargo test -p warpui --lib -- --test-threads=1` gives
`test result: ok. 41 passed; 0 failed; 10 ignored`, and `cargo fmt -p warpui -- --check` is clean.
(Single-threaded because the suite run in parallel aborts on Windows for unrelated reasons — see
[#14321](https://github.com/warpdotdev/warp/issues/14321), which reproduces on clean `master`.)

## Verification on Windows

Built `warp-oss` from this branch on Windows 11 Pro (26120), terminal font `Hack` so it has no Thai
glyphs and everything goes through the DirectWrite fallback path. Before the fix stacked marks land
on top of one another; after, `พี่ที่ปั๊มน้ำมัน เก้าอี้ ก๋วยเตี๋ยว ฟื้นฟู เพิ่ง` all render
correctly. I have also been running a patched build as my daily driver, in Thai, for real work.

Without this fix (`ที`/`พี` lose their tone marks — note the vowel drawn before its consonant):

![without the GPOS fix](https://raw.githubusercontent.com/SS-Script/warp/thai-evidence/thai-windows-evidence/run1-no-gpos-b2e61679a.png)

With it:

![with the GPOS fix](https://raw.githubusercontent.com/SS-Script/warp/thai-evidence/thai-windows-evidence/run2-with-gpos-2c3f007af.png)

## Relation to #14124

Found while testing #14124 (Thai combining marks in the terminal grid). It is a separate concern —
different crate, and it affects all `warpui` text rather than terminal cells — but that PR cannot be
correct on Windows without it, whether the clustering ends up happening at render time or at input
time. @ultramcu suggested opening it on its own:
https://github.com/warpdotdev/warp/pull/14124#issuecomment-5086705260
