### PR TITLE
[REV-1714] Use server-authoritative AI credit availability in the client

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -231,6 +231,7 @@ impl AgentMessageBar {
             if matches!(
                 event,
                 AIRequestUsageModelEvent::RequestUsageUpdated
+                    | AIRequestUsageModelEvent::CreditAvailabilityUpdated
                     | AIRequestUsageModelEvent::AmbientCreditsBannerDismissed
             ) {
                 ctx.notify();

--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -12,6 +12,7 @@ use warpui::{
 
 use crate::ai::AIRequestUsageModel;
 use crate::ai::blocklist::error_color;
+use crate::ai::credit_availability::{AICreditAvailability, AICreditDenialReason};
 use crate::auth::AuthStateProvider;
 use crate::network::NetworkStatus;
 use crate::server::ids::ServerId;
@@ -142,6 +143,16 @@ impl PromptAlertView {
             }
         }
 
+        // The server-authoritative availability decision drives the alert once
+        // it has been fetched; local data below is only a pre-fetch fallback.
+        if let Some(availability) = request_usage_model.server_availability() {
+            return Self::state_from_server_availability(availability, app);
+        }
+
+        // Legacy locally derived fallback, used only before the first
+        // successful availability fetch (e.g. right after startup or against
+        // servers that don't support the availability field yet).
+
         // Next, make sure the user isn't delinquent in their plan.
         let workspace = UserWorkspaces::as_ref(app).current_workspace();
         if workspace.is_some_and(|w| w.billing_metadata.is_delinquent_due_to_payment_issue()) {
@@ -153,8 +164,38 @@ impl PromptAlertView {
             return PromptAlertState::NoAlert;
         }
 
+        Self::out_of_credits_presentation(app)
+    }
+
+    /// Maps the server-authoritative availability decision to presentation
+    /// state. The server decides *whether* AI is available; workspace policy
+    /// only shapes the call-to-action copy.
+    fn state_from_server_availability(
+        availability: AICreditAvailability,
+        app: &AppContext,
+    ) -> PromptAlertState {
+        if availability.available {
+            return PromptAlertState::NoAlert;
+        }
+
+        match availability.denial_reason {
+            AICreditDenialReason::Delinquent => PromptAlertState::DelinquentDueToPaymentIssue,
+            AICreditDenialReason::EnterpriseTeamSpendLimitHit
+            | AICreditDenialReason::EnterprisePerUserSpendLimitHit
+            | AICreditDenialReason::EnterpriseWorkspaceSpendLimitHit => {
+                PromptAlertState::MonthlyOveragesSpendLimitReached
+            }
+            AICreditDenialReason::None
+            | AICreditDenialReason::OutOfCredits
+            | AICreditDenialReason::Unknown => Self::out_of_credits_presentation(app),
+        }
+    }
+
+    /// Picks the most actionable presentation for an out-of-credits denial
+    /// based on the current workspace's overage policy.
+    fn out_of_credits_presentation(app: &AppContext) -> PromptAlertState {
         // Check if overages are available.
-        if let Some(workspace) = workspace {
+        if let Some(workspace) = UserWorkspaces::as_ref(app).current_workspace() {
             let are_overages_toggleable = workspace.are_overages_toggleable();
             let are_overages_enabled = workspace.are_overages_enabled();
 
@@ -478,3 +519,7 @@ impl TypedActionView for PromptAlertView {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "prompt_alert_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -175,7 +175,14 @@ impl PromptAlertView {
         app: &AppContext,
     ) -> PromptAlertState {
         if availability.available {
-            return PromptAlertState::NoAlert;
+            // Capability-only availability (no credit source) is refined with
+            // local key knowledge by `has_any_ai_remaining`: the server cannot
+            // see locally stored API keys, so without a usable BYO path the
+            // user is effectively out of credits.
+            if AIRequestUsageModel::as_ref(app).has_any_ai_remaining(app) {
+                return PromptAlertState::NoAlert;
+            }
+            return Self::out_of_credits_presentation(app);
         }
 
         match availability.denial_reason {

--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -175,14 +175,7 @@ impl PromptAlertView {
         app: &AppContext,
     ) -> PromptAlertState {
         if availability.available {
-            // Capability-only availability (no credit source) is refined with
-            // local key knowledge by `has_any_ai_remaining`: the server cannot
-            // see locally stored API keys, so without a usable BYO path the
-            // user is effectively out of credits.
-            if AIRequestUsageModel::as_ref(app).has_any_ai_remaining(app) {
-                return PromptAlertState::NoAlert;
-            }
-            return Self::out_of_credits_presentation(app);
+            return PromptAlertState::NoAlert;
         }
 
         match availability.denial_reason {
@@ -194,7 +187,15 @@ impl PromptAlertView {
             }
             AICreditDenialReason::None
             | AICreditDenialReason::OutOfCredits
-            | AICreditDenialReason::Unknown => Self::out_of_credits_presentation(app),
+            | AICreditDenialReason::Unknown => {
+                // An out-of-credits denial only means the server found no path
+                // it can see; a locally stored API key still permits requests,
+                // which `has_any_ai_remaining` accounts for.
+                if AIRequestUsageModel::as_ref(app).has_any_ai_remaining(app) {
+                    return PromptAlertState::NoAlert;
+                }
+                Self::out_of_credits_presentation(app)
+            }
         }
     }
 

--- a/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use warpui::App;
+
+use super::*;
+use crate::ai::credit_availability::AICreditSource;
+use crate::server::server_api::ServerApiProvider;
+use crate::server::server_api::team::MockTeamClient;
+use crate::server::server_api::workspace::MockWorkspaceClient;
+
+fn initialize_app(app: &mut App) {
+    app.add_singleton_model(|_| NetworkStatus::new());
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+    app.add_singleton_model(|ctx| {
+        UserWorkspaces::mock(
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+            vec![],
+            ctx,
+        )
+    });
+    if app
+        .models_of_type::<settings::PrivatePreferences>()
+        .is_empty()
+    {
+        app.update(crate::settings::init_and_register_user_preferences);
+    }
+    app.update(|ctx| {
+        warpui_extras::secure_storage::register_noop("test", ctx);
+        ctx.add_singleton_model(ApiKeyManager::new);
+    });
+    app.add_singleton_model(|_| crate::pricing::PricingInfoModel::new());
+    app.add_singleton_model(|ctx| {
+        AIRequestUsageModel::new_for_test(ServerApiProvider::as_ref(ctx).get_ai_client(), ctx)
+    });
+}
+
+fn apply_server_availability(app: &mut App, availability: AICreditAvailability) {
+    AIRequestUsageModel::handle(app).update(app, |model, ctx| {
+        model.apply_server_availability(Ok(availability), ctx);
+    });
+}
+
+fn determine_state(app: &mut App) -> PromptAlertState {
+    app.read(PromptAlertView::determine_state)
+}
+
+#[test]
+fn test_server_available_maps_to_no_alert() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        apply_server_availability(
+            &mut app,
+            AICreditAvailability::available_with_source(Some(AICreditSource::BaseLimit)),
+        );
+        assert_eq!(determine_state(&mut app), PromptAlertState::NoAlert);
+    });
+}
+
+#[test]
+fn test_server_delinquent_maps_to_delinquency_alert() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        apply_server_availability(
+            &mut app,
+            AICreditAvailability::unavailable(AICreditDenialReason::Delinquent),
+        );
+        assert_eq!(
+            determine_state(&mut app),
+            PromptAlertState::DelinquentDueToPaymentIssue
+        );
+    });
+}
+
+#[test]
+fn test_server_spend_limit_reasons_map_to_spend_limit_alert() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        for reason in [
+            AICreditDenialReason::EnterpriseTeamSpendLimitHit,
+            AICreditDenialReason::EnterprisePerUserSpendLimitHit,
+            AICreditDenialReason::EnterpriseWorkspaceSpendLimitHit,
+        ] {
+            apply_server_availability(&mut app, AICreditAvailability::unavailable(reason));
+            assert_eq!(
+                determine_state(&mut app),
+                PromptAlertState::MonthlyOveragesSpendLimitReached,
+                "unexpected alert state for {reason:?}",
+            );
+        }
+    });
+}
+
+#[test]
+fn test_server_out_of_credits_maps_to_request_limit_reached() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        // With no workspace overage policy in play, an out-of-credits denial
+        // falls through to the generic request limit alert.
+        for reason in [
+            AICreditDenialReason::OutOfCredits,
+            AICreditDenialReason::Unknown,
+        ] {
+            apply_server_availability(&mut app, AICreditAvailability::unavailable(reason));
+            assert_eq!(
+                determine_state(&mut app),
+                PromptAlertState::RequestLimitReached,
+                "unexpected alert state for {reason:?}",
+            );
+        }
+    });
+}
+
+#[test]
+fn test_legacy_fallback_used_before_first_server_response() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        // No server availability applied: the default request limit info has
+        // requests remaining, so the legacy derivation reports no alert.
+        assert_eq!(determine_state(&mut app), PromptAlertState::NoAlert);
+    });
+}

--- a/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
@@ -7,8 +7,13 @@ use crate::ai::credit_availability::AICreditSource;
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::team::MockTeamClient;
 use crate::server::server_api::workspace::MockWorkspaceClient;
+use crate::workspaces::workspace::{ByoApiKeyPolicy, Workspace, WorkspaceUid};
 
 fn initialize_app(app: &mut App) {
+    initialize_app_with_workspaces(app, vec![]);
+}
+
+fn initialize_app_with_workspaces(app: &mut App, workspaces: Vec<Workspace>) {
     app.add_singleton_model(|_| NetworkStatus::new());
     app.add_singleton_model(|_| AuthStateProvider::new_for_test());
     app.add_singleton_model(|_| ServerApiProvider::new_for_test());
@@ -16,7 +21,7 @@ fn initialize_app(app: &mut App) {
         UserWorkspaces::mock(
             Arc::new(MockTeamClient::new()),
             Arc::new(MockWorkspaceClient::new()),
-            vec![],
+            workspaces,
             ctx,
         )
     });
@@ -118,6 +123,38 @@ fn test_legacy_fallback_used_before_first_server_response() {
         initialize_app(&mut app);
         // No server availability applied: the default request limit info has
         // requests remaining, so the legacy derivation reports no alert.
+        assert_eq!(determine_state(&mut app), PromptAlertState::NoAlert);
+    });
+}
+
+#[test]
+fn test_capability_only_without_local_key_maps_to_out_of_credits() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        // The server allows BYO by policy but found no credit source; with no
+        // locally stored key this is effectively out of credits.
+        apply_server_availability(&mut app, AICreditAvailability::available_with_source(None));
+        assert_eq!(
+            determine_state(&mut app),
+            PromptAlertState::RequestLimitReached
+        );
+    });
+}
+
+#[test]
+fn test_capability_only_with_local_key_maps_to_no_alert() {
+    App::test((), |mut app| async move {
+        let uid = WorkspaceUid::from(crate::server::ids::ServerId::from(1_i64));
+        let mut workspace = Workspace::from_local_cache(uid, "Test Workspace".to_string(), None);
+        workspace.billing_metadata.tier.byo_api_key_policy =
+            Some(ByoApiKeyPolicy { enabled: true });
+        initialize_app_with_workspaces(&mut app, vec![workspace]);
+
+        ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.set_openai_key(Some("test-key".to_string()), ctx);
+        });
+
+        apply_server_availability(&mut app, AICreditAvailability::available_with_source(None));
         assert_eq!(determine_state(&mut app), PromptAlertState::NoAlert);
     });
 }

--- a/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
@@ -128,21 +128,18 @@ fn test_legacy_fallback_used_before_first_server_response() {
 }
 
 #[test]
-fn test_capability_only_without_local_key_maps_to_out_of_credits() {
+fn test_server_managed_availability_maps_to_no_alert() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);
-        // The server allows BYO by policy but found no credit source; with no
-        // locally stored key this is effectively out of credits.
+        // `available` with no credit source means a server-managed BYO path
+        // is configured — definite availability, no local key required.
         apply_server_availability(&mut app, AICreditAvailability::available_with_source(None));
-        assert_eq!(
-            determine_state(&mut app),
-            PromptAlertState::RequestLimitReached
-        );
+        assert_eq!(determine_state(&mut app), PromptAlertState::NoAlert);
     });
 }
 
 #[test]
-fn test_capability_only_with_local_key_maps_to_no_alert() {
+fn test_out_of_credits_with_local_key_maps_to_no_alert() {
     App::test((), |mut app| async move {
         let uid = WorkspaceUid::from(crate::server::ids::ServerId::from(1_i64));
         let mut workspace = Workspace::from_local_cache(uid, "Test Workspace".to_string(), None);
@@ -154,7 +151,12 @@ fn test_capability_only_with_local_key_maps_to_no_alert() {
             manager.set_openai_key(Some("test-key".to_string()), ctx);
         });
 
-        apply_server_availability(&mut app, AICreditAvailability::available_with_source(None));
+        // The server cannot see the locally stored key; the client refines
+        // its OUT_OF_CREDITS answer.
+        apply_server_availability(
+            &mut app,
+            AICreditAvailability::unavailable(AICreditDenialReason::OutOfCredits),
+        );
         assert_eq!(determine_state(&mut app), PromptAlertState::NoAlert);
     });
 }

--- a/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert_tests.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use ai::LLMProvider;
 use warpui::App;
 
 use super::*;
@@ -148,7 +149,7 @@ fn test_out_of_credits_with_local_key_maps_to_no_alert() {
         initialize_app_with_workspaces(&mut app, vec![workspace]);
 
         ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
-            manager.set_openai_key(Some("test-key".to_string()), ctx);
+            manager.set_provider_key(LLMProvider::OpenAI, Some("test-key".to_string()), ctx);
         });
 
         // The server cannot see the locally stored key; the client refines

