### PR TITLE
feat(ai): promote Gemini Enterprise to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -696,6 +696,7 @@ default = [
     "solo_user_byok",
     "custom_model_routers",
     "supergrok",
+    "gemini_enterprise",
     "billing_and_usage_page_v2",
     "remote_code_review",
     "git_operations_in_code_review",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -1004,7 +1004,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::JupyterNotebookRendering,
     FeatureFlag::WaitForEventsParentRegistration,
     FeatureFlag::McpJsonTreeView,
-    FeatureFlag::GeminiEnterprise,
     FeatureFlag::BoxDrawingGlyphs,
     FeatureFlag::WellKnownMcpIds,
     FeatureFlag::FactoryMcp,


### PR DESCRIPTION
## Description

Promotes `FeatureFlag::GeminiEnterprise` from dogfood-only to all builds, so Gemini Enterprise (GEAP) BYOLLM is available to enterprise customers on stable.

Two lines:
- `app/Cargo.toml` — add `"gemini_enterprise"` to `default`
- `crates/warp_features/src/lib.rs` — remove `FeatureFlag::GeminiEnterprise` from `DOGFOOD_FLAGS`

The `gemini_enterprise` Cargo feature and its `enabled_features()` cfg bridge in `app/src/features.rs:506` already existed, so nothing new is being wired up — only which builds turn the flag on. This follows the same shape `supergrok` used, and matches the `promote-feature` skill's "Promote to Stable" path (Cargo `default` rather than `RELEASE_FLAGS`, so rollback is a one-line revert).

**Pairs with [warpdotdev/warp-server#13509](https://github.com/warpdotdev/warp-server/pull/13509)**, which flips the backend `gemini_enterprise` flag and the `VITE_ENABLE_GEMINI_ENTERPRISE` admin-UI flag in prod. Both sides are needed: the server ones let admins configure GEAP, this one lets the client mint and attach the credential.

## Every gate this flag controls

All five client-side GEAP gates are this one flag — there is no second flag and no other Cargo feature:

- `app/src/features.rs:507` — the cfg bridge (what this PR flips)
- `app/src/ai/geap_credentials.rs:78` — first check in `current_geap_policy`, so no binding and no mint without it
- `app/src/lib.rs:1660` — wires `subscribe_to_geap_settings_changes` at startup
- `app/src/settings_view/ai_page.rs:9988` — `GeminiEnterpriseWidget::should_render`
- `app/src/workspaces/user_workspaces.rs:706` — inside `is_gemini_enterprise_credentials_enabled`

## Blast radius

Inert unless a workspace admin has already turned GEAP on. `current_geap_policy` requires all of: this flag, `is_gemini_enterprise_credentials_enabled` (admin enabled the host, plus `ENFORCE` or the member's own toggle), a signed-in user, and a configured WIF audience. Any one missing and the client never mints or attaches a Google Cloud token.

Note the member toggle `gemini_enterprise_credentials_enabled` defaults to `false`, matching Bedrock's `aws_bedrock_credentials_enabled`. On a `RESPECT_USER_SETTING` org each member must opt in via Settings → AI; admins wanting org-wide GEAP should use `ENFORCE`, which bypasses the toggle.

Rollback: remove `"gemini_enterprise"` from `default`.

## TUI

The Cargo `default` bridge is normally GUI-only, but the TUI is covered here:
- `crates/warp_tui/Cargo.toml` depends on `warp` without `default-features = false`, so it inherits the new default
- `run_tui` → `run_internal` → `features::init_feature_flags()` (`app/src/lib.rs:959`), the same bridge

The TUI already renders `FailedOutputPresentation::GeminiEnterpriseCredentialsExpiredOrInvalid`, so the credential-error surface is present there too.

## No wire-compatibility impact

This PR changes no GraphQL or proto types, so it needs no coordination with `gemini_enterprise_min_client_version` on the server.

That server value is a wire-compatibility gate: it exists because clients predating [#12522](https://github.com/warpdotdev/warp/pull/12522) could not deserialize the `GEMINI_ENTERPRISE` enum and logged `Unknown LlmModelHost` to Sentry. `v0.2026.06.17` is the first release containing that fix and is already correct. It should **not** be bumped to whichever release contains this commit — its meaning is "first client that can parse the enum," not "first client that can use GEAP."

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

Not applicable — this PR adds no UI. It changes which builds enable an existing flag; every surface behind it shipped previously and is unchanged.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Automated:
- `./script/format` + `cargo fmt --all --check` clean
- `cargo clippy -p warp -p warp_tui --all-targets -- -D warnings` clean, exercising both front-ends with the new default feature set
- Confirmed the feature has exactly one cfg site (`app/src/features.rs:506`), so there is no newly-compiled gated code

Manual verification of the GEAP flow itself requires a workspace with a real WIF binding; that was done separately against a GEAP-configured workspace while the flag was dogfood-gated.

### Screenshots / Videos

N/A — no UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NEW-FEATURE: Enterprise teams can now route eligible agent requests to their own Google Cloud project through Gemini Enterprise (GEAP). Admins configure the workload identity federation audience in team settings, and inference runs in — and is billed to — the customer's GCP project instead of Warp-managed inference.
