### PR TITLE
refactor: extract shared @ context menu core from the GUI view

### DIFF
--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -102,10 +102,9 @@ use crate::editor::RangeExt;
 use crate::editor::accept_autosuggestion_keybinding_view::AcceptAutosuggestionKeybinding;
 use crate::editor::autosuggestion_ignore_view::{AutosuggestionIgnore, AutosuggestionIgnoreEvent};
 use crate::features::FeatureFlag;
+use crate::search::ai_context_menu::AIContextMenuCategory;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
-use crate::search::ai_context_menu::view::{
-    AIContextMenu, AIContextMenuCategory, AIContextMenuEvent,
-};
+use crate::search::ai_context_menu::view::{AIContextMenu, AIContextMenuEvent};
 use crate::server::telemetry::TelemetryEvent;
 #[cfg(feature = "voice_input")]
 use crate::settings::AISettingsChangedEvent;

--- a/app/src/search/ai_context_menu/core.rs
+++ b/app/src/search/ai_context_menu/core.rs
@@ -1,0 +1,572 @@
+//! Surface-neutral state for the `@` context menu.
+//!
+//! This module owns the parts of the menu whose meaning is identical on every
+//! front-end: which categories are available, the navigation state machine
+//! between the category list and a category's results, the `@` trigger grammar,
+//! and the buffer text each accepted action inserts.
+//!
+//! Front-ends keep their own selection model, rendering, key handling, and
+//! search-mixer ownership. The GUI drives this state from
+//! [`crate::search::ai_context_menu::view::AIContextMenu`]; the TUI drives it
+//! from its own inline-menu model.
+
+#[cfg(not(target_family = "wasm"))]
+use repo_metadata::repositories::DetectedRepositories;
+use settings::Setting as _;
+use warp_core::features::FeatureFlag;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::AppContext;
+#[cfg(not(target_family = "wasm"))]
+use warpui::SingletonEntity as _;
+
+use crate::drive::settings::WarpDriveSettings;
+use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
+use crate::settings::InputSettings;
+
+/// How many consecutive empty result sets the user may type past before the
+/// menu gives up and closes itself.
+const MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS: usize = 7;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AIContextMenuCategory {
+    CurrentFolderFiles,
+    RepoFiles,
+    Commands,
+    Blocks,
+    Workflows,
+    Notebooks,
+    Plans,
+    Diffs,
+    Docs,
+    Tasks,
+    Rules,
+    Servers,
+    Terminal,
+    Web,
+    RecentDiff,
+    RecentBlock,
+    Code,
+    DiffSet,
+    Conversations,
+    Skills,
+}
+
+impl AIContextMenuCategory {
+    pub fn name(&self) -> &'static str {
+        match self {
+            AIContextMenuCategory::CurrentFolderFiles => "Files and folders",
+            AIContextMenuCategory::RepoFiles => "Files and folders",
+            AIContextMenuCategory::Commands => "Commands",
+            AIContextMenuCategory::Blocks => "Blocks",
+            AIContextMenuCategory::Workflows => "Workflows",
+            AIContextMenuCategory::Notebooks => "Notebooks",
+            AIContextMenuCategory::Plans => "Plans",
+            AIContextMenuCategory::Diffs => "Diffs",
+            AIContextMenuCategory::Docs => "Docs",
+            AIContextMenuCategory::Tasks => "Past tasks",
+            AIContextMenuCategory::Rules => "Rules",
+            AIContextMenuCategory::Servers => "Servers and integrations",
+            AIContextMenuCategory::Terminal => "Terminal",
+            AIContextMenuCategory::Web => "Web",
+            AIContextMenuCategory::RecentDiff => "Most recent diff",
+            AIContextMenuCategory::RecentBlock => "Most recent block",
+            AIContextMenuCategory::Code => "Code",
+            AIContextMenuCategory::DiffSet => "Diff sets",
+            AIContextMenuCategory::Conversations => "Conversations",
+            AIContextMenuCategory::Skills => "Skills",
+        }
+    }
+}
+
+/// The different navigation states for the AI context menu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavigationState {
+    /// The main menu showing all categories.
+    MainMenu,
+    /// Viewing items from a specific category.
+    Category(AIContextMenuCategory),
+    /// Viewing search results from all categories combined.
+    AllCategories,
+}
+
+/// Surface conditions that gate which categories the menu offers.
+///
+/// Each front-end supplies the values that are meaningful for it; conditions a
+/// front-end has no concept of stay `false`. The headless TUI, for instance,
+/// has no ambient-agent session and no shared-session viewer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AtContextMenuGates {
+    /// Whether the input is in AI or autodetect mode rather than locked to the shell.
+    pub is_ai_or_autodetect_mode: bool,
+    /// Whether the surface is viewing somebody else's shared session.
+    pub is_shared_session_viewer: bool,
+    /// Whether the surface is an ambient agent session.
+    pub is_in_ambient_agent: bool,
+    /// Whether the surface is a CLI agent rich input, which only understands
+    /// files, folders, and code symbols.
+    pub is_cli_agent_input: bool,
+}
+
+impl Default for AtContextMenuGates {
+    fn default() -> Self {
+        Self {
+            is_ai_or_autodetect_mode: true,
+            is_shared_session_viewer: false,
+            is_in_ambient_agent: false,
+            is_cli_agent_input: false,
+        }
+    }
+}
+
+/// What the caller must do after the core absorbs a new filter query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtContextMenuQueryTransition {
+    /// The navigation state did not change; run the query against the sources
+    /// that are already installed.
+    SourcesUnchanged,
+    /// No category name matched the query, so the menu fell through to
+    /// searching every available category and its sources must be reinstalled.
+    EnteredAllCategories,
+}
+
+/// State shared by the GUI and TUI `@` context menus.
+///
+/// This deliberately excludes selection over *results*: each front-end already
+/// has a selection model wired to its own list rendering (the GUI's
+/// `SearchBarState`, the TUI's `TuiInlineMenuListState`). Selection over
+/// *categories* lives here, because the category list is derived from this
+/// state rather than from a mixer.
+#[derive(Debug, Clone)]
+pub struct AtContextMenuCoreState {
+    navigation_state: NavigationState,
+    gates: AtContextMenuGates,
+    /// Working directory of the surface's session, used to decide whether
+    /// repo-scoped categories are available. Front-ends keep this current as
+    /// their session navigates.
+    working_directory: Option<LocalOrRemotePath>,
+    /// Query used to filter the category list while the main menu is showing.
+    main_menu_query: String,
+    selected_category_index: usize,
+    /// How many times in a row results came back empty while the user kept
+    /// extending the query. Used to close a menu that is making no progress.
+    consecutive_empty_results_events: usize,
+}
+
+impl AtContextMenuCoreState {
+    /// Builds the initial state for a surface. `navigation_state` starts on the
+    /// category list, which [`Self::refresh_categories`] immediately narrows to
+    /// a single category when only one is available.
+    pub fn new(gates: AtContextMenuGates) -> Self {
+        Self {
+            navigation_state: NavigationState::MainMenu,
+            gates,
+            working_directory: None,
+            main_menu_query: String::new(),
+            selected_category_index: 0,
+            consecutive_empty_results_events: 0,
+        }
+    }
+
+    pub fn navigation_state(&self) -> NavigationState {
+        self.navigation_state
+    }
+
+    pub fn gates(&self) -> AtContextMenuGates {
+        self.gates
+    }
+
+    pub fn main_menu_query(&self) -> &str {
+        &self.main_menu_query
+    }
+
+    pub fn selected_category_index(&self) -> usize {
+        self.selected_category_index
+    }
+
+    /// Replaces the availability gates, returning whether anything changed so
+    /// callers can skip recomputing category-dependent state.
+    pub fn set_gates(&mut self, gates: AtContextMenuGates) -> bool {
+        let changed = self.gates != gates;
+        self.gates = gates;
+        changed
+    }
+
+    /// Replaces the working directory, returning whether it changed.
+    pub fn set_working_directory(&mut self, working_directory: Option<LocalOrRemotePath>) -> bool {
+        let changed = self.working_directory != working_directory;
+        self.working_directory = working_directory;
+        changed
+    }
+
+    pub fn working_directory(&self) -> Option<&LocalOrRemotePath> {
+        self.working_directory.as_ref()
+    }
+
+    /// The categories available for the current gates, in display order.
+    ///
+    /// A single-element result means the menu should skip the category list
+    /// entirely and open straight into that category.
+    pub fn available_categories(&self, app: &AppContext) -> Vec<AIContextMenuCategory> {
+        let show_warp_drive = WarpDriveSettings::is_warp_drive_enabled(app);
+        let is_active_dir_in_git_repo = self.is_working_directory_in_git_repo(app);
+        let AtContextMenuGates {
+            is_ai_or_autodetect_mode,
+            is_shared_session_viewer,
+            is_in_ambient_agent,
+            is_cli_agent_input,
+        } = self.gates;
+
+        // For CLI agent input, use a positive allowlist of categories that CLI agents
+        // can interpret. This is safer than a blocklist because new categories added
+        // to the enum in the future won't accidentally leak into the CLI agent menu.
+        if is_cli_agent_input {
+            let mut categories = vec![];
+            if !is_shared_session_viewer {
+                categories.push(self.files_category(is_active_dir_in_git_repo));
+            }
+            if self.is_code_category_enabled(is_active_dir_in_git_repo, app)
+                && !is_shared_session_viewer
+            {
+                categories.push(AIContextMenuCategory::Code);
+            }
+            return categories;
+        }
+
+        // For ambient agent sessions, only show limited categories
+        if is_in_ambient_agent {
+            let mut categories = vec![];
+            if show_warp_drive {
+                if FeatureFlag::DriveObjectsAsContext.is_enabled() {
+                    categories.push(AIContextMenuCategory::Workflows);
+                    categories.push(AIContextMenuCategory::Notebooks);
+                    categories.push(AIContextMenuCategory::Plans);
+                }
+                categories.push(AIContextMenuCategory::Rules);
+            }
+            return categories;
+        }
+
+        if is_ai_or_autodetect_mode {
+            let mut categories = vec![];
+
+            // Hide file options for shared session viewers
+            if !is_shared_session_viewer {
+                categories.push(self.files_category(is_active_dir_in_git_repo));
+            }
+
+            if FeatureFlag::AIContextMenuCommands.is_enabled() {
+                categories.push(AIContextMenuCategory::Commands);
+            }
+            categories.push(AIContextMenuCategory::Blocks);
+            if self.is_code_category_enabled(is_active_dir_in_git_repo, app)
+                && !is_shared_session_viewer
+            {
+                categories.push(AIContextMenuCategory::Code);
+            }
+            if show_warp_drive && FeatureFlag::DriveObjectsAsContext.is_enabled() {
+                categories.push(AIContextMenuCategory::Workflows);
+                categories.push(AIContextMenuCategory::Notebooks);
+                categories.push(AIContextMenuCategory::Plans);
+            }
+            if FeatureFlag::DiffSetAsContext.is_enabled()
+                && is_active_dir_in_git_repo
+                && !is_shared_session_viewer
+            {
+                categories.push(AIContextMenuCategory::DiffSet);
+            }
+            if FeatureFlag::ConversationsAsContext.is_enabled() {
+                categories.push(AIContextMenuCategory::Conversations);
+            }
+            if show_warp_drive {
+                categories.push(AIContextMenuCategory::Rules);
+            }
+            categories.push(AIContextMenuCategory::Skills);
+            categories
+        } else if !is_shared_session_viewer {
+            // Terminal mode: show Files and Code categories (when enabled)
+            let mut categories = vec![self.files_category(is_active_dir_in_git_repo)];
+
+            // Also show Code category in terminal mode when enabled
+            if self.is_code_category_enabled(is_active_dir_in_git_repo, app) {
+                categories.push(AIContextMenuCategory::Code);
+            }
+
+            categories
+        } else {
+            // File searching is not available in shared session viewers
+            vec![]
+        }
+    }
+
+    fn files_category(&self, is_active_dir_in_git_repo: bool) -> AIContextMenuCategory {
+        if is_active_dir_in_git_repo {
+            AIContextMenuCategory::RepoFiles
+        } else {
+            AIContextMenuCategory::CurrentFolderFiles
+        }
+    }
+
+    fn is_code_category_enabled(&self, is_active_dir_in_git_repo: bool, app: &AppContext) -> bool {
+        FeatureFlag::AIContextMenuCode.is_enabled()
+            && *InputSettings::as_ref(app)
+                .outline_codebase_symbols_for_at_context_menu
+                .value()
+            && is_active_dir_in_git_repo
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn is_working_directory_in_git_repo(&self, app: &AppContext) -> bool {
+        self.working_directory.as_ref().is_some_and(|dir| {
+            DetectedRepositories::as_ref(app)
+                .get_root_for_canonical_path(dir)
+                .is_some()
+        })
+    }
+
+    /// Repository detection is unavailable in WASM builds, where
+    /// `DetectedRepositories` is never registered.
+    #[cfg(target_family = "wasm")]
+    fn is_working_directory_in_git_repo(&self, _app: &AppContext) -> bool {
+        false
+    }
+
+    /// The subset of [`Self::available_categories`] whose names match the
+    /// main-menu filter query.
+    pub fn filtered_categories(&self, app: &AppContext) -> Vec<AIContextMenuCategory> {
+        let categories = self.available_categories(app);
+        if self.main_menu_query.is_empty() {
+            return categories;
+        }
+        let query_lower = self.main_menu_query.trim().to_lowercase();
+        categories
+            .into_iter()
+            .filter(|category| category.name().to_lowercase().contains(&query_lower))
+            .collect()
+    }
+
+    /// Resets category-derived state after the gates or working directory
+    /// change, opening straight into the only category when just one is
+    /// available.
+    pub fn refresh_categories(&mut self, app: &AppContext) {
+        let categories = self.available_categories(app);
+
+        // Zero categories has no single destination to open into, and more than
+        // one needs the list, so both land on the main menu.
+        self.navigation_state = match categories.as_slice() {
+            [only] => NavigationState::Category(*only),
+            _ => NavigationState::MainMenu,
+        };
+        self.clear_category_filter();
+    }
+
+    /// Returns to the category list, which is only worth showing when more than
+    /// one category is available. Returns whether that list is showable, so
+    /// callers can skip work that only matters once it is visible.
+    pub fn return_to_main_menu_if_multiple_categories(&mut self, app: &AppContext) -> bool {
+        if self.available_categories(app).len() <= 1 {
+            return false;
+        }
+        self.navigation_state = NavigationState::MainMenu;
+        true
+    }
+
+    /// Clears the category-list filter query and its selection.
+    pub fn clear_category_filter(&mut self) {
+        self.main_menu_query = String::new();
+        self.selected_category_index = 0;
+    }
+
+    /// Moves the category selection down the filtered list, wrapping at the end.
+    pub fn select_next_category(&mut self, app: &AppContext) {
+        let count = self.filtered_categories(app).len();
+        if count == 0 {
+            return;
+        }
+        self.selected_category_index = (self.selected_category_index + 1) % count;
+    }
+
+    /// Moves the category selection up the filtered list, wrapping at the start.
+    pub fn select_previous_category(&mut self, app: &AppContext) {
+        let count = self.filtered_categories(app).len();
+        if count == 0 {
+            return;
+        }
+        self.selected_category_index = self
+            .selected_category_index
+            .checked_sub(1)
+            .unwrap_or(count - 1);
+    }
+
+    /// The category the main-menu selection currently points at.
+    pub fn selected_category(&self, app: &AppContext) -> Option<AIContextMenuCategory> {
+        self.filtered_categories(app)
+            .get(self.selected_category_index)
+            .copied()
+    }
+
+    /// Opens a category's result list.
+    ///
+    /// The category selection index is left alone: it is only meaningful while
+    /// the category list is showing, and returning to that list resets it.
+    pub fn enter_category(&mut self, category: AIContextMenuCategory) {
+        self.navigation_state = NavigationState::Category(category);
+        self.main_menu_query = String::new();
+    }
+
+    /// Absorbs a new filter query typed after the `@`.
+    ///
+    /// While the category list is showing, the query filters category names; if
+    /// nothing matches, the menu falls through to searching every available
+    /// category instead of showing an empty list.
+    pub fn set_query(&mut self, query: &str, app: &AppContext) -> AtContextMenuQueryTransition {
+        if self.navigation_state != NavigationState::MainMenu {
+            return AtContextMenuQueryTransition::SourcesUnchanged;
+        }
+
+        self.main_menu_query = query.to_owned();
+
+        let filtered_count = self.filtered_categories(app).len();
+        if self.selected_category_index >= filtered_count {
+            self.selected_category_index = 0;
+        }
+        if filtered_count > 0 {
+            return AtContextMenuQueryTransition::SourcesUnchanged;
+        }
+
+        self.navigation_state = NavigationState::AllCategories;
+        AtContextMenuQueryTransition::EnteredAllCategories
+    }
+
+    /// Absorbs a results update and returns whether the menu should close
+    /// because the user has typed past several consecutive empty result sets.
+    ///
+    /// `query_grew` means the new query still contains the previous one, i.e.
+    /// the user narrowed rather than rewrote. The category list is exempt: it is
+    /// filtered locally and has no mixer sources, so empty mixer results there
+    /// say nothing about the user's progress.
+    #[must_use]
+    pub fn record_results_update(
+        &mut self,
+        results_are_empty: bool,
+        is_loading: bool,
+        query_grew: bool,
+    ) -> bool {
+        let counts_as_no_progress = self.navigation_state != NavigationState::MainMenu
+            && results_are_empty
+            && !is_loading
+            && query_grew;
+        if counts_as_no_progress {
+            self.consecutive_empty_results_events += 1;
+        } else {
+            self.consecutive_empty_results_events = 0;
+        }
+        self.consecutive_empty_results_events >= MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS
+    }
+
+    /// Clears the no-progress counter, for use when the menu closes.
+    pub fn reset_results_progress(&mut self) {
+        self.consecutive_empty_results_events = 0;
+    }
+}
+
+/// Returns whether an `@` just typed at `cursor_position` sits in a position
+/// that should open the context menu.
+///
+/// `cursor_position` is the offset immediately after the typed `@`. An `@` opens
+/// the menu at the start of the buffer or after any non-alphanumeric character,
+/// so `foo@bar` (an email or a package spec) does not trigger it.
+///
+/// Callers layer their own surface conditions on top; the GUI additionally
+/// suppresses the menu for package-installer command lines in shell mode.
+pub fn is_at_menu_trigger(buffer_text: &str, cursor_position: usize) -> bool {
+    if cursor_position == 0 {
+        return false;
+    }
+
+    if buffer_text
+        .chars()
+        .nth(cursor_position.saturating_sub(1))
+        .is_none_or(|c| c != '@')
+    {
+        return false;
+    }
+
+    // '@' at the very start of the buffer is always a valid trigger.
+    if cursor_position == 1 {
+        return true;
+    }
+
+    buffer_text
+        .chars()
+        .nth(cursor_position.saturating_sub(2))
+        .is_some_and(|c| !c.is_alphanumeric())
+}
+
+/// Returns whether an open menu anchored at `at_symbol_position` should close
+/// given the current buffer and cursor.
+///
+/// The menu closes when the cursor moves behind the `@`, when a newline or any
+/// non-space whitespace appears between the `@` and the cursor, or when the
+/// filter accumulates two consecutive spaces — at which point the user is
+/// writing prose rather than picking context.
+pub fn should_close_at_menu(
+    buffer_text: &str,
+    cursor_position: usize,
+    at_symbol_position: usize,
+) -> bool {
+    // If the cursor is to the left of the "@", we should close the AI context menu.
+    if cursor_position < at_symbol_position {
+        return true;
+    }
+
+    let chars_before_cursor: Vec<char> = buffer_text.chars().take(cursor_position).collect();
+    let mut prev_char_was_space = false;
+    for c in chars_before_cursor.into_iter().rev() {
+        if c.is_whitespace() && c != ' ' {
+            return true;
+        }
+        if c == '@' {
+            return prev_char_was_space;
+        }
+        if c == ' ' {
+            if prev_char_was_space {
+                return true;
+            }
+            prev_char_was_space = true;
+        } else {
+            prev_char_was_space = false;
+        }
+    }
+    true
+}
+
+/// The buffer text an accepted action inserts, for actions whose inserted
+/// representation is identical on every surface.
+///
+/// Returns `None` for the two actions that need surface-specific handling:
+/// [`AIContextMenuSearchableAction::InsertFilePath`], which the GUI rewrites
+/// relative to the session's working directory when the input is locked to the
+/// shell, and [`AIContextMenuSearchableAction::InsertDiffSet`], which attaches
+/// context rather than inserting text.
+pub fn shared_inserted_text(action: &AIContextMenuSearchableAction) -> Option<String> {
+    match action {
+        AIContextMenuSearchableAction::InsertText { text } => Some(text.clone()),
+        AIContextMenuSearchableAction::InsertDriveObject {
+            object_type,
+            object_uid,
+        } => Some(format!("<{object_type}:{object_uid}>")),
+        AIContextMenuSearchableAction::InsertPlan { ai_document_uid } => {
+            Some(format!("<plan:{ai_document_uid}>"))
+        }
+        AIContextMenuSearchableAction::InsertConversation { conversation_id } => {
+            Some(format!("<convo:{conversation_id}>"))
+        }
+        AIContextMenuSearchableAction::InsertSkill { name } => Some(format!("/{name}")),
+        AIContextMenuSearchableAction::InsertFilePath { .. }
+        | AIContextMenuSearchableAction::InsertDiffSet { .. } => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "core_tests.rs"]
+mod tests;

--- a/app/src/search/ai_context_menu/core_tests.rs
+++ b/app/src/search/ai_context_menu/core_tests.rs
@@ -1,0 +1,221 @@
+#[cfg(not(target_family = "wasm"))]
+use repo_metadata::repositories::DetectedRepositories;
+use warpui::App;
+
+use super::{
+    AIContextMenuCategory, AtContextMenuCoreState, AtContextMenuGates,
+    AtContextMenuQueryTransition, MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS, NavigationState,
+    is_at_menu_trigger, shared_inserted_text, should_close_at_menu,
+};
+use crate::cloud_object::ObjectType;
+use crate::code_review::diff_state::DiffMode;
+use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
+use crate::test_util::settings::initialize_settings_for_tests;
+
+fn register_core_dependencies(app: &mut App) {
+    initialize_settings_for_tests(app);
+    #[cfg(not(target_family = "wasm"))]
+    app.add_singleton_model(|_| DetectedRepositories::default());
+}
+
+/// Gates for an input locked to the shell, whose category list is the only one
+/// that no feature flag varies.
+fn terminal_mode_gates() -> AtContextMenuGates {
+    AtContextMenuGates {
+        is_ai_or_autodetect_mode: false,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn opens_only_on_an_at_symbol_at_a_word_boundary() {
+    // (buffer, offset just past the typed character, opens the menu)
+    let cases = [
+        ("@", 1, true),
+        ("look at @", 9, true),
+        ("(@", 2, true),
+        ("user@", 5, false),
+        ("react18@", 8, false),
+        ("", 0, false),
+        ("abc", 3, false),
+        ("@abc", 4, false),
+    ];
+
+    for (buffer, cursor, expected) in cases {
+        assert_eq!(
+            is_at_menu_trigger(buffer, cursor),
+            expected,
+            "buffer {buffer:?}, cursor {cursor}"
+        );
+    }
+}
+
+#[test]
+fn closes_when_the_filter_breaks_or_the_cursor_leaves_the_at_symbol() {
+    // (buffer, cursor, offset of the `@`, closes the menu)
+    let cases = [
+        ("@file", 5, 0, false),
+        ("look at @file", 13, 8, false),
+        ("@my file", 8, 0, false),
+        ("look at @file", 3, 8, true),
+        ("@my  file", 9, 0, true),
+        ("@my\nfile", 8, 0, true),
+        ("plain text", 10, 0, true),
+    ];
+
+    for (buffer, cursor, at_symbol_position, expected) in cases {
+        assert_eq!(
+            should_close_at_menu(buffer, cursor, at_symbol_position),
+            expected,
+            "buffer {buffer:?}, cursor {cursor}, at {at_symbol_position}"
+        );
+    }
+}
+
+#[test]
+fn formats_the_text_each_action_inserts() {
+    let cases = [
+        (
+            AIContextMenuSearchableAction::InsertText {
+                text: "@web".to_owned(),
+            },
+            Some("@web"),
+        ),
+        (
+            AIContextMenuSearchableAction::InsertDriveObject {
+                object_type: ObjectType::Workflow,
+                object_uid: "abc123".to_owned(),
+            },
+            Some("<workflow:abc123>"),
+        ),
+        (
+            AIContextMenuSearchableAction::InsertPlan {
+                ai_document_uid: "doc-1".to_owned(),
+            },
+            Some("<plan:doc-1>"),
+        ),
+        (
+            AIContextMenuSearchableAction::InsertConversation {
+                conversation_id: "convo-1".to_owned(),
+            },
+            Some("<convo:convo-1>"),
+        ),
+        (
+            AIContextMenuSearchableAction::InsertSkill {
+                name: "create-pr".to_owned(),
+            },
+            Some("/create-pr"),
+        ),
+        // The remaining two need surface-specific handling, so the core declines
+        // them: file paths are rewritten against the session's working directory
+        // in shell mode, and diff sets attach context instead of inserting text.
+        (
+            AIContextMenuSearchableAction::InsertFilePath {
+                file_path: "src/main.rs".to_owned(),
+            },
+            None,
+        ),
+        (
+            AIContextMenuSearchableAction::InsertDiffSet {
+                diff_mode: DiffMode::Head,
+            },
+            None,
+        ),
+    ];
+
+    for (action, expected) in cases {
+        assert_eq!(
+            shared_inserted_text(&action).as_deref(),
+            expected,
+            "action {action:?}"
+        );
+    }
+}
+
+#[test]
+fn closes_after_repeated_empty_results_but_never_on_the_category_list() {
+    let mut core = AtContextMenuCoreState::new(AtContextMenuGates::default());
+
+    // The category list filters locally and installs no mixer sources, so empty
+    // mixer results there say nothing about the user's progress.
+    for _ in 0..MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS * 2 {
+        assert!(!core.record_results_update(true, false, true));
+    }
+
+    core.enter_category(AIContextMenuCategory::Blocks);
+    for _ in 0..MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS - 1 {
+        assert!(!core.record_results_update(true, false, true));
+    }
+
+    assert!(core.record_results_update(true, false, true));
+}
+
+#[test]
+fn only_counts_settled_empty_results_from_a_narrowing_query() {
+    let mut core = AtContextMenuCoreState::new(AtContextMenuGates::default());
+    core.enter_category(AIContextMenuCategory::Blocks);
+
+    for _ in 0..MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS * 2 {
+        // Still loading, so an empty result set means nothing yet.
+        assert!(!core.record_results_update(true, true, true));
+        // The user rewrote the query rather than narrowing it.
+        assert!(!core.record_results_update(true, false, false));
+        // Results came back.
+        assert!(!core.record_results_update(false, false, true));
+    }
+}
+
+#[test]
+fn offers_only_current_folder_files_in_terminal_mode_without_a_repo() {
+    App::test((), |mut app| async move {
+        register_core_dependencies(&mut app);
+        let mut core = AtContextMenuCoreState::new(terminal_mode_gates());
+
+        let categories = app.read(|ctx| core.available_categories(ctx));
+        app.read(|ctx| core.refresh_categories(ctx));
+
+        assert_eq!(categories, vec![AIContextMenuCategory::CurrentFolderFiles]);
+        // A single category has no list worth showing, so the menu opens into it.
+        assert_eq!(
+            core.navigation_state(),
+            NavigationState::Category(AIContextMenuCategory::CurrentFolderFiles)
+        );
+    });
+}
+
+#[test]
+fn falls_through_to_all_categories_only_when_no_category_name_matches() {
+    App::test((), |mut app| async move {
+        register_core_dependencies(&mut app);
+        let mut core = AtContextMenuCoreState::new(terminal_mode_gates());
+
+        let matched = app.read(|ctx| core.set_query("files", ctx));
+        assert_eq!(matched, AtContextMenuQueryTransition::SourcesUnchanged);
+        assert_eq!(core.navigation_state(), NavigationState::MainMenu);
+
+        let unmatched = app.read(|ctx| core.set_query("zzzznomatch", ctx));
+        assert_eq!(
+            unmatched,
+            AtContextMenuQueryTransition::EnteredAllCategories
+        );
+        assert_eq!(core.navigation_state(), NavigationState::AllCategories);
+    });
+}
+
+#[test]
+fn wraps_category_selection_at_both_ends() {
+    App::test((), |mut app| async move {
+        register_core_dependencies(&mut app);
+        // AI mode always offers files, blocks, and skills, so the list is long
+        // enough to wrap no matter how the optional categories are gated.
+        let mut core = AtContextMenuCoreState::new(AtContextMenuGates::default());
+        let count = app.read(|ctx| core.filtered_categories(ctx).len());
+        assert!(count > 1, "expected AI mode to offer several categories");
+
+        app.read(|ctx| core.select_previous_category(ctx));
+        assert_eq!(core.selected_category_index(), count - 1);
+
+        app.read(|ctx| core.select_next_category(ctx));
+        assert_eq!(core.selected_category_index(), 0);
+    });
+}

--- a/app/src/search/ai_context_menu/mixer.rs
+++ b/app/src/search/ai_context_menu/mixer.rs
@@ -1,8 +1,179 @@
+use std::collections::HashSet;
+#[cfg(not(target_family = "wasm"))]
+use std::time::Duration;
+
+use warpui::{ModelContext, ModelHandle};
+
+use super::code::data_source::CodeSymbolCache;
+use super::core::AIContextMenuCategory;
 use crate::cloud_object::ObjectType;
 use crate::code_review::diff_state::DiffMode;
+use crate::search::data_source::{Query, QueryFilter};
+#[cfg(not(target_family = "wasm"))]
+use crate::search::mixer::AddAsyncSourceOptions;
 use crate::search::mixer::SearchMixer;
 
+/// Debounce applied to the file and code sources, whose work scales with repo size.
+#[cfg(not(target_family = "wasm"))]
+const LOCAL_SEARCH_DEBOUNCE: Duration = Duration::from_millis(50);
+
 pub type AIContextMenuMixer = SearchMixer<AIContextMenuSearchableAction>;
+
+/// Long-lived handles the `@` menu's data sources need but the surface-neutral
+/// menu state cannot own.
+pub struct AtContextMenuSourceContext {
+    /// Cache backing the Code category's symbol search. `None` on surfaces that
+    /// do not offer code symbols, and in WASM builds where the cache has no
+    /// outline to read.
+    pub code_symbol_cache: Option<ModelHandle<CodeSymbolCache>>,
+}
+
+/// The query shape the `@` menu runs. Sources are selected by installation
+/// rather than by filter, so every query is unfiltered.
+pub fn at_context_menu_query(text: &str) -> Query {
+    Query {
+        text: text.to_owned(),
+        filters: HashSet::new(),
+    }
+}
+
+/// Installs the data sources backing a single category.
+///
+/// Callers reset the mixer first and run the query afterwards, so this is safe
+/// to call once per category or in a loop across several.
+#[cfg_attr(target_family = "wasm", allow(unused_variables))]
+pub fn install_sources_for_category(
+    mixer: &mut AIContextMenuMixer,
+    category: AIContextMenuCategory,
+    source_context: &AtContextMenuSourceContext,
+    ctx: &mut ModelContext<AIContextMenuMixer>,
+) {
+    match category {
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::CurrentFolderFiles => {
+            mixer.add_async_source(
+                super::files::data_source::file_data_source_for_pwd(ctx),
+                [QueryFilter::Files],
+                local_search_options(),
+                ctx,
+            );
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::RepoFiles => {
+            mixer.add_async_source(
+                super::files::data_source::file_data_source_for_current_repo(),
+                [QueryFilter::Files],
+                local_search_options(),
+                ctx,
+            );
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Code => {
+            let Some(cache) = &source_context.code_symbol_cache else {
+                return;
+            };
+            mixer.add_async_source(
+                super::code::data_source::code_data_source(cache.as_ref(ctx)),
+                [QueryFilter::Code],
+                local_search_options(),
+                ctx,
+            );
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Commands => {
+            let source = ctx.add_model(|_| super::commands::data_source::CommandDataSource::new());
+            mixer.add_sync_source(source, [QueryFilter::Commands]);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Blocks => {
+            let source = ctx.add_model(|_| super::blocks::data_source::BlockDataSource::new());
+            mixer.add_sync_source(source, [QueryFilter::Blocks]);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Workflows => {
+            let source =
+                ctx.add_model(|_| super::workflows::data_source::WorkflowDataSource::new());
+            mixer.add_sync_source(source, [QueryFilter::Workflows]);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Notebooks => {
+            let source =
+                ctx.add_model(|_| super::notebooks::data_source::NotebookDataSource::new(false));
+            mixer.add_sync_source(source, [QueryFilter::Notebooks]);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Plans => {
+            let source =
+                ctx.add_model(|_| super::notebooks::data_source::NotebookDataSource::new(true));
+            mixer.add_sync_source(source, [QueryFilter::Notebooks]);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Rules => {
+            let source = ctx.add_model(|_| super::rules::data_source::RulesDataSource::new());
+            mixer.add_sync_source(source, [QueryFilter::Rules]);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::DiffSet => {
+            let source = ctx.add_model(|_| super::diffset::data_source::DiffSetDataSource);
+            mixer.add_sync_source(source, [QueryFilter::DiffSets]);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        AIContextMenuCategory::Skills => {
+            let source = ctx.add_model(|_| super::skills::data_source::SkillsDataSource::new());
+            mixer.add_sync_source(source, [QueryFilter::Skills]);
+        }
+        AIContextMenuCategory::Conversations => {
+            let source =
+                ctx.add_model(|_| super::conversations::data_source::ConversationDataSource);
+            mixer.add_sync_source(source, [QueryFilter::Conversations]);
+        }
+        // Categories in the enum that no data source backs yet. In WASM builds
+        // this also absorbs every category above except Conversations, since
+        // their sources are unavailable there.
+        AIContextMenuCategory::Diffs
+        | AIContextMenuCategory::Docs
+        | AIContextMenuCategory::Tasks
+        | AIContextMenuCategory::Servers
+        | AIContextMenuCategory::Terminal
+        | AIContextMenuCategory::Web
+        | AIContextMenuCategory::RecentDiff
+        | AIContextMenuCategory::RecentBlock => {}
+        #[cfg(target_family = "wasm")]
+        AIContextMenuCategory::CurrentFolderFiles
+        | AIContextMenuCategory::RepoFiles
+        | AIContextMenuCategory::Code
+        | AIContextMenuCategory::Commands
+        | AIContextMenuCategory::Blocks
+        | AIContextMenuCategory::Workflows
+        | AIContextMenuCategory::Notebooks
+        | AIContextMenuCategory::Plans
+        | AIContextMenuCategory::Rules
+        | AIContextMenuCategory::DiffSet
+        | AIContextMenuCategory::Skills => {}
+    }
+}
+
+/// Installs the data sources for every category the menu currently offers, for
+/// the all-categories search that spans all of them.
+pub fn install_sources_for_all_categories(
+    mixer: &mut AIContextMenuMixer,
+    categories: &[AIContextMenuCategory],
+    source_context: &AtContextMenuSourceContext,
+    ctx: &mut ModelContext<AIContextMenuMixer>,
+) {
+    for category in categories {
+        install_sources_for_category(mixer, *category, source_context, ctx);
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn local_search_options() -> AddAsyncSourceOptions {
+    AddAsyncSourceOptions {
+        debounce_interval: Some(LOCAL_SEARCH_DEBOUNCE),
+        run_in_zero_state: true,
+        run_when_unfiltered: true,
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AIContextMenuSearchableAction {

--- a/app/src/search/ai_context_menu/mod.rs
+++ b/app/src/search/ai_context_menu/mod.rs
@@ -2,6 +2,7 @@ mod blocks;
 mod code;
 mod commands;
 mod conversations;
+mod core;
 mod diffset;
 mod files;
 pub mod mixer;
@@ -13,6 +14,12 @@ mod skills;
 mod styles;
 pub mod view;
 mod workflows;
+
+pub use core::{
+    AIContextMenuCategory, AtContextMenuCoreState, AtContextMenuGates,
+    AtContextMenuQueryTransition, NavigationState, is_at_menu_trigger, shared_inserted_text,
+    should_close_at_menu,
+};
 
 /// Safely truncate a string at the given byte index, ensuring we don't split UTF-8 characters
 pub fn safe_truncate(s: &mut String, new_len: usize) {

--- a/app/src/search/ai_context_menu/view.rs
+++ b/app/src/search/ai_context_menu/view.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::ops::Range;
 use std::time::Duration;
 
@@ -6,8 +5,7 @@ use async_channel::Sender;
 use itertools::Itertools;
 #[cfg(not(target_family = "wasm"))]
 use repo_metadata::repositories::DetectedRepositories;
-use settings::Setting as _;
-use warp_core::features::FeatureFlag;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{
     AnchorPair, Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
     Dismiss, Empty, Fill, Flex, Hoverable, Icon, MouseStateHandle, OffsetPositioning, OffsetType,
@@ -22,37 +20,22 @@ use warpui::{
     ViewHandle, WeakViewHandle,
 };
 
+use super::core::{
+    AIContextMenuCategory, AtContextMenuCoreState, AtContextMenuGates,
+    AtContextMenuQueryTransition, NavigationState,
+};
 use super::styles;
 use crate::appearance::Appearance;
 use crate::debounce;
-use crate::drive::settings::WarpDriveSettings;
 #[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::blocks::data_source::BlockDataSource;
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::code::data_source::{CodeSymbolCache, code_data_source};
+use crate::search::ai_context_menu::code::data_source::CodeSymbolCache;
 #[cfg(not(target_family = "wasm"))]
 use crate::search::ai_context_menu::code::is_code_symbols_indexing;
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::commands::data_source::CommandDataSource;
-use crate::search::ai_context_menu::conversations::data_source::ConversationDataSource;
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::diffset::data_source::DiffSetDataSource;
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::files::data_source::{
-    file_data_source_for_current_repo, file_data_source_for_pwd,
+use crate::search::ai_context_menu::mixer::{
+    AIContextMenuMixer, AIContextMenuSearchableAction, AtContextMenuSourceContext,
+    at_context_menu_query, install_sources_for_all_categories, install_sources_for_category,
 };
-use crate::search::ai_context_menu::mixer::{AIContextMenuMixer, AIContextMenuSearchableAction};
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::notebooks::data_source::NotebookDataSource;
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::rules::data_source::RulesDataSource;
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::skills::data_source::SkillsDataSource;
-#[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::workflows::data_source::WorkflowDataSource;
-use crate::search::data_source::{Query, QueryFilter, QueryResult};
-#[cfg(not(target_family = "wasm"))]
-use crate::search::mixer::AddAsyncSourceOptions;
+use crate::search::data_source::QueryResult;
 use crate::search::result_renderer::{QueryResultRenderer, QueryResultRendererStyles};
 use crate::search::search_bar::{SearchBar, SearchBarEvent, SearchBarState, SearchResultOrdering};
 use crate::settings::InputSettings;
@@ -77,56 +60,7 @@ pub enum AIContextMenuPosition {
     AtCursor,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AIContextMenuCategory {
-    CurrentFolderFiles,
-    RepoFiles,
-    Commands,
-    Blocks,
-    Workflows,
-    Notebooks,
-    Plans,
-    Diffs,
-    Docs,
-    Tasks,
-    Rules,
-    Servers,
-    Terminal,
-    Web,
-    RecentDiff,
-    RecentBlock,
-    Code,
-    DiffSet,
-    Conversations,
-    Skills,
-}
-
 impl AIContextMenuCategory {
-    pub fn name(&self) -> &'static str {
-        match self {
-            AIContextMenuCategory::CurrentFolderFiles => "Files and folders",
-            AIContextMenuCategory::RepoFiles => "Files and folders",
-            AIContextMenuCategory::Commands => "Commands",
-            AIContextMenuCategory::Blocks => "Blocks",
-            AIContextMenuCategory::Workflows => "Workflows",
-            AIContextMenuCategory::Notebooks => "Notebooks",
-            AIContextMenuCategory::Plans => "Plans",
-            AIContextMenuCategory::Diffs => "Diffs",
-            AIContextMenuCategory::Docs => "Docs",
-            AIContextMenuCategory::Tasks => "Past tasks",
-            AIContextMenuCategory::Rules => "Rules",
-            AIContextMenuCategory::Servers => "Servers and integrations",
-            AIContextMenuCategory::Terminal => "Terminal",
-            AIContextMenuCategory::Web => "Web",
-            AIContextMenuCategory::RecentDiff => "Most recent diff",
-            AIContextMenuCategory::RecentBlock => "Most recent block",
-            AIContextMenuCategory::Code => "Code",
-            AIContextMenuCategory::DiffSet => "Diff sets",
-            AIContextMenuCategory::Conversations => "Conversations",
-            AIContextMenuCategory::Skills => "Skills",
-        }
-    }
-
     pub fn icon(&self) -> &'static str {
         match self {
             AIContextMenuCategory::CurrentFolderFiles => "bundled/svg/folder.svg",
@@ -151,17 +85,6 @@ impl AIContextMenuCategory {
             AIContextMenuCategory::Skills => "bundled/svg/stars-01.svg",
         }
     }
-}
-
-/// The different navigation states for the AI context menu.
-#[derive(Debug, Clone)]
-pub enum NavigationState {
-    /// The main menu showing all categories.
-    MainMenu,
-    /// Viewing items from a specific category.
-    Category(AIContextMenuCategory),
-    /// Viewing search results from all categories combined.
-    AllCategories,
 }
 
 #[derive(Debug, Clone)]
@@ -193,30 +116,17 @@ pub enum AIContextMenuEvent {
     },
 }
 
-/// View state for the AI context menu.
+/// GUI-only presentation state. Navigation, category selection, the
+/// availability gates, and the no-progress counter live on the shared
+/// [`AtContextMenuCoreState`].
 struct AIContextMenuState {
-    /// The current navigation state.
-    navigation_state: NavigationState,
     scroll_state: ScrollStateHandle,
     uniform_list_state: UniformListState,
     category_hover_states: Vec<MouseStateHandle>,
-    /// Selected category index in main menu
-    selected_category_index: usize,
-    /// Current query for filtering categories in main menu
-    main_menu_query: String,
-    /// Whether we're in AI/autodetect mode (true) or locked in terminal mode (false)
-    is_ai_or_autodetect_mode: bool,
-    /// Whether this terminal is viewing a shared session
-    is_shared_session_viewer: bool,
-    /// Whether this terminal is in an ambient agent session
-    is_in_ambient_agent: bool,
-    /// Whether this is a CLI agent rich input (restricts categories to files/folders + code)
-    is_cli_agent_input: bool,
 }
 
 /// Maximum number of results to display
 const MAX_SEARCH_RESULTS: usize = 250;
-const MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS: usize = 7;
 
 /// AI Context Menu View
 pub struct AIContextMenu {
@@ -227,29 +137,25 @@ pub struct AIContextMenu {
     search_bar_state: ModelHandle<SearchBarState<AIContextMenuSearchableAction>>,
     #[cfg(not(target_family = "wasm"))]
     code_symbol_cache: ModelHandle<CodeSymbolCache>,
+    /// Menu state shared with the TUI front-end.
+    core: AtContextMenuCoreState,
     state: AIContextMenuState,
     /// Debounce channel for search queries
     search_debounce_tx: Sender<String>,
     handle: WeakViewHandle<Self>,
-    /// Keep track of how many times in a row
-    /// we had 0 matches and the user continued to make the query longer.
-    /// We can use this to close the menu if the user doesn't make any progress.
-    num_consecutive_empty_results_events: usize,
 }
 
 impl AIContextMenu {
     pub fn set_is_shared_session_viewer(&mut self, is_viewer: bool, ctx: &mut ViewContext<Self>) {
-        if self.state.is_shared_session_viewer != is_viewer {
-            self.state.is_shared_session_viewer = is_viewer;
-            self.refresh_categories_state(ctx);
-        }
+        let mut gates = self.core.gates();
+        gates.is_shared_session_viewer = is_viewer;
+        self.apply_gates(gates, ctx);
     }
 
     pub fn set_is_in_ambient_agent(&mut self, is_ambient: bool, ctx: &mut ViewContext<Self>) {
-        if self.state.is_in_ambient_agent != is_ambient {
-            self.state.is_in_ambient_agent = is_ambient;
-            self.refresh_categories_state(ctx);
-        }
+        let mut gates = self.core.gates();
+        gates.is_in_ambient_agent = is_ambient;
+        self.apply_gates(gates, ctx);
     }
 
     pub fn set_is_cli_agent_input(
@@ -257,8 +163,13 @@ impl AIContextMenu {
         is_cli_agent_input: bool,
         ctx: &mut ViewContext<Self>,
     ) {
-        if self.state.is_cli_agent_input != is_cli_agent_input {
-            self.state.is_cli_agent_input = is_cli_agent_input;
+        let mut gates = self.core.gates();
+        gates.is_cli_agent_input = is_cli_agent_input;
+        self.apply_gates(gates, ctx);
+    }
+
+    fn apply_gates(&mut self, gates: AtContextMenuGates, ctx: &mut ViewContext<Self>) {
+        if self.core.set_gates(gates) {
             self.refresh_categories_state(ctx);
         }
     }
@@ -273,50 +184,30 @@ impl TypedActionView for AIContextMenu {
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
-            AIContextMenuAction::Prev => {
-                match &self.state.navigation_state {
-                    NavigationState::MainMenu => {
-                        // Navigate up in filtered categories
-                        let filtered_categories = self.get_filtered_categories(ctx);
-                        if !filtered_categories.is_empty() {
-                            if self.state.selected_category_index > 0 {
-                                self.state.selected_category_index -= 1;
-                            } else {
-                                self.state.selected_category_index = filtered_categories.len() - 1;
-                            }
-                        }
-                        ctx.notify();
-                    }
-                    NavigationState::Category(_) | NavigationState::AllCategories => {
-                        // Navigate up in search results
-                        self.search_bar.update(ctx, |search_bar, ctx| {
-                            search_bar.up(ctx);
-                        });
-                    }
+            AIContextMenuAction::Prev => match self.core.navigation_state() {
+                NavigationState::MainMenu => {
+                    self.core.select_previous_category(ctx);
+                    ctx.notify();
                 }
-            }
-            AIContextMenuAction::Next => {
-                match &self.state.navigation_state {
-                    NavigationState::MainMenu => {
-                        // Navigate down in filtered categories
-                        let filtered_categories = self.get_filtered_categories(ctx);
-                        if !filtered_categories.is_empty() {
-                            if self.state.selected_category_index < filtered_categories.len() - 1 {
-                                self.state.selected_category_index += 1;
-                            } else {
-                                self.state.selected_category_index = 0;
-                            }
-                        }
-                        ctx.notify();
-                    }
-                    NavigationState::Category(_) | NavigationState::AllCategories => {
-                        // Navigate down in search results
-                        self.search_bar.update(ctx, |search_bar, ctx| {
-                            search_bar.down(ctx);
-                        });
-                    }
+                NavigationState::Category(_) | NavigationState::AllCategories => {
+                    // Navigate up in search results
+                    self.search_bar.update(ctx, |search_bar, ctx| {
+                        search_bar.up(ctx);
+                    });
                 }
-            }
+            },
+            AIContextMenuAction::Next => match self.core.navigation_state() {
+                NavigationState::MainMenu => {
+                    self.core.select_next_category(ctx);
+                    ctx.notify();
+                }
+                NavigationState::Category(_) | NavigationState::AllCategories => {
+                    // Navigate down in search results
+                    self.search_bar.update(ctx, |search_bar, ctx| {
+                        search_bar.down(ctx);
+                    });
+                }
+            },
             AIContextMenuAction::SelectCurrentItem => {
                 self.select_current_item(ctx);
             }
@@ -331,8 +222,7 @@ impl TypedActionView for AIContextMenu {
             }
             AIContextMenuAction::CategorySelected { category } => {
                 // Navigate to the category view
-                self.state.navigation_state = NavigationState::Category(*category);
-                self.state.main_menu_query = String::new();
+                self.core.enter_category(*category);
                 self.reset_mixer(ctx);
                 // Emit CategorySelected event to let the input handle it
                 ctx.emit(AIContextMenuEvent::CategorySelected {
@@ -363,183 +253,50 @@ lazy_static::lazy_static! {
     };
 }
 impl AIContextMenu {
-    /// Get the appropriate categories based on the current input mode
-    /// If is_ai_or_autodetect_mode is true, return all AI categories
-    /// If false (locked in terminal mode), return only Files category
-    pub(crate) fn get_categories_for_mode(
-        is_ai_or_autodetect_mode: bool,
-        is_shared_session_viewer: bool,
-        is_in_ambient_agent: bool,
-        is_cli_agent_input: bool,
-        app: &AppContext,
-    ) -> Vec<AIContextMenuCategory> {
-        let show_warp_drive = WarpDriveSettings::is_warp_drive_enabled(app);
-
-        // Compute once — used by CLI agent, AI-mode, and terminal-mode branches.
-        let is_active_dir_in_git_repo = {
-            #[cfg(target_family = "wasm")]
-            {
-                false
-            }
-
-            #[cfg(not(target_family = "wasm"))]
-            {
-                let active_window_id = app.windows().state().active_window;
-                active_window_id
-                    .and_then(|window_id| ActiveSession::as_ref(app).working_directory(window_id))
-                    .is_some_and(|dir| {
-                        DetectedRepositories::as_ref(app)
-                            .get_root_for_canonical_path(dir)
-                            .is_some()
-                    })
-            }
-        };
-
-        // For CLI agent input, use a positive allowlist of categories that CLI agents
-        // can interpret. This is safer than a blocklist because new categories added
-        // to the enum in the future won't accidentally leak into the CLI agent menu.
-        if is_cli_agent_input {
-            let mut categories = vec![];
-            if !is_shared_session_viewer {
-                if is_active_dir_in_git_repo {
-                    categories.push(AIContextMenuCategory::RepoFiles);
-                } else {
-                    categories.push(AIContextMenuCategory::CurrentFolderFiles);
-                }
-            }
-            if FeatureFlag::AIContextMenuCode.is_enabled()
-                && *InputSettings::as_ref(app)
-                    .outline_codebase_symbols_for_at_context_menu
-                    .value()
-                && is_active_dir_in_git_repo
-                && !is_shared_session_viewer
-            {
-                categories.push(AIContextMenuCategory::Code);
-            }
-            return categories;
-        }
-
-        // For ambient agent sessions, only show limited categories
-        if is_in_ambient_agent {
-            let mut categories = vec![];
-            if show_warp_drive {
-                if FeatureFlag::DriveObjectsAsContext.is_enabled() {
-                    categories.push(AIContextMenuCategory::Workflows);
-                    categories.push(AIContextMenuCategory::Notebooks);
-                    categories.push(AIContextMenuCategory::Plans);
-                }
-                categories.push(AIContextMenuCategory::Rules);
-            }
-            return categories;
-        }
-
-        if is_ai_or_autodetect_mode {
-            let mut categories = vec![];
-
-            // Hide file options for shared session viewers
-            if !is_shared_session_viewer {
-                if is_active_dir_in_git_repo {
-                    categories.push(AIContextMenuCategory::RepoFiles);
-                } else {
-                    categories.push(AIContextMenuCategory::CurrentFolderFiles);
-                }
-            }
-
-            if FeatureFlag::AIContextMenuCommands.is_enabled() {
-                categories.push(AIContextMenuCategory::Commands);
-            }
-            categories.push(AIContextMenuCategory::Blocks);
-            if FeatureFlag::AIContextMenuCode.is_enabled()
-                && *InputSettings::as_ref(app)
-                    .outline_codebase_symbols_for_at_context_menu
-                    .value()
-                && is_active_dir_in_git_repo
-                && !is_shared_session_viewer
-            {
-                categories.push(AIContextMenuCategory::Code);
-            }
-            if show_warp_drive && FeatureFlag::DriveObjectsAsContext.is_enabled() {
-                categories.push(AIContextMenuCategory::Workflows);
-                categories.push(AIContextMenuCategory::Notebooks);
-                categories.push(AIContextMenuCategory::Plans);
-            }
-            if FeatureFlag::DiffSetAsContext.is_enabled()
-                && is_active_dir_in_git_repo
-                && !is_shared_session_viewer
-            {
-                categories.push(AIContextMenuCategory::DiffSet);
-            }
-            if FeatureFlag::ConversationsAsContext.is_enabled() {
-                categories.push(AIContextMenuCategory::Conversations);
-            }
-            if show_warp_drive {
-                categories.push(AIContextMenuCategory::Rules);
-            }
-            categories.push(AIContextMenuCategory::Skills);
-            categories
-        } else if !is_shared_session_viewer {
-            // Terminal mode: show Files and Code categories (when enabled)
-            let mut categories = if is_active_dir_in_git_repo {
-                vec![AIContextMenuCategory::RepoFiles]
-            } else {
-                vec![AIContextMenuCategory::CurrentFolderFiles]
-            };
-
-            // Also show Code category in terminal mode when enabled
-            if FeatureFlag::AIContextMenuCode.is_enabled()
-                && *InputSettings::as_ref(app)
-                    .outline_codebase_symbols_for_at_context_menu
-                    .value()
-                && is_active_dir_in_git_repo
-            {
-                categories.push(AIContextMenuCategory::Code);
-            }
-
-            categories
-        } else {
-            // File searching is not available in shared session viewers
-            vec![]
-        }
-    }
-
     /// Set the input mode and update the menu state accordingly
     pub fn set_input_mode(&mut self, is_ai_or_autodetect_mode: bool, ctx: &mut ViewContext<Self>) {
-        if self.state.is_ai_or_autodetect_mode != is_ai_or_autodetect_mode {
-            self.state.is_ai_or_autodetect_mode = is_ai_or_autodetect_mode;
-            self.refresh_categories_state(ctx);
-        }
+        let mut gates = self.core.gates();
+        gates.is_ai_or_autodetect_mode = is_ai_or_autodetect_mode;
+        self.apply_gates(gates, ctx);
+    }
+
+    /// The working directory of the active window's session, which decides
+    /// whether the repo-scoped categories are available.
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) fn active_working_directory(app: &AppContext) -> Option<LocalOrRemotePath> {
+        app.windows()
+            .state()
+            .active_window
+            .and_then(|window_id| ActiveSession::as_ref(app).working_directory(window_id))
+            .cloned()
+    }
+
+    /// WASM builds have no session working directory to resolve.
+    #[cfg(target_family = "wasm")]
+    pub(crate) fn active_working_directory(_app: &AppContext) -> Option<LocalOrRemotePath> {
+        None
     }
 
     /// Recompute category-dependent state when repository availability changes.
     fn refresh_categories_state(&mut self, ctx: &mut ViewContext<Self>) {
-        let categories = Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            ctx,
-        );
+        self.refresh_categories(ctx);
+        ctx.notify();
+    }
 
-        // Reset to appropriate initial state based on categories available
-        if categories.is_empty() || categories.len() > 1 {
-            // If there are zero or more than one categories, go to main menu
-            self.state.navigation_state = NavigationState::MainMenu;
-        } else {
-            // Only one category, go directly to it
-            self.state.navigation_state = NavigationState::Category(categories[0]);
-        }
+    /// The body of [`Self::refresh_categories_state`] without the redraw
+    /// request, so construction can reuse it before the view is registered.
+    fn refresh_categories(&mut self, ctx: &mut ViewContext<Self>) {
+        self.core
+            .set_working_directory(Self::active_working_directory(ctx));
+        self.core.refresh_categories(ctx);
 
-        // Update category hover states for the new set of categories
-        self.state.category_hover_states = categories.iter().map(|_| Default::default()).collect();
-
-        // Reset selection and query
-        self.state.selected_category_index = 0;
-        self.state.main_menu_query = String::new();
+        // One retained hover state per category row the main menu renders.
+        let category_count = self.core.available_categories(ctx).len();
+        self.state.category_hover_states =
+            (0..category_count).map(|_| Default::default()).collect();
 
         // Reset mixer with new category configuration
         self.reset_mixer(ctx);
-
-        ctx.notify();
     }
 
     pub fn new(ctx: &mut ViewContext<Self>) -> Self {
@@ -606,9 +363,6 @@ impl AIContextMenu {
             |_me, _ctx| {},
         );
 
-        // Get initial categories for proper initialization
-        let initial_categories = Self::get_categories_for_mode(true, false, false, false, ctx); // Default to AI mode, not a viewer, not ambient agent, not CLI agent input
-
         #[cfg(not(target_family = "wasm"))]
         let code_symbol_cache = ctx.add_model(CodeSymbolCache::new);
 
@@ -617,7 +371,7 @@ impl AIContextMenu {
         #[cfg(not(target_family = "wasm"))]
         ctx.subscribe_to_model(&code_symbol_cache, |me, _handle, _event, ctx| {
             let code_active = matches!(
-                me.state.navigation_state,
+                me.core.navigation_state(),
                 NavigationState::Category(AIContextMenuCategory::Code)
                     | NavigationState::AllCategories
             );
@@ -636,31 +390,19 @@ impl AIContextMenu {
             search_bar_state,
             #[cfg(not(target_family = "wasm"))]
             code_symbol_cache,
+            // The gate defaults start in AI mode; the input updates them through
+            // `set_input_mode` and the `set_is_*` setters as its state resolves.
+            core: AtContextMenuCoreState::new(AtContextMenuGates::default()),
             state: AIContextMenuState {
-                navigation_state: if initial_categories.len() > 1 {
-                    NavigationState::MainMenu
-                } else {
-                    NavigationState::Category(AIContextMenuCategory::RepoFiles)
-                },
                 scroll_state: Default::default(),
                 uniform_list_state: Default::default(),
-                category_hover_states: initial_categories
-                    .iter()
-                    .map(|_| Default::default())
-                    .collect(),
-                selected_category_index: 0,
-                main_menu_query: String::new(),
-                is_ai_or_autodetect_mode: true,  // Default to AI mode
-                is_shared_session_viewer: false, // Will be updated by set_is_shared_session_viewer if needed
-                is_in_ambient_agent: false, // Will be updated by set_is_in_ambient_agent if needed
-                is_cli_agent_input: false,  // Will be updated by set_is_cli_agent_input if needed
+                category_hover_states: Vec::new(),
             },
             handle: ctx.handle(),
             search_debounce_tx,
-            num_consecutive_empty_results_events: 0,
         };
 
-        result.reset_mixer(ctx);
+        result.refresh_categories(ctx);
         result
     }
 
@@ -676,18 +418,11 @@ impl AIContextMenu {
     }
 
     pub fn select_current_item(&mut self, ctx: &mut ViewContext<Self>) {
-        match &self.state.navigation_state {
+        match self.core.navigation_state() {
             NavigationState::MainMenu => {
                 // Select the current category from filtered categories
-                let filtered_categories = self.get_filtered_categories(ctx);
-                if let Some(category) = filtered_categories.get(self.state.selected_category_index)
-                {
-                    self.handle_action(
-                        &AIContextMenuAction::CategorySelected {
-                            category: *category,
-                        },
-                        ctx,
-                    );
+                if let Some(category) = self.core.selected_category(ctx) {
+                    self.handle_action(&AIContextMenuAction::CategorySelected { category }, ctx);
                 }
             }
             NavigationState::Category(_) | NavigationState::AllCategories => {
@@ -719,19 +454,10 @@ impl AIContextMenu {
     }
 
     pub fn close(&mut self, ctx: &mut ViewContext<Self>) {
-        self.num_consecutive_empty_results_events = 0;
+        self.core.reset_results_progress();
         let query_length = self.query(ctx).len();
         let item_count = self.item_count(ctx);
-        let categories = Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            ctx,
-        );
-        if categories.len() > 1 {
-            self.state.navigation_state = NavigationState::MainMenu;
-        }
+        self.core.return_to_main_menu_if_multiple_categories(ctx);
         ctx.emit(AIContextMenuEvent::Close {
             query_length,
             item_count,
@@ -741,17 +467,8 @@ impl AIContextMenu {
 
     /// Reset the menu to the main menu state only if there are more than 1 available categories.
     pub fn reset_menu_state(&mut self, ctx: &mut ViewContext<Self>) {
-        let categories = Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            ctx,
-        );
-        if categories.len() > 1 {
-            self.state.navigation_state = NavigationState::MainMenu;
-            self.state.main_menu_query = String::new();
-            self.state.selected_category_index = 0;
+        if self.core.return_to_main_menu_if_multiple_categories(ctx) {
+            self.core.clear_category_filter();
             self.reset_mixer(ctx);
             ctx.notify();
         }
@@ -764,42 +481,33 @@ impl AIContextMenu {
 
     /// Internal method called by the debounce system to actually update the search
     fn update_search_query_internal(&mut self, query: String, ctx: &mut ViewContext<Self>) {
-        let is_empty = self
+        let results_are_empty = self
             .search_bar_state
             .as_ref(ctx)
             .query_result_renderers()
             .map(|results| results.is_empty())
             .unwrap_or_default();
 
-        // Handle navigation state transitions based on query
-        if let NavigationState::MainMenu = &self.state.navigation_state {
-            self.state.main_menu_query = query.clone();
-            // Update selected index based on filtered categories
-            self.update_selected_category_for_filtered_view(ctx);
-
-            // Check if no categories match and transition to AllCategories mode
-            self.check_and_transition_to_all_categories(&query, ctx);
+        // While the category list is showing, the query filters category names.
+        // When nothing matches, the core falls through to searching every
+        // category, whose sources have to be installed before the query runs.
+        if self.core.set_query(&query, ctx) == AtContextMenuQueryTransition::EnteredAllCategories {
+            self.setup_data_sources_for_all_categories(&query, ctx);
         }
 
+        let is_loading = self.mixer.as_ref(ctx).is_loading();
+        // A query that still contains the previous one means the user narrowed
+        // rather than rewrote, which is what the no-progress counter tracks.
+        let query_grew = query.contains(&self.query(ctx));
+        let should_close =
+            self.core
+                .record_results_update(results_are_empty, is_loading, query_grew);
+
         self.search_bar.update(ctx, |search_bar, ctx| {
-            let prev_query = search_bar.query(ctx);
-            // In MainMenu state the mixer has no data sources, so empty results
-            // are expected. Skip the consecutive-empty-results counter to avoid
-            // prematurely dismissing the menu while the user is still typing a
-            // category filter.
-            let is_main_menu = matches!(self.state.navigation_state, NavigationState::MainMenu);
-            if !is_main_menu
-                && is_empty
-                && !self.mixer.as_ref(ctx).is_loading()
-                && query.contains(&prev_query)
-            {
-                self.num_consecutive_empty_results_events += 1;
-            } else {
-                self.num_consecutive_empty_results_events = 0;
-            }
             search_bar.set_query(query, ctx);
         });
-        if self.num_consecutive_empty_results_events >= MAX_CONSECUTIVE_EMPTY_RESULTS_EVENTS {
+
+        if should_close {
             self.close(ctx);
         }
     }
@@ -822,410 +530,50 @@ impl AIContextMenu {
     }
 
     fn reset_mixer(&mut self, ctx: &mut ViewContext<Self>) {
+        let navigation_state = self.core.navigation_state();
+        let source_context = self.source_context();
         self.mixer.update(ctx, |mixer, ctx| {
             mixer.reset(ctx);
+            // The category list filters locally and needs no sources, and the
+            // all-categories search installs its own set alongside the query
+            // that triggered the fall-through.
+            let NavigationState::Category(category) = navigation_state else {
+                return;
+            };
+            install_sources_for_category(mixer, category, &source_context, ctx);
+            mixer.run_query(at_context_menu_query(""), ctx);
         });
-
-        match self.state.navigation_state {
-            NavigationState::MainMenu => {}
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::CurrentFolderFiles) => {
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_async_source(
-                        file_data_source_for_pwd(ctx),
-                        [QueryFilter::Files],
-                        AddAsyncSourceOptions {
-                            debounce_interval: Some(Duration::from_millis(50)),
-                            run_in_zero_state: true,
-                            run_when_unfiltered: true,
-                        },
-                        ctx,
-                    );
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::RepoFiles) => {
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_async_source(
-                        file_data_source_for_current_repo(),
-                        [QueryFilter::Files],
-                        AddAsyncSourceOptions {
-                            debounce_interval: Some(Duration::from_millis(50)),
-                            run_in_zero_state: true,
-                            run_when_unfiltered: true,
-                        },
-                        ctx,
-                    );
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Commands) => {
-                let command_data_source = ctx.add_model(|_| CommandDataSource::new());
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(command_data_source, [QueryFilter::Commands]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Blocks) => {
-                let block_data_source = ctx.add_model(|_| BlockDataSource::new());
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(block_data_source, [QueryFilter::Blocks]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Code) => {
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_async_source(
-                        code_data_source(self.code_symbol_cache.as_ref(ctx)),
-                        [QueryFilter::Code],
-                        AddAsyncSourceOptions {
-                            debounce_interval: Some(Duration::from_millis(50)),
-                            run_in_zero_state: true,
-                            run_when_unfiltered: true,
-                        },
-                        ctx,
-                    );
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Workflows) => {
-                let workflow_data_source = ctx.add_model(|_| WorkflowDataSource::new());
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(workflow_data_source, [QueryFilter::Workflows]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Notebooks) => {
-                let notebook_data_source = ctx.add_model(|_| NotebookDataSource::new(false));
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(notebook_data_source, [QueryFilter::Notebooks]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Plans) => {
-                let notebook_data_source = ctx.add_model(|_| NotebookDataSource::new(true));
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(notebook_data_source, [QueryFilter::Notebooks]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Rules) => {
-                let rules_data_source = ctx.add_model(|_| RulesDataSource::new());
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(rules_data_source, [QueryFilter::Rules]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::DiffSet) => {
-                let diffset_data_source = ctx.add_model(|_| DiffSetDataSource);
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(diffset_data_source, [QueryFilter::DiffSets]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            NavigationState::Category(AIContextMenuCategory::Conversations) => {
-                let conversation_data_source = ctx.add_model(|_| ConversationDataSource);
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(conversation_data_source, [QueryFilter::Conversations]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            #[cfg(not(target_family = "wasm"))]
-            NavigationState::Category(AIContextMenuCategory::Skills) => {
-                let skills_data_source = ctx.add_model(|_| SkillsDataSource::new());
-                self.mixer.update(ctx, |mixer, ctx| {
-                    mixer.add_sync_source(skills_data_source, [QueryFilter::Skills]);
-                    mixer.run_query(
-                        Query {
-                            text: "".into(),
-                            filters: HashSet::new(),
-                        },
-                        ctx,
-                    );
-                });
-            }
-            NavigationState::Category(_) => {
-                // TODO: Add other data sources
-            }
-            NavigationState::AllCategories => {
-                // AllCategories state is only used when transitioning from query-based filtering
-                // This method should not be called directly for AllCategories
-                // Instead, setup_data_sources_for_all_categories should be used
-            }
-        }
     }
 
-    /// Update the selected category index to ensure it's valid for the filtered view
-    fn update_selected_category_for_filtered_view(&mut self, app: &AppContext) {
-        let filtered_categories = self.get_filtered_categories(app);
-        if filtered_categories.is_empty()
-            || self.state.selected_category_index >= filtered_categories.len()
-        {
-            self.state.selected_category_index = 0;
-        }
-        // If the current selection is still valid, keep it
-    }
-
-    /// Check and transition to AllCategories if no categories match
-    fn check_and_transition_to_all_categories(&mut self, query: &str, ctx: &mut ViewContext<Self>) {
-        let filtered_categories = self.get_filtered_categories(ctx);
-        if filtered_categories.is_empty() {
-            // No categories match - transition to AllCategories mode
-            self.state.navigation_state = NavigationState::AllCategories;
-            // Set up data sources for all categories and run the query
-            self.setup_data_sources_for_all_categories(query, ctx);
-        }
-    }
-
-    /// Set up data sources for all available categories
-    #[cfg(not(target_family = "wasm"))]
+    /// Installs the sources for every available category and runs `query`
+    /// across all of them.
     fn setup_data_sources_for_all_categories(&mut self, query: &str, ctx: &mut ViewContext<Self>) {
-        // Reset mixer first
+        // Searching across every category does not include current-folder files:
+        // outside a git repository, file results come from the dedicated files
+        // category only.
+        let categories: Vec<_> = self
+            .core
+            .available_categories(ctx)
+            .into_iter()
+            .filter(|category| *category != AIContextMenuCategory::CurrentFolderFiles)
+            .collect();
+        let source_context = self.source_context();
+        let query = query.to_owned();
         self.mixer.update(ctx, |mixer, ctx| {
             mixer.reset(ctx);
-        });
-
-        // Add all available data sources
-        let categories = Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            ctx,
-        );
-        for category in categories.iter() {
-            match category {
-                AIContextMenuCategory::RepoFiles => {
-                    self.mixer.update(ctx, |mixer, ctx| {
-                        mixer.add_async_source(
-                            file_data_source_for_current_repo(),
-                            [QueryFilter::Files],
-                            AddAsyncSourceOptions {
-                                debounce_interval: Some(Duration::from_millis(50)),
-                                run_in_zero_state: true,
-                                run_when_unfiltered: true,
-                            },
-                            ctx,
-                        );
-                    });
-                }
-                AIContextMenuCategory::Commands => {
-                    let command_data_source = ctx.add_model(|_| CommandDataSource::new());
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(command_data_source, [QueryFilter::Commands]);
-                    });
-                }
-                AIContextMenuCategory::Blocks => {
-                    let block_data_source = ctx.add_model(|_| BlockDataSource::new());
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(block_data_source, [QueryFilter::Blocks]);
-                    });
-                }
-                AIContextMenuCategory::Code => {
-                    self.mixer.update(ctx, |mixer, ctx| {
-                        mixer.add_async_source(
-                            code_data_source(self.code_symbol_cache.as_ref(ctx)),
-                            [QueryFilter::Code],
-                            AddAsyncSourceOptions {
-                                debounce_interval: Some(Duration::from_millis(50)),
-                                run_in_zero_state: true,
-                                run_when_unfiltered: true,
-                            },
-                            ctx,
-                        );
-                    });
-                }
-                AIContextMenuCategory::Workflows => {
-                    let workflow_data_source = ctx.add_model(|_| WorkflowDataSource::new());
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(workflow_data_source, [QueryFilter::Workflows]);
-                    });
-                }
-                AIContextMenuCategory::Notebooks => {
-                    let notebook_data_source = ctx.add_model(|_| NotebookDataSource::new(false));
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(notebook_data_source, [QueryFilter::Notebooks]);
-                    });
-                }
-                AIContextMenuCategory::Plans => {
-                    let notebook_data_source = ctx.add_model(|_| NotebookDataSource::new(true));
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(notebook_data_source, [QueryFilter::Notebooks]);
-                    });
-                }
-                AIContextMenuCategory::Rules => {
-                    let rules_data_source = ctx.add_model(|_| RulesDataSource::new());
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(rules_data_source, [QueryFilter::Rules]);
-                    });
-                }
-                AIContextMenuCategory::DiffSet => {
-                    let diffset_data_source = ctx.add_model(|_| DiffSetDataSource);
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(diffset_data_source, [QueryFilter::DiffSets]);
-                    });
-                }
-                AIContextMenuCategory::Conversations => {
-                    let conversation_data_source = ctx.add_model(|_| ConversationDataSource);
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(
-                            conversation_data_source,
-                            [QueryFilter::Conversations],
-                        );
-                    });
-                }
-                AIContextMenuCategory::Skills => {
-                    let skills_data_source = ctx.add_model(|_| SkillsDataSource::new());
-                    self.mixer.update(ctx, |mixer, _ctx| {
-                        mixer.add_sync_source(skills_data_source, [QueryFilter::Skills]);
-                    });
-                }
-                _ => {
-                    // TODO: Add other categories
-                }
-            }
-        }
-
-        // Run the query with all data sources
-        self.mixer.update(ctx, |mixer, ctx| {
-            mixer.run_query(
-                Query {
-                    text: query.into(),
-                    filters: HashSet::new(),
-                },
-                ctx,
-            );
+            install_sources_for_all_categories(mixer, &categories, &source_context, ctx);
+            mixer.run_query(at_context_menu_query(&query), ctx);
         });
     }
 
-    #[cfg(target_family = "wasm")]
-    fn setup_data_sources_for_all_categories(&mut self, query: &str, ctx: &mut ViewContext<Self>) {
-        self.mixer.update(ctx, |mixer, ctx| {
-            mixer.reset(ctx);
-        });
-
-        let categories = Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            ctx,
-        );
-        for category in categories.iter() {
-            if matches!(category, AIContextMenuCategory::Conversations) {
-                let conversation_data_source = ctx.add_model(|_| ConversationDataSource);
-                self.mixer.update(ctx, |mixer, _ctx| {
-                    mixer.add_sync_source(conversation_data_source, [QueryFilter::Conversations]);
-                });
-            }
-        }
-
-        self.mixer.update(ctx, |mixer, ctx| {
-            mixer.run_query(
-                Query {
-                    text: query.into(),
-                    filters: HashSet::new(),
-                },
-                ctx,
-            );
-        });
-    }
-
-    /// Get the list of categories that match the current query filter
-    fn get_filtered_categories(&self, app: &AppContext) -> Vec<AIContextMenuCategory> {
-        let categories = Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            app,
-        );
-        if self.state.main_menu_query.is_empty() {
-            categories
-        } else {
-            let query_lower = self.state.main_menu_query.trim().to_lowercase();
-            categories
-                .into_iter()
-                .filter(|category| {
-                    let category_name_lower = category.name().to_lowercase();
-                    category_name_lower.contains(&query_lower)
-                })
-                .collect()
+    /// Long-lived handles the menu's data sources need, resolved once per
+    /// installation.
+    fn source_context(&self) -> AtContextMenuSourceContext {
+        AtContextMenuSourceContext {
+            #[cfg(not(target_family = "wasm"))]
+            code_symbol_cache: Some(self.code_symbol_cache.clone()),
+            #[cfg(target_family = "wasm")]
+            code_symbol_cache: None,
         }
     }
 
@@ -1261,7 +609,7 @@ impl AIContextMenu {
         let mut flex = Flex::column();
 
         // Get filtered categories based on the current query
-        let filtered_categories = self.get_filtered_categories(app);
+        let filtered_categories = self.core.filtered_categories(app);
 
         // If no categories match the filter, show "No results found"
         // Ideally we don't enter this state because we transition to AllCategories mode
@@ -1272,7 +620,7 @@ impl AIContextMenu {
 
         let last_display_index = filtered_categories.len().saturating_sub(1);
         for (display_index, category) in filtered_categories.iter().enumerate() {
-            let is_selected = display_index == self.state.selected_category_index;
+            let is_selected = display_index == self.core.selected_category_index();
             let is_first = display_index == 0;
             let is_last = display_index == last_display_index;
             let text_color = if is_selected {
@@ -1314,13 +662,7 @@ impl AIContextMenu {
                 .finish();
 
             // Find the original index of this category in current categories for hover state
-            let categories = Self::get_categories_for_mode(
-                self.state.is_ai_or_autodetect_mode,
-                self.state.is_shared_session_viewer,
-                self.state.is_in_ambient_agent,
-                self.state.is_cli_agent_input,
-                app,
-            );
+            let categories = self.core.available_categories(app);
             let original_index = categories.iter().position(|c| *c == *category).unwrap_or(0);
             let hover_state = self
                 .state
@@ -1489,14 +831,7 @@ impl AIContextMenu {
     /// Whether the AI context menu should render.
     #[cfg(not(target_family = "wasm"))]
     pub fn should_render(&self, app: &AppContext) -> bool {
-        !Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            app,
-        )
-        .is_empty()
+        !self.core.available_categories(app).is_empty()
     }
 
     #[cfg(target_family = "wasm")]
@@ -1542,7 +877,7 @@ impl AIContextMenu {
 
     fn render_category_view(
         &self,
-        category: &AIContextMenuCategory,
+        category: AIContextMenuCategory,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
@@ -1568,14 +903,7 @@ impl AIContextMenu {
         .finish();
 
         // Only show the title if there are multiple categories
-        let categories = Self::get_categories_for_mode(
-            self.state.is_ai_or_autodetect_mode,
-            self.state.is_shared_session_viewer,
-            self.state.is_in_ambient_agent,
-            self.state.is_cli_agent_input,
-            app,
-        );
-        if categories.len() > 1 {
+        if self.core.available_categories(app).len() > 1 {
             column.add_child(title);
         }
 
@@ -1617,13 +945,13 @@ impl AIContextMenu {
     #[cfg_attr(target_family = "wasm", allow(unused_variables))]
     fn render_empty_state(
         &self,
-        category: Option<&AIContextMenuCategory>,
+        category: Option<AIContextMenuCategory>,
         fallback: Box<dyn Element>,
         app: &AppContext,
     ) -> Box<dyn Element> {
         #[cfg(not(target_family = "wasm"))]
         if let Some(cat) = category
-            && *cat == AIContextMenuCategory::Code
+            && cat == AIContextMenuCategory::Code
             && is_code_symbols_indexing(app)
         {
             return self.render_code_symbols_indexing(app);
@@ -1651,7 +979,7 @@ impl View for AIContextMenu {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
-        let body = match &self.state.navigation_state {
+        let body = match self.core.navigation_state() {
             NavigationState::MainMenu => self.render_main_menu(app),
             NavigationState::Category(category) => self.render_category_view(category, app),
             NavigationState::AllCategories => self.render_all_categories_view(app),
@@ -1684,7 +1012,7 @@ impl View for AIContextMenu {
         stack.add_child(main_container);
 
         // Add details panel overlay if there's a selected result
-        if !matches!(self.state.navigation_state, NavigationState::MainMenu)
+        if !matches!(self.core.navigation_state(), NavigationState::MainMenu)
             && let (Some(selected_result_renderer), Some(details_panel_positioning)) = (
                 self.selected_result_renderer(app),
                 self.offset_positioning_for_details_panel(app),

--- a/app/src/terminal/universal_developer_input.rs
+++ b/app/src/terminal/universal_developer_input.rs
@@ -44,6 +44,8 @@ use crate::network::NetworkStatus;
 #[cfg(not(target_family = "wasm"))]
 use crate::search::ai_context_menu::view::AIContextMenu;
 #[cfg(not(target_family = "wasm"))]
+use crate::search::ai_context_menu::{AtContextMenuCoreState, AtContextMenuGates};
+#[cfg(not(target_family = "wasm"))]
 use crate::settings::InputSettings;
 use crate::settings::{AISettings, AISettingsChangedEvent};
 use crate::settings_view::SettingsSection;
@@ -170,15 +172,12 @@ impl AtContextMenuDisabledReason {
 
         // This condition kicks in if we're locked in shell mode and not in a git repository, so we have
         // no categories available.
-        if AIContextMenu::get_categories_for_mode(
-            input_config.input_type.is_ai() || !input_config.is_locked,
-            false,
-            false, /* is_in_ambient_agent */
-            false, /* is_cli_agent_input */
-            ctx,
-        )
-        .is_empty()
-        {
+        let mut menu_state = AtContextMenuCoreState::new(AtContextMenuGates {
+            is_ai_or_autodetect_mode: input_config.input_type.is_ai() || !input_config.is_locked,
+            ..Default::default()
+        });
+        menu_state.set_working_directory(AIContextMenu::active_working_directory(ctx));
+        if menu_state.available_categories(ctx).is_empty() {
             return Some(AtContextMenuDisabledReason::NoObjectsAvailable);
         }
 

--- a/specs/CODE-1910/TECH.md
+++ b/specs/CODE-1910/TECH.md
@@ -1,0 +1,216 @@
+# Shared `@` context menu core
+
+Groundwork for bringing the `@` context menu to the headless TUI. This spec covers the first
+branch in a three-PR stack; it is a behavior-preserving refactor with no user-visible change, so
+there is no sibling `PRODUCT.md`.
+
+## Context
+
+The `@` menu lets users insert files, code symbols, blocks, Drive objects, plans, rules, diff sets,
+conversations, and skills into the agent input. Everything about it lives inside a single GUI view.
+
+- [`app/src/search/ai_context_menu/view.rs` @ 02fe6e4](https://github.com/warpdotdev/warp/blob/02fe6e4e4d08f96fad8faa0a7e85d8df824c15ea/app/src/search/ai_context_menu/view.rs) —
+  1711 lines holding the category enum, the navigation state machine, per-category search-source
+  wiring, and all rendering. `get_categories_for_mode` (369-503) and `reset_mixer` (824-1031) are
+  private methods on the view taking `ViewContext<Self>`.
+- [`app/src/terminal/input.rs` @ 02fe6e4](https://github.com/warpdotdev/warp/blob/02fe6e4e4d08f96fad8faa0a7e85d8df824c15ea/app/src/terminal/input.rs) —
+  the `@` grammar and buffer rewriting: `should_enable_ai_context` (12112-12167),
+  `should_close_ai_context_menu` (10075-10137), and the action-to-text mapping in the
+  `AcceptAIContextMenuItem` arm (11258-11360). All private to `Input`.
+- [`app/src/search/ai_context_menu/mixer.rs` @ 02fe6e4](https://github.com/warpdotdev/warp/blob/02fe6e4e4d08f96fad8faa0a7e85d8df824c15ea/app/src/search/ai_context_menu/mixer.rs) —
+  `AIContextMenuMixer` (a `SearchMixer`) and `AIContextMenuSearchableAction`, both already
+  surface-neutral.
+
+Two properties make this extractable rather than a rewrite. The mixer already lives in the
+platform-agnostic `warp_search_core` crate, which the TUI drives today for slash commands. And
+accepting an item never produces a special attachment object — it rewrites the input buffer with
+plain text that `parse_context_attachments` resolves at submission time, on a controller the TUI
+already owns.
+
+The blocker is that the reusable logic is entangled with GUI-only state. Category availability,
+navigation, and the `@` grammar are surface-neutral in meaning but private to a view and an input.
+
+## Proposed changes
+
+### New `app/src/search/ai_context_menu/core.rs`
+
+- `AIContextMenuCategory` and `NavigationState`, relocated from `view.rs`. `icon()` stays in
+  `view.rs` as a separate inherent impl, since it returns SVG asset paths that mean nothing to a
+  cell-grid front-end.
+- `AtContextMenuGates` — the four availability conditions currently held as loose bools on
+  `AIContextMenuState`. Front-ends set the ones that are meaningful for them; conditions a
+  front-end has no concept of stay `false`.
+- `AtContextMenuCoreState` — the navigation state machine: category availability and filtering,
+  category selection with wrap-around, the "filter matches no category, fall through to searching
+  all of them" transition, and the consecutive-empty-results counter that closes a menu making no
+  progress. It also holds the session working directory (see Risks).
+- `is_at_menu_trigger` / `should_close_at_menu` — the `@` grammar, lifted out of `Input`.
+- `shared_inserted_text` — the buffer text an accepted action inserts, for the actions whose
+  representation is identical on every surface. Returns `None` for `InsertFilePath` (rewritten
+  against the working directory in shell mode) and `InsertDiffSet` (attaches context instead of
+  inserting text).
+
+### Extended `mixer.rs`
+
+`install_sources_for_category`, `install_sources_for_all_categories`, and
+`at_context_menu_query`, mirroring
+[`build_slash_command_mixer` / `slash_command_query` @ 02fe6e4](https://github.com/warpdotdev/warp/blob/02fe6e4e4d08f96fad8faa0a7e85d8df824c15ea/app/src/terminal/input/slash_commands/mixer.rs#L10-L47).
+Callers reset the mixer, install, then run the query. `AtContextMenuSourceContext` carries the
+long-lived handles the sources need but the state cannot own — currently just the
+`CodeSymbolCache`.
+
+This collapses duplication that already exists: `reset_mixer` and
+`setup_data_sources_for_all_categories` each carried a full copy of the per-category match arms.
+407 lines become 39.
+
+### GUI migration
+
+`AIContextMenu` gains a `core: AtContextMenuCoreState` field and keeps `SearchBar` /
+`SearchBarState` for result selection and rendering untouched. `AIContextMenuState` shrinks to the
+three genuinely GUI-only fields (scroll, uniform-list, hover states). `universal_developer_input.rs`
+builds a throwaway core state for its "any categories available?" check, replacing a static call to
+the removed `get_categories_for_mode`.
+
+### Why this shape
+
+The slash-command menu already solved this split, and the layering is copied from it:
+
+- Generic menu primitives — `InlineMenuSelection`, `InputDrivenInlineMenuLifecycle` in
+  `warp_search_core` — are plain structs, already shared.
+- The shared domain state —
+  [`SlashCommandDataSourceState` @ 02fe6e4](https://github.com/warpdotdev/warp/blob/02fe6e4e4d08f96fad8faa0a7e85d8df824c15ea/app/src/terminal/input/slash_commands/data_source/core.rs#L169-L190) —
+  is a plain struct, not an entity.
+- The per-surface wrappers (`GuiSlashCommandDataSource`, `TuiSlashCommandDataSource`,
+  `SlashCommandModel`) are the models.
+- There are two menu models, not one: `slash_command_model.rs` for the GUI and
+  `crates/warp_tui/src/slash_commands.rs` for the TUI.
+
+Note the placement convention: even the TUI's slash-command *data source* lives in `app/`, because
+it needs app-crate internals. Only the menu model lives in `crates/warp_tui`. The `@` menu follows
+that.
+
+Result selection deliberately stays per-surface. The GUI's lives in `SearchBarState`, which holds
+`Vec<QueryResultRenderer>` — GUI renderers with styles and position ids — so it is not shareable;
+the TUI will use `TuiInlineMenuListState`.
+
+### Considered alternatives
+
+**Shared helpers only** — move the types plus free functions for category availability, source
+wiring, and the `@` grammar, and let each front-end own its own navigation state machine. Smaller
+diff, but the ~120-line state machine (main-menu/category/all-categories transitions, the
+fall-through, the empty-results counter) would exist twice and drift. Rejected.
+
+**One fully shared menu model** — a single entity owning mixer, navigation, query, and selection,
+with both front-ends rendering a snapshot. The purest split, but it requires migrating the GUI off
+`SearchBar` and re-plumbing `UniformList`, hover states, the details panel, and scroll-into-view
+inside a 1711-line view. That is regression risk on a shipped surface for the benefit of an
+unshipped one. Rejected.
+
+**Trait with default methods over `core()` / `core_mut()`**, matching `SlashCommandDataSource`
+exactly. That trait earns its keep because its default methods call back into surface-specific
+policy (`self.availability(ctx)`, `self.command_passes_common_gates(...)`). Nothing in the `@` state
+machine needs a surface hook — the gates are plain data — so the trait would be pure indirection
+over `self.core()`. Rejected in favor of inherent methods on the state struct.
+
+**`AtContextMenuCoreState` as a warpui model.** A model earns its keep when state changes from
+sources its owner cannot see; that is exactly why `TuiSlashCommandDataSource` is one, with seven
+external subscriptions feeding `UpdatedActiveCommands`. Every mutation of this state happens because
+its owner called a method on it, so there is no event to emit that the caller is not already
+positioned to emit. It would also cost an invented `Event` type, `as_ref` / `update` ceremony at
+every access, an extra hop in the notify path, and an `App` fixture for tests that currently need
+none. Rejected.
+
+## Testing and validation
+
+There are no behavior invariants to map, since the change is behavior-preserving. Correctness rests
+on the diff being mechanical, plus a small test set over the extracted surface:
+
+`app/src/search/ai_context_menu/core_tests.rs` — 8 unit tests, one per distinct behavior:
+
+- the `@` trigger grammar and the close conditions, each as a table (start of buffer, after a space,
+  after punctuation, suppressed mid-word; cursor behind the `@`, a newline, two consecutive spaces,
+  a single space allowed)
+- the text every action variant inserts, including the two the core declines
+- the no-progress counter: closing after enough settled empty results, the category list being
+  exempt because it filters locally, and loading or a rewritten query not counting
+- category availability for the one branch no feature flag varies, the fall-through to
+  all-categories, and category selection wrap-around
+
+Five of the eight need no `App` fixture. Deliberately kept small: this is a no-op refactor, and the
+code had no tests before.
+
+Also required: `./script/format`, `cargo clippy -p warp --all-targets --tests -- -D warnings`, and
+`cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` (the pass
+that unifies `warp/tui`).
+
+Manual validation, not yet done: open the `@` menu in `./script/run`, filter categories, enter one,
+accept an item, and confirm the fall-through search when the filter matches no category name.
+
+## Risks and mitigations
+
+**Working-directory caching is the one non-mechanical change.** `available_categories` reads a
+working directory cached on the core state, where `get_categories_for_mode` re-read
+`app.windows().state().active_window` on every call. The cache is refreshed from the three
+notifications the view already subscribed to in order to redraw — `DetectedRepositories`,
+`WindowManager`, and the `ActiveSession` observe — plus on any gate change, and `set_session_state`
+notifies whenever the working directory changes. Equivalent by argument rather than by
+construction, so it is the part most worth reviewing closely.
+
+**Two existing quirks are preserved on purpose** so the refactor stays a no-op, both worth fixing
+separately:
+
+1. The all-categories search installs no current-folder file source, so falling through outside a
+   git repository returns no file results. Unifying on one `install_sources_for_category` would have
+   silently fixed this, so the GUI call site filters `CurrentFolderFiles` out of the list it passes.
+   The shared function handles the category correctly; the fix is deleting the call-site filter.
+2. `is_at_menu_trigger` indexes with `chars().nth()` against what callers compute as a byte offset,
+   so it misbehaves for non-ASCII text before the `@`.
+
+**WASM cfg arms are unverified locally.** Presubmit has no WASM build step and does not run
+`--all-features` on `warp`, and this touches cfg-gated code in all three files.
+
+## Follow-ups
+
+The rest of the stack, in order:
+
+1. `harry/code-1910-explicit-working-dir` — give `FileSearchModel` and the file/skills data sources
+   an explicit working directory instead of reading `active_window`. The TUI has no active window
+   (`add_tui_window` never opens a platform window, so `set_active_window` is never reached) and
+   hosts many sessions in one window, so window-keyed state cannot express a per-session working
+   directory. `CodeSymbolCache` is out of scope, since Code symbols are excluded below and the GUI is
+   its only consumer — which also avoids the one awkward part of this change, because
+   `ensure_symbols_cached` runs inside a `spawner.spawn(move |cache, ctx| ...)` closure with no call
+   site to thread a parameter through and would have needed stored state instead.
+2. `harry/code-1910-context-menu` — the TUI menu model, in
+   `crates/warp_tui/src/at_context_menu.rs`. Scope is category parity with the GUI minus what is
+   technically blocked: files and folders, Drive objects, plans, rules, conversations, diff sets,
+   and skills. Skills stay in despite the TUI having a `/` skills menu, because the GUI lists
+   Skills in `@` alongside its own skills menu, and Conversations alongside its conversations menu.
+   Diff sets are the one category that is not a buffer rewrite: `InsertDiffSet` inserts no text, and
+   the GUI routes it through `Event::AttachDiffSetContext` into
+   `TerminalView::handle_attach_diffset_context`, which inserts a `<change:…>` reference and then
+   completes the attachment asynchronously via `LocalDiffStateModel::load_diff_data_for_mode`. The
+   TUI needs its own handler; every input it requires already exists there (`current_repo_path`,
+   `git_repo_status` branch metadata, the shared `create_attachment_reference_and_key`, the
+   span-replacement path, and the same context model).
+
+Excluded from the stack, both for technical reasons rather than product ones:
+
+- **Code symbols.** `LaunchMode::Tui` reports
+  [`supports_indexing() == false` @ 02fe6e4](https://github.com/warpdotdev/warp/blob/02fe6e4e4d08f96fad8faa0a7e85d8df824c15ea/app/src/lib.rs#L566-L583),
+  so `RepoOutlines` is built with `new_with_indexing_enabled(false)`, never subscribes to
+  `DetectedRepositories`, and `should_build_outlines` is permanently false. There are no outlines
+  for the TUI to search regardless of working-directory plumbing. Enabling them is not a flag flip:
+  `RepoOutlines` also feeds `BlocklistAIContextModel::pending_context` and
+  `GetRelevantFilesController`, so turning it on changes what context the agent receives in the TUI.
+- **Blocks.** The data source and `find_block_attachment_in_all_terminals` both iterate
+  `views_of_type::<TerminalView>`, a GUI-only view type, so `<block:…>` would not resolve in the TUI
+  even if the picker listed rows.
+
+## Parallelization
+
+Not proposed. The three branches are strictly sequential — the TUI menu needs the working-directory
+seam, which needs the extracted core — and within each branch the work is a single-crate refactor
+where the compiler is the feedback loop. Parallel agents on one `app/` checkout would serialize on
+the cargo build lock and collide in `view.rs` and `mixer.rs`, so fan-out would cost wall-clock time
+rather than save it.


### PR DESCRIPTION
## Description

First of three PRs adding the `@` context menu to the headless TUI. This one is GUI-only groundwork and is intended as a strict behavioral no-op: it extracts the surface-neutral parts of the menu out of the 1711-line GUI view so a second front-end can drive the same menu, and migrates the GUI onto the extracted core in the same PR so a second implementation never exists.

Stack:
1. **this PR** — extract the shared core, migrate the GUI onto it
2. `harry/code-1910-explicit-working-dir` — give `FileSearchModel` and the file/code/skills data sources an explicit working directory instead of reading `app.windows().state().active_window`
3. `harry/code-1910-context-menu` — the TUI `@` menu

### What moved

New `app/src/search/ai_context_menu/core.rs`:

- `AIContextMenuCategory` and `NavigationState`, relocated from `view.rs`. `icon()` stays GUI-side as a separate inherent impl since it returns SVG asset paths.
- `AtContextMenuGates` — the four availability conditions previously stored as loose bools on `AIContextMenuState`. Front-ends supply the ones that are meaningful for them; the TUI has no ambient-agent session or shared-session viewer, so those stay `false`.
- `AtContextMenuCoreState` — the navigation state machine: category availability and filtering, category selection with wrap-around, the "filter matches no category → fall through to searching all of them" transition, and the consecutive-empty-results counter that closes a menu making no progress. It also holds the session working directory, which the front-end keeps current; that is the seam PR 2 in the stack pushes down into the data sources.
- `is_at_menu_trigger` / `should_close_at_menu` — the `@` grammar, lifted from private methods on `Input`.
- `shared_inserted_text` — the buffer text each accepted action inserts, for the actions whose representation is identical on every surface.

`app/src/search/ai_context_menu/mixer.rs` gains `install_sources_for_category`, `install_sources_for_all_categories`, and `at_context_menu_query`, mirroring `build_slash_command_mixer` / `slash_command_query` in `terminal/input/slash_commands/mixer.rs`.

### Why this shape

It follows the slash-command menu, which already solved this split: a shared core plus per-surface wrappers, with only genuinely generic menu primitives (`InlineMenuSelection`, `InputDrivenInlineMenuLifecycle`) living in `warp_search_core`, and two separate menu models rather than one. Result selection deliberately stays per-surface — the GUI's lives in `SearchBarState` wired to `QueryResultRenderer`, the TUI's will use `TuiInlineMenuListState`.

One deviation from that prior art: the shared behavior is inherent methods on `AtContextMenuCoreState` rather than a trait with `state()` / `state_mut()` and default methods. `SlashCommandDataSource`'s trait earns its keep because its default methods call back into surface-specific policy; nothing in the `@` state machine needs a surface hook, since the gates are plain data.

### Net effect

`view.rs` loses ~840 lines. Most of that is the two copies of the per-category source-wiring match arms that `reset_mixer` and `setup_data_sources_for_all_categories` each carried — 407 lines collapse to 39.

### Behavior preserved deliberately

Two existing quirks survived the extraction on purpose, so this PR stays a no-op. Both are worth fixing, separately:

1. **All-categories search installs no current-folder file source.** `setup_data_sources_for_all_categories` had a `RepoFiles` arm but no `CurrentFolderFiles` arm, so falling through to all-categories search outside a git repository returns no file results. Unifying on one `install_sources_for_category` would have silently fixed that, so the GUI call site filters `CurrentFolderFiles` out of the category list it passes. The shared function itself handles the category correctly — the follow-up fix is deleting the filter at the call site.
2. **`is_at_menu_trigger` indexes with `chars().nth()` against a byte offset.** Callers compute `cursor_position` as a byte offset, so the predicate misbehaves for non-ASCII text before the `@`. Semantics preserved exactly rather than quietly changed inside a refactor.

`close()` and `reset_menu_state()` also keep their existing asymmetry: only `reset_menu_state()` clears the category filter and selection, so a stale filter can still survive a close/reopen. That is expressed as two separate core methods — `return_to_main_menu_if_multiple_categories` and `clear_category_filter` — rather than one combined one.

### The one structural change worth a look

`available_categories` now reads a working directory cached on `AtContextMenuCoreState`, where the old `get_categories_for_mode` re-read `app.windows().state().active_window` on every call. The cache is refreshed from the same three notifications the view already subscribed to in order to redraw — `DetectedRepositories`, `WindowManager`, and the `ActiveSession` observe — plus on any gate change, and `set_session_state` notifies whenever the working directory changes. So the answer should never be stale, but it is the one place where this is equivalent-by-argument rather than mechanically identical, and so the thing most worth a second pair of eyes.

## Linked Issue

CODE-1910

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

New `app/src/search/ai_context_menu/core_tests.rs` — 8 unit tests, one per distinct behavior in the extracted core, kept deliberately small since this is a no-op refactor:

- the `@` trigger grammar and the close conditions, each as a small table (start of buffer, after a space, after punctuation, suppressed mid-word; cursor behind the `@`, a newline, two consecutive spaces, a single space allowed)
- the text every action variant inserts, including the two the core declines
- the no-progress counter: that it closes after enough settled empty results, that the category list is exempt because it filters locally, and that loading or a rewritten query does not count
- category availability for the one branch no feature flag varies, the fall-through to all-categories, and category selection wrap-around

Clean: `./script/format`, `cargo clippy -p warp --all-targets --tests -- -D warnings`, and `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` (the pass that unifies `warp/tui`).

Two gaps to be aware of when reviewing:

- **Not yet exercised via `./script/run`.** This touches a shipped surface, so it wants a manual pass before leaving draft: open the `@` menu, filter categories, enter one, accept an item, and confirm the fall-through search when the filter matches no category name.
- **The WASM cfg arms are unverified locally.** Presubmit has no WASM build step and does not run `--all-features` on `warp`, and this change touches cfg-gated code in `core.rs`, `mixer.rs`, and `view.rs`.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
