### PR TITLE
Fix remote Fish SSH bootstrap and prompt mode

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1064,8 +1064,24 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             # OpenSSH passes remote commands to the user's login shell. Build the bootstrap as a
             # separate string and pass it through a small sh launcher so non-Bourne login
             # shells such as fish do not parse it before it can fall back to the login shell.
+            local local_tty_rows local_tty_columns
+            read -r local_tty_rows local_tty_columns < <(command stty size 2>/dev/null)
+            if [[ ! "$local_tty_rows" =~ ^[0-9]+$ ]]; then
+                local_tty_rows=0
+            fi
+            if [[ ! "$local_tty_columns" =~ ^[0-9]+$ ]]; then
+                local_tty_columns=0
+            fi
+
             local remote_command="
 export TERM_PROGRAM='WarpTerminal'
+# Some SSH gateways transpose the PTY dimensions when a remote command is supplied. Correct that
+# specific corruption without overriding dimensions reported correctly by the remote PTY.
+_warp_tty_size=\$(command stty size 2>/dev/null)
+if [ '$local_tty_rows' -gt 0 ] && [ '$local_tty_columns' -gt 0 ] && [ \"\$_warp_tty_size\" = '$local_tty_columns $local_tty_rows' ]; then
+  command stty rows '$local_tty_rows' cols '$local_tty_columns'
+fi
+unset _warp_tty_size
 # Mark the remote side of a Warp-managed SSH session so the bootstrap
 # body can distinguish it from local shells. Used to gate the ExitShell
 # hook which tears down the remote-server-proxy subprocess.
@@ -1080,7 +1096,9 @@ printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 if test \"\${SHELL##*/}\" = \"fish\"; then
   FISH_INIT_SCRIPT='"'set -g WARP_SESSION_ID $WARP_SESSION_ID; set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n); set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER); set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); printf "\x1b\x50\x24\x64%s\x1b\x5c" "$_msg"; set -e _hostname _user _msg'"'
   if \"\$SHELL\" --help 2>&1 | command -p grep -q -- '--init-command'; then
-    WARP_SESSION_ID='$remote_session_id' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
+    # Fish treats an unset WARP_HONOR_PS1 as custom-prompt mode. Keep it synchronized with the
+    # client so prompt redraws, including abbreviation expansion, update the command grid correctly.
+    WARP_SESSION_ID='$remote_session_id' WARP_HONOR_PS1='$WARP_HONOR_PS1' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
   fi
 fi
 

--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1060,16 +1060,11 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
                 esac
             fi
 
-            # Keep remote commands up-to-date with shell.rs & bash.sh.
-            # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
-            # escaped with "''" to avoid the local shell from expanding them before they're passed to the remote shell.
-            # We check the SHELL env var and use shell string manipulation to get the contents after the last slash to
-            # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
-            # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
-            # support.
-            command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
-            -t "${@:1}" \
-"
+            # Keep remote commands up-to-date with zsh_body.sh & fish.sh.
+            # OpenSSH passes remote commands to the user's login shell. Build the bootstrap as a
+            # separate string and pass it through a small sh launcher so non-Bourne login
+            # shells such as fish do not parse it before it can fall back to the login shell.
+            local remote_command="
 export TERM_PROGRAM='WarpTerminal'
 # Mark the remote side of a Warp-managed SSH session so the bootstrap
 # body can distinguish it from local shells. Used to gate the ExitShell
@@ -1081,6 +1076,13 @@ test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VER
 
 hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_control_master\": '"$external_control_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
+
+if test \"\${SHELL##*/}\" = \"fish\"; then
+  FISH_INIT_SCRIPT='"'set -g WARP_SESSION_ID $WARP_SESSION_ID; set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n); set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER); set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); printf "\x1b\x50\x24\x64%s\x1b\x5c" "$_msg"; set -e _hostname _user _msg'"'
+  if \"\$SHELL\" --help 2>&1 | command -p grep -q -- '--init-command'; then
+    WARP_SESSION_ID='$remote_session_id' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
+  fi
+fi
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then
   # Emulate the SSHD logic to print the MotD. Because the Warp SSH wrapper passes
@@ -1141,6 +1143,12 @@ TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" ZDOTDIR="'$W
       ;;
 esac
 "
+            # Base64 keeps the bootstrap opaque to the login shell that OpenSSH invokes. Decode
+            # it in the sh launcher, accepting the GNU, BusyBox, and BSD base64 flags.
+            local encoded_remote_command=$(printf %s "$remote_command" | base64 | tr -d '\n')
+            command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
+                -t "${@:1}" \
+                "exec sh -c 'remote_command=\$(printf %s \"\$1\" | base64 --decode 2>/dev/null) || remote_command=\$(printf %s \"\$1\" | base64 -d 2>/dev/null) || remote_command=\$(printf %s \"\$1\" | base64 -D 2>/dev/null) || exec \"\$SHELL\"; case \"\${SHELL##*/}\" in zsh|bash) exec \"\$SHELL\" -c \"\$remote_command\" ;; *) command -v bash >/dev/null 2>&1 && exec bash -c \"\$remote_command\"; exec \"\$SHELL\" ;; esac' warp '$encoded_remote_command'"
         }
 
         function ssh() {

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -683,21 +683,28 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
             end
         end
 
-        # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
-        # escaped with "''" to avoid the local shell from expanding them before they're passed to the remote shell.
-        # We check the SHELL env var and use shell string manipulation to get the contents after the last slash to
-        # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
-        # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
-        # support.
-        command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
-        -t $argv \
-"
+        # Keep remote commands up-to-date with bash_body.sh & zsh_body.sh.
+        # OpenSSH passes remote commands to the user's login shell. Build the bootstrap as a
+        # separate string and pass it through a small sh launcher so non-Bourne login
+        # shells such as fish do not parse it before it can fall back to the login shell.
+        set -l remote_command "
 export TERM_PROGRAM='WarpTerminal'
+# Mark the remote side of a Warp-managed SSH session so the bootstrap
+# body can distinguish it from local shells. Used to gate the ExitShell
+# hook which tears down the remote-server-proxy subprocess.
+export WARP_IS_SSH='1'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
 hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_control_master\": '"$external_control_master"'}}" "${SHELL##*/}" | command od -An -v -tx1 | command tr -d " \n")'"
 printf '$DCS_START$DCS_JSON_MARKER%s$DCS_END' "'$hook'"
+
+if test \"\${SHELL##*/}\" = \"fish\"; then
+  FISH_INIT_SCRIPT='"'set -g WARP_SESSION_ID $WARP_SESSION_ID; set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n); set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER); set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); printf "\x1b\x50\x24\x64%s\x1b\x5c" "$_msg"; set -e _hostname _user _msg'"'
+  if \"\$SHELL\" --help 2>&1 | command grep -q -- '--init-command'; then
+    WARP_SESSION_ID='$remote_session_id' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
+  fi
+fi
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then
   # Emulate the SSHD logic to print the MotD. Because the Warp SSH wrapper passes
@@ -759,6 +766,12 @@ TMPPREFIX="'$HOME/.zshtmp-'" WARP_SSH_RCFILES="'${ZDOTDIR:-$HOME}'" ZDOTDIR="'$W
     ;;
 esac
 "
+        # Base64 keeps the bootstrap opaque to the login shell that OpenSSH invokes. Decode
+        # it in the sh launcher, accepting the GNU, BusyBox, and BSD base64 flags.
+        set -l encoded_remote_command (printf %s "$remote_command" | base64 | tr -d '\n' | string collect)
+        command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
+            -t $argv \
+            "exec sh -c 'remote_command=\$(printf %s \"\$1\" | base64 --decode 2>/dev/null) || remote_command=\$(printf %s \"\$1\" | base64 -d 2>/dev/null) || remote_command=\$(printf %s \"\$1\" | base64 -D 2>/dev/null) || exec \"\$SHELL\"; case \"\${SHELL##*/}\" in zsh|bash) exec \"\$SHELL\" -c \"\$remote_command\" ;; *) command -v bash >/dev/null 2>&1 && exec bash -c \"\$remote_command\"; exec \"\$SHELL\" ;; esac' warp '$encoded_remote_command'"
     end
 
     function ssh

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -687,8 +687,25 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
         # OpenSSH passes remote commands to the user's login shell. Build the bootstrap as a
         # separate string and pass it through a small sh launcher so non-Bourne login
         # shells such as fish do not parse it before it can fall back to the login shell.
