### PR TITLE
Build Windows Warp Agent CLI in dev releases

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -92,11 +92,10 @@ runs:
       env:
         BINSTALL_VERSION: 1.14.4
 
-    # Load the SSH key needed to clone the private warp-channel-config repo. Only
-    # run in warpdotdev/warp-internal; elsewhere (mirrors, fork PRs) this is a no-op
-    # and install_channel_config falls back gracefully.
+    # Load the SSH key needed to clone the private warp-channel-config repo.
+    # Mirrors and fork PRs do not receive the key, so this remains a no-op there.
     - name: Setup SSH keys for warp-channel-config
-      if: ${{ github.repository == 'warpdotdev/warp-internal' && inputs.ssh_key != '' }}
+      if: ${{ inputs.ssh_key != '' }}
       uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
       with:
         ssh-private-key: ${{ inputs.ssh_key }}
@@ -146,6 +145,12 @@ runs:
           echo "::error::Missing logic to install build dependencies for OS \"${{ inputs.target_os }}\""
           exit 1
         fi
+    - name: Install warp-channel-config for Windows releases
+      if: ${{ inputs.target_os == 'windows' && inputs.install_release_deps == 'true' && inputs.ssh_key != '' }}
+      shell: bash
+      run: |
+        cd "${{ steps.repo-root.outputs.path }}"
+        ./script/install_channel_config
 
     - name: Install Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1624,6 +1624,139 @@ jobs:
           name: release-web-${{ steps.get-config.outputs.channel }}
           path: ${{ steps.bundle_app.outputs.packages_dir }}
 
