### PR TITLE
Improved /mcp experience for TUI

### DIFF
--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -298,20 +298,13 @@ impl FileBasedMCPManager {
     /// global, even if they also happen to be referenced from a global location (in which
     /// case this returns `true` due to the global reference).
     fn is_global_server(&self, hash: u64) -> bool {
-        let home_dir = dirs::home_dir();
         self.file_based_servers_by_root
             .iter()
             .any(|(root_path, provider_map)| {
                 provider_map.iter().any(|(provider, hashes)| {
-                    if !hashes.contains(&hash) {
-                        return false;
-                    }
-                    match provider {
-                        MCPProvider::Warp => Self::is_global_warp_root(root_path),
-                        MCPProvider::Claude | MCPProvider::Codex | MCPProvider::Agents => {
-                            home_dir.as_ref().is_some_and(|home| root_path == home)
-                        }
-                    }
+                    hashes.contains(&hash)
+                        && Self::scope_for_source(root_path, *provider)
+                            == FileBasedMCPServerScope::Global
                 })
             })
     }
@@ -332,6 +325,28 @@ impl FileBasedMCPManager {
     fn is_global_warp_root(root_path: &Path) -> bool {
         warp_managed_mcp_config_path().is_some_and(|path| root_path == path.root_path.as_path())
     }
+
+    fn scope_for_source(root_path: &Path, provider: MCPProvider) -> FileBasedMCPServerScope {
+        match provider {
+            MCPProvider::Warp => {
+                if Self::is_global_warp_root(root_path) {
+                    FileBasedMCPServerScope::Global
+                } else {
+                    FileBasedMCPServerScope::Project
+                }
+            }
+            MCPProvider::Claude | MCPProvider::Codex | MCPProvider::Agents => {
+                if dirs::home_dir()
+                    .as_ref()
+                    .is_some_and(|home| root_path == home)
+                {
+                    FileBasedMCPServerScope::Global
+                } else {
+                    FileBasedMCPServerScope::Project
+                }
+            }
+        }
+    }
     fn auto_start_decision(&self, hash: u64, file_based_mcp_enabled: bool) -> AutoStartDecision {
         let server_type = if self.is_global_warp_server(hash) {
             FileBasedMCPServerType::GlobalWarp
@@ -342,7 +357,9 @@ impl FileBasedMCPManager {
         };
         let should_autostart = match server_type {
             FileBasedMCPServerType::GlobalWarp => true,
-            FileBasedMCPServerType::GlobalThirdParty => file_based_mcp_enabled,
+            FileBasedMCPServerType::GlobalThirdParty => {
+                !self.defer_global_warp_autostart && file_based_mcp_enabled
+            }
             FileBasedMCPServerType::ProjectScoped => false,
         };
 
@@ -460,6 +477,12 @@ impl FileBasedMCPManager {
     }
 
     fn handle_file_based_mcp_enabled_change(&mut self, ctx: &mut ModelContext<Self>) {
+        // The setting is GUI-only. TUI-discovered third-party servers always
+        // require an explicit start action, even if a value is loaded into the
+        // shared model by tests or future settings migrations.
+        if self.defer_global_warp_autostart {
+            return;
+        }
         // Only global third-party servers are affected by the toggle:
         // - Global Warp servers always spawn regardless of the toggle.
         // - Project-scoped servers (any provider) are never auto-spawned and their
@@ -497,12 +520,21 @@ impl FileBasedMCPManager {
             .find(|(_, server)| server.uuid() == installation_uuid)
             .map(|(hash, _)| *hash)
     }
+    /// Returns owned snapshots of every current file-config diagnostic.
     #[cfg(any(feature = "tui", test))]
-    pub fn config_diagnostic(&self, config_path: &Path) -> Option<&FileMCPConfigDiagnostic> {
-        self.config_diagnostics_by_path.get(config_path)
+    pub fn config_diagnostics(&self) -> Vec<FileMCPConfigDiagnostic> {
+        self.config_diagnostics_by_path
+            .values()
+            .cloned()
+            .sorted_by(|left, right| {
+                left.config_path.cmp(&right.config_path).then_with(|| {
+                    provider_sort_key(left.provider).cmp(&provider_sort_key(right.provider))
+                })
+            })
+            .collect()
     }
 
-    #[cfg(feature = "tui")]
+    #[cfg(any(feature = "tui", test))]
     pub fn global_warp_servers(&self) -> Vec<&TemplatableMCPServerInstallation> {
         self.file_based_servers
             .iter()
@@ -511,17 +543,7 @@ impl FileBasedMCPManager {
             .collect()
     }
 
-    #[cfg(feature = "tui")]
-    pub fn global_warp_installation_by_hash(
-        &self,
-        hash: u64,
-    ) -> Option<&TemplatableMCPServerInstallation> {
-        self.is_global_warp_server(hash)
-            .then(|| self.file_based_servers.get(&hash))
-            .flatten()
-    }
-
-    #[cfg(feature = "tui")]
+    #[cfg(any(feature = "tui", test))]
     pub fn activate_global_warp_servers(&mut self, ctx: &mut ModelContext<Self>) {
         if self.global_warp_servers_activated {
             return;
@@ -540,6 +562,46 @@ impl FileBasedMCPManager {
     /// Returns all detected file-based MCP server installations.
     pub fn file_based_servers(&self) -> Vec<&TemplatableMCPServerInstallation> {
         self.file_based_servers.values().collect()
+    }
+    /// Returns owned file-based installations with every config source that
+    /// currently references each installation.
+    #[cfg(any(feature = "tui", test))]
+    pub fn file_based_servers_with_sources(&self) -> Vec<FileBasedMCPServerWithSources> {
+        self.file_based_servers
+            .iter()
+            .sorted_by_key(|(hash, _)| **hash)
+            .map(|(hash, installation)| {
+                let mut sources = self
+                    .file_based_servers_by_root
+                    .iter()
+                    .flat_map(|(root_path, provider_map)| {
+                        provider_map
+                            .iter()
+                            .filter(|(_, hashes)| hashes.contains(hash))
+                            .map(|(provider, _)| FileBasedMCPServerSource {
+                                provider: *provider,
+                                root_path: root_path.clone(),
+                                scope: Self::scope_for_source(root_path, *provider),
+                            })
+                    })
+                    .collect_vec();
+                sources.sort_by(|left, right| {
+                    left.root_path.cmp(&right.root_path).then_with(|| {
+                        provider_sort_key(left.provider).cmp(&provider_sort_key(right.provider))
+                    })
+                });
+                FileBasedMCPServerWithSources {
+                    installation: installation.clone(),
+                    sources,
+                }
+            })
+            .collect()
+    }
+
+    /// Returns a file-based installation by its stable content hash.
+    #[cfg(any(feature = "tui", test))]
+    pub fn installation_by_hash(&self, hash: u64) -> Option<&TemplatableMCPServerInstallation> {
+        self.file_based_servers.get(&hash)
     }
 
     /// Returns the installation with the given UUID, if any.
@@ -608,6 +670,36 @@ impl FileBasedMCPManager {
     }
 }
 
+#[cfg(any(feature = "tui", test))]
+fn provider_sort_key(provider: MCPProvider) -> u8 {
+    match provider {
+        MCPProvider::Warp => 0,
+        MCPProvider::Claude => 1,
+        MCPProvider::Codex => 2,
+        MCPProvider::Agents => 3,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FileBasedMCPServerScope {
+    Global,
+    Project,
+}
+
+#[cfg(any(feature = "tui", test))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FileBasedMCPServerSource {
+    pub provider: MCPProvider,
+    pub root_path: PathBuf,
+    pub scope: FileBasedMCPServerScope,
+}
+
+#[cfg(any(feature = "tui", test))]
+#[derive(Clone, Debug)]
+pub struct FileBasedMCPServerWithSources {
+    pub installation: TemplatableMCPServerInstallation,
+    pub sources: Vec<FileBasedMCPServerSource>,
+}
 struct AutoStartDecision {
     should_autostart: bool,
     server_type: FileBasedMCPServerType,

--- a/app/src/ai/mcp/file_based_manager_tests.rs
+++ b/app/src/ai/mcp/file_based_manager_tests.rs
@@ -10,7 +10,10 @@ use warp_core::features::FeatureFlag;
 use warpui::{App, Entity, ModelHandle, SingletonEntity as _};
 use watcher::HomeDirectoryWatcher;
 
-use super::{CloudEnvMcpScanServer, FileBasedMCPManager, FileBasedMCPManagerEvent, MCPProvider};
+use super::{
+    CloudEnvMcpScanServer, FileBasedMCPManager, FileBasedMCPManagerEvent, FileBasedMCPServerScope,
+    MCPProvider,
+};
 use crate::ai::mcp::file_mcp_watcher::{FileMCPConfigDiagnostic, FileMCPConfigDiagnosticKind};
 use crate::ai::mcp::{FileMCPWatcher, FileMCPWatcherEvent, ParsedTemplatableMCPServerResult};
 use crate::auth::AuthStateProvider;
@@ -190,16 +193,67 @@ fn test_config_error_preserves_last_known_good_servers() {
             );
 
             assert_eq!(manager.file_based_servers.len(), 1);
-            assert_eq!(
-                manager
-                    .config_diagnostic(&config_path)
-                    .map(|diagnostic| diagnostic.message.as_str()),
-                Some("invalid JSON")
-            );
+            let diagnostics = manager.config_diagnostics();
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].config_path, config_path);
+            assert_eq!(diagnostics[0].message, "invalid JSON");
         });
     });
 }
 
+#[test]
+fn all_config_diagnostics_are_owned_sorted_and_cleared_independently() {
+    let first_root = PathBuf::from("/tmp/a-repo");
+    let second_root = PathBuf::from("/tmp/b-repo");
+    let first_path = first_root.join(".mcp.json");
+    let second_path = second_root.join(".agents/.mcp.json");
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+        manager_handle.update(&mut app, |manager, ctx| {
+            for (config_path, provider, message) in [
+                (
+                    second_path.clone(),
+                    MCPProvider::Agents,
+                    "second diagnostic",
+                ),
+                (first_path.clone(), MCPProvider::Claude, "first diagnostic"),
+            ] {
+                manager.handle_watcher_event(
+                    &FileMCPWatcherEvent::ConfigError {
+                        diagnostic: FileMCPConfigDiagnostic {
+                            config_path,
+                            provider,
+                            kind: FileMCPConfigDiagnosticKind::Parse,
+                            message: message.to_string(),
+                        },
+                    },
+                    ctx,
+                );
+            }
+
+            let diagnostics = manager.config_diagnostics();
+            assert_eq!(diagnostics.len(), 2);
+            assert_eq!(diagnostics[0].config_path, first_path);
+            assert_eq!(diagnostics[1].config_path, second_path);
+
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigParsed {
+                    config_path: first_path.clone(),
+                    root_path: first_root,
+                    provider: MCPProvider::Claude,
+                    servers: Vec::new(),
+                },
+                ctx,
+            );
+
+            let remaining = manager.config_diagnostics();
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(remaining[0].config_path, second_path);
+            assert_eq!(diagnostics.len(), 2, "prior snapshot should remain owned");
+        });
+    });
+}
 #[test]
 fn test_update_file_based_servers_spawns_new_servers() {
     let repo_path = PathBuf::from("/tmp/test-repo");
@@ -477,6 +531,79 @@ fn test_global_non_warp_server_respects_toggle() {
     });
 }
 
+#[test]
+fn tui_global_third_party_servers_never_auto_start() {
+    let _flag_guard = FeatureFlag::FileBasedMcp.override_enabled(true);
+    let Some(home_dir) = dirs::home_dir() else {
+        return;
+    };
+    let parsed =
+        parse_mcp_json(r#"{"global-codex": {"command": "npx", "args": ["global-codex"]}}"#);
+
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let events = subscribe_events(&mut app, &manager);
+        set_file_based_mcp_enabled(&mut app, true);
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.defer_global_warp_autostart = true;
+            manager.global_warp_servers_activated = false;
+            manager.apply_parsed_servers(home_dir, MCPProvider::Codex, parsed, ctx);
+        });
+        set_file_based_mcp_enabled(&mut app, false);
+        set_file_based_mcp_enabled(&mut app, true);
+
+        events.read(&app, |events, _| {
+            assert!(
+                events.spawned_uuids.is_empty(),
+                "TUI third-party global configs require an explicit start"
+            );
+            assert!(
+                events.despawned_uuids.is_empty(),
+                "GUI toggle changes must not control TUI third-party configs"
+            );
+        });
+    });
+}
+
+#[test]
+fn tui_global_warp_servers_start_only_after_activation() {
+    let _flag_guard = FeatureFlag::FileBasedMcp.override_enabled(true);
+    let Some(warp_mcp_config_path) = warp_managed_mcp_config_path() else {
+        return;
+    };
+    let parsed = parse_mcp_json(r#"{"global-warp": {"command": "npx", "args": ["global-warp"]}}"#);
+
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let events = subscribe_events(&mut app, &manager);
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.defer_global_warp_autostart = true;
+            manager.global_warp_servers_activated = false;
+            manager.apply_parsed_servers(
+                warp_mcp_config_path.root_path,
+                MCPProvider::Warp,
+                parsed,
+                ctx,
+            );
+        });
+        events.read(&app, |events, _| {
+            assert!(events.spawned_uuids.is_empty());
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.activate_global_warp_servers(ctx);
+        });
+        events.read(&app, |events, _| {
+            assert_eq!(
+                events.spawned_uuids.len(),
+                1,
+                "post-login activation should start TUI Warp-global servers"
+            );
+        });
+    });
+}
 /// Project-scoped installations (both Warp and third-party) never auto-spawn on
 /// detection, and the toggle must not spawn or despawn them either.
 #[test]
@@ -652,6 +779,76 @@ fn test_server_referenced_from_both_global_and_project_is_global() {
                 e.spawned_uuids,
                 vec![installation_uuid],
                 "Global reference should make the server eligible for toggle-driven spawn"
+            );
+        });
+    });
+}
+
+#[test]
+fn source_snapshots_preserve_provenance_scope_spawn_root_and_hash_lookup() {
+    let Some(home_dir) = dirs::home_dir() else {
+        return;
+    };
+    let repo_path = PathBuf::from("/tmp/warp-test-provenance-repo");
+    let json = r#"{"shared-server": {"command": "npx", "args": ["shared"]}}"#;
+
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        manager.update(&mut app, |manager, ctx| {
+            manager.apply_parsed_servers(
+                home_dir.clone(),
+                MCPProvider::Claude,
+                parse_mcp_json(json),
+                ctx,
+            );
+            manager.apply_parsed_servers(
+                repo_path.clone(),
+                MCPProvider::Agents,
+                parse_mcp_json(json),
+                ctx,
+            );
+
+            let snapshots = manager.file_based_servers_with_sources();
+            assert_eq!(snapshots.len(), 1);
+            let snapshot = &snapshots[0];
+            assert_eq!(snapshot.sources.len(), 2);
+            assert!(snapshot.sources.iter().any(|source| {
+                source.provider == MCPProvider::Claude
+                    && source.root_path == home_dir
+                    && source.scope == FileBasedMCPServerScope::Global
+            }));
+            assert!(snapshot.sources.iter().any(|source| {
+                source.provider == MCPProvider::Agents
+                    && source.root_path == repo_path
+                    && source.scope == FileBasedMCPServerScope::Project
+            }));
+
+            let hash = snapshot
+                .installation
+                .hash()
+                .expect("file installation should have a stable hash");
+            assert_eq!(
+                manager
+                    .installation_by_hash(hash)
+                    .map(|installation| installation.uuid()),
+                Some(snapshot.installation.uuid())
+            );
+            assert_eq!(
+                manager.spawn_root_for_installation(snapshot.installation.uuid()),
+                Some(home_dir.clone()),
+                "global provenance remains the deterministic spawn cwd"
+            );
+
+            manager.remove_servers_for_root_provider(&home_dir, MCPProvider::Claude, ctx);
+            assert_eq!(
+                snapshots[0].sources.len(),
+                2,
+                "returned provenance remains an owned snapshot"
+            );
+            assert_eq!(
+                manager.spawn_root_for_installation(snapshot.installation.uuid()),
+                Some(repo_path),
+                "project provenance becomes the spawn cwd after global removal"
             );
         });
     });

