### PR TITLE
Revamp zero state for tui

### DIFF
--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -2902,21 +2902,25 @@ fn zero_state_renders_with_only_zero_height_bootstrap_blocks() {
             "zero-state title should render in the transcript area:\n{}",
             lines.join("\n")
         );
+        // The 32-column animation panel is centered in the 152 columns left
+        // after the 48-column copy region: 48 + (152 - 32) / 2 = 108.
+        let animation_start = 108;
+        let animation_end = 140;
         assert!(
-            lines
-                .iter()
-                .take(28)
-                .any(|line| line.chars().skip(148).any(|character| character != ' ')),
-            "animation content should use columns beyond the former 48 + 100 column cap:\n{}",
+            lines.iter().take(28).any(|line| line
+                .chars()
+                .skip(animation_start)
+                .take(animation_end - animation_start)
+                .any(|character| character != ' ')),
+            "animation content should render in the centered remaining-space panel:\n{}",
             lines.join("\n")
         );
         assert!(
-            lines
-                .iter()
-                .take(28)
-                .skip(20)
-                .any(|line| line.chars().take(48).any(|character| character != ' ')),
-            "animation content should paint beneath the status column:\n{}",
+            lines.iter().take(28).any(|line| line
+                .chars()
+                .skip(animation_end)
+                .any(|character| character != ' ')),
+            "starfield content should extend beyond the centered logo panel:\n{}",
             lines.join("\n")
         );
     });

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -290,6 +290,11 @@ impl TuiUiBuilder {
             None => self.warp_theme.background(),
         }
     }
+
+    /// Solid form of the transcript's base background for opaque overlays.
+    pub(crate) fn transcript_background(&self) -> Color {
+        cell_color(self.base_background())
+    }
     fn cyan_overlay_2(&self) -> ThemeFill {
         let cyan = ThemeFill::from(self.warp_theme.terminal_colors().normal.cyan);
         self.base_background().blend(&cyan.with_opacity(50))

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -24,7 +24,7 @@ use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::SingletonEntity;
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{
-    Modifier, TuiConstrainedBox, TuiElement, TuiFlex, TuiStack, TuiText,
+    Color, Modifier, TuiConstrainedBox, TuiContainer, TuiElement, TuiFlex, TuiStack, TuiText,
 };
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 
@@ -33,7 +33,7 @@ use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
 use crate::zero_state_animation::{
     WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent,
-    ZeroStateAnimationElement,
+    ZeroStateAnimationElement, ZeroStateStarfieldElement,
 };
 
 /// Cap on "What's new" bullets, mirroring the compact zero-state mock.
@@ -47,6 +47,9 @@ const MAX_CHANGELOG_BULLETS: usize = 3;
 /// to the full available terminal width without being capped by this constant.
 const LEFT_COLUMN_COLS: u16 = 48;
 
+/// Width of the right-aligned animation region. This keeps the logo secondary
+/// to the copy and input while leaving enough cells for its wireframe detail.
+const ANIMATION_PANEL_COLS: u16 = 32;
 // ---------------------------------------------------------------------------
 // TuiZeroStateView
 // ---------------------------------------------------------------------------
@@ -154,12 +157,67 @@ impl TuiView for TuiZeroStateView {
                 background: builder.muted_text_style(),
             },
         )
+        .without_background_stars()
+        .finish();
+        let starfield = ZeroStateStarfieldElement::new(
+            self.clock,
+            builder.muted_text_style(),
+            LEFT_COLUMN_COLS,
+            ANIMATION_PANEL_COLS,
+        )
         .finish();
         let overlay = build_zero_state_overlay(cwd.as_deref(), &builder, ctx);
-        TuiStack::new().child(animation).child(overlay).finish()
+        build_zero_state_layout(
+            starfield,
+            animation,
+            overlay,
+            builder.transcript_background(),
+        )
     }
 }
 
