### PR TITLE
Prefill Tab Config parameters from external URIs (spec)

### DIFF
--- a/specs/gh-12343/PRODUCT.md
+++ b/specs/gh-12343/PRODUCT.md
@@ -1,0 +1,64 @@
+# Prefill Tab Config parameters from external URIs
+
+GitHub: [warpdotdev/warp#12343](https://github.com/warpdotdev/warp/issues/12343)
+
+Figma: none provided. This first pass reuses the existing Tab Config parameter confirmation modal.
+
+## Summary
+
+Extend the existing `warp://tab_config/<file-stem>` URI so scripts and launchers can prefill declared Tab Config parameters. URI-provided values always remain visible and editable in the existing confirmation modal before any parameterized config runs.
+
+## Goals / Non-goals
+
+Goals:
+
+- Let shell aliases, `open`, Raycast, Alfred, and similar tools supply declared Tab Config parameter values through one stable URI format.
+- Preserve the existing Tab Config selection, modal, parameter types, rendering, and window-target behavior.
+- Treat external URIs as untrusted input: validate them strictly and require user confirmation before a parameterized config opens.
+- Keep control query parameters separate from config parameter names.
+
+Non-goals:
+
+- No dedicated `warp-terminal --tab-config` or `warp --tab-config` command in this first pass; callers invoke the existing custom URI through their platform's normal URL launcher.
+- No flag or query parameter that skips confirmation for a Tab Config that declares parameters.
+- No support for undeclared parameters, environment-variable expansion, command substitution, parameter files, stdin, or secret injection.
+- No change to Tab Config TOML schema, template syntax, parameter types, default values, or command quoting.
+- No remote download or arbitrary filesystem path to a Tab Config; selection remains limited to configs loaded from Warp's Tab Config directory.
+
+## Behavior
+
+1. Existing `warp://tab_config/<file-stem>` links continue to select a saved Tab Config by its case-insensitive on-disk file stem, with or without the `.toml` extension.
+2. A caller prefills a declared parameter using a namespaced query key:
+
+   ```text
+   warp://tab_config/<file-stem>?param.<name>=<value>
+   ```
+
+   Multiple declared parameters use multiple `param.<name>=<value>` pairs.
+3. Parameter names and values use standard URL query percent-encoding. Warp decodes each name and value exactly once. `+` follows standard query decoding and represents a space; a literal plus must be percent-encoded.
+4. The `param.` namespace is required. Unprefixed keys are never interpreted as Tab Config values. This leaves existing and future URI controls separate from user-authored parameter names.
+5. `new_window` remains the existing URI control. `new_window=1` and `new_window=true` request a new Warp window; any other value keeps the existing active-window behavior. A config parameter literally named `new_window` is supplied as `param.new_window`.
+6. Every `param.<name>` key must name a parameter declared by the selected Tab Config. If any supplied name is undeclared, empty, malformed, duplicated, or contains a Unicode control character, Warp rejects the complete request before opening a modal, tab, or new window. The serialized query is limited to 8 KiB, each decoded parameter name to 128 bytes, and each decoded value to 4 KiB; over-limit requests are rejected as a whole.
+7. Query keys other than `new_window` and `param.<declared-name>` are rejected rather than silently ignored. The `new_window` control may appear at most once. An unknown key or duplicate control rejects the complete request, making misspellings and conflicting intent visible.
+8. On rejection, Warp shows a non-blocking, generic error toast in an existing Warp window when one is available. The message may identify the error category, but it never repeats an attacker-controlled parameter name, value, or complete URI. Warp does not open the Tab Config.
+9. A Tab Config that declares parameters always opens the existing parameter modal, even when the URI supplies every required parameter. There is no URI-controlled auto-submit or confirmation bypass.
+10. URI-provided values replace the corresponding TOML defaults only for this one modal invocation. Missing parameters retain their existing defaults; a missing parameter with no default remains unsatisfied and continues to block submission.
+11. An explicitly supplied value that is blank after trimming whitespace is different from an omitted parameter:
+    - For a parameter with a default, clearing or supplying a blank value preserves the modal's existing fallback-to-default behavior. Repo and Branch pickers show that effective default rather than a blank custom item.
+    - For a required parameter without a default, the blank value remains an unselected, unsatisfied field and the modal cannot submit until the user enters or selects a value.
+12. Text parameters display the URI value in their text field. The user can edit, clear, or replace it before opening the tab.
+13. Repo parameters initialize their existing repo picker from the URI value. Branch parameters initialize their existing branch picker from the URI value. When a config declares multiple Repo parameters, the lexicographically first Repo parameter supplies the initial repository for every Branch picker, matching the modal's existing stable ordering. If the user subsequently selects any Repo parameter, the existing behavior of refreshing every Branch picker from that most recently selected repository remains unchanged.
+14. Every effective URI-derived value must be visibly represented by its field before it can be submitted. A non-blank Repo or Branch value that is not in the currently discovered list appears as an explicit selected custom value rather than being stored only in hidden picker state; the user may keep or replace it. A blank value follows invariant 11 and is never rendered or submitted as an invisible custom selection. This phase adds no new semantic rule that a non-blank Repo path or Branch name must already exist, because manually configured defaults are also free-form strings. The mandatory modal confirmation is the trust boundary.
+15. The modal marks no value as trusted merely because it came from a custom URI. It presents URI values in the same editable controls and uses the same final submit path as manually entered values.
+16. Selecting **Open Tab** submits the effective values currently visible in the modal, not the original URI payload. Editing a prefilled field changes the value used to render the Tab Config.
+17. Cancelling or dismissing the modal creates no tab and runs no config command. Prefilled values are discarded and are not persisted as new defaults.
+18. When `new_window=true` is present, the existing target-window behavior is preserved: the parameter modal appears in the selected new window, and successful confirmation opens the Tab Config there. Cancelling leaves that window as an ordinary Warp window.
+19. When no Warp window is available, Warp may create the normal fallback window needed to show a valid request's modal. Invalid requests are rejected before a new window is created.
+20. A selected Tab Config with no declared parameters preserves today's direct-open behavior. Supplying any `param.*` key for such a config is invalid and does not open it.
+21. After confirmation, values flow through the same Tab Config renderer as manual values. Existing command-value shell quoting, title/directory rendering, worktree handling, pane creation, tab color, and telemetry behavior remain unchanged.
+22. A URI cannot select a Tab Config by arbitrary path, traverse outside the Tab Config directory, or cause Warp to load a config that was not already discovered by the normal loader.
+23. Parsing is all-or-nothing. Warp never opens a config with only the subset of URI values that happened to validate.
+24. URI parameter values are invocation-local. They are not written to the TOML file, settings, history, clipboard, logs, crash metadata, or telemetry. This applies at the initial custom-URI ingress as well as in Tab Config-specific parsing and errors; the generic incoming-URI logger must not serialize a parameterized Tab Config URL.
+25. Telemetry may record that a Tab Config was opened from a parameterized URI, the number of supplied parameters, whether a new window was requested, and coarse validation status. It must not record parameter names or values.
+26. If the `TabConfigs` feature is unavailable, the URI retains the existing unsupported-host behavior. Parameter handling does not bypass the feature gate.
+27. Existing menu-based Tab Config launches and non-parameterized Tab Config URIs behave exactly as before.

--- a/specs/gh-12343/TECH.md
+++ b/specs/gh-12343/TECH.md
@@ -1,0 +1,196 @@
+# Prefill Tab Config parameters from external URIs — Tech Spec
+
+See [`PRODUCT.md`](PRODUCT.md) for user-visible behavior.
+
+Code reference: [`2fe6a4f567928c6f11b74021e55092e5f3e5bd79`](https://github.com/warpdotdev/warp/tree/2fe6a4f567928c6f11b74021e55092e5f3e5bd79)
+
+## Context
+
+Warp already recognizes `UriHost::TabConfig` behind `FeatureFlag::TabConfigs` and dispatches it to `handle_tab_config_uri` ([`app/src/uri/mod.rs:87-138`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/uri/mod.rs#L87-L138), [`app/src/uri/mod.rs:223-225`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/uri/mod.rs#L223-L225)). The handler resolves a config by case-insensitive file stem, reads only the `new_window` query control, selects a workspace, and calls `Workspace::open_tab_config` ([`app/src/uri/mod.rs:783-855`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/uri/mod.rs#L783-L855)). Current tests lock file-stem, extension, dotted-name, case, and missing-source-path behavior ([`app/src/uri/uri_tests.rs:95-146`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/uri/uri_tests.rs#L95-L146)).
+
+A `TabConfig` declares named `TabConfigParam` entries of type text, branch, or repo, with optional defaults ([`app/src/tab_configs/tab_config.rs:60-92`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/tab_configs/tab_config.rs#L60-L92), [`app/src/tab_configs/tab_config.rs:138-177`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/tab_configs/tab_config.rs#L138-L177)). Rendering already separates unquoted title/directory context from shell-quoted command context, so this feature must feed the same renderer rather than interpolate URI data itself ([`app/src/tab_configs/tab_config.rs:206-227`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/tab_configs/tab_config.rs#L206-L227)).
+
+`Workspace::open_tab_config` opens parameterless configs directly but always opens `TabConfigParamsModal` when parameters exist ([`app/src/workspace/view.rs:6931-6997`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/workspace/view.rs#L6931-L6997)). The modal currently seeds every field only from its TOML default; repo defaults determine the initial branch picker repository, and submission collects the current field values before emitting the existing submit event ([`app/src/tab_configs/params_modal.rs:183-329`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/tab_configs/params_modal.rs#L183-L329), [`app/src/tab_configs/params_modal.rs:436-452`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/tab_configs/params_modal.rs#L436-L452)).
+
+The current `warp_cli` has no Tab Config command. The custom URI is already the cross-launcher entry point, so this phase does not add a second parser or transport in the CLI crate.
+
+`handle_incoming_uri` currently sends the complete parsed URL to the `full` side of a `safe_info!` call before host-specific dispatch ([`app/src/uri/mod.rs:1221-1226`](https://github.com/warpdotdev/warp/blob/2fe6a4f567928c6f11b74021e55092e5f3e5bd79/app/src/uri/mod.rs#L1221-L1226)). A parameterized Tab Config URI would therefore leak values before any parser-level redaction. Ingress redaction is part of this feature, not a follow-up.
+
+## Proposed changes
+
+### 1. Redact parameterized Tab Config URIs at the shared ingress
+
+In `handle_incoming_uri`, classify the scheme and host before logging the full `Url`. For `warp://tab_config/...`:
+
+- emit only a constant message plus a coarse query-pair count;
+- do not include the path, raw query, fragment, decoded parameter names, or values in either the safe or full log channel;
+- do not use `Url`'s `Debug` or `Display` representation.
+
+Keep the existing diagnostic behavior for other URI hosts. Put the classification in a small pure helper and test that a sentinel config name, parameter name, parameter value, percent-encoded value, and fragment are all absent from its formatted output.
+
+### 2. Parse a strict parameterized Tab Config intent before choosing a window
+
+Add pure parsing types in `app/src/uri/mod.rs`:
+
+```rust
+struct TabConfigUriIntent {
+    config: TabConfig,
+    prefilled_params: HashMap<String, String>,
+    force_new_window: bool,
+}
+
+fn parse_tab_config_uri_intent(
+    url: &Url,
+    configs: Vec<TabConfig>,
+) -> Result<TabConfigUriIntent, TabConfigUriError>
+```
+
+The helper first reuses `get_launch_config_path` and `find_matching_tab_config`, then consumes all query pairs in one pass:
+
+- `new_window` remains a control and preserves the existing `1`/`true` truthy behavior.
+- `new_window` may occur at most once; duplicate controls are rejected rather than resolved by query order.
+- Keys beginning with `param.` are stripped to a decoded declared parameter name.
+- Every parameter name must be non-empty, appear in `config.params`, and occur once.
+- Every other key is an error.
+- `param.new_window` is a normal declared parameter and cannot collide with the unprefixed control.
+- Validate raw query components for complete `%HH` escapes and UTF-8 before consuming the `url` crate's decoded query pairs. Values are not decoded or expanded a second time.
+- Reject the request before allocating the parameter map when the serialized query exceeds 8 KiB. After one decode, reject names over 128 bytes, values over 4 KiB, NUL, and any character for which `char::is_control()` is true. The number of supplied config parameters cannot exceed the number of declarations.
+- The parser returns no partial intent on error.
+
+Keep error variants structural (`ConfigPathMissing`, `ConfigNotFound`, `QueryTooLarge`, `UnknownQueryKey`, `DuplicateControl`, `UnknownParam`, `DuplicateParam`, `EmptyParamName`, `InvalidCharacter`, `NameTooLarge`, `ValueTooLarge`). Their `Display` and `Debug` implementations expose only the error category, never an attacker-controlled name, value, config stem, or full URI. Do not derive `Debug` for a type that would expose the values to routine logging, and do not derive it for `TabConfigUriIntent`.
+
+Move intent parsing before target-window creation. On failure, log only the redacted error and request an existing-window toast when possible; do not create a fallback window merely to display an invalid request.
+
+### 3. Carry invocation-local initial values into `Workspace`
+
+Add a focused entry point:
+
+```rust
+pub(crate) fn open_tab_config_with_initial_params(
+    &mut self,
+    tab_config: TabConfig,
+    initial_params: HashMap<String, String>,
+    ctx: &mut ViewContext<Self>,
+)
+```
+
+Behavior:
+
+- If `tab_config.params` is empty, require `initial_params.is_empty()` and delegate to the current direct-open path.
+- If parameters exist, build the current cwd and modal title exactly as `open_tab_config` does, then call the modal with `initial_params`.
+- Never call `open_tab_config_with_params` from the URI handler. Only the modal submit event can reach the renderer for a parameterized URI.
+
+Keep `open_tab_config` as the menu/default wrapper that supplies an empty initial map. This avoids changing menu behavior and gives the external intent an explicit, reviewable trust boundary.
+
+### 4. Overlay prefilled values onto modal defaults
+
+Change `TabConfigParamsModal::on_open` to accept `initial_params: HashMap<String, String>`. Keep the supplied raw value only long enough to derive the same effective value that submission already uses:
+
+```text
+raw initial = URI value when present, otherwise TOML default, otherwise empty
+resolved initial = resolve_param_value(raw initial, declaration)
+```
+
+`resolve_param_value` treats a value whose trimmed form is empty as the declaration's default, or as unsatisfied when no default exists; it preserves a non-blank value byte-for-byte. Use the resolved initial value consistently:
+
+- Text: initialize the editor buffer with the raw initial value when it is non-blank. When an explicitly supplied URI value is blank, keep the field empty and show its existing default placeholder so submission's fallback remains visible. A required blank field remains empty and unsatisfied.
+- Repo: pass the resolved value to `RepoPicker::new_with_style`, retain it in `selected`, and ensure `refresh_items` inserts a selected, user-friendly custom item when a non-blank resolved value is absent from `PersistedWorkspace`. Never create or retain a blank custom selection, and never retain an initial value that the dropdown does not render.
+- Branch: pass the resolved value to `BranchPicker::new_with_style` and retain it in `selected`. Its existing custom-default item remains visible when a non-blank branch is absent from the fetched list. A required blank Branch has no selected item.
+- Initial Branch lookup cwd: sort parameters with the modal's existing stable ordering and use the resolved value of the lexicographically first Repo parameter. A blank URI override with a default therefore uses the default repository, while a required blank never constructs `PathBuf("")`; when there is no resolved Repo, fall back to the active terminal cwd as today.
+- Subsequent Repo selection: preserve `sync_branch_pickers_for_repo`, under which selecting any Repo parameter refreshes every Branch picker from that repository.
+
+The modal continues to own confirmation and final values. Repo and Branch parameters remain free-form, as existing TOML defaults are; this change guarantees visibility rather than introducing existence validation. Do not retain the initial map after fields are constructed, and do not add it to `TabConfig`, settings, or persistence. `try_submit` and `TabConfigParamsModalEvent::Submit` remain the only path to `open_tab_config_with_params`.
+
+Existing non-URI callers pass an empty map. Session-config/worktree paths that intentionally bypass the modal continue using their current internal `open_tab_config_with_params` calls.
+
+### 5. Preserve the renderer and command-safety boundary
+
+No URI-specific interpolation is added. After the user confirms, the existing submit event supplies the modal's effective `HashMap` to `render_tab_config`. This preserves:
+
+- shell quoting for values placed in commands;
+- current title and directory rendering;
+- worktree branch-name generation;
+- pane-tree validation and creation;
+- tab title/color behavior.
+
+Do not add environment expansion, shell parsing, `~` expansion, or filesystem normalization to URI values. A value from the URI must behave exactly like the same string manually entered in the modal.
+
+### 6. Add visible, redacted validation feedback
+
+`handle_tab_config_uri` should:
+
+1. parse and validate the complete intent;
+2. choose the existing/new workspace only after success;
+3. call `open_tab_config_with_initial_params`;
+4. on parser failure, show one ephemeral error toast in the primary existing window if available and emit a category-only warning.
+
+Use messages such as `Tab Config URI contains an undeclared parameter` or `Tab Config URI contains a duplicate parameter`. Never include an attacker-controlled name, value, config stem, or complete URI.
+
+Add an URI-specific telemetry source or boolean to the existing `ExistingConfigOpened` event only if it can remain value-free. Record at most the supplied parameter count, new-window flag, and coarse success/error category.
+
+## Testing and validation
+
+### URI parser tests
+
+Extend `app/src/uri/uri_tests.rs` with pure tests:
+
+- one and multiple declared `param.*` values parse;
+- standard percent encoding and plus/space behavior decode exactly once, while incomplete escapes and invalid UTF-8 fail;
+- `new_window=true`/`1` remains a control and a duplicate `new_window` is rejected;
+- `param.new_window` reaches a same-named declared parameter without colliding;
+- explicitly empty values and omitted parameters remain distinguishable in the returned map;
+- unknown, empty, malformed, duplicate, and unprefixed query keys fail the entire request;
+- control characters (including NUL, CR, and LF) and the boundaries around the 8 KiB query, 128-byte name, and 4 KiB value limits are covered;
+- a config with no declarations rejects `param.*`;
+- dotted and case-insensitive config stems retain current behavior;
+- error and ingress-log formatting contain only coarse categories/counts and never the config stem, supplied name, value, or full URI.
+
+### Modal and workspace tests
+
+Extend `app/src/tab_configs/params_modal_tests.rs` and `app/src/workspace/view_tests.rs`:
+
+- non-blank URI values override defaults for text, repo, and branch fields and every effective value is visible in its control;
+- empty and whitespace-only URI values for defaulted Text, Repo, and Branch params resolve to the visible/effective default, while the same inputs for required params remain unselected and block submission;
+- unknown Repo and Branch values appear as explicit selected custom items rather than hidden state;
+- omitted fields retain defaults and required empty fields still block submit;
+- with multiple Repo parameters, the lexicographically first resolved Repo value seeds all Branch pickers, including when its raw URI value is blank and falls back to a default; a later selection in any Repo picker refreshes all Branch pickers;
+- editing a prefilled value changes the submitted map;
+- cancelling clears the fields and persists nothing;
+- parameterized intents always show the modal and never directly call the renderer;
+- parameterless intents keep the direct-open behavior;
+- menu launches with an empty initial map behave exactly as before;
+- invalid intents are rejected before a new workspace is created.
+
+### Security and manual validation
+
+Run:
+
+```bash
+cargo nextest run -p warp -E 'test(tab_config) | test(uri)'
+./script/format
+cargo clippy -p warp --tests -- -D warnings
+git diff --check
+```
+
+Create a temporary Tab Config with text, two repo, branch, required, defaulted, and `new_window` parameters. Invoke it through macOS `open` with encoded spaces, plus signs, shell metacharacters, duplicate keys, an unknown key, control characters, over-limit values, and `new_window=true`. Record that every valid value is visible/editable before launch, malformed requests run nothing and do not appear in logs, cancelling runs nothing, and the final confirmed values follow the existing renderer's quoting.
+
+## Parallelization
+
+Use one implementation worktree, `codex/gh12343-tab-config-uri-params`, because intent parsing feeds the same `Workspace::open_tab_config` and modal initialization API that the tests exercise. A validation agent can independently audit URI parsing and redaction after implementation, but splitting the three tightly coupled API edits across branches would add merge churn.
+
+## Risks and mitigations
+
+- **Untrusted URI silently runs commands:** parameterized configs always stop at the existing modal; no skip-confirmation option is introduced.
+- **Typos silently use defaults:** unknown, duplicate, malformed, and unprefixed keys reject the complete request.
+- **Control/parameter name collision:** only unprefixed `new_window` controls window choice; all config values live under `param.`.
+- **Double decoding or unintended expansion:** consume `Url::query_pairs` once and perform no shell, environment, tilde, or second URL decoding.
+- **Secrets leak before parser dispatch:** redact Tab Config URIs in `handle_incoming_uri`; parser errors, telemetry, and full logs never include config stems, names, values, or the full URI.
+- **Invisible picker state is submitted:** compute one effective initial value per field and require Repo/Branch custom values to be rendered as selected items.
+- **URI size/control-character abuse:** reject bounded raw/decoded input before building fields or editor buffers.
+- **Multiple Repo parameters ambiguously seed branches:** codify the modal's stable first-Repo initialization and existing most-recently-selected Repo refresh behavior.
+- **Invalid request leaves an empty window:** validate before target-window creation.
+
+## Follow-ups
+
+- Consider a dedicated Warp CLI command only if custom-URI invocation proves insufficient for automation.
+- Consider a separately designed trust mechanism for non-interactive execution; do not add a modal-bypass query flag to this flow.


### PR DESCRIPTION
## Description

Adds product and technical specifications for #12343, following the maintainer's request to design parameter passing and its security boundary before implementation.

The specs define:

- the namespaced `param.<name>` query format while preserving `new_window` as a separate control;
- strict all-or-nothing decoding, size limits, duplicate and unknown-key rejection, and category-only errors;
- mandatory use of the existing editable confirmation modal for every parameterized Tab Config;
- ingress-log redaction before host-specific parsing so URI parameter values cannot leak through the current full-URL log;
- visible Text, Repo, and Branch initialization, including blank/default behavior and multiple-Repo branch-picker semantics;
- parser, modal, workspace, redaction, and manual security coverage required before implementation.

## Linked Issue

Closes #12343

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots are not applicable because this PR contains specifications only and does not change runtime UI.

## Testing

This is a documentation-only change, so no runtime tests were added.

- `./script/format --check`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `git diff --cached --check`

- [ ] I have manually tested my changes locally with `./script/run` (not applicable to a spec-only change)

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

