### PR TITLE
[APP-4992] Add --auto-approve to Warp Agent CLI

### DIFF
--- a/crates/warp_tui/src/conversation_selection.rs
+++ b/crates/warp_tui/src/conversation_selection.rs
@@ -13,6 +13,7 @@ use warpui::{AppContext, EntityId, ModelContext, SingletonEntity};
 pub(super) struct TuiConversationSelection {
     terminal_surface_id: EntityId,
     terminal_model: Arc<FairMutex<TerminalModel>>,
+    default_autoexecute_mode: AIConversationAutoexecuteMode,
     pending_query_state: PendingQueryState,
 }
 
@@ -21,9 +22,15 @@ impl TuiConversationSelection {
     pub(super) fn new(
         terminal_surface_id: EntityId,
         terminal_model: Arc<FairMutex<TerminalModel>>,
+        default_autoexecute_mode: AIConversationAutoexecuteMode,
         ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
     ) -> Self {
-        let conversation_id = Self::start_new_conversation(terminal_surface_id, false, ctx);
+        let conversation_id = Self::start_new_conversation(
+            terminal_surface_id,
+            default_autoexecute_mode.is_autoexecute_any_action(),
+            ctx,
+        );
+
         terminal_model
             .lock()
             .block_list_mut()
@@ -35,6 +42,7 @@ impl TuiConversationSelection {
         Self {
             terminal_surface_id,
             terminal_model,
+            default_autoexecute_mode,
             pending_query_state: PendingQueryState::Existing { conversation_id },
         }
     }
@@ -67,7 +75,7 @@ impl TuiConversationSelection {
         self.set_terminal_conversation_context(None);
         self.set_pending_query_state(
             PendingQueryState::New {
-                autoexecute_override: AIConversationAutoexecuteMode::RespectUserSettings,
+                autoexecute_override: self.default_autoexecute_mode,
             },
             ctx,
         );
@@ -252,7 +260,11 @@ impl ConversationSelection for TuiConversationSelection {
         if let Some(previous_conversation_id) = previous_conversation_id {
             Self::emit_deactivated(previous_conversation_id, true, ctx);
         }
-        let conversation_id = Self::start_new_conversation(self.terminal_surface_id, false, ctx);
+        let conversation_id = Self::start_new_conversation(
+            self.terminal_surface_id,
+            self.default_autoexecute_mode.is_autoexecute_any_action(),
+            ctx,
+        );
         self.set_terminal_conversation_context(Some(conversation_id));
         self.set_pending_query_state(PendingQueryState::Existing { conversation_id }, ctx);
         Self::emit_activated(origin, ctx);
@@ -353,6 +365,20 @@ impl ConversationSelection for TuiConversationSelection {
                 new_conversation_id,
                 ..
             } if self.selected_id() == Some(*old_conversation_id) => {
+                if self.default_autoexecute_mode.is_autoexecute_any_action() {
+                    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                        if history
+                            .conversation(new_conversation_id)
+                            .is_some_and(|conversation| !conversation.autoexecute_any_action())
+                        {
+                            history.toggle_autoexecute_override(
+                                new_conversation_id,
+                                self.terminal_surface_id,
+                                ctx,
+                            );
+                        }
+                    });
+                }
                 self.select_existing_conversation(
                     *new_conversation_id,
                     AgentViewEntryOrigin::AgentRequestedNewConversation,

--- a/crates/warp_tui/src/conversation_selection_tests.rs
+++ b/crates/warp_tui/src/conversation_selection_tests.rs
@@ -5,10 +5,10 @@ use warp::tui_export::{
     AIConversationAutoexecuteMode, AIConversationId, AgentConversationListEntryState,
     AgentRunDisplayStatus, AgentViewEntryOrigin, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
     ConversationSelection, ConversationSelectionEvent, ConversationSelectionHandle, Harness,
-    TerminalModel, TranscriptScope,
+    TerminalModel, TranscriptScope, register_tui_session_view_test_singletons,
 };
 use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
-use warpui::{App, EntityId, ModelHandle};
+use warpui::{App, EntityId, ModelHandle, SingletonEntity};
 
 use super::{
     ConversationListEntryContext, TuiConversationSelection, classify_conversation_list_entry,
@@ -137,6 +137,18 @@ fn build_tui_selection(
     EntityId,
     Arc<FairMutex<TerminalModel>>,
 ) {
+    build_tui_selection_with_default(app, AIConversationAutoexecuteMode::RespectUserSettings)
+}
+
+fn build_tui_selection_with_default(
+    app: &mut App,
+    default_autoexecute_mode: AIConversationAutoexecuteMode,
+) -> (
+    ModelHandle<BlocklistAIHistoryModel>,
+    ConversationSelectionHandle,
+    EntityId,
+    Arc<FairMutex<TerminalModel>>,
+) {
     app.add_singleton_model(|ctx| AppExecutionMode::new(ExecutionMode::App, false, ctx));
     let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::default());
     let terminal_surface_id = EntityId::new();
@@ -146,10 +158,165 @@ fn build_tui_selection(
         Box::new(TuiConversationSelection::new(
             terminal_surface_id,
             terminal_model_for_selection,
+            default_autoexecute_mode,
             ctx,
         )) as Box<dyn ConversationSelection>
     });
     (history, selection, terminal_surface_id, terminal_model)
+}
+fn build_tui_selection_with_full_fixture(
+    app: &mut App,
+    default_autoexecute_mode: AIConversationAutoexecuteMode,
+) -> (
+    ModelHandle<BlocklistAIHistoryModel>,
+    ConversationSelectionHandle,
+    EntityId,
+    Arc<FairMutex<TerminalModel>>,
+) {
+    register_tui_session_view_test_singletons(app);
+    let history = app.read(BlocklistAIHistoryModel::handle);
+    let terminal_surface_id = EntityId::new();
+    let terminal_model = tui_terminal_model();
+    let terminal_model_for_selection = terminal_model.clone();
+    let selection = app.add_model(|ctx| {
+        Box::new(TuiConversationSelection::new(
+            terminal_surface_id,
+            terminal_model_for_selection,
+            default_autoexecute_mode,
+            ctx,
+        )) as Box<dyn ConversationSelection>
+    });
+    (history, selection, terminal_surface_id, terminal_model)
+}
+
+#[test]
+fn tui_selection_uses_session_default_without_overwriting_conversation_choice() {
+    App::test((), |mut app| async move {
+        let (history, selection, terminal_surface_id, _) = build_tui_selection_with_full_fixture(
+            &mut app,
+            AIConversationAutoexecuteMode::RunToCompletion,
+        );
+        let initial_conversation_id = selection
+            .read(&app, |selection, ctx| {
+                selection.selected_conversation_id(ctx)
+            })
+            .expect("TUI should have an initial conversation");
+
+        history.read(&app, |history, _| {
+            assert_eq!(
+                history
+                    .conversation(&initial_conversation_id)
+                    .expect("initial conversation should exist")
+                    .autoexecute_override(),
+                AIConversationAutoexecuteMode::RunToCompletion
+            );
+        });
+
+        selection.update(&mut app, |selection, ctx| {
+            selection.toggle_pending_query_autoexecute(ctx);
+        });
+        history.read(&app, |history, _| {
+            assert_eq!(
+                history
+                    .conversation(&initial_conversation_id)
+                    .expect("initial conversation should exist")
+                    .autoexecute_override(),
+                AIConversationAutoexecuteMode::RespectUserSettings
+            );
+        });
+
+        let new_conversation_id = selection
+            .update(&mut app, |selection, ctx| {
+                selection.try_start_new_conversation(AgentViewEntryOrigin::Tui, ctx)
+            })
+            .expect("TUI conversation creation should succeed");
+        history.read(&app, |history, _| {
+            assert_eq!(
+                history
+                    .conversation(&initial_conversation_id)
+                    .expect("initial conversation should remain loaded")
+                    .autoexecute_override(),
+                AIConversationAutoexecuteMode::RespectUserSettings
+            );
+            assert_eq!(
+                history
+                    .conversation(&new_conversation_id)
+                    .expect("new conversation should exist")
+                    .autoexecute_override(),
+                AIConversationAutoexecuteMode::RunToCompletion
+            );
+            assert_eq!(
+                history
+                    .active_conversation(terminal_surface_id)
+                    .map(|conversation| conversation.id()),
+                Some(new_conversation_id)
+            );
+        });
+        selection.update(&mut app, |selection, ctx| {
+            selection.select_existing_conversation(
+                initial_conversation_id,
+                AgentViewEntryOrigin::RestoreExistingConversation,
+                ctx,
+            );
+        });
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(
+                selection.selected_conversation_id(ctx),
+                Some(initial_conversation_id)
+            );
+        });
+        history.read(&app, |history, _| {
+            assert_eq!(
+                history
+                    .conversation(&initial_conversation_id)
+                    .expect("existing conversation should remain loaded")
+                    .autoexecute_override(),
+                AIConversationAutoexecuteMode::RespectUserSettings
+            );
+        });
+    });
+}
+
+#[test]
+fn tui_selection_applies_session_default_to_agent_requested_split() {
+    App::test((), |mut app| async move {
+        let (history, selection, terminal_surface_id, _) = build_tui_selection_with_full_fixture(
+            &mut app,
+            AIConversationAutoexecuteMode::RunToCompletion,
+        );
+        let old_conversation_id = selection
+            .read(&app, |selection, ctx| {
+                selection.selected_conversation_id(ctx)
+            })
+            .expect("TUI should have an initial conversation");
+        let new_conversation_id = history.update(&mut app, |history, ctx| {
+            let conversation_id =
+                history.start_new_conversation(terminal_surface_id, false, false, false, ctx);
+            history.set_active_conversation_id(conversation_id, terminal_surface_id, ctx);
+            ctx.emit(BlocklistAIHistoryEvent::SplitConversation {
+                terminal_surface_id,
+                old_conversation_id,
+                new_conversation_id: conversation_id,
+            });
+            conversation_id
+        });
+
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(
+                selection.selected_conversation_id(ctx),
+                Some(new_conversation_id)
+            );
+        });
+        history.read(&app, |history, _| {
+            assert_eq!(
+                history
+                    .conversation(&new_conversation_id)
+                    .expect("split conversation should exist")
+                    .autoexecute_override(),
+                AIConversationAutoexecuteMode::RunToCompletion
+            );
+        });
+    });
 }
 
 #[test]
