### PR TITLE
Fix macOS line-editing shortcuts inside alt-screen TUIs (#807)

### DIFF
--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -101,6 +101,7 @@ use crate::terminal::resizable_data::ResizableData;
 use crate::terminal::shared_session::permissions_manager::SessionPermissionsManager;
 use crate::terminal::shell::ShellType;
 use crate::terminal::universal_developer_input::UniversalDeveloperInputButtonBarEvent;
+use crate::terminal::view::init::KEYBOARD_PROTOCOL_ENABLED_KEY;
 use crate::terminal::view::inline_banner::ByoLlmAuthBannerSessionState;
 use crate::terminal::writeable_pty::command_history::update_command_history;
 use crate::test_util::settings::initialize_settings_for_tests;
@@ -9443,5 +9444,120 @@ fn ctrl_enter_inserts_newline_in_normal_input_after_rich_input_closes() {
                  (the default); got Emit instead"
             );
         });
+    });
+}
+
+/// The seven readline-style line-editing bindings whose context predicate this change widens.
+const EXECUTING_COMMAND_LINE_EDITING_ACTIONS: &[&str] = &[
+    "terminal:executing_command_move_cursor_word_left",
+    "terminal:executing_command_move_cursor_word_right",
+    "terminal:executing_command_move_cursor_home",
+    "terminal:executing_command_move_cursor_end",
+    "terminal:executing_command_delete_word_left",
+    "terminal:executing_command_delete_line_start",
+    "terminal:executing_command_delete_line_end",
+];
+
+/// Build a keymap context containing exactly `keys`, mirroring what
+/// `TerminalView::keymap_context` inserts in the corresponding terminal state.
+fn keymap_context_with(keys: &[&'static str]) -> warpui::keymap::Context {
+    let mut context = warpui::keymap::Context::default();
+    for key in keys {
+        context.set.insert(key);
+    }
+    context
+}
+
+/// Assert how every line-editing binding evaluates against `context`.
+///
+/// Reads the predicate off the binding as actually registered by
+/// `crate::terminal::view::init`, so this exercises the shipped predicate rather than a
+/// copy of it.
+fn assert_line_editing_bindings(app: &App, context: &warpui::keymap::Context, expected: bool) {
+    app.read(|ctx| {
+        for name in EXECUTING_COMMAND_LINE_EDITING_ACTIONS {
+            let binding = ctx
+                .editable_bindings()
+                .find(|binding| binding.name == *name)
+                .unwrap_or_else(|| panic!("`{name}` should be a registered editable binding"));
+            assert_eq!(
+                binding.in_context(context),
+                expected,
+                "`{name}` in context {:?} should be {}",
+                context.set,
+                if expected { "active" } else { "inactive" },
+            );
+        }
+    });
+}
+
+/// The `terminal:executing_command_*` line-editing bindings must be active inside an
+/// alt-screen TUI that has not enabled the Kitty keyboard protocol.
+///
+/// Before this change they were gated on `LongRunningCommand` alone, and
+/// `TerminalView::keymap_context` explicitly declines to insert that key while the alt
+/// screen is active — so all seven were unreachable in fullscreen TUIs.
+#[test]
+fn test_line_editing_bindings_apply_in_alt_screen_without_keyboard_protocol() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        // `initialize_app` registers the *input* bindings; the line-editing bindings under
+        // test are registered by the terminal view's own `init`.
+        app.update(crate::terminal::view::init::init);
+
+        // The regression under test: a plain alt-screen TUI.
+        assert_line_editing_bindings(&app, &keymap_context_with(&["Terminal", "AltScreen"]), true);
+
+        // Unchanged: a long-running command on the normal screen still matches.
+        assert_line_editing_bindings(
+            &app,
+            &keymap_context_with(&["Terminal", "LongRunningCommand"]),
+            true,
+        );
+
+        // Not over-broadened: an idle terminal at the prompt must not match, so these
+        // chords keep reaching Warp's own input editor.
+        assert_line_editing_bindings(&app, &keymap_context_with(&["Terminal"]), false);
+
+        // The pre-existing IME guard still wins over the widened clause.
+        assert_line_editing_bindings(
+            &app,
+            &keymap_context_with(&["Terminal", "AltScreen", "IMEOpen"]),
+            false,
+        );
+    });
+}
+
+/// The same bindings must stay out of the way when the alt-screen TUI *has* enabled the
+/// Kitty keyboard protocol: it asked for rich key events, and the encoder — not a
+/// readline control byte — is what should answer.
+///
+/// Bindings are matched before the encoder runs, so without this clause a matching
+/// binding would win over KKP encoding. This was the review concern that blocked #11605.
+#[test]
+fn test_line_editing_bindings_suppressed_in_alt_screen_with_keyboard_protocol() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        // `initialize_app` registers the *input* bindings; the line-editing bindings under
+        // test are registered by the terminal view's own `init`.
+        app.update(crate::terminal::view::init::init);
+
+        assert_line_editing_bindings(
+            &app,
+            &keymap_context_with(&["Terminal", "AltScreen", KEYBOARD_PROTOCOL_ENABLED_KEY]),
+            false,
+        );
+
+        // A long-running command on the normal screen is unaffected by the protocol: the
+        // alt screen is the only place the new clause applies.
+        assert_line_editing_bindings(
+            &app,
+            &keymap_context_with(&[
+                "Terminal",
+                "LongRunningCommand",
+                KEYBOARD_PROTOCOL_ENABLED_KEY,
+            ]),
+            true,
+        );
     });
 }

