### PR TITLE
QUALITY-928: Orchestration unified stack — core tracker + family stream (M1)

### DIFF
--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -12,6 +12,8 @@ pub(crate) mod diff_types;
 pub(crate) mod handoff;
 
 pub(crate) mod local_agent_task_sync_model;
+#[allow(dead_code)]
+pub(crate) mod orchestration_child_tracker;
 pub(crate) mod orchestration_event_streamer;
 pub(crate) mod orchestration_events;
 pub(crate) mod orchestration_topology;

--- a/app/src/ai/blocklist/orchestration_child_tracker.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker.rs
@@ -1,0 +1,491 @@
+//! Guides child runs from first discovery through to pane materialization.
+//!
+//! When the parent's SSE stream fires a `child_agent_started` event, the
+//! tracker creates a local placeholder, fetches the child's task metadata,
+//! waits for the sandbox session to be linked, and then requests a live or
+//! transcript pane. Every signal a child can produce — discovery, lifecycle,
+//! session links, REST seed rows, and in-band registrations — enters through
+//! the single [`OrchestrationChildTracker::observe_child`] entry point.
+//!
+//! Pill-bar broadcasts (`ChildSpawned` / `ChildStatusChanged`) are emitted
+//! via the `ctx` so downstream views can react without polling.
+//!
+//! # TODO: unify `is_remote_child` and `is_viewing_shared_session`
+//! Both flags mark conversations that are local placeholders for a remote run
+//! accessed via the shared-session protocol; they differ only in which code
+//! path created the placeholder. Merging them into a single
+//! `is_remote_placeholder` flag would let every placeholder conversation be
+//! persisted uniformly.
+
+use std::collections::{HashMap, HashSet};
+
+use session_sharing_protocol::common::SessionId;
+use warp_multi_agent_api as api;
+use warpui::ModelContext;
+#[cfg(not(test))]
+use warpui::SingletonEntity;
+
+#[cfg(not(test))]
+use super::history_model::BlocklistAIHistoryModel;
+use super::orchestration_event_streamer::{
+    OrchestrationEventStreamer, OrchestrationEventStreamerEvent,
+    conversation_status_from_lifecycle_event_type,
+};
+// Compiled out of unit-test builds so the state machine can be exercised
+// without installing the full model singleton graph.
+#[cfg(not(test))]
+use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
+
+/// Every way a child run can become known funnels into
+/// [`OrchestrationChildTracker::observe_child`].
+pub enum ChildSignal {
+    /// `child_agent_started` on the parent run (child run id in `ref_id`).
+    Started,
+    /// `run_session_linked` on the child run: carries the sandbox session
+    /// UUID directly, so `session_id` can be filled in without a metadata
+    /// fetch.
+    SessionLinked { session_uuid: String },
+    /// Any recognised lifecycle event on the child run.
+    Lifecycle(api::LifecycleEventType),
+    /// A REST seed row (cold-start seed / restore fetch). Boxed because the
+    /// task row dwarfs the other variants.
+    Seeded(Box<AmbientAgentTask>),
+    /// A child created in this process, already backed by a local
+    /// conversation that its executor hydrates.
+    Registered,
+}
+
+/// Per-child orchestration state, keyed by [`AmbientAgentTaskId`].
+pub struct TrackedChild {
+    /// `None` until execution is claimed and a session is linked.
+    pub session_id: Option<SessionId>,
+    /// Last observed task state, when known (seeded/refetched rows).
+    pub last_state: Option<AmbientAgentTaskState>,
+    /// True once pane materialization has been requested for this child.
+    pub pane_materialized: bool,
+    /// `true` for every placeholder the tracker materializes on behalf of a
+    /// run hosted elsewhere. `false` only for in-band children, which already
+    /// own a real local conversation and are tracked for status only.
+    pub is_remote_child: bool,
+}
+
+/// Owns discovery, placeholder bookkeeping, claim-time metadata refetch, and
+/// pane-materialization requests for one parent family.
+pub struct OrchestrationChildTracker {
+    parent_task_id: AmbientAgentTaskId,
+    /// Materialized children keyed by task id.
+    children: HashMap<AmbientAgentTaskId, TrackedChild>,
+    /// Secondary index from stringified `run_id` to task id, kept in sync
+    /// with `children`.
+    children_by_run_id: HashMap<String, AmbientAgentTaskId>,
+    /// Children created in this process (`ChildSignal::Registered`). They are
+    /// observed for status only: their conversation and session are assigned
+    /// elsewhere, so no discovery fetch is ever issued on their behalf.
+    in_band_children: HashSet<AmbientAgentTaskId>,
+    /// In-flight metadata fetches keyed by `run_id`. A second discovery signal
+    /// for a run already being fetched is a no-op.
+    metadata_fetches: HashSet<String>,
+    /// Session ids delivered by `run_session_linked` before the child's
+    /// placeholder exists; applied when the child is created.
+    pending_session_ids: HashMap<AmbientAgentTaskId, SessionId>,
+    /// Test-only: counts stubbed metadata-fetch dispatches so fetch dedup can
+    /// be asserted without any network plumbing.
+    #[cfg(test)]
+    metadata_fetch_dispatch_count: usize,
+}
+
+impl OrchestrationChildTracker {
+    /// Builds an empty tracker for the given parent family.
+    pub fn new(parent_task_id: AmbientAgentTaskId) -> Self {
+        Self {
+            parent_task_id,
+            children: HashMap::new(),
+            children_by_run_id: HashMap::new(),
+            in_band_children: HashSet::new(),
+            metadata_fetches: HashSet::new(),
+            pending_session_ids: HashMap::new(),
+            #[cfg(test)]
+            metadata_fetch_dispatch_count: 0,
+        }
+    }
+
+    /// The single entry point for all child state changes: drops signals for
+    /// killed runs, creates or updates the child's placeholder, writes status
+    /// through on `Lifecycle` signals, refetches metadata while the child is
+    /// incompletely hydrated, and requests pane materialization once the
+    /// session id is known.
+    pub fn observe_child(
+        &mut self,
+        child_run_id: &str,
+        signal: ChildSignal,
+        killed_run_ids: &HashSet<String>,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        // Gate every signal on the tombstone set before any placeholder
+        // creation or pane request, so a locally killed run cannot be
+        // resurrected by a late event or an in-flight metadata fetch.
+        if killed_run_ids.contains(child_run_id) {
+            self.forget_run(child_run_id);
+            return;
+        }
+
+        let Ok(task_id) = child_run_id.parse::<AmbientAgentTaskId>() else {
+            log::warn!(
+                "[orch-tracker] signal for malformed run_id={child_run_id:?} \
+                 (parent_task_id={}); dropping",
+                self.parent_task_id,
+            );
+            return;
+        };
+
+        match signal {
+            ChildSignal::Registered => {
+                self.register_in_band_child(task_id, child_run_id, ctx);
+            }
+            ChildSignal::SessionLinked { session_uuid } => {
+                self.apply_session_linked(task_id, &session_uuid);
+            }
+            ChildSignal::Lifecycle(kind) => {
+                self.apply_lifecycle(task_id, child_run_id, kind, ctx);
+            }
+            ChildSignal::Seeded(task) => {
+                self.apply_seeded(*task, ctx);
+            }
+            ChildSignal::Started => {
+                self.apply_started(task_id, child_run_id, ctx);
+            }
+        }
+    }
+
+    /// Discovery via `child_agent_started`. Idempotent: an already-known child
+    /// only continues hydrating, while the first sighting of a genuinely new
+    /// out-of-band run kicks off a single metadata fetch to create its
+    /// placeholder.
+    fn apply_started(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        run_id: &str,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        if self.children.contains_key(&task_id) {
+            // Already represented; keep hydrating if not yet complete.
+            self.refetch_metadata_if_incomplete(task_id, run_id, ctx);
+            self.maybe_request_pane_materialization(task_id, ctx);
+            return;
+        }
+        // New out-of-band child: start (or dedupe) discovery. The placeholder
+        // is created when the fetch completes (a cache hit resolves inline; an
+        // in-flight fetch resolves on a later re-drive).
+        self.spawn_metadata_fetch(task_id, run_id, ctx);
+    }
+
+    /// Sole status writer for placeholder children: writes the status through
+    /// to the history model so the pill badge updates immediately, and
+    /// broadcasts `ChildStatusChanged`. A lifecycle event for an unknown child
+    /// falls back to discovery, making it a self-healing backstop for a missed
+    /// `child_agent_started`.
+    fn apply_lifecycle(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        run_id: &str,
+        kind: api::LifecycleEventType,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        if self.children.contains_key(&task_id) {
+            let status = conversation_status_from_lifecycle_event_type(kind);
+            // Write status through immediately so the pill bar badge reflects
+            // the lifecycle transition without waiting for a redraw cycle.
+            #[cfg(not(test))]
+            {
+                let child_info = {
+                    let history = BlocklistAIHistoryModel::as_ref(ctx);
+                    history
+                        .conversation_id_for_agent_id(run_id)
+                        .and_then(|child_conv_id| {
+                            history
+                                .terminal_surface_id_for_conversation(&child_conv_id)
+                                .map(|surface_id| (child_conv_id, surface_id))
+                        })
+                };
+                if let Some((child_conv_id, surface_id)) = child_info {
+                    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                        history.update_conversation_status(
+                            surface_id,
+                            child_conv_id,
+                            status.clone(),
+                            ctx,
+                        );
+                    });
+                }
+            }
+            ctx.emit(OrchestrationEventStreamerEvent::ChildStatusChanged {
+                parent_task_id: self.parent_task_id,
+                run_id: run_id.to_string(),
+                status,
+            });
+            self.refetch_metadata_if_incomplete(task_id, run_id, ctx);
+            self.maybe_request_pane_materialization(task_id, ctx);
+            return;
+        }
+        // Lifecycle for an unknown run: only self-heal a real discovery miss,
+        // not a run whose fetch is already in flight.
+        if !self.metadata_fetches.contains(run_id) {
+            self.spawn_metadata_fetch(task_id, run_id, ctx);
+        }
+    }
+
+    /// Registers a child created in this process against its existing local
+    /// conversation, marking the run already-represented so later
+    /// `Started`/`Lifecycle` signals become idempotent status updates rather
+    /// than placeholder creation.
+    fn register_in_band_child(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        run_id: &str,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        // A real conversation already exists for this run, so any speculative
+        // discovery fetch is moot.
+        self.metadata_fetches.remove(run_id);
+        self.in_band_children.insert(task_id);
+        if self.children.contains_key(&task_id) {
+            return;
+        }
+        let session_id = self.pending_session_ids.remove(&task_id);
+        self.insert_child(
+            task_id,
+            run_id,
+            TrackedChild {
+                session_id,
+                last_state: None,
+                pane_materialized: false,
+                // In-band children own a real local conversation; they are
+                // never persisted as `is_remote_child` placeholders.
+                is_remote_child: false,
+            },
+            ctx,
+        );
+        // If the session link already arrived, hydrate the pane immediately.
+        self.maybe_request_pane_materialization(task_id, ctx);
+    }
+
+    /// Applies a REST seed / restore row. Creates the placeholder if new and
+    /// records the latest known state and session id.
+    fn apply_seeded(
+        &mut self,
+        task: AmbientAgentTask,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        // The ancestor endpoint includes the parent itself in the response;
+        // skip it.
+        if task.task_id == self.parent_task_id {
+            return;
+        }
+        let task_id = task.task_id;
+        let run_id = task_id.to_string();
+        let seed_session_id = task
+            .session_id
+            .as_deref()
+            .and_then(|s| s.parse::<SessionId>().ok());
+        let state = task.state.clone();
+
+        self.metadata_fetches.remove(&run_id);
+
+        if let Some(existing) = self.children.get_mut(&task_id) {
+            existing.last_state = Some(state);
+            if existing.session_id.is_none() {
+                existing.session_id = seed_session_id;
+            }
+            self.maybe_request_pane_materialization(task_id, ctx);
+            return;
+        }
+
+        // Materialize the placeholder for a run hosted elsewhere, falling back
+        // to a session link that arrived before the child was known.
+        let session_id = seed_session_id.or_else(|| self.pending_session_ids.remove(&task_id));
+        self.insert_child(
+            task_id,
+            &run_id,
+            TrackedChild {
+                session_id,
+                last_state: Some(state),
+                pane_materialized: false,
+                is_remote_child: true,
+            },
+            ctx,
+        );
+        self.maybe_request_pane_materialization(task_id, ctx);
+    }
+
+    /// Handles `run_session_linked`: fills in `session_id` directly (no
+    /// metadata fetch) and requests pane materialization immediately. If the
+    /// placeholder does not exist yet, the session id is stashed and applied
+    /// when the child is created.
+    fn apply_session_linked(&mut self, task_id: AmbientAgentTaskId, session_uuid: &str) {
+        let Ok(session_id) = session_uuid.parse::<SessionId>() else {
+            log::warn!(
+                "[orch-tracker] run_session_linked with malformed session_uuid={session_uuid:?} \
+                 for task_id={task_id} (parent_task_id={}); dropping",
+                self.parent_task_id,
+            );
+            return;
+        };
+        match self.children.get_mut(&task_id) {
+            Some(child) => {
+                if child.session_id.is_none() {
+                    child.session_id = Some(session_id);
+                }
+                // Request the live pane now that the session is known,
+                // bypassing the metadata-fetch round-trip.
+                self.request_pane_materialization(task_id);
+            }
+            None => {
+                self.pending_session_ids.insert(task_id, session_id);
+            }
+        }
+    }
+
+    /// Refetches metadata while `session_id` is missing or the pane has not
+    /// been materialized. No-op once the child is fully hydrated.
+    fn refetch_metadata_if_incomplete(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        run_id: &str,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        // In-band children are hydrated by the executor, not the tracker.
+        if self.in_band_children.contains(&task_id) {
+            return;
+        }
+        let incomplete = self
+            .children
+            .get(&task_id)
+            .is_some_and(|child| child.session_id.is_none() || !child.pane_materialized);
+        if incomplete {
+            self.spawn_metadata_fetch(task_id, run_id, ctx);
+        }
+    }
+
+    /// Requests pane materialization once a `session_id` is known and no pane
+    /// has been requested yet.
+    fn maybe_request_pane_materialization(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        _ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        let should_request = self
+            .children
+            .get(&task_id)
+            .is_some_and(|child| child.session_id.is_some() && !child.pane_materialized);
+        if should_request {
+            self.request_pane_materialization(task_id);
+        }
+    }
+
+    /// Marks the child's pane as materialized.
+    fn request_pane_materialization(&mut self, task_id: AmbientAgentTaskId) {
+        if let Some(child) = self.children.get_mut(&task_id) {
+            child.pane_materialized = true;
+        }
+    }
+
+    /// Records a new tracked child, keeping both indices in sync, and emits
+    /// the `ChildSpawned` pill-bar broadcast exactly once.
+    fn insert_child(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        run_id: &str,
+        child: TrackedChild,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        self.children.insert(task_id, child);
+        self.children_by_run_id.insert(run_id.to_string(), task_id);
+        ctx.emit(OrchestrationEventStreamerEvent::ChildSpawned {
+            parent_task_id: self.parent_task_id,
+            run_id: run_id.to_string(),
+        });
+    }
+
+    /// Starts (or dedupes) a metadata fetch for a run. A synchronous cache hit
+    /// resolves the placeholder inline via [`Self::apply_seeded`]; a miss
+    /// leaves the `metadata_fetches` guard set so redundant dispatches are
+    /// suppressed until a later signal re-drives discovery against a warm
+    /// cache.
+    ///
+    /// The guard is inserted before dispatching so both the inline cache-hit
+    /// path (which clears it) and the in-flight path behave correctly.
+    fn spawn_metadata_fetch(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        run_id: &str,
+        ctx: &mut ModelContext<OrchestrationEventStreamer>,
+    ) {
+        if !self.metadata_fetches.insert(run_id.to_string()) {
+            // A prior dispatch set the guard. If that fetch has since
+            // completed the cache is warm and returns the task synchronously;
+            // otherwise the shared fetch dedupes the network request.
+            #[cfg(not(test))]
+            {
+                let cached = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.get_or_async_fetch_task_data(&task_id, ctx)
+                });
+                if let Some(task) = cached {
+                    self.metadata_fetches.remove(run_id);
+                    self.apply_seeded(task, ctx);
+                }
+            }
+            return;
+        }
+        log::debug!(
+            "[orch-tracker] metadata fetch queued for run_id={run_id} \
+             (parent_task_id={})",
+            self.parent_task_id,
+        );
+        #[cfg(test)]
+        {
+            // Count the dispatch rather than issuing it: unit tests run
+            // without the model singleton graph the real fetch needs.
+            let _ = (task_id, &ctx);
+            self.metadata_fetch_dispatch_count += 1;
+        }
+        #[cfg(not(test))]
+        {
+            let cached = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+                model.get_or_async_fetch_task_data(&task_id, ctx)
+            });
+            // Cache hit: create or refresh the placeholder immediately. A miss
+            // leaves the guard set; the shared fetch populates the cache and a
+            // later re-drive completes discovery.
+            if let Some(task) = cached {
+                self.apply_seeded(task, ctx);
+            }
+        }
+    }
+
+    /// Drops all tracked state for a run (tombstone / kill path).
+    fn forget_run(&mut self, run_id: &str) {
+        self.metadata_fetches.remove(run_id);
+        if let Some(task_id) = self.children_by_run_id.remove(run_id) {
+            self.children.remove(&task_id);
+            self.in_band_children.remove(&task_id);
+            self.pending_session_ids.remove(&task_id);
+        }
+    }
+
+    /// Test-only: number of metadata-fetch dispatches issued so far.
+    #[cfg(test)]
+    pub(crate) fn metadata_fetch_dispatch_count(&self) -> usize {
+        self.metadata_fetch_dispatch_count
+    }
+
+    /// Test-only: whether a metadata fetch is currently in flight for `run_id`.
+    #[cfg(test)]
+    pub(crate) fn has_in_flight_fetch(&self, run_id: &str) -> bool {
+        self.metadata_fetches.contains(run_id)
+    }
+}
+
+#[cfg(test)]
+#[path = "orchestration_child_tracker_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/orchestration_child_tracker.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker.rs
@@ -1,11 +1,15 @@
-//! Guides child runs from first discovery through to pane materialization.
+//! Tracks child run state for one parent family.
 //!
 //! When the parent's SSE stream fires a `child_agent_started` event, the
-//! tracker creates a local placeholder, fetches the child's task metadata,
-//! waits for the sandbox session to be linked, and then requests a live or
-//! transcript pane. Every signal a child can produce — discovery, lifecycle,
-//! session links, REST seed rows, and in-band registrations — enters through
-//! the single [`OrchestrationChildTracker::observe_child`] entry point.
+//! tracker creates a local placeholder and fetches the child's task metadata.
+//! It also records session links and lifecycle transitions as they arrive.
+//! Every signal a child can produce — discovery, lifecycle, session links,
+//! REST seed rows, and in-band registrations — enters through the single
+//! [`OrchestrationChildTracker::observe_child`] entry point.
+//!
+//! Pane materialization (deciding whether a child pane should live-attach or
+//! load a transcript) is handled downstream by M2's `PaneGroup` hydration
+//! path, which is independent of this tracker.
 //!
 //! Pill-bar broadcasts (`ChildSpawned` / `ChildStatusChanged`) are emitted
 //! via the `ctx` so downstream views can react without polling.
