### PR TITLE
[APP-4992] Configure auto-approve denylist behavior

### DIFF
--- a/app/src/ai/blocklist/permissions.rs
+++ b/app/src/ai/blocklist/permissions.rs
@@ -895,7 +895,22 @@ impl BlocklistAIPermissions {
             .map(|command| command_for_execution_predicates(command, escape_char))
             .collect::<Vec<_>>();
 
-        // The denylist takes precedence over all other conditions.
+        // Local auto-approve may bypass the user-configured denylist. Sandboxed processes use a
+        // separate organization-managed denylist that must always be evaluated, so only
+        // unsandboxed execution can return before the denylist check.
+        let auto_approve_enabled = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(conversation_id)
+            .is_some_and(|convo| convo.autoexecute_any_action());
+        if auto_approve_enabled
+            && !AppExecutionMode::as_ref(ctx).is_sandboxed()
+            && *AISettings::as_ref(ctx).auto_approve_bypasses_command_denylist
+        {
+            return CommandExecutionPermission::Allowed(
+                CommandExecutionPermissionAllowedReason::RunToCompletion,
+            );
+        }
+
+        // The denylist takes precedence over the remaining conditions.
         let denylist = self.get_execute_commands_denylist(ctx, terminal_view_id);
         if commands_for_denylist
             .iter()
@@ -906,10 +921,7 @@ impl BlocklistAIPermissions {
             );
         }
 
