### PR TITLE
Add mock MCP backend type with _meta round-trip

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, SystemTime};
 use ai::api_keys::{ApiKeyManager, AwsCredentialsRefreshStrategy};
 use ai::skills::{ParsedSkill, SKILL_PROVIDER_DEFINITIONS};
 use anyhow::{Context as _, anyhow};
+use cloud_object_models::mcp::MCPMockConfigRef;
 use futures::FutureExt as _;
 use futures::channel::oneshot;
 use futures::future::{self, Either, join_all};
@@ -70,8 +71,8 @@ use crate::ai::mcp::file_based_manager::{FileBasedMCPManager, FileBasedMCPManage
 use crate::ai::mcp::parsing::{ParsedTemplatableMCPServerResult, normalize_mcp_json, resolve_json};
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManagerEvent;
 use crate::ai::mcp::{
-    JSONMCPServer, MCPServerState, TemplatableMCPServerInstallation, TemplatableMCPServerManager,
-    VariableType, VariableValue,
+    JSONMCPServer, MCPServerState, TemplatableMCPServer, TemplatableMCPServerInstallation,
+    TemplatableMCPServerManager, VariableType, VariableValue,
 };
 use crate::ai::skills::{
     SkillManager, SkillWatcher, filter_skills_by_spec, read_skills_from_directories,
@@ -87,6 +88,7 @@ use crate::server::server_api::harness_support::{
     HarnessSupportClient, ResolvePromptAttachedSkill, ResolvePromptRequest,
 };
 use crate::server::server_api::managed_mcp::ManagedMcpClient;
+use crate::server::server_api::mock_mcp::MockMcpClient;
 use crate::terminal::cli_agent_sessions::plugin_manager::{
     CliAgentPluginManager, plugin_manager_for,
 };
@@ -478,6 +480,8 @@ pub enum AgentDriverError {
     MCPServerNotFound(uuid::Uuid),
     #[error("Failed to resolve managed MCP server {uid}: {message}")]
     ManagedMcpResolutionFailed { uid: Uuid, message: String },
+    #[error("Failed to resolve mock MCP server for template '{template}': {message}")]
+    MockMcpResolutionFailed { template: String, message: String },
     #[error("Failed to start MCP servers: {}", .details.join("; "))]
     MCPStartupFailed {
         /// One line per unavailable server (e.g. "'datadog' failed to start:
@@ -605,6 +609,23 @@ register_error!(AgentDriverError);
 struct ResolvedMcpSpecs {
     local_uuids: Vec<Uuid>,
     ephemeral_installations: Vec<TemplatableMCPServerInstallation>,
+    /// Mock-backed ephemeral installations paired with their mock config, keyed
+    /// by installation UUID. Registered with the MCP manager after startup so the
+    /// tool executor can inject `_meta` (instructions + session state) on each
+    /// `tools/call`.
+    mock_configs: Vec<(Uuid, MCPMockConfigRef)>,
+}
+
+/// A mock-backed MCP server entry extracted from an inline JSON spec, before it
+/// is resolved to a URL-backed connection via `createMockMCPClientConfig`.
+struct MockServerEntry {
+    /// The server name as declared in the MCP config map.
+    name: String,
+    /// The mock backend reference (template, instructions, model id).
+    mock: MCPMockConfigRef,
+    /// Additional headers declared alongside `mock`, passed through to the
+    /// resolved URL-backed connection. These never override `Authorization`.
+    extra_headers: HashMap<String, String>,
 }
 
 impl From<warpui::ModelDropped> for AgentDriverError {
@@ -1134,9 +1155,11 @@ impl AgentDriver {
         specs: &[MCPSpec],
         secrets: Arc<HashMap<String, ManagedSecretValue>>,
         managed_mcp_client: Arc<dyn ManagedMcpClient>,
+        mock_mcp_client: Arc<dyn MockMcpClient>,
         foreground: &ModelSpawner<Self>,
     ) -> Result<HashMap<String, JSONMCPServer>, AgentDriverError> {
-        let resolved_specs = Self::resolve_mcp_specs(specs, managed_mcp_client, foreground).await?;
+        let resolved_specs =
+            Self::resolve_mcp_specs(specs, managed_mcp_client, mock_mcp_client, foreground).await?;
 
         let local_uuids = resolved_specs.local_uuids;
         let mut installations = foreground
@@ -1180,6 +1203,7 @@ impl AgentDriver {
     async fn resolve_mcp_specs(
         specs: &[MCPSpec],
         managed_mcp_client: Arc<dyn ManagedMcpClient>,
+        mock_mcp_client: Arc<dyn MockMcpClient>,
         foreground: &ModelSpawner<Self>,
     ) -> Result<ResolvedMcpSpecs, AgentDriverError> {
         let local_installed_uuids = foreground
@@ -1192,14 +1216,20 @@ impl AgentDriver {
             })
             .await?;
 
-        Self::resolve_mcp_specs_with_local_uuids(specs, &local_installed_uuids, managed_mcp_client)
-            .await
+        Self::resolve_mcp_specs_with_local_uuids(
+            specs,
+            &local_installed_uuids,
+            managed_mcp_client,
+            mock_mcp_client,
+        )
+        .await
     }
 
     async fn resolve_mcp_specs_with_local_uuids(
         specs: &[MCPSpec],
         local_installed_uuids: &HashSet<Uuid>,
         managed_mcp_client: Arc<dyn ManagedMcpClient>,
+        mock_mcp_client: Arc<dyn MockMcpClient>,
     ) -> Result<ResolvedMcpSpecs, AgentDriverError> {
         let mut resolved = ResolvedMcpSpecs::default();
 
@@ -1263,14 +1293,135 @@ impl AgentDriver {
                     }
                 }
                 MCPSpec::Json(json_str) => {
-                    resolved
-                        .ephemeral_installations
-                        .extend(Self::installations_from_user_mcp_json(json_str)?);
+                    // Split mock-backed servers out of the inline JSON: the mock
+                    // backend must be resolved to a URL-backed connection via
+                    // GraphQL before it can be started, while any remaining
+                    // servers follow the ordinary user-JSON path.
+                    let (plain_json, mock_entries) = Self::split_mock_servers(json_str)?;
+                    if let Some(plain_json) = plain_json {
+                        resolved
+                            .ephemeral_installations
+                            .extend(Self::installations_from_user_mcp_json(&plain_json)?);
+                    }
+                    for entry in mock_entries {
+                        Self::resolve_mock_entry(entry, &mock_mcp_client, &mut resolved).await?;
+                    }
                 }
             }
         }
 
         Ok(resolved)
+    }
+
+    /// Splits an inline MCP JSON spec into the non-mock server JSON (if any) and
+    /// the list of mock-backed server entries. Mock entries carry their
+    /// `MCPMockConfigRef` plus any sibling `headers` to pass through to the
+    /// resolved URL-backed connection.
+    fn split_mock_servers(
+        json_str: &str,
+    ) -> Result<(Option<String>, Vec<MockServerEntry>), AgentDriverError> {
+        let normalized_json = normalize_mcp_json(json_str)
+            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+        let value: serde_json::Value = serde_json::from_str(&normalized_json)
+            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+        let server_map = TemplatableMCPServer::find_template_map(value)
+            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+
+        let mut plain = serde_json::Map::new();
+        let mut mocks = Vec::new();
+        for (name, config) in server_map {
+            let mock_value = config.as_object().and_then(|obj| obj.get("mock"));
+            let Some(mock_value) = mock_value else {
+                plain.insert(name, config);
+                continue;
+            };
+            let mock: MCPMockConfigRef = serde_json::from_value(mock_value.clone())
+                .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+            let extra_headers = config
+                .as_object()
+                .and_then(|obj| obj.get("headers"))
+                .and_then(|headers| headers.as_object())
+                .map(|map| {
+                    map.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_owned())))
+                        .collect::<HashMap<String, String>>()
+                })
+                .unwrap_or_default();
+            mocks.push(MockServerEntry {
+                name,
+                mock,
+                extra_headers,
+            });
+        }
+
+        let plain_json = if plain.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Object(plain).to_string())
+        };
+        Ok((plain_json, mocks))
+    }
+
+    /// Resolves a single mock-backed server entry: mints a URL + bearer token via
+    /// `createMockMCPClientConfig`, converts it to a URL-backed installation, and
+    /// records the mock config so `_meta` can be injected on each tools/call.
+    async fn resolve_mock_entry(
+        entry: MockServerEntry,
+        mock_mcp_client: &Arc<dyn MockMcpClient>,
+        resolved: &mut ResolvedMcpSpecs,
+    ) -> Result<(), AgentDriverError> {
+        let MockServerEntry {
+            name,
+            mock,
+            extra_headers,
+        } = entry;
+
+        let config = mock_mcp_client
+            .create_mock_mcp_client_config(mock.template.clone(), mock.model_id.clone())
+            .await
+            .map_err(|err| AgentDriverError::MockMcpResolutionFailed {
+                template: mock.template.clone(),
+                message: format!("{err:#}"),
+            })?;
+
+        let url_json =
+            Self::build_mock_server_json(&name, &config.mcp_url, &config.token, &extra_headers);
+        // Reuse the managed-config path so server-issued literal values (URL,
+        // Authorization) are preserved verbatim and can't be clobbered by a
+        // colliding local secret during `apply_secrets`.
+        let installations = Self::installations_from_managed_client_config_json(&url_json)
+            .map_err(|err| AgentDriverError::MockMcpResolutionFailed {
+                template: mock.template.clone(),
+                message: err.to_string(),
+            })?;
+        for installation in installations {
+            resolved
+                .mock_configs
+                .push((installation.uuid(), mock.clone()));
+            resolved.ephemeral_installations.push(installation);
+        }
+        Ok(())
+    }
+
+    /// Builds a single-server URL-backed MCP JSON config for a resolved mock
+    /// backend. `extra_headers` are merged in first so the server-issued
+    /// `Authorization` header always wins.
+    fn build_mock_server_json(
+        name: &str,
+        url: &str,
+        token: &str,
+        extra_headers: &HashMap<String, String>,
+    ) -> String {
+        let mut headers = serde_json::Map::new();
+        for (key, value) in extra_headers {
+            headers.insert(key.clone(), serde_json::Value::String(value.clone()));
+        }
+        headers.insert(
+            "Authorization".to_owned(),
+            serde_json::Value::String(format!("Bearer {token}")),
+        );
+        let server = serde_json::json!({ "url": url, "headers": headers });
+        serde_json::json!({ name: server }).to_string()
     }
 
     fn installations_from_user_mcp_json(
@@ -2206,14 +2357,22 @@ impl AgentDriver {
             let managed_mcp_client = foreground
                 .spawn(|_, ctx| ServerApiProvider::as_ref(ctx).get_managed_mcp_client())
                 .await?;
+            let mock_mcp_client = foreground
+                .spawn(|_, ctx| ServerApiProvider::as_ref(ctx).get_mock_mcp_client())
+                .await?;
 
             let mcp_startup_result = setup_events
                 .record_result(SetupStep::McpServerStartup, async {
-                    let resolved_mcp_specs =
-                        Self::resolve_mcp_specs(&mcp_specs, managed_mcp_client, &foreground)
-                            .await?;
+                    let resolved_mcp_specs = Self::resolve_mcp_specs(
+                        &mcp_specs,
+                        managed_mcp_client,
+                        mock_mcp_client,
+                        &foreground,
+                    )
+                    .await?;
                     let existing_uuids = resolved_mcp_specs.local_uuids;
                     let ephemeral_installations = resolved_mcp_specs.ephemeral_installations;
+                    let mock_configs = resolved_mcp_specs.mock_configs;
 
                     log::info!(
                         "Starting {} existing and {} ephemeral MCP servers",
@@ -2241,6 +2400,23 @@ impl AgentDriver {
                             .await?
                             .await;
                         Self::collect_mcp_degradation(result, &mut degraded)?;
+                    }
+                    // Register resolved mock configs so the tool executor can
+                    // inject `_meta` (instructions + session state) on each
+                    // tools/call to a mock-backed server.
+                    if !mock_configs.is_empty() {
+                        foreground
+                            .spawn(move |_, ctx| {
+                                TemplatableMCPServerManager::handle(ctx).update(
+                                    ctx,
+                                    |manager, _| {
+                                        for (uuid, mock) in mock_configs {
+                                            manager.set_mock_config(uuid, mock);
+                                        }
+                                    },
+                                );
+                            })
+                            .await?;
                     }
                     if degraded.is_empty() {
                         Ok(())
@@ -2805,7 +2981,14 @@ impl AgentDriver {
         harness: &dyn ThirdPartyHarness,
         foreground: &ModelSpawner<Self>,
     ) -> Result<Arc<dyn harness::HarnessRunner>, AgentDriverError> {
-        let (working_dir, task_id, server_api, managed_mcp_client, terminal_driver) = foreground
+        let (
+            working_dir,
+            task_id,
+            server_api,
+            managed_mcp_client,
+            mock_mcp_client,
+            terminal_driver,
+        ) = foreground
             .spawn(|me, ctx| {
                 if me.harness.is_some() {
                     log::error!(
@@ -2819,6 +3002,7 @@ impl AgentDriver {
                     me.task_id,
                     ServerApiProvider::as_ref(ctx).get(),
                     ServerApiProvider::as_ref(ctx).get_managed_mcp_client(),
+                    ServerApiProvider::as_ref(ctx).get_mock_mcp_client(),
                     me.terminal_driver.clone(),
                 ))
             })
@@ -2877,9 +3061,14 @@ impl AgentDriver {
 
         // Resolve MCP specs into harness-native JSON format.
         let mcp_specs = mcp_specs.to_vec();
-        let resolved_mcp_servers =
-            Self::resolve_mcp_specs_to_json(&mcp_specs, secrets, managed_mcp_client, foreground)
-                .await?;
+        let resolved_mcp_servers = Self::resolve_mcp_specs_to_json(
+            &mcp_specs,
+            secrets,
+            managed_mcp_client,
+            mock_mcp_client,
+            foreground,
+        )
+        .await?;
         if !resolved_mcp_servers.is_empty() {
             log::info!(
                 "Resolved {} MCP server(s) for third-party harness",

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -107,6 +107,15 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
+        AgentDriverError::MockMcpResolutionFailed { template, message } => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                format!(
+                    "Mock MCP server for template '{template}' could not be resolved: {message}"
+                ),
+                PlatformErrorCode::EnvironmentSetupFailed,
+            ),
+        ),
         AgentDriverError::MCPStartupFailed { details } => {
             let server_lines = details
                 .iter()

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -22,7 +22,9 @@ use warp_core::features::FeatureFlag;
 use warp_graphql::mutations::create_managed_mcp_client_config::{
     CreateManagedMcpClientConfigOutput, ManagedMcpTransportKind,
 };
+use warp_graphql::mutations::create_mock_mcp_client_config::MockMcpClientConfig;
 use warp_graphql::response_context::ResponseContext;
+use warp_graphql::scalars::Time;
 use warp_managed_secrets::ManagedSecretValue;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::{App, SingletonEntity as _};
@@ -45,6 +47,7 @@ use crate::ai::mcp::JSONTransportType;
 use crate::ai::mcp::parsing::normalize_mcp_json;
 use crate::ai::skills::SkillManager;
 use crate::server::server_api::managed_mcp::MockManagedMcpClient;
+use crate::server::server_api::mock_mcp::MockMockMcpClient;
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
 
 #[test]
@@ -157,6 +160,20 @@ fn raw_secret(value: &str) -> ManagedSecretValue {
     }
 }
 
+fn mock_client_config(mcp_url: &str, token: &str) -> MockMcpClientConfig {
+    MockMcpClientConfig {
+        mcp_url: mcp_url.to_string(),
+        token: token.to_string(),
+        expires_at: Time::from_unix_timestamp_micros(0).unwrap(),
+    }
+}
+
+/// A `MockMcpClient` that fails the test if `create_mock_mcp_client_config` is
+/// ever called. Used to assert the mock path is not taken for non-mock specs.
+fn unused_mock_mcp_client() -> Arc<MockMockMcpClient> {
+    Arc::new(MockMockMcpClient::new())
+}
+
 fn render_installations(
     installations: Vec<crate::ai::mcp::TemplatableMCPServerInstallation>,
     secrets: HashMap<String, ManagedSecretValue>,
@@ -174,6 +191,7 @@ fn managed_resolver_local_uuid_does_not_call_managed_client() {
         &[MCPSpec::Uuid(uuid)],
         &local_installed_uuids,
         Arc::new(mock),
+        unused_mock_mcp_client(),
     ))
     .unwrap();
 
@@ -198,6 +216,7 @@ fn managed_resolver_non_local_uuid_calls_managed_client() {
         &[MCPSpec::Uuid(uuid)],
         &HashSet::new(),
         Arc::new(mock),
+        unused_mock_mcp_client(),
     ))
     .unwrap();
 
@@ -221,6 +240,7 @@ fn well_known_spec_resolves_via_managed_client() {
         &[MCPSpec::WellKnown("linear".to_string())],
         &HashSet::new(),
         Arc::new(mock),
+        unused_mock_mcp_client(),
     ))
     .unwrap();
 
@@ -242,6 +262,7 @@ fn well_known_resolution_failure_skips_server() {
         &[MCPSpec::WellKnown("linear".to_string())],
         &HashSet::new(),
         Arc::new(mock),
+        unused_mock_mcp_client(),
     ))
     .unwrap();
 
@@ -274,6 +295,7 @@ fn well_known_resolution_failure_does_not_drop_other_specs() {
         ],
         &HashSet::new(),
         Arc::new(mock),
+        unused_mock_mcp_client(),
     ))
     .unwrap();
 
@@ -291,6 +313,7 @@ fn well_known_spec_is_skipped_when_flag_disabled() {
         &[MCPSpec::WellKnown("linear".to_string())],
         &HashSet::new(),
         Arc::new(mock),
+        unused_mock_mcp_client(),
     ))
     .unwrap();
 
@@ -450,6 +473,7 @@ fn managed_resolution_failure_includes_uid_and_message() {
         &[MCPSpec::Uuid(uuid)],
         &HashSet::new(),
         Arc::new(mock),
+        unused_mock_mcp_client(),
     ))
     .unwrap_err();
 
@@ -459,6 +483,124 @@ fn managed_resolution_failure_includes_uid_and_message() {
             assert!(message.contains("not active"));
         }
         other => panic!("expected managed MCP resolution failure, got {other:?}"),
+    }
+}
+
+#[test]
+fn mock_spec_resolves_to_url_with_bearer_token() {
+    let mut mock_client = MockMockMcpClient::new();
+    mock_client
+        .expect_create_mock_mcp_client_config()
+        .times(1)
+        .returning(|template, model_id| {
+            assert_eq!(template, "linear");
+            assert_eq!(model_id, None);
+            Ok(mock_client_config(
+                "http://localhost:8089/mcp-mock/abc",
+                "tok_123",
+            ))
+        });
+
+    let json = r#"{"linear":{"mock":{"template":"linear","instructions":"you are a mock linear server"}}}"#;
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::Json(json.to_string())],
+        &HashSet::new(),
+        Arc::new(MockManagedMcpClient::new()),
+        Arc::new(mock_client),
+    ))
+    .unwrap();
+
+    assert_eq!(resolved.ephemeral_installations.len(), 1);
+    assert_eq!(resolved.mock_configs.len(), 1);
+
+    let rendered = render_installations(resolved.ephemeral_installations, HashMap::new());
+    match &rendered["linear"].transport_type {
+        JSONTransportType::SSEServer { url, headers } => {
+            assert_eq!(url, "http://localhost:8089/mcp-mock/abc");
+            assert_eq!(
+                headers.get("Authorization").map(String::as_str),
+                Some("Bearer tok_123")
+            );
+        }
+        other => panic!("expected SSE server, got {other:?}"),
+    }
+}
+
+#[test]
+fn mock_spec_merges_extra_headers_with_authorization() {
+    let mut mock_client = MockMockMcpClient::new();
+    mock_client
+        .expect_create_mock_mcp_client_config()
+        .times(1)
+        .returning(|_, _| {
+            Ok(mock_client_config(
+                "http://localhost:8089/mcp-mock/abc",
+                "tok_123",
+            ))
+        });
+
+    let json = r#"{"linear":{"mock":{"template":"linear","instructions":"ctx"},"headers":{"X-Custom":"val"}}}"#;
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::Json(json.to_string())],
+        &HashSet::new(),
+        Arc::new(MockManagedMcpClient::new()),
+        Arc::new(mock_client),
+    ))
+    .unwrap();
+
+    let rendered = render_installations(resolved.ephemeral_installations, HashMap::new());
+    match &rendered["linear"].transport_type {
+        JSONTransportType::SSEServer { headers, .. } => {
+            assert_eq!(
+                headers.get("Authorization").map(String::as_str),
+                Some("Bearer tok_123")
+            );
+            assert_eq!(headers.get("X-Custom").map(String::as_str), Some("val"));
+        }
+        other => panic!("expected SSE server, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_mock_json_spec_does_not_call_mock_client() {
+    // A plain URL-backed JSON spec must not trigger the mock resolution path.
+    // `unused_mock_mcp_client` sets no expectations, so any call would panic.
+    let json = r#"{"my-server":{"url":"http://localhost:3000/mcp"}}"#;
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::Json(json.to_string())],
+        &HashSet::new(),
+        Arc::new(MockManagedMcpClient::new()),
+        unused_mock_mcp_client(),
+    ))
+    .unwrap();
+
+    assert_eq!(resolved.ephemeral_installations.len(), 1);
+    assert!(resolved.mock_configs.is_empty());
+}
+
+#[test]
+fn mock_resolution_failure_propagates() {
+    let mut mock_client = MockMockMcpClient::new();
+    mock_client
+        .expect_create_mock_mcp_client_config()
+        .times(1)
+        .returning(|_, _| Err(anyhow::anyhow!("template not found")));
+
+    let json = r#"{"linear":{"mock":{"template":"linear","instructions":"ctx"}}}"#;
+    let err = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::Json(json.to_string())],
+        &HashSet::new(),
+        Arc::new(MockManagedMcpClient::new()),
+        Arc::new(mock_client),
+    ))
+    .unwrap_err();
+
+    match err {
+        AgentDriverError::MockMcpResolutionFailed { template, message } => {
+            assert_eq!(template, "linear");
+            assert!(message.contains("template not found"));
+        }
+        other => panic!("expected mock MCP resolution failure, got {other:?}"),
     }
 }
 

