### PR TITLE
Add manual TUI attachment for running commands

### DIFF
--- a/crates/warp_tui/src/input_hints.rs
+++ b/crates/warp_tui/src/input_hints.rs
@@ -2,5 +2,18 @@
 
 /// Ghosted hint row shown in the input's slot while a user-controlled
 /// long-running command owns input (the input box itself stays hidden).
-/// ctrl-c is the reserved interrupt key in both the TUI keymap and the PTY.
-pub(crate) const LONG_RUNNING_COMMAND_HINT: &str = "ctrl-c to interrupt";
+/// ctrl-c is included only when the transcript contains visible command
+/// content; the zero state has nothing visible to interrupt.
+pub(crate) fn long_running_command_hint(
+    attach_key: Option<&str>,
+    include_interrupt: bool,
+) -> Option<String> {
+    let mut hints = Vec::with_capacity(2);
+    if let Some(key) = attach_key {
+        hints.push(format!("{key} to use agent"));
+    }
+    if include_interrupt {
+        hints.push("ctrl-c to interrupt".to_owned());
+    }
+    (!hints.is_empty()).then(|| hints.join(" • "))
+}

--- a/crates/warp_tui/src/input_hints.rs
+++ b/crates/warp_tui/src/input_hints.rs
@@ -2,18 +2,6 @@
 
 /// Ghosted hint row shown in the input's slot while a user-controlled
 /// long-running command owns input (the input box itself stays hidden).
