### PR TITLE
Defer inline history navigation to avoid circular view updates

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1134,6 +1134,9 @@ pub enum InputAction {
     CtrlR,
     CtrlD,
     Up,
+    /// Defers `Up` until the current view update completes, avoiding re-entrant updates from
+    /// synchronous platform menu callbacks.
+    DeferredUp,
     PageUp,
     PageDown,
     ClearScreen,
@@ -1835,7 +1838,7 @@ pub fn init(app: &mut AppContext) {
         FixedBinding::new("ctrl-d", InputAction::CtrlD, id!("Input")),
         FixedBinding::custom(
             CustomAction::History,
-            InputAction::Up,
+            InputAction::DeferredUp,
             "Show History",
             // We need to ensure the workflow info box is not open as the "up" arrow
             // key is used to navigate the environment variables dropdown.
@@ -15846,6 +15849,7 @@ impl TypedActionView for Input {
         match action {
             InputAction::FocusInputBox => self.focus_input_box(ctx),
             InputAction::Up => self.editor_up(ctx),
+            InputAction::DeferredUp => ctx.dispatch_typed_action_deferred(InputAction::Up),
             InputAction::PageUp => self.editor_page_up(ctx),
             InputAction::PageDown => self.editor_page_down(ctx),
             InputAction::CtrlD => self.ctrl_d(ctx),

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1134,9 +1134,9 @@ pub enum InputAction {
     CtrlR,
     CtrlD,
     Up,
-    /// Defers `Up` until the current view update completes, avoiding re-entrant updates from
-    /// synchronous platform menu callbacks.
-    DeferredUp,
+    // Dispatch these actions deferred to avoid re-entering an active inline history view update.
+    SelectPreviousInlineHistoryItem,
+    SelectNextInlineHistoryItem,
     PageUp,
     PageDown,
     ClearScreen,
@@ -1838,7 +1838,7 @@ pub fn init(app: &mut AppContext) {
         FixedBinding::new("ctrl-d", InputAction::CtrlD, id!("Input")),
         FixedBinding::custom(
             CustomAction::History,
-            InputAction::DeferredUp,
+            InputAction::Up,
             "Show History",
             // We need to ensure the workflow info box is not open as the "up" arrow
             // key is used to navigate the environment variables dropdown.
@@ -8973,6 +8973,44 @@ impl Input {
         ctx.notify();
     }
 
+    fn select_previous_inline_history_item(&mut self, ctx: &mut ViewContext<Self>) {
+        if !self
+            .suggestions_mode_model
+            .as_ref(ctx)
+            .is_inline_history_menu()
+        {
+            return;
+        }
+
+        if self.is_cloud_mode_input_v2_composing(ctx) {
+            if let Some(view) = self.cloud_mode_v2_history_menu_view.clone() {
+                view.update(ctx, |view, ctx| view.select_up(ctx));
+            }
+        } else {
+            self.inline_history_menu_view
+                .update(ctx, |view, ctx| view.select_up(ctx));
+        }
+    }
+
+    fn select_next_inline_history_item(&mut self, ctx: &mut ViewContext<Self>) {
+        if !self
+            .suggestions_mode_model
+            .as_ref(ctx)
+            .is_inline_history_menu()
+        {
+            return;
+        }
+
+        if self.is_cloud_mode_input_v2_composing(ctx) {
+            if let Some(view) = self.cloud_mode_v2_history_menu_view.clone() {
+                view.update(ctx, |view, ctx| view.select_down(ctx));
+            }
+        } else {
+            self.inline_history_menu_view
+                .update(ctx, |view, ctx| view.select_down(ctx));
+        }
+    }
+
     fn editor_up(&mut self, ctx: &mut ViewContext<Self>) {
         if self.should_show_auth_secret_ftux(ctx) {
             if let Some(ftux_view) = self.auth_secret_ftux_view().cloned() {
@@ -9078,17 +9116,7 @@ impl Input {
                 true
             }
             InputSuggestionsMode::InlineHistoryMenu { .. } => {
-                if self.is_cloud_mode_input_v2_composing(ctx) {
-                    if let Some(view) = self.cloud_mode_v2_history_menu_view.clone() {
-                        view.update(ctx, |view, ctx| {
-                            view.select_up(ctx);
-                        });
-                    }
-                } else {
-                    self.inline_history_menu_view.update(ctx, |view, ctx| {
-                        view.select_up(ctx);
-                    });
-                }
+                ctx.dispatch_typed_action_deferred(InputAction::SelectPreviousInlineHistoryItem);
                 true
             }
             InputSuggestionsMode::IndexedReposMenu => {
@@ -9472,17 +9500,7 @@ impl Input {
             .as_ref(ctx)
             .is_inline_history_menu()
         {
-            if self.is_cloud_mode_input_v2_composing(ctx) {
-                if let Some(view) = self.cloud_mode_v2_history_menu_view.clone() {
-                    view.update(ctx, |view, ctx| {
-                        view.select_down(ctx);
-                    });
-                }
-            } else {
-                self.inline_history_menu_view.update(ctx, |view, ctx| {
-                    view.select_down(ctx);
-                });
-            }
+            ctx.dispatch_typed_action_deferred(InputAction::SelectNextInlineHistoryItem);
             return;
         }
 
@@ -15849,7 +15867,10 @@ impl TypedActionView for Input {
         match action {
             InputAction::FocusInputBox => self.focus_input_box(ctx),
             InputAction::Up => self.editor_up(ctx),
-            InputAction::DeferredUp => ctx.dispatch_typed_action_deferred(InputAction::Up),
+            InputAction::SelectPreviousInlineHistoryItem => {
+                self.select_previous_inline_history_item(ctx)
+            }
+            InputAction::SelectNextInlineHistoryItem => self.select_next_inline_history_item(ctx),
             InputAction::PageUp => self.editor_page_up(ctx),
             InputAction::PageDown => self.editor_page_down(ctx),
             InputAction::CtrlD => self.ctrl_d(ctx),

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -2621,6 +2621,27 @@ fn slash_compact_still_queues_while_in_progress() {
 }
 
 #[test]
+fn custom_history_action_does_not_reenter_inline_history_menu_update() {
+    App::test((), |mut app| async move {
+        let _inline_history_menu = FeatureFlag::InlineHistoryMenu.override_enabled(true);
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let input = terminal.read(&app, |view, _| view.input().clone());
+        input.update(&mut app, |input, ctx| {
+            input.open_inline_history_menu(ctx);
+        });
+
+        let inline_history_menu =
+            input.read(&app, |input, _| input.inline_history_menu_view.clone());
+        inline_history_menu.update(&mut app, |_, ctx| {
+            let window_id = ctx.window_id();
+            ctx.dispatch_custom_action(CustomAction::History, window_id);
+        });
+    });
+}
+
+#[test]
 fn test_history_up_multiline() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -2642,6 +2642,26 @@ fn custom_history_action_does_not_reenter_inline_history_menu_update() {
 }
 
 #[test]
+fn editor_down_does_not_reenter_inline_history_menu_update() {
+    App::test((), |mut app| async move {
+        let _inline_history_menu = FeatureFlag::InlineHistoryMenu.override_enabled(true);
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let input = terminal.read(&app, |view, _| view.input().clone());
+        input.update(&mut app, |input, ctx| {
+            input.open_inline_history_menu(ctx);
+        });
+
+        let inline_history_menu =
+            input.read(&app, |input, _| input.inline_history_menu_view.clone());
+        inline_history_menu.update(&mut app, |_, ctx| {
+            input.update(ctx, |input, ctx| input.editor_down(ctx));
+        });
+    });
+}
+
+#[test]
 fn test_history_up_multiline() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);


### PR DESCRIPTION
## Description

Defers inline history menu selection until the current view update completes.

Both Up and Down could otherwise update `InlineHistoryMenuView` while it was already removed for an in-progress update, causing a `Circular view update` panic. Deferring the menu update itself covers navigation from the macOS History action and editor navigation events.

Closes #8917.

## Linked Issue

- [x] Linked issue is marked `ready-to-implement`
- [ ] Screenshots are included for UI changes (not applicable; no visual change)

## Testing

- [x] Added deterministic regression coverage for re-entrant Up and Down navigation
- [x] Verified the Down regression test fails with `Circular view update` before the fix
- [x] `cargo test -p warp does_not_reenter_inline_history_menu_update -- --nocapture`
- [x] `./script/format --check`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] Manually tested with `./script/run`

The production crash depends on re-entrant event timing, so a screen recording cannot prove the fix. The regression tests force the exact failing view-update ordering deterministically.

## Agent Mode

- [x] Warp Agent Mode was used to help implement this PR

<!--
CHANGELOG-NEW-FEATURE:
CHANGELOG-IMPROVEMENT:
CHANGELOG-IMAGE:
-->
CHANGELOG-BUG-FIX: Fixed a crash when navigating terminal history with the Up or Down Arrow.