--- a/app/src/ai/agent_sdk/mcp_config.rs
+++ b/app/src/ai/agent_sdk/mcp_config.rs
@@ -140,11 +140,15 @@ fn validate_server_config(server_name: &str, config: &Value) -> anyhow::Result<(
     let has_warp_id = obj.contains_key("warp_id");
     let has_command = obj.contains_key("command");
     let has_url = obj.contains_key("url");
+    let has_mock = obj.contains_key("mock");
 
-    let kind_count = usize::from(has_warp_id) + usize::from(has_command) + usize::from(has_url);
+    let kind_count = usize::from(has_warp_id)
+        + usize::from(has_command)
+        + usize::from(has_url)
+        + usize::from(has_mock);
     if kind_count != 1 {
         anyhow::bail!(
-            "MCP server '{server_name}' must have exactly one of: 'warp_id', 'command', or 'url'"
+            "MCP server '{server_name}' must have exactly one of: 'warp_id', 'command', 'url', or 'mock'"
         );
     }
 
@@ -197,6 +201,25 @@ fn validate_server_config(server_name: &str, config: &Value) -> anyhow::Result<(
 
         if url.is_empty() {
             anyhow::bail!("MCP server '{server_name}' field 'url' must be non-empty");
+        }
+    }
+
+    // The `mock` backend is resolved server-side to a URL-backed connection, so
+    // `headers`, `env`, and `args` are allowed alongside it and passed through.
+    if has_mock {
+        let mock = obj.get("mock").and_then(Value::as_object).ok_or_else(|| {
+            anyhow::anyhow!("MCP server '{server_name}' field 'mock' must be an object")
+        })?;
+
+        let template = mock
+            .get("template")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                anyhow::anyhow!("MCP server '{server_name}' field 'mock.template' must be a string")
+            })?;
+
+        if template.trim().is_empty() {
+            anyhow::bail!("MCP server '{server_name}' field 'mock.template' must be non-empty");
         }
     }
 