+        set -l local_tty_size (string split ' ' -- (command stty size 2>/dev/null))
+        set -l local_tty_rows $local_tty_size[1]
+        set -l local_tty_columns $local_tty_size[2]
+        if not string match --quiet --regex '^[0-9]+$' -- "$local_tty_rows"
+            set local_tty_rows 0
+        end
+        if not string match --quiet --regex '^[0-9]+$' -- "$local_tty_columns"
+            set local_tty_columns 0
+        end
+
         set -l remote_command "
 export TERM_PROGRAM='WarpTerminal'
+# Some SSH gateways transpose the PTY dimensions when a remote command is supplied. Correct that
+# specific corruption without overriding dimensions reported correctly by the remote PTY.
+_warp_tty_size=\$(command stty size 2>/dev/null)
+if [ '$local_tty_rows' -gt 0 ] && [ '$local_tty_columns' -gt 0 ] && [ \"\$_warp_tty_size\" = '$local_tty_columns $local_tty_rows' ]; then
+  command stty rows '$local_tty_rows' cols '$local_tty_columns'
+fi
+unset _warp_tty_size
 # Mark the remote side of a Warp-managed SSH session so the bootstrap
 # body can distinguish it from local shells. Used to gate the ExitShell
 # hook which tears down the remote-server-proxy subprocess.
@@ -702,7 +719,9 @@ printf '$DCS_START$DCS_JSON_MARKER%s$DCS_END' "'$hook'"
 if test \"\${SHELL##*/}\" = \"fish\"; then
   FISH_INIT_SCRIPT='"'set -g WARP_SESSION_ID $WARP_SESSION_ID; set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n); set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER); set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); printf "\x1b\x50\x24\x64%s\x1b\x5c" "$_msg"; set -e _hostname _user _msg'"'
   if \"\$SHELL\" --help 2>&1 | command grep -q -- '--init-command'; then
-    WARP_SESSION_ID='$remote_session_id' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
+    # Fish treats an unset WARP_HONOR_PS1 as custom-prompt mode. Keep it synchronized with the
+    # client so prompt redraws, including abbreviation expansion, update the command grid correctly.
+    WARP_SESSION_ID='$remote_session_id' WARP_HONOR_PS1='$WARP_HONOR_PS1' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
   fi
 fi
 

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1014,16 +1014,11 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
               esac
           fi
 
-          # Keep remote commands up-to-date with shell.rs & bash.sh.
-          # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
-          # escaped with "''" to avoid the local shell from expanding them before they're passed to the remote shell.
-          # We check the SHELL env var and use shell string manipulation to get the contents after the last slash to
-          # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
-          # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
-          # support.
-          command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
-          -t "${@:1}" \
-"
+          # Keep remote commands up-to-date with bash_body.sh & fish.sh.
+          # OpenSSH passes remote commands to the user's login shell. Build the bootstrap as a
+          # separate string and pass it through a small sh launcher so non-Bourne login
+          # shells such as fish do not parse it before it can fall back to the login shell.
+          local remote_command="
 export TERM_PROGRAM='WarpTerminal'
 # Mark the remote side of a Warp-managed SSH session so the bootstrap
 # body can distinguish it from local shells. Used to gate the ExitShell
@@ -1034,6 +1029,13 @@ test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSI
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
 hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_control_master\": '"$external_control_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
+
+if test \"\${SHELL##*/}\" = \"fish\"; then
+  FISH_INIT_SCRIPT='"'set -g WARP_SESSION_ID $WARP_SESSION_ID; set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n); set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER); set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); printf "\x1b\x50\x24\x64%s\x1b\x5c" "$_msg"; set -e _hostname _user _msg'"'
+  if \"\$SHELL\" --help 2>&1 | command -p grep -q -- '--init-command'; then
+    WARP_SESSION_ID='$remote_session_id' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
+  fi
+fi
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then
   # Emulate the SSHD logic to print the MotD. Because the Warp SSH wrapper passes
