### PR TITLE
Fix TUI background cursor ownership

### DIFF
--- a/crates/warp_tui/src/terminal_block.rs
+++ b/crates/warp_tui/src/terminal_block.rs
@@ -16,7 +16,7 @@ use warpui_core::elements::tui::{
     TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiSize, TuiStyle,
 };
 
-use crate::terminal_use::user_controls_running_command;
+use crate::terminal_use::user_controlled_running_command;
 use crate::tui_builder::TuiUiBuilder;
 const SHELL_COMMAND_PREFIX: &str = "!";
 const SHELL_COMMAND_PREFIX_WIDTH: u16 = 2;
@@ -99,10 +99,11 @@ impl TerminalBlockElement {
 
 fn terminal_block_cursor(
     block: &Block,
+    owns_cursor: bool,
     visible_rows: &Range<usize>,
     size: TuiSize,
 ) -> Option<(u16, u16)> {
-    if !user_controls_running_command(block) || !block.is_mode_set(TermMode::SHOW_CURSOR) {
+    if !owns_cursor || !block.is_mode_set(TermMode::SHOW_CURSOR) {
         return None;
     }
     let (grid, grid_start_row) = if block.is_command_grid_active() {
@@ -184,21 +185,24 @@ impl TuiElement for TerminalBlockElement {
         };
         let model = self.model.lock();
         let colors = model.colors();
-        let Some(block) = model.block_list().block_with_id(&self.block_id) else {
+        let block_list = model.block_list();
+        let cursor_owner = user_controlled_running_command(&model).map(Block::id);
+        let Some(block) = block_list.block_with_id(&self.block_id) else {
             return;
         };
         let (rows, width) = match &self.rows {
             TerminalBlockRows::Visible { rows, width } => (rows.clone(), (*width).min(size.width)),
             TerminalBlockRows::Content => (block_content_rows(block), size.width),
         };
-        let cursor = terminal_block_cursor(block, &rows, size).and_then(|(column, row)| {
-            let column = if self.command_style.is_some() && block.is_command_grid_active() {
-                column.saturating_add(SHELL_COMMAND_PREFIX_WIDTH)
-            } else {
-                column
-            };
-            (column < size.width).then_some((column, row))
-        });
+        let cursor = terminal_block_cursor(block, cursor_owner == Some(block.id()), &rows, size)
+            .and_then(|(column, row)| {
+                let column = if self.command_style.is_some() && block.is_command_grid_active() {
+                    column.saturating_add(SHELL_COMMAND_PREFIX_WIDTH)
+                } else {
+                    column
+                };
+                (column < size.width).then_some((column, row))
+            });
         render_block_rows(
             block,
             rows,

--- a/crates/warp_tui/src/terminal_block_tests.rs
+++ b/crates/warp_tui/src/terminal_block_tests.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
@@ -6,12 +7,14 @@ use warp::tui_export::{
     TerminalModel, TranscriptScope,
 };
 use warpui::App;
+use warpui_core::r#async::Timer;
 use warpui_core::elements::tui::{Color, Modifier, TuiBufferExt, TuiElement, TuiRect, TuiSize};
 use warpui_core::presenter::tui::TuiPresenter;
 
 use super::{
     TerminalBlockElement, block_content_rows, should_render_terminal_block, terminal_block_cursor,
 };
+use crate::terminal_use::user_controlled_running_command;
 use crate::tui_builder::TuiUiBuilder;
 
 /// Builds a mock model with a single simulated (started + finished) block and
@@ -233,13 +236,63 @@ fn user_controlled_running_command_submits_cursor_within_window() {
     let mut model = TerminalModel::mock(None, None);
     model.simulate_long_running_block("python3", ">>> ");
     let block = model.block_list().active_block();
+    let owns_cursor =
+        user_controlled_running_command(&model).is_some_and(|owner| owner.id() == block.id());
 
     // A finished/agent block never owns the inline cursor; an active
     // user-controlled command does when its cursor lands inside the window.
-    let in_window = terminal_block_cursor(block, &(0..8), TuiSize::new(40, 8));
-    let clipped = terminal_block_cursor(block, &(0..8), TuiSize::new(40, 0));
+    let in_window = terminal_block_cursor(block, owns_cursor, &(0..8), TuiSize::new(40, 8));
+    let clipped = terminal_block_cursor(block, owns_cursor, &(0..8), TuiSize::new(40, 0));
     assert!(in_window.is_some());
     assert_eq!(clipped, None);
+}
+
+#[test]
+fn unfinished_background_block_renders_without_submitting_cursor() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let mut model = TerminalModel::mock(None, None);
+        model.simulate_block("true", "");
+        model.process_bytes("starship: scanning files timed out");
+        let background_block = model
+            .block_list()
+            .blocks()
+            .iter()
+            .find(|block| block.is_background())
+            .expect("early output should create a background block");
+        let block_id = background_block.id().clone();
+        let model = Arc::new(FairMutex::new(model));
+        Timer::after(Duration::from_millis(200)).await;
+        let rows = {
+            let model = model.lock();
+            let background_block = model
+                .block_list()
+                .block_with_id(&block_id)
+                .expect("background block should remain in the transcript");
+            block_content_rows(background_block)
+        };
+        let height = rows.end.saturating_sub(rows.start) as u16;
+
+        app.read(|ctx| {
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                TerminalBlockElement::visible_rows(model, block_id, rows, 40).finish(),
+                TuiRect::new(0, 0, 40, height),
+                ctx,
+            );
+            let rendered_text = frame
+                .buffer
+                .to_lines()
+                .iter()
+                .map(|line| line.trim_end())
+                .collect::<String>();
+            assert!(
+                rendered_text.contains("starship: scanning files timed out"),
+                "{rendered_text:?}"
+            );
+            assert_eq!(frame.cursor, None);
+        });
+    });
 }
 
 #[test]
@@ -249,8 +302,10 @@ fn finished_command_does_not_submit_a_cursor() {
         .block_list()
         .block_with_id(&block_id)
         .expect("block should exist");
+    let owns_cursor =
+        user_controlled_running_command(&model).is_some_and(|owner| owner.id() == block.id());
     assert_eq!(
-        terminal_block_cursor(block, &(0..8), TuiSize::new(40, 8)),
+        terminal_block_cursor(block, owns_cursor, &(0..8), TuiSize::new(40, 8)),
         None
     );
 }

--- a/crates/warp_tui/src/terminal_use.rs
+++ b/crates/warp_tui/src/terminal_use.rs
@@ -127,8 +127,9 @@ pub(super) fn terminal_use_conversation_to_resume(
     .then_some(*metadata.conversation_id())
 }
 
-/// Whether a running inline command, rather than Warp's editor or agent, owns
-/// keyboard input.
+/// Whether a running command block is user-controlled. This block-local
+/// predicate supports command affordances; input and cursor ownership must use
+/// [`user_controlled_running_command`] so only the active block can qualify.
 pub(super) fn user_controls_running_command(block: &Block) -> bool {
     block.is_active_and_long_running()
         && block.is_bootstrapped()
@@ -137,8 +138,15 @@ pub(super) fn user_controls_running_command(block: &Block) -> bool {
         && !block.is_agent_tagged_in()
 }
 
+/// Returns the active running command when it, rather than Warp's editor or
+/// agent, owns inline terminal input.
+pub(super) fn user_controlled_running_command(terminal_model: &TerminalModel) -> Option<&Block> {
+    let active_block = terminal_model.block_list().active_block();
+    user_controls_running_command(active_block).then_some(active_block)
+}
+
 pub(super) fn inline_process_owns_input(terminal_model: &TerminalModel) -> bool {
-    user_controls_running_command(terminal_model.block_list().active_block())
+    user_controlled_running_command(terminal_model).is_some()
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/terminal_use_tests.rs
+++ b/crates/warp_tui/src/terminal_use_tests.rs
@@ -15,7 +15,7 @@ use warpui_core::elements::tui::{TuiLayoutContext, TuiViewportWindow, TuiViewpor
 use super::{
     TerminalUseInterruptAction, TuiInputTarget, hide_agent_requested_command_from_top_level,
     inline_process_owns_input, terminal_use_conversation_to_resume, terminal_use_interrupt_action,
-    tui_input_target, tui_input_target_for_state,
+    tui_input_target, tui_input_target_for_state, user_controlled_running_command,
 };
 use crate::tui_block_list_viewport_source::TuiBlockListViewportSource;
 
@@ -43,7 +43,31 @@ fn ordinary_long_running_command_owns_inline_input() {
     model.simulate_long_running_block("cat", "");
 
     assert!(inline_process_owns_input(&model));
+    assert_eq!(
+        user_controlled_running_command(&model).map(|block| block.id()),
+        Some(model.block_list().active_block().id())
+    );
 }
+
+#[test]
+fn unfinished_background_output_does_not_own_inline_input() {
+    let mut model = TerminalModel::mock(None, None);
+    model.simulate_block("true", "");
+    model.process_bytes("starship: scanning files timed out");
+
+    let background_block = model
+        .block_list()
+        .blocks()
+        .iter()
+        .find(|block| block.is_background())
+        .expect("early output should create a background block");
+    assert!(!background_block.finished());
+    assert!(background_block.is_active_and_long_running());
+    assert!(user_controlled_running_command(&model).is_none());
+    assert!(!inline_process_owns_input(&model));
+    assert_eq!(tui_input_target(&model), TuiInputTarget::AgentEditor);
+}
+
 #[test]
 fn shell_startup_routes_input_by_bootstrap_stage() {
     let mut model = TerminalModel::mock(None, None);


### PR DESCRIPTION
## Description

Fix the headless TUI cursor becoming visually trapped in delayed shell output, such as a Starship timeout warning.

Late output is intentionally retained as an unfinished background transcript block. That block previously reused a generic long-running-block predicate and could submit the terminal's sole hardware cursor even though the active prompt and composer still owned input. Because transcript blocks render in elevated clipping layers, that invalid cursor request outranked the focused editor cursor.

This change:

- derives inline PTY input ownership from the active foreground block in one model-scoped helper;
- requires a rendered transcript block to match that foreground owner before submitting a hardware cursor;
- preserves background output rendering, the anti-flicker delay, focus handling, and scene-layer arbitration.

Implementation plan: https://staging.warp.dev/drive/notebook/lPe5imKlAf9CWdcOF5t6HU

Agent conversation: https://staging.warp.dev/conversation/6fdee909-75a5-4819-a875-964dea7d6501

## Linked Issue

No linked issue; this was reproduced from a reported TUI Starship cursor failure.

## Testing

- Added regression coverage for an unfinished early-output background block preceding a normal active prompt:
  - the background output remains visible;
  - it does not become the inline input owner;
  - it does not submit a frame cursor;
  - the composer remains the resolved input target.
- Preserved coverage proving a genuine active, user-controlled foreground command still submits its visible terminal cursor.
- `cargo nextest run -p warp_tui -E 'test(terminal_block::tests) | test(terminal_use::tests)'` — 21 passed.
- `cargo check -p warp_tui --all-targets --all-features`
- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

Manual validation used the rebuilt standalone TUI in a real 120×40 tmux PTY:

1. Entered shell mode and ran `(sleep 1; echo MANUAL_CURSOR_REPRO >&2) &`, which returns to a fresh composer before delayed stderr arrives.
2. Before delayed output, tmux reported the hardware cursor at `(6,36)` in the composer.
3. After `MANUAL_CURSOR_REPRO` and the background-job completion line rendered in the transcript, the cursor remained at `(6,36)`.
4. Typed `composer-still-editable`; the text appeared in the composer and the cursor advanced to `(29,36)`.

- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos

Not included: a static terminal capture does not expose hardware-cursor ownership. The tmux cursor coordinates and captured text above validate the before/after state directly.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed delayed shell output trapping the cursor in the headless TUI.
