### PR TITLE
Fix TUI disclosure chevron alignment on wrapped headers

### DIFF
--- a/crates/warpui_core/src/elements/tui/collapsible.rs
+++ b/crates/warpui_core/src/elements/tui/collapsible.rs
@@ -3,11 +3,11 @@
 //!
 //! This is a plain composition of existing primitives: a [`TuiFlex`] column
 //! whose first child is the header (a [`TuiCollapsibleHeader`] — wrapping
-//! label spans with a reserved, non-wrapping disclosure chevron pinned to the
-//! first row, wrapped in a [`TuiHoverable`] for the click and hover tracking)
-//! and whose second child — built and present only when expanded — is the
-//! body. State is owned by the caller: `collapsed` and the hover state on
-//! `mouse_state` are read at composition time and `on_toggle` fires on a
+//! label spans with a reserved, non-wrapping disclosure chevron after the
+//! first rendered row, wrapped in a [`TuiHoverable`] for click and hover
+//! tracking) and whose second child — built and present only when expanded —
+//! is the body. State is owned by the caller: `collapsed` and the hover state
+//! on `mouse_state` are read at composition time and `on_toggle` fires on a
 //! header click, leaving the caller to flip its own state and re-render.
 //!
 //! The chevron is reserved as its own non-wrapping element rather than
@@ -43,24 +43,18 @@ fn disclosure_chevron(collapsed: bool) -> &'static str {
 ///
 /// The chevron is laid out first and its column reserved, then the label wraps
 /// into the remaining width. The chevron is pinned to the first row (its own
-/// one-row slot at the label's laid-out content edge), so it stays visible at
-/// narrow widths where the label text wraps onto later rows — unlike appending
-/// the chevron to a single `.truncate()`d label, which clips the chevron away
-/// once the label no longer fits. At wide widths the chevron sits right after
-/// the label, matching the single-line appearance.
+/// one-row slot after that row's rendered text), so it stays visible at narrow
+/// widths where the label text wraps onto later rows — unlike appending the
+/// chevron to a single `.truncate()`d label, which clips the chevron away once
+/// the label no longer fits. At wide widths the chevron sits right after the
+/// label, matching the single-line appearance.
 struct TuiCollapsibleHeader {
     /// The wrapping label text (header spans without the chevron).
     label: TuiText,
     /// The reserved, non-wrapping disclosure chevron (e.g. `"▸"`).
     chevron: TuiText,
-    /// Whether to leave a one-cell gap between the label and chevron.
-    ///
-    /// At the smallest widths the gap is omitted so the glyph itself remains
-    /// visible instead of truncating to a leading spacer.
-    chevron_gap: u16,
-    /// The label's size retained from the most recent layout, used to place
-    /// the chevron during render.
-    label_size: Option<TuiSize>,
+    /// Horizontal offset of the chevron after the first rendered label row.
+    chevron_offset: u16,
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
 }
