### PR TITLE
add grok sub byok support for TUI

### DIFF
--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -116,6 +116,11 @@ fn add_api_key_command_is_tui_only_and_requires_a_provider() {
         Some(LLMProvider::API_KEY_PROVIDER_VALUE_NAME)
     );
     assert!(
+        argument
+            .hint_text
+            .is_some_and(|hint| hint.split('|').any(|provider| provider == "grok"))
+    );
+    assert!(
         all_commands(settings::SettingsMode::Gui)
             .iter()
             .all(|command| command.kind != SlashCommandKind::AddApiKey)
@@ -140,6 +145,11 @@ fn clear_api_key_command_is_tui_only_and_requires_a_provider() {
     assert_eq!(
         argument.hint_text,
         Some(LLMProvider::API_KEY_PROVIDER_VALUE_NAME)
+    );
+    assert!(
+        argument
+            .hint_text
+            .is_some_and(|hint| hint.split('|').any(|provider| provider == "grok"))
     );
     assert!(
         all_commands(settings::SettingsMode::Gui)

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8257,6 +8257,7 @@ impl ApiKeysWidget {
 
         let provider_api_key_editors = LLMProvider::API_KEY_PROVIDERS
             .into_iter()
+            .filter(|provider| provider.supports_pasted_api_key())
             .map(|provider| {
                 let key = provider
                     .api_key(ApiKeyManager::as_ref(ctx).keys())

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -20,6 +20,7 @@ fn llm_provider_parses_supported_api_key_provider_names() {
         LLMProvider::from_api_key_slug("google"),
         Ok(LLMProvider::Google)
     );
+    assert_eq!(LLMProvider::from_api_key_slug("grok"), Ok(LLMProvider::Xai));
 }
 
 #[test]
@@ -77,7 +78,7 @@ fn persisted_provider_api_key_can_be_cleared() {
 fn llm_provider_rejects_unsupported_api_key_provider() {
     assert_eq!(
         LLMProvider::from_api_key_slug("openrouter"),
-        Err("provider must be one of: anthropic, openai, google".to_owned())
+        Err("provider must be one of: anthropic, openai, google, grok".to_owned())
     );
 }
 

--- a/crates/ai/src/grok_subscription/oauth.rs
+++ b/crates/ai/src/grok_subscription/oauth.rs
@@ -24,6 +24,8 @@
 
 use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context as _, bail};
@@ -70,6 +72,19 @@ fn redirect_uri() -> String {
 pub struct OauthAttempt {
     listener: TcpListener,
     pkce: PkceParams,
+    cancellation: OauthCancellationHandle,
+}
+
+/// Cancels an in-flight loopback callback wait.
+#[derive(Clone)]
+pub struct OauthCancellationHandle {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl OauthCancellationHandle {
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
 }
 
 impl OauthAttempt {
@@ -81,6 +96,9 @@ impl OauthAttempt {
         Ok(Self {
             listener: bind_callback_listener()?,
             pkce: PkceParams::generate(),
+            cancellation: OauthCancellationHandle {
+                cancelled: Arc::new(AtomicBool::new(false)),
+            },
         })
     }
 
@@ -93,7 +111,7 @@ impl OauthAttempt {
     /// callback, validates the CSRF state, and exchanges the authorization
     /// code for tokens. Consumes the attempt so its secrets can't be reused.
     pub async fn finish(self) -> anyhow::Result<TokenResponse> {
-        run_oauth_flow(self.listener, self.pkce).await
+        run_oauth_flow(self.listener, self.pkce, self.cancellation).await
     }
 
     /// Clones the PKCE verifier for the pasted-code fallback while the
@@ -102,6 +120,10 @@ impl OauthAttempt {
         ManualCodeExchange {
             verifier: self.pkce.verifier.clone(),
         }
+    }
+
+    pub fn cancellation_handle(&self) -> OauthCancellationHandle {
+        self.cancellation.clone()
     }
 }
 
@@ -216,7 +238,11 @@ fn bind_callback_listener() -> anyhow::Result<TcpListener> {
 /// Runs the full browser-based PKCE flow: waits for the loopback callback on a
 /// dedicated thread, validates the CSRF state, and exchanges the authorization
 /// code for tokens.
-async fn run_oauth_flow(listener: TcpListener, pkce: PkceParams) -> anyhow::Result<TokenResponse> {
+async fn run_oauth_flow(
+    listener: TcpListener,
+    pkce: PkceParams,
+    cancellation: OauthCancellationHandle,
+) -> anyhow::Result<TokenResponse> {
     // The loopback accept loop is blocking, so run it on a dedicated OS thread
     // and bridge the result back through a runtime-agnostic async channel.
     let (tx, rx) = async_channel::bounded(1);
@@ -225,9 +251,11 @@ async fn run_oauth_flow(listener: TcpListener, pkce: PkceParams) -> anyhow::Resu
         .spawn(move || {
             // `send_blocking` is disallowed (no wasm support); block this
             // dedicated thread on the async `send` instead.
-            let _ = warpui_core::r#async::block_on(
-                tx.send(wait_for_callback(&listener, CALLBACK_TIMEOUT)),
-            );
+            let _ = warpui_core::r#async::block_on(tx.send(wait_for_callback(
+                &listener,
+                CALLBACK_TIMEOUT,
+                &cancellation,
+            )));
         })
         .context("failed to spawn the Grok OAuth callback server thread")?;
 
@@ -245,9 +273,16 @@ async fn run_oauth_flow(listener: TcpListener, pkce: PkceParams) -> anyhow::Resu
 
 /// Blocks (on a non-blocking listener with polling) until the browser hits the
 /// redirect URI, returning the captured code and state, or an error on timeout.
-fn wait_for_callback(listener: &TcpListener, timeout: Duration) -> anyhow::Result<CallbackData> {
+fn wait_for_callback(
+    listener: &TcpListener,
+    timeout: Duration,
+    cancellation: &OauthCancellationHandle,
+) -> anyhow::Result<CallbackData> {
     let deadline = Instant::now() + timeout;
     loop {
+        if cancellation.cancelled.load(Ordering::Acquire) {
+            bail!("Grok authorization was cancelled");
+        }
         if Instant::now() >= deadline {
             bail!("timed out waiting for the Grok authorization callback");
         }

--- a/crates/ai/src/grok_subscription/oauth_tests.rs
+++ b/crates/ai/src/grok_subscription/oauth_tests.rs
@@ -55,3 +55,33 @@ fn manual_code_exchange_rejects_blank_code() {
     let result = warpui_core::r#async::block_on(exchange.exchange("   "));
     assert!(result.is_err());
 }
+
+#[test]
+fn cancelling_loopback_wait_releases_listener() {
+    let listener =
+        TcpListener::bind((REDIRECT_HOST, 0)).expect("test callback listener should bind");
+    listener
+        .set_nonblocking(true)
+        .expect("test callback listener should be non-blocking");
+    let address = listener
+        .local_addr()
+        .expect("test callback listener should have an address");
+    let cancellation = OauthCancellationHandle {
+        cancelled: Arc::new(AtomicBool::new(false)),
+    };
+    cancellation.cancel();
+
+    let result = warpui_core::r#async::block_on(run_oauth_flow(
+        listener,
+        PkceParams::generate(),
+        cancellation,
+    ));
+
+    assert_eq!(
+        result
+            .expect_err("cancelled callback wait should fail")
+            .to_string(),
+        "Grok authorization was cancelled"
+    );
+    TcpListener::bind(address).expect("cancelled callback listener should release its port");
+}

--- a/crates/ai/src/llm_provider.rs
+++ b/crates/ai/src/llm_provider.rs
@@ -14,8 +14,9 @@ pub enum LLMProvider {
 }
 
 impl LLMProvider {
-    pub const API_KEY_PROVIDERS: [Self; 3] = [Self::OpenAI, Self::Anthropic, Self::Google];
-    pub const API_KEY_PROVIDER_VALUE_NAME: &'static str = "openai|anthropic|google";
+    pub const API_KEY_PROVIDERS: [Self; 4] =
+        [Self::OpenAI, Self::Anthropic, Self::Google, Self::Xai];
+    pub const API_KEY_PROVIDER_VALUE_NAME: &'static str = "openai|anthropic|google|grok";
 
     pub fn icon(self) -> Option<Icon> {
         match self {
@@ -24,6 +25,9 @@ impl LLMProvider {
             Self::Google => Some(Icon::GeminiLogo),
             Self::Xai | Self::Unknown => None,
         }
+    }
+    pub fn supports_pasted_api_key(self) -> bool {
+        matches!(self, Self::OpenAI | Self::Anthropic | Self::Google)
     }
 
     pub fn api_key_placeholder(self) -> Option<&'static str> {
@@ -50,7 +54,8 @@ impl LLMProvider {
             Self::OpenAI => Some("openai"),
             Self::Anthropic => Some("anthropic"),
             Self::Google => Some("google"),
-            Self::Xai | Self::Unknown => None,
+            Self::Xai => Some("grok"),
+            Self::Unknown => None,
         }
     }
 
@@ -59,7 +64,8 @@ impl LLMProvider {
             "openai" | "open-ai" => Ok(Self::OpenAI),
             "anthropic" => Ok(Self::Anthropic),
             "google" => Ok(Self::Google),
-            _ => Err("provider must be one of: anthropic, openai, google".to_owned()),
+            "grok" | "xai" | "x-ai" => Ok(Self::Xai),
+            _ => Err("provider must be one of: anthropic, openai, google, grok".to_owned()),
         }
     }
 

--- a/crates/ai/src/llm_provider_tests.rs
+++ b/crates/ai/src/llm_provider_tests.rs
@@ -11,3 +11,16 @@ fn api_key_provider_help_matches_the_canonical_provider_list() {
         LLMProvider::API_KEY_PROVIDER_VALUE_NAME
     );
 }
+
+#[test]
+fn only_pasted_key_providers_report_pasted_key_support() {
+    for provider in LLMProvider::API_KEY_PROVIDERS {
+        assert_eq!(
+            provider.supports_pasted_api_key(),
+            matches!(
+                provider,
+                LLMProvider::OpenAI | LLMProvider::Anthropic | LLMProvider::Google
+            )
+        );
+    }
+}

--- a/crates/warp_tui/src/grok_oauth/mod.rs
+++ b/crates/warp_tui/src/grok_oauth/mod.rs
@@ -112,23 +112,6 @@ impl TuiGrokOAuthBlock {
         self.active_attempt_id.is_some()
     }
 
-    #[cfg(test)]
-    pub(crate) fn new_for_test(ctx: &mut ViewContext<Self>) -> Self {
-        Self {
-            active_attempt_id: Some(Uuid::new_v4()),
-            manual_exchange: None,
-            cancellation: None,
-            code_editor: ctx.add_typed_action_tui_view(TuiEditorView::single_line),
-            phase: TuiGrokOAuthPhase::Waiting { manual_error: None },
-            callback_error: None,
-        }
-    }
-
-    #[cfg(test)]
-    fn set_fatal_error_for_test(&mut self, error: impl Into<String>) {
-        self.phase = TuiGrokOAuthPhase::Fatal(error.into());
-    }
-
     fn handle_callback_result(
         &mut self,
         attempt_id: Uuid,
@@ -257,6 +240,7 @@ impl TuiGrokOAuthBlock {
                     .with_style(builder.muted_text_style())
                     .finish(),
             );
+
         match &self.phase {
             TuiGrokOAuthPhase::Waiting { manual_error } => {
                 body = body.child(
@@ -291,10 +275,6 @@ impl TuiGrokOAuthBlock {
         body.finish()
     }
 }
-
-#[cfg(test)]
-#[path = "tests.rs"]
-mod tests;
 
 impl Drop for TuiGrokOAuthBlock {
     fn drop(&mut self) {
@@ -374,3 +354,9 @@ impl TypedActionView for TuiGrokOAuthBlock {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) use tests::new_block;
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/grok_oauth/mod.rs
+++ b/crates/warp_tui/src/grok_oauth/mod.rs
@@ -1,0 +1,376 @@
+//! Input-blocking Grok OAuth interaction for the active TUI session.
+
+use ai::api_keys::ApiKeyManager;
+use ai::grok_subscription::oauth::{
+    ManualCodeExchange, OauthAttempt, OauthCancellationHandle, TokenResponse,
+};
+use uuid::Uuid;
+use warpui::SingletonEntity;
+use warpui_core::elements::CrossAxisAlignment;
+use warpui_core::elements::tui::{TuiChildView, TuiContainer, TuiElement, TuiFlex, TuiText};
+use warpui_core::keymap::macros::*;
+use warpui_core::keymap::{self, FixedBinding};
+use warpui_core::{
+    AppContext, Entity, EntityId, FocusContext, TuiView, TypedActionView, ViewContext, ViewHandle,
+};
+
+use crate::editor_view::{TuiEditorView, TuiEditorViewEvent};
+use crate::keybindings::TUI_BINDING_GROUP;
+use crate::transcript_view::BLOCK_TOP_PADDING_ROWS;
+use crate::tui_builder::TuiUiBuilder;
+
+const TITLE: &str = "Connect Grok";
+const CALLBACK_FAILURE_MESSAGE: &str =
+    "Couldn't complete Grok authorization. Press Esc, then run /add-api-key grok to try again.";
+const MANUAL_FAILURE_MESSAGE: &str =
+    "Couldn't connect Grok with that code. Check the code and try again.";
+
+pub(crate) fn init(app: &mut AppContext) {
+    let context = id!(TuiGrokOAuthBlock::ui_name());
+    app.register_fixed_bindings([
+        FixedBinding::new(
+            "enter",
+            TuiGrokOAuthBlockAction::SubmitManualCode,
+            context.clone(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "numpadenter",
+            TuiGrokOAuthBlockAction::SubmitManualCode,
+            context.clone(),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new("escape", TuiGrokOAuthBlockAction::Cancel, context)
+            .with_group(TUI_BINDING_GROUP),
+    ]);
+}
+
+#[derive(Clone)]
+pub(crate) enum TuiGrokOAuthBlockEvent {
+    Connected,
+    Cancelled,
+    LayoutInvalidated,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum TuiGrokOAuthBlockAction {
+    SubmitManualCode,
+    Cancel,
+}
+
+enum TuiGrokOAuthPhase {
+    Waiting { manual_error: Option<String> },
+    ExchangingManualCode,
+    Fatal(String),
+}
+
+pub(crate) struct TuiGrokOAuthBlock {
+    active_attempt_id: Option<Uuid>,
+    manual_exchange: Option<ManualCodeExchange>,
+    cancellation: Option<OauthCancellationHandle>,
+    code_editor: ViewHandle<TuiEditorView>,
+    phase: TuiGrokOAuthPhase,
+    callback_error: Option<String>,
+}
+
+impl TuiGrokOAuthBlock {
+    pub(crate) fn new(attempt: OauthAttempt, ctx: &mut ViewContext<Self>) -> Self {
+        let attempt_id = Uuid::new_v4();
+        let authorize_url = attempt.authorize_url();
+        let manual_exchange = attempt.manual_code_exchange();
+        let cancellation = attempt.cancellation_handle();
+        let code_editor = ctx.add_typed_action_tui_view(TuiEditorView::single_line);
+        ctx.subscribe_to_view(&code_editor, |block, _, event, ctx| {
+            if matches!(event, TuiEditorViewEvent::Changed(_))
+                && let TuiGrokOAuthPhase::Waiting { manual_error } = &mut block.phase
+            {
+                manual_error.take();
+                ctx.emit(TuiGrokOAuthBlockEvent::LayoutInvalidated);
+                ctx.notify();
+            }
+        });
+
+        ctx.open_url(&authorize_url);
+        ctx.spawn(
+            async move { attempt.finish().await },
+            move |block, result, ctx| {
+                block.handle_callback_result(attempt_id, result, ctx);
+            },
+        );
+
+        Self {
+            active_attempt_id: Some(attempt_id),
+            manual_exchange: Some(manual_exchange),
+            cancellation: Some(cancellation),
+            code_editor,
+            phase: TuiGrokOAuthPhase::Waiting { manual_error: None },
+            callback_error: None,
+        }
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.active_attempt_id.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(ctx: &mut ViewContext<Self>) -> Self {
+        Self {
+            active_attempt_id: Some(Uuid::new_v4()),
+            manual_exchange: None,
+            cancellation: None,
+            code_editor: ctx.add_typed_action_tui_view(TuiEditorView::single_line),
+            phase: TuiGrokOAuthPhase::Waiting { manual_error: None },
+            callback_error: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn set_fatal_error_for_test(&mut self, error: impl Into<String>) {
+        self.phase = TuiGrokOAuthPhase::Fatal(error.into());
+    }
+
+    fn handle_callback_result(
+        &mut self,
+        attempt_id: Uuid,
+        result: anyhow::Result<TokenResponse>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.active_attempt_id != Some(attempt_id) {
+            return;
+        }
+        match result {
+            Ok(tokens) => self.finish_success(attempt_id, tokens, ctx),
+            Err(_) if matches!(&self.phase, TuiGrokOAuthPhase::ExchangingManualCode) => {
+                self.callback_error = Some(CALLBACK_FAILURE_MESSAGE.to_owned());
+            }
+            Err(_) => {
+                self.phase = TuiGrokOAuthPhase::Fatal(CALLBACK_FAILURE_MESSAGE.to_owned());
+                ctx.emit(TuiGrokOAuthBlockEvent::LayoutInvalidated);
+                ctx.notify();
+            }
+        }
+    }
+
+    fn submit_manual_code(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(attempt_id) = self.active_attempt_id else {
+            return;
+        };
+        if !matches!(&self.phase, TuiGrokOAuthPhase::Waiting { .. }) {
+            return;
+        }
+        let Some(exchange) = self.manual_exchange.clone() else {
+            return;
+        };
+        let code = self.code_editor.as_ref(ctx).text(ctx);
+        if code.trim().is_empty() {
+            self.phase = TuiGrokOAuthPhase::Waiting {
+                manual_error: Some(
+                    "Enter the code shown in your browser to finish connecting.".to_owned(),
+                ),
+            };
+            ctx.emit(TuiGrokOAuthBlockEvent::LayoutInvalidated);
+            ctx.notify();
+            return;
+        }
+
+        self.code_editor
+            .update(ctx, |editor, ctx| editor.set_text("", ctx));
+        self.phase = TuiGrokOAuthPhase::ExchangingManualCode;
+        ctx.spawn(
+            async move { exchange.exchange(&code).await },
+            move |block, result, ctx| {
+                block.handle_manual_result(attempt_id, result, ctx);
+            },
+        );
+        ctx.emit(TuiGrokOAuthBlockEvent::LayoutInvalidated);
+        ctx.notify();
+    }
+
+    fn handle_manual_result(
+        &mut self,
+        attempt_id: Uuid,
+        result: anyhow::Result<TokenResponse>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.active_attempt_id != Some(attempt_id) {
+            return;
+        }
+        match result {
+            Ok(tokens) => self.finish_success(attempt_id, tokens, ctx),
+            Err(_) => {
+                self.phase = match self.callback_error.take() {
+                    Some(error) => TuiGrokOAuthPhase::Fatal(error),
+                    None => TuiGrokOAuthPhase::Waiting {
+                        manual_error: Some(MANUAL_FAILURE_MESSAGE.to_owned()),
+                    },
+                };
+                ctx.emit(TuiGrokOAuthBlockEvent::LayoutInvalidated);
+                ctx.notify();
+            }
+        }
+    }
+
+    fn finish_success(
+        &mut self,
+        attempt_id: Uuid,
+        tokens: TokenResponse,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.active_attempt_id != Some(attempt_id) {
+            return;
+        }
+        self.active_attempt_id = None;
+        if let Some(cancellation) = self.cancellation.take() {
+            cancellation.cancel();
+        }
+        self.manual_exchange = None;
+        self.code_editor
+            .update(ctx, |editor, ctx| editor.set_text("", ctx));
+        ApiKeyManager::handle(ctx).update(ctx, move |manager, ctx| {
+            manager.store_grok_tokens(tokens, ctx);
+        });
+        ctx.emit(TuiGrokOAuthBlockEvent::Connected);
+    }
+
+    fn cancel(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.active_attempt_id.take().is_none() {
+            return;
+        }
+        if let Some(cancellation) = self.cancellation.take() {
+            cancellation.cancel();
+        }
+        self.manual_exchange = None;
+        self.code_editor
+            .update(ctx, |editor, ctx| editor.set_text("", ctx));
+        ctx.emit(TuiGrokOAuthBlockEvent::Cancelled);
+    }
+
+    fn render_body(&self, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
+        let mut body = TuiFlex::column()
+            .child(
+                TuiText::new("Complete sign-in in the browser window that just opened.")
+                    .with_style(builder.primary_text_style())
+                    .finish(),
+            )
+            .child(
+                TuiText::new("If xAI shows an authorization code, paste it below:")
+                    .with_style(builder.muted_text_style())
+                    .finish(),
+            );
+        match &self.phase {
+            TuiGrokOAuthPhase::Waiting { manual_error } => {
+                body = body.child(
+                    TuiContainer::new(TuiChildView::new(&self.code_editor).finish())
+                        .with_border_style(builder.grok_oauth_accent_style())
+                        .with_padding_x(1)
+                        .finish(),
+                );
+                if let Some(error) = manual_error {
+                    body = body.child(
+                        TuiText::new(error.clone())
+                            .with_style(builder.error_text_style())
+                            .finish(),
+                    );
+                }
+            }
+            TuiGrokOAuthPhase::ExchangingManualCode => {
+                body = body.child(
+                    TuiText::new("Connecting…")
+                        .with_style(builder.muted_text_style())
+                        .finish(),
+                );
+            }
+            TuiGrokOAuthPhase::Fatal(error) => {
+                body = body.child(
+                    TuiText::new(error.clone())
+                        .with_style(builder.error_text_style())
+                        .finish(),
+                );
+            }
+        }
+        body.finish()
+    }
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+impl Drop for TuiGrokOAuthBlock {
+    fn drop(&mut self) {
+        if let Some(cancellation) = self.cancellation.take() {
+            cancellation.cancel();
+        }
+    }
+}
+
+impl Entity for TuiGrokOAuthBlock {
+    type Event = TuiGrokOAuthBlockEvent;
+}
+
+impl TuiView for TuiGrokOAuthBlock {
+    fn ui_name() -> &'static str {
+        "TuiGrokOAuthBlock"
+    }
+
+    fn child_view_ids(&self, _ctx: &AppContext) -> Vec<EntityId> {
+        vec![self.code_editor.id()]
+    }
+
+    fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
+        if focus_ctx.is_self_focused() && matches!(&self.phase, TuiGrokOAuthPhase::Waiting { .. }) {
+            ctx.focus(&self.code_editor);
+        }
+    }
+
+    fn keymap_context(&self, _ctx: &AppContext) -> keymap::Context {
+        let mut context = keymap::Context::default();
+        context.set.insert(Self::ui_name());
+        context
+    }
+
+    fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(ctx);
+        let header = TuiContainer::new(
+            TuiText::from_spans([
+                ("■ ".to_owned(), builder.grok_oauth_accent_style()),
+                (TITLE.to_owned(), builder.primary_text_style()),
+            ])
+            .finish(),
+        )
+        .with_background(builder.grok_oauth_header_background())
+        .with_padding_x(1)
+        .finish();
+        let body = TuiContainer::new(self.render_body(&builder))
+            .with_background(builder.grok_oauth_surface_background())
+            .with_padding_x(3)
+            .with_padding_y(1)
+            .finish();
+        let footer = TuiText::from_spans([
+            ("Esc ".to_owned(), builder.primary_text_style()),
+            ("to close".to_owned(), builder.muted_text_style()),
+        ])
+        .finish();
+        TuiContainer::new(
+            TuiFlex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .child(header)
+                .child(body)
+                .child(TuiContainer::new(footer).with_padding_top(1).finish())
+                .finish(),
+        )
+        .with_padding_top(BLOCK_TOP_PADDING_ROWS)
+        .finish()
+    }
+}
+
+impl TypedActionView for TuiGrokOAuthBlock {
+    type Action = TuiGrokOAuthBlockAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            TuiGrokOAuthBlockAction::SubmitManualCode => self.submit_manual_code(ctx),
+            TuiGrokOAuthBlockAction::Cancel => self.cancel(ctx),
+        }
+    }
+}

--- a/crates/warp_tui/src/grok_oauth/session.rs
+++ b/crates/warp_tui/src/grok_oauth/session.rs
@@ -1,0 +1,131 @@
+//! Grok OAuth lifetime and slash-command integration for a TUI session.
+
+use ai::api_keys::ApiKeyManager;
+use ai::grok_subscription::oauth::OauthAttempt;
+use warp::tui_export::{UserWorkspaces, record_static_slash_command_accepted};
+use warp_core::features::FeatureFlag;
+use warpui::SingletonEntity;
+use warpui_core::{AppContext, ViewContext, ViewHandle};
+
+use super::TuiTerminalSessionView;
+use crate::grok_oauth::{TuiGrokOAuthBlock, TuiGrokOAuthBlockEvent};
+
+const GROK_CONNECTED_HINT: &str = "Grok connected";
+const GROK_CLEARED_HINT: &str = "Grok credentials cleared";
+
+impl TuiTerminalSessionView {
+    pub(super) fn active_grok_oauth(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<ViewHandle<TuiGrokOAuthBlock>> {
+        let block = self.grok_oauth.as_ref()?;
+        block.as_ref(ctx).is_active().then(|| block.clone())
+    }
+
+    fn grok_oauth_policy_error(&self, ctx: &AppContext) -> Option<&'static str> {
+        if !FeatureFlag::SuperGrok.is_enabled() {
+            return Some("Grok subscriptions aren't available in this build.");
+        }
+        let workspaces = UserWorkspaces::as_ref(ctx);
+        if !workspaces.is_byo_api_key_enabled(ctx) {
+            return Some("Grok subscriptions require BYOK access for this workspace.");
+        }
+        if !workspaces.are_member_byo_keys_allowed() {
+            return Some("Your organization doesn't allow member-provided credentials.");
+        }
+        None
+    }
+
+    pub(super) fn start_grok_oauth(
+        &mut self,
+        command_name: &'static str,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(error) = self.grok_oauth_policy_error(ctx) {
+            self.show_error_hint(error.to_owned(), ctx);
+            return;
+        }
+        if ApiKeyManager::as_ref(ctx).has_grok_subscription() {
+            self.show_error_hint(
+                "Grok is already connected. Run /clear-provider-api-key grok to disconnect."
+                    .to_owned(),
+                ctx,
+            );
+            return;
+        }
+        if let Some(block) = self.active_grok_oauth(ctx) {
+            ctx.focus(&block);
+            return;
+        }
+        let Ok(state) = self.session_state(ctx) else {
+            return;
+        };
+        if state.has_blocking_interaction() || !state.input_target().agent_editor_owns_input() {
+            self.show_error_hint(
+                "Finish the current interaction before connecting Grok.".to_owned(),
+                ctx,
+            );
+            return;
+        }
+        let attempt = match OauthAttempt::start() {
+            Ok(attempt) => attempt,
+            Err(error) => {
+                self.show_error_hint(error.to_string(), ctx);
+                return;
+            }
+        };
+
+        self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+        let block = ctx.add_typed_action_tui_view(move |ctx| TuiGrokOAuthBlock::new(attempt, ctx));
+        self.install_grok_oauth_block(block, ctx);
+        record_static_slash_command_accepted(command_name, true, ctx);
+    }
+
+    pub(super) fn install_grok_oauth_block(
+        &mut self,
+        block: ViewHandle<TuiGrokOAuthBlock>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        ctx.subscribe_to_view(&block, |view, _, event, ctx| {
+            view.handle_grok_oauth_event(event, ctx);
+        });
+        self.grok_oauth = Some(block);
+        self.refresh_input_focus(ctx);
+    }
+
+    pub(super) fn clear_grok_oauth(
+        &mut self,
+        command_name: &'static str,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(error) = self.grok_oauth_policy_error(ctx) {
+            self.show_error_hint(error.to_owned(), ctx);
+            return;
+        }
+        ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+            manager.set_grok_tokens(None, ctx);
+        });
+        self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+        self.show_success_hint(GROK_CLEARED_HINT.to_owned(), ctx);
+        record_static_slash_command_accepted(command_name, true, ctx);
+    }
+
+    pub(super) fn handle_grok_oauth_event(
+        &mut self,
+        event: &TuiGrokOAuthBlockEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            TuiGrokOAuthBlockEvent::Connected => {
+                self.grok_oauth = None;
+                self.show_success_hint(GROK_CONNECTED_HINT.to_owned(), ctx);
+                self.refresh_input_focus(ctx);
+            }
+            TuiGrokOAuthBlockEvent::Cancelled => {
+                self.grok_oauth = None;
+                self.refresh_input_focus(ctx);
+            }
+            TuiGrokOAuthBlockEvent::LayoutInvalidated => ctx.notify(),
+        }
+    }
+}

--- a/crates/warp_tui/src/grok_oauth/session.rs
+++ b/crates/warp_tui/src/grok_oauth/session.rs
@@ -98,10 +98,6 @@ impl TuiTerminalSessionView {
         command_name: &'static str,
         ctx: &mut ViewContext<Self>,
     ) {
-        if let Some(error) = self.grok_oauth_policy_error(ctx) {
-            self.show_error_hint(error.to_owned(), ctx);
-            return;
-        }
         ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
             manager.set_grok_tokens(None, ctx);
         });

--- a/crates/warp_tui/src/grok_oauth/tests.rs
+++ b/crates/warp_tui/src/grok_oauth/tests.rs
@@ -1,3 +1,4 @@
+use uuid::Uuid;
 use warp::tui_export::Appearance;
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, App, EntityIdMap};
@@ -5,13 +6,25 @@ use warpui_core::elements::tui::{
     TuiBufferExt, TuiConstraint, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect,
     TuiScreenPosition, TuiSize,
 };
-use warpui_core::{TuiView as _, TypedActionView as _};
+use warpui_core::{TuiView as _, TypedActionView as _, ViewContext};
 
 use super::{
     CALLBACK_FAILURE_MESSAGE, MANUAL_FAILURE_MESSAGE, TuiGrokOAuthBlock, TuiGrokOAuthBlockAction,
     TuiGrokOAuthPhase,
 };
+use crate::editor_view::TuiEditorView;
 use crate::tui_builder::TuiUiBuilder;
+
+pub(crate) fn new_block(ctx: &mut ViewContext<TuiGrokOAuthBlock>) -> TuiGrokOAuthBlock {
+    TuiGrokOAuthBlock {
+        active_attempt_id: Some(Uuid::new_v4()),
+        manual_exchange: None,
+        cancellation: None,
+        code_editor: ctx.add_typed_action_tui_view(TuiEditorView::single_line),
+        phase: TuiGrokOAuthPhase::Waiting { manual_error: None },
+        callback_error: None,
+    }
+}
 
 #[test]
 fn waiting_card_uses_handoff_structure_and_only_escape_footer_hint() {
@@ -23,7 +36,7 @@ fn waiting_card_uses_handoff_structure_and_only_escape_footer_hint() {
                     window_style: WindowStyle::NotStealFocus,
                     ..Default::default()
                 },
-                TuiGrokOAuthBlock::new_for_test,
+                new_block,
             )
         });
 
@@ -90,7 +103,7 @@ fn callback_and_manual_failures_do_not_claim_success_or_expose_raw_details() {
                     window_style: WindowStyle::NotStealFocus,
                     ..Default::default()
                 },
-                TuiGrokOAuthBlock::new_for_test,
+                new_block,
             )
         });
 
@@ -148,11 +161,12 @@ fn fatal_card_sanitizes_the_body_and_escape_closes_the_attempt() {
                     window_style: WindowStyle::NotStealFocus,
                     ..Default::default()
                 },
-                TuiGrokOAuthBlock::new_for_test,
+                new_block,
             )
         });
         block.update(&mut app, |block, _| {
-            block.set_fatal_error_for_test("Authorization failed without exposing a code");
+            block.phase =
+                TuiGrokOAuthPhase::Fatal("Authorization failed without exposing a code".to_owned());
         });
         let rendered = app.read(|ctx| {
             let mut element = block.as_ref(ctx).render(ctx);

--- a/crates/warp_tui/src/grok_oauth/tests.rs
+++ b/crates/warp_tui/src/grok_oauth/tests.rs
@@ -1,0 +1,185 @@
+use warp::tui_export::Appearance;
+use warpui::platform::WindowStyle;
+use warpui::{AddWindowOptions, App, EntityIdMap};
+use warpui_core::elements::tui::{
+    TuiBufferExt, TuiConstraint, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect,
+    TuiScreenPosition, TuiSize,
+};
+use warpui_core::{TuiView as _, TypedActionView as _};
+
+use super::{
+    CALLBACK_FAILURE_MESSAGE, MANUAL_FAILURE_MESSAGE, TuiGrokOAuthBlock, TuiGrokOAuthBlockAction,
+    TuiGrokOAuthPhase,
+};
+use crate::tui_builder::TuiUiBuilder;
+
+#[test]
+fn waiting_card_uses_handoff_structure_and_only_escape_footer_hint() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (_, block) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                TuiGrokOAuthBlock::new_for_test,
+            )
+        });
+
+        app.read(|ctx| {
+            let mut element = block.as_ref(ctx).render(ctx);
+            let mut rendered_views = EntityIdMap::default();
+            let mut layout_ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            let size = element.layout(
+                TuiConstraint::loose(TuiSize::new(80, 20)),
+                &mut layout_ctx,
+                ctx,
+            );
+            let area = TuiRect::new(0, 0, size.width, size.height);
+            let mut buffer = warpui_core::elements::tui::TuiBuffer::empty(area);
+            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+
+            let lines = buffer.to_lines();
+            assert!(lines[0].trim().is_empty(), "{lines:#?}");
+            assert!(lines[1].contains("Connect Grok"), "{lines:#?}");
+            assert!(
+                lines
+                    .iter()
+                    .any(|line| line.contains("Complete sign-in in the browser")),
+                "{lines:#?}"
+            );
+            assert!(
+                lines.iter().any(|line| line.contains("paste it below")),
+                "{lines:#?}"
+            );
+            assert_eq!(
+                lines.last().map(|line| line.trim()),
+                Some("Esc to close"),
+                "{lines:#?}"
+            );
+            let rendered = lines.join("\n");
+            assert!(!rendered.contains("open URL"), "{rendered}");
+            assert!(!rendered.contains("Open link"), "{rendered}");
+
+            let builder = TuiUiBuilder::from_app(ctx);
+            assert_eq!(
+                buffer[(1, 1)].fg,
+                builder
+                    .grok_oauth_accent_style()
+                    .fg
+                    .expect("Grok accent has a foreground")
+            );
+            assert_eq!(buffer[(0, 1)].bg, builder.grok_oauth_header_background());
+            assert_eq!(buffer[(0, 2)].bg, builder.grok_oauth_surface_background());
+        });
+    });
+}
+
+#[test]
+fn callback_and_manual_failures_do_not_claim_success_or_expose_raw_details() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (_, block) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                TuiGrokOAuthBlock::new_for_test,
+            )
+        });
+
+        block.update(&mut app, |block, ctx| {
+            let attempt_id = block
+                .active_attempt_id
+                .expect("test block has an active attempt");
+            block.phase = TuiGrokOAuthPhase::ExchangingManualCode;
+            block.handle_callback_result(
+                attempt_id,
+                Err(anyhow::anyhow!("raw-callback-secret")),
+                ctx,
+            );
+            assert_eq!(
+                block.callback_error.as_deref(),
+                Some(CALLBACK_FAILURE_MESSAGE)
+            );
+            assert!(matches!(
+                &block.phase,
+                TuiGrokOAuthPhase::ExchangingManualCode
+            ));
+
+            block.handle_manual_result(attempt_id, Err(anyhow::anyhow!("raw-manual-secret")), ctx);
+            assert!(matches!(
+                &block.phase,
+                TuiGrokOAuthPhase::Fatal(message) if message == CALLBACK_FAILURE_MESSAGE
+            ));
+            assert!(block.is_active());
+
+            block.phase = TuiGrokOAuthPhase::Waiting { manual_error: None };
+            block.callback_error = None;
+            block.handle_manual_result(attempt_id, Err(anyhow::anyhow!("another-raw-secret")), ctx);
+            assert!(matches!(
+                &block.phase,
+                TuiGrokOAuthPhase::Waiting {
+                    manual_error: Some(message)
+                } if message == MANUAL_FAILURE_MESSAGE
+            ));
+
+            block.handle_action(&TuiGrokOAuthBlockAction::Cancel, ctx);
+            block.handle_callback_result(attempt_id, Err(anyhow::anyhow!("stale-raw-secret")), ctx);
+            assert!(!block.is_active());
+            assert!(block.callback_error.is_none());
+        });
+    });
+}
+
+#[test]
+fn fatal_card_sanitizes_the_body_and_escape_closes_the_attempt() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let (_, block) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                TuiGrokOAuthBlock::new_for_test,
+            )
+        });
+        block.update(&mut app, |block, _| {
+            block.set_fatal_error_for_test("Authorization failed without exposing a code");
+        });
+        let rendered = app.read(|ctx| {
+            let mut element = block.as_ref(ctx).render(ctx);
+            let mut rendered_views = EntityIdMap::default();
+            let mut layout_ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            let size = element.layout(
+                TuiConstraint::loose(TuiSize::new(80, 20)),
+                &mut layout_ctx,
+                ctx,
+            );
+            let area = TuiRect::new(0, 0, size.width, size.height);
+            let mut buffer = warpui_core::elements::tui::TuiBuffer::empty(area);
+            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+            buffer.to_lines().join("\n")
+        });
+        assert!(
+            rendered.contains("Authorization failed without exposing a code"),
+            "{rendered}"
+        );
+
+        block.update(&mut app, |block, ctx| {
+            block.handle_action(&TuiGrokOAuthBlockAction::Cancel, ctx);
+            assert!(!block.is_active());
+        });
+    });
+}