+  release_windows_tui:
+    name: Build Release (Windows TUI x64)
+    runs-on: windows-latest-large
+    needs: prepare_release
+    if: ${{ inputs.build_windows != false && inputs.channel == 'dev' }}
+    timeout-minutes: 150
+    env:
+      TRUSTED_SIGNING_ENDPOINT: https://eus.codesigning.azure.net/
+      TRUSTED_SIGNING_ACCOUNT: warpdotdev
+      TRUSTED_SIGNING_CERT_PROFILE: warpterminal
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/prepare_environment
+        with:
+          target_os: windows
+          cache_key: tui-x64
+          is_self_hosted: false
+          ref: ${{ needs.prepare_release.outputs.release_branch }}
+          install_release_deps: true
+          ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
+
+      - name: Get channel configuration
+        id: get-config
+        uses: ./.github/actions/get_channel_config/
+        with:
+          config_file: ${{ env.CONFIG_FILE }}
+          channel: ${{ inputs.channel }}
+
+      - name: Test Windows TUI packaging
+        run: ./script/windows/test_package_tui.ps1
+        shell: pwsh
+
+      - name: Build Warp Agent CLI
+        id: build_tui
+        run: script/bundle --artifact tui --channel "$CHANNEL" --skip_build_installer --arch x64
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+
+      - name: Sign Warp Agent CLI and PTY executables
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1.2.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ env.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ env.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ env.TRUSTED_SIGNING_CERT_PROFILE }}
+          files: ${{ steps.build_tui.outputs.binary_path }}
+          files-folder: ${{ github.workspace }}\app\assets\windows\x64
+          files-folder-filter: dll,exe
+          files-folder-recurse: true
+          files-folder-depth: 2
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Package signed Warp Agent CLI
+        id: package_tui
+        run: script/bundle --artifact tui --channel "$CHANNEL" --skip_build_binary --require_signatures --arch x64
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+
+      - name: Inspect and launch isolated package
+        id: inspect_tui
+        shell: pwsh
+        env:
+          ARCHIVE_PATH: ${{ steps.package_tui.outputs.archive_path }}
+          EXPECTED_VERSION: ${{ needs.prepare_release.outputs.release_tag }}
+        run: |
+          Add-Type -AssemblyName System.IO.Compression
+          $Archive = [System.IO.Compression.ZipFile]::OpenRead($env:ARCHIVE_PATH)
+          try {
+            $Entries = @($Archive.Entries.FullName | Sort-Object)
+          } finally {
+            $Archive.Dispose()
+          }
+          $RequiredEntries = @(
+            'conpty.dll',
+            'warp-tui-dev.exe',
+            'x64/OpenConsole.exe'
+          )
+          foreach ($RequiredEntry in $RequiredEntries) {
+            if ($RequiredEntry -notin $Entries) {
+              throw "Archive is missing required entry: $RequiredEntry"
+            }
+          }
+          $ResourceEntries = @($Entries | Where-Object { $_.StartsWith('resources/') })
+          if ($ResourceEntries.Count -eq 0) {
+            throw 'Archive does not contain bundled resources'
+          }
+          $UnexpectedEntries = @($Entries | Where-Object {
+            $_ -notin $RequiredEntries -and -not $_.StartsWith('resources/')
+          })
+          if ($UnexpectedEntries.Count -ne 0) {
+            throw "Archive contains unexpected entries: $($UnexpectedEntries -join ', ')"
+          }
+
+          $PackageRoot = Join-Path $env:RUNNER_TEMP 'Warp Agent CLI package with spaces'
+          Expand-Archive -LiteralPath $env:ARCHIVE_PATH -DestinationPath $PackageRoot
+          $BinaryPath = Join-Path $PackageRoot 'warp-tui-dev.exe'
+          $Version = (& $BinaryPath --version | Out-String).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "Packaged binary exited with code $LASTEXITCODE"
+          }
+          if ($Version -cne $env:EXPECTED_VERSION) {
+            throw "Packaged binary reported '$Version', expected '$env:EXPECTED_VERSION'"
+          }
+          "package_root=$PackageRoot" >> $env:GITHUB_OUTPUT
+
+      - name: Smoke test packaged ConPTY
+        shell: bash
+        run: |
+          cargo test -p warp --lib \
+            --features tui,release_bundle,standalone,crash_reporting \
+            packaged_conpty_spawns_powershell_and_reads_output \
+            -- --ignored --nocapture
+        env:
+          WARP_PACKAGED_TUI_ROOT: ${{ steps.inspect_tui.outputs.package_root }}
+
+      - name: Upload Windows TUI archives
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: release-windows-tui-x64-${{ steps.get-config.outputs.channel }}
+          path: |
+            ${{ steps.package_tui.outputs.archive_path }}
+            ${{ steps.package_tui.outputs.symbols_archive_path }}
+          if-no-files-found: error
+
   release_windows:
     name: Build Release (Windows ${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -1801,6 +1934,7 @@ jobs:
       - release_linux_arm
       - release_linux_cli_x86
       - release_web
+      - release_windows_tui
       - release_windows
     if: ${{ always() && needs.prepare_release.outputs.should_publish == 'true' }}
     steps:
@@ -1840,6 +1974,9 @@ jobs:
           fi
           if [[ ${{ needs.release_windows.result }} != 'success' ]]; then
               FAILED+=("Windows")
+          fi
+          if [[ ${{ needs.release_windows_tui.result }} != 'success' && ${{ inputs.channel }} == 'dev' ]]; then
+              FAILED+=("Windows TUI")
           fi
 
           if (( ${#FAILED[@]} )); then

--- a/app/src/terminal/local_tty/windows/mod.rs
+++ b/app/src/terminal/local_tty/windows/mod.rs
@@ -18,7 +18,9 @@ pub use environment::get_user_and_system_env_variable;
 use thiserror::Error;
 use warp_errors::{report_error, report_if_error};
 use warpui::{AppContext, SingletonEntity};
-use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::Foundation::{
+    CloseHandle, E_ACCESSDENIED, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
 use windows::Win32::System::Console::{COORD, HPCON};
 use windows::Win32::System::Threading::{
     CREATE_BREAKAWAY_FROM_JOB, CREATE_UNICODE_ENVIRONMENT, CreateProcessW,
@@ -218,7 +220,6 @@ pub(super) fn spawn(
             ));
         }
     };
-    let mut process_information = PROCESS_INFORMATION::default();
 
     let start_directory = options
         .start_dir
@@ -229,31 +230,52 @@ pub(super) fn spawn(
                 .filter(|path| path.is_dir())
         })
         .map(|path| HSTRING::from(path.as_os_str()));
-
-    unsafe {
-        CreateProcessW(
-            PCWSTR::null(), /* lpApplicationName */
-            Some(PWSTR::from_raw(shell_command.as_ptr().cast_mut())),
-            None,  /* lpProcessAttributes */
-            None,  /* lpThreadAttributes */
-            false, /* bInheritHandles */
-            PROCESS_CREATION_FLAGS(0)
-                | EXTENDED_STARTUPINFO_PRESENT
-                | CREATE_UNICODE_ENVIRONMENT
-                | CREATE_BREAKAWAY_FROM_JOB,
-            Some(environment_block.as_ptr() as *const std::ffi::c_void),
-            start_directory
-                .as_ref()
-                .map(|hstring| PCWSTR::from_raw(hstring.as_ptr()))
-                .unwrap_or(PCWSTR::null()),
-            &startup_info.StartupInfo as *const STARTUPINFOW,
-            &mut process_information,
-        )
+    let create_shell_process = |creation_flags| {
+        // CreateProcessW may mutate its command-line buffer, so each attempt
+        // needs a fresh, null-terminated copy.
+        let mut command_line = shell_command.to_vec();
+        command_line.push(0);
+        let mut process_information = PROCESS_INFORMATION::default();
+        unsafe {
+            CreateProcessW(
+                PCWSTR::null(), /* lpApplicationName */
+                Some(PWSTR::from_raw(command_line.as_mut_ptr())),
+                None,  /* lpProcessAttributes */
+                None,  /* lpThreadAttributes */
+                false, /* bInheritHandles */
+                creation_flags,
+                Some(environment_block.as_ptr() as *const std::ffi::c_void),
+                start_directory
+                    .as_ref()
+                    .map(|hstring| PCWSTR::from_raw(hstring.as_ptr()))
+                    .unwrap_or(PCWSTR::null()),
+                &startup_info.StartupInfo as *const STARTUPINFOW,
+                &mut process_information,
+            )
+        }
+        .map(|()| process_information)
+    };
+    let base_creation_flags =
+        PROCESS_CREATION_FLAGS(0) | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT;
+    let process_information =
+        match create_shell_process(base_creation_flags | CREATE_BREAKAWAY_FROM_JOB) {
+            Ok(process_information) => Ok(process_information),
+            Err(error) if error.code() == E_ACCESSDENIED => {
+                // Job-contained hosts such as WinRM and CI can forbid
+                // breakaway. Inherit that job rather than refusing to start
+                // the user's shell.
+                log::info!(
+                    "Shell process could not break away from the parent Windows job; retrying \
+                     inside the job"
+                );
+                create_shell_process(base_creation_flags)
+            }
+            Err(error) => Err(error),
+        }
         .map_err(|error| {
             let detail = shell_starter.shell_detail();
             PtySpawnError::CreateShellProcessFailed { detail, error }
         })?;
-    }
 
     let _ = unsafe { conpty_api.release(pty_handle) };
 
@@ -527,3 +549,7 @@ impl Drop for Pty {
         self.close_pseudoconsole();
     }
 }
+
+#[cfg(test)]
+#[path = "windows_tests.rs"]
+mod tests;

--- a/app/src/terminal/local_tty/windows/windows_tests.rs
+++ b/app/src/terminal/local_tty/windows/windows_tests.rs
@@ -1,0 +1,126 @@
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io::{ErrorKind, Read as _};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use instant::Instant;
+
+use crate::terminal::SizeInfo;
+use crate::terminal::local_tty::shell::{DirectShellStarter, ShellStarter};
+use crate::terminal::local_tty::{PtyOptions, mio_channel};
+use crate::terminal::shell::ShellType;
+use crate::util::windows::any_powershell_path;
+
+struct CurrentDirGuard(PathBuf);
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).expect("failed to restore working directory");
+    }
+}
+
+struct SpawnedPtyGuard {
+    result: super::PtySpawnResult,
+    child: super::PseudoConsoleChild,
+}
+
+impl Drop for SpawnedPtyGuard {
+    fn drop(&mut self) {
+        unsafe {
+            self.result.conpty_api.close(self.result.pty_handle);
+        }
+        let _ = self.result.pipe.disconnect();
+        let _ = self.child.kill();
+    }
+}
+
+#[test]
+#[ignore = "requires an extracted Windows TUI package"]
+fn packaged_conpty_spawns_powershell_and_reads_output() {
+    let package_root = std::env::var_os("WARP_PACKAGED_TUI_ROOT")
+        .map(PathBuf::from)
+        .expect("WARP_PACKAGED_TUI_ROOT must point to an extracted TUI package");
+    let original_dir = std::env::current_dir().expect("failed to read working directory");
+    std::env::set_current_dir(&package_root).expect("failed to enter packaged TUI directory");
+    let _current_dir_guard = CurrentDirGuard(original_dir);
+
+    let powershell_path = any_powershell_path()
+        .cloned()
+        .expect("PowerShell is required for the packaged ConPTY smoke test");
+    let marker = "WARP_PACKAGED_CONPTY_SMOKE_OK";
+    let shell_starter = DirectShellStarter::new_for_test(
+        ShellType::PowerShell,
+        powershell_path,
+        vec![
+            OsString::from("-NoLogo"),
+            OsString::from("-NoProfile"),
+            OsString::from("-NonInteractive"),
+            OsString::from("-Command"),
+            OsString::from(format!("Write-Output {marker}")),
+        ],
+    );
+    let options = PtyOptions {
+        size: SizeInfo::new_without_font_metrics(24, 80),
+        window_id: None,
+        shell_starter: ShellStarter::Direct(shell_starter),
+        start_dir: Some(package_root),
+        env_vars: HashMap::new(),
+        enable_ssh_wrapper: false,
+        reuse_ssh_control_master: false,
+        shell_debug_mode: false,
+        honor_ps1: false,
+        node_version_chip_enabled: false,
+        close_fds: false,
+    };
+    let (event_loop_tx, _event_loop_rx) = mio_channel::channel();
+    let spawn_info = super::spawn(options, event_loop_tx).expect("failed to spawn packaged ConPTY");
+    let mut spawned = SpawnedPtyGuard {
+        result: spawn_info.result,
+        child: spawn_info.child,
+    };
+
+    let mut poll = mio::Poll::new().expect("failed to create PTY poll");
+    poll.registry()
+        .register(
+            &mut spawned.result.pipe,
+            mio::Token(1),
+            mio::Interest::READABLE,
+        )
+        .expect("failed to register packaged ConPTY pipe");
+    let mut events = mio::Events::with_capacity(8);
+    let mut output = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(20);
+
+    while Instant::now() < deadline {
+        poll.poll(
+            &mut events,
+            Some(deadline.saturating_duration_since(Instant::now())),
+        )
+        .expect("failed to poll packaged ConPTY");
+        for event in &events {
+            if event.token() != mio::Token(1) {
+                continue;
+            }
+
+            let mut buffer = [0; 4096];
+            loop {
+                match spawned.result.pipe.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(bytes_read) => output.extend_from_slice(&buffer[..bytes_read]),
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                    Err(error) => panic!("failed to read packaged ConPTY output: {error}"),
+                }
+            }
+        }
+
+        if String::from_utf8_lossy(&output).contains(marker) {
+            return;
+        }
+    }
+
+    panic!(
+        "packaged ConPTY did not produce the expected marker; output: {}",
+        String::from_utf8_lossy(&output)
+    );
+}


### PR DESCRIPTION
## Description
Adds phase 2 of the Windows Warp Agent CLI release stack on top of #14444:

- runs a dev-only Windows x64 TUI release job
- builds the standalone CLI, signs the CLI and ConPTY executables with Azure Trusted Signing, and packages only after signing
- inspects and launches the isolated package, then exercises packaged ConPTY with PowerShell
- uploads workflow artifacts without publishing them to release storage
- installs the private channel-config generator for credentialed Windows release builds
- retries shell creation inside restrictive Windows job objects when explicit breakaway is denied

Windows artifact publication remains intentionally disabled in this stack.

Conversation: https://staging.warp.dev/conversation/7b2fa858-09f9-47dd-8819-277acd3fa779

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format`
- repository-required workspace, GUI-default, and completer Clippy invocations with `-D warnings`
- native workflow run 30400009894 passed Windows package tests and exposed the missing Windows channel-config prerequisite; this PR now installs it for credentialed release jobs
- credentialed non-publishing dev release passed real build, Azure signing, deterministic payload/symbol packaging, isolated launch, packaged ConPTY smoke, and workflow artifact upload: https://github.com/warpdotdev/warp-internal/actions/runs/30419349007

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE