### PR TITLE
Render <kbd> tags with inline-code styling in the Markdown parser

### DIFF
--- a/crates/editor/src/render/model/table_offset_map_tests.rs
+++ b/crates/editor/src/render/model/table_offset_map_tests.rs
@@ -259,3 +259,40 @@ fn test_table_cell_offset_map_handles_nested_styles() {
         );
     }
 }
+
+/// `<kbd>` tags exist in source but not in rendered text, so the offset map must skip them the
+/// same way it skips backtick code spans — verified via the issue's motivating test case
+/// (#13733). `<kbd>` is parsed as an inline-code-styled span (not a distinct style), matching
+/// backtick code span handling rather than the `<u>`/nested-style nesting path above.
+#[test]
+fn test_table_cell_offset_map_handles_kbd_markers() {
+    let source = "Press <kbd>Cmd</kbd>+<kbd>K</kbd>";
+    let inline = parse_inline_markdown(source);
+    let rendered_text: String = inline
+        .iter()
+        .map(|fragment| fragment.text.as_str())
+        .collect();
+    assert_eq!(rendered_text, "Press Cmd+K");
+    assert!(
+        inline.iter().any(|fragment| fragment.styles.inline_code),
+        "parsed inline should have an inline_code fragment for the kbd spans"
+    );
+
+    let map = TableCellOffsetMap::from_inline_and_source(source, &inline);
+    assert_eq!(
+        map.source_length(),
+        CharOffset::from(source.chars().count())
+    );
+    assert_eq!(
+        map.rendered_length(),
+        CharOffset::from(rendered_text.chars().count())
+    );
+    for (rendered_idx, rendered_char) in rendered_text.chars().enumerate() {
+        let source_pos = map.rendered_to_source(CharOffset::from(rendered_idx));
+        assert_eq!(
+            source.chars().nth(source_pos.as_usize()),
+            Some(rendered_char),
+            "rendered {rendered_idx} ({rendered_char:?}) should map to same char in source",
+        );
+    }
+}

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1034,6 +1034,12 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
             InlineToken::CodeSpan(text) => {
                 state.push_closed_node(FormattedTextFragment::inline_code(text));
             }
+            InlineToken::KbdSpan(text) => {
+                // Render `<kbd>` keyboard-shortcut tags using the existing inline-code visual
+                // treatment rather than introducing a new style, per maintainer guidance on
+                // https://github.com/warpdotdev/warp/issues/13733.
+                state.push_closed_node(FormattedTextFragment::inline_code(text));
+            }
             InlineToken::Text(text) => {
                 state.push_text(text);
             }
@@ -1564,6 +1570,7 @@ fn parse_inline_token<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     input: &'a str,
 ) -> IResult<&'a str, InlineToken<'a>, E> {
     let code_span = map(parse_code_span, InlineToken::CodeSpan);
+    let kbd_span = map(parse_kbd_span, InlineToken::KbdSpan);
     let backslash_escape = map(parse_escape, InlineToken::BackslashEscape);
     let html_entity = map(parse_html_entity, InlineToken::HtmlEntity);
     let comment = value(InlineToken::Comment, parse_html_comment);
@@ -1587,6 +1594,10 @@ fn parse_inline_token<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
             html_entity,
             // Code spans win over comments, so that `` `<!-- x -->` `` renders literally.
             code_span,
+            // Kbd spans are matched whole (like code spans) before the comment/HTML-ish parsers
+            // so that `<kbd>...</kbd>` is recognized as a unit rather than falling through to
+            // literal text.
+            kbd_span,
             comment,
             parse_inline_token_link_start,
             parse_inline_token_link_end,
@@ -1727,6 +1738,24 @@ fn parse_code_span<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     )(input)
 }
 
