### PR TITLE
refactor: resolve file search's working directory explicitly

### DIFF
--- a/app/src/search/ai_context_menu/files/data_source.rs
+++ b/app/src/search/ai_context_menu/files/data_source.rs
@@ -6,8 +6,7 @@ use std::sync::Arc;
 use futures_lite::future::yield_now;
 use fuzzy_match::FuzzyMatchResult;
 use itertools::Itertools;
-#[cfg(feature = "local_fs")]
-use repo_metadata::repositories::DetectedRepositories;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, SingletonEntity};
 
 use super::search_item::FileSearchItem;
@@ -19,8 +18,6 @@ use crate::search::data_source::{Query, QueryResult};
 use crate::search::files::model::FileSearchModel;
 use crate::search::files::search_item::FileSearchResult;
 use crate::search::mixer::{BoxFuture, DataSourceRunErrorWrapper};
-#[cfg(feature = "local_fs")]
-use crate::workspace::ActiveSession;
 
 const MAX_RESULTS: usize = 200;
 
@@ -34,13 +31,16 @@ pub(crate) struct FileSnapshot {
     pub(crate) last_opened: HashMap<String, instant::Instant>,
 }
 
-/// Builds the repository-backed file search source used by the AI context menu.
+/// Builds the repository-backed file search source used by the AI context menu,
+/// scoped to the repository containing `working_directory`.
+///
 /// For empty queries, snapshots repo contents with git-change status to prioritize modified files,
 /// and for non-empty queries snapshots repo contents only for faster fuzzy matching.