--- a/app/src/ai/credit_availability.rs
+++ b/app/src/ai/credit_availability.rs
@@ -1,0 +1,111 @@
+//! Domain types for the server-authoritative AI credit availability decision
+//! (`User.aiCreditAvailability`). The server evaluates the same credit
+//! waterfall used to authorize AI requests, so these values are the source of
+//! truth for whether the user can start an interactive AI request.
+use warp_graphql::ai::{
+    AICreditAvailability as GqlAICreditAvailability,
+    AICreditAvailabilityDenialReason as GqlAICreditAvailabilityDenialReason,
+    AICreditAvailabilitySource as GqlAICreditAvailabilitySource,
+};
+
+/// Stable, client-safe reason the server reports when no inference access
+/// exists. `None` is reported when the user is available.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AICreditDenialReason {
+    None,
+    OutOfCredits,
+    Delinquent,
+    EnterpriseTeamSpendLimitHit,
+    EnterprisePerUserSpendLimitHit,
+    EnterpriseWorkspaceSpendLimitHit,
+    /// A reason from a newer server that this client version doesn't know.
+    /// Treated as a generic denial for presentation purposes.
+    Unknown,
+}
+
+/// The credit source the server selected when inference access exists.
+/// Capability-only access (e.g. BYO API key) has no credit source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AICreditSource {
+    BaseLimit,
+    BonusGrant,
+    Payg,
+    Overage,
+    AmbientBonusGrant,
+    /// A source from a newer server that this client version doesn't know.
+    Unknown,
+}
+
+/// The server-authoritative answer to "can this user start an interactive AI
+/// request right now".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AICreditAvailability {
+    pub available: bool,
+    pub denial_reason: AICreditDenialReason,
+    pub credit_source: Option<AICreditSource>,
+}
+
+impl AICreditAvailability {
+    pub fn available_with_source(credit_source: Option<AICreditSource>) -> Self {
+        Self {
+            available: true,
+            denial_reason: AICreditDenialReason::None,
+            credit_source,
+        }
+    }
+
+    pub fn unavailable(denial_reason: AICreditDenialReason) -> Self {
+        Self {
+            available: false,
+            denial_reason,
+            credit_source: None,
+        }
+    }
+}
+
+impl From<GqlAICreditAvailabilityDenialReason> for AICreditDenialReason {
+    fn from(reason: GqlAICreditAvailabilityDenialReason) -> Self {
+        match reason {
+            GqlAICreditAvailabilityDenialReason::None => Self::None,
+            GqlAICreditAvailabilityDenialReason::OutOfCredits => Self::OutOfCredits,
+            GqlAICreditAvailabilityDenialReason::Delinquent => Self::Delinquent,
+            GqlAICreditAvailabilityDenialReason::EnterpriseTeamSpendLimitHit => {
+                Self::EnterpriseTeamSpendLimitHit
+            }
+            GqlAICreditAvailabilityDenialReason::EnterprisePerUserSpendLimitHit => {
+                Self::EnterprisePerUserSpendLimitHit
+            }
+            GqlAICreditAvailabilityDenialReason::EnterpriseWorkspaceSpendLimitHit => {
+                Self::EnterpriseWorkspaceSpendLimitHit
+            }
+            GqlAICreditAvailabilityDenialReason::Other(_) => Self::Unknown,
+        }
+    }
+}
+
+impl From<GqlAICreditAvailabilitySource> for AICreditSource {
+    fn from(source: GqlAICreditAvailabilitySource) -> Self {
+        match source {
+            GqlAICreditAvailabilitySource::BaseLimit => Self::BaseLimit,
+            GqlAICreditAvailabilitySource::BonusGrant => Self::BonusGrant,
+            GqlAICreditAvailabilitySource::Payg => Self::Payg,
+            GqlAICreditAvailabilitySource::Overage => Self::Overage,
+            GqlAICreditAvailabilitySource::AmbientBonusGrant => Self::AmbientBonusGrant,
+            GqlAICreditAvailabilitySource::Other(_) => Self::Unknown,
+        }
+    }
+}
+
+impl From<GqlAICreditAvailability> for AICreditAvailability {
+    fn from(availability: GqlAICreditAvailability) -> Self {
+        Self {
+            available: availability.available,
+            denial_reason: availability.denial_reason.into(),
+            credit_source: availability.credit_source.map(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "credit_availability_tests.rs"]
+mod tests;

--- a/app/src/ai/credit_availability_tests.rs
+++ b/app/src/ai/credit_availability_tests.rs
@@ -1,0 +1,98 @@
+use warp_graphql::ai::{
+    AICreditAvailability as GqlAICreditAvailability,
+    AICreditAvailabilityDenialReason as GqlDenialReason, AICreditAvailabilitySource as GqlSource,
+};
+
+use super::{AICreditAvailability, AICreditDenialReason, AICreditSource};
+
+#[test]
+fn converts_every_documented_denial_reason() {
+    let cases = [
+        (GqlDenialReason::None, AICreditDenialReason::None),
+        (
+            GqlDenialReason::OutOfCredits,
+            AICreditDenialReason::OutOfCredits,
+        ),
+        (
+            GqlDenialReason::Delinquent,
+            AICreditDenialReason::Delinquent,
+        ),
+        (
+            GqlDenialReason::EnterpriseTeamSpendLimitHit,
+            AICreditDenialReason::EnterpriseTeamSpendLimitHit,
+        ),
+        (
+            GqlDenialReason::EnterprisePerUserSpendLimitHit,
+            AICreditDenialReason::EnterprisePerUserSpendLimitHit,
+        ),
+        (
+            GqlDenialReason::EnterpriseWorkspaceSpendLimitHit,
+            AICreditDenialReason::EnterpriseWorkspaceSpendLimitHit,
+        ),
+    ];
+    for (gql, expected) in cases {
+        assert_eq!(AICreditDenialReason::from(gql), expected);
+    }
+}
+
+#[test]
+fn converts_every_documented_credit_source() {
+    let cases = [
+        (GqlSource::BaseLimit, AICreditSource::BaseLimit),
+        (GqlSource::BonusGrant, AICreditSource::BonusGrant),
+        (GqlSource::Payg, AICreditSource::Payg),
+        (GqlSource::Overage, AICreditSource::Overage),
+        (
+            GqlSource::AmbientBonusGrant,
+            AICreditSource::AmbientBonusGrant,
+        ),
+    ];
+    for (gql, expected) in cases {
+        assert_eq!(AICreditSource::from(gql), expected);
+    }
+}
+
+#[test]
+fn converts_unknown_enum_values_to_unknown() {
+    assert_eq!(
+        AICreditDenialReason::from(GqlDenialReason::Other("FUTURE_REASON".to_string())),
+        AICreditDenialReason::Unknown
+    );
+    assert_eq!(
+        AICreditSource::from(GqlSource::Other("FUTURE_SOURCE".to_string())),
+        AICreditSource::Unknown
+    );
+}
+
+#[test]
+fn converts_full_availability_payload() {
+    let available = AICreditAvailability::from(GqlAICreditAvailability {
+        available: true,
+        denial_reason: GqlDenialReason::None,
+        credit_source: Some(GqlSource::BaseLimit),
+    });
+    assert_eq!(
+        available,
+        AICreditAvailability::available_with_source(Some(AICreditSource::BaseLimit))
+    );
+
+    let capability_only = AICreditAvailability::from(GqlAICreditAvailability {
+        available: true,
+        denial_reason: GqlDenialReason::None,
+        credit_source: None,
+    });
+    assert_eq!(
+        capability_only,
+        AICreditAvailability::available_with_source(None)
+    );
+
+    let denied = AICreditAvailability::from(GqlAICreditAvailability {
+        available: false,
+        denial_reason: GqlDenialReason::OutOfCredits,
+        credit_source: None,
+    });
+    assert_eq!(
+        denied,
+        AICreditAvailability::unavailable(AICreditDenialReason::OutOfCredits)
+    );
+}

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod conversation_navigation;
 pub(crate) mod conversation_rename;
 pub(crate) mod conversation_status_ui;
 pub(crate) mod conversation_utils;
+pub mod credit_availability;
 pub(crate) mod custom_model_router_editor;
 pub(crate) mod custom_model_routers;
 pub(crate) mod document;
@@ -55,6 +56,7 @@ pub(crate) mod skills;
 pub(crate) mod tui_api_keys;
 pub(crate) mod voice;
 pub use agent_tips::*;
+pub use credit_availability::*;
 pub use request_usage_model::*;
 use warpui::AppContext;
 #[cfg(not(target_family = "wasm"))]

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ai::api_keys::ApiKeyManager;
+use ai::api_keys::{ApiKeyManager, AwsCredentialsState};
 use anyhow::Context as _;
 use chrono::{DateTime, Local, Utc};
 use futures::channel::oneshot::{self, Receiver};
@@ -547,14 +547,22 @@ impl AIRequestUsageModel {
         ) && Self::has_usable_byo_inference_path(ctx)
     }
 
-    /// Whether a BYO inference path is actually usable from this client: a
-    /// locally stored API key, custom endpoint, or connected Grok subscription
-    /// (when the BYOK policy allows it). Server-managed paths (team-managed
-    /// keys/endpoints, enterprise custom LLM) are already reflected in the
-    /// server's availability decision.
+    /// Whether a BYO inference path is usable with credentials held on this
+    /// machine: a stored API key, custom endpoint, or Grok subscription (when
+    /// the BYOK policy allows it), or loaded local-chain AWS credentials for
+    /// an enabled Bedrock host. Server-managed paths are already reflected in
+    /// the server's availability decision.
     fn has_usable_byo_inference_path(ctx: &AppContext) -> bool {
-        UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx)
-            && ApiKeyManager::as_ref(ctx).has_any_key()
+        let user_workspaces = UserWorkspaces::as_ref(ctx);
+        let api_keys = ApiKeyManager::as_ref(ctx);
+        if user_workspaces.is_byo_api_key_enabled(ctx) && api_keys.has_any_key() {
+            return true;
+        }
+        user_workspaces.is_aws_bedrock_credentials_enabled(ctx)
+            && matches!(
+                api_keys.aws_credentials_state(),
+                AwsCredentialsState::Loaded { .. }
+            )
     }
 
     /// Legacy locally derived availability check. Returns `true` if the user

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -15,7 +15,7 @@ use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 use crate::BlocklistAIHistoryModel;
 use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::credit_availability::AICreditAvailability;
+use crate::ai::credit_availability::{AICreditAvailability, AICreditDenialReason};
 use crate::auth::AuthStateProvider;
 use crate::pricing::PricingInfoModel;
 use crate::server::server_api::ai::AIClient;
@@ -527,36 +527,34 @@ impl AIRequestUsageModel {
         self.has_any_ai_remaining_from_local_state(ctx)
     }
 
-    /// Interprets the server-authoritative decision. Capability-only
-    /// availability (available with no credit source) means "no Warp credits,
-    /// but BYO inference is allowed by policy" — the server cannot see locally
-    /// stored API keys, so the client contributes that one fact and treats
-    /// capability-only availability without a usable BYO path as out of
-    /// credits.
+    /// Interprets the server-authoritative decision. `available` means the
+    /// server knows for a fact that requests can run (a Warp credit source or
+    /// a server-managed BYO path) and is trusted outright. An `OutOfCredits`
+    /// denial means the server found no path *it can see* — locally stored
+    /// API keys are request-level parameters invisible to it — so the client
+    /// contributes that one fact. Every other denial is a hard rejection that
+    /// local keys cannot bypass.
     fn server_availability_permits_ai(
         availability: AICreditAvailability,
         ctx: &AppContext,
     ) -> bool {
-        if !availability.available {
-            return false;
-        }
-        if availability.credit_source.is_some() {
+        if availability.available {
             return true;
         }
-        Self::has_usable_byo_inference_path(ctx)
+        matches!(
+            availability.denial_reason,
+            AICreditDenialReason::OutOfCredits
+        ) && Self::has_usable_byo_inference_path(ctx)
     }
 
     /// Whether a BYO inference path is actually usable from this client: a
     /// locally stored API key, custom endpoint, or connected Grok subscription
-    /// (when the BYOK policy allows it), or a team-managed custom LLM
-    /// configuration.
+    /// (when the BYOK policy allows it). Server-managed paths (team-managed
+    /// keys/endpoints, enterprise custom LLM) are already reflected in the
+    /// server's availability decision.
     fn has_usable_byo_inference_path(ctx: &AppContext) -> bool {
-        let has_byo_credentials = UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx)
-            && ApiKeyManager::as_ref(ctx).has_any_key();
-        let has_team_custom_llm = UserWorkspaces::as_ref(ctx)
-            .current_team()
-            .is_some_and(|team| team.is_custom_llm_enabled());
-        has_byo_credentials || has_team_custom_llm
+        UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx)
+            && ApiKeyManager::as_ref(ctx).has_any_key()
     }
 
     /// Legacy locally derived availability check. Returns `true` if the user

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -517,14 +517,46 @@ impl AIRequestUsageModel {
     ///
     /// Once a server-authoritative availability decision has been received
     /// this session, that decision (last-known-good on transient refresh
-    /// failures) is the only authority. The locally derived fallback below is
-    /// used solely before the first successful fetch, e.g. right after startup
-    /// or against servers that don't support the availability field yet.
+    /// failures) is the authority. The locally derived fallback below is used
+    /// solely before the first successful fetch, e.g. right after startup or
+    /// against servers that don't support the availability field yet.
     pub fn has_any_ai_remaining(&self, ctx: &AppContext) -> bool {
         if let Some(availability) = self.server_availability.latest {
-            return availability.available;
+            return Self::server_availability_permits_ai(availability, ctx);
         }
         self.has_any_ai_remaining_from_local_state(ctx)
+    }
+
+    /// Interprets the server-authoritative decision. Capability-only
+    /// availability (available with no credit source) means "no Warp credits,
+    /// but BYO inference is allowed by policy" — the server cannot see locally
+    /// stored API keys, so the client contributes that one fact and treats
+    /// capability-only availability without a usable BYO path as out of
+    /// credits.
+    fn server_availability_permits_ai(
+        availability: AICreditAvailability,
+        ctx: &AppContext,
+    ) -> bool {
+        if !availability.available {
+            return false;
+        }
+        if availability.credit_source.is_some() {
+            return true;
+        }
+        Self::has_usable_byo_inference_path(ctx)
+    }
+
+    /// Whether a BYO inference path is actually usable from this client: a
+    /// locally stored API key, custom endpoint, or connected Grok subscription
+    /// (when the BYOK policy allows it), or a team-managed custom LLM
+    /// configuration.
+    fn has_usable_byo_inference_path(ctx: &AppContext) -> bool {
+        let has_byo_credentials = UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx)
+            && ApiKeyManager::as_ref(ctx).has_any_key();
+        let has_team_custom_llm = UserWorkspaces::as_ref(ctx)
+            .current_team()
+            .is_some_and(|team| team.is_custom_llm_enabled());
+        has_byo_credentials || has_team_custom_llm
     }
 
     /// Legacy locally derived availability check. Returns `true` if the user

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -15,6 +15,7 @@ use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 use crate::BlocklistAIHistoryModel;
 use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::credit_availability::AICreditAvailability;
 use crate::auth::AuthStateProvider;
 use crate::pricing::PricingInfoModel;
 use crate::server::server_api::ai::AIClient;
@@ -184,6 +185,24 @@ fn get_cached_ambient_credits_banner_dismissed(app_mut: &mut AppContext) -> bool
         .unwrap_or_default()
 }
 