+/// Parse an entire `<kbd>…</kbd>` keyboard-shortcut span as a single non-nesting token, the same
+/// way [`parse_code_span`] handles backtick code spans. Tags are matched exact-case, consistent
+/// with the existing `<u>`/`</u>` underline delimiters in this parser. An unterminated `<kbd>`
+/// (no matching `</kbd>`) fails to parse here and falls through to the other token parsers, so it
+/// degrades to literal text.
+fn parse_kbd_span<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
+    input: &'a str,
+) -> IResult<&'a str, &'a str, E> {
+    context(
+        "kbd_span",
+        preceded(
+            tag("<kbd>"),
+            // take_until doesn't consume the end tag, so we do here.
+            terminated(take_until("</kbd>"), tag("</kbd>")),
+        ),
+    )(input)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum InlineToken<'a> {
     /// A run of `count` delimiter characters of `kind`.
@@ -1740,6 +1769,10 @@ enum InlineToken<'a> {
     /// An entire code span. Code spans have higher precedence than all other inline constructs,
     /// so we parse them into discrete tokens.
     CodeSpan(&'a str),
+    /// An entire `<kbd>…</kbd>` keyboard-shortcut span, matched the same way as [`CodeSpan`]:
+    /// as a single non-nesting token rather than a delimiter pair. Rendered using the existing
+    /// inline-code visual treatment (see https://github.com/warpdotdev/warp/issues/13733).
+    KbdSpan(&'a str),
     /// An autolink URL. Owned because backslash escapes are processed (e.g., `\.` → `.`),
     /// so the result may differ from the input slice.
     AutoLink(String),

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -1981,6 +1981,106 @@ fn test_parse_empty_underline() {
     )
 }
 
+/// `<kbd>` keyboard-shortcut tags are recognized in the parser and rendered using the existing
+/// inline-code visual treatment (no new style), per maintainer guidance on
+/// https://github.com/warpdotdev/warp/issues/13733.
+#[test]
+fn test_basic_parse_kbd() {
+    let source = "Press <kbd>Cmd</kbd>";
+    assert_eq!(
+        test_parse_markdown(source),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::plain_text("Press "),
+            FormattedTextFragment::inline_code("Cmd"),
+        ])]
+    );
+}
+
+/// The motivating test case from issue #13733: two adjacent keycaps joined by a literal `+`.
+#[test]
+fn test_parse_kbd_issue_test_case() {
+    let source = "Press <kbd>Cmd</kbd>+<kbd>K</kbd> to open the command palette.";
+    assert_eq!(
+        test_parse_markdown(source),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::plain_text("Press "),
+            FormattedTextFragment::inline_code("Cmd"),
+            FormattedTextFragment::plain_text("+"),
+            FormattedTextFragment::inline_code("K"),
+            FormattedTextFragment::plain_text(" to open the command palette."),
+        ])]
+    );
+}
+
+#[test]
+fn test_mixed_parse_kbd() {
+    let source = "This is ~~test~~ **with** <kbd>text</kbd>";
+    assert_eq!(
+        test_parse_markdown(source),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::plain_text("This is "),
+            FormattedTextFragment::strikethrough("test"),
+            FormattedTextFragment::plain_text(" "),
+            FormattedTextFragment::bold("with"),
+            FormattedTextFragment::plain_text(" "),
+            FormattedTextFragment::inline_code("text"),
+        ])]
+    );
+}
+
+#[test]
+fn test_multi_parse_kbd() {
+    let source = "<kbd>test1</kbd>\n<kbd>test2</kbd>";
+    assert_eq!(
+        test_parse_markdown(source),
+        vec![
+            FormattedTextLine::Line(vec![FormattedTextFragment::inline_code("test1")]),
+            FormattedTextLine::Line(vec![FormattedTextFragment::inline_code("test2")]),
+        ]
+    );
+}
+
+#[test]
+fn test_parse_empty_kbd() {
+    assert_eq!(
+        parse_all("some <kbd></kbd> text", parse_inline),
+        vec![
+            FormattedTextFragment::plain_text("some "),
+            FormattedTextFragment::inline_code(""),
+            FormattedTextFragment::plain_text(" text"),
+        ]
+    );
+}
+
+/// An unmatched `</kbd>` (no opener) degrades to literal text, never a panic.
+#[test]
+fn test_parse_unmatched_kbd_end_is_literal() {
+    assert_eq!(
+        parse_all("no opener </kbd> here", parse_inline),
+        vec![FormattedTextFragment::plain_text("no opener </kbd> here")]
+    );
+}
+
+/// An unterminated `<kbd>` (missing closer) leaves the opening tag as literal text.
+#[test]
+fn test_parse_unterminated_kbd_is_literal() {
+    assert_eq!(
+        parse_all("dangling <kbd>Cmd here", parse_inline),
+        vec![FormattedTextFragment::plain_text("dangling <kbd>Cmd here")]
+    );
+}
+
+/// `<kbd>` does not nest with bold/italic — it is matched as a single atomic token, the same
+/// way backtick code spans are. This mirrors the narrower scope requested by the maintainer:
+/// unlike a delimiter-stack style, this cannot interact with the buffer's style model.
+#[test]
+fn test_parse_kbd_does_not_interpret_nested_markdown() {
+    assert_eq!(
+        parse_all("<kbd>**Cmd**</kbd>", parse_inline),
+        vec![FormattedTextFragment::inline_code("**Cmd**")]
+    );
+}
+
 #[test]
 fn test_unordered_list_indentation_level_relative() {
     // Test that both 2-space and 4-space relative indentation produce the same structure


### PR DESCRIPTION
Closes #13733

Recognizes `<kbd>...</kbd>` keyboard-shortcut tags in the Markdown parser and renders them using the existing inline-code visual treatment, rather than adding a new style marker.

This is a narrower re-scope of my earlier attempt (#13916) per @kevinyang372's feedback there — no changes to the editor buffer model, style markers, serialization, or paste path. `<kbd>` is parsed as a single atomic span the same way backtick code spans already are, and dispatches to the existing `FormattedTextFragment::inline_code`, so both the GUI Markdown viewer and the TUI renderer pick up the styling for free through the shared style field — no per-surface wiring needed.

One tradeoff from going this route: `<kbd>` no longer nests with bold/italic (e.g. `<kbd>**Cmd**</kbd>` renders as literal text rather than bold-in-a-keycap), since avoiding the delimiter-stack machinery was the point. Tags are also matched exact-case, matching this parser's existing `<u>`/`</u>` precedent, rather than case-insensitively.

Testing: `cargo nextest run -p markdown_parser` (156 passed), `-p warp_editor` (486 passed, including a new table-cell offset-map regression test for `<kbd>` spans), `-p warp_tui` (832 passed); `cargo clippy --all-targets --all-features --tests -- -D warnings` clean; `./script/format --check` clean.

CHANGELOG-IMPROVEMENT: Markdown Viewer now renders `<kbd>` keyboard-shortcut tags using inline-code styling instead of literal text.

Screenshot now attached:
<img width="677" height="643" alt="Screenshot of the kbd-html-tag example rendering correctly" src="https://github.com/user-attachments/assets/42f37026-9f5d-453a-b510-71b54c52a15c" />


