### PR TITLE
Add 'assign distinct color to new tab groups' setting

### DIFF
--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -95,7 +95,7 @@ use crate::workspace::header_toolbar_editor::HeaderToolbarInlineEditor;
 use crate::workspace::tab_settings::{
     DirectoryTabColor, HideTitleBarSearchBarInVerticalTabs, PreserveActiveTabColor,
     ShowCodeReviewButton, ShowIndicatorsButton, ShowVerticalTabPanelInRestoredWindows,
-    TabCloseButtonPosition, TabSettings, TabSettingsChangedEvent,
+    TabCloseButtonPosition, TabGroupAutoColor, TabSettings, TabSettingsChangedEvent,
     UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
     WorkspaceDecorationVisibility, canonical_directory_key,
 };
@@ -459,6 +459,17 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
         flags::PRESERVE_ACTIVE_TAB_COLOR_FLAG,
     ));
 
+    if FeatureFlag::GroupedTabs.is_enabled() {
+        toggle_binding_pairs.push(ToggleSettingActionPair::new(
+            "tab group auto color",
+            builder(SettingsAction::AppearancePageToggle(
+                AppearancePageAction::ToggleTabGroupAutoColor,
+            )),
+            context,
+            flags::TAB_GROUP_AUTO_COLOR_FLAG,
+        ));
+    }
+
     toggle_binding_pairs.push(ToggleSettingActionPair::new(
         "custom padding in alt-screen",
         builder(SettingsAction::AppearancePageToggle(
@@ -526,6 +537,7 @@ pub enum AppearancePageAction {
     ToggleTabIndicators,
     ToggleShowCodeReviewButton,
     TogglePreserveActiveTabColor,
+    ToggleTabGroupAutoColor,
     ToggleVerticalTabs,
     ToggleShowVerticalTabPanelInRestoredWindows,
     ToggleHideTitleBarSearchBarInVerticalTabs,
@@ -708,6 +720,7 @@ impl TypedActionView for AppearanceSettingsPageView {
             ToggleTabIndicators => self.toggle_tab_indicators(ctx),
             ToggleShowCodeReviewButton => self.toggle_show_code_review_button(ctx),
             TogglePreserveActiveTabColor => self.toggle_preserve_active_tab_color(ctx),
+            ToggleTabGroupAutoColor => self.toggle_tab_group_auto_color(ctx),
             ToggleVerticalTabs => self.toggle_vertical_tabs(ctx),
             ToggleShowVerticalTabPanelInRestoredWindows => {
                 self.toggle_show_vertical_tab_panel_in_restored_windows(ctx)
@@ -1540,6 +1553,10 @@ impl AppearanceSettingsPageView {
             tab_settings_widgets.push(Box::new(TabCloseButtonPositionWidget::default()));
         }
         tab_settings_widgets.push(Box::new(PreserveActiveTabColorWidget::default()));
+
+        if FeatureFlag::GroupedTabs.is_enabled() {
+            tab_settings_widgets.push(Box::new(TabGroupAutoColorWidget::default()));
+        }
 
         if FeatureFlag::VerticalTabs.is_enabled() {
             tab_settings_widgets.push(Box::new(VerticalTabsWidget::default()));
@@ -2498,6 +2515,12 @@ impl AppearanceSettingsPageView {
                     .show_code_review_button
                     .set_value(new_value, ctx)
             );
+        });
+    }
+
+    fn toggle_tab_group_auto_color(&mut self, ctx: &mut ViewContext<Self>) {
+        TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+            report_if_error!(settings.tab_group_auto_color.toggle_and_save_value(ctx));
         });
     }
 
@@ -4981,6 +5004,54 @@ impl SettingsWidget for PreserveActiveTabColorWidget {
                 })
                 .finish(),
             None,
+        )
+    }
+}
+
+#[derive(Default)]
+struct TabGroupAutoColorWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for TabGroupAutoColorWidget {
+    type View = AppearanceSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "tab group color auto assign distinct random"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let tab_settings = TabSettings::as_ref(app);
+
+        render_body_item::<AppearancePageAction>(
+            "Assign new tab groups a distinct color".into(),
+            None,
+            LocalOnlyIconState::for_setting(
+                TabGroupAutoColor::storage_key(),
+                TabGroupAutoColor::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .switch(self.switch_state.clone())
+                .check(*tab_settings.tab_group_auto_color)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(AppearancePageAction::ToggleTabGroupAutoColor);
+                })
+                .finish(),
+            Some(
+                "When enabled, each new tab group is automatically assigned a color not already used by another group."
+                    .to_string(),
+            ),
         )
     }
 }

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -518,6 +518,7 @@ pub mod flags {
     pub const AUTO_OPEN_CODE_REVIEW_PANE_FLAG: &str = "Auto_Open_Code_Review_Pane_Enabled";
     pub const USE_VERTICAL_TABS_FLAG: &str = "Use_Vertical_Tabs";
     pub const PRESERVE_ACTIVE_TAB_COLOR_FLAG: &str = "Preserve_Active_Tab_Color";
+    pub const TAB_GROUP_AUTO_COLOR_FLAG: &str = "Tab_Group_Auto_Color";
     pub const SHOW_VERTICAL_TAB_PANEL_IN_RESTORED_WINDOWS_FLAG: &str =
         "Show_Vertical_Tab_Panel_In_Restored_Windows";
     pub const USE_LATEST_USER_PROMPT_AS_CONVERSATION_TITLE_IN_TAB_NAMES_FLAG: &str =

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -577,6 +577,17 @@ define_settings_group!(TabSettings, settings: [
     workspace_decoration_visibility: WorkspaceDecorationVisibility,
     close_button_position: TabCloseButtonPosition,
     directory_tab_colors: DirectoryTabColors,
+    tab_group_auto_color: TabGroupAutoColor {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        surface: settings::SettingSurfaces::GUI,
+        private: false,
+        toml_path: "appearance.tabs.tab_group_auto_color",
+        description: "Whether new tab groups are automatically assigned a distinct color.",
+        feature_flag: warp_core::features::FeatureFlag::GroupedTabs,
+    },
 ]);
 
 #[cfg(test)]

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3819,7 +3819,8 @@ impl Workspace {
             }
             | TabSettingsChangedEvent::VerticalTabsShowPrLink { .. }
             | TabSettingsChangedEvent::VerticalTabsShowDiffStats { .. }
-            | TabSettingsChangedEvent::HideTitleBarSearchBarInVerticalTabs { .. } => {
+            | TabSettingsChangedEvent::HideTitleBarSearchBarInVerticalTabs { .. }
+            | TabSettingsChangedEvent::TabGroupAutoColor { .. } => {
                 ctx.notify();
             }
             TabSettingsChangedEvent::VerticalTabsShowDetailsOnHover { .. } => {
@@ -7205,7 +7206,13 @@ impl Workspace {
         };
         let previous_group_id = tab.group_id;
 
-        let group = TabGroup::new();
+        let auto_color = *TabSettings::as_ref(ctx).tab_group_auto_color.value();
+        let color = auto_color.then(|| self.pick_tab_group_color());
+
+        let mut group = TabGroup::new();
+        if let Some(c) = color {
+            group.color = SelectedTabColor::Color(c);
+        }
         let group_id = group.id;
         self.tab_groups.insert(group_id, group);
 
@@ -23009,6 +23016,9 @@ impl Workspace {
         }
         if *tab_settings.preserve_active_tab_color.value() {
             context.set.insert(flags::PRESERVE_ACTIVE_TAB_COLOR_FLAG);
+        }
+        if *tab_settings.tab_group_auto_color.value() {
+            context.set.insert(flags::TAB_GROUP_AUTO_COLOR_FLAG);
         }
         if *tab_settings
             .show_vertical_tab_panel_in_restored_windows

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -1,14 +1,18 @@
 use std::collections::HashSet;
 
 use itertools::{Either, Itertools};
+use settings::Setting as _;
 use warp_core::features::FeatureFlag;
-use warpui::{EntityId, UpdateView, ViewContext};
+use warp_core::ui::theme::AnsiColorIdentifier;
+use warpui::{EntityId, SingletonEntity, UpdateView, ViewContext};
 
 use super::{Workspace, group_member_indices};
 use crate::menu::{MenuItem, MenuItemFields};
-use crate::tab::{MOVE_TO_GROUP_LABEL, TabData};
+use crate::tab::{MOVE_TO_GROUP_LABEL, SelectedTabColor, TabData};
+use crate::ui_components::color_dot::TAB_COLOR_OPTIONS;
 use crate::workspace::action::{TabContextMenuAnchor, WorkspaceAction};
 use crate::workspace::tab_group::{TabGroup, TabGroupId};
+use crate::workspace::tab_settings::TabSettings;
 use crate::workspace::util::PaneViewLocator;
 
 // TODO(johnturcoo) move tab grouping helpers here from workspace/view.rs.
@@ -195,6 +199,27 @@ impl Workspace {
         }
     }
 
+    /// Returns the first color from `TAB_COLOR_OPTIONS` not already in use by
+    /// an existing tab group, cycling back to the start if all are taken.
+    pub(super) fn pick_tab_group_color(&self) -> AnsiColorIdentifier {
+        let used_colors: Vec<AnsiColorIdentifier> = self
+            .tab_groups
+            .values()
+            .filter_map(|g| {
+                if let SelectedTabColor::Color(c) = g.color {
+                    Some(c)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        TAB_COLOR_OPTIONS
+            .iter()
+            .copied()
+            .find(|c| !used_colors.contains(c))
+            .unwrap_or(TAB_COLOR_OPTIONS[0])
+    }
+
     /// "Create group from tabs" menu action. Group membership requires
     /// tabs to be contiguous in the bar, so we gather the selected tabs into
     /// a single block anchored at the earliest selected tab's position before
@@ -224,7 +249,13 @@ impl Workspace {
             .filter_map(|index| self.tabs[*index].group_id)
             .collect();
 
-        let group = TabGroup::new();
+        let auto_color = *TabSettings::as_ref(ctx).tab_group_auto_color.value();
+        let color = auto_color.then(|| self.pick_tab_group_color());
+
+        let mut group = TabGroup::new();
+        if let Some(c) = color {
+            group.color = SelectedTabColor::Color(c);
+        }
         let group_id = group.id;
         self.tab_groups.insert(group_id, group);
 


### PR DESCRIPTION
## Description

Adds a new setting **"Assign new tab groups a distinct color"** (disabled by default), gated on `FeatureFlag::GroupedTabs`. When enabled, each new tab group is automatically assigned the first color from the standard 6-color palette (Red, Green, Yellow, Blue, Magenta, Cyan) not already in use by another open group. When all colors are taken it wraps back to Red. This mirrors Chrome's tab group auto-color behavior.

### What changed

- **`tab_settings.rs`**: New `tab_group_auto_color` bool setting (default `false`), synced to cloud, gated on `GroupedTabs` feature flag, TOML path `appearance.tabs.tab_group_auto_color`.
- **`tab_grouping.rs`**: New `pick_tab_group_color` helper on `Workspace` that iterates `TAB_COLOR_OPTIONS` and returns the first one not in use by an existing group. Applied in `new_tab_group_from_selected_tabs`.
- **`view.rs`**: Applied `pick_tab_group_color` in `new_tab_group_from_tab`; added `TabGroupAutoColor` event arm to the exhaustive `TabSettingsChangedEvent` match; added the context flag.
- **`settings_view/mod.rs`**: Added `TAB_GROUP_AUTO_COLOR_FLAG` context flag constant.
- **`settings_view/appearance_page.rs`**: Added `ToggleTabGroupAutoColor` action, toggle handler, `TabGroupAutoColorWidget` (switch + description text), registered in the Tabs settings section gated on `GroupedTabs`, and wired up a Command Palette entry.

## Linked Issue

N/A

## Testing

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

The setting is off by default and only visible when `GroupedTabs` is enabled. When enabled, newly created tab groups get the first unused color from the palette automatically, making it easy to visually distinguish groups.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Tab groups now support "Assign new tab groups a distinct color" setting (disabled by default): when on, each new group gets the first unused color from the palette automatically.
-->

_Conversation: https://staging.warp.dev/conversation/e53d3a6b-9051-4357-adce-18252f08a9a8_
_Run: https://oz.staging.warp.dev/runs/019fa930-6389-725e-a5cd-00f36b095156_

_This PR was generated with [Oz](https://warp.dev/oz)._
