### PR TITLE
Auto-attach the Warp-hosted Factory MCP server to agents (dogfood)

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -236,6 +236,9 @@ impl RequestParams {
                     .values(),
             );
 
+            // Include built-in Warp-hosted servers (e.g. the Factory MCP).
+            active_servers.extend(templatable_manager.get_active_builtin_servers().values());
+
             let servers: Vec<MCPServer> = active_servers
                 .into_iter()
                 .map(|server| MCPServer {

--- a/app/src/ai/mcp/builtin.rs
+++ b/app/src/ai/mcp/builtin.rs
@@ -1,0 +1,112 @@
+//! Built-in Warp-hosted MCP servers.
+//!
+//! Built-in servers are attached automatically for logged-in users: their
+//! definitions are constructed in code and authenticated with the user's
+//! existing session credentials (warp-server accepts both session ID tokens
+//! and API keys as `Bearer` credentials), so they require no MCP
+//! configuration and no manually minted API key.
+//!
+//! Lifecycle is owned by [`TemplatableMCPServerManager::sync_builtin_servers`]
+//! (attach on login, re-attach on token rotation, detach on logout), gated by
+//! [`warp_core::features::FeatureFlag::FactoryMcp`].
+//!
+//! [`TemplatableMCPServerManager::sync_builtin_servers`]: super::TemplatableMCPServerManager::sync_builtin_servers
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+use warp_core::channel::ChannelState;
+
+use super::templatable::{JsonTemplate, TemplatableMCPServer};
+use super::templatable_installation::TemplatableMCPServerInstallation;
+use crate::auth::credentials::Credentials;
+
+/// Stable installation UUID for the built-in Factory MCP server, so lifecycle
+/// state, request grouping, and respawns are keyed consistently.
+pub const FACTORY_MCP_INSTALLATION_UUID: Uuid =
+    Uuid::from_u128(0xfac70a11_a55e_4bde_9c3a_1c0ffee0f001);
+
+/// Stable template UUID for the built-in Factory MCP server. Log files are
+/// keyed by template UUID, so keeping it constant keeps one log per server
+/// across respawns.
+const FACTORY_MCP_TEMPLATE_UUID: Uuid = Uuid::from_u128(0xfac70a11_a55e_4bde_9c3a_1c0ffee0f002);
+
+/// The server name under which the Factory MCP's tools are grouped.
+pub const FACTORY_MCP_SERVER_NAME: &str = "warp-factory";
+
+/// Returns the bearer token built-in servers should authenticate with, or
+/// `None` when the current credentials cannot be used for one.
+///
+/// A Firebase token that expires within the next couple of minutes is treated
+/// as unusable: spawning with it would race expiry, and a 401 on the
+/// connection preflight would misroute the built-in server into the
+/// interactive MCP OAuth flow. The app's request layer refreshes tokens
+/// within a five-minute window (see `AuthSession::get_or_refresh_access_token`),
+/// and the manager respawns on the resulting `AccessTokenRefreshed` event.
+pub fn builtin_bearer_token(credentials: &Credentials) -> Option<String> {
+    if let Some(tokens) = credentials.as_firebase() {
+        let min_validity = chrono::Duration::minutes(2);
+        if chrono::Local::now().fixed_offset() + min_validity >= tokens.expiration_time {
+            return None;
+        }
+    }
+    credentials.bearer_token().bearer_token()
+}
+
+/// Builds the ephemeral installation for the built-in Factory MCP server: a
+/// streamable-HTTP MCP server hosted by warp-server at `/api/v1/mcp/factory`,
+/// pre-authenticated via the `Authorization` header.
+pub fn factory_mcp_installation(bearer_token: &str) -> TemplatableMCPServerInstallation {
+    factory_mcp_installation_for_server_root(&ChannelState::server_root_url(), bearer_token)
+}
+
+/// Like [`factory_mcp_installation`], with an explicit server root for tests.
+fn factory_mcp_installation_for_server_root(
+    server_root: &str,
+    bearer_token: &str,
+) -> TemplatableMCPServerInstallation {
+    let server_config = serde_json::json!({
+        "url": factory_mcp_url(server_root),
+        "headers": {
+            "Authorization": format!("Bearer {bearer_token}"),
+        },
+    });
+    let mut root = serde_json::Map::new();
+    root.insert(FACTORY_MCP_SERVER_NAME.to_string(), server_config);
+    let template_json = serde_json::Value::Object(root).to_string();
+
+    let templatable_mcp_server = TemplatableMCPServer {
+        uuid: FACTORY_MCP_TEMPLATE_UUID,
+        name: FACTORY_MCP_SERVER_NAME.to_string(),
+        description: Some(
+            "Warp's hosted Factory MCP server. Work with your team's software factories: \
+             list factories and their tasks, inspect a task's status and outputs, and send \
+             work in or hand it back."
+                .to_string(),
+        ),
+        template: JsonTemplate {
+            json: template_json,
+            // Fully resolved: the token is baked into the header, so there
+            // are no variables to prompt for.
+            variables: Vec::new(),
+        },
+        // Constant version: the definition is code-managed, not user-editable.
+        version: 0,
+        gallery_data: None,
+    };
+
+    TemplatableMCPServerInstallation::new(
+        FACTORY_MCP_INSTALLATION_UUID,
+        templatable_mcp_server,
+        HashMap::new(),
+    )
+}
+
+/// Joins the Factory MCP endpoint path onto a server root URL.
+fn factory_mcp_url(server_root: &str) -> String {
+    format!("{}/api/v1/mcp/factory", server_root.trim_end_matches('/'))
+}
+
+#[cfg(test)]
+#[path = "builtin_tests.rs"]
+mod tests;

--- a/app/src/ai/mcp/builtin_tests.rs
+++ b/app/src/ai/mcp/builtin_tests.rs
@@ -1,0 +1,87 @@
+use chrono::Duration;
+
+use super::*;
+use crate::ai::mcp::parsing::resolve_json;
+use crate::ai::mcp::{MCPServer, MCPServerExt as _, TransportType};
+use crate::auth::user::FirebaseAuthTokens;
+
+fn firebase_credentials(expires_in: Duration) -> Credentials {
+    Credentials::Firebase(FirebaseAuthTokens {
+        id_token: "firebase-id-token".to_string(),
+        refresh_token: "refresh-token".to_string(),
+        expiration_time: chrono::Local::now().fixed_offset() + expires_in,
+    })
+}
+
+#[test]
+fn bearer_token_uses_a_valid_firebase_id_token() {
+    assert_eq!(
+        builtin_bearer_token(&firebase_credentials(Duration::hours(1))),
+        Some("firebase-id-token".to_string())
+    );
+}
+
+#[test]
+fn bearer_token_rejects_a_firebase_token_about_to_expire() {
+    assert_eq!(
+        builtin_bearer_token(&firebase_credentials(Duration::seconds(30))),
+        None
+    );
+}
+
+#[test]
+fn bearer_token_uses_api_keys() {
+    let credentials = Credentials::ApiKey {
+        key: "wk-test-key".to_string(),
+        owner_type: None,
+    };
+    assert_eq!(
+        builtin_bearer_token(&credentials),
+        Some("wk-test-key".to_string())
+    );
+}
+
+#[test]
+fn bearer_token_rejects_session_cookie_auth() {
+    assert_eq!(builtin_bearer_token(&Credentials::SessionCookie), None);
+}
+
+#[test]
+fn factory_mcp_url_joins_server_roots_with_and_without_trailing_slash() {
+    assert_eq!(
+        factory_mcp_url("https://app.warp.dev"),
+        "https://app.warp.dev/api/v1/mcp/factory"
+    );
+    assert_eq!(
+        factory_mcp_url("http://localhost:8080/"),
+        "http://localhost:8080/api/v1/mcp/factory"
+    );
+}
+
+#[test]
+fn factory_installation_resolves_to_a_preauthenticated_http_server() {
+    let installation =
+        factory_mcp_installation_for_server_root("https://staging.warp.dev", "tok-123");
+    assert_eq!(installation.uuid(), FACTORY_MCP_INSTALLATION_UUID);
+    // Fully resolved: nothing for the variable-prompt UI to ask for, and
+    // nothing for handlebars to substitute at spawn time.
+    assert!(installation.template_variables().is_empty());
+
+    // The resolved JSON must parse into a single HTTP server with the
+    // pre-authenticated header, exactly as `spawn_server_impl` will see it.
+    let resolved = resolve_json(&installation);
+    let mut servers =
+        MCPServer::from_user_json(&resolved).expect("built-in template must parse as MCP config");
+    assert_eq!(servers.len(), 1);
+    let server = servers.pop().expect("one server");
+    assert_eq!(server.name, FACTORY_MCP_SERVER_NAME);
+    match server.transport_type {
+        TransportType::ServerSentEvents(sse) => {
+            assert_eq!(sse.url, "https://staging.warp.dev/api/v1/mcp/factory");
+            assert_eq!(sse.headers.len(), 1);
+            assert_eq!(sse.headers[0].name, "Authorization");
+            assert_eq!(sse.headers[0].value, "Bearer tok-123");
+        }
+        TransportType::CLIServer(_) => panic!("expected an HTTP transport"),
+    }
+}

--- a/app/src/ai/mcp/mod.rs
+++ b/app/src/ai/mcp/mod.rs
@@ -49,6 +49,8 @@ cfg_if::cfg_if! {
 
 pub mod gallery;
 pub use gallery::MCPGalleryManager;
+#[cfg(not(target_family = "wasm"))]
+pub mod builtin;
 pub mod templatable;
 #[cfg(not(target_family = "wasm"))]
 pub use cloud_object_models::{

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -91,6 +91,15 @@ pub struct TemplatableMCPServerManager {
     /// spawned automatically from in-code definitions and authenticated with
     /// the logged-in user's session credentials.
     builtin_server_uuids: HashSet<Uuid>,
+    /// The bearer credential the current built-in server spawn was created
+    /// with. Compared on credential-rotation events so back-to-back auth
+    /// events with the same token (common at startup) don't respawn the
+    /// server and open redundant server-side MCP sessions.
+    ///
+    /// Native-only like the spawn path that reads it; on wasm the built-in
+    /// server is never spawned, so the field would be dead code there.
+    #[cfg(not(target_family = "wasm"))]
+    builtin_server_token: Option<String>,
 }
 
 /// Information about a spawned server task.

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -87,6 +87,10 @@ pub struct TemplatableMCPServerManager {
     /// UUIDs of MCP servers started via the Oz CLI. We track these so they can be distinguished from
     /// file-based ephemeral MCP servers, which are directory-scoped.
     cli_spawned_server_uuids: HashSet<Uuid>,
+    /// UUIDs of built-in Warp-hosted servers (e.g. the Factory MCP), which are
+    /// spawned automatically from in-code definitions and authenticated with
+    /// the logged-in user's session credentials.
+    builtin_server_uuids: HashSet<Uuid>,
 }
 
 /// Information about a spawned server task.
@@ -301,6 +305,15 @@ impl TemplatableMCPServerManager {
     /// Returns CLI-spawned ephemeral servers (started via `oz agent run --mcp`) that are currently active.
     pub fn get_active_cli_spawned_servers(&self) -> HashMap<Uuid, &TemplatableMCPServerInfo> {
         self.cli_spawned_server_uuids
+            .iter()
+            .filter_map(|uuid| self.active_servers.get(uuid).map(|info| (*uuid, info)))
+            .collect()
+    }
+
+    /// Returns built-in Warp-hosted servers (e.g. the Factory MCP) that are
+    /// currently active.
+    pub fn get_active_builtin_servers(&self) -> HashMap<Uuid, &TemplatableMCPServerInfo> {
+        self.builtin_server_uuids
             .iter()
             .filter_map(|uuid| self.active_servers.get(uuid).map(|info| (*uuid, info)))
             .collect()

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -94,10 +94,9 @@ pub struct TemplatableMCPServerManager {
     /// The bearer credential the current built-in server spawn was created
     /// with. Compared on credential-rotation events so back-to-back auth
     /// events with the same token (common at startup) don't respawn the
-    /// server and open redundant server-side MCP sessions.
-    ///
-    /// Native-only like the spawn path that reads it; on wasm the built-in
-    /// server is never spawned, so the field would be dead code there.
+    /// server and open redundant server-side MCP sessions. Native-only like
+    /// the spawn path that reads it; on wasm the built-in server is never
+    /// spawned, so the field would be dead code there.
     #[cfg(not(target_family = "wasm"))]
     builtin_server_token: Option<String>,
 }

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -19,6 +19,7 @@ use warp_core::features::FeatureFlag;
 use warp_core::safe_error;
 use warp_core::settings::Setting as _;
 use warp_errors::report_error;
+use warp_server_client::auth::AuthEvent;
 use warpui::windowing::WindowManager;
 use warpui::{AppContext, ModelContext, SingletonEntity};
 
@@ -26,9 +27,6 @@ use super::{
     MCPServerState, SpawnedServerInfo, TemplatableMCPServerInfo, TemplatableMCPServerManager,
     TemplatableMCPServerManagerEvent,
 };
-use warp_server_client::auth::AuthEvent;
-
-use crate::ai::mcp::builtin;
 use crate::ai::mcp::file_based_manager::FileBasedMCPManagerEvent;
 use crate::ai::mcp::parsing::resolve_json;
 use crate::ai::mcp::templatable::{CloudTemplatableMCPServer, GalleryData};
@@ -37,7 +35,7 @@ use crate::ai::mcp::templatable_manager::FigmaMcpStatus;
 use crate::ai::mcp::{
     Author, CloudMCPServer, FileBasedMCPManager, JsonTemplate, MCPGalleryManager, MCPServer,
     MCPServerExt, MCPServerUpdate, ParsedTemplatableMCPServerResult, StaticEnvVar,
-    TemplatableMCPServer, TemplatableMCPServerInstallation, TransportType, logs,
+    TemplatableMCPServer, TemplatableMCPServerInstallation, TransportType, builtin, logs,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -410,6 +410,7 @@ impl TemplatableMCPServerManager {
             authorization_urls: Default::default(),
             cli_spawned_server_uuids: Default::default(),
             builtin_server_uuids: Default::default(),
+            builtin_server_token: Default::default(),
         };
 
         me.fetch_cloud_servers(ctx);
@@ -787,6 +788,7 @@ impl TemplatableMCPServerManager {
                 self.shutdown_server(installation_uuid, ctx);
             }
             self.builtin_server_uuids.remove(&installation_uuid);
+            self.builtin_server_token = None;
             return;
         }
 
@@ -805,11 +807,20 @@ impl TemplatableMCPServerManager {
             return;
         };
 
+        // Auth events cluster at startup (login completion, user refresh,
+        // token refresh) and usually carry the same credential. Respawning
+        // for each would open a redundant server-side MCP session per event,
+        // so only respawn when the effective bearer actually changed.
+        if is_active && self.builtin_server_token.as_deref() == Some(token.as_str()) {
+            return;
+        }
+
         if is_active {
             self.shutdown_server(installation_uuid, ctx);
         }
         log::info!("Spawning the built-in Factory MCP server");
         self.builtin_server_uuids.insert(installation_uuid);
+        self.builtin_server_token = Some(token.clone());
         self.spawn_ephemeral_server(builtin::factory_mcp_installation(&token), ctx);
     }
 

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -26,6 +26,9 @@ use super::{
     MCPServerState, SpawnedServerInfo, TemplatableMCPServerInfo, TemplatableMCPServerManager,
     TemplatableMCPServerManagerEvent,
 };
+use warp_server_client::auth::AuthEvent;
+
+use crate::ai::mcp::builtin;
 use crate::ai::mcp::file_based_manager::FileBasedMCPManagerEvent;
 use crate::ai::mcp::parsing::resolve_json;
 use crate::ai::mcp::templatable::{CloudTemplatableMCPServer, GalleryData};
@@ -37,6 +40,7 @@ use crate::ai::mcp::{
     TemplatableMCPServer, TemplatableMCPServerInstallation, TransportType, logs,
 };
 use crate::auth::AuthStateProvider;
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::cloud_object::{
     CloudObject, CloudObjectLocation, CloudObjectLookup as _, CloudObjectMetadataExt,
@@ -48,6 +52,7 @@ use crate::persistence::{
 };
 use crate::server::cloud_objects::update_manager::{InitiatedBy, UpdateManager};
 use crate::server::ids::{ClientId, ServerId, SyncId};
+use crate::server::server_api::ServerApiProvider;
 use crate::server::telemetry::{
     MCPServerModel, MCPServerTelemetryTransportType, MCPTemplateCreationSource, TelemetryEvent,
 };
@@ -350,6 +355,38 @@ impl TemplatableMCPServerManager {
             _ => {}
         });
 
+        // Built-in Warp-hosted MCP servers follow the user's auth lifecycle:
+        // attach after login, re-attach with fresh credentials when the
+        // access token rotates, and detach on logout. Skipped in tests, which
+        // construct the manager without the auth singletons.
+        if !cfg!(test) {
+            let auth_manager = AuthManager::handle(ctx);
+            ctx.subscribe_to_model(&auth_manager, |me, _, event, ctx| match event {
+                // Fires on login and on user refresh; the credentials may
+                // have rotated either way, so respawn with the current token.
+                AuthManagerEvent::AuthComplete => me.sync_builtin_servers(true, ctx),
+                AuthManagerEvent::AuthFailed(_)
+                | AuthManagerEvent::NeedsReauth
+                | AuthManagerEvent::SkippedLogin => me.sync_builtin_servers(false, ctx),
+                AuthManagerEvent::CreateAnonymousUserFailed
+                | AuthManagerEvent::AttemptedLoginGatedFeature { .. }
+                | AuthManagerEvent::LoginOverrideDetected(_)
+                | AuthManagerEvent::MintCustomTokenFailed(_)
+                | AuthManagerEvent::ReceivedDeviceAuthorizationCode { .. } => {}
+            });
+
+            let server_api_provider = ServerApiProvider::handle(ctx);
+            ctx.subscribe_to_model(&server_api_provider, |me, _, event, ctx| match event {
+                // The transport captured the token it was spawned with, so a
+                // rotated token requires a respawn.
+                AuthEvent::AccessTokenRefreshed { .. } => me.sync_builtin_servers(true, ctx),
+                AuthEvent::StagingAccessBlocked
+                | AuthEvent::NeedsReauth
+                | AuthEvent::UserAccountDisabled
+                | AuthEvent::IapChallengeReceived => {}
+            });
+        }
+
         let database_connection =
             database_file_path_for_current_scope()
                 .to_str()
@@ -374,6 +411,7 @@ impl TemplatableMCPServerManager {
             pending_oauth_csrf: Default::default(),
             authorization_urls: Default::default(),
             cli_spawned_server_uuids: Default::default(),
+            builtin_server_uuids: Default::default(),
         };
 
         me.fetch_cloud_servers(ctx);
@@ -398,6 +436,12 @@ impl TemplatableMCPServerManager {
             for installation_uuid in running_server_uuids {
                 me.spawn_server(installation_uuid, ctx)
             }
+        }
+
+        // Attach built-in Warp-hosted servers for already-logged-in users
+        // (fresh logins are handled by the AuthManager subscription above).
+        if !cfg!(test) {
+            me.sync_builtin_servers(false, ctx);
         }
 
         // Migrate legacy MCPs to be templatables on app start. Uses UpdateManager
@@ -719,6 +763,56 @@ impl TemplatableMCPServerManager {
     ) {
         self.cli_spawned_server_uuids.insert(installation.uuid());
         self.spawn_ephemeral_server(installation, ctx);
+    }
+
+    /// Reconciles built-in Warp-hosted MCP servers (currently the Factory
+    /// MCP) with the feature-flag and auth state: spawns the server when it
+    /// should be running and isn't, and shuts it down when it shouldn't be.
+    /// Safe to call repeatedly.
+    ///
+    /// `force_respawn` restarts an already-running server so it picks up
+    /// rotated credentials: the transport keeps the `Authorization` header it
+    /// was spawned with.
+    pub fn sync_builtin_servers(&mut self, force_respawn: bool, ctx: &mut ModelContext<Self>) {
+        let installation_uuid = builtin::FACTORY_MCP_INSTALLATION_UUID;
+        let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
+        // Built-ins attach only in interactive clients (GUI and TUI); CLI
+        // agent runs manage their MCP servers explicitly.
+        let eligible = FeatureFlag::FactoryMcp.is_enabled()
+            && AppExecutionMode::as_ref(ctx).can_autostart_mcp_servers()
+            && !auth_state.is_anonymous_or_logged_out();
+        let is_active = self.is_server_active_or_pending(installation_uuid);
+
+        if !eligible {
+            if is_active {
+                log::info!("Shutting down the built-in Factory MCP server (no longer eligible)");
+                self.shutdown_server(installation_uuid, ctx);
+            }
+            self.builtin_server_uuids.remove(&installation_uuid);
+            return;
+        }
+
+        if is_active && !force_respawn {
+            return;
+        }
+
+        // A missing token here means the current one is about to expire; the
+        // AccessTokenRefreshed subscription calls back in with a fresh one
+        // once the app's request layer refreshes it.
+        let Some(token) = auth_state
+            .credentials()
+            .and_then(|credentials| builtin::builtin_bearer_token(&credentials))
+        else {
+            log::debug!("Built-in Factory MCP server: no usable bearer token yet; waiting");
+            return;
+        };
+
+        if is_active {
+            self.shutdown_server(installation_uuid, ctx);
+        }
+        log::info!("Spawning the built-in Factory MCP server");
+        self.builtin_server_uuids.insert(installation_uuid);
+        self.spawn_ephemeral_server(builtin::factory_mcp_installation(&token), ctx);
     }
 
     /// Spawns a new MCP server from a given installation UUID.

--- a/app/src/auth/mod.rs
+++ b/app/src/auth/mod.rs
@@ -31,6 +31,8 @@ use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::OrchestrationPillBarModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+#[cfg(not(target_family = "wasm"))]
+use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::ai_assistant::requests::REQUEST_LIMIT_INFO_CACHE_KEY;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::code::editor_management::{CodeEditorStatus, CodeEditorSummary};
@@ -245,6 +247,12 @@ pub fn log_out(app: &mut AppContext) {
 
     AuthManager::handle(app).update(app, |auth_manager, ctx| {
         auth_manager.log_out(ctx);
+    });
+    // Detach built-in Warp-hosted MCP servers; they authenticate with the
+    // credentials that were just cleared.
+    #[cfg(not(target_family = "wasm"))]
+    TemplatableMCPServerManager::handle(app).update(app, |manager, ctx| {
+        manager.sync_builtin_servers(false, ctx);
     });
     BlocklistAIHistoryModel::handle(app).update(app, |history_model, _| {
         history_model.reset();

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -926,6 +926,12 @@ pub enum FeatureFlag {
     /// `warp_id` values in MCP configs and as bare identifiers in CLI
     /// `--mcp` arguments, resolved server-side at run setup.
     WellKnownMcpIds,
+
+    /// Automatically attaches the Warp-hosted Factory MCP server
+    /// (`/api/v1/mcp/factory`) to agents as a built-in MCP server,
+    /// authenticated with the logged-in user's session token. No manual MCP
+    /// setup or API key required.
+    FactoryMcp,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -1001,6 +1007,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::GeminiEnterprise,
     FeatureFlag::BoxDrawingGlyphs,
     FeatureFlag::WellKnownMcpIds,
+    FeatureFlag::FactoryMcp,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

Auto-attaches the Warp-hosted **Factory MCP server** (`/api/v1/mcp/factory`, dogfood on staging/local) to Warp agents as a **built-in MCP server** — no manual MCP configuration and no API key minting. This replaces the manual setup flow documented in warp-server's `specs/factory-mcp/DOGFOOD.md` for Warp clients (external clients like Claude Code/Cursor still use API keys).

**How it works**
- New `app/src/ai/mcp/builtin.rs`: constructs an ephemeral `warp-factory` installation in code — streamable-HTTP server at `<server_root>/api/v1/mcp/factory` with a pre-set `Authorization: Bearer` header. warp-server's public-API auth accepts both **session ID tokens** and API keys on that header, so the client authenticates with the credentials it already holds.
- Lifecycle in `TemplatableMCPServerManager::sync_builtin_servers` (reconciler, safe to call repeatedly):
  - attach at startup for already-logged-in users and on `AuthManagerEvent::AuthComplete` (login + user refresh)
  - respawn with fresh credentials on `AuthEvent::AccessTokenRefreshed` (the transport captures the header it was spawned with)
  - detach on logout (`auth::log_out`) and whenever ineligible
  - never spawns with a Firebase token <2 min from expiry, so the connection preflight can't 401 into the interactive MCP OAuth flow — the rotation event respawns instead
- Built-ins attach in **interactive clients only** (GUI + TUI, via `can_autostart_mcp_servers()`); CLI (`oz agent run`) keeps managing MCP servers explicitly via `--mcp`.
- Agent requests include built-ins via a new `get_active_builtin_servers()` group in `RequestParams::new` (mirrors the CLI-spawned group); the flat (non-grouped) path already includes all active servers.
- Hidden from MCP settings for v1 (not a persisted installation); a read-only settings row is a possible follow-up.
- Gated by the new `FactoryMcp` flag (dogfood builds only). Server-side, the `factory_mcp` flag is staging/local-only; if the endpoint is absent the built-in simply fails to start without affecting agents.

## Linked Issue
Client-side follow-up to the Factory MCP dogfood stack in warp-server (warpdotdev/warp-server#13237, #13239, #13243, #13246). Cloud-agent (Oz harness) native attachment is tracked separately as REMOTE-2310.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing
- Unit tests (`app/src/ai/mcp/builtin_tests.rs`): bearer-token eligibility matrix (valid Firebase token, near-expiry Firebase token rejected, API keys accepted, session-cookie auth rejected), URL joining with/without trailing slash, and an end-to-end assertion that the generated template resolves and parses into a single HTTP `MCPServer` with the pre-authenticated header — exactly what `spawn_server_impl` consumes.
- `cargo check -p warp -p warp_features`, `cargo nextest run -p warp -E 'test(/ai::mcp::builtin/)'` (6/6 pass), `cargo fmt`, and `cargo clippy -p warp -p warp_features --all-targets -- -D warnings` all clean.
- [ ] I have manually tested my changes locally with `./script/run`
  - Manual verification plan (needs a local warp-server with the `factory_mcp` flag + a seeded factory): `SERVER_ROOT_URL=http://localhost:8083 ... cargo run --features with_local_server`, confirm `warp-factory` tools appear in an agent conversation with zero MCP config, and that logout stops the server. No UI surface changes (tools attach silently), so no screenshots.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Generated with [Warp](https://staging.warp.dev/conversation/4dd5e31a-12af-4dcc-bb07-28809e10eae2)

Co-Authored-By: Oz <oz-agent@warp.dev>
