### PR TITLE
Enable API key login across Warp channels

### DIFF
--- a/.agents/skills/tui-verify-change/SKILL.md
+++ b/.agents/skills/tui-verify-change/SKILL.md
@@ -59,16 +59,11 @@ path below.
   runner) with no browser for device-auth, so reaching a **signed-in** surface
   relies on the non-interactive `WARP_API_KEY` already in the environment. That
   does **not** mean bypassing `./script/run-tui`: when the `warp-channel-config`
-  generator is available, `./script/run-tui` selects the internal **`local`
-  dogfood** binary, and with `WARP_API_KEY` inherited that binary logs in through
-  the **same** API-key path described below — so prefer `./script/run-tui`
-  whenever it resolves to a dogfood channel, rather than skipping the maintained
-  runner. Build and run a dogfood binary **explicitly** (`warp-tui-dev`, see
-  **Logging in non-interactively** below) only when `./script/run-tui` would fall
-  back to **`warp-tui-oss`** (no generator / no repo access) — OSS isn't a dogfood
-  channel and silently drops the key — or when you need a specific binary or
-  profile. Either way, in the cloud it's the inherited `WARP_API_KEY` that signs
-  you in; the browser device-auth login is the local-only path.
+  generator is available, `./script/run-tui` selects the internal `local`
+  binary; otherwise it falls back to `warp-tui-oss`. Both accept the inherited
+  `WARP_API_KEY`, so prefer the maintained runner unless you need a specific
+  binary or profile. In the cloud, the inherited key signs you in without the
+  browser device-auth flow.
 
 The logged-**out** surface (the `Sign in to continue` placeholder and any pure
 element/layout) needs neither login path — a plain OSS build is enough in either
@@ -124,16 +119,14 @@ headless cloud runner where the key *is* set and there's no browser for
 device-auth.
 
 You can reach the authenticated (`LoggedIn`) state headlessly — no browser, no
-device-auth flow — by launching a **dogfood-channel** TUI binary with a
-`WARP_API_KEY` in the environment. This is the fast way to verify live
-terminal/transcript/input changes.
+device-auth flow — by launching any TUI channel binary with a `WARP_API_KEY` in
+the environment. This is the fast way to verify live terminal/transcript/input
+changes.
 
 Key constraints:
 
-- **Dogfood channels only.** API-key login is gated to dogfood channels (`dev`,
-  `local`) behind the `APIKeyAuthentication` flag, so it works with
-  `warp-tui-dev` (or the internal `local` binary) — **not** `warp-tui-oss`,
-  which is not a dogfood channel and will stay logged out.
+- **All channels are supported.** API-key login works with `warp-tui-oss` as
+  well as the Preview, Dev, Local, and Stable binaries.
 - **The key must already be in the environment.** In a sandbox where
   `WARP_API_KEY` is set, a freshly started `tmux` server inherits it. Never echo,
   print, or inline the secret value in a command — just rely on the inherited
