### PR TITLE
Remove implicit fork-on-rewind behavior (APP-5005)

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -3517,9 +3517,6 @@ fn update_forked_task_properties(
 /// The default prefix used when forking a conversation.
 pub const FORK_PREFIX: &str = "(Fork) ";
 
-/// The prefix used when saving a conversation before a rewind operation.
-pub const PRE_REWIND_PREFIX: &str = "(Pre-Rewind) ";
-
 #[cfg(test)]
 #[path = "history_model_tests.rs"]
 mod tests;

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -107,7 +107,6 @@ pub(crate) use conversation_selection::{
 pub(crate) use history_model::{
     AIQueryHistory, AIQueryHistoryOutputStatus, BeginConversationRenameError,
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate, FORK_PREFIX,
-    PRE_REWIND_PREFIX,
 };
 // The policy types are re-exported for the TUI frontend via `tui_export`.
 #[cfg_attr(not(feature = "tui"), allow(unused_imports))]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -259,7 +259,7 @@ use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputEvent, BlocklistAIInputModel,
     ClientIdentifiers, ConversationSelection, ConversationStatusUpdate, InputConfig, InputType,
     InputTypeAutoDetectionSource, LegacyPassiveSuggestionsEvent, LegacyPassiveSuggestionsModel,
-    MaaPassiveSuggestionsEvent, MaaPassiveSuggestionsModel, PRE_REWIND_PREFIX,
+    MaaPassiveSuggestionsEvent, MaaPassiveSuggestionsModel,
     PassiveSuggestionsModels, PendingAttachment, PendingQueryState, QueuedQuery, QueuedQueryId,
     QueuedQueryModel, QueuedQueryOrigin, RequestFileEditsFormatKind, ShellCommandExecutor,
     ShellCommandExecutorEvent, SlashCommandRequest, StartAgentExecutor, StartAgentExecutorEvent,
@@ -24837,23 +24837,6 @@ impl TerminalView {
                 }
             }
         }
-
-        // Save a backup of the conversation before truncating, so users can restore it later.
-        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-            match history_model.conversation(&conversation_id).cloned() { Some(conversation) => {
-                if let Err(e) = history_model.fork_conversation(
-                    &conversation,
-                    PRE_REWIND_PREFIX,
-                    false, /* preserve_task_ids */
-                    None,
-                    ctx,
-                ) {
-                    log::warn!("Failed to save pre-rewind backup of conversation {conversation_id}: {e}");
-                }
-            } _ => {
-                log::warn!("Failed to save pre-rewind backup: conversation {conversation_id} not found in memory");
-            }}
-        });
 
         // Truncate the conversation history
         let removed_exchange_ids =

--- a/app/src/workspace/rewind_confirmation_dialog.rs
+++ b/app/src/workspace/rewind_confirmation_dialog.rs
@@ -200,7 +200,7 @@ impl View for RewindConfirmationDialog {
             Dialog::new(
                 "Rewind".into(),
                 Some(
-                    "Are you sure you want to rewind? This will restore your code and conversation to before this point, and cancel any commands the agent is currently running. A copy of the original conversation will be saved in your conversation history."
+                    "Are you sure you want to rewind? This will restore your code and conversation to before this point, and cancel any commands the agent is currently running."
                         .into(),
                 ),
                 UiComponentStyles {


### PR DESCRIPTION
## Description

Removes the implicit fork-on-rewind behavior that was creating confusing `(Pre-Rewind)` entries in the conversation list. Previously, rewinding a conversation would automatically create a full copy of the conversation with a `(Pre-Rewind)` prefix before truncating. Combined with the existing explicit fork feature (`(Fork)` prefix), this led to conversation lists cluttered with entries like:

- `(Pre-Rewind) Iterate Automation Schema Design`
- `(Pre-Rewind) (Fork) Iterate Automation Schema Design open in different pane`
- `(Fork) Iterate Automation Schema Design open in different pane`

**Changes:**
- Removed the `fork_conversation()` call in `rewind_ai_conversation()` — rewind now modifies the conversation in-place without creating a backup copy
- Removed the `PRE_REWIND_PREFIX` constant and its re-export since it is no longer used
- Updated the confirmation dialog text to remove the sentence "A copy of the original conversation will be saved in your conversation history."

Users who want to preserve conversation history before rewinding can use the explicit Fork action first.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Closes APP-5005

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

### Testing notes

The change can be verified by:
1. Starting an agent conversation
2. Clicking "Rewind" on an exchange
3. Confirming the rewind — the conversation should be truncated in-place, without a new `(Pre-Rewind)` entry appearing in the conversation list

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Conversation rewind no longer creates a confusing '(Pre-Rewind)' backup entry — rewinding now modifies the conversation in-place.
-->

_Conversation: https://staging.warp.dev/conversation/14437383-1943-4eb9-806b-6c9abf287708_
_Run: https://oz.staging.warp.dev/runs/019fa5d3-0a1e-7a00-a396-21b4d7e32048_

_This PR was generated with [Oz](https://warp.dev/oz)._