-        if BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(conversation_id)
-            .is_some_and(|convo| convo.autoexecute_any_action())
-        {
+        if auto_approve_enabled {
             return CommandExecutionPermission::Allowed(
                 CommandExecutionPermissionAllowedReason::RunToCompletion,
             );

--- a/app/src/ai/blocklist/permissions.rs
+++ b/app/src/ai/blocklist/permissions.rs
@@ -895,23 +895,25 @@ impl BlocklistAIPermissions {
             .map(|command| command_for_execution_predicates(command, escape_char))
             .collect::<Vec<_>>();
 
-        // Local auto-approve may bypass the user-configured denylist. Sandboxed processes use a
-        // separate organization-managed denylist that must always be evaluated, so only
-        // unsandboxed execution can return before the denylist check.
+        // Local auto-approve may bypass the user-configured denylist, but workspace policy must
+        // always be evaluated. Sandboxed processes use a separate organization-managed denylist
+        // that cannot be bypassed.
         let auto_approve_enabled = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(conversation_id)
             .is_some_and(|convo| convo.autoexecute_any_action());
-        if auto_approve_enabled
+        let bypass_user_denylist = auto_approve_enabled
             && !AppExecutionMode::as_ref(ctx).is_sandboxed()
-            && *AISettings::as_ref(ctx).auto_approve_bypasses_command_denylist
-        {
-            return CommandExecutionPermission::Allowed(
-                CommandExecutionPermissionAllowedReason::RunToCompletion,
-            );
-        }
+            && *AISettings::as_ref(ctx).auto_approve_bypasses_command_denylist;
 
         // The denylist takes precedence over the remaining conditions.
-        let denylist = self.get_execute_commands_denylist(ctx, terminal_view_id);
+        let denylist = if bypass_user_denylist {
+            // Auto-approve may bypass the user denylist, but the organization denylist
+            // must always be enforced.
+            Self::get_org_execute_commands_denylist(ctx)
+        } else {
+            // Without the bypass, enforce both the organization and user denylists.
+            self.get_execute_commands_denylist(ctx, terminal_view_id)
+        };
         if commands_for_denylist
             .iter()
             .any(|c| denylist.iter().any(|d| d.matches(c)))

--- a/app/src/ai/blocklist/permissions_tests.rs
+++ b/app/src/ai/blocklist/permissions_tests.rs
@@ -863,7 +863,7 @@ fn test_can_autoexecute_command_allowlist_precedence() {
 }
 
 #[test]
-fn test_can_autoexecute_command_auto_approve_bypasses_local_denylists() {
+fn test_can_autoexecute_command_auto_approve_bypasses_user_denylist_but_not_workspace_denylist() {
     App::test((), |mut app| async move {
         let PermissionsTestState {
             convo_id,
@@ -900,25 +900,39 @@ fn test_can_autoexecute_command_auto_approve_bypasses_local_denylists() {
             history.toggle_autoexecute_override(&convo_id, terminal_view_id, ctx);
         });
 
-        for command in ["rm important.txt", "git status"] {
-            permissions.read(&app, |model, ctx| {
-                let result = model.can_autoexecute_command(
-                    &convo_id,
-                    command,
-                    EscapeChar::Backslash,
-                    false,
-                    None,
-                    Some(terminal_view_id),
-                    ctx,
-                );
-                assert!(matches!(
-                    result,
-                    CommandExecutionPermission::Allowed(
-                        CommandExecutionPermissionAllowedReason::RunToCompletion
-                    )
-                ));
-            });
-        }
+        permissions.read(&app, |model, ctx| {
+            let user_denylisted = model.can_autoexecute_command(
+                &convo_id,
+                "rm important.txt",
+                EscapeChar::Backslash,
+                false,
+                None,
+                Some(terminal_view_id),
+                ctx,
+            );
+            assert!(matches!(
+                user_denylisted,
+                CommandExecutionPermission::Allowed(
+                    CommandExecutionPermissionAllowedReason::RunToCompletion
+                )
+            ));
+
+            let workspace_denylisted = model.can_autoexecute_command(
+                &convo_id,
+                "git status",
+                EscapeChar::Backslash,
+                false,
+                None,
+                Some(terminal_view_id),
+                ctx,
+            );
+            assert!(matches!(
+                workspace_denylisted,
+                CommandExecutionPermission::Denied(
+                    CommandExecutionPermissionDeniedReason::ExplicitlyDenylisted
+                )
+            ));
+        });
     })
 }
 

--- a/app/src/ai/blocklist/permissions_tests.rs
+++ b/app/src/ai/blocklist/permissions_tests.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 
 use uuid::Uuid;
 use warp_core::execution_mode::ExecutionMode;
+use warp_core::settings::Setting as _;
 use warp_util::path::EscapeChar;
-use warpui::{App, EntityId, ModelHandle};
+use warpui::{App, EntityId, ModelHandle, SingletonEntity};
 
 use super::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
@@ -22,7 +23,7 @@ use crate::cloud_object::model::persistence::CloudModel;
 use crate::network::NetworkStatus;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::sync_queue::SyncQueue;
-use crate::settings::{AgentModeCommandExecutionPredicate, PrivacySettings};
+use crate::settings::{AISettings, AgentModeCommandExecutionPredicate, PrivacySettings};
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::test_util::settings::initialize_settings_for_tests_with_mode;
 use crate::workspaces::team_tester::TeamTesterStatus;
@@ -862,7 +863,7 @@ fn test_can_autoexecute_command_allowlist_precedence() {
 }
 
 #[test]
-fn test_can_autoexecute_command_denylist_beats_run_to_completion() {
+fn test_can_autoexecute_command_auto_approve_bypasses_local_denylists() {
     App::test((), |mut app| async move {
         let PermissionsTestState {
             convo_id,
@@ -870,6 +871,7 @@ fn test_can_autoexecute_command_denylist_beats_run_to_completion() {
             history,
             profile_model,
             terminal_view_id,
+            user_workspaces,
             ..
         } = initialize_permissions_test(&mut app);
 
@@ -882,14 +884,77 @@ fn test_can_autoexecute_command_denylist_beats_run_to_completion() {
             );
         });
 
-        // Toggle run-to-completion override for this conversation.
+        user_workspaces.update(&mut app, |model, ctx| {
+            model.setup_test_workspace(ctx);
+            model.update_ai_autonomy_settings(
+                |settings| {
+                    settings.execute_commands_denylist = Some(vec![
+                        AgentModeCommandExecutionPredicate::new_regex("git .*").unwrap(),
+                    ]);
+                },
+                ctx,
+            );
+        });
+        // Enable auto-approve for this conversation.
         history.update(&mut app, |history, ctx| {
             history.toggle_autoexecute_override(&convo_id, terminal_view_id, ctx);
         });
 
-        // Despite run-to-completion, denylist must take precedence and deny execution.
+        for command in ["rm important.txt", "git status"] {
+            permissions.read(&app, |model, ctx| {
+                let result = model.can_autoexecute_command(
+                    &convo_id,
+                    command,
+                    EscapeChar::Backslash,
+                    false,
+                    None,
+                    Some(terminal_view_id),
+                    ctx,
+                );
+                assert!(matches!(
+                    result,
+                    CommandExecutionPermission::Allowed(
+                        CommandExecutionPermissionAllowedReason::RunToCompletion
+                    )
+                ));
+            });
+        }
+    })
+}
+
+#[test]
+fn test_can_autoexecute_command_auto_approve_respects_local_denylist_when_bypass_disabled() {
+    App::test((), |mut app| async move {
+        let PermissionsTestState {
+            convo_id,
+            permissions,
+            history,
+            profile_model,
+            terminal_view_id,
+            ..
+        } = initialize_permissions_test(&mut app);
+
+        profile_model.update(&mut app, |model, ctx| {
+            model.add_to_command_denylist(
+                model.active_profile(Some(terminal_view_id), ctx).id(),
+                &AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap(),
+                ctx,
+            );
+        });
+        app.update(|ctx| {
+            AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .auto_approve_bypasses_command_denylist
+                    .set_value(false, ctx)
+                    .expect("setting should update");
+            });
+        });
+        history.update(&mut app, |history, ctx| {
+            history.toggle_autoexecute_override(&convo_id, terminal_view_id, ctx);
+        });
+
         permissions.read(&app, |model, ctx| {
-            let result = model.can_autoexecute_command(
+            let denied = model.can_autoexecute_command(
                 &convo_id,
                 "rm important.txt",
                 EscapeChar::Backslash,
@@ -898,11 +963,26 @@ fn test_can_autoexecute_command_denylist_beats_run_to_completion() {
                 Some(terminal_view_id),
                 ctx,
             );
-            assert!(!result.is_allowed());
             assert!(matches!(
-                result,
+                denied,
                 CommandExecutionPermission::Denied(
                     CommandExecutionPermissionDeniedReason::ExplicitlyDenylisted
+                )
+            ));
+
+            let allowed = model.can_autoexecute_command(
+                &convo_id,
+                "echo hello",
+                EscapeChar::Backslash,
+                false,
+                None,
+                Some(terminal_view_id),
+                ctx,
+            );
+            assert!(matches!(
+                allowed,
+                CommandExecutionPermission::Allowed(
+                    CommandExecutionPermissionAllowedReason::RunToCompletion
                 )
             ));
         });
@@ -910,7 +990,7 @@ fn test_can_autoexecute_command_denylist_beats_run_to_completion() {
 }
 
 #[test]
-fn test_can_autoexecute_command_run_to_completion_allows_non_denylisted() {
+fn test_can_autoexecute_command_auto_approve_allows_non_denylisted() {
     App::test((), |mut app| async move {
         let PermissionsTestState {
             convo_id,
@@ -920,12 +1000,12 @@ fn test_can_autoexecute_command_run_to_completion_allows_non_denylisted() {
             ..
         } = initialize_permissions_test(&mut app);
 
-        // Enable run-to-completion override for the conversation.
+        // Enable auto-approve for the conversation.
         history.update(&mut app, |history, ctx| {
             history.toggle_autoexecute_override(&convo_id, terminal_view_id, ctx);
         });
 
-        // Since the command is not denylisted, the override should allow execution with RunToCompletion.
+        // Auto-approve should still allow commands that are not denylisted.
         permissions.read(&app, |model, ctx| {
             let result = model.can_autoexecute_command(
                 &convo_id,
@@ -1317,6 +1397,7 @@ fn test_sandboxed_denylist_used_in_sandboxed_mode() {
     App::test((), |mut app| async move {
         let PermissionsTestState {
             convo_id,
+            history,
             permissions,
             user_workspaces,
             terminal_view_id,
@@ -1347,6 +1428,17 @@ fn test_sandboxed_denylist_used_in_sandboxed_mode() {
             );
         });
 
+        history.update(&mut app, |history, ctx| {
+            history.toggle_autoexecute_override(&convo_id, terminal_view_id, ctx);
+        });
+        app.update(|ctx| {
+            AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .auto_approve_bypasses_command_denylist
+                    .set_value(false, ctx)
+                    .expect("setting should update");
+            });
+        });
         permissions.read(&app, |model, ctx| {
             // "git status" should be allowed: the regular denylist is not consulted in
             // sandboxed mode, so only the sandboxed denylist ("rm .*") applies.
@@ -1359,10 +1451,12 @@ fn test_sandboxed_denylist_used_in_sandboxed_mode() {
                 Some(terminal_view_id),
                 ctx,
             );
-            assert!(
-                result.is_allowed(),
-                "git status should be allowed in sandboxed mode (regular denylist bypassed)"
-            );
+            assert!(matches!(
+                result,
+                CommandExecutionPermission::Allowed(
+                    CommandExecutionPermissionAllowedReason::RunToCompletion
+                )
+            ));
 
             // "rm file.txt" should be denied by the sandboxed denylist.
             let result = model.can_autoexecute_command(

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1981,6 +1981,18 @@ define_settings_group!(AISettings, settings: [
         description: "Whether agent-executed commands are included in command history.",
     }
 
+    // Whether fast forward / auto-approve can run commands that match the command denylist.
+    auto_approve_bypasses_command_denylist: AutoApproveBypassesCommandDenylist {
+        type: bool,
+        default: true,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        surface: settings::SettingSurfaces::ALL,
+        private: false,
+        toml_path: "agents.warp_agent.other.auto_approve_bypasses_command_denylist",
+        description: "Whether auto-approve bypasses the command denylist.",
+    }
+
     // Controls whether the conversation history view appears in the tools panel.
     show_conversation_history: ShowConversationHistory {
         type: bool,

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -1,4 +1,6 @@
 use chrono::Utc;
+use settings::schema::SettingSchemaEntry;
+use settings::{Setting, SettingSurfaces, SettingsMode};
 use warp_graphql::scalars::time::ServerTimestamp;
 use warpui::{App, SingletonEntity};
 
@@ -29,6 +31,27 @@ fn create_test_request_limit_info(
         max_files_per_repo: 5000,
         embedding_generation_batch_size: 100,
     }
+}
+
+#[test]
+fn auto_approve_denylist_bypass_defaults_on_and_is_available_in_gui_and_tui_settings() {
+    let setting = AutoApproveBypassesCommandDenylist::new(None);
+    assert!(*setting.value());
+    assert_eq!(
+        AutoApproveBypassesCommandDenylist::toml_path(),
+        Some("agents.warp_agent.other.auto_approve_bypasses_command_denylist")
+    );
+
+    let entry = inventory::iter::<SettingSchemaEntry>
+        .into_iter()
+        .find(|entry| {
+            entry.hierarchy == Some("agents.warp_agent.other")
+                && entry.storage_key == "auto_approve_bypasses_command_denylist"
+        })
+        .expect("expected auto-approve denylist bypass schema entry");
+    let surfaces: SettingSurfaces = (entry.surfaces_fn)();
+    assert!(surfaces.includes(SettingsMode::Gui));
+    assert!(surfaces.includes(SettingsMode::Tui));
 }
 
 fn add_ai_enablement_dependencies_for_test(app: &mut App) {

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -91,16 +91,17 @@ use crate::modal::{Modal, ModalEvent, ModalViewState};
 use crate::settings::{
     AIAutoDetectionEnabled, AICommandDenylist, AISettingsChangedEvent,
     AgentModeCodingPermissionsType, AgentModeCommandExecutionDenylist,
-    AgentModeCommandExecutionPredicate, AgentModeQuerySuggestionsEnabled, AwsBedrockAutoLogin,
-    AwsBedrockCredentialsEnabled, CanUseWarpCreditsForFallback, CodeSettings,
-    CodebaseContextEnabled, FileBasedMcpEnabled, GeminiEnterpriseCredentialsEnabled,
-    GitOperationsAutogenEnabled, IncludeAgentCommandsInHistory, InputSettings,
-    IntelligentAutosuggestionsEnabled, LongRunningCommandSubmissionMode, MemoryEnabled,
-    NLDInTerminalEnabled, NaturalLanguageAutosuggestionsEnabled, OrchestrationMessageDisplayMode,
-    PromptSubmissionMode, RuleSuggestionsEnabled, SharedBlockTitleGenerationEnabled,
-    ShouldRenderCLIAgentToolbar, ShouldRenderUseAgentToolbarForUserCommands,
-    ShouldShowOzUpdatesInZeroState, ShowAgentTips, ShowConversationHistory, ShowHintText,
-    ThinkingDisplayMode, VoiceInputEnabled, WarpDriveContextEnabled,
+    AgentModeCommandExecutionPredicate, AgentModeQuerySuggestionsEnabled,
+    AutoApproveBypassesCommandDenylist, AwsBedrockAutoLogin, AwsBedrockCredentialsEnabled,
+    CanUseWarpCreditsForFallback, CodeSettings, CodebaseContextEnabled, FileBasedMcpEnabled,
+    GeminiEnterpriseCredentialsEnabled, GitOperationsAutogenEnabled, IncludeAgentCommandsInHistory,
+    InputSettings, IntelligentAutosuggestionsEnabled, LongRunningCommandSubmissionMode,
+    MemoryEnabled, NLDInTerminalEnabled, NaturalLanguageAutosuggestionsEnabled,
+    OrchestrationMessageDisplayMode, PromptSubmissionMode, RuleSuggestionsEnabled,
+    SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
+    ShouldRenderUseAgentToolbarForUserCommands, ShouldShowOzUpdatesInZeroState, ShowAgentTips,
+    ShowConversationHistory, ShowHintText, ThinkingDisplayMode, VoiceInputEnabled,
+    WarpDriveContextEnabled,
 };
 use crate::terminal::CLIAgent;
 use crate::terminal::session_settings::{SessionSettings, SessionSettingsChangedEvent};
@@ -546,6 +547,25 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
                 )),
                 &(context.clone() & id!(flags::IS_ANY_AI_ENABLED)),
                 flags::INCLUDE_AGENT_COMMANDS_IN_HISTORY_FLAG,
+            )
+            .with_group(bindings::BindingGroup::WarpAi),
+            ToggleSettingActionPair::custom(
+                SettingActionPairDescriptions::new(
+                    "Allow auto-approve to bypass command denylist",
+                    "Require approval for denylisted commands in auto-approve",
+                ),
+                builder(SettingsAction::AI(
+                    AISettingsPageAction::ToggleAutoApproveBypassesCommandDenylist,
+                )),
+                SettingActionPairContexts::new(
+                    context.clone()
+                        & id!(flags::IS_ANY_AI_ENABLED)
+                        & !id!(flags::AUTO_APPROVE_BYPASSES_COMMAND_DENYLIST_FLAG),
+                    context.clone()
+                        & id!(flags::IS_ANY_AI_ENABLED)
+                        & id!(flags::AUTO_APPROVE_BYPASSES_COMMAND_DENYLIST_FLAG),
+                ),
+                None,
             )
             .with_group(bindings::BindingGroup::WarpAi),
             ToggleSettingActionPair::new(
@@ -3718,6 +3738,7 @@ pub enum AISettingsPageAction {
     ToggleCloudAgentComputerUse,
     ToggleFileBasedMcp,
     ToggleIncludeAgentCommandsInHistory,
+    ToggleAutoApproveBypassesCommandDenylist,
     ToggleAgentAttribution,
 
     // Custom model routers
@@ -4521,6 +4542,16 @@ impl TypedActionView for AISettingsPageView {
                     report_if_error!(
                         settings
                             .include_agent_commands_in_history
+                            .toggle_and_save_value(ctx)
+                    );
+                });
+                ctx.notify();
+            }
+            AISettingsPageAction::ToggleAutoApproveBypassesCommandDenylist => {
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(
+                        settings
+                            .auto_approve_bypasses_command_denylist
                             .toggle_and_save_value(ctx)
                     );
                 });
@@ -6594,13 +6625,14 @@ struct AIInputWidget {
     show_input_hint_toggle: SwitchStateHandle,
     show_agent_tips_toggle: SwitchStateHandle,
     include_agent_commands_in_history_toggle: SwitchStateHandle,
+    auto_approve_bypasses_command_denylist_toggle: SwitchStateHandle,
 }
 
 impl SettingsWidget for AIInputWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "oz agent ai input natural language detection autodetection prompt terminal command commands history shell executed execution queue interrupt submission submit auto-queue response while responding default long-running long running lrc"
+        "oz agent ai input natural language detection autodetection prompt terminal command commands history shell executed execution queue interrupt submission submit auto-queue response while responding default long-running long running lrc auto-approve fast forward denylist permissions"
     }
 
     fn render(
@@ -6669,6 +6701,28 @@ impl SettingsWidget for AIInputWidget {
             &view.local_only_icon_tooltip_states,
             app,
         ));
+
+        widget_children.push(
+            Flex::column()
+                .with_child(render_ai_setting_toggle::<
+                    AutoApproveBypassesCommandDenylist,
+                >(
+                    "Allow auto-approve to bypass command denylist",
+                    AISettingsPageAction::ToggleAutoApproveBypassesCommandDenylist,
+                    *ai_settings.auto_approve_bypasses_command_denylist,
+                    is_any_ai_enabled,
+                    self.auto_approve_bypasses_command_denylist_toggle
+                        .clone(),
+                    &view.local_only_icon_tooltip_states,
+                    app,
+                ))
+                .with_child(render_ai_setting_description(
+                    "When enabled, fast forward and auto-approve run denylisted commands without asking for confirmation.",
+                    is_any_ai_enabled,
+                    app,
+                ))
+                .finish(),
+        );
 
         if FeatureFlag::QueueSlashCommand.is_enabled() {
             widget_children.push(render_dropdown_item(

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -579,6 +579,8 @@ pub mod flags {
     pub const SHARED_BLOCK_TITLE_GENERATION_FLAG: &str = "Shared_Block_Title_Generation";
     pub const GIT_OPERATIONS_AUTOGEN_FLAG: &str = "Git_Operations_Autogen";
     pub const INCLUDE_AGENT_COMMANDS_IN_HISTORY_FLAG: &str = "Include_Agent_Commands_In_History";
+    pub const AUTO_APPROVE_BYPASSES_COMMAND_DENYLIST_FLAG: &str =
+        "Auto_Approve_Bypasses_Command_Denylist";
     pub const AI_RULES_FLAG: &str = "AI_Rules";
     pub const SUGGESTED_RULES_FLAG: &str = "Suggested_Rules";
     pub const WARP_DRIVE_CONTEXT_FLAG: &str = "Warp_Drive_Context";

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3308,7 +3308,8 @@ impl Workspace {
             }
             AISettingsChangedEvent::IsActiveAIEnabled { .. }
             | AISettingsChangedEvent::ThinkingDisplayMode { .. }
-            | AISettingsChangedEvent::PromptSubmissionMode { .. } => {
+            | AISettingsChangedEvent::PromptSubmissionMode { .. }
+            | AISettingsChangedEvent::AutoApproveBypassesCommandDenylist { .. } => {
                 ctx.notify();
             }
             AISettingsChangedEvent::ShowAgentNotifications { .. } => {
@@ -23160,6 +23161,13 @@ impl Workspace {
                 .set
                 .insert(flags::INCLUDE_AGENT_COMMANDS_IN_HISTORY_FLAG);
         }
+
+        if *ai_settings.auto_approve_bypasses_command_denylist.value() {
+            context
+                .set
+                .insert(flags::AUTO_APPROVE_BYPASSES_COMMAND_DENYLIST_FLAG);
+        }
+
         if *ai_settings.memory_enabled.value() {
             context.set.insert(flags::AI_RULES_FLAG);
         }


### PR DESCRIPTION
## Description

Adds a default-on `auto_approve_bypasses_command_denylist` setting shared by GUI and Warp Agent CLI settings files. Local auto-approve/fast-forward uses the setting to decide whether denylisted commands can run without confirmation; sandboxed cloud-agent permission ordering remains unchanged from `master`.

The GUI exposes the setting under **Settings → Agents → Warp Agent → Input**, with matching command-palette actions.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Screenshot/video

https://www.loom.com/share/325b497283454f5f9a9925230d94a533

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
