### PR TITLE
color dots in one chunk to fix aliasing issues

### DIFF
--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -4400,9 +4400,9 @@ impl TuiView for TuiTerminalSessionView {
                     .and_then(|exchange| exchange.time_since_start());
                 if let Some(elapsed) = warping_elapsed {
                     let label = if conversation.is_summarizing() {
-                        "Summarizing conversation..."
+                        "Summarizing conversation"
                     } else {
-                        "Warping..."
+                        "Warping"
                     };
                     content = content.child(
                         TuiContainer::new(self.render_warping_indicator(

--- a/crates/warp_tui/src/warping_indicator.rs
+++ b/crates/warp_tui/src/warping_indicator.rs
@@ -102,6 +102,7 @@ pub(crate) fn render_warping_indicator_row(
         ShimmerConfig::default(),
         clock,
     )
+    .with_grouped_suffix("...")
     .with_modifier(Modifier::BOLD);
 
     let counter_style = builder.muted_text_style();

--- a/crates/warp_tui/src/warping_indicator_tests.rs
+++ b/crates/warp_tui/src/warping_indicator_tests.rs
@@ -47,7 +47,7 @@ fn renders_the_indicator_row_and_requests_a_repaint() {
         });
         app.read(|app_ctx| {
             let element = render_warping_indicator_row(
-                "Warping...",
+                "Warping",
                 Duration::ZERO,
                 TuiText::new("▶▶ Auto approve off")
                     .with_style(TuiUiBuilder::from_app(app_ctx).muted_text_style())
@@ -81,7 +81,7 @@ fn renders_the_indicator_row_and_requests_a_repaint() {
 }
 
 #[test]
-fn shimmer_only_applies_to_the_warping_label() {
+fn shimmer_only_applies_to_the_warping_label_and_groups_its_ellipsis() {
     App::test((), |mut app| async move {
         app.update(|ctx| {
             ctx.add_singleton_model(|_| Appearance::mock());
@@ -89,7 +89,7 @@ fn shimmer_only_applies_to_the_warping_label() {
         app.read(|app_ctx| {
             let config = ShimmerConfig::default();
             let element = render_warping_indicator_row(
-                "Warping...",
+                "Warping",
                 config.period / 2,
                 TuiText::new("▶▶ Auto approve off").finish(),
                 app_ctx,
@@ -101,6 +101,9 @@ fn shimmer_only_applies_to_the_warping_label() {
             let base = Color::Rgb(base.r, base.g, base.b);
             assert_eq!(frame.buffer[(0, 0)].fg, base);
             assert_ne!(frame.buffer[(5, 0)].fg, base);
+            let first_dot_color = frame.buffer[(9, 0)].fg;
+            assert_eq!(frame.buffer[(10, 0)].fg, first_dot_color);
+            assert_eq!(frame.buffer[(11, 0)].fg, first_dot_color);
         });
     });
 }
@@ -114,7 +117,7 @@ fn renders_a_custom_progress_label() {
         app.read(|app_ctx| {
             let builder = TuiUiBuilder::from_app(app_ctx);
             let element = render_warping_indicator_row(
-                "Summarizing conversation...",
+                "Summarizing conversation",
                 Duration::ZERO,
                 TuiText::new("▶▶ Auto approve on")
                     .with_style(builder.success_glyph_style())

--- a/crates/warpui_core/src/elements/tui/shimmering_text.rs
+++ b/crates/warpui_core/src/elements/tui/shimmering_text.rs
@@ -34,6 +34,7 @@ pub struct TuiShimmeringText {
     /// The clock the band's phase is derived from.
     clock: AnimationClock,
     modifier: Modifier,
+    grouped_suffix_glyph_count: usize,
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
 }
@@ -56,6 +57,7 @@ impl TuiShimmeringText {
             config,
             clock,
             modifier: Modifier::empty(),
+            grouped_suffix_glyph_count: 0,
             size: None,
             origin: None,
         }
@@ -64,6 +66,15 @@ impl TuiShimmeringText {
     /// Adds `modifier` (e.g. [`Modifier::BOLD`]) to every painted cell.
     pub fn with_modifier(mut self, modifier: Modifier) -> Self {
         self.modifier = self.modifier.union(modifier);
+        self
+    }
+
+    /// Appends `suffix` and makes all of its glyphs sample one shared shimmer
+    /// intensity.
+    pub fn with_grouped_suffix(mut self, suffix: impl AsRef<str>) -> Self {
+        let suffix = suffix.as_ref();
+        self.grouped_suffix_glyph_count = suffix.chars().count();
+        self.text.push_str(suffix);
         self
     }
 }
@@ -104,13 +115,23 @@ impl TuiElement for TuiShimmeringText {
 
         let glyph_count = self.text.chars().count();
         let center = shimmer_math::shimmer_center(glyph_count, self.clock.elapsed(), &self.config);
+        let grouped_suffix = (self.grouped_suffix_glyph_count > 0).then(|| {
+            let start = glyph_count - self.grouped_suffix_glyph_count;
+            (
+                start,
+                start + (self.grouped_suffix_glyph_count.saturating_sub(1) / 2),
+            )
+        });
 
         for (index, char) in self.text.chars().enumerate() {
             let x = index.min(usize::from(u16::MAX)) as u16;
             if x >= size.width {
                 break;
             }
-            let intensity = shimmer_math::intensity_at(index, center, &self.config);
+            let shimmer_index = grouped_suffix
+                .filter(|(start, _)| index >= *start)
+                .map_or(index, |(_, center)| center);
+            let intensity = shimmer_math::intensity_at(shimmer_index, center, &self.config);
             let color =
                 shimmer_math::shimmer_color_at(self.base_color, self.shimmer_color, intensity);
             let style = TuiStyle::default()

--- a/crates/warpui_core/src/elements/tui/shimmering_text_tests.rs
+++ b/crates/warpui_core/src/elements/tui/shimmering_text_tests.rs
@@ -7,7 +7,7 @@ use crate::color::ColorU;
 use crate::elements::animation::AnimationClock;
 use crate::elements::shimmer_math::ShimmerConfig;
 use crate::elements::tui::test_support::render_to_frame;
-use crate::elements::tui::{TuiBuffer, TuiSize};
+use crate::elements::tui::{TuiBuffer, TuiBufferExt, TuiSize};
 
 const BASE: ColorU = ColorU {
     r: 254,
@@ -23,8 +23,12 @@ const SHIMMER: ColorU = ColorU {
 };
 
 fn element(initial_elapsed: Duration) -> TuiShimmeringText {
+    element_with_text("Warping", initial_elapsed)
+}
+
+fn element_with_text(text: &str, initial_elapsed: Duration) -> TuiShimmeringText {
     TuiShimmeringText::new(
-        "Warping",
+        text,
         BASE,
         SHIMMER,
         ShimmerConfig::default(),
@@ -66,6 +70,33 @@ fn paints_the_shimmer_color_at_the_band_center_mid_sweep() {
     let edge_cell = &buffer[(0, 0)];
     assert_ne!(center_cell.fg, edge_cell.fg);
     assert_ne!(edge_cell.fg, Color::Rgb(BASE.r, BASE.g, BASE.b));
+}
+#[test]
+fn appends_and_paints_grouped_suffix_with_one_color_across_the_sweep() {
+    let config = ShimmerConfig::default();
+    for elapsed in [
+        config.period / 2,
+        config.period * 2 / 3,
+        config.period * 3 / 4,
+    ] {
+        let (buffer, _) = render(element_with_text("Warping", elapsed).with_grouped_suffix("..."));
+        assert_eq!(buffer.to_lines()[0], "Warping...");
+        let first_dot_color = buffer[(7, 0)].fg;
+        assert_eq!(buffer[(8, 0)].fg, first_dot_color);
+        assert_eq!(buffer[(9, 0)].fg, first_dot_color);
+    }
+
+    let (buffer, _) =
+        render(element_with_text("Warping", config.period / 2).with_grouped_suffix("..."));
+    assert_ne!(buffer[(7, 0)].fg, Color::Rgb(BASE.r, BASE.g, BASE.b));
+}
+
+#[test]
+fn leaves_trailing_ellipsis_ungrouped_by_default() {
+    let config = ShimmerConfig::default();
+    let (buffer, _) = render(element_with_text("Warping...", config.period / 2));
+    assert_ne!(buffer[(7, 0)].fg, buffer[(8, 0)].fg);
+    assert_ne!(buffer[(8, 0)].fg, buffer[(9, 0)].fg);
 }
 
 #[test]


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fixes the Warp Agent CLI warping indicator's trailing ellipsis appearing to shift as the shimmer passes through it in Ghostty. Ghostty reshapes JetBrains Mono's `...` ligature when the periods receive different foreground colors, which changes their apparent spacing even though the terminal cells remain fixed.

Adds a general `with_grouped_suffix` API to `TuiShimmeringText`. The API appends the supplied suffix to the base text and treats the appended glyphs as one shimmer unit, structurally guaranteeing that the grouped range exists. The warping indicator now builds labels from `Warping` or `Summarizing conversation` plus a grouped `...` suffix, so all three periods sample one shared intensity while remaining part of the animation. Regression coverage verifies suffix appending, shared colors across multiple shimmer phases, default ungrouped behavior, and the rendered indicator row.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/ec6f33e8ddf741908fd7a0ab7b6a6e32

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode