### PR TITLE
disable remote ssh for tui

### DIFF
--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -49,7 +49,7 @@ use crate::terminal::model::terminal_model::BlockIndex;
 use crate::terminal::model::terminal_model::ExitReason;
 #[cfg(unix)]
 use crate::terminal::model_events::ModelEvent as TerminalModelEvent;
-use crate::terminal::model_events::ModelEventDispatcher;
+use crate::terminal::model_events::{ModelEventDispatcher, SshRemoteServerSupport};
 use crate::terminal::session_settings::{SessionSettings, ToolbarChipSelection};
 use crate::terminal::shared_session::sharer::network::Network;
 use crate::terminal::shared_session::{IsSharedSessionCreator, SharedSessionStatus};
@@ -225,6 +225,7 @@ impl<S> TerminalManager<S> {
             model_event_sender,
             chosen_shell,
             BlockSpacing::for_gui(ctx),
+            SshRemoteServerSupport::Enabled,
             ctx,
             create_surface,
             |manager| Box::new(manager),
@@ -265,6 +266,7 @@ impl<S> TerminalManager<S> {
             model_event_sender,
             chosen_shell,
             block_spacing,
+            SshRemoteServerSupport::Disabled,
             ctx,
             create_surface,
             |manager| Box::new(TuiTerminalManager(manager)),
@@ -283,6 +285,7 @@ impl<S> TerminalManager<S> {
         model_event_sender: Option<SyncSender<ModelEvent>>,
         chosen_shell: Option<AvailableShell>,
         block_spacing: BlockSpacing,
+        ssh_remote_server_support: SshRemoteServerSupport,
         ctx: &mut AppContext,
         create_surface: impl FnOnce(
             TerminalSurfaceInit,
@@ -312,8 +315,14 @@ impl<S> TerminalManager<S> {
         // Initialize the sessions model.
         let sessions = ctx.add_model(|ctx| Sessions::new(executor_command_tx.clone(), ctx));
 
-        let model_events =
-            ctx.add_model(|ctx| ModelEventDispatcher::new(events_rx, sessions.clone(), ctx));
+        let model_events = ctx.add_model(|ctx| {
+            ModelEventDispatcher::new_with_ssh_remote_server_support(
+                events_rx,
+                sessions.clone(),
+                ssh_remote_server_support,
+                ctx,
+            )
+        });
 
         // Have ApiKeyManager subscribe to block completion events for AWS credential refresh
         ai::api_keys::ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {

--- a/app/src/terminal/model_events.rs
+++ b/app/src/terminal/model_events.rs
@@ -25,6 +25,7 @@ use crate::terminal::shell::ShellType;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SshRemoteServerSupport {
     Enabled,
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     Disabled,
 }
 

--- a/app/src/terminal/model_events.rs
+++ b/app/src/terminal/model_events.rs
@@ -22,6 +22,17 @@ use crate::terminal::event::{
 };
 use crate::terminal::model::session::Sessions;
 use crate::terminal::shell::ShellType;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SshRemoteServerSupport {
+    Enabled,
+    Disabled,
+}
+
+impl SshRemoteServerSupport {
+    fn should_use_remote_server(self, feature_enabled: bool, is_ssh_wrapper_session: bool) -> bool {
+        matches!(self, Self::Enabled) && feature_enabled && is_ssh_wrapper_session
+    }
+}
 
 /// Model that dispatches events that have been emitted by the [`crate::terminal::TerminalModel`],
 /// allowing other models/views to subscribe to `TerminalModel` events like it would any other
@@ -30,12 +41,27 @@ pub struct ModelEventDispatcher {
     last_start_prompt_marker: Option<PromptKind>,
     active_session_id: Option<SessionId>,
     sessions: ModelHandle<Sessions>,
+    ssh_remote_server_support: SshRemoteServerSupport,
 }
 
 impl ModelEventDispatcher {
     pub fn new(
         model_events_rx: Receiver<Event>,
         sessions: ModelHandle<Sessions>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        Self::new_with_ssh_remote_server_support(
+            model_events_rx,
+            sessions,
+            SshRemoteServerSupport::Enabled,
+            ctx,
+        )
+    }
+
+    pub(crate) fn new_with_ssh_remote_server_support(
+        model_events_rx: Receiver<Event>,
+        sessions: ModelHandle<Sessions>,
+        ssh_remote_server_support: SshRemoteServerSupport,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.spawn_stream_local(
@@ -47,7 +73,14 @@ impl ModelEventDispatcher {
             active_session_id: None,
             last_start_prompt_marker: None,
             sessions,
+            ssh_remote_server_support,
         }
+    }
+    fn should_use_ssh_remote_server(&self, is_ssh_wrapper_session: bool) -> bool {
+        self.ssh_remote_server_support.should_use_remote_server(
+            FeatureFlag::SshRemoteServer.is_enabled(),
+            is_ssh_wrapper_session,
+        )
     }
 
     /// Returns the active session to which the PTY is currently attached.
@@ -78,7 +111,7 @@ impl ModelEventDispatcher {
                     pending_session_info.is_ssh_wrapper_session,
                     IsSSHWrapperSession::Yes { .. }
                 );
-                if FeatureFlag::SshRemoteServer.is_enabled() && is_ssh_wrapper_session {
+                if self.should_use_ssh_remote_server(is_ssh_wrapper_session) {
                     ModelEvent::SshInitShell {
                         pending_session_info,
                     }
@@ -300,7 +333,7 @@ impl ModelEventDispatcher {
         // `SessionsEvent::SessionBootstrapped`, which causes subscribers to
         // immediately queue `RunCommand` requests (e.g. `load_external_commands`).
         // The daemon must have the executor ready before those requests arrive.
-        if FeatureFlag::SshRemoteServer.is_enabled() && is_ssh_wrapper_session {
+        if self.should_use_ssh_remote_server(is_ssh_wrapper_session) {
             RemoteServerManager::handle(ctx).update(ctx, |mgr, _ctx| {
                 mgr.notify_session_bootstrapped(
                     session_id,
@@ -474,3 +507,7 @@ pub enum AnsiHandlerEvent {
 impl Entity for ModelEventDispatcher {
     type Event = ModelEvent;
 }
+
+#[cfg(test)]
+#[path = "model_events_tests.rs"]
+mod tests;

--- a/app/src/terminal/model_events_tests.rs
+++ b/app/src/terminal/model_events_tests.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[test]
+fn enabled_support_uses_remote_server_for_ssh_wrapper_when_feature_is_enabled() {
+    assert!(SshRemoteServerSupport::Enabled.should_use_remote_server(true, true,));
+}
+
+#[test]
+fn disabled_support_skips_remote_server_for_ssh_wrapper() {
+    assert!(!SshRemoteServerSupport::Disabled.should_use_remote_server(true, true,));
+}
+
+#[test]
+fn enabled_support_skips_remote_server_when_feature_is_disabled() {
+    assert!(!SshRemoteServerSupport::Enabled.should_use_remote_server(false, true,));
+}
+
+#[test]
+fn enabled_support_skips_remote_server_for_non_ssh_session() {
+    assert!(!SshRemoteServerSupport::Enabled.should_use_remote_server(true, false,));
+}


### PR DESCRIPTION
## Description
Disable remote ssh for now for TUI. This will come as a fast follow after v0

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
https://github.com/user-attachments/assets/025001c2-ecca-4ce3-843d-3cf29c2d997d

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode