### PR TITLE
TUI: let inline menus own shared input

### DIFF
--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -126,6 +126,8 @@ pub(crate) struct TuiEditorElement {
     /// Whether to elide the buffer's final empty line (see
     /// [`Self::hide_trailing_empty_line`]).
     hide_trailing_empty_line: bool,
+    /// Whether buffer characters are painted as fixed-width mask glyphs.
+    masked: bool,
     styles: TuiEditorStyles,
     trailing_ghost_text: Option<(String, TuiStyle)>,
     /// Resolves the empty-buffer placeholder hint against fresh app state
@@ -202,6 +204,7 @@ impl TuiEditorElement {
             viewport_rows: None,
             line_number_gutter: false,
             hide_trailing_empty_line: false,
+            masked: false,
             styles: TuiEditorStyles::default(),
             trailing_ghost_text: None,
             placeholder_ghost_text_provider: None,
@@ -255,6 +258,12 @@ impl TuiEditorElement {
     /// rows (e.g. the diff body, which scrolls with the transcript).
     pub(crate) fn with_viewport_rows(mut self, max_visible_rows: u32) -> Self {
         self.viewport_rows = Some(max_visible_rows);
+        self
+    }
+
+    /// Conceals buffer text while preserving the backing editor model for editing.
+    pub(crate) fn masked(mut self) -> Self {
+        self.masked = true;
         self
     }
 
@@ -519,6 +528,11 @@ impl TuiEditorElement {
                 let content = lattice
                     .row_text(row, chars)
                     .expect("buffer display rows have source text");
+                let content = if self.masked {
+                    "•".repeat(content.chars().count())
+                } else {
+                    content
+                };
                 let style = self
                     .styles
                     .line_overrides

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -29,6 +29,20 @@ fn model(ctx: &mut AppContext, text: &str) -> ModelHandle<CodeEditorModel> {
 }
 
 #[test]
+fn masked_editor_paints_only_mask_glyphs() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let model = model(ctx, "top-secret");
+            let element = TuiEditorElement::new(&model, ctx).masked();
+            let rendered = render_lines(ctx, element, 20, 1).join("\n");
+            assert_eq!(rendered, "••••••••••");
+            assert!(!rendered.contains("top-secret"));
+        });
+    });
+}
+
+#[test]
 fn selection_span_uses_grapheme_width() {
     App::test((), |mut app| async move {
         app.update(|ctx| {

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -360,6 +360,30 @@ pub(crate) enum TuiInlineMenuAccepted {
     Completion(TuiCompletionAcceptance),
 }
 
+/// Who owns the shared TUI editor while an inline menu is active.
+///
+/// The variants are exhaustive so ownership and masking cannot disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum TuiInlineMenuInputOwnership {
+    /// The composer owns editor behavior; the menu only observes input and handles menu actions.
+    Composer,
+    /// The inline menu owns ordinary plaintext editor behavior.
+    InlineMenuPlainText,
+    /// The inline menu owns editor behavior, with masked rendering and clipboard export disabled.
+    InlineMenuMasked,
+}
+
+impl TuiInlineMenuInputOwnership {
+    pub(crate) fn inline_menu_owns_input(self) -> bool {
+        matches!(self, Self::InlineMenuPlainText | Self::InlineMenuMasked)
+    }
+
+    pub(crate) fn is_masked(self) -> bool {
+        matches!(self, Self::InlineMenuMasked)
+    }
+}
+
 /// Type alias for mouse-interaction callbacks stored in the element tree.
 type InlineMenuAcceptFn = dyn Fn(usize, &mut TuiEventContext<'_>, &AppContext);
 type InlineMenuScrollFn = dyn Fn(isize, &mut TuiEventContext<'_>, &AppContext);
@@ -375,6 +399,10 @@ pub(crate) trait TuiInlineMenuHandle {
     fn mode(&self) -> TuiInputSuggestionsMode;
     /// Returns whether this menu is open.
     fn is_open(&self, ctx: &AppContext) -> bool;
+    /// Returns who owns the shared editor while this menu is active.
+    fn input_ownership(&self, _ctx: &AppContext) -> TuiInlineMenuInputOwnership {
+        TuiInlineMenuInputOwnership::Composer
+    }
     /// Opens the menu when it supports explicit opening.
     fn open(&self, _ctx: &mut AppContext) {}
     /// Returns the input range highlighted by this menu.
@@ -436,6 +464,9 @@ impl TuiInlineMenu {
 
     pub(crate) fn mode(&self) -> TuiInputSuggestionsMode {
         self.handle.mode()
+    }
+    pub(crate) fn input_ownership(&self, ctx: &AppContext) -> TuiInlineMenuInputOwnership {
+        self.handle.input_ownership(ctx)
     }
 
     /// Renders the menu without mouse interactions (used in tests and other

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -987,6 +987,8 @@ impl TuiInputView {
                 });
                 TuiEditorInteractionOutcome::FollowCursor
             }
+            // These menu-policy actions were handled by
+            // `handle_inline_menu_action` before input ownership was resolved.
             TuiInputAction::Submit
             | TuiInputAction::HandleEscape
             | TuiInputAction::LogOutSelectedMcp

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -52,7 +52,9 @@ use crate::editor_interaction::{
     TuiEditorBehavior, TuiEditorCommand, TuiEditorInteractionOutcome, TuiEditorState,
     apply_editor_action, apply_editor_clipboard_action, follow_editor_cursor,
 };
-use crate::inline_menu::{TuiInlineMenu, TuiInlineMenuAccepted, active_inline_menu};
+use crate::inline_menu::{
+    TuiInlineMenu, TuiInlineMenuAccepted, TuiInlineMenuInputOwnership, active_inline_menu,
+};
 use crate::input_mode_policy::{self, AI_LOCKED_CONFIG, SHELL_LOCKED_CONFIG};
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 use crate::keybindings::{
@@ -513,6 +515,7 @@ impl TuiInputView {
     /// construct it directly to exercise mouse dispatch.
     fn render_element(&self, ctx: &AppContext) -> TuiEditorElement {
         let builder = TuiUiBuilder::from_app(ctx);
+        let input_ownership = self.active_inline_menu_input_ownership(ctx);
         let mut styles = TuiEditorStyles::default();
         if let Some(range) = self
             .inline_menus
@@ -538,6 +541,9 @@ impl TuiInputView {
                 .vim_visual_selection_ranges(motion_type, ctx);
             element = element.with_selection_ranges(ranges);
         }
+        if input_ownership.is_masked() {
+            element = element.masked();
+        }
         if let Some(hint_text) = self
             .inline_menus
             .iter()
@@ -551,15 +557,19 @@ impl TuiInputView {
         // provider on every layout pass instead of being snapshotted here.
         // Shell mode teaches how to exit; agent mode adapts to the transcript
         // state.
-        let session_state = self.session_state.clone();
-        element.with_placeholder_ghost_text(move |app| {
-            session_state
-                .as_ref(app)
-                .resolve(app)
-                .ok()
-                .and_then(|state| state.hint_text())
-                .map(|hint| (hint, TuiUiBuilder::from_app(app).muted_text_style()))
-        })
+        if !input_ownership.inline_menu_owns_input() {
+            let session_state = self.session_state.clone();
+            element.with_placeholder_ghost_text(move |app| {
+                session_state
+                    .as_ref(app)
+                    .resolve(app)
+                    .ok()
+                    .and_then(|state| state.hint_text())
+                    .map(|hint| (hint, TuiUiBuilder::from_app(app).muted_text_style()))
+            })
+        } else {
+            element
+        }
     }
     /// Collapses the current text selection to its head without changing text.
     pub(crate) fn clear_selection(&mut self, ctx: &mut ViewContext<Self>) {
@@ -626,10 +636,13 @@ impl TuiView for TuiInputView {
 
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(ctx);
-        if self.voice_is_active(ctx) {
+        let inline_menu_owns_input = self
+            .active_inline_menu_input_ownership(ctx)
+            .inline_menu_owns_input();
+        if self.voice_is_active(ctx) && !inline_menu_owns_input {
             return self.render_input(ctx);
         }
-        let (prefix, prefix_style) = if self.is_shell_mode(ctx) {
+        let (prefix, prefix_style) = if self.is_shell_mode(ctx) && !inline_menu_owns_input {
             ("!", builder.shell_command_accent_style())
         } else {
             (">", builder.accent_text_style())
@@ -653,6 +666,9 @@ impl TuiView for TuiInputView {
 
     fn keymap_context(&self, ctx: &AppContext) -> keymap::Context {
         let suggestions_mode = self.suggestions_mode.as_ref(ctx).mode();
+        let inline_menu_owns_input = self
+            .active_inline_menu_input_ownership(ctx)
+            .inline_menu_owns_input();
         // In vim mode, escape is handled only when vim actually needs it:
         // - Non-Normal modes (Insert→Normal, Visual→Normal, Replace→Normal)
         // - Normal mode with pending input (clear the partial command)
@@ -672,7 +688,7 @@ impl TuiView for TuiInputView {
             mcp_menu_active: suggestions_mode == TuiInputSuggestionsMode::Mcp,
             plan_toggle_available: self.plan_toggle_available(ctx),
             keyboard_enhancement_supported: self.keyboard_enhancement_supported,
-            shell_completion_available: self.is_shell_mode(ctx),
+            shell_completion_available: self.is_shell_mode(ctx) && !inline_menu_owns_input,
         })
     }
 
@@ -728,6 +744,11 @@ impl TypedActionView for TuiInputView {
 
     fn handle_action(&mut self, action: &TuiInputAction, ctx: &mut ViewContext<Self>) {
         if self.handle_inline_menu_action(action, ctx) {
+            return;
+        }
+        let input_ownership = self.active_inline_menu_input_ownership(ctx);
+        if input_ownership.inline_menu_owns_input() {
+            self.handle_inline_menu_owned_input_action(action, input_ownership, ctx);
             return;
         }
         let outcome = match action {
@@ -945,6 +966,54 @@ impl TypedActionView for TuiInputView {
 // ─────────────────────────────────────────────────────────────────────────────
 
 impl TuiInputView {
+    fn handle_inline_menu_owned_input_action(
+        &mut self,
+        action: &TuiInputAction,
+        input_ownership: TuiInlineMenuInputOwnership,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let outcome = match action {
+            TuiInputAction::Editor(action) => {
+                apply_editor_action(&self.model, action, self.editor_behavior, ctx)
+            }
+            TuiInputAction::EditorCommand(command) => {
+                self.editor_state
+                    .apply_command(&self.model, *command, self.editor_behavior, ctx)
+            }
+            TuiInputAction::SetCursor { offset } => {
+                self.model.update(ctx, |model, ctx| {
+                    model.select_at(*offset, false, ctx);
+                    model.end_selection(ctx);
+                });
+                TuiEditorInteractionOutcome::FollowCursor
+            }
+            TuiInputAction::Submit
+            | TuiInputAction::HandleEscape
+            | TuiInputAction::LogOutSelectedMcp
+            | TuiInputAction::Complete => TuiEditorInteractionOutcome::PreserveViewport,
+        };
+        let outcome = match outcome {
+            TuiEditorInteractionOutcome::Clipboard(_) if input_ownership.is_masked() => {
+                TuiEditorInteractionOutcome::FollowCursor
+            }
+            TuiEditorInteractionOutcome::Clipboard(action) => {
+                match apply_editor_clipboard_action(&self.model, action, ctx) {
+                    Ok(true) => ctx.emit(TuiInputViewEvent::ClipboardCopySucceeded),
+                    Ok(false) => {}
+                    Err(error) => {
+                        log::error!("Failed to copy TUI input selection: {error}");
+                        ctx.emit(TuiInputViewEvent::ClipboardCopyFailed);
+                    }
+                }
+                TuiEditorInteractionOutcome::FollowCursor
+            }
+            outcome => outcome,
+        };
+        if outcome == TuiEditorInteractionOutcome::FollowCursor {
+            self.follow_cursor(ctx);
+        }
+        ctx.notify();
+    }
     // ── Read helpers ──────────────────────────────────────────────────────────
     fn open_inline_menu(&self, mode: TuiInputSuggestionsMode, ctx: &mut ViewContext<Self>) {
         if let Some(menu) = self.inline_menus.iter().find(|menu| menu.mode() == mode) {
@@ -1357,6 +1426,14 @@ impl TuiInputView {
             self.suggestions_mode.as_ref(ctx).mode(),
             ctx,
         )
+    }
+
+    /// Resolves the shared editor owner from the one active inline menu.
+    fn active_inline_menu_input_ownership(&self, ctx: &AppContext) -> TuiInlineMenuInputOwnership {
+        self.active_inline_menu(ctx)
+            .map_or(TuiInlineMenuInputOwnership::Composer, |menu| {
+                menu.input_ownership(ctx)
+            })
     }
 }
 

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -46,7 +46,8 @@ use crate::editor_element::{TuiEditorAction, TuiEditorElement};
 use crate::editor_interaction::TuiEditorCommand;
 use crate::inline_menu::{
     TuiInlineMenu, TuiInlineMenuAccepted, TuiInlineMenuHandle, TuiInlineMenuHeader,
-    TuiInlineMenuScrollAnchor, TuiInlineMenuSnapshot, TuiInlineMenuStatus,
+    TuiInlineMenuInputOwnership, TuiInlineMenuScrollAnchor, TuiInlineMenuSnapshot,
+    TuiInlineMenuStatus,
 };
 use crate::input_mode_policy::AI_LOCKED_CONFIG;
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
@@ -93,6 +94,126 @@ impl InputModePolicy for TestInputModePolicy {
     ) -> Option<PolicyConfigUpdate> {
         None
     }
+}
+
+struct TestSecretMenu;
+
+impl Entity for TestSecretMenu {
+    type Event = ();
+}
+
+impl TuiInlineMenuHandle for ModelHandle<TestSecretMenu> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::ModelSelector
+    }
+
+    fn is_open(&self, _ctx: &AppContext) -> bool {
+        true
+    }
+
+    fn input_ownership(&self, _ctx: &AppContext) -> TuiInlineMenuInputOwnership {
+        TuiInlineMenuInputOwnership::InlineMenuMasked
+    }
+
+    fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
+        None
+    }
+
+    fn input_argument_hint_text(&self, _ctx: &AppContext) -> Option<&'static str> {
+        None
+    }
+
+    fn select_previous(&self, _ctx: &mut AppContext) {}
+    fn select_next(&self, _ctx: &mut AppContext) {}
+    fn accept(&self, _ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        None
+    }
+    fn dismiss(&self, _ctx: &mut AppContext) {}
+    fn snapshot(&self, _ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        Some(TuiInlineMenuSnapshot {
+            header: Some(TuiInlineMenuHeader {
+                title: Some("Secret".to_owned()),
+                tabs: Vec::new(),
+            }),
+            rows: Vec::new(),
+            selected_index: None,
+            scroll_offset: 0,
+            scroll_anchor: TuiInlineMenuScrollAnchor::Selection,
+            max_visible_rows: 1,
+            status: None,
+        })
+    }
+}
+
+#[test]
+fn masked_inline_menu_input_suppresses_copy_and_composer_modes() {
+    App::test((), |mut app| async move {
+        let (view, copied) = app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            add_test_semantic_selection(ctx);
+            let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
+            let input_mode = add_test_input_mode(ctx);
+            let suggestions_mode =
+                add_suggestions_mode(ctx, TuiInputSuggestionsMode::ModelSelector);
+            let menu = ctx.add_model(|_| TestSecretMenu);
+            let (_, view) = ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                move |ctx| {
+                    TuiInputView::new_for_test(
+                        input_model,
+                        input_mode,
+                        suggestions_mode,
+                        vec![TuiInlineMenu::new(menu)],
+                        |_| false,
+                        ctx,
+                    )
+                },
+            );
+            let copied = Rc::new(Cell::new(false));
+            let copied_for_subscription = copied.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiInputViewEvent::ClipboardCopySucceeded) {
+                    copied_for_subscription.set(true);
+                }
+            });
+            (view, copied)
+        });
+
+        app.update(|ctx| {
+            type_str(&view, ctx, "top-secret");
+            dispatch(
+                &view,
+                ctx,
+                &[
+                    TuiInputAction::EditorCommand(TuiEditorCommand::SelectAll),
+                    TuiInputAction::EditorCommand(TuiEditorCommand::Copy),
+                ],
+            );
+        });
+        app.read(|ctx| {
+            let rendered = render_input_buffer(&view, ctx).to_lines().join("\n");
+            assert!(rendered.contains("••••••••••"), "{rendered}");
+            assert!(!rendered.contains("top-secret"), "{rendered}");
+            assert!(!view.as_ref(ctx).is_shell_mode(ctx));
+        });
+        assert!(!copied.get());
+
+        app.update(|ctx| {
+            view.update(ctx, |view, ctx| view.set_text("", ctx));
+            type_str(&view, ctx, "!?");
+        });
+        app.read(|ctx| {
+            assert_eq!(text(&view, ctx), "!?");
+            assert!(!view.as_ref(ctx).is_shell_mode(ctx));
+            assert_eq!(
+                view.as_ref(ctx).suggestions_mode.as_ref(ctx).mode(),
+                TuiInputSuggestionsMode::ModelSelector
+            );
+        });
+    });
 }
 
 fn add_test_input_mode(ctx: &mut AppContext) -> ModelHandle<BlocklistAIInputModel> {

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -146,40 +146,24 @@ impl TuiInlineMenuHandle for ModelHandle<TestSecretMenu> {
 }
 
 #[test]
-fn masked_inline_menu_input_suppresses_copy_and_composer_modes() {
+fn masked_inline_menu_input_keeps_copy_and_paste_inside_masked_editor() {
     App::test((), |mut app| async move {
-        let (view, copied) = app.update(|ctx| {
-            ctx.add_singleton_model(|_| Appearance::mock());
-            add_test_semantic_selection(ctx);
-            let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
-            let input_mode = add_test_input_mode(ctx);
-            let suggestions_mode =
-                add_suggestions_mode(ctx, TuiInputSuggestionsMode::ModelSelector);
-            let menu = ctx.add_model(|_| TestSecretMenu);
-            let (_, view) = ctx.add_tui_window(
-                AddWindowOptions {
-                    window_style: WindowStyle::NotStealFocus,
-                    ..Default::default()
-                },
-                move |ctx| {
-                    TuiInputView::new_for_test(
-                        input_model,
-                        input_mode,
-                        suggestions_mode,
-                        vec![TuiInlineMenu::new(menu)],
-                        |_| false,
-                        ctx,
-                    )
-                },
-            );
-            let copied = Rc::new(Cell::new(false));
-            let copied_for_subscription = copied.clone();
+        let (view, leaked_event_count) = app.update(|ctx| {
+            let view = build_view_with_masked_inline_menu(ctx);
+            let leaked_event_count = Rc::new(Cell::new(0));
+            let leaked_event_count_for_subscription = leaked_event_count.clone();
             ctx.subscribe_to_view(&view, move |_, event, _| {
-                if matches!(event, TuiInputViewEvent::ClipboardCopySucceeded) {
-                    copied_for_subscription.set(true);
+                if matches!(
+                    event,
+                    TuiInputViewEvent::Pasted(_)
+                        | TuiInputViewEvent::ClipboardCopySucceeded
+                        | TuiInputViewEvent::ClipboardCopyFailed
+                ) {
+                    leaked_event_count_for_subscription
+                        .set(leaked_event_count_for_subscription.get() + 1);
                 }
             });
-            (view, copied)
+            (view, leaked_event_count)
         });
 
         app.update(|ctx| {
@@ -190,22 +174,77 @@ fn masked_inline_menu_input_suppresses_copy_and_composer_modes() {
                 &[
                     TuiInputAction::EditorCommand(TuiEditorCommand::SelectAll),
                     TuiInputAction::EditorCommand(TuiEditorCommand::Copy),
+                    TuiInputAction::Editor(TuiEditorAction::PasteText(
+                        "replacement-secret".to_owned(),
+                    )),
                 ],
             );
         });
         app.read(|ctx| {
             let rendered = render_input_buffer(&view, ctx).to_lines().join("\n");
-            assert!(rendered.contains("••••••••••"), "{rendered}");
+            assert_eq!(text(&view, ctx), "replacement-secret");
+            assert!(rendered.contains("••••••••••••••••••"), "{rendered}");
             assert!(!rendered.contains("top-secret"), "{rendered}");
-            assert!(!view.as_ref(ctx).is_shell_mode(ctx));
+            assert!(!rendered.contains("replacement-secret"), "{rendered}");
         });
-        assert!(!copied.get());
+        assert_eq!(
+            leaked_event_count.get(),
+            0,
+            "masked copy and paste must not emit composer or clipboard events"
+        );
+    });
+}
+
+#[test]
+fn masked_inline_menu_input_keeps_undo_and_redo_inside_masked_editor() {
+    App::test((), |mut app| async move {
+        let view = app.update(build_view_with_masked_inline_menu);
 
         app.update(|ctx| {
-            view.update(ctx, |view, ctx| view.set_text("", ctx));
-            type_str(&view, ctx, "!?");
+            type_str(&view, ctx, "top-secret");
+            dispatch(
+                &view,
+                ctx,
+                &[
+                    TuiInputAction::EditorCommand(TuiEditorCommand::SelectAll),
+                    TuiInputAction::Editor(TuiEditorAction::PasteText(
+                        "replacement-secret".to_owned(),
+                    )),
+                    TuiInputAction::EditorCommand(TuiEditorCommand::Undo),
+                ],
+            );
         });
         app.read(|ctx| {
+            assert_eq!(text(&view, ctx), "top-secret");
+            let rendered = render_input_buffer(&view, ctx).to_lines().join("\n");
+            assert!(rendered.contains("••••••••••"), "{rendered}");
+            assert!(!rendered.contains("top-secret"), "{rendered}");
+            assert!(!rendered.contains("replacement-secret"), "{rendered}");
+        });
+
+        app.update(|ctx| {
+            dispatch(
+                &view,
+                ctx,
+                &[TuiInputAction::EditorCommand(TuiEditorCommand::Redo)],
+            );
+        });
+        app.read(|ctx| {
+            assert_eq!(text(&view, ctx), "replacement-secret");
+            let rendered = render_input_buffer(&view, ctx).to_lines().join("\n");
+            assert!(rendered.contains("••••••••••••••••••"), "{rendered}");
+            assert!(!rendered.contains("top-secret"), "{rendered}");
+            assert!(!rendered.contains("replacement-secret"), "{rendered}");
+        });
+    });
+}
+
+#[test]
+fn masked_inline_menu_input_suppresses_composer_modes() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view_with_masked_inline_menu(ctx);
+            type_str(&view, ctx, "!?");
             assert_eq!(text(&view, ctx), "!?");
             assert!(!view.as_ref(ctx).is_shell_mode(ctx));
             assert_eq!(
@@ -216,6 +255,31 @@ fn masked_inline_menu_input_suppresses_copy_and_composer_modes() {
     });
 }
 
+fn build_view_with_masked_inline_menu(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
+    ctx.add_singleton_model(|_| Appearance::mock());
+    add_test_semantic_selection(ctx);
+    let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
+    let input_mode = add_test_input_mode(ctx);
+    let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::ModelSelector);
+    let menu = ctx.add_model(|_| TestSecretMenu);
+    let (_, view) = ctx.add_tui_window(
+        AddWindowOptions {
+            window_style: WindowStyle::NotStealFocus,
+            ..Default::default()
+        },
+        move |ctx| {
+            TuiInputView::new_for_test(
+                input_model,
+                input_mode,
+                suggestions_mode,
+                vec![TuiInlineMenu::new(menu)],
+                |_| false,
+                ctx,
+            )
+        },
+    );
+    view
+}
 fn add_test_input_mode(ctx: &mut AppContext) -> ModelHandle<BlocklistAIInputModel> {
     register_tui_input_mode_test_settings(ctx);
     BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx)

--- a/crates/warp_tui/src/keybindings_tests.rs
+++ b/crates/warp_tui/src/keybindings_tests.rs
@@ -8,7 +8,7 @@ use crate::attachment_bar::{FOCUS_ATTACHMENTS_BINDING_NAME, TuiAttachmentBar};
 use crate::input::TuiInputView;
 use crate::input::view::{MCP_LOGOUT_BINDING_NAME, MCP_MENU_ACTIVE_FLAG};
 use crate::terminal_session_view::{
-    PASTE_IMAGE_BINDING_NAME, SESSION_COMPOSER_OWNS_INPUT_FLAG, TuiTerminalSessionView,
+    PASTE_IMAGE_BINDING_NAME, SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG, TuiTerminalSessionView,
 };
 
 #[test]
@@ -138,7 +138,7 @@ fn attachment_bindings_are_scoped_to_available_and_focused_contexts() {
             let mut composer_context = plain_input.clone();
             composer_context
                 .set
-                .insert(SESSION_COMPOSER_OWNS_INPUT_FLAG);
+                .insert(SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG);
             assert!(
                 paste_bindings
                     .iter()

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -196,7 +196,7 @@ const SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG: &str =
     "TuiSessionCanDetachAgentFromRunningCommand";
 const SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG: &str =
     "TuiSessionCanAcceptBlockedTerminalUseAction";
-pub(crate) const SESSION_COMPOSER_OWNS_INPUT_FLAG: &str = "TuiSessionComposerOwnsInput";
+pub(crate) const SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG: &str = "TuiSessionComposerShortcutsActive";
 pub(crate) const PASTE_IMAGE_BINDING_NAME: &str = "tui:session:paste_image";
 pub(crate) const AUTO_APPROVE_TOGGLE_BINDING_NAME: &str = "tui:session:toggle_auto_approve";
 pub(crate) const ACCEPT_BLOCKED_TERMINAL_USE_ACTION_BINDING_NAME: &str =
@@ -810,7 +810,7 @@ pub(crate) fn init(app: &mut AppContext) {
         )
         .with_context_predicate(
             (id!(TuiInputView::ui_name()) | id!(TuiTerminalSessionView::ui_name()))
-                & id!(SESSION_COMPOSER_OWNS_INPUT_FLAG),
+                & id!(SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG),
         )
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("ctrl-v"),
@@ -821,7 +821,7 @@ pub(crate) fn init(app: &mut AppContext) {
         )
         .with_context_predicate(
             (id!(TuiInputView::ui_name()) | id!(TuiTerminalSessionView::ui_name()))
-                & id!(SESSION_COMPOSER_OWNS_INPUT_FLAG),
+                & id!(SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG),
         )
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("ctrl-shift-V"),
@@ -832,7 +832,7 @@ pub(crate) fn init(app: &mut AppContext) {
         )
         .with_context_predicate(
             (id!(TuiInputView::ui_name()) | id!(TuiTerminalSessionView::ui_name()))
-                & id!(SESSION_COMPOSER_OWNS_INPUT_FLAG),
+                & id!(SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG),
         )
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("ctrl-s"),
@@ -844,7 +844,7 @@ pub(crate) fn init(app: &mut AppContext) {
         )
         .with_context_predicate(
             (id!(TuiInputView::ui_name()) | id!(TuiTerminalSessionView::ui_name()))
-                & id!(SESSION_COMPOSER_OWNS_INPUT_FLAG),
+                & id!(SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG),
         )
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("alt-v"),
@@ -3572,12 +3572,12 @@ impl TuiTerminalSessionView {
     fn with_voice_hold_handler(
         &self,
         child: Box<dyn TuiElement>,
-        composer_owns_input: bool,
+        composer_shortcuts_active: bool,
         ctx: &AppContext,
     ) -> Box<dyn TuiElement> {
         let active_hold_key = self.input_view.as_ref(ctx).voice_hold_key(ctx);
         if !self.keyboard_enhancement_supported
-            || (!composer_owns_input && active_hold_key.is_none())
+            || (!composer_shortcuts_active && active_hold_key.is_none())
         {
             return child;
         }
@@ -3587,7 +3587,7 @@ impl TuiTerminalSessionView {
         TuiEventHandler::new(child)
             .on_modifier_key_changed(move |key, state, event_ctx, _| {
                 if key != expected_key
-                    || (matches!(state, KeyState::Pressed) && !composer_owns_input)
+                    || (matches!(state, KeyState::Pressed) && !composer_shortcuts_active)
                 {
                     return TuiDispatchEventResult::PropagateToParent;
                 }
@@ -4565,7 +4565,7 @@ impl TuiView for TuiTerminalSessionView {
         }
         if state
             .as_ref()
-            .is_some_and(|state| state.agent_is_tagged_in() && state.composer_owns_input())
+            .is_some_and(|state| state.agent_is_tagged_in() && state.composer_shortcuts_active())
         {
             context
                 .set
@@ -4587,9 +4587,9 @@ impl TuiView for TuiTerminalSessionView {
         }
         if state
             .as_ref()
-            .is_some_and(|state| state.composer_owns_input())
+            .is_some_and(|state| state.composer_shortcuts_active())
         {
-            context.set.insert(SESSION_COMPOSER_OWNS_INPUT_FLAG);
+            context.set.insert(SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG);
             if attachment_focus_available(
                 self.is_shell_mode(ctx),
                 self.attachment_bar.as_ref(ctx).should_render(ctx),
@@ -4601,13 +4601,13 @@ impl TuiView for TuiTerminalSessionView {
     }
 
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
-        let (content, composer_owns_input) = self.render_session_content(ctx);
-        self.with_voice_hold_handler(content, composer_owns_input, ctx)
+        let (content, composer_shortcuts_active) = self.render_session_content(ctx);
+        self.with_voice_hold_handler(content, composer_shortcuts_active, ctx)
     }
 }
 
 impl TuiTerminalSessionView {
-    /// Renders the session body and reports whether the composer owns input.
+    /// Renders the session body and reports whether composer shortcuts are active.
     ///
     /// Every path returns through [`TuiView::render`]'s single hold-handler
     /// wrap, so a session state that renders its own screen — a conversation
@@ -4730,7 +4730,7 @@ impl TuiTerminalSessionView {
             } else {
                 session
             };
-            return (session, state.composer_owns_input());
+            return (session, state.composer_shortcuts_active());
         }
 
         // Ctrl-c (cancel/clear/exit) is handled by the keymap pass via the
@@ -4907,7 +4907,7 @@ impl TuiTerminalSessionView {
             session
         };
 
-        (session, state.composer_owns_input())
+        (session, state.composer_shortcuts_active())
     }
 }
 

--- a/crates/warp_tui/src/terminal_session_view/input_detection.rs
+++ b/crates/warp_tui/src/terminal_session_view/input_detection.rs
@@ -99,6 +99,16 @@ impl TuiTerminalSessionView {
         ctx: &mut ViewContext<Self>,
     ) {
         self.abort_input_detection(ctx);
+        let inline_menu_owns_input = active_inline_menu(
+            &self.inline_menus,
+            self.suggestions_mode.as_ref(ctx).mode(),
+            ctx,
+        )
+        .is_some_and(|menu| menu.input_ownership(ctx).inline_menu_owns_input());
+        if inline_menu_owns_input {
+            self.abort_shell_completion(ctx);
+            return;
+        }
         self.handle_completion_editor_changed(ctx);
         if is_user_edit {
             self.schedule_input_detection(ctx);

--- a/crates/warp_tui/src/terminal_session_view/state.rs
+++ b/crates/warp_tui/src/terminal_session_view/state.rs
@@ -208,7 +208,7 @@ impl TuiTerminalSessionStateModel {
                                     agent_controlled_terminal_use: false,
                                 }
                             };
-                            TuiInteractionState::Composer(TuiComposerState {
+                            TuiInteractionState::AgentEditor(TuiAgentEditorState {
                                 mode,
                                 suggestions_mode: suggestions_mode.as_ref(ctx).mode(),
                             })
@@ -287,13 +287,16 @@ pub(crate) struct TuiBlockSessionState {
 pub(super) enum TuiInteractionState {
     Blocking(BlockingInputSource),
     StartingShell,
-    Composer(TuiComposerState),
+    AgentEditor(TuiAgentEditorState),
     Pty(TuiPtyState),
 }
 
-/// Composer state, which cannot exist under alt-screen, blocking, or PTY input.
+/// State for the agent-editor surface, which cannot coexist with blocking or PTY input.
+///
+/// The active inline menu separately resolves whether it or the composer owns
+/// the shared editor's behavior.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct TuiComposerState {
+pub(super) struct TuiAgentEditorState {
     pub(super) mode: TuiComposerMode,
     pub(super) suggestions_mode: TuiInputSuggestionsMode,
 }
@@ -359,7 +362,7 @@ impl TuiTerminalSessionState {
         match self.interaction() {
             TuiInteractionState::Blocking(source) => Some(source),
             TuiInteractionState::StartingShell
-            | TuiInteractionState::Composer(_)
+            | TuiInteractionState::AgentEditor(_)
             | TuiInteractionState::Pty(_) => None,
         }
     }
@@ -379,7 +382,7 @@ impl TuiTerminalSessionState {
             }
         };
         Self::Block(TuiBlockSessionState {
-            interaction: TuiInteractionState::Composer(TuiComposerState {
+            interaction: TuiInteractionState::AgentEditor(TuiAgentEditorState {
                 mode,
                 suggestions_mode,
             }),
@@ -404,7 +407,7 @@ impl TuiTerminalSessionState {
                     | BlockingInputSource::GrokOAuth(_) => TuiInputTarget::Disabled,
                 },
                 TuiInteractionState::StartingShell => TuiInputTarget::Disabled,
-                TuiInteractionState::Composer(_) => TuiInputTarget::AgentEditor,
+                TuiInteractionState::AgentEditor(_) => TuiInputTarget::AgentEditor,
                 TuiInteractionState::Pty(_) => TuiInputTarget::Pty,
             },
         }
@@ -440,10 +443,11 @@ impl TuiTerminalSessionState {
         self.state().agent_is_tagged_in
     }
 
-    pub(crate) fn composer_owns_input(&self) -> bool {
+    /// Returns whether composer shortcuts are active without a suggestions overlay.
+    pub(crate) fn composer_shortcuts_active(&self) -> bool {
         matches!(
             self.interaction(),
-            TuiInteractionState::Composer(TuiComposerState {
+            TuiInteractionState::AgentEditor(TuiAgentEditorState {
                 suggestions_mode,
                 ..
             }) if !suggestions_mode.is_visible()
@@ -452,13 +456,13 @@ impl TuiTerminalSessionState {
 
     pub(crate) fn hint_text(&self) -> Option<String> {
         let state = self.state();
-        let TuiInteractionState::Composer(composer) = &state.interaction else {
+        let TuiInteractionState::AgentEditor(agent_editor) = &state.interaction else {
             return None;
         };
-        if composer.suggestions_mode.read_only_menu().is_some() {
+        if agent_editor.suggestions_mode.read_only_menu().is_some() {
             return None;
         }
-        Some(match composer.mode {
+        Some(match agent_editor.mode {
             TuiComposerMode::Shell => SHELL_HINT.to_owned(),
             TuiComposerMode::Agent { .. } => {
                 agent_input_hint(state.transcript_is_empty, state.orchestration_available)
@@ -467,10 +471,10 @@ impl TuiTerminalSessionState {
     }
 
     pub(crate) fn read_only_menu(&self) -> Option<TuiReadOnlyMenuKind> {
-        let TuiInteractionState::Composer(composer) = self.interaction() else {
+        let TuiInteractionState::AgentEditor(agent_editor) = self.interaction() else {
             return None;
         };
-        composer.suggestions_mode.read_only_menu()
+        agent_editor.suggestions_mode.read_only_menu()
     }
 
     pub(crate) fn shortcut_sections(
@@ -479,7 +483,7 @@ impl TuiTerminalSessionState {
         ctx: &AppContext,
     ) -> Vec<TuiShortcutSection> {
         let state = self.state();
-        let composer = match &state.interaction {
+        let agent_editor = match &state.interaction {
             TuiInteractionState::Blocking(BlockingInputSource::LongRunningCommand) => {
                 return vec![TuiShortcutSection {
                     title: "Terminal",
@@ -507,14 +511,14 @@ impl TuiTerminalSessionState {
                     }],
                 }];
             }
-            TuiInteractionState::Composer(composer) => composer,
+            TuiInteractionState::AgentEditor(agent_editor) => agent_editor,
         };
 
         let mut shortcuts = vec![TuiShortcut {
             key: "?".to_owned(),
             description: "shortcuts",
         }];
-        match composer.mode {
+        match agent_editor.mode {
             TuiComposerMode::Agent { .. } => shortcuts.extend([
                 TuiShortcut {
                     key: "/".to_owned(),
@@ -534,7 +538,7 @@ impl TuiTerminalSessionState {
                 description: "agent mode",
             }),
         }
-        if matches!(composer.mode, TuiComposerMode::Agent { .. }) {
+        if matches!(agent_editor.mode, TuiComposerMode::Agent { .. }) {
             shortcuts.push(TuiShortcut {
                 key: "↑".to_owned(),
                 description: "input history",
@@ -560,7 +564,7 @@ impl TuiTerminalSessionState {
             shortcuts,
         }];
         if matches!(
-            composer.mode,
+            agent_editor.mode,
             TuiComposerMode::Agent {
                 agent_controlled_terminal_use: true
             }

--- a/crates/warp_tui/src/terminal_session_view/state_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view/state_tests.rs
@@ -3,7 +3,7 @@ use warpui_core::{App, TuiView};
 
 use super::{
     ASK_AGENT_HINT, COMMANDS_HINT, CONVERSATIONS_HINT, SHELL_HINT, SHELL_MODE_HINT, SHORTCUTS_HINT,
-    TuiBlockSessionState, TuiComposerMode, TuiComposerState, TuiInteractionState, TuiPtyState,
+    TuiAgentEditorState, TuiBlockSessionState, TuiComposerMode, TuiInteractionState, TuiPtyState,
     TuiTerminalSessionState, TuiTerminalSessionStateResolveError, agent_input_hint,
     upgrade_terminal_model,
 };
@@ -14,9 +14,12 @@ use crate::terminal_session_view::{
 };
 use crate::terminal_use::TuiInputTarget;
 
-fn composer_state(mode: TuiComposerMode, orchestration_available: bool) -> TuiTerminalSessionState {
+fn agent_editor_state(
+    mode: TuiComposerMode,
+    orchestration_available: bool,
+) -> TuiTerminalSessionState {
     TuiTerminalSessionState::Block(TuiBlockSessionState {
-        interaction: TuiInteractionState::Composer(TuiComposerState {
+        interaction: TuiInteractionState::AgentEditor(TuiAgentEditorState {
             mode,
             suggestions_mode: TuiInputSuggestionsMode::Closed,
         }),
@@ -33,7 +36,7 @@ fn tagged_in_composer_exposes_detach_shortcut() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);
         app.read(|ctx| {
-            let mut state = composer_state(
+            let mut state = agent_editor_state(
                 TuiComposerMode::Agent {
                     agent_controlled_terminal_use: false,
                 },
@@ -110,7 +113,7 @@ fn resolve_returns_error_after_terminal_model_owner_drops() {
 
 #[test]
 fn shell_hint_is_selected_with_additive_orchestration() {
-    let state = composer_state(TuiComposerMode::Shell, true);
+    let state = agent_editor_state(TuiComposerMode::Shell, true);
     assert_eq!(state.hint_text().as_deref(), Some(SHELL_HINT));
 }
 
@@ -151,7 +154,7 @@ fn only_composer_interactions_produce_input_hints() {
         assert_eq!(state.hint_text(), None);
     }
 
-    let mut state = composer_state(
+    let mut state = agent_editor_state(
         TuiComposerMode::Agent {
             agent_controlled_terminal_use: false,
         },
@@ -162,10 +165,10 @@ fn only_composer_interactions_produce_input_hints() {
         let TuiTerminalSessionState::Block(block) = &mut state else {
             unreachable!();
         };
-        let TuiInteractionState::Composer(composer) = &mut block.interaction else {
+        let TuiInteractionState::AgentEditor(agent_editor) = &mut block.interaction else {
             unreachable!();
         };
-        composer.suggestions_mode =
+        agent_editor.suggestions_mode =
             TuiInputSuggestionsMode::ReadOnlyMenu(TuiReadOnlyMenuKind::Shortcuts);
     }
     assert_eq!(state.hint_text(), None);
@@ -174,17 +177,17 @@ fn only_composer_interactions_produce_input_hints() {
         let TuiTerminalSessionState::Block(block) = &mut state else {
             unreachable!();
         };
-        let TuiInteractionState::Composer(composer) = &mut block.interaction else {
+        let TuiInteractionState::AgentEditor(agent_editor) = &mut block.interaction else {
             unreachable!();
         };
-        composer.suggestions_mode =
+        agent_editor.suggestions_mode =
             TuiInputSuggestionsMode::ReadOnlyMenu(TuiReadOnlyMenuKind::Status);
     }
     assert_eq!(state.hint_text(), None);
 }
 
 #[test]
-fn hierarchy_encodes_input_ownership() {
+fn hierarchy_selects_one_input_surface() {
     assert_eq!(
         alt_screen_state(
             TuiInputTarget::Pty,
@@ -209,15 +212,30 @@ fn hierarchy_encodes_input_ownership() {
         TuiInputTarget::Pty
     );
 
-    let state = composer_state(TuiComposerMode::Shell, false);
+    let state = agent_editor_state(TuiComposerMode::Shell, false);
     assert_eq!(state.input_target(), TuiInputTarget::AgentEditor);
-    assert!(state.composer_owns_input());
+    assert!(state.composer_shortcuts_active());
+}
+
+#[test]
+fn suggestions_overlay_disables_composer_shortcuts_without_changing_the_input_surface() {
+    let mut state = agent_editor_state(TuiComposerMode::Shell, false);
+    let TuiTerminalSessionState::Block(block) = &mut state else {
+        unreachable!();
+    };
+    let TuiInteractionState::AgentEditor(agent_editor) = &mut block.interaction else {
+        unreachable!();
+    };
+    agent_editor.suggestions_mode = TuiInputSuggestionsMode::SlashCommands;
+
+    assert_eq!(state.input_target(), TuiInputTarget::AgentEditor);
+    assert!(!state.composer_shortcuts_active());
 }
 #[test]
 fn alt_screen_can_retain_an_agent_composer() {
     let state = alt_screen_state(
         TuiInputTarget::AgentEditor,
-        TuiInteractionState::Composer(TuiComposerState {
+        TuiInteractionState::AgentEditor(TuiAgentEditorState {
             mode: TuiComposerMode::Agent {
                 agent_controlled_terminal_use: true,
             },
@@ -227,7 +245,7 @@ fn alt_screen_can_retain_an_agent_composer() {
 
     assert!(state.is_alt_screen());
     assert_eq!(state.input_target(), TuiInputTarget::AgentEditor);
-    assert!(state.composer_owns_input());
+    assert!(state.composer_shortcuts_active());
     assert!(state.hint_text().is_some());
 }
 
@@ -236,7 +254,7 @@ fn shell_and_orchestration_contribute_active_shortcut_sections() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);
         app.read(|ctx| {
-            let mut state = composer_state(TuiComposerMode::Shell, true);
+            let mut state = agent_editor_state(TuiComposerMode::Shell, true);
             let TuiTerminalSessionState::Block(block) = &mut state else {
                 unreachable!();
             };
@@ -280,7 +298,7 @@ fn agent_terminal_use_and_orchestration_are_additive() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);
         app.read(|ctx| {
-            let state = composer_state(
+            let state = agent_editor_state(
                 TuiComposerMode::Agent {
                     agent_controlled_terminal_use: true,
                 },
@@ -328,7 +346,7 @@ fn user_controlled_terminal_use_has_terminal_only_shortcuts() {
             assert_eq!(sections[0].shortcuts[0].description, "hand back control");
             assert!(state.user_owns_running_command());
             assert!(state.can_hand_back_terminal_use());
-            assert!(!state.composer_owns_input());
+            assert!(!state.composer_shortcuts_active());
         });
     });
 }

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -61,7 +61,7 @@ use super::{
     LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT, RUNNING_COMMAND_DETACH_HINT,
     SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG,
     SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG,
-    SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG, SESSION_COMPOSER_OWNS_INPUT_FLAG,
+    SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG, SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG,
     SHELL_MODE_HINT, STATUSLINE_RESET_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
     TuiTerminalSessionEvent, TuiTerminalSessionView, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
     attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
@@ -4470,7 +4470,7 @@ fn blocked_terminal_use_action_acceptance_uses_ctrl_enter_without_rebinding_subm
     });
 }
 #[test]
-fn voice_input_keeps_ctrl_s_as_the_default_keybinding() {
+fn voice_input_uses_ctrl_s_only_when_composer_shortcuts_are_active() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);
         app.read(|ctx| {
@@ -4489,7 +4489,9 @@ fn voice_input_keeps_ctrl_s_as_the_default_keybinding() {
                 .insert(TuiTerminalSessionView::ui_name());
             assert!(!binding.in_context(&session_context));
 
-            session_context.set.insert(SESSION_COMPOSER_OWNS_INPUT_FLAG);
+            session_context
+                .set
+                .insert(SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG);
             assert!(binding.in_context(&session_context));
         });
     });


### PR DESCRIPTION
## Description
Adds a single, explicit ownership model for the shared TUI editor so an active inline menu can own plaintext or masked input without leaving composer behavior partially enabled.

This is the downstack infrastructure PR for #14472. The ownership variants are exercised by a focused test menu here; the `/api-keys` production consumer lands immediately upstack.

## Linked Issue
CODE-1930

## Testing
- [x] I have manually tested my changes locally with `./script/run`

This is a behavioral no-op, so nothing to show yet.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>