### PR TITLE
fix(passive-suggestions): cap block output size for file path detection to fix high CPU

### DIFF
--- a/app/src/ai/blocklist/passive_suggestions/maa.rs
+++ b/app/src/ai/blocklist/passive_suggestions/maa.rs
@@ -967,3 +967,7 @@ async fn read_files(
         }
     }
 }
+
+#[cfg(all(test, feature = "local_fs"))]
+#[path = "maa_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/passive_suggestions/maa.rs
+++ b/app/src/ai/blocklist/passive_suggestions/maa.rs
@@ -853,13 +853,35 @@ fn is_prompt_suggestions_enabled(ctx: &ModelContext<PassiveSuggestionsModel>) ->
         && UserWorkspaces::as_ref(ctx).is_prompt_suggestions_toggleable()
 }
 
-/// Maximum byte length of block text to scan for file paths when building passive code-diff
-/// context. Caps CPU and memory usage for large shell outputs (e.g. a Rails console session
-/// that emits thousands of lines). File paths relevant to code suggestions almost always
-/// appear near the beginning of output (error messages, stack traces, compiler output), so
-/// truncating here has negligible impact on suggestion quality while avoiding an expensive
-/// O(n) token scan + filesystem-stat loop on megabyte-sized outputs.
+/// Maximum total byte length of block text to scan for file paths when building passive
+/// code-diff context. Caps CPU and memory usage for large shell outputs (e.g. a Rails
+/// console session that emits thousands of lines) by bounding the per-block token scan +
+/// filesystem-stat loop to a fixed amount of work regardless of output size.
+///
+/// The budget is split between the start and end of the text: relevant paths cluster both
+/// near the beginning of output (the command itself, early compiler/build errors) and near
+/// the end (stack traces and test failures printed right before the prompt returns).
+#[cfg(feature = "local_fs")]
 const MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION: usize = 100_000;
