### PR TITLE
Detect shell exit in setup command

### DIFF
--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -916,7 +916,7 @@ impl Display for RenderableAIError {
             Self::Other { error_message, .. } => write!(f, "{error_message}"),
             Self::AgentExitedShell { command } => write!(
                 f,
-                "The shell exited while the agent was running the command {command}, so the run \
+                "The shell exited while the agent was running the command `{command}`, so the run \
                  could not continue. Ensure the agent is not asked to run commands or source \
                  scripts that can exit the shell."
             ),

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -727,15 +727,16 @@ pub enum RenderableAIError {
     },
     /// An agent-issued command caused the shell process to exit, so the run
     /// cannot continue. Surfaced as a terminal failure (FAILED) rather than a
-    /// user cancellation.
-    AgentExitedShell,
+    /// user cancellation. `command` is the (secret-redacted) command that
+    /// exited the shell.
+    AgentExitedShell {
+        command: String,
+    },
 }
 
 impl RenderableAIError {
     const TRANSIENT_NETWORK_ERROR_MESSAGE: &'static str =
         "Warp lost connection while receiving the agent response. This is usually temporary.";
-    /// User-facing message shown when an agent-issued command exits the shell.
-    pub const AGENT_EXITED_SHELL_MESSAGE: &'static str = "The shell exited while the agent was running a command, so the run could not continue. Ensure the agent is not asked to run commands or source scripts that can exit the shell.";
     /// Creates a transient network error. `kind` is the structured cause (including the raw API
     /// error where one exists), preserved so user reports can disambiguate the different causes
     /// behind the shared user-facing copy.
@@ -913,7 +914,12 @@ impl Display for RenderableAIError {
                 )
             }
             Self::Other { error_message, .. } => write!(f, "{error_message}"),
-            Self::AgentExitedShell => write!(f, "{}", Self::AGENT_EXITED_SHELL_MESSAGE),
+            Self::AgentExitedShell { command } => write!(
+                f,
+                "The shell exited while the agent was running the command {command}, so the run \
+                 could not continue. Ensure the agent is not asked to run commands or source \
+                 scripts that can exit the shell."
+            ),
         }
     }
 }

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -526,6 +526,13 @@ pub enum AgentDriverError {
     ConversationCancelled { reason: CancellationReason },
     #[error("The agent got stuck waiting for user confirmation on the action: {blocked_action}")]
     ConversationBlocked { blocked_action: String },
+    /// The shell process exited while the driver was executing a command
+    /// outside a conversation (e.g. an environment setup command ran `exit`),
+    /// so the run cannot continue. Carries the same user-facing message as
+    /// the conversation-level [`RenderableAIError::AgentExitedShell`] failure
+    /// so both paths report identically.
+    #[error("{}", RenderableAIError::AGENT_EXITED_SHELL_MESSAGE)]
+    AgentExitedShell,
     #[error("Timed out refreshing team metadata")]
     TeamMetadataRefreshTimeout,
     #[error("{0}")]
@@ -1074,7 +1081,11 @@ impl AgentDriver {
             // Success/blocked/cancelled are handled by LocalAgentTaskSyncModel.
             if let (Some(task_id), Err(err)) = (task_id, &result) {
                 report_driver_error(task_id, err, &server_api_for_error).await;
-                if matches!(err, AgentDriverError::EnvironmentSetupFailed(_)) {
+                if matches!(
+                    err,
+                    AgentDriverError::EnvironmentSetupFailed(_)
+                        | AgentDriverError::AgentExitedShell
+                ) {
                     let _ = foreground_for_error
                         .spawn(|me, ctx| {
                             me.extend_shared_session_retention(

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -531,7 +531,7 @@ pub enum AgentDriverError {
     /// `command` is the command that was in flight (or most recently
     /// submitted) when the shell died.
     #[error(
-        "The shell exited during setup command {command}, so the run could not continue. \
+        "The shell exited during setup command `{command}`, so the run could not continue. \
          Check the setup commands for this environment."
     )]
     SetupCommandExitedShell { command: String },

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -528,8 +528,8 @@ pub enum AgentDriverError {
     ConversationBlocked { blocked_action: String },
     /// The shell process exited while an environment setup command was
     /// running (e.g. the command ran `exit`), so the run cannot continue.
-    /// `command` is the command that was in flight (or most recently
-    /// submitted) when the shell died.
+    /// `command` is the (secret-redacted) command that was in flight (or
+    /// most recently submitted) when the shell died.
     #[error(
         "The shell exited during setup command `{command}`, so the run could not continue. \
          Check the setup commands for this environment."

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -526,13 +526,15 @@ pub enum AgentDriverError {
     ConversationCancelled { reason: CancellationReason },
     #[error("The agent got stuck waiting for user confirmation on the action: {blocked_action}")]
     ConversationBlocked { blocked_action: String },
-    /// The shell process exited while the driver was executing a command
-    /// outside a conversation (e.g. an environment setup command ran `exit`),
-    /// so the run cannot continue. Carries the same user-facing message as
-    /// the conversation-level [`RenderableAIError::AgentExitedShell`] failure
-    /// so both paths report identically.
-    #[error("{}", RenderableAIError::AGENT_EXITED_SHELL_MESSAGE)]
-    AgentExitedShell,
+    /// The shell process exited while an environment setup command was
+    /// running (e.g. the command ran `exit`), so the run cannot continue.
+    /// `command` is the command that was in flight (or most recently
+    /// submitted) when the shell died.
+    #[error(
+        "The shell exited during setup command {command}, so the run could not continue. \
+         Check the setup commands for this environment."
+    )]
+    SetupCommandExitedShell { command: String },
     #[error("Timed out refreshing team metadata")]
     TeamMetadataRefreshTimeout,
     #[error("{0}")]
@@ -1084,7 +1086,7 @@ impl AgentDriver {
                 if matches!(
                     err,
                     AgentDriverError::EnvironmentSetupFailed(_)
-                        | AgentDriverError::AgentExitedShell
+                        | AgentDriverError::SetupCommandExitedShell { .. }
                 ) {
                     let _ = foreground_for_error
                         .spawn(|me, ctx| {

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -2,7 +2,6 @@ use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::AgentDriverError;
 use super::terminal::ShareSessionError;
-use crate::ai::agent::RenderableAIError;
 use crate::ai::blocklist::local_agent_task_sync_model::classify_renderable_error;
 use crate::server::server_api::ai::TaskStatusUpdate;
 
@@ -174,22 +173,16 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
-        // The shell died under a driver-issued command (e.g. a setup command
-        // ran `exit`). Reuse the conversation-level shell-exit classification
-        // so the reported state, message, and error code are identical to an
-        // agent-issued command exiting the shell.
-        AgentDriverError::AgentExitedShell => {
-            let (state, update) = classify_renderable_error(&RenderableAIError::AgentExitedShell);
-            (
-                state,
-                update.unwrap_or_else(|| {
-                    TaskStatusUpdate::with_error_code(
-                        RenderableAIError::AGENT_EXITED_SHELL_MESSAGE,
-                        PlatformErrorCode::InvalidRequest,
-                    )
-                }),
-            )
-        }
+        // The shell died while an environment setup command was running
+        // (e.g. the command ran `exit`). This is a user-side environment
+        // configuration problem, so classify as FAILED.
+        AgentDriverError::SetupCommandExitedShell { .. } => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                error.to_string(),
+                PlatformErrorCode::EnvironmentSetupFailed,
+            ),
+        ),
         AgentDriverError::InvalidWorkingDirectory { path, .. } => (
             AgentTaskState::Failed,
             TaskStatusUpdate::with_error_code(

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -2,6 +2,7 @@ use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::AgentDriverError;
 use super::terminal::ShareSessionError;
+use crate::ai::agent::RenderableAIError;
 use crate::ai::blocklist::local_agent_task_sync_model::classify_renderable_error;
 use crate::server::server_api::ai::TaskStatusUpdate;
 
@@ -173,6 +174,22 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
+        // The shell died under a driver-issued command (e.g. a setup command
+        // ran `exit`). Reuse the conversation-level shell-exit classification
+        // so the reported state, message, and error code are identical to an
+        // agent-issued command exiting the shell.
+        AgentDriverError::AgentExitedShell => {
+            let (state, update) = classify_renderable_error(&RenderableAIError::AgentExitedShell);
+            (
+                state,
+                update.unwrap_or_else(|| {
+                    TaskStatusUpdate::with_error_code(
+                        RenderableAIError::AGENT_EXITED_SHELL_MESSAGE,
+                        PlatformErrorCode::InvalidRequest,
+                    )
+                }),
+            )
+        }
         AgentDriverError::InvalidWorkingDirectory { path, .. } => (
             AgentTaskState::Failed,
             TaskStatusUpdate::with_error_code(

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -1,6 +1,7 @@
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::classify_driver_error;
+use crate::ai::agent::RenderableAIError;
 use crate::ai::agent_sdk::driver::AgentDriverError;
 use crate::ai::agent_sdk::driver::terminal::{BootstrapError, ShareSessionError};
 
@@ -160,6 +161,19 @@ fn environment_setup_failed_is_failed() {
         AgentDriverError::EnvironmentSetupFailed("bad repo".into()),
         AgentTaskState::Failed,
         Some(PlatformErrorCode::EnvironmentSetupFailed),
+    );
+}
+
+#[test]
+fn agent_exited_shell_is_failed_with_same_message_as_conversation_path() {
+    let (state, update) = classify_driver_error(&AgentDriverError::AgentExitedShell);
+    assert_eq!(state, AgentTaskState::Failed);
+    assert_eq!(update.error_code, Some(PlatformErrorCode::InvalidRequest));
+    // A shell exit during a setup command must report the exact same
+    // user-facing message as an agent-issued command exiting the shell.
+    assert_eq!(
+        update.message,
+        RenderableAIError::AGENT_EXITED_SHELL_MESSAGE
     );
 }
 

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -1,7 +1,6 @@
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::classify_driver_error;
-use crate::ai::agent::RenderableAIError;
 use crate::ai::agent_sdk::driver::AgentDriverError;
 use crate::ai::agent_sdk::driver::terminal::{BootstrapError, ShareSessionError};
 
@@ -165,15 +164,24 @@ fn environment_setup_failed_is_failed() {
 }
 
 #[test]
-fn agent_exited_shell_is_failed_with_same_message_as_conversation_path() {
-    let (state, update) = classify_driver_error(&AgentDriverError::AgentExitedShell);
+fn setup_command_exited_shell_is_failed_with_env_setup_and_names_command() {
+    let (state, update) = classify_driver_error(&AgentDriverError::SetupCommandExitedShell {
+        command: "./setup.sh".into(),
+    });
     assert_eq!(state, AgentTaskState::Failed);
-    assert_eq!(update.error_code, Some(PlatformErrorCode::InvalidRequest));
-    // A shell exit during a setup command must report the exact same
-    // user-facing message as an agent-issued command exiting the shell.
     assert_eq!(
-        update.message,
-        RenderableAIError::AGENT_EXITED_SHELL_MESSAGE
+        update.error_code,
+        Some(PlatformErrorCode::EnvironmentSetupFailed)
+    );
+    // The message must name the setup command that exited the shell and
+    // point the user at the environment's setup commands.
+    assert!(update.message.contains("./setup.sh"), "{}", update.message);
+    assert!(
+        update
+            .message
+            .contains("Check the setup commands for this environment"),
+        "{}",
+        update.message
     );
 }
 

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -20,6 +20,7 @@ use warpui::r#async::FutureExt;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity as _, ViewHandle};
 
 use super::AgentDriverError;
+use crate::ai::agent::redaction::redact_secrets;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::attachment_utils::attachments_download_dir;
 use crate::pane_group::NewTerminalOptions;
@@ -163,11 +164,14 @@ pub(crate) struct TerminalDriver {
     /// [`AgentDriverError::SetupCommandExitedShell`].
     shell_exited: bool,
 
-    /// The most recently submitted command, used to attribute a shell exit
-    /// to the command that caused it. When the shell dies mid-command, the
-    /// exit path force-finishes the command's block (with exit code 0)
-    /// before `Event::Exited` is delivered, so at exit time this — not any
-    /// still-pending command — names the culprit.
+    /// The most recently submitted command (secret-redacted), used to
+    /// attribute a shell exit to the command that caused it. When the shell
+    /// dies mid-command, the exit path force-finishes the command's block
+    /// (with exit code 0) before `Event::Exited` is delivered, so at exit
+    /// time this — not any still-pending command — names the culprit.
+    ///
+    /// Stored redacted because it flows into error reports (server task
+    /// status, Sentry) via [`AgentDriverError::SetupCommandExitedShell`].
     last_command: Option<String>,
 }
 
@@ -523,7 +527,12 @@ impl TerminalDriver {
         }
 
         let command_string = command.to_string();
-        self.last_command = Some(command_string.clone());
+        // Store a secret-redacted copy for shell-exit attribution: the text
+        // flows into error reports (server task status, Sentry) if the shell
+        // dies, so never retain the raw command here.
+        let mut redacted_command = command_string.clone();
+        redact_secrets(&mut redacted_command);
+        self.last_command = Some(redacted_command);
         self.terminal_view.update(ctx, |terminal, ctx| {
             self.waiting_command = Some(exit_tx);
             self.pending_command_start = Some((command_string, start_tx));

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -146,8 +146,9 @@ pub(crate) struct TerminalDriver {
     session_share_rx: Option<oneshot::Receiver<Result<(), ShareSessionError>>>,
     pending_share_requests: Vec<ShareRequest>,
     /// Resolves the in-flight command's exit status. Sent `Ok` when the
-    /// command's block completes, or `Err(AgentDriverError::AgentExitedShell)`
-    /// if the shell process exits while the command is still running.
+    /// command's block completes, or
+    /// `Err(AgentDriverError::SetupCommandExitedShell)` if the shell process
+    /// exits while the command is still running.
     waiting_command: Option<oneshot::Sender<Result<ExitCode, AgentDriverError>>>,
 
     /// State for the pending command we're expecting to start executing.
@@ -159,8 +160,15 @@ pub(crate) struct TerminalDriver {
     /// True once the shell process backing this session has exited
     /// post-bootstrap. No further commands can execute, so
     /// [`Self::execute_command`] fails fast with
-    /// [`AgentDriverError::AgentExitedShell`].
+    /// [`AgentDriverError::SetupCommandExitedShell`].
     shell_exited: bool,
+
+    /// The most recently submitted command, used to attribute a shell exit
+    /// to the command that caused it. When the shell dies mid-command, the
+    /// exit path force-finishes the command's block (with exit code 0)
+    /// before `Event::Exited` is delivered, so at exit time this — not any
+    /// still-pending command — names the culprit.
+    last_command: Option<String>,
 }
 
 impl Entity for TerminalDriver {
@@ -314,6 +322,7 @@ impl TerminalDriver {
             waiting_command: None,
             pending_command_start: None,
             shell_exited: false,
+            last_command: None,
         }
     }
 
@@ -475,6 +484,17 @@ impl TerminalDriver {
         })
     }
 
+    /// The error reported for commands affected by a shell exit, attributing
+    /// the most recently submitted command as the cause.
+    fn shell_exited_error(&self) -> AgentDriverError {
+        AgentDriverError::SetupCommandExitedShell {
+            command: self
+                .last_command
+                .clone()
+                .unwrap_or_else(|| "<unknown>".to_string()),
+        }
+    }
+
     /// Execute a command in the terminal and return a future that resolves to a
     /// [`CommandHandle`] once the command starts executing.
     pub fn execute_command(
@@ -486,11 +506,11 @@ impl TerminalDriver {
         AgentDriverError,
     > {
         // The shell process has exited, so no further commands can run in
-        // this session. Fail fast with the canonical shell-exit error so
-        // callers (e.g. environment setup) report the failure instead of
-        // waiting forever on a command that can never start.
+        // this session. Fail fast with the shell-exit error so callers
+        // (e.g. environment setup) report the failure instead of waiting
+        // forever on a command that can never start.
         if self.shell_exited {
-            return Err(AgentDriverError::AgentExitedShell);
+            return Err(self.shell_exited_error());
         }
 
         let (exit_tx, exit_rx) = oneshot::channel::<Result<ExitCode, AgentDriverError>>();
@@ -503,6 +523,7 @@ impl TerminalDriver {
         }
 
         let command_string = command.to_string();
+        self.last_command = Some(command_string.clone());
         self.terminal_view.update(ctx, |terminal, ctx| {
             self.waiting_command = Some(exit_tx);
             self.pending_command_start = Some((command_string, start_tx));
@@ -767,15 +788,14 @@ impl TerminalDriver {
 
                 // The shell is gone: no further command can start or finish.
                 // Fail any in-flight command (e.g. an environment setup
-                // command) with the canonical shell-exit error so the run
-                // reports the failure instead of hanging until the sandbox
-                // is killed.
+                // command) with the shell-exit error so the run reports the
+                // failure instead of hanging until the sandbox is killed.
                 self.shell_exited = true;
                 if let Some((_, sender)) = self.pending_command_start.take() {
-                    let _ = sender.send(Err(AgentDriverError::AgentExitedShell));
+                    let _ = sender.send(Err(self.shell_exited_error()));
                 }
                 if let Some(sender) = self.waiting_command.take() {
-                    let _ = sender.send(Err(AgentDriverError::AgentExitedShell));
+                    let _ = sender.send(Err(self.shell_exited_error()));
                 }
             }
             crate::terminal::view::Event::SlowBootstrap => {

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -145,12 +145,22 @@ pub(crate) struct TerminalDriver {
     /// and `wait_for_session_shared` has not yet been called.
     session_share_rx: Option<oneshot::Receiver<Result<(), ShareSessionError>>>,
     pending_share_requests: Vec<ShareRequest>,
-    waiting_command: Option<oneshot::Sender<ExitCode>>,
+    /// Resolves the in-flight command's exit status. Sent `Ok` when the
+    /// command's block completes, or `Err(AgentDriverError::AgentExitedShell)`
+    /// if the shell process exits while the command is still running.
+    waiting_command: Option<oneshot::Sender<Result<ExitCode, AgentDriverError>>>,
 
     /// State for the pending command we're expecting to start executing.
     /// The `String` is the expected command text, and the sender is used
-    /// to send the block ID to the waiting caller.
-    pending_command_start: Option<(String, oneshot::Sender<BlockId>)>,
+    /// to send the block ID to the waiting caller (or a shell-exit error if
+    /// the shell dies before the command starts).
+    pending_command_start: Option<(String, oneshot::Sender<Result<BlockId, AgentDriverError>>)>,
+
+    /// True once the shell process backing this session has exited
+    /// post-bootstrap. No further commands can execute, so
+    /// [`Self::execute_command`] fails fast with
+    /// [`AgentDriverError::AgentExitedShell`].
+    shell_exited: bool,
 }
 
 impl Entity for TerminalDriver {
@@ -303,6 +313,7 @@ impl TerminalDriver {
             pending_share_requests: Vec::new(),
             waiting_command: None,
             pending_command_start: None,
+            shell_exited: false,
         }
     }
 
@@ -474,8 +485,16 @@ impl TerminalDriver {
         impl Future<Output = Result<CommandHandle, AgentDriverError>> + use<>,
         AgentDriverError,
     > {
-        let (exit_tx, exit_rx) = oneshot::channel::<ExitCode>();
-        let (start_tx, start_rx) = oneshot::channel::<BlockId>();
+        // The shell process has exited, so no further commands can run in
+        // this session. Fail fast with the canonical shell-exit error so
+        // callers (e.g. environment setup) report the failure instead of
+        // waiting forever on a command that can never start.
+        if self.shell_exited {
+            return Err(AgentDriverError::AgentExitedShell);
+        }
+
+        let (exit_tx, exit_rx) = oneshot::channel::<Result<ExitCode, AgentDriverError>>();
+        let (start_tx, start_rx) = oneshot::channel::<Result<BlockId, AgentDriverError>>();
 
         // We should not be able to execute a command while we are still waiting on another one.
         // This is enforced by the caller by waiting on rx before continuing.
@@ -493,7 +512,7 @@ impl TerminalDriver {
         Ok(async move {
             let block_id = start_rx
                 .await
-                .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
+                .map_err(|_| AgentDriverError::InvalidRuntimeState)??;
             Ok(CommandHandle {
                 exit_status_rx: exit_rx,
                 block_id,
@@ -689,7 +708,7 @@ pub(crate) struct BlockOutputMatch {
 /// Also carries the [`BlockId`] so callers can retrieve the block snapshot
 /// after completion.
 pub(crate) struct CommandHandle {
-    exit_status_rx: oneshot::Receiver<ExitCode>,
+    exit_status_rx: oneshot::Receiver<Result<ExitCode, AgentDriverError>>,
     block_id: BlockId,
 }
 
@@ -706,7 +725,10 @@ impl Future for CommandHandle {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.exit_status_rx)
             .poll(cx)
-            .map(|result| result.map_err(|_| AgentDriverError::InvalidRuntimeState))
+            .map(|result| match result {
+                Ok(exit_status) => exit_status,
+                Err(_) => Err(AgentDriverError::InvalidRuntimeState),
+            })
     }
 }
 
@@ -741,6 +763,19 @@ impl TerminalDriver {
                 // point; the logs will have details.
                 if let Some(tx) = self.bootstrap_tx.take() {
                     let _ = tx.send(Err(BootstrapError::PtySpawnFailed { reason: None }));
+                }
+
+                // The shell is gone: no further command can start or finish.
+                // Fail any in-flight command (e.g. an environment setup
+                // command) with the canonical shell-exit error so the run
+                // reports the failure instead of hanging until the sandbox
+                // is killed.
+                self.shell_exited = true;
+                if let Some((_, sender)) = self.pending_command_start.take() {
+                    let _ = sender.send(Err(AgentDriverError::AgentExitedShell));
+                }
+                if let Some(sender) = self.waiting_command.take() {
+                    let _ = sender.send(Err(AgentDriverError::AgentExitedShell));
                 }
             }
             crate::terminal::view::Event::SlowBootstrap => {
@@ -777,7 +812,7 @@ impl TerminalDriver {
                     let block_id = self.terminal_view.read(ctx, |terminal, _| {
                         terminal.model.lock().block_list().active_block_id().clone()
                     });
-                    let _ = sender.send(block_id);
+                    let _ = sender.send(Ok(block_id));
                 }
             }
             crate::terminal::view::Event::BlockCompleted { block, .. } => {
@@ -796,7 +831,7 @@ impl TerminalDriver {
                     // we instead simply make sure it was not a background block.
                     bootstrapping_done && !block.is_background
                 }) {
-                    let _ = sender.send(block.exit_code);
+                    let _ = sender.send(Ok(block.exit_code));
                 }
             }
             _ => (),

--- a/app/src/ai/agent_sdk/driver/terminal_tests.rs
+++ b/app/src/ai/agent_sdk/driver/terminal_tests.rs
@@ -5,6 +5,7 @@ use session_sharing_protocol::sharer::SessionRetentionReason;
 use warpui::App;
 
 use super::TerminalDriver;
+use crate::ai::agent_sdk::driver::AgentDriverError;
 use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::view::Event;
 use crate::test_util::add_window_with_terminal;
@@ -54,5 +55,48 @@ fn extend_shared_session_retention_emits_event_for_active_sharer() {
             emitted_reasons[0],
             SessionRetentionReason::SetupFailed
         ));
+    });
+}
+
+#[test]
+fn shell_exit_fails_in_flight_and_subsequent_commands() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal_view = add_window_with_terminal(&mut app, None);
+        let terminal_driver =
+            app.update(|ctx| TerminalDriver::create_from_existing_view(terminal_view.clone(), ctx));
+
+        // Start a command (e.g. an environment setup command) so the driver
+        // has an in-flight command waiting on the terminal session.
+        let command_future = terminal_driver
+            .update(&mut app, |driver, ctx| {
+                driver.execute_command("echo hi", ctx)
+            })
+            .expect("command should be accepted before the shell exits");
+
+        // The shell process dies (e.g. the command ran `exit 1`).
+        terminal_view.update(&mut app, |_, ctx| ctx.emit(Event::Exited));
+
+        // The in-flight command must resolve with the shell-exit error
+        // instead of hanging forever, regardless of whether it had already
+        // started executing.
+        let result = match command_future.await {
+            Ok(handle) => handle.await,
+            Err(error) => Err(error),
+        };
+        assert!(
+            matches!(result, Err(AgentDriverError::AgentExitedShell)),
+            "in-flight command should fail with AgentExitedShell, got {result:?}"
+        );
+
+        // Any further command must fail fast with the same error.
+        let fail_fast = terminal_driver.update(&mut app, |driver, ctx| {
+            driver.execute_command("echo again", ctx).err()
+        });
+        assert!(
+            matches!(fail_fast, Some(AgentDriverError::AgentExitedShell)),
+            "commands after shell exit should fail fast with AgentExitedShell, got {fail_fast:?}"
+        );
     });
 }

--- a/app/src/ai/agent_sdk/driver/terminal_tests.rs
+++ b/app/src/ai/agent_sdk/driver/terminal_tests.rs
@@ -1,11 +1,14 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use regex::Regex;
+use serial_test::serial;
 use session_sharing_protocol::sharer::SessionRetentionReason;
 use warpui::App;
 
 use super::TerminalDriver;
 use crate::ai::agent_sdk::driver::AgentDriverError;
+use crate::terminal::model::secrets::set_user_and_enterprise_secret_regexes;
 use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::view::Event;
 use crate::test_util::add_window_with_terminal;
@@ -58,20 +61,38 @@ fn extend_shared_session_retention_emits_event_for_active_sharer() {
     });
 }
 
+// #[serial] because the secret regexes configured below are global state.
 #[test]
+#[serial]
 fn shell_exit_fails_in_flight_and_subsequent_commands() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
+
+        // Configure a secret pattern (a GitHub classic PAT). In production
+        // these are populated from the user's/enterprise's privacy settings
+        // via CustomSecretRegexUpdater.
+        set_user_and_enterprise_secret_regexes(
+            [&Regex::new(r"\bghp_[A-Za-z0-9_]{36}\b").expect("pattern should compile")],
+            std::iter::empty(),
+        );
 
         let terminal_view = add_window_with_terminal(&mut app, None);
         let terminal_driver =
             app.update(|ctx| TerminalDriver::create_from_existing_view(terminal_view.clone(), ctx));
 
+        // A command containing a secret matching the configured pattern. The
+        // attributed command in the shell-exit error must have the token
+        // redacted, since the error flows into server task status and Sentry
+        // reports.
+        let token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
+        let submitted = format!("echo {token}");
+        let expected_redacted = format!("echo {}", "*".repeat(token.len()));
+
         // Start a command (e.g. an environment setup command) so the driver
         // has an in-flight command waiting on the terminal session.
         let command_future = terminal_driver
             .update(&mut app, |driver, ctx| {
-                driver.execute_command("echo hi", ctx)
+                driver.execute_command(&submitted, ctx)
             })
             .expect("command should be accepted before the shell exits");
 
@@ -80,15 +101,15 @@ fn shell_exit_fails_in_flight_and_subsequent_commands() {
 
         // The in-flight command must resolve with the shell-exit error
         // instead of hanging forever, regardless of whether it had already
-        // started executing. The error must name the command that was
-        // running when the shell died.
+        // started executing. The error must name the (redacted) command that
+        // was running when the shell died.
         let result = match command_future.await {
             Ok(handle) => handle.await,
             Err(error) => Err(error),
         };
         match &result {
             Err(AgentDriverError::SetupCommandExitedShell { command }) => {
-                assert_eq!(command, "echo hi");
+                assert_eq!(command, &expected_redacted);
             }
             other => {
                 panic!("in-flight command should fail with SetupCommandExitedShell, got {other:?}")
@@ -96,14 +117,14 @@ fn shell_exit_fails_in_flight_and_subsequent_commands() {
         }
 
         // Any further command must fail fast with the same error, still
-        // attributing the command that killed the shell (not the newly
-        // attempted one).
+        // attributing the (redacted) command that killed the shell (not the
+        // newly attempted one).
         let fail_fast = terminal_driver.update(&mut app, |driver, ctx| {
             driver.execute_command("echo again", ctx).err()
         });
         match &fail_fast {
             Some(AgentDriverError::SetupCommandExitedShell { command }) => {
-                assert_eq!(command, "echo hi");
+                assert_eq!(command, &expected_redacted);
             }
             other => panic!(
                 "commands after shell exit should fail fast with SetupCommandExitedShell, got {other:?}"

--- a/app/src/ai/agent_sdk/driver/terminal_tests.rs
+++ b/app/src/ai/agent_sdk/driver/terminal_tests.rs
@@ -80,23 +80,34 @@ fn shell_exit_fails_in_flight_and_subsequent_commands() {
 
         // The in-flight command must resolve with the shell-exit error
         // instead of hanging forever, regardless of whether it had already
-        // started executing.
+        // started executing. The error must name the command that was
+        // running when the shell died.
         let result = match command_future.await {
             Ok(handle) => handle.await,
             Err(error) => Err(error),
         };
-        assert!(
-            matches!(result, Err(AgentDriverError::AgentExitedShell)),
-            "in-flight command should fail with AgentExitedShell, got {result:?}"
-        );
+        match &result {
+            Err(AgentDriverError::SetupCommandExitedShell { command }) => {
+                assert_eq!(command, "echo hi");
+            }
+            other => {
+                panic!("in-flight command should fail with SetupCommandExitedShell, got {other:?}")
+            }
+        }
 
-        // Any further command must fail fast with the same error.
+        // Any further command must fail fast with the same error, still
+        // attributing the command that killed the shell (not the newly
+        // attempted one).
         let fail_fast = terminal_driver.update(&mut app, |driver, ctx| {
             driver.execute_command("echo again", ctx).err()
         });
-        assert!(
-            matches!(fail_fast, Some(AgentDriverError::AgentExitedShell)),
-            "commands after shell exit should fail fast with AgentExitedShell, got {fail_fast:?}"
-        );
+        match &fail_fast {
+            Some(AgentDriverError::SetupCommandExitedShell { command }) => {
+                assert_eq!(command, "echo hi");
+            }
+            other => panic!(
+                "commands after shell exit should fail fast with SetupCommandExitedShell, got {other:?}"
+            ),
+        }
     });
 }

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -782,7 +782,7 @@ fn should_fork_from_last_known_good_state(
         | RenderableAIError::GeminiEnterpriseCredentialsExpiredOrInvalid => false,
         // A shell-exit failure can't resume in this (now-dead) pane, but the user
         // can fork from the last known good state to continue in a fresh one.
-        RenderableAIError::InternalWarpError | RenderableAIError::AgentExitedShell => true,
+        RenderableAIError::InternalWarpError | RenderableAIError::AgentExitedShell { .. } => true,
         RenderableAIError::Other {
             will_attempt_resume,
             ..

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2725,17 +2725,20 @@ impl BlocklistAIController {
     ///
     /// Invoked from the terminal view's shell-exit handler before the pane is
     /// torn down. The conversation is moved into a terminal `Error` state with a
-    /// shell-exit message so that the Oz run reports `FAILED` (with an
-    /// explanation) instead of "Cancelled by user", and so the subsequent
-    /// pane-close cancellation — which is guarded by `is_in_progress` — becomes a
-    /// no-op and cannot overwrite the failure.
+    /// shell-exit message (naming the secret-redacted `command` that exited the
+    /// shell) so that the Oz run reports `FAILED` (with an explanation) instead
+    /// of "Cancelled by user", and so the subsequent pane-close cancellation —
+    /// which is guarded by `is_in_progress` — becomes a no-op and cannot
+    /// overwrite the failure.
     pub fn fail_conversation_due_to_shell_exit(
         &mut self,
         conversation_id: AIConversationId,
+        command: String,
         ctx: &mut ModelContext<Self>,
     ) {
         let terminal_surface_id = self.terminal_surface_id;
         let history_model = BlocklistAIHistoryModel::handle(ctx);
+        let shell_exit_error = RenderableAIError::AgentExitedShell { command };
 
         // Only act on conversations that are still running. A finished
         // conversation (e.g. the agent already completed) must not be
@@ -2759,9 +2762,10 @@ impl BlocklistAIController {
             .stream_ids_for_conversation(conversation_id, ctx);
         let had_in_flight_stream = !stream_ids.is_empty();
         for stream_id in &stream_ids {
+            let error = shell_exit_error.clone();
             history_model.update(ctx, |history_model, ctx| {
                 history_model.mark_response_stream_completed_with_error(
-                    RenderableAIError::AgentExitedShell,
+                    error,
                     /* recovery_pending */ false,
                     stream_id,
                     conversation_id,
@@ -2797,7 +2801,7 @@ impl BlocklistAIController {
                     terminal_surface_id,
                     conversation_id,
                     ConversationStatus::Error,
-                    Some(RenderableAIError::AgentExitedShell),
+                    Some(shell_exit_error),
                     ctx,
                 );
             });

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -381,7 +381,11 @@ fn fail_conversation_due_to_shell_exit_reports_error_and_survives_manual_cancel(
             let stream = ctx.add_model(|_| ResponseStream::new_for_test(stream_id.clone()));
             view.ai_controller().update(ctx, |controller, ctx| {
                 controller.register_mock_stream_for_test(stream_id, conversation_id, stream, ctx);
-                controller.fail_conversation_due_to_shell_exit(conversation_id, ctx);
+                controller.fail_conversation_due_to_shell_exit(
+                    conversation_id,
+                    "exit 1".to_string(),
+                    ctx,
+                );
             });
             conversation_id
         });

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -538,7 +538,7 @@ pub(crate) fn classify_renderable_error(
                 )
             }
         }
-        RenderableAIError::AgentExitedShell => (
+        RenderableAIError::AgentExitedShell { .. } => (
             AgentTaskState::Failed,
             Some(TaskStatusUpdate::with_error_code(
                 error.to_string(),

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -174,10 +174,13 @@ fn transient_network_error_is_error_with_internal_and_debug_details() {
 #[test]
 fn agent_exited_shell_is_failed_with_invalid_request() {
     assert_update(
-        classify_renderable_error(&RenderableAIError::AgentExitedShell),
+        classify_renderable_error(&RenderableAIError::AgentExitedShell {
+            command: "exit 1".into(),
+        }),
         AgentTaskState::Failed,
         Some(PlatformErrorCode::InvalidRequest),
-        Some("shell exited"),
+        // The message must name the command that exited the shell.
+        Some("exit 1"),
     );
 }
 
@@ -329,7 +332,11 @@ fn map_conversation_status_error_without_exchange_error_is_generic() {
 #[test]
 fn map_conversation_status_error_classifies_agent_exited_shell() {
     let mut conversation = AIConversation::new(false, false);
-    conversation.append_root_exchange_for_test(error_exchange(RenderableAIError::AgentExitedShell));
+    conversation.append_root_exchange_for_test(error_exchange(
+        RenderableAIError::AgentExitedShell {
+            command: "exit 1".into(),
+        },
+    ));
     conversation.set_status_for_test(ConversationStatus::Error);
     assert_update(
         map_conversation_status(&conversation),
@@ -360,7 +367,9 @@ fn map_conversation_status_error_classifies_status_error_via_setter() {
                 .expect("conversation was just restored");
             conv.update_status_with_error(
                 ConversationStatus::Error,
-                Some(RenderableAIError::AgentExitedShell),
+                Some(RenderableAIError::AgentExitedShell {
+                    command: "exit 1".into(),
+                }),
                 terminal_view_id,
                 ctx,
             );
@@ -403,7 +412,9 @@ fn map_conversation_status_error_classifies_status_error_other_as_error() {
 fn map_conversation_status_error_classifies_status_error() {
     let mut conversation = AIConversation::new(false, false);
     conversation.set_status_for_test(ConversationStatus::Error);
-    conversation.set_status_error_for_test(Some(RenderableAIError::AgentExitedShell));
+    conversation.set_status_error_for_test(Some(RenderableAIError::AgentExitedShell {
+        command: "exit 1".into(),
+    }));
     assert_update(
         map_conversation_status(&conversation),
         AgentTaskState::Failed,

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -161,7 +161,7 @@ pub fn failed_output_presentation(
         RenderableAIError::Other { error_message, .. } => {
             FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{error_message}"))
         }
-        RenderableAIError::AgentExitedShell => {
+        RenderableAIError::AgentExitedShell { .. } => {
             FailedOutputPresentation::Message(format!("{ERROR_APOLOGY_TEXT}\n\n{error}"))
         }
     })

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -11266,12 +11266,13 @@ impl TerminalView {
     }
 
     /// Sends telemetry if an AI-requested command caused the shell to exit, and
-    /// returns the conversation that issued that command so the caller can
-    /// finalize it as a shell-exit failure.
+    /// returns the conversation that issued that command along with the
+    /// (secret-redacted) command text so the caller can finalize it as a
+    /// shell-exit failure.
     fn maybe_send_agent_exited_shell_telemetry(
         &self,
         ctx: &mut ViewContext<Self>,
-    ) -> Option<AIConversationId> {
+    ) -> Option<(AIConversationId, String)> {
         let model = self.model.lock();
         let block_list = model.block_list();
         let blocks = block_list.blocks();
@@ -11310,12 +11311,12 @@ impl TerminalView {
         });
         send_telemetry_from_ctx!(
             TelemetryEvent::AgentExitedShellProcess {
-                command,
+                command: command.clone(),
                 server_output_id,
             },
             ctx
         );
-        conversation_id
+        conversation_id.map(|conversation_id| (conversation_id, command))
     }
 
     /// Updates the back button's state and label. For child agents the
@@ -11700,15 +11701,20 @@ impl TerminalView {
             }
             ModelEvent::Exit { reason } => {
                 if !self.manual_pty_shutdown_requested
-                    && let Some(conversation_id) = self.maybe_send_agent_exited_shell_telemetry(ctx)
+                    && let Some((conversation_id, command)) =
+                        self.maybe_send_agent_exited_shell_telemetry(ctx)
                 {
                     // The agent's command caused the shell to exit. Finalize the
-                    // conversation as a failure (with a message) before the pane is
-                    // torn down, so the Oz run reports the failure instead of
-                    // "Cancelled by user" (which the pane-close cancellation would
-                    // otherwise produce).
+                    // conversation as a failure (with a message naming the command)
+                    // before the pane is torn down, so the Oz run reports the
+                    // failure instead of "Cancelled by user" (which the pane-close
+                    // cancellation would otherwise produce).
                     self.ai_controller.update(ctx, |controller, ctx| {
-                        controller.fail_conversation_due_to_shell_exit(conversation_id, ctx);
+                        controller.fail_conversation_due_to_shell_exit(
+                            conversation_id,
+                            command,
+                            ctx,
+                        );
                     });
                 }
 


### PR DESCRIPTION
## Description

Contributes to the largest cluster of https://linear.app/warpdotdev/issue/REMOTE-2338/sandbox-unexpectedly-failed

When a setup command causes the shell to exit, we weren't reporting this failure. The run would end up stuck at `Session Started` until eventually the sandbox closes 12 hours later.

Now, we detect shell exit in setup commands and report the failure with an error message, closing the sandbox. We also update the `AgentExitedShell` error to include the command name.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

Reproduced the original issue using an environment with `exit` as a setup command. In staging the run is stuck at session started. The sandbox is alive, but the shared session is dead. 12 hours later the sandbox will close, putting it in error with `Sandbox unexpectedly closed`

https://oz.staging.warp.dev/runs/019fb010-6a48-7b9e-9ea5-9fe0f0df939c?createdBy=5biMwfUWwagla4lNcR9OSWcZW9H3

Testing locally, it now reports the failure
### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

<img width="441" height="854" alt="Screenshot 2026-07-29 at 4 15 07 PM" src="https://github.com/user-attachments/assets/6d3e37ff-fe95-46b3-a89f-6d086baa5cb0" />
