### PR TITLE
fix(terminal): send Ctrl+/ as Unit Separator

### DIFF
--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -193,7 +193,7 @@ lazy_static! {
     /// Though caret notation uses uppercase letters (`^C` instead of `^c`), we validate using
     /// _lowercase_ characters because it is impossible to create a [`Keystroke`] of the form
     /// `ctrl-[A-Z]`. See [`Keystroke::parse`].
-    pub static ref CONTROL_CHARACTER_KEY_REGEX: Regex = Regex::new(r"^ctrl-[a-z@\[\\\]^_/?]$").expect("should be able to construct regex");
+    pub static ref CONTROL_CHARACTER_KEY_REGEX: Regex = Regex::new(r"^(?:ctrl-[a-z@\[\\\]^_/?]|ctrl-shift-/)$").expect("should be able to construct regex");
 
     /// Set of actions on Mac that should be considered valid bindings even though they aren't PTY
     /// compliant. We weren't always diligent about avoiding bindings that could conflict with
@@ -360,10 +360,9 @@ pub fn custom_tag_to_keystroke(custom: CustomTag) -> Option<Keystroke> {
         // Set this to mac-only. On Linux this conflicts with the cmd-enter keybindings
         // (used for actions on the input suggestions menu, and for accepting passive code diffs).
         CustomAction::ToggleMaximizePane => mac_only_keystroke("cmd-shift-enter"),
-        // Note: The base character '/' is used instead of '?' as mac registers keybindings
-        // differently compared to the app which saves the resulting character used with shift
-        // TODO: resolve these keybinding differences
-        CustomAction::ToggleResourceCenter => Keystroke::parse("ctrl-shift-/").ok(),
+        // Keep Ctrl+Shift+/ available to the PTY because some layouts require Shift to produce
+        // the logical "/" key. The Resource Center remains assignable on every platform.
+        CustomAction::ToggleResourceCenter => None,
         CustomAction::ToggleKeybindingsPage => mac_only_keystroke("cmd-/"),
         CustomAction::ScrollToTopOfSelectedBlocks => Keystroke::parse("cmdorctrl-shift-up").ok(),
         CustomAction::ScrollToBottomOfSelectedBlocks => {
@@ -837,11 +836,12 @@ impl BindingGroup {
 /// of using `cmdorctrl-XX` to construct a platform agnostic keybinding does not work here because
 /// `ctrl-XX` would conflict with the PTY because it is reserved as a control character.
 ///
-/// Bindings of the form `ctrl-[a-z@[\]^_/?]` are reserved as control characters. We don't want to
-/// create bindings for in-app actions that would conflict with these control characters because we
-/// would end up preventing the user from sending these control characters to the PTY. To avoid
-/// this, we follow other terminals and use `ctrl-shift-XX` for in-app bindings if the binding would
-/// otherwise conflict with the PTY.
+/// Bindings of the form `ctrl-[a-z@[\]^_/?]` are reserved as control characters. `ctrl-shift-/`
+/// is also reserved because some layouts require Shift to produce the logical slash key. We don't
+/// want to create bindings for in-app actions that would conflict with these control characters
+/// because we would end up preventing the user from sending these control characters to the PTY.
+/// To avoid this, we follow other terminals and use `ctrl-shift-XX` for in-app bindings if the
+/// binding would otherwise conflict with the PTY.
 ///
 /// ## Panics
 /// Panics if debug assertions are enabled and a non "A-Z" key was passed in an environment where `ctrl-shift` would be
@@ -887,7 +887,8 @@ pub fn cmd_or_ctrl_shift(key: &str) -> String {
 /// Returns whether the given [`BindingLens`] is compliant with the PTY.
 /// A binding is considered PTY compliant if it does not interfere with a control character that
 /// needs to be sent to the PTY. A binding is considered to be a control character if the only
-/// modifier set is `ctrl` and the key is one of `a-z@[\]^_/?`.
+/// modifier set is `ctrl` and the key is one of `a-z@[\]^_/?`, or if it is `ctrl-shift-/` on a
+/// layout where Shift produces the logical slash key.
 pub fn is_binding_pty_compliant(binding: BindingLens) -> IsBindingValid {
     let trigger = binding.original_trigger.unwrap_or(binding.trigger);
     let Some(keystroke) = trigger_to_keystroke(trigger) else {

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -186,13 +186,14 @@ lazy_static! {
     /// * `^]`: Group Separator
     /// * `^^`: Record Separator
     /// * `^_`: Unit Separator
+    /// * `^/`: Unit Separator (legacy alias)
     /// * `^?`: Delete
     ///
     /// ## Note
     /// Though caret notation uses uppercase letters (`^C` instead of `^c`), we validate using
     /// _lowercase_ characters because it is impossible to create a [`Keystroke`] of the form
     /// `ctrl-[A-Z]`. See [`Keystroke::parse`].
-    pub static ref CONTROL_CHARACTER_KEY_REGEX: Regex = Regex::new(r"^ctrl-[a-z@\[\\\]^_?]$").expect("should be able to construct regex");
+    pub static ref CONTROL_CHARACTER_KEY_REGEX: Regex = Regex::new(r"^ctrl-[a-z@\[\\\]^_/?]$").expect("should be able to construct regex");
 
     /// Set of actions on Mac that should be considered valid bindings even though they aren't PTY
     /// compliant. We weren't always diligent about avoiding bindings that could conflict with
@@ -363,7 +364,7 @@ pub fn custom_tag_to_keystroke(custom: CustomTag) -> Option<Keystroke> {
         // differently compared to the app which saves the resulting character used with shift
         // TODO: resolve these keybinding differences
         CustomAction::ToggleResourceCenter => Keystroke::parse("ctrl-shift-/").ok(),
-        CustomAction::ToggleKeybindingsPage => Keystroke::parse("cmdorctrl-/").ok(),
+        CustomAction::ToggleKeybindingsPage => mac_only_keystroke("cmd-/"),
         CustomAction::ScrollToTopOfSelectedBlocks => Keystroke::parse("cmdorctrl-shift-up").ok(),
         CustomAction::ScrollToBottomOfSelectedBlocks => {
             Keystroke::parse("cmdorctrl-shift-down").ok()
@@ -836,7 +837,7 @@ impl BindingGroup {
 /// of using `cmdorctrl-XX` to construct a platform agnostic keybinding does not work here because
 /// `ctrl-XX` would conflict with the PTY because it is reserved as a control character.
 ///
-/// Bindings of the form `ctrl-[a-z@[\]^_?]` are reserved as control characters. We don't want to
+/// Bindings of the form `ctrl-[a-z@[\]^_/?]` are reserved as control characters. We don't want to
 /// create bindings for in-app actions that would conflict with these control characters because we
 /// would end up preventing the user from sending these control characters to the PTY. To avoid
 /// this, we follow other terminals and use `ctrl-shift-XX` for in-app bindings if the binding would
@@ -886,7 +887,7 @@ pub fn cmd_or_ctrl_shift(key: &str) -> String {
 /// Returns whether the given [`BindingLens`] is compliant with the PTY.
 /// A binding is considered PTY compliant if it does not interfere with a control character that
 /// needs to be sent to the PTY. A binding is considered to be a control character if the only
-/// modifier set is `ctrl` and the key is one of `a-z@[\]^_?`.
+/// modifier set is `ctrl` and the key is one of `a-z@[\]^_/?`.
 pub fn is_binding_pty_compliant(binding: BindingLens) -> IsBindingValid {
     let trigger = binding.original_trigger.unwrap_or(binding.trigger);
     let Some(keystroke) = trigger_to_keystroke(trigger) else {

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -79,6 +79,8 @@ fn test_keybinding_name_to_display_string() {
 #[test]
 fn test_ctrl_slash_is_reserved_for_pty_input() {
     assert!(CONTROL_CHARACTER_KEY_REGEX.is_match("ctrl-/"));
+    assert!(CONTROL_CHARACTER_KEY_REGEX.is_match("ctrl-shift-/"));
+    assert!(!CONTROL_CHARACTER_KEY_REGEX.is_match("ctrl-shift-?"));
 }
 
 #[test]
@@ -89,6 +91,12 @@ fn test_toggle_keybindings_page_default_is_mac_only() {
     } else {
         assert_eq!(keystroke, None);
     }
+}
+
+#[test]
+fn test_toggle_resource_center_default_does_not_intercept_ctrl_slash() {
+    let keystroke = custom_tag_to_keystroke(CustomAction::ToggleResourceCenter.into());
+    assert_eq!(keystroke, None);
 }
 
 #[test]

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -3,7 +3,10 @@ use warpui::keymap::{EditableBinding, Keystroke, Trigger};
 use warpui::platform::OperatingSystem;
 
 use crate::terminal;
-use crate::util::bindings::{keybinding_name_to_display_string, trigger_to_keystroke};
+use crate::util::bindings::{
+    CONTROL_CHARACTER_KEY_REGEX, CustomAction, custom_tag_to_keystroke,
+    keybinding_name_to_display_string, trigger_to_keystroke,
+};
 use crate::workspace::WorkspaceAction;
 
 #[test]
@@ -71,6 +74,21 @@ fn test_keybinding_name_to_display_string() {
             );
         });
     });
+}
+
+#[test]
+fn test_ctrl_slash_is_reserved_for_pty_input() {
+    assert!(CONTROL_CHARACTER_KEY_REGEX.is_match("ctrl-/"));
+}
+
+#[test]
+fn test_toggle_keybindings_page_default_is_mac_only() {
+    let keystroke = custom_tag_to_keystroke(CustomAction::ToggleKeybindingsPage.into());
+    if OperatingSystem::get().is_mac() {
+        assert_eq!(keystroke, Keystroke::parse("cmd-/").ok());
+    } else {
+        assert_eq!(keystroke, None);
+    }
 }
 
 #[test]

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -476,6 +476,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
 
     // Keyboard protocol tests
     register_test!(test_keyboard_protocol_disabled_shift_enter);
+    register_test!(test_ctrl_slash_emits_unit_separator_in_legacy_mode);
     register_test!(test_keyboard_protocol_enabled_shift_enter);
     register_test!(test_keyboard_protocol_enabled_shifted_symbol_uses_unshifted_keycode);
     register_test!(test_keyboard_protocol_query_and_apply_modes);

--- a/crates/integration/src/test/keyboard_protocol.rs
+++ b/crates/integration/src/test/keyboard_protocol.rs
@@ -140,6 +140,82 @@ pub fn test_keyboard_protocol_disabled_shift_enter() -> Builder {
         )
 }
 
+/// Test that Ctrl+/ sends Unit Separator in legacy terminal mode. These synthetic events model the
+/// output of the platform event conversion for both dedicated and shifted slash keys; native
+/// NSEvent conversion itself is covered by platform-level probes rather than this hermetic runner.
+pub fn test_ctrl_slash_emits_unit_separator_in_legacy_mode() -> Builder {
+    new_builder()
+        .with_setup(setup_python_script!(
+            "read_keys.py",
+            "../../assets/read_keys.py"
+        ))
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            TestStep::new("Execute read_keys.py")
+                .with_typed_characters(&["python3 ~/read_keys.py"])
+                .with_keystrokes(&["enter"])
+                .add_assertion(
+                    assert_long_running_block_executing_for_single_terminal_in_tab(true, 0),
+                ),
+        )
+        .with_step(
+            TestStep::new("Wait for script to be ready")
+                .add_assertion(assert_output_contains(
+                    "Ready",
+                    "Expected the key reader to be ready",
+                ))
+                .set_timeout(Duration::from_secs(5)),
+        )
+        .with_step(
+            TestStep::new("Send Ctrl+/ from a layout with a dedicated slash key")
+                .with_event(Event::KeyDown {
+                    keystroke: Keystroke::parse("ctrl-/").unwrap(),
+                    chars: "/".to_string(),
+                    details: KeyEventDetails {
+                        key_without_modifiers: Some("/".to_string()),
+                        ..Default::default()
+                    },
+                    is_composing: false,
+                })
+                .set_timeout(Duration::from_secs(5))
+                .add_assertion(assert_output_contains(
+                    "0x1f",
+                    "Expected Ctrl+/ to send Unit Separator (0x1f)",
+                )),
+        )
+        .with_step(
+            TestStep::new("Send Ctrl+/ from a layout that requires Shift for slash")
+                .with_event(Event::KeyDown {
+                    // macOS Turkish-QWERTY-PC reports:
+                    // - charactersIgnoringModifiers (the logical key): "/"
+                    // - the physical base key: "7"
+                    // - characters with Control held: "7"
+                    keystroke: Keystroke::parse("ctrl-shift-/").unwrap(),
+                    chars: "7".to_string(),
+                    details: KeyEventDetails {
+                        key_without_modifiers: Some("7".to_string()),
+                        ..Default::default()
+                    },
+                    is_composing: false,
+                })
+                .set_timeout(Duration::from_secs(5))
+                .add_assertion(|app, window_id| {
+                    let terminal_view = single_terminal_view_for_tab(app, window_id, 0);
+                    terminal_view.read(app, |view, _ctx| {
+                        let model = view.model.lock();
+                        let output = model.block_list().active_block().output_to_string();
+                        async_assert!(
+                            output.matches("0x1f").count() >= 2,
+                            "Expected both Ctrl+/ events to send Unit Separator (0x1f), but output was: {output}"
+                        )
+                    })
+                }),
+        )
+        .with_step(
+            new_step_with_default_assertions("Send Ctrl+C to exit").with_keystrokes(&["ctrl-c"]),
+        )
+}
+
 /// Test that when keyboard protocol is enabled, Shift+Enter sends CSI u sequence
 pub fn test_keyboard_protocol_enabled_shift_enter() -> Builder {
     FeatureFlag::KittyKeyboardProtocol.set_enabled(true);

--- a/crates/integration/src/test/keyboard_protocol.rs
+++ b/crates/integration/src/test/keyboard_protocol.rs
@@ -144,6 +144,10 @@ pub fn test_keyboard_protocol_disabled_shift_enter() -> Builder {
 /// output of the platform event conversion for both dedicated and shifted slash keys; native
 /// NSEvent conversion itself is covered by platform-level probes rather than this hermetic runner.
 pub fn test_ctrl_slash_emits_unit_separator_in_legacy_mode() -> Builder {
+    // Exercise the configuration that registers the legacy Resource Center action. Its old
+    // Ctrl+Shift+/ default intercepted Ctrl+/ on layouts where slash requires Shift.
+    FeatureFlag::AvatarInTabBar.set_user_preference(false);
+
     new_builder()
         .with_setup(setup_python_script!(
             "read_keys.py",

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -350,6 +350,7 @@ integration_tests! {
 
     // Keyboard protocol tests
     test_keyboard_protocol_disabled_shift_enter,
+    test_ctrl_slash_emits_unit_separator_in_legacy_mode,
     test_keyboard_protocol_enabled_shift_enter,
     test_keyboard_protocol_enabled_shifted_symbol_uses_unshifted_keycode,
     test_keyboard_protocol_query_and_apply_modes,

--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -588,6 +588,16 @@ fn keystroke_to_c0_control_code(
         ]);
     }
 
+    // Legacy terminal input encodes logical Ctrl+/ as Unit Separator. The Kitty legacy mapping
+    // likewise distinguishes "/" (31) from "?" (127), so matching the semantic key does not
+    // consume Ctrl+? on layouts where Shift changes slash to question mark. Other layouts require
+    // Shift to produce the logical "/" character, so do not reject Shift here. Enhanced keyboard
+    // protocols are handled before this legacy fallback and retain the complete modifier state.
+    if keystroke.ctrl && !keystroke.alt && !keystroke.cmd && !keystroke.meta && keystroke.key == "/"
+    {
+        return Some(vec![C0::US]);
+    }
+
     // Only emit C0 codes on ctrl-modified keystrokes, without other modifiers, per the VT-220
     // spec.
     if !(keystroke.ctrl && !keystroke.alt && !keystroke.shift && !keystroke.meta) {

--- a/crates/warp_terminal/src/model/escape_sequences_tests.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_tests.rs
@@ -58,6 +58,101 @@ fn test_keystroke_to_c0_control_code() {
 }
 
 #[test]
+fn test_ctrl_slash_emits_unit_separator_with_a_dedicated_slash_key() {
+    let keystroke = Keystroke::parse("ctrl-/").unwrap();
+    let terminal_model_mock = TerminalModelMock::new();
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &keystroke,
+            key_without_modifiers: Some("/"),
+            chars: Some("/"),
+        }
+        .to_escape_sequence(&terminal_model_mock),
+        Some(vec![C0::US])
+    );
+}
+
+#[test]
+fn test_ctrl_slash_emits_unit_separator_when_the_layout_requires_shift() {
+    // macOS reports these values for Ctrl+Shift+7 on Turkish-QWERTY-PC: the logical key from
+    // `charactersIgnoringModifiers` is "/", while both the physical base key and `characters`
+    // are "7".
+    let keystroke = Keystroke::parse("ctrl-shift-/").unwrap();
+    let terminal_model_mock = TerminalModelMock::new();
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &keystroke,
+            key_without_modifiers: Some("7"),
+            chars: Some("7"),
+        }
+        .to_escape_sequence(&terminal_model_mock),
+        Some(vec![C0::US])
+    );
+}
+
+#[test]
+fn test_ctrl_slash_legacy_mapping_preserves_other_modified_keys() {
+    let terminal_model_mock = TerminalModelMock::new();
+    let unit_separator = Some(vec![C0::US]);
+
+    // On a US layout, Shift changes the logical slash key to "?"; the OS-provided DEL character
+    // must remain available to the caller instead of being replaced with Unit Separator.
+    let ctrl_question_mark = Keystroke::parse("ctrl-shift-?").unwrap();
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &ctrl_question_mark,
+            key_without_modifiers: Some("/"),
+            chars: Some("\x7f"),
+        }
+        .to_escape_sequence(&terminal_model_mock),
+        None
+    );
+
+    for keystroke in [
+        Keystroke::parse("ctrl-alt-/").unwrap(),
+        Keystroke::parse("ctrl-cmd-/").unwrap(),
+        Keystroke::parse("ctrl-meta-/").unwrap(),
+    ] {
+        assert_ne!(
+            KeystrokeWithDetails {
+                keystroke: &keystroke,
+                key_without_modifiers: Some("/"),
+                chars: Some("/"),
+            }
+            .to_escape_sequence(&terminal_model_mock),
+            unit_separator
+        );
+    }
+}
+
+#[test]
+fn test_ctrl_slash_uses_kitty_encoding_when_the_protocol_is_enabled() {
+    let terminal_model_mock = mock_with_all_keys_as_escape();
+
+    let dedicated_slash = Keystroke::parse("ctrl-/").unwrap();
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &dedicated_slash,
+            key_without_modifiers: Some("/"),
+            chars: Some("/"),
+        }
+        .to_escape_sequence(&terminal_model_mock),
+        Some(b"\x1b[47;5u".to_vec())
+    );
+
+    let shifted_layout_slash = Keystroke::parse("ctrl-shift-/").unwrap();
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &shifted_layout_slash,
+            key_without_modifiers: Some("7"),
+            chars: Some("7"),
+        }
+        .to_escape_sequence(&terminal_model_mock),
+        Some(b"\x1b[55;6u".to_vec())
+    );
+}
+
+#[test]
 fn test_shift_backspace_emits_del_sequence() {
     // Regression test: Shift+Backspace must emit DEL (0x7f), not BS (0x08).
     // 0x08 is Ctrl+H, which readline-style TUIs interpret as backward-kill-word.


### PR DESCRIPTION
## Description

Fixes legacy terminal input for `Ctrl+/` by encoding the logical slash key as the C0 Unit Separator byte (`0x1f`), which terminal applications such as Neovim expect.

The change deliberately preserves enhanced Kitty keyboard protocol encoding and keeps `Ctrl+?` distinct. It also removes the two default app bindings that can intercept the relevant legacy input shapes before they reach the PTY: non-macOS `Ctrl+/` for the Keybindings page and `Ctrl+Shift+/` for the Resource Center. The actions remain available for user-defined bindings, and macOS keeps its existing `Cmd+/` Keybindings default.

`Ctrl+Shift+/` is now explicitly treated as PTY-reserved because layouts such as `Turkish-QWERTY-PC` require Shift to produce the logical slash key.

## Linked Issue

Closes #4620

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format --check`
- All three Clippy profiles from `script/presubmit`
- Fork-PR-equivalent workspace suite: 10,228/10,228 passed
- `cargo test -p warp_terminal test_ctrl_slash_ -- --nocapture`
- `cargo test -p warp test_ctrl_slash_is_reserved_for_pty_input -- --nocapture`
- `cargo test -p warp test_toggle_keybindings_page_default_is_mac_only -- --nocapture`
- `cargo test -p warp test_toggle_resource_center_default_does_not_intercept_ctrl_slash -- --nocapture`
- `cargo run -p integration --bin integration -- test_ctrl_slash_emits_unit_separator_in_legacy_mode`
- `cargo nextest run -p warp_completer --features v2`: 117/117 passed
- `cargo test --doc`: 43 passed, 4 ignored
- The integration regression test disables `AvatarInTabBar` so it exercises the legacy Resource Center registration that previously intercepted shifted-layout `Ctrl+/`.
- A native AppKit probe on `Turkish-QWERTY-PC` verified the shifted-layout event shape used by the regression test: `Ctrl+Shift+7` reports `/` as the logical key while the base key and characters remain `7`.
- Before the fix, the end-to-end regression test displayed `0x2f` (`/`). After the fix, both dedicated-slash and shifted-layout cases display `0x1f`.

- [x] I have manually tested my changes locally with `./script/run`

A manual smoke test on macOS (`Turkish-QWERTY-PC`) used a raw `stty`/`od` PTY probe. Pressing `Ctrl+Shift+7` (the layout's `Ctrl+/`) produced `1f`.

The end-to-end test was also run locally against the branch app on a real macOS display. It drives a shell/PTY, displays the received bytes, and records the full run.

### Screenshots / Videos

The attached real-display integration recording shows both `Ctrl+/` input shapes reaching the PTY as `0x1f` Unit Separator. Playback is slowed 4x and the final frame is held for readability; the captured frames are otherwise unchanged.

https://github.com/user-attachments/assets/c11506aa-943b-408c-aac4-38062f2c01b9

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Ctrl+/ so terminal applications receive the expected Unit Separator control character.