+/// Centers the animation within the space beside the copy and centers the
+/// opaque copy block vertically. Reserving the copy column before measuring
+/// the animation also hides the artwork when a narrow terminal cannot display
+/// both regions.
+fn build_zero_state_layout(
+    starfield: Box<dyn TuiElement>,
+    animation: Box<dyn TuiElement>,
+    overlay: Box<dyn TuiElement>,
+    background: Color,
+) -> Box<dyn TuiElement> {
+    let copy_column_reservation = TuiConstrainedBox::new(TuiText::new("").finish())
+        .with_min_cols(LEFT_COLUMN_COLS)
+        .with_max_cols(LEFT_COLUMN_COLS)
+        .finish();
+    let animation = TuiConstrainedBox::new(animation)
+        .with_max_cols(ANIMATION_PANEL_COLS)
+        .finish();
+    let animation_region = TuiFlex::row()
+        .flex_child(TuiText::new("").finish())
+        .child(animation)
+        .flex_child(TuiText::new("").finish())
+        .finish();
+    let animation_layer = TuiFlex::row()
+        .child(copy_column_reservation)
+        .flex_child(animation_region)
+        .finish();
+
+    let overlay = TuiContainer::new(overlay)
+        .with_background(background)
+        .finish();
+    let overlay_layer = TuiFlex::column()
+        .flex_child(TuiText::new("").finish())
+        .child(overlay)
+        .flex_child(TuiText::new("").finish())
+        .finish();
+
+    TuiStack::new()
+        .child(starfield)
+        .child(animation_layer)
+        .child(overlay_layer)
+        .finish()
+}
 /// Assembles the text-overlay column placed on top of the animation layer.
 ///
 /// Both [`TuiZeroStateView::render`] and the regression tests call this function so

--- a/crates/warp_tui/src/zero_state_animation.rs
+++ b/crates/warp_tui/src/zero_state_animation.rs
@@ -120,6 +120,88 @@ impl LogoGlyph {
         }
     }
 }
+
+fn starfield_emitter_x(size: TuiSize, leading_reserved_cols: u16, logo_panel_cols: u16) -> f64 {
+    let available_cols = size.width.saturating_sub(leading_reserved_cols);
+    if available_cols < MIN_ANIMATION_COLS {
+        return (f64::from(size.width) - 1.0) / 2.0;
+    }
+    let panel_cols = available_cols.min(logo_panel_cols);
+    let leading_spacer_cols = available_cols.saturating_sub(panel_cols).div_ceil(2);
+    f64::from(leading_reserved_cols + leading_spacer_cols) + (f64::from(panel_cols) - 1.0) / 2.0
+}
+
+pub(crate) struct ZeroStateStarfieldElement {
+    clock: AnimationClock,
+    style: TuiStyle,
+    leading_reserved_cols: u16,
+    logo_panel_cols: u16,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
+}
+
+impl ZeroStateStarfieldElement {
+    pub(crate) fn new(
+        clock: AnimationClock,
+        style: TuiStyle,
+        leading_reserved_cols: u16,
+        logo_panel_cols: u16,
+    ) -> Self {
+        Self {
+            clock,
+            style,
+            leading_reserved_cols,
+            logo_panel_cols,
+            size: None,
+            origin: None,
+        }
+    }
+}
+
+impl TuiElement for ZeroStateStarfieldElement {
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        _ctx: &mut TuiLayoutContext,
+        _app: &AppContext,
+    ) -> TuiSize {
+        let size = constraint.max;
+        self.size = Some(size);
+        size
+    }
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else { return };
+        let mut frame = LogoFrame::new(size);
+        draw_background_stars_from(
+            &mut frame,
+            self.clock.elapsed(),
+            starfield_emitter_x(size, self.leading_reserved_cols, self.logo_panel_cols),
+        );
+        for (x, y, cell) in frame.iter_cells() {
+            if let Some(destination) = surface.cell_mut(origin.offset(x as i32, y as i32)) {
+                destination
+                    .set_symbol(cell.glyph.as_str())
+                    .set_style(self.style);
+            }
+        }
+        ctx.repaint_after(REPAINT_INTERVAL);
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct LogoCell {
     surface: LogoSurface,
@@ -176,6 +258,7 @@ pub struct ZeroStateAnimationElement {
     clock: AnimationClock,
     config: Arc<ZeroStateAnimationConfig>,
     styles: WarpLogoStyles,
+    draw_background_stars: bool,
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
 }
@@ -190,9 +273,15 @@ impl ZeroStateAnimationElement {
             clock,
             config,
             styles,
+            draw_background_stars: true,
             size: None,
             origin: None,
         }
+    }
+
+    pub(crate) fn without_background_stars(mut self) -> Self {
+        self.draw_background_stars = false;
+        self
     }
 }
 
@@ -222,7 +311,12 @@ impl TuiElement for ZeroStateAnimationElement {
     ) {
         self.origin = Some(ctx.scene_point(origin));
         let Some(size) = self.size else { return };
-        let Some(frame) = object_frame_at(self.clock.elapsed(), size, &self.config) else {
+        let Some(frame) = object_frame_at_with_background(
+            self.clock.elapsed(),
+            size,
+            &self.config,
+            self.draw_background_stars,
+        ) else {
             return;
         };
 
@@ -255,10 +349,20 @@ pub(crate) fn logo_frame_at(elapsed: Duration, size: TuiSize) -> Option<LogoFram
     object_frame_at(elapsed, size, &ZeroStateAnimationConfig::default())
 }
 
+#[cfg(test)]
 fn object_frame_at(
     elapsed: Duration,
     size: TuiSize,
     config: &ZeroStateAnimationConfig,
+) -> Option<LogoFrame> {
+    object_frame_at_with_background(elapsed, size, config, true)
+}
+
+fn object_frame_at_with_background(
+    elapsed: Duration,
+    size: TuiSize,
+    config: &ZeroStateAnimationConfig,
+    draw_stars: bool,
 ) -> Option<LogoFrame> {
     let cell_aspect_ratio = config.shape.cell_aspect_ratio();
     let (logo_cols, logo_rows) = fitted_logo_size(size, cell_aspect_ratio)?;
@@ -266,7 +370,9 @@ fn object_frame_at(
     let angle = (elapsed.as_secs_f64() % revolution_secs) / revolution_secs * std::f64::consts::TAU;
     let (sin, cos) = angle.sin_cos();
     let mut frame = LogoFrame::new(size);
-    draw_background_stars(&mut frame, elapsed);
+    if draw_stars {
+        draw_background_stars(&mut frame, elapsed);
+    }
     let mut z_buffer = vec![None; usize::from(size.width) * usize::from(size.height)];
 
     let source_cols = usize::from(logo_cols) * SURFACE_SAMPLES;
@@ -362,10 +468,14 @@ fn object_frame_at(
 }
 
 fn draw_background_stars(frame: &mut LogoFrame, elapsed: Duration) {
+    let center_x = (f64::from(frame.size.width) - 1.0) / 2.0;
+    draw_background_stars_from(frame, elapsed, center_x);
+}
+
+fn draw_background_stars_from(frame: &mut LogoFrame, elapsed: Duration, center_x: f64) {
     let width = usize::from(frame.size.width);
     let height = usize::from(frame.size.height);
     let star_count = star_count_for_size(frame.size);
-    let center_x = (f64::from(frame.size.width) - 1.0) / 2.0;
     let center_y = (f64::from(frame.size.height) - 1.0) / 2.0;
     let elapsed = elapsed.as_secs_f64();
 

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -22,7 +22,7 @@ use super::config::{
 use super::{
     BUILT_IN_LOGO_CELL_ASPECT_RATIO, LogoCell, LogoSurface, WarpLogoStyles,
     ZeroStateAnimationElement, fitted_logo_size, logo_frame_at, object_frame_at,
-    star_count_for_size, warp_logo_contains,
+    object_frame_at_with_background, star_count_for_size, starfield_emitter_x, warp_logo_contains,
 };
 
 const PANEL_SIZE: TuiSize = TuiSize::new(52, 20);
@@ -51,6 +51,18 @@ fn starfield_density_scales_with_the_full_panel_area() {
     assert_eq!(star_count_for_size(TuiSize::new(1_000, 200)), 6_923);
     assert_eq!(star_count_for_size(TuiSize::new(2_000, 200)), 8_192);
     assert_eq!(star_count_for_size(TuiSize::new(u16::MAX, u16::MAX)), 8_192);
+}
+
+#[test]
+fn starfield_emitter_tracks_the_centered_logo_panel() {
+    assert_eq!(starfield_emitter_x(TuiSize::new(80, 20), 48, 32), 63.5);
+    assert_eq!(starfield_emitter_x(TuiSize::new(120, 20), 48, 32), 83.5);
+    assert_eq!(starfield_emitter_x(TuiSize::new(160, 20), 48, 32), 103.5);
+    assert_eq!(
+        starfield_emitter_x(TuiSize::new(60, 20), 48, 32),
+        29.5,
+        "when the logo is hidden, stars should fall back to the screen center"
+    );
 }
 
 fn logo_cells(frame: &super::LogoFrame) -> Vec<(usize, usize, LogoCell)> {
@@ -157,6 +169,35 @@ fn background_stars_move_between_frames() {
 }
 
 #[test]
+fn adjacent_builtin_frames_have_bounded_cell_churn() {
+    let config = ZeroStateAnimationConfig::default();
+    let size = TuiSize::new(32, 28);
+    let frames = (0..=76)
+        .map(|frame| {
+            object_frame_at_with_background(Duration::from_millis(frame * 66), size, &config, false)
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    let max_changed_cells = frames
+        .windows(2)
+        .map(|frames| {
+            frames[0]
+                .cells
+                .iter()
+                .zip(&frames[1].cells)
+                .filter(|(before, after)| before.is_some() != after.is_some())
+                .count()
+        })
+        .max()
+        .unwrap();
+
+    assert!(
+        max_changed_cells <= 80,
+        "adjacent built-in frames changed occupancy in {max_changed_cells} cells"
+    );
+}
+
+#[test]
 fn quarter_turn_is_narrower_and_exposes_the_side() {
     let face = logo_frame_at(Duration::ZERO, PANEL_SIZE).unwrap();
     let edge = logo_frame_at(Duration::from_millis(1250), PANEL_SIZE).unwrap();
@@ -210,6 +251,11 @@ fn logo_scales_down_while_preserving_cell_aspect() {
         Some((25, 10))
     );
     assert_eq!(fitted_logo_size(TuiSize::new(100, 40), 4.0), Some((68, 17)));
+    assert_eq!(
+        fitted_logo_size(TuiSize::new(32, 28), BUILT_IN_LOGO_CELL_ASPECT_RATIO),
+        Some((30, 12)),
+        "the layout panel should keep the restored dev animation compact"
+    );
 }
 
 #[test]
@@ -455,7 +501,11 @@ fn settings_model_reloads_only_object_changes() {
 
 #[test]
 fn representative_ascii_shapes_rotate_through_front_side_and_back() {
-    for art in [DIAMOND_ART, ROCKET_ART, WARP_W_ART] {
+    for (name, art) in [
+        ("diamond", DIAMOND_ART),
+        ("rocket", ROCKET_ART),
+        ("Warp W", WARP_W_ART),
+    ] {
         let config = custom_config(art, 4.0, 0.18);
         let face = object_frame_at(Duration::ZERO, PANEL_SIZE, &config).unwrap();
         let edge = object_frame_at(Duration::from_secs(1), PANEL_SIZE, &config).unwrap();
@@ -464,7 +514,8 @@ fn representative_ascii_shapes_rotate_through_front_side_and_back() {
         assert!(logo_cells(&face).len() > 20);
         assert!(
             edge.iter_cells()
-                .any(|(_, _, cell)| cell.surface == LogoSurface::Side)
+                .any(|(_, _, cell)| cell.surface == LogoSurface::Side),
+            "{name} should retain visible side stitches at a quarter turn"
         );
         assert!(
             back.iter_cells()

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -1,4 +1,6 @@
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 
 use uuid::Uuid;
 use warp::tui_export::{
@@ -6,14 +8,21 @@ use warp::tui_export::{
     TuiMcpTransport, register_tui_session_view_test_singletons,
 };
 use warpui::{EntityIdMap, SingletonEntity};
+use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{
-    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext,
-    TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize, text_width,
+    Color, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize, TuiStyle, TuiText, text_width,
 };
 use warpui_core::{App, AppContext};
 
-use super::{LEFT_COLUMN_COLS, build_zero_state_overlay, mcp_status_label};
+use super::{
+    ANIMATION_PANEL_COLS, LEFT_COLUMN_COLS, build_zero_state_layout, build_zero_state_overlay,
+    mcp_status_label,
+};
 use crate::tui_builder::TuiUiBuilder;
+use crate::zero_state_animation::{
+    WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationElement, ZeroStateStarfieldElement,
+};
 
 fn server(id: u64, status: TuiMcpServerStatus) -> TuiMcpServerSnapshot {
     TuiMcpServerSnapshot {
@@ -142,6 +151,125 @@ fn render_element_lines(
     height: u16,
 ) -> Vec<String> {
     render_to_buffer(element, ctx, width, height).to_lines()
+}
+
+#[test]
+fn zero_state_copy_content_rectangle_is_centered_and_opaque_without_covering_margins() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let layout = build_zero_state_layout(
+                TuiText::new("").finish(),
+                TuiText::new("").finish(),
+                TuiText::new("copy here\n\nline").finish(),
+                Color::Red,
+            );
+            let buffer = render_to_buffer(layout, ctx, 80, 9);
+            let lines = buffer.to_lines();
+            assert_eq!(lines[3].trim_end(), "copy here");
+            assert_eq!(lines[5].trim_end(), "line");
+            assert_eq!(buffer[(1, 3)].bg, Color::Red);
+            assert_eq!(buffer[(4, 3)].bg, Color::Red);
+            assert_eq!(buffer[(1, 4)].bg, Color::Red);
+            assert_eq!(buffer[(8, 5)].bg, Color::Red);
+            assert_eq!(buffer[(1, 2)].bg, Color::Reset);
+            assert_eq!(buffer[(1, 6)].bg, Color::Reset);
+            assert_eq!(buffer[(9, 3)].bg, Color::Reset);
+        });
+    });
+}
+#[test]
+fn zero_state_starfield_spans_the_full_width() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let layout = build_zero_state_layout(
+                ZeroStateStarfieldElement::new(
+                    AnimationClock::starting_at(Duration::ZERO),
+                    TuiStyle::default(),
+                    LEFT_COLUMN_COLS,
+                    ANIMATION_PANEL_COLS,
+                )
+                .finish(),
+                TuiText::new("").finish(),
+                TuiText::new("").finish(),
+                Color::Reset,
+            );
+            let buffer = render_to_buffer(layout, ctx, 120, 20);
+            let occupied_columns = buffer
+                .content
+                .iter()
+                .enumerate()
+                .filter_map(|(index, cell)| {
+                    (cell.symbol() != " ").then_some(index % usize::from(buffer.area.width))
+                })
+                .collect::<Vec<_>>();
+
+            assert!(occupied_columns.iter().any(|column| *column < 30));
+            assert!(occupied_columns.iter().any(|column| *column >= 90));
+        });
+    });
+}
+
+#[test]
+fn zero_state_animation_is_centered_in_remaining_space_and_hidden_when_space_is_tight() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let animation = || {
+                let style = TuiStyle::default();
+                ZeroStateAnimationElement::new(
+                    AnimationClock::starting_at(Duration::ZERO),
+                    Arc::new(ZeroStateAnimationConfig::default()),
+                    WarpLogoStyles {
+                        front: style,
+                        back: style,
+                        side: style,
+                        background: style,
+                    },
+                )
+                .without_background_stars()
+                .finish()
+            };
+            let layout = build_zero_state_layout(
+                TuiText::new("").finish(),
+                animation(),
+                TuiText::new("").finish(),
+                Color::Reset,
+            );
+            let wide_width = 120;
+            let wide = render_to_buffer(layout, ctx, wide_width, 20);
+            let occupied = wide
+                .content
+                .iter()
+                .enumerate()
+                .filter_map(|(index, cell)| {
+                    (cell.symbol() != " ").then_some(index % usize::from(wide.area.width))
+                })
+                .collect::<Vec<_>>();
+            let remaining_cols = wide_width - LEFT_COLUMN_COLS;
+            let animation_start = LEFT_COLUMN_COLS + (remaining_cols - ANIMATION_PANEL_COLS) / 2;
+            let animation_end = animation_start + ANIMATION_PANEL_COLS;
+
+            assert!(!occupied.is_empty());
+            assert!(
+                occupied
+                    .iter()
+                    .all(|column| *column >= usize::from(animation_start)
+                        && *column < usize::from(animation_end))
+            );
+
+            let layout = build_zero_state_layout(
+                TuiText::new("").finish(),
+                animation(),
+                TuiText::new("").finish(),
+                Color::Reset,
+            );
+            assert!(
+                render_to_buffer(layout, ctx, 60, 20)
+                    .content
+                    .iter()
+                    .all(|cell| cell.symbol() == " ")
+            );
+        });
+    });
 }
 /// When the terminal is wide enough, the path header must stay on one row and
 /// must not be capped at LEFT_COLUMN_COLS.


### PR DESCRIPTION
## Description
Revamps the Warp Agent CLI zero state to improve readability and visual hierarchy across terminal sizes.

- Vertically centers the project/status copy and gives its measured content rectangle an opaque, theme-matched background so stars do not bleed through it.
- Keeps the Warp logo compact and centered in the space beside the copy, while hiding it when the terminal is too narrow to display both regions safely.
- Renders the radial starfield across the full transcript and aligns its emitter with the responsive logo center.
- Preserves the existing dev animation algorithm (17-row sampling, original side stitching, rotation timing, and z-buffer behavior); the new 32-column layout panel controls the displayed size instead.
- Adds render and animation regressions for responsive placement, opaque copy bounds, full-width stars, emitter alignment, and frame-to-frame occupancy stability.

This follows design feedback that the copy should remain prominent and readable, the logo should be smaller without drifting to the screen edge, and the surrounding animation should continue to fill the zero state.

## Linked Issue
N/A — design follow-up for the TUI zero state.

## Testing
- [x] Manually tested the zero state with `./script/run-tui` at wide and narrow terminal sizes.
- [x] Verified successive live frames near the 66 ms repaint interval.
- [x] `cargo nextest run -p warp_tui -E 'test(zero_state)'` — 44 tests passed.
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- [x] `cargo fmt -p warp_tui`

### Screenshots / Videos
Iteration screenshots and live verification details are available in the [Warp conversation](https://staging.warp.dev/conversation/e7b7be61-6dda-450e-9b86-0764d61f490e).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Improved the Warp Agent CLI zero state with a responsive, readable layout and full-screen animation.

Co-Authored-By: Warp <agent@warp.dev>