--- a/crates/warp_tui/src/keybindings.rs
+++ b/crates/warp_tui/src/keybindings.rs
@@ -29,6 +29,7 @@ use crate::attachment_bar::TuiAttachmentBar;
 use crate::cloud_run_view::TuiCloudRunView;
 use crate::editor_interaction::{TuiEditorBindingTarget, TuiEditorCommand, editor_binding_specs};
 use crate::editor_view::{TuiEditorView, TuiEditorViewAction};
+use crate::grok_oauth::TuiGrokOAuthBlock;
 use crate::handoff::TuiHandoffBlock;
 use crate::input::TuiInputView;
 use crate::input::view::TuiInputAction;
@@ -91,6 +92,7 @@ pub(crate) fn init(app: &mut AppContext) {
         TuiEditorViewAction::Command,
     );
     crate::orchestration_block::init(app);
+    crate::grok_oauth::init(app);
     crate::handoff::init(app);
     crate::tui_ask_question_view::init(app);
     crate::statusline_config_view::init(app);
@@ -154,6 +156,7 @@ fn register_binding_validators(app: &mut AppContext) {
     app.register_tui_binding_validator::<TuiEditorView>(is_tui_owned_binding);
     app.register_tui_binding_validator::<TuiTranscriptView>(is_tui_owned_binding);
     app.register_tui_binding_validator::<TuiOrchestrationBlock>(is_tui_owned_binding);
+    app.register_tui_binding_validator::<TuiGrokOAuthBlock>(is_tui_owned_binding);
     app.register_tui_binding_validator::<TuiHandoffBlock>(is_tui_owned_binding);
     app.register_tui_binding_validator::<TuiOptionSelector>(is_tui_owned_binding);
 }

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -31,6 +31,7 @@ mod editor_element;
 mod editor_interaction;
 mod editor_view;
 mod exit_confirmation;