-/// ctrl-c is included only when the transcript contains visible command
-/// content; the zero state has nothing visible to interrupt.
-pub(crate) fn long_running_command_hint(
-    attach_key: Option<&str>,
-    include_interrupt: bool,
-) -> Option<String> {
-    let mut hints = Vec::with_capacity(2);
-    if let Some(key) = attach_key {
-        hints.push(format!("{key} to use agent"));
-    }
-    if include_interrupt {
-        hints.push("ctrl-c to interrupt".to_owned());
-    }
-    (!hints.is_empty()).then(|| hints.join(" • "))
+pub(crate) fn long_running_command_hint(attach_key: Option<&str>) -> Option<String> {
+    attach_key.map(|key| format!("{key}  to use agent"))
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -85,7 +85,7 @@ use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestions
 use crate::keybindings::{
     ATTACHMENTS_AVAILABLE_FLAG, CONTEXTUAL_PLAN_TOGGLE_BINDING_NAME,
     KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG, PLAN_TOGGLE_AVAILABLE_FLAG, PLAN_TOGGLE_BINDING_NAME,
-    TUI_BINDING_GROUP,
+    TUI_BINDING_GROUP, binding_hint,
 };
 use crate::mcp_menu::{TuiMcpMenuEvent, TuiMcpMenuModel};
 use crate::model_menu::{TuiModelMenuEvent, TuiModelMenuModel};
@@ -173,6 +173,10 @@ fn status_menu_is_open(mode: TuiInputSuggestionsMode) -> bool {
 }
 const SESSION_CAN_CANCEL_RESTORE_FLAG: &str = "TuiSessionCanCancelRestore";
 const SESSION_CAN_HAND_BACK_CONTROL_FLAG: &str = "TuiSessionCanHandBackControl";
+const SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG: &str =
+    "TuiSessionCanAttachAgentToRunningCommand";
+const SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG: &str =
+    "TuiSessionCanDetachAgentFromRunningCommand";
 const SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG: &str =
     "TuiSessionCanAcceptBlockedTerminalUseAction";
 pub(crate) const SESSION_COMPOSER_OWNS_INPUT_FLAG: &str = "TuiSessionComposerOwnsInput";
@@ -180,6 +184,10 @@ pub(crate) const PASTE_IMAGE_BINDING_NAME: &str = "tui:session:paste_image";
 pub(crate) const AUTO_APPROVE_TOGGLE_BINDING_NAME: &str = "tui:session:toggle_auto_approve";
 pub(crate) const ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME: &str =
     "tui:session:accept_blocked_terminal_use_action";
+pub(crate) const ATTACH_AGENT_TO_RUNNING_COMMAND_BINDING_NAME: &str =
+    "tui:session:attach_agent_to_running_command";
+pub(crate) const DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME: &str =
+    "tui:session:detach_agent_from_running_command";
 pub(crate) const VOICE_INPUT_BINDING_NAME: &str = "tui:session:start_voice_input";
 
 /// The current source preventing the normal session composer from owning input.
@@ -685,6 +693,10 @@ pub(crate) enum TuiTerminalSessionAction {
     CancelRestore,
     /// Return a user-controlled terminal-use command to the agent.
     HandBackTerminalUseControl,
+    /// Show the agent composer for an eligible user-started running command.
+    AttachAgentToRunningCommand,
+    /// Hide the composer before submission and return input to the running command.
+    DetachAgentFromRunningCommand,
     /// Accept the active terminal-use agent's blocked action.
     AcceptBlockedTerminalUseAction,
     /// Reject the active terminal-use agent's blocked action.
@@ -846,6 +858,28 @@ pub(crate) fn init(app: &mut AppContext) {
         .with_group(TUI_BINDING_GROUP),
     ]);
     app.register_editable_bindings([
+        EditableBinding::new(
+            ATTACH_AGENT_TO_RUNNING_COMMAND_BINDING_NAME,
+            "Use the agent with the running command",
+            TuiTerminalSessionAction::AttachAgentToRunningCommand,
+        )
+        .with_context_predicate(
+            (id!(TuiInputView::ui_name()) | view_context.clone())
+                & id!(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG),
+        )
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("ctrl-shift-enter"),
+        EditableBinding::new(
+            DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME,
+            "Return control to the running command",
+            TuiTerminalSessionAction::DetachAgentFromRunningCommand,
+        )
+        .with_context_predicate(
+            (id!(TuiInputView::ui_name()) | view_context.clone())
+                & id!(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG),
+        )
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("escape"),
         EditableBinding::new(
             ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME,
             "Accept the blocked terminal-use action",
@@ -1103,6 +1137,14 @@ impl TuiTerminalSessionView {
             );
         });
     }
+    fn handle_block_completed(&mut self, block_id: &BlockId, ctx: &mut ViewContext<Self>) {
+        self.input_view.update(ctx, |input, ctx| {
+            input.reset_after_agent_control(ctx);
+        });
+        self.resume_after_user_controlled_command(block_id, ctx);
+        self.refresh_input_focus(ctx);
+        ctx.notify();
+    }
 
     fn detach_cli_subagent_view(
         &mut self,
@@ -1230,6 +1272,48 @@ impl TuiTerminalSessionView {
             controller.handoff_active_command_control_to_agent(ctx);
         });
         self.refresh_input_focus(ctx);
+    }
+    fn attach_agent_to_running_command(&mut self, ctx: &mut ViewContext<Self>) {
+        let did_attach = {
+            let mut terminal_model = self.terminal_model.lock();
+            let active_block = terminal_model.block_list_mut().active_block_mut();
+            if !active_block.is_eligible_to_tag_in_agent() {
+                false
+            } else {
+                active_block.set_is_agent_tagged_in(true);
+                true
+            }
+        };
+        if !did_attach {
+            return;
+        }
+        self.input_view.update(ctx, |input, ctx| {
+            input.clear(ctx);
+            input.lock_for_agent_control(ctx);
+        });
+        self.refresh_input_focus(ctx);
+        ctx.notify();
+    }
+
+    fn detach_agent_from_running_command(&mut self, ctx: &mut ViewContext<Self>) {
+        let did_detach = {
+            let mut terminal_model = self.terminal_model.lock();
+            let active_block = terminal_model.block_list_mut().active_block_mut();
+            if !active_block.is_agent_tagged_in() {
+                false
+            } else {
+                active_block.set_is_agent_tagged_in(false);
+                true
+            }
+        };
+        if !did_detach {
+            return;
+        }
+        self.input_view.update(ctx, |input, ctx| {
+            input.reset_after_agent_control(ctx);
+        });
+        self.refresh_input_focus(ctx);
+        ctx.notify();
     }
 
     fn active_agent_controlled_target(&self, ctx: &AppContext) -> Option<CLISubagentTarget> {
@@ -1807,9 +1891,7 @@ impl TuiTerminalSessionView {
         // PTY output redraws are driven by `wakeups_rx` below.
         ctx.subscribe_to_model(&model_events, |view, _, event, ctx| match event {
             ModelEvent::BlockCompleted(completed) => {
-                view.resume_after_user_controlled_command(&completed.block_id, ctx);
-                view.refresh_input_focus(ctx);
-                ctx.notify();
+                view.handle_block_completed(&completed.block_id, ctx);
             }
             ModelEvent::AfterBlockStarted { .. } => {
                 view.refresh_input_focus(ctx);
@@ -2160,6 +2242,11 @@ impl TuiTerminalSessionView {
     /// Footer shown while orchestration tabs own keyboard focus.
     fn render_orchestration_tab_footer(&self, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
         render_orchestration_tab_footer(builder)
+    }
+    fn running_command_hint(&self, include_interrupt: bool, ctx: &AppContext) -> Option<String> {
+        let context = self.keymap_context(ctx);
+        let attach_key = binding_hint(ATTACH_AGENT_TO_RUNNING_COMMAND_BINDING_NAME, &context, ctx);
+        input_hints::long_running_command_hint(attach_key.as_deref(), include_interrupt)
     }
 
     fn render_input_area(
@@ -4366,6 +4453,22 @@ impl TuiView for TuiTerminalSessionView {
         {
             context.set.insert(SESSION_CAN_HAND_BACK_CONTROL_FLAG);
         }
+        if state
+            .as_ref()
+            .is_some_and(|state| state.can_attach_agent_to_running_command())
+        {
+            context
+                .set
+                .insert(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG);
+        }
+        if state
+            .as_ref()
+            .is_some_and(|state| state.agent_is_tagged_in() && state.composer_owns_input())
+        {
+            context
+                .set
+                .insert(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG);
+        }
         if self
             .active_cli_subagent_view(ctx)
             .is_some_and(|view| view.as_ref(ctx).has_blocked_action(ctx))
@@ -4459,6 +4562,22 @@ impl TuiView for TuiTerminalSessionView {
                 terminal_content
             };
             let mut content = TuiFlex::column().flex_child(terminal_content.finish());
+            if input_target.pty_owns_input()
+                && state.user_owns_running_command()
+                && let Some(hint) = self.running_command_hint(true, ctx)
+            {
+                content = content.child(
+                    TuiContainer::new(
+                        TuiText::new(hint)
+                            .with_style(builder.muted_text_style())
+                            .truncate()
+                            .finish(),
+                    )
+                    .with_padding_x(2)
+                    .with_padding_bottom(1)
+                    .finish(),
+                );
+            }
             if input_target.agent_editor_owns_input() {
                 let mut agent_area = TuiFlex::column();
                 if let Some(cli_subagent_view) = cli_subagent_view {
@@ -4506,7 +4625,8 @@ impl TuiView for TuiTerminalSessionView {
         // slot; the first accepted submission produces a visible block, which
         // swaps the transcript back in.
         let mut content = TuiFlex::column();
-        if self.transcript.as_ref(ctx).is_empty() {
+        let transcript_is_empty = self.transcript.as_ref(ctx).is_empty();
+        if transcript_is_empty {
             content = content.flex_child(TuiChildView::new(&self.zero_state_view).finish());
         } else {
             content = content.flex_child(TuiChildView::new(&self.transcript).finish());
@@ -4600,16 +4720,21 @@ impl TuiView for TuiTerminalSessionView {
         }
         // While a user-controlled long-running command owns input, the input
         // box and footer stay hidden; a one-line ghosted hint row takes the
-        // input's slot so the interrupt affordance stays discoverable. Gated
-        // on the user-controlled-command predicate, not the broader PTY input
-        // target: visible startup-script execution also routes input to the
-        // PTY but is not a command the user should be told to interrupt.
-        // (Agent-driven terminal use keeps the composer, and its control
-        // hints come from the CLI-subagent status line.)
-        if !blocker_active && state.user_owns_running_command() {
+        // input's slot. The interrupt affordance is omitted when the zero
+        // state is visible because there is no visible command content to
+        // interrupt; manual attachment remains discoverable. Gated on the
+        // user-controlled-command predicate, not the broader PTY input target:
+        // visible startup-script execution also routes input to the PTY but is
+        // not a command the user should be told to interrupt. (Agent-driven
+        // terminal use keeps the composer, and its control hints come from the
+        // CLI-subagent status line.)
+        if !blocker_active
+            && state.user_owns_running_command()
+            && let Some(hint) = self.running_command_hint(!transcript_is_empty, ctx)
+        {
             content = content.child(
                 TuiContainer::new(
-                    TuiText::new(input_hints::LONG_RUNNING_COMMAND_HINT)
+                    TuiText::new(hint)
                         .with_style(builder.muted_text_style())
                         .truncate()
                         .finish(),
@@ -4713,6 +4838,12 @@ impl TypedActionView for TuiTerminalSessionView {
             }
             TuiTerminalSessionAction::HandBackTerminalUseControl => {
                 self.hand_back_terminal_use_control(ctx)
+            }
+            TuiTerminalSessionAction::AttachAgentToRunningCommand => {
+                self.attach_agent_to_running_command(ctx)
+            }
+            TuiTerminalSessionAction::DetachAgentFromRunningCommand => {
+                self.detach_agent_from_running_command(ctx)
             }
             TuiTerminalSessionAction::AcceptBlockedTerminalUseAction => {
                 self.accept_active_cli_subagent_action(ctx);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -156,6 +156,7 @@ const VOICE_INPUT_BORDER_REPAINT_INTERVAL: Duration = Duration::from_millis(33);
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
 const CTRL_C_EXIT_HINT: &str = "ctrl-c again to exit";
+const RUNNING_COMMAND_DETACH_HINT: &str = "ctrl-c to return to command";
 const STARTING_SHELL_HINT: &str = "Starting shell...";
 
 /// Fallback strings for the /status status menu.
@@ -1233,6 +1234,9 @@ impl TuiTerminalSessionView {
     }
 
     fn handle_terminal_use_interrupt(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        if self.try_detach_agent_from_running_command(ctx) {
+            return true;
+        }
         let control_state = self
             .cli_subagent_controller
             .as_ref(ctx)
@@ -1273,7 +1277,10 @@ impl TuiTerminalSessionView {
         });
         self.refresh_input_focus(ctx);
     }
-    fn attach_agent_to_running_command(&mut self, ctx: &mut ViewContext<Self>) {
+    /// Attempts to expose the agent composer for the active user-controlled LRC.
+    ///
+    /// Returns false when a stale action no longer targets an eligible block.
+    fn try_attach_agent_to_running_command(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         let did_attach = {
             let mut terminal_model = self.terminal_model.lock();
             let active_block = terminal_model.block_list_mut().active_block_mut();
@@ -1285,7 +1292,7 @@ impl TuiTerminalSessionView {
             }
         };
         if !did_attach {
-            return;
+            return false;
         }
         self.input_view.update(ctx, |input, ctx| {
             input.clear(ctx);
@@ -1293,9 +1300,13 @@ impl TuiTerminalSessionView {
         });
         self.refresh_input_focus(ctx);
         ctx.notify();
+        true
     }
 
-    fn detach_agent_from_running_command(&mut self, ctx: &mut ViewContext<Self>) {
+    /// Attempts to return input to the active manually tagged LRC.
+    ///
+    /// Returns false when no active block has a manually attached agent.
+    fn try_detach_agent_from_running_command(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         let did_detach = {
             let mut terminal_model = self.terminal_model.lock();
             let active_block = terminal_model.block_list_mut().active_block_mut();
@@ -1307,13 +1318,14 @@ impl TuiTerminalSessionView {
             }
         };
         if !did_detach {
-            return;
+            return false;
         }
         self.input_view.update(ctx, |input, ctx| {
             input.reset_after_agent_control(ctx);
         });
         self.refresh_input_focus(ctx);
         ctx.notify();
+        true
     }
 
     fn active_agent_controlled_target(&self, ctx: &AppContext) -> Option<CLISubagentTarget> {
@@ -2243,10 +2255,10 @@ impl TuiTerminalSessionView {
     fn render_orchestration_tab_footer(&self, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
         render_orchestration_tab_footer(builder)
     }
-    fn running_command_hint(&self, include_interrupt: bool, ctx: &AppContext) -> Option<String> {
+    fn running_command_hint(&self, ctx: &AppContext) -> Option<String> {
         let context = self.keymap_context(ctx);
         let attach_key = binding_hint(ATTACH_AGENT_TO_RUNNING_COMMAND_BINDING_NAME, &context, ctx);
-        input_hints::long_running_command_hint(attach_key.as_deref(), include_interrupt)
+        input_hints::long_running_command_hint(attach_key.as_deref())
     }
 
     fn render_input_area(
@@ -3039,6 +3051,12 @@ impl TuiTerminalSessionView {
             };
             return Some(FooterHint { text, style });
         }
+        if self
+            .session_state(ctx)
+            .is_ok_and(|state| state.agent_is_tagged_in())
+        {
+            return Some(FooterHint::muted(RUNNING_COMMAND_DETACH_HINT));
+        }
         if voice_statusline_visible {
             return None;
         }
@@ -3060,8 +3078,9 @@ impl TuiTerminalSessionView {
     /// the persisted item order and visibility; shell mode always leads with
     /// its mode label and resolves configured shell-relevant metadata. A
     /// replacing hint — the ctrl-c exit confirmation while armed, the
-    /// conversation-list loading hint, or an active transient notice — occupies
-    /// the whole row instead. An empty resolved configuration consumes no row.
+    /// conversation-list loading hint, an active transient notice, or the
+    /// interrupt hint for a manually attached running command — occupies the
+    /// whole row instead. An empty resolved configuration consumes no row.
     fn render_footer(&self, ctx: &AppContext) -> TuiFlex {
         let builder = TuiUiBuilder::from_app(ctx);
         let shell_mode = self.is_shell_mode(ctx);
@@ -4564,7 +4583,7 @@ impl TuiView for TuiTerminalSessionView {
             let mut content = TuiFlex::column().flex_child(terminal_content.finish());
             if input_target.pty_owns_input()
                 && state.user_owns_running_command()
-                && let Some(hint) = self.running_command_hint(true, ctx)
+                && let Some(hint) = self.running_command_hint(ctx)
             {
                 content = content.child(
                     TuiContainer::new(
@@ -4720,17 +4739,15 @@ impl TuiView for TuiTerminalSessionView {
         }
         // While a user-controlled long-running command owns input, the input
         // box and footer stay hidden; a one-line ghosted hint row takes the
-        // input's slot. The interrupt affordance is omitted when the zero
-        // state is visible because there is no visible command content to
-        // interrupt; manual attachment remains discoverable. Gated on the
+        // input's slot when manual attachment is available. Gated on the
         // user-controlled-command predicate, not the broader PTY input target:
-        // visible startup-script execution also routes input to the PTY but is
-        // not a command the user should be told to interrupt. (Agent-driven
-        // terminal use keeps the composer, and its control hints come from the
-        // CLI-subagent status line.)
+        // visible startup-script execution also routes input to the PTY but
+        // does not support agent attachment. (Agent-driven terminal use keeps
+        // the composer, and its control hints come from the CLI-subagent status
+        // line.)
         if !blocker_active
             && state.user_owns_running_command()
-            && let Some(hint) = self.running_command_hint(!transcript_is_empty, ctx)
+            && let Some(hint) = self.running_command_hint(ctx)
         {
             content = content.child(
                 TuiContainer::new(
@@ -4840,10 +4857,10 @@ impl TypedActionView for TuiTerminalSessionView {
                 self.hand_back_terminal_use_control(ctx)
             }
             TuiTerminalSessionAction::AttachAgentToRunningCommand => {
-                self.attach_agent_to_running_command(ctx)
+                let _ = self.try_attach_agent_to_running_command(ctx);
             }
             TuiTerminalSessionAction::DetachAgentFromRunningCommand => {
-                self.detach_agent_from_running_command(ctx)
+                let _ = self.try_detach_agent_from_running_command(ctx);
             }
             TuiTerminalSessionAction::AcceptBlockedTerminalUseAction => {
                 self.accept_active_cli_subagent_action(ctx);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -1305,7 +1305,8 @@ impl TuiTerminalSessionView {
 
     /// Attempts to return input to the active manually tagged LRC.
     ///
-    /// Returns false when no active block has a manually attached agent.
+    /// Discards any unsent agent prompt. Returns false when no active block has
+    /// a manually attached agent.
     fn try_detach_agent_from_running_command(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         let did_detach = {
             let mut terminal_model = self.terminal_model.lock();
@@ -1321,7 +1322,7 @@ impl TuiTerminalSessionView {
             return false;
         }
         self.input_view.update(ctx, |input, ctx| {
-            input.reset_after_agent_control(ctx);
+            input.clear(ctx);
         });
         self.refresh_input_focus(ctx);
         ctx.notify();

--- a/crates/warp_tui/src/terminal_session_view/state.rs
+++ b/crates/warp_tui/src/terminal_session_view/state.rs
@@ -8,7 +8,10 @@ use warp::tui_export::{BlocklistAIInputModel, CLISubagentController, TerminalMod
 use warpui_core::keymap::Context;
 use warpui_core::{AppContext, Entity, ModelHandle, ViewHandle, WeakModelHandle, WeakViewHandle};
 
-use super::{AUTO_APPROVE_TOGGLE_BINDING_NAME, BlockingInputSource};
+use super::{
+    AUTO_APPROVE_TOGGLE_BINDING_NAME, BlockingInputSource,
+    DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME,
+};
 use crate::input_mode_policy;
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 use crate::keybindings::{PLAN_TOGGLE_BINDING_NAME, binding_hint};
@@ -154,12 +157,21 @@ impl TuiTerminalSessionStateModel {
                 let orchestration_tab_bar = orchestration_tab_bar
                     .upgrade(ctx)
                     .ok_or(TuiTerminalSessionStateResolveError::OrchestrationTabBar)?;
-                let (alt_screen_active, input_target, user_owns_running_command) = {
+                let (
+                    alt_screen_active,
+                    input_target,
+                    user_owns_running_command,
+                    can_attach_agent_to_running_command,
+                    agent_is_tagged_in,
+                ) = {
                     let terminal_model = terminal_model.lock();
+                    let active_block = terminal_model.block_list().active_block();
                     (
                         terminal_model.is_alt_screen_active(),
                         tui_input_target(&terminal_model),
                         inline_process_owns_input(&terminal_model),
+                        active_block.is_eligible_to_tag_in_agent(),
+                        active_block.is_agent_tagged_in(),
                     )
                 };
                 let terminal_use_control = cli_subagent_controller
@@ -208,6 +220,8 @@ impl TuiTerminalSessionStateModel {
                     transcript_is_empty: transcript.as_ref(ctx).is_empty(),
                     orchestration_available: orchestration_tab_bar.as_ref(ctx).has_tabs(),
                     plan_available: transcript.as_ref(ctx).has_toggleable_plan(ctx),
+                    can_attach_agent_to_running_command,
+                    agent_is_tagged_in,
                 };
                 Ok(if alt_screen_active {
                     TuiTerminalSessionState::AltScreen {
@@ -264,6 +278,8 @@ pub(crate) struct TuiBlockSessionState {
     pub(super) transcript_is_empty: bool,
     pub(super) orchestration_available: bool,
     pub(super) plan_available: bool,
+    pub(super) can_attach_agent_to_running_command: bool,
+    pub(super) agent_is_tagged_in: bool,
 }
 
 /// The single interaction that currently owns the block UI's input area.
@@ -370,6 +386,8 @@ impl TuiTerminalSessionState {
             transcript_is_empty,
             orchestration_available,
             plan_available: false,
+            can_attach_agent_to_running_command: false,
+            agent_is_tagged_in: false,
         })
     }
 
@@ -413,6 +431,13 @@ impl TuiTerminalSessionState {
             self.interaction(),
             TuiInteractionState::Pty(TuiPtyState::UserControlledTerminalUse)
         )
+    }
+    pub(crate) fn can_attach_agent_to_running_command(&self) -> bool {
+        self.state().can_attach_agent_to_running_command
+    }
+
+    pub(crate) fn agent_is_tagged_in(&self) -> bool {
+        self.state().agent_is_tagged_in
     }
 
     pub(crate) fn composer_owns_input(&self) -> bool {
@@ -545,6 +570,17 @@ impl TuiTerminalSessionState {
                 shortcuts: vec![TuiShortcut {
                     key: TAKE_CONTROL_KEY_BINDING.to_owned(),
                     description: "take control",
+                }],
+            });
+        } else if state.agent_is_tagged_in
+            && let Some(key) =
+                binding_hint(DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME, context, ctx)
+        {
+            sections.push(TuiShortcutSection {
+                title: "Terminal use",
+                shortcuts: vec![TuiShortcut {
+                    key,
+                    description: "return control to command",
                 }],
             });
         }

--- a/crates/warp_tui/src/terminal_session_view/state_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view/state_tests.rs
@@ -9,7 +9,9 @@ use super::{
 };
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
 use crate::read_only_menu::TuiReadOnlyMenuKind;
-use crate::terminal_session_view::{BlockingInputSource, TuiTerminalSessionView};
+use crate::terminal_session_view::{
+    BlockingInputSource, SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG, TuiTerminalSessionView,
+};
 use crate::terminal_use::TuiInputTarget;
 
 fn composer_state(mode: TuiComposerMode, orchestration_available: bool) -> TuiTerminalSessionState {
@@ -21,7 +23,48 @@ fn composer_state(mode: TuiComposerMode, orchestration_available: bool) -> TuiTe
         transcript_is_empty: false,
         orchestration_available,
         plan_available: false,
+        can_attach_agent_to_running_command: false,
+        agent_is_tagged_in: false,
     })
+}
+
+#[test]
+fn tagged_in_composer_exposes_detach_shortcut() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        app.read(|ctx| {
+            let mut state = composer_state(
+                TuiComposerMode::Agent {
+                    agent_controlled_terminal_use: false,
+                },
+                false,
+            );
+            let TuiTerminalSessionState::Block(block) = &mut state else {
+                unreachable!();
+            };
+            block.agent_is_tagged_in = true;
+            let mut context = Context::default();
+            context.set.insert(TuiTerminalSessionView::ui_name());
+            context
+                .set
+                .insert(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG);
+
+            let sections = state.shortcut_sections(&context, ctx);
+
+            assert_eq!(
+                sections
+                    .iter()
+                    .map(|section| section.title)
+                    .collect::<Vec<_>>(),
+                vec!["Shortcuts", "Terminal use"]
+            );
+            assert_eq!(sections[1].shortcuts[0].key, "Escape");
+            assert_eq!(
+                sections[1].shortcuts[0].description,
+                "return control to command"
+            );
+        });
+    });
 }
 fn alt_screen_state(
     input_target: TuiInputTarget,
@@ -34,6 +77,8 @@ fn alt_screen_state(
             transcript_is_empty: false,
             orchestration_available: false,
             plan_available: false,
+            can_attach_agent_to_running_command: false,
+            agent_is_tagged_in: false,
         },
     }
 }
@@ -44,6 +89,8 @@ fn block_state(interaction: TuiInteractionState) -> TuiTerminalSessionState {
         transcript_is_empty: false,
         orchestration_available: false,
         plan_available: false,
+        can_attach_agent_to_running_command: false,
+        agent_is_tagged_in: false,
     })
 }
 

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -15,10 +15,11 @@ use warp::terminal::model::ansi::{Handler, InputBufferValue, Mode};
 use warp::tui_export::{
     AIAgentActionId, AIAgentExchangeId, AIConversationAutoexecuteMode, AIConversationId,
     AgentViewEntryOrigin, BlockPadding, BlocklistAIHistoryModel, ConversationStatus,
-    ConversationUsageTotals, Harness, LLMPreferences, LinkedWorkflowData,
-    LongRunningCommandControlState, PtyIntent, PtyIntentEvent, QueuedQueryModel, SizeInfo,
-    SizeUpdate, TaskId, TranscriptScope, TuiUpArrowHistoryItemKind, UserTakeOverReason,
-    export_conversation_markdown, register_tui_session_view_test_singletons, slash_commands,
+    ConversationUsageTotals, Harness, InputTypeAutoDetectionSource, LLMPreferences,
+    LinkedWorkflowData, LongRunningCommandControlState, PtyIntent, PtyIntentEvent,
+    QueuedQueryModel, SizeInfo, SizeUpdate, TaskId, TranscriptScope, TuiUpArrowHistoryItemKind,
+    UserTakeOverReason, export_conversation_markdown, register_tui_session_view_test_singletons,
+    slash_commands,
 };
 use warp_core::channel::Channel;
 use warp_core::settings::Setting as _;
@@ -40,20 +41,22 @@ use warpui_core::telemetry::{EventPayload, flush_events};
 use warpui_core::{App, AppContext, TuiView, TypedActionView as _, WindowInvalidation};
 
 use super::{
-    ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME, AUTO_APPROVE_DISABLED_HINT,
-    AUTO_APPROVE_ENABLED_HINT, AUTO_APPROVE_FEEDBACK_DURATION, AUTO_APPROVE_TOGGLE_BINDING_NAME,
-    BlockingInputSource, COST_CONVERSATION_IN_PROGRESS_HINT, COST_EMPTY_CONVERSATION_HINT,
-    COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT, ConversationRestoreState, FooterSegment,
+    ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME, ATTACH_AGENT_TO_RUNNING_COMMAND_BINDING_NAME,
+    AUTO_APPROVE_DISABLED_HINT, AUTO_APPROVE_ENABLED_HINT, AUTO_APPROVE_FEEDBACK_DURATION,
+    AUTO_APPROVE_TOGGLE_BINDING_NAME, BlockingInputSource, COST_CONVERSATION_IN_PROGRESS_HINT,
+    COST_EMPTY_CONVERSATION_HINT, COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT,
+    ConversationRestoreState, DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME, FooterSegment,
     FooterSegments, INLINE_MENU_TOP_PADDING_ROWS, LOADING_CONVERSATION_HINT,
     LOG_BUNDLE_FAILED_HINT, SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG,
-    SESSION_COMPOSER_OWNS_INPUT_FLAG, SHELL_MODE_HINT, TuiConversationRestoreOrigin,
-    TuiTerminalSessionAction, TuiTerminalSessionEvent, TuiTerminalSessionView,
-    VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT, attachment_focus_available,
-    cost_command_unavailable_hint, export_file_success_message, format_context_window_usage,
-    format_statusline_date, format_statusline_time_12_hour, format_statusline_time_24_hour,
-    format_todo_progress, log_bundle_success_message, raw_prompt_if_not_blank,
-    render_status_footer_row, render_statusline_datetime, voice_argument_is_empty,
-    voice_command_argument,
+    SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG,
+    SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG, SESSION_COMPOSER_OWNS_INPUT_FLAG,
+    SHELL_MODE_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
+    TuiTerminalSessionEvent, TuiTerminalSessionView, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
+    attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
+    format_context_window_usage, format_statusline_date, format_statusline_time_12_hour,
+    format_statusline_time_24_hour, format_todo_progress, log_bundle_success_message,
+    raw_prompt_if_not_blank, render_status_footer_row, render_statusline_datetime,
+    voice_argument_is_empty, voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
 use crate::grok_oauth::{TuiGrokOAuthBlockAction, new_block};
@@ -1981,18 +1984,27 @@ fn accepted_prompt_history_submits_to_the_selected_ai_conversation() {
 #[test]
 fn long_running_command_keeps_input_hidden() {
     App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
         view.update(&mut app, |view, ctx| {
-            view.terminal_model
-                .lock()
-                .simulate_long_running_block("cat", "");
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model
+                .block_list_mut()
+                .set_transcript_scope(TranscriptScope::Unfiltered);
+            terminal_model.simulate_block("echo ready", "ready\r\n");
+            terminal_model.simulate_long_running_block("cat", "");
+            drop(terminal_model);
             assert!(matches!(
                 view.session_state(ctx)
                     .expect("session state resolves")
                     .blocking_input_source(),
                 Some(&BlockingInputSource::LongRunningCommand)
             ));
+            assert!(
+                !view.transcript.as_ref(ctx).is_empty(),
+                "command output should make the transcript visible"
+            );
         });
 
         let lines = render_session(&mut app, &view, 80, 40);
@@ -2012,16 +2024,237 @@ fn long_running_command_keeps_input_hidden() {
         );
         // The interrupt affordance renders as a ghosted row in the input's
         // slot while the command owns input.
+        let hint = view.read(&app, |view, ctx| {
+            view.running_command_hint(true, ctx)
+                .expect("visible running command should have a hint")
+        });
+        assert!(
+            lines.iter().any(|line| line.trim() == hint),
+            "LRC must render the attach and interrupt hint row:\n{}",
+            lines.join("\n")
+        );
+        assert!(hint.contains("to use agent"));
+        assert!(hint.contains("ctrl-c to interrupt"));
+    });
+}
+
+#[test]
+fn zero_state_running_command_hint_omits_interrupt() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, ctx| {
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model.simulate_long_running_block("cat", "");
+            terminal_model
+                .block_list_mut()
+                .active_block_mut()
+                .set_should_hide_command_grid(true);
+            drop(terminal_model);
+
+            assert!(
+                view.transcript.as_ref(ctx).is_empty(),
+                "hidden command without output should preserve zero state"
+            );
+            assert!(
+                view.session_state(ctx)
+                    .expect("session state resolves")
+                    .user_owns_running_command()
+            );
+        });
+
+        let lines = render_session(&mut app, &view, 80, 40);
+        assert!(
+            lines.iter().any(|line| line.contains("Warp Agent CLI")),
+            "zero state should remain visible:\n{}",
+            lines.join("\n")
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("to use agent")),
+            "zero state should preserve manual attachment:\n{}",
+            lines.join("\n")
+        );
         assert!(
             lines
                 .iter()
-                .any(|line| line.trim() == crate::input_hints::LONG_RUNNING_COMMAND_HINT),
-            "LRC must render the interrupt hint row:\n{}",
+                .all(|line| !line.contains("ctrl-c to interrupt")),
+            "zero state should not advertise an inapplicable interrupt:\n{}",
             lines.join("\n")
         );
     });
 }
 
+#[test]
+fn manual_attach_and_detach_switch_running_command_input_ownership() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, ctx| {
+            view.input_view.update(ctx, |input, ctx| {
+                input.set_text("stale draft", ctx);
+            });
+            view.terminal_model
+                .lock()
+                .simulate_long_running_block("cat", "");
+
+            let state = view.session_state(ctx).expect("session state resolves");
+            assert!(state.can_attach_agent_to_running_command());
+            assert!(
+                view.keymap_context(ctx)
+                    .set
+                    .contains(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG)
+            );
+
+            view.handle_action(&TuiTerminalSessionAction::AttachAgentToRunningCommand, ctx);
+
+            assert!(view.input_target().agent_editor_owns_input());
+            assert!(
+                view.terminal_model
+                    .lock()
+                    .block_list()
+                    .active_block()
+                    .is_agent_tagged_in()
+            );
+            assert_eq!(
+                view.ai_input_model
+                    .as_ref(ctx)
+                    .last_ai_autodetection_source(),
+                Some(InputTypeAutoDetectionSource::AgentTerminalControl)
+            );
+            assert!(
+                view.keymap_context(ctx)
+                    .set
+                    .contains(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG)
+            );
+            view.suggestions_mode.update(ctx, |mode, ctx| {
+                mode.set_mode(TuiInputSuggestionsMode::Shortcuts, ctx);
+            });
+            assert!(
+                !view
+                    .keymap_context(ctx)
+                    .set
+                    .contains(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG)
+            );
+            view.suggestions_mode.update(ctx, |mode, ctx| {
+                mode.set_mode(TuiInputSuggestionsMode::Closed, ctx);
+            });
+            assert!(
+                view.keymap_context(ctx)
+                    .set
+                    .contains(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG)
+            );
+        });
+        assert_eq!(app.read(|ctx| input_text(&view, ctx)), "");
+
+        let lines = render_session(&mut app, &view, 80, 40);
+        assert!(
+            lines.iter().any(|line| line.contains('┌')),
+            "tagging in should render the composer:\n{}",
+            lines.join("\n")
+        );
+
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(
+                &TuiTerminalSessionAction::DetachAgentFromRunningCommand,
+                ctx,
+            );
+
+            assert!(view.input_target().pty_owns_input());
+            assert!(
+                !view
+                    .terminal_model
+                    .lock()
+                    .block_list()
+                    .active_block()
+                    .is_agent_tagged_in()
+            );
+            assert_ne!(
+                view.ai_input_model
+                    .as_ref(ctx)
+                    .last_ai_autodetection_source(),
+                Some(InputTypeAutoDetectionSource::AgentTerminalControl)
+            );
+        });
+    });
+}
+
+#[test]
+fn running_command_completion_clears_transient_attachment_lock() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, ctx| {
+            view.terminal_model
+                .lock()
+                .simulate_long_running_block("sleep 1", "");
+            view.handle_action(&TuiTerminalSessionAction::AttachAgentToRunningCommand, ctx);
+            assert_eq!(
+                view.ai_input_model
+                    .as_ref(ctx)
+                    .last_ai_autodetection_source(),
+                Some(InputTypeAutoDetectionSource::AgentTerminalControl)
+            );
+
+            let block_id = {
+                let mut terminal_model = view.terminal_model.lock();
+                let block_id = terminal_model.block_list().active_block().id().clone();
+                terminal_model.finish_block();
+                block_id
+            };
+            view.handle_block_completed(&block_id, ctx);
+
+            assert_ne!(
+                view.ai_input_model
+                    .as_ref(ctx)
+                    .last_ai_autodetection_source(),
+                Some(InputTypeAutoDetectionSource::AgentTerminalControl)
+            );
+            assert!(view.input_target().agent_editor_owns_input());
+        });
+    });
+}
+
+#[test]
+fn tagged_in_alt_screen_keeps_output_and_composer_visible() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, ctx| {
+            let mut terminal_model = view.terminal_model.lock();
+            terminal_model.simulate_long_running_block("vim", "");
+            terminal_model.set_mode(Mode::SwapScreen {
+                save_cursor_and_clear_screen: true,
+            });
+            for character in "TAGGED ALT SCREEN".chars() {
+                terminal_model.alt_screen_mut().input(character);
+            }
+            drop(terminal_model);
+            view.handle_action(&TuiTerminalSessionAction::AttachAgentToRunningCommand, ctx);
+        });
+
+        assert!(view.read(&app, |view, _| {
+            view.input_target().agent_editor_owns_input()
+        }));
+        let lines = render_session(&mut app, &view, 80, 12);
+        let compact_output = lines
+            .iter()
+            .flat_map(|line| line.chars())
+            .filter(|character| !character.is_whitespace())
+            .collect::<String>();
+        assert!(
+            compact_output.contains("TAGGEDALTSCREEN"),
+            "tagged-in alternate-screen output should remain visible:\n{}",
+            lines.join("\n")
+        );
+        assert!(
+            lines.iter().any(|line| line.contains('┌')),
+            "tagged-in alternate screen should render the composer:\n{}",
+            lines.join("\n")
+        );
+    });
+}
 #[test]
 fn agent_controlled_alt_screen_keeps_output_and_composer_visible() {
     App::test((), |mut app| async move {
@@ -2089,6 +2322,7 @@ fn agent_controlled_alt_screen_keeps_output_and_composer_visible() {
 #[test]
 fn user_controlled_alt_screen_keeps_full_session_input_on_the_pty() {
     App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
         view.update(&mut app, |view, _| {
@@ -2118,7 +2352,16 @@ fn user_controlled_alt_screen_keeps_full_session_input_on_the_pty() {
             !lines
                 .iter()
                 .any(|line| line.contains('┌') || line.contains("auto (cost-efficient)")),
-            "user-controlled alternate screen should not reserve rows for agent input:\n{}",
+            "user-controlled alternate screen should not render the agent composer:\n{}",
+            lines.join("\n")
+        );
+        let hint = view.read(&app, |view, ctx| {
+            view.running_command_hint(true, ctx)
+                .expect("alternate screen should have a running-command hint")
+        });
+        assert!(
+            lines.iter().any(|line| line.trim() == hint),
+            "user-controlled alternate screen should render the attach hint:\n{}",
             lines.join("\n")
         );
     });
@@ -2188,14 +2431,31 @@ fn visible_startup_script_shows_no_interrupt_hint() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
-        view.update(&mut app, |view, _| {
-            let mut terminal_model = view.terminal_model.lock();
-            terminal_model.block_list_mut().reinit_shell();
-            terminal_model.update_blockheight_items(TRANSCRIPT_BLOCK_SPACING.block_padding, 0.0);
-            // Advance past WarpInput, then leave an unfinished startup-script
-            // block with visible output owning PTY input.
-            terminal_model.simulate_block("bootstrap", "");
-            terminal_model.simulate_long_running_block("shell init", "startup output\r\n");
+        view.update(&mut app, |view, ctx| {
+            {
+                let mut terminal_model = view.terminal_model.lock();
+                terminal_model.block_list_mut().reinit_shell();
+                terminal_model
+                    .update_blockheight_items(TRANSCRIPT_BLOCK_SPACING.block_padding, 0.0);
+                // Advance past WarpInput, then leave an unfinished startup-script
+                // block with visible output owning PTY input.
+                terminal_model.simulate_block("bootstrap", "");
+                terminal_model.simulate_long_running_block("shell init", "startup output\r\n");
+            }
+            assert!(
+                !view
+                    .session_state(ctx)
+                    .expect("session state resolves")
+                    .can_attach_agent_to_running_command()
+            );
+            assert!(
+                !view
+                    .keymap_context(ctx)
+                    .set
+                    .contains(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG)
+            );
+            view.handle_action(&TuiTerminalSessionAction::AttachAgentToRunningCommand, ctx);
+            assert!(view.input_target().pty_owns_input());
         });
         assert!(
             view.read(&app, |view, _| view.input_target().pty_owns_input()),
@@ -2203,10 +2463,10 @@ fn visible_startup_script_shows_no_interrupt_hint() {
         );
 
         let lines = render_session(&mut app, &view, 80, 40);
+        let fallback_hint = crate::input_hints::long_running_command_hint(None, true)
+            .expect("interrupt-only fallback hint");
         assert!(
-            !lines
-                .iter()
-                .any(|line| line.trim() == crate::input_hints::LONG_RUNNING_COMMAND_HINT),
+            !lines.iter().any(|line| line.trim() == fallback_hint),
             "startup-script execution must not advertise the interrupt hint:\n{}",
             lines.join("\n")
         );
@@ -2992,6 +3252,50 @@ fn user_input_event_projects_to_raw_user_bytes() {
         panic!("user input event should map to raw PTY bytes");
     };
     assert_eq!(&*bytes, b"hello\r");
+}
+#[test]
+fn running_command_attachment_bindings_are_context_scoped() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        app.read(|ctx| {
+            let attach = ctx
+                .editable_bindings()
+                .find(|binding| binding.name == ATTACH_AGENT_TO_RUNNING_COMMAND_BINDING_NAME)
+                .expect("running-command attach binding");
+            assert_eq!(
+                *attach.trigger,
+                Trigger::Keystrokes(vec![Keystroke::parse("ctrl-shift-enter").unwrap()])
+            );
+            let detach = ctx
+                .editable_bindings()
+                .find(|binding| binding.name == DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME)
+                .expect("running-command detach binding");
+            assert_eq!(
+                *detach.trigger,
+                Trigger::Keystrokes(vec![Keystroke::parse("escape").unwrap()])
+            );
+
+            let mut input_context = Context::default();
+            input_context.set.insert("TuiInputView");
+            assert!(!attach.in_context(&input_context));
+            assert!(!detach.in_context(&input_context));
+
+            input_context
+                .set
+                .insert(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG);
+            assert!(attach.in_context(&input_context));
+            assert!(!detach.in_context(&input_context));
+
+            input_context
+                .set
+                .remove(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG);
+            input_context
+                .set
+                .insert(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG);
+            assert!(!attach.in_context(&input_context));
+            assert!(detach.in_context(&input_context));
+        });
+    });
 }
 #[test]
 fn plan_toggle_uses_contextual_ctrl_p_and_ctrl_shift_p() {

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -47,7 +47,8 @@ use super::{
     COST_EMPTY_CONVERSATION_HINT, COST_NO_ACTIVE_CONVERSATION_HINT, CTRL_C_EXIT_HINT,
     ConversationRestoreState, DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME, FooterSegment,
     FooterSegments, INLINE_MENU_TOP_PADDING_ROWS, LOADING_CONVERSATION_HINT,
-    LOG_BUNDLE_FAILED_HINT, SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG,
+    LOG_BUNDLE_FAILED_HINT, RUNNING_COMMAND_DETACH_HINT,
+    SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG,
     SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG,
     SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG, SESSION_COMPOSER_OWNS_INPUT_FLAG,
     SHELL_MODE_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
@@ -2022,24 +2023,29 @@ fn long_running_command_keeps_input_hidden() {
             "LRC must keep the input editor hidden:\n{}",
             lines.join("\n")
         );
-        // The interrupt affordance renders as a ghosted row in the input's
-        // slot while the command owns input.
+        // Manual attachment remains advertised while the running command is visible.
         let hint = view.read(&app, |view, ctx| {
-            view.running_command_hint(true, ctx)
-                .expect("visible running command should have a hint")
+            view.running_command_hint(ctx)
+                .expect("visible running command should have an attachment hint")
         });
         assert!(
             lines.iter().any(|line| line.trim() == hint),
-            "LRC must render the attach and interrupt hint row:\n{}",
+            "LRC must render the attach hint row:\n{}",
             lines.join("\n")
         );
-        assert!(hint.contains("to use agent"));
-        assert!(hint.contains("ctrl-c to interrupt"));
+        assert_eq!(hint, "Ctrl + Shift + ⏎  to use agent");
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains(RUNNING_COMMAND_DETACH_HINT)),
+            "LRC must not show the detach hint before agent attachment:\n{}",
+            lines.join("\n")
+        );
     });
 }
 
 #[test]
-fn zero_state_running_command_hint_omits_interrupt() {
+fn zero_state_running_command_hint_shows_attachment() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);
         let fixture = focus_test_fixture(&mut app);
@@ -2075,13 +2081,6 @@ fn zero_state_running_command_hint_omits_interrupt() {
             "zero state should preserve manual attachment:\n{}",
             lines.join("\n")
         );
-        assert!(
-            lines
-                .iter()
-                .all(|line| !line.contains("ctrl-c to interrupt")),
-            "zero state should not advertise an inapplicable interrupt:\n{}",
-            lines.join("\n")
-        );
     });
 }
 
@@ -2091,6 +2090,15 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
         app.update(crate::keybindings::init);
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let interrupt_count = Rc::new(RefCell::new(0));
+        let interrupt_count_for_events = interrupt_count.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiTerminalSessionEvent::InterruptPty) {
+                    *interrupt_count_for_events.borrow_mut() += 1;
+                }
+            });
+        });
         view.update(&mut app, |view, ctx| {
             view.input_view.update(ctx, |input, ctx| {
                 input.set_text("stale draft", ctx);
@@ -2107,7 +2115,7 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
                     .contains(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG)
             );
 
-            view.handle_action(&TuiTerminalSessionAction::AttachAgentToRunningCommand, ctx);
+            assert!(view.try_attach_agent_to_running_command(ctx));
 
             assert!(view.input_target().agent_editor_owns_input());
             assert!(
@@ -2154,11 +2162,18 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
             "tagging in should render the composer:\n{}",
             lines.join("\n")
         );
-
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.trim() == RUNNING_COMMAND_DETACH_HINT),
+            "tagging in should replace the footer with the detach hint:\n{}",
+            lines.join("\n")
+        );
         view.update(&mut app, |view, ctx| {
-            view.handle_action(
-                &TuiTerminalSessionAction::DetachAgentFromRunningCommand,
-                ctx,
+            view.handle_action(&TuiTerminalSessionAction::Interrupt, ctx);
+            assert!(
+                !view.exit_confirmation.is_armed(),
+                "leaving a tagged LRC must not arm TUI exit"
             );
 
             assert!(view.input_target().pty_owns_input());
@@ -2176,7 +2191,29 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
                     .last_ai_autodetection_source(),
                 Some(InputTypeAutoDetectionSource::AgentTerminalControl)
             );
+            assert!(
+                !view.try_detach_agent_from_running_command(ctx),
+                "detaching an already-detached command should report no transition"
+            );
         });
+        assert_eq!(
+            *interrupt_count.borrow(),
+            0,
+            "leaving the tagged composer must not send ctrl-c to the running command"
+        );
+        let lines = render_session(&mut app, &view, 80, 40);
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.contains(RUNNING_COMMAND_DETACH_HINT)),
+            "ctrl-c should remove the detach footer hint:\n{}",
+            lines.join("\n")
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("to use agent")),
+            "detaching should restore the attach hint:\n{}",
+            lines.join("\n")
+        );
     });
 }
 