--- a/app/src/ai/agent_sdk/mcp_config_tests.rs
+++ b/app/src/ai/agent_sdk/mcp_config_tests.rs
@@ -249,7 +249,7 @@ fn validation_rejects_invalid_entries() {
     let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
     assert!(
         err.to_string()
-            .contains("must have exactly one of: 'warp_id', 'command', or 'url'")
+            .contains("must have exactly one of: 'warp_id', 'command', 'url', or 'mock'")
     );
 
     // warp_id must be a non-empty string (UUID or, behind WellKnownMcpIds,
@@ -294,6 +294,90 @@ fn validation_rejects_invalid_entries() {
     let spec = json!({ "mcpServers": { "bad": 1 } }).to_string();
     let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
     assert!(err.to_string().contains("config must be a JSON object"));
+}
+
+#[test]
+fn mock_backend_is_accepted() {
+    let spec = json!({
+        "mcpServers": {
+            "linear": { "mock": { "template": "linear", "instructions": "5 open bugs" } }
+        }
+    })
+    .to_string();
+
+    let servers = build(vec![MCPSpec::Json(spec)]);
+
+    assert_eq!(
+        servers["linear"]["mock"]["template"].as_str(),
+        Some("linear")
+    );
+}
+
+#[test]
+fn mock_with_empty_instructions_is_accepted() {
+    let spec = json!({
+        "mcpServers": {
+            "linear": { "mock": { "template": "linear", "instructions": "" } }
+        }
+    })
+    .to_string();
+
+    let servers = build(vec![MCPSpec::Json(spec)]);
+
+    assert_eq!(
+        servers["linear"]["mock"]["template"].as_str(),
+        Some("linear")
+    );
+}
+
+#[test]
+fn mock_with_headers_is_accepted() {
+    // Headers may be set alongside mock; they pass through to the resolved connection.
+    let spec = json!({
+        "mcpServers": {
+            "linear": {
+                "mock": { "template": "linear", "instructions": "ctx" },
+                "headers": { "Authorization": "Bearer x" }
+            }
+        }
+    })
+    .to_string();
+
+    let servers = build(vec![MCPSpec::Json(spec)]);
+
+    assert_eq!(
+        servers["linear"]["headers"]["Authorization"].as_str(),
+        Some("Bearer x")
+    );
+}
+
+#[test]
+fn mock_and_url_together_fails_validation() {
+    let spec = json!({
+        "mcpServers": {
+            "bad": {
+                "mock": { "template": "linear", "instructions": "ctx" },
+                "url": "https://example.com/mcp"
+            }
+        }
+    })
+    .to_string();
+
+    let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
+    assert!(err.to_string().contains("must have exactly one"));
+}
+
+#[test]
+fn mock_with_empty_template_fails_validation() {
+    let spec = json!({
+        "mcpServers": {
+            "bad": { "mock": { "template": "", "instructions": "ctx" } }
+        }
+    })
+    .to_string();
+
+    let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
+    assert!(err.to_string().contains("template"));
 }
 
 #[test]

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -20,6 +20,8 @@ use crate::{
     },
     send_telemetry_from_app_ctx,
 };
