### PR TITLE
Free-plan ad-hoc credit purchases at a 10% premium (desktop UI)

### DIFF
--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -380,9 +380,10 @@ impl View for PromptAlertView {
             .zip(current_team)
             .is_some_and(|(email, team)| team.has_admin_permissions(&email));
 
-        let can_purchase_addon_credits = current_team
-            .and_then(|team| team.billing_metadata.tier.purchase_add_on_credits_policy)
-            .is_some_and(|policy| policy.enabled);
+        let can_purchase_addon_credits = current_team.is_some_and(|team| {
+            team.billing_metadata
+                .is_purchase_add_on_credits_policy_enabled()
+        });
 
         let suggest_buy_credits = can_purchase_addon_credits
             && has_admin_permissions

--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -385,8 +385,8 @@ impl View for PromptAlertView {
         });
 
         let can_purchase_addon_credits = workspaces
-            .purchase_billing_metadata(current_team)
-            .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
+            .purchase_policy(current_team)
+            .is_some_and(|policy| policy.allows_purchases());
 
         let suggest_buy_credits = can_purchase_addon_credits
             && has_admin_permissions

--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -376,8 +376,7 @@ impl View for PromptAlertView {
         let auth_state = AuthStateProvider::as_ref(app).get();
         let workspaces = UserWorkspaces::as_ref(app);
         let current_team = workspaces.team_for_view_handle(&self.view_handle, app);
-        // A teamless user manages their own personal purchases; the server
-        // creates their team on first purchase.
+        // A teamless user can be considered the admin of their non-existent team.
         let has_admin_permissions = current_team.is_none_or(|team| {
             auth_state
                 .user_email()
@@ -385,7 +384,7 @@ impl View for PromptAlertView {
         });
 
         let can_purchase_addon_credits = workspaces
-            .purchase_policy(current_team)
+            .purchase_policy_for_team(current_team)
             .is_some_and(|policy| policy.allows_purchases());
 
         let suggest_buy_credits = can_purchase_addon_credits

--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -374,16 +374,19 @@ impl View for PromptAlertView {
         self.primary_text(&state, &mut text_fragments);
 
         let auth_state = AuthStateProvider::as_ref(app).get();
-        let current_team = UserWorkspaces::as_ref(app).team_for_view_handle(&self.view_handle, app);
-        let has_admin_permissions = auth_state
-            .user_email()
-            .zip(current_team)
-            .is_some_and(|(email, team)| team.has_admin_permissions(&email));
-
-        let can_purchase_addon_credits = current_team.is_some_and(|team| {
-            team.billing_metadata
-                .is_purchase_add_on_credits_policy_enabled()
+        let workspaces = UserWorkspaces::as_ref(app);
+        let current_team = workspaces.team_for_view_handle(&self.view_handle, app);
+        // A teamless user manages their own personal purchases; the server
+        // creates their team on first purchase.
+        let has_admin_permissions = current_team.is_none_or(|team| {
+            auth_state
+                .user_email()
+                .is_some_and(|email| team.has_admin_permissions(&email))
         });
+
+        let can_purchase_addon_credits = workspaces
+            .purchase_billing_metadata(current_team)
+            .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
 
         let suggest_buy_credits = can_purchase_addon_credits
             && has_admin_permissions

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -607,9 +607,7 @@ impl AIRequestUsageModel {
         let policy_allows_purchasing = current_workspace
             .map(|w| {
                 w.billing_metadata
-                    .tier
-                    .purchase_add_on_credits_policy
-                    .is_some_and(|p| p.enabled)
+                    .is_purchase_add_on_credits_policy_enabled()
             })
             .unwrap_or(false);
 

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -605,11 +605,8 @@ impl AIRequestUsageModel {
         }
         let user_workspaces = UserWorkspaces::as_ref(ctx);
         let current_workspace = user_workspaces.current_workspace();
-        // Resolved without a team on purpose: this is a model-level check and
-        // the policy-bearing team metadata mirrors the workspace's. The
-        // resolver's user-level leg keeps this working for teamless users.
         let policy_allows_purchasing = user_workspaces
-            .purchase_policy(None)
+            .purchase_policy()
             .is_some_and(|policy| policy.allows_purchases());
 
         // TODO: we might want to suggest credits purchase if request_remain/bonus credits is below certain threshold

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -603,13 +603,14 @@ impl AIRequestUsageModel {
         if self.buy_addon_credits_banner_dismissed {
             return BuyCreditsBannerDisplayState::Hidden;
         }
-        let current_workspace = UserWorkspaces::as_ref(ctx).current_workspace();
-        let policy_allows_purchasing = current_workspace
-            .map(|w| {
-                w.billing_metadata
-                    .is_purchase_add_on_credits_policy_enabled()
-            })
-            .unwrap_or(false);
+        let user_workspaces = UserWorkspaces::as_ref(ctx);
+        let current_workspace = user_workspaces.current_workspace();
+        // Resolved without a team on purpose: this is a model-level check and
+        // the policy-bearing team metadata mirrors the workspace's. The
+        // resolver's user-level leg keeps this working for teamless users.
+        let policy_allows_purchasing = user_workspaces
+            .purchase_policy(None)
+            .is_some_and(|policy| policy.allows_purchases());
 
         // TODO: we might want to suggest credits purchase if request_remain/bonus credits is below certain threshold
         // something to consider after launch

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -283,6 +283,9 @@ fn test_buy_credits_banner_shows_with_only_ambient_bonus_credits() {
 #[test]
 fn test_buy_credits_banner_shows_for_premium_enabled_plan_out_of_credits() {
     App::test((), |mut app| async move {
+        // The test workspace has no teams: this covers the teamless fresh
+        // free user, whose purchase policy lives on the workspace billing
+        // metadata until their first purchase creates a team server-side.
         let (_uid, mut workspace) = create_test_workspace();
         workspace
             .billing_metadata
@@ -293,6 +296,10 @@ fn test_buy_credits_banner_shows_for_premium_enabled_plan_out_of_credits() {
         let request_usage_model = add_request_usage_model(&mut app);
 
         request_usage_model.update(&mut app, |model, ctx| {
+            assert!(
+                !UserWorkspaces::as_ref(ctx).has_teams(),
+                "this test covers the teamless case"
+            );
             model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
             model.bonus_grants.clear();
 
@@ -307,6 +314,8 @@ fn test_buy_credits_banner_shows_for_premium_enabled_plan_out_of_credits() {
 #[test]
 fn test_buy_credits_banner_hidden_when_policy_fully_disabled() {
     App::test((), |mut app| async move {
+        // Also a teamless workspace: without premiumEnabled the purchase
+        // surfaces must stay hidden for fresh free users.
         let (_uid, mut workspace) = create_test_workspace();
         workspace
             .billing_metadata

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -654,6 +654,65 @@ fn test_has_any_ai_remaining_true_with_self_serve_auto_reload() {
 }
 
 #[test]
+fn test_has_any_ai_remaining_true_with_premium_auto_reload() {
+    App::test((), |mut app| async move {
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace
+            .billing_metadata
+            .tier
+            .purchase_add_on_credits_policy = Some(premium_purchase_policy());
+        enable_auto_reload(&mut workspace);
+
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+        set_addon_credits_pricing_info(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.bonus_grants.clear();
+
+            assert!(
+                model.has_any_ai_remaining(ctx),
+                "expected has_any_ai_remaining to be true when premium-plan auto-reload is enabled",
+            );
+        });
+    });
+}
+
+#[test]
+fn test_has_any_ai_remaining_false_when_premium_auto_reload_would_exceed_limit() {
+    App::test((), |mut app| async move {
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace
+            .billing_metadata
+            .tier
+            .purchase_add_on_credits_policy = Some(premium_purchase_policy());
+        enable_auto_reload(&mut workspace);
+        // The reload's list price is $10.00 but the premium price is $11.00;
+        // a $10.50 monthly limit only blocks the reload when the premium
+        // surcharge is included in the check.
+        workspace
+            .settings
+            .addon_credits_settings
+            .max_monthly_spend_cents = Some(1050);
+
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+        set_addon_credits_pricing_info(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.bonus_grants.clear();
+
+            assert!(
+                !model.has_any_ai_remaining(ctx),
+                "expected has_any_ai_remaining to be false when the premium-priced reload would exceed the monthly spend limit",
+            );
+        });
+    });
+}
+
+#[test]
 fn test_has_any_ai_remaining_true_with_self_serve_auto_reload_and_billing_v2_disabled() {
     App::test((), |mut app| async move {
         let _guard = FeatureFlag::BillingAndUsagePageV2.override_enabled(false);

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -91,6 +91,22 @@ fn set_addon_credits_pricing_info(app: &mut App) {
     });
 }
 
+fn standard_purchase_policy() -> PurchaseAddOnCreditsPolicy {
+    PurchaseAddOnCreditsPolicy {
+        enabled: true,
+        premium_enabled: false,
+        price_premium_bps: 0,
+    }
+}
+
+fn premium_purchase_policy() -> PurchaseAddOnCreditsPolicy {
+    PurchaseAddOnCreditsPolicy {
+        enabled: false,
+        premium_enabled: true,
+        price_premium_bps: 1000,
+    }
+}
+
 fn enable_auto_reload(workspace: &mut Workspace) {
     workspace
         .settings
@@ -237,7 +253,7 @@ fn test_buy_credits_banner_shows_with_only_ambient_bonus_credits() {
         workspace
             .billing_metadata
             .tier
-            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy { enabled: true });
+            .purchase_add_on_credits_policy = Some(standard_purchase_policy());
 
         add_user_workspaces_with_workspace(&mut app, workspace);
         let request_usage_model = add_request_usage_model(&mut app);
@@ -265,13 +281,65 @@ fn test_buy_credits_banner_shows_with_only_ambient_bonus_credits() {
 }
 
 #[test]
+fn test_buy_credits_banner_shows_for_premium_enabled_plan_out_of_credits() {
+    App::test((), |mut app| async move {
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace
+            .billing_metadata
+            .tier
+            .purchase_add_on_credits_policy = Some(premium_purchase_policy());
+
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.bonus_grants.clear();
+
+            assert_eq!(
+                model.compute_buy_addon_credits_banner_display_state(ctx),
+                BuyCreditsBannerDisplayState::OutOfCredits,
+            );
+        });
+    });
+}
+
+#[test]
+fn test_buy_credits_banner_hidden_when_policy_fully_disabled() {
+    App::test((), |mut app| async move {
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace
+            .billing_metadata
+            .tier
+            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy {
+            enabled: false,
+            premium_enabled: false,
+            price_premium_bps: 0,
+        });
+
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.bonus_grants.clear();
+
+            assert_eq!(
+                model.compute_buy_addon_credits_banner_display_state(ctx),
+                BuyCreditsBannerDisplayState::Hidden,
+            );
+        });
+    });
+}
+
+#[test]
 fn test_buy_credits_banner_hidden_with_non_ambient_bonus_credits() {
     App::test((), |mut app| async move {
         let (_uid, mut workspace) = create_test_workspace();
         workspace
             .billing_metadata
             .tier
-            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy { enabled: true });
+            .purchase_add_on_credits_policy = Some(standard_purchase_policy());
 
         add_user_workspaces_with_workspace(&mut app, workspace);
         let request_usage_model = add_request_usage_model(&mut app);
@@ -305,7 +373,7 @@ fn test_buy_credits_banner_shows_when_non_ambient_bonus_credits_are_depleted() {
         workspace
             .billing_metadata
             .tier
-            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy { enabled: true });
+            .purchase_add_on_credits_policy = Some(standard_purchase_policy());
 
         add_user_workspaces_with_workspace(&mut app, workspace);
         let request_usage_model = add_request_usage_model(&mut app);
@@ -566,7 +634,7 @@ fn test_has_any_ai_remaining_true_with_self_serve_auto_reload() {
         workspace
             .billing_metadata
             .tier
-            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy { enabled: true });
+            .purchase_add_on_credits_policy = Some(standard_purchase_policy());
         enable_auto_reload(&mut workspace);
 
         add_user_workspaces_with_workspace(&mut app, workspace);
@@ -594,7 +662,7 @@ fn test_has_any_ai_remaining_true_with_self_serve_auto_reload_and_billing_v2_dis
         workspace
             .billing_metadata
             .tier
-            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy { enabled: true });
+            .purchase_add_on_credits_policy = Some(standard_purchase_policy());
         enable_auto_reload(&mut workspace);
 
         add_user_workspaces_with_workspace(&mut app, workspace);
@@ -620,7 +688,7 @@ fn test_has_any_ai_remaining_false_with_add_on_credits_policy_when_purchase_woul
         workspace
             .billing_metadata
             .tier
-            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy { enabled: true });
+            .purchase_add_on_credits_policy = Some(standard_purchase_policy());
         enable_auto_reload(&mut workspace);
         workspace
             .settings

--- a/app/src/server/server_api/workspace.rs
+++ b/app/src/server/server_api/workspace.rs
@@ -56,7 +56,7 @@ pub trait WorkspaceClient: 'static + Send + Sync {
 
     async fn purchase_addon_credits(
         &self,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         credits: i32,
     ) -> Result<PurchaseAddonCreditsOutcome>;
 
@@ -162,12 +162,12 @@ impl WorkspaceClient for ServerApi {
 
     async fn purchase_addon_credits(
         &self,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         credits: i32,
     ) -> Result<PurchaseAddonCreditsOutcome> {
         let variables = PurchaseAddonCreditsVariables {
             input: PurchaseAddonCreditsInput {
-                team_uid: team_uid.into(),
+                team_uid: team_uid.map(Into::into),
                 credits,
             },
             request_context: get_request_context(),

--- a/app/src/server/server_api/workspace.rs
+++ b/app/src/server/server_api/workspace.rs
@@ -28,6 +28,17 @@ use crate::server::ids::ServerId;
 use crate::workspaces::user_workspaces::WorkspacesMetadataResponse;
 use crate::workspaces::workspace::AiOverages;
 
+/// Outcome of a successful `purchaseAddonCredits` mutation.
+pub enum PurchaseAddonCreditsOutcome {
+    /// The saved payment method was charged synchronously and credits were
+    /// granted immediately. Carries refreshed workspace metadata.
+    Completed(Box<WorkspacesMetadataResponse>),
+    /// There was no saved payment method to charge. The user must complete
+    /// the purchase in the browser at `checkout_url`; credits are granted
+    /// via webhook shortly after checkout completes.
+    CheckoutRequired { checkout_url: String },
+}
+
 #[cfg_attr(test, automock)]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
@@ -47,7 +58,7 @@ pub trait WorkspaceClient: 'static + Send + Sync {
         &self,
         team_uid: ServerId,
         credits: i32,
-    ) -> Result<WorkspacesMetadataResponse>;
+    ) -> Result<PurchaseAddonCreditsOutcome>;
 
     async fn update_addon_credits_settings(
         &self,
@@ -153,7 +164,7 @@ impl WorkspaceClient for ServerApi {
         &self,
         team_uid: ServerId,
         credits: i32,
-    ) -> Result<WorkspacesMetadataResponse> {
+    ) -> Result<PurchaseAddonCreditsOutcome> {
         let variables = PurchaseAddonCreditsVariables {
             input: PurchaseAddonCreditsInput {
                 team_uid: team_uid.into(),
@@ -167,10 +178,13 @@ impl WorkspaceClient for ServerApi {
         match response {
             Err(_) => Err(anyhow!("Failed to purchase add-on credits")),
             Ok(response) => match response.purchase_addon_credits {
-                PurchaseAddonCreditsResult::PurchaseAddonCreditsOutput(_) => {
+                PurchaseAddonCreditsResult::PurchaseAddonCreditsOutput(output) => {
+                    if let Some(checkout_url) = output.checkout_url {
+                        return Ok(PurchaseAddonCreditsOutcome::CheckoutRequired { checkout_url });
+                    }
                     TeamClient::workspaces_metadata(self)
                         .await
-                        .map(|w| w.metadata)
+                        .map(|w| PurchaseAddonCreditsOutcome::Completed(Box::new(w.metadata)))
                 }
                 PurchaseAddonCreditsResult::UserFacingError(error) => match error.error {
                     UserFacingErrorInterface::BudgetExceededError(budget_error) => {

--- a/app/src/server/server_api/workspace.rs
+++ b/app/src/server/server_api/workspace.rs
@@ -28,7 +28,8 @@ use crate::server::ids::ServerId;
 use crate::workspaces::user_workspaces::WorkspacesMetadataResponse;
 use crate::workspaces::workspace::AiOverages;
 
-/// Outcome of a successful `purchaseAddonCredits` mutation.
+/// Outcome of a successful `purchaseAddonCredits` mutation. Mirrors the
+/// server's `PurchaseAddonCreditsResult` union members one-to-one.
 pub enum PurchaseAddonCreditsOutcome {
     /// The saved payment method was charged synchronously and credits were
     /// granted immediately. Carries refreshed workspace metadata.
@@ -178,13 +179,15 @@ impl WorkspaceClient for ServerApi {
         match response {
             Err(_) => Err(anyhow!("Failed to purchase add-on credits")),
             Ok(response) => match response.purchase_addon_credits {
-                PurchaseAddonCreditsResult::PurchaseAddonCreditsOutput(output) => {
-                    if let Some(checkout_url) = output.checkout_url {
-                        return Ok(PurchaseAddonCreditsOutcome::CheckoutRequired { checkout_url });
-                    }
+                PurchaseAddonCreditsResult::PurchaseAddonCreditsOutput(_) => {
                     TeamClient::workspaces_metadata(self)
                         .await
                         .map(|w| PurchaseAddonCreditsOutcome::Completed(Box::new(w.metadata)))
+                }
+                PurchaseAddonCreditsResult::PurchaseAddonCreditsCheckoutOutput(output) => {
+                    Ok(PurchaseAddonCreditsOutcome::CheckoutRequired {
+                        checkout_url: output.checkout_url,
+                    })
                 }
                 PurchaseAddonCreditsResult::UserFacingError(error) => match error.error {
                     UserFacingErrorInterface::BudgetExceededError(budget_error) => {

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -1735,7 +1735,6 @@ impl BillingAndUsagePageView {
         let team_can_purchase_addon_credits = workspace
             .billing_metadata
             .is_purchase_add_on_credits_policy_enabled();
-        let is_premium_purchase = workspace.billing_metadata.is_premium_addon_credits_purchase();
         let premium_bps = workspace.billing_metadata.addon_credits_price_premium_bps();
         let can_upgrade_to_build = workspace.billing_metadata.can_upgrade_to_build_plan();
 
@@ -1968,13 +1967,10 @@ impl BillingAndUsagePageView {
 
         let selected_option = addon_credits_options.get(selected_topup_denomination);
 
-        // Auto-reload only applies to plans with standard (list price)
-        // purchasing; premium-purchase plans always use one-time purchases.
-        let auto_reload_enabled = !is_premium_purchase
-            && workspace
-                .settings
-                .addon_credits_settings
-                .auto_reload_enabled;
+        let auto_reload_enabled = workspace
+            .settings
+            .addon_credits_settings
+            .auto_reload_enabled;
 
         let auto_reload_amount = selected_option
             .map(|option| option.credits.to_string())
@@ -1997,6 +1993,17 @@ impl BillingAndUsagePageView {
                 .finish()
         };
 
+        let mut auto_reload_description = format!(
+            "When enabled, auto reload will automatically purchase {auto_reload_amount} \
+            credits when your add-on credit balance reaches 100 credits remaining."
+        );
+        if premium_bps > 0 {
+            let percent = format_addon_premium_percent(premium_bps);
+            auto_reload_description.push_str(&format!(
+                " Auto-reload purchases include the {percent} Free plan surcharge."
+            ));
+        }
+
         let auto_reload_switch = Container::new(render_body_item::<BillingAndUsagePageAction>(
             "Auto reload".into(),
             None,
@@ -2004,10 +2011,7 @@ impl BillingAndUsagePageView {
             Default::default(),
             appearance,
             auto_reload_switch,
-            Some(format!(
-                "When enabled, auto reload will automatically purchase {auto_reload_amount} \
-                credits when your add-on credit balance reaches 100 credits remaining."
-            )),
+            Some(auto_reload_description),
         ))
         .with_padding_right(-TOGGLE_BUTTON_RIGHT_PADDING)
         .finish();
@@ -2028,9 +2032,7 @@ impl BillingAndUsagePageView {
         if let Some(purchased_row) = purchased_this_month_row {
             card_content_upper.add_child(purchased_row);
         }
-        if !is_premium_purchase {
-            card_content_upper.add_child(auto_reload_switch);
-        }
+        card_content_upper.add_child(auto_reload_switch);
 
         let base_rate = addon_credits_options
             .first()
@@ -2142,6 +2144,13 @@ impl BillingAndUsagePageView {
 
         if auto_reload_enabled {
             card_content_upper.add_child(buy_row.finish());
+            if premium_bps > 0 {
+                card_content_upper.add_child(render_premium_surcharge_note(
+                    team_uid,
+                    premium_bps,
+                    appearance,
+                ));
+            }
             if delinquent_due_to_payment_issue {
                 card_content_upper.add_child(self.render_warning_row(
                     appearance,

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -137,7 +137,7 @@ pub(crate) const CHECKOUT_PENDING_MESSAGE: &str =
 /// plans that purchase at a premium over list price, linking to the upgrade
 /// page.
 pub(crate) fn render_premium_upgrade_savings_note(
-    team_uid: ServerId,
+    upgrade_url: String,
     premium_bps: i32,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
@@ -145,10 +145,7 @@ pub(crate) fn render_premium_upgrade_savings_note(
     let percent = format_addon_premium_percent(premium_bps);
     let fragments = vec![
         FormattedTextFragment::plain_text(format!("Save {percent} on add-on credits by ")),
-        FormattedTextFragment::hyperlink(
-            "upgrading to a Build plan",
-            UserWorkspaces::upgrade_link_for_team(team_uid),
-        ),
+        FormattedTextFragment::hyperlink("upgrading to a Build plan", upgrade_url),
         FormattedTextFragment::plain_text("."),
     ];
 
@@ -1108,7 +1105,7 @@ pub enum BillingAndUsagePageAction {
     RenderMoreUsageEntries,
     SelectTopupDenomination(usize),
     PurchaseAddonCredits {
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
     },
     ShowAddOnCreditModal,
     UpdateAutoReloadEnabled {
@@ -1659,7 +1656,7 @@ impl BillingAndUsagePageView {
         &self,
         selected_topup_denomination: usize,
         workspace: &Workspace,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         has_admin_permissions: bool,
         bonus_credit_balance: i32,
         addon_credits_options: &[AddonCreditsOption],
@@ -1703,11 +1700,24 @@ impl BillingAndUsagePageView {
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .finish();
 
-        let team_can_purchase_addon_credits = workspace
-            .billing_metadata
-            .is_purchase_add_on_credits_policy_enabled();
-        let premium_bps = workspace.billing_metadata.addon_credits_price_premium_bps();
+        let workspaces = UserWorkspaces::as_ref(app);
+        let purchase_billing_metadata = workspaces.purchase_billing_metadata(
+            team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)),
+        );
+        let team_can_purchase_addon_credits = purchase_billing_metadata
+            .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
+        let premium_bps = purchase_billing_metadata
+            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
         let can_upgrade_to_build = workspace.billing_metadata.can_upgrade_to_build_plan();
+        let upgrade_url = match team_uid {
+            Some(team_uid) => UserWorkspaces::upgrade_link_for_team(team_uid),
+            None => UserWorkspaces::upgrade_link(
+                AuthStateProvider::as_ref(app)
+                    .get()
+                    .user_id()
+                    .unwrap_or_default(),
+            ),
+        };
 
         let no_credits_access_explanation = match (
             team_can_purchase_addon_credits,
@@ -1721,7 +1731,7 @@ impl BillingAndUsagePageView {
             // If the team cannot purchase addon credits, but they can upgrade to a Build-like plan,
             // and the current user is an admin, then we show them a nudge to switch to Build.
             (false, true, true) => {
-                let upgrade_url = UserWorkspaces::upgrade_link_for_team(team_uid);
+                let upgrade_url = upgrade_url.clone();
                 let is_legacy_paid = workspace.billing_metadata.is_on_legacy_paid_plan();
                 let (link_text, suffix) = if is_legacy_paid {
                     ("Switch to the Build plan", " to purchase add-on credits.")
@@ -1956,10 +1966,14 @@ impl BillingAndUsagePageView {
             auto_reload_switch
                 .build()
                 .on_click(move |ctx, _, _| {
-                    ctx.dispatch_typed_action(BillingAndUsagePageAction::UpdateAutoReloadEnabled {
-                        team_uid,
-                        enabled: !auto_reload_enabled,
-                    });
+                    if let Some(team_uid) = team_uid {
+                        ctx.dispatch_typed_action(
+                            BillingAndUsagePageAction::UpdateAutoReloadEnabled {
+                                team_uid,
+                                enabled: !auto_reload_enabled,
+                            },
+                        );
+                    }
                 })
                 .finish()
         };
@@ -1989,13 +2003,21 @@ impl BillingAndUsagePageView {
             .finish();
 
         let mut card_content_upper = Flex::column()
-            .with_children([card_header, paragraph, monthly_spend_row])
+            .with_children([card_header, paragraph])
             .with_spacing(8.);
 
+        // Monthly spend limits and auto-reload persist team settings; a
+        // teamless user has no team to configure until their first purchase
+        // creates one server-side.
+        if team_uid.is_some() {
+            card_content_upper.add_child(monthly_spend_row);
+        }
         if let Some(purchased_row) = purchased_this_month_row {
             card_content_upper.add_child(purchased_row);
         }
-        card_content_upper.add_child(auto_reload_switch);
+        if team_uid.is_some() {
+            card_content_upper.add_child(auto_reload_switch);
+        }
 
         let base_rate = addon_credits_options
             .first()
@@ -2101,7 +2123,7 @@ impl BillingAndUsagePageView {
             card_content_upper.add_child(buy_row.finish());
             if premium_bps > 0 {
                 card_content_upper.add_child(render_premium_upgrade_savings_note(
-                    team_uid,
+                    upgrade_url.clone(),
                     premium_bps,
                     appearance,
                 ));
@@ -2139,7 +2161,7 @@ impl BillingAndUsagePageView {
 
             if premium_bps > 0 {
                 card_content_lower_children.push(render_premium_upgrade_savings_note(
-                    team_uid,
+                    upgrade_url.clone(),
                     premium_bps,
                     appearance,
                 ));
@@ -2925,7 +2947,7 @@ impl BillingAndUsagePageView {
             usage.add_child(ambient_trial_widget);
         }
 
-        if let (Some(workspace), Some(team)) = (workspace, team) {
+        if let Some(workspace) = workspace {
             let bonus_credit_balance =
                 ai_request_usage_model.total_workspace_bonus_credits_remaining(workspace.uid);
 
@@ -2935,12 +2957,17 @@ impl BillingAndUsagePageView {
                 .is_enterprise_pay_as_you_go_enabled()
                 && bonus_credit_balance == 0;
 
+            // A teamless user manages their own personal purchases; the
+            // server creates their team on first purchase.
+            let can_manage_addon_credits =
+                team.is_none_or(|team| team.has_admin_permissions(&current_user_email));
+
             if !is_enterprise_payg_with_zero_credits {
                 usage.add_child(self.render_addon_credits_panel(
                     self.selected_addon_denomination,
                     workspace,
-                    team.uid,
-                    has_admin_permissions,
+                    team.map(|team| team.uid),
+                    can_manage_addon_credits,
                     bonus_credit_balance,
                     &self.addon_credits_options,
                     &self.addon_credit_denomination_buttons,

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -120,6 +120,84 @@ pub fn create_discount_badge(discount: u32, appearance: &Appearance) -> Box<dyn 
     .finish()
 }
 
+/// Formats an add-on credits price surcharge, expressed in basis points, as a
+/// human-readable percentage (e.g. 1000 -> "10%").
+pub fn format_addon_premium_percent(premium_bps: i32) -> String {
+    if premium_bps % 100 == 0 {
+        format!("{}%", premium_bps / 100)
+    } else {
+        format!("{:.2}%", premium_bps as f64 / 100.0)
+    }
+}
+
+/// Renders a "+10%"-style badge for plans that purchase add-on credits at a
+/// premium over list price.
+pub fn create_premium_surcharge_badge(
+    premium_bps: i32,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    if premium_bps <= 0 {
+        return Empty::new().finish();
+    }
+
+    let theme = appearance.theme();
+    let bg_color: Fill = theme.terminal_colors().normal.yellow.into();
+
+    Container::new(
+        Text::new_inline(
+            format!("+{}", format_addon_premium_percent(premium_bps)),
+            appearance.ui_font_family(),
+            10.,
+        )
+        .with_color(theme.main_text_color(bg_color).into())
+        .finish(),
+    )
+    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+    .with_background(bg_color)
+    .with_uniform_padding(4.)
+    .finish()
+}
+
+pub(crate) const CHECKOUT_PENDING_MESSAGE: &str =
+    "Finish your purchase in the browser — credits will appear shortly.";
+
+/// Renders the note shown under the one-time purchase row for plans that pay
+/// a premium over list price, with an upgrade link to skip the surcharge.
+pub(crate) fn render_premium_surcharge_note(
+    team_uid: ServerId,
+    premium_bps: i32,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let percent = format_addon_premium_percent(premium_bps);
+    let fragments = vec![
+        FormattedTextFragment::plain_text(format!(
+            "Prices include a {percent} Free plan surcharge. "
+        )),
+        FormattedTextFragment::hyperlink(
+            "Upgrade to skip the surcharge",
+            UserWorkspaces::upgrade_link_for_team(team_uid),
+        ),
+        FormattedTextFragment::plain_text("."),
+    ];
+
+    FormattedTextElement::new(
+        FormattedText::new([FormattedTextLine::Line(fragments)]),
+        appearance.ui_font_size(),
+        appearance.ui_font_family(),
+        appearance.ui_font_family(),
+        theme.sub_text_color(theme.background()).into(),
+        HighlightedHyperlink::default(),
+    )
+    .with_hyperlink_font_color(theme.accent().into_solid())
+    .register_default_click_handlers_with_action_support(|hyperlink_lens, _, ctx| {
+        if let warpui::elements::HyperlinkLens::Url(url) = hyperlink_lens {
+            ctx.open_url(url);
+        }
+    })
+    .finish()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BillingUsageTab {
     Overview,
@@ -462,6 +540,24 @@ impl BillingAndUsagePageView {
                 AIRequestUsageModel::handle(ctx).update(ctx, |ai_request_usage_model, ctx| {
                     ai_request_usage_model.refresh_request_usage_async(ctx)
                 });
+            }
+            UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired { checkout_url } => {
+                // Multiple surfaces subscribe to purchase events; only the one
+                // that initiated the purchase should hand off to the browser.
+                if self.purchase_addon_credits_loading {
+                    self.purchase_addon_credits_loading = false;
+                    ctx.open_url(checkout_url);
+                    self.show_toast(CHECKOUT_PENDING_MESSAGE, ToastFlavor::Default, ctx);
+                    // Credits are granted via webhook once checkout completes;
+                    // refresh billing data so polling picks them up promptly.
+                    std::mem::drop(
+                        TeamUpdateManager::handle(ctx)
+                            .update(ctx, |manager, ctx| manager.refresh_workspace_metadata(ctx)),
+                    );
+                    AIRequestUsageModel::handle(ctx).update(ctx, |ai_request_usage_model, ctx| {
+                        ai_request_usage_model.refresh_request_usage_async(ctx)
+                    });
+                }
             }
             UserWorkspacesEvent::PurchaseAddonCreditsRejected(err) => {
                 self.purchase_addon_credits_loading = false;
@@ -1638,9 +1734,9 @@ impl BillingAndUsagePageView {
 
         let team_can_purchase_addon_credits = workspace
             .billing_metadata
-            .tier
-            .purchase_add_on_credits_policy
-            .is_some_and(|policy| policy.enabled);
+            .is_purchase_add_on_credits_policy_enabled();
+        let is_premium_purchase = workspace.billing_metadata.is_premium_addon_credits_purchase();
+        let premium_bps = workspace.billing_metadata.addon_credits_price_premium_bps();
         let can_upgrade_to_build = workspace.billing_metadata.can_upgrade_to_build_plan();
 
         let no_credits_access_explanation = match (
@@ -1872,10 +1968,13 @@ impl BillingAndUsagePageView {
 
         let selected_option = addon_credits_options.get(selected_topup_denomination);
 
-        let auto_reload_enabled = workspace
-            .settings
-            .addon_credits_settings
-            .auto_reload_enabled;
+        // Auto-reload only applies to plans with standard (list price)
+        // purchasing; premium-purchase plans always use one-time purchases.
+        let auto_reload_enabled = !is_premium_purchase
+            && workspace
+                .settings
+                .addon_credits_settings
+                .auto_reload_enabled;
 
         let auto_reload_amount = selected_option
             .map(|option| option.credits.to_string())
@@ -1929,7 +2028,9 @@ impl BillingAndUsagePageView {
         if let Some(purchased_row) = purchased_this_month_row {
             card_content_upper.add_child(purchased_row);
         }
-        card_content_upper.add_child(auto_reload_switch);
+        if !is_premium_purchase {
+            card_content_upper.add_child(auto_reload_switch);
+        }
 
         let base_rate = addon_credits_options
             .first()
@@ -1937,7 +2038,7 @@ impl BillingAndUsagePageView {
 
         let (rendered_price, discount_badge) = match selected_option {
             Some(option) => {
-                let price_dollars = option.price_usd_cents as f64 / 100.0;
+                let price_dollars = option.price_usd_cents_with_premium(premium_bps) as f64 / 100.0;
                 let rendered_price = Container::new(
                     Text::new_inline(
                         format!("${price_dollars:.2}"),
@@ -1973,7 +2074,7 @@ impl BillingAndUsagePageView {
         };
 
         let would_exceed_limit = selected_option.is_some_and(|option| {
-            let purchase_cost_cents = option.price_usd_cents;
+            let purchase_cost_cents = option.price_usd_cents_with_premium(premium_bps);
             let monthly_limit_cents = workspace
                 .settings
                 .addon_credits_settings
@@ -2021,12 +2122,20 @@ impl BillingAndUsagePageView {
 
         let buy_button = buy_button.finish();
 
+        let premium_surcharge_badge = if premium_bps > 0 {
+            Container::new(create_premium_surcharge_badge(premium_bps, appearance))
+                .with_margin_right(8.)
+                .finish()
+        } else {
+            Empty::new().finish()
+        };
+
         let mut buy_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_children([
                 Shrinkable::new(1., denominations).finish(),
                 Flex::row()
-                    .with_children([discount_badge, rendered_price])
+                    .with_children([discount_badge, premium_surcharge_badge, rendered_price])
                     .with_cross_axis_alignment(CrossAxisAlignment::Center)
                     .finish(),
             ]);
@@ -2063,6 +2172,14 @@ impl BillingAndUsagePageView {
                 ui_builder.span("One-time purchase").build().finish(),
                 buy_row.finish(),
             ];
+
+            if premium_bps > 0 {
+                card_content_lower_children.push(render_premium_surcharge_note(
+                    team_uid,
+                    premium_bps,
+                    appearance,
+                ));
+            }
 
             if delinquent_due_to_payment_issue {
                 card_content_lower_children.push(self.render_warning_row(

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -1701,13 +1701,11 @@ impl BillingAndUsagePageView {
             .finish();
 
         let workspaces = UserWorkspaces::as_ref(app);
-        let purchase_billing_metadata = workspaces.purchase_billing_metadata(
-            team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)),
-        );
-        let team_can_purchase_addon_credits = purchase_billing_metadata
-            .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
-        let premium_bps = purchase_billing_metadata
-            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
+        let purchase_policy = workspaces
+            .purchase_policy(team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)));
+        let team_can_purchase_addon_credits =
+            purchase_policy.is_some_and(|policy| policy.allows_purchases());
+        let premium_bps = purchase_policy.map_or(0, |policy| policy.effective_premium_bps());
         let can_upgrade_to_build = workspace.billing_metadata.can_upgrade_to_build_plan();
         let upgrade_url = match team_uid {
             Some(team_uid) => UserWorkspaces::upgrade_link_for_team(team_uid),

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -130,8 +130,7 @@ fn format_addon_premium_percent(premium_bps: i32) -> String {
     }
 }
 
-pub(crate) const CHECKOUT_PENDING_MESSAGE: &str =
-    "Finish your purchase in the browser — credits will appear shortly.";
+pub(crate) const CHECKOUT_PENDING_MESSAGE: &str = "Opening your browser to complete your purchase";
 
 /// Renders the savings-framed upsell shown in the add-on credits panel for
 /// plans that purchase at a premium over list price, linking to the upgrade
@@ -510,21 +509,13 @@ impl BillingAndUsagePageView {
                 });
             }
             UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired { checkout_url } => {
-                // Multiple surfaces subscribe to purchase events; only the one
-                // that initiated the purchase should hand off to the browser.
                 if self.purchase_addon_credits_loading {
                     self.purchase_addon_credits_loading = false;
                     ctx.open_url(checkout_url);
                     self.show_toast(CHECKOUT_PENDING_MESSAGE, ToastFlavor::Default, ctx);
                     // Credits are granted via webhook once checkout completes;
-                    // refresh billing data so polling picks them up promptly.
-                    std::mem::drop(
-                        TeamUpdateManager::handle(ctx)
-                            .update(ctx, |manager, ctx| manager.refresh_workspace_metadata(ctx)),
-                    );
-                    AIRequestUsageModel::handle(ctx).update(ctx, |ai_request_usage_model, ctx| {
-                        ai_request_usage_model.refresh_request_usage_async(ctx)
-                    });
+                    // `on_page_selected` refreshes billing data when the user
+                    // returns (e.g. via the confirmation page's Open Warp link).
                 }
             }
             UserWorkspacesEvent::PurchaseAddonCreditsRejected(err) => {
@@ -1701,13 +1692,12 @@ impl BillingAndUsagePageView {
             .finish();
 
         let workspaces = UserWorkspaces::as_ref(app);
-        let purchase_policy = workspaces
-            .purchase_policy(team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)));
+        let purchase_policy = workspaces.purchase_policy_for_team(
+            team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)),
+        );
         let team_can_purchase_addon_credits =
             purchase_policy.is_some_and(|policy| policy.allows_purchases());
         let premium_bps = purchase_policy.map_or(0, |policy| policy.effective_premium_bps());
-        // Teamless users have no workspace yet; they're on the free tier and
-        // can always upgrade.
         let can_upgrade_to_build = workspace
             .is_none_or(|workspace| workspace.billing_metadata.can_upgrade_to_build_plan());
         let upgrade_url = match team_uid {
@@ -1725,9 +1715,10 @@ impl BillingAndUsagePageView {
             can_upgrade_to_build,
             has_admin_permissions,
         ) {
-            // If the team can purchase addon credits (which implies they're already on a Build-like plan)
-            // and the current user is a team admin, don't show any explanation, so that we show the
-            // fuller experience with the rest of the settings below this.
+            // If addon credits can be purchased in this context (any purchase-enabled plan,
+            // including free plans buying at a premium) and the current user can manage them,
+            // don't show any explanation, so that we show the fuller experience with the rest
+            // of the settings below this.
             (true, _, true) => None,
             // If the team cannot purchase addon credits, but they can upgrade to a Build-like plan,
             // and the current user is an admin, then we show them a nudge to switch to Build.
@@ -2013,9 +2004,6 @@ impl BillingAndUsagePageView {
             .with_children([card_header, paragraph])
             .with_spacing(8.);
 
-        // Monthly spend limits and auto-reload persist team settings; a
-        // teamless user has no team to configure until their first purchase
-        // creates one server-side.
         if team_uid.is_some() {
             card_content_upper.add_child(monthly_spend_row);
         }
@@ -2959,13 +2947,9 @@ impl BillingAndUsagePageView {
             usage.add_child(ambient_trial_widget);
         }
 
-        // A teamless fresh free user has no (non-placeholder) workspace at
-        // all, so `workspace` alone can't gate the purchase panel: still
-        // render it whenever the resolved purchase policy allows purchases
-        // (the user-level leg covers the teamless case).
         let show_addon_credits_panel = workspace.is_some()
             || workspaces
-                .purchase_policy(None)
+                .purchase_policy_for_team(team)
                 .is_some_and(|policy| policy.allows_purchases());
         if show_addon_credits_panel {
             let bonus_credit_balance = workspace.map_or_else(
@@ -2982,8 +2966,6 @@ impl BillingAndUsagePageView {
                     .is_enterprise_pay_as_you_go_enabled()
             }) && bonus_credit_balance == 0;
 
-            // A teamless user manages their own personal purchases; the
-            // server creates their team on first purchase.
             let can_manage_addon_credits =
                 team.is_none_or(|team| team.has_admin_permissions(&current_user_email));
 

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -120,9 +120,9 @@ pub fn create_discount_badge(discount: u32, appearance: &Appearance) -> Box<dyn 
     .finish()
 }
 
-/// Formats an add-on credits price surcharge, expressed in basis points, as a
+/// Formats an add-on credits price premium, expressed in basis points, as a
 /// human-readable percentage (e.g. 1000 -> "10%").
-pub fn format_addon_premium_percent(premium_bps: i32) -> String {
+fn format_addon_premium_percent(premium_bps: i32) -> String {
     if premium_bps % 100 == 0 {
         format!("{}%", premium_bps / 100)
     } else {
@@ -130,40 +130,13 @@ pub fn format_addon_premium_percent(premium_bps: i32) -> String {
     }
 }
 
-/// Renders a "+10%"-style badge for plans that purchase add-on credits at a
-/// premium over list price.
-pub fn create_premium_surcharge_badge(
-    premium_bps: i32,
-    appearance: &Appearance,
-) -> Box<dyn Element> {
-    if premium_bps <= 0 {
-        return Empty::new().finish();
-    }
-
-    let theme = appearance.theme();
-    let bg_color: Fill = theme.terminal_colors().normal.yellow.into();
-
-    Container::new(
-        Text::new_inline(
-            format!("+{}", format_addon_premium_percent(premium_bps)),
-            appearance.ui_font_family(),
-            10.,
-        )
-        .with_color(theme.main_text_color(bg_color).into())
-        .finish(),
-    )
-    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
-    .with_background(bg_color)
-    .with_uniform_padding(4.)
-    .finish()
-}
-
 pub(crate) const CHECKOUT_PENDING_MESSAGE: &str =
     "Finish your purchase in the browser — credits will appear shortly.";
 
-/// Renders the note shown under the one-time purchase row for plans that pay
-/// a premium over list price, with an upgrade link to skip the surcharge.
-pub(crate) fn render_premium_surcharge_note(
+/// Renders the savings-framed upsell shown in the add-on credits panel for
+/// plans that purchase at a premium over list price, linking to the upgrade
+/// page.
+pub(crate) fn render_premium_upgrade_savings_note(
     team_uid: ServerId,
     premium_bps: i32,
     appearance: &Appearance,
@@ -171,11 +144,9 @@ pub(crate) fn render_premium_surcharge_note(
     let theme = appearance.theme();
     let percent = format_addon_premium_percent(premium_bps);
     let fragments = vec![
-        FormattedTextFragment::plain_text(format!(
-            "Prices include a {percent} Free plan surcharge. "
-        )),
+        FormattedTextFragment::plain_text(format!("Save {percent} on add-on credits by ")),
         FormattedTextFragment::hyperlink(
-            "Upgrade to skip the surcharge",
+            "upgrading to a Build plan",
             UserWorkspaces::upgrade_link_for_team(team_uid),
         ),
         FormattedTextFragment::plain_text("."),
@@ -1993,17 +1964,6 @@ impl BillingAndUsagePageView {
                 .finish()
         };
 
-        let mut auto_reload_description = format!(
-            "When enabled, auto reload will automatically purchase {auto_reload_amount} \
-            credits when your add-on credit balance reaches 100 credits remaining."
-        );
-        if premium_bps > 0 {
-            let percent = format_addon_premium_percent(premium_bps);
-            auto_reload_description.push_str(&format!(
-                " Auto-reload purchases include the {percent} Free plan surcharge."
-            ));
-        }
-
         let auto_reload_switch = Container::new(render_body_item::<BillingAndUsagePageAction>(
             "Auto reload".into(),
             None,
@@ -2011,7 +1971,10 @@ impl BillingAndUsagePageView {
             Default::default(),
             appearance,
             auto_reload_switch,
-            Some(auto_reload_description),
+            Some(format!(
+                "When enabled, auto reload will automatically purchase {auto_reload_amount} \
+                credits when your add-on credit balance reaches 100 credits remaining."
+            )),
         ))
         .with_padding_right(-TOGGLE_BUTTON_RIGHT_PADDING)
         .finish();
@@ -2124,20 +2087,12 @@ impl BillingAndUsagePageView {
 
         let buy_button = buy_button.finish();
 
-        let premium_surcharge_badge = if premium_bps > 0 {
-            Container::new(create_premium_surcharge_badge(premium_bps, appearance))
-                .with_margin_right(8.)
-                .finish()
-        } else {
-            Empty::new().finish()
-        };
-
         let mut buy_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_children([
                 Shrinkable::new(1., denominations).finish(),
                 Flex::row()
-                    .with_children([discount_badge, premium_surcharge_badge, rendered_price])
+                    .with_children([discount_badge, rendered_price])
                     .with_cross_axis_alignment(CrossAxisAlignment::Center)
                     .finish(),
             ]);
@@ -2145,7 +2100,7 @@ impl BillingAndUsagePageView {
         if auto_reload_enabled {
             card_content_upper.add_child(buy_row.finish());
             if premium_bps > 0 {
-                card_content_upper.add_child(render_premium_surcharge_note(
+                card_content_upper.add_child(render_premium_upgrade_savings_note(
                     team_uid,
                     premium_bps,
                     appearance,
@@ -2183,7 +2138,7 @@ impl BillingAndUsagePageView {
             ];
 
             if premium_bps > 0 {
-                card_content_lower_children.push(render_premium_surcharge_note(
+                card_content_lower_children.push(render_premium_upgrade_savings_note(
                     team_uid,
                     premium_bps,
                     appearance,

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -1655,7 +1655,7 @@ impl BillingAndUsagePageView {
     fn render_addon_credits_panel(
         &self,
         selected_topup_denomination: usize,
-        workspace: &Workspace,
+        workspace: Option<&Workspace>,
         team_uid: Option<ServerId>,
         has_admin_permissions: bool,
         bonus_credit_balance: i32,
@@ -1706,7 +1706,10 @@ impl BillingAndUsagePageView {
         let team_can_purchase_addon_credits =
             purchase_policy.is_some_and(|policy| policy.allows_purchases());
         let premium_bps = purchase_policy.map_or(0, |policy| policy.effective_premium_bps());
-        let can_upgrade_to_build = workspace.billing_metadata.can_upgrade_to_build_plan();
+        // Teamless users have no workspace yet; they're on the free tier and
+        // can always upgrade.
+        let can_upgrade_to_build = workspace
+            .is_none_or(|workspace| workspace.billing_metadata.can_upgrade_to_build_plan());
         let upgrade_url = match team_uid {
             Some(team_uid) => UserWorkspaces::upgrade_link_for_team(team_uid),
             None => UserWorkspaces::upgrade_link(
@@ -1730,7 +1733,8 @@ impl BillingAndUsagePageView {
             // and the current user is an admin, then we show them a nudge to switch to Build.
             (false, true, true) => {
                 let upgrade_url = upgrade_url.clone();
-                let is_legacy_paid = workspace.billing_metadata.is_on_legacy_paid_plan();
+                let is_legacy_paid = workspace
+                    .is_some_and(|workspace| workspace.billing_metadata.is_on_legacy_paid_plan());
                 let (link_text, suffix) = if is_legacy_paid {
                     ("Switch to the Build plan", " to purchase add-on credits.")
                 } else {
@@ -1820,7 +1824,7 @@ impl BillingAndUsagePageView {
                 .finish();
         }
 
-        let team_member_count = workspace.members.len();
+        let team_member_count = workspace.map_or(1, |workspace| workspace.members.len());
 
         let paragraph_text = if team_member_count > 1 {
             format!("{ADDON_CREDITS_DESCRIPTION} {ADDITIONAL_ADDON_CREDITS_DESCRIPTION_FOR_TEAM}")
@@ -1849,9 +1853,12 @@ impl BillingAndUsagePageView {
         );
 
         let spend_limit_text = workspace
-            .settings
-            .addon_credits_settings
-            .max_monthly_spend_cents
+            .and_then(|workspace| {
+                workspace
+                    .settings
+                    .addon_credits_settings
+                    .max_monthly_spend_cents
+            })
             .map(|cents| format!("${:.2}", cents as f64 / 100.0))
             .unwrap_or_else(|| "$200.00".to_string());
 
@@ -1946,10 +1953,12 @@ impl BillingAndUsagePageView {
 
         let selected_option = addon_credits_options.get(selected_topup_denomination);
 
-        let auto_reload_enabled = workspace
-            .settings
-            .addon_credits_settings
-            .auto_reload_enabled;
+        let auto_reload_enabled = workspace.is_some_and(|workspace| {
+            workspace
+                .settings
+                .addon_credits_settings
+                .auto_reload_enabled
+        });
 
         let auto_reload_amount = selected_option
             .map(|option| option.credits.to_string())
@@ -2058,18 +2067,22 @@ impl BillingAndUsagePageView {
             "Buy".to_string()
         };
 
-        let would_exceed_limit = selected_option.is_some_and(|option| {
-            let purchase_cost_cents = option.price_usd_cents_with_premium(premium_bps);
-            let monthly_limit_cents = workspace
-                .settings
-                .addon_credits_settings
-                .max_monthly_spend_cents
-                .unwrap_or(20000); // Default $200 limit
+        let would_exceed_limit =
+            workspace
+                .zip(selected_option)
+                .is_some_and(|(workspace, option)| {
+                    let purchase_cost_cents = option.price_usd_cents_with_premium(premium_bps);
+                    let monthly_limit_cents = workspace
+                        .settings
+                        .addon_credits_settings
+                        .max_monthly_spend_cents
+                        .unwrap_or(20000); // Default $200 limit
 
-            let already_spent_cents = workspace.bonus_grants_purchased_this_month.cents_spent;
+                    let already_spent_cents =
+                        workspace.bonus_grants_purchased_this_month.cents_spent;
 
-            (already_spent_cents + purchase_cost_cents) > monthly_limit_cents
-        });
+                    (already_spent_cents + purchase_cost_cents) > monthly_limit_cents
+                });
 
         let is_buy_button_disabled =
             purchase_addon_credits_loading || would_exceed_limit || delinquent_due_to_payment_issue;
@@ -2170,10 +2183,11 @@ impl BillingAndUsagePageView {
                     appearance,
                     AUTO_RELOAD_DELINQUENT_WARNING_STRING.to_string(),
                 ));
-            } else if workspace
-                .billing_metadata
-                .has_failed_addon_credit_auto_reload_status()
-            {
+            } else if workspace.is_some_and(|workspace| {
+                workspace
+                    .billing_metadata
+                    .has_failed_addon_credit_auto_reload_status()
+            }) {
                 card_content_lower_children.push(self.render_warning_row(
                     appearance,
                     RESTRICTED_BILLING_USAGE_WARNING_STRING.to_string(),
@@ -2945,15 +2959,28 @@ impl BillingAndUsagePageView {
             usage.add_child(ambient_trial_widget);
         }
 
-        if let Some(workspace) = workspace {
-            let bonus_credit_balance =
-                ai_request_usage_model.total_workspace_bonus_credits_remaining(workspace.uid);
+        // A teamless fresh free user has no (non-placeholder) workspace at
+        // all, so `workspace` alone can't gate the purchase panel: still
+        // render it whenever the resolved purchase policy allows purchases
+        // (the user-level leg covers the teamless case).
+        let show_addon_credits_panel = workspace.is_some()
+            || workspaces
+                .purchase_policy(None)
+                .is_some_and(|policy| policy.allows_purchases());
+        if show_addon_credits_panel {
+            let bonus_credit_balance = workspace.map_or_else(
+                || ai_request_usage_model.total_user_interactive_bonus_credits_remaining(),
+                |workspace| {
+                    ai_request_usage_model.total_workspace_bonus_credits_remaining(workspace.uid)
+                },
+            );
 
             // Hide addon credits panel for Enterprise PAYG users when they have 0 credits.
-            let is_enterprise_payg_with_zero_credits = workspace
-                .billing_metadata
-                .is_enterprise_pay_as_you_go_enabled()
-                && bonus_credit_balance == 0;
+            let is_enterprise_payg_with_zero_credits = workspace.is_some_and(|workspace| {
+                workspace
+                    .billing_metadata
+                    .is_enterprise_pay_as_you_go_enabled()
+            }) && bonus_credit_balance == 0;
 
             // A teamless user manages their own personal purchases; the
             // server creates their team on first purchase.

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -1064,7 +1064,7 @@ impl BillingAndUsagePageV2View {
 
     fn render_addon_credits_panel(
         &self,
-        workspace: &Workspace,
+        workspace: Option<&Workspace>,
         team_uid: Option<ServerId>,
         has_admin_permissions: bool,
         delinquent: bool,
@@ -1097,7 +1097,7 @@ impl BillingAndUsagePageV2View {
 
     fn addon_credits_panel_state(
         &self,
-        workspace: &Workspace,
+        workspace: Option<&Workspace>,
         team_uid: Option<ServerId>,
         has_admin_permissions: bool,
         delinquent: bool,
@@ -1108,7 +1108,10 @@ impl BillingAndUsagePageV2View {
             .purchase_policy(team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)));
         let team_can_purchase = purchase_policy.is_some_and(|policy| policy.allows_purchases());
         let premium_bps = purchase_policy.map_or(0, |policy| policy.effective_premium_bps());
-        let can_upgrade = workspace.billing_metadata.can_upgrade_to_build_plan();
+        // Teamless users have no workspace yet; they're on the free tier and
+        // can always upgrade.
+        let can_upgrade = workspace
+            .is_none_or(|workspace| workspace.billing_metadata.can_upgrade_to_build_plan());
         let upgrade_url = match team_uid {
             Some(team_uid) => UserWorkspaces::upgrade_link_for_team(team_uid),
             None => UserWorkspaces::upgrade_link(self.auth_state.user_id().unwrap_or_default()),
@@ -1136,10 +1139,12 @@ impl BillingAndUsagePageV2View {
             .addon_credits
             .options
             .get(self.addon_credits.selected_denomination);
-        let auto_reload_enabled = workspace
-            .settings
-            .addon_credits_settings
-            .auto_reload_enabled;
+        let auto_reload_enabled = workspace.is_some_and(|workspace| {
+            workspace
+                .settings
+                .addon_credits_settings
+                .auto_reload_enabled
+        });
 
         let team_count = workspaces
             .team_for_view_handle(&self.self_handle, app)
@@ -1151,16 +1156,18 @@ impl BillingAndUsagePageV2View {
             ADDON_CREDITS_DESCRIPTION.to_string()
         };
 
-        let would_exceed = selected_credit_option.is_some_and(|opt| {
-            let limit = workspace
-                .settings
-                .addon_credits_settings
-                .max_monthly_spend_cents
-                .unwrap_or(DEFAULT_MAX_MONTHLY_SPEND_CENTS);
-            (workspace.bonus_grants_purchased_this_month.cents_spent
-                + opt.price_usd_cents_with_premium(premium_bps))
-                > limit
-        });
+        let would_exceed = workspace
+            .zip(selected_credit_option)
+            .is_some_and(|(workspace, opt)| {
+                let limit = workspace
+                    .settings
+                    .addon_credits_settings
+                    .max_monthly_spend_cents
+                    .unwrap_or(DEFAULT_MAX_MONTHLY_SPEND_CENTS);
+                (workspace.bonus_grants_purchased_this_month.cents_spent
+                    + opt.price_usd_cents_with_premium(premium_bps))
+                    > limit
+            });
         let purchase_disabled = self.addon_credits.purchase_loading
             || would_exceed
             || delinquent
@@ -1189,10 +1196,11 @@ impl BillingAndUsagePageV2View {
             Some(ADDON_CREDITS_DELINQUENT_WARNING_STRING)
         } else if delinquent {
             Some(ADDON_CREDITS_NON_ADMIN_DELINQUENT_WARNING_STRING)
-        } else if workspace
-            .billing_metadata
-            .has_failed_addon_credit_auto_reload_status()
-        {
+        } else if workspace.is_some_and(|workspace| {
+            workspace
+                .billing_metadata
+                .has_failed_addon_credit_auto_reload_status()
+        }) {
             Some(if has_admin_permissions {
                 RESTRICTED_BILLING_USAGE_WARNING_STRING
             } else {
@@ -1219,9 +1227,12 @@ impl BillingAndUsagePageV2View {
 
         if !has_admin_permissions && auto_reload_enabled {
             let configured_auto_reload_option = workspace
-                .settings
-                .addon_credits_settings
-                .selected_auto_reload_credit_denomination
+                .and_then(|workspace| {
+                    workspace
+                        .settings
+                        .addon_credits_settings
+                        .selected_auto_reload_credit_denomination
+                })
                 .and_then(|credits| {
                     self.addon_credits
                         .options
@@ -1382,7 +1393,7 @@ impl BillingAndUsagePageV2View {
 
     fn render_addon_credits_purchase_card(
         &self,
-        workspace: &Workspace,
+        workspace: Option<&Workspace>,
         team_uid: Option<ServerId>,
         state: AddonCreditsPurchaseState,
         appearance: &Appearance,
@@ -1404,7 +1415,7 @@ impl BillingAndUsagePageV2View {
 
     fn render_addon_credits_upper_section(
         &self,
-        workspace: &Workspace,
+        workspace: Option<&Workspace>,
         state: &AddonCreditsPurchaseState,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
@@ -1440,9 +1451,12 @@ impl BillingAndUsagePageV2View {
                 },
             );
             let spend_limit = workspace
-                .settings
-                .addon_credits_settings
-                .max_monthly_spend_cents
+                .and_then(|workspace| {
+                    workspace
+                        .settings
+                        .addon_credits_settings
+                        .max_monthly_spend_cents
+                })
                 .map(|c| format!("${:.2}", c as f64 / 100.0))
                 .unwrap_or_else(|| "$200.00".to_string());
             let spend_row = Flex::row()
@@ -1466,8 +1480,8 @@ impl BillingAndUsagePageV2View {
                 .finish();
             upper_section.add_child(spend_row);
 
-            if let Some(purchased_row) =
-                Self::render_purchased_this_month_row(workspace, appearance)
+            if let Some(purchased_row) = workspace
+                .and_then(|workspace| Self::render_purchased_this_month_row(workspace, appearance))
             {
                 upper_section.add_child(purchased_row);
             }
@@ -1749,11 +1763,21 @@ impl BillingAndUsagePageV2View {
                 .is_delinquent_due_to_payment_issue()
         });
 
-        if let Some(ws) = workspaces.current_workspace() {
+        // A teamless fresh free user has no (non-placeholder) workspace at
+        // all, so the workspace alone can't gate the purchase panel: still
+        // render it whenever the resolved purchase policy allows purchases
+        // (the user-level leg covers the teamless case).
+        let ws = workspaces.current_workspace();
+        let show_addon_credits_panel = ws.is_some()
+            || workspaces
+                .purchase_policy(None)
+                .is_some_and(|policy| policy.allows_purchases());
+        if show_addon_credits_panel {
             let team = workspaces.team_for_view_handle(&self.self_handle, app);
-            let workspace_bonus_credits = ai_model.total_workspace_bonus_credits_remaining(ws.uid);
-            let is_payg_zero = ws.billing_metadata.is_enterprise_pay_as_you_go_enabled()
-                && workspace_bonus_credits == 0;
+            let is_payg_zero = ws.is_some_and(|ws| {
+                ws.billing_metadata.is_enterprise_pay_as_you_go_enabled()
+                    && ai_model.total_workspace_bonus_credits_remaining(ws.uid) == 0
+            });
 
             if !is_payg_zero {
                 // A teamless user manages their own personal purchases; the

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -1104,13 +1104,10 @@ impl BillingAndUsagePageV2View {
         app: &AppContext,
     ) -> AddonCreditsPanelState {
         let workspaces = UserWorkspaces::as_ref(app);
-        let purchase_billing_metadata = workspaces.purchase_billing_metadata(
-            team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)),
-        );
-        let team_can_purchase = purchase_billing_metadata
-            .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
-        let premium_bps = purchase_billing_metadata
-            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
+        let purchase_policy = workspaces
+            .purchase_policy(team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)));
+        let team_can_purchase = purchase_policy.is_some_and(|policy| policy.allows_purchases());
+        let premium_bps = purchase_policy.map_or(0, |policy| policy.effective_premium_bps());
         let can_upgrade = workspace.billing_metadata.can_upgrade_to_build_plan();
         let upgrade_url = match team_uid {
             Some(team_uid) => UserWorkspaces::upgrade_link_for_team(team_uid),

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -35,7 +35,7 @@ use super::billing_and_usage::usage_history_model::UsageHistoryModel;
 pub use super::billing_and_usage_page::BillingAndUsagePageEvent;
 use super::billing_and_usage_page::{
     BillingAndUsagePageAction, BillingUsageTab, CHECKOUT_PENDING_MESSAGE,
-    create_premium_surcharge_badge, format_addon_premium_percent, render_premium_surcharge_note,
+    render_premium_upgrade_savings_note,
 };
 use super::settings_page::{AdditionalInfo, render_customer_type_badge, render_info_icon};
 use crate::ai::AIRequestUsageModel;
@@ -1171,16 +1171,10 @@ impl BillingAndUsagePageV2View {
         let auto_reload_credit_amount = selected_credit_option
             .map(|o| format!("{} credits", o.credits.separate_with_commas()))
             .unwrap_or_else(|| "selected credit amount".to_string());
-        let mut auto_reload_tooltip_text = format!(
+        let auto_reload_tooltip_text = format!(
             "When any member on your team’s credit balance reaches 100 credits remaining, \
             automatically purchase {auto_reload_credit_amount}."
         );
-        if premium_bps > 0 {
-            let percent = format_addon_premium_percent(premium_bps);
-            auto_reload_tooltip_text.push_str(&format!(
-                " Auto-reload purchases include the {percent} Free plan surcharge."
-            ));
-        }
         let warning_text = if delinquent && has_admin_permissions {
             Some(ADDON_CREDITS_DELINQUENT_WARNING_STRING)
         } else if delinquent {
@@ -1600,7 +1594,7 @@ impl BillingAndUsagePageV2View {
             purchase_button = purchase_button.disable();
         }
         let purchase_button = purchase_button.finish();
-        let mut price_row = Flex::row()
+        let price_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_child(
                 Text::new_inline(state.price_label.clone(), appearance.ui_font_family(), 14.)
@@ -1608,16 +1602,6 @@ impl BillingAndUsagePageV2View {
                     .with_style(Properties::default().weight(Weight::Medium))
                     .finish(),
             );
-        if state.premium_bps > 0 {
-            price_row.add_child(
-                Container::new(create_premium_surcharge_badge(
-                    state.premium_bps,
-                    appearance,
-                ))
-                .with_margin_left(8.)
-                .finish(),
-            );
-        }
 
         let mut right_group = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
         if state.has_admin_permissions {
@@ -1679,7 +1663,7 @@ impl BillingAndUsagePageV2View {
         let mut lower_children: Vec<Box<dyn Element>> = vec![lower_row.finish()];
 
         if state.premium_bps > 0 {
-            lower_children.push(render_premium_surcharge_note(
+            lower_children.push(render_premium_upgrade_savings_note(
                 team_uid,
                 state.premium_bps,
                 appearance,

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -33,7 +33,10 @@ use super::billing_and_usage::overage_limit_modal::{SpendingLimitModal, Spending
 use super::billing_and_usage::usage_history_entry::UsageHistoryEntry;
 use super::billing_and_usage::usage_history_model::UsageHistoryModel;
 pub use super::billing_and_usage_page::BillingAndUsagePageEvent;
-use super::billing_and_usage_page::{BillingAndUsagePageAction, BillingUsageTab};
+use super::billing_and_usage_page::{
+    BillingAndUsagePageAction, BillingUsageTab, CHECKOUT_PENDING_MESSAGE,
+    create_premium_surcharge_badge, render_premium_surcharge_note,
+};
 use super::settings_page::{AdditionalInfo, render_customer_type_badge, render_info_icon};
 use crate::ai::AIRequestUsageModel;
 use crate::ai::request_usage_model::{
@@ -167,6 +170,11 @@ struct AddonCreditsPurchaseState {
     price_label: String,
     auto_reload_tooltip_text: String,
     warning_text: Option<&'static str>,
+    /// True when purchases on this plan go through the premium (surcharged)
+    /// path; hides auto-reload, which only applies to list-price plans.
+    is_premium_purchase: bool,
+    /// Surcharge in basis points applied to displayed prices (0 = none).
+    premium_bps: i32,
 }
 
 struct UsageHistoryState {
@@ -436,6 +444,23 @@ impl BillingAndUsagePageV2View {
                 );
                 AIRequestUsageModel::handle(ctx)
                     .update(ctx, |m, ctx| m.refresh_request_usage_async(ctx));
+            }
+            UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired { checkout_url } => {
+                // Multiple surfaces subscribe to purchase events; only the one
+                // that initiated the purchase should hand off to the browser.
+                if self.addon_credits.purchase_loading {
+                    self.addon_credits.purchase_loading = false;
+                    ctx.open_url(checkout_url);
+                    self.show_toast(CHECKOUT_PENDING_MESSAGE, ToastFlavor::Default, ctx);
+                    // Credits are granted via webhook once checkout completes;
+                    // refresh billing data so polling picks them up promptly.
+                    std::mem::drop(
+                        TeamUpdateManager::handle(ctx)
+                            .update(ctx, |mgr, ctx| mgr.refresh_workspace_metadata(ctx)),
+                    );
+                    AIRequestUsageModel::handle(ctx)
+                        .update(ctx, |m, ctx| m.refresh_request_usage_async(ctx));
+                }
             }
             UserWorkspacesEvent::PurchaseAddonCreditsRejected(err) => {
                 self.addon_credits.purchase_loading = false;
@@ -1078,9 +1103,9 @@ impl BillingAndUsagePageV2View {
     ) -> AddonCreditsPanelState {
         let team_can_purchase = workspace
             .billing_metadata
-            .tier
-            .purchase_add_on_credits_policy
-            .is_some_and(|p| p.enabled);
+            .is_purchase_add_on_credits_policy_enabled();
+        let is_premium_purchase = workspace.billing_metadata.is_premium_addon_credits_purchase();
+        let premium_bps = workspace.billing_metadata.addon_credits_price_premium_bps();
         let can_upgrade = workspace.billing_metadata.can_upgrade_to_build_plan();
 
         if !team_can_purchase {
@@ -1105,10 +1130,13 @@ impl BillingAndUsagePageV2View {
             .addon_credits
             .options
             .get(self.addon_credits.selected_denomination);
-        let auto_reload_enabled = workspace
-            .settings
-            .addon_credits_settings
-            .auto_reload_enabled;
+        // Auto-reload only applies to plans with standard (list price)
+        // purchasing; premium-purchase plans always use one-time purchases.
+        let auto_reload_enabled = !is_premium_purchase
+            && workspace
+                .settings
+                .addon_credits_settings
+                .auto_reload_enabled;
 
         let team_count = UserWorkspaces::as_ref(app)
             .team_for_view_handle(&self.self_handle, app)
@@ -1126,7 +1154,9 @@ impl BillingAndUsagePageV2View {
                 .addon_credits_settings
                 .max_monthly_spend_cents
                 .unwrap_or(DEFAULT_MAX_MONTHLY_SPEND_CENTS);
-            (workspace.bonus_grants_purchased_this_month.cents_spent + opt.price_usd_cents) > limit
+            (workspace.bonus_grants_purchased_this_month.cents_spent
+                + opt.price_usd_cents_with_premium(premium_bps))
+                > limit
         });
         let purchase_disabled = self.addon_credits.purchase_loading
             || would_exceed
@@ -1138,7 +1168,10 @@ impl BillingAndUsagePageV2View {
         let price_label = selected_credit_option
             .map(|opt| {
                 let credits = opt.credits.separate_with_commas();
-                let dollars = format!("${:.2}", opt.price_usd_cents as f64 / 100.0);
+                let dollars = format!(
+                    "${:.2}",
+                    opt.price_usd_cents_with_premium(premium_bps) as f64 / 100.0
+                );
                 format!("{credits} credits / {dollars}")
             })
             .unwrap_or_default();
@@ -1220,6 +1253,8 @@ impl BillingAndUsagePageV2View {
             price_label,
             auto_reload_tooltip_text,
             warning_text,
+            is_premium_purchase,
+            premium_bps,
         })
     }
 
@@ -1564,7 +1599,7 @@ impl BillingAndUsagePageV2View {
             purchase_button = purchase_button.disable();
         }
         let purchase_button = purchase_button.finish();
-        let price_row = Flex::row()
+        let mut price_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_child(
                 Text::new_inline(state.price_label.clone(), appearance.ui_font_family(), 14.)
@@ -1572,9 +1607,19 @@ impl BillingAndUsagePageV2View {
                     .with_style(Properties::default().weight(Weight::Medium))
                     .finish(),
             );
+        if state.premium_bps > 0 {
+            price_row.add_child(
+                Container::new(create_premium_surcharge_badge(
+                    state.premium_bps,
+                    appearance,
+                ))
+                .with_margin_left(8.)
+                .finish(),
+            );
+        }
 
         let mut right_group = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-        if state.has_admin_permissions {
+        if state.has_admin_permissions && !state.is_premium_purchase {
             let auto_reload_switch_element = {
                 let switch_builder = appearance
                     .ui_builder()
@@ -1621,7 +1666,13 @@ impl BillingAndUsagePageV2View {
         }
         right_group.add_child(
             Container::new(purchase_button)
-                .with_margin_left(if state.has_admin_permissions { 16. } else { 0. })
+                .with_margin_left(
+                    if state.has_admin_permissions && !state.is_premium_purchase {
+                        16.
+                    } else {
+                        0.
+                    },
+                )
                 .finish(),
         );
         let lower_row = Flex::row()
@@ -1631,6 +1682,14 @@ impl BillingAndUsagePageV2View {
             .with_child(price_row.finish())
             .with_child(right_group.finish());
         let mut lower_children: Vec<Box<dyn Element>> = vec![lower_row.finish()];
+
+        if state.premium_bps > 0 {
+            lower_children.push(render_premium_surcharge_note(
+                team_uid,
+                state.premium_bps,
+                appearance,
+            ));
+        }
 
         if let Some(warning_text) = state.warning_text {
             lower_children.push(self.render_warning_row(appearance, warning_text.to_string()));

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -165,6 +165,11 @@ struct AddonCreditsPurchaseState {
     description_text: String,
     auto_reload_enabled: bool,
     has_admin_permissions: bool,
+    /// Whether team-level purchase settings (spend limit, auto-reload) can be
+    /// edited: requires admin permission AND an existing team. Teamless users
+    /// can purchase, but have no team settings until their first purchase
+    /// creates a team server-side.
+    can_edit_team_settings: bool,
     purchase_disabled: bool,
     auto_reload_switch_disabled: bool,
     price_label: String,
@@ -1060,7 +1065,7 @@ impl BillingAndUsagePageV2View {
     fn render_addon_credits_panel(
         &self,
         workspace: &Workspace,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         has_admin_permissions: bool,
         delinquent: bool,
         app: &AppContext,
@@ -1093,16 +1098,24 @@ impl BillingAndUsagePageV2View {
     fn addon_credits_panel_state(
         &self,
         workspace: &Workspace,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         has_admin_permissions: bool,
         delinquent: bool,
         app: &AppContext,
     ) -> AddonCreditsPanelState {
-        let team_can_purchase = workspace
-            .billing_metadata
-            .is_purchase_add_on_credits_policy_enabled();
-        let premium_bps = workspace.billing_metadata.addon_credits_price_premium_bps();
+        let workspaces = UserWorkspaces::as_ref(app);
+        let purchase_billing_metadata = workspaces.purchase_billing_metadata(
+            team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)),
+        );
+        let team_can_purchase = purchase_billing_metadata
+            .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
+        let premium_bps = purchase_billing_metadata
+            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
         let can_upgrade = workspace.billing_metadata.can_upgrade_to_build_plan();
+        let upgrade_url = match team_uid {
+            Some(team_uid) => UserWorkspaces::upgrade_link_for_team(team_uid),
+            None => UserWorkspaces::upgrade_link(self.auth_state.user_id().unwrap_or_default()),
+        };
 
         if !team_can_purchase {
             if !has_admin_permissions {
@@ -1113,7 +1126,7 @@ impl BillingAndUsagePageV2View {
                 return AddonCreditsPanelState::IneligiblePlan(
                     AddonCreditsRestriction::UpgradeToBuild {
                         link_text: "Upgrade to Build",
-                        url: UserWorkspaces::upgrade_link_for_team(team_uid),
+                        url: upgrade_url,
                     },
                 );
             }
@@ -1131,7 +1144,7 @@ impl BillingAndUsagePageV2View {
             .addon_credits_settings
             .auto_reload_enabled;
 
-        let team_count = UserWorkspaces::as_ref(app)
+        let team_count = workspaces
             .team_for_view_handle(&self.self_handle, app)
             .map(|team| team.members.len())
             .unwrap_or(1);
@@ -1244,6 +1257,7 @@ impl BillingAndUsagePageV2View {
             description_text,
             auto_reload_enabled,
             has_admin_permissions,
+            can_edit_team_settings: has_admin_permissions && team_uid.is_some(),
             purchase_disabled,
             auto_reload_switch_disabled,
             price_label,
@@ -1372,7 +1386,7 @@ impl BillingAndUsagePageV2View {
     fn render_addon_credits_purchase_card(
         &self,
         workspace: &Workspace,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         state: AddonCreditsPurchaseState,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
@@ -1416,7 +1430,7 @@ impl BillingAndUsagePageV2View {
             .with_children([header, paragraph])
             .with_spacing(8.);
 
-        if state.has_admin_permissions {
+        if state.can_edit_team_settings {
             let info_icon = render_info_icon(
                 appearance,
                 AdditionalInfo::<BillingAndUsagePageAction> {
@@ -1549,7 +1563,7 @@ impl BillingAndUsagePageV2View {
 
     fn render_addon_credits_lower_section(
         &self,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         state: &AddonCreditsPurchaseState,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
@@ -1604,7 +1618,7 @@ impl BillingAndUsagePageV2View {
             );
 
         let mut right_group = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-        if state.has_admin_permissions {
+        if state.can_edit_team_settings {
             let auto_reload_switch_element = {
                 let switch_builder = appearance
                     .ui_builder()
@@ -1616,12 +1630,14 @@ impl BillingAndUsagePageV2View {
                     switch_builder
                         .build()
                         .on_click(move |ctx, _, _| {
-                            ctx.dispatch_typed_action(
-                                BillingAndUsagePageAction::UpdateAutoReloadEnabled {
-                                    team_uid,
-                                    enabled: !auto_reload_enabled,
-                                },
-                            );
+                            if let Some(team_uid) = team_uid {
+                                ctx.dispatch_typed_action(
+                                    BillingAndUsagePageAction::UpdateAutoReloadEnabled {
+                                        team_uid,
+                                        enabled: !auto_reload_enabled,
+                                    },
+                                );
+                            }
                         })
                         .finish()
                 }
@@ -1651,7 +1667,11 @@ impl BillingAndUsagePageV2View {
         }
         right_group.add_child(
             Container::new(purchase_button)
-                .with_margin_left(if state.has_admin_permissions { 16. } else { 0. })
+                .with_margin_left(if state.can_edit_team_settings {
+                    16.
+                } else {
+                    0.
+                })
                 .finish(),
         );
         let lower_row = Flex::row()
@@ -1663,8 +1683,12 @@ impl BillingAndUsagePageV2View {
         let mut lower_children: Vec<Box<dyn Element>> = vec![lower_row.finish()];
 
         if state.premium_bps > 0 {
+            let upgrade_url = match team_uid {
+                Some(team_uid) => UserWorkspaces::upgrade_link_for_team(team_uid),
+                None => UserWorkspaces::upgrade_link(self.auth_state.user_id().unwrap_or_default()),
+            };
             lower_children.push(render_premium_upgrade_savings_note(
-                team_uid,
+                upgrade_url,
                 state.premium_bps,
                 appearance,
             ));
@@ -1728,25 +1752,25 @@ impl BillingAndUsagePageV2View {
                 .is_delinquent_due_to_payment_issue()
         });
 
-        if let (Some(ws), Some(team)) = (
-            workspaces.current_workspace(),
-            workspaces.team_for_view_handle(&self.self_handle, app),
-        ) {
+        if let Some(ws) = workspaces.current_workspace() {
+            let team = workspaces.team_for_view_handle(&self.self_handle, app);
             let workspace_bonus_credits = ai_model.total_workspace_bonus_credits_remaining(ws.uid);
             let is_payg_zero = ws.billing_metadata.is_enterprise_pay_as_you_go_enabled()
                 && workspace_bonus_credits == 0;
 
             if !is_payg_zero {
-                let current_user_is_admin = {
+                // A teamless user manages their own personal purchases; the
+                // server creates their team on first purchase.
+                let current_user_is_admin = team.is_none_or(|team| {
                     let email = AuthStateProvider::as_ref(app)
                         .get()
                         .user_email()
                         .unwrap_or_default();
                     team.has_admin_permissions(&email)
-                };
+                });
                 content.add_child(self.render_addon_credits_panel(
                     ws,
-                    team.uid,
+                    team.map(|team| team.uid),
                     current_user_is_admin,
                     delinquent,
                     app,

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -448,20 +448,13 @@ impl BillingAndUsagePageV2View {
                     .update(ctx, |m, ctx| m.refresh_request_usage_async(ctx));
             }
             UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired { checkout_url } => {
-                // Multiple surfaces subscribe to purchase events; only the one
-                // that initiated the purchase should hand off to the browser.
                 if self.addon_credits.purchase_loading {
                     self.addon_credits.purchase_loading = false;
                     ctx.open_url(checkout_url);
                     self.show_toast(CHECKOUT_PENDING_MESSAGE, ToastFlavor::Default, ctx);
                     // Credits are granted via webhook once checkout completes;
-                    // refresh billing data so polling picks them up promptly.
-                    std::mem::drop(
-                        TeamUpdateManager::handle(ctx)
-                            .update(ctx, |mgr, ctx| mgr.refresh_workspace_metadata(ctx)),
-                    );
-                    AIRequestUsageModel::handle(ctx)
-                        .update(ctx, |m, ctx| m.refresh_request_usage_async(ctx));
+                    // `on_page_selected` refreshes billing data when the user
+                    // returns (e.g. via the confirmation page's Open Warp link).
                 }
             }
             UserWorkspacesEvent::PurchaseAddonCreditsRejected(err) => {
@@ -1104,12 +1097,11 @@ impl BillingAndUsagePageV2View {
         app: &AppContext,
     ) -> AddonCreditsPanelState {
         let workspaces = UserWorkspaces::as_ref(app);
-        let purchase_policy = workspaces
-            .purchase_policy(team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)));
+        let purchase_policy = workspaces.purchase_policy_for_team(
+            team_uid.and_then(|team_uid| workspaces.team_from_uid(team_uid)),
+        );
         let team_can_purchase = purchase_policy.is_some_and(|policy| policy.allows_purchases());
         let premium_bps = purchase_policy.map_or(0, |policy| policy.effective_premium_bps());
-        // Teamless users have no workspace yet; they're on the free tier and
-        // can always upgrade.
         let can_upgrade = workspace
             .is_none_or(|workspace| workspace.billing_metadata.can_upgrade_to_build_plan());
         let upgrade_url = match team_uid {
@@ -1763,25 +1755,19 @@ impl BillingAndUsagePageV2View {
                 .is_delinquent_due_to_payment_issue()
         });
 
-        // A teamless fresh free user has no (non-placeholder) workspace at
-        // all, so the workspace alone can't gate the purchase panel: still
-        // render it whenever the resolved purchase policy allows purchases
-        // (the user-level leg covers the teamless case).
         let ws = workspaces.current_workspace();
+        let team = workspaces.team_for_view_handle(&self.self_handle, app);
         let show_addon_credits_panel = ws.is_some()
             || workspaces
-                .purchase_policy(None)
+                .purchase_policy_for_team(team)
                 .is_some_and(|policy| policy.allows_purchases());
         if show_addon_credits_panel {
-            let team = workspaces.team_for_view_handle(&self.self_handle, app);
             let is_payg_zero = ws.is_some_and(|ws| {
                 ws.billing_metadata.is_enterprise_pay_as_you_go_enabled()
                     && ai_model.total_workspace_bonus_credits_remaining(ws.uid) == 0
             });
 
             if !is_payg_zero {
-                // A teamless user manages their own personal purchases; the
-                // server creates their team on first purchase.
                 let current_user_is_admin = team.is_none_or(|team| {
                     let email = AuthStateProvider::as_ref(app)
                         .get()

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -35,7 +35,7 @@ use super::billing_and_usage::usage_history_model::UsageHistoryModel;
 pub use super::billing_and_usage_page::BillingAndUsagePageEvent;
 use super::billing_and_usage_page::{
     BillingAndUsagePageAction, BillingUsageTab, CHECKOUT_PENDING_MESSAGE,
-    create_premium_surcharge_badge, render_premium_surcharge_note,
+    create_premium_surcharge_badge, format_addon_premium_percent, render_premium_surcharge_note,
 };
 use super::settings_page::{AdditionalInfo, render_customer_type_badge, render_info_icon};
 use crate::ai::AIRequestUsageModel;
@@ -170,9 +170,6 @@ struct AddonCreditsPurchaseState {
     price_label: String,
     auto_reload_tooltip_text: String,
     warning_text: Option<&'static str>,
-    /// True when purchases on this plan go through the premium (surcharged)
-    /// path; hides auto-reload, which only applies to list-price plans.
-    is_premium_purchase: bool,
     /// Surcharge in basis points applied to displayed prices (0 = none).
     premium_bps: i32,
 }
@@ -1104,7 +1101,6 @@ impl BillingAndUsagePageV2View {
         let team_can_purchase = workspace
             .billing_metadata
             .is_purchase_add_on_credits_policy_enabled();
-        let is_premium_purchase = workspace.billing_metadata.is_premium_addon_credits_purchase();
         let premium_bps = workspace.billing_metadata.addon_credits_price_premium_bps();
         let can_upgrade = workspace.billing_metadata.can_upgrade_to_build_plan();
 
@@ -1130,13 +1126,10 @@ impl BillingAndUsagePageV2View {
             .addon_credits
             .options
             .get(self.addon_credits.selected_denomination);
-        // Auto-reload only applies to plans with standard (list price)
-        // purchasing; premium-purchase plans always use one-time purchases.
-        let auto_reload_enabled = !is_premium_purchase
-            && workspace
-                .settings
-                .addon_credits_settings
-                .auto_reload_enabled;
+        let auto_reload_enabled = workspace
+            .settings
+            .addon_credits_settings
+            .auto_reload_enabled;
 
         let team_count = UserWorkspaces::as_ref(app)
             .team_for_view_handle(&self.self_handle, app)
@@ -1178,10 +1171,16 @@ impl BillingAndUsagePageV2View {
         let auto_reload_credit_amount = selected_credit_option
             .map(|o| format!("{} credits", o.credits.separate_with_commas()))
             .unwrap_or_else(|| "selected credit amount".to_string());
-        let auto_reload_tooltip_text = format!(
+        let mut auto_reload_tooltip_text = format!(
             "When any member on your team’s credit balance reaches 100 credits remaining, \
             automatically purchase {auto_reload_credit_amount}."
         );
+        if premium_bps > 0 {
+            let percent = format_addon_premium_percent(premium_bps);
+            auto_reload_tooltip_text.push_str(&format!(
+                " Auto-reload purchases include the {percent} Free plan surcharge."
+            ));
+        }
         let warning_text = if delinquent && has_admin_permissions {
             Some(ADDON_CREDITS_DELINQUENT_WARNING_STRING)
         } else if delinquent {
@@ -1229,7 +1228,10 @@ impl BillingAndUsagePageV2View {
             let description_text = match configured_auto_reload_option {
                 Some(option) => {
                     let credits = option.credits.separate_with_commas();
-                    let price = format!("${:.2}", option.price_usd_cents as f64 / 100.0);
+                    let price = format!(
+                        "${:.2}",
+                        option.price_usd_cents_with_premium(premium_bps) as f64 / 100.0
+                    );
                     format!(
                         "Your admin has enabled auto-reload for add-on credits. When your personal add-on credit balance runs low, Warp will automatically purchase {credits} credits for {price} and add them to your balance."
                     )
@@ -1253,7 +1255,6 @@ impl BillingAndUsagePageV2View {
             price_label,
             auto_reload_tooltip_text,
             warning_text,
-            is_premium_purchase,
             premium_bps,
         })
     }
@@ -1619,7 +1620,7 @@ impl BillingAndUsagePageV2View {
         }
 
         let mut right_group = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-        if state.has_admin_permissions && !state.is_premium_purchase {
+        if state.has_admin_permissions {
             let auto_reload_switch_element = {
                 let switch_builder = appearance
                     .ui_builder()
@@ -1666,13 +1667,7 @@ impl BillingAndUsagePageV2View {
         }
         right_group.add_child(
             Container::new(purchase_button)
-                .with_margin_left(
-                    if state.has_admin_permissions && !state.is_premium_purchase {
-                        16.
-                    } else {
-                        0.
-                    },
-                )
+                .with_margin_left(if state.has_admin_permissions { 16. } else { 0. })
                 .finish(),
         );
         let lower_row = Flex::row()

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -119,7 +119,7 @@ mod warpify_page;
 #[cfg(not(target_family = "wasm"))]
 pub(crate) use ai_page::cli_agent_settings_widget_id;
 pub(crate) use ai_page::custom_model_routers_widget_id;
-pub use billing_and_usage_page::{create_discount_badge, format_addon_premium_percent};
+pub use billing_and_usage_page::create_discount_badge;
 pub use code_page::CodeSettingsPageView;
 pub use features_page::FeaturesPageAction;
 pub use main_page::handle_experiment_change;

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -119,7 +119,7 @@ mod warpify_page;
 #[cfg(not(target_family = "wasm"))]
 pub(crate) use ai_page::cli_agent_settings_widget_id;
 pub(crate) use ai_page::custom_model_routers_widget_id;
-pub use billing_and_usage_page::create_discount_badge;
+pub use billing_and_usage_page::{create_discount_badge, format_addon_premium_percent};
 pub use code_page::CodeSettingsPageView;
 pub use features_page::FeaturesPageAction;
 pub use main_page::handle_experiment_change;

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -1049,6 +1049,9 @@ impl TeamsPageView {
             UserWorkspacesEvent::PurchaseAddonCreditsSuccess => {
                 // Addon credits purchase success is handled in billing_and_usage_page
             }
+            UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired { .. } => {
+                // Checkout handoff is handled by the surface that initiated the purchase
+            }
             UserWorkspacesEvent::PurchaseAddonCreditsRejected(_) => {
                 // Addon credits purchase rejection is handled in billing_and_usage_page
             }

--- a/app/src/terminal/buy_credits_banner.rs
+++ b/app/src/terminal/buy_credits_banner.rs
@@ -389,11 +389,10 @@ impl BuyCreditsBanner {
             .map(|opts| opts.to_vec())
             .unwrap_or_default();
 
-        let premium_bps = UserWorkspaces::as_ref(ctx)
-            .team_for_view(ctx)
-            .map_or(0, |team| {
-                team.billing_metadata.addon_credits_price_premium_bps()
-            });
+        let workspaces = UserWorkspaces::as_ref(ctx);
+        let premium_bps = workspaces
+            .purchase_billing_metadata(workspaces.team_for_view(ctx))
+            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
         let base_rate = self
             .addon_credits_options
             .first()
@@ -679,27 +678,30 @@ impl BuyCreditsBanner {
         };
 
         let auth_state = AuthStateProvider::as_ref(app).get();
-        let current_team = UserWorkspaces::as_ref(app).team_for_view_handle(&self.view_handle, app);
-        let has_admin_permissions = auth_state
-            .user_email()
-            .zip(current_team)
-            .map(|(email, team)| team.has_admin_permissions(&email))
-            .unwrap_or_default();
-        let delinquent_due_to_payment_issue = current_team
-            .is_some_and(|team| team.billing_metadata.is_delinquent_due_to_payment_issue());
+        let workspaces = UserWorkspaces::as_ref(app);
+        let current_team = workspaces.team_for_view_handle(&self.view_handle, app);
+        let purchase_billing_metadata = workspaces.purchase_billing_metadata(current_team);
+        // A teamless user manages their own personal purchases; the server
+        // creates their team on first purchase.
+        let has_admin_permissions = current_team.is_none_or(|team| {
+            auth_state
+                .user_email()
+                .is_some_and(|email| team.has_admin_permissions(&email))
+        });
+        let delinquent_due_to_payment_issue = purchase_billing_metadata
+            .is_some_and(|billing| billing.is_delinquent_due_to_payment_issue());
         let auto_reload_banner_toggle_ff =
             FeatureFlag::BuildPlanAutoReloadBannerToggle.is_enabled();
 
         // Check if user has reached their monthly addon credits limit
-        let current_workspace = UserWorkspaces::as_ref(app).current_workspace();
+        let current_workspace = workspaces.current_workspace();
         let is_at_monthly_limit = current_workspace
             .map(|workspace| workspace.is_at_addon_credits_monthly_limit())
             .unwrap_or(false);
 
         // Check if the selected purchase would reach/exceed the monthly limit
-        let premium_bps = current_team.map_or(0, |team| {
-            team.billing_metadata.addon_credits_price_premium_bps()
-        });
+        let premium_bps = purchase_billing_metadata
+            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
         let selected_option = self
             .addon_credits_options
             .get(self.selected_denomination_index);
@@ -794,6 +796,8 @@ impl BuyCreditsBanner {
         };
 
         let make_buy_button = || {
+            // May be None for teamless users; the server auto-creates their
+            // personal team on purchase.
             let team_uid = current_team.map(|team| team.uid);
 
             let buy_button_disabled = self.purchase_addon_credits_loading
@@ -836,9 +840,7 @@ impl BuyCreditsBanner {
                 .with_text_label(button_text)
                 .build()
                 .on_click(move |ctx, _, _| {
-                    if let Some(team_uid) = team_uid {
-                        ctx.dispatch_typed_action(Action::PurchaseAddonCredits { team_uid });
-                    }
+                    ctx.dispatch_typed_action(Action::PurchaseAddonCredits { team_uid });
                 });
 
             if buy_button_disabled {
@@ -1006,7 +1008,7 @@ impl View for BuyCreditsBanner {
 pub enum Action {
     SelectDenomination(usize),
     Close,
-    PurchaseAddonCredits { team_uid: ServerId },
+    PurchaseAddonCredits { team_uid: Option<ServerId> },
     ManageBilling,
     ToggleAutoReload,
 }

--- a/app/src/terminal/buy_credits_banner.rs
+++ b/app/src/terminal/buy_credits_banner.rs
@@ -59,6 +59,10 @@ pub struct BuyCreditsBanner {
     is_denomination_dropdown_open: bool,
     auto_reload_enabled: bool,
     banner_auto_reload_update_in_flight: bool,
+    /// True after a purchase was handed off to the browser for checkout (no
+    /// saved payment method). Shows a "finish in browser" banner until the
+    /// credits land via polling or the user dismisses it.
+    checkout_pending: bool,
 }
 
 impl BuyCreditsBanner {
@@ -77,8 +81,20 @@ impl BuyCreditsBanner {
 
         ctx.subscribe_to_model(
             &AIRequestUsageModel::handle(ctx),
-            |_me, _handle, event, ctx| {
+            |me, _handle, event, ctx| {
                 if let AIRequestUsageModelEvent::RequestUsageUpdated = event {
+                    // Once purchased credits land (the banner would hide),
+                    // clear any pending checkout so a future out-of-credits
+                    // banner starts fresh.
+                    if me.checkout_pending
+                        && matches!(
+                            AIRequestUsageModel::as_ref(ctx)
+                                .compute_buy_addon_credits_banner_display_state(ctx),
+                            BuyCreditsBannerDisplayState::Hidden
+                        )
+                    {
+                        me.checkout_pending = false;
+                    }
                     ctx.notify();
                 }
             },
@@ -119,6 +135,7 @@ impl BuyCreditsBanner {
             is_denomination_dropdown_open: false,
             auto_reload_enabled: false,
             banner_auto_reload_update_in_flight: false,
+            checkout_pending: false,
         };
         me.update_addon_credits_options(ctx);
         me
@@ -130,8 +147,25 @@ impl BuyCreditsBanner {
         ctx: &mut ViewContext<Self>,
     ) {
         match event {
+            UserWorkspacesEvent::TeamsChanged => {
+                // Pricing labels depend on the current team's purchase policy
+                // (premium surcharge), so rebuild them when teams change.
+                self.update_addon_credits_options(ctx);
+                ctx.notify();
+            }
+            UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired { checkout_url } => {
+                // Multiple surfaces subscribe to purchase events; only the one
+                // that initiated the purchase should hand off to the browser.
+                if self.purchase_addon_credits_loading {
+                    self.purchase_addon_credits_loading = false;
+                    self.checkout_pending = true;
+                    ctx.open_url(checkout_url);
+                    ctx.notify();
+                }
+            }
             UserWorkspacesEvent::PurchaseAddonCreditsSuccess => {
                 self.purchase_addon_credits_loading = false;
+                self.checkout_pending = false;
 
                 let banner_toggle_flag_enabled =
                     FeatureFlag::BuildPlanAutoReloadBannerToggle.is_enabled();
@@ -326,6 +360,11 @@ impl BuyCreditsBanner {
             .map(|opts| opts.to_vec())
             .unwrap_or_default();
 
+        let premium_bps = UserWorkspaces::as_ref(ctx)
+            .team_for_view(ctx)
+            .map_or(0, |team| {
+                team.billing_metadata.addon_credits_price_premium_bps()
+            });
         let base_rate = self
             .addon_credits_options
             .first()
@@ -335,11 +374,13 @@ impl BuyCreditsBanner {
             .iter()
             .enumerate()
             .map(|(index, option)| {
-                let primary_text = format!(
-                    "${:.0} / {} credits",
-                    option.price_usd_cents as f32 / 100.,
-                    option.credits
-                );
+                let price_cents = option.price_usd_cents_with_premium(premium_bps);
+                let price_label = if price_cents % 100 == 0 {
+                    format!("${}", price_cents / 100)
+                } else {
+                    format!("${:.2}", price_cents as f64 / 100.)
+                };
+                let primary_text = format!("{price_label} / {} credits", option.credits);
                 let discount_percent = if base_rate > 0.0 {
                     let actual_rate = option.rate();
                     ((base_rate - actual_rate) / base_rate * 100.0).round() as u32
@@ -514,6 +555,76 @@ impl BuyCreditsBanner {
             .finish()
     }
 
+    /// Rendered instead of the out-of-credits banner after a purchase was
+    /// handed off to the browser for checkout.
+    fn render_checkout_pending(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let theme = appearance.theme();
+
+        let alert_icon = Container::new(
+            ConstrainedBox::new(
+                Icon::AlertCircle
+                    .to_warpui_icon(theme.foreground())
+                    .finish(),
+            )
+            .with_height(16.)
+            .with_width(16.)
+            .finish(),
+        )
+        .with_margin_right(8.)
+        .finish();
+
+        let banner_text = Flex::column()
+            .with_children([
+                appearance
+                    .ui_builder()
+                    .paragraph("Finish your purchase in the browser")
+                    .with_style(UiComponentStyles {
+                        font_size: Some(14.),
+                        ..Default::default()
+                    })
+                    .build()
+                    .finish(),
+                appearance
+                    .ui_builder()
+                    .paragraph("Credits will be added to your account shortly after checkout.")
+                    .with_style(UiComponentStyles {
+                        font_color: Some(theme.sub_text_color(theme.surface_1()).into()),
+                        ..Default::default()
+                    })
+                    .build()
+                    .finish(),
+            ])
+            .finish();
+
+        let close_button = appearance
+            .ui_builder()
+            .close_button(16., self.mouse_states.close_button.clone())
+            .build()
+            .on_click(|ctx, _, _| ctx.dispatch_typed_action(Action::Close))
+            .finish();
+
+        let content = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_children([
+                alert_icon,
+                Shrinkable::new(1., Align::new(banner_text).left().finish()).finish(),
+                close_button,
+            ])
+            .finish();
+
+        Container::new(content)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .with_border(Border::all(1.).with_border_fill(theme.outline()))
+            .with_background_color(theme.surface_1().into())
+            .with_horizontal_padding(16.)
+            .with_vertical_padding(12.)
+            .with_horizontal_margin(8.)
+            .with_drop_shadow(DropShadow::new_with_standard_offset_and_spread(
+                ColorU::new(0, 0, 0, 48),
+            ))
+            .finish()
+    }
+
     fn render_out_of_credits(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         // When the auto-reload checkbox is present, we need more horizontal space before we can
         // fit everything on one row.
@@ -557,13 +668,18 @@ impl BuyCreditsBanner {
             .unwrap_or(false);
 
         // Check if the selected purchase would reach/exceed the monthly limit
+        let premium_bps = current_team.map_or(0, |team| {
+            team.billing_metadata.addon_credits_price_premium_bps()
+        });
         let selected_option = self
             .addon_credits_options
             .get(self.selected_denomination_index);
         let would_purchase_exceed_limit = current_workspace
             .zip(selected_option)
             .map(|(workspace, option)| {
-                workspace.would_addon_purchase_reach_limit(option.price_usd_cents)
+                workspace.would_addon_purchase_reach_limit(
+                    option.price_usd_cents_with_premium(premium_bps),
+                )
             })
             .unwrap_or(false);
 
@@ -844,7 +960,11 @@ impl View for BuyCreditsBanner {
                 Container::new(warpui::elements::Empty::new().finish()).finish()
             }
             BuyCreditsBannerDisplayState::OutOfCredits => {
-                self.render_out_of_credits(appearance, app)
+                if self.checkout_pending {
+                    self.render_checkout_pending(appearance)
+                } else {
+                    self.render_out_of_credits(appearance, app)
+                }
             }
             BuyCreditsBannerDisplayState::MonthlyLimitReached => {
                 self.render_auto_reload_blocked(appearance, app)
@@ -885,6 +1005,7 @@ impl warpui::TypedActionView for BuyCreditsBanner {
                     ctx
                 );
 
+                self.checkout_pending = false;
                 self.should_display_banner = false;
                 AIRequestUsageModel::handle(ctx).update(ctx, |model, ctx| {
                     model.dismiss_buy_credits_banner(ctx);

--- a/app/src/terminal/buy_credits_banner.rs
+++ b/app/src/terminal/buy_credits_banner.rs
@@ -34,7 +34,7 @@ use crate::pricing::{PricingInfoModel, PricingInfoModelEvent};
 use crate::send_telemetry_from_ctx;
 use crate::server::ids::ServerId;
 use crate::server::telemetry::{OutOfCreditsBannerAction, TelemetryEvent};
-use crate::settings_view::create_discount_badge;
+use crate::settings_view::{create_discount_badge, format_addon_premium_percent};
 use crate::view_components::{Dropdown, DropdownAction};
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 
@@ -94,6 +94,10 @@ impl BuyCreditsBanner {
                         )
                     {
                         me.checkout_pending = false;
+                        // The browser checkout completed; honor the
+                        // auto-reload opt-in made when initiating the
+                        // purchase, like the synchronous purchase path does.
+                        me.enable_auto_reload_if_requested(ctx);
                     }
                     ctx.notify();
                 }
@@ -209,24 +213,7 @@ impl BuyCreditsBanner {
                 // - Banner toggle flow: optionally enable auto-reload immediately.
                 // - Post-purchase modal flow: show the modal.
                 if banner_toggle_flag_enabled {
-                    if has_admin_permissions && self.auto_reload_enabled {
-                        self.banner_auto_reload_update_in_flight = true;
-
-                        if let Some(team_uid) = UserWorkspaces::as_ref(ctx)
-                            .team_for_view(ctx)
-                            .map(|team| team.uid)
-                        {
-                            UserWorkspaces::handle(ctx).update(ctx, |user_workspaces, ctx| {
-                                user_workspaces.update_addon_credits_settings(
-                                    team_uid,
-                                    Some(true),
-                                    None, // Don't change monthly spend limit
-                                    selected_credits,
-                                    ctx,
-                                );
-                            });
-                        }
-                    }
+                    self.enable_auto_reload_if_requested(ctx);
                 } else if has_admin_permissions && post_purchase_modal_flag_enabled {
                     // Default selection in the modal should match the denomination the user clicked "buy" on.
                     ctx.emit(BuyCreditsBannerEvent::OpenAutoReloadModal {
@@ -268,7 +255,53 @@ impl BuyCreditsBanner {
         }
     }
 
-    fn render_auto_reload_checkbox(&self, appearance: &Appearance) -> Box<dyn Element> {
+    /// If the user opted into auto-reload via the banner checkbox (banner
+    /// toggle experiment), persist the setting after a completed purchase.
+    fn enable_auto_reload_if_requested(&mut self, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::BuildPlanAutoReloadBannerToggle.is_enabled() || !self.auto_reload_enabled {
+            return;
+        }
+
+        let has_admin_permissions = {
+            let auth_state = AuthStateProvider::as_ref(ctx).get();
+            let current_team = UserWorkspaces::as_ref(ctx).team_for_view(ctx);
+            auth_state
+                .user_email()
+                .zip(current_team)
+                .map(|(email, team)| team.has_admin_permissions(&email))
+                .unwrap_or_default()
+        };
+        if !has_admin_permissions {
+            return;
+        }
+
+        let selected_credits = self
+            .addon_credits_options
+            .get(self.selected_denomination_index)
+            .map(|option| option.credits);
+        self.banner_auto_reload_update_in_flight = true;
+
+        if let Some(team_uid) = UserWorkspaces::as_ref(ctx)
+            .team_for_view(ctx)
+            .map(|team| team.uid)
+        {
+            UserWorkspaces::handle(ctx).update(ctx, |user_workspaces, ctx| {
+                user_workspaces.update_addon_credits_settings(
+                    team_uid,
+                    Some(true),
+                    None, // Don't change monthly spend limit
+                    selected_credits,
+                    ctx,
+                );
+            });
+        }
+    }
+
+    fn render_auto_reload_checkbox(
+        &self,
+        premium_bps: i32,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
         let theme = appearance.theme();
         let check_color = theme.background().into_solid();
         let auto_reload_enabled = self.auto_reload_enabled;
@@ -303,10 +336,16 @@ impl BuyCreditsBanner {
             .map(|option| option.credits)
             .unwrap_or(0);
 
-        let tooltip_text = format!(
+        let mut tooltip_text = format!(
             "When enabled, auto reload will purchase {} credits when your credit balance gets low",
             selected_credits
         );
+        if premium_bps > 0 {
+            let percent = format_addon_premium_percent(premium_bps);
+            tooltip_text.push_str(&format!(
+                ". Auto-reload purchases include the {percent} Free plan surcharge"
+            ));
+        }
 
         // Create info icon with a custom sub_text_color & mouse cursor (i.e. as opposed to using IconWithTooltip)
         let ui_builder = appearance.ui_builder();
@@ -840,7 +879,7 @@ impl BuyCreditsBanner {
 
             if auto_reload_banner_toggle_ff {
                 children.push(
-                    Container::new(self.render_auto_reload_checkbox(appearance))
+                    Container::new(self.render_auto_reload_checkbox(premium_bps, appearance))
                         .with_margin_right(8.)
                         .finish(),
                 );

--- a/app/src/terminal/buy_credits_banner.rs
+++ b/app/src/terminal/buy_credits_banner.rs
@@ -34,7 +34,7 @@ use crate::pricing::{PricingInfoModel, PricingInfoModelEvent};
 use crate::send_telemetry_from_ctx;
 use crate::server::ids::ServerId;
 use crate::server::telemetry::{OutOfCreditsBannerAction, TelemetryEvent};
-use crate::settings_view::{create_discount_badge, format_addon_premium_percent};
+use crate::settings_view::create_discount_badge;
 use crate::view_components::{Dropdown, DropdownAction};
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 
@@ -297,11 +297,7 @@ impl BuyCreditsBanner {
         }
     }
 
-    fn render_auto_reload_checkbox(
-        &self,
-        premium_bps: i32,
-        appearance: &Appearance,
-    ) -> Box<dyn Element> {
+    fn render_auto_reload_checkbox(&self, appearance: &Appearance) -> Box<dyn Element> {
         let theme = appearance.theme();
         let check_color = theme.background().into_solid();
         let auto_reload_enabled = self.auto_reload_enabled;
@@ -336,16 +332,10 @@ impl BuyCreditsBanner {
             .map(|option| option.credits)
             .unwrap_or(0);
 
-        let mut tooltip_text = format!(
+        let tooltip_text = format!(
             "When enabled, auto reload will purchase {} credits when your credit balance gets low",
             selected_credits
         );
-        if premium_bps > 0 {
-            let percent = format_addon_premium_percent(premium_bps);
-            tooltip_text.push_str(&format!(
-                ". Auto-reload purchases include the {percent} Free plan surcharge"
-            ));
-        }
 
         // Create info icon with a custom sub_text_color & mouse cursor (i.e. as opposed to using IconWithTooltip)
         let ui_builder = appearance.ui_builder();
@@ -879,7 +869,7 @@ impl BuyCreditsBanner {
 
             if auto_reload_banner_toggle_ff {
                 children.push(
-                    Container::new(self.render_auto_reload_checkbox(premium_bps, appearance))
+                    Container::new(self.render_auto_reload_checkbox(appearance))
                         .with_margin_right(8.)
                         .finish(),
                 );

--- a/app/src/terminal/buy_credits_banner.rs
+++ b/app/src/terminal/buy_credits_banner.rs
@@ -83,9 +83,6 @@ impl BuyCreditsBanner {
             &AIRequestUsageModel::handle(ctx),
             |me, _handle, event, ctx| {
                 if let AIRequestUsageModelEvent::RequestUsageUpdated = event {
-                    // Once purchased credits land (the banner would hide),
-                    // clear any pending checkout so a future out-of-credits
-                    // banner starts fresh.
                     if me.checkout_pending
                         && matches!(
                             AIRequestUsageModel::as_ref(ctx)
@@ -158,8 +155,6 @@ impl BuyCreditsBanner {
                 ctx.notify();
             }
             UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired { checkout_url } => {
-                // Multiple surfaces subscribe to purchase events; only the one
-                // that initiated the purchase should hand off to the browser.
                 if self.purchase_addon_credits_loading {
                     self.purchase_addon_credits_loading = false;
                     self.checkout_pending = true;
@@ -391,7 +386,7 @@ impl BuyCreditsBanner {
 
         let workspaces = UserWorkspaces::as_ref(ctx);
         let premium_bps = workspaces
-            .purchase_policy(workspaces.team_for_view(ctx))
+            .purchase_policy_for_team(workspaces.team_for_view(ctx))
             .map_or(0, |policy| policy.effective_premium_bps());
         let base_rate = self
             .addon_credits_options
@@ -614,7 +609,7 @@ impl BuyCreditsBanner {
                     .finish(),
                 appearance
                     .ui_builder()
-                    .paragraph("Credits will be added to your account shortly after checkout.")
+                    .paragraph("Credits will be added to your account after checkout.")
                     .with_style(UiComponentStyles {
                         font_color: Some(theme.sub_text_color(theme.surface_1()).into()),
                         ..Default::default()
@@ -680,17 +675,13 @@ impl BuyCreditsBanner {
         let auth_state = AuthStateProvider::as_ref(app).get();
         let workspaces = UserWorkspaces::as_ref(app);
         let current_team = workspaces.team_for_view_handle(&self.view_handle, app);
-        // A teamless user manages their own personal purchases; the server
-        // creates their team on first purchase.
         let has_admin_permissions = current_team.is_none_or(|team| {
             auth_state
                 .user_email()
                 .is_some_and(|email| team.has_admin_permissions(&email))
         });
-        // Delinquency stays team/workspace-scoped: teamless users have no
-        // subscription to be delinquent on.
         let delinquent_due_to_payment_issue = workspaces
-            .purchase_billing_metadata(current_team)
+            .team_billing_metadata(current_team)
             .is_some_and(|billing| billing.is_delinquent_due_to_payment_issue());
         let auto_reload_banner_toggle_ff =
             FeatureFlag::BuildPlanAutoReloadBannerToggle.is_enabled();
@@ -703,7 +694,7 @@ impl BuyCreditsBanner {
 
         // Check if the selected purchase would reach/exceed the monthly limit
         let premium_bps = workspaces
-            .purchase_policy(current_team)
+            .purchase_policy_for_team(current_team)
             .map_or(0, |policy| policy.effective_premium_bps());
         let selected_option = self
             .addon_credits_options
@@ -799,8 +790,6 @@ impl BuyCreditsBanner {
         };
 
         let make_buy_button = || {
-            // May be None for teamless users; the server auto-creates their
-            // personal team on purchase.
             let team_uid = current_team.map(|team| team.uid);
 
             let buy_button_disabled = self.purchase_addon_credits_loading

--- a/app/src/terminal/buy_credits_banner.rs
+++ b/app/src/terminal/buy_credits_banner.rs
@@ -391,8 +391,8 @@ impl BuyCreditsBanner {
 
         let workspaces = UserWorkspaces::as_ref(ctx);
         let premium_bps = workspaces
-            .purchase_billing_metadata(workspaces.team_for_view(ctx))
-            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
+            .purchase_policy(workspaces.team_for_view(ctx))
+            .map_or(0, |policy| policy.effective_premium_bps());
         let base_rate = self
             .addon_credits_options
             .first()
@@ -680,7 +680,6 @@ impl BuyCreditsBanner {
         let auth_state = AuthStateProvider::as_ref(app).get();
         let workspaces = UserWorkspaces::as_ref(app);
         let current_team = workspaces.team_for_view_handle(&self.view_handle, app);
-        let purchase_billing_metadata = workspaces.purchase_billing_metadata(current_team);
         // A teamless user manages their own personal purchases; the server
         // creates their team on first purchase.
         let has_admin_permissions = current_team.is_none_or(|team| {
@@ -688,7 +687,10 @@ impl BuyCreditsBanner {
                 .user_email()
                 .is_some_and(|email| team.has_admin_permissions(&email))
         });
-        let delinquent_due_to_payment_issue = purchase_billing_metadata
+        // Delinquency stays team/workspace-scoped: teamless users have no
+        // subscription to be delinquent on.
+        let delinquent_due_to_payment_issue = workspaces
+            .purchase_billing_metadata(current_team)
             .is_some_and(|billing| billing.is_delinquent_due_to_payment_issue());
         let auto_reload_banner_toggle_ff =
             FeatureFlag::BuildPlanAutoReloadBannerToggle.is_enabled();
@@ -700,8 +702,9 @@ impl BuyCreditsBanner {
             .unwrap_or(false);
 
         // Check if the selected purchase would reach/exceed the monthly limit
-        let premium_bps = purchase_billing_metadata
-            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
+        let premium_bps = workspaces
+            .purchase_policy(current_team)
+            .map_or(0, |policy| policy.effective_premium_bps());
         let selected_option = self
             .addon_credits_options
             .get(self.selected_denomination_index);

--- a/app/src/terminal/enable_auto_reload_modal.rs
+++ b/app/src/terminal/enable_auto_reload_modal.rs
@@ -153,7 +153,7 @@ impl EnableAutoReloadModalBody {
 
         let workspaces = UserWorkspaces::as_ref(ctx);
         let premium_bps = workspaces
-            .purchase_policy(workspaces.team_for_view(ctx))
+            .purchase_policy_for_team(workspaces.team_for_view(ctx))
             .map_or(0, |policy| policy.effective_premium_bps());
         let base_rate = self
             .addon_credits_options

--- a/app/src/terminal/enable_auto_reload_modal.rs
+++ b/app/src/terminal/enable_auto_reload_modal.rs
@@ -151,11 +151,10 @@ impl EnableAutoReloadModalBody {
             .map(|opts| opts.to_vec())
             .unwrap_or_default();
 
-        let premium_bps = UserWorkspaces::as_ref(ctx)
-            .team_for_view(ctx)
-            .map_or(0, |team| {
-                team.billing_metadata.addon_credits_price_premium_bps()
-            });
+        let workspaces = UserWorkspaces::as_ref(ctx);
+        let premium_bps = workspaces
+            .purchase_billing_metadata(workspaces.team_for_view(ctx))
+            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
         let base_rate = self
             .addon_credits_options
             .first()

--- a/app/src/terminal/enable_auto_reload_modal.rs
+++ b/app/src/terminal/enable_auto_reload_modal.rs
@@ -12,7 +12,10 @@ use warpui::elements::{
 use warpui::fonts::Weight;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{Coords, UiComponent as _, UiComponentStyles};
-use warpui::{AppContext, Element, Entity, SingletonEntity as _, View, ViewContext, ViewHandle};
+use warpui::{
+    AppContext, Element, Entity, SingletonEntity as _, View, ViewContext, ViewHandle,
+    WeakViewHandle,
+};
 
 use crate::features::FeatureFlag;
 use crate::menu::MenuItemFields;
@@ -20,7 +23,7 @@ use crate::modal::{MODAL_PADDING, MODAL_WIDTH, Modal, ModalEvent};
 use crate::pricing::{PricingInfoModel, PricingInfoModelEvent};
 use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::{AutoReloadModalAction, TelemetryEvent};
-use crate::settings_view::create_discount_badge;
+use crate::settings_view::{create_discount_badge, format_addon_premium_percent};
 use crate::ui_components::blended_colors;
 use crate::view_components::{Dropdown, DropdownAction, ToastFlavor};
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
@@ -35,6 +38,7 @@ struct MouseStates {
 
 /// The body content of the enable auto-reload modal
 pub struct EnableAutoReloadModalBody {
+    view_handle: WeakViewHandle<Self>,
     mouse_states: MouseStates,
     denomination_dropdown: ViewHandle<Dropdown<Action>>,
     addon_credits_options: Vec<AddonCreditsOption>,
@@ -77,6 +81,13 @@ impl EnableAutoReloadModalBody {
             &UserWorkspaces::handle(ctx),
             |me, _handle, event, ctx| {
                 match event {
+                    UserWorkspacesEvent::TeamsChanged => {
+                        // Pricing labels depend on the current team's purchase
+                        // policy (premium surcharge), so rebuild them when
+                        // teams change.
+                        me.update_addon_credits_options(ctx);
+                        ctx.notify();
+                    }
                     UserWorkspacesEvent::UpdateWorkspaceSettingsSuccess => {
                         if me.update_workspace_settings_loading {
                             me.update_workspace_settings_loading = false;
@@ -128,6 +139,7 @@ impl EnableAutoReloadModalBody {
         });
 
         let mut me = Self {
+            view_handle: ctx.handle(),
             mouse_states: Default::default(),
             denomination_dropdown,
             addon_credits_options: Default::default(),
@@ -144,6 +156,11 @@ impl EnableAutoReloadModalBody {
             .map(|opts| opts.to_vec())
             .unwrap_or_default();
 
+        let premium_bps = UserWorkspaces::as_ref(ctx)
+            .team_for_view(ctx)
+            .map_or(0, |team| {
+                team.billing_metadata.addon_credits_price_premium_bps()
+            });
         let base_rate = self
             .addon_credits_options
             .first()
@@ -153,11 +170,13 @@ impl EnableAutoReloadModalBody {
             .iter()
             .enumerate()
             .map(|(index, option)| {
-                let primary_text = format!(
-                    "${:.0} / {} credits",
-                    option.price_usd_cents as f32 / 100.,
-                    option.credits
-                );
+                let price_cents = option.price_usd_cents_with_premium(premium_bps);
+                let price_label = if price_cents % 100 == 0 {
+                    format!("${}", price_cents / 100)
+                } else {
+                    format!("${:.2}", price_cents as f64 / 100.)
+                };
+                let primary_text = format!("{price_label} / {} credits", option.credits);
                 let discount_percent = if base_rate > 0.0 {
                     let actual_rate = option.rate();
                     ((base_rate - actual_rate) / base_rate * 100.0).round() as u32
@@ -213,19 +232,30 @@ impl EnableAutoReloadModalBody {
         });
     }
 
-    fn render_content(&self, appearance: &Appearance) -> Box<dyn Element> {
+    fn render_content(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let theme = appearance.theme();
-        let explanation_fragments = vec![
+        let premium_bps = UserWorkspaces::as_ref(app)
+            .team_for_view_handle(&self.view_handle, app)
+            .map_or(0, |team| {
+                team.billing_metadata.addon_credits_price_premium_bps()
+            });
+        let mut explanation_fragments = vec![
             FormattedTextFragment::plain_text("When enabled, "),
             FormattedTextFragment::bold("auto-reload"),
             FormattedTextFragment::plain_text(
                 " will automatically purchase your selected package when you run out. ",
             ),
-            FormattedTextFragment::hyperlink(
-                "Learn more",
-                "https://docs.warp.dev/support-and-community/plans-and-billing/add-on-credits#id-2.-enable-auto-reload",
-            ),
         ];
+        if premium_bps > 0 {
+            let percent = format_addon_premium_percent(premium_bps);
+            explanation_fragments.push(FormattedTextFragment::plain_text(format!(
+                "Auto-reload purchases include the {percent} Free plan surcharge. "
+            )));
+        }
+        explanation_fragments.push(FormattedTextFragment::hyperlink(
+            "Learn more",
+            "https://docs.warp.dev/support-and-community/plans-and-billing/add-on-credits#id-2.-enable-auto-reload",
+        ));
         let explanation_text = warpui::elements::FormattedTextElement::new(
             FormattedText::new([FormattedTextLine::Line(explanation_fragments)]),
             appearance.ui_font_size(),
@@ -344,7 +374,7 @@ impl View for EnableAutoReloadModalBody {
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
 
-        let content = Container::new(self.render_content(appearance))
+        let content = Container::new(self.render_content(appearance, app))
             .with_horizontal_padding(MODAL_PADDING)
             .with_margin_top(0.) // let the header padding handle the top margin
             .finish();

--- a/app/src/terminal/enable_auto_reload_modal.rs
+++ b/app/src/terminal/enable_auto_reload_modal.rs
@@ -153,8 +153,8 @@ impl EnableAutoReloadModalBody {
 
         let workspaces = UserWorkspaces::as_ref(ctx);
         let premium_bps = workspaces
-            .purchase_billing_metadata(workspaces.team_for_view(ctx))
-            .map_or(0, |billing| billing.addon_credits_price_premium_bps());
+            .purchase_policy(workspaces.team_for_view(ctx))
+            .map_or(0, |policy| policy.effective_premium_bps());
         let base_rate = self
             .addon_credits_options
             .first()

--- a/app/src/terminal/enable_auto_reload_modal.rs
+++ b/app/src/terminal/enable_auto_reload_modal.rs
@@ -12,10 +12,7 @@ use warpui::elements::{
 use warpui::fonts::Weight;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{Coords, UiComponent as _, UiComponentStyles};
-use warpui::{
-    AppContext, Element, Entity, SingletonEntity as _, View, ViewContext, ViewHandle,
-    WeakViewHandle,
-};
+use warpui::{AppContext, Element, Entity, SingletonEntity as _, View, ViewContext, ViewHandle};
 
 use crate::features::FeatureFlag;
 use crate::menu::MenuItemFields;
@@ -23,7 +20,7 @@ use crate::modal::{MODAL_PADDING, MODAL_WIDTH, Modal, ModalEvent};
 use crate::pricing::{PricingInfoModel, PricingInfoModelEvent};
 use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::{AutoReloadModalAction, TelemetryEvent};
-use crate::settings_view::{create_discount_badge, format_addon_premium_percent};
+use crate::settings_view::create_discount_badge;
 use crate::ui_components::blended_colors;
 use crate::view_components::{Dropdown, DropdownAction, ToastFlavor};
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
@@ -38,7 +35,6 @@ struct MouseStates {
 
 /// The body content of the enable auto-reload modal
 pub struct EnableAutoReloadModalBody {
-    view_handle: WeakViewHandle<Self>,
     mouse_states: MouseStates,
     denomination_dropdown: ViewHandle<Dropdown<Action>>,
     addon_credits_options: Vec<AddonCreditsOption>,
@@ -139,7 +135,6 @@ impl EnableAutoReloadModalBody {
         });
 
         let mut me = Self {
-            view_handle: ctx.handle(),
             mouse_states: Default::default(),
             denomination_dropdown,
             addon_credits_options: Default::default(),
@@ -232,30 +227,19 @@ impl EnableAutoReloadModalBody {
         });
     }
 
-    fn render_content(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
+    fn render_content(&self, appearance: &Appearance) -> Box<dyn Element> {
         let theme = appearance.theme();
-        let premium_bps = UserWorkspaces::as_ref(app)
-            .team_for_view_handle(&self.view_handle, app)
-            .map_or(0, |team| {
-                team.billing_metadata.addon_credits_price_premium_bps()
-            });
-        let mut explanation_fragments = vec![
+        let explanation_fragments = vec![
             FormattedTextFragment::plain_text("When enabled, "),
             FormattedTextFragment::bold("auto-reload"),
             FormattedTextFragment::plain_text(
                 " will automatically purchase your selected package when you run out. ",
             ),
+            FormattedTextFragment::hyperlink(
+                "Learn more",
+                "https://docs.warp.dev/support-and-community/plans-and-billing/add-on-credits#id-2.-enable-auto-reload",
+            ),
         ];
-        if premium_bps > 0 {
-            let percent = format_addon_premium_percent(premium_bps);
-            explanation_fragments.push(FormattedTextFragment::plain_text(format!(
-                "Auto-reload purchases include the {percent} Free plan surcharge. "
-            )));
-        }
-        explanation_fragments.push(FormattedTextFragment::hyperlink(
-            "Learn more",
-            "https://docs.warp.dev/support-and-community/plans-and-billing/add-on-credits#id-2.-enable-auto-reload",
-        ));
         let explanation_text = warpui::elements::FormattedTextElement::new(
             FormattedText::new([FormattedTextLine::Line(explanation_fragments)]),
             appearance.ui_font_size(),
@@ -374,7 +358,7 @@ impl View for EnableAutoReloadModalBody {
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
 
-        let content = Container::new(self.render_content(appearance, app))
+        let content = Container::new(self.render_content(appearance))
             .with_horizontal_padding(MODAL_PADDING)
             .with_margin_top(0.) // let the header padding handle the top margin
             .finish();

--- a/app/src/terminal/input/common.rs
+++ b/app/src/terminal/input/common.rs
@@ -485,8 +485,7 @@ pub(super) fn maybe_add_buy_credits_banner(
 ) {
     let can_purchase_addon_credits = UserWorkspaces::as_ref(app)
         .team_for_view_handle(input_view_handle, app)
-        .and_then(|team| team.billing_metadata.tier.purchase_add_on_credits_policy)
-        .is_some_and(|policy| policy.enabled);
+        .is_some_and(|team| team.billing_metadata.is_purchase_add_on_credits_policy_enabled());
 
     // Show buy credits banner if billing policy allows purchasing, input is focused,
     // and either:

--- a/app/src/terminal/input/common.rs
+++ b/app/src/terminal/input/common.rs
@@ -485,8 +485,8 @@ pub(super) fn maybe_add_buy_credits_banner(
 ) {
     let workspaces = UserWorkspaces::as_ref(app);
     let can_purchase_addon_credits = workspaces
-        .purchase_billing_metadata(workspaces.team_for_view_handle(input_view_handle, app))
-        .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
+        .purchase_policy(workspaces.team_for_view_handle(input_view_handle, app))
+        .is_some_and(|policy| policy.allows_purchases());
 
     // Show buy credits banner if billing policy allows purchasing, input is focused,
     // and either:

--- a/app/src/terminal/input/common.rs
+++ b/app/src/terminal/input/common.rs
@@ -483,9 +483,10 @@ pub(super) fn maybe_add_buy_credits_banner(
     is_input_at_top: bool,
     app: &AppContext,
 ) {
-    let can_purchase_addon_credits = UserWorkspaces::as_ref(app)
-        .team_for_view_handle(input_view_handle, app)
-        .is_some_and(|team| team.billing_metadata.is_purchase_add_on_credits_policy_enabled());
+    let workspaces = UserWorkspaces::as_ref(app);
+    let can_purchase_addon_credits = workspaces
+        .purchase_billing_metadata(workspaces.team_for_view_handle(input_view_handle, app))
+        .is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled());
 
     // Show buy credits banner if billing policy allows purchasing, input is focused,
     // and either:

--- a/app/src/terminal/input/common.rs
+++ b/app/src/terminal/input/common.rs
@@ -470,7 +470,8 @@ fn render_command_token_description(
 
 /// Conditionally adds the "buy credits" banner overlay.
 /// The overlay only is shown if all of the following is true:
-/// - The user is on a team that can purchase addon credits
+/// - The purchase policy for the pane's team (or the viewer, when teamless)
+///   allows buying addon credits
 /// - The user is out of credits (or at their auto-reload limit)
 /// - The input is focused
 /// - There is not a BYO API key for the current model
@@ -485,7 +486,7 @@ pub(super) fn maybe_add_buy_credits_banner(
 ) {
     let workspaces = UserWorkspaces::as_ref(app);
     let can_purchase_addon_credits = workspaces
-        .purchase_policy(workspaces.team_for_view_handle(input_view_handle, app))
+        .purchase_policy_for_team(workspaces.team_for_view_handle(input_view_handle, app))
         .is_some_and(|policy| policy.allows_purchases());
 
     // Show buy credits banner if billing policy allows purchasing, input is focused,

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -1165,14 +1165,9 @@ impl From<GqlUser> for WorkspacesMetadataResponse {
 
         // A teamless user's only workspace is the placeholder filtered out
         // above, so the user-level policy is the only place their add-on
-        // credits purchase policy survives (see
+        // credits purchase policy — gating and premium pricing alike —
+        // survives (see
         // [`crate::workspaces::user_workspaces::UserWorkspaces::purchase_policy`]).
-        // Once free-plan purchasing is rolled out to 100%, purchase GATING can
-        // default to "can purchase" when workspace metadata is absent (only
-        // enterprise tiers can't purchase, and they always have a workspace).
-        // The policy also supplies price_premium_bps for teamless price
-        // display, though, so it can only be removed once final prices come
-        // from the server.
         let user_purchase_policy = gql_user
             .billing_metadata
             .and_then(|billing_metadata| billing_metadata.tier.purchase_add_on_credits_policy)

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -476,6 +476,8 @@ impl From<GqlPurchaseAddOnCreditsPolicy> for PurchaseAddOnCreditsPolicy {
     ) -> PurchaseAddOnCreditsPolicy {
         Self {
             enabled: gql_purchase_add_on_credits_policy.enabled,
+            premium_enabled: gql_purchase_add_on_credits_policy.premium_enabled,
+            price_premium_bps: gql_purchase_add_on_credits_policy.price_premium_bps,
         }
     }
 }

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -1167,6 +1167,12 @@ impl From<GqlUser> for WorkspacesMetadataResponse {
         // above, so the user-level policy is the only place their add-on
         // credits purchase policy survives (see
         // [`crate::workspaces::user_workspaces::UserWorkspaces::purchase_policy`]).
+        // Once free-plan purchasing is rolled out to 100%, purchase GATING can
+        // default to "can purchase" when workspace metadata is absent (only
+        // enterprise tiers can't purchase, and they always have a workspace).
+        // The policy also supplies price_premium_bps for teamless price
+        // display, though, so it can only be removed once final prices come
+        // from the server.
         let user_purchase_policy = gql_user
             .billing_metadata
             .and_then(|billing_metadata| billing_metadata.tier.purchase_add_on_credits_policy)

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -1163,12 +1163,22 @@ impl From<GqlUser> for WorkspacesMetadataResponse {
             .experiments
             .and_then(|experiments| convert_to_server_experiment!(experiments));
 
+        // A teamless user's only workspace is the placeholder filtered out
+        // above, so the user-level policy is the only place their add-on
+        // credits purchase policy survives (see
+        // [`crate::workspaces::user_workspaces::UserWorkspaces::purchase_policy`]).
+        let user_purchase_policy = gql_user
+            .billing_metadata
+            .and_then(|billing_metadata| billing_metadata.tier.purchase_add_on_credits_policy)
+            .map(Into::into);
+
         // TODO(skambashi) refactor to return back workspaces, and not teams
         WorkspacesMetadataResponse {
             workspaces,
             joinable_teams,
             experiments,
             feature_model_choices,
+            user_purchase_policy,
         }
     }
 }

--- a/app/src/workspaces/update_manager.rs
+++ b/app/src/workspaces/update_manager.rs
@@ -125,6 +125,7 @@ impl TeamUpdateManager {
                     joinable_teams: vec![],
                     experiments: None,
                     feature_model_choices: None,
+                    user_purchase_policy: None,
                 },
                 pricing_info: None,
             })
@@ -349,8 +350,10 @@ impl TeamUpdateManager {
 
                 let workspaces = response.metadata.workspaces;
                 let joinable_teams = response.metadata.joinable_teams;
+                let user_purchase_policy = response.metadata.user_purchase_policy;
 
                 UserWorkspaces::handle(ctx).update(ctx, |user_workspaces, ctx| {
+                    user_workspaces.set_user_purchase_policy(user_purchase_policy);
                     user_workspaces.update_workspaces(workspaces.clone(), ctx);
                     user_workspaces.update_joinable_teams(joinable_teams, ctx);
                 });
@@ -468,8 +471,10 @@ impl TeamUpdateManager {
                 let workspaces = user_workspaces_access.workspaces;
                 let joinable_teams = user_workspaces_access.joinable_teams;
                 let experiments = user_workspaces_access.experiments;
+                let user_purchase_policy = user_workspaces_access.user_purchase_policy;
 
                 UserWorkspaces::handle(ctx).update(ctx, |user_workspaces, ctx| {
+                    user_workspaces.set_user_purchase_policy(user_purchase_policy);
                     user_workspaces.update_workspaces(workspaces.clone(), ctx);
                     user_workspaces.update_joinable_teams(joinable_teams.clone(), ctx);
                 });

--- a/app/src/workspaces/update_manager_tests.rs
+++ b/app/src/workspaces/update_manager_tests.rs
@@ -20,7 +20,7 @@ use crate::workflows::workflow::Workflow;
 use crate::workflows::{CloudWorkflow, CloudWorkflowModel, WorkflowId};
 use crate::workspaces::team::Team;
 use crate::workspaces::user_profiles::UserProfiles;
-use crate::workspaces::workspace::{Workspace, WorkspaceUid};
+use crate::workspaces::workspace::{PurchaseAddOnCreditsPolicy, Workspace, WorkspaceUid};
 
 fn initialize_app(
     team_client: Arc<dyn TeamClient>,
@@ -96,6 +96,7 @@ fn test_leaving_team_removes_objects() {
                     joinable_teams: vec![],
                     experiments: None,
                     feature_model_choices: None,
+                    user_purchase_policy: None,
                 },
                 pricing_info: None,
             })
@@ -165,6 +166,7 @@ fn test_leaving_team_removes_objects() {
                         joinable_teams: vec![],
                         experiments: None,
                         feature_model_choices: None,
+                        user_purchase_policy: None,
                     },
                     pricing_info: None,
                 }),
@@ -203,6 +205,63 @@ fn test_leaving_team_removes_objects() {
                     personal_workflow_id.to_string(),
                     shared_workflow_id.to_string()
                 ]
+            );
+        });
+    });
+}
+
+#[test]
+fn test_poll_path_apply_refreshes_user_purchase_policy() {
+    App::test((), |mut app| async move {
+        let team_client = Arc::new(MockTeamClient::new());
+        let workspace_client = Arc::new(MockWorkspaceClient::new());
+        initialize_app(team_client.clone(), workspace_client, vec![], &mut app);
+
+        let team_update_manager =
+            app.add_singleton_model(|ctx| TeamUpdateManager::new(team_client, None, ctx));
+
+        // The periodic poll applies metadata through TeamUpdateManager's
+        // own on_workspaces_updated; it must refresh the stored user-level
+        // policy.
+        let response_with_policy = WorkspacesMetadataResponse {
+            workspaces: vec![],
+            joinable_teams: vec![],
+            experiments: None,
+            feature_model_choices: None,
+            user_purchase_policy: Some(PurchaseAddOnCreditsPolicy {
+                enabled: false,
+                premium_enabled: true,
+                price_premium_bps: 1000,
+            }),
+        };
+        team_update_manager.update(&mut app, |manager, ctx| {
+            manager.on_workspaces_updated(Ok(response_with_policy), ctx);
+        });
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx)
+                    .purchase_policy(None)
+                    .is_some_and(|policy| policy.allows_purchases()),
+                "a poll-path apply should store the user-level policy"
+            );
+        });
+
+        // A later poll without the policy must clear the stored fallback so
+        // it can't go stale.
+        let response_without_policy = WorkspacesMetadataResponse {
+            workspaces: vec![],
+            joinable_teams: vec![],
+            experiments: None,
+            feature_model_choices: None,
+            user_purchase_policy: None,
+        };
+        team_update_manager.update(&mut app, |manager, ctx| {
+            manager.on_workspaces_updated(Ok(response_without_policy), ctx);
+        });
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx).purchase_policy(None).is_none(),
+                "a poll-path apply without the policy should clear the stored fallback"
             );
         });
     });

--- a/app/src/workspaces/update_manager_tests.rs
+++ b/app/src/workspaces/update_manager_tests.rs
@@ -240,7 +240,7 @@ fn test_poll_path_apply_refreshes_user_purchase_policy() {
         app.read(|ctx| {
             assert!(
                 UserWorkspaces::as_ref(ctx)
-                    .purchase_policy(None)
+                    .purchase_policy()
                     .is_some_and(|policy| policy.allows_purchases()),
                 "a poll-path apply should store the user-level policy"
             );
@@ -260,7 +260,7 @@ fn test_poll_path_apply_refreshes_user_purchase_policy() {
         });
         app.read(|ctx| {
             assert!(
-                UserWorkspaces::as_ref(ctx).purchase_policy(None).is_none(),
+                UserWorkspaces::as_ref(ctx).purchase_policy().is_none(),
                 "a poll-path apply without the policy should clear the stored fallback"
             );
         });

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -28,7 +28,7 @@ use crate::pricing::PricingInfoModel;
 use crate::server::experiments::{ServerExperiment, ServerExperiments, ServerExperimentsEvent};
 use crate::server::ids::ServerId;
 use crate::server::server_api::team::TeamClient;
-use crate::server::server_api::workspace::WorkspaceClient;
+use crate::server::server_api::workspace::{PurchaseAddonCreditsOutcome, WorkspaceClient};
 #[cfg(test)]
 use crate::server::server_api::{team::MockTeamClient, workspace::MockWorkspaceClient};
 use crate::settings::{
@@ -74,6 +74,12 @@ pub enum UserWorkspacesEvent {
     UpdateWorkspaceSettingsRejected(anyhow::Error),
     AiOveragesUpdated,
     PurchaseAddonCreditsSuccess,
+    /// The purchase requires the user to complete checkout in the browser
+    /// (no saved payment method). Credits arrive via webhook + polling after
+    /// checkout completes.
+    PurchaseAddonCreditsCheckoutRequired {
+        checkout_url: String,
+    },
     PurchaseAddonCreditsRejected(anyhow::Error),
     /// Fired whenever the set of teams the user is on changes.
     TeamsChanged,
@@ -1479,17 +1485,22 @@ impl UserWorkspaces {
 
     fn on_purchase_addon_credits(
         &mut self,
-        result: Result<WorkspacesMetadataResponse>,
+        result: Result<PurchaseAddonCreditsOutcome>,
         ctx: &mut ModelContext<Self>,
     ) {
         match result {
-            Ok(result) => {
+            Ok(PurchaseAddonCreditsOutcome::Completed(result)) => {
                 let wrapped = WorkspacesMetadataWithPricing {
-                    metadata: result,
+                    metadata: *result,
                     pricing_info: None,
                 };
                 self.on_workspaces_updated(Ok(wrapped), ctx);
                 ctx.emit(UserWorkspacesEvent::PurchaseAddonCreditsSuccess);
+            }
+            Ok(PurchaseAddonCreditsOutcome::CheckoutRequired { checkout_url }) => {
+                ctx.emit(UserWorkspacesEvent::PurchaseAddonCreditsCheckoutRequired {
+                    checkout_url,
+                });
             }
             Err(err) => {
                 ctx.emit(UserWorkspacesEvent::PurchaseAddonCreditsRejected(

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -451,6 +451,18 @@ impl UserWorkspaces {
             .map(|workspace| &workspace.billing_metadata)
     }
 
+    /// Billing metadata governing add-on credit purchase surfaces: the given
+    /// team's when one exists, otherwise the current workspace's. Fresh free
+    /// users have no team until their first purchase creates one server-side,
+    /// but their workspace billing metadata still carries the purchase policy.
+    pub fn purchase_billing_metadata<'a>(
+        &'a self,
+        team: Option<&'a Team>,
+    ) -> Option<&'a BillingMetadata> {
+        team.map(|team| &team.billing_metadata)
+            .or_else(|| self.current_workspace_billing_metadata())
+    }
+
     pub fn current_workspace_mut(&mut self) -> Option<&mut Workspace> {
         self.current_workspace_uid
             .and_then(|workspace_uid| self.workspace_from_uid_mut(workspace_uid))
@@ -1466,9 +1478,11 @@ impl UserWorkspaces {
         ctx.notify();
     }
 
+    /// Purchases add-on credits. `team_uid` may be `None` for teamless (fresh
+    /// free) users; the server then auto-creates their personal team.
     pub fn purchase_addon_credits(
         &mut self,
-        team_uid: ServerId,
+        team_uid: Option<ServerId>,
         credits: i32,
         ctx: &mut ModelContext<Self>,
     ) {

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -463,12 +463,15 @@ impl UserWorkspaces {
             .map(|workspace| &workspace.billing_metadata)
     }
 
-    /// Billing metadata for purchase surfaces that need team/workspace-scoped
-    /// state (e.g. delinquency): the given team's when one exists, otherwise
-    /// the current workspace's. For the purchase POLICY itself, use
-    /// [`Self::purchase_policy`], which adds the user-level fallback for
-    /// teamless users.
-    pub fn purchase_billing_metadata<'a>(
+    /// The given team's billing metadata when the team is known, otherwise
+    /// the current workspace's. For purchase surfaces that need
+    /// team/workspace-scoped state (e.g. delinquency); for the purchase
+    /// policy itself use [`Self::purchase_policy_for_team`], which adds the
+    /// user-level fallback for teamless users.
+    ///
+    /// The explicit lifetime unifies `self` and `team`: the returned
+    /// reference may borrow from either, which elision cannot express.
+    pub fn team_billing_metadata<'a>(
         &'a self,
         team: Option<&'a Team>,
     ) -> Option<&'a BillingMetadata> {
@@ -476,44 +479,33 @@ impl UserWorkspaces {
             .or_else(|| self.current_workspace_billing_metadata())
     }
 
-    /// The add-on credits purchase policy governing purchase surfaces: the
-    /// given team's policy when set, else the current workspace's, else the
-    /// user-level policy from the workspaces-metadata response. The user leg
-    /// is what keeps purchases available for teamless (fresh free) users:
-    /// they have no team until their first purchase creates one server-side,
-    /// and their only workspace is the placeholder that is filtered out of
-    /// `workspaces` (REV-717).
-    pub fn purchase_policy(&self, team: Option<&Team>) -> Option<PurchaseAddOnCreditsPolicy> {
-        team.and_then(|team| team.billing_metadata.tier.purchase_add_on_credits_policy)
-            .or_else(|| {
-                self.current_workspace_billing_metadata()
-                    .and_then(|billing| billing.tier.purchase_add_on_credits_policy)
-            })
+    /// The add-on credits purchase policy for the current viewer context: the
+    /// current workspace's policy when one exists, else the user-level policy
+    /// from the workspaces-metadata response (how teamless users get one).
+    ///
+    /// Callers bound to a view/window should use
+    /// [`Self::purchase_policy_for_team`] instead, since their team can
+    /// differ from the current workspace's in multi-team situations.
+    pub fn purchase_policy(&self) -> Option<PurchaseAddOnCreditsPolicy> {
+        self.current_workspace_billing_metadata()
+            .and_then(|billing| billing.tier.purchase_add_on_credits_policy)
             .or(self.user_purchase_policy)
+    }
+
+    /// [`Self::purchase_policy`], preferring the given team's policy when the
+    /// team is known (e.g. resolved from a view or window).
+    pub fn purchase_policy_for_team(
+        &self,
+        team: Option<&Team>,
+    ) -> Option<PurchaseAddOnCreditsPolicy> {
+        team.and_then(|team| team.billing_metadata.tier.purchase_add_on_credits_policy)
+            .or_else(|| self.purchase_policy())
     }
 
     /// Updates the user-level add-on credits purchase policy captured from a
     /// workspaces-metadata response. Must be called on every path that
     /// applies such a response so the teamless fallback can't go stale.
     pub fn set_user_purchase_policy(&mut self, policy: Option<PurchaseAddOnCreditsPolicy>) {
-        // State-change diagnostic for purchase-surface gating: fires only
-        // when the resolved policy changes (not on every metadata poll), so
-        // one log line explains why teamless purchase surfaces appeared or
-        // disappeared. Policy flags and bps only; no user data.
-        if self.user_purchase_policy != policy {
-            match policy {
-                Some(PurchaseAddOnCreditsPolicy {
-                    enabled,
-                    premium_enabled,
-                    price_premium_bps,
-                }) => log::info!(
-                    "[Add-on credits] user-level purchase policy changed: \
-                    enabled={enabled} premium_enabled={premium_enabled} \
-                    price_premium_bps={price_premium_bps}"
-                ),
-                None => log::info!("[Add-on credits] user-level purchase policy changed: none"),
-            }
-        }
         self.user_purchase_policy = policy;
     }
 
@@ -1533,8 +1525,6 @@ impl UserWorkspaces {
         ctx.notify();
     }
 
-    /// Purchases add-on credits. `team_uid` may be `None` for teamless (fresh
-    /// free) users; the server then auto-creates their personal team.
     pub fn purchase_addon_credits(
         &mut self,
         team_uid: Option<ServerId>,

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -496,6 +496,24 @@ impl UserWorkspaces {
     /// workspaces-metadata response. Must be called on every path that
     /// applies such a response so the teamless fallback can't go stale.
     pub fn set_user_purchase_policy(&mut self, policy: Option<PurchaseAddOnCreditsPolicy>) {
+        // State-change diagnostic for purchase-surface gating: fires only
+        // when the resolved policy changes (not on every metadata poll), so
+        // one log line explains why teamless purchase surfaces appeared or
+        // disappeared. Policy flags and bps only; no user data.
+        if self.user_purchase_policy != policy {
+            match policy {
+                Some(PurchaseAddOnCreditsPolicy {
+                    enabled,
+                    premium_enabled,
+                    price_premium_bps,
+                }) => log::info!(
+                    "[Add-on credits] user-level purchase policy changed: \
+                    enabled={enabled} premium_enabled={premium_enabled} \
+                    price_premium_bps={price_premium_bps}"
+                ),
+                None => log::info!("[Add-on credits] user-level purchase policy changed: none"),
+            }
+        }
         self.user_purchase_policy = policy;
     }
 

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -37,7 +37,8 @@ use crate::settings::{
 #[cfg(test)]
 use crate::workspaces::workspace::{AIAutonomyPolicy, WorkspaceMember, WorkspaceSettings};
 use crate::workspaces::workspace::{
-    AiAutonomySettings, AiOverages, SandboxedAgentSettings, UsageBasedPricingSettings,
+    AiAutonomySettings, AiOverages, PurchaseAddOnCreditsPolicy, SandboxedAgentSettings,
+    UsageBasedPricingSettings,
 };
 
 const STRIPE_SUBSCRIPTION_INTERVAL_PAGE_PREFIX: &str = "/upgrade";
@@ -97,6 +98,12 @@ pub struct UserWorkspaces {
     workspaces: Tracked<Vec<Workspace>>,
     window_team_uids: HashMap<WindowId, Option<ServerId>>,
     joinable_teams: Vec<DiscoverableTeam>,
+    /// The user-level add-on credits purchase policy from the latest
+    /// workspaces-metadata response. Teamless (fresh free) users have no
+    /// team and their only workspace is the server's placeholder, which is
+    /// filtered out of `workspaces` — this is the only place their purchase
+    /// policy survives.
+    user_purchase_policy: Option<PurchaseAddOnCreditsPolicy>,
     team_client: Arc<dyn TeamClient>,
     workspace_client: Arc<dyn WorkspaceClient>,
 }
@@ -115,6 +122,9 @@ pub struct WorkspacesMetadataResponse {
     /// It makes most sense to fetch this in workspaces which is queried every 10 minutes.
     /// This is list of available LLM models for the user.
     pub feature_model_choices: Option<FeatureModelChoice>,
+    /// The user-level add-on credits purchase policy; the teamless-purchase
+    /// fallback (see [`UserWorkspaces::purchase_policy`]).
+    pub user_purchase_policy: Option<PurchaseAddOnCreditsPolicy>,
 }
 
 // A representation of all data we fetch at a single time via our 10 minute poll.
@@ -146,6 +156,7 @@ impl UserWorkspaces {
             workspaces: cached_workspaces.into(),
             window_team_uids: Default::default(),
             joinable_teams: Default::default(),
+            user_purchase_policy: None,
             team_client,
             workspace_client,
         }
@@ -195,6 +206,7 @@ impl UserWorkspaces {
             workspaces: cached_workspaces.into(),
             window_team_uids: Default::default(),
             joinable_teams: Default::default(),
+            user_purchase_policy: None,
             team_client,
             workspace_client,
         }
@@ -451,16 +463,40 @@ impl UserWorkspaces {
             .map(|workspace| &workspace.billing_metadata)
     }
 
-    /// Billing metadata governing add-on credit purchase surfaces: the given
-    /// team's when one exists, otherwise the current workspace's. Fresh free
-    /// users have no team until their first purchase creates one server-side,
-    /// but their workspace billing metadata still carries the purchase policy.
+    /// Billing metadata for purchase surfaces that need team/workspace-scoped
+    /// state (e.g. delinquency): the given team's when one exists, otherwise
+    /// the current workspace's. For the purchase POLICY itself, use
+    /// [`Self::purchase_policy`], which adds the user-level fallback for
+    /// teamless users.
     pub fn purchase_billing_metadata<'a>(
         &'a self,
         team: Option<&'a Team>,
     ) -> Option<&'a BillingMetadata> {
         team.map(|team| &team.billing_metadata)
             .or_else(|| self.current_workspace_billing_metadata())
+    }
+
+    /// The add-on credits purchase policy governing purchase surfaces: the
+    /// given team's policy when set, else the current workspace's, else the
+    /// user-level policy from the workspaces-metadata response. The user leg
+    /// is what keeps purchases available for teamless (fresh free) users:
+    /// they have no team until their first purchase creates one server-side,
+    /// and their only workspace is the placeholder that is filtered out of
+    /// `workspaces` (REV-717).
+    pub fn purchase_policy(&self, team: Option<&Team>) -> Option<PurchaseAddOnCreditsPolicy> {
+        team.and_then(|team| team.billing_metadata.tier.purchase_add_on_credits_policy)
+            .or_else(|| {
+                self.current_workspace_billing_metadata()
+                    .and_then(|billing| billing.tier.purchase_add_on_credits_policy)
+            })
+            .or(self.user_purchase_policy)
+    }
+
+    /// Updates the user-level add-on credits purchase policy captured from a
+    /// workspaces-metadata response. Must be called on every path that
+    /// applies such a response so the teamless fallback can't go stale.
+    pub fn set_user_purchase_policy(&mut self, policy: Option<PurchaseAddOnCreditsPolicy>) {
+        self.user_purchase_policy = policy;
     }
 
     pub fn current_workspace_mut(&mut self) -> Option<&mut Workspace> {
@@ -1001,6 +1037,7 @@ impl UserWorkspaces {
                 let workspaces = response.metadata.workspaces;
                 let joinable_teams = response.metadata.joinable_teams;
 
+                self.set_user_purchase_policy(response.metadata.user_purchase_policy);
                 self.update_workspaces(workspaces.clone(), ctx);
                 self.update_joinable_teams(joinable_teams, ctx);
 

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -468,9 +468,6 @@ impl UserWorkspaces {
     /// team/workspace-scoped state (e.g. delinquency); for the purchase
     /// policy itself use [`Self::purchase_policy_for_team`], which adds the
     /// user-level fallback for teamless users.
-    ///
-    /// The explicit lifetime unifies `self` and `team`: the returned
-    /// reference may borrow from either, which elision cannot express.
     pub fn team_billing_metadata<'a>(
         &'a self,
         team: Option<&'a Team>,

--- a/app/src/workspaces/user_workspaces_tests.rs
+++ b/app/src/workspaces/user_workspaces_tests.rs
@@ -2,6 +2,30 @@ use std::time::Duration;
 
 use mockall::Sequence;
 use settings::{PrivatePreferences, PublicPreferences};
+use warp_graphql::billing::{
+    BillingMetadata as GqlBillingMetadata, BonusGrantsInfo as GqlBonusGrantsInfo,
+    CustomerType as GqlCustomerType, DelinquencyStatus as GqlDelinquencyStatus,
+    PurchaseAddOnCreditsPolicy as GqlPurchaseAddOnCreditsPolicy, Tier as GqlTier,
+};
+use warp_graphql::queries::get_workspaces_metadata_for_user::{
+    User as GqlUser, UserProfile as GqlUserProfile, UserPurchasePolicyBillingMetadata,
+    UserPurchasePolicyTier,
+};
+use warp_graphql::workspace::{
+    AddonCreditsSettings as GqlAddonCreditsSettings,
+    AdminEnablementSetting as GqlAdminEnablementSetting,
+    AiAutonomySettings as GqlAiAutonomySettings, AiPermissionsSettings as GqlAiPermissionsSettings,
+    AvailableLlms as GqlAvailableLlms,
+    CloudConversationStorageSettings as GqlCloudConversationStorageSettings,
+    CodebaseContextSettings as GqlCodebaseContextSettings,
+    FeatureModelChoice as GqlFeatureModelChoice, LinkSharingSettings as GqlLinkSharingSettings,
+    LlmSettings as GqlLlmSettings, SecretRedactionSettings as GqlSecretRedactionSettings,
+    TelemetrySettings as GqlTelemetrySettings,
+    UgcCollectionEnablementSetting as GqlUgcCollectionEnablementSetting,
+    UgcCollectionSettings as GqlUgcCollectionSettings,
+    UsageBasedPricingSettings as GqlUsageBasedPricingSettings, Workspace as GqlWorkspace,
+    WorkspaceSettings as GqlWorkspaceSettings,
+};
 use warpui::{AddSingletonModel, App, WindowId};
 use warpui_extras::user_preferences;
 
@@ -23,6 +47,7 @@ use crate::settings::{AISettings, CodeSettings, FocusedTerminalInfo};
 use crate::system::SystemStats;
 use crate::workflows::workflow::Workflow;
 use crate::workflows::{CloudWorkflow, CloudWorkflowModel};
+use crate::workspaces::gql_convert::PLACEHOLDER_WORKSPACE_UID;
 use crate::workspaces::team::Team;
 use crate::workspaces::team_tester::TeamTesterStatus;
 use crate::workspaces::update_manager::TeamUpdateManager;
@@ -167,6 +192,7 @@ fn test_loading_all_spaces_after_switching_from_offline() {
                         joinable_teams: vec![],
                         experiments: None,
                         feature_model_choices: None,
+                        user_purchase_policy: None,
                     },
                     pricing_info: None,
                 })
@@ -184,6 +210,7 @@ fn test_loading_all_spaces_after_switching_from_offline() {
                         joinable_teams: vec![],
                         experiments: None,
                         feature_model_choices: None,
+                        user_purchase_policy: None,
                     },
                     pricing_info: None,
                 })
@@ -321,6 +348,7 @@ fn test_aws_bedrock_credentials_respect_user_setting() {
                 joinable_teams: vec![],
                 experiments: None,
                 feature_model_choices: None,
+                user_purchase_policy: None,
             },
             pricing_info: None,
         })
@@ -377,6 +405,7 @@ fn test_aws_bedrock_credentials_enforced_by_admin() {
                 joinable_teams: vec![],
                 experiments: None,
                 feature_model_choices: None,
+                user_purchase_policy: None,
             },
             pricing_info: None,
         })
@@ -1547,5 +1576,307 @@ fn test_purchase_addon_credits_forwards_team_uid_when_present() {
         // Give the spawned client call time to run so the mock expectation is
         // exercised before the test ends.
         warpui::r#async::Timer::after(Duration::from_millis(100)).await;
+    })
+}
+
+fn gql_tier(purchase_policy: Option<GqlPurchaseAddOnCreditsPolicy>) -> GqlTier {
+    GqlTier {
+        name: "Free".to_string(),
+        description: "Free tier".to_string(),
+        warp_ai_policy: None,
+        team_size_policy: None,
+        shared_notebooks_policy: None,
+        shared_workflows_policy: None,
+        session_sharing_policy: None,
+        ai_autonomy_policy: None,
+        telemetry_data_collection_policy: None,
+        ugc_data_collection_policy: None,
+        usage_based_pricing_policy: None,
+        codebase_context_policy: None,
+        byo_api_key_policy: None,
+        byo_endpoint_policy: None,
+        managed_byok_byoe_policy: None,
+        purchase_add_on_credits_policy: purchase_policy,
+        enterprise_pay_as_you_go_policy: None,
+        enterprise_credits_auto_reload_policy: None,
+        multi_admin_policy: None,
+        ambient_agents_policy: None,
+        usage_visibility_policy: None,
+    }
+}
+
+fn gql_workspace(
+    uid: &str,
+    purchase_policy: Option<GqlPurchaseAddOnCreditsPolicy>,
+) -> GqlWorkspace {
+    let empty_llms = GqlAvailableLlms {
+        default_id: String::new(),
+        choices: vec![],
+        preferred_codex_model_id: None,
+    };
+    GqlWorkspace {
+        uid: uid.into(),
+        name: "workspace".to_string(),
+        stripe_customer_id: None,
+        members: vec![],
+        teams: vec![],
+        billing_metadata: GqlBillingMetadata {
+            customer_type: GqlCustomerType::Free,
+            delinquency_status: GqlDelinquencyStatus::NoDelinquency,
+            tier: gql_tier(purchase_policy),
+            service_agreements: vec![],
+            ai_overages: None,
+        },
+        bonus_grants_info: GqlBonusGrantsInfo {
+            grants: vec![],
+            spending_info: None,
+        },
+        billing_cycle_usage_history: None,
+        settings: GqlWorkspaceSettings {
+            is_discoverable: false,
+            is_invite_link_enabled: false,
+            llm_settings: GqlLlmSettings {
+                enabled: false,
+                host_configs: vec![],
+            },
+            team_byo: None,
+            telemetry_settings: GqlTelemetrySettings {
+                force_enabled: false,
+            },
+            ugc_collection_settings: GqlUgcCollectionSettings {
+                setting: GqlUgcCollectionEnablementSetting::RespectUserSetting,
+            },
+            cloud_conversation_storage_settings: GqlCloudConversationStorageSettings {
+                setting: GqlAdminEnablementSetting::RespectUserSetting,
+            },
+            ai_permissions_settings: GqlAiPermissionsSettings {
+                allow_ai_in_remote_sessions: true,
+                remote_session_regex_list: vec![],
+            },
+            link_sharing_settings: GqlLinkSharingSettings {
+                anyone_with_link_sharing_enabled: true,
+                direct_link_sharing_enabled: true,
+            },
+            secret_redaction_settings: GqlSecretRedactionSettings {
+                enabled: false,
+                regexes: vec![],
+            },
+            ai_autonomy_settings: GqlAiAutonomySettings {
+                apply_code_diffs_setting: None,
+                read_files_setting: None,
+                read_files_allowlist: None,
+                create_plans_setting: None,
+                execute_commands_setting: None,
+                execute_commands_allowlist: None,
+                execute_commands_denylist: None,
+                write_to_pty_setting: None,
+                computer_use_setting: None,
+            },
+            usage_based_pricing_settings: GqlUsageBasedPricingSettings {
+                enabled: false,
+                max_monthly_spend_cents: None,
+            },
+            addon_credits_settings: GqlAddonCreditsSettings {
+                auto_reload_enabled: false,
+                max_monthly_spend_cents: None,
+                selected_auto_reload_credit_denomination: None,
+            },
+            codebase_context_settings: GqlCodebaseContextSettings {
+                enabled: true,
+                setting: GqlAdminEnablementSetting::RespectUserSetting,
+            },
+            sandboxed_agent_settings: None,
+            ambient_agent_settings: None,
+        },
+        has_billing_history: false,
+        invite_code: None,
+        pending_email_invites: vec![],
+        invite_link_domain_restrictions: vec![],
+        is_eligible_for_discovery: false,
+        feature_model_choice: GqlFeatureModelChoice {
+            agent_mode: empty_llms.clone(),
+            planning: empty_llms.clone(),
+            coding: empty_llms.clone(),
+            cli_agent: empty_llms.clone(),
+            computer_use_agent: empty_llms,
+        },
+        total_requests_used_since_last_refresh: 0,
+    }
+}
+
+fn gql_premium_purchase_policy() -> GqlPurchaseAddOnCreditsPolicy {
+    GqlPurchaseAddOnCreditsPolicy {
+        enabled: false,
+        premium_enabled: true,
+        price_premium_bps: 1000,
+    }
+}
+
+fn gql_user(
+    user_purchase_policy: Option<GqlPurchaseAddOnCreditsPolicy>,
+    workspaces: Vec<GqlWorkspace>,
+) -> GqlUser {
+    GqlUser {
+        profile: GqlUserProfile {
+            uid: "test-user".to_string(),
+        },
+        billing_metadata: user_purchase_policy.map(|policy| UserPurchasePolicyBillingMetadata {
+            tier: UserPurchasePolicyTier {
+                purchase_add_on_credits_policy: Some(policy),
+            },
+        }),
+        workspaces,
+        experiments: None,
+        discoverable_teams: vec![],
+    }
+}
+
+#[test]
+fn test_user_level_policy_survives_placeholder_filtering_for_teamless_users() {
+    App::test((), |mut app| async move {
+        initialize_window_team_test_app(&mut app, vec![]);
+
+        // The real conversion path: a teamless user's ONLY workspace is the
+        // placeholder, which must stay filtered out of `workspaces`, while
+        // the user-level purchase policy is captured separately.
+        let response: WorkspacesMetadataResponse = gql_user(
+            Some(gql_premium_purchase_policy()),
+            vec![gql_workspace(PLACEHOLDER_WORKSPACE_UID, None)],
+        )
+        .into();
+        assert!(
+            response.workspaces.is_empty(),
+            "the placeholder workspace must stay filtered out"
+        );
+        assert_eq!(
+            response.user_purchase_policy,
+            Some(PurchaseAddOnCreditsPolicy {
+                enabled: false,
+                premium_enabled: true,
+                price_premium_bps: 1000,
+            })
+        );
+
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.on_workspaces_updated(
+                Ok(WorkspacesMetadataWithPricing {
+                    metadata: response,
+                    pricing_info: None,
+                }),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let user_workspaces = UserWorkspaces::as_ref(ctx);
+            assert!(
+                user_workspaces.current_workspace().is_none(),
+                "teamless users keep having no workspace"
+            );
+            let policy = user_workspaces.purchase_policy(None);
+            assert!(
+                policy.is_some_and(|policy| policy.allows_purchases()),
+                "the user-level policy should enable purchases without a team or workspace"
+            );
+            assert_eq!(
+                policy.map_or(0, |policy| policy.effective_premium_bps()),
+                1000
+            );
+        });
+    })
+}
+
+#[test]
+fn test_workspace_policy_wins_over_user_level_policy() {
+    App::test((), |mut app| async move {
+        initialize_window_team_test_app(&mut app, vec![]);
+
+        let standard_policy = GqlPurchaseAddOnCreditsPolicy {
+            enabled: true,
+            premium_enabled: false,
+            price_premium_bps: 0,
+        };
+        let response: WorkspacesMetadataResponse = gql_user(
+            Some(gql_premium_purchase_policy()),
+            vec![
+                gql_workspace(PLACEHOLDER_WORKSPACE_UID, None),
+                gql_workspace("workspace_uid123456789", Some(standard_policy)),
+            ],
+        )
+        .into();
+        assert_eq!(response.workspaces.len(), 1);
+
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.on_workspaces_updated(
+                Ok(WorkspacesMetadataWithPricing {
+                    metadata: response,
+                    pricing_info: None,
+                }),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let policy = UserWorkspaces::as_ref(ctx).purchase_policy(None);
+            assert_eq!(
+                policy.map(|policy| policy.enabled),
+                Some(true),
+                "a real workspace's policy should win over the user-level fallback"
+            );
+            assert_eq!(
+                policy.map_or(-1, |policy| policy.effective_premium_bps()),
+                0
+            );
+        });
+    })
+}
+
+#[test]
+fn test_team_policy_wins_over_workspace_and_user_policy() {
+    let mut team = team_for_test();
+    team.billing_metadata.tier.purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy {
+        enabled: true,
+        premium_enabled: false,
+        price_premium_bps: 0,
+    });
+    let mut workspace = workspace_for_test(&team);
+    workspace
+        .billing_metadata
+        .tier
+        .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy {
+        enabled: false,
+        premium_enabled: true,
+        price_premium_bps: 1000,
+    });
+
+    App::test((), |mut app| async move {
+        initialize_window_team_test_app(&mut app, vec![workspace]);
+
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, _| {
+            user_workspaces.set_user_purchase_policy(Some(PurchaseAddOnCreditsPolicy {
+                enabled: false,
+                premium_enabled: true,
+                price_premium_bps: 2000,
+            }));
+        });
+
+        app.read(|ctx| {
+            let user_workspaces = UserWorkspaces::as_ref(ctx);
+            let team = user_workspaces.team_from_uid(123.into());
+            assert_eq!(
+                user_workspaces
+                    .purchase_policy(team)
+                    .map(|policy| policy.enabled),
+                Some(true),
+                "the team's policy should win over workspace and user legs"
+            );
+            // Without a team, the workspace's policy still beats the user leg.
+            assert_eq!(
+                user_workspaces
+                    .purchase_policy(None)
+                    .map_or(0, |policy| policy.effective_premium_bps()),
+                1000
+            );
+        });
     })
 }

--- a/app/src/workspaces/user_workspaces_tests.rs
+++ b/app/src/workspaces/user_workspaces_tests.rs
@@ -29,7 +29,7 @@ use crate::workspaces::update_manager::TeamUpdateManager;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::workspaces::workspace::{
     AdminEnablementSetting, CodebaseContextSettings, HostEnablementSetting, LlmHostSettings,
-    Workspace,
+    PurchaseAddOnCreditsPolicy, Workspace,
 };
 
 #[derive(Default)]
@@ -1389,5 +1389,163 @@ fn test_leaving_team_moves_objects() {
                 .space(ctx);
             assert_eq!(space, Space::Shared);
         });
+    })
+}
+
+#[test]
+fn test_purchase_billing_metadata_prefers_team_over_workspace() {
+    let mut team = team_for_test();
+    team.billing_metadata.customer_type = CustomerType::Build;
+    let mut workspace = workspace_for_test(&team);
+    workspace.billing_metadata.customer_type = CustomerType::Free;
+
+    App::test((), |mut app| async move {
+        initialize_window_team_test_app(&mut app, vec![workspace]);
+
+        app.read(|ctx| {
+            let user_workspaces = UserWorkspaces::as_ref(ctx);
+            let team = user_workspaces.team_from_uid(123.into());
+            assert!(team.is_some(), "test team should exist");
+            assert_eq!(
+                user_workspaces
+                    .purchase_billing_metadata(team)
+                    .map(|billing| billing.customer_type),
+                Some(CustomerType::Build),
+                "the team's billing metadata should win when a team exists"
+            );
+            assert_eq!(
+                user_workspaces
+                    .purchase_billing_metadata(None)
+                    .map(|billing| billing.customer_type),
+                Some(CustomerType::Free),
+                "the workspace's billing metadata should be used without a team"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_purchase_billing_metadata_enables_teamless_premium_purchases() {
+    let team = team_for_test();
+    let mut workspace = workspace_for_test(&team);
+    workspace.teams.clear();
+    workspace
+        .billing_metadata
+        .tier
+        .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy {
+        enabled: false,
+        premium_enabled: true,
+        price_premium_bps: 1000,
+    });
+
+    App::test((), |mut app| async move {
+        initialize_window_team_test_app(&mut app, vec![workspace]);
+
+        app.read(|ctx| {
+            let user_workspaces = UserWorkspaces::as_ref(ctx);
+            assert!(!user_workspaces.has_teams(), "user should be teamless");
+            let billing = user_workspaces.purchase_billing_metadata(None);
+            assert!(
+                billing.is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled()),
+                "premiumEnabled on the workspace policy should enable purchases without a team"
+            );
+            assert_eq!(
+                billing.map_or(0, |billing| billing.addon_credits_price_premium_bps()),
+                1000
+            );
+        });
+    })
+}
+
+#[test]
+fn test_purchase_billing_metadata_disabled_policy_stays_disabled_without_team() {
+    let team = team_for_test();
+    let mut workspace = workspace_for_test(&team);
+    workspace.teams.clear();
+    workspace
+        .billing_metadata
+        .tier
+        .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy {
+        enabled: false,
+        premium_enabled: false,
+        price_premium_bps: 0,
+    });
+
+    App::test((), |mut app| async move {
+        initialize_window_team_test_app(&mut app, vec![workspace]);
+
+        app.read(|ctx| {
+            let billing = UserWorkspaces::as_ref(ctx).purchase_billing_metadata(None);
+            assert!(
+                !billing.is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled()),
+                "a fully disabled policy should keep purchases disabled without a team"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_purchase_addon_credits_forwards_teamless_team_uid() {
+    App::test((), |mut app| async move {
+        let mut workspace_client = MockWorkspaceClient::new();
+        workspace_client
+            .expect_purchase_addon_credits()
+            .withf(|team_uid, credits| team_uid.is_none() && *credits == 1_000)
+            .times(1)
+            .returning(|_, _| {
+                Ok(PurchaseAddonCreditsOutcome::CheckoutRequired {
+                    checkout_url: "https://example.com/checkout".to_string(),
+                })
+            });
+
+        app.add_singleton_model(|ctx| {
+            UserWorkspaces::mock(
+                Arc::new(MockTeamClient::new()),
+                Arc::new(workspace_client),
+                vec![],
+                ctx,
+            )
+        });
+
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.purchase_addon_credits(None, 1_000, ctx);
+        });
+
+        // Give the spawned client call time to run so the mock expectation is
+        // exercised before the test ends.
+        warpui::r#async::Timer::after(Duration::from_millis(100)).await;
+    })
+}
+
+#[test]
+fn test_purchase_addon_credits_forwards_team_uid_when_present() {
+    App::test((), |mut app| async move {
+        let mut workspace_client = MockWorkspaceClient::new();
+        workspace_client
+            .expect_purchase_addon_credits()
+            .withf(|team_uid, credits| *team_uid == Some(123.into()) && *credits == 2_000)
+            .times(1)
+            .returning(|_, _| {
+                Ok(PurchaseAddonCreditsOutcome::CheckoutRequired {
+                    checkout_url: "https://example.com/checkout".to_string(),
+                })
+            });
+
+        app.add_singleton_model(|ctx| {
+            UserWorkspaces::mock(
+                Arc::new(MockTeamClient::new()),
+                Arc::new(workspace_client),
+                vec![],
+                ctx,
+            )
+        });
+
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.purchase_addon_credits(Some(123.into()), 2_000, ctx);
+        });
+
+        // Give the spawned client call time to run so the mock expectation is
+        // exercised before the test ends.
+        warpui::r#async::Timer::after(Duration::from_millis(100)).await;
     })
 }

--- a/app/src/workspaces/user_workspaces_tests.rs
+++ b/app/src/workspaces/user_workspaces_tests.rs
@@ -1422,7 +1422,7 @@ fn test_leaving_team_moves_objects() {
 }
 
 #[test]
-fn test_purchase_billing_metadata_prefers_team_over_workspace() {
+fn test_team_billing_metadata_prefers_team_over_workspace() {
     let mut team = team_for_test();
     team.billing_metadata.customer_type = CustomerType::Build;
     let mut workspace = workspace_for_test(&team);
@@ -1437,14 +1437,14 @@ fn test_purchase_billing_metadata_prefers_team_over_workspace() {
             assert!(team.is_some(), "test team should exist");
             assert_eq!(
                 user_workspaces
-                    .purchase_billing_metadata(team)
+                    .team_billing_metadata(team)
                     .map(|billing| billing.customer_type),
                 Some(CustomerType::Build),
                 "the team's billing metadata should win when a team exists"
             );
             assert_eq!(
                 user_workspaces
-                    .purchase_billing_metadata(None)
+                    .team_billing_metadata(None)
                     .map(|billing| billing.customer_type),
                 Some(CustomerType::Free),
                 "the workspace's billing metadata should be used without a team"
@@ -1454,7 +1454,7 @@ fn test_purchase_billing_metadata_prefers_team_over_workspace() {
 }
 
 #[test]
-fn test_purchase_billing_metadata_enables_teamless_premium_purchases() {
+fn test_team_billing_metadata_enables_teamless_premium_purchases() {
     let team = team_for_test();
     let mut workspace = workspace_for_test(&team);
     workspace.teams.clear();
@@ -1473,7 +1473,7 @@ fn test_purchase_billing_metadata_enables_teamless_premium_purchases() {
         app.read(|ctx| {
             let user_workspaces = UserWorkspaces::as_ref(ctx);
             assert!(!user_workspaces.has_teams(), "user should be teamless");
-            let billing = user_workspaces.purchase_billing_metadata(None);
+            let billing = user_workspaces.team_billing_metadata(None);
             assert!(
                 billing.is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled()),
                 "premiumEnabled on the workspace policy should enable purchases without a team"
@@ -1487,7 +1487,7 @@ fn test_purchase_billing_metadata_enables_teamless_premium_purchases() {
 }
 
 #[test]
-fn test_purchase_billing_metadata_disabled_policy_stays_disabled_without_team() {
+fn test_team_billing_metadata_disabled_policy_stays_disabled_without_team() {
     let team = team_for_test();
     let mut workspace = workspace_for_test(&team);
     workspace.teams.clear();
@@ -1504,7 +1504,7 @@ fn test_purchase_billing_metadata_disabled_policy_stays_disabled_without_team() 
         initialize_window_team_test_app(&mut app, vec![workspace]);
 
         app.read(|ctx| {
-            let billing = UserWorkspaces::as_ref(ctx).purchase_billing_metadata(None);
+            let billing = UserWorkspaces::as_ref(ctx).team_billing_metadata(None);
             assert!(
                 !billing.is_some_and(|billing| billing.is_purchase_add_on_credits_policy_enabled()),
                 "a fully disabled policy should keep purchases disabled without a team"
@@ -1773,7 +1773,7 @@ fn test_user_level_policy_survives_placeholder_filtering_for_teamless_users() {
                 user_workspaces.current_workspace().is_none(),
                 "teamless users keep having no workspace"
             );
-            let policy = user_workspaces.purchase_policy(None);
+            let policy = user_workspaces.purchase_policy();
             assert!(
                 policy.is_some_and(|policy| policy.allows_purchases()),
                 "the user-level policy should enable purchases without a team or workspace"
@@ -1817,7 +1817,7 @@ fn test_workspace_policy_wins_over_user_level_policy() {
         });
 
         app.read(|ctx| {
-            let policy = UserWorkspaces::as_ref(ctx).purchase_policy(None);
+            let policy = UserWorkspaces::as_ref(ctx).purchase_policy();
             assert_eq!(
                 policy.map(|policy| policy.enabled),
                 Some(true),
@@ -1865,7 +1865,7 @@ fn test_team_policy_wins_over_workspace_and_user_policy() {
             let team = user_workspaces.team_from_uid(123.into());
             assert_eq!(
                 user_workspaces
-                    .purchase_policy(team)
+                    .purchase_policy_for_team(team)
                     .map(|policy| policy.enabled),
                 Some(true),
                 "the team's policy should win over workspace and user legs"
@@ -1873,7 +1873,7 @@ fn test_team_policy_wins_over_workspace_and_user_policy() {
             // Without a team, the workspace's policy still beats the user leg.
             assert_eq!(
                 user_workspaces
-                    .purchase_policy(None)
+                    .purchase_policy()
                     .map_or(0, |policy| policy.effective_premium_bps()),
                 1000
             );

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -175,7 +175,8 @@ impl Workspace {
         }
     }
 
-    /// Returns the price in cents for the selected auto-reload credit denomination.
+    /// Returns the price in cents for the selected auto-reload credit denomination,
+    /// including any plan surcharge (premium plans reload at the premium price).
     /// Returns None if auto-reload is not configured or if the denomination can't be found in pricing options.
     pub fn get_auto_reload_price_cents(
         &self,
@@ -189,7 +190,11 @@ impl Workspace {
         addon_credits_options
             .iter()
             .find(|option| option.credits == selected_credits)
-            .map(|option| option.price_usd_cents)
+            .map(|option| {
+                option.price_usd_cents_with_premium(
+                    self.billing_metadata.addon_credits_price_premium_bps(),
+                )
+            })
     }
 }
 

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -388,6 +388,14 @@ pub struct ManagedByokByoePolicy {
 #[derive(Clone, Debug, Copy, Serialize, Deserialize)]
 pub struct PurchaseAddOnCreditsPolicy {
     pub enabled: bool,
+    /// When `enabled` is false, allows purchasing add-on credit packs at a
+    /// `price_premium_bps` surcharge over list price (e.g. on the Free plan).
+    #[serde(default)]
+    pub premium_enabled: bool,
+    /// Surcharge in basis points applied to list prices when purchasing via
+    /// the premium path (1000 bps = +10%). 0 for standard purchasing plans.
+    #[serde(default)]
+    pub price_premium_bps: i32,
 }
 
 #[derive(Clone, Debug, Copy, Serialize, Deserialize)]
@@ -775,10 +783,34 @@ impl BillingMetadata {
                 .is_some_and(|policy| policy.enabled)
     }
 
+    /// Whether this plan may purchase add-on credit packs at all, either at
+    /// list price (`enabled`) or at a premium surcharge (`premium_enabled`).
     pub fn is_purchase_add_on_credits_policy_enabled(&self) -> bool {
         self.tier
             .purchase_add_on_credits_policy
-            .is_some_and(|policy| policy.enabled)
+            .is_some_and(|policy| policy.enabled || policy.premium_enabled)
+    }
+
+    /// Whether add-on credit purchases on this plan go through the premium
+    /// (surcharged) path rather than standard list-price purchasing.
+    pub fn is_premium_addon_credits_purchase(&self) -> bool {
+        self.tier
+            .purchase_add_on_credits_policy
+            .is_some_and(|policy| !policy.enabled && policy.premium_enabled)
+    }
+
+    /// The surcharge in basis points applied to add-on credit pack list
+    /// prices for this plan. 0 whenever standard purchasing is enabled.
+    pub fn addon_credits_price_premium_bps(&self) -> i32 {
+        self.tier
+            .purchase_add_on_credits_policy
+            .map_or(0, |policy| {
+                if !policy.enabled && policy.premium_enabled {
+                    policy.price_premium_bps
+                } else {
+                    0
+                }
+            })
     }
 }
 

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -390,7 +390,7 @@ pub struct ManagedByokByoePolicy {
     pub enabled: bool,
 }
 
-#[derive(Clone, Debug, Copy, Serialize, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PurchaseAddOnCreditsPolicy {
     pub enabled: bool,
     /// When `enabled` is false, allows purchasing add-on credit packs at a
@@ -401,6 +401,25 @@ pub struct PurchaseAddOnCreditsPolicy {
     /// the premium path (1000 bps = +10%). 0 for standard purchasing plans.
     #[serde(default)]
     pub price_premium_bps: i32,
+}
+
+impl PurchaseAddOnCreditsPolicy {
+    /// Whether this plan may purchase add-on credit packs at all, either at
+    /// list price (`enabled`) or at a premium surcharge (`premium_enabled`).
+    pub fn allows_purchases(&self) -> bool {
+        self.enabled || self.premium_enabled
+    }
+
+    /// The surcharge in basis points applied to pack list prices. 0 whenever
+    /// standard (list price) purchasing is enabled — standard purchasing
+    /// wins if the server ever sends both flags.
+    pub fn effective_premium_bps(&self) -> i32 {
+        if !self.enabled && self.premium_enabled {
+            self.price_premium_bps
+        } else {
+            0
+        }
+    }
 }
 
 #[derive(Clone, Debug, Copy, Serialize, Deserialize)]
@@ -793,7 +812,7 @@ impl BillingMetadata {
     pub fn is_purchase_add_on_credits_policy_enabled(&self) -> bool {
         self.tier
             .purchase_add_on_credits_policy
-            .is_some_and(|policy| policy.enabled || policy.premium_enabled)
+            .is_some_and(|policy| policy.allows_purchases())
     }
 
     /// Whether add-on credit purchases on this plan go through the premium
@@ -809,13 +828,7 @@ impl BillingMetadata {
     pub fn addon_credits_price_premium_bps(&self) -> i32 {
         self.tier
             .purchase_add_on_credits_policy
-            .map_or(0, |policy| {
-                if !policy.enabled && policy.premium_enabled {
-                    policy.price_premium_bps
-                } else {
-                    0
-                }
-            })
+            .map_or(0, |policy| policy.effective_premium_bps())
     }
 }
 

--- a/app/src/workspaces/workspace_tests.rs
+++ b/app/src/workspaces/workspace_tests.rs
@@ -106,3 +106,78 @@ fn admin_inherits_tier_full_breakdown_unlimited() {
     );
     assert_eq!(resolved.max_prior_cycles, MaxPriorCycles::Unlimited);
 }
+
+fn billing_metadata_with_purchase_policy(
+    purchase_policy: Option<PurchaseAddOnCreditsPolicy>,
+) -> BillingMetadata {
+    let mut billing_metadata = BillingMetadata::default();
+    billing_metadata.tier.purchase_add_on_credits_policy = purchase_policy;
+    billing_metadata
+}
+
+#[test]
+fn purchase_policy_disabled_without_policy() {
+    let billing_metadata = billing_metadata_with_purchase_policy(None);
+
+    assert!(!billing_metadata.is_purchase_add_on_credits_policy_enabled());
+    assert!(!billing_metadata.is_premium_addon_credits_purchase());
+    assert_eq!(billing_metadata.addon_credits_price_premium_bps(), 0);
+}
+
+#[test]
+fn purchase_policy_standard_plan_has_no_premium() {
+    let billing_metadata =
+        billing_metadata_with_purchase_policy(Some(PurchaseAddOnCreditsPolicy {
+            enabled: true,
+            premium_enabled: false,
+            price_premium_bps: 0,
+        }));
+
+    assert!(billing_metadata.is_purchase_add_on_credits_policy_enabled());
+    assert!(!billing_metadata.is_premium_addon_credits_purchase());
+    assert_eq!(billing_metadata.addon_credits_price_premium_bps(), 0);
+}
+
+#[test]
+fn purchase_policy_premium_plan_enables_surcharged_purchasing() {
+    let billing_metadata =
+        billing_metadata_with_purchase_policy(Some(PurchaseAddOnCreditsPolicy {
+            enabled: false,
+            premium_enabled: true,
+            price_premium_bps: 1000,
+        }));
+
+    assert!(billing_metadata.is_purchase_add_on_credits_policy_enabled());
+    assert!(billing_metadata.is_premium_addon_credits_purchase());
+    assert_eq!(billing_metadata.addon_credits_price_premium_bps(), 1000);
+}
+
+#[test]
+fn purchase_policy_fully_disabled_plan_remains_disabled() {
+    let billing_metadata =
+        billing_metadata_with_purchase_policy(Some(PurchaseAddOnCreditsPolicy {
+            enabled: false,
+            premium_enabled: false,
+            price_premium_bps: 1000,
+        }));
+
+    assert!(!billing_metadata.is_purchase_add_on_credits_policy_enabled());
+    assert!(!billing_metadata.is_premium_addon_credits_purchase());
+    assert_eq!(billing_metadata.addon_credits_price_premium_bps(), 0);
+}
+
+#[test]
+fn purchase_policy_standard_purchasing_wins_over_premium() {
+    // Standard (list price) purchasing takes precedence if the server ever
+    // sends both flags; no surcharge should be displayed or applied.
+    let billing_metadata =
+        billing_metadata_with_purchase_policy(Some(PurchaseAddOnCreditsPolicy {
+            enabled: true,
+            premium_enabled: true,
+            price_premium_bps: 1000,
+        }));
+
+    assert!(billing_metadata.is_purchase_add_on_credits_policy_enabled());
+    assert!(!billing_metadata.is_premium_addon_credits_purchase());
+    assert_eq!(billing_metadata.addon_credits_price_premium_bps(), 0);
+}

--- a/crates/graphql/src/api/billing.rs
+++ b/crates/graphql/src/api/billing.rs
@@ -200,6 +200,8 @@ pub struct ManagedByokByoePolicy {
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct PurchaseAddOnCreditsPolicy {
     pub enabled: bool,
+    pub premium_enabled: bool,
+    pub price_premium_bps: i32,
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
@@ -272,7 +274,26 @@ impl AddonCreditsOption {
     pub fn rate(&self) -> f32 {
         self.price_usd_cents as f32 / self.credits as f32
     }
+
+    /// Returns the purchase price in cents after applying a plan surcharge
+    /// expressed in basis points (1000 bps = +10%). `price_usd_cents` always
+    /// carries the list price; plans whose `PurchaseAddOnCreditsPolicy` has a
+    /// non-zero `price_premium_bps` pay a premium on top of it. The surcharge
+    /// is rounded up to the next cent using the same integer math as the
+    /// server so displayed prices always match what is charged.
+    pub fn price_usd_cents_with_premium(&self, premium_bps: i32) -> i32 {
+        if premium_bps <= 0 {
+            return self.price_usd_cents;
+        }
+        let price = self.price_usd_cents as i64;
+        let surcharge = (price * premium_bps as i64 + 9_999) / 10_000;
+        (price + surcharge) as i32
+    }
 }
+
+#[cfg(test)]
+#[path = "billing_tests.rs"]
+mod tests;
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct PricingInfo {

--- a/crates/graphql/src/api/billing_tests.rs
+++ b/crates/graphql/src/api/billing_tests.rs
@@ -1,0 +1,60 @@
+use super::AddonCreditsOption;
+
+fn option(credits: i32, price_usd_cents: i32) -> AddonCreditsOption {
+    AddonCreditsOption {
+        credits,
+        price_usd_cents,
+    }
+}
+
+#[test]
+fn premium_price_is_list_price_at_zero_bps() {
+    assert_eq!(option(1_000, 1_000).price_usd_cents_with_premium(0), 1_000);
+    assert_eq!(
+        option(10_000, 10_000).price_usd_cents_with_premium(0),
+        10_000
+    );
+}
+
+#[test]
+fn premium_price_applies_ten_percent_surcharge_at_1000_bps() {
+    // The standard packs: $10 / $20 / $50 / $100 become $11 / $22 / $55 / $110.
+    assert_eq!(
+        option(1_000, 1_000).price_usd_cents_with_premium(1_000),
+        1_100
+    );
+    assert_eq!(
+        option(2_000, 2_000).price_usd_cents_with_premium(1_000),
+        2_200
+    );
+    assert_eq!(
+        option(5_000, 5_000).price_usd_cents_with_premium(1_000),
+        5_500
+    );
+    assert_eq!(
+        option(10_000, 10_000).price_usd_cents_with_premium(1_000),
+        11_000
+    );
+}
+
+#[test]
+fn premium_surcharge_rounds_up_to_the_next_cent() {
+    // 999 * 1000 bps = 99.9 cents of surcharge, which must round up to 100.
+    assert_eq!(option(100, 999).price_usd_cents_with_premium(1_000), 1_099);
+    // 1 cent at 1 bp is a fractional surcharge (0.0001 cents) and still
+    // rounds up to a full cent.
+    assert_eq!(option(1, 1).price_usd_cents_with_premium(1), 2);
+    // 1250 bps (+12.5%) on $10.01 => 125.125 cents of surcharge => 126.
+    assert_eq!(
+        option(1_000, 1_001).price_usd_cents_with_premium(1_250),
+        1_127
+    );
+}
+
+#[test]
+fn premium_price_ignores_negative_bps() {
+    assert_eq!(
+        option(1_000, 1_000).price_usd_cents_with_premium(-500),
+        1_000
+    );
+}

--- a/crates/graphql/src/api/mutations/purchase_addon_credits.rs
+++ b/crates/graphql/src/api/mutations/purchase_addon_credits.rs
@@ -7,7 +7,7 @@ use crate::schema;
 pub struct PurchaseAddonCreditsInput {
     pub credits: i32,
     /// Optional server-side: omitting it lets the server auto-create a
-    /// personal team for teamless (fresh free) purchasers.
+    /// personal team for free plan purchasers.
     pub team_uid: Option<cynic::Id>,
 }
 
@@ -33,17 +33,24 @@ crate::client::define_operation! {
 #[derive(cynic::InlineFragments, Debug)]
 pub enum PurchaseAddonCreditsResult {
     PurchaseAddonCreditsOutput(PurchaseAddonCreditsOutput),
+    PurchaseAddonCreditsCheckoutOutput(PurchaseAddonCreditsCheckoutOutput),
     UserFacingError(UserFacingError),
     #[cynic(fallback)]
     Unknown,
 }
 
+/// The purchase was charged synchronously and credits were granted.
 #[derive(cynic::QueryFragment, Debug)]
 pub struct PurchaseAddonCreditsOutput {
     pub success: bool,
-    /// When set, the purchase could not be charged synchronously (no saved
-    /// payment method) and the user must complete checkout in the browser at
-    /// this URL. Credits are granted via webhook after checkout completes.
-    pub checkout_url: Option<String>,
+    pub response_context: ResponseContext,
+}
+
+/// The purchase could not be charged synchronously (no saved payment method):
+/// the user must complete checkout in the browser at `checkout_url`. Credits
+/// are granted via webhook after checkout completes.
+#[derive(cynic::QueryFragment, Debug)]
+pub struct PurchaseAddonCreditsCheckoutOutput {
+    pub checkout_url: String,
     pub response_context: ResponseContext,
 }

--- a/crates/graphql/src/api/mutations/purchase_addon_credits.rs
+++ b/crates/graphql/src/api/mutations/purchase_addon_credits.rs
@@ -6,7 +6,9 @@ use crate::schema;
 #[derive(cynic::InputObject, Debug)]
 pub struct PurchaseAddonCreditsInput {
     pub credits: i32,
-    pub team_uid: cynic::Id,
+    /// Optional server-side: omitting it lets the server auto-create a
+    /// personal team for teamless (fresh free) purchasers.
+    pub team_uid: Option<cynic::Id>,
 }
 
 #[derive(cynic::QueryVariables, Debug)]

--- a/crates/graphql/src/api/mutations/purchase_addon_credits.rs
+++ b/crates/graphql/src/api/mutations/purchase_addon_credits.rs
@@ -39,5 +39,9 @@ pub enum PurchaseAddonCreditsResult {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct PurchaseAddonCreditsOutput {
     pub success: bool,
+    /// When set, the purchase could not be charged synchronously (no saved
+    /// payment method) and the user must complete checkout in the browser at
+    /// this URL. Credits are granted via webhook after checkout completes.
+    pub checkout_url: Option<String>,
     pub response_context: ResponseContext,
 }

--- a/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
+++ b/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
@@ -1,4 +1,4 @@
-use crate::billing::PricingInfo;
+use crate::billing::{PricingInfo, PurchaseAddOnCreditsPolicy};
 use crate::experiment::Experiment;
 use crate::request_context::RequestContext;
 use crate::schema;
@@ -12,6 +12,15 @@ query GetWorkspacesMetadataForUser($requestContext: RequestContext!) {
       user {
         profile {
           uid
+        }
+        billingMetadata {
+          tier {
+            purchaseAddOnCreditsPolicy {
+              enabled
+              premiumEnabled
+              pricePremiumBps
+            }
+          }
         }
         workspaces {
           uid
@@ -226,9 +235,26 @@ pub enum PricingInfoResult {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct User {
     pub profile: UserProfile,
+    pub billing_metadata: Option<UserPurchasePolicyBillingMetadata>,
     pub workspaces: Vec<Workspace>,
     pub experiments: Option<Vec<Experiment>>,
     pub discoverable_teams: Vec<DiscoverableTeamData>,
+}
+
+/// Slim selection of the user-level `billingMetadata`: only the add-on
+/// credits purchase policy. This is the teamless-purchase fallback (fresh
+/// free users have no team and their only workspace is the server's
+/// placeholder) — do not widen it into the full `BillingMetadata` selection.
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "BillingMetadata")]
+pub struct UserPurchasePolicyBillingMetadata {
+    pub tier: UserPurchasePolicyTier,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Tier")]
+pub struct UserPurchasePolicyTier {
+    pub purchase_add_on_credits_policy: Option<PurchaseAddOnCreditsPolicy>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -2707,18 +2707,28 @@ type PurchaseAddOnCreditsPolicy {
   pricePremiumBps: Int!
 }
 
+"""
+The purchase could not be charged synchronously because the customer has no
+saved payment method. The user must complete the purchase in the browser at
+`checkoutUrl`; credits are granted via webhook after checkout completes.
+"""
+type PurchaseAddonCreditsCheckoutOutput implements Response {
+  checkoutUrl: String!
+  responseContext: ResponseContext!
+}
+
 input PurchaseAddonCreditsInput {
   credits: Int!
   teamUid: ID
 }
 
+"""The purchase was charged synchronously and credits were granted."""
 type PurchaseAddonCreditsOutput implements Response {
-  checkoutUrl: String
   responseContext: ResponseContext!
   success: Boolean!
 }
 
-union PurchaseAddonCreditsResult = PurchaseAddonCreditsOutput | UserFacingError
+union PurchaseAddonCreditsResult = PurchaseAddonCreditsCheckoutOutput | PurchaseAddonCreditsOutput | UserFacingError
 
 """
 The request contains a UTC timestamp of when the action occurred. The JSON data

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -2703,14 +2703,17 @@ type PullRequestArtifact {
 
 type PurchaseAddOnCreditsPolicy {
   enabled: Boolean!
+  premiumEnabled: Boolean!
+  pricePremiumBps: Int!
 }
 
 input PurchaseAddonCreditsInput {
   credits: Int!
-  teamUid: ID!
+  teamUid: ID
 }
 
 type PurchaseAddonCreditsOutput implements Response {
+  checkoutUrl: String
   responseContext: ResponseContext!
   success: Boolean!
 }


### PR DESCRIPTION
## Description

Desktop UI for free-plan ad-hoc credit purchases at a 10% premium (Pricing Transparency M5, pulled forward). Server side: warpdotdev/warp-server#13446. Plan: https://staging.warp.dev/drive/notebook/uxcmHeaDP7Dd2RwDKFL6kd

**What**: Free-plan (premium-policy) users — including fresh users with **no team yet**, the primary persona — get the full add-on credits purchase experience: billing pages (v1 + v2), out-of-credits banner, prompt alert, at premium-adjusted prices, including auto-reload. Per copy review, premium pricing is presented as one final price with a single savings-framed upsell ("Save 10% on add-on credits by upgrading to a Build plan."); no surcharge language or +X% badges anywhere. Branch is rebased onto master `02b53fcd8` (post-#14393 window-scoped team APIs).

**How**:
- GraphQL crate: `PurchaseAddOnCreditsPolicy` gains `premiumEnabled`/`pricePremiumBps`; the `PurchaseAddonCreditsResult` union gains a dedicated `PurchaseAddonCreditsCheckoutOutput` member (warpdotdev/warp-server#13618); vendored schema updated to match the server SDL.
- Gating is centralized on the policy fields (`enabled || premiumEnabled` to show purchase surfaces; premium treatment iff `!enabled && premiumEnabled`). There is no client-side flag: while the server rollout flag is off it masks the policy, so this UI stays dormant and free plans keep today's upgrade-only nudge.
- Display prices use `price_usd_cents_with_premium` — byte-identical integer ceiling math to the server — everywhere prices surface: pack rows, banner dropdown, auto-reload labels/tooltips, post-purchase modal, and all monthly-spend-limit checks (`Workspace::get_auto_reload_price_cents` is premium-adjusted centrally).
- Purchases without a saved payment method return the checkout union member: the initiating surface opens the browser (single-opener via each surface's loading flag), shows a pending state, and credits land via existing polling. The banner's auto-reload opt-in persists only after purchased credits are observed landing, so an abandoned checkout never silently enables auto-reload.
- Teamless support: `UserWorkspaces::purchase_policy_for_team` resolves the governing policy with a strict three-leg chain — team's → current workspace's → **user-level** `billingMetadata` (a slim, dedicated selection carrying only the purchase policy; the teamless fallback exists because a fresh free user's only workspace is the REV-717 placeholder, which the client rightly filters out — no placeholder mining). The stored user-level policy refreshes on all three metadata apply paths so it can't go stale. `teamUid` is `Option` end-to-end (omitted → the server auto-creates the personal team), teamless users are permitted for their own purchase, and team-settings affordances (spend-limit row, auto-reload switch) stay hidden until the server-created team lands.
- Paid-tier rendering is unchanged (0 bps degenerates every new code path to existing values).

**Why**: Free users' only option today is subscribing; the 10% premium is the subscription incentive, framed in-product as savings for upgrading. See the PRODUCT/TECH specs in the server PR.

## Linked Issue
No GitHub issue; part of the Pricing Transparency effort tracked in the plan/spec linked above.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Automated:
- `crates/graphql` unit tests for the premium price math (exact cents at 1000 bps, round-up edges, negative-bps guard).
- `workspace_tests` for policy gating (premium enables purchasing; standard plans 0 bps; both-set falls back to standard).
- `request_usage_model_tests` for banner display-state gating (with explicit teamless assertions), premium auto-reload counting as AI remaining, and a reload blocked at the premium price but not list price.
- `user_workspaces_tests` + `update_manager_tests`: regression coverage through the REAL conversion/apply paths — a `GqlUser` fixture whose only workspace is the placeholder resolves the user-level premium policy while `workspaces` stays empty; workspace and team legs each win over the user leg; the poll-path apply stores and clears the fallback; plus `Option` teamUid forwarding to a mocked `WorkspaceClient`.
- `cargo check` / `cargo clippy --all-targets --tests -- -D warnings` / `./script/format` clean on touched crates; targeted `cargo nextest` 48/48.

Manual (against a local warp-server on the server feature branch, rollout flag on):
1. Free user → Settings > Billing & Usage (both page variants): packs at $11/$22/$55/$110, the "Save 10% on add-on credits by upgrading to a Build plan." note with a working upgrade link, and the auto-reload switch present with its standard copy (no premium annotations).
1a. Fresh free user with NO team: same panel appears (minus spend-limit row and auto-reload switch); buying with no card opens browser checkout, and after the webhook grant the personal team appears and the team-settings rows materialize.
2. Buy with no saved card → browser opens Stripe Checkout, pending state shown, credits land via polling; second purchase charges synchronously.
3. Out-of-credits banner: premium prices in dropdown, checkout handoff state, auto-reload checkbox opt-in applied after credits land.
4. Regression: Build-plan account renders identically to master; flag off → free plan shows the old upgrade nudge.

- [ ] I have manually tested my changes locally with `./script/run`

(Manual QA pass on staging pending — tracked before marking ready for review.)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/a516b043-08e8-46c3-9ae5-9b903e94458b

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
Co-Authored-By: Oz <oz-agent@warp.dev>

> **Deploy order**: depends on warpdotdev/warp-server#13618 being deployed before this ships, since the client selects the new `PurchaseAddonCreditsCheckoutOutput` union member.