--- a/app/src/ai/mcp/file_mcp_watcher.rs
+++ b/app/src/ai/mcp/file_mcp_watcher.rs
@@ -139,7 +139,7 @@ pub struct FileMCPWatcher {
 impl FileMCPWatcher {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         let (file_mcp_tx, file_mcp_rx) = async_channel::unbounded::<FileMCPDetectionMessage>();
-        let is_tui = settings::settings_mode() == settings::SettingsMode::Tui;
+        let settings_mode = settings::settings_mode();
 
         ctx.spawn_stream_local(
             file_mcp_rx,
@@ -149,32 +149,24 @@ impl FileMCPWatcher {
             |_, _| {},
         );
 
-        if !is_tui {
-            // TODO: Extend TUI discovery to project and third-party provider
-            // configs in a later phase.
-            ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), {
-                let file_mcp_tx = file_mcp_tx.clone();
-                move |me, _, event, ctx| {
-                    let DetectedRepositoriesEvent::DetectedGitRepo { repository, source } = event;
-                    if matches!(
-                        source,
-                        RepoDetectionSource::TerminalNavigation
-                            | RepoDetectionSource::CloudEnvironmentPrep
-                    ) {
-                        let repo_path = repository.as_ref(ctx).root_dir().to_local_path_lossy();
-                        if matches!(source, RepoDetectionSource::CloudEnvironmentPrep) {
-                            let count =
-                                providers_in_scope(repo_path.clone(), repo_path.clone()).count();
-                            me.cloud_env_pending.insert(repo_path.clone(), count);
-                        }
-                        me.register_repo_for_file_mcp_watching(repo_path, ctx, file_mcp_tx.clone());
+        ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), {
+            let file_mcp_tx = file_mcp_tx.clone();
+            move |me, _, event, ctx| {
+                let DetectedRepositoriesEvent::DetectedGitRepo { repository, source } = event;
+                if should_watch_repository(*source, settings_mode) {
+                    let repo_path = repository.as_ref(ctx).root_dir().to_local_path_lossy();
+                    if matches!(source, RepoDetectionSource::CloudEnvironmentPrep) {
+                        let count =
+                            providers_in_scope(repo_path.clone(), repo_path.clone()).count();
+                        me.cloud_env_pending.insert(repo_path.clone(), count);
                     }
+                    me.register_repo_for_file_mcp_watching(repo_path, ctx, file_mcp_tx.clone());
                 }
-            });
-            ctx.subscribe_to_model(&HomeDirectoryWatcher::handle(ctx), |me, _, event, ctx| {
-                me.handle_home_directory_watcher_event(event, ctx);
-            });
-        }
+            }
+        });
+        ctx.subscribe_to_model(&HomeDirectoryWatcher::handle(ctx), |me, _, event, ctx| {
+            me.handle_home_directory_watcher_event(event, ctx);
+        });
         ctx.subscribe_to_model(
             &WarpManagedPathsWatcher::handle(ctx),
             |me, _, event, ctx| {
@@ -192,7 +184,7 @@ impl FileMCPWatcher {
             ));
         }
 
-        if !is_tui && let Some(home_dir) = dirs::home_dir() {
+        if let Some(home_dir) = dirs::home_dir() {
             for provider in MCPProvider::iter() {
                 if provider == MCPProvider::Warp {
                     continue;
@@ -518,10 +510,7 @@ impl FileMCPWatcher {
         let mut configs_to_update = Vec::new();
 
         for (provider, config_path) in providers_in_scope(root_path.clone(), watched_dir.clone()) {
-            let was_deleted = update.deleted.iter().any(|f| f.path == config_path)
-                || update.moved.values().any(|f| f.path == config_path);
-            let was_added = update.added_or_modified().any(|f| f.path == config_path)
-                || update.moved.keys().any(|f| f.path == config_path);
+            let (was_deleted, was_added) = config_change_flags(&update, &config_path);
             configs_to_update.push((provider, config_path, was_deleted, was_added));
         }
 
@@ -606,6 +595,36 @@ impl FileMCPWatcher {
     }
 }
 
+fn should_watch_repository(
+    source: RepoDetectionSource,
+    settings_mode: settings::SettingsMode,
+) -> bool {
+    match settings_mode {
+        settings::SettingsMode::Gui => match source {
+            RepoDetectionSource::TerminalNavigation | RepoDetectionSource::CloudEnvironmentPrep => {
+                true
+            }
+            RepoDetectionSource::ProjectRulesIndexing
+            | RepoDetectionSource::CodeReviewInitialization => false,
+        },
+        settings::SettingsMode::Tui => match source {
+            RepoDetectionSource::TerminalNavigation => true,
+            RepoDetectionSource::ProjectRulesIndexing
+            | RepoDetectionSource::CodeReviewInitialization
+            | RepoDetectionSource::CloudEnvironmentPrep => false,
+        },
+    }
+}
+
+fn config_change_flags(update: &RepositoryUpdate, config_path: &Path) -> (bool, bool) {
+    let was_deleted = update.deleted.iter().any(|file| file.path == config_path)
+        || update.moved.values().any(|file| file.path == config_path);
+    let was_added = update
+        .added_or_modified()
+        .any(|file| file.path == config_path)
+        || update.moved.keys().any(|file| file.path == config_path);
+    (was_deleted, was_added)
+}
 /// Returns an iterator of `(provider, config_path)` pairs for MCP providers whose configuration file
 /// paths fall within the watched directory.
 fn providers_in_scope(

--- a/app/src/ai/mcp/file_mcp_watcher_tests.rs
+++ b/app/src/ai/mcp/file_mcp_watcher_tests.rs
@@ -3,9 +3,13 @@ use std::env;
 use std::path::PathBuf;
 
 use futures::stream::AbortHandle;
+use repo_metadata::repositories::RepoDetectionSource;
+use repo_metadata::{RepositoryUpdate, TargetFile};
+use settings::SettingsMode;
 
 use super::{
-    FileMCPConfigDiagnosticKind, FileMCPConfigParseOutcome, FileMCPWatcher, parse_mcp_config_file,
+    FileMCPConfigDiagnosticKind, FileMCPConfigParseOutcome, FileMCPWatcher, config_change_flags,
+    home_subdir_to_watch, parse_mcp_config_file, providers_in_scope, should_watch_repository,
     substitute_env_vars,
 };
 use crate::ai::mcp::MCPProvider;
@@ -36,6 +40,109 @@ fn abort_config_parse_cancels_and_removes_inflight_task() {
 
     assert!(observed_handle.is_aborted());
     assert!(!watcher.parse_abort_handles.contains_key(&key));
+}
+
+#[test]
+fn repository_discovery_is_surface_aware() {
+    assert!(should_watch_repository(
+        RepoDetectionSource::TerminalNavigation,
+        SettingsMode::Gui
+    ));
+    assert!(should_watch_repository(
+        RepoDetectionSource::CloudEnvironmentPrep,
+        SettingsMode::Gui
+    ));
+    assert!(!should_watch_repository(
+        RepoDetectionSource::ProjectRulesIndexing,
+        SettingsMode::Gui
+    ));
+    assert!(!should_watch_repository(
+        RepoDetectionSource::CodeReviewInitialization,
+        SettingsMode::Gui
+    ));
+
+    assert!(should_watch_repository(
+        RepoDetectionSource::TerminalNavigation,
+        SettingsMode::Tui
+    ));
+    assert!(!should_watch_repository(
+        RepoDetectionSource::ProjectRulesIndexing,
+        SettingsMode::Tui
+    ));
+    assert!(!should_watch_repository(
+        RepoDetectionSource::CodeReviewInitialization,
+        SettingsMode::Tui
+    ));
+    assert!(!should_watch_repository(
+        RepoDetectionSource::CloudEnvironmentPrep,
+        SettingsMode::Tui
+    ));
+}
+
+#[test]
+fn global_provider_initial_scans_cover_claude_codex_and_agents() {
+    let home = PathBuf::from("/home/test");
+
+    assert_eq!(home_subdir_to_watch(MCPProvider::Claude), None);
+    assert_eq!(
+        home.join(MCPProvider::Claude.home_config_path()),
+        home.join(".claude.json")
+    );
+
+    for (provider, subdir, config) in [
+        (MCPProvider::Codex, ".codex", ".codex/config.toml"),
+        (MCPProvider::Agents, ".agents", ".agents/.mcp.json"),
+    ] {
+        assert_eq!(home_subdir_to_watch(provider), Some(PathBuf::from(subdir)));
+        let discovered =
+            providers_in_scope(home.clone(), home.join(subdir)).collect::<HashSet<_>>();
+        assert!(
+            discovered.contains(&(provider, home.join(config))),
+            "{provider:?} config should be included in its home subdirectory scan"
+        );
+    }
+}
+
+#[test]
+fn project_initial_scan_covers_each_supported_provider_config() {
+    let repo = PathBuf::from("/work/repository");
+    let discovered = providers_in_scope(repo.clone(), repo.clone()).collect::<HashSet<_>>();
+
+    for provider in [
+        MCPProvider::Warp,
+        MCPProvider::Claude,
+        MCPProvider::Codex,
+        MCPProvider::Agents,
+    ] {
+        assert!(
+            discovered.contains(&(provider, repo.join(provider.project_config_path()))),
+            "{provider:?} project config should be included in a repository scan"
+        );
+    }
+}
+
+#[test]
+fn incremental_updates_detect_each_supported_provider_config() {
+    let repo = PathBuf::from("/work/repository");
+    for provider in [
+        MCPProvider::Warp,
+        MCPProvider::Claude,
+        MCPProvider::Codex,
+        MCPProvider::Agents,
+    ] {
+        let config_path = repo.join(provider.project_config_path());
+        let mut added = RepositoryUpdate::default();
+        added
+            .added
+            .insert(TargetFile::new(config_path.clone(), false));
+        assert_eq!(config_change_flags(&added, &config_path), (false, true));
+
+        let mut deleted = RepositoryUpdate::default();
+        deleted
+            .deleted
+            .insert(TargetFile::new(config_path.clone(), false));
+        assert_eq!(config_change_flags(&deleted, &config_path), (true, false));
+    }
 }
 #[test]
 fn test_substitute_env_vars_success() {

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -243,6 +243,14 @@ impl TemplatableMCPServerManager {
         self.get_template_uuid(installation_uuid)
             .is_some_and(|uuid| self.server_credentials.contains_key(&uuid))
     }
+    #[cfg(all(not(target_family = "wasm"), feature = "tui"))]
+    pub fn can_log_out(&self, installation_uuid: Uuid, app: &warpui::AppContext) -> bool {
+        self.has_credentials(installation_uuid, app)
+            || self
+                .active_servers
+                .get(&installation_uuid)
+                .is_some_and(TemplatableMCPServerInfo::is_authenticated_transport)
+    }
 
     /// Returns the JSON Schema `input_schema` for a named tool across active MCP servers.
     ///

--- a/app/src/tui/mcp.rs
+++ b/app/src/tui/mcp.rs
@@ -1,18 +1,27 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::path::PathBuf;
 
 use uuid::Uuid;
 use warpui::{Entity, ModelContext, SingletonEntity};
 
+use crate::ai::mcp::file_based_manager::FileBasedMCPServerScope;
+use crate::ai::mcp::gallery::MCPGalleryManagerEvent;
 use crate::ai::mcp::parsing::resolve_json;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManagerEvent;
 use crate::ai::mcp::{
-    FileBasedMCPManager, FileMCPWatcher, MCPServer, MCPServerExt, MCPServerState,
-    TemplatableMCPServerManager, TransportType,
+    FileBasedMCPManager, FileMCPWatcher, MCPGalleryManager, MCPServer, MCPServerExt,
+    MCPServerState, TemplatableMCPServer, TemplatableMCPServerInstallation,
+    TemplatableMCPServerManager, TransportType, VariableType, VariableValue,
 };
-use crate::warp_managed_paths_watcher::active_mcp_config_file_path;
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct TuiMcpServerId(pub u64);
+pub enum TuiMcpServerId {
+    FileBased(u64),
+    Installation(Uuid),
+    SyncedTemplate(Uuid),
+    Gallery(Uuid),
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TuiMcpTransport {
@@ -20,8 +29,30 @@ pub enum TuiMcpTransport {
     HttpOrSse,
 }
 
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum TuiMcpFileScope {
+    Global,
+    Project,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct TuiMcpFileSource {
+    pub provider: String,
+    pub root_path: PathBuf,
+    pub scope: TuiMcpFileScope,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TuiMcpServerSource {
+    FileBased { sources: Vec<TuiMcpFileSource> },
+    Installation,
+    SyncedTemplate,
+    Gallery,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TuiMcpServerStatus {
+    Available,
     Offline,
     Starting,
     Authenticating,
@@ -33,32 +64,65 @@ pub enum TuiMcpServerStatus {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TuiMcpServerSnapshot {
     pub id: TuiMcpServerId,
-    pub installation_uuid: Uuid,
+    pub installation_uuid: Option<Uuid>,
     pub name: String,
-    pub transport: TuiMcpTransport,
+    pub description: Option<String>,
+    pub source: TuiMcpServerSource,
+    pub transport: Option<TuiMcpTransport>,
     pub status: TuiMcpServerStatus,
     pub tool_count: usize,
     pub resource_count: usize,
-    pub has_credentials: bool,
+    pub can_log_out: bool,
     pub authorization_url: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum TuiMcpConfigState {
-    Missing,
-    Ready,
-    Invalid { message: String },
+pub struct TuiMcpConfigDiagnostic {
+    pub provider: String,
+    pub config_path: PathBuf,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TuiMcpSnapshot {
+    pub diagnostics: Vec<TuiMcpConfigDiagnostic>,
+    pub servers: Vec<TuiMcpServerSnapshot>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TuiMcpSnapshot {
-    pub config_path: PathBuf,
-    pub config_state: TuiMcpConfigState,
-    pub servers: Vec<TuiMcpServerSnapshot>,
+pub struct TuiMcpTemplateVariable {
+    pub key: String,
+    pub allowed_values: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TuiMcpInstallRequest {
+    pub id: TuiMcpServerId,
+    pub name: String,
+    pub description: Option<String>,
+    pub source: TuiMcpServerSource,
+    pub instructions: Option<String>,
+    pub variables: Vec<TuiMcpTemplateVariable>,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct TuiMcpVariableValue {
+    pub key: String,
+    pub value: String,
+}
+impl fmt::Debug for TuiMcpVariableValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TuiMcpVariableValue")
+            .field("key", &self.key)
+            .field("value", &"[REDACTED]")
+            .finish()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TuiMcpAction {
+    Enable(TuiMcpServerId),
     Start(TuiMcpServerId),
     Stop(TuiMcpServerId),
     Retry(TuiMcpServerId),
@@ -72,11 +136,11 @@ pub enum TuiMcpManagerEvent {
     Updated,
 }
 
-/// TUI-facing aggregate over every global Warp MCP server.
+/// TUI-facing aggregate over installed, synced, gallery, and file-based MCPs.
 ///
-/// There is one singleton model for the TUI process, not one model per
-/// server. Its snapshot joins file-config health with runtime state for all
-/// configured servers; per-server actions are routed by [`TuiMcpServerId`].
+/// Refreshing this model is a pure read. Available catalog items become
+/// runnable only through [`Self::confirm_install`], after the frontend has
+/// collected values and presented its final confirmation.
 pub struct TuiMcpManager {
     snapshot: TuiMcpSnapshot,
 }
@@ -86,11 +150,7 @@ impl TuiMcpManager {
     #[cfg(any(test, all(feature = "tui", feature = "test-util")))]
     pub(crate) fn new_for_test(_ctx: &mut ModelContext<Self>) -> Self {
         Self {
-            snapshot: TuiMcpSnapshot {
-                config_path: PathBuf::new(),
-                config_state: TuiMcpConfigState::Missing,
-                servers: Vec::new(),
-            },
+            snapshot: TuiMcpSnapshot::default(),
         }
     }
 
@@ -100,26 +160,34 @@ impl TuiMcpManager {
         });
         ctx.subscribe_to_model(
             &TemplatableMCPServerManager::handle(ctx),
-            |me, _, event, ctx| match event {
-                TemplatableMCPServerManagerEvent::StateChanged { .. } => me.refresh(ctx),
-                TemplatableMCPServerManagerEvent::AuthenticationRequired { uuid }
-                | TemplatableMCPServerManagerEvent::CredentialsChanged { uuid } => {
-                    let _ = uuid;
-                    me.refresh(ctx);
+            |me, _, event, ctx| {
+                match event {
+                    TemplatableMCPServerManagerEvent::StateChanged { uuid, state } => {
+                        let _ = (uuid, state);
+                    }
+                    TemplatableMCPServerManagerEvent::AuthenticationRequired { uuid }
+                    | TemplatableMCPServerManagerEvent::CredentialsChanged { uuid } => {
+                        let _ = uuid;
+                    }
+                    TemplatableMCPServerManagerEvent::ServerInstallationAdded(uuid)
+                    | TemplatableMCPServerManagerEvent::ServerInstallationDeleted(uuid) => {
+                        let _ = uuid;
+                    }
+                    TemplatableMCPServerManagerEvent::TemplatableMCPServersUpdated
+                    | TemplatableMCPServerManagerEvent::LegacyServerConverted => {}
                 }
-                TemplatableMCPServerManagerEvent::ServerInstallationAdded(_)
-                | TemplatableMCPServerManagerEvent::ServerInstallationDeleted(_)
-                | TemplatableMCPServerManagerEvent::TemplatableMCPServersUpdated
-                | TemplatableMCPServerManagerEvent::LegacyServerConverted => {}
+                me.refresh(ctx);
+            },
+        );
+        ctx.subscribe_to_model(
+            &MCPGalleryManager::handle(ctx),
+            |me, _, event, ctx| match event {
+                MCPGalleryManagerEvent::ItemsRefreshed => me.refresh(ctx),
             },
         );
 
         let mut model = Self {
-            snapshot: TuiMcpSnapshot {
-                config_path: active_mcp_config_file_path().unwrap_or_default(),
-                config_state: TuiMcpConfigState::Missing,
-                servers: Vec::new(),
-            },
+            snapshot: TuiMcpSnapshot::default(),
         };
         model.refresh(ctx);
         model
@@ -129,8 +197,100 @@ impl TuiMcpManager {
         &self.snapshot
     }
 
+    pub fn prepare_install(
+        &self,
+        id: TuiMcpServerId,
+        ctx: &ModelContext<Self>,
+    ) -> Result<TuiMcpInstallRequest, String> {
+        if !self
+            .snapshot
+            .servers
+            .iter()
+            .any(|server| server.id == id && matches!(server.status, TuiMcpServerStatus::Available))
+        {
+            return Err("This MCP is no longer available to enable".to_owned());
+        }
+
+        let (server, instructions, source) = match id {
+            TuiMcpServerId::SyncedTemplate(template_uuid) => {
+                let server = TemplatableMCPServerManager::as_ref(ctx)
+                    .get_templatable_mcp_server(template_uuid)
+                    .cloned()
+                    .ok_or_else(|| "The synced MCP template is no longer available".to_owned())?;
+                (server, None, TuiMcpServerSource::SyncedTemplate)
+            }
+            TuiMcpServerId::Gallery(gallery_uuid) => {
+                let gallery = MCPGalleryManager::as_ref(ctx)
+                    .get_gallery_item(gallery_uuid)
+                    .ok_or_else(|| "The gallery MCP is no longer available".to_owned())?;
+                let instructions = gallery.instructions_in_markdown().cloned();
+                let server = MCPGalleryManager::as_ref(ctx)
+                    .get_templatable_mcp_server(gallery_uuid)
+                    .cloned()
+                    .ok_or_else(|| "The gallery MCP template is no longer available".to_owned())?;
+                (server, instructions, TuiMcpServerSource::Gallery)
+            }
+            TuiMcpServerId::FileBased(_) | TuiMcpServerId::Installation(_) => {
+                return Err("This MCP is already installed".to_owned());
+            }
+        };
+
+        Ok(TuiMcpInstallRequest {
+            id,
+            name: server.name,
+            description: server.description,
+            source,
+            instructions,
+            variables: server
+                .template
+                .variables
+                .into_iter()
+                .map(|variable| TuiMcpTemplateVariable {
+                    key: variable.key,
+                    allowed_values: variable.allowed_values,
+                })
+                .collect(),
+        })
+    }
+
+    /// Installs and starts an available template after the frontend's final
+    /// confirmation. Catalog refresh and selection never call this method.
+    pub fn confirm_install(
+        &mut self,
+        id: TuiMcpServerId,
+        values: Vec<TuiMcpVariableValue>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<Uuid, String> {
+        let request = self.prepare_install(id, ctx)?;
+        let values = validate_variable_values(&request.variables, values)?;
+        let server = match id {
+            TuiMcpServerId::SyncedTemplate(template_uuid) => {
+                TemplatableMCPServerManager::as_ref(ctx)
+                    .get_templatable_mcp_server(template_uuid)
+                    .cloned()
+                    .ok_or_else(|| "The synced MCP template is no longer available".to_owned())?
+            }
+            TuiMcpServerId::Gallery(gallery_uuid) => MCPGalleryManager::as_ref(ctx)
+                .get_templatable_mcp_server(gallery_uuid)
+                .cloned()
+                .ok_or_else(|| "The gallery MCP template is no longer available".to_owned())?,
+            TuiMcpServerId::FileBased(_) | TuiMcpServerId::Installation(_) => {
+                return Err("This MCP is already installed".to_owned());
+            }
+        };
+        let installation = TemplatableMCPServerManager::handle(ctx).update(ctx, |manager, ctx| {
+            manager.install_from_template(server, values, true, ctx)
+        });
+        let installation =
+            installation.ok_or_else(|| "Unable to install this MCP server".to_owned())?;
+        let uuid = installation.uuid();
+        self.refresh(ctx);
+        Ok(uuid)
+    }
+
     pub fn apply_action(&mut self, action: TuiMcpAction, ctx: &mut ModelContext<Self>) {
         match action {
+            TuiMcpAction::Enable(_) => {}
             TuiMcpAction::ReloadConfig => {
                 FileMCPWatcher::handle(ctx).update(ctx, |watcher, ctx| {
                     watcher.reload_global_config(ctx);
@@ -147,22 +307,36 @@ impl TuiMcpManager {
                     ctx.open_url(url);
                 }
             }
-            TuiMcpAction::Start(id) | TuiMcpAction::Retry(id) => {
-                let installation = FileBasedMCPManager::as_ref(ctx)
-                    .global_warp_installation_by_hash(id.0)
-                    .cloned();
-                if let Some(installation) = installation {
+            TuiMcpAction::Start(id) | TuiMcpAction::Retry(id) => match id {
+                TuiMcpServerId::FileBased(hash) => {
+                    let installation = FileBasedMCPManager::as_ref(ctx)
+                        .installation_by_hash(hash)
+                        .cloned();
+                    if let Some(installation) = installation {
+                        TemplatableMCPServerManager::handle(ctx).update(ctx, |manager, ctx| {
+                            if !manager.is_server_active_or_pending(installation.uuid()) {
+                                manager.spawn_ephemeral_server(installation, ctx);
+                            }
+                        });
+                    }
+                }
+                TuiMcpServerId::Installation(uuid) => {
                     TemplatableMCPServerManager::handle(ctx).update(ctx, |manager, ctx| {
-                        if !manager.is_server_active_or_pending(installation.uuid()) {
-                            manager.spawn_ephemeral_server(installation, ctx);
+                        if !manager.is_server_active_or_pending(uuid) {
+                            manager.spawn_server(uuid, ctx);
                         }
                     });
                 }
-            }
+                TuiMcpServerId::SyncedTemplate(_) | TuiMcpServerId::Gallery(_) => {}
+            },
             TuiMcpAction::Stop(id) | TuiMcpAction::LogOut(id) => {
-                let installation_uuid = FileBasedMCPManager::as_ref(ctx)
-                    .global_warp_installation_by_hash(id.0)
-                    .map(|installation| installation.uuid());
+                let installation_uuid = match id {
+                    TuiMcpServerId::FileBased(hash) => FileBasedMCPManager::as_ref(ctx)
+                        .installation_by_hash(hash)
+                        .map(TemplatableMCPServerInstallation::uuid),
+                    TuiMcpServerId::Installation(uuid) => Some(uuid),
+                    TuiMcpServerId::SyncedTemplate(_) | TuiMcpServerId::Gallery(_) => None,
+                };
                 if let Some(installation_uuid) = installation_uuid {
                     TemplatableMCPServerManager::handle(ctx).update(ctx, |manager, ctx| {
                         manager.shutdown_server(installation_uuid, ctx);
@@ -176,70 +350,130 @@ impl TuiMcpManager {
     }
 
     fn refresh(&mut self, ctx: &mut ModelContext<Self>) {
-        let config_path = active_mcp_config_file_path().unwrap_or_default();
         let file_manager = FileBasedMCPManager::as_ref(ctx);
         let runtime_manager = TemplatableMCPServerManager::as_ref(ctx);
-        let config_state = if let Some(diagnostic) = file_manager.config_diagnostic(&config_path) {
-            TuiMcpConfigState::Invalid {
-                message: diagnostic.message.clone(),
-            }
-        } else if config_path.exists() {
-            TuiMcpConfigState::Ready
-        } else {
-            TuiMcpConfigState::Missing
-        };
+        let gallery_manager = MCPGalleryManager::as_ref(ctx);
 
-        let mut servers = file_manager
-            .global_warp_servers()
+        let mut diagnostics = file_manager
+            .config_diagnostics()
             .into_iter()
-            .filter_map(|installation| {
-                let hash = installation.hash()?;
-                let uuid = installation.uuid();
-                let transport = MCPServer::from_user_json(&resolve_json(installation))
-                    .ok()?
-                    .pop()
-                    .map(|server| match server.transport_type {
-                        TransportType::CLIServer(_) => TuiMcpTransport::Stdio,
-                        TransportType::ServerSentEvents(_) => TuiMcpTransport::HttpOrSse,
-                    })?;
-                let status = match runtime_manager.get_server_state(uuid) {
-                    None | Some(MCPServerState::NotRunning) => TuiMcpServerStatus::Offline,
-                    Some(MCPServerState::Starting) => TuiMcpServerStatus::Starting,
-                    Some(MCPServerState::Authenticating) => TuiMcpServerStatus::Authenticating,
-                    Some(MCPServerState::Running) => TuiMcpServerStatus::Running,
-                    Some(MCPServerState::ShuttingDown) => TuiMcpServerStatus::Stopping,
-                    Some(MCPServerState::FailedToStart) => TuiMcpServerStatus::Failed {
-                        message: runtime_manager
-                            .get_server_error_message(uuid)
-                            .unwrap_or("Failed to start")
-                            .to_string(),
-                    },
-                };
-                Some(TuiMcpServerSnapshot {
-                    id: TuiMcpServerId(hash),
-                    installation_uuid: uuid,
-                    name: installation.templatable_mcp_server().name.clone(),
-                    transport,
-                    status,
-                    tool_count: runtime_manager.tools_for_server(uuid).len(),
-                    resource_count: runtime_manager.resources_for_server(uuid).len(),
-                    has_credentials: runtime_manager.has_credentials(uuid, ctx),
-                    authorization_url: runtime_manager
-                        .authorization_url(uuid)
-                        .map(ToString::to_string),
-                })
+            .map(|diagnostic| TuiMcpConfigDiagnostic {
+                provider: diagnostic.provider.display_name().to_owned(),
+                config_path: diagnostic.config_path,
+                message: diagnostic.message,
             })
             .collect::<Vec<_>>();
-        servers.sort_by(|left, right| {
-            left.name
-                .to_lowercase()
-                .cmp(&right.name.to_lowercase())
-                .then(left.id.cmp(&right.id))
+        diagnostics.sort_by(|left, right| {
+            left.provider
+                .cmp(&right.provider)
+                .then(left.config_path.cmp(&right.config_path))
+                .then(left.message.cmp(&right.message))
         });
 
+        let mut servers = Vec::new();
+        let installations = runtime_manager
+            .get_installed_templatable_servers()
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let installed_template_uuids = installations
+            .iter()
+            .map(TemplatableMCPServerInstallation::template_uuid)
+            .collect::<HashSet<_>>();
+        let installed_gallery_uuids = installations
+            .iter()
+            .filter_map(TemplatableMCPServerInstallation::gallery_uuid)
+            .collect::<HashSet<_>>();
+
+        for installation in installations {
+            servers.push(snapshot_for_installation(
+                TuiMcpServerId::Installation(installation.uuid()),
+                TuiMcpServerSource::Installation,
+                &installation,
+                runtime_manager,
+                ctx,
+            ));
+        }
+
+        let synced_templates = runtime_manager
+            .get_all_templatable_mcp_servers()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let reserved_gallery_uuids = synced_templates
+            .iter()
+            .filter_map(|template| template.gallery_data.map(|data| data.gallery_item_id))
+            .chain(installed_gallery_uuids.iter().copied())
+            .collect::<HashSet<_>>();
+        let reserved_names = synced_templates
+            .iter()
+            .map(|template| template.name.to_ascii_lowercase())
+            .chain(installations_names(
+                runtime_manager.get_installed_templatable_servers(),
+            ))
+            .collect::<HashSet<_>>();
+
+        for template in synced_templates {
+            if installed_template_uuids.contains(&template.uuid) {
+                continue;
+            }
+            servers.push(snapshot_for_available(
+                TuiMcpServerId::SyncedTemplate(template.uuid),
+                TuiMcpServerSource::SyncedTemplate,
+                &template,
+            ));
+        }
+
+        for gallery in gallery_manager.get_gallery() {
+            if reserved_gallery_uuids.contains(&gallery.uuid())
+                || reserved_names.contains(&gallery.title().to_ascii_lowercase())
+            {
+                continue;
+            }
+            let Some(template) = gallery_manager
+                .get_templatable_mcp_server(gallery.uuid())
+                .cloned()
+            else {
+                continue;
+            };
+            servers.push(snapshot_for_available(
+                TuiMcpServerId::Gallery(gallery.uuid()),
+                TuiMcpServerSource::Gallery,
+                &template,
+            ));
+        }
+
+        for file_server in file_manager.file_based_servers_with_sources() {
+            let installation = file_server.installation;
+            let Some(hash) = installation.hash() else {
+                continue;
+            };
+            let mut sources = file_server
+                .sources
+                .into_iter()
+                .map(|source| TuiMcpFileSource {
+                    provider: source.provider.display_name().to_owned(),
+                    root_path: source.root_path,
+                    scope: match source.scope {
+                        FileBasedMCPServerScope::Global => TuiMcpFileScope::Global,
+                        FileBasedMCPServerScope::Project => TuiMcpFileScope::Project,
+                    },
+                })
+                .collect::<Vec<_>>();
+            sources.sort();
+            sources.dedup();
+            servers.push(snapshot_for_installation(
+                TuiMcpServerId::FileBased(hash),
+                TuiMcpServerSource::FileBased { sources },
+                &installation,
+                runtime_manager,
+                ctx,
+            ));
+        }
+
+        sort_servers(&mut servers);
         let snapshot = TuiMcpSnapshot {
-            config_path,
-            config_state,
+            diagnostics,
             servers,
         };
         if self.snapshot != snapshot {
@@ -250,8 +484,176 @@ impl TuiMcpManager {
     }
 }
 
+fn installations_names(
+    installations: &HashMap<Uuid, TemplatableMCPServerInstallation>,
+) -> impl Iterator<Item = String> + '_ {
+    installations.values().map(|installation| {
+        installation
+            .templatable_mcp_server()
+            .name
+            .to_ascii_lowercase()
+    })
+}
+
+fn validate_variable_values(
+    variables: &[TuiMcpTemplateVariable],
+    values: Vec<TuiMcpVariableValue>,
+) -> Result<HashMap<String, VariableValue>, String> {
+    let expected = variables
+        .iter()
+        .map(|variable| variable.key.as_str())
+        .collect::<HashSet<_>>();
+    if values.len() != expected.len() {
+        return Err("Every required MCP variable must have a value".to_owned());
+    }
+
+    let mut resolved = HashMap::new();
+    for value in values {
+        if value.value.is_empty() || !expected.contains(value.key.as_str()) {
+            return Err("Every required MCP variable must have a value".to_owned());
+        }
+        let variable = variables
+            .iter()
+            .find(|variable| variable.key == value.key)
+            .expect("expected keys were checked");
+        if variable
+            .allowed_values
+            .as_ref()
+            .is_some_and(|allowed| !allowed.contains(&value.value))
+        {
+            return Err("Select one of the allowed values for this MCP variable".to_owned());
+        }
+        if resolved
+            .insert(
+                value.key,
+                VariableValue {
+                    variable_type: VariableType::Text,
+                    value: value.value,
+                },
+            )
+            .is_some()
+        {
+            return Err("Each MCP variable may only be provided once".to_owned());
+        }
+    }
+    Ok(resolved)
+}
+
+fn snapshot_for_available(
+    id: TuiMcpServerId,
+    source: TuiMcpServerSource,
+    template: &TemplatableMCPServer,
+) -> TuiMcpServerSnapshot {
+    TuiMcpServerSnapshot {
+        id,
+        installation_uuid: None,
+        name: template.name.clone(),
+        description: template.description.clone(),
+        source,
+        transport: transport_from_template(template),
+        status: TuiMcpServerStatus::Available,
+        tool_count: 0,
+        resource_count: 0,
+        can_log_out: false,
+        authorization_url: None,
+    }
+}
+
+fn snapshot_for_installation(
+    id: TuiMcpServerId,
+    source: TuiMcpServerSource,
+    installation: &TemplatableMCPServerInstallation,
+    runtime_manager: &TemplatableMCPServerManager,
+    ctx: &ModelContext<TuiMcpManager>,
+) -> TuiMcpServerSnapshot {
+    let uuid = installation.uuid();
+    TuiMcpServerSnapshot {
+        id,
+        installation_uuid: Some(uuid),
+        name: installation.templatable_mcp_server().name.clone(),
+        description: installation.templatable_mcp_server().description.clone(),
+        source,
+        transport: transport_from_installation(installation),
+        status: runtime_status(uuid, runtime_manager),
+        tool_count: runtime_manager.tools_for_server(uuid).len(),
+        resource_count: runtime_manager.resources_for_server(uuid).len(),
+        can_log_out: runtime_manager.can_log_out(uuid, ctx),
+        authorization_url: runtime_manager
+            .authorization_url(uuid)
+            .map(ToOwned::to_owned),
+    }
+}
+
+fn transport_from_template(template: &TemplatableMCPServer) -> Option<TuiMcpTransport> {
+    MCPServer::from_user_json(&template.template.json)
+        .ok()?
+        .pop()
+        .map(|server| transport_type(server.transport_type))
+}
+
+fn transport_from_installation(
+    installation: &TemplatableMCPServerInstallation,
+) -> Option<TuiMcpTransport> {
+    MCPServer::from_user_json(&resolve_json(installation))
+        .ok()?
+        .pop()
+        .map(|server| transport_type(server.transport_type))
+}
+
+fn transport_type(transport: TransportType) -> TuiMcpTransport {
+    match transport {
+        TransportType::CLIServer(_) => TuiMcpTransport::Stdio,
+        TransportType::ServerSentEvents(_) => TuiMcpTransport::HttpOrSse,
+    }
+}
+
+fn runtime_status(uuid: Uuid, runtime_manager: &TemplatableMCPServerManager) -> TuiMcpServerStatus {
+    match runtime_manager.get_server_state(uuid) {
+        None | Some(MCPServerState::NotRunning) => TuiMcpServerStatus::Offline,
+        Some(MCPServerState::Starting) => TuiMcpServerStatus::Starting,
+        Some(MCPServerState::Authenticating) => TuiMcpServerStatus::Authenticating,
+        Some(MCPServerState::Running) => TuiMcpServerStatus::Running,
+        Some(MCPServerState::ShuttingDown) => TuiMcpServerStatus::Stopping,
+        Some(MCPServerState::FailedToStart) => TuiMcpServerStatus::Failed {
+            message: runtime_manager
+                .get_server_error_message(uuid)
+                .unwrap_or("Failed to start")
+                .to_owned(),
+        },
+    }
+}
+
+fn sort_servers(servers: &mut [TuiMcpServerSnapshot]) {
+    servers.sort_by(|left, right| {
+        server_priority(left)
+            .cmp(&server_priority(right))
+            .then_with(|| {
+                left.name
+                    .to_ascii_lowercase()
+                    .cmp(&right.name.to_ascii_lowercase())
+            })
+            .then(left.id.cmp(&right.id))
+    });
+}
+
+fn server_priority(server: &TuiMcpServerSnapshot) -> u8 {
+    match server.status {
+        TuiMcpServerStatus::Available => 1,
+        TuiMcpServerStatus::Offline
+        | TuiMcpServerStatus::Starting
+        | TuiMcpServerStatus::Authenticating
+        | TuiMcpServerStatus::Running
+        | TuiMcpServerStatus::Stopping
+        | TuiMcpServerStatus::Failed { .. } => 0,
+    }
+}
+
 impl Entity for TuiMcpManager {
     type Event = TuiMcpManagerEvent;
 }
 
 impl SingletonEntity for TuiMcpManager {}
+
+#[cfg(test)]
+#[path = "mcp_tests.rs"]
+mod tests;

--- a/app/src/tui/mcp_tests.rs
+++ b/app/src/tui/mcp_tests.rs
@@ -1,0 +1,150 @@
+use uuid::Uuid;
+
+use super::{
+    TuiMcpFileScope, TuiMcpFileSource, TuiMcpServerId, TuiMcpServerSnapshot, TuiMcpServerSource,
+    TuiMcpServerStatus, TuiMcpTemplateVariable, TuiMcpVariableValue, server_priority, sort_servers,
+    validate_variable_values,
+};
+
+fn server(id: TuiMcpServerId, name: &str, status: TuiMcpServerStatus) -> TuiMcpServerSnapshot {
+    TuiMcpServerSnapshot {
+        id,
+        installation_uuid: None,
+        name: name.to_owned(),
+        description: None,
+        source: TuiMcpServerSource::SyncedTemplate,
+        transport: None,
+        status,
+        tool_count: 0,
+        resource_count: 0,
+        can_log_out: false,
+        authorization_url: None,
+    }
+}
+
+#[test]
+fn source_aware_ids_do_not_alias() {
+    let uuid = Uuid::from_u128(7);
+    let ids = [
+        TuiMcpServerId::FileBased(7),
+        TuiMcpServerId::Installation(uuid),
+        TuiMcpServerId::SyncedTemplate(uuid),
+        TuiMcpServerId::Gallery(uuid),
+    ];
+
+    for (index, id) in ids.iter().enumerate() {
+        assert!(!ids[index + 1..].contains(id));
+    }
+}
+
+#[test]
+fn installed_rows_sort_before_available_rows_then_by_name_and_id() {
+    let mut servers = vec![
+        server(
+            TuiMcpServerId::Gallery(Uuid::from_u128(1)),
+            "Alpha",
+            TuiMcpServerStatus::Available,
+        ),
+        server(
+            TuiMcpServerId::Installation(Uuid::from_u128(3)),
+            "Zulu",
+            TuiMcpServerStatus::Running,
+        ),
+        server(
+            TuiMcpServerId::FileBased(2),
+            "alpha",
+            TuiMcpServerStatus::Offline,
+        ),
+    ];
+
+    sort_servers(&mut servers);
+
+    assert_eq!(
+        servers.iter().map(|server| server.id).collect::<Vec<_>>(),
+        vec![
+            TuiMcpServerId::FileBased(2),
+            TuiMcpServerId::Installation(Uuid::from_u128(3)),
+            TuiMcpServerId::Gallery(Uuid::from_u128(1)),
+        ]
+    );
+    assert_eq!(server_priority(&servers[0]), 0);
+    assert_eq!(server_priority(&servers[2]), 1);
+}
+
+#[test]
+fn file_sources_keep_distinct_provider_scope_and_root_provenance() {
+    let sources = vec![
+        TuiMcpFileSource {
+            provider: "Claude".to_owned(),
+            root_path: "/repo".into(),
+            scope: TuiMcpFileScope::Project,
+        },
+        TuiMcpFileSource {
+            provider: "Claude".to_owned(),
+            root_path: "/home/user".into(),
+            scope: TuiMcpFileScope::Global,
+        },
+    ];
+
+    let source = TuiMcpServerSource::FileBased {
+        sources: sources.clone(),
+    };
+
+    assert_eq!(
+        source,
+        TuiMcpServerSource::FileBased { sources },
+        "same-named definitions retain every source"
+    );
+}
+
+#[test]
+fn variable_validation_requires_exact_keys_and_allowed_values() {
+    let variables = vec![
+        TuiMcpTemplateVariable {
+            key: "TOKEN".to_owned(),
+            allowed_values: None,
+        },
+        TuiMcpTemplateVariable {
+            key: "REGION".to_owned(),
+            allowed_values: Some(vec!["us".to_owned(), "eu".to_owned()]),
+        },
+    ];
+
+    let values = validate_variable_values(
+        &variables,
+        vec![
+            TuiMcpVariableValue {
+                key: "TOKEN".to_owned(),
+                value: "secret".to_owned(),
+            },
+            TuiMcpVariableValue {
+                key: "REGION".to_owned(),
+                value: "eu".to_owned(),
+            },
+        ],
+    )
+    .expect("valid values should resolve");
+    assert_eq!(values.len(), 2);
+
+    assert!(
+        validate_variable_values(
+            &variables,
+            vec![
+                TuiMcpVariableValue {
+                    key: "TOKEN".to_owned(),
+                    value: "secret".to_owned(),
+                },
+                TuiMcpVariableValue {
+                    key: "REGION".to_owned(),
+                    value: "invalid".to_owned(),
+                },
+            ],
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn zero_variable_confirmation_accepts_no_values() {
+    assert!(validate_variable_values(&[], Vec::new()).is_ok());
+}

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -9,8 +9,10 @@ mod mcp;
 mod user_info;
 
 pub use mcp::{
-    TuiMcpAction, TuiMcpConfigState, TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerId,
-    TuiMcpServerSnapshot, TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport,
+    TuiMcpAction, TuiMcpConfigDiagnostic, TuiMcpFileScope, TuiMcpFileSource, TuiMcpInstallRequest,
+    TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerId, TuiMcpServerSnapshot, TuiMcpServerSource,
+    TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTemplateVariable, TuiMcpTransport,
+    TuiMcpVariableValue,
 };
 use url::Url;
 pub use user_info::{TuiUserInfoManager, TuiUserInfoManagerEvent, TuiUserInfoSnapshot};

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -231,9 +231,11 @@ pub use crate::terminal::{
 pub use crate::themes::default_themes::{dark_theme, light_theme};
 pub use crate::throttle::throttle;
 pub use crate::tui::{
-    TuiMcpAction, TuiMcpConfigState, TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerId,
-    TuiMcpServerSnapshot, TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport, TuiUserInfoManager,
-    TuiUserInfoManagerEvent, TuiUserInfoSnapshot, log_out_tui,
+    TuiMcpAction, TuiMcpConfigDiagnostic, TuiMcpFileScope, TuiMcpFileSource, TuiMcpInstallRequest,
+    TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerId, TuiMcpServerSnapshot, TuiMcpServerSource,
+    TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTemplateVariable, TuiMcpTransport,
+    TuiMcpVariableValue, TuiUserInfoManager, TuiUserInfoManagerEvent, TuiUserInfoSnapshot,
+    log_out_tui,
 };
 #[cfg(any(test, feature = "test-util"))]
 pub use crate::tui_test_support::{

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -46,6 +46,9 @@ impl TemplatableMCPServerInfo {
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref()
     }
+    pub fn is_authenticated_transport(&self) -> bool {
+        self.is_authenticated_transport
+    }
 
     pub fn peer(&self) -> rmcp::Peer<rmcp::RoleClient> {
         self.service.clone()

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -20,6 +20,7 @@ use warpui_core::{AppContext, ModelHandle};
 use crate::completion_menu::TuiCompletionAcceptance;
 use crate::conversation_menu::TuiConversationMenuModel;
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
+use crate::mcp_install_flow::{TuiMcpInstallFlowAction, TuiMcpInstallFlowModel};
 use crate::mcp_menu::TuiMcpMenuModel;
 use crate::model_menu::TuiModelMenuModel;
 use crate::prompt_and_command_history_menu::TuiPromptAndCommandHistoryMenuModel;
@@ -74,8 +75,8 @@ impl TuiInlineMenuHandle for ModelHandle<TuiMcpMenuModel> {
         None
     }
 
-    fn input_argument_hint_text(&self, _ctx: &AppContext) -> Option<&'static str> {
-        None
+    fn input_argument_hint_text(&self, ctx: &AppContext) -> Option<&'static str> {
+        self.as_ref(ctx).input_hint_text(ctx)
     }
 
     fn select_previous(&self, ctx: &mut AppContext) {
@@ -87,8 +88,62 @@ impl TuiInlineMenuHandle for ModelHandle<TuiMcpMenuModel> {
     }
 
     fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
-        self.update(ctx, |model, ctx| model.accept_selected(ctx))
+        self.as_ref(ctx)
+            .accept_selected(ctx)
             .map(TuiInlineMenuAccepted::Mcp)
+    }
+    fn accept_secondary(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        self.as_ref(ctx)
+            .logout_selected(ctx)
+            .map(TuiInlineMenuAccepted::Mcp)
+    }
+
+    fn dismiss(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.dismiss(ctx));
+    }
+
+    fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        self.as_ref(ctx).snapshot(ctx)
+    }
+
+    fn select_by_snapshot_index(&self, index: usize, ctx: &mut AppContext) -> bool {
+        self.update(ctx, |model, ctx| model.select_at_snapshot_index(index, ctx))
+    }
+
+    fn scroll_by_delta(&self, delta: isize, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.scroll_by_delta(delta, ctx));
+    }
+}
+
+impl TuiInlineMenuHandle for ModelHandle<TuiMcpInstallFlowModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::McpInstall
+    }
+
+    fn is_open(&self, ctx: &AppContext) -> bool {
+        self.as_ref(ctx).is_open(ctx)
+    }
+
+    fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
+        None
+    }
+
+    fn input_argument_hint_text(&self, ctx: &AppContext) -> Option<&'static str> {
+        self.as_ref(ctx).input_hint_text(ctx)
+    }
+
+    fn select_previous(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_previous(ctx));
+    }
+
+    fn select_next(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_next(ctx));
+    }
+
+    fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        self.as_ref(ctx)
+            .accept(ctx)
+            .map(TuiInlineMenuAccepted::McpInstall)
     }
 
     fn dismiss(&self, ctx: &mut AppContext) {
@@ -346,6 +401,7 @@ pub(crate) enum TuiInlineMenuAccepted {
     Conversation(AgentConversationEntryId),
     Model(LLMId),
     Mcp(TuiMcpAction),
+    McpInstall(TuiMcpInstallFlowAction),
     PromptAndCommandHistory {
         text: String,
         kind: TuiUpArrowHistoryItemKind,
@@ -381,6 +437,10 @@ pub(crate) trait TuiInlineMenuHandle {
     fn select_next(&self, ctx: &mut AppContext);
     /// Accepts the selected row.
     fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted>;
+    /// Accepts the selected row's optional secondary action.
+    fn accept_secondary(&self, _ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        None
+    }
     /// Dismisses the menu.
     fn dismiss(&self, ctx: &mut AppContext);
     /// Returns the menu's presentation snapshot.
@@ -488,6 +548,13 @@ impl TuiInlineMenu {
 
     pub(crate) fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
         let result = self.handle.accept(ctx);
+        if result.is_some() {
+            reset_hover_states(&self.item_mouse_states);
+        }
+        result
+    }
+    pub(crate) fn accept_secondary(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        let result = self.handle.accept_secondary(ctx);
         if result.is_some() {
             reset_hover_states(&self.item_mouse_states);
         }
@@ -1146,15 +1213,10 @@ pub(crate) fn keep_selected_visible(
 }
 
 fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
-    TuiContainer::new(
-        TuiText::new(label.to_owned())
-            .with_style(builder.dim_text_style())
-            .truncate()
-            .finish(),
-    )
-    .with_padding_left(1)
-    .with_padding_right(1)
-    .finish()
+    TuiText::new(label.to_owned())
+        .with_style(builder.dim_text_style())
+        .truncate()
+        .finish()
 }
 
 fn menu_scroll_indicator_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -221,14 +221,14 @@ fn status_snapshot(status: TuiInlineMenuStatus) -> TuiInlineMenuSnapshot {
 }
 
 #[test]
-fn renders_loading_and_empty_statuses() {
+fn renders_loading_and_empty_statuses_left_aligned() {
     let loading = render(status_snapshot(TuiInlineMenuStatus::Loading(
         "Loading conversations…".to_owned(),
     )));
     assert!(
         loading
             .iter()
-            .any(|line| line.contains("Loading conversations…"))
+            .any(|line| line.starts_with("Loading conversations…"))
     );
 
     let empty = render(status_snapshot(TuiInlineMenuStatus::Empty(
@@ -237,7 +237,7 @@ fn renders_loading_and_empty_statuses() {
     assert!(
         empty
             .iter()
-            .any(|line| line.contains("No conversations found"))
+            .any(|line| line.starts_with("No conversations found"))
     );
 }
 

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -56,6 +56,7 @@ use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestions
 use crate::keybindings::{
     KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG, PLAN_TOGGLE_AVAILABLE_FLAG, TUI_BINDING_GROUP,
 };
+use crate::mcp_install_flow::TuiMcpInstallFlowAction;
 use crate::read_only_menu::TuiReadOnlyMenuKind;
 use crate::terminal_session_view::state::TuiTerminalSessionStateModel;
 use crate::tui_builder::TuiUiBuilder;
@@ -69,6 +70,8 @@ use crate::voice_input::{TuiVoiceInputModel, TuiVoiceInputState, VoiceInputStart
 /// after the menu branch.
 const INPUT_HANDLES_ESCAPE_FLAG: &str = "TuiInputHandlesEscape";
 const SHELL_COMPLETION_AVAILABLE_FLAG: &str = "TuiShellCompletionAvailable";
+pub(crate) const MCP_MENU_ACTIVE_FLAG: &str = "TuiMcpMenuActive";
+pub(crate) const MCP_LOGOUT_BINDING_NAME: &str = "tui:input:mcp_logout";
 // ─────────────────────────────────────────────────────────────────────────────
 // Keybindings
 // ─────────────────────────────────────────────────────────────────────────────
@@ -105,6 +108,14 @@ pub fn init(app: &mut AppContext) {
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("escape"),
         EditableBinding::new(
+            MCP_LOGOUT_BINDING_NAME,
+            "Log out of the selected MCP server and remove its credentials",
+            TuiInputAction::LogOutSelectedMcp,
+        )
+        .with_context_predicate(id!("TuiInputView") & id!(MCP_MENU_ACTIVE_FLAG))
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("ctrl-r"),
+        EditableBinding::new(
             "tui:input:complete_shell_command",
             "Complete the shell command",
             TuiInputAction::Complete,
@@ -137,6 +148,8 @@ pub enum TuiInputViewEvent {
     AcceptedModel(LLMId),
     /// The user selected an action from the MCP menu.
     AcceptedMcp(TuiMcpAction),
+    /// The user advanced the explicit MCP installation flow.
+    AcceptedMcpInstall(TuiMcpInstallFlowAction),
     /// Shift+Up should move focus from the first visual row to the region above.
     MoveFocusUp,
     /// The user accepted an item from the up-arrow prompt-and-command history menu.
@@ -170,6 +183,8 @@ pub enum TuiInputAction {
     Submit,
     /// Handle contextual input Escape behavior, prioritizing an open inline menu.
     HandleEscape,
+    /// Log out of the selected MCP server and remove its stored credentials.
+    LogOutSelectedMcp,
     /// Request or advance shell-command completion.
     Complete,
     /// Apply an editing command shared with generic TUI editors.
@@ -621,6 +636,7 @@ impl TuiView for TuiInputView {
                 || (vim_mode_enabled
                     && (!matches!(vim_state.mode, VimMode::Normal)
                         || !vim_state.showcmd.is_empty())),
+            mcp_menu_active: suggestions_mode == TuiInputSuggestionsMode::Mcp,
             plan_toggle_available: self.plan_toggle_available(ctx),
             keyboard_enhancement_supported: self.keyboard_enhancement_supported,
             shell_completion_available: self.is_shell_mode(ctx),
@@ -648,6 +664,7 @@ impl TuiView for TuiInputView {
 #[derive(Clone, Copy, Debug, Default)]
 struct InputKeymapContextConfig {
     input_handles_escape: bool,
+    mcp_menu_active: bool,
     plan_toggle_available: bool,
     keyboard_enhancement_supported: bool,
     shell_completion_available: bool,
@@ -658,6 +675,9 @@ fn input_keymap_context(config: InputKeymapContextConfig) -> keymap::Context {
     context.set.insert(TuiInputView::ui_name());
     if config.input_handles_escape {
         context.set.insert(INPUT_HANDLES_ESCAPE_FLAG);
+    }
+    if config.mcp_menu_active {
+        context.set.insert(MCP_MENU_ACTIVE_FLAG);
     }
     if config.plan_toggle_available {
         context.set.insert(PLAN_TOGGLE_AVAILABLE_FLAG);
@@ -749,6 +769,7 @@ impl TypedActionView for TuiInputView {
                 self.handle_escape(ctx);
                 TuiEditorInteractionOutcome::FollowCursor
             }
+            TuiInputAction::LogOutSelectedMcp => TuiEditorInteractionOutcome::PreserveViewport,
             TuiInputAction::Complete => {
                 if self.is_shell_mode(ctx) {
                     ctx.emit(TuiInputViewEvent::RequestShellCompletion);
@@ -1162,6 +1183,9 @@ impl TuiInputView {
             TuiInlineMenuAccepted::Mcp(action) => {
                 ctx.emit(TuiInputViewEvent::AcceptedMcp(action));
             }
+            TuiInlineMenuAccepted::McpInstall(action) => {
+                ctx.emit(TuiInputViewEvent::AcceptedMcpInstall(action));
+            }
             TuiInlineMenuAccepted::PromptAndCommandHistory { text, kind } => {
                 ctx.emit(TuiInputViewEvent::AcceptedPromptAndCommandHistory { text, kind });
             }
@@ -1180,6 +1204,7 @@ impl TuiInputView {
             TuiInputAction::EditorCommand(TuiEditorCommand::MoveUp | TuiEditorCommand::MoveDown)
                 | TuiInputAction::Submit
                 | TuiInputAction::HandleEscape
+                | TuiInputAction::LogOutSelectedMcp
                 | TuiInputAction::Complete
         ) {
             return false;
@@ -1212,6 +1237,12 @@ impl TuiInputView {
             TuiInputAction::Submit => {
                 if let Some(accepted) = inline_menu.accept(ctx) {
                     self.route_inline_menu_acceptance(accepted, ctx);
+                }
+            }
+            TuiInputAction::LogOutSelectedMcp => {
+                if let Some(TuiInlineMenuAccepted::Mcp(action)) = inline_menu.accept_secondary(ctx)
+                {
+                    ctx.emit(TuiInputViewEvent::AcceptedMcp(action));
                 }
             }
             TuiInputAction::HandleEscape => return self.handle_escape(ctx),

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -16,8 +16,8 @@ use warp::settings::AISettingsChangedEvent;
 use warp::tui_export::{
     AcceptSlashCommandOrSavedPrompt, BlocklistAIHistoryModel, BlocklistAIInputModel,
     ConversationSelectionEvent, InputConfig, InputModePolicy, InputType, LLMId, PolicyConfigUpdate,
-    SlashCommandId, SlashCommandMixer, TuiUpArrowHistoryItemKind, VoiceInput,
-    add_tui_history_test_models, blocklist_ai_history_model_with_queries,
+    SlashCommandId, SlashCommandMixer, TuiMcpAction, TuiMcpServerId, TuiUpArrowHistoryItemKind,
+    VoiceInput, add_tui_history_test_models, blocklist_ai_history_model_with_queries,
     register_tui_input_mode_test_settings, register_tui_session_view_test_singletons,
 };
 use warp_core::features::FeatureFlag;
@@ -37,8 +37,9 @@ use warpui_core::{
 };
 
 use super::{
-    INPUT_HANDLES_ESCAPE_FLAG, InputKeymapContextConfig, SHELL_COMPLETION_AVAILABLE_FLAG,
-    TuiInputAction, TuiInputView, TuiInputViewEvent, input_keymap_context,
+    INPUT_HANDLES_ESCAPE_FLAG, InputKeymapContextConfig, MCP_MENU_ACTIVE_FLAG,
+    SHELL_COMPLETION_AVAILABLE_FLAG, TuiInputAction, TuiInputView, TuiInputViewEvent,
+    input_keymap_context,
 };
 use crate::completion_menu::{TuiCompletionAcceptance, TuiCompletionMenuModel};
 use crate::editor_element::{TuiEditorAction, TuiEditorElement};
@@ -897,12 +898,14 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
 
     let open = input_keymap_context(InputKeymapContextConfig {
         input_handles_escape: true,
+        mcp_menu_active: true,
         plan_toggle_available: true,
         keyboard_enhancement_supported: true,
         shell_completion_available: true,
     });
     assert!(open.set.contains("TuiInputView"));
     assert!(open.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
+    assert!(open.set.contains(MCP_MENU_ACTIVE_FLAG));
     assert!(
         open.set
             .contains(crate::keybindings::PLAN_TOGGLE_AVAILABLE_FLAG)
@@ -912,6 +915,100 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
             .contains(crate::keybindings::KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG)
     );
     assert!(open.set.contains(SHELL_COMPLETION_AVAILABLE_FLAG));
+}
+#[derive(Clone)]
+struct TestMcpMenu {
+    action: TuiMcpAction,
+}
+
+impl TuiInlineMenuHandle for TestMcpMenu {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::Mcp
+    }
+
+    fn is_open(&self, _ctx: &AppContext) -> bool {
+        true
+    }
+
+    fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
+        None
+    }
+
+    fn input_argument_hint_text(&self, _ctx: &AppContext) -> Option<&'static str> {
+        None
+    }
+
+    fn select_previous(&self, _ctx: &mut AppContext) {}
+
+    fn select_next(&self, _ctx: &mut AppContext) {}
+
+    fn accept(&self, _ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        None
+    }
+
+    fn accept_secondary(&self, _ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        Some(TuiInlineMenuAccepted::Mcp(self.action))
+    }
+
+    fn dismiss(&self, _ctx: &mut AppContext) {}
+
+    fn snapshot(&self, _ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        None
+    }
+}
+
+#[test]
+fn ctrl_r_dispatches_selected_mcp_credential_removal() {
+    App::test((), |mut app| async move {
+        let (window_id, view, expected, accepted) = app.update(|ctx| {
+            crate::input::init(ctx);
+            ctx.add_singleton_model(|_| Appearance::mock());
+            add_test_semantic_selection(ctx);
+            let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
+            let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
+            let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::Mcp);
+            let expected = TuiMcpAction::LogOut(TuiMcpServerId::FileBased(7));
+            let menu = TuiInlineMenu::new(TestMcpMenu { action: expected });
+            let (window_id, view) = ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                move |ctx| {
+                    TuiInputView::new_for_test(
+                        input_model,
+                        input_mode,
+                        suggestions_mode,
+                        vec![menu],
+                        |_| false,
+                        ctx,
+                    )
+                },
+            );
+            view.update(ctx, |_, ctx| ctx.focus_self());
+
+            let accepted = Rc::new(RefCell::new(Vec::new()));
+            let accepted_for_subscription = accepted.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if let TuiInputViewEvent::AcceptedMcp(action) = event {
+                    accepted_for_subscription.borrow_mut().push(*action);
+                }
+            });
+            (window_id, view, expected, accepted)
+        });
+
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &[view.id()],
+                &Keystroke::parse("ctrl-r").expect("valid keystroke"),
+                false,
+            )
+            .expect("keystroke dispatch succeeds");
+
+        assert!(handled);
+        assert_eq!(accepted.borrow().as_slice(), &[expected]);
+    });
 }
 
 fn add_suggestions_mode(
@@ -1063,6 +1160,7 @@ fn enter_and_escape_stop_listening_while_escape_cancels_transcribing() {
                 | TuiInputViewEvent::AcceptedConversation(_)
                 | TuiInputViewEvent::AcceptedModel(_)
                 | TuiInputViewEvent::AcceptedMcp(_)
+                | TuiInputViewEvent::AcceptedMcpInstall(_)
                 | TuiInputViewEvent::MoveFocusUp
                 | TuiInputViewEvent::AcceptedPromptAndCommandHistory { .. }
                 | TuiInputViewEvent::RequestShellCompletion
@@ -1941,6 +2039,7 @@ fn multiline_paste_emits_once_and_fallback_inserts_without_submitting() {
                 | TuiInputViewEvent::AcceptedConversation(_)
                 | TuiInputViewEvent::AcceptedModel(_)
                 | TuiInputViewEvent::AcceptedMcp(_)
+                | TuiInputViewEvent::AcceptedMcpInstall(_)
                 | TuiInputViewEvent::AcceptedPromptAndCommandHistory { .. }
                 | TuiInputViewEvent::RequestShellCompletion
                 | TuiInputViewEvent::BackspaceAtEmptyInput

--- a/crates/warp_tui/src/input_suggestions_mode.rs
+++ b/crates/warp_tui/src/input_suggestions_mode.rs
@@ -17,6 +17,7 @@ pub(crate) enum TuiInputSuggestionsMode {
     ModelSelector,
     SkillMenu,
     Mcp,
+    McpInstall,
     PromptAndCommandHistory,
     CompletionSuggestions,
     ReadOnlyMenu(TuiReadOnlyMenuKind),
@@ -36,6 +37,7 @@ impl TuiInputSuggestionsMode {
             | Self::ModelSelector
             | Self::SkillMenu
             | Self::Mcp
+            | Self::McpInstall
             | Self::PromptAndCommandHistory
             | Self::CompletionSuggestions => None,
         }
@@ -91,6 +93,7 @@ impl TuiInputSuggestionsModeModel {
             | TuiInputSuggestionsMode::ModelSelector
             | TuiInputSuggestionsMode::SkillMenu
             | TuiInputSuggestionsMode::Mcp
+            | TuiInputSuggestionsMode::McpInstall
             | TuiInputSuggestionsMode::PromptAndCommandHistory
             | TuiInputSuggestionsMode::CompletionSuggestions
             | TuiInputSuggestionsMode::ReadOnlyMenu(_) => false,

--- a/crates/warp_tui/src/keybindings_tests.rs
+++ b/crates/warp_tui/src/keybindings_tests.rs
@@ -6,6 +6,7 @@ use warpui_core::{App, TuiView};
 use super::{ATTACHMENTS_AVAILABLE_FLAG, TUI_BINDING_GROUP, is_tui_owned};
 use crate::attachment_bar::{FOCUS_ATTACHMENTS_BINDING_NAME, TuiAttachmentBar};
 use crate::input::TuiInputView;
+use crate::input::view::{MCP_LOGOUT_BINDING_NAME, MCP_MENU_ACTIVE_FLAG};
 use crate::terminal_session_view::{
     PASTE_IMAGE_BINDING_NAME, SESSION_COMPOSER_OWNS_INPUT_FLAG, TuiTerminalSessionView,
 };
@@ -32,6 +33,38 @@ fn tui_ownership_is_by_name_prefix_or_group() {
 fn tui_binding_registration_passes_the_cross_surface_validators() {
     App::test((), |mut app| async move {
         app.update(super::init);
+    });
+}
+
+#[test]
+fn mcp_logout_binding_uses_ctrl_r_only() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            crate::input::init(ctx);
+            let bindings = ctx
+                .editable_bindings()
+                .filter(|binding| binding.name == MCP_LOGOUT_BINDING_NAME)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                bindings
+                    .iter()
+                    .filter_map(|binding| match binding.trigger {
+                        Trigger::Keystrokes(keys) => keys.first().map(|key| key.normalized()),
+                        Trigger::Empty | Trigger::Standard(_) | Trigger::Custom(_) => None,
+                    })
+                    .collect::<HashSet<_>>(),
+                HashSet::from(["ctrl-r".to_owned()])
+            );
+
+            let mut mcp_context = Context::default();
+            mcp_context.set.insert(TuiInputView::ui_name());
+            mcp_context.set.insert(MCP_MENU_ACTIVE_FLAG);
+            let mut plain_input_context = Context::default();
+            plain_input_context.set.insert(TuiInputView::ui_name());
+            assert_eq!(bindings.len(), 1);
+            assert!(bindings[0].in_context(&mcp_context));
+            assert!(!bindings[0].in_context(&plain_input_context));
+        });
     });
 }
 

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -40,6 +40,7 @@ mod input_mode_policy;
 mod input_suggestions_mode;
 mod keybindings;
 mod link;
+mod mcp_install_flow;
 mod mcp_menu;
 mod model_menu;
 mod option_selector;

--- a/crates/warp_tui/src/mcp_install_flow.rs
+++ b/crates/warp_tui/src/mcp_install_flow.rs
@@ -1,0 +1,412 @@
+use std::fmt;
+
+use warp::editor::CodeEditorModel;
+use warp::tui_export::{
+    TuiMcpFileScope, TuiMcpInstallRequest, TuiMcpServerId, TuiMcpServerSource,
+    TuiMcpTemplateVariable, TuiMcpVariableValue,
+};
+use warp_editor::model::CoreEditorModel;
+use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
+
+use crate::inline_menu::{
+    MAX_INLINE_MENU_ROWS, TuiInlineMenuHeader, TuiInlineMenuListState, TuiInlineMenuRow,
+    TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, result_row_capacity,
+};
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
+
+const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
+
+#[derive(Clone, Eq, PartialEq)]
+pub enum TuiMcpInstallFlowAction {
+    ProvideValue { key: String, value: String },
+    Confirm,
+}
+impl fmt::Debug for TuiMcpInstallFlowAction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProvideValue { key, .. } => formatter
+                .debug_struct("ProvideValue")
+                .field("key", key)
+                .field("value", &"[REDACTED]")
+                .finish(),
+            Self::Confirm => formatter.write_str("Confirm"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TuiMcpInstallChoice {
+    value: String,
+}
+
+#[derive(Default)]
+enum TuiMcpInstallStep {
+    #[default]
+    Closed,
+    Variable {
+        index: usize,
+        choices: TuiInlineMenuListState<TuiMcpInstallChoice>,
+    },
+    Confirmation,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TuiMcpInstallFlowEvent {
+    Updated,
+    Dismissed,
+}
+
+pub(crate) struct TuiMcpInstallFlowModel {
+    input_editor: ModelHandle<CodeEditorModel>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+    request: Option<TuiMcpInstallRequest>,
+    values: Vec<TuiMcpVariableValue>,
+    step: TuiMcpInstallStep,
+}
+
+impl TuiMcpInstallFlowModel {
+    pub(crate) fn new(
+        input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+    ) -> Self {
+        Self {
+            input_editor,
+            suggestions_mode,
+            request: None,
+            values: Vec::new(),
+            step: TuiMcpInstallStep::Closed,
+        }
+    }
+
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        !matches!(self.step, TuiMcpInstallStep::Closed)
+            && self.suggestions_mode.as_ref(ctx).mode() == TuiInputSuggestionsMode::McpInstall
+    }
+
+    pub(crate) fn start(
+        &mut self,
+        request: TuiMcpInstallRequest,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        if !self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::McpInstall, ctx)
+        }) {
+            return false;
+        }
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
+        self.values.clear();
+        self.step = if request.variables.is_empty() {
+            TuiMcpInstallStep::Confirmation
+        } else {
+            variable_step(&request.variables[0])
+        };
+        self.request = Some(request);
+        ctx.emit(TuiMcpInstallFlowEvent::Updated);
+        true
+    }
+
+    pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_open(ctx) {
+            return;
+        }
+        self.request = None;
+        self.values.clear();
+        self.step = TuiMcpInstallStep::Closed;
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::McpInstall, ctx);
+        });
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
+        ctx.emit(TuiMcpInstallFlowEvent::Dismissed);
+    }
+
+    pub(crate) fn select_previous(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiMcpInstallStep::Variable { choices, .. } = &mut self.step else {
+            return;
+        };
+        choices.select_previous(MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiMcpInstallFlowEvent::Updated);
+    }
+
+    pub(crate) fn select_next(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiMcpInstallStep::Variable { choices, .. } = &mut self.step else {
+            return;
+        };
+        choices.select_next(MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiMcpInstallFlowEvent::Updated);
+    }
+
+    pub(crate) fn select_at_snapshot_index(
+        &mut self,
+        index: usize,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let TuiMcpInstallStep::Variable { choices, .. } = &mut self.step else {
+            return matches!(self.step, TuiMcpInstallStep::Confirmation) && index == 0;
+        };
+        let selected = choices.select_absolute(index, MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiMcpInstallFlowEvent::Updated);
+        selected
+    }
+
+    pub(crate) fn scroll_by_delta(&mut self, delta: isize, ctx: &mut ModelContext<Self>) {
+        let TuiMcpInstallStep::Variable { choices, .. } = &mut self.step else {
+            return;
+        };
+        choices.scroll_by(delta, MAX_VISIBLE_ROWS);
+        ctx.emit(TuiMcpInstallFlowEvent::Updated);
+    }
+
+    pub(crate) fn accept(&self, ctx: &AppContext) -> Option<TuiMcpInstallFlowAction> {
+        let request = self.request.as_ref()?;
+        match &self.step {
+            TuiMcpInstallStep::Closed => None,
+            TuiMcpInstallStep::Confirmation => Some(TuiMcpInstallFlowAction::Confirm),
+            TuiMcpInstallStep::Variable { index, choices } => {
+                let variable = request.variables.get(*index)?;
+                let value = match &variable.allowed_values {
+                    Some(_) => choices.selected_row()?.value.clone(),
+                    None => input_text(&self.input_editor, ctx),
+                };
+                (!value.is_empty()).then(|| TuiMcpInstallFlowAction::ProvideValue {
+                    key: variable.key.clone(),
+                    value,
+                })
+            }
+        }
+    }
+
+    pub(crate) fn apply_value(
+        &mut self,
+        key: String,
+        value: String,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<(), String> {
+        let request = self
+            .request
+            .as_ref()
+            .ok_or_else(|| "The MCP installation flow is no longer active".to_owned())?;
+        let TuiMcpInstallStep::Variable { index, .. } = &self.step else {
+            return Err("The MCP installation flow is not collecting a variable".to_owned());
+        };
+        let variable = request
+            .variables
+            .get(*index)
+            .ok_or_else(|| "The MCP variable is no longer available".to_owned())?;
+        if variable.key != key || value.is_empty() {
+            return Err("Enter a value for the required MCP variable".to_owned());
+        }
+        if variable
+            .allowed_values
+            .as_ref()
+            .is_some_and(|allowed| !allowed.contains(&value))
+        {
+            return Err("Select one of the listed values".to_owned());
+        }
+
+        self.values.push(TuiMcpVariableValue { key, value });
+        let next = *index + 1;
+        self.step = request
+            .variables
+            .get(next)
+            .map(|variable| variable_step_at(next, variable))
+            .unwrap_or(TuiMcpInstallStep::Confirmation);
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
+        ctx.emit(TuiMcpInstallFlowEvent::Updated);
+        Ok(())
+    }
+
+    pub(crate) fn confirmation(
+        &self,
+    ) -> Option<(TuiMcpServerId, String, Vec<TuiMcpVariableValue>)> {
+        matches!(self.step, TuiMcpInstallStep::Confirmation).then(|| {
+            let request = self.request.as_ref().expect("open flow has a request");
+            (request.id, request.name.clone(), self.values.clone())
+        })
+    }
+
+    pub(crate) fn primary_action_hint(&self) -> Option<&'static str> {
+        match &self.step {
+            TuiMcpInstallStep::Closed => None,
+            TuiMcpInstallStep::Variable { .. } => Some("to continue"),
+            TuiMcpInstallStep::Confirmation => Some("to enable & start"),
+        }
+    }
+
+    pub(crate) fn input_hint_text(&self, ctx: &AppContext) -> Option<&'static str> {
+        if !self.is_open(ctx) {
+            return None;
+        }
+        let request = self.request.as_ref()?;
+        let TuiMcpInstallStep::Variable { index, .. } = &self.step else {
+            return None;
+        };
+        request
+            .variables
+            .get(*index)
+            .is_some_and(|variable| variable.allowed_values.is_none())
+            .then_some("Enter value…")
+    }
+
+    pub(crate) fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(ctx) {
+            return None;
+        }
+        let request = self.request.as_ref()?;
+        let title = format!(
+            "Enable {} · {}",
+            request.name,
+            source_label(&request.source)
+        );
+        let header = Some(TuiInlineMenuHeader {
+            title: Some(title),
+            tabs: Vec::new(),
+        });
+        match &self.step {
+            TuiMcpInstallStep::Closed => None,
+            TuiMcpInstallStep::Variable { index, choices } => {
+                let variable = request.variables.get(*index)?;
+                let status = variable.allowed_values.is_none().then(|| {
+                    TuiInlineMenuStatus::Empty(format!(
+                        "Enter a value for {} ({}/{})",
+                        variable.key,
+                        index + 1,
+                        request.variables.len()
+                    ))
+                });
+                Some(TuiInlineMenuSnapshot {
+                    header,
+                    rows: choices
+                        .rows()
+                        .iter()
+                        .map(|choice| TuiInlineMenuRow {
+                            title: choice.value.clone(),
+                            prefix: None,
+                            description: Some(format!(
+                                "{} · {}/{}",
+                                variable.key,
+                                index + 1,
+                                request.variables.len()
+                            )),
+                            state_suffix: None,
+                            is_selectable: true,
+                            style: TuiInlineMenuRowStyle::Default,
+                        })
+                        .collect(),
+                    selected_index: choices.selected_index(),
+                    scroll_offset: choices.scroll_offset(),
+                    scroll_anchor: choices.scroll_anchor(),
+                    max_visible_rows: MAX_VISIBLE_ROWS,
+                    status,
+                })
+            }
+            TuiMcpInstallStep::Confirmation => Some(TuiInlineMenuSnapshot {
+                header,
+                rows: vec![TuiInlineMenuRow {
+                    title: "Enable and start".to_owned(),
+                    prefix: None,
+                    description: Some(confirmation_description(request)),
+                    state_suffix: None,
+                    is_selectable: true,
+                    style: TuiInlineMenuRowStyle::Default,
+                }],
+                selected_index: Some(0),
+                scroll_offset: 0,
+                scroll_anchor: crate::inline_menu::TuiInlineMenuScrollAnchor::Selection,
+                max_visible_rows: MAX_VISIBLE_ROWS,
+                status: None,
+            }),
+        }
+    }
+}
+
+fn variable_step(variable: &TuiMcpTemplateVariable) -> TuiMcpInstallStep {
+    variable_step_at(0, variable)
+}
+
+fn variable_step_at(index: usize, variable: &TuiMcpTemplateVariable) -> TuiMcpInstallStep {
+    let rows = variable
+        .allowed_values
+        .as_ref()
+        .into_iter()
+        .flatten()
+        .cloned()
+        .map(|value| TuiMcpInstallChoice { value })
+        .collect();
+    let mut choices = TuiInlineMenuListState::default();
+    choices.replace_rows(rows, false, Some(0), MAX_VISIBLE_ROWS, |_| true);
+    TuiMcpInstallStep::Variable { index, choices }
+}
+
+fn confirmation_description(request: &TuiMcpInstallRequest) -> String {
+    let mut parts = Vec::new();
+    if let Some(description) = request.description.as_deref().and_then(concise_line) {
+        parts.push(description);
+    }
+    if let Some(instructions) = request.instructions.as_deref().and_then(concise_line)
+        && !parts.contains(&instructions)
+    {
+        parts.push(instructions);
+    }
+    if parts.is_empty() {
+        "Create a TUI-local installation and start it".to_owned()
+    } else {
+        parts.join(" · ")
+    }
+}
+
+fn concise_line(text: &str) -> Option<&str> {
+    text.lines()
+        .map(str::trim)
+        .map(|line| line.trim_start_matches('#').trim())
+        .find(|line| !line.is_empty())
+}
+
+fn source_label(source: &TuiMcpServerSource) -> String {
+    match source {
+        TuiMcpServerSource::Installation => "TUI local".to_owned(),
+        TuiMcpServerSource::SyncedTemplate => "synced".to_owned(),
+        TuiMcpServerSource::Gallery => "gallery".to_owned(),
+        TuiMcpServerSource::FileBased { sources } => {
+            let labels = sources
+                .iter()
+                .map(|source| match source.scope {
+                    TuiMcpFileScope::Global => format!("{} global", source.provider),
+                    TuiMcpFileScope::Project => {
+                        let root = source
+                            .root_path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap_or("project");
+                        format!("{} · {root}", source.provider)
+                    }
+                })
+                .collect::<Vec<_>>();
+            if labels.is_empty() {
+                "file config".to_owned()
+            } else {
+                labels.join(", ")
+            }
+        }
+    }
+}
+
+fn input_text(editor: &ModelHandle<CodeEditorModel>, ctx: &AppContext) -> String {
+    let model = editor.as_ref(ctx);
+    let buffer = model.content().as_ref(ctx);
+    if buffer.is_empty() {
+        String::new()
+    } else {
+        buffer.text().into_string()
+    }
+}
+
+impl Entity for TuiMcpInstallFlowModel {
+    type Event = TuiMcpInstallFlowEvent;
+}
+
+#[cfg(test)]
+#[path = "mcp_install_flow_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/mcp_install_flow_tests.rs
+++ b/crates/warp_tui/src/mcp_install_flow_tests.rs
@@ -1,0 +1,121 @@
+use uuid::Uuid;
+use warp::appearance::Appearance;
+use warp::editor::CodeEditorModel;
+use warp::tui_export::{
+    TuiMcpInstallRequest, TuiMcpServerId, TuiMcpServerSource, TuiMcpTemplateVariable,
+};
+use warpui_core::App;
+
+use super::{TuiMcpInstallFlowAction, TuiMcpInstallFlowModel, TuiMcpInstallStep};
+use crate::input_suggestions_mode::TuiInputSuggestionsModeModel;
+
+fn input_editor(ctx: &mut warpui_core::AppContext) -> warpui_core::ModelHandle<CodeEditorModel> {
+    ctx.add_singleton_model(|_| Appearance::mock());
+    ctx.add_model(|ctx| CodeEditorModel::new_tui(80, ctx))
+}
+
+fn request(variables: Vec<TuiMcpTemplateVariable>) -> TuiMcpInstallRequest {
+    TuiMcpInstallRequest {
+        id: TuiMcpServerId::Gallery(Uuid::from_u128(1)),
+        name: "Example".to_owned(),
+        description: Some("Example MCP".to_owned()),
+        source: TuiMcpServerSource::Gallery,
+        instructions: Some("# Setup\nFollow the instructions".to_owned()),
+        variables,
+    }
+}
+
+#[test]
+fn zero_variable_flow_still_requires_confirmation() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let editor = input_editor(ctx);
+            let mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
+            let flow = ctx.add_model(|_| TuiMcpInstallFlowModel::new(editor, mode));
+
+            assert!(flow.update(ctx, |flow, ctx| flow.start(request(Vec::new()), ctx)));
+            assert!(matches!(
+                &flow.as_ref(ctx).step,
+                TuiMcpInstallStep::Confirmation
+            ));
+            assert!(flow.as_ref(ctx).confirmation().is_some());
+            assert_eq!(
+                flow.as_ref(ctx)
+                    .snapshot(ctx)
+                    .expect("flow is visible")
+                    .rows[0]
+                    .description
+                    .as_deref(),
+                Some("Example MCP · Setup")
+            );
+        });
+    });
+}
+
+#[test]
+fn collected_value_actions_are_redacted_from_debug_output() {
+    let action = TuiMcpInstallFlowAction::ProvideValue {
+        key: "TOKEN".to_owned(),
+        value: "do-not-log-this".to_owned(),
+    };
+
+    let debug = format!("{action:?}");
+
+    assert!(debug.contains("TOKEN"));
+    assert!(debug.contains("[REDACTED]"));
+    assert!(!debug.contains("do-not-log-this"));
+}
+
+#[test]
+fn allowed_values_are_presented_as_selectable_rows() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let editor = input_editor(ctx);
+            let mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
+            let flow = ctx.add_model(|_| TuiMcpInstallFlowModel::new(editor, mode));
+            let variable = TuiMcpTemplateVariable {
+                key: "REGION".to_owned(),
+                allowed_values: Some(vec!["us".to_owned(), "eu".to_owned()]),
+            };
+
+            flow.update(ctx, |flow, ctx| {
+                assert!(flow.start(request(vec![variable]), ctx));
+            });
+            let snapshot = flow.as_ref(ctx).snapshot(ctx).expect("flow is visible");
+            assert_eq!(
+                snapshot
+                    .rows
+                    .iter()
+                    .map(|row| row.title.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["us", "eu"]
+            );
+            assert_eq!(snapshot.selected_index, Some(0));
+        });
+    });
+}
+
+#[test]
+fn cancellation_discards_collected_values() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let editor = input_editor(ctx);
+            let mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
+            let flow = ctx.add_model(|_| TuiMcpInstallFlowModel::new(editor, mode));
+            let variable = TuiMcpTemplateVariable {
+                key: "TOKEN".to_owned(),
+                allowed_values: None,
+            };
+
+            flow.update(ctx, |flow, ctx| {
+                assert!(flow.start(request(vec![variable]), ctx));
+                flow.apply_value("TOKEN".to_owned(), "secret".to_owned(), ctx)
+                    .expect("value is accepted");
+                flow.dismiss(ctx);
+            });
+
+            assert!(flow.as_ref(ctx).confirmation().is_none());
+            assert!(flow.as_ref(ctx).values.is_empty());
+        });
+    });
+}

--- a/crates/warp_tui/src/mcp_menu.rs
+++ b/crates/warp_tui/src/mcp_menu.rs
@@ -1,7 +1,9 @@
+use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::tui_export::{
-    TuiMcpAction, TuiMcpConfigState, TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerStatus,
-    TuiMcpTransport,
+    TuiMcpAction, TuiMcpFileScope, TuiMcpManager, TuiMcpManagerEvent, TuiMcpServerId,
+    TuiMcpServerSource, TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport,
 };
+use warp_editor::model::CoreEditorModel;
 use warpui_core::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity as _};
 
 use crate::inline_menu::{
@@ -9,15 +11,16 @@ use crate::inline_menu::{
     TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, result_row_capacity,
 };
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
-use crate::ui::abbreviate_home_prefix;
 
 const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
 
 #[derive(Clone, Debug)]
 struct TuiMcpMenuRow {
+    server_id: Option<TuiMcpServerId>,
     title: String,
     description: Option<String>,
-    action: Option<TuiMcpAction>,
+    primary_action: Option<TuiMcpAction>,
+    logout_action: Option<TuiMcpAction>,
 }
 
 #[derive(Default)]
@@ -35,15 +38,22 @@ pub(crate) enum TuiMcpMenuEvent {
 }
 
 pub(crate) struct TuiMcpMenuModel {
+    input_editor: ModelHandle<CodeEditorModel>,
     suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     state: TuiMcpMenuState,
 }
 
 impl TuiMcpMenuModel {
     pub(crate) fn new(
+        input_editor: ModelHandle<CodeEditorModel>,
         suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
+        ctx.subscribe_to_model(&input_editor, |model, _, event, ctx| {
+            if model.is_open(ctx) && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
+                model.refresh_rows(ctx);
+            }
+        });
         ctx.subscribe_to_model(
             &TuiMcpManager::handle(ctx),
             |model, _, _: &TuiMcpManagerEvent, ctx| {
@@ -53,6 +63,7 @@ impl TuiMcpMenuModel {
             },
         );
         Self {
+            input_editor,
             suggestions_mode,
             state: TuiMcpMenuState::Closed,
         }
@@ -77,6 +88,8 @@ impl TuiMcpMenuModel {
         if !did_open {
             return;
         }
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         self.state = TuiMcpMenuState::Open {
             list: TuiInlineMenuListState::default(),
         };
@@ -89,6 +102,8 @@ impl TuiMcpMenuModel {
             self.suggestions_mode.update(ctx, |mode, ctx| {
                 mode.close_if_active(TuiInputSuggestionsMode::Mcp, ctx);
             });
+            self.input_editor
+                .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
             ctx.emit(TuiMcpMenuEvent::Updated);
         }
     }
@@ -97,7 +112,7 @@ impl TuiMcpMenuModel {
         let TuiMcpMenuState::Open { list } = &mut self.state else {
             return;
         };
-        list.select_previous(MAX_VISIBLE_ROWS, |row| row.action.is_some());
+        list.select_previous(MAX_VISIBLE_ROWS, row_is_selectable);
         ctx.emit(TuiMcpMenuEvent::Updated);
     }
 
@@ -105,13 +120,13 @@ impl TuiMcpMenuModel {
         let TuiMcpMenuState::Open { list } = &mut self.state else {
             return;
         };
-        list.select_next(MAX_VISIBLE_ROWS, |row| row.action.is_some());
+        list.select_next(MAX_VISIBLE_ROWS, row_is_selectable);
         ctx.emit(TuiMcpMenuEvent::Updated);
     }
 
     /// Selects the row at absolute snapshot index `index` (for mouse click).
     /// Returns `true` when the row was actually selected, `false` when the
-    /// index is out of bounds, the menu is not open, or the row has no action.
+    /// index is out of bounds, the menu is not open, or the row is not selectable.
     pub(crate) fn select_at_snapshot_index(
         &mut self,
         index: usize,
@@ -120,7 +135,7 @@ impl TuiMcpMenuModel {
         let TuiMcpMenuState::Open { list } = &mut self.state else {
             return false;
         };
-        let selected = list.select_absolute(index, MAX_VISIBLE_ROWS, |row| row.action.is_some());
+        let selected = list.select_absolute(index, MAX_VISIBLE_ROWS, row_is_selectable);
         ctx.emit(TuiMcpMenuEvent::Updated);
         selected
     }
@@ -133,15 +148,35 @@ impl TuiMcpMenuModel {
         list.scroll_by(delta, MAX_VISIBLE_ROWS);
         ctx.emit(TuiMcpMenuEvent::Updated);
     }
-
-    pub(crate) fn accept_selected(
-        &mut self,
-        _ctx: &mut ModelContext<Self>,
-    ) -> Option<TuiMcpAction> {
+    pub(crate) fn selected_primary_action(&self, ctx: &AppContext) -> Option<TuiMcpAction> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiMcpMenuState::Open { list } = &self.state else {
             return None;
         };
-        list.selected_row().and_then(|row| row.action)
+        list.selected_row().and_then(|row| row.primary_action)
+    }
+    pub(crate) fn accept_selected(&self, ctx: &AppContext) -> Option<TuiMcpAction> {
+        self.selected_primary_action(ctx)
+    }
+
+    pub(crate) fn logout_selected(&self, ctx: &AppContext) -> Option<TuiMcpAction> {
+        if !self.is_open(ctx) {
+            return None;
+        }
+        let TuiMcpMenuState::Open { list } = &self.state else {
+            return None;
+        };
+        list.selected_row().and_then(|row| row.logout_action)
+    }
+    pub(crate) fn can_log_out_selected(&self, ctx: &AppContext) -> bool {
+        self.logout_selected(ctx).is_some()
+    }
+
+    pub(crate) fn input_hint_text(&self, ctx: &AppContext) -> Option<&'static str> {
+        (self.is_open(ctx) && input_text(&self.input_editor, ctx).is_empty())
+            .then_some("Search MCP servers…")
     }
 
     pub(crate) fn snapshot(&self, app: &AppContext) -> Option<TuiInlineMenuSnapshot> {
@@ -151,25 +186,18 @@ impl TuiMcpMenuModel {
         let TuiMcpMenuState::Open { list } = &self.state else {
             return None;
         };
-        let mcp = TuiMcpManager::as_ref(app);
-        let snapshot = mcp.snapshot();
+        let query = input_text(&self.input_editor, app);
         let status = list.rows().is_empty().then(|| {
-            let label = match &snapshot.config_state {
-                TuiMcpConfigState::Missing => format!(
-                    "No MCP config found at {}",
-                    abbreviate_home_prefix(&snapshot.config_path.display().to_string())
-                ),
-                TuiMcpConfigState::Ready => "No MCP servers configured".to_string(),
-                TuiMcpConfigState::Invalid { message } => format!("Config error: {message}"),
+            let label = if !query.trim().is_empty() {
+                "No matching MCP servers".to_owned()
+            } else {
+                "No MCP servers available".to_owned()
             };
             TuiInlineMenuStatus::Empty(label)
         });
         Some(TuiInlineMenuSnapshot {
             header: Some(TuiInlineMenuHeader {
-                title: Some(format!(
-                    "MCP · {}",
-                    abbreviate_home_prefix(&snapshot.config_path.display().to_string())
-                )),
+                title: Some("MCP servers".to_owned()),
                 tabs: Vec::new(),
             }),
             rows: list
@@ -180,7 +208,7 @@ impl TuiMcpMenuModel {
                     prefix: None,
                     description: row.description.clone(),
                     state_suffix: None,
-                    is_selectable: row.action.is_some(),
+                    is_selectable: row_is_selectable(row),
                     style: TuiInlineMenuRowStyle::Default,
                 })
                 .collect(),
@@ -197,65 +225,156 @@ impl TuiMcpMenuModel {
             return;
         }
         let snapshot = TuiMcpManager::as_ref(ctx).snapshot();
-        let mut rows = Vec::new();
-        if let TuiMcpConfigState::Invalid { message } = &snapshot.config_state {
-            rows.push(TuiMcpMenuRow {
-                title: "Config error".to_string(),
-                description: Some(message.clone()),
-                action: None,
-            });
-        }
-        for server in &snapshot.servers {
-            let transport = match server.transport {
-                TuiMcpTransport::Stdio => "stdio",
-                TuiMcpTransport::HttpOrSse => "HTTP/SSE",
-            };
-            let (status, action) = match &server.status {
-                TuiMcpServerStatus::Offline => {
-                    ("offline".to_string(), Some(TuiMcpAction::Start(server.id)))
-                }
-                TuiMcpServerStatus::Starting => ("starting…".to_string(), None),
-                TuiMcpServerStatus::Authenticating => (
-                    "authentication required".to_string(),
-                    server
-                        .authorization_url
-                        .as_ref()
-                        .map(|_| TuiMcpAction::ReopenAuthorization(server.id)),
-                ),
-                TuiMcpServerStatus::Running => (
-                    format!("running · {} tools", server.tool_count),
-                    Some(TuiMcpAction::Stop(server.id)),
-                ),
-                TuiMcpServerStatus::Stopping => ("stopping…".to_string(), None),
-                TuiMcpServerStatus::Failed { message } => (
-                    format!("failed · {message}"),
-                    Some(TuiMcpAction::Retry(server.id)),
-                ),
-            };
-            rows.push(TuiMcpMenuRow {
-                title: server.name.clone(),
-                description: Some(format!("{transport} · {status}")),
-                action,
-            });
-            if server.has_credentials {
-                rows.push(TuiMcpMenuRow {
-                    title: format!("Log out {}", server.name),
-                    description: Some("Remove saved OAuth credentials".to_string()),
-                    action: Some(TuiMcpAction::LogOut(server.id)),
+        let previous_server_id = match &self.state {
+            TuiMcpMenuState::Open { list } => list.selected_row().and_then(|row| row.server_id),
+            TuiMcpMenuState::Closed => return,
+        };
+        let rows = menu_rows(snapshot, &input_text(&self.input_editor, ctx));
+        let preferred_index = previous_server_id
+            .and_then(|server_id| {
+                rows.iter()
+                    .position(|row| row.server_id == Some(server_id) && row_is_selectable(row))
+            })
+            .or_else(|| rows.iter().position(row_is_selectable));
+        let TuiMcpMenuState::Open { list } = &mut self.state else {
+            return;
+        };
+        list.replace_rows(
+            rows,
+            false,
+            preferred_index,
+            MAX_VISIBLE_ROWS,
+            row_is_selectable,
+        );
+        ctx.emit(TuiMcpMenuEvent::Updated);
+    }
+}
+fn menu_rows(snapshot: &TuiMcpSnapshot, query: &str) -> Vec<TuiMcpMenuRow> {
+    let mut rows = Vec::new();
+    for diagnostic in &snapshot.diagnostics {
+        rows.push(TuiMcpMenuRow {
+            server_id: None,
+            title: format!("{} config error", diagnostic.provider),
+            description: Some(format!(
+                "{} · {}",
+                diagnostic.config_path.display(),
+                diagnostic.message
+            )),
+            primary_action: None,
+            logout_action: None,
+        });
+    }
+    let query = query.trim().to_lowercase();
+    rows.extend(
+        snapshot
+            .servers
+            .iter()
+            .filter(|server| {
+                query.is_empty()
+                    || server.name.to_lowercase().contains(&query)
+                    || server
+                        .description
+                        .as_deref()
+                        .is_some_and(|description| description.to_lowercase().contains(&query))
+                    || source_label(&server.source).to_lowercase().contains(&query)
+            })
+            .map(|server| {
+                let transport = server.transport.map(|transport| match transport {
+                    TuiMcpTransport::Stdio => "stdio",
+                    TuiMcpTransport::HttpOrSse => "HTTP/SSE",
                 });
+                let (status, primary_action) = match &server.status {
+                    TuiMcpServerStatus::Available => (
+                        "available".to_owned(),
+                        Some(TuiMcpAction::Enable(server.id)),
+                    ),
+                    TuiMcpServerStatus::Offline => {
+                        ("offline".to_string(), Some(TuiMcpAction::Start(server.id)))
+                    }
+                    TuiMcpServerStatus::Starting => ("starting…".to_string(), None),
+                    TuiMcpServerStatus::Authenticating => (
+                        "authentication required".to_string(),
+                        server
+                            .authorization_url
+                            .as_ref()
+                            .map(|_| TuiMcpAction::ReopenAuthorization(server.id)),
+                    ),
+                    TuiMcpServerStatus::Running => (
+                        format!("running · {} tools", server.tool_count),
+                        Some(TuiMcpAction::Stop(server.id)),
+                    ),
+                    TuiMcpServerStatus::Stopping => ("stopping…".to_string(), None),
+                    TuiMcpServerStatus::Failed { message } => (
+                        format!("failed · {message}"),
+                        Some(TuiMcpAction::Retry(server.id)),
+                    ),
+                };
+                let mut description = vec![source_label(&server.source)];
+                if let Some(transport) = transport {
+                    description.push(transport.to_owned());
+                }
+                description.push(status);
+                TuiMcpMenuRow {
+                    server_id: Some(server.id),
+                    title: server.name.clone(),
+                    description: Some(description.join(" · ")),
+                    primary_action,
+                    logout_action: server
+                        .can_log_out
+                        .then_some(TuiMcpAction::LogOut(server.id)),
+                }
+            }),
+    );
+    rows
+}
+
+fn source_label(source: &TuiMcpServerSource) -> String {
+    match source {
+        TuiMcpServerSource::Installation => "TUI local".to_owned(),
+        TuiMcpServerSource::SyncedTemplate => "synced".to_owned(),
+        TuiMcpServerSource::Gallery => "gallery".to_owned(),
+        TuiMcpServerSource::FileBased { sources } => {
+            let labels = sources
+                .iter()
+                .map(|source| match source.scope {
+                    TuiMcpFileScope::Global => format!("{} global", source.provider),
+                    TuiMcpFileScope::Project => {
+                        let root = source
+                            .root_path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap_or("project");
+                        format!("{} · {root}", source.provider)
+                    }
+                })
+                .collect::<Vec<_>>();
+            if labels.is_empty() {
+                "file config".to_owned()
+            } else {
+                labels.join(", ")
             }
         }
+    }
+}
 
-        let preferred_index = rows.iter().position(|row| row.action.is_some());
-        let mut list = TuiInlineMenuListState::default();
-        list.replace_rows(rows, false, preferred_index, MAX_VISIBLE_ROWS, |row| {
-            row.action.is_some()
-        });
-        self.state = TuiMcpMenuState::Open { list };
-        ctx.emit(TuiMcpMenuEvent::Updated);
+fn row_is_selectable(row: &TuiMcpMenuRow) -> bool {
+    row.server_id.is_some()
+}
+
+fn input_text(editor: &ModelHandle<CodeEditorModel>, app: &AppContext) -> String {
+    let model = editor.as_ref(app);
+    let buffer = model.content().as_ref(app);
+    if buffer.is_empty() {
+        String::new()
+    } else {
+        buffer.text().into_string()
     }
 }
 
 impl Entity for TuiMcpMenuModel {
     type Event = TuiMcpMenuEvent;
 }
+
+#[cfg(test)]
+#[path = "mcp_menu_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/mcp_menu_tests.rs
+++ b/crates/warp_tui/src/mcp_menu_tests.rs
@@ -1,0 +1,202 @@
+use uuid::Uuid;
+use warp::tui_export::{
+    TuiMcpAction, TuiMcpConfigDiagnostic, TuiMcpFileScope, TuiMcpFileSource, TuiMcpServerId,
+    TuiMcpServerSnapshot, TuiMcpServerSource, TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport,
+};
+
+use super::{menu_rows, row_is_selectable};
+
+fn server(
+    id: TuiMcpServerId,
+    name: &str,
+    source: TuiMcpServerSource,
+    status: TuiMcpServerStatus,
+    can_log_out: bool,
+) -> TuiMcpServerSnapshot {
+    TuiMcpServerSnapshot {
+        id,
+        installation_uuid: match id {
+            TuiMcpServerId::FileBased(_) | TuiMcpServerId::Installation(_) => {
+                Some(Uuid::from_u128(1))
+            }
+            TuiMcpServerId::SyncedTemplate(_) | TuiMcpServerId::Gallery(_) => None,
+        },
+        name: name.to_owned(),
+        description: None,
+        source,
+        transport: Some(TuiMcpTransport::Stdio),
+        status,
+        tool_count: 2,
+        resource_count: 0,
+        can_log_out,
+        authorization_url: None,
+    }
+}
+
+fn snapshot(servers: Vec<TuiMcpServerSnapshot>) -> TuiMcpSnapshot {
+    TuiMcpSnapshot {
+        diagnostics: Vec::new(),
+        servers,
+    }
+}
+
+#[test]
+fn query_filters_server_rows_case_insensitively() {
+    let first = TuiMcpServerId::Installation(Uuid::from_u128(1));
+    let snapshot = snapshot(vec![
+        server(
+            first,
+            "GitHub",
+            TuiMcpServerSource::Installation,
+            TuiMcpServerStatus::Running,
+            true,
+        ),
+        server(
+            TuiMcpServerId::FileBased(2),
+            "Linear",
+            TuiMcpServerSource::FileBased {
+                sources: Vec::new(),
+            },
+            TuiMcpServerStatus::Offline,
+            false,
+        ),
+    ]);
+
+    let rows = menu_rows(&snapshot, "hub");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].title, "GitHub");
+    assert_eq!(rows[0].primary_action, Some(TuiMcpAction::Stop(first)));
+}
+
+#[test]
+fn available_row_is_distinct_from_offline_and_requires_enable() {
+    let id = TuiMcpServerId::Gallery(Uuid::from_u128(7));
+    let snapshot = snapshot(vec![server(
+        id,
+        "Figma",
+        TuiMcpServerSource::Gallery,
+        TuiMcpServerStatus::Available,
+        false,
+    )]);
+
+    let rows = menu_rows(&snapshot, "");
+
+    assert_eq!(rows[0].primary_action, Some(TuiMcpAction::Enable(id)));
+    assert_eq!(
+        rows[0].description.as_deref(),
+        Some("gallery · stdio · available")
+    );
+}
+
+#[test]
+fn file_provenance_includes_provider_scope_and_repository() {
+    let snapshot = snapshot(vec![server(
+        TuiMcpServerId::FileBased(8),
+        "Repo MCP",
+        TuiMcpServerSource::FileBased {
+            sources: vec![
+                TuiMcpFileSource {
+                    provider: "Claude".to_owned(),
+                    root_path: "/home/me".into(),
+                    scope: TuiMcpFileScope::Global,
+                },
+                TuiMcpFileSource {
+                    provider: "Other Agents".to_owned(),
+                    root_path: "/work/project".into(),
+                    scope: TuiMcpFileScope::Project,
+                },
+            ],
+        },
+        TuiMcpServerStatus::Offline,
+        false,
+    )]);
+
+    let rows = menu_rows(&snapshot, "");
+
+    assert_eq!(
+        rows[0].description.as_deref(),
+        Some("Claude global, Other Agents · project · stdio · offline")
+    );
+}
+
+#[test]
+fn multiple_diagnostics_render_without_hiding_healthy_servers() {
+    let mut snapshot = snapshot(vec![server(
+        TuiMcpServerId::FileBased(2),
+        "Healthy",
+        TuiMcpServerSource::FileBased {
+            sources: Vec::new(),
+        },
+        TuiMcpServerStatus::Offline,
+        false,
+    )]);
+    snapshot.diagnostics = vec![
+        TuiMcpConfigDiagnostic {
+            provider: "Claude".to_owned(),
+            config_path: "/tmp/.claude.json".into(),
+            message: "invalid JSON".to_owned(),
+        },
+        TuiMcpConfigDiagnostic {
+            provider: "Codex".to_owned(),
+            config_path: "/tmp/config.toml".into(),
+            message: "missing variable".to_owned(),
+        },
+    ];
+
+    let rows = menu_rows(&snapshot, "");
+
+    assert_eq!(rows.len(), 3);
+    assert!(!row_is_selectable(&rows[0]));
+    assert!(!row_is_selectable(&rows[1]));
+    assert_eq!(rows[2].title, "Healthy");
+    assert!(row_is_selectable(&rows[2]));
+}
+
+#[test]
+fn logout_capability_adds_a_secondary_action_without_adding_a_logout_row() {
+    let first = TuiMcpServerId::Installation(Uuid::from_u128(1));
+    let snapshot = snapshot(vec![
+        server(
+            first,
+            "GitHub",
+            TuiMcpServerSource::Installation,
+            TuiMcpServerStatus::Running,
+            true,
+        ),
+        server(
+            TuiMcpServerId::FileBased(2),
+            "Linear",
+            TuiMcpServerSource::FileBased {
+                sources: Vec::new(),
+            },
+            TuiMcpServerStatus::Offline,
+            false,
+        ),
+    ]);
+
+    let rows = menu_rows(&snapshot, "");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].logout_action, Some(TuiMcpAction::LogOut(first)));
+    assert_eq!(rows[1].logout_action, None);
+}
+
+#[test]
+fn actionless_server_transition_remains_selectable() {
+    let snapshot = snapshot(vec![server(
+        TuiMcpServerId::FileBased(1),
+        "GitHub",
+        TuiMcpServerSource::FileBased {
+            sources: Vec::new(),
+        },
+        TuiMcpServerStatus::Stopping,
+        false,
+    )]);
+
+    let rows = menu_rows(&snapshot, "");
+
+    assert_eq!(rows[0].primary_action, None);
+    assert_eq!(rows[0].logout_action, None);
+    assert!(row_is_selectable(&rows[0]));
+}

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -352,6 +352,7 @@ impl TuiSlashCommandModel {
                 | TuiInputSuggestionsMode::ModelSelector
                 | TuiInputSuggestionsMode::SkillMenu
                 | TuiInputSuggestionsMode::Mcp
+                | TuiInputSuggestionsMode::McpInstall
         ) {
             self.set_highlighted_prefix_len(None, ctx);
             self.set_argument_hint_text(None, ctx);

--- a/crates/warp_tui/src/slash_commands_tests.rs
+++ b/crates/warp_tui/src/slash_commands_tests.rs
@@ -570,6 +570,10 @@ fn model_menu_blocks_slash_command_activation() {
 fn skill_menu_blocks_slash_command_activation() {
     assert_explicit_menu_blocks_slash_commands(TuiInputSuggestionsMode::SkillMenu);
 }
+#[test]
+fn mcp_install_flow_blocks_slash_command_activation() {
+    assert_explicit_menu_blocks_slash_commands(TuiInputSuggestionsMode::McpInstall);
+}
 
 #[test]
 fn accepting_a_result_does_not_disable_input_driven_lifecycle() {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -90,6 +90,9 @@ use crate::keybindings::{
     KEYBOARD_ENHANCEMENT_AVAILABLE_FLAG, PLAN_TOGGLE_AVAILABLE_FLAG, PLAN_TOGGLE_BINDING_NAME,
     TUI_BINDING_GROUP, binding_hint,
 };
+use crate::mcp_install_flow::{
+    TuiMcpInstallFlowAction, TuiMcpInstallFlowEvent, TuiMcpInstallFlowModel,
+};
 use crate::mcp_menu::{TuiMcpMenuEvent, TuiMcpMenuModel};
 use crate::model_menu::{TuiModelMenuEvent, TuiModelMenuModel};
 use crate::orchestration_block::TuiOrchestrationBlock;
@@ -237,6 +240,24 @@ impl BlockingInputSource {
             Self::GrokOAuth(view) => Some(TuiChildView::new(&view).finish()),
         }
     }
+}
+
+fn render_mcp_install_footer(
+    builder: &TuiUiBuilder,
+    primary_action_hint: Option<&'static str>,
+) -> TuiFlex {
+    let mut spans = Vec::new();
+    if let Some(hint) = primary_action_hint {
+        spans.extend([
+            ("Enter".to_owned(), builder.primary_text_style()),
+            (format!(" {hint}  "), builder.muted_text_style()),
+        ]);
+    }
+    spans.extend([
+        ("Esc".to_owned(), builder.primary_text_style()),
+        (" to cancel".to_owned(), builder.muted_text_style()),
+    ]);
+    TuiFlex::row().child(TuiText::from_spans(spans).truncate().finish())
 }
 /// Events emitted by the TUI terminal session surface.
 pub(crate) enum TuiTerminalSessionEvent {
@@ -651,6 +672,45 @@ fn render_status_footer_row(segments: FooterSegments, builder: &TuiUiBuilder) ->
 
     row
 }
+
+fn mcp_primary_action_hint(action: TuiMcpAction) -> Option<&'static str> {
+    match action {
+        TuiMcpAction::Enable(_) => Some("to enable"),
+        TuiMcpAction::Start(_) => Some("to start"),
+        TuiMcpAction::Stop(_) => Some("to stop"),
+        TuiMcpAction::Retry(_) => Some("to retry"),
+        TuiMcpAction::ReopenAuthorization(_) => Some("to authenticate"),
+        TuiMcpAction::LogOut(_) | TuiMcpAction::ReloadConfig => None,
+    }
+}
+
+fn render_mcp_menu_footer(
+    builder: &TuiUiBuilder,
+    primary_action: Option<TuiMcpAction>,
+    can_log_out: bool,
+) -> TuiFlex {
+    let mut spans = Vec::new();
+    if let Some(hint) = primary_action.and_then(mcp_primary_action_hint) {
+        spans.extend([
+            ("Enter".to_owned(), builder.primary_text_style()),
+            (format!(" {hint}  "), builder.muted_text_style()),
+        ]);
+    }
+    if can_log_out {
+        spans.extend([
+            ("Ctrl+R".to_owned(), builder.primary_text_style()),
+            (
+                " to log out & remove credentials  ".to_owned(),
+                builder.muted_text_style(),
+            ),
+        ]);
+    }
+    spans.extend([
+        ("Esc".to_owned(), builder.primary_text_style()),
+        (" to close".to_owned(), builder.muted_text_style()),
+    ]);
+    TuiFlex::row().child(TuiText::from_spans(spans).truncate().finish())
+}
 /// Entry point that requested conversation restoration.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum TuiConversationRestoreOrigin {
@@ -810,6 +870,7 @@ pub(crate) struct TuiTerminalSessionView {
     model_menu: ModelHandle<TuiModelMenuModel>,
     skills_menu: ModelHandle<TuiSkillMenuModel>,
     mcp_menu: ModelHandle<TuiMcpMenuModel>,
+    mcp_install_flow: ModelHandle<TuiMcpInstallFlowModel>,
     completion_menu: ModelHandle<TuiCompletionMenuModel>,
     slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
     conversation_selection: ConversationSelectionHandle,
@@ -1092,6 +1153,42 @@ impl TuiTerminalSessionView {
 
     fn refresh_input_focus(&mut self, ctx: &mut ViewContext<Self>) {
         self.focus_current_owner_if_active(ctx);
+        ctx.notify();
+    }
+
+    fn handle_accepted_mcp_install_action(
+        &mut self,
+        action: TuiMcpInstallFlowAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match action {
+            TuiMcpInstallFlowAction::ProvideValue { key, value } => {
+                let result = self
+                    .mcp_install_flow
+                    .update(ctx, |flow, ctx| flow.apply_value(key, value, ctx));
+                if let Err(message) = result {
+                    self.show_error_hint(message, ctx);
+                }
+            }
+            TuiMcpInstallFlowAction::Confirm => {
+                let Some((id, name, values)) = self.mcp_install_flow.as_ref(ctx).confirmation()
+                else {
+                    self.show_error_hint(
+                        "The MCP installation flow is no longer ready".to_owned(),
+                        ctx,
+                    );
+                    return;
+                };
+                let result = TuiMcpManager::handle(ctx)
+                    .update(ctx, |manager, ctx| manager.confirm_install(id, values, ctx));
+                self.mcp_install_flow
+                    .update(ctx, |flow, ctx| flow.dismiss(ctx));
+                match result {
+                    Ok(_) => self.show_success_hint(format!("{name} enabled and starting"), ctx),
+                    Err(message) => self.show_error_hint(message, ctx),
+                }
+            }
+        }
         ctx.notify();
     }
 
@@ -1688,10 +1785,22 @@ impl TuiTerminalSessionView {
         ctx.subscribe_to_model(&skills_menu, |_, _, _: &TuiSkillMenuEvent, ctx| {
             ctx.notify();
         });
-        let mcp_menu = ctx.add_model(|ctx| TuiMcpMenuModel::new(suggestions_mode.clone(), ctx));
+        let mcp_menu = ctx.add_model(|ctx| {
+            TuiMcpMenuModel::new(input_editor_model.clone(), suggestions_mode.clone(), ctx)
+        });
         ctx.subscribe_to_model(&mcp_menu, |_, _, event, ctx| {
             let TuiMcpMenuEvent::Updated = event;
             ctx.notify();
+        });
+        let mcp_install_flow = ctx.add_model(|_| {
+            TuiMcpInstallFlowModel::new(input_editor_model.clone(), suggestions_mode.clone())
+        });
+        ctx.subscribe_to_model(&mcp_install_flow, |view, _, event, ctx| match event {
+            TuiMcpInstallFlowEvent::Updated => ctx.notify(),
+            TuiMcpInstallFlowEvent::Dismissed => {
+                view.mcp_menu.update(ctx, |menu, ctx| menu.open(ctx));
+                ctx.notify();
+            }
         });
         let prompt_and_command_history_menu = ctx.add_model(|ctx| {
             TuiPromptAndCommandHistoryMenuModel::new(
@@ -1761,6 +1870,7 @@ impl TuiTerminalSessionView {
             TuiInlineMenu::new(model_menu.clone()),
             TuiInlineMenu::new(skills_menu.clone()),
             TuiInlineMenu::new(mcp_menu.clone()),
+            TuiInlineMenu::new(mcp_install_flow.clone()),
             TuiInlineMenu::new(prompt_and_command_history_menu.clone()),
             TuiInlineMenu::new(completion_menu.clone()),
         ];
@@ -1864,6 +1974,9 @@ impl TuiTerminalSessionView {
             }
             TuiInputViewEvent::AcceptedMcp(action) => {
                 view.handle_accepted_mcp_action(*action, ctx);
+            }
+            TuiInputViewEvent::AcceptedMcpInstall(action) => {
+                view.handle_accepted_mcp_install_action(action.clone(), ctx);
             }
             TuiInputViewEvent::AcceptedPromptAndCommandHistory { text, kind } => {
                 view.handle_accepted_prompt_and_command_history(text.clone(), kind.clone(), ctx);
@@ -2125,6 +2238,7 @@ impl TuiTerminalSessionView {
             model_menu,
             skills_menu,
             mcp_menu,
+            mcp_install_flow,
             completion_menu,
             slash_commands_source,
             conversation_selection,
@@ -3316,7 +3430,8 @@ impl TuiTerminalSessionView {
     /// replacing hint — the ctrl-c exit confirmation while armed, the
     /// conversation-list loading hint, an active transient notice, or the
     /// interrupt hint for a manually attached running command — occupies the
-    /// whole row instead. An empty resolved configuration consumes no row.
+    /// whole row instead. The open MCP menu similarly replaces the statusline
+    /// with its controls. An empty resolved configuration consumes no row.
     fn render_footer(&self, ctx: &AppContext) -> TuiFlex {
         let builder = TuiUiBuilder::from_app(ctx);
         let shell_mode = self.is_shell_mode(ctx);
@@ -3325,6 +3440,20 @@ impl TuiTerminalSessionView {
             && self.voice_statusline_is_available(shell_mode, ctx);
         if let Some(hint) = self.footer_hint(voice_statusline_visible, ctx) {
             return hint.render(&builder);
+        }
+        if self.mcp_install_flow.as_ref(ctx).is_open(ctx) {
+            return render_mcp_install_footer(
+                &builder,
+                self.mcp_install_flow.as_ref(ctx).primary_action_hint(),
+            );
+        }
+        if self.mcp_menu.as_ref(ctx).is_open(ctx) {
+            let menu = self.mcp_menu.as_ref(ctx);
+            return render_mcp_menu_footer(
+                &builder,
+                menu.selected_primary_action(ctx),
+                menu.can_log_out_selected(ctx),
+            );
         }
         let git_metadata = self.git_status_metadata(ctx);
         let mut ordered = Vec::new();
@@ -4210,9 +4339,37 @@ impl TuiTerminalSessionView {
         self.model_menu.update(ctx, |menu, ctx| menu.dismiss(ctx));
     }
     fn handle_accepted_mcp_action(&mut self, action: TuiMcpAction, ctx: &mut ViewContext<Self>) {
-        TuiMcpManager::handle(ctx).update(ctx, |model, ctx| {
-            model.apply_action(action, ctx);
-        });
+        match action {
+            TuiMcpAction::Enable(id) => {
+                let request = TuiMcpManager::handle(ctx)
+                    .update(ctx, |model, ctx| model.prepare_install(id, ctx));
+                match request {
+                    Ok(request) => {
+                        self.mcp_menu.update(ctx, |menu, ctx| menu.dismiss(ctx));
+                        if !self
+                            .mcp_install_flow
+                            .update(ctx, |flow, ctx| flow.start(request, ctx))
+                        {
+                            self.show_error_hint(
+                                "Unable to open the MCP installation flow".to_owned(),
+                                ctx,
+                            );
+                        }
+                    }
+                    Err(message) => self.show_error_hint(message, ctx),
+                }
+            }
+            TuiMcpAction::Start(_)
+            | TuiMcpAction::Stop(_)
+            | TuiMcpAction::Retry(_)
+            | TuiMcpAction::LogOut(_)
+            | TuiMcpAction::ReopenAuthorization(_)
+            | TuiMcpAction::ReloadConfig => {
+                TuiMcpManager::handle(ctx).update(ctx, |model, ctx| {
+                    model.apply_action(action, ctx);
+                });
+            }
+        }
         ctx.notify();
     }
 
@@ -4397,7 +4554,6 @@ impl TuiTerminalSessionView {
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
             SlashCommandKind::Mcp => {
-                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 self.mcp_menu.update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }

--- a/crates/warp_tui/src/terminal_session_view/input_detection.rs
+++ b/crates/warp_tui/src/terminal_session_view/input_detection.rs
@@ -100,7 +100,9 @@ impl TuiTerminalSessionView {
     ) {
         self.abort_input_detection(ctx);
         self.handle_completion_editor_changed(ctx);
-        if is_user_edit {
+        if is_user_edit
+            && self.suggestions_mode.as_ref(ctx).mode() != TuiInputSuggestionsMode::McpInstall
+        {
             self.schedule_input_detection(ctx);
         }
     }

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -19,8 +19,8 @@ use warp::tui_export::{
     Harness, InputTypeAutoDetectionSource, LLMPreferences, LinkedWorkflowData,
     LongRunningCommandControlState, PtyIntent, PtyIntentEvent, QueuedQueryModel, SizeInfo,
     SizeUpdate, SlashCommandDataSource as _, SlashCommandKind, TaskId, TranscriptScope,
-    TuiUpArrowHistoryItemKind, UserTakeOverReason, export_conversation_markdown,
-    register_tui_session_view_test_singletons, slash_commands,
+    TuiMcpAction, TuiMcpServerId, TuiUpArrowHistoryItemKind, UserTakeOverReason,
+    export_conversation_markdown, register_tui_session_view_test_singletons, slash_commands,
 };
 use warp_core::channel::Channel;
 use warp_core::features::FeatureFlag;
@@ -58,7 +58,8 @@ use super::{
     attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
     format_context_window_usage, format_statusline_date, format_statusline_time_12_hour,
     format_statusline_time_24_hour, format_todo_progress, log_bundle_success_message,
-    raw_prompt_if_not_blank, render_status_footer_row, render_statusline_datetime,
+    mcp_primary_action_hint, raw_prompt_if_not_blank, render_mcp_install_footer,
+    render_mcp_menu_footer, render_status_footer_row, render_statusline_datetime,
     voice_argument_is_empty, voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
@@ -96,6 +97,22 @@ struct FocusTestFixture {
     sessions: ModelHandle<TuiSessions>,
 }
 
+#[test]
+fn mcp_install_footer_requires_explicit_confirmation() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let footer =
+                render_mcp_install_footer(&TuiUiBuilder::from_app(ctx), Some("to enable & start"))
+                    .finish();
+            assert_eq!(
+                render_element(footer, ctx, 120).to_lines(),
+                vec!["Enter to enable & start  Esc to cancel".to_owned()],
+            );
+        });
+    });
+}
+
 fn todo(id: &str, title: &str) -> AIAgentTodo {
     AIAgentTodo::new(id.to_owned().into(), title.to_owned(), String::new())
 }
@@ -127,6 +144,92 @@ fn set_selected_todo_list(
         });
         conversation_id
     })
+}
+
+#[test]
+fn mcp_menu_footer_replaces_status_with_controls() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let footer = render_mcp_menu_footer(
+                &TuiUiBuilder::from_app(ctx),
+                Some(TuiMcpAction::Stop(TuiMcpServerId::FileBased(1))),
+                true,
+            )
+            .finish();
+            assert_eq!(
+                render_element(footer, ctx, 120).to_lines(),
+                vec![
+                    "Enter to stop  Ctrl+R to log out & remove credentials  Esc to close"
+                        .to_owned()
+                ],
+            );
+        });
+    });
+}
+#[test]
+fn mcp_menu_footer_hides_unavailable_primary_control() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let builder = TuiUiBuilder::from_app(ctx);
+            let logout_only = render_mcp_menu_footer(&builder, None, true).finish();
+            assert_eq!(
+                render_element(logout_only, ctx, 120).to_lines(),
+                vec!["Ctrl+R to log out & remove credentials  Esc to close".to_owned()],
+            );
+            let close_only = render_mcp_menu_footer(&builder, None, false).finish();
+            assert_eq!(
+                render_element(close_only, ctx, 120).to_lines(),
+                vec!["Esc to close".to_owned()],
+            );
+        });
+    });
+}
+
+#[test]
+fn mcp_primary_action_hints_match_available_actions() {
+    let id = TuiMcpServerId::FileBased(1);
+    assert_eq!(
+        mcp_primary_action_hint(TuiMcpAction::Enable(id)),
+        Some("to enable")
+    );
+    assert_eq!(
+        mcp_primary_action_hint(TuiMcpAction::Start(id)),
+        Some("to start")
+    );
+    assert_eq!(
+        mcp_primary_action_hint(TuiMcpAction::Stop(id)),
+        Some("to stop")
+    );
+    assert_eq!(
+        mcp_primary_action_hint(TuiMcpAction::Retry(id)),
+        Some("to retry")
+    );
+    assert_eq!(
+        mcp_primary_action_hint(TuiMcpAction::ReopenAuthorization(id)),
+        Some("to authenticate")
+    );
+    assert_eq!(mcp_primary_action_hint(TuiMcpAction::LogOut(id)), None);
+    assert_eq!(mcp_primary_action_hint(TuiMcpAction::ReloadConfig), None);
+}
+#[test]
+fn mcp_menu_footer_hides_unavailable_logout_control() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let footer = render_mcp_menu_footer(
+                &TuiUiBuilder::from_app(ctx),
+                Some(TuiMcpAction::Start(TuiMcpServerId::FileBased(1))),
+                false,
+            )
+            .finish();
+            assert_eq!(
+                render_element(footer, ctx, 120).to_lines(),
+                vec!["Enter to start  Esc to close".to_owned()],
+            );
+        });
+    });
 }
 
 #[test]

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -16,8 +16,8 @@ use ai::project_context::model::{
 };
 use warp::tui_export::{
     ActiveSession, ActiveSessionEvent, ChangelogModel, ChangelogModelEvent, ChangelogState,
-    SkillManager, SkillManagerEvent, TuiMcpConfigState, TuiMcpManager, TuiMcpServerStatus,
-    TuiUserInfoManager, TuiUserInfoManagerEvent,
+    SkillManager, SkillManagerEvent, TuiMcpManager, TuiMcpServerStatus, TuiUserInfoManager,
+    TuiUserInfoManagerEvent,
 };
 use warp_core::channel::ChannelState;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -316,16 +316,6 @@ fn render_mcp_section(mut column: TuiFlex, builder: &TuiUiBuilder, app: &AppCont
             .truncate()
             .finish(),
     );
-    if matches!(snapshot.config_state, TuiMcpConfigState::Missing) {
-        column = column.child(
-            TuiText::new(abbreviate_home_prefix(
-                &snapshot.config_path.display().to_string(),
-            ))
-            .with_style(builder.dim_text_style())
-            .truncate()
-            .finish(),
-        );
-    }
 
     let (label, is_error) = mcp_status_label(snapshot);
     let style = if is_error {
@@ -337,51 +327,56 @@ fn render_mcp_section(mut column: TuiFlex, builder: &TuiUiBuilder, app: &AppCont
 }
 
 fn mcp_status_label(snapshot: &warp::tui_export::TuiMcpSnapshot) -> (String, bool) {
-    match &snapshot.config_state {
-        TuiMcpConfigState::Invalid { .. } => ("Config error · run /mcp".to_string(), true),
-        TuiMcpConfigState::Missing => ("Not configured · /mcp".to_string(), false),
-        TuiMcpConfigState::Ready if snapshot.servers.is_empty() => {
-            ("No servers configured · run /mcp".to_string(), false)
-        }
-        TuiMcpConfigState::Ready => {
-            let mut running = 0;
-            let mut starting = 0;
-            let mut authenticating = 0;
-            let mut stopping = 0;
-            let mut failed = 0;
-            let mut offline = 0;
-            for server in &snapshot.servers {
-                match &server.status {
-                    TuiMcpServerStatus::Offline => offline += 1,
-                    TuiMcpServerStatus::Starting => starting += 1,
-                    TuiMcpServerStatus::Authenticating => authenticating += 1,
-                    TuiMcpServerStatus::Running => running += 1,
-                    TuiMcpServerStatus::Stopping => stopping += 1,
-                    TuiMcpServerStatus::Failed { .. } => failed += 1,
-                }
-            }
-            let mut parts = Vec::new();
-            if running > 0 {
-                parts.push(format!("{running} connected"));
-            }
-            if starting > 0 {
-                parts.push(format!("{starting} starting"));
-            }
-            if authenticating > 0 {
-                parts.push(format!("{authenticating} needs auth"));
-            }
-            if stopping > 0 {
-                parts.push(format!("{stopping} stopping"));
-            }
-            if failed > 0 {
-                parts.push(format!("{failed} failed"));
-            }
-            if offline > 0 {
-                parts.push(format!("{offline} offline"));
-            }
-            (format!("{} · /mcp", parts.join(" · ")), false)
+    if snapshot.servers.is_empty() && snapshot.diagnostics.is_empty() {
+        return ("No servers available · run /mcp".to_owned(), false);
+    }
+    let mut running = 0;
+    let mut starting = 0;
+    let mut authenticating = 0;
+    let mut stopping = 0;
+    let mut failed = 0;
+    let mut offline = 0;
+    let mut available = 0;
+    for server in &snapshot.servers {
+        match &server.status {
+            TuiMcpServerStatus::Available => available += 1,
+            TuiMcpServerStatus::Offline => offline += 1,
+            TuiMcpServerStatus::Starting => starting += 1,
+            TuiMcpServerStatus::Authenticating => authenticating += 1,
+            TuiMcpServerStatus::Running => running += 1,
+            TuiMcpServerStatus::Stopping => stopping += 1,
+            TuiMcpServerStatus::Failed { .. } => failed += 1,
         }
     }
+    let mut parts = Vec::new();
+    if running > 0 {
+        parts.push(format!("{running} connected"));
+    }
+    if starting > 0 {
+        parts.push(format!("{starting} starting"));
+    }
+    if authenticating > 0 {
+        parts.push(format!("{authenticating} needs auth"));
+    }
+    if stopping > 0 {
+        parts.push(format!("{stopping} stopping"));
+    }
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if offline > 0 {
+        parts.push(format!("{offline} offline"));
+    }
+    if available > 0 {
+        parts.push(format!("{available} available"));
+    }
+    if !snapshot.diagnostics.is_empty() {
+        parts.push(format!("{} config errors", snapshot.diagnostics.len()));
+    }
+    (
+        format!("{} · /mcp", parts.join(" · ")),
+        !snapshot.diagnostics.is_empty(),
+    )
 }
 
 /// The login-info line: the signed-in account (email, falling back to the

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use uuid::Uuid;
 use warp::tui_export::{
-    TuiMcpConfigState, TuiMcpServerId, TuiMcpServerSnapshot, TuiMcpServerStatus, TuiMcpSnapshot,
-    TuiMcpTransport, register_tui_session_view_test_singletons,
+    TuiMcpConfigDiagnostic, TuiMcpServerId, TuiMcpServerSnapshot, TuiMcpServerSource,
+    TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport, register_tui_session_view_test_singletons,
 };
 use warpui::{EntityIdMap, SingletonEntity};
 use warpui_core::elements::tui::{
@@ -17,37 +17,37 @@ use crate::tui_builder::TuiUiBuilder;
 
 fn server(id: u64, status: TuiMcpServerStatus) -> TuiMcpServerSnapshot {
     TuiMcpServerSnapshot {
-        id: TuiMcpServerId(id),
-        installation_uuid: Uuid::from_u128(id as u128),
+        id: TuiMcpServerId::Installation(Uuid::from_u128(id as u128)),
+        installation_uuid: Some(Uuid::from_u128(id as u128)),
         name: format!("server-{id}"),
-        transport: TuiMcpTransport::Stdio,
+        description: None,
+        source: TuiMcpServerSource::Installation,
+        transport: Some(TuiMcpTransport::Stdio),
         status,
         tool_count: 2,
         resource_count: 0,
-        has_credentials: false,
+        can_log_out: false,
         authorization_url: None,
     }
 }
 
 #[test]
-fn mcp_summary_keeps_missing_config_action_short() {
+fn mcp_summary_keeps_empty_catalog_action_short() {
     let snapshot = TuiMcpSnapshot {
-        config_path: PathBuf::from("/tmp/.mcp.json"),
-        config_state: TuiMcpConfigState::Missing,
+        diagnostics: Vec::new(),
         servers: Vec::new(),
     };
 
     assert_eq!(
         mcp_status_label(&snapshot),
-        ("Not configured · /mcp".to_string(), false)
+        ("No servers available · run /mcp".to_string(), false)
     );
 }
 
 #[test]
 fn mcp_summary_reports_mixed_runtime_states() {
     let snapshot = TuiMcpSnapshot {
-        config_path: PathBuf::from("/tmp/.mcp.json"),
-        config_state: TuiMcpConfigState::Ready,
+        diagnostics: Vec::new(),
         servers: vec![
             server(1, TuiMcpServerStatus::Running),
             server(2, TuiMcpServerStatus::Starting),
@@ -60,13 +60,14 @@ fn mcp_summary_reports_mixed_runtime_states() {
                 },
             ),
             server(6, TuiMcpServerStatus::Offline),
+            server(7, TuiMcpServerStatus::Available),
         ],
     };
 
     assert_eq!(
         mcp_status_label(&snapshot),
         (
-            "1 connected · 1 starting · 1 needs auth · 1 stopping · 1 failed · 1 offline · /mcp"
+            "1 connected · 1 starting · 1 needs auth · 1 stopping · 1 failed · 1 offline · 1 available · /mcp"
                 .to_string(),
             false
         )
@@ -76,16 +77,24 @@ fn mcp_summary_reports_mixed_runtime_states() {
 #[test]
 fn mcp_summary_marks_config_errors() {
     let snapshot = TuiMcpSnapshot {
-        config_path: PathBuf::from("/tmp/.mcp.json"),
-        config_state: TuiMcpConfigState::Invalid {
-            message: "invalid JSON".to_string(),
-        },
+        diagnostics: vec![
+            TuiMcpConfigDiagnostic {
+                provider: "Claude".to_owned(),
+                config_path: PathBuf::from("/tmp/.claude.json"),
+                message: "invalid JSON".to_owned(),
+            },
+            TuiMcpConfigDiagnostic {
+                provider: "Codex".to_owned(),
+                config_path: PathBuf::from("/tmp/config.toml"),
+                message: "invalid TOML".to_owned(),
+            },
+        ],
         servers: Vec::new(),
     };
 
     assert_eq!(
         mcp_status_label(&snapshot),
-        ("Config error · run /mcp".to_string(), true)
+        ("2 config errors · /mcp".to_string(), true)
     );
 }
 

--- a/crates/warpui_core/src/runtime/event_conversion_tests.rs
+++ b/crates/warpui_core/src/runtime/event_conversion_tests.rs
@@ -137,6 +137,13 @@ fn ctrl_modifier_is_carried_into_keystroke() {
     assert!(keystroke.ctrl, "ctrl modifier should be set");
     assert_eq!(keystroke.key, "c");
 }
+#[test]
+fn legacy_safe_ctrl_r_chord_is_preserved_for_keybindings() {
+    let keystroke = keystroke(KeyCode::Char('r'), KeyModifiers::CONTROL);
+    assert!(keystroke.ctrl);
+    assert_eq!(keystroke.key, "r");
+    assert_eq!(keystroke.normalized(), "ctrl-r");
+}
 
 #[test]
 fn non_shift_modifiers_are_preserved_from_the_key_event() {


### PR DESCRIPTION
## Description
Expands the TUI `/mcp` experience so users can discover and explicitly enable MCP servers from the same sources represented by Warp's broader MCP catalog.

- Shows TUI-local installations, synced templates, gallery entries, Warp-global definitions, third-party global definitions, and current-repository definitions in one searchable list.
- Labels entries with source and scope, preserves same-named file definitions from distinct providers, and reports diagnostics for multiple config files.
- Represents uninstalled synced and gallery entries as `available`; catalog refresh never installs, starts, or initiates OAuth for them.
- Adds a TUI-native enable flow for template variables and final confirmation. Installation and startup happen only after confirmation, and cancellation leaves catalog/runtime state unchanged.
- Detects Claude, Codex, `.agents`, and current-repository MCP configs in place without copying them into Warp's global config.
- Keeps third-party and repository definitions offline by default in TUI while preserving existing Warp-global activation and GUI auto-start behavior.
- Retains the existing streamlined `/mcp` search, row controls, stable selection, and credential logout behavior.

## Linked Issue
N/A

## Testing
- [x] I have manually tested my changes locally with `./script/run-tui`
- [x] Live `/mcp` verification in a real terminal:
  - Confirmed synced entries render as `available` with `Enter to enable`.
  - Confirmed enabling opens a separate `Enable and start` confirmation screen.
  - Canceled the flow and verified counts remained `2 connected · 1 failed · 1 offline · 26 available`.
  - Confirmed a current-repository Claude MCP appears as offline and is not auto-started.
- [x] `cargo nextest run -p warp_tui` (823 passed)
- [x] Focused `warp` MCP tests (29 passed; 6016 skipped)
- [x] `cargo check -p warp_tui`
- [x] `./script/format --check`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] `git diff --check`

The full workspace test suite was not rerun for this update.

### Screenshots / Videos
N/A — the interaction was validated directly in the terminal with `./script/run-tui`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Agent conversation](https://staging.warp.dev/conversation/1592c723-6dbc-49fa-a6c8-1b0cf9699f1d)

CHANGELOG-IMPROVEMENT: Expanded TUI `/mcp` discovery and added explicit opt-in installation for synced and gallery MCP servers.