+#[cfg(not(target_family = "wasm"))]
+use uuid::Uuid;
 
 pub struct CallMCPToolExecutor {
     _active_session: ModelHandle<ActiveSession>,
@@ -126,30 +128,42 @@ impl CallMCPToolExecutor {
                 coerce_integer_args(&mut arguments, &schema);
             }
 
-            let templatable_peer = if let Some(installation_id) = server_id {
-                templatable_mcp_manager
-                    .server_with_installation_id_and_tool_name(*installation_id, name.to_owned())
-            } else {
-                templatable_mcp_manager.server_with_tool_name(name.to_owned())
-            };
-
-            let Some(reconnecting_peer) = templatable_peer else {
+            let Some((installation_uuid, reconnecting_peer)) = templatable_mcp_manager
+                .server_and_installation_with_tool(*server_id, name.as_str())
+            else {
                 return ActionExecution::Sync(AIAgentActionResultType::CallMCPTool(
                     CallMCPToolResult::Error("MCP server for tool not found".to_owned()),
                 ));
             };
 
+            // Mock-backed servers receive the scenario instructions plus the
+            // rolling session state as `_meta`; ordinary servers get none.
+            let outbound_meta = build_outbound_meta(
+                templatable_mcp_manager
+                    .mock_config(installation_uuid)
+                    .as_ref(),
+                templatable_mcp_manager
+                    .last_meta(installation_uuid)
+                    .as_ref(),
+            );
+
             let name_owned_inner = name_owned.clone();
             ActionExecution::new_async(
                 async move {
-                    reconnecting_peer
-                        .call_tool(
-                            rmcp::model::CallToolRequestParams::new(name_owned_inner)
-                                .with_arguments(arguments),
-                        )
-                        .await
+                    let mut params = rmcp::model::CallToolRequestParams::new(name_owned_inner)
+                        .with_arguments(arguments);
+                    params.meta = outbound_meta;
+                    reconnecting_peer.call_tool(params).await
                 },
-                move |res, ctx| handle_call_tool_result(res, server_output_id, name_clone, ctx),
+                move |res, ctx| {
+                    handle_call_tool_result(
+                        res,
+                        server_output_id,
+                        name_clone,
+                        installation_uuid,
+                        ctx,
+                    )
+                },
             )
         }
     }