@@ -70,8 +64,7 @@ impl TuiCollapsibleHeader {
         Self {
             label,
             chevron,
-            chevron_gap: 0,
-            label_size: None,
+            chevron_offset: 0,
             size: None,
             origin: None,
         }
@@ -100,7 +93,6 @@ impl TuiElement for TuiCollapsibleHeader {
         } else {
             0
         };
-        self.chevron_gap = chevron_gap;
         // The label wraps into whatever width remains after the chevron's
         // reserved column, so wrapping label text can never push the chevron
         // off the first row.
@@ -112,13 +104,15 @@ impl TuiElement for TuiCollapsibleHeader {
             TuiSize::new(label_max_width, constraint.max.height),
         );
         let label_size = self.label.layout(label_constraint, ctx, app);
-        self.label_size = Some(label_size);
 
-        let width = label_size
-            .width
-            .saturating_add(chevron_gap)
-            .saturating_add(chevron_size.width)
-            .min(available);
+        // Use row one's actual rendered width rather than the label's widest
+        // wrapped row, so a longer continuation row cannot right-align the
+        // chevron.
+        let first_row_width = self.label.first_rendered_line_width(label_max_width);
+        let chevron_offset = first_row_width.saturating_add(chevron_gap);
+        self.chevron_offset = chevron_offset;
+        let chevron_edge = chevron_offset.saturating_add(chevron_size.width);
+        let width = label_size.width.max(chevron_edge).min(available);
         let height = label_size.height.max(chevron_size.height);
         let size = TuiSize::new(width, height);
         self.size = Some(size);
@@ -137,17 +131,17 @@ impl TuiElement for TuiCollapsibleHeader {
         ctx: &mut TuiPaintContext,
     ) {
         self.origin = Some(ctx.scene_point(origin));
-        let Some(label_size) = self.label_size else {
+        if self.size.is_none() {
             return;
-        };
+        }
         // The label paints from the header's origin; the chevron is pinned to
-        // the first row, immediately after the label's laid-out content edge.
+        // the first row, immediately after that row's rendered text.
         self.label.render(origin, surface, ctx);
-        let chevron_origin = origin.offset(
-            i32::from(label_size.width.saturating_add(self.chevron_gap)),
-            0,
+        self.chevron.render(
+            origin.offset(i32::from(self.chevron_offset), 0),
+            surface,
+            ctx,
         );
-        self.chevron.render(chevron_origin, surface, ctx);
     }
 
     fn size(&self) -> Option<TuiSize> {
@@ -160,8 +154,8 @@ impl TuiElement for TuiCollapsibleHeader {
 }
 
 /// Composes a collapsible section: a clickable rich-text header (a wrapping
-/// label with a reserved disclosure chevron pinned to the first row) over a
-/// body that is built only when `collapsed` is `false`. `on_toggle` runs when
+/// label with a reserved disclosure chevron after its first rendered row) over
+/// a body that is built only when `collapsed` is `false`. `on_toggle` runs when
 /// the header is clicked. Callers own the header styles, including any
 /// hover-dependent styling; hover transitions are recorded on `mouse_state`,
 /// which the caller owns so it survives re-renders.

--- a/crates/warpui_core/src/elements/tui/collapsible_tests.rs
+++ b/crates/warpui_core/src/elements/tui/collapsible_tests.rs
@@ -160,6 +160,35 @@ fn narrow_header_keeps_chevron_on_first_row_while_label_wraps() {
 }
 
 #[test]
+fn wrapped_header_places_chevron_after_first_row_text() {
+    for (collapsed, glyph) in [(true, '▸'), (false, '▾')] {
+        let lines = render_collapsible_to_lines(
+            tui_collapsible(
+                collapsed,
+                [
+                    ("✓ ".to_owned(), TuiStyle::default()),
+                    ("Ran `print` ".to_owned(), TuiStyle::default()),
+                ],
+                TuiStyle::default(),
+                MouseStateHandle::default(),
+                || TuiText::new("body").finish(),
+                |_, _| {},
+            ),
+            TuiSize::new(12, 4),
+        );
+
+        // The continuation is longer than the first row. It must not push the
+        // chevron to the right edge; the disclosure gap follows the first
+        // row's rendered text instead.
+        assert_eq!(lines[0].trim_end(), format!("✓ Ran {glyph}"));
+        assert_eq!(lines[1].trim_end(), "`print`");
+        if !collapsed {
+            assert_eq!(lines[2].trim_end(), "body");
+        }
+    }
+}
+
+#[test]
 fn very_narrow_header_keeps_chevron_visible_without_a_truncated_spacer() {
     for (width, collapsed, glyph) in [
         (1, true, '▸'),

--- a/crates/warpui_core/src/elements/tui/text.rs
+++ b/crates/warpui_core/src/elements/tui/text.rs
@@ -29,8 +29,10 @@
 
 use std::mem;
 
+use ratatui::buffer::{Buffer, Cell};
+use ratatui::layout::Rect;
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Paragraph, Wrap};
+use ratatui::widgets::{Paragraph, Widget, Wrap};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{
@@ -103,6 +105,33 @@ impl TuiText {
             return 0;
         }
         u16::try_from(self.paragraph(width).line_count(width)).unwrap_or(u16::MAX)
+    }
+    /// The cell width occupied by the first rendered row at `width`, including
+    /// trailing whitespace that belongs to the row.
+    pub(super) fn first_rendered_line_width(&self, width: u16) -> u16 {
+        if width == 0 || self.is_empty() {
+            return 0;
+        }
+
+        let area = Rect::new(0, 0, width, 1);
+        // An explicitly empty symbol distinguishes untouched cells from
+        // rendered spaces, whose symbols are `" "`. This lets callers retain
+        // intentional trailing whitespace without duplicating the wrapping
+        // algorithm used by `Paragraph`.
+        let mut buffer = Buffer::filled(area, Cell::new(""));
+        self.paragraph(width).render(area, &mut buffer);
+        let mut occupied_width = 0;
+        let mut column = 0;
+        while column < width {
+            let symbol = buffer[(column, 0)].symbol();
+            if symbol.is_empty() {
+                break;
+            }
+            let symbol_width = text_width(symbol).max(1);
+            occupied_width = column.saturating_add(symbol_width).min(width);
+            column = column.saturating_add(symbol_width);
+        }
+        occupied_width
     }
 
     /// Whether this element holds no text at all (and so occupies no rows).


### PR DESCRIPTION
## Description
Follow-up to #14222.

Wrapped TUI collapsible headers kept the disclosure chevron on the first row, but positioned it using the widest wrapped label row. When a continuation row was longer than the first row, the chevron appeared unnecessarily right-aligned.

This change measures the first rendered label row using Ratatui's actual wrapping behavior and places the reserved chevron immediately after that row. It preserves styled spans, intentional whitespace, wide glyph handling, and degenerate-width visibility.

## Linked Issue
N/A — follow-up fix for #14222.

## Testing
- `./script/format --check`
- All three Clippy configurations from `./script/presubmit`, with warnings denied
- `cargo nextest run -p warpui_core --features tui` — 527 passed, 7 skipped
- Added `wrapped_header_places_chevron_after_first_row_text`
- Live-tested with `./script/run-tui`; long shell-command headers rendered the chevron directly after the first row while the command continued below
- Integration tests were not run; this TUI element is covered by render-to-lines unit tests, and the GUI integration harness is not applicable

- [x] I have manually tested my changes locally with `./script/run-tui`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed disclosure chevrons appearing too far right on wrapped TUI headers.

[Oz conversation](https://staging.warp.dev/conversation/afc4d77d-fed4-4c3e-8a4d-83454241fcc0)

Co-Authored-By: Oz <oz-agent@warp.dev>