--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -468,6 +468,11 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(
             id!("Terminal") & !id!("IMEOpen") & id!("TerminalView_NonEmptyBlockList"),
         ),
+        // The readline-style editing bindings below apply while a command is executing and
+        // inside alt-screen TUIs, so line editing keeps working in fullscreen programs
+        // (Claude Code, opencode, ...). They are suppressed when the TUI has enabled the
+        // Kitty keyboard protocol: it asked for rich key events and should receive those
+        // rather than these control bytes. Same shape as the `shift-enter` binding above.
         EditableBinding::new(
             "terminal:executing_command_move_cursor_word_left",
             "Move cursor one word to the left within an executing command",
@@ -475,7 +480,12 @@ pub fn init(app: &mut AppContext) {
         )
         .with_mac_key_binding("alt-left")
         .with_linux_or_windows_key_binding("ctrl-left")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & (id!("LongRunningCommand")
+                    | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))),
+        ),
         EditableBinding::new(
             "terminal:executing_command_move_cursor_word_right",
             "Move cursor one word to the right within an executing command",
@@ -483,7 +493,12 @@ pub fn init(app: &mut AppContext) {
         )
         .with_mac_key_binding("alt-right")
         .with_linux_or_windows_key_binding("ctrl-right")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & (id!("LongRunningCommand")
+                    | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))),
+        ),
         EditableBinding::new(
             "terminal:executing_command_move_cursor_home",
             "Move cursor home within an executing command",
@@ -492,14 +507,24 @@ pub fn init(app: &mut AppContext) {
         // We already have bindings for home/end (the keybindings for this on Linux and Mac) that
         // send the correct control sequence to the PTY.
         .with_mac_key_binding("cmd-left")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & (id!("LongRunningCommand")
+                    | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))),
+        ),
         EditableBinding::new(
             "terminal:executing_command_move_cursor_end",
             "Move cursor end within an executing command",
             TerminalAction::ControlSequence(vec![escape_sequences::C0::ENQ]),
         )
         .with_mac_key_binding("cmd-right")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & (id!("LongRunningCommand")
+                    | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))),
+        ),
         EditableBinding::new(
             "terminal:executing_command_delete_word_left",
             "Delete word left within an executing command",
@@ -507,13 +532,23 @@ pub fn init(app: &mut AppContext) {
         )
         .with_mac_key_binding("alt-backspace")
         .with_linux_or_windows_key_binding("ctrl-backspace")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & (id!("LongRunningCommand")
+                    | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))),
+        ),
         EditableBinding::new(
             "terminal:executing_command_delete_line_start",
             "Delete to line start within an executing command",
             TerminalAction::ControlSequence(vec![escape_sequences::C0::NAK]),
         )
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand"))
+        .with_context_predicate(
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & (id!("LongRunningCommand")
+                    | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))),
+        )
         // Set this for mac-only. The default binding for this on Linux / Windows is `ctrl-y`, which
         // we can't hijack because it is already reserved for the PTY.
         .with_mac_key_binding("cmd-backspace"),