+/// The server-authoritative AI credit availability state shared by all AI
+/// surfaces. It is fed from exactly two paths: the workspace metadata refresh
+/// piggyback (primary cadence) and targeted fetches after meaningful state
+/// changes (auth completion, plan/billing, workspace selection, credentials).
+#[derive(Default)]
+struct ServerAvailabilityState {
+    /// The last successfully fetched decision. Retained as last-known-good
+    /// when a refresh fails; never cleared by transient errors.
+    latest: Option<AICreditAvailability>,
+    /// When `latest` was last updated from a successful response.
+    last_success_time: Option<Instant>,
+    /// Whether a targeted availability fetch is currently in flight. Used to
+    /// coalesce coincident event-triggered fetches.
+    refresh_in_flight: bool,
+    /// The most recent refresh failure, kept until the next success.
+    last_error: Option<String>,
+}
+
 pub struct AIRequestUsageModel {
     ai_client: Arc<dyn AIClient>,
 
@@ -193,6 +212,8 @@ pub struct AIRequestUsageModel {
     request_limit_info: RequestLimitInfo,
 
     bonus_grants: Vec<BonusGrant>,
+
+    server_availability: ServerAvailabilityState,
 
     /// Whether the buy credits banner has been dismissed by the user.
     buy_addon_credits_banner_dismissed: bool,
@@ -207,6 +228,8 @@ impl Entity for AIRequestUsageModel {
 
 pub enum AIRequestUsageModelEvent {
     RequestUsageUpdated,
+    /// The server-authoritative credit availability decision was updated.
+    CreditAvailabilityUpdated,
     AmbientCreditsBannerDismissed,
     RequestBonusRefunded {
         requests_refunded: i32,
@@ -228,6 +251,7 @@ impl AIRequestUsageModel {
             request_limit_info,
             last_update_time: None,
             bonus_grants: vec![],
+            server_availability: ServerAvailabilityState::default(),
             buy_addon_credits_banner_dismissed: false,
             ambient_credits_banner_dismissed,
         }
@@ -240,6 +264,7 @@ impl AIRequestUsageModel {
             last_update_time: None,
             request_limit_info: RequestLimitInfo::default(),
             bonus_grants: vec![],
+            server_availability: ServerAvailabilityState::default(),
             buy_addon_credits_banner_dismissed: false,
             ambient_credits_banner_dismissed: get_cached_ambient_credits_banner_dismissed(ctx),
         }
@@ -308,6 +333,72 @@ impl AIRequestUsageModel {
         });
 
         ctx.emit(AIRequestUsageModelEvent::RequestUsageUpdated);
+    }
+
+    /// The server-authoritative availability decision, if one has been
+    /// successfully fetched this session (last-known-good on refresh failure).
+    pub fn server_availability(&self) -> Option<AICreditAvailability> {
+        self.server_availability.latest
+    }
+
+    /// Records the outcome of an availability fetch, whether piggybacked on a
+    /// workspace metadata refresh or from a targeted fetch.
+    ///
+    /// A failure keeps the last-known-good decision: a transport or resolver
+    /// error must never flip availability in either direction, and legacy
+    /// locally derived availability must not be re-enabled once a valid server
+    /// decision has been received.
+    pub fn apply_server_availability(
+        &mut self,
+        result: Result<AICreditAvailability, anyhow::Error>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match result {
+            Ok(availability) => {
+                self.server_availability.latest = Some(availability);
+                self.server_availability.last_success_time = Some(Instant::now());
+                self.server_availability.last_error = None;
+                ctx.emit(AIRequestUsageModelEvent::CreditAvailabilityUpdated);
+                ctx.notify();
+            }
+            Err(e) => {
+                log::warn!("Failed to refresh AI credit availability: {e:#}");
+                self.server_availability.last_error = Some(format!("{e:#}"));
+            }
+        }
+    }
+
+    /// Fetches the server-authoritative availability decision in response to a
+    /// meaningful state change (auth completion, plan/billing change,
+    /// workspace selection change, or API-key/credential change).
+    ///
+    /// Coincident triggers are coalesced: if a fetch is already in flight this
+    /// is a no-op. There is intentionally no retry loop — the next qualifying
+    /// trigger or workspace metadata refresh serves as the retry.
+    pub fn request_availability_refresh(&mut self, ctx: &mut ModelContext<Self>) {
+        if !AuthStateProvider::as_ref(ctx).get().is_logged_in() {
+            return;
+        }
+        if self.server_availability.refresh_in_flight {
+            return;
+        }
+        self.server_availability.refresh_in_flight = true;
+
+        let ai_client = self.ai_client.clone();
+        ctx.spawn(
+            async move { ai_client.get_ai_credit_availability().await },
+            |model, result, ctx| {
+                model.server_availability.refresh_in_flight = false;
+                model.apply_server_availability(result, ctx);
+            },
+        );
+    }
+
+    /// Clears the server-authoritative availability state, e.g. on logout.
+    pub fn reset_server_availability(&mut self, ctx: &mut ModelContext<Self>) {
+        self.server_availability = ServerAvailabilityState::default();
+        ctx.emit(AIRequestUsageModelEvent::CreditAvailabilityUpdated);
+        ctx.notify();
     }
 
     pub fn provide_negative_feedback_response_for_ai_conversation(
@@ -421,7 +512,23 @@ impl AIRequestUsageModel {
         self.requests_remaining() > 0
     }
 
-    /// Returns `true` if the user meets one of the following conditions:
+    /// Returns `true` if the user can start an interactive AI request.
+    /// Use this method as the starting point for AI availability checking.
+    ///
+    /// Once a server-authoritative availability decision has been received
+    /// this session, that decision (last-known-good on transient refresh
+    /// failures) is the only authority. The locally derived fallback below is
+    /// used solely before the first successful fetch, e.g. right after startup
+    /// or against servers that don't support the availability field yet.
+    pub fn has_any_ai_remaining(&self, ctx: &AppContext) -> bool {
+        if let Some(availability) = self.server_availability.latest {
+            return availability.available;
+        }
+        self.has_any_ai_remaining_from_local_state(ctx)
+    }
+
+    /// Legacy locally derived availability check. Returns `true` if the user
+    /// meets one of the following conditions:
     /// 1. user has ai credits from the plan base limit
     /// 2. user has overage enabled
     /// 3. user has bonus grants (either team grants or user grants)
@@ -430,8 +537,7 @@ impl AIRequestUsageModel {
     /// 6. user's team has self-serve auto-reload enabled within its monthly spend limit
     /// 7. user has BYOK enabled and has either provided at least one API key or
     ///    connected a Grok subscription
-    /// Use this method as the starting point for AI availability checking.
-    pub fn has_any_ai_remaining(&self, ctx: &AppContext) -> bool {
+    fn has_any_ai_remaining_from_local_state(&self, ctx: &AppContext) -> bool {
         let current_workspace = UserWorkspaces::as_ref(ctx).current_workspace();
 
         let has_base_plan_ai_requests = self.has_requests_remaining();

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -8,9 +8,11 @@ use warp_graphql::billing::{AddonCreditsOption, OveragesPricing, PricingInfo};
 use warpui::{App, ModelHandle};
 
 use super::*;
+use crate::ai::credit_availability::{AICreditDenialReason, AICreditSource};
 use crate::auth::AuthStateProvider;
 use crate::pricing::PricingInfoModel;
 use crate::server::server_api::ServerApiProvider;
+use crate::server::server_api::ai::MockAIClient;
 use crate::server::server_api::team::MockTeamClient;
 use crate::server::server_api::workspace::MockWorkspaceClient;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -71,6 +73,16 @@ fn add_request_usage_model_without_auth(app: &mut App) -> ModelHandle<AIRequestU
     app.add_singleton_model(|ctx| {
         AIRequestUsageModel::new_for_test(ServerApiProvider::as_ref(ctx).get_ai_client(), ctx)
     })
+}
+
+/// Registers the request usage model backed by an explicit AI client so tests
+/// can control the availability fetch behavior.
+fn add_request_usage_model_with_client(
+    app: &mut App,
+    ai_client: Arc<dyn AIClient>,
+) -> ModelHandle<AIRequestUsageModel> {
+    register_user_preferences_for_tests(app);
+    app.add_singleton_model(|ctx| AIRequestUsageModel::new_for_test(ai_client, ctx))
 }
 
 fn set_addon_credits_pricing_info(app: &mut App) {
@@ -901,6 +913,172 @@ fn test_has_any_ai_remaining_false_with_only_ambient_bonus_credits() {
                 !model.has_any_ai_remaining(ctx),
                 "expected has_any_ai_remaining to be false when only ambient-only bonus credits exist",
             );
+        });
+    });
+}
+
+#[test]
+fn test_server_availability_overrides_locally_derived_state() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            // Local state says AI is available.
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 5);
+            assert!(model.has_any_ai_remaining(ctx));
+
+            // The server-authoritative decision wins over local state.
+            model.apply_server_availability(
+                Ok(AICreditAvailability::unavailable(
+                    AICreditDenialReason::OutOfCredits,
+                )),
+                ctx,
+            );
+            assert!(!model.has_any_ai_remaining(ctx));
+
+            // And in the other direction: local state is exhausted, but the
+            // server reports a usable fallback source.
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.apply_server_availability(
+                Ok(AICreditAvailability::available_with_source(Some(
+                    AICreditSource::BonusGrant,
+                ))),
+                ctx,
+            );
+            assert!(model.has_any_ai_remaining(ctx));
+        });
+    });
+}
+
+#[test]
+fn test_availability_refresh_failure_keeps_last_known_good() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            // Local state says AI is available, so any legacy fallback would
+            // report `true`.
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 5);
+
+            let denied = AICreditAvailability::unavailable(AICreditDenialReason::Delinquent);
+            model.apply_server_availability(Ok(denied), ctx);
+            model.apply_server_availability(Err(anyhow::anyhow!("transient failure")), ctx);
+
+            // The last-known-good server decision is retained: the error is
+            // recorded but neither flips availability nor re-enables the
+            // legacy locally derived decision.
+            assert_eq!(model.server_availability(), Some(denied));
+            assert!(!model.has_any_ai_remaining(ctx));
+            assert_eq!(
+                model.server_availability.last_error.as_deref(),
+                Some("transient failure")
+            );
+        });
+    });
+}
+
+#[test]
+fn test_availability_refresh_failure_before_first_success_uses_legacy_fallback() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 5);
+            model.apply_server_availability(Err(anyhow::anyhow!("unsupported operation")), ctx);
+
+            // Without any successful fetch (e.g. server doesn't support the
+            // field yet), the legacy locally derived decision still applies.
+            assert_eq!(model.server_availability(), None);
+            assert!(model.has_any_ai_remaining(ctx));
+        });
+    });
+}
+
+#[test]
+fn test_reset_server_availability_restores_legacy_fallback() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 5);
+            model.apply_server_availability(
+                Ok(AICreditAvailability::unavailable(
+                    AICreditDenialReason::OutOfCredits,
+                )),
+                ctx,
+            );
+            assert!(!model.has_any_ai_remaining(ctx));
+
+            // On logout the server decision is cleared and pre-fetch behavior
+            // is restored for the next principal.
+            model.reset_server_availability(ctx);
+            assert_eq!(model.server_availability(), None);
+            assert!(model.has_any_ai_remaining(ctx));
+        });
+    });
+}
+
+#[test]
+fn test_availability_refresh_coalesces_concurrent_fetches() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+
+        let mut ai_client = MockAIClient::new();
+        // Exactly one fetch may go out even though two triggers fire while the
+        // first request is still in flight.
+        ai_client
+            .expect_get_ai_credit_availability()
+            .times(1)
+            .returning(|| {
+                Ok(AICreditAvailability::available_with_source(Some(
+                    AICreditSource::BaseLimit,
+                )))
+            });
+        let request_usage_model =
+            add_request_usage_model_with_client(&mut app, Arc::new(ai_client));
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_availability_refresh(ctx);
+            model.request_availability_refresh(ctx);
+            assert!(model.server_availability.refresh_in_flight);
+        });
+
+        // Let the spawned fetch complete.
+        warpui::r#async::Timer::after(std::time::Duration::from_millis(100)).await;
+
+        request_usage_model.read(&app, |model, _| {
+            assert!(!model.server_availability.refresh_in_flight);
+            assert_eq!(
+                model.server_availability(),
+                Some(AICreditAvailability::available_with_source(Some(
+                    AICreditSource::BaseLimit,
+                )))
+            );
+        });
+    });
+}
+
+#[test]
+fn test_availability_refresh_skipped_when_logged_out() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| AuthStateProvider::new_logged_out_for_test());
+
+        // No expectations: any fetch would panic the test.
+        let ai_client = MockAIClient::new();
+        let request_usage_model =
+            add_request_usage_model_with_client(&mut app, Arc::new(ai_client));
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_availability_refresh(ctx);
+            assert!(!model.server_availability.refresh_in_flight);
+        });
+
+        request_usage_model.read(&app, |model, _| {
+            assert_eq!(model.server_availability(), None);
         });
     });
 }

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -1023,6 +1023,100 @@ fn test_reset_server_availability_restores_legacy_fallback() {
 }
 
 #[test]
