### PR TITLE
Reconstruct URLs wrapped across rich output lines

### DIFF
--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -246,6 +246,252 @@ fn detect_urls(text: &str) -> Vec<Range<usize>> {
     url_ranges
 }
 
+/// Maximum number of characters in a URL reconstructed across wrapped lines. Mirrors
+/// `URL_SCAN_CHARACTER_MAX_COUNT` in the terminal-grid path: offering an incomplete link
+/// is worse UX than offering none.
+const MAX_RECONSTRUCTED_URL_CHARS: usize = 1000;
+/// Maximum number of formatted lines that a single reconstructed URL may span.
+const MAX_WRAPPED_URL_LINES: usize = 32;
+
+/// A URL rebuilt from fragments that a CLI agent hard-wrapped across formatted lines,
+/// along with the per-line char ranges that display it.
+struct WrappedUrl {
+    url: String,
+    /// `(index into the run of lines, char range within that line)`.
+    segments: Vec<(usize, Range<usize>)>,
+}
+
+/// Returns a formatted line without the trailing newline that [`FormattedTextLine::raw_text`]
+/// appends, so char ranges line up with what the renderer registers as clickable.
+fn line_body(text: &str) -> &str {
+    text.strip_suffix('\n').unwrap_or(text)
+}
+
+/// Returns true when `line` opens a new layout row rather than continuing a wrapped URL.
+///
+/// TUIs draw lists, tables and quotes with leading markers, and a URL can never resume
+/// after one. Markers that are also legal URL characters (`-`, `#`, `+`, ...) only count
+/// when whitespace follows, since `https://a.example/-x` must keep wrapping normally.
+fn looks_like_new_layout_row(line: &str) -> bool {
+    let mut chars = line.chars();
+    let Some(first) = chars.next() else {
+        return true;
+    };
+    if first.is_whitespace() {
+        return true;
+    }
+
+    const LAYOUT_DELIMITERS: &[char] = &[
+        '|', '│', '┃', '├', '└', '┌', '┐', '┘', '┤', '┬', '┴', '┼', '─', '║', '╠', '╚', '═', '╦',
+        '╩', '╬', '•', '‣', '⁃',
+    ];
+    if LAYOUT_DELIMITERS.contains(&first) {
+        return true;
+    }
+
+    let rest = chars.as_str();
+    if matches!(first, '-' | '*' | '+' | '>' | '$' | '%' | '#')
+        && rest.chars().next().is_none_or(char::is_whitespace)
+    {
+        return true;
+    }
+    if first == '#'
+        && line
+            .trim_start_matches('#')
+            .starts_with(char::is_whitespace)
+    {
+        return true;
+    }
+
+    // Ordered list markers such as `2.` or `3)`.
+    let digit_count = line.chars().take_while(char::is_ascii_digit).count();
+    if digit_count > 0 {
+        let mut after = line.chars().skip(digit_count);
+        if matches!(after.next(), Some('.') | Some(')'))
+            && after.next().is_none_or(char::is_whitespace)
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Returns true for characters that carry URL structure rather than prose.
+fn is_url_structural(c: char) -> bool {
+    c.is_ascii_digit()
+        || matches!(
+            c,
+            '/' | '?' | '=' | '&' | '%' | '#' | '.' | '_' | '~' | '+' | ':' | '@' | '-'
+        )
+}
+
+/// Attempts to grow a URL that runs to the end of `bodies[start]` across the lines after it.
+///
+/// Every continuation must clear the guards below; the detector deliberately prefers false
+/// negatives, since a wrong link target is worse than a link that stays split.
+fn extend_wrapped_url(bodies: &[&str], start: usize) -> Option<WrappedUrl> {
+    let first = bodies[start];
+    let first_len = first.chars().count();
+    // Only a URL touching the very end of a line can continue onto the next one.
+    let url_start = detect_urls(first)
+        .into_iter()
+        .find(|range| range.end == first_len)?
+        .start;
+
+    let mut acc = first.to_owned();
+    let mut acc_len = first_len;
+    let mut url_end = first_len;
+    let mut last = start;
+
+    for (offset, body) in bodies[start + 1..].iter().enumerate() {
+        if offset >= MAX_WRAPPED_URL_LINES {
+            break;
+        }
+        // The URL must still run to the end of everything joined so far.
+        if url_end != acc_len || looks_like_new_layout_row(body) {
+            break;
+        }
+        // A line that opens its own URL is a new link, not the tail of a wrapped one.
+        if detect_urls(body).iter().any(|range| range.start == 0) {
+            break;
+        }
+        let body_len = body.chars().count();
+        if url_end - url_start + body_len > MAX_RECONSTRUCTED_URL_CHARS {
+            break;
+        }
+
+        let candidate = format!("{acc}{body}");
+        let Some(extended) = detect_urls(&candidate)
+            .into_iter()
+            .find(|range| range.start == url_start && range.end > acc_len)
+        else {
+            break;
+        };
+
+        // Guard against swallowing prose that merely abuts the URL. A genuine wrap either
+        // runs through the whole continuation line or contributes URL structure, whereas
+        // `https://example.com` followed by `This is a sentence.` only gains a bare word.
+        let appended_len = extended.end - acc_len;
+        let Some(appended) = char_slice(body, 0, appended_len) else {
+            break;
+        };
+        if appended_len != body_len && !appended.chars().any(is_url_structural) {
+            break;
+        }
+
+        acc = candidate;
+        acc_len += body_len;
+        url_end = extended.end;
+        last = start + 1 + offset;
+    }
+
+    if last == start {
+        return None;
+    }
+
+    let mut segments = Vec::new();
+    let mut line_start = 0;
+    for (index, body) in bodies[start..=last].iter().enumerate() {
+        let line_end = line_start + body.chars().count();
+        let segment_start = url_start.max(line_start);
+        let segment_end = url_end.min(line_end);
+        if segment_start < segment_end {
+            segments.push((
+                start + index,
+                (segment_start - line_start)..(segment_end - line_start),
+            ));
+        }
+        line_start = line_end;
+    }
+
+    Some(WrappedUrl {
+        url: char_slice(&acc, url_start, url_end)?.to_owned(),
+        segments,
+    })
+}
+
+/// Reconstructs URLs that a CLI agent hard-wrapped across consecutive formatted lines.
+fn reconstruct_wrapped_urls(bodies: &[&str]) -> Vec<WrappedUrl> {
+    let mut wrapped = Vec::new();
+    let mut line = 0;
+    while line + 1 < bodies.len() {
+        match extend_wrapped_url(bodies, line) {
+            // Resume from the last participating line: it may still end with another URL.
+            Some(url) => {
+                let last = url.segments.last().map_or(line, |(index, _)| *index);
+                wrapped.push(url);
+                line = last;
+            }
+            None => line += 1,
+        }
+    }
+    wrapped
+}
+
+/// Returns true when `next` is the formatted line immediately after `previous` in the
+/// same output section.
+fn is_next_output_line(previous: &TextLocation, next: &TextLocation) -> bool {
+    match (previous, next) {
+        (
+            TextLocation::Output {
+                section_index: previous_section,
+                line_index: previous_line,
+            },
+            TextLocation::Output {
+                section_index: next_section,
+                line_index: next_line,
+            },
+        ) => previous_section == next_section && *next_line == previous_line + 1,
+        _ => false,
+    }
+}
+
+/// Groups `texts` into runs of consecutive formatted lines from a single output section.
+///
+/// Joining is confined to these runs so a URL can never be stitched across separate
+/// sections, code blocks, tables, images or action rows.
+fn consecutive_output_line_runs(
+    texts: &[(String, TextLocation)],
+) -> Vec<&[(String, TextLocation)]> {
+    let mut runs = Vec::new();
+    let mut start = 0;
+    for index in 1..texts.len() {
+        if !is_next_output_line(&texts[index - 1].1, &texts[index].1) {
+            runs.push(&texts[start..index]);
+            start = index;
+        }
+    }
+    if start < texts.len() {
+        runs.push(&texts[start..]);
+    }
+    runs
+}
+
+/// Maps every reconstructed cross-line URL onto the per-line clickable ranges that show it.
+/// Each participating range resolves to the same full URL, so Cmd+clicking any visual line
+/// opens the whole link.
+fn wrapped_url_links(
+    texts: &[(String, TextLocation)],
+) -> HashMap<TextLocation, HashMap<Range<usize>, String>> {
+    let mut links: HashMap<TextLocation, HashMap<Range<usize>, String>> = HashMap::new();
+    for run in consecutive_output_line_runs(texts) {
+        let bodies = run
+            .iter()
+            .map(|(text, _)| line_body(text))
+            .collect::<Vec<_>>();
+        for wrapped in reconstruct_wrapped_urls(&bodies) {
+            for (index, range) in wrapped.segments {
+                links
+                    .entry(run[index].1)
+                    .or_default()
+                    .insert(range, wrapped.url.clone());
+            }
+        }
+    }
+    links
+}
+
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 fn addr_of(s: &str) -> usize {
     s.as_ptr() as usize
@@ -690,12 +936,30 @@ pub(crate) fn detect_all_links(
     let mut all_links: HashMap<TextLocation, HashMap<Range<usize>, DetectedLinkType>> =
         HashMap::new();
 
+    // URLs that a CLI agent hard-wrapped across formatted lines, rebuilt before per-line
+    // detection so each fragment can resolve to the whole link instead of its own prefix.
+    let wrapped_urls = wrapped_url_links(texts);
+
     for (text, location) in texts {
+        let wrapped = wrapped_urls.get(location);
+        let overlaps_wrapped = |range: &Range<usize>| {
+            wrapped.is_some_and(|segments| {
+                segments
+                    .keys()
+                    .any(|segment| segment.start < range.end && range.start < segment.end)
+            })
+        };
+
         let url_ranges = detect_urls(text);
         let mut links = HashMap::new();
 
         // Detect URLs via regex
         for url_range in &url_ranges {
+            // A reconstructed URL supersedes the truncated fragment that per-line detection
+            // finds over the same characters.
+            if overlaps_wrapped(url_range) {
+                continue;
+            }
             if let Some(link_text) = char_slice(text, url_range.start, url_range.end) {
                 links.insert(
                     url_range.clone(),
@@ -712,9 +976,16 @@ pub(crate) fn detect_all_links(
                 if !url_ranges
                     .iter()
                     .any(|ur| ur.start < range.end && range.start < ur.end)
+                    && !overlaps_wrapped(&range)
                 {
                     links.insert(range, link);
                 }
+            }
+        }
+
+        if let Some(segments) = wrapped {
+            for (range, url) in segments {
+                links.insert(range.clone(), DetectedLinkType::Url(url.clone()));
             }
         }
 

--- a/app/src/util/link_detection_tests.rs
+++ b/app/src/util/link_detection_tests.rs
@@ -242,3 +242,210 @@ fn link_tooltip_anchor_ids_are_unique_per_block() {
         RICH_CONTENT_LINK_FIRST_CHAR_POSITION_ID
     );
 }
+
+// Cross-line URL reconstruction (GH9385).
+//
+// CLI agents such as Claude Code hard-wrap their TUI output, so a long URL arrives as
+// several formatted lines. Detecting each line on its own found only the prefix that
+// happened to parse as a URL, and Cmd+click opened that truncated target.
+
+fn output_line(line_index: usize) -> TextLocation {
+    TextLocation::Output {
+        section_index: 0,
+        line_index,
+    }
+}
+
+/// Builds the `(text, location)` pairs that `collect_output_data_for_link_detection`
+/// produces for one plain-text section. `raw_text()` terminates every formatted line
+/// with a newline, so the fixtures do too.
+fn output_lines(lines: &[&str]) -> Vec<(String, TextLocation)> {
+    lines
+        .iter()
+        .enumerate()
+        .map(|(line_index, line)| (format!("{line}\n"), output_line(line_index)))
+        .collect_vec()
+}
+
+fn urls_in(
+    links: &HashMap<TextLocation, HashMap<Range<usize>, DetectedLinkType>>,
+    location: TextLocation,
+) -> Vec<(Range<usize>, String)> {
+    links
+        .get(&location)
+        .map(|detected| {
+            detected
+                .iter()
+                .filter_map(|(range, link)| match link {
+                    DetectedLinkType::Url(url) => Some((range.clone(), url.clone())),
+                    #[cfg(feature = "local_fs")]
+                    DetectedLinkType::FilePath { .. } => None,
+                })
+                .sorted_by_key(|(range, _)| range.start)
+                .collect_vec()
+        })
+        .unwrap_or_default()
+}
+
+fn detected_urls_by_line(lines: &[&str]) -> Vec<Vec<(Range<usize>, String)>> {
+    let texts = output_lines(lines);
+    let links = detect_all_links(&texts, vec![], None, None);
+    (0..lines.len())
+        .map(|line_index| urls_in(&links, output_line(line_index)))
+        .collect_vec()
+}
+
+#[test]
+fn test_reconstructs_url_hard_wrapped_across_two_lines() {
+    const FULL_URL: &str =
+        "https://example.com/some/very/long/path?param1=value1&param2=value2&param3=value3";
+    let detected = detected_urls_by_line(&[
+        "https://example.com/some/very/long/path?param1=value1&param",
+        "2=value2&param3=value3",
+    ]);
+
+    // Both visual lines stay individually clickable, and both open the whole URL.
+    assert_eq!(detected[0], vec![(0..59, FULL_URL.to_owned())]);
+    assert_eq!(detected[1], vec![(0..22, FULL_URL.to_owned())]);
+}
+
+#[test]
+fn test_reconstructs_url_hard_wrapped_across_three_lines() {
+    const FULL_URL: &str =
+        "https://example.com/a/very/long/path/that/keeps/going/and/going?q=1&r=2";
+    let detected = detected_urls_by_line(&[
+        "Docs: https://example.com/a/very/long",
+        "/path/that/keeps/going/and/going",
+        "?q=1&r=2",
+    ]);
+
+    assert_eq!(detected[0], vec![(6..37, FULL_URL.to_owned())]);
+    assert_eq!(detected[1], vec![(0..32, FULL_URL.to_owned())]);
+    assert_eq!(detected[2], vec![(0..8, FULL_URL.to_owned())]);
+}
+
+#[test]
+fn test_single_line_url_detection_is_unchanged() {
+    let detected = detected_urls_by_line(&["see https://example.com/foo and more", "next line"]);
+
+    assert_eq!(
+        detected[0],
+        vec![(4..27, "https://example.com/foo".to_owned())]
+    );
+    assert!(detected[1].is_empty());
+}
+
+#[test]
+fn test_url_followed_by_prose_is_not_joined() {
+    let detected = detected_urls_by_line(&["Visit https://example.com", "This is a sentence."]);
+
+    // Joining would have produced `https://example.comThis`.
+    assert_eq!(detected[0], vec![(6..25, "https://example.com".to_owned())]);
+    assert!(detected[1].is_empty());
+}
+
+#[test]
+fn test_adjacent_independent_urls_stay_separate() {
+    let detected = detected_urls_by_line(&["https://example.com", "https://other.example.org"]);
+
+    assert_eq!(detected[0], vec![(0..19, "https://example.com".to_owned())]);
+    assert_eq!(
+        detected[1],
+        vec![(0..25, "https://other.example.org".to_owned())]
+    );
+}
+
+#[test]
+fn test_layout_rows_are_not_joined_onto_a_url() {
+    // A URL can never resume after a list marker, table delimiter or indentation, so each
+    // of these must leave the first line's URL exactly as detected on its own.
+    for continuation in [
+        "- another item",
+        "* another item",
+        "2. another item",
+        "│ cell │",
+        "|cell|",
+        "    indented/continuation",
+        "",
+    ] {
+        let detected = detected_urls_by_line(&["https://example.com/foo", continuation]);
+        assert_eq!(
+            detected[0],
+            vec![(0..23, "https://example.com/foo".to_owned())],
+            "unexpectedly joined continuation {continuation:?}"
+        );
+    }
+}
+
+#[test]
+fn test_reconstructed_ranges_are_char_based_not_byte_based() {
+    const FULL_URL: &str = "https://example.com/very/long/tail?x=1";
+    let detected = detected_urls_by_line(&["日本語 https://example.com/very/long", "/tail?x=1"]);
+
+    // "日本語 " is 4 chars but 10 bytes; the range must start at char 4.
+    assert_eq!(detected[0], vec![(4..33, FULL_URL.to_owned())]);
+    assert_eq!(detected[1], vec![(0..9, FULL_URL.to_owned())]);
+}
+
+#[test]
+fn test_urls_are_not_reconstructed_across_output_sections() {
+    let texts = vec![
+        (
+            "https://example.com/some/very/long/path?param1=value1&param\n".to_owned(),
+            TextLocation::Output {
+                section_index: 0,
+                line_index: 0,
+            },
+        ),
+        (
+            "2=value2&param3=value3\n".to_owned(),
+            TextLocation::Output {
+                section_index: 1,
+                line_index: 0,
+            },
+        ),
+    ];
+    let links = detect_all_links(&texts, vec![], None, None);
+
+    assert_eq!(
+        urls_in(
+            &links,
+            TextLocation::Output {
+                section_index: 0,
+                line_index: 0
+            }
+        ),
+        vec![(
+            0..59,
+            "https://example.com/some/very/long/path?param1=value1&param".to_owned()
+        )]
+    );
+    assert!(
+        urls_in(
+            &links,
+            TextLocation::Output {
+                section_index: 1,
+                line_index: 0
+            }
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn test_markdown_hyperlinks_take_precedence_over_reconstructed_urls() {
+    let texts = output_lines(&[
+        "https://example.com/some/very/long/path?param1=value1&param",
+        "2=value2&param3=value3",
+    ]);
+    let md_hyperlinks = vec![(
+        output_line(0),
+        vec![(0..59, "https://override.example".to_owned())],
+    )];
+    let links = detect_all_links(&texts, md_hyperlinks, None, None);
+
+    assert_eq!(
+        urls_in(&links, output_line(0)),
+        vec![(0..59, "https://override.example".to_owned())]
+    );
+}


### PR DESCRIPTION
## Description

Fixes Cmd+click opening only the first-line portion of a URL that arrives split across several lines of rich CLI-agent / AI output.

CLI agents hard-wrap their own TUI output, so a long URL reaches Warp as several `FormattedTextLine`s. `collect_output_data_for_link_detection` pushes each formatted line as its own `(String, TextLocation)`, and `detect_all_links` then runs `detect_urls` independently per line. Only the fragment that independently parses as a URL is detected, so `AIBlock::open_link` opens that truncated target.

This PR rebuilds the logical URL before detection (Option B from the tech spec in #9989):

- Adjacent formatted lines are grouped into runs that share a `section_index` and have consecutive `line_index`es, so joining can never cross output sections, code blocks, tables, images, or action rows.
- Within a run, a URL that touches the end of a line is grown onto the next line, and the reconstructed range is mapped back to **per-line** clickable ranges. Every participating segment stores the *full* URL, so Cmd+clicking any visual line opens the whole link while hover/registration stays per rendered line exactly as before.
- Markdown hyperlinks keep precedence, since they are still applied last.

Joining is deliberately conservative and prefers false negatives over a wrong target. A continuation is rejected when it:

- starts a new layout row — leading whitespace, `-`/`*`/`+`/`#`/ordered-list markers, or table/box-drawing glyphs;
- opens its own URL (two stacked links stay separate);
- only contributes a bare word to a URL that was already complete (`https://example.com` followed by `This is a sentence.` must not become `https://example.comThis`);
- would exceed 1000 characters, mirroring `URL_SCAN_CHARACTER_MAX_COUNT` in the terminal-grid path, or span more than 32 lines.

Ranges are char-based throughout, matching the existing `Range<usize>` semantics used by `FormattedTextElement`, and the trailing newline that `raw_text()` appends is stripped before offsets are computed.

## Linked Issue

Closes #9385 (tech spec: #9989)

> Linked with `Closes` so Oz can pick this up — but please re-check before merge. As explained in the open question below, this fixes the rich-output path that the tech spec scopes, while the reporter's `claude` CLI session most likely runs through the terminal-grid path instead. If that's confirmed, #9385 should stay open (or get a follow-up) rather than auto-close on merge.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Nine regression tests added in `app/src/util/link_detection_tests.rs`, driving the real `detect_all_links` entry point:

| Test | Covers |
| --- | --- |
| `test_reconstructs_url_hard_wrapped_across_two_lines` | the reported repro; both lines resolve to the full URL |
| `test_reconstructs_url_hard_wrapped_across_three_lines` | three-line reconstruction |
| `test_single_line_url_detection_is_unchanged` | no behaviour change for unwrapped URLs |
| `test_url_followed_by_prose_is_not_joined` | prose is not swallowed |
| `test_adjacent_independent_urls_stay_separate` | stacked links stay separate |
| `test_layout_rows_are_not_joined_onto_a_url` | bullets, ordered lists, `\|` and `│` table rows, indentation, blank lines |
| `test_reconstructed_ranges_are_char_based_not_byte_based` | multi-byte text before the URL |
| `test_urls_are_not_reconstructed_across_output_sections` | no stitching across sections |
| `test_markdown_hyperlinks_take_precedence_over_reconstructed_urls` | markdown hyperlink precedence |

```
cargo test -p warp --lib -- util::link_detection
test result: ok. 23 passed; 0 failed
```

`./script/format --check` and `./script/check_no_inline_test_modules` pass.

- [ ] I have manually tested my changes locally with `./script/run`

**I was not able to do the required manual verification**, and I would rather say so than check the box. This was developed on Linux and I have no macOS build to reproduce the original Claude Code session against. Everything above is automated-test evidence only. Happy for a maintainer to take it for a spin, or I can pair with someone who can run the Mac build.

## Question for maintainers: should the terminal-grid path be covered too?

The tech spec (§6) says explicitly not to change terminal-grid behaviour, so this PR does not. While verifying, though, I probed `GridHandler::url_at_point` directly, and it reproduces the reported symptom whenever a TUI emits **real newlines** instead of letting the terminal soft-wrap:

```
HARD (\r\n, TUI wrapped it itself)   row0 => Link(row 0, col 0..59)   <- truncated
                                     row1 => None
SOFT (\n, terminal reflowed)         row0 => Link(row 0 -> row 1)     <- already correct
```

That matters because the reporter's case is the `claude` CLI running as an ordinary subprocess. Its output goes through the terminal grid, not through `AIAgentOutput` — so I don't think this PR alone fixes the original reproduction, even though it does fix the class of bug the spec describes for rich output. It's possible the auto-triage attributed it to the rich path more confidently than the evidence supports.

Extending the fix into the grid would mean joining across hard newlines, which is currently deliberate (`test_find_url_line_breaks` asserts it) and which @zachlloyd flagged as risky for arbitrary TUI layouts such as tables.

One signal exists in the grid that the rich-text path doesn't have: **a TUI hard-wrap always breaks at the terminal width**, so a join could additionally require the preceding row to be full-width. Rows that merely happen to end in a URL would be left alone, which should keep the false-positive surface close to zero while still fixing wrapped OAuth/login URLs.

Would you like that in this PR, as a follow-up, or not at all? Happy to implement it either way — I just didn't want to silently contradict the spec.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Cmd+clicking a URL that wraps across multiple lines of AI and CLI-agent output now opens the whole URL instead of just the first line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