@@ -2221,6 +2258,15 @@ fn tagged_in_alt_screen_keeps_output_and_composer_visible() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let interrupt_count = Rc::new(RefCell::new(0));
+        let interrupt_count_for_events = interrupt_count.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiTerminalSessionEvent::InterruptPty) {
+                    *interrupt_count_for_events.borrow_mut() += 1;
+                }
+            });
+        });
         view.update(&mut app, |view, ctx| {
             let mut terminal_model = view.terminal_model.lock();
             terminal_model.simulate_long_running_block("vim", "");
@@ -2252,6 +2298,34 @@ fn tagged_in_alt_screen_keeps_output_and_composer_visible() {
             lines.iter().any(|line| line.contains('┌')),
             "tagged-in alternate screen should render the composer:\n{}",
             lines.join("\n")
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.trim() == RUNNING_COMMAND_DETACH_HINT),
+            "tagged-in alternate screen should show the detach footer hint:\n{}",
+            lines.join("\n")
+        );
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiTerminalSessionAction::Interrupt, ctx);
+            assert!(
+                !view.exit_confirmation.is_armed(),
+                "leaving a tagged alternate-screen LRC must not arm TUI exit"
+            );
+            assert!(view.input_target().pty_owns_input());
+            assert!(
+                !view
+                    .terminal_model
+                    .lock()
+                    .block_list()
+                    .active_block()
+                    .is_agent_tagged_in()
+            );
+        });
+        assert_eq!(
+            *interrupt_count.borrow(),
+            0,
+            "leaving the tagged composer must not send ctrl-c to the alternate-screen command"
         );
     });
 }
