### PR TITLE
Add indexed navigation for Tab Groups

### DIFF
--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -309,6 +309,10 @@ pub enum WorkspaceAction {
         key_code: KeyCode,
         pressed: bool,
     },
+    ActivateTabOrGroupByNumber(usize),
+    ActivateLastTabOrGroup,
+    ActivateTabInActiveGroupByNumber(usize),
+    ActivateLastTabInActiveGroup,
     OpenPalette {
         mode: PaletteMode,
         source: PaletteSource,
@@ -939,6 +943,10 @@ impl WorkspaceAction {
             ActivateTab(_)
             | ActivateTabByNumber(_)
             | SetTabShortcutModifierKey { .. }
+            | ActivateTabOrGroupByNumber(_)
+            | ActivateLastTabOrGroup
+            | ActivateTabInActiveGroupByNumber(_)
+            | ActivateLastTabInActiveGroup
             | ActivatePrevTab
             | ActivateNextTab
             | ActivateLastTab

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -614,6 +614,168 @@ pub fn init(app: &mut AppContext) {
         .with_group(bindings::BindingGroup::Navigation.as_str())
         .with_key_binding("cmdorctrl-9"),
         EditableBinding::new(
+            "workspace:activate_first_tab_or_group",
+            "Switch to 1st tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(1),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_second_tab_or_group",
+            "Switch to 2nd tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(2),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_third_tab_or_group",
+            "Switch to 3rd tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(3),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_fourth_tab_or_group",
+            "Switch to 4th tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(4),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_fifth_tab_or_group",
+            "Switch to 5th tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(5),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_sixth_tab_or_group",
+            "Switch to 6th tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(6),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_seventh_tab_or_group",
+            "Switch to 7th tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(7),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_eighth_tab_or_group",
+            "Switch to 8th tab or group",
+            WorkspaceAction::ActivateTabOrGroupByNumber(8),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_last_tab_or_group",
+            "Switch to last tab or group",
+            WorkspaceAction::ActivateLastTabOrGroup,
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_first_tab_in_active_group",
+            "Switch to 1st tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(1),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_second_tab_in_active_group",
+            "Switch to 2nd tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(2),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_third_tab_in_active_group",
+            "Switch to 3rd tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(3),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_fourth_tab_in_active_group",
+            "Switch to 4th tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(4),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_fifth_tab_in_active_group",
+            "Switch to 5th tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(5),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_sixth_tab_in_active_group",
+            "Switch to 6th tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(6),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_seventh_tab_in_active_group",
+            "Switch to 7th tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(7),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_eighth_tab_in_active_group",
+            "Switch to 8th tab in active group",
+            WorkspaceAction::ActivateTabInActiveGroupByNumber(8),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
+            "workspace:activate_last_tab_in_active_group",
+            "Switch to last tab in active group",
+            WorkspaceAction::ActivateLastTabInActiveGroup,
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        )
+        .with_group(bindings::BindingGroup::Navigation.as_str()),
+        EditableBinding::new(
             "workspace:activate_prev_tab",
             "Activate previous tab",
             WorkspaceAction::ActivatePrevTab,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5325,6 +5325,94 @@ impl Workspace {
         ctx.notify();
     }
 
+    fn top_level_tab_or_group_indices(&self) -> Vec<usize> {
+        let mut previous_group_id = None;
+        self.tabs
+            .iter()
+            .enumerate()
+            .filter_map(|(index, tab)| {
+                let group_id = tab
+                    .group_id
+                    .filter(|group_id| self.tab_groups.contains_key(group_id));
+                let starts_top_level_item = group_id.is_none() || group_id != previous_group_id;
+                previous_group_id = group_id;
+                starts_top_level_item.then_some(index)
+            })
+            .collect()
+    }
+
+    fn preferred_tab_index_for_top_level_item(&self, index: usize) -> Option<usize> {
+        let tab = self.tabs.get(index)?;
+        let Some(group_id) = tab
+            .group_id
+            .filter(|group_id| self.tab_groups.contains_key(group_id))
+        else {
+            return Some(index);
+        };
+
+        self.tab_mru_order
+            .iter()
+            .find_map(|pane_group_id| {
+                self.tabs.iter().position(|tab| {
+                    tab.group_id == Some(group_id) && tab.pane_group.id() == *pane_group_id
+                })
+            })
+            .or(Some(index))
+    }
+
+    fn activate_tab_or_group_by_number(&mut self, number: usize, ctx: &mut ViewContext<Self>) {
+        let Some(index) = self
+            .top_level_tab_or_group_indices()
+            .get(number.saturating_sub(1))
+            .and_then(|index| self.preferred_tab_index_for_top_level_item(*index))
+        else {
+            return;
+        };
+        self.activate_tab(index, ctx);
+    }
+
+    fn activate_last_tab_or_group(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(index) = self
+            .top_level_tab_or_group_indices()
+            .into_iter()
+            .last()
+            .and_then(|index| self.preferred_tab_index_for_top_level_item(index))
+        else {
+            return;
+        };
+        self.activate_tab(index, ctx);
+    }
+
+    fn active_tab_group_id(&self) -> Option<TabGroupId> {
+        self.tabs
+            .get(self.active_tab_index)?
+            .group_id
+            .filter(|group_id| self.tab_groups.contains_key(group_id))
+    }
+
+    fn activate_tab_in_active_group_by_number(
+        &mut self,
+        number: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(index) = self.active_tab_group_id().and_then(|group_id| {
+            group_member_indices(&self.tabs, group_id).nth(number.saturating_sub(1))
+        }) else {
+            return;
+        };
+        self.activate_tab(index, ctx);
+    }
+
+    fn activate_last_tab_in_active_group(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(index) = self
+            .active_tab_group_id()
+            .and_then(|group_id| group_member_indices(&self.tabs, group_id).last())
+        else {
+            return;
+        };
+        self.activate_tab(index, ctx);
+    }
+
     /// This function is meant to be used by other actions to perform the logic to update the
     /// view's state. It's not meant to be invoked directly by an action.
     pub fn activate_tab_internal(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
@@ -23888,6 +23976,12 @@ impl TypedActionView for Workspace {
                     state.set_key_held(*key_code, *pressed, ctx);
                 });
             }
+            ActivateTabOrGroupByNumber(num) => self.activate_tab_or_group_by_number(*num, ctx),
+            ActivateLastTabOrGroup => self.activate_last_tab_or_group(ctx),
+            ActivateTabInActiveGroupByNumber(num) => {
+                self.activate_tab_in_active_group_by_number(*num, ctx)
+            }
+            ActivateLastTabInActiveGroup => self.activate_last_tab_in_active_group(ctx),
             ActivatePrevTab => self.activate_prev_tab(ctx),
             OpenLaunchConfigSaveModal => self.open_launch_config_save_modal(ctx),
             ActivateNextTab => self.activate_next_tab(ctx),

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -4172,6 +4172,212 @@ fn test_tab_mru_order() {
 }
 
 #[test]
+fn test_activate_tab_or_group_by_number_uses_top_level_visual_order() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Build this top-level layout:
+            // 1. ungrouped tab
+            // 2. group A (three tabs)
+            // 3. ungrouped tab
+            // 4. group B (two tabs)
+            for _ in 0..6 {
+                workspace.add_terminal_tab(false, ctx);
+            }
+
+            let group_a = TabGroup::new();
+            let group_a_id = group_a.id;
+            workspace.tab_groups.insert(group_a_id, group_a);
+            for index in 1..=3 {
+                workspace.tabs[index].group_id = Some(group_a_id);
+            }
+
+            let group_b = TabGroup::new();
+            let group_b_id = group_b.id;
+            workspace.tab_groups.insert(group_b_id, group_b);
+            for index in 5..=6 {
+                workspace.tabs[index].group_id = Some(group_b_id);
+            }
+
+            // Establish a preferred member for each group, then leave focus on
+            // the ungrouped tab between them.
+            workspace.activate_tab(2, ctx);
+            workspace.activate_tab(5, ctx);
+            workspace.activate_tab(4, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabOrGroupByNumber(1), ctx);
+            assert_eq!(workspace.active_tab_index(), 0);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabOrGroupByNumber(2), ctx);
+            assert_eq!(workspace.active_tab_index(), 2);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabOrGroupByNumber(3), ctx);
+            assert_eq!(workspace.active_tab_index(), 4);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabOrGroupByNumber(4), ctx);
+            assert_eq!(workspace.active_tab_index(), 5);
+        });
+    });
+}
+
+#[test]
+fn test_activate_last_tab_or_group_uses_group_mru() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            for _ in 0..3 {
+                workspace.add_terminal_tab(false, ctx);
+            }
+
+            let group = TabGroup::new();
+            let group_id = group.id;
+            workspace.tab_groups.insert(group_id, group);
+            workspace.tabs[2].group_id = Some(group_id);
+            workspace.tabs[3].group_id = Some(group_id);
+
+            workspace.activate_tab(2, ctx);
+            workspace.activate_tab(0, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ActivateLastTabOrGroup, ctx);
+
+            assert_eq!(workspace.active_tab_index(), 2);
+        });
+    });
+}
+
+#[test]
+fn test_activate_tab_or_group_by_number_out_of_range_is_noop() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            workspace.activate_tab(0, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabOrGroupByNumber(8), ctx);
+
+            assert_eq!(workspace.active_tab_index(), 0);
+        });
+    });
+}
+
+#[test]
+fn test_activate_tab_in_active_group_by_number_uses_group_relative_order() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            for _ in 0..4 {
+                workspace.add_terminal_tab(false, ctx);
+            }
+
+            let group = TabGroup::new();
+            let group_id = group.id;
+            workspace.tab_groups.insert(group_id, group);
+            for index in 1..=3 {
+                workspace.tabs[index].group_id = Some(group_id);
+            }
+            workspace.activate_tab(2, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabInActiveGroupByNumber(1), ctx);
+            assert_eq!(workspace.active_tab_index(), 1);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabInActiveGroupByNumber(2), ctx);
+            assert_eq!(workspace.active_tab_index(), 2);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabInActiveGroupByNumber(3), ctx);
+            assert_eq!(workspace.active_tab_index(), 3);
+        });
+    });
+}
+
+#[test]
+fn test_activate_last_tab_in_active_group_uses_last_group_member() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            for _ in 0..3 {
+                workspace.add_terminal_tab(false, ctx);
+            }
+
+            let group = TabGroup::new();
+            let group_id = group.id;
+            workspace.tab_groups.insert(group_id, group);
+            for index in 1..=3 {
+                workspace.tabs[index].group_id = Some(group_id);
+            }
+            workspace.activate_tab(1, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ActivateLastTabInActiveGroup, ctx);
+
+            assert_eq!(workspace.active_tab_index(), 3);
+        });
+    });
+}
+
+#[test]
+fn test_activate_tab_in_active_group_without_group_is_noop() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            workspace.activate_tab(0, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabInActiveGroupByNumber(1), ctx);
+
+            assert_eq!(workspace.active_tab_index(), 0);
+        });
+    });
+}
+
+#[test]
+fn test_activate_tab_in_active_group_by_number_out_of_range_is_noop() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+
+            let group = TabGroup::new();
+            let group_id = group.id;
+            workspace.tab_groups.insert(group_id, group);
+            workspace.tabs[0].group_id = Some(group_id);
+            workspace.tabs[1].group_id = Some(group_id);
+            workspace.activate_tab(0, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ActivateTabInActiveGroupByNumber(8), ctx);
+
+            assert_eq!(workspace.active_tab_index(), 0);
+        });
+    });
+}
+
+#[test]
 fn test_create_new_tab_group_groups_active_tab() {
     let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
 


### PR DESCRIPTION
## Description

Adds keyless, bindable actions for two-level keyboard navigation:

- activate a top-level tab or Tab Group by its visual index
- activate a tab by index within the active Tab Group

Each ungrouped tab counts as one top-level item, while each contiguous Tab Group counts as one item. No default keybindings are introduced.

## Linked Issue

Closes #13398

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- Added coverage for top-level tab/group navigation.
- Added coverage for navigation within the active Tab Group.
- Ran `cargo test -p warp tab_or_group`.
- Ran `cargo test -p warp active_group`.
- Ran `./script/presubmit`; all local checks passed except five GCP SSH integration tests that require internal IAP access (`4033: not authorized`).

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

<img width="818" height="585" alt="image" src="https://github.com/user-attachments/assets/6642e83a-b28e-4786-b34b-90c19440e9b6" />

https://github.com/user-attachments/assets/a981e323-b633-4189-a619-c02b68bbab1d

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added bindable actions for navigating Tab Groups and tabs within the active group by index.