+fn test_capability_only_availability_requires_local_byo_path() {
+    App::test((), |mut app| async move {
+        // BYOK is allowed by policy, but no key has been stored locally.
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace.billing_metadata.tier.byo_api_key_policy =
+            Some(ByoApiKeyPolicy { enabled: true });
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        // Capability-only: the server allows BYO by policy but found no Warp
+        // credit source. It cannot see locally stored keys.
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.apply_server_availability(
+                Ok(AICreditAvailability::available_with_source(None)),
+                ctx,
+            );
+            assert!(
+                !model.has_any_ai_remaining(ctx),
+                "capability-only availability without a stored key should be treated as out of credits",
+            );
+        });
+
+        // Storing a key makes the capability usable.
+        ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.set_openai_key(Some("test-key".to_string()), ctx);
+        });
+        request_usage_model.read(&app, |model, ctx| {
+            assert!(
+                model.has_any_ai_remaining(ctx),
+                "capability-only availability with a stored key should permit AI",
+            );
+        });
+    });
+}
+
+#[test]
+fn test_capability_only_availability_with_team_custom_llm() {
+    App::test((), |mut app| async move {
+        // A team-managed custom LLM configuration is a usable BYO path even
+        // without any locally stored API key.
+        let mut team = crate::workspaces::team::Team::from_local_cache(
+            123.into(),
+            "Test Team".to_string(),
+            None,
+            None,
+            None,
+        );
+        team.organization_settings.llm_settings.enabled = true;
+        let (uid, _workspace) = create_test_workspace();
+        let workspace =
+            Workspace::from_local_cache(uid, "Test Workspace".to_string(), Some(vec![team]));
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.apply_server_availability(
+                Ok(AICreditAvailability::available_with_source(None)),
+                ctx,
+            );
+            assert!(model.has_any_ai_remaining(ctx));
+        });
+    });
+}
+
+#[test]
+fn test_server_unavailable_overrides_local_byo_key() {
+    App::test((), |mut app| async move {
+        // A locally stored key never overrides an explicit server denial —
+        // the refinement only applies to capability-only availability.
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace.billing_metadata.tier.byo_api_key_policy =
+            Some(ByoApiKeyPolicy { enabled: true });
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.set_openai_key(Some("test-key".to_string()), ctx);
+        });
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.apply_server_availability(
+                Ok(AICreditAvailability::unavailable(
+                    AICreditDenialReason::Delinquent,
+                )),
+                ctx,
+            );
+            assert!(!model.has_any_ai_remaining(ctx));
+        });
+    });
+}
+
+#[test]
 fn test_availability_refresh_coalesces_concurrent_fetches() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| AuthStateProvider::new_for_test());

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use ai::LLMProvider;
-use ai::api_keys::{ApiKeyManager, GrokTokens};
+use ai::api_keys::{ApiKeyManager, AwsCredentials, AwsCredentialsState, GrokTokens};
 use chrono::Duration;
 use warp_core::features::FeatureFlag;
 use warp_graphql::billing::{AddonCreditsOption, OveragesPricing, PricingInfo};
@@ -1050,13 +1051,62 @@ fn test_out_of_credits_refined_by_local_byo_key() {
 
         // Storing a key supplies the one fact the server cannot know.
         ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
-            manager.set_openai_key(Some("test-key".to_string()), ctx);
+            manager.set_provider_key(LLMProvider::OpenAI, Some("test-key".to_string()), ctx);
         });
         request_usage_model.read(&app, |model, ctx| {
             assert!(
                 model.has_any_ai_remaining(ctx),
                 "out of credits with a stored key should permit AI",
             );
+        });
+    });
+}
+
+#[test]
+fn test_out_of_credits_refined_by_local_bedrock_credentials() {
+    App::test((), |mut app| async move {
+        // Bedrock via the local AWS chain: the org enables the host, but the
+        // credentials live on this machine.
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace.settings.llm_settings.enabled = true;
+        workspace.settings.llm_settings.host_configs.insert(
+            crate::ai::llms::LLMModelHost::AwsBedrock,
+            crate::workspaces::workspace::LlmHostSettings {
+                enabled: true,
+                enablement_setting: crate::workspaces::workspace::HostEnablementSetting::Enforce,
+                ..Default::default()
+            },
+        );
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.apply_server_availability(
+                Ok(AICreditAvailability::unavailable(
+                    AICreditDenialReason::OutOfCredits,
+                )),
+                ctx,
+            );
+            assert!(!model.has_any_ai_remaining(ctx));
+        });
+
+        ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.set_aws_credentials_state(
+                AwsCredentialsState::Loaded {
+                    credentials: AwsCredentials::new(
+                        "access".to_string(),
+                        "secret".to_string(),
+                        None,
+                        None,
+                    ),
+                    loaded_at: SystemTime::now(),
+                },
+                ctx,
+            );
+        });
+        request_usage_model.read(&app, |model, ctx| {
+            assert!(model.has_any_ai_remaining(ctx));
         });
     });
 }
