### PR TITLE
Center the search bar in vertical tab layouts

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -1,5 +1,6 @@
 pub(crate) mod auto_handoff_sleep_modal;
 mod build_plan_migration_modal;
+mod centered_toolbar;
 pub(crate) mod cloud_agent_capacity_modal;
 pub(crate) mod codex_modal;
 pub mod conversation_list;
@@ -115,6 +116,7 @@ use warpui::{
     UpdateModel, UpdateView, View, ViewAsRef, ViewContext, ViewHandle, WeakViewHandle, WindowId,
 };
 
+use self::centered_toolbar::CenteredToolbar;
 use self::vertical_tabs::telemetry::{VerticalTabsDisplayOption, VerticalTabsTelemetryEvent};
 use self::vertical_tabs::{
     SummaryPaneKind, SummaryPaneKindIcons, VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
@@ -20710,49 +20712,50 @@ impl Workspace {
 
             let left_padding = self.compute_tab_bar_left_padding(ctx);
 
-            // The title bar search bar can be hidden via a user setting; when hidden,
-            // an empty flexible slot keeps the right-side controls aligned to the right.
-            let hide_search_bar =
-                *TabSettings::as_ref(ctx).hide_title_bar_search_bar_in_vertical_tabs;
-            let search_bar_slot = if hide_search_bar {
-                Expanded::new(1., Empty::new().finish()).finish()
-            } else {
-                Shrinkable::new(
-                    1.,
-                    Clipped::new(
-                        Container::new(
-                            Align::new(self.render_title_bar_search_bar(appearance)).finish(),
-                        )
-                        .with_padding_left(TITLE_BAR_SEARCH_BAR_SLOT_PADDING)
-                        .with_padding_right(TITLE_BAR_SEARCH_BAR_SLOT_PADDING)
-                        .finish(),
-                    )
-                    .finish(),
-                )
-                .finish()
-            };
-
-            let tab_bar = Flex::row()
-                .with_main_axis_size(MainAxisSize::Max)
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(tab_bar.finish())
-                .with_child(search_bar_slot)
-                .with_child(right_controls.finish())
+            // Keep the left/right padding with their respective controls so the centered toolbar
+            // spans the full title bar rather than the asymmetric padded content area.
+            let left_controls = Container::new(tab_bar.finish())
+                .with_padding_left(left_padding)
+                .finish();
+            let right_controls = Container::new(right_controls.finish())
+                .with_padding_right(TAB_BAR_PADDING_RIGHT)
                 .finish();
 
-            return EventHandler::new(
-                Container::new(tab_bar)
-                    .with_padding_left(left_padding)
-                    .with_padding_right(TAB_BAR_PADDING_RIGHT)
-                    .finish(),
+            // The title bar search bar can be hidden via a user setting.
+            let hide_search_bar =
+                *TabSettings::as_ref(ctx).hide_title_bar_search_bar_in_vertical_tabs;
+            let (search_bar_slot, search_bar_slot_min_width, search_bar_slot_max_width) =
+                if hide_search_bar {
+                    (Empty::new().finish(), 0., 0.)
+                } else {
+                    (
+                        // At the maximum slot width, Align leaves the same 8px of space on
+                        // either side of the 320px search bar. Unlike a padded Container, it
+                        // also honors narrower slot constraints so that the toolbar's allocation
+                        // remains authoritative.
+                        Align::new(self.render_title_bar_search_bar(appearance)).finish(),
+                        2. * TITLE_BAR_SEARCH_BAR_SLOT_PADDING,
+                        TITLE_BAR_SEARCH_BAR_MAX_WIDTH + 2. * TITLE_BAR_SEARCH_BAR_SLOT_PADDING,
+                    )
+                };
+
+            let tab_bar = CenteredToolbar::new(
+                left_controls,
+                search_bar_slot,
+                right_controls,
+                search_bar_slot_min_width,
+                search_bar_slot_max_width,
             )
-            .on_right_mouse_down(|ctx, _, position| {
-                ctx.dispatch_typed_action(WorkspaceAction::ShowHeaderToolbarContextMenu {
-                    position,
-                });
-                DispatchEventResult::StopPropagation
-            })
             .finish();
+
+            return EventHandler::new(tab_bar)
+                .on_right_mouse_down(|ctx, _, position| {
+                    ctx.dispatch_typed_action(WorkspaceAction::ShowHeaderToolbarContextMenu {
+                        position,
+                    });
+                    DispatchEventResult::StopPropagation
+                })
+                .finish();
         } else {
             // Copy from our saved tab_bar_state to ensure all tabs get rendered with the same state
             let active_tab_index = if FeatureFlag::AgentManagementView.is_enabled()

--- a/app/src/workspace/view/centered_toolbar.rs
+++ b/app/src/workspace/view/centered_toolbar.rs
@@ -1,0 +1,208 @@
+use pathfinder_geometry::vector::{Vector2F, vec2f};
+use warpui::elements::Point;
+use warpui::event::DispatchedEvent;
+use warpui::{
+    AfterLayoutContext, AppContext, ClipBounds, Element, EventContext, LayoutContext, PaintContext,
+    SizeConstraint,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct CenteredToolbarGeometry {
+    center_width: f32,
+    center_origin_x: f32,
+    right_origin_x: f32,
+}
+
+fn centered_toolbar_geometry(
+    width: f32,
+    left_width: f32,
+    center_min_width: f32,
+    center_max_width: f32,
+    right_width: f32,
+) -> CenteredToolbarGeometry {
+    let side_clearance = left_width.max(right_width);
+    let symmetric_center_width = (width - 2. * side_clearance).max(0.);
+    let physical_center_width = (width - left_width - right_width).max(0.);
+    let center_min_width = center_min_width.min(center_max_width);
+    let center_width = if symmetric_center_width >= center_min_width {
+        center_max_width.min(symmetric_center_width)
+    } else {
+        center_min_width.min(physical_center_width)
+    };
+    let center_origin_x = if center_width > 0. {
+        let centered_origin_x = (width - center_width) / 2.;
+        centered_origin_x.clamp(left_width, width - right_width - center_width)
+    } else {
+        width / 2.
+    };
+
+    CenteredToolbarGeometry {
+        center_width,
+        center_origin_x,
+        right_origin_x: width - right_width,
+    }
+}
+
+/// Lays out a toolbar whose middle child stays centered against the full row.
+///
+/// The left and right children keep their intrinsic widths. The middle child
+/// first shrinks symmetrically. Below its minimum useful width, it shifts
+/// continuously into the remaining physical gap before shrinking again.
+pub(super) struct CenteredToolbar {
+    left: Box<dyn Element>,
+    center: Box<dyn Element>,
+    right: Box<dyn Element>,
+    center_min_width: f32,
+    center_max_width: f32,
+    size: Option<Vector2F>,
+    origin: Option<Point>,
+    child_origins: Option<[Vector2F; 3]>,
+    center_clip_size: Option<Vector2F>,
+    center_was_painted: bool,
+}
+
+impl CenteredToolbar {
+    pub(super) fn new(
+        left: Box<dyn Element>,
+        center: Box<dyn Element>,
+        right: Box<dyn Element>,
+        center_min_width: f32,
+        center_max_width: f32,
+    ) -> Self {
+        Self {
+            left,
+            center,
+            right,
+            center_min_width,
+            center_max_width,
+            size: None,
+            origin: None,
+            child_origins: None,
+            center_clip_size: None,
+            center_was_painted: false,
+        }
+    }
+}
+
+impl Element for CenteredToolbar {
+    fn layout(
+        &mut self,
+        constraint: SizeConstraint,
+        ctx: &mut LayoutContext,
+        app: &AppContext,
+    ) -> Vector2F {
+        let intrinsic_constraint =
+            SizeConstraint::new(Vector2F::zero(), vec2f(f32::INFINITY, constraint.max.y()));
+        let left_size = self.left.layout(intrinsic_constraint, ctx, app);
+        let right_size = self.right.layout(intrinsic_constraint, ctx, app);
+
+        let width = if constraint.max.x().is_finite() {
+            constraint.max.x().max(constraint.min.x())
+        } else {
+            (2. * left_size.x().max(right_size.x()) + self.center_max_width).max(constraint.min.x())
+        };
+        let geometry = centered_toolbar_geometry(
+            width,
+            left_size.x(),
+            self.center_min_width,
+            self.center_max_width,
+            right_size.x(),
+        );
+        let center_size = self.center.layout(
+            SizeConstraint::new(
+                Vector2F::zero(),
+                vec2f(geometry.center_width, constraint.max.y()),
+            ),
+            ctx,
+            app,
+        );
+
+        let height = left_size
+            .y()
+            .max(center_size.y())
+            .max(right_size.y())
+            .max(constraint.min.y())
+            .min(constraint.max.y());
+        self.child_origins = Some([
+            vec2f(0., (height - left_size.y()) / 2.),
+            vec2f(geometry.center_origin_x, (height - center_size.y()) / 2.),
+            vec2f(geometry.right_origin_x, (height - right_size.y()) / 2.),
+        ]);
+        self.center_clip_size = Some(vec2f(geometry.center_width, center_size.y()));
+        self.center_was_painted = false;
+
+        let size = vec2f(width, height);
+        self.size = Some(size);
+        size
+    }
+
+    fn after_layout(&mut self, ctx: &mut AfterLayoutContext, app: &AppContext) {
+        self.left.after_layout(ctx, app);
+        self.center.after_layout(ctx, app);
+        self.right.after_layout(ctx, app);
+    }
+
+    fn paint(&mut self, origin: Vector2F, ctx: &mut PaintContext, app: &AppContext) {
+        self.origin = Some(Point::from_vec2f(origin, ctx.scene.z_index()));
+        let [left_origin, center_origin, right_origin] = self
+            .child_origins
+            .expect("toolbar must be laid out before paint");
+        self.left.paint(origin + left_origin, ctx, app);
+        let center_clip_size = self
+            .center_clip_size
+            .expect("toolbar must be laid out before paint");
+        self.center_was_painted = false;
+        if center_clip_size.x() > 0.
+            && center_clip_size.y() > 0.
+            && let Some(bounds) = ctx.scene.visible_rect(
+                Point::from_vec2f(origin + center_origin, ctx.scene.z_index()),
+                center_clip_size,
+            )
+        {
+            ctx.scene.start_layer(ClipBounds::BoundedBy(bounds));
+            self.center.paint(origin + center_origin, ctx, app);
+            ctx.scene.stop_layer();
+            self.center_was_painted = true;
+        }
+        self.right.paint(origin + right_origin, ctx, app);
+    }
+
+    fn size(&self) -> Option<Vector2F> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<Point> {
+        self.origin
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &DispatchedEvent,
+        ctx: &mut EventContext,
+        app: &AppContext,
+    ) -> bool {
+        let mut handled = self.left.dispatch_event(event, ctx, app);
+        if self.center_was_painted {
+            handled |= self.center.dispatch_event(event, ctx, app);
+        }
+        handled |= self.right.dispatch_event(event, ctx, app);
+        handled
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    fn debug_text_content(&self) -> Option<String> {
+        let text = [
+            self.left.debug_text_content(),
+            self.center.debug_text_content(),
+            self.right.debug_text_content(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<String>();
+        (!text.is_empty()).then_some(text)
+    }
+}
+
+#[cfg(test)]
+#[path = "centered_toolbar_tests.rs"]
+mod tests;

--- a/app/src/workspace/view/centered_toolbar_tests.rs
+++ b/app/src/workspace/view/centered_toolbar_tests.rs
@@ -1,0 +1,202 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pathfinder_geometry::vector::{Vector2F, vec2f};
+use warpui::elements::{ConstrainedBox, Empty, Point};
+use warpui::event::DispatchedEvent;
+use warpui::platform::WindowStyle;
+use warpui::{
+    AfterLayoutContext, App, AppContext, Element, Entity, EntityIdSet, EventContext, LayoutContext,
+    PaintContext, Presenter, SizeConstraint, TypedActionView, View, WindowInvalidation,
+};
+
+use super::{CenteredToolbar, centered_toolbar_geometry};
+
+#[test]
+fn center_stays_at_full_row_midpoint_with_asymmetric_sides() {
+    let geometry = centered_toolbar_geometry(1_000., 56., 16., 336., 110.);
+
+    assert_eq!(geometry.center_origin_x + geometry.center_width / 2., 500.);
+}
+
+#[test]
+fn center_shrinks_symmetrically_before_overlapping_the_wider_side() {
+    let geometry = centered_toolbar_geometry(500., 56., 16., 336., 110.);
+
+    assert_eq!(geometry.center_width, 280.);
+    assert_eq!(geometry.center_origin_x, 110.);
+    assert_eq!(geometry.right_origin_x, 390.);
+}
+
+#[test]
+fn center_continues_smoothly_across_zero_symmetric_space() {
+    let just_above = centered_toolbar_geometry(220.1, 80., 16., 336., 110.);
+    let at_zero = centered_toolbar_geometry(220., 80., 16., 336., 110.);
+
+    assert_eq!(just_above.center_width, 16.);
+    assert_eq!(at_zero.center_width, 16.);
+    assert!((just_above.center_origin_x - at_zero.center_origin_x - 0.1).abs() < 0.001);
+}
+
+#[test]
+fn center_uses_physical_gap_when_symmetric_space_is_exhausted() {
+    let geometry = centered_toolbar_geometry(200., 80., 16., 336., 110.);
+
+    assert_eq!(geometry.center_width, 10.);
+    assert_eq!(geometry.center_origin_x, 80.);
+    assert_eq!(geometry.right_origin_x, 90.);
+}
+
+#[test]
+fn fixed_sides_remain_edge_anchored_when_they_overlap() {
+    let geometry = centered_toolbar_geometry(150., 80., 16., 336., 110.);
+
+    assert_eq!(geometry.center_width, 0.);
+    assert_eq!(geometry.center_origin_x, 75.);
+    assert_eq!(geometry.right_origin_x, 40.);
+}
+
+#[derive(Default)]
+struct CenterProbeState {
+    layout_max_width: Option<f32>,
+    paint_origin_x: Option<f32>,
+    visible_width: Option<f32>,
+}
+
+struct OversizedCenterProbe {
+    state: Rc<RefCell<CenterProbeState>>,
+    size: Option<Vector2F>,
+    origin: Option<Point>,
+}
+
+impl OversizedCenterProbe {
+    fn new(state: Rc<RefCell<CenterProbeState>>) -> Self {
+        Self {
+            state,
+            size: None,
+            origin: None,
+        }
+    }
+}
+
+impl Element for OversizedCenterProbe {
+    fn layout(
+        &mut self,
+        constraint: SizeConstraint,
+        _: &mut LayoutContext,
+        _: &AppContext,
+    ) -> Vector2F {
+        self.state.borrow_mut().layout_max_width = Some(constraint.max.x());
+        let size = vec2f(16., 20.);
+        self.size = Some(size);
+        size
+    }
+
+    fn after_layout(&mut self, _: &mut AfterLayoutContext, _: &AppContext) {}
+
+    fn paint(&mut self, origin: Vector2F, ctx: &mut PaintContext, _: &AppContext) {
+        let origin = Point::from_vec2f(origin, ctx.scene.z_index());
+        self.origin = Some(origin);
+        let mut state = self.state.borrow_mut();
+        state.paint_origin_x = Some(origin.xy().x());
+        state.visible_width = ctx
+            .scene
+            .visible_rect(
+                origin,
+                self.size.expect("probe must be laid out before paint"),
+            )
+            .map(|bounds| bounds.width());
+    }
+
+    fn size(&self) -> Option<Vector2F> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<Point> {
+        self.origin
+    }
+
+    fn dispatch_event(
+        &mut self,
+        _: &DispatchedEvent,
+        _: &mut EventContext,
+        _: &AppContext,
+    ) -> bool {
+        false
+    }
+}
+
+struct CenteredToolbarTestView {
+    center_state: Rc<RefCell<CenterProbeState>>,
+}
+
+impl Entity for CenteredToolbarTestView {
+    type Event = ();
+}
+
+impl View for CenteredToolbarTestView {
+    fn ui_name() -> &'static str {
+        "centered_toolbar_test_view"
+    }
+
+    fn render(&self, _: &AppContext) -> Box<dyn Element> {
+        ConstrainedBox::new(
+            CenteredToolbar::new(
+                ConstrainedBox::new(Empty::new().finish())
+                    .with_width(80.)
+                    .with_height(20.)
+                    .finish(),
+                OversizedCenterProbe::new(self.center_state.clone()).finish(),
+                ConstrainedBox::new(Empty::new().finish())
+                    .with_width(110.)
+                    .with_height(20.)
+                    .finish(),
+                16.,
+                336.,
+            )
+            .finish(),
+        )
+        .with_width(200.)
+        .with_height(20.)
+        .finish()
+    }
+}
+
+impl TypedActionView for CenteredToolbarTestView {
+    type Action = ();
+}
+
+#[test]
+fn center_paint_is_clipped_to_its_allocated_width() {
+    App::test((), |mut app| async move {
+        let center_state = Rc::new(RefCell::new(CenterProbeState::default()));
+        let center_state_for_view = center_state.clone();
+        let (window_id, _) = app.add_window(WindowStyle::NotStealFocus, move |_| {
+            CenteredToolbarTestView {
+                center_state: center_state_for_view,
+            }
+        });
+        let mut presenter = Presenter::new(window_id);
+        let mut updated = EntityIdSet::default();
+        updated.insert(
+            app.root_view_id(window_id)
+                .expect("test window must have a root view"),
+        );
+
+        app.update(move |ctx| {
+            presenter.invalidate(
+                WindowInvalidation {
+                    updated,
+                    ..Default::default()
+                },
+                ctx,
+            );
+            presenter.build_scene(vec2f(200., 20.), 1., None, ctx);
+        });
+
+        let center_state = center_state.borrow();
+        assert_eq!(center_state.layout_max_width, Some(10.));
+        assert_eq!(center_state.paint_origin_x, Some(80.));
+        assert_eq!(center_state.visible_width, Some(10.));
+    });
+}


### PR DESCRIPTION
## Description

Fixes #12217.

The vertical-tabs title search was centered within the remaining flex space, so asymmetric macOS traffic-light and right-toolbar widths shifted it away from the full window midpoint.

This change introduces a focused toolbar layout that:

- keeps the left and right controls anchored to their respective window edges;
- centers the search slot against the full title bar while symmetric space is available;
- continuously shrinks and shifts the slot into the remaining physical gap as the window narrows;
- clips the center child to its authoritative allocation so it cannot draw or receive pointer interactions above edge controls;
- preserves the existing `hide_title_bar_search_bar_in_vertical_tabs` behavior.

This also incorporates the outstanding maintainer feedback from the closed #12899 attempt: the search remains a shrinking layout child instead of disappearing at narrow widths.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots of the implementation are included below.

## Testing

Added six regression tests covering:

- full-window centering with asymmetric side controls;
- symmetric shrink behavior;
- continuity at the minimum-width transition;
- physical-gap allocation and overlapping side controls;
- a real `Presenter` layout/paint lifecycle where an oversized child is clipped to its assigned width.

Validation:

- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo test -p warp --lib workspace::view::centered_toolbar::tests -- --nocapture` — 6 passed
- `./script/format --check`
- `./script/check_no_inline_test_modules`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `git diff --cached --check`

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

| Normal width | Narrow width | Hidden by setting |
| --- | --- | --- |
| <img width="1229" height="768" alt="Vertical tabs title search centered at normal width" src="https://github.com/user-attachments/assets/6d654437-2121-4c08-9c99-bd0a25bac1ef" /> | <img width="543" height="582" alt="Vertical tabs title search shrinking at narrow width" src="https://github.com/user-attachments/assets/d30e6073-58d6-4eec-8108-6d5eb9483b22" /> | <img width="1360" height="768" alt="Vertical tabs title search hidden by its existing setting" src="https://github.com/user-attachments/assets/6bb3de97-721f-4c2a-b445-39d3c38b38fe" /> |
| Centered against the full window despite asymmetric controls. | Shrinks without overlapping the edge controls. | The existing hide-search setting still removes the title-bar search. |

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the vertical-tabs title search alignment so it stays centered at normal widths and safely shrinks as the window narrows.