@@ -282,7 +449,10 @@ fn tui_selection_creates_and_selects_terminal_surface_scoped_conversation() {
 #[test]
 fn tui_selection_reconciles_split_and_removed_selection() {
     App::test((), |mut app| async move {
-        let (history, selection, terminal_surface_id, _) = build_tui_selection(&mut app);
+        let (history, selection, terminal_surface_id, _) = build_tui_selection_with_default(
+            &mut app,
+            AIConversationAutoexecuteMode::RunToCompletion,
+        );
         let old_conversation_id = AIConversationId::new();
         let new_conversation_id = AIConversationId::new();
 
@@ -357,7 +527,7 @@ fn tui_selection_reconciles_split_and_removed_selection() {
                     .conversation(&replacement_conversation_id)
                     .expect("replacement conversation should exist")
                     .autoexecute_override(),
-                AIConversationAutoexecuteMode::RespectUserSettings
+                AIConversationAutoexecuteMode::RunToCompletion
             );
         });
     });
@@ -413,6 +583,7 @@ fn tui_new_conversations_respect_the_active_execution_profile() {
             Box::new(TuiConversationSelection::new(
                 terminal_surface_id,
                 terminal_model,
+                AIConversationAutoexecuteMode::RespectUserSettings,
                 ctx,
             )) as Box<dyn ConversationSelection>
         });

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use clap::error::ErrorKind;
 use inquire::{InquireError, Password, PasswordDisplayMode};
 use warp::settings::{TuiThemeSettings, TuiVoiceSettings, TuiVoiceSettingsChangedEvent};