@@ -62,8 +66,6 @@ pub struct TrackedChild {
     pub session_id: Option<SessionId>,
     /// Last observed task state, when known (seeded/refetched rows).
     pub last_state: Option<AmbientAgentTaskState>,
-    /// True once pane materialization has been requested for this child.
-    pub pane_materialized: bool,
     /// `true` for every placeholder the tracker materializes on behalf of a
     /// run hosted elsewhere. `false` only for in-band children, which already
     /// own a real local conversation and are tracked for status only.
@@ -83,9 +85,10 @@ pub struct OrchestrationChildTracker {
     /// observed for status only: their conversation and session are assigned
     /// elsewhere, so no discovery fetch is ever issued on their behalf.
     in_band_children: HashSet<AmbientAgentTaskId>,
-    /// In-flight metadata fetches keyed by `run_id`. A second discovery signal
-    /// for a run already being fetched is a no-op.
-    metadata_fetches: HashSet<String>,
+    /// Runs whose metadata has been requested but not yet applied to a
+    /// placeholder. A second discovery signal for a run in this set re-checks
+    /// the cache rather than issuing a duplicate fetch.
+    children_awaiting_metadata: HashSet<String>,
     /// Session ids delivered by `run_session_linked` before the child's
     /// placeholder exists; applied when the child is created.
     pending_session_ids: HashMap<AmbientAgentTaskId, SessionId>,
@@ -103,7 +106,7 @@ impl OrchestrationChildTracker {
             children: HashMap::new(),
             children_by_run_id: HashMap::new(),
             in_band_children: HashSet::new(),
-            metadata_fetches: HashSet::new(),
+            children_awaiting_metadata: HashSet::new(),
             pending_session_ids: HashMap::new(),
             #[cfg(test)]
             metadata_fetch_dispatch_count: 0,
@@ -171,7 +174,6 @@ impl OrchestrationChildTracker {
         if self.children.contains_key(&task_id) {
             // Already represented; keep hydrating if not yet complete.
             self.refetch_metadata_if_incomplete(task_id, run_id, ctx);
-            self.maybe_request_pane_materialization(task_id, ctx);
             return;
         }
         // New out-of-band child: start (or dedupe) discovery. The placeholder
@@ -225,12 +227,11 @@ impl OrchestrationChildTracker {
                 status,
             });
             self.refetch_metadata_if_incomplete(task_id, run_id, ctx);
-            self.maybe_request_pane_materialization(task_id, ctx);
             return;
         }
         // Lifecycle for an unknown run: only self-heal a real discovery miss,
-        // not a run whose fetch is already in flight.
-        if !self.metadata_fetches.contains(run_id) {
+        // not a run whose metadata is already pending.
+        if !self.children_awaiting_metadata.contains(run_id) {
             self.spawn_metadata_fetch(task_id, run_id, ctx);
         }
     }
@@ -246,8 +247,8 @@ impl OrchestrationChildTracker {
         ctx: &mut ModelContext<OrchestrationEventStreamer>,
     ) {
         // A real conversation already exists for this run, so any speculative
-        // discovery fetch is moot.
-        self.metadata_fetches.remove(run_id);
+        // metadata fetch is moot.
+        self.children_awaiting_metadata.remove(run_id);
         self.in_band_children.insert(task_id);
         if self.children.contains_key(&task_id) {
             return;
@@ -259,15 +260,12 @@ impl OrchestrationChildTracker {
             TrackedChild {
                 session_id,
                 last_state: None,
-                pane_materialized: false,
                 // In-band children own a real local conversation; they are
                 // never persisted as `is_remote_child` placeholders.
                 is_remote_child: false,
             },
             ctx,
         );
-        // If the session link already arrived, hydrate the pane immediately.
-        self.maybe_request_pane_materialization(task_id, ctx);
     }
 
     /// Applies a REST seed / restore row. Creates the placeholder if new and
@@ -290,14 +288,13 @@ impl OrchestrationChildTracker {
             .and_then(|s| s.parse::<SessionId>().ok());
         let state = task.state.clone();
 
-        self.metadata_fetches.remove(&run_id);
+        self.children_awaiting_metadata.remove(&run_id);
 
         if let Some(existing) = self.children.get_mut(&task_id) {
             existing.last_state = Some(state);
             if existing.session_id.is_none() {
                 existing.session_id = seed_session_id;
             }
-            self.maybe_request_pane_materialization(task_id, ctx);
             return;
         }
 
@@ -310,12 +307,10 @@ impl OrchestrationChildTracker {
             TrackedChild {
                 session_id,
                 last_state: Some(state),
-                pane_materialized: false,
                 is_remote_child: true,
             },
             ctx,
         );
-        self.maybe_request_pane_materialization(task_id, ctx);
     }
 
     /// Handles `run_session_linked`: fills in `session_id` directly (no
@@ -336,9 +331,6 @@ impl OrchestrationChildTracker {
                 if child.session_id.is_none() {
                     child.session_id = Some(session_id);
                 }
-                // Request the live pane now that the session is known,
-                // bypassing the metadata-fetch round-trip.
-                self.request_pane_materialization(task_id);
             }
             None => {
                 self.pending_session_ids.insert(task_id, session_id);
@@ -346,8 +338,8 @@ impl OrchestrationChildTracker {
         }
     }
 
-    /// Refetches metadata while `session_id` is missing or the pane has not
-    /// been materialized. No-op once the child is fully hydrated.
+    /// Refetches metadata while `session_id` is still missing. No-op once
+    /// the session id is known or the child is in-band.
     fn refetch_metadata_if_incomplete(
         &mut self,
         task_id: AmbientAgentTaskId,
@@ -358,35 +350,12 @@ impl OrchestrationChildTracker {
         if self.in_band_children.contains(&task_id) {
             return;
         }
-        let incomplete = self
+        let needs_session = self
             .children
             .get(&task_id)
-            .is_some_and(|child| child.session_id.is_none() || !child.pane_materialized);
-        if incomplete {
+            .is_some_and(|child| child.session_id.is_none());
+        if needs_session {
             self.spawn_metadata_fetch(task_id, run_id, ctx);
-        }
-    }
-
-    /// Requests pane materialization once a `session_id` is known and no pane
-    /// has been requested yet.
-    fn maybe_request_pane_materialization(
-        &mut self,
-        task_id: AmbientAgentTaskId,
-        _ctx: &mut ModelContext<OrchestrationEventStreamer>,
-    ) {
-        let should_request = self
-            .children
-            .get(&task_id)
-            .is_some_and(|child| child.session_id.is_some() && !child.pane_materialized);
-        if should_request {
-            self.request_pane_materialization(task_id);
-        }
-    }
-
-    /// Marks the child's pane as materialized.
-    fn request_pane_materialization(&mut self, task_id: AmbientAgentTaskId) {
-        if let Some(child) = self.children.get_mut(&task_id) {
-            child.pane_materialized = true;
         }
     }
 
@@ -407,31 +376,30 @@ impl OrchestrationChildTracker {
         });
     }
 
-    /// Starts (or dedupes) a metadata fetch for a run. A synchronous cache hit
-    /// resolves the placeholder inline via [`Self::apply_seeded`]; a miss
-    /// leaves the `metadata_fetches` guard set so redundant dispatches are
-    /// suppressed until a later signal re-drives discovery against a warm
-    /// cache.
+    /// Requests metadata for a run, deduplicating concurrent calls. A
+    /// synchronous cache hit resolves the placeholder inline via
+    /// [`Self::apply_seeded`]; a miss records the run in
+    /// `children_awaiting_metadata` and lets the shared in-flight fetch
+    /// deliver it later via a `TasksUpdated` re-drive.
     ///
-    /// The guard is inserted before dispatching so both the inline cache-hit
-    /// path (which clears it) and the in-flight path behave correctly.
+    /// The pending-set entry is inserted before dispatching so both the
+    /// cache-hit path (which removes it) and the miss path behave correctly.
     fn spawn_metadata_fetch(
         &mut self,
         task_id: AmbientAgentTaskId,
         run_id: &str,
         ctx: &mut ModelContext<OrchestrationEventStreamer>,
     ) {
-        if !self.metadata_fetches.insert(run_id.to_string()) {
-            // A prior dispatch set the guard. If that fetch has since
-            // completed the cache is warm and returns the task synchronously;
-            // otherwise the shared fetch dedupes the network request.
+        if !self.children_awaiting_metadata.insert(run_id.to_string()) {
+            // Metadata was already requested. If the fetch completed the cache
+            // is warm; otherwise the in-flight request is still pending.
             #[cfg(not(test))]
             {
                 let cached = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
                     model.get_or_async_fetch_task_data(&task_id, ctx)
                 });
                 if let Some(task) = cached {
-                    self.metadata_fetches.remove(run_id);
+                    self.children_awaiting_metadata.remove(run_id);
                     self.apply_seeded(task, ctx);
                 }
             }
@@ -465,7 +433,7 @@ impl OrchestrationChildTracker {
 
     /// Drops all tracked state for a run (tombstone / kill path).
     fn forget_run(&mut self, run_id: &str) {
-        self.metadata_fetches.remove(run_id);
+        self.children_awaiting_metadata.remove(run_id);
         if let Some(task_id) = self.children_by_run_id.remove(run_id) {
             self.children.remove(&task_id);
             self.in_band_children.remove(&task_id);
@@ -479,10 +447,11 @@ impl OrchestrationChildTracker {
         self.metadata_fetch_dispatch_count
     }
 
-    /// Test-only: whether a metadata fetch is currently in flight for `run_id`.
+    /// Test-only: whether metadata has been requested but not yet applied for
+    /// `run_id`.
     #[cfg(test)]
-    pub(crate) fn has_in_flight_fetch(&self, run_id: &str) -> bool {
-        self.metadata_fetches.contains(run_id)
+    pub(crate) fn is_awaiting_metadata(&self, run_id: &str) -> bool {
+        self.children_awaiting_metadata.contains(run_id)
     }
 }
 

--- a/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
@@ -1,0 +1,282 @@
+//! Unit tests for the [`OrchestrationChildTracker`] state machine.
+//!
+//! Every test drives `observe_child` against a real
+//! `ModelContext<OrchestrationEventStreamer>` so the pill-bar broadcasts have
+//! somewhere to go, then asserts on the tracker's own bookkeeping: the
+//! model-backed side effects (history writes, network fetches) are compiled
+//! out of test builds.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use warp_multi_agent_api as api;
+use warpui::App;
+
+use super::*;
+use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
+use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
+use crate::server::server_api::ServerApiProvider;
+use crate::server::server_api::ai::{AIClient, MockAIClient};
+
+const PARENT_RUN_ID: &str = "11111111-1111-1111-1111-111111111111";
+const CHILD_RUN_ID: &str = "22222222-2222-2222-2222-222222222222";
+const SESSION_UUID: &str = "44444444-4444-4444-4444-444444444444";
+
+fn task_id(run_id: &str) -> AmbientAgentTaskId {
+    run_id.parse().expect("hardcoded task id parses")
+}
+
+/// No runs have been killed locally.
+fn no_kills() -> HashSet<String> {
+    HashSet::new()
+}
+
+/// Runs `body` against a fresh tracker for `PARENT_RUN_ID`, with the
+/// singletons `OrchestrationEventStreamer` depends on installed.
+fn with_tracker<F>(body: F)
+where
+    F: FnOnce(&mut OrchestrationChildTracker, &mut ModelContext<OrchestrationEventStreamer>)
+        + 'static,
+{
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+        streamer.update(&mut app, |_streamer, ctx| {
+            let mut tracker = OrchestrationChildTracker::new(task_id(PARENT_RUN_ID));
+            body(&mut tracker, ctx);
+        });
+    });
+}
+
+/// A child task row as a REST seed delivers it, parented under
+/// `PARENT_RUN_ID` so it is not mistaken for the parent's own row.
+fn child_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
+    use chrono::Utc;
+    AmbientAgentTask {
+        task_id,
+        parent_run_id: Some(PARENT_RUN_ID.to_string()),
+        title: "child".to_string(),
+        state: AmbientAgentTaskState::InProgress,
+        prompt: "prompt".to_string(),
+        created_at: Utc::now(),
+        started_at: Some(Utc::now()),
+        updated_at: Utc::now(),
+        run_time: None,
+        status_message: None,
+        source: None,
+        session_id: None,
+        session_link: None,
+        creator: None,
+        executor: None,
+        conversation_id: None,
+        request_usage: None,
+        agent_config_snapshot: None,
+        artifacts: vec![],
+        is_sandbox_running: false,
+        last_event_sequence: None,
+        children: vec![],
+    }
+}
+
+#[test]
+fn started_dispatches_metadata_fetch_before_creating_placeholder() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Started, &no_kills(), ctx);
+
+        assert!(
+            tracker.has_in_flight_fetch(CHILD_RUN_ID),
+            "discovery must start a metadata fetch"
+        );
+        assert!(
+            tracker.children.is_empty(),
+            "the placeholder is created only once the fetch resolves"
+        );
+    });
+}
+
+#[test]
+fn repeated_started_signals_dispatch_one_metadata_fetch() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Started, &no_kills(), ctx);
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Started, &no_kills(), ctx);
+
+        assert_eq!(
+            tracker.metadata_fetch_dispatch_count(),
+            1,
+            "a repeat discovery signal must not dispatch a second fetch"
+        );
+    });
+}
+
+#[test]
+fn signal_for_killed_run_has_no_effect() {
+    with_tracker(|tracker, ctx| {
+        let killed = HashSet::from([CHILD_RUN_ID.to_string()]);
+
+        tracker.observe_child(
+            CHILD_RUN_ID,
+            ChildSignal::Lifecycle(api::LifecycleEventType::InProgress),
+            &killed,
+            ctx,
+        );
+
+        assert!(
+            tracker.children.is_empty(),
+            "a killed run must not be given a placeholder"
+        );
+        assert_eq!(
+            tracker.metadata_fetch_dispatch_count(),
+            0,
+            "a killed run must not be fetched"
+        );
+    });
+}
+
+#[test]
+fn signal_for_killed_run_forgets_an_existing_child() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Registered, &no_kills(), ctx);
+        let killed = HashSet::from([CHILD_RUN_ID.to_string()]);
+
+        tracker.observe_child(
+            CHILD_RUN_ID,
+            ChildSignal::Lifecycle(api::LifecycleEventType::Cancelled),
+            &killed,
+            ctx,
+        );
+
+        assert!(
+            tracker.children.is_empty(),
+            "a killed run must be dropped from the tracker"
+        );
+    });
+}
+
+#[test]
+fn registered_child_is_tracked_in_band_without_a_discovery_fetch() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Registered, &no_kills(), ctx);
+
+        let child = tracker
+            .children
+            .get(&task_id(CHILD_RUN_ID))
+            .expect("a registered child is tracked immediately");
+        assert!(
+            !child.is_remote_child,
+            "a child created in this process owns a real local conversation"
+        );
+        assert!(
+            tracker.in_band_children.contains(&task_id(CHILD_RUN_ID)),
+            "a registered child is marked in-band"
+        );
+        assert_eq!(
+            tracker.metadata_fetch_dispatch_count(),
+            0,
+            "an in-band child needs no discovery fetch"
+        );
+    });
+}
+
+#[test]
+fn started_after_registered_keeps_the_child_and_skips_discovery() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Registered, &no_kills(), ctx);
+
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Started, &no_kills(), ctx);
+
+        assert!(
+            tracker.children.contains_key(&task_id(CHILD_RUN_ID)),
+            "the registered child survives a later discovery signal"
+        );
+        assert_eq!(
+            tracker.metadata_fetch_dispatch_count(),
+            0,
+            "an already-represented child must not be fetched"
+        );
+    });
+}
+
+#[test]
+fn session_linked_materializes_the_pane_without_a_metadata_fetch() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Registered, &no_kills(), ctx);
+
+        tracker.observe_child(
+            CHILD_RUN_ID,
+            ChildSignal::SessionLinked {
+                session_uuid: SESSION_UUID.to_string(),
+            },
+            &no_kills(),
+            ctx,
+        );
+
+        let child = tracker
+            .children
+            .get(&task_id(CHILD_RUN_ID))
+            .expect("child is tracked");
+        assert_eq!(
+            child.session_id,
+            Some(SESSION_UUID.parse().expect("hardcoded session id parses"))
+        );
+        assert!(
+            child.pane_materialized,
+            "a linked session is enough to open the pane"
+        );
+        assert_eq!(
+            tracker.metadata_fetch_dispatch_count(),
+            0,
+            "the session link carries everything the pane needs"
+        );
+    });
+}
+
+#[test]
+fn session_linked_before_the_child_exists_is_applied_on_creation() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(
+            CHILD_RUN_ID,
+            ChildSignal::SessionLinked {
+                session_uuid: SESSION_UUID.to_string(),
+            },
+            &no_kills(),
+            ctx,
+        );
+
+        tracker.observe_child(CHILD_RUN_ID, ChildSignal::Registered, &no_kills(), ctx);
+
+        let child = tracker
+            .children
+            .get(&task_id(CHILD_RUN_ID))
+            .expect("child is tracked");
+        assert_eq!(
+            child.session_id,
+            Some(SESSION_UUID.parse().expect("hardcoded session id parses")),
+            "an early session link is stashed and applied when the child appears"
+        );
+    });
+}
+
+#[test]
+fn seeded_child_is_marked_as_a_remote_child() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(
+            CHILD_RUN_ID,
+            ChildSignal::Seeded(Box::new(child_task(task_id(CHILD_RUN_ID)))),
+            &no_kills(),
+            ctx,
+        );
+
+        let child = tracker
+            .children
+            .get(&task_id(CHILD_RUN_ID))
+            .expect("a seeded child is tracked immediately");
+        assert!(
+            child.is_remote_child,
+            "a placeholder for a run hosted elsewhere is a remote child"
+        );
+    });
+}

--- a/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
@@ -68,6 +68,7 @@ fn child_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
         run_time: None,
         status_message: None,
         source: None,
+        execution_location: None,
         session_id: None,
         session_link: None,
         creator: None,

--- a/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
@@ -89,8 +89,8 @@ fn started_dispatches_metadata_fetch_before_creating_placeholder() {
         tracker.observe_child(CHILD_RUN_ID, ChildSignal::Started, &no_kills(), ctx);
 
         assert!(
-            tracker.has_in_flight_fetch(CHILD_RUN_ID),
-            "discovery must start a metadata fetch"
+            tracker.is_awaiting_metadata(CHILD_RUN_ID),
+            "discovery must mark the run as awaiting metadata"
         );
         assert!(
             tracker.children.is_empty(),
@@ -202,7 +202,7 @@ fn started_after_registered_keeps_the_child_and_skips_discovery() {
 }
 
 #[test]
-fn session_linked_materializes_the_pane_without_a_metadata_fetch() {
+fn session_linked_records_the_session_id_without_a_metadata_fetch() {
     with_tracker(|tracker, ctx| {
         tracker.observe_child(CHILD_RUN_ID, ChildSignal::Registered, &no_kills(), ctx);
 
@@ -221,16 +221,13 @@ fn session_linked_materializes_the_pane_without_a_metadata_fetch() {
             .expect("child is tracked");
         assert_eq!(
             child.session_id,
-            Some(SESSION_UUID.parse().expect("hardcoded session id parses"))
-        );
-        assert!(
-            child.pane_materialized,
-            "a linked session is enough to open the pane"
+            Some(SESSION_UUID.parse().expect("hardcoded session id parses")),
+            "session id is recorded immediately from the session-linked event"
         );
         assert_eq!(
             tracker.metadata_fetch_dispatch_count(),
             0,
-            "the session link carries everything the pane needs"
+            "the session link carries everything the tracker needs"
         );
     });
 }

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -15,6 +15,7 @@ use warpui::{
 };
 
 use super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
+use super::orchestration_child_tracker::{ChildSignal, OrchestrationChildTracker};
 use super::orchestration_events::{
     LifecycleEventDetailPayload, LifecycleEventDetailStage, OrchestrationEventService,
     PendingEvent, PendingEventDetail, build_lifecycle_event,
@@ -42,9 +43,17 @@ const SSE_DRAIN_INTERVAL_MS: u64 = 500;
 /// Cap killed-run tombstones while keeping normal sessions well below the limit.
 const MAX_KILLED_RUN_IDS: usize = 1024;
 /// Max child runs fetched per cold-start `?ancestor_run_id=` REST seed in
-/// viewer mode. Matches the legacy `OrchestrationViewerModel` poller's value
-/// (the server caps at 100 anyway).
+/// viewer mode. The server caps at 100 regardless.
 const VIEWER_MODE_SEED_FETCH_LIMIT: i32 = 100;
+
+/// Wire `event_type` for a parent's own inbox message events.
+const EVENT_NEW_MESSAGE: &str = "new_message";
+/// Wire `event_type` emitted on a PARENT run when a child task is created
+/// (`AddTask` with `parent_run_id`); the child run id is carried in `ref_id`.
+const EVENT_CHILD_AGENT_STARTED: &str = "child_agent_started";
+/// Wire `event_type` emitted on a CHILD run when its sandbox session links;
+/// the session UUID is carried in `ref_id`.
+const EVENT_RUN_SESSION_LINKED: &str = "run_session_linked";
 
 /// Per-event item delivered from the SSE background task to the entity.
 struct SseStreamItem {
@@ -72,35 +81,19 @@ struct SseForwardingConsumer {
 }
 
 /// Per-event item delivered from the ancestor SSE background task to the
-/// entity. Mirrors [`SseStreamItem`] but does not currently carry a
-/// hydrated message: the only ancestor consumer today is viewer mode,
-/// which surfaces only lifecycle transitions and so skips message
-/// hydration. If/when the ancestor path picks up a non-viewer caller
-/// (e.g. a local orchestrator subscribing to its own `ancestor_run_id`
-/// stream in lieu of N per-run-ids streams for its children — see
-/// [`AncestorForwardingConsumer`]), this struct would gain a hydrated-
-/// message field analogous to [`SseStreamItem`].
+/// entity. Carries no hydrated message because the ancestor consumer only
+/// surfaces lifecycle transitions.
 struct AncestorSseStreamItem {
     event: AgentRunEvent,
 }
 
-/// Forwarding consumer used by the ancestor SSE driver. Mirrors
-/// [`SseForwardingConsumer`] but does no message hydration: the only
-/// current caller is the shared-session viewer's pill bar, which only
-/// surfaces lifecycle events.
-///
-/// Future direction: a local orchestrator could subscribe to its own
-/// `ancestor_run_id` stream (one SSE per parent family) instead of
-/// having each local child open its own per-run-ids stream. At that
-/// point this consumer would gain an opt-in hydrate flag analogous to
-/// [`SseForwardingConsumer::hydrate_new_messages`].
+/// Forwarding consumer used by the ancestor SSE driver. Skips message
+/// hydration because the ancestor stream surfaces lifecycle events only.
 struct AncestorForwardingConsumer {
     tx: mpsc::UnboundedSender<AncestorSseStreamItem>,
 }
 
-/// State for an ancestor SSE connection. Mirrors [`SseConnectionState`]
-/// but parameterised on [`AncestorSseStreamItem`] because the only
-/// current caller (viewer mode) does not hydrate messages.
+/// State for an ancestor SSE connection.
 struct AncestorSseConnectionState {
     event_receiver: mpsc::UnboundedReceiver<AncestorSseStreamItem>,
     generation: u64,
@@ -226,6 +219,9 @@ struct ConversationStreamState {
     /// Consecutive `get_ambient_agent_task` failure count for the
     /// post-restore retry loop; resets on success.
     restore_fetch_failures: usize,
+    /// Owner-side child tracker for this orchestrator family. `None` until
+    /// the family drain creates one on the first batch it handles.
+    tracker: Option<OrchestrationChildTracker>,
 }
 
 /// Per-orchestrator SSE stream state. Parallels [`ConversationStreamState`]
@@ -265,6 +261,9 @@ struct OrchestratorStreamState {
     /// cursor, so a replay does not generate spurious `ChildSpawned` events
     /// for already-known children.
     seeded: bool,
+    /// Viewer-mode child tracker for this orchestrator family. `None` until
+    /// the family drain creates one on the first batch it handles.
+    tracker: Option<OrchestrationChildTracker>,
 }
 
 /// Async network coordinator for v2 orchestration event delivery via SSE.
@@ -329,6 +328,89 @@ enum DesiredSseFilter {
     Filter(AgentEventFilter),
     /// Nothing to watch yet; do not open a stream.
     NoFilter,
+}
+
+/// Which family-event consumer role a drain is servicing: parent-self delivery
+/// (Primary only) and cursor authority (Primary pushes the server cursor,
+/// Observer persists locally only). Says nothing about authenticated ownership
+/// or pane capability.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum FamilyDrainMode {
+    Primary,
+    Observer,
+}
+
+/// Classification of a single event from a parent-family (`include_self`)
+/// SSE stream. Produced by [`classify_family_event`] and fanned out by
+/// [`OrchestrationEventStreamer::drain_family_events`].
+#[derive(Debug, PartialEq)]
+enum FamilyEvent {
+    /// Inbox message or lifecycle event on the parent's own run. Delivered by
+    /// a Primary consumer; dropped by an Observer.
+    ParentSelf(AgentRunEvent),
+    /// `child_agent_started` on the parent run; the child run id is the
+    /// event's `ref_id`.
+    ChildStarted { child_run_id: String },
+    /// `run_session_linked` on a child run; the session UUID is the event's
+    /// `ref_id`, letting the tracker fill in `session_id` without a fetch.
+    ChildSessionLinked {
+        child_run_id: String,
+        session_uuid: String,
+    },
+    /// A recognised lifecycle event on a child run.
+    ChildLifecycle {
+        child_run_id: String,
+        kind: api::LifecycleEventType,
+    },
+    /// Anything else (unrecognised type, malformed discovery/session event):
+    /// advances the cursor only, for forward compatibility.
+    Opaque,
+}
+
+/// Classifies one family-stream event relative to the parent's own
+/// `self_run_id`. Discovery (`child_agent_started`) is recognised only on
+/// the parent's own run; session links and lifecycle events are recognised
+/// only on other (child) runs; the parent's own inbox/lifecycle events
+/// become [`FamilyEvent::ParentSelf`]; everything else is
+/// [`FamilyEvent::Opaque`].
+fn classify_family_event(event: &AgentRunEvent, self_run_id: &str) -> FamilyEvent {
+    let is_self = event.run_id == self_run_id;
+    match (is_self, event.event_type.as_str()) {
+        (true, EVENT_CHILD_AGENT_STARTED) => match event.ref_id.as_deref() {
+            Some(child_run_id) if !child_run_id.is_empty() => FamilyEvent::ChildStarted {
+                child_run_id: child_run_id.to_string(),
+            },
+            // A discovery event with no child run id is unusable.
+            _ => FamilyEvent::Opaque,
+        },
+        (false, EVENT_RUN_SESSION_LINKED) => match event.ref_id.as_deref() {
+            Some(session_uuid) if !session_uuid.is_empty() => FamilyEvent::ChildSessionLinked {
+                child_run_id: event.run_id.clone(),
+                session_uuid: session_uuid.to_string(),
+            },
+            _ => FamilyEvent::Opaque,
+        },
+        (false, event_type) => match lifecycle_event_type_from_wire(event_type) {
+            Some(kind) => FamilyEvent::ChildLifecycle {
+                child_run_id: event.run_id.clone(),
+                kind,
+            },
+            // A child `new_message` or any unrecognised type: not actionable
+            // by the tracker (the viewer drops it, the owner has no delivery
+            // path for another run's inbox).
+            None => FamilyEvent::Opaque,
+        },
+        (true, EVENT_NEW_MESSAGE) => FamilyEvent::ParentSelf(event.clone()),
+        (true, event_type) => {
+            // The parent's own lifecycle events are ParentSelf; unrecognised
+            // self events advance the cursor only.
+            if lifecycle_event_type_from_wire(event_type).is_some() {
+                FamilyEvent::ParentSelf(event.clone())
+            } else {
+                FamilyEvent::Opaque
+            }
+        }
+    }
 }
 
 impl OrchestrationEventStreamer {
@@ -406,6 +488,451 @@ impl OrchestrationEventStreamer {
                     }
                 },
             );
+        }
+    }
+
+    // ---- Unified family drain (OrchestrationUnifiedStack) --------------
+
+    /// Primary cursor authority for the family drain: persists the cursor to
+    /// SQLite and pushes it to the server, which only the Primary consumer of
+    /// a run may do.
+    fn persist_cursor_local_and_server(
+        &mut self,
+        conversation_id: AIConversationId,
+        sequence: i64,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.persist_event_cursor(conversation_id, sequence, ctx);
+    }
+
+    /// Observer cursor authority for the family drain: persist to SQLite
+    /// only, never pushing the server cursor (only a Primary consumer may
+    /// write the server-side cursor). Monotonic: folds in the conversation's
+    /// already-persisted sequence.
+    fn persist_cursor_local_only(
+        &mut self,
+        conversation_id: AIConversationId,
+        sequence: i64,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let persisted = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|conversation| conversation.last_event_sequence())
+            .unwrap_or(0);
+        let effective = sequence.max(persisted);
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
+            model.update_event_sequence(conversation_id, effective, ctx);
+        });
+    }
+
+    /// Fans out one family (`include_self`) SSE batch: classifies each event
+    /// and routes it to the tracker (discovery / session-link / lifecycle) or
+    /// Primary parent-self delivery (`ParentSelf`), then advances the cursor
+    /// with consumer-appropriate authority.
+    ///
+    /// The tracker is passed by value and returned so callers can keep it in
+    /// `self` state without a borrow conflict against `handle_event_batch`
+    /// and `killed_run_ids`. The tracker is the sole status writer for child
+    /// status and emits `ChildStatusChanged`; child lifecycle events are also
+    /// forwarded to `handle_event_batch` in Primary mode so the parent's
+    /// `OrchestrationEventService` receives them for conversation injection.
+    #[allow(clippy::too_many_arguments)]
+    fn drain_family_events(
+        &mut self,
+        cursor_conversation_id: AIConversationId,
+        self_run_id: &str,
+        mode: FamilyDrainMode,
+        mut tracker: OrchestrationChildTracker,
+        previous_cursor: i64,
+        events: Vec<AgentRunEvent>,
+        messages: Vec<ReceivedMessageInput>,
+        ctx: &mut ModelContext<Self>,
+    ) -> OrchestrationChildTracker {
+        let max_seq = events
+            .iter()
+            .map(|event| event.sequence)
+            .max()
+            .unwrap_or(previous_cursor);
+
+        let mut parent_self_events = Vec::new();
+        // Child lifecycle events are forwarded to `handle_event_batch` as well
+        // as to the tracker, so a Primary consumer's conversation receives
+        // them as orchestration events and not just as status updates.
+        let mut child_lifecycle_for_batch = Vec::new();
+        for event in events {
+            match classify_family_event(&event, self_run_id) {
+                FamilyEvent::ParentSelf(event) => parent_self_events.push(event),
+                FamilyEvent::ChildStarted { child_run_id } => {
+                    log::debug!(
+                        "[orch-drain] ChildStarted child_run_id={child_run_id} \
+                         parent={cursor_conversation_id:?} mode={mode:?}"
+                    );
+                    // Create a local placeholder so the pill bar reflects the new
+                    // child immediately, without waiting for the tracker's async
+                    // metadata fetch to resolve.
+                    if mode == FamilyDrainMode::Primary {
+                        self.ensure_remote_child_placeholder(
+                            cursor_conversation_id,
+                            child_run_id.clone(),
+                            ctx,
+                        );
+                    }
+                    tracker.observe_child(
+                        &child_run_id,
+                        ChildSignal::Started,
+                        &self.killed_run_ids,
+                        ctx,
+                    );
+                }
+                FamilyEvent::ChildSessionLinked {
+                    child_run_id,
+                    session_uuid,
+                } => {
+                    log::debug!(
+                        "[orch-drain] ChildSessionLinked child_run_id={child_run_id} \
+                         parent={cursor_conversation_id:?}"
+                    );
+                    tracker.observe_child(
+                        &child_run_id,
+                        ChildSignal::SessionLinked { session_uuid },
+                        &self.killed_run_ids,
+                        ctx,
+                    );
+                }
+                FamilyEvent::ChildLifecycle { child_run_id, kind } => {
+                    log::debug!(
+                        "[orch-drain] ChildLifecycle child_run_id={child_run_id} \
+                         parent={cursor_conversation_id:?} mode={mode:?}"
+                    );
+                    // Backstop: if this lifecycle arrives before (or instead of)
+                    // `child_agent_started`, ensure a placeholder still exists.
+                    if mode == FamilyDrainMode::Primary {
+                        self.ensure_remote_child_placeholder(
+                            cursor_conversation_id,
+                            child_run_id.clone(),
+                            ctx,
+                        );
+                    }
+                    if mode == FamilyDrainMode::Primary {
+                        child_lifecycle_for_batch.push(event);
+                    }
+                    tracker.observe_child(
+                        &child_run_id,
+                        ChildSignal::Lifecycle(kind),
+                        &self.killed_run_ids,
+                        ctx,
+                    );
+                }
+                FamilyEvent::Opaque => {}
+            }
+        }
+
+        match mode {
+            FamilyDrainMode::Primary => {
+                let mut events_for_batch = parent_self_events;
+                events_for_batch.extend(child_lifecycle_for_batch);
+                if !events_for_batch.is_empty() || !messages.is_empty() {
+                    self.handle_event_batch(
+                        cursor_conversation_id,
+                        self_run_id,
+                        previous_cursor,
+                        events_for_batch,
+                        messages,
+                        ctx,
+                    );
+                }
+                // Ensure a child-only batch still advances the Primary cursor.
+                self.persist_cursor_local_and_server(cursor_conversation_id, max_seq, ctx);
+            }
+            FamilyDrainMode::Observer => {
+                // Observer drops parent-self events and persists the cursor
+                // locally only (never pushes the server cursor).
+                self.persist_cursor_local_only(cursor_conversation_id, max_seq, ctx);
+            }
+        }
+
+        tracker
+    }
+
+    // ---- Remote-child placeholder creation (owner path) ------------------
+
+    /// Creates a local `is_remote_child` placeholder for an out-of-band
+    /// (cloud) child announced by a `child_agent_started` event on the owner's
+    /// family SSE stream, so the orchestrator pill bar renders the child
+    /// immediately without waiting for the tracker's async metadata fetch.
+    ///
+    /// Idempotent: a no-op if the history model already knows this `run_id`
+    /// (e.g. an in-band child registered by `StartAgentExecutor`, a restored
+    /// placeholder, or a race-completed fetch). Passive remote views are also
+    /// skipped since they are not the authoritative process for the run.
+    fn ensure_remote_child_placeholder(
+        &mut self,
+        parent_conversation_id: AIConversationId,
+        child_run_id: String,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation_id_for_agent_id(&child_run_id)
+            .is_some()
+        {
+            // Already represented locally; nothing to do.
+            return;
+        }
+        // Don't create placeholders on behalf of passive views — the actual
+        // owning process (in another window/machine) handles those.
+        if self.is_remote_run_view(parent_conversation_id, ctx) {
+            return;
+        }
+        let Ok(task_id) = child_run_id.parse::<AmbientAgentTaskId>() else {
+            log::warn!(
+                "[orch-drain] ensure_remote_child_placeholder: malformed \
+                 child_run_id={child_run_id:?}; skipping"
+            );
+            return;
+        };
+        log::info!(
+            "[orch-drain] fetching metadata for out-of-band child \
+             child_run_id={child_run_id} parent={parent_conversation_id:?}"
+        );
+        let ai_client = self.ai_client.clone();
+        ctx.spawn(
+            async move { ai_client.get_ambient_agent_task(&task_id).await },
+            move |me, result, ctx| {
+                me.finish_remote_child_placeholder(
+                    parent_conversation_id,
+                    child_run_id,
+                    result,
+                    ctx,
+                );
+            },
+        );
+    }
+
+    /// Completion callback for [`Self::ensure_remote_child_placeholder`].
+    /// Creates the child `AIConversation` from the fetched task metadata and
+    /// marks it `is_remote_child` so no redundant per-child SSE is opened —
+    /// the child's events already arrive on the parent's ancestor stream.
+    fn finish_remote_child_placeholder(
+        &mut self,
+        parent_conversation_id: AIConversationId,
+        child_run_id: String,
+        result: anyhow::Result<crate::ai::ambient_agents::task::AmbientAgentTask>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let task = match result {
+            Ok(task) => task,
+            Err(err) => {
+                log::warn!(
+                    "[orch-drain] finish_remote_child_placeholder: failed to fetch \
+                     metadata for child_run_id={child_run_id}: {err:#}; \
+                     no owner-side placeholder created"
+                );
+                return;
+            }
+        };
+        // Re-check: a locally-started child may have stamped this run_id
+        // while the fetch was in flight.
+        if BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation_id_for_agent_id(&child_run_id)
+            .is_some()
+        {
+            return;
+        }
+        let Some(terminal_surface_id) = BlocklistAIHistoryModel::as_ref(ctx)
+            .terminal_surface_id_for_conversation(&parent_conversation_id)
+        else {
+            log::warn!(
+                "[orch-drain] finish_remote_child_placeholder: parent conversation \
+                 {parent_conversation_id:?} has no terminal surface; \
+                 cannot create placeholder for child_run_id={child_run_id}"
+            );
+            return;
+        };
+        let name = task.display_name().to_string();
+        let fallback_title = task.title.trim().to_string();
+        let harness = agent_task_harness(&task);
+        let task_id = task.task_id;
+        log::info!(
+            "[orch-drain] creating remote-child placeholder for \
+             child_run_id={child_run_id} name={name:?} parent={parent_conversation_id:?}"
+        );
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+            let child_conversation_id = history.start_new_child_conversation(
+                terminal_surface_id,
+                name,
+                parent_conversation_id,
+                harness,
+                ctx,
+            );
+            history.mark_conversation_as_remote_child(child_conversation_id, ctx);
+            if !fallback_title.is_empty()
+                && let Some(conversation) = history.conversation_mut(&child_conversation_id)
+            {
+                conversation.set_fallback_display_title(fallback_title);
+            }
+            history.assign_run_id_for_conversation(
+                child_conversation_id,
+                child_run_id,
+                Some(task_id),
+                terminal_surface_id,
+                ctx,
+            );
+        });
+    }
+
+    /// Owner-side family drain: reads the conversation's SSE buffer and routes
+    /// it through [`Self::drain_family_events`]. Falls back to
+    /// [`Self::drain_sse_events`] when there is no `self_run_id` yet, since
+    /// there is nothing to key a tracker on but events still need delivering.
+    fn drain_owner_family_events(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(self_run_id) = self.self_run_id(conversation_id, ctx) else {
+            self.drain_sse_events(conversation_id, ctx);
+            return;
+        };
+        let Ok(parent_task_id) = self_run_id.parse::<AmbientAgentTaskId>() else {
+            self.drain_sse_events(conversation_id, ctx);
+            return;
+        };
+
+        let cursor;
+        let mut events = Vec::new();
+        let mut messages = Vec::new();
+        {
+            let Some(stream) = self.streams.get_mut(&conversation_id) else {
+                return;
+            };
+            cursor = stream.event_cursor;
+            let Some(sse) = stream.sse_connection.as_mut() else {
+                return;
+            };
+            while let Ok(Some(item)) = sse.event_receiver.try_next() {
+                if item.event.sequence > cursor {
+                    if let Some(message) = item.fetched_message {
+                        messages.push(message);
+                    }
+                    events.push(item.event);
+                }
+            }
+        }
+        if events.is_empty() {
+            return;
+        }
+
+        let tracker = self
+            .streams
+            .get_mut(&conversation_id)
+            .and_then(|stream| stream.tracker.take())
+            .unwrap_or_else(|| OrchestrationChildTracker::new(parent_task_id));
+        let tracker = self.drain_family_events(
+            conversation_id,
+            &self_run_id,
+            FamilyDrainMode::Primary,
+            tracker,
+            cursor,
+            events,
+            messages,
+            ctx,
+        );
+        if let Some(stream) = self.streams.get_mut(&conversation_id) {
+            stream.tracker = Some(tracker);
+        }
+    }
+
+    /// Viewer-side family drain: reads the orchestrator's ancestor SSE buffer
+    /// and routes it through [`Self::drain_family_events`] as an Observer,
+    /// then mirrors the advanced cursor onto the in-memory entry and every
+    /// registered viewer placeholder.
+    fn drain_viewer_family_events(
+        &mut self,
+        parent_task_id: AmbientAgentTaskId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let self_run_id = parent_task_id.to_string();
+
+        let cursor;
+        let mut events = Vec::new();
+        {
+            let Some(entry) = self.viewer_mode_orchestrators.get_mut(&parent_task_id) else {
+                return;
+            };
+            cursor = entry.event_cursor;
+            let Some(sse) = entry.sse_connection.as_mut() else {
+                return;
+            };
+            while let Ok(Some(item)) = sse.event_receiver.try_next() {
+                if item.event.sequence > cursor {
+                    events.push(item.event);
+                }
+            }
+        }
+        if events.is_empty() {
+            return;
+        }
+
+        let placeholders = self.viewer_mode_placeholders(parent_task_id);
+        let Some(primary_placeholder) = placeholders.first().copied() else {
+            return;
+        };
+        let max_seq = events
+            .iter()
+            .map(|event| event.sequence)
+            .max()
+            .unwrap_or(cursor);
+
+        let tracker = self
+            .viewer_mode_orchestrators
+            .get_mut(&parent_task_id)
+            .and_then(|entry| entry.tracker.take())
+            .unwrap_or_else(|| OrchestrationChildTracker::new(parent_task_id));
+        let tracker = self.drain_family_events(
+            primary_placeholder,
+            &self_run_id,
+            FamilyDrainMode::Observer,
+            tracker,
+            cursor,
+            events,
+            Vec::new(),
+            ctx,
+        );
+        if let Some(entry) = self.viewer_mode_orchestrators.get_mut(&parent_task_id) {
+            entry.tracker = Some(tracker);
+            entry.event_cursor = entry.event_cursor.max(max_seq);
+        }
+        // Mirror the advanced cursor onto every registered viewer placeholder.
+        for placeholder in placeholders {
+            self.persist_cursor_local_only(placeholder, max_seq, ctx);
+        }
+    }
+
+    /// Owner drain dispatcher: the unified family drain when
+    /// `OrchestrationUnifiedStack` is on, else the per-conversation drain.
+    fn drain_owner_events(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if FeatureFlag::OrchestrationUnifiedStack.is_enabled() {
+            self.drain_owner_family_events(conversation_id, ctx);
+        } else {
+            self.drain_sse_events(conversation_id, ctx);
+        }
+    }
+
+    /// Viewer drain dispatcher: the unified family drain when
+    /// `OrchestrationUnifiedStack` is on, else the ancestor-only drain.
+    fn drain_viewer_events(
+        &mut self,
+        parent_task_id: AmbientAgentTaskId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if FeatureFlag::OrchestrationUnifiedStack.is_enabled() {
+            self.drain_viewer_family_events(parent_task_id, ctx);
+        } else {
+            self.drain_ancestor_events(parent_task_id, ctx);
         }
     }
 
