### PR TITLE
Add dogfood-gated factory-mcp skill documenting the Factory MCP server

### DIFF
--- a/resources/channel-gated-skills/dogfood/factory-mcp/SKILL.md
+++ b/resources/channel-gated-skills/dogfood/factory-mcp/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: factory-mcp
+description: Work with software factories via the Warp-hosted Factory MCP server. Use when sending a task or ticket to a factory, listing factories or their tasks, checking factory task status, or handing work back to a factory foreman.
+---
+
+# factory-mcp
+
+Software factories are automated pipelines of named agents — foreman, triage, spec, implement, review, and verify — that take tasks from intake to a verified PR. Warp hosts a Factory MCP server for working with them.
+
+## In Warp clients
+
+Warp auto-attaches the Factory MCP server as a built-in MCP server named `warp-factory`. No configuration is needed. For ANY factory-related work — sending a task to a factory, checking factory or task status, or handing work back — look for `warp-factory` among your available MCP servers and PREFER its tools over ad-hoc REST calls or CLI commands.
+
+## Tools
+
+* `list_factories`: List the software factories visible to you, including each factory's uid and agent roster. Use this first to discover factories and get the factory uid the other tools need.
+* `list_tasks`: List a factory's tasks with their `factory_task_uid`, ticket metadata, current stage, and PR outputs. Use to find a task's uid or survey factory progress.
+* `get_task`: Get one task's status, runs, and outputs. Pass `start_working=true` to add an active-run report plus exact local git next-actions; pass `notify_foreman=true` to send the foreman a heads-up that you're picking up the task.
+* `send_task`: The ONE write path. Sending a new ticket starts a foreman intake run; sending for an existing ticket hands work back by resuming that ticket's foreman conversation. `note` is required. Supports branch and `pr_url` references plus a `stage_hint`. Prefer a plan-first flow: agree on a plan with the user before sending. Warp clients should pass `source_conversation_id` to transfer plan, file, and screenshot artifacts; other MCP clients should use the plan/context text fields instead.
+
+## Non-Warp MCP clients
+
+External MCP clients (Claude Code, Cursor, etc.) can connect to the same server manually:
+
+* Endpoint (streamable HTTP): `{{warp_server_url}}/api/v1/mcp/factory`
+* Auth header: `Authorization: Bearer <WARP_API_KEY>` — generate an API key in Warp settings on the `Platform` page.


### PR DESCRIPTION
## Description
Adds a new bundled skill documenting Warp's Factory MCP server, so agents discover and prefer the built-in `warp-factory` MCP server for factory-related work (motivated by a conversation where an agent never invoked the Factory MCP because the server-level description is the primary discovery surface in grouped MCP context).

The skill covers:
- What software factories are (foreman/triage/spec/implement/review/verify pipelines from intake to a verified PR)
- That Warp clients auto-attach the server as the built-in `warp-factory` MCP server (PR #14416), and that its tools should be PREFERRED over ad-hoc REST/CLI for factory work
- The four tools (`list_factories`, `list_tasks`, `get_task` incl. `start_working`/`notify_foreman`, `send_task` as the one write path with `note` required and `source_conversation_id` for Warp callers)
- Manual connection for non-Warp MCP clients via `{{warp_server_url}}/api/v1/mcp/factory` with `Authorization: Bearer <WARP_API_KEY>`

### Why a standalone dogfood-gated skill instead of editing oz-platform
The Factory MCP is gated by the dogfood-only `FactoryMcp` feature flag, so its docs must not ship to preview/stable. The always-bundled `resources/bundled/skills/oz-platform/SKILL.md` ships on all channels, so it is left untouched.

An overlay (a `channel-gated-skills/dogfood/oz-platform/` dir overriding the bundled skill) was considered and rejected: while the bash build works (bundled resources are staged in `script/prepare_bundled_resources` lines 57-63, gated skills copied after at lines 78-84, and `script/copy_conditional_skills` line 106 merge-copies with `cp -R \"\$skill_dir\"/. \"\$dest\"/`), the Windows script breaks the overlay: `script/windows/prepare_bundled_resources.ps1` line 112 uses `Copy-Item -Destination \$Dest -Recurse -Force`, which nests the source *inside* an already-existing destination directory (producing `oz-platform/oz-platform/SKILL.md` that the skill loader never reads), so Windows dogfood builds would silently keep the stale skill. A standalone `factory-mcp` skill avoids the collision entirely.

## Linked Issue
N/A — follow-up documentation for the Factory MCP built-in server (PR #14416).

## Testing
Documentation-only change (no code). Validated the channel gating locally:
- `./script/copy_conditional_skills dev resources/channel-gated-skills <dest>` copies `factory-mcp` (dogfood gate)
- `./script/copy_conditional_skills preview ...` skips the dogfood gate (factory-mcp excluded)
- `./script/copy_conditional_skills stable ...` copies nothing

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>