-use warp::tui_export::{Appearance, ServerConversationToken};
+use warp::tui_export::{AIConversationAutoexecuteMode, Appearance, ServerConversationToken};
 use warp::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
 use warp_core::channel::ChannelState;
 use warp_core::telemetry::TelemetryEvent as _;
@@ -47,6 +47,10 @@ struct TuiArgs {
     /// Resume an Oz/Warp conversation by server token.
     #[arg(long)]
     resume: Option<String>,
+
+    /// Enable auto-approve by default for new conversations.
+    #[arg(long)]
+    auto_approve: bool,
 
     /// API key for non-interactive authentication.
     #[arg(long, env = "WARP_API_KEY")]
@@ -180,11 +184,23 @@ pub fn run() -> Result<()> {
         }));
     }
     let resume_token = args.resume.map(parse_resume_token).transpose()?;
+    let default_autoexecute_mode = if args.auto_approve {
+        AIConversationAutoexecuteMode::RunToCompletion
+    } else {
+        AIConversationAutoexecuteMode::RespectUserSettings
+    };
     let exit_summary = TuiExitSummaryHandle::default();
     let exit_summary_for_app = exit_summary.clone();
     let result = warp::run_tui(
         args.api_key,
-        Box::new(move |ctx| init(resume_token, exit_summary_for_app, ctx)),
+        Box::new(move |ctx| {
+            init(
+                resume_token,
+                default_autoexecute_mode,
+                exit_summary_for_app,
+                ctx,
+            )
+        }),
     );
     if result.is_ok()
         && let Some(token) = exit_summary.token()