+mod grok_oauth;
 mod handoff;
 mod inline_menu;
 mod input_hints;

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -134,13 +134,25 @@ pub fn run() -> Result<()> {
         Err(error) => return Err(anyhow::Error::new(error)),
     };
     let provider_api_key_command = if let Some(provider) = args.set_provider_api_key {
+        if !provider.supports_pasted_api_key() {
+            return Err(anyhow!(
+                "Grok credentials must be connected with /add-api-key grok in an active TUI"
+            ));
+        }
         let Some(api_key) = read_provider_api_key()? else {
             return Err(anyhow!("No provider API key was supplied"));
         };
         Some(ProviderApiKeyCommand::Set { provider, api_key })
     } else {
-        args.clear_provider_api_key
-            .map(|provider| ProviderApiKeyCommand::Clear { provider })
+        match args.clear_provider_api_key {
+            Some(LLMProvider::Xai) => {
+                return Err(anyhow!(
+                    "Grok credentials must be cleared with /clear-provider-api-key grok in an active TUI"
+                ));
+            }
+            Some(provider) => Some(ProviderApiKeyCommand::Clear { provider }),
+            None => None,
+        }
     };
     if let Some(command) = provider_api_key_command {
         return warp::run_tui_cli_command(Box::new(move |ctx| {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -74,6 +74,7 @@ use crate::conversation_menu::{TuiConversationMenuEvent, TuiConversationMenuMode
 use crate::conversation_selection::TuiConversationSelection;
 use crate::editor_interaction::TuiEditorCommand;
 use crate::exit_confirmation::{CTRL_C_EXIT_WINDOW, ExitConfirmation};
+use crate::grok_oauth::TuiGrokOAuthBlock;
 use crate::handoff::TuiHandoffBlock;
 use crate::inline_menu::{MAX_INLINE_MENU_ROWS, TuiInlineMenu, active_inline_menu};
 use crate::input::view::TuiInputAction;
@@ -127,6 +128,8 @@ use crate::zero_state_animation::{
 };
 mod completions;
 
+#[path = "grok_oauth/session.rs"]
+mod grok_oauth_session;
 #[path = "handoff/session.rs"]
 mod handoff_session;
 mod input_detection;
@@ -173,6 +176,8 @@ pub(super) enum BlockingInputSource {
     Orchestration(ViewHandle<TuiOrchestrationBlock>),
     /// A local-to-cloud handoff configuration or result card.
     Handoff(ViewHandle<TuiHandoffBlock>),
+    /// An in-process Grok OAuth connection flow.
+    GrokOAuth(ViewHandle<TuiGrokOAuthBlock>),
 }
 
 impl BlockingInputSource {
@@ -187,6 +192,7 @@ impl BlockingInputSource {
             Self::Permission(view) => Some(TuiChildView::new(&view).finish()),
             Self::Orchestration(view) => Some(TuiChildView::new(&view).finish()),
             Self::Handoff(view) => Some(TuiChildView::new(&view).finish()),
+            Self::GrokOAuth(view) => Some(TuiChildView::new(&view).finish()),
         }
     }
 }
@@ -358,6 +364,9 @@ fn provider_api_key_shell_command(
     provider: LLMProvider,
     operation: ProviderApiKeyOperation,
 ) -> Option<String> {
+    if !provider.supports_pasted_api_key() {
+        return None;
+    }
     let provider = provider.api_key_slug()?;
     let flag = match operation {
         ProviderApiKeyOperation::Set => "--set-provider-api-key",
@@ -751,6 +760,7 @@ pub(crate) struct TuiTerminalSessionView {
     next_restore_request_id: u64,
     exit_summary: TuiExitSummaryHandle,
     handoff: Option<ViewHandle<TuiHandoffBlock>>,
+    grok_oauth: Option<ViewHandle<TuiGrokOAuthBlock>>,
     statusline_config_view: Option<ViewHandle<TuiStatuslineConfigView>>,
     orchestration_tab_bar: ViewHandle<TuiTabBarView>,
     orchestration_tabs_focused: bool,
@@ -931,7 +941,9 @@ impl TuiTerminalSessionView {
         ctx: &AppContext,
     ) -> Result<TuiTerminalSessionState, TuiTerminalSessionStateResolveError> {
         let state = self.session_state.as_ref(ctx).resolve(ctx)?;
-        Ok(if let Some(handoff) = self.active_handoff(ctx) {
+        Ok(if let Some(grok_oauth) = self.active_grok_oauth(ctx) {
+            state.with_blocking_input_source(BlockingInputSource::GrokOAuth(grok_oauth))
+        } else if let Some(handoff) = self.active_handoff(ctx) {
             state.with_blocking_input_source(BlockingInputSource::Handoff(handoff))
         } else {
             state
@@ -954,6 +966,7 @@ impl TuiTerminalSessionView {
             BlockingInputSource::Permission(view) => ctx.focus(&view),
             BlockingInputSource::Orchestration(view) => ctx.focus(&view),
             BlockingInputSource::Handoff(view) => ctx.focus(&view),
+            BlockingInputSource::GrokOAuth(view) => ctx.focus(&view),
         }
     }
 
@@ -1911,6 +1924,7 @@ impl TuiTerminalSessionView {
             next_restore_request_id: 0,
             exit_summary,
             handoff: None,
+            grok_oauth: None,
             statusline_config_view: None,
             orchestration_tab_bar,
             orchestration_tabs_focused: false,
@@ -3203,21 +3217,31 @@ impl TuiTerminalSessionView {
             );
             return;
         };
-        let Some(command_text) =
-            provider_api_key_shell_command(ChannelState::channel(), provider, operation)
-        else {
-            self.show_error_hint(
-                format!(
-                    "Usage: {} <{}>",
-                    command.name,
-                    LLMProvider::API_KEY_PROVIDER_VALUE_NAME
-                ),
-                ctx,
-            );
-            return;
-        };
-        self.execute_user_command(&command_text, None, ctx);
-        record_static_slash_command_accepted(command.name, true, ctx);
+        match (provider, operation) {
+            (LLMProvider::Xai, ProviderApiKeyOperation::Set) => {
+                self.start_grok_oauth(command.name, ctx);
+            }
+            (LLMProvider::Xai, ProviderApiKeyOperation::Clear) => {
+                self.clear_grok_oauth(command.name, ctx);
+            }
+            (LLMProvider::OpenAI | LLMProvider::Anthropic | LLMProvider::Google, operation) => {
+                let command_text =
+                    provider_api_key_shell_command(ChannelState::channel(), provider, operation)
+                        .expect("pasted-key providers have canonical API-key slugs");
+                self.execute_user_command(&command_text, None, ctx);
+                record_static_slash_command_accepted(command.name, true, ctx);
+            }
+            (LLMProvider::Unknown, _) => {
+                self.show_error_hint(
+                    format!(
+                        "Usage: {} <{}>",
+                        command.name,
+                        LLMProvider::API_KEY_PROVIDER_VALUE_NAME
+                    ),
+                    ctx,
+                );
+            }
+        }
     }
 
     /// Routes a submission to shell execution or the agent conversation based
@@ -4182,6 +4206,9 @@ impl TuiView for TuiTerminalSessionView {
         if let Some(handoff) = self.active_handoff(ctx) {
             view_ids.push(handoff.id());
         }
+        if let Some(grok_oauth) = self.active_grok_oauth(ctx) {
+            view_ids.push(grok_oauth.id());
+        }
         if let Some(statusline_config_view) = self.statusline_config_view.as_ref() {
             view_ids.push(statusline_config_view.id());
         }
@@ -4461,6 +4488,9 @@ impl TuiView for TuiTerminalSessionView {
         }
         if let Some(BlockingInputSource::Handoff(handoff)) = state.blocking_input_source() {
             content = content.child(TuiChildView::new(handoff).finish());
+        }
+        if let Some(BlockingInputSource::GrokOAuth(grok_oauth)) = state.blocking_input_source() {
+            content = content.child(TuiChildView::new(grok_oauth).finish());
         }
         if !blocker_active
             && let Some(statusline_config_view) = self.statusline_config_view.as_ref()

--- a/crates/warp_tui/src/terminal_session_view/state.rs
+++ b/crates/warp_tui/src/terminal_session_view/state.rs
@@ -381,7 +381,8 @@ impl TuiTerminalSessionState {
                     BlockingInputSource::AskQuestion(_)
                     | BlockingInputSource::Permission(_)
                     | BlockingInputSource::Orchestration(_)
-                    | BlockingInputSource::Handoff(_) => TuiInputTarget::Disabled,
+                    | BlockingInputSource::Handoff(_)
+                    | BlockingInputSource::GrokOAuth(_) => TuiInputTarget::Disabled,
                 },
                 TuiInteractionState::StartingShell => TuiInputTarget::Disabled,
                 TuiInteractionState::Composer(_) => TuiInputTarget::AgentEditor,
@@ -472,7 +473,8 @@ impl TuiTerminalSessionState {
                 BlockingInputSource::AskQuestion(_)
                 | BlockingInputSource::Permission(_)
                 | BlockingInputSource::Orchestration(_)
-                | BlockingInputSource::Handoff(_),
+                | BlockingInputSource::Handoff(_)
+                | BlockingInputSource::GrokOAuth(_),
             )
             | TuiInteractionState::StartingShell
             | TuiInteractionState::Pty(TuiPtyState::Process) => return Vec::new(),

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -56,7 +56,7 @@ use super::{
     voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
-use crate::grok_oauth::{TuiGrokOAuthBlock, TuiGrokOAuthBlockAction};
+use crate::grok_oauth::{TuiGrokOAuthBlockAction, new_block};
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
 use crate::input_mode_policy::{AI_LOCKED_CONFIG, AI_UNLOCKED_CONFIG};
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
@@ -453,7 +453,7 @@ fn grok_oauth_block_exclusively_owns_input_until_escape() {
                 input.set_text("/add-api-key grok", ctx);
                 input.clear(ctx);
             });
-            let block = ctx.add_typed_action_tui_view(TuiGrokOAuthBlock::new_for_test);
+            let block = ctx.add_typed_action_tui_view(new_block);
             view.install_grok_oauth_block(block.clone(), ctx);
             block
         });

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -56,6 +56,7 @@ use super::{
     voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
+use crate::grok_oauth::{TuiGrokOAuthBlock, TuiGrokOAuthBlockAction};
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
 use crate::input_mode_policy::{AI_LOCKED_CONFIG, AI_UNLOCKED_CONFIG};
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
@@ -430,8 +431,63 @@ fn provider_api_key_shell_command_uses_shared_tui_launcher() {
         ),
         None
     );
+    assert_eq!(
+        super::provider_api_key_shell_command(
+            Channel::Stable,
+            LLMProvider::Xai,
+            super::ProviderApiKeyOperation::Set,
+        ),
+        None,
+        "Grok OAuth must stay in the active TUI process"
+    );
 }
 
+#[test]
+fn grok_oauth_block_exclusively_owns_input_until_escape() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let block = view.update(&mut app, |view, ctx| {
+            view.input_view.update(ctx, |input, ctx| {
+                input.set_text("/add-api-key grok", ctx);
+                input.clear(ctx);
+            });
+            let block = ctx.add_typed_action_tui_view(TuiGrokOAuthBlock::new_for_test);
+            view.install_grok_oauth_block(block.clone(), ctx);
+            block
+        });
+
+        view.read(&app, |session, ctx| {
+            let state = session.session_state(ctx).expect("session state resolves");
+            assert!(matches!(
+                state.blocking_input_source(),
+                Some(BlockingInputSource::GrokOAuth(active)) if active.id() == block.id()
+            ));
+            assert_eq!(state.input_target(), TuiInputTarget::Disabled);
+            assert!(session.child_view_ids(ctx).contains(&block.id()));
+            assert!(session.input_view.as_ref(ctx).is_empty(ctx));
+        });
+        let rendered = render_session(&mut app, &view, 80, 40).join("\n");
+        assert!(rendered.contains("Connect Grok"), "{rendered}");
+        assert!(rendered.contains("Esc to close"), "{rendered}");
+        assert!(!rendered.contains("Ask the agent anything"), "{rendered}");
+        assert!(!rendered.contains("for commands"), "{rendered}");
+
+        block.update(&mut app, |block, ctx| {
+            block.handle_action(&TuiGrokOAuthBlockAction::Cancel, ctx);
+        });
+        view.read(&app, |session, ctx| {
+            assert!(session.grok_oauth.is_none());
+            let state = session.session_state(ctx).expect("session state resolves");
+            assert!(!state.has_blocking_interaction());
+            assert_eq!(state.input_target(), TuiInputTarget::AgentEditor);
+            assert!(session.input_view.as_ref(ctx).is_empty(ctx));
+        });
+        let rendered = render_session(&mut app, &view, 80, 40).join("\n");
+        assert!(!rendered.contains("Connect Grok"), "{rendered}");
+    });
+}
 #[test]
 fn log_bundle_failure_hint_does_not_hardcode_a_frontend_path() {
     assert!(!LOG_BUNDLE_FAILED_HINT.contains("warp.log"));

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -234,6 +234,30 @@ impl TuiUiBuilder {
             self.warp_theme.terminal_colors().bright.green,
         )))
     }
+
+    /// Themed light-blue accent for the Grok OAuth card and code field.
+    pub(crate) fn grok_oauth_accent_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::from(
+            self.warp_theme.terminal_colors().bright.blue,
+        )))
+    }
+
+    /// Light-blue overlay behind the Grok OAuth card body.
+    pub(crate) fn grok_oauth_surface_background(&self) -> Color {
+        let blue = ThemeFill::from(self.warp_theme.terminal_colors().bright.blue);
+        cell_color(self.base_background().blend(&blue.with_opacity(10)))
+    }
+
+    /// Stronger light-blue overlay behind the Grok OAuth title row.
+    pub(crate) fn grok_oauth_header_background(&self) -> Color {
+        let blue = ThemeFill::from(self.warp_theme.terminal_colors().bright.blue);
+        cell_color(
+            self.base_background()
+                .blend(&blue.with_opacity(10))
+                .blend(&blue.with_opacity(10)),
+        )
+    }
+
     /// Background-independent bold pale-green `!` marker shared by shell-command surfaces.
     pub(crate) fn shell_command_prefix_style(&self) -> TuiStyle {
         self.shell_command_accent_style()

--- a/crates/warp_tui/src/tui_builder_tests.rs
+++ b/crates/warp_tui/src/tui_builder_tests.rs
@@ -63,6 +63,20 @@ fn text_styles_follow_light_theme_foreground() {
         CoreFill::from(theme.background().blend(&shortcut_accent.with_opacity(10))).into();
     assert_eq!(builder.shortcuts_background(), shortcuts_background);
     assert_eq!(builder.shell_command_background(), shell_command_background);
+    let grok_fill = ThemeFill::from(theme.terminal_colors().bright.blue);
+    let grok_accent: Color = CoreFill::from(grok_fill).into();
+    let grok_surface: Color =
+        CoreFill::from(theme.background().blend(&grok_fill.with_opacity(10))).into();
+    let grok_header: Color = CoreFill::from(
+        theme
+            .background()
+            .blend(&grok_fill.with_opacity(10))
+            .blend(&grok_fill.with_opacity(10)),
+    )
+    .into();
+    assert_eq!(builder.grok_oauth_accent_style().fg, Some(grok_accent));
+    assert_eq!(builder.grok_oauth_surface_background(), grok_surface);
+    assert_eq!(builder.grok_oauth_header_background(), grok_header);
     let shell_command_prefix_style = builder.shell_command_prefix_style();
     assert_eq!(
         shell_command_prefix_style.fg,


### PR DESCRIPTION
## Description

Adds Grok subscription BYOK support to the headless TUI.

- Routes `/add-api-key grok` through an in-process xAI OAuth flow, opening the browser and accepting either the loopback callback or a manually pasted authorization code.
- Adds an input-blocking, themed connection card with sanitized failure states, cancellation, credential persistence, and `/clear-provider-api-key grok` support.
- Keeps Grok OAuth separate from pasted provider API keys while adding Grok to shared provider parsing and slash-command suggestions.
- Cancels the loopback listener when an attempt finishes or closes, and covers the provider, OAuth, rendering, and session-input behavior with unit tests.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/8108ac54463c437d8ff56a0853b1a0b7

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp&#39;s AI Agent Mode