@@ -1093,7 +1143,7 @@ fn test_server_unavailable_overrides_local_byo_key() {
         let request_usage_model = add_request_usage_model(&mut app);
 
         ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
-            manager.set_openai_key(Some("test-key".to_string()), ctx);
+            manager.set_provider_key(LLMProvider::OpenAI, Some("test-key".to_string()), ctx);
         });
 
         request_usage_model.update(&mut app, |model, ctx| {

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -1023,7 +1023,7 @@ fn test_reset_server_availability_restores_legacy_fallback() {
 }
 
 #[test]
-fn test_capability_only_availability_requires_local_byo_path() {
+fn test_out_of_credits_refined_by_local_byo_key() {
     App::test((), |mut app| async move {
         // BYOK is allowed by policy, but no key has been stored locally.
         let (_uid, mut workspace) = create_test_workspace();
@@ -1032,50 +1032,42 @@ fn test_capability_only_availability_requires_local_byo_path() {
         add_user_workspaces_with_workspace(&mut app, workspace);
         let request_usage_model = add_request_usage_model(&mut app);
 
-        // Capability-only: the server allows BYO by policy but found no Warp
-        // credit source. It cannot see locally stored keys.
+        // OUT_OF_CREDITS means the server found no path it can see; locally
+        // stored keys are request-level parameters invisible to it.
         request_usage_model.update(&mut app, |model, ctx| {
             model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
             model.apply_server_availability(
-                Ok(AICreditAvailability::available_with_source(None)),
+                Ok(AICreditAvailability::unavailable(
+                    AICreditDenialReason::OutOfCredits,
+                )),
                 ctx,
             );
             assert!(
                 !model.has_any_ai_remaining(ctx),
-                "capability-only availability without a stored key should be treated as out of credits",
+                "out of credits without a stored key should gate AI",
             );
         });
 
-        // Storing a key makes the capability usable.
+        // Storing a key supplies the one fact the server cannot know.
         ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
             manager.set_openai_key(Some("test-key".to_string()), ctx);
         });
         request_usage_model.read(&app, |model, ctx| {
             assert!(
                 model.has_any_ai_remaining(ctx),
-                "capability-only availability with a stored key should permit AI",
+                "out of credits with a stored key should permit AI",
             );
         });
     });
 }
 
 #[test]
-fn test_capability_only_availability_with_team_custom_llm() {
+fn test_server_managed_availability_trusted_without_local_keys() {
     App::test((), |mut app| async move {
-        // A team-managed custom LLM configuration is a usable BYO path even
-        // without any locally stored API key.
-        let mut team = crate::workspaces::team::Team::from_local_cache(
-            123.into(),
-            "Test Team".to_string(),
-            None,
-            None,
-            None,
-        );
-        team.organization_settings.llm_settings.enabled = true;
-        let (uid, _workspace) = create_test_workspace();
-        let workspace =
-            Workspace::from_local_cache(uid, "Test Workspace".to_string(), Some(vec![team]));
-        add_user_workspaces_with_workspace(&mut app, workspace);
+        // `available` with no credit source now means a server-managed BYO
+        // path (team keys/endpoints or enterprise custom LLM) is configured;
+        // the server knows this for a fact, so no local key is required.
+        app.add_singleton_model(UserWorkspaces::default_mock);
         let request_usage_model = add_request_usage_model(&mut app);
 
         request_usage_model.update(&mut app, |model, ctx| {
@@ -1092,8 +1084,8 @@ fn test_capability_only_availability_with_team_custom_llm() {
 #[test]
 fn test_server_unavailable_overrides_local_byo_key() {
     App::test((), |mut app| async move {
-        // A locally stored key never overrides an explicit server denial —
-        // the refinement only applies to capability-only availability.
+        // A locally stored key never overrides a hard server denial — the
+        // local refinement applies only to OUT_OF_CREDITS.
         let (_uid, mut workspace) = create_test_workspace();
         workspace.billing_metadata.tier.byo_api_key_policy =
             Some(ByoApiKeyPolicy { enabled: true });

--- a/app/src/ai_assistant/panel.rs
+++ b/app/src/ai_assistant/panel.rs
@@ -33,6 +33,7 @@ use super::{
     AI_ASSISTANT_FEATURE_NAME, AI_ASSISTANT_LOGO_COLOR, AI_ASSISTANT_SVG_PATH,
     ASK_AI_ASSISTANT_TEXT, AskAIType, PROMPT_CHARACTER_LIMIT,
 };
+use crate::ai::AIRequestUsageModel;
 use crate::appearance::Appearance;
 use crate::editor::{
     EditorOptions, EditorView, Event as EditorEvent, PropagateAndNoOpNavigationKeys, TextOptions,
@@ -688,10 +689,6 @@ impl AIAssistantPanelView {
         self.requests_model.as_ref(app).request_status()
     }
 
-    fn num_remaining_reqs(&self, app: &AppContext) -> usize {
-        self.requests_model.as_ref(app).num_remaining_reqs()
-    }
-
     #[cfg(feature = "integration_tests")]
     pub fn editor(&self) -> &ViewHandle<EditorView> {
         &self.editor
@@ -916,7 +913,7 @@ impl AIAssistantPanelView {
                 .finish(),
             );
 
-        if self.num_remaining_reqs(app) > 0 {
+        if AIRequestUsageModel::as_ref(app).has_any_ai_remaining(app) {
             column.add_children([
                 Container::new(render_prepared_response_button(
                     appearance,

--- a/app/src/ai_assistant/transcript.rs
+++ b/app/src/ai_assistant/transcript.rs
@@ -28,6 +28,7 @@ use super::utils::{
     TranscriptPartSubType, code_block_position_id, markdown_segments_from_text,
     render_prepared_response_button, render_request_limit_info, save_as_workflow_position_id,
 };
+use crate::ai::AIRequestUsageModel;
 use crate::appearance::Appearance;
 use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::{SaveAsWorkflowModalSource, TelemetryEvent, WarpAIActionType};
@@ -816,7 +817,7 @@ impl View for Transcript {
         let theme = appearance.theme();
         let transcript = self.requests_model.as_ref(app).transcript();
         let request_status = self.requests_model.as_ref(app).request_status();
-        let num_remaining_reqs = self.requests_model.as_ref(app).num_remaining_reqs();
+        let has_ai_available = AIRequestUsageModel::as_ref(app).has_any_ai_remaining(app);
 
         let mut blocks = Flex::column();
         for (index, part) in transcript.iter().enumerate() {
@@ -850,7 +851,7 @@ impl View for Transcript {
         if !transcript.is_empty() && matches!(request_status, RequestStatus::NotInFlight) {
             // Only show the prepared responses if the last response wasn't an error
             // and the user still has remaining requests.
-            if !transcript.last().is_none_or(|p| p.assistant.is_error) && num_remaining_reqs > 0 {
+            if !transcript.last().is_none_or(|p| p.assistant.is_error) && has_ai_available {
                 blocks.add_child(
                     Container::new(self.render_prepared_responses(appearance))
                         .with_margin_top(15.)

--- a/app/src/auth/auth_manager.rs
+++ b/app/src/auth/auth_manager.rs
@@ -432,6 +432,7 @@ impl AuthManager {
 
                 AIRequestUsageModel::handle(ctx).update(ctx, |usage_model, ctx| {
                     usage_model.refresh_request_usage_async(ctx);
+                    usage_model.request_availability_refresh(ctx);
                 });
 
                 LLMPreferences::handle(ctx).update(ctx, |prefs, ctx| {

--- a/app/src/auth/mod.rs
+++ b/app/src/auth/mod.rs
@@ -33,6 +33,7 @@ use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::Orchestratio
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::mcp::TemplatableMCPServerManager;
+use crate::ai::request_usage_model::AIRequestUsageModel;
 use crate::ai_assistant::requests::REQUEST_LIMIT_INFO_CACHE_KEY;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::code::editor_management::{CodeEditorStatus, CodeEditorSummary};
@@ -253,6 +254,9 @@ pub fn log_out(app: &mut AppContext) {
     #[cfg(not(target_family = "wasm"))]
     TemplatableMCPServerManager::handle(app).update(app, |manager, ctx| {
         manager.sync_builtin_servers(false, ctx);
+    });
+    AIRequestUsageModel::handle(app).update(app, |usage_model, ctx| {
+        usage_model.reset_server_availability(ctx);
     });
     BlocklistAIHistoryModel::handle(app).update(app, |history_model, _| {
         history_model.reset();

--- a/app/src/code_review/comment_list_view.rs
+++ b/app/src/code_review/comment_list_view.rs
@@ -235,7 +235,11 @@ impl CommentListView {
 
         // Keep the stored button state in sync when AI availability changes.
         ctx.subscribe_to_model(&AIRequestUsageModel::handle(ctx), |me, _, event, ctx| {
-            if let AIRequestUsageModelEvent::RequestUsageUpdated = event {
+            if matches!(
+                event,
+                AIRequestUsageModelEvent::RequestUsageUpdated
+                    | AIRequestUsageModelEvent::CreditAvailabilityUpdated
+            ) {
                 me.sync_send_button(ctx);
             }
         });

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1680,6 +1680,34 @@ pub(crate) fn initialize_app(
         manager
     });
 
+    // Keep the server-authoritative AI credit availability fresh across
+    // meaningful state changes. The primary cadence is the workspace metadata
+    // refresh piggyback; these targeted triggers cover changes that don't
+    // immediately produce a metadata response. `TeamsChanged` is deliberately
+    // not a trigger: it fires on every metadata poll, whose response already
+    // carries the piggybacked availability.
+    ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), |_, event, ctx| {
+        if matches!(
+            event,
+            UserWorkspacesEvent::CurrentWorkspaceChanged
+                | UserWorkspacesEvent::AiOveragesUpdated
+                | UserWorkspacesEvent::PurchaseAddonCreditsSuccess
+        ) {
+            AIRequestUsageModel::handle(ctx).update(ctx, |usage_model, ctx| {
+                usage_model.request_availability_refresh(ctx);
+            });
+        }
+    });
+    ctx.subscribe_to_model(
+        &::ai::api_keys::ApiKeyManager::handle(ctx),
+        |_, event, ctx| {
+            let ::ai::api_keys::ApiKeyManagerEvent::KeysUpdated = event;
+            AIRequestUsageModel::handle(ctx).update(ctx, |usage_model, ctx| {
+                usage_model.request_availability_refresh(ctx);
+            });
+        },
+    );
+
     ctx.add_singleton_model(AntivirusInfo::new);
 
     cfg_if::cfg_if! {

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -76,6 +76,10 @@ use warp_graphql::queries::free_available_models::{
     FreeAvailableModels, FreeAvailableModelsInput, FreeAvailableModelsResult,
     FreeAvailableModelsVariables,
 };
+#[cfg(not(feature = "agent_mode_evals"))]
+use warp_graphql::queries::get_ai_credit_availability::{
+    GetAICreditAvailability, GetAICreditAvailabilityVariables,
+};
 use warp_graphql::queries::get_available_harnesses::{
     GetAvailableHarnesses, GetAvailableHarnessesVariables,
 };
@@ -117,7 +121,6 @@ use super::download::write_response_body_to_path;
 use super::harness_support::{UploadField, UploadFieldValue, UploadTarget};
 #[cfg(not(feature = "agent_mode_evals"))]
 use crate::ai::BonusGrant;
-use crate::ai::RequestUsageInfo;
 pub use crate::ai::agent::UserQueryMode;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
@@ -141,6 +144,7 @@ use crate::ai::llms::{
 };
 #[cfg(feature = "agent_mode_evals")]
 use crate::ai::request_usage_model::RequestLimitInfo;
+use crate::ai::{AICreditAvailability, RequestUsageInfo};
 use crate::ai_assistant::execution_context::WarpAiExecutionContext;
 use crate::ai_assistant::requests::GenerateDialogueResult;
 use crate::ai_assistant::utils::TranscriptPart;
@@ -1157,6 +1161,10 @@ pub trait AIClient: 'static + Send + Sync {
 
     async fn get_request_limit_info(&self) -> Result<RequestUsageInfo, anyhow::Error>;
 
+    /// Fetches the server-authoritative decision on whether the authenticated
+    /// user can start an interactive AI request.
+    async fn get_ai_credit_availability(&self) -> Result<AICreditAvailability, anyhow::Error>;
+
     /// Returns conversation usage history for the current user over the requested number of days.
     ///
     /// If `last_updated_end_timestamp` is provided, only conversations updated before that timestamp are returned.
@@ -1806,6 +1814,34 @@ impl AIClient for ServerApi {
             }
             warp_graphql::queries::get_request_limit_info::UserResult::Unknown => {
                 Err(anyhow!("failed to get request limit info"))
+            }
+        }
+    }
+
+    #[cfg(feature = "agent_mode_evals")]
+    async fn get_ai_credit_availability(&self) -> Result<AICreditAvailability, anyhow::Error> {
+        Ok(AICreditAvailability::available_with_source(Some(
+            crate::ai::AICreditSource::BaseLimit,
+        )))
+    }
+
+    #[cfg(not(feature = "agent_mode_evals"))]
+    async fn get_ai_credit_availability(&self) -> Result<AICreditAvailability, anyhow::Error> {
+        let variables = GetAICreditAvailabilityVariables {
+            request_context: get_request_context(),
+        };
+        let operation = GetAICreditAvailability::build(variables);
+        let response = self.send_graphql_request(operation, None).await?;
+
+        match response.user {
+            warp_graphql::queries::get_ai_credit_availability::UserResult::UserOutput(output) => {
+                Ok(output.user.ai_credit_availability.into())
+            }
+            warp_graphql::queries::get_ai_credit_availability::UserResult::UserFacingError(e) => {
+                Err(anyhow!(get_user_facing_error_message(e)))
+            }
+            warp_graphql::queries::get_ai_credit_availability::UserResult::Unknown => {
+                Err(anyhow!("failed to get AI credit availability"))
             }
         }
     }

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -1796,6 +1796,7 @@ impl AISettingsPageView {
         ctx.subscribe_to_model(&ai_request_model, |me, _, event, ctx| {
             match event {
                 AIRequestUsageModelEvent::RequestUsageUpdated => ctx.notify(),
+                AIRequestUsageModelEvent::CreditAvailabilityUpdated => ctx.notify(),
                 AIRequestUsageModelEvent::RequestBonusRefunded { .. } => ctx.notify(),
                 AIRequestUsageModelEvent::AmbientCreditsBannerDismissed => {}
             }

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -933,6 +933,10 @@ impl TeamsPageView {
 
                 ctx.emit(TeamsPageViewEvent::TeamsChanged);
             }
+            UserWorkspacesEvent::CurrentWorkspaceChanged => {
+                // A workspace selection change always emits `TeamsChanged` too,
+                // which already refreshes this page.
+            }
             UserWorkspacesEvent::ToggleInviteLinksSuccess => {
                 self.show_success("Toggled invite links", ctx);
                 ctx.notify();

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -1167,6 +1167,7 @@ impl From<GqlUser> for WorkspacesMetadataResponse {
             joinable_teams,
             experiments,
             feature_model_choices,
+            ai_credit_availability: Some(gql_user.ai_credit_availability.into()),
         }
     }
 }

--- a/app/src/workspaces/update_manager.rs
+++ b/app/src/workspaces/update_manager.rs
@@ -16,6 +16,7 @@ use super::user_workspaces::{
 };
 use super::workspace::WorkspaceUid;
 use crate::ai::llms::LLMPreferences;
+use crate::ai::request_usage_model::AIRequestUsageModel;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::CloudObjectEventEntrypoint;
 use crate::network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind};
@@ -125,6 +126,7 @@ impl TeamUpdateManager {
                     joinable_teams: vec![],
                     experiments: None,
                     feature_model_choices: None,
+                    ai_credit_availability: None,
                 },
                 pricing_info: None,
             })
@@ -347,6 +349,12 @@ impl TeamUpdateManager {
                     });
                 }
 
+                if let Some(availability) = response.metadata.ai_credit_availability {
+                    AIRequestUsageModel::handle(ctx).update(ctx, |usage_model, ctx| {
+                        usage_model.apply_server_availability(Ok(availability), ctx);
+                    });
+                }
+
                 let workspaces = response.metadata.workspaces;
                 let joinable_teams = response.metadata.joinable_teams;
 
@@ -468,6 +476,12 @@ impl TeamUpdateManager {
                 let workspaces = user_workspaces_access.workspaces;
                 let joinable_teams = user_workspaces_access.joinable_teams;
                 let experiments = user_workspaces_access.experiments;
+
+                if let Some(availability) = user_workspaces_access.ai_credit_availability {
+                    AIRequestUsageModel::handle(ctx).update(ctx, |usage_model, ctx| {
+                        usage_model.apply_server_availability(Ok(availability), ctx);
+                    });
+                }
 
                 UserWorkspaces::handle(ctx).update(ctx, |user_workspaces, ctx| {
                     user_workspaces.update_workspaces(workspaces.clone(), ctx);

--- a/app/src/workspaces/update_manager_tests.rs
+++ b/app/src/workspaces/update_manager_tests.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use warpui::{AddSingletonModel, App};
 
 use super::*;
+use crate::ai::credit_availability::{AICreditAvailability, AICreditDenialReason};
 use crate::auth::AuthManager;
 use crate::cloud_object::model::actions::ObjectActions;
 use crate::cloud_object::model::persistence::CloudModel;
@@ -96,6 +97,7 @@ fn test_leaving_team_removes_objects() {
                     joinable_teams: vec![],
                     experiments: None,
                     feature_model_choices: None,
+                    ai_credit_availability: None,
                 },
                 pricing_info: None,
             })
@@ -165,6 +167,7 @@ fn test_leaving_team_removes_objects() {
                         joinable_teams: vec![],
                         experiments: None,
                         feature_model_choices: None,
+                        ai_credit_availability: None,
                     },
                     pricing_info: None,
                 }),
@@ -204,6 +207,48 @@ fn test_leaving_team_removes_objects() {
                     shared_workflow_id.to_string()
                 ]
             );
+        });
+    });
+}
+
+#[test]
+fn test_workspace_metadata_piggyback_feeds_ai_credit_availability() {
+    App::test((), |mut app| async move {
+        let team_client = Arc::new(MockTeamClient::new());
+        initialize_app(
+            team_client.clone(),
+            Arc::new(MockWorkspaceClient::new()),
+            vec![],
+            &mut app,
+        );
+        if app
+            .models_of_type::<settings::PrivatePreferences>()
+            .is_empty()
+        {
+            app.update(crate::settings::init_and_register_user_preferences);
+        }
+        app.add_singleton_model(|ctx| {
+            AIRequestUsageModel::new_for_test(ServerApiProvider::as_ref(ctx).get_ai_client(), ctx)
+        });
+        let team_update_manager =
+            app.add_singleton_model(|ctx| TeamUpdateManager::new(team_client, None, ctx));
+
+        let availability = AICreditAvailability::unavailable(AICreditDenialReason::OutOfCredits);
+        team_update_manager.update(&mut app, |manager, ctx| {
+            manager.on_workspaces_updated(
+                Ok(WorkspacesMetadataResponse {
+                    workspaces: vec![],
+                    joinable_teams: vec![],
+                    experiments: None,
+                    feature_model_choices: None,
+                    ai_credit_availability: Some(availability),
+                }),
+                ctx,
+            );
+        });
+
+        AIRequestUsageModel::handle(&app).read(&app, |model, _| {
+            assert_eq!(model.server_availability(), Some(availability));
         });
     });
 }

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -19,7 +19,9 @@ use super::workspace::{
     AdminEnablementSetting, BillingMetadata, CustomerType, EnterpriseSecretRegex,
     HostEnablementSetting, UgcCollectionEnablementSetting, Workspace, WorkspaceUid,
 };
+use crate::ai::credit_availability::AICreditAvailability;
 use crate::ai::llms::LLMModelHost;
+use crate::ai::request_usage_model::AIRequestUsageModel;
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::channel::ChannelState;
 use crate::cloud_object::model::persistence::CloudModel;
@@ -77,6 +79,8 @@ pub enum UserWorkspacesEvent {
     PurchaseAddonCreditsRejected(anyhow::Error),
     /// Fired whenever the set of teams the user is on changes.
     TeamsChanged,
+    /// Fired when the selected workspace actually changes to a different one.
+    CurrentWorkspaceChanged,
     CodebaseContextEnablementChanged,
     /// Fired when a service agreement's sunsetted_to_build_ts field is updated.
     SunsettedToBuildDataUpdated,
@@ -109,6 +113,9 @@ pub struct WorkspacesMetadataResponse {
     /// It makes most sense to fetch this in workspaces which is queried every 10 minutes.
     /// This is list of available LLM models for the user.
     pub feature_model_choices: Option<FeatureModelChoice>,
+    /// The server-authoritative AI credit availability decision, piggybacked
+    /// on the metadata query so every refresh keeps the shared state fresh.
+    pub ai_credit_availability: Option<AICreditAvailability>,
 }
 
 // A representation of all data we fetch at a single time via our 10 minute poll.
@@ -459,9 +466,13 @@ impl UserWorkspaces {
         workspace_uid: WorkspaceUid,
         ctx: &mut ModelContext<Self>,
     ) {
+        let changed = *self.current_workspace_uid != Some(workspace_uid);
         *self.current_workspace_uid = Some(workspace_uid);
         self.reconcile_window_team_assignments();
         self.notify_and_emit_teams_changed(ctx);
+        if changed {
+            ctx.emit(UserWorkspacesEvent::CurrentWorkspaceChanged);
+        }
     }
 
     /// Returns `true` if active AI is allowed for the current workspace, based on billing config.
@@ -977,6 +988,12 @@ impl UserWorkspaces {
                 if let Some(pricing_info) = response.pricing_info {
                     PricingInfoModel::handle(ctx).update(ctx, |model, ctx| {
                         model.update_pricing_info(pricing_info, ctx);
+                    });
+                }
+
+                if let Some(availability) = response.metadata.ai_credit_availability {
+                    AIRequestUsageModel::handle(ctx).update(ctx, |usage_model, ctx| {
+                        usage_model.apply_server_availability(Ok(availability), ctx);
                     });
                 }
 

--- a/app/src/workspaces/user_workspaces_tests.rs
+++ b/app/src/workspaces/user_workspaces_tests.rs
@@ -167,6 +167,7 @@ fn test_loading_all_spaces_after_switching_from_offline() {
                         joinable_teams: vec![],
                         experiments: None,
                         feature_model_choices: None,
+                        ai_credit_availability: None,
                     },
                     pricing_info: None,
                 })
@@ -184,6 +185,7 @@ fn test_loading_all_spaces_after_switching_from_offline() {
                         joinable_teams: vec![],
                         experiments: None,
                         feature_model_choices: None,
+                        ai_credit_availability: None,
                     },
                     pricing_info: None,
                 })
@@ -321,6 +323,7 @@ fn test_aws_bedrock_credentials_respect_user_setting() {
                 joinable_teams: vec![],
                 experiments: None,
                 feature_model_choices: None,
+                ai_credit_availability: None,
             },
             pricing_info: None,
         })
@@ -377,6 +380,7 @@ fn test_aws_bedrock_credentials_enforced_by_admin() {
                 joinable_teams: vec![],
                 experiments: None,
                 feature_model_choices: None,
+                ai_credit_availability: None,
             },
             pricing_info: None,
         })

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -12,6 +12,36 @@ pub enum RequestLimitRefreshDuration {
     EveryTwoWeeks,
 }
 
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+pub enum AICreditAvailabilityDenialReason {
+    None,
+    OutOfCredits,
+    Delinquent,
+    EnterpriseTeamSpendLimitHit,
+    EnterprisePerUserSpendLimitHit,
+    EnterpriseWorkspaceSpendLimitHit,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+pub enum AICreditAvailabilitySource {
+    BaseLimit,
+    BonusGrant,
+    Payg,
+    Overage,
+    AmbientBonusGrant,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct AICreditAvailability {
+    pub available: bool,
+    pub denial_reason: AICreditAvailabilityDenialReason,
+    pub credit_source: Option<AICreditAvailabilitySource>,
+}
+
 #[derive(cynic::QueryFragment, Debug)]
 pub struct RequestLimitInfo {
     pub is_unlimited: bool,

--- a/crates/graphql/src/api/queries/get_ai_credit_availability.rs
+++ b/crates/graphql/src/api/queries/get_ai_credit_availability.rs
@@ -1,0 +1,61 @@
+use crate::ai::AICreditAvailability;
+use crate::error::UserFacingError;
+use crate::request_context::RequestContext;
+use crate::schema;
+
+/*
+query GetAICreditAvailability($requestContext: RequestContext!) {
+  user(requestContext: $requestContext) {
+    ... on UserOutput {
+      user {
+        aiCreditAvailability {
+          available
+          denialReason
+          creditSource
+        }
+      }
+    }
+    ... on UserFacingError {
+      error {
+        message
+      }
+    }
+  }
+}
+*/
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct GetAICreditAvailabilityVariables {
+    pub request_context: RequestContext,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct UserOutput {
+    pub user: User,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct User {
+    pub ai_credit_availability: AICreditAvailability,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "RootQuery",
+    variables = "GetAICreditAvailabilityVariables"
+)]
+pub struct GetAICreditAvailability {
+    #[arguments(requestContext: $request_context)]
+    pub user: UserResult,
+}
+crate::client::define_operation! {
+    get_ai_credit_availability(GetAICreditAvailabilityVariables) -> GetAICreditAvailability;
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum UserResult {
+    UserOutput(UserOutput),
+    UserFacingError(UserFacingError),
+    #[cynic(fallback)]
+    Unknown,
+}

--- a/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
+++ b/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
@@ -1,3 +1,4 @@
+use crate::ai::AICreditAvailability;
 use crate::billing::PricingInfo;
 use crate::experiment::Experiment;
 use crate::request_context::RequestContext;
@@ -12,6 +13,11 @@ query GetWorkspacesMetadataForUser($requestContext: RequestContext!) {
       user {
         profile {
           uid
+        }
+        aiCreditAvailability {
+          available
+          denialReason
+          creditSource
         }
         workspaces {
           uid
@@ -226,6 +232,7 @@ pub enum PricingInfoResult {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct User {
     pub profile: UserProfile,
+    pub ai_credit_availability: AICreditAvailability,
     pub workspaces: Vec<Workspace>,
     pub experiments: Option<Vec<Experiment>>,
     pub discoverable_teams: Vec<DiscoverableTeamData>,

--- a/crates/graphql/src/api/queries/mod.rs
+++ b/crates/graphql/src/api/queries/mod.rs
@@ -2,6 +2,7 @@ pub mod api_keys;
 pub mod codebase_context_config;
 pub mod free_available_models;
 pub mod get_ai_conversation_format;
+pub mod get_ai_credit_availability;
 pub mod get_ai_overages_for_workspace;
 pub mod get_available_harnesses;
 pub mod get_blocks_for_user;

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -79,6 +79,29 @@ type AIConversationFormat {
   hasTaskList: Boolean!
 }
 
+type AICreditAvailability {
+  available: Boolean!
+  creditSource: AICreditAvailabilitySource
+  denialReason: AICreditAvailabilityDenialReason!
+}
+
+enum AICreditAvailabilityDenialReason {
+  DELINQUENT
+  ENTERPRISE_PER_USER_SPEND_LIMIT_HIT
+  ENTERPRISE_TEAM_SPEND_LIMIT_HIT
+  ENTERPRISE_WORKSPACE_SPEND_LIMIT_HIT
+  NONE
+  OUT_OF_CREDITS
+}
+
+enum AICreditAvailabilitySource {
+  AMBIENT_BONUS_GRANT
+  BASE_LIMIT
+  BONUS_GRANT
+  OVERAGE
+  PAYG
+}
+
 enum AICreditsUsageAndCostSubjectType {
   SERVICE_ACCOUNT
   TEAM
@@ -4322,6 +4345,7 @@ The User type is the primary way of interacting with our graph.
 Nearly all data is scoped to the currently logged-in user.
 """
 type User {
+  aiCreditAvailability: AICreditAvailability!
   anonymousUserInfo: AnonymousUserInfo
   availableHarnesses: AvailableHarnesses!
   billingMetadata: BillingMetadata


### PR DESCRIPTION
## Description
Consumes the server-authoritative `User.aiCreditAvailability` GraphQL field (added in [warp-server#12935](https://github.com/warpdotdev/warp-server/pull/12935)) so Warp clients no longer infer AI availability from stale request limits, grants, workspace metadata, or local BYO settings. Implements the "Proposed client changes" section of the REV-1714 spec (`warp-server/agents/specs/REV-1714: server-authoritative credit availability.md`).

**What / How:**
- **GraphQL:** mirrors the `AICreditAvailability` types into the client schema, adds cynic bindings (with fallback variants for unknown future enum values), a focused `GetAICreditAvailability` query, and piggybacks the selection onto `GetWorkspacesMetadataForUser` so every metadata refresh carries the decision.
- **Shared state:** `AIRequestUsageModel` holds the server decision with last-known-good semantics — refresh failures never flip availability in either direction, and the legacy locally derived `has_any_ai_remaining` calculation only applies before the first successful fetch (rollout compatibility with servers lacking the field).
- **Feed paths (exactly two, per spec):** the workspace metadata refresh piggyback (primary cadence, including all team mutations which re-query metadata), plus coalesced single-shot targeted fetches on meaningful state changes: auth completion, API-key/credential changes, workspace selection changes, and add-on credit/overage changes. No fixed-interval timer, no AI-surface-open or request-completion triggers. State resets on logout.
- **Consumers:** prompt alerts map server denial reasons (`DELINQUENT`, enterprise spend limits, `OUT_OF_CREDITS`) to existing presentation states — workspace policy only picks CTA copy; AI Assistant zero-state/prepared prompts gate on the shared availability instead of `num_remaining_reqs`; Agent Mode input, prompt suggestions, and code review inherit it via `has_any_ai_remaining`. Request-limit counts remain display-only.
- **Local-key refinement:** per the reworked server contract, `available=true` means the server *knows for a fact* requests can run (a Warp credit source or a configured server-managed BYO path) and is trusted outright. An `OUT_OF_CREDITS` denial means the server found no path it can see — locally stored API keys and locally resolved Bedrock credentials are request-level parameters invisible to it — so the client supplies that one fact and permits AI when a usable local key/custom endpoint/Grok subscription/loaded local-chain Bedrock credentials exist (policy permitting). Delinquency and spend-limit denials are hard rejections that local keys never bypass.

**Depends on** [warp-server#13369](https://github.com/warpdotdev/warp-server/pull/13369) (now merged), which defines this contract: one shared `AdmitsInference` decision for the request middleware and the availability endpoint, with `available` reporting only definite access. The server change must deploy before this client change ships — against the original endpoint semantics, `available=true` was near-universal (BYOK capability on every tier) and would suppress out-of-credits/delinquency alerts.

## Linked Issue
Linear: [REV-1714](https://linear.app/warpdotdev/issue/REV-1714/add-gql-api-endpoint-for-server-authoritative-credit-availability) (client-side follow-up to the server endpoint).

## Testing
- New unit tests: gql→domain conversions (every reason/source + unknown-value tolerance), server-decision-overrides-local, last-known-good on transient failure, no legacy fallback after first success, legacy fallback before first success, targeted-fetch coalescing (exactly one in-flight request), logged-out no-op, logout reset, metadata piggyback feed, and prompt-alert mapping for each server reason.
- Local-key refinement tests: OUT_OF_CREDITS + no local key → gated (model + prompt alert); OUT_OF_CREDITS + stored key → available/no alert; OUT_OF_CREDITS + loaded local-chain Bedrock credentials (Bedrock enabled by policy) → available; server-managed availability (`available`, null source) trusted without local keys; hard denials (delinquency) never overridden by a local key.
- `cargo nextest run -p warp -E 'test(credit_availability) + test(request_usage_model) + test(prompt_alert) + test(update_manager) + test(user_workspaces)'` — 142 passed.
- `cargo nextest run -p warp_graphql` — passed.
- `./script/format --check` and both presubmit clippy invocations — passed.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---
- _Conversation: https://staging.warp.dev/conversation/7fe7ee90-8c14-4d9b-b73b-ff5253f029a3_
- _Plan: [Client: server-authoritative AI credit availability (REV-1714)](https://staging.warp.dev/drive/notebook/CuLVyr2mh4mGV0EVEQzBqP)_

Co-Authored-By: Oz <oz-agent@warp.dev>

CHANGELOG-IMPROVEMENT: Out-of-credits, delinquency, and spend-limit states across AI surfaces now reflect the server's authoritative credit availability, so they stay accurate as your plan, credits, or API keys change.
