### PR TITLE
Open repository-browser Markdown links as local files (spec)

### DIFF
--- a/specs/gh-13434/PRODUCT.md
+++ b/specs/gh-13434/PRODUCT.md
@@ -1,0 +1,58 @@
+# Open repository-browser Markdown links as local files
+
+GitHub: [warpdotdev/warp#13434](https://github.com/warpdotdev/warp/issues/13434)
+
+Figma: none provided. This first pass adds an alternate link action without changing the rendered Markdown layout.
+
+## Summary
+
+Let users deliberately open the local checkout copy of a file referenced by a remote repository-browser link in rendered Markdown. A platform-specific alternate-click gesture resolves an exact repository-relative path against the active local checkout; normal link opening remains unchanged.
+
+## Goals / Non-goals
+
+Goals:
+
+- Make remote GitHub and GitLab file links useful while reviewing Markdown inside a local checkout.
+- Keep the action explicit and deterministic: resolve one exact local file or report that no local match exists.
+- Reuse the user's existing local-file opening behavior.
+- Avoid network access, repository mutation, background indexing, and branch or commit checkout.
+
+Non-goals:
+
+- No fuzzy filename search, link-text matching, multiple-match picker, or repository selector.
+- No checkout, fetch, branch switch, detached worktree, or attempt to make the local file match the URL's revision.
+- No extraction of line or column locations from URL fragments in this first pass.
+- No automatic hyperlinking of bare paths or code spans.
+- No change to Agent Mode rich-output links, terminal hyperlinks, shared-session links, or remote-only files in this first pass.
+- No new setting or default change for ordinary Markdown links.
+
+## Behavior
+
+1. In a rendered local Markdown file, plan, or notebook that has an active local repository context, the user can invoke **Open local repository file** on an `http` or `https` Markdown link by holding the platform's primary modifier plus Alt/Option while clicking it:
+   - macOS: Command+Option-click.
+   - Windows and Linux: Control+Alt-click.
+2. A normal click, Command-click on macOS, or Control-click on Windows/Linux keeps the existing link behavior. In particular, an ordinary remote link continues to open its web URL and an ordinary local-path link continues to use the existing local-file behavior.
+3. The alternate action applies only when the primary+Alt/Option mouse-down starts on an HTTP(S) rendered Markdown link and the mouse-up still identifies that same pressed link without producing a text selection. Warp clears the pending link press after mouse-up, cancellation, or a drag-created selection. Pressing on non-link text and releasing over a link, or pressing one link and releasing over another, never opens either the URL or a local file.
+4. When the alternate gesture is used on a local path, `file:` URL, same-document anchor, `warp:` URL, email link, or another non-HTTP(S) target, Warp preserves that target's existing behavior rather than reinterpreting it as a remote repository link.
+5. Warp resolves against the repository that contains the rendered Markdown document when that repository is known. For a plan or notebook that is not backed by a local file, Warp resolves against the active local terminal's detected repository. Warp never searches every repository known to the app.
+6. If no local repository context is available, Warp does not open the remote URL as a fallback for the alternate gesture. It shows a non-blocking `No matching local file found` toast and leaves the current view unchanged.
+7. The repository root's final directory name is the repository identity used for matching. The decoded URL path must contain that name as a complete path segment in the position used by a supported repository-browser file URL.
+8. This first pass recognizes file-view URLs on the public GitHub and GitLab hosts:
+   - `github.com/.../<repository>/blob/<revision>/<path>` and `github.com/.../<repository>/raw/<revision>/<path>`.
+   - `gitlab.com/.../<repository>/-/blob/<revision>/<path>` and `gitlab.com/.../<repository>/-/raw/<revision>/<path>`.
+   Self-hosted forges and other HTTP(S) URL shapes are not interpreted as local paths.
+9. The repository owner/group, browser marker, and revision portion are used only to identify the possible file-path boundary. Warp does not compare the remote owner, fetch the remote repository, verify the revision, or change the local checkout.
+10. Repository-browser URLs do not unambiguously encode where a branch name containing `/` ends and the file path begins. Warp therefore considers each non-empty decoded suffix after the browser marker, while leaving at least one preceding segment as the remote revision. Query parameters and fragments are ignored. Warp validates the original encoded path before a generic URL parser can normalize dot segments or backslashes, then decodes each segment exactly once. Incomplete or malformed percent escapes, raw or encoded separators within a segment, NUL, and raw or encoded `.`/`..` path segments make the request invalid.
+11. Every considered suffix is checked as an exact repository-relative path according to the local filesystem. Warp does not use the rendered link text, final filename alone, fuzzy ranking, or case folding beyond the filesystem's own behavior.
+12. A considered suffix is eligible only when it resolves to an existing regular file whose canonical location remains inside the canonical local repository root. Absolute paths, empty paths, `.`/`..` traversal, NUL bytes, directories, and symlinks that resolve outside the repository are rejected. The path retained after validation is the canonical in-repository file path, not the original joined path or a symlink alias.
+13. When exactly one distinct canonical file resolves, Warp passes that verified canonical path through the same configured file-opening behavior used by an ordinary local Markdown file link. Existing Markdown Viewer and external-editor preferences remain authoritative. Returning the canonical path prevents an original symlink alias from being retargeted between validation and opening.
+14. The URL's branch, tag, or commit is not a selector. Warp opens the file currently present in the checkout, even if its contents differ from the remote revision named by the URL.
+15. When no suffix resolves, more than one suffix resolves, or the URL/path is invalid, over the documented resource limits, outside the repository, a directory, or unsupported, Warp shows `No matching local file found`. It does not guess between matches, open the web URL, create a file, open a picker, or change repository state.
+16. Resolution uses the repository and filesystem state at invocation time. If the document, active session, working directory, repository detection, or target file changes between renders, the next alternate click uses the new current state. This path-based first pass does not claim an atomic file-descriptor lease against a concurrent mutation of the already-canonical path after resolution; it does guarantee that the unverified joined or symlink path is never handed to the opener.
+17. The alternate action performs no network request and does not send the URL, candidate path, repository path, or file contents to a service.
+18. Telemetry may record that the alternate action succeeded, failed, or lacked repository context, but it must not record the full URL, repository path, candidate path, link text, or file contents.
+19. Remote sessions, remote Markdown files, shared-session viewers, static file panes without local repository context, and browser/WASM contexts without an eligible local filesystem report no local match. Opening or reusing a Markdown pane for remote/static content clears any prior local link context before the content becomes interactive. Warp must not accidentally resolve a remote path against an active or previously associated same-named directory on the local machine.
+20. Holding Alt/Option, including primary+Alt/Option, over non-link text preserves existing selection and multi-select behavior. On an HTTP(S) rendered link, primary+Alt/Option records a pending alternate link press instead of starting Alt multi-select; Alt/Option without the primary modifier remains the existing multi-select gesture.
+21. The feature adds no background scan or persistent mapping. Closing the Markdown surface leaves no link-to-file association behind.
+22. Failure is non-destructive: it does not move focus away from the Markdown surface, modify the document, dismiss an open pane, or replace the user's clipboard.
+23. Resolution bounds the input before constructing suffix candidates or performing candidate filesystem work: the complete source URL may contain at most 16 KiB, its decoded path at most 4 KiB, at most 128 decoded path segments, and at most 127 candidate suffixes. Exceeding any limit fails with the same no-match behavior and performs no candidate filesystem reads.

--- a/specs/gh-13434/PRODUCT.md
+++ b/specs/gh-13434/PRODUCT.md
@@ -2,17 +2,18 @@
 
 GitHub: [warpdotdev/warp#13434](https://github.com/warpdotdev/warp/issues/13434)
 
-Figma: none provided. This first pass adds an alternate link action without changing the rendered Markdown layout.
+Figma: none provided. This first pass adds an action to the existing link tooltip without changing the rendered Markdown layout.
 
 ## Summary
 
-Let users deliberately open the local checkout copy of a file referenced by a remote repository-browser link in rendered Markdown. A platform-specific alternate-click gesture resolves an exact repository-relative path against the active local checkout; normal link opening remains unchanged.
+Let users deliberately open the local checkout copy of a file referenced by a remote repository-browser link in rendered Markdown. When a link is a possible local-repository file, its existing tooltip exposes an **Open local file** action that resolves an exact repository-relative path against the active local checkout; the tooltip's main target and all other link-opening behavior remain unchanged.
 
 ## Goals / Non-goals
 
 Goals:
 
 - Make remote GitHub and GitLab file links useful while reviewing Markdown inside a local checkout.
+- Make the local-file action discoverable in the existing link tooltip.
 - Keep the action explicit and deterministic: resolve one exact local file or report that no local match exists.
 - Reuse the user's existing local-file opening behavior.
 - Avoid network access, repository mutation, background indexing, and branch or commit checkout.
@@ -24,35 +25,41 @@ Non-goals:
 - No extraction of line or column locations from URL fragments in this first pass.
 - No automatic hyperlinking of bare paths or code spans.
 - No change to Agent Mode rich-output links, terminal hyperlinks, shared-session links, or remote-only files in this first pass.
+- No new mouse modifier gesture, key binding, or setting.
 - No new setting or default change for ordinary Markdown links.
 
 ## Behavior
 
-1. In a rendered local Markdown file, plan, or notebook that has an active local repository context, the user can invoke **Open local repository file** on an `http` or `https` Markdown link by holding the platform's primary modifier plus Alt/Option while clicking it:
-   - macOS: Command+Option-click.
-   - Windows and Linux: Control+Alt-click.
-2. A normal click, Command-click on macOS, or Control-click on Windows/Linux keeps the existing link behavior. In particular, an ordinary remote link continues to open its web URL and an ordinary local-path link continues to use the existing local-file behavior.
-3. The alternate action applies only when the primary+Alt/Option mouse-down starts on an HTTP(S) rendered Markdown link and the mouse-up still identifies that same pressed link without producing a text selection. Warp clears the pending link press after mouse-up, cancellation, or a drag-created selection. Pressing on non-link text and releasing over a link, or pressing one link and releasing over another, never opens either the URL or a local file.
-4. When the alternate gesture is used on a local path, `file:` URL, same-document anchor, `warp:` URL, email link, or another non-HTTP(S) target, Warp preserves that target's existing behavior rather than reinterpreting it as a remote repository link.
-5. Warp resolves against the repository that contains the rendered Markdown document when that repository is known. For a plan or notebook that is not backed by a local file, Warp resolves against the active local terminal's detected repository. Warp never searches every repository known to the app.
-6. If no local repository context is available, Warp does not open the remote URL as a fallback for the alternate gesture. It shows a non-blocking `No matching local file found` toast and leaves the current view unchanged.
-7. The repository root's final directory name is the repository identity used for matching. The decoded URL path must contain that name as a complete path segment in the position used by a supported repository-browser file URL.
-8. This first pass recognizes file-view URLs on the public GitHub and GitLab hosts:
+1. Activating an `http` or `https` link uses the existing link tooltip as follows:
+   - Editable local plans/notebooks retain their current tooltip behavior.
+   - In the read-only local Markdown Viewer, a plain click on a link eligible for **Open local file** shows that same tooltip instead of immediately opening the remote URL, so the alternative is discoverable.
+   - Other read-only/selectable surfaces, ordinary web links, and modified direct-open clicks retain their current behavior.
+2. That tooltip includes a text action labeled **Open local file** only when all of the following are true at tooltip resolution time:
+   - the Markdown surface has an eligible local repository context;
+   - the raw URL has a supported public GitHub or GitLab repository-browser shape; and
+   - the pure URL/path parser can derive at least one syntactically possible repository-relative file candidate for that local repository name.
+3. Determining whether to show **Open local file** performs no candidate filesystem reads, network requests, git operations, or remote-revision checks. A visible action means the URL is a possible local-file reference, not that a matching file has already been proven to exist.
+4. The action is absent for ordinary web URLs, unsupported or malformed repository URLs, local paths, `file:` URLs, same-document anchors, `warp:` URLs, email links, and any surface without eligible local repository context. Those targets retain their existing tooltip and opening behavior.
+5. The tooltip's main link target remains the remote URL, and its Copy, Edit, and any existing link-specific action remain unchanged. Selecting the main target opens the URL. Existing modified direct-open behavior remains unchanged; this feature does not claim Command+Option-click, Control+Alt-click, or another new shortcut.
+6. **Open local file** is available through the same pointer, keyboard-focus, and accessibility interaction conventions as the tooltip's existing text actions. Selecting it revalidates the URL, repository context, and filesystem state at that moment.
+7. Warp resolves against the repository that contains the rendered Markdown document when that repository is known. For a plan or notebook that is not backed by a local file, Warp resolves against the active local terminal's detected repository. Warp never searches every repository known to the app.
+8. If the repository context becomes unavailable after the tooltip appeared, selecting **Open local file** shows a non-blocking `No matching local file found` toast and leaves the current view unchanged. It never opens the remote URL as a fallback.
+9. The repository root's final directory name is the repository identity used for matching. The decoded URL path must contain that name as a complete path segment in the position used by a supported repository-browser file URL.
+10. This first pass recognizes file-view URLs on the public GitHub and GitLab hosts:
    - `github.com/.../<repository>/blob/<revision>/<path>` and `github.com/.../<repository>/raw/<revision>/<path>`.
    - `gitlab.com/.../<repository>/-/blob/<revision>/<path>` and `gitlab.com/.../<repository>/-/raw/<revision>/<path>`.
    Self-hosted forges and other HTTP(S) URL shapes are not interpreted as local paths.
-9. The repository owner/group, browser marker, and revision portion are used only to identify the possible file-path boundary. Warp does not compare the remote owner, fetch the remote repository, verify the revision, or change the local checkout.
-10. Repository-browser URLs do not unambiguously encode where a branch name containing `/` ends and the file path begins. Warp therefore considers each non-empty decoded suffix after the browser marker, while leaving at least one preceding segment as the remote revision. Query parameters and fragments are ignored. Warp validates the original encoded path before a generic URL parser can normalize dot segments or backslashes, then decodes each segment exactly once. Incomplete or malformed percent escapes, raw or encoded separators within a segment, NUL, and raw or encoded `.`/`..` path segments make the request invalid.
-11. Every considered suffix is checked as an exact repository-relative path according to the local filesystem. Warp does not use the rendered link text, final filename alone, fuzzy ranking, or case folding beyond the filesystem's own behavior.
-12. A considered suffix is eligible only when it resolves to an existing regular file whose canonical location remains inside the canonical local repository root. Absolute paths, empty paths, `.`/`..` traversal, NUL bytes, directories, and symlinks that resolve outside the repository are rejected. The path retained after validation is the canonical in-repository file path, not the original joined path or a symlink alias.
-13. When exactly one distinct canonical file resolves, Warp passes that verified canonical path through the same configured file-opening behavior used by an ordinary local Markdown file link. Existing Markdown Viewer and external-editor preferences remain authoritative. Returning the canonical path prevents an original symlink alias from being retargeted between validation and opening.
-14. The URL's branch, tag, or commit is not a selector. Warp opens the file currently present in the checkout, even if its contents differ from the remote revision named by the URL.
-15. When no suffix resolves, more than one suffix resolves, or the URL/path is invalid, over the documented resource limits, outside the repository, a directory, or unsupported, Warp shows `No matching local file found`. It does not guess between matches, open the web URL, create a file, open a picker, or change repository state.
-16. Resolution uses the repository and filesystem state at invocation time. If the document, active session, working directory, repository detection, or target file changes between renders, the next alternate click uses the new current state. This path-based first pass does not claim an atomic file-descriptor lease against a concurrent mutation of the already-canonical path after resolution; it does guarantee that the unverified joined or symlink path is never handed to the opener.
-17. The alternate action performs no network request and does not send the URL, candidate path, repository path, or file contents to a service.
-18. Telemetry may record that the alternate action succeeded, failed, or lacked repository context, but it must not record the full URL, repository path, candidate path, link text, or file contents.
-19. Remote sessions, remote Markdown files, shared-session viewers, static file panes without local repository context, and browser/WASM contexts without an eligible local filesystem report no local match. Opening or reusing a Markdown pane for remote/static content clears any prior local link context before the content becomes interactive. Warp must not accidentally resolve a remote path against an active or previously associated same-named directory on the local machine.
-20. Holding Alt/Option, including primary+Alt/Option, over non-link text preserves existing selection and multi-select behavior. On an HTTP(S) rendered link, primary+Alt/Option records a pending alternate link press instead of starting Alt multi-select; Alt/Option without the primary modifier remains the existing multi-select gesture.
-21. The feature adds no background scan or persistent mapping. Closing the Markdown surface leaves no link-to-file association behind.
-22. Failure is non-destructive: it does not move focus away from the Markdown surface, modify the document, dismiss an open pane, or replace the user's clipboard.
-23. Resolution bounds the input before constructing suffix candidates or performing candidate filesystem work: the complete source URL may contain at most 16 KiB, its decoded path at most 4 KiB, at most 128 decoded path segments, and at most 127 candidate suffixes. Exceeding any limit fails with the same no-match behavior and performs no candidate filesystem reads.
+11. The repository owner/group, browser marker, and revision portion are used only to identify the possible file-path boundary. Warp does not compare the remote owner, fetch the remote repository, verify the revision, or change the local checkout.
+12. Repository-browser URLs do not unambiguously encode where a branch name containing `/` ends and the file path begins. Warp therefore considers each non-empty decoded suffix after the browser marker, while leaving at least one preceding segment as the remote revision. Query parameters and fragments are ignored. Warp validates the original encoded path before a generic URL parser can normalize dot segments or backslashes, then decodes each segment exactly once. Incomplete or malformed percent escapes, raw or encoded separators within a segment, NUL, and raw or encoded `.`/`..` path segments make the request invalid.
+13. Every considered suffix is checked as an exact repository-relative path according to the local filesystem when the user selects **Open local file**. Warp does not use the rendered link text, final filename alone, fuzzy ranking, or case folding beyond the filesystem's own behavior.
+14. A considered suffix is eligible only when it resolves to an existing regular file whose canonical location remains inside the canonical local repository root. Absolute paths, empty paths, `.`/`..` traversal, NUL bytes, directories, and symlinks that resolve outside the repository are rejected. The path retained after validation is the canonical in-repository file path, not the original joined path or a symlink alias.
+15. When exactly one distinct canonical file resolves, Warp passes that verified canonical path through the same configured file-opening behavior used by an ordinary local Markdown file link. Existing Markdown Viewer and external-editor preferences remain authoritative. Returning the canonical path prevents an original symlink alias from being retargeted between validation and opening.
+16. The URL's branch, tag, or commit is not a selector. Warp opens the file currently present in the checkout, even if its contents differ from the remote revision named by the URL.
+17. When no suffix resolves, more than one suffix resolves, or the URL/path is invalid, over the documented resource limits, outside the repository, a directory, or unsupported, Warp shows `No matching local file found`. It does not guess between matches, open the web URL, create a file, open a picker, or change repository state.
+18. Resolution uses the repository and filesystem state when **Open local file** is selected. If the document, active session, working directory, repository detection, or target file changes while the tooltip is open, the action uses the new current state. This path-based first pass does not claim an atomic file-descriptor lease against a concurrent mutation of the already-canonical path after resolution; it does guarantee that the unverified joined or symlink path is never handed to the opener.
+19. The tooltip eligibility check and local-file action perform no network request and do not send the URL, candidate path, repository path, or file contents to a service.
+20. Telemetry may record that the local-file action was shown, succeeded, failed, or lacked repository context, but it must not record the full URL, repository path, candidate path, link text, or file contents.
+21. Remote sessions, remote Markdown files, shared-session viewers, static file panes without local repository context, and browser/WASM contexts without an eligible local filesystem do not show **Open local file**. Opening or reusing a Markdown pane for remote/static content clears any prior local link context before the content becomes interactive. Warp must not accidentally resolve a remote path against an active or previously associated same-named directory on the local machine.
+22. The feature adds no background scan or persistent mapping. Closing the tooltip or Markdown surface leaves no link-to-file association behind.
+23. Failure is non-destructive: it does not move focus away from the Markdown surface, modify the document, dismiss an open pane, or replace the user's clipboard.
+24. Eligibility and resolution bound the input before constructing suffix candidates or performing candidate filesystem work: the complete source URL may contain at most 16 KiB, its decoded path at most 4 KiB, at most 128 decoded path segments, and at most 127 candidate suffixes. Exceeding any limit hides the action during eligibility evaluation or produces the same no-match behavior if state changed after the tooltip appeared, and performs no candidate filesystem reads.

--- a/specs/gh-13434/TECH.md
+++ b/specs/gh-13434/TECH.md
@@ -1,0 +1,177 @@
+# Open repository-browser Markdown links as local files — Tech Spec
+
+See [`PRODUCT.md`](PRODUCT.md) for user-visible behavior.
+
+Code reference: [`2fe6a4f567928c6f11b74021e55092e5f3e5bd79`](https://github.com/warpdotdev/warp/tree/2fe6a4f567928c6f11b74021e55092e5f3e5bd79)
+
+## Context
+
+Rendered Markdown in local files and notebooks uses `RichTextEditorView`. Mouse-up currently converts the mouse modifiers into `EditorViewAction::MaybeOpenFileOrUrl`, but Alt/Option is discarded one layer earlier: `RichTextElement::handle_left_mouse_up` forwards only `cmd` and `shift` through the shared `RichTextAction::left_mouse_up` trait ([`crates/editor/src/render/element/mod.rs:349-356`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/crates/editor/src/render/element/mod.rs#L349-L356), [`crates/editor/src/render/element/mod.rs:672-697`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/crates/editor/src/render/element/mod.rs#L672-L697)). Both `RichTextEditorView` and `CodeEditorView` implement that trait, so its signature cannot be changed in only the notebook crate ([`app/src/notebooks/editor/view.rs:3409-3569`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/editor/view.rs#L3409-L3569), [`app/src/code/editor/view/actions.rs:1162-1270`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/code/editor/view/actions.rs#L1162-L1270)).
+
+`RichTextEditorView::left_mouse_down` already receives full `ModifiersState`, but currently interprets every Alt/Option press as rich-text multiselect before mouse-up can decide to open a link. `maybe_open_file_or_url` later suppresses opening when the editor no longer has one cursor. The alternate gesture therefore needs a pressed-link state established on mouse-down, not only an extra bit on the final action. After that gate, `maybe_open_file_or_url` gives detected file paths priority and routes URL links through `NotebookLinks` ([`app/src/notebooks/editor/view.rs:1911-1993`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/editor/view.rs#L1911-L1993)).
+
+`NotebookLinks::resolve` intentionally parses valid URLs before local paths, so an HTTP repository-browser URL always becomes `LinkTarget::Url` and opens through `ctx.open_url` ([`app/src/notebooks/link.rs:124-160`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L124-L160), [`app/src/notebooks/link.rs:253-299`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L253-L299)). Local file opening already centralizes the configured editor/Markdown Viewer choice and avoids handing executable-looking files to an unsafe system-default handler ([`app/src/notebooks/link.rs:353-400`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L353-L400)); the new path must finish through that code rather than introducing another opener.
+
+Each `NotebookLinks` instance owns a `SessionSource`. A local Markdown file changes that source to the file's parent directory and its target session, while an unbound plan/notebook uses the active window session ([`app/src/notebooks/file/mod.rs:367-384`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/file/mod.rs#L367-L384), [`app/src/notebooks/link.rs:470-496`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L470-L496)). However, `FileNotebookView::open_remote` does not replace the model's initial `SessionSource::Active` or a previous local `Target`, so checking only whether the current source resolves to a local session would permit remote content to reuse unrelated local state ([`app/src/notebooks/file/mod.rs:586-679`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/file/mod.rs#L586-L679)). Repository detection already maps a working directory to its detected root; `FileSearchModel::repo_root_location` demonstrates the existing `DetectedRepositories::get_root_for_path` lookup and rejects local/remote type confusion ([`app/src/search/files/model.rs:72-99`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/search/files/model.rs#L72-L99)).
+
+`FilePane` and `NotebookPane` subscribe their `NotebookLinks` models to the shared `subscribe_to_link_model` adapter, which forwards local-file events to the containing pane group. `AIDocumentPane` does not currently make that subscription, so a plan can resolve a target but cannot complete the existing `NotebookLinks::open` event path ([`app/src/pane_group/pane/notebook_pane.rs:84-120`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/pane_group/pane/notebook_pane.rs#L84-L120), [`app/src/pane_group/pane/notebook_pane.rs:168-212`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/pane_group/pane/notebook_pane.rs#L168-L212), [`app/src/pane_group/pane/ai_document_pane.rs:62-143`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/pane_group/pane/ai_document_pane.rs#L62-L143)).
+
+Agent rich output has a separate detected-link and click path that opens `DetectedLinkType::Url` directly. It is intentionally outside this first implementation, matching the maintainer request to keep the initially separate Markdown surfaces scoped.
+
+## Proposed changes
+
+### 1. Preserve full mouse-up modifiers and establish a pressed-link gesture
+
+At the shared editor boundary:
+
+- Change `RichTextAction::left_mouse_up` in `crates/editor/src/render/element/mod.rs` to receive copyable `ModifiersState` rather than separate `cmd` and `shift` booleans, and pass the full value from `RichTextElement::handle_left_mouse_up`.
+- Update both implementations. `CodeEditorViewAction` reads the same `cmd`/`shift` bits it uses today and otherwise remains behaviorally unchanged. `EditorViewAction::MaybeOpenFileOrUrl` receives explicit `primary_modifier` and `alt` fields, or the small copied modifier value.
+- Update direct trait/element tests so macOS Command+Option and Windows/Linux Control+Alt reach the rich-text action without changing code-editor mouse behavior.
+
+In `app/src/notebooks/editor/view.rs`:
+
+- Add invocation-local `PendingAlternateLinkPress` state containing the raw target plus the existing hit-tested `block_start` and pressed `char_offset`. Set it only when primary+Alt mouse-down hits an HTTP(S) rendered link. Do not reduce identity to the URL alone: two separately rendered links may share a target.
+- For that eligible press, do not start Alt multiselect. Alt-only and primary+Alt over non-link or non-HTTP(S) content retain the current multiselect path.
+- On mouse-up, require the same raw target and block, and require the selection to remain the single cursor anchored by that press; a changed character offset that produced a range is a selection, not a click. Clear the pending state after mouse-up, drag selection, cancellation, focus loss, or content reset so it cannot be replayed against a later render.
+- Preserve the existing primary-modifier behavior for anchors, local files, editable-link tooltips, and normal URL opening.
+- Treat `primary_modifier && alt` as the local-repository alternate action only for that confirmed pending HTTP(S) link.
+
+Do not add a key binding or setting. This is pointer state already available at the event boundary.
+
+### 2. Validate the original encoded URL and add a pure path extractor
+
+Add a small pure helper next to `NotebookLinks` in `app/src/notebooks/link.rs` (with tests in `link_tests.rs`):
+
+```rust
+fn repository_relative_path_candidates_from_url(
+    raw_url: &str,
+    repository_name: &OsStr,
+) -> Result<Vec<PathBuf>, RepositoryLinkError>
+```
+
+The helper:
+
+- rejects a source string larger than `MAX_REPOSITORY_URL_BYTES` (16 KiB) before parsing or allocating candidate paths;
+- rejects any raw backslash in the source, then isolates the original encoded path before query/fragment data and validates it before `Url::parse` can apply WHATWG dot-segment or separator normalization;
+- validates complete `%HH` escapes, decodes each raw path segment exactly once, and rejects a decoded `.`/`..` segment, decoded `/` or `\` within a segment, NUL, and invalid UTF-8;
+- accepts only `http` and `https`;
+- walks decoded path segments and matches the repository name as one complete segment;
+- requires the public `github.com` or `gitlab.com` host and recognizes GitHub `blob`/`raw` and GitLab `-/blob`/`-/raw` forms;
+- requires at least one segment after the provider marker to remain the uninterpreted remote revision;
+- returns every non-empty suffix that could be the repository-relative path, so a revision containing `/` does not make Warp silently choose the wrong boundary;
+- rejects missing/empty remainder, root/prefix components, and repository names that cannot be compared to a decoded provider segment;
+- rejects a decoded provider path larger than `MAX_DECODED_REPOSITORY_PATH_BYTES` (4 KiB), more than `MAX_REPOSITORY_PATH_SEGMENTS` (128), or more than `MAX_REPOSITORY_PATH_CANDIDATES` (127) before any filesystem lookup;
+- ignores query and fragment data;
+- does not read the filesystem, inspect git state, or perform fuzzy search.
+
+`Url` may be used for the scheme, host, and provider-shape checks only after validation of the original encoded path. Do not change this API back to `&Url`: that would lose the information needed to reject normalization-altering encoded dot segments. Keep provider-shape parsing separate from filesystem validation so the URL matrix is deterministic and unit-testable without an app or repository fixture. The raw input is the Markdown link target, not its rendered label.
+
+### 3. Resolve the candidate against the link's local repository context
+
+Add `NotebookLinks::resolve_repository_url_as_local_file`:
+
+1. Extend `SessionSource` with an explicit `Unavailable` state. `FileNotebookView::open_remote` and `open_static` set it before making the new content interactive, clearing either the initial `Active` source or a previous local `Target`. Local file context sets `Target` as today; plans/notebooks intentionally retain `Active`. `Unavailable`, remote sessions, and non-local filesystem builds fail before repository or candidate filesystem lookup.
+2. Require a local session and base directory from the eligible source, then ask `DetectedRepositories` for the local root containing that exact base directory. This makes a file-backed Markdown viewer use the repository containing the document, while an unbound plan/notebook uses the active local terminal repository.
+3. Take the root's final directory name and pass it with the parsed URL to the pure extractor.
+4. Join each relative candidate to the root and asynchronously obtain canonical paths for the root and candidates.
+5. Retain only candidates whose metadata describes a regular file and whose canonical path starts with the canonical root. This rejects traversal and symlink escapes while still allowing an in-repository symlink whose canonical target remains in the repository.
+6. Require exactly one distinct canonical match. Zero or multiple matches return a non-match error rather than picking a suffix.
+7. Return the existing `LinkTarget::LocalFile` with the verified canonical candidate as `path`, `line_and_column: None`, the current session, and `is_markdown` derived from that canonical path. Never return the original joined path or symlink alias after validating a different canonical path.
+
+Use a dedicated error enum that distinguishes unsupported URL, missing local repository context, invalid/unsafe path, and missing/non-file target for tests and coarse telemetry. Do not include sensitive paths or the source URL in safe logs.
+
+This removes the actionable symlink-retarget validation/open gap while retaining the existing path-based opener. It does not introduce a file-descriptor lease or claim atomicity against a concurrent mutation of the already-canonical path after resolution; that broader filesystem capability is outside this first pass.
+
+### 4. Route success through the existing opener and failure through one toast
+
+In `RichTextEditorView::maybe_open_url`:
+
+- For a confirmed pending primary+Alt HTTP(S) press, pass the original raw link target to `resolve_repository_url_as_local_file`.
+- On success, call `NotebookLinks::open` with the returned target so editor preferences and executable-file safety remain centralized.
+- On every expected resolution failure, add one ephemeral `No matching local file found` toast to the current window.
+- Consume the alternate action in both success and failure cases. Never fall back to `ctx.open_url`; an accidental fallback would make a failed local-only request navigate away.
+- Do not change tooltip state, selection, focus, clipboard, or document contents.
+
+Unexpected I/O failures may be logged at a non-sensitive level and use the same toast. No URL or local path is included in telemetry or logs.
+
+To make the same centralized opener complete for plans, add a `NotebookLinks` getter to `AIDocumentView`, call the existing `subscribe_to_link_model` helper from `AIDocumentPane::attach`, and unsubscribe in `detach`, matching `FilePane` and `NotebookPane`. Do not add a second plan-specific file opener.
+
+### 5. Keep surface boundaries explicit
+
+This change applies to `RichTextEditorView` consumers with an eligible local `NotebookLinks` context: local Markdown Viewer and local plans/notebooks. The only plan-specific plumbing is the missing `NotebookLinks` pane subscription described above. Do not modify `app/src/util/link_detection.rs` or Agent block-list click handlers in this PR. The latter lack the same document/repository context and would otherwise turn this into a cross-renderer feature.
+
+No feature flag is necessary: normal link behavior is unchanged, failure is non-destructive, and the new branch runs only for a previously unused modifier combination.
+
+## Testing and validation
+
+### Pure URL/path tests
+
+Extend `app/src/notebooks/link_tests.rs` with table-driven coverage mapped to PRODUCT invariants 7–12:
+
+- Public GitHub `blob` and `raw` URLs and public GitLab `-/blob` and `-/raw` URLs yield the expected candidate suffixes.
+- Owner/group prefixes, percent-encoded safe path segments, query strings, and fragments do not change the candidate.
+- Repository-name substring matches, wrong or non-UTF-8 repository names, self-hosted/unsupported providers or shapes, missing revision/path, empty path, raw or encoded traversal/separators, absolute/root components, malformed encoding, NUL, and non-HTTP(S) schemes fail.
+- A raw URL containing `src/%2e%2e/file`, `src/../file`, or a backslash fails before `Url` normalization; the normalized path is never accepted as if it were the original input.
+- Inputs at each byte, segment, and candidate limit succeed or continue to normal resolution; one unit over each limit fails before filesystem resolution.
+- Single-segment revisions and slash-containing revision prefixes can resolve an exact file without being used to select or mutate git state.
+
+### Filesystem resolution tests
+
+Using a temporary repository fixture and a local test session:
+
+- an existing nested regular file resolves to `LinkTarget::LocalFile`;
+- a slash-containing revision resolves when exactly one candidate suffix exists;
+- two distinct existing suffixes fail as ambiguous rather than choosing one;
+- a missing file, directory, and outside-root traversal fail;
+- an in-root symlink to an in-root file succeeds where supported;
+- a symlink escaping the root fails;
+- the returned target contains the verified canonical file rather than the original symlink alias;
+- missing repository detection, an explicitly unavailable source, remote session context, and remote/static Markdown content fail without consulting the local candidate filesystem;
+- switching one file pane from local content to remote content cannot reuse the prior local target, and a fresh remote pane cannot use an active local terminal repository;
+- success preserves the current session and sets no line/column selector.
+
+### Editor interaction tests
+
+Extend `app/src/notebooks/editor/view_tests.rs`:
+
+- full modifiers survive `RichTextElement` dispatch for the notebook implementation while CodeEditor behavior remains unchanged;
+- primary+Alt mouse-down/up on the same eligible HTTP link opens the local file event and does not open the URL;
+- failure produces the toast and does not open the URL;
+- normal click, primary-only click, local-file links, anchors, and non-links retain their existing behavior;
+- Alt-only multiselect remains available, while primary+Alt over an eligible HTTP link does not create an extra cursor;
+- primary+Alt over non-link or non-HTTP(S) content preserves existing multiselect/selection behavior;
+- non-link mouse-down followed by link mouse-up, different-link down/up, a drag-created selection, focus loss, and content reset suppress and clear the pending action;
+- FilePane, NotebookPane, and AIDocumentPane receive the successful `NotebookLinks` event and forward the same canonical target to the pane group.
+
+Run:
+
+```bash
+cargo nextest run -p warp -E 'test(link) | test(markdown_anchor)'
+cargo nextest run -p warp_editor -E 'test(mouse)'
+./script/format
+cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
+git diff --check
+```
+
+Manually open a local Markdown file containing one GitHub file link, one missing link, and one ordinary web link. Record that normal click opens the browser, primary+Alt opens the checkout file, and primary+Alt on the missing link stays in Warp and shows the toast.
+
+## Parallelization
+
+Use one implementation worktree, `codex/gh13434-local-markdown-links`. The shared editor trait/dispatcher, both action implementations, pressed-link state, resolver, remote-context transition, and pane subscription form one behavior chain; splitting them across branches would make intermediate states uncompilable or untestable. A second local validation agent can independently review the finished diff and run the targeted tests after the implementation branch is coherent.
+
+## Risks and mitigations
+
+- **Opening a file outside the repository:** canonicalize both paths and require the target to remain under the canonical root.
+- **Remote/local path confusion:** require a local session and local repository root; never reinterpret a remote session's path on the host filesystem.
+- **Provider URL ambiguity or parser normalization:** validate and bound the original encoded path before generic URL parsing, support only the documented GitHub/GitLab shapes and exact repository segment, and fail closed.
+- **Unexpected browser navigation after failure:** consume the alternate gesture before async resolution and never fall back to normal URL opening.
+- **Rich-text selection regression:** preserve full modifiers through the shared trait, record the pressed link on mouse-down, and suppress Alt multiselect only for the confirmed alternate-link gesture.
+- **Symlink retarget between validation and opening:** pass the verified canonical file to the existing opener, never the joined alias. Atomic protection against a later mutation of that canonical path would require a file-descriptor-based opening contract and remains out of scope.
+- **Oversized crafted links:** enforce URL byte, decoded path byte, segment, and candidate limits before allocating suffixes or touching the candidate filesystem.
+- **Scope expansion across renderers:** leave Agent rich output and generic detected-link code untouched.
+
+## Follow-ups
+
+- Evaluate Agent Mode rich-output support once it has an explicit repository-context contract.
+- Evaluate line/column fragments and an accessible non-pointer action separately.
+- Add providers only with deterministic URL-shape tests rather than a suffix-search fallback.

--- a/specs/gh-13434/TECH.md
+++ b/specs/gh-13434/TECH.md
@@ -6,9 +6,7 @@ Code reference: [`2fe6a4f567928c6f11b74021e55092e5f3e5bd79`](https://github.com/
 
 ## Context
 
-Rendered Markdown in local files and notebooks uses `RichTextEditorView`. Mouse-up currently converts the mouse modifiers into `EditorViewAction::MaybeOpenFileOrUrl`, but Alt/Option is discarded one layer earlier: `RichTextElement::handle_left_mouse_up` forwards only `cmd` and `shift` through the shared `RichTextAction::left_mouse_up` trait ([`crates/editor/src/render/element/mod.rs:349-356`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/crates/editor/src/render/element/mod.rs#L349-L356), [`crates/editor/src/render/element/mod.rs:672-697`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/crates/editor/src/render/element/mod.rs#L672-L697)). Both `RichTextEditorView` and `CodeEditorView` implement that trait, so its signature cannot be changed in only the notebook crate ([`app/src/notebooks/editor/view.rs:3409-3569`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/editor/view.rs#L3409-L3569), [`app/src/code/editor/view/actions.rs:1162-1270`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/code/editor/view/actions.rs#L1162-L1270)).
-
-`RichTextEditorView::left_mouse_down` already receives full `ModifiersState`, but currently interprets every Alt/Option press as rich-text multiselect before mouse-up can decide to open a link. `maybe_open_file_or_url` later suppresses opening when the editor no longer has one cursor. The alternate gesture therefore needs a pressed-link state established on mouse-down, not only an extra bit on the final action. After that gate, `maybe_open_file_or_url` gives detected file paths priority and routes URL links through `NotebookLinks` ([`app/src/notebooks/editor/view.rs:1911-1993`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/editor/view.rs#L1911-L1993)).
+Rendered Markdown in local files and notebooks uses `RichTextEditorView`. Activating a URL without the existing direct-open modifier creates a `LinkToolTipConfig`, resolves the raw target through `NotebookLinks`, and renders the existing link tooltip. The tooltip keeps the resolved target as its main link and adds Copy, Edit, and any `LinkTarget::secondary_action` buttons ([`app/src/notebooks/editor/view.rs:1907-2005`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/editor/view.rs#L1907-L2005), [`app/src/notebooks/editor/view.rs:2280-2485`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/editor/view.rs#L2280-L2485)). `LinkTarget::Url` deliberately has no current secondary action, so the remote URL remains the primary target ([`app/src/notebooks/link.rs:25-66`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L25-L66)). Read-only/selectable editors currently bypass the tooltip and open every URL directly, so the Markdown Viewer needs a narrowly configured exception for eligible repository links without changing comment chips or other selectable consumers. The local-repository action should extend this established tooltip pattern rather than claim a new mouse gesture or modify the shared rich-text event boundary.
 
 `NotebookLinks::resolve` intentionally parses valid URLs before local paths, so an HTTP repository-browser URL always becomes `LinkTarget::Url` and opens through `ctx.open_url` ([`app/src/notebooks/link.rs:124-160`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L124-L160), [`app/src/notebooks/link.rs:253-299`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L253-L299)). Local file opening already centralizes the configured editor/Markdown Viewer choice and avoids handing executable-looking files to an unsafe system-default handler ([`app/src/notebooks/link.rs:353-400`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/notebooks/link.rs#L353-L400)); the new path must finish through that code rather than introducing another opener.
 
@@ -20,23 +18,24 @@ Agent rich output has a separate detected-link and click path that opens `Detect
 
 ## Proposed changes
 
-### 1. Preserve full mouse-up modifiers and establish a pressed-link gesture
+### 1. Add a contextual action to the existing link tooltip
 
-At the shared editor boundary:
+In `app/src/notebooks/link.rs`:
 
-- Change `RichTextAction::left_mouse_up` in `crates/editor/src/render/element/mod.rs` to receive copyable `ModifiersState` rather than separate `cmd` and `shift` booleans, and pass the full value from `RichTextElement::handle_left_mouse_up`.
-- Update both implementations. `CodeEditorViewAction` reads the same `cmd`/`shift` bits it uses today and otherwise remains behaviorally unchanged. `EditorViewAction::MaybeOpenFileOrUrl` receives explicit `primary_modifier` and `alt` fields, or the small copied modifier value.
-- Update direct trait/element tests so macOS Command+Option and Windows/Linux Control+Alt reach the rich-text action without changing code-editor mouse behavior.
+- Add a context-level eligibility method on `NotebookLinks` that obtains the current eligible local base directory, asks `DetectedRepositories` for the containing repository root, and calls the pure parser from section 2 with the root's final directory name.
+- Eligibility succeeds when the parser returns at least one syntactically possible path candidate. It must not stat, canonicalize, or open any candidate; a file may disappear, be ambiguous, or never have existed after the action is shown.
+- Return only availability to the view. Do not retain the repository root or candidate paths in tooltip state, because the full action must re-read current context and revalidate the filesystem when selected.
 
 In `app/src/notebooks/editor/view.rs`:
 
-- Add invocation-local `PendingAlternateLinkPress` state containing the raw target plus the existing hit-tested `block_start` and pressed `char_offset`. Set it only when primary+Alt mouse-down hits an HTTP(S) rendered link. Do not reduce identity to the URL alone: two separately rendered links may share a target.
-- For that eligible press, do not start Alt multiselect. Alt-only and primary+Alt over non-link or non-HTTP(S) content retain the current multiselect path.
-- On mouse-up, require the same raw target and block, and require the selection to remain the single cursor anchored by that press; a changed character offset that produced a range is a selection, not a click. Clear the pending state after mouse-up, drag selection, cancellation, focus loss, or content reset so it cannot be replayed against a later render.
-- Preserve the existing primary-modifier behavior for anchors, local files, editable-link tooltips, and normal URL opening.
-- Treat `primary_modifier && alt` as the local-repository alternate action only for that confirmed pending HTTP(S) link.
+- Extend `LinkToolTipConfig` with contextual **Open local file** availability while retaining the raw URL and existing resolved `LinkTarget` state.
+- Add a `RepositoryLinkTooltipMode` field to `RichTextEditorView`, initialized to `Disabled` by `RichTextEditorView::new`, plus a narrow setter used by owning surfaces after construction. `FileNotebookView` selects `SelectableFileViewer`, which both enables the contextual action and permits a plain eligible link click to open the tooltip while the editor is selectable. `NotebookView` and `AIDocumentView` select `ExistingTooltipsOnly`, which adds the action only when their normal interaction already opens a tooltip. Apply the owning surface's mode every time it installs or replaces an editor; in particular, `AIDocumentView::refresh`/`set_editor_model` must configure the replacement editor rather than relying on the constructor's initial handle. Every other consumer, including selectable comment chips, remains `Disabled`; no `RichTextEditorConfig` struct literal changes or broad selectable behavior changes are required. Existing `cmd`/primary-modifier direct-open behavior remains unchanged.
+- Add a dedicated `EditorViewAction` for selecting **Open local file** and a persistent `MouseStateHandle` created with the view's other tooltip handles.
+- Render the new `ButtonVariant::Text` action beside the existing tooltip actions only when the context-level eligibility check succeeds. Give it the visible label and accessibility content `Open local file`.
+- Keep the main resolved URL, Copy, Edit, and `LinkTarget::secondary_action` behavior unchanged. Do not reinterpret the remote URL as `LinkTarget::LocalFile` and do not add this contextual operation to `LinkTarget::secondary_action`, which describes actions intrinsic to an already-resolved target.
+- Subscribe `RichTextEditorView` directly to its `NotebookLinks` model. On `LinkEvent::RefreshLinks`, recompute availability for any open tooltip from its raw URL and notify the view; leave all other link events to the existing pane subscriptions. Treat the rendered flag only as discoverability state; the click handler never trusts it as authorization to open a path.
 
-Do not add a key binding or setting. This is pointer state already available at the event boundary.
+Do not change `RichTextAction`, mouse-down/up dispatch, multiselect behavior, key bindings, or settings. Existing direct-open modifiers remain available for their existing targets, and Command+Option/Control+Alt remains unclaimed by this feature.
 
 ### 2. Validate the original encoded URL and add a pure path extractor
 
@@ -70,27 +69,29 @@ The helper:
 
 Add `NotebookLinks::resolve_repository_url_as_local_file`:
 
-1. Extend `SessionSource` with an explicit `Unavailable` state. `FileNotebookView::open_remote` and `open_static` set it before making the new content interactive, clearing either the initial `Active` source or a previous local `Target`. Local file context sets `Target` as today; plans/notebooks intentionally retain `Active`. `Unavailable`, remote sessions, and non-local filesystem builds fail before repository or candidate filesystem lookup.
-2. Require a local session and base directory from the eligible source, then ask `DetectedRepositories` for the local root containing that exact base directory. This makes a file-backed Markdown viewer use the repository containing the document, while an unbound plan/notebook uses the active local terminal repository.
-3. Take the root's final directory name and pass it with the parsed URL to the pure extractor.
-4. Join each relative candidate to the root and asynchronously obtain canonical paths for the root and candidates.
-5. Retain only candidates whose metadata describes a regular file and whose canonical path starts with the canonical root. This rejects traversal and symlink escapes while still allowing an in-repository symlink whose canonical target remains in the repository.
-6. Require exactly one distinct canonical match. Zero or multiple matches return a non-match error rather than picking a suffix.
-7. Return the existing `LinkTarget::LocalFile` with the verified canonical candidate as `path`, `line_and_column: None`, the current session, and `is_markdown` derived from that canonical path. Never return the original joined path or symlink alias after validating a different canonical path.
+1. Extend `SessionSource` with an explicit `Unavailable` state. `FileNotebookView::open_remote` and `open_static` set it before making the new content interactive, clearing either the initial `Active` source or a previous local `Target`. Local file context sets `Target` as today; normal local plans/notebooks retain `Active`. `Unavailable`, remote sessions, and non-local filesystem builds fail before repository or candidate filesystem lookup.
+2. Add a separate repository-link-action availability flag to `NotebookLinks`, defaulting to enabled and consulted only by the new eligibility/resolution methods. Disabling it must not alter existing URL, local-path, anchor, or shared-session link resolution. Its setter emits `LinkEvent::RefreshLinks` when the value changes.
+3. `AIDocumentView` disables that feature-specific flag before the first render when its conversation is already being viewed through a shared session. Make `BlocklistAIHistoryModel::set_viewing_shared_session_for_conversation` publish a focused event carrying the conversation id and new viewing state, and have `AIDocumentView` update the flag when the matching conversation enters or leaves shared-session viewing. This provides an observable transition seam without changing existing shared-session link behavior.
+4. Require a local session and base directory from the eligible source, then ask `DetectedRepositories` for the local root containing that exact base directory. This makes a file-backed Markdown viewer use the repository containing the document, while an unbound plan/notebook uses the active local terminal repository.
+5. Take the root's final directory name and pass it with the parsed URL to the pure extractor.
+6. Join each relative candidate to the root and asynchronously obtain canonical paths for the root and candidates.
+7. Retain only candidates whose metadata describes a regular file and whose canonical path starts with the canonical root. This rejects traversal and symlink escapes while still allowing an in-repository symlink whose canonical target remains in the repository.
+8. Require exactly one distinct canonical match. Zero or multiple matches return a non-match error rather than picking a suffix.
+9. Return the existing `LinkTarget::LocalFile` with the verified canonical candidate as `path`, `line_and_column: None`, the current session, and `is_markdown` derived from that canonical path. Never return the original joined path or symlink alias after validating a different canonical path.
 
 Use a dedicated error enum that distinguishes unsupported URL, missing local repository context, invalid/unsafe path, and missing/non-file target for tests and coarse telemetry. Do not include sensitive paths or the source URL in safe logs.
 
 This removes the actionable symlink-retarget validation/open gap while retaining the existing path-based opener. It does not introduce a file-descriptor lease or claim atomicity against a concurrent mutation of the already-canonical path after resolution; that broader filesystem capability is outside this first pass.
 
-### 4. Route success through the existing opener and failure through one toast
+### 4. Route the tooltip action through the existing opener and one failure toast
 
-In `RichTextEditorView::maybe_open_url`:
+When `RichTextEditorView` handles the dedicated **Open local file** action:
 
-- For a confirmed pending primary+Alt HTTP(S) press, pass the original raw link target to `resolve_repository_url_as_local_file`.
+- Pass the tooltip's original raw link target to `resolve_repository_url_as_local_file`. That method must repeat the local-context and pure-parser checks before touching the candidate filesystem, so a stale tooltip cannot reuse an old repository association.
 - On success, call `NotebookLinks::open` with the returned target so editor preferences and executable-file safety remain centralized.
 - On every expected resolution failure, add one ephemeral `No matching local file found` toast to the current window.
-- Consume the alternate action in both success and failure cases. Never fall back to `ctx.open_url`; an accidental fallback would make a failed local-only request navigate away.
-- Do not change tooltip state, selection, focus, clipboard, or document contents.
+- Consume the tooltip action in both success and failure cases. Never fall back to `ctx.open_url`; the tooltip's main link remains the only route that opens the remote URL.
+- Do not change selection, focus, clipboard, or document contents. If the link or repository context changes while the tooltip is open, use current state or fail closed rather than opening a stale target.
 
 Unexpected I/O failures may be logged at a non-sensitive level and use the same toast. No URL or local path is included in telemetry or logs.
 
@@ -100,7 +101,7 @@ To make the same centralized opener complete for plans, add a `NotebookLinks` ge
 
 This change applies to `RichTextEditorView` consumers with an eligible local `NotebookLinks` context: local Markdown Viewer and local plans/notebooks. The only plan-specific plumbing is the missing `NotebookLinks` pane subscription described above. Do not modify `app/src/util/link_detection.rs` or Agent block-list click handlers in this PR. The latter lack the same document/repository context and would otherwise turn this into a cross-renderer feature.
 
-No feature flag is necessary: normal link behavior is unchanged, failure is non-destructive, and the new branch runs only for a previously unused modifier combination.
+No feature flag is necessary: the main link target and all unrelated link behavior remain unchanged, failure is non-destructive, and the new branch runs only when the user selects a context-gated action in an existing tooltip.
 
 ## Testing and validation
 
@@ -130,42 +131,55 @@ Using a temporary repository fixture and a local test session:
 - switching one file pane from local content to remote content cannot reuse the prior local target, and a fresh remote pane cannot use an active local terminal repository;
 - success preserves the current session and sets no line/column selector.
 
+### Tooltip eligibility tests
+
+Cover PRODUCT invariants 1–8 and 21:
+
+- a supported GitHub/GitLab file URL with eligible local repository context exposes **Open local file** when the pure parser returns at least one candidate, even when the candidate does not exist yet;
+- ordinary web URLs, malformed/unsupported provider shapes, non-HTTP(S) targets, missing repository detection, unavailable/remote context, and browser/WASM builds do not expose the action;
+- eligibility performs no candidate metadata or canonicalization calls;
+- changing or clearing the link context refreshes the open tooltip's availability, and selecting a previously rendered action still revalidates current context;
+- a conversation already in shared-session viewer state initializes with the repository action disabled; entering that state later removes the action from an open tooltip and performs no local candidate lookup; leaving it re-enables only the feature-specific gate;
+- shared-session transitions do not change existing `NotebookLinks::resolve` results for URLs, local paths, or anchors;
+- the main URL target and existing Copy, Edit, and target-specific secondary actions are unchanged.
+
 ### Editor interaction tests
 
 Extend `app/src/notebooks/editor/view_tests.rs`:
 
-- full modifiers survive `RichTextElement` dispatch for the notebook implementation while CodeEditor behavior remains unchanged;
-- primary+Alt mouse-down/up on the same eligible HTTP link opens the local file event and does not open the URL;
-- failure produces the toast and does not open the URL;
-- normal click, primary-only click, local-file links, anchors, and non-links retain their existing behavior;
-- Alt-only multiselect remains available, while primary+Alt over an eligible HTTP link does not create an extra cursor;
-- primary+Alt over non-link or non-HTTP(S) content preserves existing multiselect/selection behavior;
-- non-link mouse-down followed by link mouse-up, different-link down/up, a drag-created selection, focus loss, and content reset suppress and clear the pending action;
+- clicking an eligible HTTP link in the local Markdown Viewer opens the existing tooltip with **Open local file** and does not change the main link target;
+- ordinary selectable web links and selectable comment-chip links retain direct-open behavior, while existing modified direct-open clicks bypass the tooltip as before;
+- replacing an `AIDocumentView` editor during refresh preserves `ExistingTooltipsOnly` on the new editor handle;
+- pointer and keyboard activation of **Open local file** open the local file event and do not open the URL;
+- missing, ambiguous, or newly unavailable targets produce the toast and do not open the URL;
+- ordinary web URLs, local-file links, anchors, non-links, normal URL activation, and existing modified clicks retain their current behavior;
+- Copy, Edit, and existing target-specific secondary actions continue to dispatch their original actions;
 - FilePane, NotebookPane, and AIDocumentPane receive the successful `NotebookLinks` event and forward the same canonical target to the pane group.
 
 Run:
 
 ```bash
 cargo nextest run -p warp -E 'test(link) | test(markdown_anchor)'
-cargo nextest run -p warp_editor -E 'test(mouse)'
+cargo nextest run -p warp_editor -E 'test(link) | test(mouse)'
 ./script/format
 cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
 git diff --check
 ```
 
-Manually open a local Markdown file containing one GitHub file link, one missing link, and one ordinary web link. Record that normal click opens the browser, primary+Alt opens the checkout file, and primary+Alt on the missing link stays in Warp and shows the toast.
+Manually open a local Markdown file containing one existing GitHub file link, one syntactically eligible missing link, and one ordinary web link. Record that a plain click shows the existing link tooltip with **Open local file** only for the two repository-browser links; its main link still opens the browser; the local action opens the existing checkout file; the missing target shows the toast; and the ordinary web link still opens directly. Also verify that an eligible link in a selectable comment chip retains its existing direct-open behavior. Capture the tooltip and the end-to-end success/failure behavior in screenshots or a short recording.
 
 ## Parallelization
 
-Use one implementation worktree, `codex/gh13434-local-markdown-links`. The shared editor trait/dispatcher, both action implementations, pressed-link state, resolver, remote-context transition, and pane subscription form one behavior chain; splitting them across branches would make intermediate states uncompilable or untestable. A second local validation agent can independently review the finished diff and run the targeted tests after the implementation branch is coherent.
+Use one implementation worktree, `codex/gh13434-local-markdown-links`. Tooltip eligibility, the pure parser, resolver, remote-context transition, and pane subscription form one behavior chain; splitting them across branches would make intermediate states difficult to validate without duplicating fixtures. A second local validation agent can independently review the finished diff and run the targeted tests after the implementation branch is coherent.
 
 ## Risks and mitigations
 
 - **Opening a file outside the repository:** canonicalize both paths and require the target to remain under the canonical root.
 - **Remote/local path confusion:** require a local session and local repository root; never reinterpret a remote session's path on the host filesystem.
 - **Provider URL ambiguity or parser normalization:** validate and bound the original encoded path before generic URL parsing, support only the documented GitHub/GitLab shapes and exact repository segment, and fail closed.
-- **Unexpected browser navigation after failure:** consume the alternate gesture before async resolution and never fall back to normal URL opening.
-- **Rich-text selection regression:** preserve full modifiers through the shared trait, record the pressed link on mouse-down, and suppress Alt multiselect only for the confirmed alternate-link gesture.
+- **Unexpected browser navigation after failure:** keep the contextual button separate from the main URL action and never fall back to normal URL opening.
+- **Tooltip false positives or stale context:** use the strict pure parser only for discoverability, then repeat context, canonical-path, and regular-file validation when the user selects the action.
+- **Tooltip regression:** preserve the existing main target, Copy, Edit, and target-specific secondary actions and add focused interaction coverage for each.
 - **Symlink retarget between validation and opening:** pass the verified canonical file to the existing opener, never the joined alias. Atomic protection against a later mutation of that canonical path would require a file-descriptor-based opening contract and remains out of scope.
 - **Oversized crafted links:** enforce URL byte, decoded path byte, segment, and candidate limits before allocating suffixes or touching the candidate filesystem.
 - **Scope expansion across renderers:** leave Agent rich output and generic detected-link code untouched.
@@ -173,5 +187,5 @@ Use one implementation worktree, `codex/gh13434-local-markdown-links`. The share
 ## Follow-ups
 
 - Evaluate Agent Mode rich-output support once it has an explicit repository-context contract.
-- Evaluate line/column fragments and an accessible non-pointer action separately.
+- Evaluate line/column fragments separately.
 - Add providers only with deterministic URL-shape tests rather than a suffix-search fallback.


### PR DESCRIPTION
## Description

Adds product and technical specifications for #13434, following the maintainer's proposed narrow first pass.

The specs define:

- an explicit Command+Option / Control+Alt action for opening supported GitHub and GitLab file links from the active local checkout;
- deterministic repository-root and URL-path matching without branch checkout, selectors, fuzzy search, or network access;
- raw-URL validation, bounded candidate generation, canonical-path containment, and fail-closed symlink handling;
- the exact Markdown, plan, and notebook surfaces in scope, including the missing plan link-model subscription;
- editor gesture, URL parser, filesystem, remote-context, and pane integration coverage required before implementation.

## Linked Issue

Closes #13434

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots are not applicable because this PR contains specifications only and does not change runtime UI.

## Testing

This is a documentation-only change, so no runtime tests were added.

- `./script/format --check`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `git diff --cached --check`

- [ ] I have manually tested my changes locally with `./script/run` (not applicable to a spec-only change)

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