+
+/// Splits `text` into a head slice and an optional tail slice whose combined length is at
+/// most `max_bytes`, cutting at UTF-8 char boundaries. The tail is `None` when `text`
+/// already fits within the budget.
+#[cfg(feature = "local_fs")]
+fn head_and_tail_within_budget(text: &str, max_bytes: usize) -> (&str, Option<&str>) {
+    if text.len() <= max_bytes {
+        return (text, None);
+    }
+    let mut head_end = max_bytes / 2;
+    while !text.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    let mut tail_start = text.len() - max_bytes / 2;
+    while !text.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    (&text[..head_end], Some(&text[tail_start..]))
+}
 
 #[cfg(feature = "local_fs")]
 fn detect_relevant_file_paths_for_block(
@@ -867,18 +889,19 @@ fn detect_relevant_file_paths_for_block(
     current_working_directory: &str,
     shell: Option<&ShellLaunchData>,
 ) -> Vec<PathBuf> {
-    // Truncate to a UTF-8-safe boundary to avoid an expensive scan of huge outputs.
-    let block_contents = if block_contents.len() > MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION {
-        let boundary = (0..=MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION)
-            .rev()
-            .find(|&i| block_contents.is_char_boundary(i))
-            .unwrap_or(0);
-        &block_contents[..boundary]
-    } else {
-        block_contents
-    };
-    detect_file_paths(current_working_directory, block_contents, shell)
+    // Cap how much text is scanned so huge outputs can't pin a CPU core; the middle of the
+    // output is the least likely place for paths relevant to code suggestions.
+    let (head, tail) =
+        head_and_tail_within_budget(block_contents, MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION);
+    // TODO (suraj): use line num hint to limit the line range to read.
+    let mut links: Vec<_> = detect_file_paths(current_working_directory, head, shell)
         .into_values()
+        .collect();
+    if let Some(tail) = tail {
+        links.extend(detect_file_paths(current_working_directory, tail, shell).into_values());
+    }
+    links
+        .into_iter()
         .filter_map(|link| match link {
             DetectedLinkType::FilePath { absolute_path, .. } => Some(absolute_path),
             DetectedLinkType::Url(_) => None,

--- a/app/src/ai/blocklist/passive_suggestions/maa.rs
+++ b/app/src/ai/blocklist/passive_suggestions/maa.rs
@@ -853,13 +853,30 @@ fn is_prompt_suggestions_enabled(ctx: &ModelContext<PassiveSuggestionsModel>) ->
         && UserWorkspaces::as_ref(ctx).is_prompt_suggestions_toggleable()
 }
 
+/// Maximum byte length of block text to scan for file paths when building passive code-diff
+/// context. Caps CPU and memory usage for large shell outputs (e.g. a Rails console session
+/// that emits thousands of lines). File paths relevant to code suggestions almost always
+/// appear near the beginning of output (error messages, stack traces, compiler output), so
+/// truncating here has negligible impact on suggestion quality while avoiding an expensive
+/// O(n) token scan + filesystem-stat loop on megabyte-sized outputs.
+const MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION: usize = 100_000;
+
 #[cfg(feature = "local_fs")]
 fn detect_relevant_file_paths_for_block(
     block_contents: &str,
     current_working_directory: &str,
     shell: Option<&ShellLaunchData>,
 ) -> Vec<PathBuf> {
-    // TODO (suraj): use line num hint to limit the line range to read.
+    // Truncate to a UTF-8-safe boundary to avoid an expensive scan of huge outputs.
+    let block_contents = if block_contents.len() > MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION {
+        let boundary = (0..=MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION)
+            .rev()
+            .find(|&i| block_contents.is_char_boundary(i))
+            .unwrap_or(0);
+        &block_contents[..boundary]
+    } else {
+        block_contents
+    };
     detect_file_paths(current_working_directory, block_contents, shell)
         .into_values()
         .filter_map(|link| match link {

--- a/app/src/ai/blocklist/passive_suggestions/maa_tests.rs
+++ b/app/src/ai/blocklist/passive_suggestions/maa_tests.rs
@@ -1,0 +1,47 @@
+use std::fs;
+
+use super::{
+    MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION, detect_relevant_file_paths_for_block,
+    head_and_tail_within_budget,
+};
+
+#[test]
+fn splits_at_char_boundaries_within_budget() {
+    let text = "é".repeat(50_000); // 100,000 bytes; every odd byte index is mid-char.
+    for max_bytes in [0, 1, 3, 99_999, 100_000, 100_001] {
+        let (head, tail) = head_and_tail_within_budget(&text, max_bytes);
+        if text.len() <= max_bytes {
+            assert_eq!(head, text);
+            assert_eq!(tail, None);
+        } else {
+            // Slicing mid-char would have panicked; verify the budget holds.
+            assert!(head.len() + tail.unwrap().len() <= max_bytes);
+        }
+    }
+}
+
+#[test]
+fn detects_paths_in_head_and_tail_of_capped_block_contents() {
+    let dir = std::env::temp_dir().join(format!("warp_maa_tests_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    for file in ["head.rs", "mid.rs", "tail.rs"] {
+        fs::write(dir.join(file), "// rust\n").unwrap();
+    }
+    let cwd = dir.to_string_lossy().to_string();
+
+    // Real paths planted at the start, middle, and end of a block whose size is
+    // well over the cap, separated by path-free filler.
+    let filler = "filler ".repeat(MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION / 7);
+    let text =
+        format!("error in head.rs:1\n{filler}\nerror in mid.rs:1\n{filler}\nerror in tail.rs:1\n");
+    assert!(text.len() > MAX_BLOCK_CONTENTS_BYTES_FOR_PATH_DETECTION);
+
+    let paths = detect_relevant_file_paths_for_block(&text, &cwd, None);
+    assert!(paths.iter().any(|path| path.ends_with("head.rs")));
+    assert!(paths.iter().any(|path| path.ends_with("tail.rs")));
+    // The middle of an over-budget block is not scanned.
+    assert!(!paths.iter().any(|path| path.ends_with("mid.rs")));
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Description

Fixes a high-CPU regression where Warp pegs a background thread after every shell command completes, when the **code suggestions** (passive code diffs) feature is enabled.

### Root Cause

When a shell block completes, `PassiveSuggestionsModel::handle_user_block_completed` runs `detect_relevant_file_paths_for_block` to scan the command + output text for file paths to include as context for code diff suggestions.

This function delegates to `detect_file_paths`, which:
1. Calls `text.split_whitespace()` — iterates every whitespace-separated token in the full output
2. For each token, calls `possible_file_paths_in_word` — generates path substring candidates between separator characters
3. For each candidate, calls `compute_valid_file_path` — performs a filesystem stat/lookup

**The problem**: there was no cap on the size of `block_contents` passed to this function. With AI UGC telemetry enabled, the block output is serialised as up to 5000 lines (first 2500 + last 2500), which can be multiple MB of text. On a dense Rails console session with thousands of tokens, this pinned a core for seconds after every command — matching the reporter's observation in #10117 (measured below: an uncapped 4MB scan takes ~2.2s in a release build, and scaling is superlinear).

The process sample attached to #10117 confirms the hot stack:
```
PassiveSuggestionsModel::handle_user_block_completed
  → detect_relevant_file_paths_for_block
    → detect_file_paths (regex/path parsing in memchr)
```

### Fix

Cap the text scanned by `detect_relevant_file_paths_for_block` to a fixed 100KB budget:
- The budget is **split between the first 50KB and last 50KB** of the block text, since relevant paths cluster both near the beginning of output (the command itself, early compiler/build errors) and near the end (stack traces and test failures printed right before the prompt returns). The middle of a huge output is the least likely place for suggestion-relevant paths.
- Both cuts land on valid UTF-8 char boundaries via a small `head_and_tail_within_budget` helper.
- The new const is gated behind `#[cfg(feature = "local_fs")]` (matching its only consumer) so non-`local_fs` builds (wasm) don't fail `clippy -D warnings` on an unused const.

### Perf Results

Measured with a temporary in-crate harness (not merged) in a **release build** on an Apple Silicon Mac: separator-dense synthetic Rails console output (SQL logs, stack frames, inspect dumps, timestamps) scanned against a real on-disk project directory so relative paths resolve. Best of 3 runs (before) / 5 runs (after); "Before" = uncapped scan of the full text, "After" = capped head+tail scan including the `is_file`/binary-file filters.

| Input size | Before (uncapped) | After (capped) | Speedup |
|---|---|---|---|
| 100KB | 21.5ms | 21.3ms | parity (input ≈ cap) |
| 400KB | 94.6ms | 18.6ms | **~5x** |
| 1MB | 287ms | 21.0ms | **~14x** |
| 4MB | 2.19s | 21.0ms | **~104x** |

- Before scales superlinearly (4x the input from 1MB→4MB costs 7.6x the time) and is unbounded; After is flat **~21ms regardless of output size** — the per-block cost is now bounded.
- The 4MB row reproduces the multi-second CPU pins from the issue's process sample.
- A marker path planted only in the final line of every input was detected on all runs, confirming the tail half is genuinely scanned (a head-only truncation would miss it).

## Linked Issue

- Fixes #10117

## Testing

This is a perf fix; the behaviour is correct as long as:
1. `detect_relevant_file_paths_for_block` still returns paths from the scanned head/tail windows (no regression for typical commands — verified: planted head and tail paths are both detected).
2. Large outputs no longer cause a full scan (verified: flat ~21ms from 400KB through 4MB in release).

Also verified:
- UTF-8 char-boundary safety of the head/tail split against multibyte-only input across budgets 0→100,001 bytes (no panics, slices within budget).
- `cargo check -p warp --lib`, `cargo clippy -p warp --lib -- -D warnings`, and `cargo fmt` clean.

Manually verifiable by running a command with a very large output (e.g. `cat /usr/share/dict/words`) with code suggestions and AI UGC telemetry enabled and profiling before/after.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed high CPU usage after shell commands complete when code suggestions are enabled and the command produces large output (e.g. a long-running Rails console session).
-->

_Run: https://oz.staging.warp.dev/runs/019faa9c-00cc-7253-8990-f070ae0ff917_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