-pub fn file_data_source_for_current_repo()
--> AsyncSnapshotDataSource<FileSnapshot, AIContextMenuSearchableAction> {
+pub fn file_data_source_for_current_repo(
+    working_directory: Option<LocalOrRemotePath>,
+) -> AsyncSnapshotDataSource<FileSnapshot, AIContextMenuSearchableAction> {
     AsyncSnapshotDataSource::new(
-        |query: &Query, app: &AppContext| {
+        move |query: &Query, app: &AppContext| {
             if FileSearchModel::should_skip_overly_broad_query(&query.text) {
                 return FileSnapshot {
                     contents: Arc::new(Vec::new()),
@@ -50,11 +50,12 @@ pub fn file_data_source_for_current_repo()
                 };
             }
 
+            let working_directory = working_directory.as_ref();
             let file_search_model = FileSearchModel::as_ref(app);
-            let last_opened = snapshot_last_opened(app);
+            let last_opened = snapshot_last_opened(working_directory, app);
             if query.text.is_empty() {
                 let (contents, git_changed_files) =
-                    file_search_model.get_repo_contents_with_git_status(app);
+                    file_search_model.get_repo_contents_with_git_status(working_directory, app);
                 FileSnapshot {
                     contents,
                     git_changed_files,
@@ -62,7 +63,8 @@ pub fn file_data_source_for_current_repo()
                     last_opened,
                 }
             } else {
-                let contents = file_search_model.get_repo_contents(&query.text, app);
+                let contents =
+                    file_search_model.get_repo_contents(&query.text, working_directory, app);
                 FileSnapshot {
                     contents,
                     git_changed_files: HashSet::new(),
@@ -75,11 +77,14 @@ pub fn file_data_source_for_current_repo()
     )
 }
 
+/// Builds the non-recursive file search source for `working_directory` itself,
+/// used when the directory is not inside a repository.
 pub fn file_data_source_for_pwd(
+    working_directory: Option<&LocalOrRemotePath>,
     app: &AppContext,
 ) -> AsyncSnapshotDataSource<FileSnapshot, AIContextMenuSearchableAction> {
     let file_search_model = FileSearchModel::as_ref(app);
-    let mut cached_contents = file_search_model.get_folder_contents(app);
+    let mut cached_contents = file_search_model.get_folder_contents(working_directory, app);
     // Reverse sort to put what you'd expect at the top for zero-state
     cached_contents.sort_by(|a, b| b.path.cmp(&a.path));
     let cached_contents = Arc::new(cached_contents);
@@ -106,16 +111,14 @@ pub fn file_data_source_for_pwd(
     )
 }
 
-/// Captures last-opened timestamps from `OpenedFilesModel` for the active
-/// repo at snapshot time. Returns an empty map when no repo is active.
+/// Captures last-opened timestamps from `OpenedFilesModel` for the repository
+/// containing `working_directory`. Returns an empty map when there is no repo.
 #[cfg(feature = "local_fs")]
-fn snapshot_last_opened(app: &AppContext) -> HashMap<String, instant::Instant> {
-    let repo_root = app
-        .windows()
-        .state()
-        .active_window
-        .and_then(|window_id| ActiveSession::as_ref(app).working_directory(window_id))
-        .and_then(|working_dir| DetectedRepositories::as_ref(app).get_root_for_path(working_dir));
+fn snapshot_last_opened(
+    working_directory: Option<&LocalOrRemotePath>,
+    app: &AppContext,
+) -> HashMap<String, instant::Instant> {
+    let repo_root = FileSearchModel::as_ref(app).repo_root_location(working_directory, app);
 
     let Some(repo_root) = repo_root else {
         return HashMap::new();
@@ -134,7 +137,10 @@ fn snapshot_last_opened(app: &AppContext) -> HashMap<String, instant::Instant> {
 
 /// File-open recency is unavailable without a local filesystem.
 #[cfg(not(feature = "local_fs"))]
-fn snapshot_last_opened(_app: &AppContext) -> HashMap<String, instant::Instant> {
+fn snapshot_last_opened(
+    _working_directory: Option<&LocalOrRemotePath>,
+    _app: &AppContext,
+) -> HashMap<String, instant::Instant> {
     HashMap::new()
 }
 

--- a/app/src/search/ai_context_menu/files/data_source_tests.rs
+++ b/app/src/search/ai_context_menu/files/data_source_tests.rs
@@ -6,11 +6,9 @@ use std::sync::Arc;
 use repo_metadata::RepoMetadataModel;
 use repo_metadata::repositories::DetectedRepositories;
 use tempfile::tempdir;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::App;
 use warpui::r#async::block_on;
-use warpui::elements::Empty;
-use warpui::platform::WindowStyle;
-use warpui::windowing::WindowManager;
-use warpui::{App, AppContext, Element, Entity, SingletonEntity, TypedActionView, View};
 
 use crate::search::ai_context_menu::files::data_source::{
     FileSnapshot, file_data_source_for_pwd, fuzzy_match_files,
@@ -21,27 +19,6 @@ use crate::search::files::model::FileSearchModel;
 use crate::search::files::search_item::FileSearchResult;
 use crate::search::item::SearchItem;
 use crate::search::mixer::AsyncDataSource;
-use crate::terminal::model::session::Session;
-use crate::workspace::ActiveSession;
-struct TestView;
-
-impl Entity for TestView {
-    type Event = ();
-}
-
-impl View for TestView {
-    fn ui_name() -> &'static str {
-        "AIContextMenuFilesDataSourceTestView"
-    }
-
-    fn render(&self, _app: &AppContext) -> Box<dyn Element> {
-        Empty::new().finish()
-    }
-}
-
-impl TypedActionView for TestView {
-    type Action = ();
-}
 
 #[test]
 fn test_single_term_query() {
@@ -745,33 +722,18 @@ fn test_fuzzy_match_files_respects_max_results() {
 #[test]
 #[cfg(feature = "local_fs")]
 fn test_file_data_source_for_pwd_holistic_behavior() {
-    App::test((), |mut app| async move {
+    App::test((), |app| async move {
         app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(FileSearchModel::new);
-        app.add_singleton_model(|_| ActiveSession::default());
         let test_dir = tempdir().expect("failed to create temp dir");
         let test_dir_path = test_dir.path().to_path_buf();
         fs::write(test_dir_path.join("needle.rs"), "fn main() {}")
             .expect("failed to write test file");
         fs::write(test_dir_path.join("other.txt"), "other").expect("failed to write test file");
 
-        let (window_id, _view) = app.add_window(WindowStyle::NotStealFocus, |_ctx| TestView);
-        WindowManager::handle(&app).update(&mut app, |windowing_state, _ctx| {
-            windowing_state.overwrite_for_test(windowing_state.stage(), Some(window_id));
-        });
-
-        ActiveSession::handle(&app).update(&mut app, |active_session, ctx| {
-            active_session.set_session_for_test(
-                window_id,
-                Arc::new(Session::test()),
-                Some(test_dir_path),
-                None,
-                ctx,
-            );
-        });
-
-        let data_source = app.read(file_data_source_for_pwd);
+        let working_directory = LocalOrRemotePath::Local(test_dir_path);
+        let data_source = app.read(|ctx| file_data_source_for_pwd(Some(&working_directory), ctx));
 
         let broad_query_results = app
             .read(|ctx| {

--- a/app/src/search/ai_context_menu/mixer.rs
+++ b/app/src/search/ai_context_menu/mixer.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{ModelContext, ModelHandle};
 
 use super::code::data_source::CodeSymbolCache;
@@ -26,6 +27,10 @@ pub struct AtContextMenuSourceContext {
     /// do not offer code symbols, and in WASM builds where the cache has no
     /// outline to read.
     pub code_symbol_cache: Option<ModelHandle<CodeSymbolCache>>,
+    /// Directory the file and skill sources are scoped to. The GUI resolves this
+    /// from the active window's session; the TUI passes its own session's
+    /// directory, since it has no active window.
+    pub working_directory: Option<LocalOrRemotePath>,
 }
 
 /// The query shape the `@` menu runs. Sources are selected by installation
@@ -51,17 +56,18 @@ pub fn install_sources_for_category(
     match category {
         #[cfg(not(target_family = "wasm"))]
         AIContextMenuCategory::CurrentFolderFiles => {
-            mixer.add_async_source(
-                super::files::data_source::file_data_source_for_pwd(ctx),
-                [QueryFilter::Files],
-                local_search_options(),
+            let source = super::files::data_source::file_data_source_for_pwd(
+                source_context.working_directory.as_ref(),
                 ctx,
             );
+            mixer.add_async_source(source, [QueryFilter::Files], local_search_options(), ctx);
         }
         #[cfg(not(target_family = "wasm"))]
         AIContextMenuCategory::RepoFiles => {
             mixer.add_async_source(
-                super::files::data_source::file_data_source_for_current_repo(),
+                super::files::data_source::file_data_source_for_current_repo(
+                    source_context.working_directory.clone(),
+                ),
                 [QueryFilter::Files],
                 local_search_options(),
                 ctx,
@@ -119,7 +125,10 @@ pub fn install_sources_for_category(
         }
         #[cfg(not(target_family = "wasm"))]
         AIContextMenuCategory::Skills => {
-            let source = ctx.add_model(|_| super::skills::data_source::SkillsDataSource::new());
+            let working_directory = source_context.working_directory.clone();
+            let source = ctx.add_model(|_| {
+                super::skills::data_source::SkillsDataSource::new(working_directory)
+            });
             mixer.add_sync_source(source, [QueryFilter::Skills]);
         }
         AIContextMenuCategory::Conversations => {

--- a/app/src/search/ai_context_menu/skills/data_source.rs
+++ b/app/src/search/ai_context_menu/skills/data_source.rs
@@ -7,16 +7,18 @@ use crate::ai::skills::SkillManager;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::data_source::{Query, QueryResult};
 use crate::search::mixer::{DataSourceRunErrorWrapper, SyncDataSource};
-#[cfg(not(target_family = "wasm"))]
-use crate::workspace::ActiveSession;
 
 const MAX_RESULTS: usize = 50;
 
-pub struct SkillsDataSource;
+pub struct SkillsDataSource {
+    /// Directory whose skill providers are offered. Skill discovery walks up from
+    /// here, so it has to be the surface's own working directory.
+    working_directory: Option<LocalOrRemotePath>,
+}
 
 impl SkillsDataSource {
-    pub fn new() -> Self {
-        Self
+    pub fn new(working_directory: Option<LocalOrRemotePath>) -> Self {
+        Self { working_directory }
     }
 }
 
@@ -30,20 +32,8 @@ impl SyncDataSource for SkillsDataSource {
     ) -> Result<Vec<QueryResult<Self::Action>>, DataSourceRunErrorWrapper> {
         let query_text = &query.text;
 
-        // Resolve the current working directory from the active window's session.
-        #[cfg(not(target_family = "wasm"))]
-        let cwd: Option<LocalOrRemotePath> = app
-            .windows()
-            .state()
-            .active_window
-            .map(|window_id| {
-                let active_session = ActiveSession::as_ref(app);
-                active_session.working_directory(window_id).cloned()
-            })
-            .unwrap_or(None);
-        #[cfg(target_family = "wasm")]
-        let cwd: Option<LocalOrRemotePath> = None;
-        let skills = SkillManager::as_ref(app).get_skills_for_working_directory(cwd.as_ref(), app);
+        let skills = SkillManager::as_ref(app)
+            .get_skills_for_working_directory(self.working_directory.as_ref(), app);
 
         let mut results: Vec<QueryResult<Self::Action>> = if query_text.is_empty() {
             // Zero state: show all skills with a uniform high score.

--- a/app/src/search/ai_context_menu/view.rs
+++ b/app/src/search/ai_context_menu/view.rs
@@ -5,7 +5,6 @@ use async_channel::Sender;
 use itertools::Itertools;
 #[cfg(not(target_family = "wasm"))]
 use repo_metadata::repositories::DetectedRepositories;
-use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{
     AnchorPair, Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
     Dismiss, Empty, Fill, Flex, Hoverable, Icon, MouseStateHandle, OffsetPositioning, OffsetType,
@@ -41,6 +40,7 @@ use crate::search::search_bar::{SearchBar, SearchBarEvent, SearchBarState, Searc
 use crate::settings::InputSettings;
 #[cfg(not(target_family = "wasm"))]
 use crate::workspace::ActiveSession;
+use crate::workspace::active_window_working_directory;
 
 const CORNER_RADIUS: f32 = 8.0;
 const DEFAULT_PALETTE_WIDTH: f32 = 320.0;
@@ -260,23 +260,6 @@ impl AIContextMenu {
         self.apply_gates(gates, ctx);
     }
 
-    /// The working directory of the active window's session, which decides
-    /// whether the repo-scoped categories are available.
-    #[cfg(not(target_family = "wasm"))]
-    pub(crate) fn active_working_directory(app: &AppContext) -> Option<LocalOrRemotePath> {
-        app.windows()
-            .state()
-            .active_window
-            .and_then(|window_id| ActiveSession::as_ref(app).working_directory(window_id))
-            .cloned()
-    }
-
-    /// WASM builds have no session working directory to resolve.
-    #[cfg(target_family = "wasm")]
-    pub(crate) fn active_working_directory(_app: &AppContext) -> Option<LocalOrRemotePath> {
-        None
-    }
-
     /// Recompute category-dependent state when repository availability changes.
     fn refresh_categories_state(&mut self, ctx: &mut ViewContext<Self>) {
         self.refresh_categories(ctx);
@@ -287,7 +270,7 @@ impl AIContextMenu {
     /// request, so construction can reuse it before the view is registered.
     fn refresh_categories(&mut self, ctx: &mut ViewContext<Self>) {
         self.core
-            .set_working_directory(Self::active_working_directory(ctx));
+            .set_working_directory(active_window_working_directory(ctx));
         self.core.refresh_categories(ctx);
 
         // One retained hover state per category row the main menu renders.
@@ -574,6 +557,7 @@ impl AIContextMenu {
             code_symbol_cache: Some(self.code_symbol_cache.clone()),
             #[cfg(target_family = "wasm")]
             code_symbol_cache: None,
+            working_directory: self.core.working_directory().cloned(),
         }
     }
 

--- a/app/src/search/command_palette/data_sources.rs
+++ b/app/src/search/command_palette/data_sources.rs
@@ -20,6 +20,7 @@ use crate::search::files::model::FileSearchModel;
 use crate::search::mixer::AddAsyncSourceOptions;
 use crate::session_management::SessionSource;
 use crate::settings::AISettings;
+use crate::workspace::active_window_working_directory;
 
 /// Store of all of the [`crate::search::DataSource`]s for the command palette.
 pub struct DataSourceStore {
@@ -121,13 +122,22 @@ impl DataSourceStore {
             }
 
             if FeatureFlag::CommandPaletteFileSearch.is_enabled() && !is_shared_session_viewer {
-                let file_search_model = FileSearchModel::as_ref(ctx);
-                let is_in_git_repo = file_search_model.repo_root_location(ctx).is_some();
+                let working_directory = active_window_working_directory(ctx);
+                let is_in_git_repo = FileSearchModel::as_ref(ctx)
+                    .repo_root_location(working_directory.as_ref(), ctx)
+                    .is_some();
 
                 let files_data_source = if is_in_git_repo {
-                    ctx.add_model(|_| files::data_source::FileDataSource::new())
+                    ctx.add_model(|_| {
+                        files::data_source::FileDataSource::new(working_directory.clone())
+                    })
                 } else {
-                    ctx.add_model(|ctx| files::data_source::FileDataSource::new_current_folder(ctx))
+                    ctx.add_model(|ctx| {
+                        files::data_source::FileDataSource::new_current_folder(
+                            working_directory.clone(),
+                            ctx,
+                        )
+                    })
                 };
                 mixer.add_async_source(
                     files_data_source,

--- a/app/src/search/command_palette/files/data_source.rs
+++ b/app/src/search/command_palette/files/data_source.rs
@@ -9,6 +9,7 @@ use futures_lite::FutureExt;
 use fuzzy_match::FuzzyMatchResult;
 use instant::Instant;
 use itertools::Itertools;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::path::CleanPathResult;
 use warpui::{AppContext, Entity, SingletonEntity};
 
@@ -31,6 +32,9 @@ enum FileRanking {
 
 pub struct FileDataSource {
     mode: FileDataSourceMode,
+    /// Directory the search is scoped to, resolved by the caller rather than read
+    /// from window state.
+    working_directory: Option<LocalOrRemotePath>,
 }
 
 enum FileDataSourceMode {
@@ -43,22 +47,27 @@ enum FileDataSourceMode {
 }
 
 impl FileDataSource {
-    pub fn new() -> Self {
+    pub fn new(working_directory: Option<LocalOrRemotePath>) -> Self {
         // Default to repo search to preserve existing call sites
         Self {
             mode: FileDataSourceMode::Repo,
+            working_directory,
         }
     }
 
     /// Create a data source that searches only within the current folder.
     /// This will read folder contents once at creation and reuse them for subsequent queries.
-    pub fn new_current_folder(app: &AppContext) -> Self {
+    pub fn new_current_folder(
+        working_directory: Option<LocalOrRemotePath>,
+        app: &AppContext,
+    ) -> Self {
         let file_search_model = FileSearchModel::as_ref(app);
-        let contents = file_search_model.get_folder_contents(app);
+        let contents = file_search_model.get_folder_contents(working_directory.as_ref(), app);
         Self {
             mode: FileDataSourceMode::CurrentFolder {
                 cached_contents: contents,
             },
+            working_directory,
         }
     }
 }
@@ -101,7 +110,8 @@ impl FileDataSource {
         match &self.mode {
             FileDataSourceMode::Repo => {
                 let file_search_model = FileSearchModel::as_ref(app);
-                file_search_model.get_repo_contents_with_git_status(app)
+                file_search_model
+                    .get_repo_contents_with_git_status(self.working_directory.as_ref(), app)
             }
             FileDataSourceMode::CurrentFolder { cached_contents } => {
                 (Arc::new(cached_contents.clone()), HashSet::new())
@@ -113,7 +123,11 @@ impl FileDataSource {
         match &self.mode {
             FileDataSourceMode::Repo => {
                 let file_search_model = FileSearchModel::as_ref(app);
-                file_search_model.get_repo_file_contents(query, app)
+                file_search_model.get_repo_file_contents(
+                    query,
+                    self.working_directory.as_ref(),
+                    app,
+                )
             }
             FileDataSourceMode::CurrentFolder { cached_contents } => {
                 Arc::new(cached_contents.clone())
@@ -135,7 +149,7 @@ impl FileDataSource {
 
         let opened_files = OpenedFilesModel::as_ref(app);
 
-        let repo_root = file_search_model.repo_root_location(app);
+        let repo_root = file_search_model.repo_root_location(self.working_directory.as_ref(), app);
         let opened_files = repo_root
             .and_then(|repo_root| opened_files.opened_files_for_repo(&repo_root))
             .cloned();
@@ -208,8 +222,9 @@ impl FileDataSource {
         let opened_files = OpenedFilesModel::as_ref(app);
 
         #[cfg(feature = "local_fs")]
-        let repo_root = file_search_model.repo_root(app);
-        let repo_root_location = file_search_model.repo_root_location(app);
+        let repo_root = file_search_model.repo_root(self.working_directory.as_ref(), app);
+        let repo_root_location =
+            file_search_model.repo_root_location(self.working_directory.as_ref(), app);
 
         // For the "Create file" fallback, use the expanded (but not repo-root-stripped)
         // path so that absolute paths work correctly with Path::join.
@@ -217,13 +232,11 @@ impl FileDataSource {
 
         // Get the current directory for the "Create file" option and for path stripping.
         #[cfg(feature = "local_fs")]
-        let current_directory = {
-            use crate::workspace::ActiveSession;
-            let active_window_id = app.windows().state().active_window;
-            active_window_id
-                .and_then(|window_id| ActiveSession::as_ref(app).path_if_local(window_id))
-                .map(|path| path.to_string_lossy().to_string())
-        };
+        let current_directory = self
+            .working_directory
+            .as_ref()
+            .and_then(|working_directory| working_directory.to_local_path())
+            .map(|path| path.to_string_lossy().to_string());
         #[cfg(not(feature = "local_fs"))]
         let current_directory: Option<String> = None;
 

--- a/app/src/search/command_palette/files/data_source_tests.rs
+++ b/app/src/search/command_palette/files/data_source_tests.rs
@@ -44,6 +44,7 @@ fn any_file_result(results: &[QueryResult<CommandPaletteItemAction>]) -> bool {
 fn current_folder_source(cached_contents: Vec<FileSearchResult>) -> FileDataSource {
     FileDataSource {
         mode: FileDataSourceMode::CurrentFolder { cached_contents },
+        working_directory: None,
     }
 }
 #[test]

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -7,11 +7,11 @@ use fuzzy_match::{
     FuzzyMatchResult, contains_wildcards, match_indices_case_insensitive,
     match_wildcard_pattern_case_insensitive,
 };
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
-        use crate::workspace::ActiveSession;
         use command::blocking::Command;
         use repo_metadata::local_model::GetContentsArgs;
         use repo_metadata::wrapper_model::RepoMetadataEvent;
@@ -20,7 +20,6 @@ cfg_if::cfg_if! {
         use repo_metadata::repositories::DetectedRepositories;
         use std::cell::RefCell;
         use std::collections::HashMap;
-        use warp_util::local_or_remote_path::LocalOrRemotePath;
     }
 }
 
@@ -70,36 +69,52 @@ impl FileSearchModel {
     }
 
     #[cfg(not(feature = "local_fs"))]
-    pub fn repo_root(&self, _app: &AppContext) -> Option<PathBuf> {
+    pub fn repo_root(
+        &self,
+        _working_directory: Option<&LocalOrRemotePath>,
+        _app: &AppContext,
+    ) -> Option<PathBuf> {
         None
     }
 
     #[cfg(feature = "local_fs")]
-    pub fn repo_root(&self, app: &AppContext) -> Option<PathBuf> {
-        self.repo_root_location(app)
+    pub fn repo_root(
+        &self,
+        working_directory: Option<&LocalOrRemotePath>,
+        app: &AppContext,
+    ) -> Option<PathBuf> {
+        self.repo_root_location(working_directory, app)
             .and_then(|loc| PathBuf::try_from(loc).ok())
     }
 
-    /// Returns the repo root as a `LocalOrRemotePath`, supporting both local and SSH sessions.
+    /// Returns the repo root containing `working_directory`, supporting both local
+    /// and SSH sessions.
     #[cfg(not(feature = "local_fs"))]
     pub fn repo_root_location(
         &self,
+        _working_directory: Option<&LocalOrRemotePath>,
         _app: &AppContext,
-    ) -> Option<warp_util::local_or_remote_path::LocalOrRemotePath> {
+    ) -> Option<LocalOrRemotePath> {
         None
     }
 
-    /// Returns the repo root as a `LocalOrRemotePath`, supporting both local and SSH sessions.
+    /// Returns the repo root containing `working_directory`, supporting both local
+    /// and SSH sessions.
     #[cfg(feature = "local_fs")]
-    pub fn repo_root_location(&self, app: &AppContext) -> Option<LocalOrRemotePath> {
-        let active_window_id = app.windows().state().active_window;
-        let working_dir =
-            active_window_id.and_then(|wid| ActiveSession::as_ref(app).working_directory(wid))?;
-        DetectedRepositories::as_ref(app).get_root_for_path(working_dir)
+    pub fn repo_root_location(
+        &self,
+        working_directory: Option<&LocalOrRemotePath>,
+        app: &AppContext,
+    ) -> Option<LocalOrRemotePath> {
+        DetectedRepositories::as_ref(app).get_root_for_path(working_directory?)
     }
 
     #[cfg(not(feature = "local_fs"))]
-    pub fn get_folder_contents(&self, _app: &AppContext) -> Vec<FileSearchResult> {
+    pub fn get_folder_contents(
+        &self,
+        _working_directory: Option<&LocalOrRemotePath>,
+        _app: &AppContext,
+    ) -> Vec<FileSearchResult> {
         Vec::new()
     }
 
@@ -110,12 +125,12 @@ impl FileSearchModel {
     /// lazy-loaded first-level snapshots from the remote server on every
     /// `NavigatedToDirectory`.
     #[cfg(feature = "local_fs")]
-    pub fn get_folder_contents(&self, app: &AppContext) -> Vec<FileSearchResult> {
-        let active_window_id = app.windows().state().active_window;
-        let working_dir =
-            active_window_id.and_then(|wid| ActiveSession::as_ref(app).working_directory(wid));
-
-        match working_dir {
+    pub fn get_folder_contents(
+        &self,
+        working_directory: Option<&LocalOrRemotePath>,
+        app: &AppContext,
+    ) -> Vec<FileSearchResult> {
+        match working_directory {
             // Local session: read the filesystem directly.
             Some(LocalOrRemotePath::Local(local_path)) => {
                 let current_dir: &Path = local_path.as_path();
@@ -197,8 +212,13 @@ impl FileSearchModel {
     /// state) the full unfiltered contents are returned and cached per repo
     /// root location, invalidated when the file tree changes.
     #[cfg(feature = "local_fs")]
-    pub fn get_repo_contents(&self, query: &str, app: &AppContext) -> Arc<Vec<FileSearchResult>> {
-        self.get_repo_contents_with_options(query, true, app)
+    pub fn get_repo_contents(
+        &self,
+        query: &str,
+        working_directory: Option<&LocalOrRemotePath>,
+        app: &AppContext,
+    ) -> Arc<Vec<FileSearchResult>> {
+        self.get_repo_contents_with_options(query, true, working_directory, app)
     }
 
     /// Gets repository files (no directories) for the current working directory.
@@ -211,9 +231,10 @@ impl FileSearchModel {
     pub fn get_repo_file_contents(
         &self,
         query: &str,
+        working_directory: Option<&LocalOrRemotePath>,
         app: &AppContext,
     ) -> Arc<Vec<FileSearchResult>> {
-        self.get_repo_contents_with_options(query, false, app)
+        self.get_repo_contents_with_options(query, false, working_directory, app)
     }
 
     #[cfg(feature = "local_fs")]
@@ -221,9 +242,10 @@ impl FileSearchModel {
         &self,
         query: &str,
         include_folders: bool,
+        working_directory: Option<&LocalOrRemotePath>,
         app: &AppContext,
     ) -> Arc<Vec<FileSearchResult>> {
-        let Some(repo_root) = self.repo_root_location(app) else {
+        let Some(repo_root) = self.repo_root_location(working_directory, app) else {
             return Arc::new(Vec::new());
         };
 
@@ -253,27 +275,34 @@ impl FileSearchModel {
     #[cfg(feature = "local_fs")]
     pub fn get_repo_contents_with_git_status(
         &self,
+        working_directory: Option<&LocalOrRemotePath>,
         app: &AppContext,
     ) -> (Arc<Vec<FileSearchResult>>, HashSet<String>) {
-        let contents = self.get_repo_contents("", app);
+        let contents = self.get_repo_contents("", working_directory, app);
         let git_changed_files = self
-            .repo_root(app)
+            .repo_root(working_directory, app)
             .and_then(|repo_root| self.get_git_changed_files(&repo_root).ok())
             .unwrap_or_default();
         (contents, git_changed_files)
     }
 
-    /// Gets repository contents from the LocalRepoMetadataModel for the current working directory (WASM stub)
+    /// Gets repository contents from the LocalRepoMetadataModel for the given working directory (WASM stub)
     #[cfg(not(feature = "local_fs"))]
-    pub fn get_repo_contents(&self, _query: &str, _app: &AppContext) -> Arc<Vec<FileSearchResult>> {
+    pub fn get_repo_contents(
+        &self,
+        _query: &str,
+        _working_directory: Option<&LocalOrRemotePath>,
+        _app: &AppContext,
+    ) -> Arc<Vec<FileSearchResult>> {
         Arc::new(Vec::new())
     }
 
-    /// Gets repository files (no directories) for the current working directory (WASM stub)
+    /// Gets repository files (no directories) for the given working directory (WASM stub)
     #[cfg(not(feature = "local_fs"))]
     pub fn get_repo_file_contents(
         &self,
         _query: &str,
+        _working_directory: Option<&LocalOrRemotePath>,
         _app: &AppContext,
     ) -> Arc<Vec<FileSearchResult>> {
         Arc::new(Vec::new())
@@ -283,6 +312,7 @@ impl FileSearchModel {
     #[cfg(not(feature = "local_fs"))]
     pub fn get_repo_contents_with_git_status(
         &self,
+        _working_directory: Option<&LocalOrRemotePath>,
         _app: &AppContext,
     ) -> (Arc<Vec<FileSearchResult>>, HashSet<String>) {
         (Arc::new(Vec::new()), HashSet::new())

--- a/app/src/terminal/universal_developer_input.rs
+++ b/app/src/terminal/universal_developer_input.rs
@@ -42,8 +42,6 @@ use crate::ai::llms::LLMPreferences;
 use crate::cloud_object::model::generic_string_model::StringModel;
 use crate::network::NetworkStatus;
 #[cfg(not(target_family = "wasm"))]
-use crate::search::ai_context_menu::view::AIContextMenu;
-#[cfg(not(target_family = "wasm"))]
 use crate::search::ai_context_menu::{AtContextMenuCoreState, AtContextMenuGates};
 #[cfg(not(target_family = "wasm"))]
 use crate::settings::InputSettings;
@@ -176,7 +174,7 @@ impl AtContextMenuDisabledReason {
             is_ai_or_autodetect_mode: input_config.input_type.is_ai() || !input_config.is_locked,
             ..Default::default()
         });
-        menu_state.set_working_directory(AIContextMenu::active_working_directory(ctx));
+        menu_state.set_working_directory(crate::workspace::active_window_working_directory(ctx));
         if menu_state.available_categories(ctx).is_empty() {
             return Some(AtContextMenuDisabledReason::NoObjectsAvailable);
         }

--- a/app/src/workspace/active_session.rs
+++ b/app/src/workspace/active_session.rs
@@ -5,9 +5,23 @@ use std::path::PathBuf;
 use std::sync::{Arc, Weak};
 
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warpui::{Entity, EntityId, ModelContext, SingletonEntity, WindowId};
+use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity, WindowId};
 
 use crate::terminal::model::session::Session;
+
+/// The working directory of the active window's session, if there is one.
+///
+/// Search surfaces that are scoped to "wherever the user currently is" resolve
+/// their directory through this. It is inherently GUI-shaped: the headless TUI
+/// has no active window and hosts several sessions per window, so it passes its
+/// own per-session working directory instead.
+pub fn active_window_working_directory(app: &AppContext) -> Option<LocalOrRemotePath> {
+    app.windows()
+        .state()
+        .active_window
+        .and_then(|window_id| ActiveSession::as_ref(app).working_directory(window_id))
+        .cloned()
+}
 
 /// The active terminal session in each window. The active session of a window is the current
 /// session of the most-recently-focused terminal pane of the active tab of the window's workspace.

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -28,7 +28,7 @@ pub use action::{
     AutoCloudHandoffTrigger, CommandSearchOptions, InitContent, RestoreConversationLayout,
     TabContextMenuAnchor, VerticalTabsPaneContextMenuTarget, WorkspaceAction,
 };
-pub use active_session::ActiveSession;
+pub use active_session::{ActiveSession, active_window_working_directory};
 pub use global_actions::{
     ForkAIConversationParams, ForkFromExchange, ForkedConversationDestination,
 };


### PR DESCRIPTION
## Description

Second of three PRs adding the `@` context menu to the headless TUI. Stacked on #14502.

`FileSearchModel` and the file/skills data sources resolved their working directory by reading `app.windows().state().active_window` and looking the session up in the window-keyed `workspace::ActiveSession`. That only works in the GUI. This PR makes callers pass the directory in.

### Why window-keyed state cannot work for the TUI

Two independent reasons, both verified rather than assumed:

1. **The TUI has no active window.** `WindowManager::set_active_window` is `pub(crate)` in `warpui_core` and is only reached through `AppCallbackDispatcher::active_window_changed`, which fires from the platform `WindowManager::open_window`. `AppContext::add_tui_window` never opens a platform window — it inserts a `Window`, builds the root view, and focuses it. So `active_window` is `None` for the entire TUI process, and outside `warpui_core` the only way to set it is `overwrite_for_test`.
2. **One TUI window hosts many sessions.** `TuiSessions.sessions` is a `Vec<TuiSession>`, and every session view is created against the same `window_id`. Sessions have independent working directories, so a single window-keyed entry has no correct value — whichever session last changed directory would win and the rest would silently search the wrong tree.

### Changes

`FileSearchModel` gains a `working_directory: Option<&LocalOrRemotePath>` parameter on `repo_root`, `repo_root_location`, `get_folder_contents`, `get_repo_contents`, `get_repo_file_contents`, and `get_repo_contents_with_git_status` (plus the private `get_repo_contents_with_options` and the WASM stubs). Repo-root derivation via `DetectedRepositories::get_root_for_path` stays inside the model exactly as before.

New `workspace::active_window_working_directory` is the single place the GUI resolves "wherever the user currently is." It replaces four copies of the same `active_window` → `ActiveSession` → working-directory chain, previously inlined in `FileSearchModel`, the `@` menu's `snapshot_last_opened`, the skills data source, and the command-palette file source.

Callers:

- `@` menu file sources — `file_data_source_for_current_repo` takes an owned directory it captures in its snapshot closure; `file_data_source_for_pwd` takes a borrowed one, since it reads contents at construction.
- `@` menu skills source — stores the directory, because `SyncDataSource::run_query` has no call site to thread one through.
- `@` menu wiring — `AtContextMenuSourceContext` carries the directory, and the GUI view supplies the one its core state already holds. That is the seam PR 3 uses to pass a per-session directory from the TUI.
- Command-palette file source — stores the directory. Its "Create file" fallback previously used `ActiveSession::path_if_local`; it now uses `LocalOrRemotePath::to_local_path()` on the passed directory, which is the same operation.
- `command_palette/data_sources.rs` — resolves the directory once and passes it to whichever source mode it picks, instead of calling `repo_root_location` to decide and then letting the source re-resolve.

### Not included

`CodeSymbolCache` keeps reading window state. Code symbols are excluded from the TUI for a reason the working directory cannot fix — `LaunchMode::Tui` reports `supports_indexing() == false`, so `RepoOutlines` never builds outlines — which leaves the GUI as its only consumer. That also avoids the one genuinely awkward part of this change: `ensure_symbols_cached` runs inside a `spawner.spawn(move |cache, ctx| ...)` closure with no call site to thread a parameter through, so it would have needed stored state rather than a signature change.

## Linked Issue

CODE-1910

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

No new tests — this is signature threading with no behavior change, and the existing suites cover the call sites. All 212 tests under `search::` pass.

One existing test got materially simpler. `test_file_data_source_for_pwd_holistic_behavior` had to fabricate a window, force it active via `WindowManager::overwrite_for_test`, and install a fake `Session` through `set_session_for_test` just to make the data source see a directory. It now passes the directory directly, which dropped ~40 lines of scaffolding along with the `TestView` type that existed only to have something to put in the window.

Clean: `./script/format`, `cargo clippy -p warp --all-targets --tests -- -D warnings`, and `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`.

Same two caveats as #14502: not yet exercised via `./script/run`, and the WASM stub signatures are unverified locally since presubmit has no WASM build step. Worth a manual pass on both surfaces this touches — the `@` menu's file and skill categories, and the command palette's file filter including the "Create file" fallback.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