@@ -2356,7 +2430,7 @@ fn user_controlled_alt_screen_keeps_full_session_input_on_the_pty() {
             lines.join("\n")
         );
         let hint = view.read(&app, |view, ctx| {
-            view.running_command_hint(true, ctx)
+            view.running_command_hint(ctx)
                 .expect("alternate screen should have a running-command hint")
         });
         assert!(
@@ -2425,9 +2499,9 @@ fn stale_user_pty_bytes_are_dropped_after_agent_takes_control_or_is_tagged_in() 
     });
 }
 /// Visible startup-script execution also routes input to the PTY, but it is
-/// not a user-controlled command: the interrupt hint row must not appear.
+/// not a user-controlled command: the running-command hint row must not appear.
 #[test]
-fn visible_startup_script_shows_no_interrupt_hint() {
+fn visible_startup_script_shows_no_running_command_hint() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
@@ -2454,7 +2528,10 @@ fn visible_startup_script_shows_no_interrupt_hint() {
                     .set
                     .contains(SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG)
             );
-            view.handle_action(&TuiTerminalSessionAction::AttachAgentToRunningCommand, ctx);
+            assert!(
+                !view.try_attach_agent_to_running_command(ctx),
+                "startup-script input is not an attachable user LRC"
+            );
             assert!(view.input_target().pty_owns_input());
         });
         assert!(
@@ -2463,11 +2540,9 @@ fn visible_startup_script_shows_no_interrupt_hint() {
         );
 
         let lines = render_session(&mut app, &view, 80, 40);
-        let fallback_hint = crate::input_hints::long_running_command_hint(None, true)
-            .expect("interrupt-only fallback hint");
         assert!(
-            !lines.iter().any(|line| line.trim() == fallback_hint),
-            "startup-script execution must not advertise the interrupt hint:\n{}",
+            !lines.iter().any(|line| line.contains("to use agent")),
+            "startup-script execution must not advertise agent attachment:\n{}",
             lines.join("\n")
         );
     });

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -2170,6 +2170,9 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
             lines.join("\n")
         );
         view.update(&mut app, |view, ctx| {
+            view.input_view.update(ctx, |input, ctx| {
+                input.set_text("unsent agent prompt", ctx);
+            });
             view.handle_action(&TuiTerminalSessionAction::Interrupt, ctx);
             assert!(
                 !view.exit_confirmation.is_armed(),
@@ -2197,6 +2200,11 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
             );
         });
         assert_eq!(
+            app.read(|ctx| input_text(&view, ctx)),
+            "",
+            "detaching must discard an unsent agent prompt"
+        );
+        assert_eq!(
             *interrupt_count.borrow(),
             0,
             "leaving the tagged composer must not send ctrl-c to the running command"
@@ -2213,6 +2221,21 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
             lines.iter().any(|line| line.contains("to use agent")),
             "detaching should restore the attach hint:\n{}",
             lines.join("\n")
+        );
+        view.update(&mut app, |view, ctx| {
+            let block_id = {
+                let mut terminal_model = view.terminal_model.lock();
+                let block_id = terminal_model.block_list().active_block().id().clone();
+                terminal_model.finish_block();
+                block_id
+            };
+            view.handle_block_completed(&block_id, ctx);
+            assert!(view.input_target().agent_editor_owns_input());
+        });
+        assert_eq!(
+            app.read(|ctx| input_text(&view, ctx)),
+            "",
+            "the discarded prompt must not reappear after command completion"
         );
     });
 }

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -2137,7 +2137,10 @@ fn manual_attach_and_detach_switch_running_command_input_ownership() {
                     .contains(SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG)
             );
             view.suggestions_mode.update(ctx, |mode, ctx| {
-                mode.set_mode(TuiInputSuggestionsMode::Shortcuts, ctx);
+                mode.set_mode(
+                    TuiInputSuggestionsMode::ReadOnlyMenu(TuiReadOnlyMenuKind::Shortcuts),
+                    ctx,
+                );
             });
             assert!(
                 !view


### PR DESCRIPTION
## Description

- Adds `Ctrl+Shift+Enter` to attach Warp Agent to an eligible user-started long-running command or alternate-screen application in the TUI.
- Routes pre-submission input to the agent composer, supports `Escape` detachment back to the PTY, and reuses the existing CLI-subagent lifecycle after submission.
- Adds binding-aware attach and interrupt hints, completion cleanup, and focused coverage for ownership, rendering, and keybinding scope.

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
https://www.loom.com/share/adb16c8ff73945e1b6fd655485bff6dc

- `./script/format`
- `cargo nextest run -p warp_tui -E 'test(long_running) | test(alt_screen) | test(terminal_use) | test(attach_agent) | test(running_command) | test(tagged_in)'` — 29 passed
- `cargo nextest run -p warp_tui --no-fail-fast` — 676 passed
- `cargo check -p warp_tui`
- `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- Ran `./script/run-tui` in a real PTY and verified the final attach/interrupt hint for a normal long-running command and `vim`, including preservation of alternate-screen output. The automation PTY could not transport modified Enter, so attach/detach transitions are covered by action, keybinding, ownership, and render regression tests rather than an end-to-end recording.
- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos

The local verification environment did not have `tmux` or `asciinema`, so no durable capture was produced.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Warp Agent conversation: https://staging.warp.dev/conversation/79da9896-6996-476d-98c2-6d204e2d3395

CHANGELOG-IMPROVEMENT: Attach Warp Agent to user-started long-running commands in the TUI.

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)