@@ -933,7 +1460,7 @@ impl OrchestrationEventStreamer {
                 if !is_current {
                     return;
                 }
-                me.drain_ancestor_events(parent_task_id, ctx);
+                me.drain_viewer_events(parent_task_id, ctx);
                 if let Err(err) = result {
                     log::warn!(
                         "Ancestor SSE driver exited for parent_task_id={parent_task_id} \
@@ -977,7 +1504,7 @@ impl OrchestrationEventStreamer {
                 if !is_current {
                     return;
                 }
-                me.drain_ancestor_events(parent_task_id, ctx);
+                me.drain_viewer_events(parent_task_id, ctx);
                 me.start_ancestor_sse_drain_timer(parent_task_id, generation, ctx);
             },
         );
@@ -1063,7 +1590,7 @@ impl OrchestrationEventStreamer {
         parent_task_id: AmbientAgentTaskId,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.drain_ancestor_events(parent_task_id, ctx);
+        self.drain_viewer_events(parent_task_id, ctx);
         let cursor;
         {
             let Some(entry) = self.viewer_mode_orchestrators.get_mut(&parent_task_id) else {
@@ -1941,7 +2468,7 @@ impl OrchestrationEventStreamer {
                     return;
                 }
 
-                me.drain_sse_events(conversation_id, ctx);
+                me.drain_owner_events(conversation_id, ctx);
 
                 if let Err(err) = result {
                     log::warn!(
@@ -2010,7 +2537,7 @@ impl OrchestrationEventStreamer {
                 if !is_current {
                     return;
                 }
-                me.drain_sse_events(conversation_id, ctx);
+                me.drain_owner_events(conversation_id, ctx);
                 me.start_sse_drain_timer(conversation_id, generation, ctx);
             },
         );
@@ -2143,7 +2670,7 @@ impl OrchestrationEventStreamer {
     fn reconnect_sse(&mut self, conversation_id: AIConversationId, ctx: &mut ModelContext<Self>) {
         // Drain buffered events before dropping the channel so we don't
         // discard already-fetched message bodies.
-        self.drain_sse_events(conversation_id, ctx);
+        self.drain_owner_events(conversation_id, ctx);
         if let Some(stream) = self.streams.get_mut(&conversation_id)
             && let Some(connection) = stream.sse_connection.take()
         {
@@ -2160,7 +2687,7 @@ impl OrchestrationEventStreamer {
     /// external state and are pruned through their own paths.
     fn teardown_sse(&mut self, conversation_id: AIConversationId, ctx: &mut ModelContext<Self>) {
         // Drain anything buffered so we don't lose hydrated messages.
-        self.drain_sse_events(conversation_id, ctx);
+        self.drain_owner_events(conversation_id, ctx);
         if let Some(stream) = self.streams.get_mut(&conversation_id)
             && let Some(connection) = stream.sse_connection.take()
         {

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -79,6 +79,18 @@ fn make_run_event(event_type: &str, run_id: &str, ref_id: Option<&str>) -> Agent
     }
 }
 
+fn make_seq_event(
+    event_type: &str,
+    run_id: &str,
+    ref_id: Option<&str>,
+    sequence: i64,
+) -> AgentRunEvent {
+    AgentRunEvent {
+        sequence,
+        ..make_run_event(event_type, run_id, ref_id)
+    }
+}
+
 #[test]
 fn convert_lifecycle_events_includes_run_blocked() {
     let events = vec![make_run_event("run_blocked", "child-run", None)];
@@ -2477,6 +2489,256 @@ fn register_parent_on_wait_flag_off_is_noop() {
         });
         poller.read(&app, |me, _| {
             assert!(connected_filter(me, conversation_id).is_none());
+        });
+    });
+}
+
+// ---- classify_family_event ----------------------------------------------
+
+#[test]
+fn classify_child_agent_started_on_self_is_child_started() {
+    let event = make_run_event(EVENT_CHILD_AGENT_STARTED, "parent-run", Some("child-run"));
+    assert_eq!(
+        classify_family_event(&event, "parent-run"),
+        FamilyEvent::ChildStarted {
+            child_run_id: "child-run".to_string(),
+        }
+    );
+}
+
+#[test]
+fn classify_child_agent_started_without_ref_id_is_opaque() {
+    // A discovery event with no child run id carries nothing actionable.
+    let event = make_run_event(EVENT_CHILD_AGENT_STARTED, "parent-run", None);
+    assert_eq!(
+        classify_family_event(&event, "parent-run"),
+        FamilyEvent::Opaque
+    );
+}
+
+#[test]
+fn classify_run_session_linked_on_child_is_session_linked() {
+    let event = make_run_event(EVENT_RUN_SESSION_LINKED, "child-run", Some("session-uuid"));
+    assert_eq!(
+        classify_family_event(&event, "parent-run"),
+        FamilyEvent::ChildSessionLinked {
+            child_run_id: "child-run".to_string(),
+            session_uuid: "session-uuid".to_string(),
+        }
+    );
+}
+
+#[test]
+fn classify_run_in_progress_on_child_is_child_lifecycle() {
+    let event = make_run_event("run_in_progress", "child-run", None);
+    assert_eq!(
+        classify_family_event(&event, "parent-run"),
+        FamilyEvent::ChildLifecycle {
+            child_run_id: "child-run".to_string(),
+            kind: api::LifecycleEventType::InProgress,
+        }
+    );
+}
+
+#[test]
+fn classify_new_message_on_self_is_parent_self() {
+    let event = make_run_event("new_message", "parent-run", Some("msg-1"));
+    assert_eq!(
+        classify_family_event(&event, "parent-run"),
+        FamilyEvent::ParentSelf(event.clone())
+    );
+}
+
+#[test]
+fn classify_lifecycle_on_self_is_parent_self() {
+    // The parent's own lifecycle events belong to the parent (ParentSelf),
+    // not the child tracker.
+    let event = make_run_event("run_in_progress", "parent-run", None);
+    assert_eq!(
+        classify_family_event(&event, "parent-run"),
+        FamilyEvent::ParentSelf(event.clone())
+    );
+}
+
+#[test]
+fn classify_unknown_type_is_opaque() {
+    let event = make_run_event("some_unknown_event", "child-run", None);
+    assert_eq!(
+        classify_family_event(&event, "parent-run"),
+        FamilyEvent::Opaque
+    );
+}
+
+// ---- drain_family_events ------------------------------------------------
+
+#[test]
+fn drain_family_events_primary_routes_mixed_batch_and_delivers_inbox() {
+    // A mixed family batch under Primary consumption routes discovery and
+    // lifecycle events to the tracker, delivers parent-self events through
+    // handle_event_batch, and advances the Primary cursor (local + server).
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let event_service = app.add_singleton_model(|_| OrchestrationEventService::default());
+
+        let parent_task_id = make_parent_task_id_for_test(0xf1);
+        let parent_run_id = parent_task_id.to_string();
+        let child_a = make_parent_task_id_for_test(0xf2).to_string();
+        let child_b = make_parent_task_id_for_test(0xf3).to_string();
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(parent_run_id.clone());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mut mock = MockAIClient::new();
+        // Primary consumer is the authoritative server-cursor writer.
+        mock.expect_update_event_sequence_on_server()
+            .returning(|_, _| Ok(()));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        let events = vec![
+            make_seq_event(
+                EVENT_CHILD_AGENT_STARTED,
+                &parent_run_id,
+                Some(&child_a),
+                10,
+            ),
+            make_seq_event("run_in_progress", &child_a, None, 11),
+            make_seq_event("new_message", &parent_run_id, Some("msg-1"), 12),
+            make_seq_event("some_unknown_event", &child_b, None, 13),
+        ];
+        let messages = vec![ReceivedMessageInput {
+            message_id: "msg-1".to_string(),
+            sender_agent_id: child_a.clone(),
+            addresses: vec![parent_run_id.clone()],
+            subject: "hello parent".to_string(),
+            message_body: "body".to_string(),
+        }];
+
+        streamer.update(&mut app, |me, ctx| {
+            let tracker = OrchestrationChildTracker::new(parent_task_id);
+            let tracker = me.drain_family_events(
+                conversation_id,
+                &parent_run_id,
+                FamilyDrainMode::Primary,
+                tracker,
+                0,
+                events,
+                messages,
+                ctx,
+            );
+            assert!(
+                tracker.has_in_flight_fetch(&child_a),
+                "ChildStarted / ChildLifecycle must route into the tracker"
+            );
+            assert_eq!(
+                tracker.metadata_fetch_dispatch_count(),
+                1,
+                "a Started followed by Lifecycle for the same run must fetch once"
+            );
+            assert!(
+                !tracker.has_in_flight_fetch(&child_b),
+                "an Opaque event must not touch the tracker"
+            );
+        });
+
+        event_service.read(&app, |service, _| {
+            assert!(
+                service.has_pending_events(conversation_id),
+                "ParentSelf inbox message must be delivered through handle_event_batch"
+            );
+        });
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .and_then(|c| c.last_event_sequence()),
+                Some(13),
+                "Primary cursor must advance to the batch max sequence"
+            );
+        });
+    });
+}
+
+#[test]
+fn drain_family_events_observer_advances_cursor_without_server_push() {
+    // Observer routes child lifecycle to the tracker and persists the cursor
+    // locally, but must never push the server cursor. The mock has no
+    // expectation for `update_event_sequence_on_server`, so it panics if the
+    // Observer path attempts the push.
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+
+        let parent_task_id = make_parent_task_id_for_test(0xf4);
+        let parent_run_id = parent_task_id.to_string();
+        let child = make_parent_task_id_for_test(0xf5).to_string();
+
+        // Viewer placeholder: a shared-session view (is_viewing_shared_session).
+        let placeholder = AIConversation::new(true, false);
+        let placeholder_id = placeholder.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![placeholder], ctx);
+        });
+
+        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        let events = vec![
+            make_seq_event("run_in_progress", &child, None, 7),
+            make_seq_event("new_message", &parent_run_id, Some("msg-9"), 8),
+        ];
+
+        streamer.update(&mut app, |me, ctx| {
+            let tracker = OrchestrationChildTracker::new(parent_task_id);
+            let tracker = me.drain_family_events(
+                placeholder_id,
+                &parent_run_id,
+                FamilyDrainMode::Observer,
+                tracker,
+                0,
+                events,
+                Vec::new(),
+                ctx,
+            );
+            assert!(
+                tracker.has_in_flight_fetch(&child),
+                "child lifecycle must route into the Observer tracker"
+            );
+        });
+
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&placeholder_id)
+                    .and_then(|c| c.last_event_sequence()),
+                Some(8),
+                "Observer cursor must advance locally to the batch max sequence"
+            );
         });
     });
 }

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -2642,7 +2642,7 @@ fn drain_family_events_primary_routes_mixed_batch_and_delivers_inbox() {
                 ctx,
             );
             assert!(
-                tracker.has_in_flight_fetch(&child_a),
+                tracker.is_awaiting_metadata(&child_a),
                 "ChildStarted / ChildLifecycle must route into the tracker"
             );
             assert_eq!(
@@ -2651,7 +2651,7 @@ fn drain_family_events_primary_routes_mixed_batch_and_delivers_inbox() {
                 "a Started followed by Lifecycle for the same run must fetch once"
             );
             assert!(
-                !tracker.has_in_flight_fetch(&child_b),
+                !tracker.is_awaiting_metadata(&child_b),
                 "an Opaque event must not touch the tracker"
             );
         });
@@ -2726,7 +2726,7 @@ fn drain_family_events_observer_advances_cursor_without_server_push() {
                 ctx,
             );
             assert!(
-                tracker.has_in_flight_fetch(&child),
+                tracker.is_awaiting_metadata(&child),
                 "child lifecycle must route into the Observer tracker"
             );
         });

--- a/app/src/pane_group/child_agent/hydration.rs
+++ b/app/src/pane_group/child_agent/hydration.rs
@@ -189,7 +189,17 @@ impl PaneGroup {
 
         match decide_remote_child_hydration_action(&task) {
             RemoteChildHydrationAction::LiveAttach => {
+                let live_session_id = match task.active_live_session_state() {
+                    AmbientAgentLiveSessionState::Attachable { session_id } => Some(session_id),
+                    _ => None,
+                };
                 self.apply_existing_ambient_task_to_pane(pane_id, child_id, task_id, ctx);
+                // Attach the live shared session so the pane renders the
+                // child's output immediately rather than showing a blank
+                // placeholder until the next ambient agent poll.
+                if let Some(session_id) = live_session_id {
+                    self.attach_execution_session_to_ambient_pane(pane_id, session_id, ctx);
+                }
             }
             RemoteChildHydrationAction::LoadTranscript {
                 server_token,

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1645,8 +1645,8 @@ fn launch_local_no_harness_child(
                     // so the share-reporter in
                     // `local_tty/terminal_manager.rs` can resolve it from
                     // the selected conversation when the share handshake
-                    // succeeds. Mirrors the pattern used by
-                    // `OrchestrationViewerModel::apply_children_fetch`.
+                    // succeeds. Mirrors how `OrchestrationViewerModel`
+                    // stamps run/task ids onto viewer child placeholders.
                     BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
                         if let Some(conversation) = model.conversation_mut(&conversation_id) {
                             conversation.set_task_id(child_task_id);

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -365,7 +365,7 @@ pub struct AgentMessageHeader {
     pub read_at: Option<String>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AgentRunEvent {
     pub event_type: String,
     pub run_id: String,

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -718,6 +718,12 @@ pub enum FeatureFlag {
     /// fails gracefully instead of presenting a card in a hidden pane.
     MultiLevelOrchestration,
 
+    /// Gates the unified orchestration child-tracking stack: a single
+    /// `OrchestrationChildTracker` as the sole entry point for child state,
+    /// one `include_self` ancestor SSE per parent family, and a single
+    /// `is_remote_child` placeholder flavor for both owner and viewer.
+    OrchestrationUnifiedStack,
+
     /// Shows a pending user query indicator during summarization when a follow-up
     /// prompt is queued via `/fork-and-compact` or `/compact-and`.
     PendingUserQueryIndicator,
@@ -1020,6 +1026,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::JupyterNotebookRendering,
     FeatureFlag::WaitForEventsParentRegistration,
     FeatureFlag::MultiLevelOrchestration,
+    FeatureFlag::OrchestrationUnifiedStack,
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::BoxDrawingGlyphs,
     FeatureFlag::WellKnownMcpIds,

--- a/specs/QUALITY-928/TECH.md
+++ b/specs/QUALITY-928/TECH.md
@@ -1,0 +1,1022 @@
+# TECH: Orchestration Child Tracking — Unified North-Star Implementation
+
+Linear: QUALITY-928 — Emit a `child_agent_started` event so parents discover
+children via push, and implement the full north-star orchestration tracking
+architecture in a two-PR client stack.
+Follow-up to QUALITY-919 (PR #13208), whose spec sketched this work under
+"Always-on child discovery (lazy listening at first wait)".
+
+## 1. Scope and status
+This document is the single spec for orchestration child tracking. It covers:
+- **M1 — Core tracker + unified stream** (branch `matthew/orch-unified-m1`,
+  base `origin/master`): `OrchestrationChildTracker` as the sole entry point
+  for child state; `classify_family_event` + `drain_family_events` replacing
+  both separate drain pipelines; unified `is_remote_child` placeholder;
+  `OrchestrationUnifiedStack` dogfood flag; rolled-out flag cleanup. §3
+  specifies it.
+- **M2 — Pane path + transcript** (branch `matthew/orch-unified-m2`, base M1
+  branch): `ChildPaneMaterialization` unified dispatch; converged attach;
+  transcript for both owner and viewer. §7.5 specifies the design.
+- **Phases 1–3 of the earlier incremental roadmap are superseded**: the full
+  north-star is implemented directly, avoiding ~600 lines of intermediate
+  scaffold that would have been written and then deleted.
+
+The server-side emits (S1–S5 + ACL propagation, §3.2) are in a separate
+warp-server PR against `develop`; they are additive and safe to ship first.
+Pinned research SHAs: warp-server `9eba7d0932`. No `warp-proto-apis` change
+is needed: event types are Go string constants surfaced via `openapi.yaml`,
+and the client deserializes generically into `AgentRunEvent`.
+
+A reader should come away with: (a) a working mental model of how child
+agents are discovered, represented, and shown in the north-star system;
+(b) what M1 changes and why; and (c) the design decisions behind M2.
+
+## 2. Background: concepts and vocabulary
+- **Run / task**: a server-side agent run (`ai_tasks` row), identified by a
+  `run_id` (stringified `AmbientAgentTaskId`). Client-side, an
+  `AIConversation` may be linked to a run via `run_id`/`task_id`.
+- **Parent / child**: a child run has `parent_run_id = P`. **One-level-tree
+  invariant** (carried from QUALITY-919, load-bearing): a run is either a
+  root orchestrator or a leaf child; the server ancestor query is
+  single-level (`parent_run_id = $1`), consistent end-to-end. Revisit
+  alongside the server query if multi-level trees are introduced.
+- **Event consumer**: the *Primary* process hosts the orchestrator
+  conversation (local root, or the cloud worker's driver), consumes the
+  parent's inbox, and writes the authoritative server cursor. An *Observer*
+  watches through a shared session, drops parent-self events, and persists
+  only a local cursor. Authenticated task ownership never changes this role.
+- **Pane origin**: `ChildPaneOrigin::{HostedConversation, SharedSession}`
+  records the construction context for a child pane. Origin never grants
+  live input or terminal continuation.
+- **Task ownership**: `TaskOwnership::{Owned, NotOwned, Unknown}` is derived
+  from the public run API's authoritative user/team `scope`. Exact creator
+  equality is a compatibility fallback only when older payloads omit scope.
+- **Conversation access**: `ConversationAccess::{Edit, ViewOnly, Unknown}`
+  is derived from conversation object permissions. Terminal Edit access
+  enables continuation; ViewOnly and Unknown remain passive.
+- **Live role**: a child shared-session join's returned `Role` is the sole
+  authority for live input. Task ownership and pane origin cannot promote a
+  Reader or bypass a failed/inaccessible join.
+- **Event log + SSE**: the server keeps an append-only `ai_run_event_log`
+  with a monotonic global `sequence`, a publish path
+  (`PublishLifecycleEvent` → `publishAgentRunEvent`), and an SSE handler
+  with `RunIds([...])` and `AncestorRunId { ancestor_run_id, include_self }`
+  filters whose ancestor query JOINs the children's `parent_run_id`
+  (`include_self` adds the parent's own events). Children are created (any
+  path: `run_agents`, Oz CLI, web API) through one funnel, `AddTask`.
+  Relevant server code @ 9eba7d0932: `logic/ai/ambient_agents/add_task.go`
+  (348-388, the child insert), `logic/agent_lifecycle.go` (13-81, event-type
+  constants + `PublishLifecycleEvent`), `logic/agent_event_publish.go`
+  (14-79, payload + PubSub), `model/ai_run_event_log.go` (35-120,
+  `InsertEvent` + ancestor JOIN).
+- **Cursor**: each consumer tracks the last fully-handled `sequence` and
+  resumes SSE from it (`since=`). Primary-side it is per-conversation
+  (`ConversationStreamState::event_cursor`), persisted to SQLite and pushed
+  to the server; Observer-side it is per-orchestrator
+  (`OrchestratorStreamState::event_cursor`), persisted to each viewer
+  placeholder row but **not** pushed to the server.
+- **Placeholder flavors**: a child that is not a local conversation is
+  represented by a placeholder `AIConversation` in one of two flavors:
+  - `is_remote_child` (hosted-conversation origin): **persisted** in
+    `AgentConversationData` (`crates/persistence/src/model.rs:1196`), alongside
+    `parent_conversation_id`, `parent_agent_id`, `run_id`, `agent_name`.
+  - `is_viewing_shared_session` (shared-session origin): **runtime-only** —
+    the flavor is a constructor argument (`AIConversation::new(true, ...)`) and is not
+    written to `AgentConversationData`, so viewer children do not survive
+    restart (§6, item 3).
+  The current M2 implementation still uses this viewer flavor in
+  `OrchestrationViewerModel`; the persisted single-flavor north star below
+  has not fully replaced that path yet.
+- **Owner-side child kinds.** Not every owner-side child is out-of-band:
+  1. *Local in-band children* (`run_agents` local execution): real
+     conversations running in this process with real hidden terminal panes —
+     not placeholders. Each also holds its own child-role SSE
+     (`RunIds([self])`) for its inbox.
+  2. *Cloud in-band children* (`run_agents`/`start_agent` with cloud
+     execution): started by this process. The `StartAgentExecutor` creates an
+     `is_remote_child` placeholder up-front and stamps the run id via
+     `assign_run_id_for_conversation` when the server responds.
+  3. *Out-of-band cloud children* (Oz CLI, web API, another client):
+     discovered only via `child_agent_started`/lifecycle events; the
+     discovery path (§3.4) creates the same `is_remote_child` flavor.
+  Kinds 2 and 3 converge on one representation and one hydration path — the
+  discovery machinery only *creates* for kind 3, but refetch and pane
+  hydration serve both. Kind 1 is deliberately different (§9.4).
+
+## 3. M1 — Core Tracker + Unified Stream
+**Behavioral contract.** Whenever a child task is created with
+`parent_run_id = P` (by any method), a parent client watching `P` discovers
+that child within one SSE round-trip — no polling — and surfaces its
+subsequent lifecycle and inbox events. Children render as named child pills
+with inbox messages attributed correctly. Clicking a child pill hydrates its
+pane: live session join while running; transcript for both owner and viewer
+once terminal (M2 implements the unified pane path).
+
+### 3.1 Precondition: rolled-out flag cleanup
+M1 deletes `FeatureFlag::OrchestrationViewerStreamer` and
+`FeatureFlag::OwnerOrchestrationAncestorStreamer` (both already in the
+`default` cargo set, i.e. on for all channels) along with the legacy viewer
+REST polling path (`fetch_children` / `schedule_next_poll` / `maybe_kick_polling`
+/ `apply_children_fetch`). The SSE-driven path is now unconditional on the
+flag-off baseline.
+
+### 3.2 Server: emit `child_agent_started` (separate warp-server PR)
+**S1 — event-type constant.** In `logic/agent_lifecycle.go`, alongside the
+existing `LifecycleEvent*` constants:
+```go
+const (
+	LifecycleEventRunInProgress = "run_in_progress"
+	// ... existing constants unchanged ...
+	LifecycleEventRunCancelled  = "run_cancelled"
+
+	// EventChildAgentStarted is emitted on a PARENT run when a child task is
+	// created with parent_run_id = <parent>. The child run id is carried in
+	// ref_id. This is a discovery signal, not a run status.
+	EventChildAgentStarted = "child_agent_started"
+)
+```
+**S2 — emit after the child is committed.** In `AddTask`
+(`logic/ai/ambient_agents/add_task.go`) the child row is inserted inside
+`database.TransactionWithNoResult(...)`. Add the emit *after* that block
+returns successfully, next to the other post-commit side effects:
+```go
+// Notify the parent (if any) that a child was created so its client discovers
+// the child via push instead of polling. Emitted on the PARENT run with the
+// child run id in ref_id. Best-effort: a failure must not fail child creation.
+// Placed after the commit because PublishLifecycleEvent both inserts and
+// publishes and must not run inside the caller's transaction.
+if params.ParentRunID != nil && *params.ParentRunID != "" {
+	if _, err := logic.PublishLifecycleEvent(
+		ctx,
+		td.db,
+		td.datastores,
+		*params.ParentRunID,          // run_id the event is recorded on
+		nil,                          // execution_id: the parent has none here
+		logic.EventChildAgentStarted, // event_type
+		&task.ID,                     // ref_id: the new child run id
+	); err != nil {
+		log.Warnf(ctx, "Failed to emit %s on parent %s for child %s: %v",
+			logic.EventChildAgentStarted, *params.ParentRunID, task.ID, err)
+	}
+}
+```
+`PublishLifecycleEvent` inserts into `ai_run_event_log` (assigning the
+monotonic `sequence`) and publishes to PubSub/SSE. Its
+`resolveParentRunIDForPublish` looks up the *parent's own* parent for
+routing metadata, which is `nil` under the one-level-tree invariant.
+
+**S3 — document the type** in the events schemas in
+`public_api/openapi.yaml`.
+
+**S4 — tests.** In the `AddTask` suite, inject a mock via
+`getEventPubSubClient` and assert: a task created with `ParentRunID` set
+produces exactly one published event with `event_type=child_agent_started`,
+`run_id=<parent>`, `ref_id=<child>`; a task with `ParentRunID` nil produces
+none. Verify the event surfaces on both a `run_ids=[P]` stream and an
+`ancestor_run_id=P&include_self=true` stream.
+
+No schema/migration changes: the event lives on the parent run in the
+existing log, so both filter shapes deliver it. **No server feature flag**:
+the event is additive; old clients ignore unknown `event_type` values
+(`lifecycle_event_type_from_wire` returns `None`; the cursor still advances
+harmonlessly). Consumption is gated client-side.
+
+**S5 — emit `run_session_linked` when a sandbox session links** (also in the
+warp-server PR). In `updateSharedSessionLink`
+(`logic/ai/ambient_agents/execution.go`), after the commit, best-effort emit
+on the **child** run (session UUID in `ref_id`):
+```go
+if sharedSessionUUID != nil {
+    if _, emitErr := logic.PublishLifecycleEvent(
+        ctx, db, td.datastores,
+        runID, nil, logic.EventRunSessionLinked, sharedSessionUUID,
+    ); emitErr != nil {
+        log.Warnf(ctx, "Failed to emit %s for run %s: %v",
+            logic.EventRunSessionLinked, runID, emitErr)
+    }
+}
+```
+Old clients ignore this via the `_ => None` catch-all. The session UUID in
+`ref_id` is consumed directly by M1: `classify_family_event` produces
+`FamilyEvent::ChildSessionLinked { session_uuid }` and `observe_child` fills
+in `session_id` without a metadata fetch. The event surfaces on the child's
+run in both owner (`include_self=true`) and viewer (same stream, `ParentSelf`
+drops) ancestor streams.
+
+### 3.3 Client: OrchestrationUnifiedStack flag and stream opening
+`FeatureFlag::OrchestrationUnifiedStack` (dogfood-only) gates the entire M1
+system. Flag-off: behavior identical to the pre-M1 master baseline. Flag-on:
+one `include_self: true` ancestor SSE per parent (`drain_family_events`), tracker
+owns all child state.
+
+`register_root_on_wait` is preserved: a root orchestrator registers for the
+family stream at its first `wait_for_events` when the flag is on, before any
+child exists. `WaitForEventsParentRegistration` continues to guard this
+mechanism on the flag-off baseline and is superseded (not deleted) in M1.
+
+On the flag-on path, both owner and viewer open a single `include_self: true`
+ancestor SSE. The viewer drops `ParentSelf` events (no inbox). Owner and
+viewer each hold one `OrchestrationChildTracker` — the streamer hosts it in
+`ConversationStreamState` (owner) and `OrchestratorStreamState` (viewer).
+
+`register_root_on_wait` (flag-on path):
+```rust
+pub fn register_root_on_wait(&mut self, conversation_id: AIConversationId, ctx: ...) {
+    if !FeatureFlag::WaitForEventsParentRegistration.is_enabled() { return; }
+    // guards: not a child (one-level tree), not a passive remote-run view,
+    // has a self_run_id ...
+    let stream = self.streams.entry(conversation_id).or_default();
+    if stream.ancestor_on_wait { return; }
+    stream.ancestor_on_wait = true;
+    stream.watched_run_ids.insert(self_run_id);
+    self.reevaluate_eligibility(conversation_id, ctx);
+}
+```
+`is_eligible` treats a wait-registered root (`ancestor_on_wait`) as having
+an orchestration role, and `desired_sse_filter` selects
+`AncestorRunId { ancestor_run_id: self_run_id, include_self: true }` — one
+connection carrying the parent's own inbox (`new_message`), child lifecycle
+events, and `child_agent_started`. The call site is
+`wait_for_events.rs::execute`. The method does **no network fetch**
+(replacing QUALITY-919's per-wait `get_ambient_agent_task`).
+
+**Design decision — open the superset stream up front.** The QUALITY-919
+follow-up sketched opening a cheap `RunIds([self])` stream and *upgrading*
+to the ancestor filter on the first `child_agent_started`. That introduces a
+cursor-handoff gap: the per-conversation `event_cursor` is a single scalar
+over the *global* sequence space, but a self stream only delivers run-`P`
+events, so a parent-self event can advance the cursor past a lower-sequenced
+child event the narrow filter never delivered; the ancestor reconnect then
+resumes from the advanced cursor and skips it. Opening the ancestor
+(superset) stream from the start means the filter never widens, so the
+cursor always covers the full watched set. The cost — a childless waiting
+root holds a JOIN stream rather than a run-ids stream — is one idle SSE
+either way. Consequence: `child_agent_started` is a discovery-latency
+optimization, not a correctness-critical upgrade trigger; a child created
+during an already-blocked wait before the stream opens is caught by replay
+from the cursor when it connects (self-healing).
+
+**Gating.** `OrchestrationUnifiedStack` gates the whole system. Off ⇒
+behavior identical to master: roots discovered only via `run_agents`/restore,
+`drain_family_events` never called, `observe_child` never called. Gating the
+consumption is necessary because a `run_agents`/restore parent holds an open
+ancestor stream even with the flag off; without consumption gates the new
+machinery would ship ungated to production the moment the server starts emitting.
+
+**`WaitForEventsParentRegistration`** remains as a secondary gate on the
+`register_root_on_wait` call site (flag-off baseline), superseded when
+`OrchestrationUnifiedStack` is on. Safe to promote/remove separately.
+
+**None-handling.** When a parent or wait-root has no `self_run_id` yet,
+`desired_sse_filter` returns `NoFilter` (with a warn) and defers until
+`on_server_token_assigned` re-evaluates. Safe in practice because the run id
+arrives via StreamInit / task creation before the model can emit any tool call.
+
+### 3.4 Client: OrchestrationChildTracker and observe_child
+All child state changes on both owner and viewer funnel through
+`OrchestrationChildTracker::observe_child` (see §7.2 for the full design
+and `ChildSignal` variant list). The four-step logic:
+
+0. Drop tombstoned runs and runs owned by a non-placeholder local conversation.
+1. Create-or-update child membership, then converge the fetched task metadata
+   through `BlocklistAIHistoryModel::ensure_remote_child_conversation`
+   (`is_remote_child = true`, both modes).
+2. Write status through on `Lifecycle` signals and emit the shared status event.
+3. Refetch metadata via the shared task cache while
+   `session_id` is missing or pane not materialized.
+4. Request pane materialization once `session_id` is known, or transcript once terminal.
+
+`ChildSignal::SessionLinked { session_uuid }` is handled directly from
+`run_session_linked` events: the session UUID is extracted from `ref_id`
+and fills in `session_id` without a metadata fetch, then pane materialization
+is requested immediately. This eliminates the metadata-fetch round-trip
+for the attach-time window.
+
+`ChildSignal::Started` (from `child_agent_started`) is idempotent:
+calling it again for the same run id is a no-op (explicit tracker state
+replaces the old `conversation_id_for_agent_id(...).is_none()` implicit guard).
+An unknown `ChildSignal::Lifecycle` performs the same eager membership insert
+and emits `ChildSpawned` before the metadata fetch, so lifecycle-before-started
+is a complete discovery backstop rather than a tracker-only fetch.
+`ChildSignal::Registered` (from `StartAgentExecutor`) prevents placeholder
+creation for in-band children — tracker marks them as already-represented.
+Tombstoned runs are checked at step 0 so kills mid-fetch cannot resurrect placeholders.
+
+```mermaid
+flowchart TD
+  Create["AddTask(parent_run_id=P)"] --> Emit["server: emit child_agent_started on run P (ref_id=child)"]
+  Wait["client: first wait_for_events (root)"] --> Anc["register_root_on_wait: open AncestorRunId include_self=true"]
+  Emit --> Recv["drain_family_events: ChildStarted → tracker.observe_child(Started)"]
+  Anc --> Recv
+  Anc --> Track["child lifecycle + inbox delivered via drain_family_events"]
+```
+
+### 3.5 M1 drain: drain_family_events and classify_family_event
+`drain_family_events` replaces both `drain_sse_events` (owner) and
+`drain_ancestor_events` (viewer). Events are classified by
+`classify_family_event(event, self_run_id)` into `FamilyEvent` variants
+(see §7.3 for the full sketch):
+
+- **`ChildStarted`** → start/dedupe real task metadata hydration and
+  `tracker.observe_child(Started)`
+- **`ChildSessionLinked`** → `tracker.observe_child(SessionLinked { session_uuid })`
+  (extracts UUID from `ref_id`; no metadata fetch needed)
+- **`ChildLifecycle`** → the same metadata backstop plus
+  `tracker.observe_child(Lifecycle(kind))`
+- **`ParentSelf`** → Primary: `handle_event_batch` (inbox + lifecycle);
+  Observer: dropped (no parent-self delivery)
+- **`Opaque`** → cursor advances only (forward compat)
+
+Cursor authority: Primary calls `persist_cursor_local_and_server`; Observer
+calls `persist_cursor_local_only`. `refresh_task_data` coalesces in-flight
+fetches: a refetch arriving mid-fetch is recorded and one follow-up issues
+on completion.
+
+### 3.6 M1 validation
+`cargo nextest run -p warp --no-fail-fast`, `./script/format`, and clippy
+(`-D warnings`) all pass.
+- Flag OFF: all pre-M1 tests pass; `OrchestrationEventStreamer` keeps the two
+  drain paths; viewer children NOT persisted. Behavior identical to master.
+- Flag ON: `drain_family_events` is the sole drain; `observe_child` is the
+  sole entry point for child state; viewer children persisted as
+  `is_remote_child = true`.
+- `observe_child` idempotency: two `Started` signals for the same run id
+  issue exactly one metadata fetch.
+- Tombstoned-run skip: `observe_child(Lifecycle)` for a killed run id is a no-op.
+- `Registered` prevents placeholder creation for in-band children.
+- `SessionLinked { session_uuid }` fills in `session_id` without a fetch.
+- `classify_family_event`: all five variants covered by unit tests.
+- Cursor authority: flag-ON + Observer → cursor advance does NOT push to server.
+- Rolled-out flags deleted; legacy REST polling path absent.
+
+Manual (dogfood, `OrchestrationUnifiedStack` on, server PR deployed): create
+a child via Oz CLI/web API with `parent_run_id`, have the parent
+`wait_for_events`; verify the child surfaces without polling latency as a
+named pill with attributed messages. Click a child pill at three lifecycle
+moments (early/Queued, running, completed) and verify re-drive → live join →
+transcript respectively (§4.5 empirical contract).
+
+## 4. North-star architecture
+### 4.1 At a glance
+```mermaid
+flowchart LR
+  LOG[("server<br/>ai_run_event_log")] --> FS["one family SSE<br/>AncestorRunId include_self=true"]
+  subgraph STREAMER["OrchestrationEventStreamer"]
+    FS --> CF["classify_family_event"]
+    CF -->|ChildStarted/SessionLinked/Lifecycle| TRK["OrchestrationChildTracker<br/>observe_child"]
+    CF -->|ParentSelf| HEB["handle_event_batch<br/>inbox + lifecycle; cursor authority"]
+    TRK --> PILL["pill bar (both modes)"]
+    TRK --> PANE["create_hidden_child_agent_pane<br/>ChildPaneMaterialization dispatch (M2)"]
+  end
+```
+
+One SSE per parent family; `OrchestrationEventStreamer` hosts both Primary and
+Observer tracker instances. The streamer's state maps (`streams` for Primary,
+`viewer_mode_orchestrators` for Observer, retaining its legacy field name)
+each carry an `OrchestrationChildTracker`. The tracker is the sole entry point
+for child state changes; `OrchestrationViewerModel` and the Primary drain both
+delegate to it.
+
+### 4.2 Delivery path
+`handle_event_batch` is called for `ParentSelf` events by Primary only.
+It advances and persists the cursor (SQLite + server for Primary, SQLite-only
+for Observer), drops killed-run events, and enqueues inbox messages and
+lifecycle items into `OrchestrationEventService` for the parent's LLM
+input path (`drain_and_convert_events`). The tracker, not `handle_event_batch`,
+writes child `ConversationStatus` — this fixes the owner-side pill-staleness
+gap (§6, item 3) where status lagged until pane attach.
+
+### 4.3 Pane path (M2)
+See §7.5. `ChildPaneMaterialization` with three variants:
+- **`AttachLive { session_id }`**: `attach_child_session` using the pane
+  origin's construction path. The joined shared-session `Role`, not origin or
+  task ownership, controls live input.
+- **`LoadTranscript { server_token }`**: fetch transcript and permissions.
+  Explicit `ConversationAccess::Edit` uses the continuation-capable ambient
+  presentation when the task source permits cloud follow-ups; blocked sources,
+  `ViewOnly`, and `Unknown` use the passive read-only transcript.
+  When permissions metadata is unavailable, authoritative
+  `TaskOwnership::Owned` is the compatibility fallback; it cannot override
+  explicit ViewOnly.
+- **`Pending`**: tracker re-drives when state changes via `observe_child`.
+
+`ChildPaneOrigin::{HostedConversation, SharedSession}` is orthogonal to this
+state decision and to capabilities.
+
+### 4.4 Empirical grounding (three click-timing cases)
+Validated against a healthy session-sharing server:
+- **Early click (Queued/Pending)**: child not attachable for ~10s; pane
+  re-drives as the task advances. `run_session_linked` fires at sandbox claim;
+  `SessionLinked` signal fills in `session_id` directly without a metadata fetch.
+- **Running click**: single immediate `AttachLive`.
+- **Completed click**: single terminal `LoadTranscript` (owner and viewer).
+
+## 5. Differences that drove the unified design
+*These were the gaps in the pre-M1 baseline; all are closed by M1 + M2.*
+
+1. **Consumer gating.** OVM registered only in the viewer context; the owner
+   drain maintained separate helpers. M1: both delegate to `observe_child`.
+2. **Placeholder flavor.** `is_remote_child` (owner, persisted) vs
+   `is_viewing_shared_session` (viewer, runtime-only). M1: unified to
+   `is_remote_child = true` for all child placeholders, fixing the viewer
+   restore-after-restart bug.
+3. **Broadcast events were viewer-only.** `ChildSpawned`/`ChildStatusChanged`
+   emitted only by `drain_ancestor_events`; owner drain fed `handle_event_batch`
+   directly (no status writes). M1: tracker emits them for both modes and is
+   the sole status writer.
+4. **Two ancestor SSEs with different wire filters and cursor authority.**
+   M1: one `include_self: true` family SSE; viewer drops `ParentSelf` events;
+   cursor authority dispatched by mode inside `drain_family_events`.
+5. **Pane materialization differed.** Owner had `LoadTranscript`; viewer
+   dead-ended at loading state for completed children. M2: `ChildPaneMaterialization`
+   with `LoadTranscript` for both modes.
+
+## 6. Why unify (the value)
+1. **Duplication and drift.** Six near-identical concerns implemented
+   twice, in one file plus two pane paths. Each fix must be discovered and
+   applied twice. Historical evidence: the pre-M1 owner side had to re-grow
+   refetch, self-heal, and placeholder logic that OVM already had.
+2. **Two ancestor SSE connections per parent** when an owner and a viewer run
+   in the same process family (and always two server-side query shapes to
+   maintain). One JOIN-backed stream per parent family is strictly cheaper
+   and removes a whole class of "which stream saw it first" reasoning.
+3. **Capability gaps are side-of-origin accidents, not decisions.**
+   - The **restore-after-restart bug**: a `/cloud-agent` shared-session parent
+     restores without its children — no pills, children render as "Unknown
+     agent" — because viewer placeholders are runtime-only (§2) and OVM's
+     registration precondition isn't re-established on restore. The owner
+     flavor survives restart; the viewer flavor does not.
+   - The **terminal-transcript gap**: clicking a finished child works
+     owner-side (`LoadTranscript`) but dead-ends viewer-side (loading
+     placeholder forever), because only one stack grew the branch.
+   - The **owner-side pill-staleness gap**: owner-side cloud-child
+     placeholders had no event-driven status writer (lifecycle events were
+     consumed as LLM inputs, not status writes). M1 fix: tracker is sole
+     status writer for both modes.
+4. **Bespoke machinery outlives its cause.** The pending/settle re-drive
+   (`pending_remote_child_hydrations`, `settles()`) existed because the owner
+   pane path could be entered before task data was complete. M2 fix: tracker
+   re-drives `Pending` children from `observe_child`; no bespoke machinery.
+5. **Reviewability.** `orchestration_event_streamer.rs` is ~2600 lines
+   hosting two parallel pipelines with different key types, cursor rules,
+   and event contracts. Collapsing them is the single biggest lever on
+   comprehension and future orchestration work (e.g. multi-level trees would
+   today need to be implemented twice).
+
+## 7. North star architecture
+### 7.1 Overview
+One of each mechanism:
+- **One discovery signal**: `child_agent_started` (creation-time) plus child
+  lifecycle events as the self-healing backstop, consumed identically for
+  owner and viewer.
+- **One ancestor stream per parent family**: a single
+  `AncestorRunId { include_self: true }` SSE whose drain fans out by event
+  kind — parent inbox to the owner's inbox consumer, discovery/lifecycle to
+  the child tracker — while respecting cursor authority. This is the
+  `AncestorForwardingConsumer` generalization the code already anticipates.
+- **One child tracker**: an `OrchestrationChildTracker` owning discovery,
+  claim-time refetch, placeholder creation, and materialization requests for
+  both Primary and Observer consumers.
+- **One placeholder flavor**: a single persisted conversation kind with a
+  mode tag, fixing the viewer restore bug by construction.
+- **One pane path**: a state-only materialization function with live-session,
+  terminal-transcript, and pending branches, followed by independent origin
+  and access presentation decisions.
+- **Refresh**: event-driven with a bounded fallback (already true after
+  Phase 0 on both sides).
+
+```mermaid
+flowchart LR
+  LOG[("server<br/>ai_run_event_log")] --> FS["one family SSE per parent<br/>AncestorRunId include_self=true"]
+  FS --> FD["family drain<br/>(AncestorForwardingConsumer)"]
+  FD --> INBOX["parent inbox delivery<br/>(Primary only)"]
+  FD --> TRK["OrchestrationChildTracker<br/>observe_child()"]
+  FD --> CUR["cursor advance<br/>Primary → SQLite + server<br/>Observer → SQLite only"]
+  TRK --> PLH["one placeholder flavor<br/>(persisted, mode-tagged)"]
+  TRK --> PB["pill bar<br/>ChildSpawned / ChildStatusChanged"]
+  TRK --> MAT["one pane path<br/>live / transcript / pending"]
+```
+
+### 7.2 `OrchestrationChildTracker` (sketch)
+Extract OVM's core into a model keyed on the orchestrator, running in both
+modes. The mode captures the only real behavioral differences:
+```rust
+/// Family-event consumption role (not authenticated ownership / permissions).
+enum OrchestrationEventConsumer {
+    /// Primary family-event consumer: deliver parent-self events and
+    /// persist local + authoritative server cursor.
+    Primary { orchestrator_conversation_id: AIConversationId },
+    /// Observer family-event consumer: drop parent-self events; persist
+    /// local cursor only (never push server cursor).
+    Observer { placeholder_conversation_id: AIConversationId },
+}
+
+struct TrackedChild {
+    conversation_id: AIConversationId,   // the unified placeholder
+    session_id: Option<SessionId>,       // None until claim time
+    last_state: AmbientAgentTaskState,
+    pane_materialized: bool,
+}
+
+pub struct OrchestrationChildTracker {
+    parent_task_id: AmbientAgentTaskId,
+    mode: OrchestrationEventConsumer,
+    children: HashMap<AmbientAgentTaskId, TrackedChild>,
+    children_by_run_id: HashMap<String, AmbientAgentTaskId>,
+    /// In-flight metadata fetches (today's `remote_child_placeholder_fetches`
+    /// and OVM's dispatch guard, unified).
+    metadata_fetches: HashSet<String>,
+}
+
+/// Every way a child can become known funnels into one entry point.
+enum ChildSignal {
+    Started,                                  // child_agent_started (ref_id)
+    Lifecycle(api::LifecycleEventType),       // any recognised lifecycle event
+    Seeded(AmbientAgentTask),                 // REST seed / restore fetch row
+    /// Created by this process (run_agents / start_agent): the executor
+    /// registers the child it just made, with its existing conversation.
+    Registered { conversation_id: AIConversationId },
+}
+
+impl OrchestrationChildTracker {
+    fn observe_child(&mut self, child_run_id: &str, signal: ChildSignal, ctx: ...) {
+        // 0. drop tombstoned (locally killed) runs, and runs owned by a
+        //    non-placeholder local conversation (local in-band children)
+        // 1. ensure placeholder exists (create-or-update; self-healing by
+        //    construction since every signal funnels here)
+        // 2. write status through on lifecycle signals (sole writer, §7.3)
+        // 3. refetch metadata while session_id is missing or pane not
+        //    materialized (claim-time wait)
+        // 4. request pane materialization once session_id is known, or a
+        //    transcript view once terminal (§7.5)
+    }
+}
+```
+This subsumes, on the owner side: `register_children_from_events`'s
+placeholder work,
+`ensure_remote_child_placeholder`/`finish_remote_child_placeholder`,
+`ensure_placeholders_for_child_lifecycle_events`, and
+`trigger_child_task_refreshes`; on the viewer side: `handle_child_spawned`,
+`handle_child_status_changed`, `spawn_task_metadata_fetch`, `register_child`.
+
+**Child membership has one writer.** The streamer keeps only wire concerns.
+Under the family (ancestor) filter the wire shape needs just the parent's
+`self_run_id` (`desired_sse_filter`'s ancestor branch already uses nothing
+else), so per-child run-id sets stop being filter inputs: child membership
+lives in the tracker alone, and the streamer's parent-role check and
+`RunIds`-fallback derivation read tracker state instead of maintaining
+`watched_run_ids` copies. `watched_run_ids` shrinks to self-inbox watching
+for the legacy fallback. This avoids re-creating the dual-source-of-truth
+problem §7.6's fifth item warns about.
+
+In-band children flow through the same funnel: the `StartAgentExecutor`
+registers each child it spawns (`ChildSignal::Registered`), so later
+`Started`/`Lifecycle` signals for that run id are idempotent status updates
+rather than placeholder creation — replacing today's implicit
+`conversation_id_for_agent_id(...).is_none()` guards with explicit tracker
+state. Local in-process children are observed for status only and never get
+placeholders or metadata fetches (§9.4). All tracker metadata fetches route
+through `AgentConversationsModel`, not raw client calls (§7.6, item 1).
+
+**Cardinality, mode resolution, and lifetime.** One tracker per
+`parent_task_id` per process, hosted in a singleton registry with refcounted
+consumers — exactly the shape of today's `viewer_mode_orchestrators` entries.
+OVM and the owner's agent view become thin per-pane consumers that register
+and unregister. Mode is *derived*, not configured: `Primary` when this process is the
+family-event primary (delivers parent-self + server cursor); `Observer`
+otherwise. A second local pane on the same family registers as another
+consumer of the existing tracker rather than creating a second tracker.
+Primary trackers live as long as the orchestrator conversation; Observer
+trackers tear down when the last consumer unregisters (today's refcounting
+rule). This type describes family-event consumption and cursor
+responsibility only — not authenticated ownership, permissions, or pane
+capability.
+
+### 7.3 One family stream per parent (sketch)
+The streamer keeps one connection per parent family, always
+`include_self: true`, and the drain classifies rather than duplicates:
+```rust
+enum FamilyEvent {
+    /// Event on the parent's own run: inbox message or parent lifecycle.
+    ParentSelf(AgentRunEvent),
+    /// child_agent_started on the parent run; child run id in ref_id.
+    ChildStarted { child_run_id: String },
+    /// Lifecycle event on a child run.
+    ChildLifecycle { child_run_id: String, kind: api::LifecycleEventType },
+    /// Unrecognised event type: advances the cursor only (forward compat).
+    Opaque,
+}
+
+fn drain_family_events(&mut self, parent_task_id: AmbientAgentTaskId, ctx: ...) {
+    for event in buffered {
+        match classify(&event, &self_run_id) {
+            // Primary only; an Observer drops parent-self events.
+            // hydration is skipped, or receives-and-drops them (see §9.2).
+            FamilyEvent::ParentSelf(e) => self.deliver_owner_inbox(e, ctx),
+            FamilyEvent::ChildStarted { child_run_id } =>
+                tracker.observe_child(&child_run_id, ChildSignal::Started, ctx),
+            FamilyEvent::ChildLifecycle { child_run_id, kind } => {
+                tracker.observe_child(&child_run_id, ChildSignal::Lifecycle(kind), ctx);
+                ctx.emit(ChildStatusChanged { .. });   // pill bar, both modes
+            }
+            FamilyEvent::Opaque => {}
+        }
+    }
+    // Cursor authority: one scalar per family stream.
+    match mode {
+        Primary { .. }  => self.persist_cursor_local_and_server(max_seq, ctx),
+        Observer { .. } => self.persist_cursor_local_only(max_seq, ctx),
+    }
+}
+```
+Message hydration becomes an opt-in on the forwarding consumer (exactly the
+flag `AncestorForwardingConsumer`'s doc comment anticipates), enabled for
+Primary and disabled for Observer.
+
+The tracker maps lifecycle status and writes through when the durable mapping
+already exists. OVM consumes the same broadcast and writes the identical
+status for its pane; task-snapshot registration also initializes status.
+These writes are idempotent and converge on the one history conversation.
+Local in-band children keep their own controller as their status authority.
+
+### 7.4 One placeholder flavor
+Persist a single child-placeholder kind; keep the on-disk shape
+backward-compatible by reusing the existing fields:
+- Keep `is_remote_child: bool` in `AgentConversationData` as the persisted
+  marker for "child placeholder without a local run" (rows written by today's
+  builds already have it).
+- Represent viewer-ness as a **runtime mode on the tracker**, not a persisted
+  conversation flavor. Viewer-created placeholders start persisting with the
+  same marker, which fixes child restore and run-id attribution.
+- Server-status-report suppression keys off the unified
+  `is_remote_child` marker instead of `is_viewing_shared_session()`.
+`is_viewing_shared_session` remains for the *parent* viewer placeholder (a
+genuine shared-session concept); only the child-placeholder use retires.
+`BlocklistAIHistoryModel::ensure_remote_child_conversation` is the atomic
+run-id mapping authority. The Primary placeholder callback and OVM metadata
+callback may race, but both create-or-adopt this mapping, so exactly one named
+conversation populates `agent_id_to_conversation_id`. OVM retains only its
+per-pane materialization state and adopts the durable `is_remote_child`
+conversation. Restored pane origin is derived from the restored parent being
+a shared-session Observer, never from child ownership.
+
+**Durable Observer parent.** `is_viewing_shared_session` stays runtime-only
+and passive links remain ephemeral. When OVM resolves the parent task as
+`TaskOwnership::Owned`, it stamps the narrow, serde-defaulted
+`is_durable_observer_parent` marker and the real task/run ID. This exception
+allows the shared parent conversation, its local-only cursor, and child links
+to persist. Startup eagerly hydrates only marked parents; the existing
+`AmbientAgentPaneSnapshot.task_id` identifies the exact pane/task. Running
+parents select the shared-session attach path; `TerminalManager` reattaches
+the local conversation before OVM registration and response replay. Terminal
+parents resolve to `RestoreOrNavigateToConversation`; the ambient app-state
+restorer recognizes that action only for the durable marker and replaces the
+loading pane with the established restored cloud-mode conversation. This
+installs the existing conversation ID/exchanges before agent view entry and
+prevents the New cloud agent zero state. Arbitrary shared links never receive
+the marker, and flag-off retains the fresh-pane fallback. Older rows default
+the field to false.
+
+### 7.5 One pane path
+`create_hidden_child_agent_pane` collapses to a single child-placeholder
+branch that dispatches on observable state, unifying today's
+`decide_remote_child_hydration_action` with the viewer materialization and
+adding the missing transcript branch for viewers:
+```rust
+enum ChildPaneMaterialization {
+    /// Attachable live session: join it. Returned SSS Role controls input.
+    AttachLive { session_id: SessionId },
+    /// Terminal run with a server conversation: load transcript + permissions.
+    LoadTranscript { server_token: ServerConversationToken },
+    /// Not yet attachable: show pending state; the tracker re-drives on the
+    /// next lifecycle-driven refetch.
+    Pending,
+}
+```
+`ChildPaneOrigin::{HostedConversation, SharedSession}` selects construction
+context only. After `LoadTranscript`, `ConversationAccess::Edit` selects the
+continuation-capable ambient presentation; ViewOnly/Unknown remain passive.
+Authoritative task scope is used only when conversation permissions metadata
+is unavailable.
+`settles()`/`pending_remote_child_hydrations` disappear: "pending" is simply a
+tracked child whose `pane_materialized` is false, re-driven by
+`observe_child`. The local-child branch of `create_hidden_child_agent_pane`
+(a real hidden terminal pane for an in-process child) is untouched: the
+unified path replaces only the two placeholder branches.
+
+### 7.6 Adjacent consolidations across all child kinds
+Walking the full taxonomy (§2) surfaces four further consolidations that the
+tracker makes cheap; the first three belong to Phase 1, the fourth to
+Phase 3+.
+1. **Task-metadata fetch convergence.** `get_ambient_agent_task` for
+   children runs through five independent paths with three different
+   retry/dedup schemes: the post-restore fetch (own exponential backoff,
+   `RESTORE_FETCH_BACKOFF_STEPS`), the harness fetch
+   (`spawn_task_harness_fetch_if_needed`), the placeholder fetch (own
+   in-flight guard), OVM's `spawn_task_metadata_fetch` (raw client, no
+   dedup), and `AgentConversationsModel::async_fetch_task` — the only one
+   with in-flight dedup, failure cooldowns, a cache, and a `TasksUpdated`
+   signal. The tracker and pane hydration use `AgentConversationsModel`.
+   Streamer placeholder completion and OVM still have raw fetch adapters, but
+   OVM dedupes in flight and both callbacks converge atomically through
+   `ensure_remote_child_conversation`; a later cleanup can move the remaining
+   requests behind the shared cache without changing identity semantics.
+2. **One status-mapping module.** Child status exists in three
+   representations — wire `event_type`, REST `AmbientAgentTaskState`, client
+   `ConversationStatus` — with mirrored mappings in two files:
+   `conversation_status_from_lifecycle_event_type` (streamer) documents that
+   it mirrors `conversation_status_from_state` (OVM), and hydration
+   separately consults `is_terminal_run_state()`. One mapping module, owned
+   alongside the tracker, replaces the mirror-comment contract with a single
+   function set.
+3. **One cold-start seed.** The post-restore fetch
+   (`finish_restore_fetch`/`apply_task_children`), the viewer REST seed
+   (`finish_ancestor_seed_fetch`), and wait-time registration are all
+   "cold-start: fetch children, merge cursor, install" with different
+   retry and cursor-merge logic. `ChildSignal::Seeded` makes them one
+   mode-agnostic seed routine (already implied by the Phase 3 scorecard's
+   "seed-vs-restore duality"; the seed routine itself can unify in Phase 1).
+4. **Deduplicate local-child event delivery.** With the parent's family
+   stream open (`include_self=true`), every local in-band child's events are
+   already delivered to this process — and delivered *again* on that child's
+   own `RunIds([self])` stream (disjoint consumption: the parent takes
+   lifecycle, the child takes its inbox). N local children means N+1
+   connections carrying overlapping data. Folding child inbox delivery into
+   the family drain collapses this to one connection — and the dormant-Claude
+   wake listener becomes a drain classification case instead of a third
+   connection type. Complication: each child's own per-run server cursor must
+   still advance (or be explicitly retired) — see §9.2. This is the §11 open
+   question, promoted to a named opportunity.
+A fifth, softer one: child identity/relationship maps proliferate
+(`watched_run_ids`, `known_children`, OVM's `children`/`children_by_run_id`,
+`child_agent_panes`, `pending_remote_child_hydrations`, history's
+`children_by_parent`/`agent_id_to_conversation_id`). The end state should
+declare exactly two sources of truth — the history model (identity/linkage)
+and the tracker (orchestration state) — with everything else derived.
+
+## 8. Migration plan
+**Unified north-star implementation — two-PR stack from master.** Rather
+than shipping an intermediate Phase 0 layer and then layering Phases 1–3 on
+top (which would require writing and then deleting ~600 lines of scaffold),
+the full north-star architecture is implemented directly in two stacked PRs
+behind a single `OrchestrationUnifiedStack` dogfood flag.
+
+**M1 — Core tracker + unified stream (PR targets master).** `OrchestrationChildTracker`
+(§7.2) as the sole entry point for child state; `classify_family_event` +
+`drain_family_events` replacing both `drain_sse_events` and `drain_ancestor_events`
+(§7.3); unified `is_remote_child` placeholder including viewer-created children
+(§7.4); `ChildSignal::SessionLinked` carries the session UUID directly from
+`run_session_linked` events, eliminating metadata fetches for the attach-time
+window; rolled-out flag removal (`OrchestrationViewerStreamer`,
+`OwnerOrchestrationAncestorStreamer`) + legacy viewer REST polling deletion.
+Flag-off: behavior identical to master before this PR. Flag-on: one SSE per
+parent, tracker owns all child state.
+
+**M2 — Pane path + transcript (PR targets M1 branch).** `ChildPaneMaterialization`
+(§7.5) as the single dispatch for all placeholder children; converged
+`attach_child_session` for both pane origins; state-independent
+`ChildPaneOrigin`; typed task ownership; and capability-aware transcript
+presentation (`LoadTranscript` when terminal + `conversation_id`,
+authorization resolved per §9.1). Edit access restores the established
+ambient continuation pane; ViewOnly/Unknown stays passive. Deletes old
+dispatch machinery:
+`decide_remote_child_hydration_action`, `RemoteChildHydrationAction`,
+`settles()`, `pending_remote_child_hydrations`,
+`process_pending_remote_child_hydrations`, `hydrate_task_backed_hidden_child_pane`,
+`live_attach_ambient_session_to_pane`, `ensure_shared_session_viewer_child_pane`.
+
+```mermaid
+flowchart LR
+  MASTER([master]) --> M1["M1 (PR1)<br/>OrchestrationChildTracker<br/>+ family drain<br/>+ placeholder unification"]
+  M1 --> M2["M2 (PR2)<br/>ChildPaneMaterialization<br/>+ converge attach<br/>+ transcript both modes"]
+  M2 --> DONE(["North star"])
+```
+
+### Flag-gating strategy
+- **One flag (`OrchestrationUnifiedStack`)** gates the entire system. Flag-off
+  preserves exact master baseline; flag-on is the full north-star. No
+  intermediate states to maintain.
+- **Persisted format is forward-compatible**: `is_remote_child = true` rows
+  written by the new system are treated as owner-side pills by old builds
+  (click-through degrades gracefully per §9.3). The flag only controls whether
+  viewer-created rows are written; the encoding is unchanged.
+- **`WaitForEventsParentRegistration`** is preserved in M1 (it guards the
+  `register_root_on_wait` mechanism used by the flag-off path) but superseded
+  by `OrchestrationUnifiedStack` when the flag is on. Promote/remove it
+  separately after `OrchestrationUnifiedStack` is fully rolled out.
+
+## 9. Hard sub-problems and design decisions
+### 9.1 Terminal child transcript (Phase 2a)
+The viewer path materializes only on a live `session_id`. Clicking a finished
+child must show its transcript; the unified path adds the transcript branch
+(terminal + `conversation_id`, no live session) — additive to OVM and
+effectively the surviving piece of today's `LoadTranscript`. The empirical
+contract (§4.5) is the acceptance test.
+
+**Authorization (resolved).** Policy decision: if a user has access to view
+a parent orchestrator session, they have access to view the transcripts of
+that session's direct children. Implementation: when a child run's conversation
+object is created (in `UpsertAIConversationMetadata` or
+`CreateThirdPartyConversation` in warp-server), propagate the *parent run's*
+shared session ACLs to the child conversation, in addition to the child's own
+session ACLs. This gives parent-session viewers `ViewAction` on child
+conversation objects, making `getAndVerifyManifest`'s `ViewAction` check
+pass for them. The server change is a prerequisite for Phase 2a's viewer
+transcript branch. Client-side: both pane origins return `LoadTranscript` from
+the unified dispatch when the run is terminal and a `conversation_id` exists.
+
+**Ownership-aware presentation.** Family-event consumer authority remains
+Primary/Observer regardless of authenticated ownership. Pane construction
+records `ChildPaneOrigin`, also without granting permissions. Task payloads
+deserialize authoritative `scope: { type: User|Team, uid }` and resolve
+tri-state `TaskOwnership`; exact creator equality is used only when older
+payloads omit scope.
+
+After transcript fetch, conversation object permissions resolve
+`ConversationAccess::{Edit, ViewOnly, Unknown}`. Explicit Edit selects the
+continuation-capable restored ambient cloud-mode pane when task source policy
+allows follow-ups; blocked sources, ViewOnly, and Unknown select the passive
+read-only transcript. When permissions metadata is absent,
+`TaskOwnership::Owned` may provide a compatibility fallback to Edit, but it
+never overrides explicit ViewOnly.
+
+**Live child authorization.** A successful child shared-session join's
+returned role is authoritative. Reader stays read-only; executable roles may
+send input. Task ownership and pane origin never override Reader,
+`SessionNotAccessible`, or join failure. `SessionNotFound` is a stale/missing
+session signal: evict/refetch task state and transition to transcript if the
+run is terminal. Parent-to-child live authorization for non-owners is a
+separate future server policy and is not part of M2.
+
+### 9.2 One stream serving inbox + lifecycle with split cursor authority (Phase 3)
+Primary needs `include_self=true` + hydrated `new_message` delivery *and*
+the lifecycle broadcasts; Observer must get lifecycle without paying for
+inbox hydration and without pushing the server cursor. Decisions to make:
+- Hydration opt-in on the forwarding consumer (Primary on, Observer off) — the
+  direction `AncestorForwardingConsumer`'s doc already sketches.
+- Whether an Observer's `include_self=true` stream simply drops `ParentSelf`
+  events client-side (simplest; costs the parent's event volume on the wire)
+  or keeps `include_self=false` as a viewer-only optimization (two query
+  shapes survive, but only as a parameter, not two pipelines).
+- Cursor: one scalar per family stream; `persist_event_cursor`'s Observer
+  short-circuit becomes the mode dispatch in §7.3.
+- Local in-band children (§7.6, item 4): if their inbox delivery moves onto
+  the family stream, each child's own per-run server cursor must still
+  advance (or be explicitly retired); until then their per-child streams stay
+  for inbox while lifecycle rides the family stream.
+
+### 9.3 Placeholder persistence compatibility (Phase 1)
+Old builds must restore rows written by new builds and vice versa. Reusing
+`is_remote_child` as the persisted marker (§7.4) makes new viewer-child rows
+look like owner placeholders to old builds — acceptable (they render as
+pills; click-through degrades to transcript-when-terminal). New builds
+restoring old rows see no viewer children (status quo). The new parent
+`is_durable_observer_parent` field is serde-defaulted and skipped when false;
+old builds ignore it, while new builds treat absent as false. No migration
+is needed.
+
+### 9.4 What stays deliberately un-unified
+- The **wake-only listener** for dormant local Claude children
+  (`DormantClaudeWakeConsumer`) — a different lifecycle problem (folds into
+  the family drain only if §7.6 item 4 proceeds).
+- **Local (same-process) in-band children**: their conversations, terminal
+  panes, and child-role inbox SSEs (`RunIds([self])`) are real and unchanged.
+  The tracker treats them as already-represented — no placeholder, no
+  metadata fetch — and only their lifecycle status flows through it (pill
+  updates). Whether their inbox delivery could later ride the family stream
+  too is deliberately out of scope here (§11).
+- The **parent viewer placeholder** (`is_viewing_shared_session` on the
+  orchestrator conversation itself) — a shared-session concept, not a child
+  representation.
+
+## 10. Deletion scorecard
+**M1 deletes (never written or deleted from baseline):**
+- `FeatureFlag::OrchestrationViewerStreamer`, `FeatureFlag::OwnerOrchestrationAncestorStreamer`
+  and all usage sites (fully rolled out, deleted from `features.rs`)
+- Legacy viewer REST polling path: `fetch_children`, `schedule_next_poll`,
+  `maybe_kick_polling`, `apply_children_fetch` + interval constants
+- Both separate drain pipelines: `drain_sse_events` + `drain_ancestor_events`
+  replaced by `drain_family_events`; `drain_sse_events`' helpers
+  `register_children_from_events`, `ensure_placeholders_for_child_lifecycle_events`,
+  `trigger_child_task_refreshes` (all subsumed by `observe_child`)
+- OVM child creation no longer writes a second
+  `is_viewing_shared_session` flavor; its fetch/status handlers remain thin
+  pane-state adapters and adopt the history model's mapping.
+- `is_viewing_shared_session` child-placeholder flavor for new writes
+- `WatchedRunIds` per-child run-id sets as filter inputs (child membership
+  lives in the tracker; streamer uses only `self_run_id` for the ancestor filter)
+
+**M2 deletes:**
+- `decide_remote_child_hydration_action`, `RemoteChildHydrationAction`, `settles()`
+- `pending_remote_child_hydrations`, `process_pending_remote_child_hydrations`
+- `hydrate_task_backed_hidden_child_pane`
+- `live_attach_ambient_session_to_pane`, `ensure_shared_session_viewer_child_pane`
+  (converged into `attach_child_session`)
+- Second live-attach construction path; `is_remote_child` and
+  `is_viewing_shared_session` separate branches of `create_hidden_child_agent_pane`
+  (unified to one placeholder branch)
+
+## 11. Risks, validation, open questions
+### Follow-up cleanup
+- **Single task metadata fetch authority.** Flag-on discovery currently has two
+  ways to learn child task metadata: the streamer's placeholder-creation path
+  fetches the child task so it can create a named history row, while the
+  tracker asks `AgentConversationsModel` to fetch or refresh task state for
+  session/transcript materialization. Both paths are idempotent, but they can
+  duplicate network requests and maintain overlapping task snapshots. A
+  follow-up should make `AgentConversationsModel` the only fetch/in-flight
+  authority and have placeholder creation, tracker state, and pane
+  materialization re-drive from that cache.
+- **Child registry consolidation.** Child identity and live state are still
+  split across `BlocklistAIHistoryModel` (persisted conversation/run mapping),
+  `OrchestrationChildTracker` (family event state), `OrchestrationViewerModel`
+  (observer pane/status adapters), and `PaneGroup` (pane materialization and
+  pending hydration maps). The current implementation uses explicit
+  idempotency guards at each boundary, but the long-term shape should be:
+  history as the durable identity source of truth, tracker as transient event
+  state, OVM as a thin observer adapter, and PaneGroup as pane lifecycle only.
+  Defer this until the dogfood behavior stabilizes so the actual invariants are
+  clear.
+
+**Risks**
+- *Viewer regression*: OVM is load-bearing. M1 keeps all pre-M1 tests
+  green and adds tracker coverage; flag-off is byte-identical to master.
+- *Cursor authority*: the owner is the authoritative server-cursor writer; a
+  shared stream must preserve the viewer's read-only cursor (mode dispatch,
+  §7.3), else a viewer could fast-forward the owner's resume point.
+- *One-level-tree invariant*: discovery assumes direct children; preserve
+  `register_root_on_wait`'s child guard and revisit alongside the server JOIN
+  if multi-level trees arrive.
+- *Forward/backward compat*: old clients ignore `child_agent_started` and
+  `run_session_linked` (unknown event types, cursor advances harmlessly). The
+  server PR is safe to ship before the client. `OrchestrationUnifiedStack`
+  off ⇒ flag-off baseline, no exposure.
+- *`include_self` semantics*: resolved in M1 — viewer receives the same
+  `include_self: true` stream and drops `ParentSelf` events client-side.
+  See `classify_family_event` in §3.5.
+- *Kill tombstones*: `observe_child` step 0 is the sole tombstone gate;
+  it runs before any placeholder creation or pane request, including across
+  the metadata-fetch await and the cancel-during-spawn race.
+- *Reconciliation SSE churn (known transient)*: dropping a stale placeholder
+  in `assign_run_id_for_conversation` emits removal events whose run id the
+  streamer prunes from every watched set — including the parent mid-claiming
+  that run for its real local child. For a single-child parent this tears
+  down and reopens the parent SSE (the executor's `register_watched_run_id`
+  re-adds it); drain-before-teardown prevents data loss and the cursor is
+  preserved, but correctness leans on the emission order of three history
+  events. M1 should make re-pointing explicit (prune the run-id index without
+  treating it as child death) rather than relying on event ordering.
+
+**Validation (M1 validation in §3.6; M2 below)**
+- Task scope serde and ownership: user match/mismatch; team member/nonmember;
+  service-account team; absent scope creator fallback; unknown/malformed
+  scope remains Unknown.
+- An authenticated owner observing through a shared link remains an Observer:
+  no parent-self delivery and no server cursor write.
+- Completed child presentation: Edit → continuation-capable ambient pane;
+  ViewOnly/Unknown → passive transcript; explicit ViewOnly overrides task
+  ownership fallback.
+- Live role: Reader cannot send input; executable SSS roles can. Ownership and
+  pane origin do not affect this result.
+- Re-run the three click-timing cases (early / running / completed) for
+  HostedConversation and SharedSession origins after M2 lands; the completed
+  shared-session case is new coverage delivered by M2.
+- Restart-restore case: an owned `/cloud-agent` Observer parent restores from
+  its ambient pane task ID with the persisted local cursor, re-registers OVM,
+  and reconstructs named child pills from persisted `is_remote_child` rows.
+  App-state tests cover both running shared-session selection and terminal
+  existing-conversation restoration with exchanges and no compose zero state.
+- Owner-side pill status updates while the child pane stays closed (M1:
+  tracker is sole status writer in both modes).
+- Unit surfaces: tracker state machine (`observe_child` idempotency, signal
+  ordering, tombstone skip, fetch dedup), drain classification,
+  cursor-authority dispatch, pane-path branch selection, stale terminal
+  session, bounded SessionNotFound recovery, and empty-transcript/no-compose
+  presentation.
+- Run native and WASM checks. If WASM fails before compiling Warp code due to
+  the local C/clang target, record that pre-Warp toolchain blocker explicitly.
+- Observability: counters/logs for placeholder creations, metadata-fetch
+  failures, and family-stream opens per mode, so a flag-on regression shows
+  up in dogfood telemetry rather than only in bug reports.
+
+**Open questions**
+- **RESOLVED.** Does the server reliably emit a lifecycle event at (or just
+  after) `session_id` linking? Yes: `run_session_linked` (S5) is emitted
+  and M1 consumes it via `ChildSignal::SessionLinked`, filling in `session_id`
+  without a metadata fetch. No polling fallback needed.
+- **RESOLVED.** Phase 3 topology: M1 ships one `include_self: true` family
+  SSE per parent; viewer drops `ParentSelf` events client-side (simplest;
+  avoids a second wire shape). Resolved by implementation decision in M1.
+- Should the unified placeholder eventually rename `is_remote_child` to a
+  neutral `is_child_placeholder` (serde alias for compatibility), or is the
+  legacy name acceptable indefinitely?
+- Should local in-band children's inbox delivery eventually ride the family
+  stream as well (retiring their per-child `RunIds([self])` streams, per the
+  `AncestorForwardingConsumer` sketch), or is per-child stream isolation
+  worth keeping?
+- **RESOLVED.** Viewer transcript authorization (§9.1): parent-session
+  viewers are granted access to child transcripts. Server must propagate
+  parent session ACLs to child conversation objects at creation time.
+- Viewer seed pagination: the cold-start REST seed caps at 100 children
+  (server cap); fine today, but the unified seed should define behavior
+  beyond it.

--- a/specs/QUALITY-928/TECH.md
+++ b/specs/QUALITY-928/TECH.md
@@ -1,1022 +1,446 @@
-# TECH: Orchestration Child Tracking — Unified North-Star Implementation
+# TECH: Unified Orchestration Child Stack
 
-Linear: QUALITY-928 — Emit a `child_agent_started` event so parents discover
-children via push, and implement the full north-star orchestration tracking
-architecture in a two-PR client stack.
-Follow-up to QUALITY-919 (PR #13208), whose spec sketched this work under
-"Always-on child discovery (lazy listening at first wait)".
+## 1. Overview
+An orchestrated agent run is a parent (orchestrator) run plus a set of direct
+child runs. The unified orchestration child stack is the client machinery that
+answers two questions for any orchestrator the user has open:
 
-## 1. Scope and status
-This document is the single spec for orchestration child tracking. It covers:
-- **M1 — Core tracker + unified stream** (branch `matthew/orch-unified-m1`,
-  base `origin/master`): `OrchestrationChildTracker` as the sole entry point
-  for child state; `classify_family_event` + `drain_family_events` replacing
-  both separate drain pipelines; unified `is_remote_child` placeholder;
-  `OrchestrationUnifiedStack` dogfood flag; rolled-out flag cleanup. §3
-  specifies it.
-- **M2 — Pane path + transcript** (branch `matthew/orch-unified-m2`, base M1
-  branch): `ChildPaneMaterialization` unified dispatch; converged attach;
-  transcript for both owner and viewer. §7.5 specifies the design.
-- **Phases 1–3 of the earlier incremental roadmap are superseded**: the full
-  north-star is implemented directly, avoiding ~600 lines of intermediate
-  scaffold that would have been written and then deleted.
+1. **Which children exist?** — discovery.
+2. **What should this child's pane show right now?** — materialization.
 
-The server-side emits (S1–S5 + ACL propagation, §3.2) are in a separate
-warp-server PR against `develop`; they are additive and safe to ship first.
-Pinned research SHAs: warp-server `9eba7d0932`. No `warp-proto-apis` change
-is needed: event types are Go string constants surfaced via `openapi.yaml`,
-and the client deserializes generically into `AgentRunEvent`.
+It solves two problems:
 
-A reader should come away with: (a) a working mental model of how child
-agents are discovered, represented, and shown in the north-star system;
-(b) what M1 changes and why; and (c) the design decisions behind M2.
+**(a) Real-time child discovery during a live run.** A child can be created by
+any path — the parent's own `run_agents` tool call, the Oz CLI, the web API, or
+another client. The client learns about every one of them from a single
+server-sent event stream on the parent's run, with no polling, and surfaces
+each child as a named pill with live status.
 
-## 2. Background: concepts and vocabulary
-- **Run / task**: a server-side agent run (`ai_tasks` row), identified by a
-  `run_id` (stringified `AmbientAgentTaskId`). Client-side, an
-  `AIConversation` may be linked to a run via `run_id`/`task_id`.
-- **Parent / child**: a child run has `parent_run_id = P`. **One-level-tree
-  invariant** (carried from QUALITY-919, load-bearing): a run is either a
-  root orchestrator or a leaf child; the server ancestor query is
-  single-level (`parent_run_id = $1`), consistent end-to-end. Revisit
-  alongside the server query if multi-level trees are introduced.
-- **Event consumer**: the *Primary* process hosts the orchestrator
-  conversation (local root, or the cloud worker's driver), consumes the
-  parent's inbox, and writes the authoritative server cursor. An *Observer*
-  watches through a shared session, drops parent-self events, and persists
-  only a local cursor. Authenticated task ownership never changes this role.
-- **Pane origin**: `ChildPaneOrigin::{HostedConversation, SharedSession}`
-  records the construction context for a child pane. Origin never grants
-  live input or terminal continuation.
-- **Task ownership**: `TaskOwnership::{Owned, NotOwned, Unknown}` is derived
-  from the public run API's authoritative user/team `scope`. Exact creator
-  equality is a compatibility fallback only when older payloads omit scope.
-- **Conversation access**: `ConversationAccess::{Edit, ViewOnly, Unknown}`
-  is derived from conversation object permissions. Terminal Edit access
-  enables continuation; ViewOnly and Unknown remain passive.
-- **Live role**: a child shared-session join's returned `Role` is the sole
-  authority for live input. Task ownership and pane origin cannot promote a
-  Reader or bypass a failed/inaccessible join.
-- **Event log + SSE**: the server keeps an append-only `ai_run_event_log`
-  with a monotonic global `sequence`, a publish path
-  (`PublishLifecycleEvent` → `publishAgentRunEvent`), and an SSE handler
-  with `RunIds([...])` and `AncestorRunId { ancestor_run_id, include_self }`
-  filters whose ancestor query JOINs the children's `parent_run_id`
-  (`include_self` adds the parent's own events). Children are created (any
-  path: `run_agents`, Oz CLI, web API) through one funnel, `AddTask`.
-  Relevant server code @ 9eba7d0932: `logic/ai/ambient_agents/add_task.go`
-  (348-388, the child insert), `logic/agent_lifecycle.go` (13-81, event-type
-  constants + `PublishLifecycleEvent`), `logic/agent_event_publish.go`
-  (14-79, payload + PubSub), `model/ai_run_event_log.go` (35-120,
-  `InsertEvent` + ancestor JOIN).
-- **Cursor**: each consumer tracks the last fully-handled `sequence` and
-  resumes SSE from it (`since=`). Primary-side it is per-conversation
-  (`ConversationStreamState::event_cursor`), persisted to SQLite and pushed
-  to the server; Observer-side it is per-orchestrator
-  (`OrchestratorStreamState::event_cursor`), persisted to each viewer
-  placeholder row but **not** pushed to the server.
-- **Placeholder flavors**: a child that is not a local conversation is
-  represented by a placeholder `AIConversation` in one of two flavors:
-  - `is_remote_child` (hosted-conversation origin): **persisted** in
-    `AgentConversationData` (`crates/persistence/src/model.rs:1196`), alongside
-    `parent_conversation_id`, `parent_agent_id`, `run_id`, `agent_name`.
-  - `is_viewing_shared_session` (shared-session origin): **runtime-only** —
-    the flavor is a constructor argument (`AIConversation::new(true, ...)`) and is not
-    written to `AgentConversationData`, so viewer children do not survive
-    restart (§6, item 3).
-  The current M2 implementation still uses this viewer flavor in
-  `OrchestrationViewerModel`; the persisted single-flavor north star below
-  has not fully replaced that path yet.
-- **Owner-side child kinds.** Not every owner-side child is out-of-band:
-  1. *Local in-band children* (`run_agents` local execution): real
-     conversations running in this process with real hidden terminal panes —
-     not placeholders. Each also holds its own child-role SSE
-     (`RunIds([self])`) for its inbox.
-  2. *Cloud in-band children* (`run_agents`/`start_agent` with cloud
-     execution): started by this process. The `StartAgentExecutor` creates an
-     `is_remote_child` placeholder up-front and stamps the run id via
-     `assign_run_id_for_conversation` when the server responds.
-  3. *Out-of-band cloud children* (Oz CLI, web API, another client):
-     discovered only via `child_agent_started`/lifecycle events; the
-     discovery path (§3.4) creates the same `is_remote_child` flavor.
-  Kinds 2 and 3 converge on one representation and one hydration path — the
-  discovery machinery only *creates* for kind 3, but refetch and pane
-  hydration serve both. Kind 1 is deliberately different (§9.4).
+**(b) Restore of the pill bar and child panes after a restart.** Cloud child
+runs and shared-session parent views are ephemeral cloud state and are
+deliberately not written to the local database. After a restart the client
+rebuilds the parent→child relationship from the server's ancestor listing and
+re-materializes child panes through the same dispatch used during a live run.
 
-## 3. M1 — Core Tracker + Unified Stream
-**Behavioral contract.** Whenever a child task is created with
-`parent_run_id = P` (by any method), a parent client watching `P` discovers
-that child within one SSE round-trip — no polling — and surfaces its
-subsequent lifecycle and inbox events. Children render as named child pills
-with inbox messages attributed correctly. Clicking a child pill hydrates its
-pane: live session join while running; transcript for both owner and viewer
-once terminal (M2 implements the unified pane path).
+Everything below is gated by `FeatureFlag::OrchestrationUnifiedStack`
+(`crates/warp_features/src/lib.rs:715`, listed in `DOGFOOD_FLAGS`). With the
+flag off, the client takes the separate owner and viewer paths described in §8.
 
-### 3.1 Precondition: rolled-out flag cleanup
-M1 deletes `FeatureFlag::OrchestrationViewerStreamer` and
-`FeatureFlag::OwnerOrchestrationAncestorStreamer` (both already in the
-`default` cargo set, i.e. on for all channels) along with the legacy viewer
-REST polling path (`fetch_children` / `schedule_next_poll` / `maybe_kick_polling`
-/ `apply_children_fetch`). The SSE-driven path is now unconditional on the
-flag-off baseline.
-
-### 3.2 Server: emit `child_agent_started` (separate warp-server PR)
-**S1 — event-type constant.** In `logic/agent_lifecycle.go`, alongside the
-existing `LifecycleEvent*` constants:
-```go
-const (
-	LifecycleEventRunInProgress = "run_in_progress"
-	// ... existing constants unchanged ...
-	LifecycleEventRunCancelled  = "run_cancelled"
-
-	// EventChildAgentStarted is emitted on a PARENT run when a child task is
-	// created with parent_run_id = <parent>. The child run id is carried in
-	// ref_id. This is a discovery signal, not a run status.
-	EventChildAgentStarted = "child_agent_started"
-)
-```
-**S2 — emit after the child is committed.** In `AddTask`
-(`logic/ai/ambient_agents/add_task.go`) the child row is inserted inside
-`database.TransactionWithNoResult(...)`. Add the emit *after* that block
-returns successfully, next to the other post-commit side effects:
-```go
-// Notify the parent (if any) that a child was created so its client discovers
-// the child via push instead of polling. Emitted on the PARENT run with the
-// child run id in ref_id. Best-effort: a failure must not fail child creation.
-// Placed after the commit because PublishLifecycleEvent both inserts and
-// publishes and must not run inside the caller's transaction.
-if params.ParentRunID != nil && *params.ParentRunID != "" {
-	if _, err := logic.PublishLifecycleEvent(
-		ctx,
-		td.db,
-		td.datastores,
-		*params.ParentRunID,          // run_id the event is recorded on
-		nil,                          // execution_id: the parent has none here
-		logic.EventChildAgentStarted, // event_type
-		&task.ID,                     // ref_id: the new child run id
-	); err != nil {
-		log.Warnf(ctx, "Failed to emit %s on parent %s for child %s: %v",
-			logic.EventChildAgentStarted, *params.ParentRunID, task.ID, err)
-	}
-}
-```
-`PublishLifecycleEvent` inserts into `ai_run_event_log` (assigning the
-monotonic `sequence`) and publishes to PubSub/SSE. Its
-`resolveParentRunIDForPublish` looks up the *parent's own* parent for
-routing metadata, which is `nil` under the one-level-tree invariant.
-
-**S3 — document the type** in the events schemas in
-`public_api/openapi.yaml`.
-
-**S4 — tests.** In the `AddTask` suite, inject a mock via
-`getEventPubSubClient` and assert: a task created with `ParentRunID` set
-produces exactly one published event with `event_type=child_agent_started`,
-`run_id=<parent>`, `ref_id=<child>`; a task with `ParentRunID` nil produces
-none. Verify the event surfaces on both a `run_ids=[P]` stream and an
-`ancestor_run_id=P&include_self=true` stream.
-
-No schema/migration changes: the event lives on the parent run in the
-existing log, so both filter shapes deliver it. **No server feature flag**:
-the event is additive; old clients ignore unknown `event_type` values
-(`lifecycle_event_type_from_wire` returns `None`; the cursor still advances
-harmonlessly). Consumption is gated client-side.
-
-**S5 — emit `run_session_linked` when a sandbox session links** (also in the
-warp-server PR). In `updateSharedSessionLink`
-(`logic/ai/ambient_agents/execution.go`), after the commit, best-effort emit
-on the **child** run (session UUID in `ref_id`):
-```go
-if sharedSessionUUID != nil {
-    if _, emitErr := logic.PublishLifecycleEvent(
-        ctx, db, td.datastores,
-        runID, nil, logic.EventRunSessionLinked, sharedSessionUUID,
-    ); emitErr != nil {
-        log.Warnf(ctx, "Failed to emit %s for run %s: %v",
-            logic.EventRunSessionLinked, runID, emitErr)
-    }
-}
-```
-Old clients ignore this via the `_ => None` catch-all. The session UUID in
-`ref_id` is consumed directly by M1: `classify_family_event` produces
-`FamilyEvent::ChildSessionLinked { session_uuid }` and `observe_child` fills
-in `session_id` without a metadata fetch. The event surfaces on the child's
-run in both owner (`include_self=true`) and viewer (same stream, `ParentSelf`
-drops) ancestor streams.
-
-### 3.3 Client: OrchestrationUnifiedStack flag and stream opening
-`FeatureFlag::OrchestrationUnifiedStack` (dogfood-only) gates the entire M1
-system. Flag-off: behavior identical to the pre-M1 master baseline. Flag-on:
-one `include_self: true` ancestor SSE per parent (`drain_family_events`), tracker
-owns all child state.
-
-`register_root_on_wait` is preserved: a root orchestrator registers for the
-family stream at its first `wait_for_events` when the flag is on, before any
-child exists. `WaitForEventsParentRegistration` continues to guard this
-mechanism on the flag-off baseline and is superseded (not deleted) in M1.
-
-On the flag-on path, both owner and viewer open a single `include_self: true`
-ancestor SSE. The viewer drops `ParentSelf` events (no inbox). Owner and
-viewer each hold one `OrchestrationChildTracker` — the streamer hosts it in
-`ConversationStreamState` (owner) and `OrchestratorStreamState` (viewer).
-
-`register_root_on_wait` (flag-on path):
-```rust
-pub fn register_root_on_wait(&mut self, conversation_id: AIConversationId, ctx: ...) {
-    if !FeatureFlag::WaitForEventsParentRegistration.is_enabled() { return; }
-    // guards: not a child (one-level tree), not a passive remote-run view,
-    // has a self_run_id ...
-    let stream = self.streams.entry(conversation_id).or_default();
-    if stream.ancestor_on_wait { return; }
-    stream.ancestor_on_wait = true;
-    stream.watched_run_ids.insert(self_run_id);
-    self.reevaluate_eligibility(conversation_id, ctx);
-}
-```
-`is_eligible` treats a wait-registered root (`ancestor_on_wait`) as having
-an orchestration role, and `desired_sse_filter` selects
-`AncestorRunId { ancestor_run_id: self_run_id, include_self: true }` — one
-connection carrying the parent's own inbox (`new_message`), child lifecycle
-events, and `child_agent_started`. The call site is
-`wait_for_events.rs::execute`. The method does **no network fetch**
-(replacing QUALITY-919's per-wait `get_ambient_agent_task`).
-
-**Design decision — open the superset stream up front.** The QUALITY-919
-follow-up sketched opening a cheap `RunIds([self])` stream and *upgrading*
-to the ancestor filter on the first `child_agent_started`. That introduces a
-cursor-handoff gap: the per-conversation `event_cursor` is a single scalar
-over the *global* sequence space, but a self stream only delivers run-`P`
-events, so a parent-self event can advance the cursor past a lower-sequenced
-child event the narrow filter never delivered; the ancestor reconnect then
-resumes from the advanced cursor and skips it. Opening the ancestor
-(superset) stream from the start means the filter never widens, so the
-cursor always covers the full watched set. The cost — a childless waiting
-root holds a JOIN stream rather than a run-ids stream — is one idle SSE
-either way. Consequence: `child_agent_started` is a discovery-latency
-optimization, not a correctness-critical upgrade trigger; a child created
-during an already-blocked wait before the stream opens is caught by replay
-from the cursor when it connects (self-healing).
-
-**Gating.** `OrchestrationUnifiedStack` gates the whole system. Off ⇒
-behavior identical to master: roots discovered only via `run_agents`/restore,
-`drain_family_events` never called, `observe_child` never called. Gating the
-consumption is necessary because a `run_agents`/restore parent holds an open
-ancestor stream even with the flag off; without consumption gates the new
-machinery would ship ungated to production the moment the server starts emitting.
-
-**`WaitForEventsParentRegistration`** remains as a secondary gate on the
-`register_root_on_wait` call site (flag-off baseline), superseded when
-`OrchestrationUnifiedStack` is on. Safe to promote/remove separately.
-
-**None-handling.** When a parent or wait-root has no `self_run_id` yet,
-`desired_sse_filter` returns `NoFilter` (with a warn) and defers until
-`on_server_token_assigned` re-evaluates. Safe in practice because the run id
-arrives via StreamInit / task creation before the model can emit any tool call.
-
-### 3.4 Client: OrchestrationChildTracker and observe_child
-All child state changes on both owner and viewer funnel through
-`OrchestrationChildTracker::observe_child` (see §7.2 for the full design
-and `ChildSignal` variant list). The four-step logic:
-
-0. Drop tombstoned runs and runs owned by a non-placeholder local conversation.
-1. Create-or-update child membership, then converge the fetched task metadata
-   through `BlocklistAIHistoryModel::ensure_remote_child_conversation`
-   (`is_remote_child = true`, both modes).
-2. Write status through on `Lifecycle` signals and emit the shared status event.
-3. Refetch metadata via the shared task cache while
-   `session_id` is missing or pane not materialized.
-4. Request pane materialization once `session_id` is known, or transcript once terminal.
-
-`ChildSignal::SessionLinked { session_uuid }` is handled directly from
-`run_session_linked` events: the session UUID is extracted from `ref_id`
-and fills in `session_id` without a metadata fetch, then pane materialization
-is requested immediately. This eliminates the metadata-fetch round-trip
-for the attach-time window.
-
-`ChildSignal::Started` (from `child_agent_started`) is idempotent:
-calling it again for the same run id is a no-op (explicit tracker state
-replaces the old `conversation_id_for_agent_id(...).is_none()` implicit guard).
-An unknown `ChildSignal::Lifecycle` performs the same eager membership insert
-and emits `ChildSpawned` before the metadata fetch, so lifecycle-before-started
-is a complete discovery backstop rather than a tracker-only fetch.
-`ChildSignal::Registered` (from `StartAgentExecutor`) prevents placeholder
-creation for in-band children — tracker marks them as already-represented.
-Tombstoned runs are checked at step 0 so kills mid-fetch cannot resurrect placeholders.
-
-```mermaid
-flowchart TD
-  Create["AddTask(parent_run_id=P)"] --> Emit["server: emit child_agent_started on run P (ref_id=child)"]
-  Wait["client: first wait_for_events (root)"] --> Anc["register_root_on_wait: open AncestorRunId include_self=true"]
-  Emit --> Recv["drain_family_events: ChildStarted → tracker.observe_child(Started)"]
-  Anc --> Recv
-  Anc --> Track["child lifecycle + inbox delivered via drain_family_events"]
-```
-
-### 3.5 M1 drain: drain_family_events and classify_family_event
-`drain_family_events` replaces both `drain_sse_events` (owner) and
-`drain_ancestor_events` (viewer). Events are classified by
-`classify_family_event(event, self_run_id)` into `FamilyEvent` variants
-(see §7.3 for the full sketch):
-
-- **`ChildStarted`** → start/dedupe real task metadata hydration and
-  `tracker.observe_child(Started)`
-- **`ChildSessionLinked`** → `tracker.observe_child(SessionLinked { session_uuid })`
-  (extracts UUID from `ref_id`; no metadata fetch needed)
-- **`ChildLifecycle`** → the same metadata backstop plus
-  `tracker.observe_child(Lifecycle(kind))`
-- **`ParentSelf`** → Primary: `handle_event_batch` (inbox + lifecycle);
-  Observer: dropped (no parent-self delivery)
-- **`Opaque`** → cursor advances only (forward compat)
-
-Cursor authority: Primary calls `persist_cursor_local_and_server`; Observer
-calls `persist_cursor_local_only`. `refresh_task_data` coalesces in-flight
-fetches: a refetch arriving mid-fetch is recorded and one follow-up issues
-on completion.
-
-### 3.6 M1 validation
-`cargo nextest run -p warp --no-fail-fast`, `./script/format`, and clippy
-(`-D warnings`) all pass.
-- Flag OFF: all pre-M1 tests pass; `OrchestrationEventStreamer` keeps the two
-  drain paths; viewer children NOT persisted. Behavior identical to master.
-- Flag ON: `drain_family_events` is the sole drain; `observe_child` is the
-  sole entry point for child state; viewer children persisted as
-  `is_remote_child = true`.
-- `observe_child` idempotency: two `Started` signals for the same run id
-  issue exactly one metadata fetch.
-- Tombstoned-run skip: `observe_child(Lifecycle)` for a killed run id is a no-op.
-- `Registered` prevents placeholder creation for in-band children.
-- `SessionLinked { session_uuid }` fills in `session_id` without a fetch.
-- `classify_family_event`: all five variants covered by unit tests.
-- Cursor authority: flag-ON + Observer → cursor advance does NOT push to server.
-- Rolled-out flags deleted; legacy REST polling path absent.
-
-Manual (dogfood, `OrchestrationUnifiedStack` on, server PR deployed): create
-a child via Oz CLI/web API with `parent_run_id`, have the parent
-`wait_for_events`; verify the child surfaces without polling latency as a
-named pill with attributed messages. Click a child pill at three lifecycle
-moments (early/Queued, running, completed) and verify re-drive → live join →
-transcript respectively (§4.5 empirical contract).
-
-## 4. North-star architecture
-### 4.1 At a glance
-```mermaid
-flowchart LR
-  LOG[("server<br/>ai_run_event_log")] --> FS["one family SSE<br/>AncestorRunId include_self=true"]
-  subgraph STREAMER["OrchestrationEventStreamer"]
-    FS --> CF["classify_family_event"]
-    CF -->|ChildStarted/SessionLinked/Lifecycle| TRK["OrchestrationChildTracker<br/>observe_child"]
-    CF -->|ParentSelf| HEB["handle_event_batch<br/>inbox + lifecycle; cursor authority"]
-    TRK --> PILL["pill bar (both modes)"]
-    TRK --> PANE["create_hidden_child_agent_pane<br/>ChildPaneMaterialization dispatch (M2)"]
-  end
-```
-
-One SSE per parent family; `OrchestrationEventStreamer` hosts both Primary and
-Observer tracker instances. The streamer's state maps (`streams` for Primary,
-`viewer_mode_orchestrators` for Observer, retaining its legacy field name)
-each carry an `OrchestrationChildTracker`. The tracker is the sole entry point
-for child state changes; `OrchestrationViewerModel` and the Primary drain both
-delegate to it.
-
-### 4.2 Delivery path
-`handle_event_batch` is called for `ParentSelf` events by Primary only.
-It advances and persists the cursor (SQLite + server for Primary, SQLite-only
-for Observer), drops killed-run events, and enqueues inbox messages and
-lifecycle items into `OrchestrationEventService` for the parent's LLM
-input path (`drain_and_convert_events`). The tracker, not `handle_event_batch`,
-writes child `ConversationStatus` — this fixes the owner-side pill-staleness
-gap (§6, item 3) where status lagged until pane attach.
-
-### 4.3 Pane path (M2)
-See §7.5. `ChildPaneMaterialization` with three variants:
-- **`AttachLive { session_id }`**: `attach_child_session` using the pane
-  origin's construction path. The joined shared-session `Role`, not origin or
-  task ownership, controls live input.
-- **`LoadTranscript { server_token }`**: fetch transcript and permissions.
-  Explicit `ConversationAccess::Edit` uses the continuation-capable ambient
-  presentation when the task source permits cloud follow-ups; blocked sources,
-  `ViewOnly`, and `Unknown` use the passive read-only transcript.
-  When permissions metadata is unavailable, authoritative
-  `TaskOwnership::Owned` is the compatibility fallback; it cannot override
-  explicit ViewOnly.
-- **`Pending`**: tracker re-drives when state changes via `observe_child`.
-
-`ChildPaneOrigin::{HostedConversation, SharedSession}` is orthogonal to this
-state decision and to capabilities.
-
-### 4.4 Empirical grounding (three click-timing cases)
-Validated against a healthy session-sharing server:
-- **Early click (Queued/Pending)**: child not attachable for ~10s; pane
-  re-drives as the task advances. `run_session_linked` fires at sandbox claim;
-  `SessionLinked` signal fills in `session_id` directly without a metadata fetch.
-- **Running click**: single immediate `AttachLive`.
-- **Completed click**: single terminal `LoadTranscript` (owner and viewer).
-
-## 5. Differences that drove the unified design
-*These were the gaps in the pre-M1 baseline; all are closed by M1 + M2.*
-
-1. **Consumer gating.** OVM registered only in the viewer context; the owner
-   drain maintained separate helpers. M1: both delegate to `observe_child`.
-2. **Placeholder flavor.** `is_remote_child` (owner, persisted) vs
-   `is_viewing_shared_session` (viewer, runtime-only). M1: unified to
-   `is_remote_child = true` for all child placeholders, fixing the viewer
-   restore-after-restart bug.
-3. **Broadcast events were viewer-only.** `ChildSpawned`/`ChildStatusChanged`
-   emitted only by `drain_ancestor_events`; owner drain fed `handle_event_batch`
-   directly (no status writes). M1: tracker emits them for both modes and is
-   the sole status writer.
-4. **Two ancestor SSEs with different wire filters and cursor authority.**
-   M1: one `include_self: true` family SSE; viewer drops `ParentSelf` events;
-   cursor authority dispatched by mode inside `drain_family_events`.
-5. **Pane materialization differed.** Owner had `LoadTranscript`; viewer
-   dead-ended at loading state for completed children. M2: `ChildPaneMaterialization`
-   with `LoadTranscript` for both modes.
-
-## 6. Why unify (the value)
-1. **Duplication and drift.** Six near-identical concerns implemented
-   twice, in one file plus two pane paths. Each fix must be discovered and
-   applied twice. Historical evidence: the pre-M1 owner side had to re-grow
-   refetch, self-heal, and placeholder logic that OVM already had.
-2. **Two ancestor SSE connections per parent** when an owner and a viewer run
-   in the same process family (and always two server-side query shapes to
-   maintain). One JOIN-backed stream per parent family is strictly cheaper
-   and removes a whole class of "which stream saw it first" reasoning.
-3. **Capability gaps are side-of-origin accidents, not decisions.**
-   - The **restore-after-restart bug**: a `/cloud-agent` shared-session parent
-     restores without its children — no pills, children render as "Unknown
-     agent" — because viewer placeholders are runtime-only (§2) and OVM's
-     registration precondition isn't re-established on restore. The owner
-     flavor survives restart; the viewer flavor does not.
-   - The **terminal-transcript gap**: clicking a finished child works
-     owner-side (`LoadTranscript`) but dead-ends viewer-side (loading
-     placeholder forever), because only one stack grew the branch.
-   - The **owner-side pill-staleness gap**: owner-side cloud-child
-     placeholders had no event-driven status writer (lifecycle events were
-     consumed as LLM inputs, not status writes). M1 fix: tracker is sole
-     status writer for both modes.
-4. **Bespoke machinery outlives its cause.** The pending/settle re-drive
-   (`pending_remote_child_hydrations`, `settles()`) existed because the owner
-   pane path could be entered before task data was complete. M2 fix: tracker
-   re-drives `Pending` children from `observe_child`; no bespoke machinery.
-5. **Reviewability.** `orchestration_event_streamer.rs` is ~2600 lines
-   hosting two parallel pipelines with different key types, cursor rules,
-   and event contracts. Collapsing them is the single biggest lever on
-   comprehension and future orchestration work (e.g. multi-level trees would
-   today need to be implemented twice).
-
-## 7. North star architecture
-### 7.1 Overview
-One of each mechanism:
-- **One discovery signal**: `child_agent_started` (creation-time) plus child
-  lifecycle events as the self-healing backstop, consumed identically for
-  owner and viewer.
-- **One ancestor stream per parent family**: a single
-  `AncestorRunId { include_self: true }` SSE whose drain fans out by event
-  kind — parent inbox to the owner's inbox consumer, discovery/lifecycle to
-  the child tracker — while respecting cursor authority. This is the
-  `AncestorForwardingConsumer` generalization the code already anticipates.
-- **One child tracker**: an `OrchestrationChildTracker` owning discovery,
-  claim-time refetch, placeholder creation, and materialization requests for
-  both Primary and Observer consumers.
-- **One placeholder flavor**: a single persisted conversation kind with a
-  mode tag, fixing the viewer restore bug by construction.
-- **One pane path**: a state-only materialization function with live-session,
-  terminal-transcript, and pending branches, followed by independent origin
-  and access presentation decisions.
-- **Refresh**: event-driven with a bounded fallback (already true after
-  Phase 0 on both sides).
+The moving parts:
 
 ```mermaid
 flowchart LR
-  LOG[("server<br/>ai_run_event_log")] --> FS["one family SSE per parent<br/>AncestorRunId include_self=true"]
-  FS --> FD["family drain<br/>(AncestorForwardingConsumer)"]
-  FD --> INBOX["parent inbox delivery<br/>(Primary only)"]
-  FD --> TRK["OrchestrationChildTracker<br/>observe_child()"]
-  FD --> CUR["cursor advance<br/>Primary → SQLite + server<br/>Observer → SQLite only"]
-  TRK --> PLH["one placeholder flavor<br/>(persisted, mode-tagged)"]
-  TRK --> PB["pill bar<br/>ChildSpawned / ChildStatusChanged"]
-  TRK --> MAT["one pane path<br/>live / transcript / pending"]
+  LOG[("server<br/>ai_run_event_log")] --> SSE["ancestor SSE<br/>filtered on ancestor_run_id"]
+  SSE --> CF["classify_family_event"]
+  CF -->|ParentSelf| HEB["handle_event_batch<br/>(Primary only)"]
+  CF -->|ChildStarted / SessionLinked / Lifecycle| TRK["OrchestrationChildTracker<br/>observe_child"]
+  CF -->|any| CUR["cursor advance<br/>Primary: local + server<br/>Observer: local only"]
+  TRK --> HIST["BlocklistAIHistoryModel<br/>ensure_remote_child_conversation"]
+  HIST --> PILL["pill bar<br/>(children_by_parent)"]
+  HIST --> MAT["decide_child_pane_materialization<br/>AttachLive / LoadTranscript / Pending"]
+  REST["ancestor-list seed<br/>GET /agent/runs?ancestor_run_id="] --> HIST
 ```
 
-### 7.2 `OrchestrationChildTracker` (sketch)
-Extract OVM's core into a model keyed on the orchestrator, running in both
-modes. The mode captures the only real behavioral differences:
-```rust
-/// Family-event consumption role (not authenticated ownership / permissions).
-enum OrchestrationEventConsumer {
-    /// Primary family-event consumer: deliver parent-self events and
-    /// persist local + authoritative server cursor.
-    Primary { orchestrator_conversation_id: AIConversationId },
-    /// Observer family-event consumer: drop parent-self events; persist
-    /// local cursor only (never push server cursor).
-    Observer { placeholder_conversation_id: AIConversationId },
-}
+## 2. Core concepts
+**Run / task.** A server-side agent run, identified by a `run_id` (the
+stringified `AmbientAgentTaskId`). Client-side an `AIConversation` may be linked
+to a run through its `run_id` / `task_id`.
 
-struct TrackedChild {
-    conversation_id: AIConversationId,   // the unified placeholder
-    session_id: Option<SessionId>,       // None until claim time
-    last_state: AmbientAgentTaskState,
-    pane_materialized: bool,
-}
+**Parent (orchestrator) and direct child.** A child run carries
+`parent_run_id = P`. The tree is one level deep: a run is either a root
+orchestrator or a leaf child. The server's ancestor query is single-level
+(`parent_run_id = $1`), and the client's discovery, seed, and pane paths all
+assume the same shape.
 
-pub struct OrchestrationChildTracker {
-    parent_task_id: AmbientAgentTaskId,
-    mode: OrchestrationEventConsumer,
-    children: HashMap<AmbientAgentTaskId, TrackedChild>,
-    children_by_run_id: HashMap<String, AmbientAgentTaskId>,
-    /// In-flight metadata fetches (today's `remote_child_placeholder_fetches`
-    /// and OVM's dispatch guard, unified).
-    metadata_fetches: HashSet<String>,
-}
+**`is_remote_child`.** The marker on an `AIConversation` for "this conversation
+is a local stand-in for a run executing elsewhere". It is set on every
+placeholder the client materializes for a cloud child, on both the owner and
+the viewer side. It has two consequences:
+- The conversation is never persisted to SQLite
+  (`app/src/ai/agent/conversation.rs:3485`). Remote children are rediscovered
+  from the server on restore, so a persisted row could only go stale.
+- The streamer treats the conversation as a passive view of a run hosted
+  elsewhere (`is_remote_run_view`), so it never opens a per-child SSE or writes
+  the server-side cursor for that run. The child's events already arrive on the
+  parent's stream.
 
-/// Every way a child can become known funnels into one entry point.
-enum ChildSignal {
-    Started,                                  // child_agent_started (ref_id)
-    Lifecycle(api::LifecycleEventType),       // any recognised lifecycle event
-    Seeded(AmbientAgentTask),                 // REST seed / restore fetch row
-    /// Created by this process (run_agents / start_agent): the executor
-    /// registers the child it just made, with its existing conversation.
-    Registered { conversation_id: AIConversationId },
-}
+In-process children are the complement: they own a real local conversation with
+a real hidden terminal pane, are persisted normally, and carry
+`is_remote_child = false`.
 
-impl OrchestrationChildTracker {
-    fn observe_child(&mut self, child_run_id: &str, signal: ChildSignal, ctx: ...) {
-        // 0. drop tombstoned (locally killed) runs, and runs owned by a
-        //    non-placeholder local conversation (local in-band children)
-        // 1. ensure placeholder exists (create-or-update; self-healing by
-        //    construction since every signal funnels here)
-        // 2. write status through on lifecycle signals (sole writer, §7.3)
-        // 3. refetch metadata while session_id is missing or pane not
-        //    materialized (claim-time wait)
-        // 4. request pane materialization once session_id is known, or a
-        //    transcript view once terminal (§7.5)
-    }
-}
-```
-This subsumes, on the owner side: `register_children_from_events`'s
-placeholder work,
-`ensure_remote_child_placeholder`/`finish_remote_child_placeholder`,
-`ensure_placeholders_for_child_lifecycle_events`, and
-`trigger_child_task_refreshes`; on the viewer side: `handle_child_spawned`,
-`handle_child_status_changed`, `spawn_task_metadata_fetch`, `register_child`.
+**Primary mode vs Observer mode (`FamilyDrainMode`).** One enum
+(`app/src/ai/blocklist/orchestration_event_streamer.rs:339`) captures the only
+two behavioral differences between the process that hosts an orchestrator
+conversation and a process watching one through a shared session:
 
-**Child membership has one writer.** The streamer keeps only wire concerns.
-Under the family (ancestor) filter the wire shape needs just the parent's
-`self_run_id` (`desired_sse_filter`'s ancestor branch already uses nothing
-else), so per-child run-id sets stop being filter inputs: child membership
-lives in the tracker alone, and the streamer's parent-role check and
-`RunIds`-fallback derivation read tracker state instead of maintaining
-`watched_run_ids` copies. `watched_run_ids` shrinks to self-inbox watching
-for the legacy fallback. This avoids re-creating the dual-source-of-truth
-problem §7.6's fifth item warns about.
+- **Primary** — hosts the orchestrator conversation. Delivers the parent's own
+  events (inbox messages and parent lifecycle) into the parent's
+  `OrchestrationEventService`, and is the authoritative writer of the run's
+  server-side event cursor (`persist_cursor_local_and_server`).
+- **Observer** — watches through a shared session. Drops parent-self events —
+  it has no inbox to deliver them to — and persists the cursor to SQLite only
+  (`persist_cursor_local_only`), so a viewer can never fast-forward the owner's
+  resume point.
 
-In-band children flow through the same funnel: the `StartAgentExecutor`
-registers each child it spawns (`ChildSignal::Registered`), so later
-`Started`/`Lifecycle` signals for that run id are idempotent status updates
-rather than placeholder creation — replacing today's implicit
-`conversation_id_for_agent_id(...).is_none()` guards with explicit tracker
-state. Local in-process children are observed for status only and never get
-placeholders or metadata fetches (§9.4). All tracker metadata fetches route
-through `AgentConversationsModel`, not raw client calls (§7.6, item 1).
+The mode describes event-consumption role and cursor responsibility only. It
+says nothing about authenticated task ownership, conversation permissions, or
+what a pane is allowed to do.
 
-**Cardinality, mode resolution, and lifetime.** One tracker per
-`parent_task_id` per process, hosted in a singleton registry with refcounted
-consumers — exactly the shape of today's `viewer_mode_orchestrators` entries.
-OVM and the owner's agent view become thin per-pane consumers that register
-and unregister. Mode is *derived*, not configured: `Primary` when this process is the
-family-event primary (delivers parent-self + server cursor); `Observer`
-otherwise. A second local pane on the same family registers as another
-consumer of the existing tracker rather than creating a second tracker.
-Primary trackers live as long as the orchestrator conversation; Observer
-trackers tear down when the last consumer unregisters (today's refcounting
-rule). This type describes family-event consumption and cursor
-responsibility only — not authenticated ownership, permissions, or pane
-capability.
+**`OrchestrationUnifiedStack` scope.** The flag gates: the unified family drain
+and its classification, the tracker, remote-child placeholder creation from the
+drain, the ancestor-list restore seed, and the task-driven pane dispatch. With
+the flag off none of that code runs.
 
-### 7.3 One family stream per parent (sketch)
-The streamer keeps one connection per parent family, always
-`include_self: true`, and the drain classifies rather than duplicates:
-```rust
-enum FamilyEvent {
-    /// Event on the parent's own run: inbox message or parent lifecycle.
-    ParentSelf(AgentRunEvent),
-    /// child_agent_started on the parent run; child run id in ref_id.
-    ChildStarted { child_run_id: String },
-    /// Lifecycle event on a child run.
-    ChildLifecycle { child_run_id: String, kind: api::LifecycleEventType },
-    /// Unrecognised event type: advances the cursor only (forward compat).
-    Opaque,
-}
+## 3. Child discovery (live session)
+The server records an append-only event log per run with a monotonic global
+`sequence`. Three event types matter here:
 
-fn drain_family_events(&mut self, parent_task_id: AmbientAgentTaskId, ctx: ...) {
-    for event in buffered {
-        match classify(&event, &self_run_id) {
-            // Primary only; an Observer drops parent-self events.
-            // hydration is skipped, or receives-and-drops them (see §9.2).
-            FamilyEvent::ParentSelf(e) => self.deliver_owner_inbox(e, ctx),
-            FamilyEvent::ChildStarted { child_run_id } =>
-                tracker.observe_child(&child_run_id, ChildSignal::Started, ctx),
-            FamilyEvent::ChildLifecycle { child_run_id, kind } => {
-                tracker.observe_child(&child_run_id, ChildSignal::Lifecycle(kind), ctx);
-                ctx.emit(ChildStatusChanged { .. });   // pill bar, both modes
-            }
-            FamilyEvent::Opaque => {}
-        }
-    }
-    // Cursor authority: one scalar per family stream.
-    match mode {
-        Primary { .. }  => self.persist_cursor_local_and_server(max_seq, ctx),
-        Observer { .. } => self.persist_cursor_local_only(max_seq, ctx),
-    }
-}
-```
-Message hydration becomes an opt-in on the forwarding consumer (exactly the
-flag `AncestorForwardingConsumer`'s doc comment anticipates), enabled for
-Primary and disabled for Observer.
+- `child_agent_started` — emitted on the **parent** run when a task is created
+  with `parent_run_id` set. The new child's run id is carried in `ref_id`.
+- `run_session_linked` — emitted on the **child** run when its sandbox session
+  is linked. The session UUID is carried in `ref_id`.
+- lifecycle events (`run_in_progress`, `succeeded`, `failed`, …) and
+  `new_message`.
 
-The tracker maps lifecycle status and writes through when the durable mapping
-already exists. OVM consumes the same broadcast and writes the identical
-status for its pane; task-snapshot registration also initializes status.
-These writes are idempotent and converge on the one history conversation.
-Local in-band children keep their own controller as their status authority.
+A parent conversation with an orchestration role subscribes with
+`AgentEventFilter::AncestorRunId { ancestor_run_id: self_run_id, include_self:
+true }` (`desired_sse_filter`). One connection carries the parent's own inbox,
+child lifecycle, and child discovery events, so the filter never has to widen
+and the single scalar cursor always covers the whole watched set.
 
-### 7.4 One placeholder flavor
-Persist a single child-placeholder kind; keep the on-disk shape
-backward-compatible by reusing the existing fields:
-- Keep `is_remote_child: bool` in `AgentConversationData` as the persisted
-  marker for "child placeholder without a local run" (rows written by today's
-  builds already have it).
-- Represent viewer-ness as a **runtime mode on the tracker**, not a persisted
-  conversation flavor. Viewer-created placeholders start persisting with the
-  same marker, which fixes child restore and run-id attribution.
-- Server-status-report suppression keys off the unified
-  `is_remote_child` marker instead of `is_viewing_shared_session()`.
-`is_viewing_shared_session` remains for the *parent* viewer placeholder (a
-genuine shared-session concept); only the child-placeholder use retires.
-`BlocklistAIHistoryModel::ensure_remote_child_conversation` is the atomic
-run-id mapping authority. The Primary placeholder callback and OVM metadata
-callback may race, but both create-or-adopt this mapping, so exactly one named
-conversation populates `agent_id_to_conversation_id`. OVM retains only its
-per-pane materialization state and adopts the durable `is_remote_child`
-conversation. Restored pane origin is derived from the restored parent being
-a shared-session Observer, never from child ownership.
+`drain_family_events` classifies each buffered event with
+`classify_family_event(event, self_run_id)` into a `FamilyEvent`:
 
-**Durable Observer parent.** `is_viewing_shared_session` stays runtime-only
-and passive links remain ephemeral. When OVM resolves the parent task as
-`TaskOwnership::Owned`, it stamps the narrow, serde-defaulted
-`is_durable_observer_parent` marker and the real task/run ID. This exception
-allows the shared parent conversation, its local-only cursor, and child links
-to persist. Startup eagerly hydrates only marked parents; the existing
-`AmbientAgentPaneSnapshot.task_id` identifies the exact pane/task. Running
-parents select the shared-session attach path; `TerminalManager` reattaches
-the local conversation before OVM registration and response replay. Terminal
-parents resolve to `RestoreOrNavigateToConversation`; the ambient app-state
-restorer recognizes that action only for the durable marker and replaces the
-loading pane with the established restored cloud-mode conversation. This
-installs the existing conversation ID/exchanges before agent view entry and
-prevents the New cloud agent zero state. Arbitrary shared links never receive
-the marker, and flag-off retains the fresh-pane fallback. Older rows default
-the field to false.
+- `ChildStarted { child_run_id }` — `child_agent_started` on the parent's run.
+- `ChildSessionLinked { child_run_id, session_uuid }` — `run_session_linked` on
+  another run.
+- `ChildLifecycle { child_run_id, kind }` — a recognised lifecycle event on
+  another run.
+- `ParentSelf(event)` — `new_message` or a recognised lifecycle event on the
+  parent's own run.
+- `Opaque` — anything else. Advances the cursor only, which keeps unknown
+  server event types forward-compatible.
 
-### 7.5 One pane path
-`create_hidden_child_agent_pane` collapses to a single child-placeholder
-branch that dispatches on observable state, unifying today's
-`decide_remote_child_hydration_action` with the viewer materialization and
-adding the missing transcript branch for viewers:
-```rust
-enum ChildPaneMaterialization {
-    /// Attachable live session: join it. Returned SSS Role controls input.
-    AttachLive { session_id: SessionId },
-    /// Terminal run with a server conversation: load transcript + permissions.
-    LoadTranscript { server_token: ServerConversationToken },
-    /// Not yet attachable: show pending state; the tracker re-drives on the
-    /// next lifecycle-driven refetch.
-    Pending,
-}
-```
-`ChildPaneOrigin::{HostedConversation, SharedSession}` selects construction
-context only. After `LoadTranscript`, `ConversationAccess::Edit` selects the
-continuation-capable ambient presentation; ViewOnly/Unknown remain passive.
-Authoritative task scope is used only when conversation permissions metadata
-is unavailable.
-`settles()`/`pending_remote_child_hydrations` disappear: "pending" is simply a
-tracked child whose `pane_materialized` is false, re-driven by
-`observe_child`. The local-child branch of `create_hidden_child_agent_pane`
-(a real hidden terminal pane for an in-process child) is untouched: the
-unified path replaces only the two placeholder branches.
+### 3.1 `ChildStarted`
+Two things happen, in order:
 
-### 7.6 Adjacent consolidations across all child kinds
-Walking the full taxonomy (§2) surfaces four further consolidations that the
-tracker makes cheap; the first three belong to Phase 1, the fourth to
-Phase 3+.
-1. **Task-metadata fetch convergence.** `get_ambient_agent_task` for
-   children runs through five independent paths with three different
-   retry/dedup schemes: the post-restore fetch (own exponential backoff,
-   `RESTORE_FETCH_BACKOFF_STEPS`), the harness fetch
-   (`spawn_task_harness_fetch_if_needed`), the placeholder fetch (own
-   in-flight guard), OVM's `spawn_task_metadata_fetch` (raw client, no
-   dedup), and `AgentConversationsModel::async_fetch_task` — the only one
-   with in-flight dedup, failure cooldowns, a cache, and a `TasksUpdated`
-   signal. The tracker and pane hydration use `AgentConversationsModel`.
-   Streamer placeholder completion and OVM still have raw fetch adapters, but
-   OVM dedupes in flight and both callbacks converge atomically through
-   `ensure_remote_child_conversation`; a later cleanup can move the remaining
-   requests behind the shared cache without changing identity semantics.
-2. **One status-mapping module.** Child status exists in three
-   representations — wire `event_type`, REST `AmbientAgentTaskState`, client
-   `ConversationStatus` — with mirrored mappings in two files:
-   `conversation_status_from_lifecycle_event_type` (streamer) documents that
-   it mirrors `conversation_status_from_state` (OVM), and hydration
-   separately consults `is_terminal_run_state()`. One mapping module, owned
-   alongside the tracker, replaces the mirror-comment contract with a single
-   function set.
-3. **One cold-start seed.** The post-restore fetch
-   (`finish_restore_fetch`/`apply_task_children`), the viewer REST seed
-   (`finish_ancestor_seed_fetch`), and wait-time registration are all
-   "cold-start: fetch children, merge cursor, install" with different
-   retry and cursor-merge logic. `ChildSignal::Seeded` makes them one
-   mode-agnostic seed routine (already implied by the Phase 3 scorecard's
-   "seed-vs-restore duality"; the seed routine itself can unify in Phase 1).
-4. **Deduplicate local-child event delivery.** With the parent's family
-   stream open (`include_self=true`), every local in-band child's events are
-   already delivered to this process — and delivered *again* on that child's
-   own `RunIds([self])` stream (disjoint consumption: the parent takes
-   lifecycle, the child takes its inbox). N local children means N+1
-   connections carrying overlapping data. Folding child inbox delivery into
-   the family drain collapses this to one connection — and the dormant-Claude
-   wake listener becomes a drain classification case instead of a third
-   connection type. Complication: each child's own per-run server cursor must
-   still advance (or be explicitly retired) — see §9.2. This is the §11 open
-   question, promoted to a named opportunity.
-A fifth, softer one: child identity/relationship maps proliferate
-(`watched_run_ids`, `known_children`, OVM's `children`/`children_by_run_id`,
-`child_agent_panes`, `pending_remote_child_hydrations`, history's
-`children_by_parent`/`agent_id_to_conversation_id`). The end state should
-declare exactly two sources of truth — the history model (identity/linkage)
-and the tracker (orchestration state) — with everything else derived.
+1. `ensure_remote_child_placeholder` fetches the child's task metadata and
+   creates the local placeholder through
+   `BlocklistAIHistoryModel::ensure_remote_child_conversation`, so the pill bar
+   shows a correctly named child as soon as the fetch lands. It is a no-op when
+   the history model already knows the run id, and it is skipped in Primary
+   mode for a passive remote view, which must not impersonate the owning
+   process.
+2. `tracker.observe_child(run_id, ChildSignal::Started, killed_run_ids, ctx)`
+   records the child in tracker state.
 
-## 8. Migration plan
-**Unified north-star implementation — two-PR stack from master.** Rather
-than shipping an intermediate Phase 0 layer and then layering Phases 1–3 on
-top (which would require writing and then deleting ~600 lines of scaffold),
-the full north-star architecture is implemented directly in two stacked PRs
-behind a single `OrchestrationUnifiedStack` dogfood flag.
+### 3.2 `OrchestrationChildTracker`
+`observe_child` (`app/src/ai/blocklist/orchestration_child_tracker.rs:118`) is
+the single entry point for every child state change. It first drops the signal
+if the run is tombstoned (locally killed), which is what makes a kill immune to
+a late event or an in-flight fetch resurrecting the child. Then it dispatches on
+the signal:
 
-**M1 — Core tracker + unified stream (PR targets master).** `OrchestrationChildTracker`
-(§7.2) as the sole entry point for child state; `classify_family_event` +
-`drain_family_events` replacing both `drain_sse_events` and `drain_ancestor_events`
-(§7.3); unified `is_remote_child` placeholder including viewer-created children
-(§7.4); `ChildSignal::SessionLinked` carries the session UUID directly from
-`run_session_linked` events, eliminating metadata fetches for the attach-time
-window; rolled-out flag removal (`OrchestrationViewerStreamer`,
-`OwnerOrchestrationAncestorStreamer`) + legacy viewer REST polling deletion.
-Flag-off: behavior identical to master before this PR. Flag-on: one SSE per
-parent, tracker owns all child state.
+- **`Started`** — a known child keeps hydrating (refetch while incomplete, then
+  request a pane); an unknown child starts a deduplicated metadata fetch. The
+  fetch guard makes repeat `Started` signals for the same run idempotent.
+- **`SessionLinked { session_uuid }`** — fills in `session_id` directly and
+  requests pane materialization, skipping the metadata round trip entirely. If
+  the placeholder does not exist yet the session id is stashed in
+  `pending_session_ids` and applied when the child is created.
+- **`Lifecycle(kind)`** — the tracker is the sole status writer for placeholder
+  children: it writes the mapped `ConversationStatus` through to the history
+  model so the pill badge updates immediately, and emits `ChildStatusChanged`.
+  A lifecycle event for an unknown run falls through to a metadata fetch, which
+  makes lifecycle a complete self-healing backstop for a missed
+  `child_agent_started`.
+- **`Seeded(task)`** — a task row from the metadata cache or a REST listing.
+  Creates the `TrackedChild` if new, otherwise refreshes `last_state` and fills
+  in a missing `session_id`.
+- **`Registered`** — a child created in this process. It already owns a real
+  local conversation, so it is recorded in `in_band_children`, marked
+  `is_remote_child: false`, and never issued a discovery fetch; later
+  `Started` / `Lifecycle` signals for it become plain status updates.
 
-**M2 — Pane path + transcript (PR targets M1 branch).** `ChildPaneMaterialization`
-(§7.5) as the single dispatch for all placeholder children; converged
-`attach_child_session` for both pane origins; state-independent
-`ChildPaneOrigin`; typed task ownership; and capability-aware transcript
-presentation (`LoadTranscript` when terminal + `conversation_id`,
-authorization resolved per §9.1). Edit access restores the established
-ambient continuation pane; ViewOnly/Unknown stays passive. Deletes old
-dispatch machinery:
-`decide_remote_child_hydration_action`, `RemoteChildHydrationAction`,
-`settles()`, `pending_remote_child_hydrations`,
-`process_pending_remote_child_hydrations`, `hydrate_task_backed_hidden_child_pane`,
-`live_attach_ambient_session_to_pane`, `ensure_shared_session_viewer_child_pane`.
+`TrackedChild` holds exactly what the state machine needs: `session_id`
+(`None` until execution is claimed), `last_state`, `pane_materialized`, and
+`is_remote_child`. `ChildSpawned` is emitted exactly once per child, from
+`insert_child`.
 
-```mermaid
-flowchart LR
-  MASTER([master]) --> M1["M1 (PR1)<br/>OrchestrationChildTracker<br/>+ family drain<br/>+ placeholder unification"]
-  M1 --> M2["M2 (PR2)<br/>ChildPaneMaterialization<br/>+ converge attach<br/>+ transcript both modes"]
-  M2 --> DONE(["North star"])
-```
+All tracker metadata fetches route through
+`AgentConversationsModel::get_or_async_fetch_task_data`, which is the single
+fetch authority for task data: it dedupes in-flight requests per task id, backs
+off separately after transient and permanent failures, caches results, and
+emits `TasksUpdated` when fresh data lands. A cache hit resolves the child
+inline; a miss leaves the tracker's guard set and a later signal — or the
+`TasksUpdated` re-drive — completes discovery against a warm cache.
 
-### Flag-gating strategy
-- **One flag (`OrchestrationUnifiedStack`)** gates the entire system. Flag-off
-  preserves exact master baseline; flag-on is the full north-star. No
-  intermediate states to maintain.
-- **Persisted format is forward-compatible**: `is_remote_child = true` rows
-  written by the new system are treated as owner-side pills by old builds
-  (click-through degrades gracefully per §9.3). The flag only controls whether
-  viewer-created rows are written; the encoding is unchanged.
-- **`WaitForEventsParentRegistration`** is preserved in M1 (it guards the
-  `register_root_on_wait` mechanism used by the flag-off path) but superseded
-  by `OrchestrationUnifiedStack` when the flag is on. Promote/remove it
-  separately after `OrchestrationUnifiedStack` is fully rolled out.
+### 3.3 Keeping the task cache honest
+Two drain-side cache updates keep `decide_child_pane_materialization` from
+acting on a stale snapshot taken at discovery time, when the child was still
+`Queued`:
 
-## 9. Hard sub-problems and design decisions
-### 9.1 Terminal child transcript (Phase 2a)
-The viewer path materializes only on a live `session_id`. Clicking a finished
-child must show its transcript; the unified path adds the transcript branch
-(terminal + `conversation_id`, no live session) — additive to OVM and
-effectively the surviving piece of today's `LoadTranscript`. The empirical
-contract (§4.5) is the acceptance test.
+- on `ChildSessionLinked`, `update_task_as_running_with_session` writes the
+  session id onto the cached task and promotes a queued/pending/claimed state to
+  `InProgress`, never downgrading a terminal state that arrived concurrently;
+- on a terminal `ChildLifecycle`, `evict_and_refetch_task` drops the cached
+  entry and refetches, so the refreshed row carries the server conversation
+  token needed for a transcript.
 
-**Authorization (resolved).** Policy decision: if a user has access to view
-a parent orchestrator session, they have access to view the transcripts of
-that session's direct children. Implementation: when a child run's conversation
-object is created (in `UpsertAIConversationMetadata` or
-`CreateThirdPartyConversation` in warp-server), propagate the *parent run's*
-shared session ACLs to the child conversation, in addition to the child's own
-session ACLs. This gives parent-session viewers `ViewAction` on child
-conversation objects, making `getAndVerifyManifest`'s `ViewAction` check
-pass for them. The server change is a prerequisite for Phase 2a's viewer
-transcript branch. Client-side: both pane origins return `LoadTranscript` from
-the unified dispatch when the run is terminal and a `conversation_id` exists.
+### 3.4 Reaching the pill bar
+Placeholders are linked to their parent through
+`BlocklistAIHistoryModel::set_parent_for_conversation`, which maintains the
+`children_by_parent` index. The pill bar renders straight off that index, so a
+child becomes visible the moment `ensure_remote_child_conversation` returns.
 
-**Ownership-aware presentation.** Family-event consumer authority remains
-Primary/Observer regardless of authenticated ownership. Pane construction
-records `ChildPaneOrigin`, also without granting permissions. Task payloads
-deserialize authoritative `scope: { type: User|Team, uid }` and resolve
-tri-state `TaskOwnership`; exact creator equality is used only when older
-payloads omit scope.
+## 4. Child pane materialization
+`decide_child_pane_materialization(task)`
+(`app/src/pane_group/child_agent/materialization.rs:26`) is the single dispatch
+point. It is a free function over an `AmbientAgentTask` — origin-agnostic and
+side-effect free, so identical task state always produces the same action, and
+owner-side and viewer-side children cannot drift apart:
 
-After transcript fetch, conversation object permissions resolve
-`ConversationAccess::{Edit, ViewOnly, Unknown}`. Explicit Edit selects the
-continuation-capable restored ambient cloud-mode pane when task source policy
-allows follow-ups; blocked sources, ViewOnly, and Unknown select the passive
-read-only transcript. When permissions metadata is absent,
-`TaskOwnership::Owned` may provide a compatibility fallback to Edit, but it
-never overrides explicit ViewOnly.
+- **`AttachLive { session_id }`** — the task reports an attachable live session.
+  `attach_ambient_orchestration_child_session` builds a pane that joins that
+  shared session from the start, discards any loading pane already showing for
+  the child, and swaps the replacement into the same anchor only once its
+  session manager, ambient model, and conversation are wired up, so the user
+  never sees a half-built pane. The joined session's role is what governs
+  whether input is allowed.
+- **`LoadTranscript { server_token }`** — the run is terminal and has a
+  non-empty server conversation token. `hydrate_child_transcript` loads the
+  cloud transcript, merges it into the placeholder, then chooses the
+  presentation from the caller's access to the conversation:
+  `CompletedChildPresentation::Continuation` restores the continuation-capable
+  ambient cloud-mode pane when access is `Edit` and the task source permits
+  cloud follow-ups; otherwise `PassiveTranscript` renders a read-only transcript
+  with a conversation-ended tombstone.
+- **`Pending`** — neither an attachable session nor a loadable transcript. The
+  child gets (or keeps) a loading placeholder and is recorded in
+  `pending_child_hydrations`. `process_pending_child_hydrations` re-drives it on
+  the next `TasksUpdated`, re-running the same dispatch.
 
-**Live child authorization.** A successful child shared-session join's
-returned role is authoritative. Reader stays read-only; executable roles may
-send input. Task ownership and pane origin never override Reader,
-`SessionNotAccessible`, or join failure. `SessionNotFound` is a stale/missing
-session signal: evict/refetch task state and transition to transcript if the
-run is terminal. Parent-to-child live authorization for non-owners is a
-separate future server policy and is not part of M2.
+A live join that fails is recorded in `failed_viewer_child_sessions`. The same
+dead session is never retried; the child returns to pending and the pane is
+marked live-unavailable, and refreshed task data can later upgrade it to a
+transcript or attach a subsequent execution
+(`recover_viewer_child_join_failure`).
 
-### 9.2 One stream serving inbox + lifecycle with split cursor authority (Phase 3)
-Primary needs `include_self=true` + hydrated `new_message` delivery *and*
-the lifecycle broadcasts; Observer must get lifecycle without paying for
-inbox hydration and without pushing the server cursor. Decisions to make:
-- Hydration opt-in on the forwarding consumer (Primary on, Observer off) — the
-  direction `AncestorForwardingConsumer`'s doc already sketches.
-- Whether an Observer's `include_self=true` stream simply drops `ParentSelf`
-  events client-side (simplest; costs the parent's event volume on the wire)
-  or keeps `include_self=false` as a viewer-only optimization (two query
-  shapes survive, but only as a parameter, not two pipelines).
-- Cursor: one scalar per family stream; `persist_event_cursor`'s Observer
-  short-circuit becomes the mode dispatch in §7.3.
-- Local in-band children (§7.6, item 4): if their inbox delivery moves onto
-  the family stream, each child's own per-run server cursor must still
-  advance (or be explicitly retired); until then their per-child streams stay
-  for inbox while lifecycle rides the family stream.
+Entry points converge on this dispatch:
+`materialize_child_pane` (from restore, given a placeholder conversation),
+`materialize_viewer_child_pane_from_task` (from a viewer's `TerminalView`
+event), and `process_pending_child_hydrations` (re-drive) all end in
+`apply_child_pane_materialization`.
 
-### 9.3 Placeholder persistence compatibility (Phase 1)
-Old builds must restore rows written by new builds and vice versa. Reusing
-`is_remote_child` as the persisted marker (§7.4) makes new viewer-child rows
-look like owner placeholders to old builds — acceptable (they render as
-pills; click-through degrades to transcript-when-terminal). New builds
-restoring old rows see no viewer children (status quo). The new parent
-`is_durable_observer_parent` field is serde-defaulted and skipped when false;
-old builds ignore it, while new builds treat absent as false. No migration
-is needed.
+### 4.1 Discovery and materialization by parent/child type
+"Local" vs "remote" means different things on each side of the pair. For the
+**parent** it means whether the user is running the orchestrator locally or
+watching it as a shared-session viewer. For the **child** it means whether the
+child runs in-process (local) or as a separate cloud task (remote,
+`is_remote_child = true`).
 
-### 9.4 What stays deliberately un-unified
-- The **wake-only listener** for dormant local Claude children
-  (`DormantClaudeWakeConsumer`) — a different lifecycle problem (folds into
-  the family drain only if §7.6 item 4 proceeds).
-- **Local (same-process) in-band children**: their conversations, terminal
-  panes, and child-role inbox SSEs (`RunIds([self])`) are real and unchanged.
-  The tracker treats them as already-represented — no placeholder, no
-  metadata fetch — and only their lifecycle status flows through it (pill
-  updates). Whether their inbox delivery could later ride the family stream
-  too is deliberately out of scope here (§11).
-- The **parent viewer placeholder** (`is_viewing_shared_session` on the
-  orchestrator conversation itself) — a shared-session concept, not a child
-  representation.
+**1. Local parent / local child.** The parent is a local Warp agent and the
+child is spawned in-process. `create_hidden_child_agent_conversation` creates a
+real child conversation (`is_remote = false`) with a hidden terminal pane, and
+it is persisted normally. Discovery needs no server round trip — the executor
+creates the conversation directly. On restore the conversation is loaded from
+the database, `restore_missing_child_agent_panes_for_parent` finds it in
+`children_by_parent` from the startup index, and `create_hidden_child_agent_pane`
+takes the local branch: a hidden terminal pane restoring the child conversation.
+Task-driven dispatch is not involved.
 
-## 10. Deletion scorecard
-**M1 deletes (never written or deleted from baseline):**
-- `FeatureFlag::OrchestrationViewerStreamer`, `FeatureFlag::OwnerOrchestrationAncestorStreamer`
-  and all usage sites (fully rolled out, deleted from `features.rs`)
-- Legacy viewer REST polling path: `fetch_children`, `schedule_next_poll`,
-  `maybe_kick_polling`, `apply_children_fetch` + interval constants
-- Both separate drain pipelines: `drain_sse_events` + `drain_ancestor_events`
-  replaced by `drain_family_events`; `drain_sse_events`' helpers
-  `register_children_from_events`, `ensure_placeholders_for_child_lifecycle_events`,
-  `trigger_child_task_refreshes` (all subsumed by `observe_child`)
-- OVM child creation no longer writes a second
-  `is_viewing_shared_session` flavor; its fetch/status handlers remain thin
-  pane-state adapters and adopt the history model's mapping.
-- `is_viewing_shared_session` child-placeholder flavor for new writes
-- `WatchedRunIds` per-child run-id sets as filter inputs (child membership
-  lives in the tracker; streamer uses only `self_run_id` for the ancestor filter)
+**2. Local parent / remote child.** The parent is a local Warp agent; the child
+is dispatched to a cloud runner. The child conversation is a placeholder with
+`is_remote_child = true` and is not persisted. Discovery is live:
+`child_agent_started` on the parent's ancestor SSE →
+`ensure_remote_child_placeholder` + `observe_child(Started)` → placeholder in
+`children_by_parent` → pill. Clicking the pill runs
+`decide_child_pane_materialization`. On restore the parent comes back with no
+remote children in its index, so `restore_missing_child_agent_panes_for_parent`
+triggers the ancestor-list seed (§5) and the children are rediscovered from the
+server.
 
-**M2 deletes:**
-- `decide_remote_child_hydration_action`, `RemoteChildHydrationAction`, `settles()`
-- `pending_remote_child_hydrations`, `process_pending_remote_child_hydrations`
-- `hydrate_task_backed_hidden_child_pane`
-- `live_attach_ambient_session_to_pane`, `ensure_shared_session_viewer_child_pane`
-  (converged into `attach_child_session`)
-- Second live-attach construction path; `is_remote_child` and
-  `is_viewing_shared_session` separate branches of `create_hidden_child_agent_pane`
-  (unified to one placeholder branch)
+**3. Remote parent / local child.** The parent is a cloud agent the user is
+watching as a shared-session viewer; the child runs in-process inside that
+cloud run. From the viewer's perspective the child is another run it can only
+observe. Discovery is either the `OrchestrationViewerModel` ancestor seed at
+startup or a live `child_agent_started` on the ancestor stream, both of which
+land in `OrchestrationViewerModel::register_child`, which creates the
+placeholder through `ensure_remote_child_conversation`. Materialization goes
+through the same dispatch; while the run is live this resolves to `AttachLive`
+and joins the child's shared session.
 
-## 11. Risks, validation, open questions
-### Follow-up cleanup
-- **Single task metadata fetch authority.** Flag-on discovery currently has two
-  ways to learn child task metadata: the streamer's placeholder-creation path
-  fetches the child task so it can create a named history row, while the
-  tracker asks `AgentConversationsModel` to fetch or refresh task state for
-  session/transcript materialization. Both paths are idempotent, but they can
-  duplicate network requests and maintain overlapping task snapshots. A
-  follow-up should make `AgentConversationsModel` the only fetch/in-flight
-  authority and have placeholder creation, tracker state, and pane
-  materialization re-drive from that cache.
-- **Child registry consolidation.** Child identity and live state are still
-  split across `BlocklistAIHistoryModel` (persisted conversation/run mapping),
-  `OrchestrationChildTracker` (family event state), `OrchestrationViewerModel`
-  (observer pane/status adapters), and `PaneGroup` (pane materialization and
-  pending hydration maps). The current implementation uses explicit
-  idempotency guards at each boundary, but the long-term shape should be:
-  history as the durable identity source of truth, tracker as transient event
-  state, OVM as a thin observer adapter, and PaneGroup as pane lifecycle only.
-  Defer this until the dogfood behavior stabilizes so the actual invariants are
-  clear.
+**4. Remote parent / remote child.** A cloud agent that spawns another cloud
+agent. Discovery is identical to (3) — the viewer cannot distinguish the two,
+which is the point. Materialization resolves to `AttachLive` while the child is
+running and to `LoadTranscript` once it completes.
 
-**Risks**
-- *Viewer regression*: OVM is load-bearing. M1 keeps all pre-M1 tests
-  green and adds tracker coverage; flag-off is byte-identical to master.
-- *Cursor authority*: the owner is the authoritative server-cursor writer; a
-  shared stream must preserve the viewer's read-only cursor (mode dispatch,
-  §7.3), else a viewer could fast-forward the owner's resume point.
-- *One-level-tree invariant*: discovery assumes direct children; preserve
-  `register_root_on_wait`'s child guard and revisit alongside the server JOIN
-  if multi-level trees arrive.
-- *Forward/backward compat*: old clients ignore `child_agent_started` and
-  `run_session_linked` (unknown event types, cursor advances harmlessly). The
-  server PR is safe to ship before the client. `OrchestrationUnifiedStack`
-  off ⇒ flag-off baseline, no exposure.
-- *`include_self` semantics*: resolved in M1 — viewer receives the same
-  `include_self: true` stream and drops `ParentSelf` events client-side.
-  See `classify_family_event` in §3.5.
-- *Kill tombstones*: `observe_child` step 0 is the sole tombstone gate;
-  it runs before any placeholder creation or pane request, including across
-  the metadata-fetch await and the cancel-during-spawn race.
-- *Reconciliation SSE churn (known transient)*: dropping a stale placeholder
-  in `assign_run_id_for_conversation` emits removal events whose run id the
-  streamer prunes from every watched set — including the parent mid-claiming
-  that run for its real local child. For a single-child parent this tears
-  down and reopens the parent SSE (the executor's `register_watched_run_id`
-  re-adds it); drain-before-teardown prevents data loss and the cursor is
-  preserved, but correctness leans on the emission order of three history
-  events. M1 should make re-pointing explicit (prune the run-id index without
-  treating it as child death) rather than relying on event ordering.
+Cases 2, 3, and 4 all converge on one placeholder flavor, one discovery funnel,
+and one pane dispatch. Case 1 is deliberately different: a real local
+conversation with a real terminal needs neither a placeholder nor a task fetch.
 
-**Validation (M1 validation in §3.6; M2 below)**
-- Task scope serde and ownership: user match/mismatch; team member/nonmember;
-  service-account team; absent scope creator fallback; unknown/malformed
-  scope remains Unknown.
-- An authenticated owner observing through a shared link remains an Observer:
-  no parent-self delivery and no server cursor write.
-- Completed child presentation: Edit → continuation-capable ambient pane;
-  ViewOnly/Unknown → passive transcript; explicit ViewOnly overrides task
-  ownership fallback.
-- Live role: Reader cannot send input; executable SSS roles can. Ownership and
-  pane origin do not affect this result.
-- Re-run the three click-timing cases (early / running / completed) for
-  HostedConversation and SharedSession origins after M2 lands; the completed
-  shared-session case is new coverage delivered by M2.
-- Restart-restore case: an owned `/cloud-agent` Observer parent restores from
-  its ambient pane task ID with the persisted local cursor, re-registers OVM,
-  and reconstructs named child pills from persisted `is_remote_child` rows.
-  App-state tests cover both running shared-session selection and terminal
-  existing-conversation restoration with exchanges and no compose zero state.
-- Owner-side pill status updates while the child pane stays closed (M1:
-  tracker is sole status writer in both modes).
-- Unit surfaces: tracker state machine (`observe_child` idempotency, signal
-  ordering, tombstone skip, fetch dedup), drain classification,
-  cursor-authority dispatch, pane-path branch selection, stale terminal
-  session, bounded SessionNotFound recovery, and empty-transcript/no-compose
-  presentation.
-- Run native and WASM checks. If WASM fails before compiling Warp code due to
-  the local C/clang target, record that pre-Warp toolchain blocker explicitly.
-- Observability: counters/logs for placeholder creations, metadata-fetch
-  failures, and family-stream opens per mode, so a flag-on regression shows
-  up in dogfood telemetry rather than only in bug reports.
+## 5. Restore (after restart)
+Remote child conversations and shared-session parent conversations are not
+persisted (`write_updated_conversation_state` returns early for
+`is_viewing_shared_session` or `is_remote_child`). After a restart the client
+therefore starts with no knowledge of a parent's cloud children and rebuilds it
+from the server.
 
-**Open questions**
-- **RESOLVED.** Does the server reliably emit a lifecycle event at (or just
-  after) `session_id` linking? Yes: `run_session_linked` (S5) is emitted
-  and M1 consumes it via `ChildSignal::SessionLinked`, filling in `session_id`
-  without a metadata fetch. No polling fallback needed.
-- **RESOLVED.** Phase 3 topology: M1 ships one `include_self: true` family
-  SSE per parent; viewer drops `ParentSelf` events client-side (simplest;
-  avoids a second wire shape). Resolved by implementation decision in M1.
-- Should the unified placeholder eventually rename `is_remote_child` to a
-  neutral `is_child_placeholder` (serde alias for compatibility), or is the
-  legacy name acceptable indefinitely?
-- Should local in-band children's inbox delivery eventually ride the family
-  stream as well (retiring their per-child `RunIds([self])` streams, per the
-  `AncestorForwardingConsumer` sketch), or is per-child stream isolation
-  worth keeping?
-- **RESOLVED.** Viewer transcript authorization (§9.1): parent-session
-  viewers are granted access to child transcripts. Server must propagate
-  parent session ACLs to child conversation objects at creation time.
-- Viewer seed pagination: the cold-start REST seed caps at 100 children
-  (server cap); fine today, but the unified seed should define behavior
-  beyond it.
+`restore_missing_child_agent_panes_for_parent(parent_conversation_id,
+parent_pane_id, trigger_seed_if_empty, ctx)` runs when a parent agent view is
+restored or entered fullscreen. It reads the parent's children from
+`children_by_parent` and, when `trigger_seed_if_empty` is set and none of them
+are remote, kicks off the ancestor-list seed. The "none are remote" test rather
+than "the list is empty" matters: a parent with a mix of persisted local
+children and not-yet-discovered remote ones would otherwise never seed.
+
+`seed_child_conversations_from_task` records the parent in
+`pending_parent_child_seeds`, ensures the shared `TasksUpdated` subscription is
+installed, and issues `GET /agent/runs?ancestor_run_id=<parent_task_id>` with a
+limit of 100 (the server's cap).
+
+`finish_seed_child_conversations_from_task` applies the response:
+
+- a fetch error leaves the pending entry in place so
+  `process_pending_parent_child_seeds` retries on the next `TasksUpdated`;
+- the parent's own row is skipped (the ancestor endpoint includes it);
+- each child's task data is resolved through the shared cache, and each
+  resolved child is linked under the parent with
+  `ensure_remote_child_conversation` — idempotent, so racing the SSE family
+  drain or a repeat seed costs nothing;
+- if any child's task data is still being fetched the parent stays pending;
+  otherwise the pending entry is cleared;
+- finally it calls `restore_missing_child_agent_panes_for_parent` with
+  `trigger_seed_if_empty = false` so panes materialize in the same pass.
+
+Children linked this way land in `children_by_parent`, and the pill bar renders
+off that index. Children registered before the parent's run id was known have
+their `parent_agent_id` backfilled when the parent's
+`ConversationServerTokenAssigned` history event fires, which is also what
+prompts the streamer to re-evaluate the parent's stream eligibility now that a
+`self_run_id` exists.
+
+The seed also runs directly from the cloud-agent restore paths
+(`load_data_into_transcript_viewer` and
+`replace_loading_pane_with_restored_ambient_cloud_mode_pane_inner`), after the
+pane swap so the parent's pane is resolvable when children materialize.
+
+## 6. Observer mode (viewer discovering children)
+When a viewer joins a shared session and the session's source identifies it as
+an ambient agent run, `NetworkEvent::JoinedSuccessfully` creates an
+`OrchestrationViewerModel` for the parent task
+(`app/src/terminal/shared_session/viewer/terminal_manager.rs:899`). The model is
+per pane; durable child identity is shared through `BlocklistAIHistoryModel`,
+and the streamer is a process-wide singleton.
+
+The model registers itself as a viewer-mode consumer for the parent task once
+the pane's active conversation is the orchestrator placeholder. Registration is
+refcounted: several viewer panes on the same parent share one entry and one SSE,
+and the entry (with its SSE) is torn down when the last consumer unregisters.
+
+On first registration the streamer issues the cold-start ancestor seed
+(`spawn_ancestor_seed_fetch`): `GET /agent/runs?ancestor_run_id=<parent>`. Each
+returned child is recorded in `known_children`, the cursor is advanced to the
+highest `last_event_sequence` seen, and `ChildSpawned` is emitted for each. Only
+after the seed lands does the ancestor SSE open, resuming from that cursor, so
+replayed events for already-known children do not produce duplicate spawns. A
+failed seed is not retried on a timer; the next consumer registration or
+reconnect re-issues it.
+
+Live discovery then runs through the same family drain in
+`FamilyDrainMode::Observer`: `child_agent_started`, `run_session_linked`, and
+child lifecycle events all flow into the tracker, `ChildSpawned` /
+`ChildStatusChanged` reach the viewer model, and the cursor is persisted locally
+onto every registered placeholder and never pushed to the server. The observer's
+connection is opened with `include_self: false` — a viewer has no use for the
+orchestrator's inbox — and the drain drops `ParentSelf` events regardless, so
+the behavior does not depend on the wire filter.
+
+`OrchestrationViewerModel::register_child` creates the placeholder through
+`ensure_remote_child_conversation`, writes status through on change, and asks
+the parent's `TerminalView` to materialize the child pane by emitting
+`EnsureUnifiedViewerChildPane { conversation_id, task }`. Carrying the task
+snapshot is what lets the pane group run the same
+`decide_child_pane_materialization` dispatch the owner side uses, instead of
+only being able to act on a raw session id. A short poll re-fetches metadata for
+children that are not yet materializable, which covers the window between a
+child being created and its sandbox session being linked.
+
+## 7. Cursor authority
+Each family stream has one cursor: the highest fully-handled `sequence`.
+Reconnects resume from it (`since=`).
+
+- Primary persists to SQLite and pushes to the server. The push happens even
+  when a batch contained only child events, so the parent's resume point never
+  lags behind its own stream.
+- Observer persists to SQLite only, folding in the conversation's
+  already-persisted value so the write stays monotonic, and mirrors the advanced
+  cursor onto every registered viewer placeholder.
+
+`Opaque` events advance the cursor without any other effect, so an unrecognised
+server event type can never wedge a stream.
+
+## 8. Flag-off path
+With `OrchestrationUnifiedStack` disabled the client takes the per-conversation
+owner drain and the ancestor-only viewer drain, and none of the unified code
+runs. This code is unmodified by the unified stack; both dispatchers pick a path
+and nothing else in the flag-off branches is touched.
+
+- `drain_owner_events` → `drain_sse_events`: the per-conversation drain feeds
+  `handle_event_batch` directly and persists the cursor locally and to the
+  server.
+- `drain_viewer_events` → `drain_ancestor_events`: the ancestor-only drain
+  emits `ChildSpawned` / `ChildStatusChanged` from `known_children`, drops
+  `new_message`, and persists the cursor to every viewer placeholder.
+- Viewer children are created as `is_viewing_shared_session` conversations by
+  `OrchestrationViewerModel`, which fetches task metadata with its own
+  in-flight guard and emits `EnsureSharedSessionViewerChildPane` once a raw
+  `session_id` is available; `ensure_shared_session_viewer_child_pane` builds
+  the per-child viewer pane.
+- Owner-side remote children restore through
+  `hydrate_task_backed_hidden_child_pane`, whose action is chosen by
+  `decide_remote_child_hydration_action` (`LiveAttach` / `LoadTranscript` /
+  `Fallback`), with pending entries re-driven by
+  `process_pending_remote_child_hydrations`.
+- `seed_child_conversations_from_task`, `process_pending_parent_child_seeds`,
+  and `process_pending_child_hydrations` all return immediately, so no seed runs
+  and no pending map is populated.
+
+## 9. Key invariants
+**`is_remote_child` is set before the first database write, or the child is
+never written at all.** `start_new_child_conversation` takes `is_remote` and
+applies it before its initial `persist_conversation_state`
+(`app/src/ai/blocklist/history_model.rs:542`). Setting the marker after that
+first persist would write a row with `is_remote_child = false` and
+`run_id = None`, and the persistence guard would then block every later,
+correct write for that conversation — leaving a permanently wrong row on disk.
+
+**`trigger_seed_if_empty` is `false` when
+`finish_seed_child_conversations_from_task` calls back into
+`restore_missing_child_agent_panes_for_parent`.** That call is itself the
+completion of a seed. A parent that legitimately has no children would otherwise
+see an empty child list, start another seed, complete it empty, and loop
+forever. Every entry point that is *not* downstream of a seed completion passes
+`true`.
+
+**The ancestor seed never retries on a completed empty result.** A successful
+fetch whose children all resolved — including the zero-children case — clears
+the parent's `pending_parent_child_seeds` entry. Only a fetch error or a child
+whose task data is still in flight leaves the entry pending for
+`process_pending_parent_child_seeds` to re-drive.
+
+**Tombstoned runs are gated before any side effect.** The tombstone check is
+the first thing `observe_child` does, ahead of placeholder creation, status
+writes, and pane requests, so a kill cannot be undone by a late event or a
+metadata fetch that was already in flight.
+
+**Placeholder creation is idempotent and has one authority.**
+`ensure_remote_child_conversation` is the only way a remote-child placeholder
+and its run-id mapping come into existence. The drain's placeholder callback,
+the viewer model's metadata callback, and the restore seed can all race; each
+either creates the mapping or adopts the existing one, so exactly one named
+conversation ever occupies `agent_id_to_conversation_id` for a run.
+
+**Pane materialization is idempotent.** Every materialization entry point first
+checks whether the child already has a live tracked pane in `child_agent_panes`
+and returns if so, rather than creating a second pane and orphaning the first.

--- a/specs/QUALITY-928/TECH.md
+++ b/specs/QUALITY-928/TECH.md
@@ -8,19 +8,30 @@ answers two questions for any orchestrator the user has open:
 1. **Which children exist?** — discovery.
 2. **What should this child's pane show right now?** — materialization.
 
+**The concrete problem this work addresses:** when a cloud-hosted orchestrator
+calls `run_agents`, the children execute in a separate sandbox that the local
+Warp client never created. For a shared-session viewer of that orchestrator the
+client's process also never created the children. In both cases the children
+must be discovered by the client rather than found in its local state.
+
 It solves two problems:
 
-**(a) Real-time child discovery during a live run.** A child can be created by
-any path — the parent's own `run_agents` tool call, the Oz CLI, the web API, or
-another client. The client learns about every one of them from a single
-server-sent event stream on the parent's run, with no polling, and surfaces
-each child as a named pill with live status.
+**(a) Real-time child discovery during a live run.** The client discovers every
+child from a single server-sent event stream on the parent's run — regardless
+of which process created the child — with no polling, surfacing each as a named
+pill with live status.
 
 **(b) Restore of the pill bar and child panes after a restart.** Cloud child
 runs and shared-session parent views are ephemeral cloud state and are
 deliberately not written to the local database. After a restart the client
 rebuilds the parent→child relationship from the server's ancestor listing and
 re-materializes child panes through the same dispatch used during a live run.
+
+**M1 scope.** This PR establishes the core machinery: the family-stream
+classification (`drain_family_events`, `classify_family_event`) that routes SSE
+events to the right handler, and the `OrchestrationChildTracker` that manages
+per-child state. Pane materialization and the restore seed path land in M2,
+which builds directly on this foundation.
 
 Everything below is gated by `FeatureFlag::OrchestrationUnifiedStack`
 (`crates/warp_features/src/lib.rs:715`, listed in `DOGFOOD_FLAGS`). With the
@@ -163,9 +174,8 @@ the signal:
   `Started` / `Lifecycle` signals for it become plain status updates.
 
 `TrackedChild` holds exactly what the state machine needs: `session_id`
-(`None` until execution is claimed), `last_state`, `pane_materialized`, and
-`is_remote_child`. `ChildSpawned` is emitted exactly once per child, from
-`insert_child`.
+(`None` until execution is claimed), `last_state`, and `is_remote_child`.
+`ChildSpawned` is emitted exactly once per child, from `insert_child`.
 
 All tracker metadata fetches route through
 `AgentConversationsModel::get_or_async_fetch_task_data`, which is the single


### PR DESCRIPTION
## Description

Introduces the orchestration child tracking foundation for the unified orchestration stack (QUALITY-928).

## What

- `OrchestrationChildTracker`: a single `observe_child` entry point for every child signal — discovery, session link, lifecycle, REST seed, and in-band registration. `Started` kicks off a deduped metadata fetch; the `TrackedChild` is inserted when that resolves.
- `FamilyDrainMode` (`Primary` / `Observer`) is the sole mode axis. Primary delivers parent-self events and writes the server cursor; Observer drops parent-self events and persists the cursor locally only.
- `TrackedChild` holds no `conversation_id`. `ChildSignal::Registered` is a unit variant.
- `ensure_remote_child_placeholder` creates a local `is_remote_child` placeholder on `child_agent_started`, with a child-lifecycle backstop for missed discovery events.
- `drain_family_events` classifies each event on the family SSE stream and routes it to the tracker or to parent-self delivery.
- `FeatureFlag::OrchestrationUnifiedStack` gates all flag-ON code paths; flag-OFF falls back to the existing per-conversation and ancestor-only drains unchanged.

## Why

A single observer entry point with a clear Primary/Observer distinction makes child tracking auditable and race-safe. The unified tracker is the foundation M2 builds on for pane materialization and task-driven restore.

## Linked Issue

QUALITY-928

## Testing

- `orchestration_child_tracker_tests.rs`: observe_child idempotency, tombstone skip, fetch dedup, lifecycle-first discovery, and viewer child placeholder behavior.
- `orchestration_event_streamer_tests.rs`: FamilyEvent classification, drain routing, Primary parent delivery, Observer local-only cursor, and child-status routing.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->