### PR TITLE
[SPEC] Incremental i18n and Simplified Chinese with Fluent

### DIFF
--- a/specs/GH10928/product.md
+++ b/specs/GH10928/product.md
@@ -1,0 +1,198 @@
+# Incremental Internationalization and Simplified Chinese — Product Spec
+
+GitHub issue: https://github.com/warpdotdev/warp/issues/10928
+
+Related issue: https://github.com/warpdotdev/warp/issues/1194
+
+Related proposal: https://github.com/warpdotdev/warp/issues/14397
+
+Related prior spec: https://github.com/warpdotdev/warp/pull/10990
+
+Figma: none provided
+
+## Summary
+
+Add the first production-ready internationalization foundation to Warp and
+validate it with a deliberately small Simplified Chinese (`zh-CN`) release.
+Users choose the UI language manually in Settings. English remains the default
+and complete fallback language.
+
+The first release translates only the language picker, the command palette, and
+low-risk help/navigation entries in the user menu. Later product surfaces are
+migrated in separate changes after the foundation is approved. This keeps the
+initial review and visual validation bounded while establishing the behavior
+required for additional languages.
+
+## Problem
+
+Warp currently renders its application UI in English. Chinese-speaking users
+cannot select a Simplified Chinese interface, and contributors do not have a
+standard way to add or maintain translations.
+
+Earlier community implementations attempted to migrate most of the application
+at once and proposed a custom message format. That created unresolved questions
+about pluralization, fallback behavior, developer maintenance, enforcement,
+dynamic strings, and the review risk of changing thousands of call sites in one
+pull request.
+
+## Goals
+
+- Let users explicitly select English or Simplified Chinese from Settings.
+- Keep English as a complete, reliable fallback.
+- Preserve product names and technical terms when English communicates the
+  concept more accurately.
+- Support variables, plural-sensitive messages, and reusable terminology from
+  the start.
+- Make the first implementation small enough to review, test, and visually
+  verify.
+- Establish a repeatable contribution path for later language and product
+  surface migrations.
+
+## Non-goals
+
+- Automatically following the operating-system language in the first release.
+- Changing the language without restarting Warp.
+- Translating the entire application in one pull request.
+- Translating terminal output, commands, file paths, keyboard shortcuts,
+  user-authored text, model output, server-provided content, or third-party
+  content.
+- Translating authentication, billing and purchase confirmations, sharing and
+  permission prompts, or Agent consent/action descriptions in the first
+  release.
+- Localizing the TUI or web/wasm surfaces in the first release.
+- Synchronizing the selected language through Warp Drive.
+- Localizing documentation outside the Warp application.
+
+## Terminology
+
+The Simplified Chinese catalog keeps product names and technical terms in
+English when translation would make them less precise. The initial protected
+terms are:
+
+- Warp
+- Warp Drive
+- Agent
+- Token
+- Workflow
+- MCP
+- API
+- CLI
+- Shell
+- Block
+- Model names
+
+Commands, file paths, keyboard shortcuts, identifiers, and user data also remain
+unchanged. Ordinary interface copy is translated, for example `Settings` to
+`设置`, `Search` to `搜索`, and `Feedback` to `反馈`.
+
+## Behavior
+
+1. When no language has been selected, Warp renders the application UI in
+   English (`en-US`). Existing users see no language change after upgrading.
+
+2. Settings → Appearance contains a **Language** section with one selector.
+   The selector initially offers exactly:
+   - `English`
+   - `简体中文`
+
+3. Language options are always displayed using their self-names above, rather
+   than translating both option names into the currently active language.
+
+4. Selecting a language saves the preference on the current device. It is not
+   uploaded or synchronized to other devices.
+
+5. Changing the selection does not partially relocalize the current process.
+   The Language section displays a localized `Restart Warp to apply this
+   language` notice after the saved selection differs from the active language.
+
+6. After the user quits and relaunches Warp, the saved supported language is
+   active before the first application window is rendered.
+
+7. If the stored language value is missing, invalid, or no longer supported,
+   Warp uses English and keeps Settings usable so the user can make another
+   selection.
+
+8. The first Simplified Chinese release translates these complete, bounded
+   surfaces:
+   - the Settings window title, the Appearance navigation label, and the
+     Language section;
+   - the command palette search placeholder and empty-result message;
+   - the low-risk user-menu entries for What's new, Settings, Keyboard
+     shortcuts, Documentation, Feedback, View Warp logs, and joining the Warp
+     Slack community.
+
+9. User-menu actions involving updates, signup, billing, upgrades, referrals,
+   and logout remain English in the first release. Authentication, payments,
+   permissions, sharing, and Agent consent/action surfaces remain English until
+   each surface receives separate translation and security review.
+
+10. If a message is unavailable or cannot be formatted in the selected
+    language, Warp renders the canonical English message. A missing translation
+    never produces an empty label, raw message identifier, or unusable control.
+
+11. Dynamic values are inserted into localized messages without being
+    translated or interpreted as localization syntax. This includes usernames,
+    versions, model names, paths, repository names, commands, and values
+    received from a server.
+
+12. A message that depends on a numeric quantity selects the correct grammatical
+    variant for the active language. English singular/plural behavior and
+    Simplified Chinese behavior are tested even if the first migrated UI slice
+    does not yet expose every plural form.
+
+13. Protected product and technical terms render exactly as defined in the
+    terminology section in both English and Simplified Chinese.
+
+14. Localized resources provide plain text only. They cannot introduce links,
+    actions, Markdown, or other executable/rich UI structure. Interactive
+    elements remain defined by trusted application code.
+
+15. Localization changes visible text only. Existing action identifiers,
+    settings paths, deep links, analytics values, keyboard behavior, focus
+    order, and accessibility roles remain stable and language-independent.
+
+16. At supported UI scale factors, translated controls remain readable without
+    unintended clipping, overlap, replacement glyphs, or loss of their
+    accessible labels.
+
+17. English labels and behavior on the migrated surfaces remain identical to
+    the current English UI, except for the addition of the Language setting.
+
+18. A developer-only pseudo-localized locale may be used for layout testing, but
+    it is not shown in the end-user Language selector.
+
+## Validation
+
+- Start Warp with no saved language and confirm the migrated surfaces remain
+  unchanged in English.
+- Select `简体中文`, confirm the restart notice appears, relaunch, and confirm
+  the phase-one surfaces render in Simplified Chinese.
+- Relaunch a second time and confirm the device-local preference persists.
+- Switch back to `English`, relaunch, and confirm English is restored.
+- Inject an invalid stored language in a test and confirm Warp starts in
+  English with a usable Language selector.
+- Force a missing Simplified Chinese message in a test and confirm the canonical
+  English message is rendered.
+- Verify variable and plural examples in both supported languages.
+- Capture English and Simplified Chinese screenshots of Settings, the command
+  palette, and the user menu at the default UI scale.
+- Check translated screenshots for clipping, alignment, missing glyphs, and
+  unchanged action behavior.
+
+## Rollout
+
+The first implementation is guarded by one localization feature flag while it
+is validated in development and dogfood builds. The same flag controls the
+Language selector and translated call sites so users never see a selector that
+does not affect the advertised surfaces. The flag is removed after the initial
+release is stable.
+
+Later migrations are organized by complete product surface, with separate
+translation and visual review. Security-sensitive surfaces require explicit
+human copy review before they can be enabled in a non-English locale.
+
+## Open questions
+
+None for the first implementation. Automatic system-locale detection, live
+language switching, cloud synchronization, and additional surfaces/locales are
+explicit follow-up decisions.

--- a/specs/GH10928/tech.md
+++ b/specs/GH10928/tech.md
@@ -1,0 +1,517 @@
+# Incremental Internationalization and Simplified Chinese — Tech Spec
+
+GitHub issue: https://github.com/warpdotdev/warp/issues/10928
+
+Related issue: https://github.com/warpdotdev/warp/issues/1194
+
+Related proposal: https://github.com/warpdotdev/warp/issues/14397
+
+Related prior spec: https://github.com/warpdotdev/warp/pull/10990
+
+## Context
+
+Warp does not currently have an application localization layer. User-facing
+English strings are constructed directly in Rust:
+
+- `app/src/search/command_palette/view.rs:278-295` creates the command palette
+  with the English search placeholder and empty-result message.
+- `app/src/workspace/view.rs:9602-9733` constructs the user menu from English
+  literals and dynamic values.
+- `app/src/settings_view/mod.rs:244-310` defines stable Settings section
+  identifiers and their current English display strings, while line 2881
+  constructs the English Settings window title.
+- `app/src/settings_view/appearance_page.rs:1379-1565` assembles Appearance
+  categories and widgets from English labels.
+
+The existing settings system provides the persistence and UI patterns needed
+for a language preference:
+
+- `app/src/settings/input_mode.rs:6-20` shows an enum-backed setting declared
+  with `define_settings_group!`.
+- `app/src/settings/init.rs:53-115` registers every setting group before the
+  application builds its views.
+- `app/src/settings_view/appearance_page.rs:1205-1242` shows the existing
+  dropdown construction pattern.
+
+The workspace automatically includes crates under `crates/*`
+(`Cargo.toml:1-5`), and presubmit runs formatting, Clippy, workspace tests, and
+doc tests (`script/presubmit:9-68`).
+
+The prior spec in #10990 proposes a custom YAML runtime and a whole-application
+migration. Maintainer feedback in #10928 asks for established prior art,
+pluralization, ongoing enforcement, low developer maintenance, safe handling of
+dynamic strings, and smaller implementation increments. This spec is an
+alternative architecture and rollout plan addressing those concerns.
+
+## Decision summary
+
+- Use [Project Fluent](https://projectfluent.org/) rather than a custom message
+  format.
+- Use the Rust [`fluent-bundle`](https://docs.rs/fluent-bundle/latest/fluent_bundle/)
+  runtime and Fluent syntax parser. Fluent provides language-aware
+  selectors/plurals, [variables](https://projectfluent.org/fluent/guide/variables.html),
+  and reusable
+  [terms](https://projectfluent.org/fluent/guide/terms.html).
+- Embed trusted FTL resources in the binary; do not load arbitrary locale files
+  from disk in production.
+- Use typed message identifiers at Rust call sites and validate catalogs during
+  builds and tests.
+- Store an explicit, device-local language setting. Do not infer the user's
+  language from environment variables or the OS in phase one.
+- Apply a changed language on the next launch, avoiding partial live updates.
+- Migrate only the Settings language UI, command palette, and low-risk user-menu
+  entries in the first implementation.
+- Add catalog checks, an incremental copy linter, developer documentation, and
+  an agent skill so future UI copy follows the same path.
+
+## Proposed changes
+
+### 1. Add a renderer-independent `warp_i18n` crate
+
+Create:
+
+```text
+crates/warp_i18n/
+├── Cargo.toml
+├── build.rs
+├── locales/
+│   ├── en-US/
+│   │   ├── main.ftl
+│   │   └── terms.ftl
+│   └── zh-CN/
+│       ├── main.ftl
+│       └── terms.ftl
+└── src/
+    ├── lib.rs
+    ├── catalog.rs
+    ├── coverage.rs
+    ├── locale.rs
+    └── catalog_tests.rs
+```
+
+The crate depends on a Cargo.lock-pinned compatible release of
+`fluent-bundle`, `fluent-syntax`, and `unic-langid`. The implementation uses the
+concurrent Fluent bundle specialization because translated text can be
+requested by UI code running on different threads.
+
+`Locale` is a closed enum in phase one:
+
+```rust
+pub enum Locale {
+    EnUs,
+    ZhCn,
+}
+```
+
+It provides stable BCP 47 tags (`en-US`, `zh-CN`), settings serialization, and
+self-names (`English`, `简体中文`). Unsupported strings return an error rather
+than being prefix-matched. In particular, Traditional Chinese locale tags are
+never mapped to Simplified Chinese.
+
+`build.rs` generates a typed `MessageId` enum from the canonical English Fluent
+IDs. Kebab-case IDs are converted deterministically to Rust variants, and the
+build fails if two IDs would produce the same variant. Application code cannot
+request a message with an arbitrary string:
+
+```rust
+// Generated into OUT_DIR from locales/en-US/main.ftl.
+pub enum MessageId {
+    CommandPaletteSearch,
+    CommandPaletteNoResults,
+    SettingsTitle,
+    SettingsAppearance,
+    SettingsLanguage,
+    SettingsLanguageRestartRequired,
+    UserMenuWhatsNew,
+    UserMenuSettings,
+    UserMenuKeyboardShortcuts,
+    UserMenuDocumentation,
+    UserMenuFeedback,
+    UserMenuViewLogs,
+    UserMenuJoinSlack,
+}
+```
+
+Removing an English message therefore breaks any Rust call sites that still use
+its generated variant. Adding a canonical English message creates the new
+variant without requiring a second hand-maintained key registry.
+
+The public API accepts either no arguments or `FluentArgs` and returns owned
+plain text:
+
+```rust
+pub struct Translator { /* selected and English bundles */ }
+
+impl Translator {
+    pub fn new(locale: Locale) -> Result<Self, CatalogError>;
+    pub fn locale(&self) -> Locale;
+    pub fn text(&self, id: MessageId) -> String;
+    pub fn format(&self, id: MessageId, args: &FluentArgs<'_>) -> String;
+}
+```
+
+Call sites pass `MessageId`, not English text and not raw FTL keys. This makes
+message lookup discoverable and prevents spelling mistakes from silently
+becoming runtime fallbacks.
+
+### 2. Embed and validate Fluent resources
+
+`main.ftl` contains messages. `terms.ftl` contains reusable product vocabulary:
+
+```ftl
+-warp = Warp
+-agent = Agent
+-token = Token
+
+user-menu-settings = Settings
+agent-token-count =
+    { $count ->
+        [one] { $count } Token
+       *[other] { $count } Tokens
+    }
+```
+
+The Simplified Chinese catalog references the same protected terms rather than
+translating them. Catalog comments give translators context and identify
+screenshots or constraints where useful.
+
+`build.rs` parses the exact FTL bytes later embedded with `include_str!` and
+fails compilation when:
+
+- either catalog has invalid Fluent syntax;
+- two canonical IDs would generate the same `MessageId` variant;
+- a message registered as required for the phase-one `zh-CN` surface in
+  `coverage.rs` is missing or empty;
+- variables differ between an English message and its Simplified Chinese
+  translation;
+- a selector in either locale lacks a default variant;
+- a protected term is missing or has a different value;
+- duplicate message or term IDs are present.
+
+Simplified Chinese is not required to reproduce English plural-category arms:
+Fluent selects categories per locale. The validator compares referenced
+variables and requires valid/default selectors, while locale-specific tests
+verify the expected output.
+
+Canonical English may contain a message that is not yet present in Simplified
+Chinese; that message uses the normal English fallback and produces a coverage
+warning. A message becomes a hard `zh-CN` requirement only when its complete
+surface is added to `coverage.rs`. This prevents an unrelated English feature
+from being blocked on translation while ensuring advertised localized surfaces
+cannot silently regress.
+
+The runtime constructs the selected-language and English bundles from embedded
+resources only. There is no production environment variable or filesystem
+override, which keeps the resource trust boundary inside the signed executable.
+
+Resolution is per message:
+
+1. Format the selected-locale message.
+2. If it is missing or produces a formatting error, record a rate-limited
+   diagnostic and format the canonical English message.
+3. English resources are build-validated and embedded. Failure to initialize
+   the English bundle is treated as an application programming error during
+   startup, not as a reason to show raw message IDs.
+
+The translator returns plain strings. FTL values are never parsed as Markdown,
+URLs, menu actions, or rich UI. Dynamic/user/server values enter only as
+`FluentArgs`; application code continues to own rendering and interaction.
+Rich text must localize trusted text spans separately while keeping link/action
+targets in Rust.
+
+### 3. Add a device-local language setting
+
+Create `app/src/settings/language.rs` with
+`define_settings_group!(LanguageSettings, ...)`, following the pattern in
+`app/src/settings/input_mode.rs:6-20`.
+
+The setting has:
+
+- type: `warp_i18n::Locale`;
+- default: `Locale::EnUs`;
+- supported platforms: native GUI platforms;
+- `SyncToCloud::Never`;
+- storage key: `UiLanguage`;
+- TOML path: `appearance.language`;
+- public visibility so invalid values receive normal Settings validation.
+
+Export the module from `app/src/settings/mod.rs` and register
+`LanguageSettings` in `register_all_settings`
+(`app/src/settings/init.rs:53-115`).
+
+After settings are registered and loaded, construct a singleton
+`LocalizationState` from the saved `Locale` before any window or localized view
+is created. The state owns an immutable `Translator` for the lifetime of the
+process. This ordering guarantees that the first rendered frame uses one
+language consistently.
+
+The first implementation intentionally does not observe preference changes.
+Changing the setting writes the next locale but leaves
+`LocalizationState::active_locale` unchanged until relaunch.
+
+### 4. Add the Settings language selector
+
+Extend `AppearanceSettingsPageView` with a language dropdown and a
+`SetLanguage(Locale)` action, following the dropdown/state update pattern at
+`app/src/settings_view/appearance_page.rs:1205-1242`.
+
+Add a Language category near the top of `build_page`
+(`app/src/settings_view/appearance_page.rs:1379-1393`). The widget:
+
+- renders `English` and `简体中文` using `Locale::self_name()`;
+- writes `LanguageSettings` when selected;
+- compares the saved locale with `LocalizationState::active_locale`;
+- renders the localized restart-required notice only when they differ.
+
+Add localized rendering helpers for the Settings title and Appearance
+navigation label. Do not change `SettingsSection`'s `Display` or `FromStr`
+representations: `Display` is currently also used for telemetry and tests, so
+stable English identifiers remain unchanged. Rendering calls a separate
+`localized_label(&LocalizationState)` method.
+
+The selector and localized Settings labels are hidden behind one
+`FeatureFlag::Localization` gate until rollout.
+
+### 5. Migrate a bounded set of GUI call sites
+
+Replace only the phase-one literals:
+
+| Surface | Current code | Phase-one messages |
+|---|---|---|
+| Settings shell | `app/src/settings_view/mod.rs:244-310`, header construction | Settings title and Appearance label |
+| Language selector | `app/src/settings_view/appearance_page.rs` | Language label, option help, restart notice |
+| Command palette | `app/src/search/command_palette/view.rs:278-295` | Search placeholder and no-results text |
+| User menu | `app/src/workspace/view.rs:9657-9688` | What's new, Settings, Keyboard shortcuts, Documentation, Feedback, View Warp logs, Join Slack community |
+
+The implementation does not migrate the update states at
+`app/src/workspace/view.rs:9611-9654` or signup, billing, upgrade, referral, and
+logout actions at `app/src/workspace/view.rs:9690-9731`. Those remain English
+until their full surface and risk-sensitive copy can be reviewed.
+
+Telemetry names, settings/deep-link identifiers, action enums, commands,
+keyboard shortcuts, paths, usernames, versions, and server/model content do not
+pass through localization.
+
+### 6. Add incremental enforcement and contributor tooling
+
+Add `script/check_i18n` and invoke its non-networked checks from
+`script/presubmit` after formatting and before Clippy.
+
+Hard failures:
+
+- all catalog/build invariants in section 2;
+- direct user-facing string literals reintroduced at registered phase-one
+  localized call sites;
+- a phase-one required key without canonical English and Simplified Chinese
+  entries;
+- variables or protected terms that drift between catalogs.
+
+Advisory warnings:
+
+- added Rust lines in a pull-request diff that pass a literal to known UI text
+  constructors without using localization;
+- canonical English messages not yet covered by a Simplified Chinese surface;
+- changed protected terms in Simplified Chinese;
+- messages lacking translator context comments.
+
+The diff-based advisory check uses the CI base SHA when available. Locally it
+checks staged and unstaged additions; if no diff base is available, it still
+runs every hard catalog check. A documented, reason-bearing suppression is
+allowed for non-user-facing identifiers, test fixtures, protocol values, and
+other false positives.
+
+Add `docs/i18n.md` describing:
+
+- when text is and is not user-facing;
+- message-ID naming and translator comments;
+- variables, selectors, fallback, and protected terms;
+- plain-text/rich-text security rules;
+- the phase-by-phase migration process;
+- commands for validation and pseudo-localized QA.
+
+Add a `localize-ui-copy` skill to `warpdotdev/common-skills` in a linked PR,
+then update `skills-lock.json` after that skill is merged. The skill guides
+coding agents to add the typed message ID, update both FTL catalogs, preserve
+protected terms, run `script/check_i18n`, and request screenshots. This avoids
+adding an unpinned repo-local skill contrary to the repository's common-skills
+workflow.
+
+### 7. Pseudo-localization
+
+Expose a development-only pseudo locale through a test/debug override, not the
+end-user Language selector. Use Fluent's text transform hook (or an equivalent
+test-only transform) to expand text and add visible delimiters while preserving
+variables and protected terms.
+
+Pseudo-localization is used to find hard-coded English, clipping, and layout
+assumptions before another real locale is added.
+
+## Data and control flow
+
+```mermaid
+flowchart TD
+    A["Settings registration"] --> B["Load device-local UiLanguage"]
+    B --> C["Parse embedded en-US bundle"]
+    C --> D["Parse selected embedded bundle"]
+    D --> E["Create immutable LocalizationState"]
+    E --> F["Build first application window"]
+    F --> G["UI requests typed MessageId"]
+    G --> H{"Selected message formats?"}
+    H -- "yes" --> I["Render selected-language plain text"]
+    H -- "no" --> J["Log diagnostic and format en-US"]
+    J --> K["Render canonical English plain text"]
+    L["User changes Language setting"] --> M["Persist next locale locally"]
+    M --> N["Show restart-required notice"]
+    N --> A
+```
+
+## Testing and validation
+
+### `warp_i18n` unit tests
+
+- Every embedded FTL resource parses.
+- Generated `MessageId` variants exactly match canonical English IDs and have no
+  collisions.
+- Phase-one English and Simplified Chinese catalogs have complete key coverage.
+- Variables match where a translation exists, every selector has a default, and
+  locale-specific plural arms format correctly.
+- Protected terms have identical values.
+- A selected-locale miss or formatting error returns canonical English.
+- No successful lookup returns an empty string or raw message ID.
+- English and Simplified Chinese numeric selector examples produce the expected
+  variants.
+- `Locale` accepts only exact supported serialized tags.
+- Pseudo-localization preserves variables and protected terms.
+
+### Settings tests
+
+- The default language is `en-US`.
+- `UiLanguage` round-trips through public Settings storage.
+- The setting uses `SyncToCloud::Never`.
+- Invalid serialized values fall back through normal Settings validation.
+- Selecting another locale produces a pending-restart state while leaving the
+  active translator unchanged.
+
+### UI and integration tests
+
+- Command palette snapshots/assertions cover English and Simplified Chinese
+  placeholder/empty-state text.
+- Appearance Settings exposes both self-named language options.
+- The restart notice appears only when saved and active locales differ.
+- User-menu tests assert the exact phase-one translated items and confirm the
+  excluded risk-sensitive actions remain English.
+- Stable `SettingsSection::Display`, deep links, action IDs, and telemetry values
+  retain their existing English values.
+- Default-feature GUI builds compile on macOS, Windows, and Linux.
+
+### Manual validation
+
+1. Run `./script/presubmit`.
+2. Start an English build and capture Settings, command palette, and user-menu
+   screenshots.
+3. Choose `简体中文`, verify the restart notice, relaunch, and capture the same
+   surfaces.
+4. Compare action behavior, keyboard focus, accessibility labels, glyphs,
+   clipping, and alignment at default and enlarged UI scales.
+5. Run the pseudo locale and check the same surfaces for hidden hard-coded
+   English and fixed-width assumptions.
+6. Build a release-style bundle and confirm localization works without external
+   locale files.
+
+## Rollout and implementation slices
+
+1. **Spec PR:** land the approved product and technical design.
+2. **Foundation slice:** add `warp_i18n`, embedded catalogs, validation,
+   device-local setting, feature flag, Language selector, and phase-one call
+   sites. Implementation may continue on the approved spec PR if maintainers
+   prefer the repository's standard flow.
+3. **Tooling slice:** land the linked common-skills change and enable the
+   incremental advisory linter.
+4. **Dogfood:** validate English, Simplified Chinese, fallback, and pseudo
+   locale with the feature flag enabled.
+5. **Release:** enable the feature flag after automated and manual validation.
+6. **Follow-ups:** migrate one complete product surface per reviewable change;
+   require explicit human copy review before translating security-sensitive
+   surfaces.
+
+No whole-application string replacement is part of the first implementation.
+
+## Alternatives considered
+
+### Custom JSON or YAML catalogs
+
+Simple key/value formats are easy to prototype but require Warp to design and
+maintain plural rules, selectors, term reuse, escaping, parser behavior, and
+tooling. This repeats the central concern raised on #10928 and is not proposed.
+
+### ICU MessageFormat
+
+ICU MessageFormat can express complex language rules, but Fluent has a direct
+Rust implementation, first-class reusable terms, selector/plural support, and a
+focused plain-text resource model suitable for Warp's Rust UI. This spec does
+not require Warp to design a MessageFormat subset.
+
+### Whole-application migration
+
+Migrating thousands of call sites would make architecture review, translation
+review, visual QA, and rebasing high risk. An incremental surface registry
+proves the foundation and enforcement model before broad adoption.
+
+### Automatic system-locale selection
+
+Environment and operating-system locale precedence differs by launch path and
+platform. An explicit local setting is deterministic and matches the requested
+user experience. Automatic detection can be proposed separately.
+
+## Risks and mitigations
+
+### New dependencies and runtime parsing
+
+Fluent adds maintained third-party dependencies and parses resources during
+startup. Versions are pinned in Cargo.lock and reviewed through the existing
+dependency process. The same embedded bytes are parsed during the build, locale
+files are small and trusted, and there is no production arbitrary-file loading.
+
+### Partial localization
+
+A mixed-language application can feel inconsistent. The selector clearly
+offers a first release, the migrated surfaces are bounded, and every missing
+message falls back to usable English. Follow-ups migrate complete surfaces
+rather than isolated strings.
+
+### Unlocalized copy can still be introduced
+
+Perfect classification of Rust string literals is not feasible without false
+positives. Hard checks protect migrated surfaces and catalog integrity; a
+diff-based advisory linter warns elsewhere; contributor docs and the agent skill
+provide a low-friction repair path. Coverage expands as each surface migrates.
+
+### Longer Chinese labels can affect layout
+
+Pseudo-localization, screenshot comparisons, enlarged-scale checks, and manual
+testing are required before rollout. Layout fixes remain part of the same
+surface migration.
+
+### Security-sensitive copy can lose meaning
+
+Those surfaces remain English in phase one. Later migrations require explicit
+human copy review, canonical English fallback, plain-text resources, and trusted
+application-owned actions/links.
+
+## Maintainer concern mapping
+
+| Concern raised in #10928 | Proposed answer |
+|---|---|
+| Prior art instead of an in-house solution | Project Fluent and its Rust runtime |
+| Pluralization | Fluent language-aware selectors and numeric values |
+| Maintenance as code changes | Typed IDs, build validation, contributor docs, and a common agent skill |
+| Enforcement | Hard checks for migrated surfaces plus repository-wide diff warnings |
+| Non-static server/variable strings | Values remain data and enter only through `FluentArgs`; they are never used as message syntax |
+| Developer friction | Self-contained checks, precise diagnostics, documented suppressions, and agent-assisted edits |
+| Whole-app blast radius | Foundation plus three bounded GUI surfaces; later migrations are separate |
+
+## Open questions
+
+None required to begin the first implementation. Dependency versions and the
+exact location of the linked common-skills change are resolved during
+implementation review without changing the behavior or architecture above.

--- a/specs/GH10928/tech.md
+++ b/specs/GH10928/tech.md
@@ -209,9 +209,21 @@ Resolution is per message:
 1. Format the selected-locale message.
 2. If it is missing or produces a formatting error, record a rate-limited
    diagnostic and format the canonical English message.
-3. English resources are build-validated and embedded. Failure to initialize
+3. If canonical English also cannot format, return the constant built-in
+   emergency text `Text unavailable`. This final fallback takes no arguments,
+   never returns a raw message ID or partially formatted value, and prevents a
+   caller error from producing an empty UI label.
+4. English resources are build-validated and embedded. Failure to initialize
    the English bundle is treated as an application programming error during
-   startup, not as a reason to show raw message IDs.
+   startup.
+
+Formatting diagnostics contain only the message ID, selected locale, fallback
+stage, and a bounded error category such as `missing-message`,
+`missing-variable`, or `resolver-error`. They must not contain `FluentArgs`
+names or values, partially formatted output, or error debug strings that may
+include those values. Dynamic arguments can contain user input, paths,
+repository data, commands, or server-provided content and therefore remain
+outside logs and telemetry.
 
 The translator returns plain strings. FTL values are never parsed as Markdown,
 URLs, menu actions, or rich UI. Dynamic/user/server values enter only as
@@ -359,7 +371,9 @@ flowchart TD
     G --> H{"Selected message formats?"}
     H -- "yes" --> I["Render selected-language plain text"]
     H -- "no" --> J["Log diagnostic and format en-US"]
-    J --> K["Render canonical English plain text"]
+    J --> K{"Canonical English formats?"}
+    K -- "yes" --> O["Render canonical English plain text"]
+    K -- "no" --> P["Render constant emergency text"]
     L["User changes Language setting"] --> M["Persist next locale locally"]
     M --> N["Show restart-required notice"]
     N --> A
@@ -377,6 +391,10 @@ flowchart TD
   locale-specific plural arms format correctly.
 - Protected terms have identical values.
 - A selected-locale miss or formatting error returns canonical English.
+- Missing or invalid arguments in both selected-locale and English messages
+  return the constant emergency text without panicking.
+- Formatting diagnostics never include argument names or values, partially
+  formatted output, or unbounded error debug strings.
 - No successful lookup returns an empty string or raw message ID.
 - English and Simplified Chinese numeric selector examples produce the expected
   variants.


### PR DESCRIPTION
## Description

Adds product and technical specs for an incremental internationalization foundation, with Simplified Chinese (`zh-CN`) as the first additional locale.

The proposal uses Fluent instead of a custom YAML message format and deliberately limits the initial implementation to a small, low-risk set of UI surfaces. It directly addresses the maintainer questions in #10928: prior art, pluralization and interpolation, ongoing maintenance and enforcement, dynamic strings, developer friction, and implementation blast radius.

The proposed language choice is manual under Settings > Appearance. English remains the default and fallback language. Product and technical terms such as Warp, Warp Drive, Agent, Token, Workflow, MCP, API, CLI, Shell, and Block remain in English.

This PR is spec-only and does not change runtime behavior.

## Linked Issue

Closes #10928

Related: #1194, #14397, #10990

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots or video are not applicable because this PR changes specs only.

## Testing

- `./script/format --check`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- Markdown whitespace validation for both new spec files

No runtime behavior changed, so manual GUI testing is not applicable.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not applicable for a spec-only PR.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