@@ -200,6 +216,7 @@ pub fn run() -> Result<()> {
 /// Creates the login-gated root and starts the headless draw and input driver.
 fn init(
     resume_token: Option<ServerConversationToken>,
+    default_autoexecute_mode: AIConversationAutoexecuteMode,
     exit_summary: TuiExitSummaryHandle,
     ctx: &mut AppContext,
 ) {
@@ -238,8 +255,9 @@ fn init(
         requires_modifier_key_reporting(ctx),
     ) {
         Ok(driver) => {
-            let sessions =
-                ctx.add_singleton_model(|_| TuiSessions::new(driver, exit_summary, resume_token));
+            let sessions = ctx.add_singleton_model(|_| {
+                TuiSessions::new(driver, exit_summary, resume_token, default_autoexecute_mode)
+            });
             let sessions_for_voice_settings = sessions.clone();
             ctx.subscribe_to_model(&TuiVoiceSettings::handle(ctx), move |_, event, ctx| {
                 let TuiVoiceSettingsChangedEvent::TuiVoiceInputHoldKeySetting { .. } = event;

--- a/crates/warp_tui/src/session_registry.rs
+++ b/crates/warp_tui/src/session_registry.rs
@@ -9,9 +9,10 @@ use std::path::PathBuf;
 
 use pathfinder_geometry::vector::Vector2F;
 use warp::tui_export::{
-    AIConversation, AIConversationId, AmbientAgentTaskId, BannerState, BlocklistAIHistoryModel,
-    IsSharedSessionCreator, LocalTtyTerminalManager, PersistenceWriter, ServerConversationToken,
-    TerminalManagerTrait, TerminalSurfaceResult, oz_run_url,
+    AIConversation, AIConversationAutoexecuteMode, AIConversationId, AmbientAgentTaskId,
+    BannerState, BlocklistAIHistoryModel, IsSharedSessionCreator, LocalTtyTerminalManager,
+    PersistenceWriter, ServerConversationToken, TerminalManagerTrait, TerminalSurfaceResult,
+    oz_run_url,
 };
 use warpui::SingletonEntity;
 use warpui_core::runtime::TuiDriverHandle;
@@ -135,6 +136,7 @@ pub(crate) struct TuiSessions {
     sessions: Vec<TuiSession>,
     focused_session_id: Option<TuiSessionId>,
     resume_token: Option<ServerConversationToken>,
+    default_autoexecute_mode: AIConversationAutoexecuteMode,
 }
 
 impl Entity for TuiSessions {
@@ -152,12 +154,14 @@ impl TuiSessions {
         startup_directory: Option<PathBuf>,
         ctx: &mut AppContext,
     ) -> (TuiSessionId, ViewHandle<TuiTerminalSessionView>) {
-        let (exit_summary, keyboard_enhancement_supported) = sessions.read(ctx, |sessions, _| {
-            (
-                sessions.exit_summary.clone(),
-                sessions.keyboard_enhancement_supported,
-            )
-        });
+        let (exit_summary, keyboard_enhancement_supported, default_autoexecute_mode) = sessions
+            .read(ctx, |sessions, _| {
+                (
+                    sessions.exit_summary.clone(),
+                    sessions.keyboard_enhancement_supported,
+                    sessions.default_autoexecute_mode,
+                )
+            });
         // The manager uses this internal model for unsupported-shell state; the
         // TUI does not render a separate banner surface.
         let banner = ctx.add_model(|_| BannerState::default());
@@ -179,6 +183,7 @@ impl TuiSessions {
                         surface_init,
                         exit_summary,
                         keyboard_enhancement_supported,
+                        default_autoexecute_mode,
                         ctx,
                     )
                 });
@@ -546,6 +551,7 @@ impl TuiSessions {
         driver: TuiDriverHandle,
         exit_summary: TuiExitSummaryHandle,
         resume_token: Option<ServerConversationToken>,
+        default_autoexecute_mode: AIConversationAutoexecuteMode,
     ) -> Self {
         let keyboard_enhancement_supported = driver.keyboard_enhancement_supported();
         Self {
@@ -555,6 +561,7 @@ impl TuiSessions {
             sessions: Vec::new(),
             focused_session_id: None,
             resume_token,
+            default_autoexecute_mode,
         }
     }
 
@@ -568,6 +575,7 @@ impl TuiSessions {
             sessions: Vec::new(),
             focused_session_id: None,
             resume_token: None,
+            default_autoexecute_mode: AIConversationAutoexecuteMode::RespectUserSettings,
         }
     }
 

--- a/crates/warp_tui/src/session_tests.rs
+++ b/crates/warp_tui/src/session_tests.rs
@@ -51,6 +51,7 @@ fn provider_api_key_help_lists_supported_providers() {
         let expected = format!("{flag} <{}>", LLMProvider::API_KEY_PROVIDER_VALUE_NAME);
         assert!(help.contains(&expected));
     }
+    assert!(help.contains("--auto-approve"));
 }
 
 #[test]
@@ -60,12 +61,14 @@ fn parses_resume_server_token() {
         "warp",
         "--resume",
         token.as_str(),
+        "--auto-approve",
         "--api-key",
         "test-api-key",
     ])
     .expect("TUI launch arguments should parse together");
 
     assert_eq!(args.resume.as_deref(), Some(token.as_str()));
+    assert!(args.auto_approve);
     assert_eq!(args.api_key.as_deref(), Some("test-api-key"));
     assert_eq!(
         parse_resume_token(token.clone())
@@ -92,6 +95,7 @@ fn accepts_startup_without_resume() {
     let args = TuiArgs::try_parse_from(["warp"]).expect("empty arguments should parse");
 
     assert_eq!(args.resume, None);
+    assert!(!args.auto_approve);
     assert_eq!(args.api_key, None);
     assert_eq!(args.set_provider_api_key, None);
     assert_eq!(args.clear_provider_api_key, None);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -17,20 +17,21 @@ use warp::settings::{
 };
 use warp::tui_export::{
     AIAgentActionId, AIAgentActionResultType, AIAgentContext, AIAgentExchangeId,
-    AIAgentPtyWriteMode, AIConversation, AIConversationId, AcceptSlashCommandOrSavedPrompt,
-    ActiveSession, ActiveSessionEvent, AgentConversationEntryId, AgentConversationListEntryState,
-    AgentConversationsModel, AgentInteractionMetadata, AgentViewEntryOrigin, Appearance, BlockId,
-    BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
-    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController,
-    CLISubagentEvent, CLISubagentTarget, COMMAND_REGISTRY, CancellationReason, ChangelogModel,
-    ChangelogRequestType, CloudConversationData, CommandExecutionSource, ConversationFileExport,
-    ConversationSelection, ConversationSelectionHandle, ExecuteCommandEvent,
-    GetRelevantFilesController, GitHubRepoModel, GitRepoStatusModel, LLMId, LLMPreferences,
-    LLMPreferencesEvent, LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, LinkedWorkflowData,
-    ModelEvent, ParsedSlashCommandInput, PersistenceWriter, PtyIntent, PtyIntentEvent,
-    QueuedQueryEvent, QueuedQueryModel, RepoDetectionSessionType, RepoDetectionSource,
-    ServerConversationToken, Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate,
-    SkillReference, SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
+    AIAgentPtyWriteMode, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
+    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AgentConversationEntryId,
+    AgentConversationListEntryState, AgentConversationsModel, AgentInteractionMetadata,
+    AgentViewEntryOrigin, Appearance, BlockId, BlocklistAIActionEvent, BlocklistAIActionModel,
+    BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
+    BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController, CLISubagentEvent,
+    CLISubagentTarget, COMMAND_REGISTRY, CancellationReason, ChangelogModel, ChangelogRequestType,
+    CloudConversationData, CommandExecutionSource, ConversationFileExport, ConversationSelection,
+    ConversationSelectionHandle, ExecuteCommandEvent, GetRelevantFilesController, GitHubRepoModel,
+    GitRepoStatusModel, LLMId, LLMPreferences, LLMPreferencesEvent,
+    LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, LinkedWorkflowData, ModelEvent,
+    ParsedSlashCommandInput, PersistenceWriter, PtyIntent, PtyIntentEvent, QueuedQueryEvent,
+    QueuedQueryModel, RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
+    Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
+    SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
     StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TerminalModel, TerminalSurface,
     TerminalSurfaceInit, TranscriptScope, TuiMcpAction, TuiMcpManager, TuiSlashCommandDataSource,
     TuiSlashCommandDataSourceArgs, TuiUpArrowHistoryItemKind, TuiUserInfoManager,
@@ -1279,6 +1280,7 @@ impl TuiTerminalSessionView {
         surface_init: TerminalSurfaceInit,
         exit_summary: TuiExitSummaryHandle,
         keyboard_enhancement_supported: bool,
+        default_autoexecute_mode: AIConversationAutoexecuteMode,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let TerminalSurfaceInit {
@@ -1315,6 +1317,7 @@ impl TuiTerminalSessionView {
             Box::new(TuiConversationSelection::new(
                 terminal_surface_id,
                 model_for_conversation_selection,
+                default_autoexecute_mode,
                 ctx,
             )) as Box<dyn ConversationSelection>
         });

--- a/crates/warp_tui/src/test_fixtures.rs
+++ b/crates/warp_tui/src/test_fixtures.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    ActiveSession, Appearance, BlocklistAIActionModel, BlocklistAIHistoryModel,
-    ConversationSelection, ConversationSelectionHandle, GetRelevantFilesController,
-    ModelEventDispatcher, Sessions, TerminalManagerTrait, TerminalModel, TerminalSurfaceInit,
-    TranscriptScope,
+    AIConversationAutoexecuteMode, ActiveSession, Appearance, BlocklistAIActionModel,
+    BlocklistAIHistoryModel, ConversationSelection, ConversationSelectionHandle,
+    GetRelevantFilesController, ModelEventDispatcher, Sessions, TerminalManagerTrait,
+    TerminalModel, TerminalSurfaceInit, TranscriptScope,
 };
 use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
 use warp_core::semantic_selection::SemanticSelection;
@@ -79,6 +79,7 @@ pub(crate) fn add_test_conversation_selection(ctx: &mut AppContext) -> Conversat
         Box::new(TuiConversationSelection::new(
             terminal_surface_id,
             terminal_model,
+            AIConversationAutoexecuteMode::RespectUserSettings,
             ctx,
         )) as Box<dyn ConversationSelection>
     })
@@ -143,7 +144,13 @@ pub(crate) fn add_test_terminal_session(
         let surface_init = TerminalSurfaceInit::new_for_test(ctx);
         let terminal_model = surface_init.model.clone();
         let view = ctx.add_typed_action_tui_view(window_id, |ctx| {
-            TuiTerminalSessionView::new(surface_init, TuiExitSummaryHandle::default(), false, ctx)
+            TuiTerminalSessionView::new(
+                surface_init,
+                TuiExitSummaryHandle::default(),
+                false,
+                AIConversationAutoexecuteMode::RespectUserSettings,
+                ctx,
+            )
         });
         let manager = ctx.add_model(|_| {
             Box::new(TestTerminalManager(terminal_model)) as Box<dyn TerminalManagerTrait>


### PR DESCRIPTION
## Description

Adds `--auto-approve` to Warp Agent CLI. When supplied, each newly created conversation starts with auto-approve enabled; users can still disable it per conversation, and later new conversations continue to use the launch default.

This PR is stacked on the shared auto-approve behavior/settings PR #14489.

Conversation: https://staging.warp.dev/conversation/d10bb56c-e246-4f82-bd19-df7ff0e89fff
Plan: https://staging.warp.dev/drive/notebook/Va3dmzZABva7S8hIXP5yeu

## Linked Issue

APP-4992

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Screenshots/video

https://www.loom.com/share/e12ec600aeb9403abb096049243f92c4

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Added an `--auto-approve` launch flag to Warp Agent CLI.

Co-Authored-By: Oz <oz-agent@warp.dev>
