### PR TITLE
Fix integration getters for hidden terminal panes

### DIFF
--- a/app/src/integration_testing/view_getters.rs
+++ b/app/src/integration_testing/view_getters.rs
@@ -107,9 +107,10 @@ pub fn single_terminal_view_for_tab(
     tab_index: usize,
 ) -> ViewHandle<TerminalView> {
     pane_group_view(app, window_id, tab_index).read(app, |pane_group, ctx| {
-        let num_terminal_views = pane_group.terminal_pane_ids().count();
+        let mut terminal_views = pane_group.visible_terminal_views(ctx);
+        let num_terminal_views = terminal_views.len();
         assert_eq!(num_terminal_views, 1, "window_id={window_id}, tab_index={tab_index} doesn't have a single terminal view. Has {num_terminal_views} terminal views instead");
-        pane_group.terminal_view_at_pane_index(0, ctx).unwrap().to_owned()
+        terminal_views.pop().unwrap()
     })
 }
 
@@ -120,9 +121,20 @@ pub fn single_terminal_pane_view_for_tab(
     tab_index: usize,
 ) -> ViewHandle<PaneView<TerminalView>> {
     pane_group_view(app, window_id, tab_index).read(app, |pane_group, _ctx| {
-        let num_terminal_views = pane_group.terminal_pane_ids().count();
+        let terminal_pane_indices = pane_group
+            .visible_pane_ids()
+            .into_iter()
+            .enumerate()
+            .filter_map(|(pane_index, pane_id)| {
+                pane_id.is_terminal_pane().then_some(pane_index)
+            })
+            .collect::<Vec<_>>();
+        let num_terminal_views = terminal_pane_indices.len();
         assert_eq!(num_terminal_views, 1, "window_id={window_id}, tab_index={tab_index} doesn't have a single terminal pane view. Has {num_terminal_views} pane views instead");
-        pane_group.terminal_pane_view_at_pane_index(0).unwrap().to_owned()
+        pane_group
+            .terminal_pane_view_at_pane_index(terminal_pane_indices[0])
+            .unwrap()
+            .to_owned()
     })
 }
 

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -764,6 +764,7 @@ fn test_insert_hidden_child_agent_pane_keeps_focus_and_active_session() {
 
             assert_eq!(panes.pane_count(), initial_tree_pane_count);
             assert_eq!(panes.pane_ids().count(), initial_content_pane_count + 1);
+            assert_eq!(panes.terminal_pane_ids().count(), 2);
             assert_eq!(panes.visible_pane_count(), initial_visible_count);
             assert!(panes.has_pane_id(child_pane_id.into()));
             assert!(!panes.panes.is_pane_in_tree(child_pane_id.into()));
@@ -771,6 +772,15 @@ fn test_insert_hidden_child_agent_pane_keeps_focus_and_active_session() {
             // The new child pane should remain off-tree and not affect visible ordering.
             assert_eq!(panes.pane_id_by_index(0), Some(parent_pane_id));
             assert_eq!(panes.pane_id_by_index(1), None);
+            let visible_terminal_views = panes.visible_terminal_views(ctx);
+            assert_eq!(visible_terminal_views.len(), 1);
+            assert_eq!(
+                visible_terminal_views[0].id(),
+                panes
+                    .terminal_view_from_pane_id(parent_pane_id, ctx)
+                    .unwrap()
+                    .id()
+            );
 
             // Creating a hidden child pane should not steal focus or active session.
             assert_eq!(panes.focused_pane_id(ctx), parent_pane_id);


### PR DESCRIPTION
## Context
https://github.com/warpdotdev/agent-mode-evals/actions/runs/30380897703
Terminal-bench runs that spawn child agents finish the agent task but panic during final integration assertions because single_terminal_view_for_tab counts every terminal in PaneGroup::pane_contents, including intentionally off-tree child-agent terminals. The helper then retrieves pane index 0 through visible layout ordering, so its cardinality check and selection semantics disagree 

## Fix

Updates the integration-test view getters to operate on visible terminal panes rather than all registered terminal panes. Hidden child-agent terminals remain registered in the pane group, so counting every terminal could make single-terminal helpers fail or select the wrong pane even when the tab only displays one terminal.

The existing hidden-child-pane regression test now verifies that the hidden terminal remains registered while `visible_terminal_views` returns only the parent terminal.

## Linked Issue

N/A — internal integration-test helper fix.

## Verification
Before: https://github.com/warpdotdev/agent-mode-evals/actions/runs/30380897703 (15 of 17 runtime panics)
After: https://github.com/warpdotdev/agent-mode-evals/actions/runs/30422559498 (no panics)

## Testing

- Extended `test_insert_hidden_child_agent_pane_keeps_focus_and_active_session` with regression assertions covering registered versus visible terminal panes.
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