@@ -1096,6 +1098,12 @@ case "'${SHELL##*/}'" in
       ;;
 esac
 "
+          # Base64 keeps the bootstrap opaque to the login shell that OpenSSH invokes. Decode
+          # it in the sh launcher, accepting the GNU, BusyBox, and BSD base64 flags.
+          local encoded_remote_command=$(printf %s "$remote_command" | base64 | tr -d '\n')
+          command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
+              -t "${@:1}" \
+              "exec sh -c 'remote_command=\$(printf %s \"\$1\" | base64 --decode 2>/dev/null) || remote_command=\$(printf %s \"\$1\" | base64 -d 2>/dev/null) || remote_command=\$(printf %s \"\$1\" | base64 -D 2>/dev/null) || exec \"\$SHELL\"; case \"\${SHELL##*/}\" in zsh|bash) exec \"\$SHELL\" -c \"\$remote_command\" ;; *) command -v bash >/dev/null 2>&1 && exec bash -c \"\$remote_command\"; exec \"\$SHELL\" ;; esac' warp '$encoded_remote_command'"
       }
 
       function ssh() {

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1018,8 +1018,24 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
           # OpenSSH passes remote commands to the user's login shell. Build the bootstrap as a
           # separate string and pass it through a small sh launcher so non-Bourne login
           # shells such as fish do not parse it before it can fall back to the login shell.
+          local local_tty_rows local_tty_columns
+          read -r local_tty_rows local_tty_columns < <(command stty size 2>/dev/null)
+          if [[ ! "$local_tty_rows" =~ ^[0-9]+$ ]]; then
+              local_tty_rows=0
+          fi
+          if [[ ! "$local_tty_columns" =~ ^[0-9]+$ ]]; then
+              local_tty_columns=0
+          fi
+
           local remote_command="
 export TERM_PROGRAM='WarpTerminal'
+# Some SSH gateways transpose the PTY dimensions when a remote command is supplied. Correct that
+# specific corruption without overriding dimensions reported correctly by the remote PTY.
+_warp_tty_size=\$(command stty size 2>/dev/null)
+if [ '$local_tty_rows' -gt 0 ] && [ '$local_tty_columns' -gt 0 ] && [ \"\$_warp_tty_size\" = '$local_tty_columns $local_tty_rows' ]; then
+  command stty rows '$local_tty_rows' cols '$local_tty_columns'
+fi
+unset _warp_tty_size
 # Mark the remote side of a Warp-managed SSH session so the bootstrap
 # body can distinguish it from local shells. Used to gate the ExitShell
 # hook which tears down the remote-server-proxy subprocess.
@@ -1033,7 +1049,9 @@ printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 if test \"\${SHELL##*/}\" = \"fish\"; then
   FISH_INIT_SCRIPT='"'set -g WARP_SESSION_ID $WARP_SESSION_ID; set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n); set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER); set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); printf "\x1b\x50\x24\x64%s\x1b\x5c" "$_msg"; set -e _hostname _user _msg'"'
   if \"\$SHELL\" --help 2>&1 | command -p grep -q -- '--init-command'; then
-    WARP_SESSION_ID='$remote_session_id' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
+    # Fish treats an unset WARP_HONOR_PS1 as custom-prompt mode. Keep it synchronized with the
+    # client so prompt redraws, including abbreviation expansion, update the command grid correctly.
+    WARP_SESSION_ID='$remote_session_id' WARP_HONOR_PS1='$WARP_HONOR_PS1' exec \"\$SHELL\" -f no-mark-prompt --login --init-command \"\$FISH_INIT_SCRIPT\"
   fi
 fi
 

--- a/app/src/terminal/writeable_pty/pty_controller.rs
+++ b/app/src/terminal/writeable_pty/pty_controller.rs
@@ -454,6 +454,15 @@ impl<T: EventLoopSender> PtyController<T> {
                     move |me, _, ctx| me.write_bytes(chunk, ctx),
                 );
             }
+        } else if shell_type == ShellType::Fish {
+            // A remote fish session cannot source a bootstrap file created on the local machine.
+            // Paste the script as one bracketed-paste command instead, then explicitly submit it.
+            // The leading space keeps the bootstrap out of fish history.
+            self.write_bytes(&b" "[..], ctx);
+            self.write_bytes(escape_sequences::BRACKETED_PASTE_START, ctx);
+            self.write_bytes(bootstrap, ctx);
+            self.write_bytes(escape_sequences::BRACKETED_PASTE_END, ctx);
+            self.write_terminating_bootstrap_bytes(ctx);
         } else {
             self.write_bytes(bootstrap, ctx);
         }

--- a/crates/integration/tests/integration/shell_integration_tests.rs
+++ b/crates/integration/tests/integration/shell_integration_tests.rs
@@ -81,8 +81,8 @@ integration_tests! {
     // Tests of ssh wrapper logic from bootstrap script.
     test_ssh_wrapper_into_bash,
     test_ssh_wrapper_into_zsh,
-    // TODO(vorporeal): Reenable fish once we actually support it as a remote
-    // shell.
+    // TODO: Upgrade fish in the testing VM to a version with `--init-command`,
+    // then replace this fallback-only test with a remote bootstrap test.
     // test_ssh_into_fish,
     test_ssh_into_sh,
     test_ssh_into_ash,

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -599,8 +599,8 @@ impl ShellType {
     /// If true, Warp will bootstrap the shell if it's the login shell on the remote host.
     pub fn is_fully_supported_remotely(&self) -> bool {
         match self {
-            ShellType::Zsh | ShellType::Bash => true,
-            ShellType::Fish | ShellType::PowerShell => false,
+            ShellType::Zsh | ShellType::Bash | ShellType::Fish => true,
+            ShellType::PowerShell => false,
         }
     }
 

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -124,6 +124,14 @@ fn test_from_name() {
 }
 
 #[test]
+fn test_fully_supported_remote_shells() {
+    assert!(ShellType::Bash.is_fully_supported_remotely());
+    assert!(ShellType::Zsh.is_fully_supported_remotely());
+    assert!(ShellType::Fish.is_fully_supported_remotely());
+    assert!(!ShellType::PowerShell.is_fully_supported_remotely());
+}
+
+#[test]
 fn test_from_markdown_language_spec() {
     // Standard shell languages
     assert_eq!(


### PR DESCRIPTION
## Description

Fix remote Fish shell bootstrap for Warp-managed SSH sessions.

The SSH wrapper now keeps the bootstrap payload opaque to the remote login shell, so a remote Fish login shell does not try to parse Bash/Zsh-oriented bootstrap syntax. When the installed Fish supports `--init-command`, Warp starts it with the required initialization hook and forwards `WARP_HONOR_PS1`. Forwarding this variable keeps remote Fish in the same prompt mode as the client, so command-grid redraws after Fish abbreviation expansion do not duplicate command text (for example, `ls` → `lsd` no longer renders as `lslsd`).

This also adds Fish shell recognition to the terminal shell model and updates the SSH integration-test registration comments to document the remote VM's Fish-version limitation.

Implementation was AI-assisted by GPT-5.6 and manually tested by a human on a MacBook Pro M2. 

Closes #871 .

## Linked Issue

- [ ] No linked issue.

## Testing

- [x] Manually tested locally on a MacBook Pro M2 with `./script/run`.
- [x] `bash -n app/assets/bundled/bootstrap/bash_body.sh`
- [x] `fish -n app/assets/bundled/bootstrap/fish.sh`
- [x] `zsh -n app/assets/bundled/bootstrap/zsh_body.sh`
- [x] `./script/format`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] `cargo test -p warp_terminal test_fully_supported_remote_shells`
- [ ] Full `./script/presubmit` is not green locally: external-contributor environment cannot access the internal GCP/IAP SSH integration host. CI should validate those SSH integration tests. The run also had unrelated OSC8 and Zsh-history failures.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed remote Fish SSH sessions rendering duplicated text after abbreviation expansion.

Co-Authored-By: Warp <agent@warp.dev>
