### PR TITLE
Display Anthropic promotion credits

### DIFF
--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -24,6 +24,7 @@ use crate::workspaces::workspace::WorkspaceUid;
 
 /// Threshold of ambient-only credits at which we surface upgrade/CTA UI.
 pub const AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD: i32 = 20;
+pub const ANTHROPIC_PROMOTION_REASON: &str = "anthropic_model_checkout_promotion";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BonusGrantScope {
@@ -50,6 +51,12 @@ pub struct BonusGrant {
     pub request_credits_granted: i32,
     pub request_credits_remaining: i32,
     pub scope: BonusGrantScope,
+}
+
+impl BonusGrant {
+    pub fn is_anthropic_promotion(&self) -> bool {
+        self.scope == BonusGrantScope::User && self.reason == ANTHROPIC_PROMOTION_REASON
+    }
 }
 
 /// The key for the corresponding entry in UserDefaults.
@@ -437,6 +444,9 @@ impl AIRequestUsageModel {
         let has_base_plan_ai_requests = self.has_requests_remaining();
 
         let user_bonus_credits = self.total_user_interactive_bonus_credits_remaining() > 0;
+        let anthropic_promotion_credits = self
+            .anthropic_credits_remaining()
+            .is_some_and(|credits| credits > 0);
         let workspace_bonus_credits = current_workspace
             .map(|workspace| self.total_workspace_bonus_credits_remaining(workspace.uid) > 0)
             .unwrap_or_default();
@@ -469,6 +479,7 @@ impl AIRequestUsageModel {
 
         has_base_plan_ai_requests
             || (user_bonus_credits || workspace_bonus_credits)
+            || anthropic_promotion_credits
             || workspace_has_overages
             || is_payg_enabled
             || is_enterprise_auto_reload_enabled
@@ -552,6 +563,26 @@ impl AIRequestUsageModel {
         }
     }
 
+    /// Returns the active Anthropic promotion balance, or None when there is no promotion history.
+    pub fn anthropic_credits_remaining(&self) -> Option<i32> {
+        let now = Utc::now();
+        let has_promotion_history = self
+            .bonus_grants
+            .iter()
+            .any(|grant| grant.is_anthropic_promotion());
+        if !has_promotion_history {
+            return None;
+        }
+        Some(
+            self.bonus_grants
+                .iter()
+                .filter(|grant| grant.is_anthropic_promotion())
+                .filter(|grant| grant.expiration.is_none_or(|expiration| now < expiration))
+                .map(|grant| grant.request_credits_remaining)
+                .sum(),
+        )
+    }
+
     pub fn is_ambient_credits_banner_dismissed(&self) -> bool {
         self.ambient_credits_banner_dismissed
     }
@@ -588,6 +619,7 @@ impl AIRequestUsageModel {
             .iter()
             .filter(|grant| grant.scope == BonusGrantScope::User)
             .filter(|grant| grant.grant_type != BonusGrantType::AmbientOnly)
+            .filter(|grant| !grant.is_anthropic_promotion())
             .filter(|grant| grant.expiration.is_none_or(|exp| now < exp))
             .map(|grant| grant.request_credits_remaining)
             .sum()
@@ -621,6 +653,7 @@ impl AIRequestUsageModel {
             .bonus_grants
             .iter()
             .filter(|grant| grant.grant_type != BonusGrantType::AmbientOnly)
+            .filter(|grant| !grant.is_anthropic_promotion())
             .filter(|grant| grant.expiration.is_none_or(|exp| now < exp))
             .filter(|grant| grant.request_credits_remaining > 0)
             .any(|grant| match grant.scope {

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -26,6 +26,109 @@ fn create_test_workspace() -> (WorkspaceUid, Workspace) {
     (uid, workspace)
 }
 
+#[test]
+fn test_buy_credits_banner_shows_with_only_anthropic_promotion_credits() {
+    App::test((), |mut app| async move {
+        let (_uid, mut workspace) = create_test_workspace();
+        workspace
+            .billing_metadata
+            .tier
+            .purchase_add_on_credits_policy = Some(PurchaseAddOnCreditsPolicy { enabled: true });
+
+        add_user_workspaces_with_workspace(&mut app, workspace);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.bonus_grants = vec![BonusGrant {
+                created_at: Utc::now(),
+                cost_cents: 0,
+                expiration: Some(Utc::now() + chrono::Duration::days(7)),
+                grant_type: BonusGrantType::Any,
+                reason: ANTHROPIC_PROMOTION_REASON.to_string(),
+                user_facing_message: None,
+                request_credits_granted: 2500,
+                request_credits_remaining: 2500,
+                scope: BonusGrantScope::User,
+            }];
+
+            assert_eq!(
+                model.compute_buy_addon_credits_banner_display_state(ctx),
+                BuyCreditsBannerDisplayState::OutOfCredits,
+            );
+        });
+    });
+}
+
+#[test]
+fn test_anthropic_and_personal_credit_balances_remain_independent() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, ctx| {
+            model.request_limit_info = RequestLimitInfo::new_for_test(10, 10);
+            model.bonus_grants = vec![
+                BonusGrant {
+                    created_at: Utc::now(),
+                    cost_cents: 0,
+                    expiration: Some(Utc::now() + chrono::Duration::days(7)),
+                    grant_type: BonusGrantType::Any,
+                    reason: ANTHROPIC_PROMOTION_REASON.to_string(),
+                    user_facing_message: None,
+                    request_credits_granted: 2500,
+                    request_credits_remaining: 2500,
+                    scope: BonusGrantScope::User,
+                },
+                BonusGrant {
+                    created_at: Utc::now(),
+                    cost_cents: 100,
+                    expiration: Some(Utc::now() + chrono::Duration::days(7)),
+                    grant_type: BonusGrantType::Any,
+                    reason: "purchased_addon_credits_a_la_carte".to_string(),
+                    user_facing_message: None,
+                    request_credits_granted: 500,
+                    request_credits_remaining: 500,
+                    scope: BonusGrantScope::User,
+                },
+            ];
+
+            assert_eq!(model.anthropic_credits_remaining(), Some(2500));
+            assert_eq!(model.total_user_interactive_bonus_credits_remaining(), 500);
+            assert!(model.has_any_ai_remaining(ctx));
+
+            model.bonus_grants[0].request_credits_remaining = 2490;
+            assert_eq!(model.anthropic_credits_remaining(), Some(2490));
+            assert_eq!(model.total_user_interactive_bonus_credits_remaining(), 500);
+            assert_eq!(model.bonus_grants[1].request_credits_remaining, 500);
+        });
+    });
+}
+
+#[test]
+fn test_expired_anthropic_promotion_has_zero_active_balance() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        let request_usage_model = add_request_usage_model(&mut app);
+
+        request_usage_model.update(&mut app, |model, _ctx| {
+            model.bonus_grants = vec![BonusGrant {
+                created_at: Utc::now() - chrono::Duration::days(10),
+                cost_cents: 0,
+                expiration: Some(Utc::now() - chrono::Duration::days(1)),
+                grant_type: BonusGrantType::Any,
+                reason: ANTHROPIC_PROMOTION_REASON.to_string(),
+                user_facing_message: None,
+                request_credits_granted: 2500,
+                request_credits_remaining: 1200,
+                scope: BonusGrantScope::User,
+            }];
+
+            assert_eq!(model.anthropic_credits_remaining(), Some(0));
+        });
+    });
+}
+
 fn add_user_workspaces_with_workspace(app: &mut App, workspace: Workspace) {
     app.add_singleton_model(|ctx| {
         UserWorkspaces::mock(

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -101,6 +101,58 @@ const AMBIENT_AGENT_TRIAL_TITLE: &str = "Cloud agent trial";
 /// The threshold below which we only show the "Buy more" button (not "New agent").
 use crate::ai::request_usage_model::AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD;
 
+pub(super) fn render_anthropic_credits_widget(
+    ai_request_usage_model: &AIRequestUsageModel,
+    appearance: &Appearance,
+) -> Option<Box<dyn Element>> {
+    let credits_remaining = ai_request_usage_model.anthropic_credits_remaining()?;
+    if credits_remaining <= 0 {
+        return None;
+    }
+
+    let theme = appearance.theme();
+    let credits_text = if credits_remaining == 1 {
+        "1 credit remaining".to_string()
+    } else {
+        format!(
+            "{} credits remaining",
+            credits_remaining.separate_with_commas()
+        )
+    };
+    let content = Flex::row()
+        .with_child(
+            Text::new_inline("Anthropic credits", appearance.ui_font_family(), 14.)
+                .with_color(theme.active_ui_text_color().into())
+                .with_style(Properties::default().weight(Weight::Semibold))
+                .finish(),
+        )
+        .with_child(
+            Container::new(
+                Text::new_inline(credits_text, appearance.ui_font_family(), 12.)
+                    .with_color(blended_colors::text_sub(theme, theme.surface_1()))
+                    .finish(),
+            )
+            .with_margin_left(8.)
+            .finish(),
+        )
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .finish();
+
+    let bright_blue: ColorU = theme.terminal_colors().bright.blue.into();
+    let gradient_start = ColorU::transparent_black();
+    let gradient_end = ColorU::new(bright_blue.r, bright_blue.g, bright_blue.b, 40);
+
+    Some(
+        Container::new(content)
+            .with_horizontal_background_gradient(gradient_start, gradient_end)
+            .with_border(Border::all(1.).with_border_color(theme.accent_overlay().into()))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .with_margin_bottom(16.)
+            .with_uniform_padding(12.)
+            .finish(),
+    )
+}
+
 pub fn create_discount_badge(discount: u32, appearance: &Appearance) -> Box<dyn Element> {
     if discount == 0 {
         return Empty::new().finish();
@@ -2842,6 +2894,11 @@ impl BillingAndUsagePageView {
             self.render_ambient_agent_trial_widget(ai_request_usage_model, appearance, app)
         {
             usage.add_child(ambient_trial_widget);
+        }
+        if let Some(anthropic_credits_widget) =
+            render_anthropic_credits_widget(ai_request_usage_model, appearance)
+        {
+            usage.add_child(anthropic_credits_widget);
         }
 
         if let (Some(workspace), Some(team)) = (workspace, team) {

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -33,7 +33,9 @@ use super::billing_and_usage::overage_limit_modal::{SpendingLimitModal, Spending
 use super::billing_and_usage::usage_history_entry::UsageHistoryEntry;
 use super::billing_and_usage::usage_history_model::UsageHistoryModel;
 pub use super::billing_and_usage_page::BillingAndUsagePageEvent;
-use super::billing_and_usage_page::{BillingAndUsagePageAction, BillingUsageTab};
+use super::billing_and_usage_page::{
+    BillingAndUsagePageAction, BillingUsageTab, render_anthropic_credits_widget,
+};
 use super::settings_page::{AdditionalInfo, render_customer_type_badge, render_info_icon};
 use crate::ai::AIRequestUsageModel;
 use crate::ai::request_usage_model::{
@@ -232,7 +234,7 @@ impl ClassifiedGrants {
             let in_user_scope = grant.scope == BonusGrantScope::User;
             let in_workspace_scope =
                 workspace_uid.is_some_and(|uid| grant.scope == BonusGrantScope::Workspace(uid));
-            if grant.grant_type == BonusGrantType::AmbientOnly {
+            if grant.is_anthropic_promotion() || grant.grant_type == BonusGrantType::AmbientOnly {
                 continue;
             } else if in_user_scope {
                 personal.push(grant.clone());
@@ -1679,6 +1681,11 @@ impl BillingAndUsagePageV2View {
         {
             content.add_child(ambient_trial_widget);
         }
+        if let Some(anthropic_credits_widget) =
+            render_anthropic_credits_widget(ai_model, appearance)
+        {
+            content.add_child(anthropic_credits_widget);
+        }
         if let Some(balance) = self.render_balance_section(appearance, app) {
             content.add_child(balance);
         }
@@ -2249,4 +2256,38 @@ fn render_balance_card(
     .with_horizontal_padding(16.)
     .with_vertical_padding(12.)
     .finish()
+}
+
+#[cfg(test)]
+mod classified_grants_tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    fn user_grant(reason: &str, balance: i32) -> BonusGrant {
+        BonusGrant {
+            created_at: Utc::now(),
+            cost_cents: 0,
+            expiration: Some(Utc::now() + chrono::Duration::days(7)),
+            grant_type: BonusGrantType::Any,
+            reason: reason.to_string(),
+            user_facing_message: None,
+            request_credits_granted: balance,
+            request_credits_remaining: balance,
+            scope: BonusGrantScope::User,
+        }
+    }
+
+    #[test]
+    fn anthropic_promotion_is_not_in_personal_balance() {
+        let grants = vec![
+            user_grant("anthropic_model_checkout_promotion", 2500),
+            user_grant("purchased_addon_credits_a_la_carte", 500),
+        ];
+
+        let classified = ClassifiedGrants::new(&grants, None);
+
+        assert_eq!(classified.personal.total_balance(), 500);
+        assert!(classified.team.is_empty());
+    }
 }

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -6,9 +6,10 @@ use warp_errors::report_error;
 use warp_graphql::billing::{
     AiAutonomyPolicy as GqlAiAutonomyPolicy, AmbientAgentsPolicy as GqlAmbientAgentsPolicy,
     BillingCycleUsageHistory as GqlBillingCycleUsageHistory, BillingMetadata as GqlBillingMetadata,
-    BonusGrant as GqlBonusGrant, ByoApiKeyPolicy as GqlByoApiKeyPolicy,
-    ByoEndpointPolicy as GqlByoEndpointPolicy, CodebaseContextPolicy as GqlCodebaseContextPolicy,
-    CustomerType as GqlCustomerType, DelinquencyStatus as GqlDelinquencyStatus,
+    BonusGrant as GqlBonusGrant, BonusGrantType as GqlBonusGrantType,
+    ByoApiKeyPolicy as GqlByoApiKeyPolicy, ByoEndpointPolicy as GqlByoEndpointPolicy,
+    CodebaseContextPolicy as GqlCodebaseContextPolicy, CustomerType as GqlCustomerType,
+    DelinquencyStatus as GqlDelinquencyStatus,
     EnterpriseCreditsAutoReloadPolicy as GqlEnterpriseCreditsAutoReloadPolicy,
     EnterprisePayAsYouGoPolicy as GqlEnterprisePayAsYouGoPolicy, InstanceShape as GqlInstanceShape,
     ManagedByokByoePolicy as GqlManagedByokByoePolicy, MultiAdminPolicy as GqlMultiAdminPolicy,
@@ -88,6 +89,13 @@ impl From<GqlTeamMember> for TeamMember {
             email: gql_team_member.email,
             role: gql_team_member.role.into(),
         }
+    }
+}
+
+fn normalize_bonus_grant_type(grant_type: GqlBonusGrantType) -> GqlBonusGrantType {
+    match grant_type {
+        GqlBonusGrantType::AmbientOnly => GqlBonusGrantType::AmbientOnly,
+        GqlBonusGrantType::Any | GqlBonusGrantType::Other(_) => GqlBonusGrantType::Any,
     }
 }
 
@@ -669,11 +677,12 @@ impl From<GqlDelinquencyStatus> for DelinquencyStatus {
 
 impl BonusGrant {
     pub fn from_gql_bonus_grant(bonus_grant: GqlBonusGrant, scope: BonusGrantScope) -> Self {
+        let grant_type = normalize_bonus_grant_type(bonus_grant.grant_type);
         Self {
             created_at: bonus_grant.created_at.utc(),
             cost_cents: bonus_grant.cost_cents,
             expiration: bonus_grant.expiration.map(|exp| exp.utc()),
-            grant_type: bonus_grant.grant_type,
+            grant_type,
             reason: bonus_grant.reason,
             user_facing_message: bonus_grant.user_facing_message,
             request_credits_granted: bonus_grant.request_credits_granted,

--- a/app/src/workspaces/gql_convert_tests.rs
+++ b/app/src/workspaces/gql_convert_tests.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+#[test]
+fn unknown_bonus_grant_type_normalizes_to_any() {
+    assert_eq!(
+        normalize_bonus_grant_type(GqlBonusGrantType::Other("FUTURE_GRANT".to_string())),
+        GqlBonusGrantType::Any,
+    );
+    assert_eq!(
+        normalize_bonus_grant_type(GqlBonusGrantType::AmbientOnly),
+        GqlBonusGrantType::AmbientOnly,
+    );
+}
+
 fn team(name: &str, member_uids: &[&str]) -> Team {
     Team::from_local_cache(
         ServerId::from_string_lossy(format!("{name:0>22}")),

--- a/crates/graphql/src/api/billing.rs
+++ b/crates/graphql/src/api/billing.rs
@@ -31,10 +31,12 @@ pub struct BonusGrantSpendingInfo {
     pub current_month_spend_cents: i32,
 }
 
-#[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
 pub enum BonusGrantType {
     AmbientOnly,
     Any,
+    #[cynic(fallback)]
+    Other(String),
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]


### PR DESCRIPTION
## Description

Preserves the Warp client side of the Anthropic subscriber promotion experiment for later iteration.

- Adds a Cynic fallback for unknown `BonusGrantType` values and normalizes unknown values to `ANY` in the application model.
- Identifies the promotion through `reason = anthropic_model_checkout_promotion` rather than a new public GraphQL enum.
- Tracks the active Anthropic balance separately from generic user bonus credits while keeping it available for request-admission checks.
- Prevents the restricted promotion from suppressing generic add-on purchase messaging.
- Adds separate Anthropic credit presentation to both legacy and V2 Billing & Usage pages.
- Adds request-usage and enum-conversion regression coverage.

Companion server draft: https://github.com/warpdotdev/warp-server/pull/13506

This is intentionally a draft artifact. The promotion UI has not been visually verified end to end, and the branch is being preserved so the work can be resumed later.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

No linked issue; this PR preserves an experimental implementation.

## Testing

- [x] `./script/format --check`
- [x] `cargo check -p warp`
- [x] `cargo test -p warp request_usage_model -- --nocapture` — 33 passed
- [x] `cargo test -p warp unknown_bonus_grant_type_normalizes_to_any -- --nocapture`
- [x] Exact Clippy commands from `script/presubmit`:
  - `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
  - `cargo clippy -p warp --all-targets --tests -- -D warnings`
  - `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] `git diff --check`
- [ ] I have manually tested my changes locally with `./script/run`

Manual visual verification was intentionally skipped for this draft artifact.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Conversation: https://staging.warp.dev/conversation/1d99a334-842c-4a0d-9c79-e1c54593ece2

Co-Authored-By: Oz <oz-agent@warp.dev>
