### PR TITLE
Make auth flow more reliable

### DIFF
--- a/app/src/auth/auth_manager.rs
+++ b/app/src/auth/auth_manager.rs
@@ -1,8 +1,10 @@
+use std::future::Future;
 use std::result::Result as StdResult;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
+use futures::future::Either;
 use settings::Setting as _;
 #[cfg(target_family = "wasm")]
 use url::Url;
@@ -14,6 +16,7 @@ use warp_graphql::mutations::create_anonymous_user::{
     AnonymousUserType, CreateAnonymousUserResult,
 };
 use warp_server_auth::user::persistence::PersistedUser;
+use warpui::r#async::Timer;
 use warpui::clipboard::ClipboardContent;
 use warpui::{Entity, ModelContext, SingletonEntity, UpdateModel};
 
@@ -86,6 +89,46 @@ pub enum AuthManagerEvent {
 pub type LoginGatedFeature = &'static str;
 
 type URLConstructorCallback = Box<dyn FnOnce(Option<&str>) -> String>;
+const DEVICE_CODE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const DEVICE_CODE_REQUEST_ATTEMPTS: usize = 2;
+
+async fn request_device_code_with_timeout<F, Fut>(
+    mut request: F,
+    timeout: Duration,
+    attempts: usize,
+) -> StdResult<oauth2::StandardDeviceAuthorizationResponse, UserAuthenticationError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<
+        Output = StdResult<oauth2::StandardDeviceAuthorizationResponse, UserAuthenticationError>,
+    >,
+{
+    assert!(
+        attempts > 0,
+        "device code request requires at least one attempt"
+    );
+
+    for attempt in 1..=attempts {
+        let request = request();
+        let timeout = Timer::after(timeout);
+        futures::pin_mut!(request);
+        futures::pin_mut!(timeout);
+
+        match futures::future::select(request, timeout).await {
+            Either::Left((result, _)) => return result,
+            Either::Right(_) if attempt < attempts => {
+                log::info!(
+                    "Device authorization code request timed out; retrying ({attempt}/{attempts})"
+                );
+            }
+            Either::Right(_) => {
+                return Err(UserAuthenticationError::DeviceCodeRequestTimedOut { attempts });
+            }
+        }
+    }
+
+    unreachable!("attempt count is asserted to be nonzero")
+}
 
 /// AuthManager is a singleton model which manages the currently logged-in user's state.
 /// If you need to access the state, use `AuthStateProvider`.
@@ -274,7 +317,14 @@ impl AuthManager {
         let auth_client = self.auth_client.clone();
         // Request a device code the user can enter in their browser.
         ctx.spawn(
-            async move { auth_client.request_device_code().await },
+            async move {
+                request_device_code_with_timeout(
+                    || auth_client.request_device_code(),
+                    DEVICE_CODE_REQUEST_TIMEOUT,
+                    DEVICE_CODE_REQUEST_ATTEMPTS,
+                )
+                .await
+            },
             Self::on_device_code_received,
         );
     }
@@ -504,6 +554,7 @@ impl AuthManager {
                         self.set_needs_reauth(true, ctx);
                     }
                     UserAuthenticationError::UserAccountDisabled(_) => {}
+                    UserAuthenticationError::DeviceCodeRequestTimedOut { .. } => {}
                     UserAuthenticationError::Unexpected(_) => {}
                     UserAuthenticationError::InvalidStateParameter => {}
                     UserAuthenticationError::MissingStateParameter => {}

--- a/app/src/auth/auth_manager_tests.rs
+++ b/app/src/auth/auth_manager_tests.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
 
 use warpui::{App, SingletonEntity};
 
-use super::{AuthManager, AuthManagerEvent};
+use super::{AuthManager, AuthManagerEvent, request_device_code_with_timeout};
 use crate::ServerApiProvider;
 use crate::auth::auth_view_modal::AuthRedirectPayload;
 use crate::auth::credentials::{Credentials, RefreshToken};
@@ -88,6 +89,35 @@ fn test_duplicate_redirect_for_logged_in_user_is_silently_ignored() {
         AuthManager::handle(&app).update(&mut app, |auth_manager, ctx| {
             auth_manager.initialize_user_from_auth_payload(auth_payload, true, ctx);
         });
+    });
+}
+
+#[test]
+fn test_device_code_request_retries_then_times_out() {
+    App::test((), |_app| async move {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_request = attempts.clone();
+
+        let result = request_device_code_with_timeout(
+            move || {
+                attempts_for_request.fetch_add(1, Ordering::Relaxed);
+                futures::future::pending()
+            },
+            Duration::from_millis(1),
+            2,
+        )
+        .await;
+
+        assert_eq!(attempts.load(Ordering::Relaxed), 2);
+        let error = result.unwrap_err();
+        assert!(matches!(
+            &error,
+            UserAuthenticationError::DeviceCodeRequestTimedOut { attempts: 2 }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Timed out requesting a sign-in link after 2 attempts"
+        );
     });
 }
 

--- a/app/src/auth/paste_auth_token_modal.rs
+++ b/app/src/auth/paste_auth_token_modal.rs
@@ -153,6 +153,7 @@ impl PasteAuthTokenModalView {
                     }
                     UserAuthenticationError::DeniedAccessToken(_)
                     | UserAuthenticationError::UserAccountDisabled(_)
+                    | UserAuthenticationError::DeviceCodeRequestTimedOut { .. }
                     | UserAuthenticationError::Unexpected(_) => {
                         LoginFailureReason::FailedUserAuthentication
                     }

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -3458,6 +3458,7 @@ impl RootView {
                 UserAuthenticationError::Unexpected(_) => {
                     report_error!(err);
                 }
+                UserAuthenticationError::DeviceCodeRequestTimedOut { .. } => {}
                 UserAuthenticationError::InvalidStateParameter => {}
                 UserAuthenticationError::MissingStateParameter => {}
             },

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -37,6 +37,8 @@ pub enum TuiLoginPhase {
 
 /// Events emitted by [`TuiLoginModel`].
 pub enum TuiLoginEvent {
+    /// The login phase changed and the root view must repaint.
+    PhaseChanged,
     /// Authentication completed and the TUI can create its terminal session.
     LoggedIn,
     /// The current user logged out and the TUI should return to authentication.
@@ -84,7 +86,22 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
 
     // Keep the auth subscription alive for the full process lifetime so a
     // logged-in TUI can complete device authorization again after logout.
-    ctx.subscribe_to_model(&AuthManager::handle(ctx), |_, event, ctx| match event {
+    ctx.subscribe_to_model(&AuthManager::handle(ctx), |_, event, ctx| {
+        handle_auth_manager_event(event, ctx);
+    });
+    // Mount the TUI now so it renders immediately; the root view shows the
+    // login placeholder until the model flips to `LoggedIn`.
+    mount(ctx);
+
+    if logged_in {
+        activate_global_mcp_servers(ctx);
+    } else {
+        authorize_device(ctx);
+    }
+}
+
+fn handle_auth_manager_event(event: &AuthManagerEvent, ctx: &mut AppContext) {
+    match event {
         AuthManagerEvent::ReceivedDeviceAuthorizationCode {
             verification_url,
             verification_url_complete,
@@ -95,14 +112,16 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
                 .as_deref()
                 .unwrap_or(verification_url.as_str());
             let url_to_open = tui_verification_url(url_to_open);
-            ctx.open_url(&url_to_open);
             set_login_phase(
                 ctx,
                 TuiLoginPhase::AwaitingLogin {
-                    verification_uri: Some(url_to_open),
+                    verification_uri: Some(url_to_open.clone()),
                     user_code: Some(user_code.clone()),
                 },
             );
+            if !ctx.try_open_url(&url_to_open) {
+                log::warn!("Unable to open the device authorization URL in the default browser");
+            }
         }
         AuthManagerEvent::AuthComplete => {
             set_login_phase(ctx, TuiLoginPhase::LoggedIn);
@@ -115,15 +134,6 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
             },
         ),
         _ => {}
-    });
-    // Mount the TUI now so it renders immediately; the root view shows the
-    // login placeholder until the model flips to `LoggedIn`.
-    mount(ctx);
-
-    if logged_in {
-        activate_global_mcp_servers(ctx);
-    } else {
-        authorize_device(ctx);
     }
 }
 
@@ -161,6 +171,7 @@ fn set_logged_out_phase(ctx: &mut AppContext) {
             user_code: None,
         };
         ctx.notify();
+        ctx.emit(TuiLoginEvent::PhaseChanged);
         ctx.emit(TuiLoginEvent::LoggedOut);
     });
 }