@@ -142,10 +135,10 @@ Key constraints:
 
 ```bash
 cd <warp-repo-root>
-CARGO_BUILD_JOBS=2 cargo build -p warp_tui --bin warp-tui-dev
+CARGO_BUILD_JOBS=2 cargo build -p warp_tui --bin warp-tui-oss
 tmux kill-session -t tuicheck 2>/dev/null
 # WARP_API_KEY is inherited from the environment by the new tmux server.
-tmux new-session -d -s tuicheck -x 120 -y 40 './target/debug/warp-tui-dev'
+tmux new-session -d -s tuicheck -x 120 -y 40 './target/debug/warp-tui-oss'
 sleep 20                                      # login + session start
 tmux capture-pane -t tuicheck -p              # expect the logged-in zero state
 ```

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -579,7 +579,6 @@ default = [
     "mcp_oauth",
     "expand_edit_to_pane",
     "fallback_model_load_output_messaging",
-    "api_key_authentication",
     "api_key_management",
     "summarization_cancellation_confirmation",
     "ui_zoom",
@@ -942,7 +941,6 @@ code_review_save_changes = []
 remote_code_review = []
 file_tree = []
 code_launch_modal = []
-api_key_authentication = []
 api_key_management = []
 diff_set_as_context = []
 discard_per_file_and_all_changes = []

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -283,8 +283,6 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::ConversationApi,
         #[cfg(feature = "code_launch_modal")]
         FeatureFlag::CodeLaunchModal,
-        #[cfg(feature = "api_key_authentication")]
-        FeatureFlag::APIKeyAuthentication,
         #[cfg(feature = "api_key_management")]
         FeatureFlag::APIKeyManagement,
         #[cfg(feature = "mcp_oauth")]

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -383,7 +383,6 @@ pub(crate) enum LaunchMode {
     App {
         args: warp_cli::AppArgs,
         /// API key for server authentication, if provided via `--api-key` or `WARP_API_KEY`.
-        /// Only used on dogfood channels.
         api_key: Option<String>,
     },
 
@@ -429,9 +428,8 @@ pub(crate) enum LaunchMode {
         /// this mode.
         mount: TuiMountFn,
         /// API key for server authentication, if provided via `--api-key` or
-        /// `WARP_API_KEY`. Parsed by the TUI front-end and only used on dogfood
-        /// channels (mirrors `App`); lets the TUI log in non-interactively
-        /// instead of the device-auth flow.
+        /// `WARP_API_KEY`. Parsed by the TUI front-end and lets the TUI log in
+        /// non-interactively instead of the device-auth flow.
         api_key: Option<String>,
     },
 }
@@ -1337,6 +1335,16 @@ fn refresh_user_after_iap_access(ctx: &mut AppContext) {
     iap_manager.update(ctx, |manager, ctx| manager.ensure_access(ctx));
 }
 
+fn api_key_from_launch_mode(launch_mode: &LaunchMode) -> Option<String> {
+    match launch_mode {
+        LaunchMode::CommandLine { global_options, .. } => global_options.api_key.clone(),
+        LaunchMode::App { api_key, .. } | LaunchMode::Tui { api_key, .. } => api_key.clone(),
+        LaunchMode::Test { .. }
+        | LaunchMode::RemoteServerProxy
+        | LaunchMode::RemoteServerDaemon { .. } => None,
+    }
+}
+
 #[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 pub(crate) fn initialize_app(
     launch_mode: &LaunchMode,
@@ -1391,38 +1399,7 @@ pub(crate) fn initialize_app(
     }
 
     // Extract API key from command line options, if applicable.
-    let api_key = match launch_mode {
-        LaunchMode::CommandLine { global_options, .. } => global_options.api_key.clone(),
-        LaunchMode::App { api_key, .. } if ChannelState::channel().is_dogfood() => api_key.clone(),
-        LaunchMode::Tui { api_key, .. } if ChannelState::channel().is_dogfood() => api_key.clone(),
-        _ => None,
-    };
-    let api_key = if FeatureFlag::APIKeyAuthentication.is_enabled() {
-        api_key
-    } else {
-        None
-    };
-
-    // A key supplied to an App launch but dropped here means Warp will start logged out
-    // (non-dogfood channel or feature disabled). Surface this loudly so it isn't silent.
-    if api_key.is_none()
-        && matches!(
-            launch_mode,
-            LaunchMode::App {
-                api_key: Some(_),
-                ..
-            } | LaunchMode::Tui {
-                api_key: Some(_),
-                ..
-            }
-        )
-    {
-        let channel = ChannelState::channel();
-        let warning = format!(
-            "WARNING: --api-key/WARP_API_KEY was provided but IGNORED on the '{channel}' channel — Warp is starting LOGGED OUT. API-key auth is only available on internal (dogfood) builds."
-        );
-        eprintln!("{warning}");
-    }
+    let api_key = api_key_from_launch_mode(launch_mode);
 
     let auth_state = Arc::new(AuthState::initialize(ctx, api_key));
     timer.mark_interval_end("AUTH_MANAGER_SET_USER");

--- a/app/src/lib_tests.rs
+++ b/app/src/lib_tests.rs
@@ -1,6 +1,27 @@
 use super::*;
 
 #[test]
+fn app_and_tui_accept_api_keys() {
+    let app = LaunchMode::App {
+        args: Default::default(),
+        api_key: Some("app-api-key".to_owned()),
+    };
+    let tui = LaunchMode::Tui {
+        mount: Box::new(|_| {}),
+        api_key: Some("tui-api-key".to_owned()),
+    };
+
+    assert_eq!(
+        api_key_from_launch_mode(&app).as_deref(),
+        Some("app-api-key")
+    );
+    assert_eq!(
+        api_key_from_launch_mode(&tui).as_deref(),
+        Some("tui-api-key")
+    );
+}
+
+#[test]
 fn tui_uses_distinct_secure_storage_service_name() {
     let launch_mode = LaunchMode::Tui {
         mount: Box::new(|_| {}),

--- a/crates/warp_cli/Cargo.toml
+++ b/crates/warp_cli/Cargo.toml
@@ -34,7 +34,6 @@ cfg_aliases.workspace = true
 [features]
 plugin_host = []
 integration_tests = []
-api_key_authentication = []
 
 
 [dev-dependencies]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -418,9 +418,6 @@ pub enum FeatureFlag {
     /// Enables the one-time modal on app startup for existing users for the Code launch.
     CodeLaunchModal,
 
-    /// Enables API key authentication for Agent SDK
-    APIKeyAuthentication,
-
     /// Enables API key management UI in settings
     APIKeyManagement,
 


### PR DESCRIPTION
## Description

Enable direct Warp API-key authentication for every application and TUI build channel.

- Removes the obsolete `APIKeyAuthentication` runtime and Cargo feature gates.
- Passes `--api-key` / `WARP_API_KEY` through for App, TUI, and command-line launch modes without channel filtering.
- Keeps the separate `APIKeyManagement` gate unchanged.
- Updates TUI verification guidance and adds focused launch-mode coverage.

This makes non-interactive login consistent in Stable, Preview, Dev, Local, and OSS builds, which is particularly useful in headless and remote environments.

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] `./script/format`
- [x] `cargo clippy -p warp --lib --tests -- -D warnings`
- [x] `cargo test -p warp --lib app_and_tui_accept_api_keys`
- [x] Confirmed no `APIKeyAuthentication` or `api_key_authentication` references remain.
- [ ] Full `./script/presubmit`: formatting, Clippy, clang-format, and WGSL checks passed; environment-dependent SSH integration tests were blocked by expired non-interactive gcloud IAP credentials, and external suggestion tests received HTTP 501 responses.
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not applicable; this changes authentication availability without altering rendered UI.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent conversation: https://staging.warp.dev/conversation/bc9f32ca-80cf-456a-8d64-165a48e86aa2

CHANGELOG-OZ: Warp Agent CLI now supports API-key login across all build channels.

Co-Authored-By: Oz <oz-agent@warp.dev>