@@ -522,7 +557,12 @@ pub fn init(app: &mut AppContext) {
             "Delete to line end within an executing command",
             TerminalAction::ControlSequence(vec![escape_sequences::C0::VT]),
         )
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand"))
+        .with_context_predicate(
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & (id!("LongRunningCommand")
+                    | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))),
+        )
         // Set this for mac-only since the corresponding editor action is also Mac-only.
         .with_mac_key_binding("cmd-delete"),
         EditableBinding::new(


### PR DESCRIPTION
## Description

When a readline-style TUI runs on the alternate screen (Claude Code in `fullscreen` mode, opencode, etc.), the macOS line-editing shortcuts stop working: `cmd+Backspace`, `cmd+Delete`, `cmd+Left`, `cmd+Right` and `alt+Backspace` no longer perform their editing actions.

**Root cause.** The seven `terminal:executing_command_*` bindings in `app/src/terminal/view/init.rs` are gated on `id!("LongRunningCommand")`, and that context key is explicitly suppressed while the alt screen is active — `app/src/terminal/view.rs`:

```rust
if active_block.is_active_and_long_running() {
    if !model_lock.is_alt_screen_active() {
        context.set.insert("LongRunningCommand");
    }
    ...
}
```

So `LongRunningCommand` and `AltScreen` are mutually exclusive by construction, and the predicate can never be satisfied while an alt-screen TUI is in the foreground. The keystroke falls through to the encoder, which wildcards `cmd` on macOS, so nothing useful reaches the PTY — the key silently does nothing.

**Fix.** Widen the predicate on those seven bindings to

```rust
id!("LongRunningCommand") | (id!("AltScreen") & !id!(KEYBOARD_PROTOCOL_ENABLED_KEY))
```

This is the same shape as the `shift-enter` binding at `init.rs:117-124`, and `terminal:backward_tabulation` in this very block already uses `(LongRunningCommand | AltScreen)`. Behaviour inside long-running command blocks is unchanged.

**Why the Kitty keyboard protocol clause is there.** A previous attempt at this fix (#11605) was reviewed and closed; the outstanding review concern was that a bare `| AltScreen` would also match while KKP is active, so KKP-aware TUIs would receive readline control bytes instead of the rich key events they explicitly requested. That concern is valid — bindings are matched before the encoder runs, so a matching binding wins over KKP encoding. Excluding `KEYBOARD_PROTOCOL_ENABLED_KEY` resolves it structurally: TUIs that negotiated KKP are left completely untouched by this change, and only non-KKP alt-screen TUIs pick up the editing bindings.

## Linked Issue

Fixes #807 (open since 2022, labeled `ready-to-implement`).

Related: #9159 / #14012 cover the complementary gap — encoding `cmd`/`option` modifiers *within* the KKP encoder for TUIs that do negotiate the protocol. The two changes do not overlap: this PR only affects sessions where KKP is off, which is precisely where the encoder has nothing to send.

Supersedes #11605, which was auto-closed by the stale-PR workflow after the author stopped responding to review, not on merit.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Visual evidence

Both captures come from a local debug build of this branch. The chords are driven into a small
alt-screen probe: it enters the alternate screen (`CSI ? 1049 h`), goes into raw mode, and prints
the raw bytes it reads from stdin — the smallest faithful stand-in for Claude Code / opencode, a
fullscreen TUI doing its own line editing.

**1. Fix working — plain alt screen, no keyboard protocol.** All seven bindings fire, delivering
exactly the bytes their actions specify:

<img width="1784" height="1124" alt="alt-screen key probe with the fix, no keyboard protocol" src="https://github.com/user-attachments/assets/79660642-89fb-422f-9ad6-155c4a0f3821" />

| chord | byte | action |
|---|---|---|
| <kbd>cmd</kbd>+<kbd>backspace</kbd> | `15` NAK ^U | `terminal:executing_command_delete_line_start` |
| <kbd>cmd</kbd>+<kbd>delete</kbd> | `0b` VT ^K | `terminal:executing_command_delete_line_end` |
| <kbd>cmd</kbd>+<kbd>left</kbd> | `01` SOH ^A | `terminal:executing_command_move_cursor_home` |
| <kbd>cmd</kbd>+<kbd>right</kbd> | `05` ENQ ^E | `terminal:executing_command_move_cursor_end` |
| <kbd>alt</kbd>+<kbd>backspace</kbd> | `17` ETB ^W | `terminal:executing_command_delete_word_left` |
| <kbd>alt</kbd>+<kbd>left</kbd> | `1b 62` ESC b | `terminal:executing_command_move_cursor_word_left` |
| <kbd>alt</kbd>+<kbd>right</kbd> | `1b 66` ESC f | `terminal:executing_command_move_cursor_word_right` |

On `master` the same pane emits nothing for any of these chords — that is the bug in #807.

**2. Guard working — same build, same chords, KKP enabled.** Identical build and keystrokes,
except the probe pushed `CSI > 1 u` first:

<img width="1784" height="1124" alt="alt-screen key probe with keyboard protocol enabled" src="https://github.com/user-attachments/assets/b0b8fff4-f6f0-4e72-8f7a-814b61adf153" />

None of `0x15 / 0x0b / 0x01 / 0x05 / 0x17` appear — the chords fall through to their normal
encodings (`7f`, `1b 5b 44`, `1b 5b 31 3b 33 44`, …), so a keyboard-protocol TUI still receives
the rich key events it asked for. That is the `& !id!(KEYBOARD_PROTOCOL_ENABLED_KEY)` half of the
predicate, exercised at runtime rather than only in the unit test. (The repeated `1b 4f 41` — SS3
A, up-arrow — lines are noise from the scripted key driver; none of the seven chords produce that
sequence. The point of the capture is the absence of the five C0 bytes above.)

### Automated coverage

Two new tests in `app/src/terminal/input_tests.rs`. They look up each binding **as actually
registered by `terminal::view::init`** and evaluate its predicate with
`EditableBindingLens::in_context` against the exact context sets `TerminalView::keymap_context`
produces — so they exercise the shipped predicate rather than a copy of it.

`test_line_editing_bindings_apply_in_alt_screen_without_keyboard_protocol`, for all seven bindings:

| context | expected |
|---|---|
| `Terminal`, `AltScreen` | **active** — the regression this PR fixes |
| `Terminal`, `LongRunningCommand` | active — unchanged behaviour |
| `Terminal` | inactive — not over-broadened; at an idle prompt these chords still reach Warp's own input editor |
| `Terminal`, `AltScreen`, `IMEOpen` | inactive — the pre-existing IME guard still wins |

`test_line_editing_bindings_suppressed_in_alt_screen_with_keyboard_protocol`:

| context | expected |
|---|---|
| `Terminal`, `AltScreen`, `KeyboardProtocolEnabled` | **inactive** |
| `Terminal`, `LongRunningCommand`, `KeyboardProtocolEnabled` | active — the new clause only applies on the alt screen |

Both were run against three variants of `init.rs` to confirm neither passes vacuously:

| `init.rs` variant | apply test | suppress test |
|---|---|---|
| upstream `c20645b`, unmodified | **FAIL** | pass |
| naive `\| id!("AltScreen")` with no KKP guard (the #11605 shape) | pass | **FAIL** |
| this PR | pass | pass |

The middle row is the point: it shows the `KEYBOARD_PROTOCOL_ENABLED_KEY` exclusion is
load-bearing and is itself covered by a test — the review concern that blocked #11605.

On unmodified upstream:

```
assertion `left == right` failed: `terminal:executing_command_move_cursor_word_left` in context {"Terminal", "AltScreen"} should be active
  left: false
 right: true
```

On the naive variant:

```
assertion `left == right` failed: `terminal:executing_command_move_cursor_word_left` in context {"AltScreen", "KeyboardProtocolEnabled", "Terminal"} should be inactive
  left: true
 right: false
```

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed macOS line-editing shortcuts (cmd+backspace, cmd+delete, cmd+left/right, alt+backspace) not working inside fullscreen TUIs such as Claude Code and opencode.