@@ -173,6 +184,7 @@ fn set_login_phase(ctx: &mut AppContext, phase: TuiLoginPhase) {
         let logged_in = matches!(phase, TuiLoginPhase::LoggedIn);
         model.phase = phase;
         ctx.notify();
+        ctx.emit(TuiLoginEvent::PhaseChanged);
         if logged_in {
             ctx.emit(TuiLoginEvent::LoggedIn);
         }

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -4,9 +4,11 @@ use std::rc::Rc;
 use warpui::{App, SingletonEntity};
 
 use super::{
-    TuiLoginEvent, TuiLoginModel, TuiLoginPhase, set_logged_out_phase, set_login_phase,
-    tui_verification_url,
+    TuiLoginEvent, TuiLoginModel, TuiLoginPhase, handle_auth_manager_event, set_logged_out_phase,
+    set_login_phase, tui_verification_url,
 };
+use crate::auth::auth_manager::AuthManagerEvent;
+use crate::server::server_api::auth::UserAuthenticationError;
 
 #[test]
 fn tags_tui_verification_url_without_losing_existing_query_parameters() {
@@ -32,6 +34,75 @@ fn leaves_invalid_verification_url_unchanged() {
 }
 
 #[test]
+fn stores_device_fallback_before_opening_browser() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| TuiLoginModel {
+            phase: TuiLoginPhase::AwaitingLogin {
+                verification_uri: None,
+                user_code: None,
+            },
+        });
+
+        let browser_opened = Rc::new(Cell::new(false));
+        let browser_opened_for_callback = browser_opened.clone();
+        app.update(|ctx| {
+            ctx.set_before_open_url(move |url, ctx| {
+                assert!(matches!(
+                    TuiLoginModel::as_ref(ctx).phase(),
+                    TuiLoginPhase::AwaitingLogin {
+                        verification_uri: Some(verification_uri),
+                        user_code: Some(user_code),
+                    } if verification_uri == url && user_code == "ABCD-EFGH"
+                ));
+                browser_opened_for_callback.set(true);
+                url.to_owned()
+            });
+            handle_auth_manager_event(
+                &AuthManagerEvent::ReceivedDeviceAuthorizationCode {
+                    verification_url: "https://app.warp.dev/device".to_owned(),
+                    verification_url_complete: Some(
+                        "https://app.warp.dev/device?user_code=ABCD-EFGH".to_owned(),
+                    ),
+                    user_code: "ABCD-EFGH".to_owned(),
+                },
+                ctx,
+            );
+        });
+
+        assert!(browser_opened.get());
+    });
+}
+
+#[test]
+fn renders_device_code_request_timeout_without_id_token_prefix() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| TuiLoginModel {
+            phase: TuiLoginPhase::AwaitingLogin {
+                verification_uri: None,
+                user_code: None,
+            },
+        });
+
+        app.update(|ctx| {
+            handle_auth_manager_event(
+                &AuthManagerEvent::AuthFailed(UserAuthenticationError::DeviceCodeRequestTimedOut {
+                    attempts: 2,
+                }),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::Failed { message }
+                    if message == "Timed out requesting a sign-in link after 2 attempts"
+                        && !message.contains("ID token")
+            ));
+        });
+    });
+}
+#[test]
 fn emits_logged_in_event_when_login_completes() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| TuiLoginModel {
@@ -43,10 +114,16 @@ fn emits_logged_in_event_when_login_completes() {
 
         let logged_in_events = Rc::new(Cell::new(0));
         let logged_in_events_for_subscription = logged_in_events.clone();
+        let phase_changed_events = Rc::new(Cell::new(0));
+        let phase_changed_events_for_subscription = phase_changed_events.clone();
         app.update(|ctx| {
             ctx.subscribe_to_model(
                 &TuiLoginModel::handle(ctx),
                 move |_, event, _| match event {
+                    TuiLoginEvent::PhaseChanged => {
+                        phase_changed_events_for_subscription
+                            .set(phase_changed_events_for_subscription.get() + 1);
+                    }
                     TuiLoginEvent::LoggedIn => {
                         logged_in_events_for_subscription
                             .set(logged_in_events_for_subscription.get() + 1);
@@ -65,9 +142,11 @@ fn emits_logged_in_event_when_login_completes() {
             );
         });
         assert_eq!(logged_in_events.get(), 0);
+        assert_eq!(phase_changed_events.get(), 1);
 
         app.update(|ctx| set_login_phase(ctx, TuiLoginPhase::LoggedIn));
         assert_eq!(logged_in_events.get(), 1);
+        assert_eq!(phase_changed_events.get(), 2);
     });
 }
 
@@ -84,6 +163,7 @@ fn emits_logged_out_event_and_resets_login_details() {
             ctx.subscribe_to_model(
                 &TuiLoginModel::handle(ctx),
                 move |_, event, _| match event {
+                    TuiLoginEvent::PhaseChanged => {}
                     TuiLoginEvent::LoggedIn => {}
                     TuiLoginEvent::LoggedOut => {
                         logged_out_events_for_subscription

--- a/crates/warp_server_client/src/auth/mod.rs
+++ b/crates/warp_server_client/src/auth/mod.rs
@@ -480,6 +480,8 @@ pub enum UserAuthenticationError {
     InvalidStateParameter,
     #[error("Missing state parameter in auth redirect")]
     MissingStateParameter,
+    #[error("Timed out requesting a sign-in link after {attempts} attempts")]
+    DeviceCodeRequestTimedOut { attempts: usize },
     #[error("unexpected error occurred when fetching an ID token: {0:#}")]
     Unexpected(#[from] anyhow::Error),
 }
@@ -499,6 +501,7 @@ impl ErrorExt for UserAuthenticationError {
                 log::info!("ignoring user account disabled error: {error:#}");
                 false
             }
+            UserAuthenticationError::DeviceCodeRequestTimedOut { .. } => false,
             UserAuthenticationError::Unexpected(error) => error.is_actionable(),
             UserAuthenticationError::InvalidStateParameter
             | UserAuthenticationError::MissingStateParameter => {

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -146,6 +146,9 @@ fn init(
             let root_for_login = root.clone();
             let login_model = TuiLoginModel::handle(ctx);
             ctx.subscribe_to_model(&login_model, move |_, event, ctx| match event {
+                TuiLoginEvent::PhaseChanged => {
+                    root_for_login.update(ctx, |_, ctx| ctx.notify());
+                }
                 TuiLoginEvent::LoggedIn => {
                     create_terminal_session_after_login(&sessions_for_login, &root_for_login, ctx)
                 }

--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -157,7 +157,7 @@ pub(crate) fn login_placeholder(
         }
         _ => {
             content = content.child(
-                TuiText::new("Opening your browser…")
+                TuiText::new("Requesting a sign-in link…")
                     .with_style(dim)
                     .truncate()
                     .finish(),

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -69,7 +69,7 @@ fn login_placeholder_is_centered_for_all_states() {
                 (
                     None,
                     None,
-                    vec!["Sign in to continue", "Opening your browser…"],
+                    vec!["Sign in to continue", "Requesting a sign-in link…"],
                 ),
                 (
                     Some("https://warp.dev/device"),

--- a/crates/warpui/src/platform/headless/delegate.rs
+++ b/crates/warpui/src/platform/headless/delegate.rs
@@ -82,16 +82,16 @@ impl platform::Delegate for AppDelegate {
         platform::SystemTheme::Light
     }
 
-    fn open_url(&self, url: &str) {
+    fn open_url(&self, url: &str) -> bool {
         #[cfg(target_os = "macos")]
         {
             // Use macOS platform implementation
-            crate::platform::mac::Window::open_url(url);
+            crate::platform::mac::Window::open_url(url)
         }
         #[cfg(not(target_os = "macos"))]
         {
             // Reuse the winit implementation for non-mac platforms
-            crate::windowing::winit::delegate::open_url_in_system(url);
+            crate::windowing::winit::delegate::open_url_in_system(url)
         }
     }
 

--- a/crates/warpui/src/platform/mac/delegate.rs
+++ b/crates/warpui/src/platform/mac/delegate.rs
@@ -79,8 +79,8 @@ impl platform::Delegate for IntegrationTestDelegate {
         self.app_delegate.set_cursor_shape(cursor)
     }
 
-    fn open_url(&self, _: &str) {
-        // no-op
+    fn open_url(&self, _: &str) -> bool {
+        true
     }
 
     fn open_file_path(&self, _: &Path) {
@@ -217,8 +217,8 @@ impl platform::Delegate for AppDelegate {
     fn get_cursor_shape(&self) -> Cursor {
         unimplemented!("only implemented in tests")
     }
-    fn open_url(&self, url: &str) {
-        Window::open_url(url);
+    fn open_url(&self, url: &str) -> bool {
+        Window::open_url(url)
     }
 
     fn open_file_path(&self, path: &Path) {

--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -1024,9 +1024,12 @@ void open_save_file_picker(void *callback, NSString *defaultFilename, NSString *
 }
 
 // Open a given url.
-void open_url(NSString *urlString) {
+BOOL open_url(NSString *urlString) {
     NSURL *url = [NSURL URLWithString:urlString];
-    [[NSWorkspace sharedWorkspace] openURL:url];
+    if (url == nil) {
+        return NO;
+    }
+    return [[NSWorkspace sharedWorkspace] openURL:url];
 }
 
 void hide_app() {

--- a/crates/warpui/src/platform/mac/window.rs
+++ b/crates/warpui/src/platform/mac/window.rs
@@ -473,7 +473,7 @@ unsafe extern "C" {
         default_filename: &NSString,
         default_directory: &NSString,
     );
-    fn open_url(urlString: &NSString);
+    fn open_url(urlString: &NSString) -> Bool;
     fn set_titlebar_height(window: &NSWindow, height: f64);
 }
 
@@ -742,11 +742,9 @@ impl Window {
         }
     }
 
-    pub fn open_url(url: &str) {
+    pub fn open_url(url: &str) -> bool {
         // SAFETY: `open_url` reads the string for the duration of the call.
-        unsafe {
-            open_url(&NSString::from_str(url));
-        }
+        unsafe { open_url(&NSString::from_str(url)).as_bool() }
     }
 
     pub fn open_file_path(path: &Path) {

--- a/crates/warpui/src/windowing/winit/delegate.rs
+++ b/crates/warpui/src/windowing/winit/delegate.rs
@@ -55,18 +55,19 @@ impl GlobalHotKeyHandler {
 static MAIN_THREAD_ID: OnceLock<thread::ThreadId> = OnceLock::new();
 
 /// Open a URL using the platform's default handler.
-pub fn open_url_in_system(url: &str) {
+pub fn open_url_in_system(url: &str) -> bool {
     #[cfg(target_family = "wasm")]
-    if let Some(window) = web_sys::window() {
-        if let Some(safe_url) = crate::browser::safe_browser_open_url(url) {
-            let _ = window.open_with_url_and_target_and_features(
-                &safe_url,
-                "_blank",
-                "noopener,noreferrer",
-            );
-        } else {
+    {
+        let Some(window) = web_sys::window() else {
+            return false;
+        };
+        let Some(safe_url) = crate::browser::safe_browser_open_url(url) else {
             log::warn!("Skipping browser URL open for invalid or unsafe URL");
-        }
+            return false;
+        };
+        window
+            .open_with_url_and_target_and_features(&safe_url, "_blank", "noopener,noreferrer")
+            .is_ok_and(|window| window.is_some())
     }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -84,7 +85,7 @@ pub fn open_url_in_system(url: &str) {
         // 3. Fall back to default linux url opening behavior.
         if platform::linux::is_wsl() {
             match open::with_detached(url, "wslview") {
-                Ok(_) => return,
+                Ok(_) => return true,
                 Err(e) => log::info!(
                     "Failed to open url with wslview {e:?}, falling back to another method"
                 ),
@@ -112,7 +113,11 @@ pub fn open_url_in_system(url: &str) {
                         .stderr(std::process::Stdio::null())
                         .status()
                     {
-                        Ok(_) => return,
+                        Ok(status) if status.success() => return true,
+                        Ok(status) => log::info!(
+                            "Failed to open url with rundll32.exe: process exited with {status}, \
+                             falling back to another method"
+                        ),
                         Err(e) => log::info!(
                             "Failed to open url with rundll32.exe {e:?}, falling back to another method"
                         ),
@@ -122,17 +127,33 @@ pub fn open_url_in_system(url: &str) {
                 }
             }
         }
-        if let Err(e) = open::that_detached(url) {
-            log::warn!("Unable to open url {e:?}");
+        match open::that_detached(url) {
+            Ok(_) => true,
+            Err(e) => {
+                log::warn!("Unable to open url {e:?}");
+                false
+            }
         }
     }
 
     #[cfg(windows)]
     {
-        if let Err(e) = open::that_detached(url) {
-            log::warn!("Unable to open url {e:?}");
+        match open::that_detached(url) {
+            Ok(_) => true,
+            Err(e) => {
+                log::warn!("Unable to open url {e:?}");
+                false
+            }
         }
     }
+
+    #[cfg(not(any(
+        target_family = "wasm",
+        target_os = "linux",
+        target_os = "freebsd",
+        windows
+    )))]
+    false
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -299,8 +320,8 @@ impl platform::Delegate for AppDelegate {
         platform::SystemTheme::Light
     }
 
-    fn open_url(&self, url: &str) {
-        open_url_in_system(url);
+    fn open_url(&self, url: &str) -> bool {
+        open_url_in_system(url)
     }
 
     fn open_file_path(&self, path: &Path) {
@@ -604,8 +625,8 @@ impl platform::Delegate for IntegrationTestDelegate {
         self.app_delegate.system_theme()
     }
 
-    fn open_url(&self, _: &str) {
-        // no-op
+    fn open_url(&self, _: &str) -> bool {
+        true
     }
 
     fn open_file_path(&self, _: &Path) {

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -4725,8 +4725,13 @@ impl AppContext {
 
     /// Opens the given URL in the default application configured to handle the URL.
     pub fn open_url(&self, url: &str) {
+        self.try_open_url(url);
+    }
+
+    /// Opens the given URL and returns whether the platform accepted the launch request.
+    pub fn try_open_url(&self, url: &str) -> bool {
         let effective_url = (self.before_open_url_callback)(url, self);
-        self.platform_delegate.open_url(&effective_url);
+        self.platform_delegate.open_url(&effective_url)
     }
 
     pub fn system_theme(&self) -> SystemTheme {

--- a/crates/warpui_core/src/platform/mod.rs
+++ b/crates/warpui_core/src/platform/mod.rs
@@ -194,7 +194,8 @@ pub trait Delegate: 'static {
 
     fn system_theme(&self) -> SystemTheme;
 
-    fn open_url(&self, url: &str);
+    /// Opens a URL in its default system handler and returns whether the launch request succeeded.
+    fn open_url(&self, url: &str) -> bool;
 
     /// Opens an absolute file path with native system API.
     fn open_file_path(&self, path: &Path);

--- a/crates/warpui_core/src/platform/test/delegate.rs
+++ b/crates/warpui_core/src/platform/test/delegate.rs
@@ -188,8 +188,8 @@ impl platform::Delegate for AppDelegate {
         *self.cursor_shape.lock() = cursor;
     }
 
-    fn open_url(&self, _: &str) {
-        // no-op for tests
+    fn open_url(&self, _: &str) -> bool {
+        true
     }
 
     fn close_ime_async(&self, _window_id: WindowId) {
@@ -303,8 +303,8 @@ impl platform::Delegate for IntegrationTestDelegate {
         *self.cursor_shape.lock() = cursor;
     }
 
-    fn open_url(&self, _: &str) {
-        // no-op for tests
+    fn open_url(&self, _: &str) -> bool {
+        true
     }
 
     fn close_ime_async(&self, _window_id: WindowId) {


### PR DESCRIPTION
## Description
Fixes three independent failure modes in the Warp Agent CLI device-auth flow:

- Bounds the initial device-code request to two 10-second attempts so a stalled request becomes a visible login failure instead of hanging indefinitely. The timeout now uses a dedicated error that says “Timed out requesting a sign-in link…” rather than the unrelated ID-token error prefix.
- Propagates browser-launch success from platform delegates, including the result of macOS `NSWorkspace::openURL`, and logs launch failures without exposing the URL or device code.
- Stores the manual verification URL/code before opening the browser and emits a login phase event that invalidates the root TUI view, so the fallback appears immediately without requiring a terminal resize.

The initial placeholder now says “Requesting a sign-in link…” rather than claiming the browser is already opening.

## Linked Issue
[CODE-1834: TUI login screen doesn't repaint when the device auth code arrives](https://linear.app/warpdotdev/issue/CODE-1834/tui-login-screen-doesnt-repaint-when-the-device-auth-code-arrives)

- [x] The linked issue is ready to implement.
- [x] The user-visible behavior was manually verified end to end in the real TUI. A screenshot is intentionally omitted because the rendered fallback contains a short-lived device authorization code.

## Testing
Automated validation:

- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo check -p warp_tui --bin warp-tui-oss`
- `cargo nextest run -p warp_tui` — 657 passed
- Focused auth/TUI regressions — 5 passed, covering bounded retry exhaustion, the clear timeout message without the ID-token prefix, phase-change events, fallback state ordering before browser launch, and login state reset

Manual TUI validation used standalone OSS builds with isolated `WARP_DATA_PROFILE` values so existing credentials were not modified:

- Against production auth, the verification URL/code appeared within three seconds without a resize, and macOS accepted the system-browser launch request.
- Through a local nonresponsive HTTPS proxy, the TUI first showed “Requesting a sign-in link…”, retried after 10 seconds, then rendered a controlled `Login failed` state after the second timeout.

- [x] I have manually tested my changes locally with the real standalone TUI.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Warp conversation](https://staging.warp.dev/conversation/df38a2fd-7b50-403c-9d9f-6141466507c5)

CHANGELOG-BUG-FIX: Fixed Warp Agent CLI sign-in hangs and ensured manual device authorization codes appear immediately.