@@ -290,14 +304,55 @@ fn coerce_value_against_schema(value: &mut serde_json::Value, schema: &serde_jso
 #[path = "call_mcp_tool_tests.rs"]
 mod tests;
 
+/// Builds the outbound `_meta` payload for a `tools/call`.
+///
+/// Mock-backed servers receive the scenario `mock_instructions` on every call
+/// plus the rolling `session_state` captured from the previous result (absent on
+/// the first call). Ordinary servers get no `_meta`.
+#[cfg(not(target_family = "wasm"))]
+fn build_outbound_meta(
+    mock: Option<&cloud_object_models::mcp::MCPMockConfigRef>,
+    last_meta: Option<&serde_json::Value>,
+) -> Option<rmcp::model::Meta> {
+    let mock = mock?;
+    let mut meta_map = serde_json::Map::new();
+    meta_map.insert(
+        "mock_instructions".to_owned(),
+        serde_json::Value::String(mock.instructions.clone()),
+    );
+    if let Some(last) = last_meta {
+        meta_map.insert("session_state".to_owned(), last.clone());
+    }
+    Some(rmcp::model::Meta(meta_map))
+}
+
+/// Extracts the `session_state` entry from a tool result's `_meta`, if present,
+/// so it can be forwarded on the next call to a mock-backed server.
+#[cfg(not(target_family = "wasm"))]
+fn capture_session_state(result_meta: Option<&rmcp::model::Meta>) -> Option<serde_json::Value> {
+    result_meta.and_then(|meta| meta.0.get("session_state").cloned())
+}
+
 /// Handles the result of a call_tool request, converting it to an AIAgentActionResultType.
 #[cfg(not(target_family = "wasm"))]
 fn handle_call_tool_result(
     res: Result<rmcp::model::CallToolResult, rmcp::ServiceError>,
     server_output_id: Option<crate::ai::blocklist::action_model::execute::ServerOutputId>,
     tool_name: String,
-    ctx: &warpui::AppContext,
+    installation_uuid: Uuid,
+    ctx: &mut warpui::AppContext,
 ) -> AIAgentActionResultType {
+    // Persist the rolling `_meta` session state from a mock-backed server so it is
+    // forwarded on the next tools/call. No-op for ordinary servers, which do not
+    // return a `session_state`.
+    if let Ok(result) = &res
+        && let Some(state) = capture_session_state(result.meta.as_ref())
+    {
+        TemplatableMCPServerManager::handle(ctx).update(ctx, |manager, _ctx| {
+            manager.set_last_meta(installation_uuid, Some(state));
+        });
+    }
+
     let action_result = match res {
         Ok(result) => {
             // Even if the call was successful, the response could still be an error so we need to check.

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
@@ -318,3 +318,81 @@ fn already_integer_value_is_unchanged() {
     assert_eq!(args["x"].as_i64(), Some(5));
     assert_eq!(serde_json::to_string(&args["x"]).unwrap(), "5");
 }
+
+// Tests for outbound `_meta` injection and inbound `session_state` capture used
+// by mock-backed MCP servers.
+#[cfg(not(target_family = "wasm"))]
+mod meta {
+    use cloud_object_models::mcp::MCPMockConfigRef;
+    use serde_json::{Value, json};
+
+    use super::super::{build_outbound_meta, capture_session_state};
+
+    fn mock_cfg(instructions: &str) -> MCPMockConfigRef {
+        MCPMockConfigRef {
+            template: "linear".to_owned(),
+            instructions: instructions.to_owned(),
+            model_id: None,
+        }
+    }
+
+    #[test]
+    fn mock_server_injects_mock_instructions() {
+        let cfg = mock_cfg("5 open bugs");
+        let meta = build_outbound_meta(Some(&cfg), None).expect("mock server produces _meta");
+        assert_eq!(
+            meta.0.get("mock_instructions"),
+            Some(&Value::String("5 open bugs".to_owned()))
+        );
+    }
+
+    #[test]
+    fn non_mock_server_produces_no_meta() {
+        assert!(build_outbound_meta(None, None).is_none());
+        // A stored session state without a mock config still yields no `_meta`.
+        assert!(build_outbound_meta(None, Some(&json!({ "turns": 1 }))).is_none());
+    }
+
+    #[test]
+    fn last_meta_is_forwarded_as_session_state() {
+        let cfg = mock_cfg("instructions");
+        let state = json!({ "history": ["turn one"] });
+        let meta =
+            build_outbound_meta(Some(&cfg), Some(&state)).expect("mock server produces _meta");
+        assert_eq!(meta.0.get("session_state"), Some(&state));
+        assert_eq!(
+            meta.0.get("mock_instructions"),
+            Some(&Value::String("instructions".to_owned()))
+        );
+    }
+
+    #[test]
+    fn absent_last_meta_omits_session_state() {
+        let cfg = mock_cfg("instructions");
+        let meta = build_outbound_meta(Some(&cfg), None).expect("mock server produces _meta");
+        assert!(!meta.0.contains_key("session_state"));
+        assert!(meta.0.contains_key("mock_instructions"));
+    }
+
+    #[test]
+    fn capture_reads_session_state_from_result_meta() {
+        let mut map = serde_json::Map::new();
+        map.insert("session_state".to_owned(), Value::String("abc".to_owned()));
+        let meta = rmcp::model::Meta(map);
+        assert_eq!(
+            capture_session_state(Some(&meta)),
+            Some(Value::String("abc".to_owned()))
+        );
+    }
+
+    #[test]
+    fn capture_returns_none_without_meta_or_session_state() {
+        // Absent `_meta` entirely.
+        assert_eq!(capture_session_state(None), None);
+        // Present `_meta` but no `session_state` key.
+        let mut map = serde_json::Map::new();
+        map.insert("other".to_owned(), Value::Bool(true));
+        let meta = rmcp::model::Meta(map);
+        assert_eq!(capture_session_state(Some(&meta)), None);
+    }
+}

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -46,6 +46,11 @@ pub struct TemplatableMCPServerManager {
     locally_installed_servers: HashMap<Uuid, TemplatableMCPServerInstallation>,
     server_states: HashMap<Uuid, MCPServerState>,
     active_servers: HashMap<Uuid, TemplatableMCPServerInfo>,
+    /// Resolved mock-backend configuration for mock-backed servers, keyed by
+    /// installation UUID. Populated when a mock server connection is established
+    /// and consumed by the tool executor to inject `_meta` on each tools/call.
+    #[cfg(not(target_family = "wasm"))]
+    mock_configs: HashMap<Uuid, cloud_object_models::mcp::MCPMockConfigRef>,
 
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
     spawned_servers: HashMap<Uuid, SpawnedServerInfo>,
@@ -247,8 +252,8 @@ impl TemplatableMCPServerManager {
     /// Returns the JSON Schema `input_schema` for a named tool across active MCP servers.
     ///
     /// If `installation_id` is `Some`, only that server is considered; otherwise, the
-    /// first active server providing a matching tool name wins (matching the existing
-    /// `server_with_tool_name` lookup behavior).
+    /// first active server providing a matching tool name wins (matching the
+    /// `server_and_installation_with_tool` lookup behavior).
     ///
     /// Used by the MCP tool executor to coerce integer-typed args before dispatch, since
     /// `structpb.NumberValue` on the wire cannot preserve the integer/float distinction.

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -1945,8 +1945,6 @@ impl TemplatableMCPServerManager {
 
     /// Stores the resolved mock-backend configuration for an installation. Invoked
     /// when a mock-backed server connection is established.
-    // Populated by mock backend resolution (createMockMCPClientConfig wiring).
-    #[allow(dead_code)]
     pub fn set_mock_config(
         &mut self,
         installation_uuid: Uuid,

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -398,6 +398,7 @@ impl TemplatableMCPServerManager {
             cloud_templatable_mcp_servers: Default::default(),
             server_states: Default::default(),
             active_servers: Default::default(),
+            mock_configs: Default::default(),
             spawned_servers: Default::default(),
             server_credentials: Default::default(),
             file_based_server_credentials: Default::default(),
@@ -1898,42 +1899,75 @@ impl TemplatableMCPServerManager {
         }
     }
 
-    /// Returns a reconnecting peer for a server that has the given tool.
+    /// Resolves the installation providing a tool along with a reconnecting peer
+    /// for it.
     ///
-    /// The returned peer will automatically reconnect if the underlying transport is closed.
-    pub fn server_with_tool_name(
+    /// When `installation_id` is `Some`, only that server is considered; otherwise
+    /// the first active server offering the tool wins. The returned peer
+    /// automatically reconnects if the underlying transport is closed, and the
+    /// returned UUID lets the caller look up per-connection state such as the mock
+    /// backend config and the rolling `_meta` session state.
+    pub fn server_and_installation_with_tool(
         &self,
-        tool_name: String,
-    ) -> Option<crate::ai::mcp::reconnecting_peer::ReconnectingPeer> {
+        installation_id: Option<Uuid>,
+        tool_name: &str,
+    ) -> Option<(Uuid, crate::ai::mcp::reconnecting_peer::ReconnectingPeer)> {
         let spawner = self.spawner.as_ref()?;
-        self.active_servers
-            .iter()
-            .find(|(_, server)| server.has_tool(&tool_name))
-            .map(|(installation_uuid, _)| {
-                crate::ai::mcp::reconnecting_peer::ReconnectingPeer::new(
-                    *installation_uuid,
-                    spawner.clone(),
-                )
-            })
+        let installation_uuid = match installation_id {
+            Some(uuid) => self
+                .active_servers
+                .get(&uuid)
+                .filter(|server| server.has_tool(tool_name))
+                .map(|_| uuid)?,
+            None => self
+                .active_servers
+                .iter()
+                .find(|(_, server)| server.has_tool(tool_name))
+                .map(|(uuid, _)| *uuid)?,
+        };
+        Some((
+            installation_uuid,
+            crate::ai::mcp::reconnecting_peer::ReconnectingPeer::new(
+                installation_uuid,
+                spawner.clone(),
+            ),
+        ))
     }
 
-    /// Returns a reconnecting peer for a server with the given installation ID and tool.
-    ///
-    /// The returned peer will automatically reconnect if the underlying transport is closed.
-    pub fn server_with_installation_id_and_tool_name(
+    /// Returns the resolved mock-backend configuration for an installation, if the
+    /// server is mock-backed.
+    pub fn mock_config(
         &self,
-        installation_id: Uuid,
-        tool_name: String,
-    ) -> Option<crate::ai::mcp::reconnecting_peer::ReconnectingPeer> {
-        let spawner = self.spawner.as_ref()?;
-        let server = self.active_servers.get(&installation_id)?;
-        if server.has_tool(&tool_name) {
-            Some(crate::ai::mcp::reconnecting_peer::ReconnectingPeer::new(
-                installation_id,
-                spawner.clone(),
-            ))
-        } else {
-            None
+        installation_uuid: Uuid,
+    ) -> Option<cloud_object_models::mcp::MCPMockConfigRef> {
+        self.mock_configs.get(&installation_uuid).cloned()
+    }
+
+    /// Stores the resolved mock-backend configuration for an installation. Invoked
+    /// when a mock-backed server connection is established.
+    // Populated by mock backend resolution (createMockMCPClientConfig wiring).
+    #[allow(dead_code)]
+    pub fn set_mock_config(
+        &mut self,
+        installation_uuid: Uuid,
+        mock: cloud_object_models::mcp::MCPMockConfigRef,
+    ) {
+        self.mock_configs.insert(installation_uuid, mock);
+    }
+
+    /// Returns the most recent `_meta` session state round-tripped from a mock
+    /// backend for the given installation, if any.
+    pub fn last_meta(&self, installation_uuid: Uuid) -> Option<serde_json::Value> {
+        self.active_servers
+            .get(&installation_uuid)
+            .and_then(|server| server.last_meta.clone())
+    }
+
+    /// Stores the `_meta` session state captured from a mock backend's tool result
+    /// so it is forwarded on the next tools/call for the same connection.
+    pub fn set_last_meta(&mut self, installation_uuid: Uuid, meta: Option<serde_json::Value>) {
+        if let Some(server) = self.active_servers.get_mut(&installation_uuid) {
+            server.last_meta = meta;
         }
     }
 

--- a/app/src/ai/mcp/templatable_manager/wasm.rs
+++ b/app/src/ai/mcp/templatable_manager/wasm.rs
@@ -110,6 +110,18 @@ impl TemplatableMCPServerManager {
         log::warn!("Ephemeral MCP server spawning not supported in WASM");
     }
 
+    /// Stores the resolved mock-backend configuration for an installation.
+    ///
+    /// This is a no-op in WASM, as MCP servers are not supported in WASM.
+    #[allow(dead_code)]
+    pub fn set_mock_config(
+        &mut self,
+        _installation_uuid: Uuid,
+        _mock: cloud_object_models::mcp::MCPMockConfigRef,
+    ) {
+        log::warn!("Mock MCP config storage not supported in WASM");
+    }
+
     /// Shuts down a running MCP server.
     ///
     /// This is a no-op in WASM, as MCP servers are not supported in WASM.

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -8,6 +8,7 @@ pub mod harness_support;
 pub mod integrations;
 pub mod managed_mcp;
 pub mod managed_secrets;
+pub mod mock_mcp;
 pub mod object;
 pub(crate) mod presigned_upload;
 pub mod referral;
@@ -29,6 +30,7 @@ use chrono::{DateTime, FixedOffset};
 use factory::FactoryClient;
 use instant::Instant;
 use managed_mcp::ManagedMcpClient;
+use mock_mcp::MockMcpClient;
 use object::ObjectClient;
 use parking_lot::Mutex;
 use referral::ReferralsClient;
@@ -1384,6 +1386,11 @@ impl ServerApiProvider {
 
     #[cfg_attr(target_family = "wasm", expect(dead_code))]
     pub fn get_managed_mcp_client(&self) -> Arc<dyn ManagedMcpClient> {
+        self.server_api.clone()
+    }
+
+    #[cfg_attr(target_family = "wasm", expect(dead_code))]
+    pub fn get_mock_mcp_client(&self) -> Arc<dyn MockMcpClient> {
         self.server_api.clone()
     }
 

--- a/app/src/server/server_api/mock_mcp.rs
+++ b/app/src/server/server_api/mock_mcp.rs
@@ -1,0 +1,46 @@
+// Mock MCP backends are only resolved from agent run flows, which don't run on WASM.
+#![cfg_attr(target_family = "wasm", expect(dead_code))]
+
+use anyhow::Result;
+use async_trait::async_trait;
+use cynic::MutationBuilder;
+#[cfg(test)]
+use mockall::automock;
+use warp_graphql::mutations::create_mock_mcp_client_config::{
+    CreateMockMcpClientConfig, CreateMockMcpClientConfigInput, CreateMockMcpClientConfigVariables,
+    MockMcpClientConfig,
+};
+
+use super::ServerApi;
+
+#[cfg_attr(test, automock)]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+pub trait MockMcpClient: 'static + Send + Sync {
+    /// Resolves a mock MCP backend to a URL-backed connection. `template` is a
+    /// managed MCP warp_id or well-known integration id (e.g. "linear") whose
+    /// stored tool catalog the mock endpoint mirrors; `model_id` is an optional
+    /// user-facing model alias for the LLM that generates tool responses.
+    async fn create_mock_mcp_client_config(
+        &self,
+        template: String,
+        model_id: Option<String>,
+    ) -> Result<MockMcpClientConfig>;
+}
+
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+impl MockMcpClient for ServerApi {
+    async fn create_mock_mcp_client_config(
+        &self,
+        template: String,
+        model_id: Option<String>,
+    ) -> Result<MockMcpClientConfig> {
+        let variables = CreateMockMcpClientConfigVariables {
+            input: CreateMockMcpClientConfigInput { template, model_id },
+        };
+        let operation = CreateMockMcpClientConfig::build(variables);
+        let response = self.send_graphql_request(operation, None).await?;
+        Ok(response.create_mock_mcp_client_config)
+    }
+}

--- a/crates/cloud_object_models/src/mcp.rs
+++ b/crates/cloud_object_models/src/mcp.rs
@@ -98,6 +98,20 @@ pub struct ServerSentEvents {
     pub headers: Vec<StaticHeader>,
 }
 
+/// Reference to a mock MCP backend, resolved server-side to an LLM-backed
+/// endpoint that stands in for a real integration during an agent run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MCPMockConfigRef {
+    /// warp_id or well-known integration name (e.g. "linear") whose stored tool
+    /// catalog the mock endpoint mirrors.
+    pub template: String,
+    /// Scenario context injected in `_meta.mock_instructions` on every tools/call.
+    pub instructions: String,
+    /// User-facing model alias (e.g. "claude-3-5-haiku"). Defaults server-side when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+}
+
 impl JsonModel for MCPServer {
     fn json_object_type() -> JsonObjectType {
         JsonObjectType::MCPServer

--- a/crates/cloud_object_models/src/mcp_tests.rs
+++ b/crates/cloud_object_models/src/mcp_tests.rs
@@ -1,4 +1,6 @@
-use super::{CLIServer, MCPServer, ServerSentEvents, StaticEnvVar, TransportType};
+use super::{
+    CLIServer, MCPMockConfigRef, MCPServer, ServerSentEvents, StaticEnvVar, TransportType,
+};
 
 #[test]
 fn test_mcp_server_config_serialization_excludes_secret_env_values() {
@@ -115,4 +117,34 @@ fn test_sse_server_serialization() {
         serialized.contains("sse-server"),
         "Serialized SSE server should contain name: {serialized}",
     );
+}
+
+#[test]
+fn test_mock_config_ref_omits_absent_model_id() {
+    let mock = MCPMockConfigRef {
+        template: "linear".to_string(),
+        instructions: "The project has 5 open bugs.".to_string(),
+        model_id: None,
+    };
+
+    let serialized = serde_json::to_string(&mock).expect("Failed to serialize mock config ref");
+
+    assert!(serialized.contains("linear"));
+    // An absent model_id should be omitted from the serialized output entirely.
+    assert!(
+        !serialized.contains("model_id"),
+        "model_id should be omitted when None: {serialized}",
+    );
+}
+
+#[test]
+fn test_mock_config_ref_round_trips() {
+    let json = r#"{"template": "linear", "instructions": "ctx", "model_id": "claude-3-5-haiku"}"#;
+
+    let mock: MCPMockConfigRef =
+        serde_json::from_str(json).expect("Failed to deserialize mock config ref");
+
+    assert_eq!(mock.template, "linear");
+    assert_eq!(mock.instructions, "ctx");
+    assert_eq!(mock.model_id.as_deref(), Some("claude-3-5-haiku"));
 }

--- a/crates/graphql/src/api/mutations/create_mock_mcp_client_config.rs
+++ b/crates/graphql/src/api/mutations/create_mock_mcp_client_config.rs
@@ -1,0 +1,37 @@
+use crate::scalars::Time;
+use crate::schema;
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct CreateMockMcpClientConfigVariables {
+    pub input: CreateMockMcpClientConfigInput,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "RootMutation",
+    variables = "CreateMockMcpClientConfigVariables"
+)]
+pub struct CreateMockMcpClientConfig {
+    #[arguments(input: $input)]
+    #[cynic(rename = "createMockMCPClientConfig")]
+    pub create_mock_mcp_client_config: MockMcpClientConfig,
+}
+
+crate::client::define_operation! {
+    create_mock_mcp_client_config(CreateMockMcpClientConfigVariables) -> CreateMockMcpClientConfig;
+}
+
+#[derive(cynic::InputObject, Debug)]
+#[cynic(graphql_type = "CreateMockMCPClientConfigInput")]
+pub struct CreateMockMcpClientConfigInput {
+    pub template: String,
+    pub model_id: Option<String>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(graphql_type = "MockMCPClientConfig")]
+pub struct MockMcpClientConfig {
+    pub mcp_url: String,
+    pub token: String,
+    pub expires_at: Time,
+}

--- a/crates/graphql/src/api/mutations/mod.rs
+++ b/crates/graphql/src/api/mutations/mod.rs
@@ -9,6 +9,7 @@ pub mod create_folder;
 pub mod create_generic_string_object;
 pub mod create_managed_mcp_client_config;
 pub mod create_managed_secret;
+pub mod create_mock_mcp_client_config;
 pub mod create_notebook;
 pub mod create_simple_integration;
 pub mod create_team;

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -24,6 +24,10 @@ pub struct TemplatableMCPServerInfo {
     /// to provide a "log out" button.
     #[allow(dead_code)]
     is_authenticated_transport: bool,
+    /// Most recent `_meta` state round-tripped from a mock MCP backend's tool
+    /// results, forwarded on the next tool call to preserve conversation history.
+    /// In-memory only; reset on reconnect since the mock is ephemeral per run.
+    pub last_meta: Option<serde_json::Value>,
 }
 
 impl TemplatableMCPServerInfo {

--- a/crates/mcp/src/runtime.rs
+++ b/crates/mcp/src/runtime.rs
@@ -331,6 +331,7 @@ pub async fn spawn_server(
         installation_id: uuid,
         description,
         is_authenticated_transport,
+        last_meta: None,
     })
 }
 

--- a/crates/warp_graphql_schema/api/client-schema.ts
+++ b/crates/warp_graphql_schema/api/client-schema.ts
@@ -14,6 +14,7 @@ const clientMutations = [
   'createGenericStringObject',
   'createManagedMcpClientConfig',
   'createManagedSecret',
+  'createMockMCPClientConfig',
   'createNotebook',
   'createTeam',
   'createWorkflow',

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -993,6 +993,17 @@ type CreateManagedMcpClientConfigOutput implements Response {
 
 union CreateManagedMcpClientConfigResult = CreateManagedMcpClientConfigOutput | UserFacingError
 
+input CreateMockMCPClientConfigInput {
+  template: String!
+  modelId: String
+}
+
+type MockMCPClientConfig {
+  mcpUrl: String!
+  token: String!
+  expiresAt: Time!
+}
+
 input CreateNotebookInput {
   aiDocumentId: String
   conversationId: String
@@ -3063,6 +3074,7 @@ type RootMutation {
   createGenericStringObject(input: CreateGenericStringObjectInput!, requestContext: RequestContext!): CreateGenericStringObjectResult!
   createManagedMcpClientConfig(input: CreateManagedMcpClientConfigInput!, requestContext: RequestContext!): CreateManagedMcpClientConfigResult!
   createManagedSecret(input: CreateManagedSecretInput!, requestContext: RequestContext!): CreateManagedSecretResult!
+  createMockMCPClientConfig(input: CreateMockMCPClientConfigInput!): MockMCPClientConfig!
   createNotebook(input: CreateNotebookInput!, requestContext: RequestContext!): CreateNotebookResult!
   createSimpleIntegration(input: CreateSimpleIntegrationInput!, requestContext: RequestContext!): CreateSimpleIntegrationResult!
   createTeam(input: CreateTeamInput!, requestContext: RequestContext!): CreateTeamResult!


### PR DESCRIPTION
## What

Adds `MCPMockConfigRef` struct and a fourth exclusive `mock` backend type to MCP server config. At agent run-start, mock-backed configs call `createMockMCPClientConfig` on the server to get a session URL and bearer token, then connect as a URL-backed server.

On each `tools/call`, injects `_meta.mock_instructions` (from the mock config) and `_meta.session_state` (accumulated conversation history from the previous response) into the outgoing request, and captures `_meta.session_state` from the result to maintain stateless conversation context across calls.

## Why

Companion client changes for the LLM-backed mock MCP server added in warp-server. Allows factory agents to use mock MCP servers without real external integrations (Linear, GitHub, etc.).

## Testing

- [x] Unit tests for `MCPMockConfigRef` validation (4th exclusive backend type enforcement)
- [x] Unit tests for `_meta` injection/capture logic in `call_mcp_tool.rs` (6 tests: outbound _meta field injection, inbound session_state capture, round-trip state propagation)
- [x] Unit tests for mock backend resolution in `driver.rs` (4 tests: mock config lookup, URL+token wiring, fallback behavior)

## Agent Mode
- [x] This PR was created by Warp Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
