### PR TITLE
feat: add the @ context menu to the TUI

### DIFF
--- a/app/src/search/ai_context_menu/commands/search_item.rs
+++ b/app/src/search/ai_context_menu/commands/search_item.rs
@@ -5,7 +5,7 @@ use warpui::{AppContext, Element, SingletonEntity};
 
 use crate::appearance::Appearance;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 
 #[derive(Clone, Debug)]
@@ -82,5 +82,13 @@ impl SearchItem for CommandSearchItem {
 
     fn accessibility_label(&self) -> String {
         format!("Command: {}", self.command)
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        Some(SearchItemDetail {
+            title: self.command.clone(),
+            description: None,
+            title_font_family: None,
+        })
     }
 }

--- a/app/src/search/ai_context_menu/conversations/search_item.rs
+++ b/app/src/search/ai_context_menu/conversations/search_item.rs
@@ -10,7 +10,7 @@ use super::ConversationContextItem;
 use crate::appearance::Appearance;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::ai_context_menu::styles;
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 use crate::util::time_format::format_approx_duration_from_now_utc;
 use crate::util::truncation::truncate_from_end;
@@ -121,6 +121,14 @@ impl SearchItem for ConversationSearchItem {
 
     fn execute_result(&self) -> Self::Action {
         self.accept_result()
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        Some(SearchItemDetail {
+            title: self.item.title.clone(),
+            description: None,
+            title_font_family: None,
+        })
     }
 
     fn accessibility_label(&self) -> String {

--- a/app/src/search/ai_context_menu/core.rs
+++ b/app/src/search/ai_context_menu/core.rs
@@ -105,6 +105,10 @@ pub struct AtContextMenuGates {
     /// Whether the surface is a CLI agent rich input, which only understands
     /// files, folders, and code symbols.
     pub is_cli_agent_input: bool,
+    /// Whether the surface can resolve terminal block references.
+    pub supports_blocks: bool,
+    /// Whether the surface has code outlines to search.
+    pub supports_code_symbols: bool,
 }
 
 impl Default for AtContextMenuGates {
@@ -114,6 +118,8 @@ impl Default for AtContextMenuGates {
             is_shared_session_viewer: false,
             is_in_ambient_agent: false,
             is_cli_agent_input: false,
+            supports_blocks: true,
+            supports_code_symbols: true,
         }
     }
 }
@@ -214,6 +220,8 @@ impl AtContextMenuCoreState {
             is_shared_session_viewer,
             is_in_ambient_agent,
             is_cli_agent_input,
+            supports_blocks,
+            supports_code_symbols,
         } = self.gates;
 
         // For CLI agent input, use a positive allowlist of categories that CLI agents
@@ -224,7 +232,7 @@ impl AtContextMenuCoreState {
             if !is_shared_session_viewer {
                 categories.push(self.files_category(is_active_dir_in_git_repo));
             }
-            if self.is_code_category_enabled(is_active_dir_in_git_repo, app)
+            if self.is_code_category_enabled(supports_code_symbols, is_active_dir_in_git_repo, app)
                 && !is_shared_session_viewer
             {
                 categories.push(AIContextMenuCategory::Code);
@@ -257,8 +265,10 @@ impl AtContextMenuCoreState {
             if FeatureFlag::AIContextMenuCommands.is_enabled() {
                 categories.push(AIContextMenuCategory::Commands);
             }
-            categories.push(AIContextMenuCategory::Blocks);
-            if self.is_code_category_enabled(is_active_dir_in_git_repo, app)
+            if supports_blocks {
+                categories.push(AIContextMenuCategory::Blocks);
+            }
+            if self.is_code_category_enabled(supports_code_symbols, is_active_dir_in_git_repo, app)
                 && !is_shared_session_viewer
             {
                 categories.push(AIContextMenuCategory::Code);
@@ -287,7 +297,8 @@ impl AtContextMenuCoreState {
             let mut categories = vec![self.files_category(is_active_dir_in_git_repo)];
 
             // Also show Code category in terminal mode when enabled
-            if self.is_code_category_enabled(is_active_dir_in_git_repo, app) {
+            if self.is_code_category_enabled(supports_code_symbols, is_active_dir_in_git_repo, app)
+            {
                 categories.push(AIContextMenuCategory::Code);
             }
 
@@ -306,8 +317,14 @@ impl AtContextMenuCoreState {
         }
     }
 
-    fn is_code_category_enabled(&self, is_active_dir_in_git_repo: bool, app: &AppContext) -> bool {
-        FeatureFlag::AIContextMenuCode.is_enabled()
+    fn is_code_category_enabled(
+        &self,
+        supports_code_symbols: bool,
+        is_active_dir_in_git_repo: bool,
+        app: &AppContext,
+    ) -> bool {
+        supports_code_symbols
+            && FeatureFlag::AIContextMenuCode.is_enabled()
             && *InputSettings::as_ref(app)
                 .outline_codebase_symbols_for_at_context_menu
                 .value()
@@ -333,7 +350,16 @@ impl AtContextMenuCoreState {
     /// The subset of [`Self::available_categories`] whose names match the
     /// main-menu filter query.
     pub fn filtered_categories(&self, app: &AppContext) -> Vec<AIContextMenuCategory> {
-        let categories = self.available_categories(app);
+        self.filtered_categories_from(self.available_categories(app))
+    }
+
+    /// Filters a caller-supplied category set with the current main-menu query.
+    /// Surfaces use this after discovering which potentially available
+    /// categories actually have entries.
+    pub fn filtered_categories_from(
+        &self,
+        categories: Vec<AIContextMenuCategory>,
+    ) -> Vec<AIContextMenuCategory> {
         if self.main_menu_query.is_empty() {
             return categories;
         }
@@ -374,6 +400,14 @@ impl AtContextMenuCoreState {
     pub fn clear_category_filter(&mut self) {
         self.main_menu_query = String::new();
         self.selected_category_index = 0;
+    }
+
+    /// Starts a fresh category-list session. Surfaces that discover source
+    /// availability dynamically use this even when only one potential category
+    /// exists, because that source may still be empty.
+    pub fn reset_to_main_menu(&mut self) {
+        self.navigation_state = NavigationState::MainMenu;
+        self.clear_category_filter();
     }
 
     /// Moves the category selection down the filtered list, wrapping at the end.
@@ -419,13 +453,23 @@ impl AtContextMenuCoreState {
     /// nothing matches, the menu falls through to searching every available
     /// category instead of showing an empty list.
     pub fn set_query(&mut self, query: &str, app: &AppContext) -> AtContextMenuQueryTransition {
+        self.set_query_for_categories(query, self.available_categories(app))
+    }
+
+    /// Applies a query against a caller-supplied set of categories, falling
+    /// through to all-category result search only when none of those names
+    /// match.
+    pub fn set_query_for_categories(
+        &mut self,
+        query: &str,
+        categories: Vec<AIContextMenuCategory>,
+    ) -> AtContextMenuQueryTransition {
         if self.navigation_state != NavigationState::MainMenu {
             return AtContextMenuQueryTransition::SourcesUnchanged;
         }
 
         self.main_menu_query = query.to_owned();
-
-        let filtered_count = self.filtered_categories(app).len();
+        let filtered_count = self.filtered_categories_from(categories).len();
         if self.selected_category_index >= filtered_count {
             self.selected_category_index = 0;
         }

--- a/app/src/search/ai_context_menu/diffset/search_item.rs
+++ b/app/src/search/ai_context_menu/diffset/search_item.rs
@@ -9,7 +9,7 @@ use crate::appearance::Appearance;
 use crate::code_review::diff_state::DiffMode;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::ai_context_menu::styles;
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 
 #[derive(Debug, Clone)]
@@ -109,6 +109,14 @@ impl SearchItem for DiffSetSearchItem {
 
     fn execute_result(&self) -> Self::Action {
         self.accept_result()
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        Some(SearchItemDetail {
+            title: self.name(),
+            description: Some(self.description()),
+            title_font_family: None,
+        })
     }
 
     fn accessibility_label(&self) -> String {

--- a/app/src/search/ai_context_menu/files/search_item.rs
+++ b/app/src/search/ai_context_menu/files/search_item.rs
@@ -10,7 +10,7 @@ use crate::appearance::Appearance;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::ai_context_menu::styles;
 use crate::search::files::icon::icon_from_file_path;
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 use crate::ui_components::render_file_search_row::{FileSearchRowOptions, render_file_search_row};
 
@@ -75,6 +75,16 @@ impl SearchItem for FileSearchItem {
 
     fn execute_result(&self) -> Self::Action {
         self.accept_result()
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        // The path is the whole content of a file row, so there is nothing to
+        // put in a secondary line.
+        Some(SearchItemDetail {
+            title: self.path.to_string_lossy().to_string(),
+            description: None,
+            title_font_family: None,
+        })
     }
 
     fn accessibility_label(&self) -> String {

--- a/app/src/search/ai_context_menu/mixer.rs
+++ b/app/src/search/ai_context_menu/mixer.rs
@@ -220,3 +220,40 @@ pub enum AIContextMenuSearchableAction {
         name: String,
     },
 }
+
+impl AIContextMenuSearchableAction {
+    /// Category that produced this action, for surfaces that discover category
+    /// availability from a combined zero-state query.
+    ///
+    /// File actions need the caller's current file category because repo and
+    /// current-folder files intentionally share one action shape.
+    pub fn category(&self, file_category: AIContextMenuCategory) -> Option<AIContextMenuCategory> {
+        match self {
+            AIContextMenuSearchableAction::InsertFilePath { .. } => Some(file_category),
+            // Blocks also use InsertText, but a surface that supports Blocks
+            // should not infer availability this way because the action cannot
+            // distinguish them from Commands.
+            AIContextMenuSearchableAction::InsertText { .. } => {
+                Some(AIContextMenuCategory::Commands)
+            }
+            AIContextMenuSearchableAction::InsertDriveObject { object_type, .. } => {
+                match object_type {
+                    ObjectType::Workflow => Some(AIContextMenuCategory::Workflows),
+                    ObjectType::Notebook => Some(AIContextMenuCategory::Notebooks),
+                    ObjectType::GenericStringObject(_) => Some(AIContextMenuCategory::Rules),
+                    ObjectType::Folder => None,
+                }
+            }
+            AIContextMenuSearchableAction::InsertPlan { .. } => Some(AIContextMenuCategory::Plans),
+            AIContextMenuSearchableAction::InsertDiffSet { .. } => {
+                Some(AIContextMenuCategory::DiffSet)
+            }
+            AIContextMenuSearchableAction::InsertConversation { .. } => {
+                Some(AIContextMenuCategory::Conversations)
+            }
+            AIContextMenuSearchableAction::InsertSkill { .. } => {
+                Some(AIContextMenuCategory::Skills)
+            }
+        }
+    }
+}

--- a/app/src/search/ai_context_menu/notebooks/search_item.rs
+++ b/app/src/search/ai_context_menu/notebooks/search_item.rs
@@ -12,7 +12,7 @@ use crate::appearance::Appearance;
 use crate::cloud_object::ObjectType;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::ai_context_menu::{safe_truncate, styles};
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 
 const MAX_COMBINED_LENGTH: usize = 55;
@@ -185,6 +185,14 @@ impl SearchItem for NotebookSearchItem {
 
     fn execute_result(&self) -> Self::Action {
         self.accept_result()
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        Some(SearchItemDetail {
+            title: self.notebook_name.clone(),
+            description: self.notebook_description.clone(),
+            title_font_family: None,
+        })
     }
 
     fn accessibility_label(&self) -> String {

--- a/app/src/search/ai_context_menu/rules/search_item.rs
+++ b/app/src/search/ai_context_menu/rules/search_item.rs
@@ -12,7 +12,7 @@ use crate::appearance::Appearance;
 use crate::cloud_object::{GenericStringObjectFormat, JsonObjectType, ObjectType};
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::ai_context_menu::{safe_truncate, styles};
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 
 const MAX_COMBINED_LENGTH: usize = 55;
@@ -223,6 +223,22 @@ impl SearchItem for RuleSearchItem {
 
     fn execute_result(&self) -> Self::Action {
         self.accept_result()
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        // Unnamed rules lead with their content, since that is all they have.
+        match &self.rule_name {
+            Some(rule_name) => Some(SearchItemDetail {
+                title: rule_name.clone(),
+                description: Some(self.rule_content.clone()),
+                title_font_family: None,
+            }),
+            None => Some(SearchItemDetail {
+                title: self.rule_content.clone(),
+                description: None,
+                title_font_family: None,
+            }),
+        }
     }
 
     fn accessibility_label(&self) -> String {

--- a/app/src/search/ai_context_menu/skills/search_item.rs
+++ b/app/src/search/ai_context_menu/skills/search_item.rs
@@ -11,7 +11,7 @@ use warpui::{AppContext, Element, SingletonEntity};
 use crate::appearance::Appearance;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::ai_context_menu::styles;
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 
 const MAX_DESCRIPTION_LEN: usize = 60;
@@ -126,6 +126,15 @@ impl SearchItem for SkillSearchItem {
 
     fn execute_result(&self) -> Self::Action {
         self.accept_result()
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        // Titled with the text acceptance inserts, matching the `/` skills menu.
+        Some(SearchItemDetail {
+            title: format!("/{}", self.name),
+            description: (!self.description.is_empty()).then(|| self.description.clone()),
+            title_font_family: None,
+        })
     }
 
     fn accessibility_label(&self) -> String {

--- a/app/src/search/ai_context_menu/workflows/search_item.rs
+++ b/app/src/search/ai_context_menu/workflows/search_item.rs
@@ -12,7 +12,7 @@ use crate::appearance::Appearance;
 use crate::cloud_object::ObjectType;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::ai_context_menu::{safe_truncate, styles};
-use crate::search::item::SearchItem;
+use crate::search::item::{SearchItem, SearchItemDetail};
 use crate::search::result_renderer::ItemHighlightState;
 
 const MAX_COMBINED_LENGTH: usize = 55;
@@ -175,6 +175,14 @@ impl SearchItem for WorkflowSearchItem {
 
     fn execute_result(&self) -> Self::Action {
         self.accept_result()
+    }
+
+    fn detail_data(&self) -> Option<SearchItemDetail> {
+        Some(SearchItemDetail {
+            title: self.workflow_name.clone(),
+            description: self.workflow_description.clone(),
+            title_font_family: None,
+        })
     }
 
     fn accessibility_label(&self) -> String {

--- a/app/src/terminal/input/slash_commands/cloud_mode_v2_view.rs
+++ b/app/src/terminal/input/slash_commands/cloud_mode_v2_view.rs
@@ -77,7 +77,10 @@ fn item_is_truncated_in_row(detail: &SearchItemDetail, app: &AppContext) -> bool
     let appearance = Appearance::as_ref(app);
     let font_size = inline_styles::font_size(appearance);
     let font_cache = app.font_cache();
-    let name_em = font_cache.em_width(detail.title_font_family, font_size);
+    let title_font_family = detail
+        .title_font_family
+        .unwrap_or_else(|| appearance.ui_font_family());
+    let name_em = font_cache.em_width(title_font_family, font_size);
     let name_px = name_em * detail.title.chars().count() as f32;
     let row_chrome_px = MENU_HORIZONTAL_PADDING * 2. + ICON_SIZE + inline_styles::ICON_MARGIN;
     let available = MENU_WIDTH - row_chrome_px;
@@ -972,7 +975,9 @@ impl CloudModeV2SlashCommandView {
 
         let title = Text::new_inline(
             detail.title.clone(),
-            detail.title_font_family,
+            detail
+                .title_font_family
+                .unwrap_or_else(|| appearance.ui_font_family()),
             inline_styles::font_size(appearance),
         )
         .with_color(primary.into())

--- a/app/src/terminal/input/slash_commands/search_item.rs
+++ b/app/src/terminal/input/slash_commands/search_item.rs
@@ -184,7 +184,7 @@ impl SearchItem for InlineItem {
         Some(SearchItemDetail {
             title: self.name.clone(),
             description: self.description.clone(),
-            title_font_family: self.font_family,
+            title_font_family: Some(self.font_family),
         })
     }
 }

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -42,6 +42,8 @@ pub use crate::ai::agent::{
     StartAgentExecutionMode, StopRecordingResult, SuggestNewConversationResult, SummarizationType,
     TodoOperation, UserQueryMode,
 };
+#[cfg(feature = "local_fs")]
+pub use crate::ai::agent::{CurrentHead, DiffBase};
 pub use crate::ai::agent_conversations_model::{
     AgentConversationEntry, AgentConversationEntryId, AgentConversationListEntryState,
     AgentConversationListPolicy, AgentConversationsModel, AgentConversationsModelEvent,
@@ -164,14 +166,35 @@ pub use crate::changelog_model::{
     ChangelogModel, ChangelogRequestType, ChangelogState, Event as ChangelogModelEvent,
 };
 pub use crate::code::DiffResult;
+#[cfg(feature = "local_fs")]
+pub use crate::code_review::DiffSetScope;
+#[cfg(feature = "local_fs")]
+pub use crate::code_review::context::{
+    convert_file_diffs_to_diffset_hunks, create_attachment_reference_and_key,
+    register_diffset_attachment,
+};
+pub use crate::code_review::diff_state::DiffMode;
+#[cfg(feature = "local_fs")]
+pub use crate::code_review::diff_state::LocalDiffStateModel;
 pub use crate::code_review::git_repo_model::{
     GitRepoModels, GitRepoStatusModel, GitStatusMetadata,
 };
 pub use crate::code_review::github_repo_model::GitHubRepoModel;
 pub use crate::completer::SessionContext;
+pub use crate::drive::settings::WarpDriveSettings;
 pub use crate::global_resource_handles::GlobalResourceHandlesProvider;
 pub use crate::persistence::PersistenceWriter;
 pub use crate::prefix::longest_common_prefix;
+pub use crate::search::ai_context_menu::mixer::{
+    AIContextMenuMixer, AIContextMenuSearchableAction, AtContextMenuSourceContext,
+    at_context_menu_query, install_sources_for_all_categories, install_sources_for_category,
+};
+pub use crate::search::ai_context_menu::search::is_valid_search_query as is_valid_at_menu_query;
+pub use crate::search::ai_context_menu::{
+    AIContextMenuCategory, AtContextMenuCoreState, AtContextMenuGates,
+    AtContextMenuQueryTransition, NavigationState, is_at_menu_trigger, shared_inserted_text,
+    should_close_at_menu,
+};
 pub use crate::search::slash_command_menu::static_commands::commands::{
     self as slash_commands, COMMAND_REGISTRY,
 };

--- a/app/src/tui_test_support.rs
+++ b/app/src/tui_test_support.rs
@@ -36,8 +36,10 @@ use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::code_review::git_repo_model::GitRepoModels;
+use crate::drive::settings::WarpDriveSettings;
 use crate::network::NetworkStatus;
 use crate::persistence::PersistenceWriter;
+use crate::search::files::model::FileSearchModel;
 use crate::server::server_api::ServerApiProvider;
 use crate::server::sync_queue::SyncQueue;
 #[cfg(feature = "voice_input")]
@@ -234,6 +236,7 @@ pub fn register_tui_session_view_test_singletons(app: &mut warpui::App) {
     });
     app.update(AISettings::register_and_subscribe_to_events);
     app.update(TuiVoiceSettings::register);
+    WarpDriveSettings::register(app);
     CloudAgentSettings::register(app);
     app.add_singleton_model(ApiKeyManager::new);
 
@@ -321,6 +324,7 @@ pub fn register_tui_session_view_test_singletons(app: &mut warpui::App) {
     app.add_singleton_model(repo_metadata::watcher::DirectoryWatcher::new);
     #[cfg(feature = "local_fs")]
     app.add_singleton_model(repo_metadata::RepoMetadataModel::new);
+    app.add_singleton_model(FileSearchModel::new);
     app.add_singleton_model(
         crate::warp_managed_paths_watcher::WarpManagedPathsWatcher::new_for_testing,
     );

--- a/crates/warp_search_core/src/item.rs
+++ b/crates/warp_search_core/src/item.rs
@@ -10,7 +10,10 @@ use super::result_renderer::ItemHighlightState;
 pub struct SearchItemDetail {
     pub title: String,
     pub description: Option<String>,
-    pub title_font_family: FamilyId,
+    /// Font the title is rendered in, for pixel-rendering front-ends that need
+    /// to measure it. `None` when the item has no font opinion, which is every
+    /// item whose only consumer is a cell-grid front-end.
+    pub title_font_family: Option<FamilyId>,
 }
 
 /// Location where icon should be rendered relative to the [`SearchItem`].

--- a/crates/warp_tui/src/at_context_menu.rs
+++ b/crates/warp_tui/src/at_context_menu.rs
@@ -1,0 +1,742 @@
+//! Searchable `@` context menu state for the TUI input.
+
+use std::ops::Range;
+
+use string_offset::CharOffset;
+use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
+use warp::search::mixer::SearchMixerEvent;
+use warp::settings::InputSettings;
+use warp::tui_export::{
+    AIContextMenuCategory, AIContextMenuMixer, AIContextMenuSearchableAction, ActiveSession,
+    ActiveSessionEvent, AtContextMenuCoreState, AtContextMenuGates, AtContextMenuQueryTransition,
+    AtContextMenuSourceContext, BlocklistAIInputModel, NavigationState, at_context_menu_query,
+    install_sources_for_all_categories, install_sources_for_category, is_at_menu_trigger,
+    is_valid_at_menu_query, should_close_at_menu,
+};
+use warp_core::features::FeatureFlag;
+use warp_core::settings::Setting as _;
+use warp_editor::model::CoreEditorModel;
+use warp_search_core::inline_menu::InlineMenuResultsUpdate;
+use warpui::SingletonEntity as _;
+use warpui_core::text::{byte_offset_for_char_offset, char_slice};
+use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
+
+use crate::inline_menu::{
+    MAX_INLINE_MENU_ROWS, TuiInlineMenuAccepted, TuiInlineMenuHandle, TuiInlineMenuHeader,
+    TuiInlineMenuListState, TuiInlineMenuRow, TuiInlineMenuRowStyle, TuiInlineMenuSnapshot,
+    TuiInlineMenuStatus, result_row_capacity,
+};
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
+
+const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
+
+#[derive(Debug, Clone)]
+enum TuiAtContextMenuRow {
+    Category(AIContextMenuCategory),
+    Result {
+        title: String,
+        description: Option<String>,
+        action: AIContextMenuSearchableAction,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+enum TuiAtContextMenuState {
+    #[default]
+    Closed,
+    Open {
+        /// Zero-based character offset of the `@` in the editor buffer.
+        at_symbol_position: usize,
+        query: String,
+        list: TuiInlineMenuListState<TuiAtContextMenuRow>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TuiAtContextMenuAcceptance {
+    pub(crate) action: AIContextMenuSearchableAction,
+    /// Byte range covering the `@` and the filter text it replaces.
+    pub(crate) replacement_range: Range<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TuiAtContextMenuEvent;
+
+pub(crate) struct TuiAtContextMenuModel {
+    input_editor: ModelHandle<CodeEditorModel>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+    active_session: ModelHandle<ActiveSession>,
+    input_mode: ModelHandle<BlocklistAIInputModel>,
+    mixer: ModelHandle<AIContextMenuMixer>,
+    core: AtContextMenuCoreState,
+    state: TuiAtContextMenuState,
+    /// Potential categories whose zero-state sources returned at least one
+    /// result, kept in the core's display order. `None` while discovery loads.
+    discovered_categories: Option<Vec<AIContextMenuCategory>>,
+    /// An Escape-dismissed trigger must not reopen just because the cursor moves
+    /// away and back. Deleting it or typing a different `@` clears the block.
+    dismissed_at_symbol_position: Option<usize>,
+}
+
+impl TuiAtContextMenuModel {
+    pub(crate) fn new(
+        input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+        active_session: ModelHandle<ActiveSession>,
+        input_mode: ModelHandle<BlocklistAIInputModel>,
+        mixer: ModelHandle<AIContextMenuMixer>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        ctx.subscribe_to_model(&input_editor, |model, _, event, ctx| {
+            if matches!(
+                event,
+                CodeEditorModelEvent::ContentChanged { .. }
+                    | CodeEditorModelEvent::SelectionChanged
+            ) {
+                model.update_from_input(ctx);
+            }
+        });
+        ctx.subscribe_to_model(&active_session, |model, _, event, ctx| {
+            if matches!(
+                event,
+                ActiveSessionEvent::UpdatedPwd | ActiveSessionEvent::Bootstrapped
+            ) {
+                model.update_working_directory(ctx);
+            }
+        });
+        ctx.subscribe_to_model(&mixer, |model, _, event, ctx| {
+            if matches!(event, SearchMixerEvent::ResultsChanged) {
+                model.refresh_result_rows(ctx);
+            }
+        });
+
+        let core = AtContextMenuCoreState::new(AtContextMenuGates {
+            supports_blocks: false,
+            supports_code_symbols: false,
+            ..Default::default()
+        });
+        let mut model = Self {
+            input_editor,
+            suggestions_mode,
+            active_session,
+            input_mode,
+            mixer,
+            core,
+            state: TuiAtContextMenuState::Closed,
+            discovered_categories: None,
+            dismissed_at_symbol_position: None,
+        };
+        model.update_working_directory(ctx);
+        model
+    }
+
+    fn has_open_state(&self) -> bool {
+        matches!(self.state, TuiAtContextMenuState::Open { .. })
+    }
+
+    pub(crate) fn is_open(&self, app: &AppContext) -> bool {
+        self.has_open_state()
+            && self.suggestions_mode.as_ref(app).mode() == TuiInputSuggestionsMode::AtContextMenu
+    }
+
+    pub(crate) fn at_symbol_position(&self) -> Option<usize> {
+        match self.state {
+            TuiAtContextMenuState::Closed => None,
+            TuiAtContextMenuState::Open {
+                at_symbol_position, ..
+            } => Some(at_symbol_position),
+        }
+    }
+
+    fn refresh_discovered_categories(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.mixer.as_ref(ctx).is_loading() {
+            return;
+        }
+        let potential_categories = self.core.available_categories(ctx);
+        let file_category = potential_categories
+            .iter()
+            .copied()
+            .find(|category| {
+                matches!(
+                    category,
+                    AIContextMenuCategory::CurrentFolderFiles | AIContextMenuCategory::RepoFiles
+                )
+            })
+            .unwrap_or(AIContextMenuCategory::CurrentFolderFiles);
+        let result_categories: Vec<_> = self
+            .mixer
+            .as_ref(ctx)
+            .results()
+            .iter()
+            .filter_map(|result| result.accept_result().category(file_category))
+            .collect();
+        let discovered_categories: Vec<_> = potential_categories
+            .into_iter()
+            .filter(|category| {
+                matches!(
+                    category,
+                    AIContextMenuCategory::CurrentFolderFiles | AIContextMenuCategory::RepoFiles
+                ) || result_categories.contains(category)
+            })
+            .collect();
+        self.discovered_categories = Some(discovered_categories.clone());
+
+        let query = match &self.state {
+            TuiAtContextMenuState::Closed => return,
+            TuiAtContextMenuState::Open { query, .. } => query.clone(),
+        };
+        if query.is_empty() {
+            self.refresh_category_rows(ctx);
+        } else {
+            match self
+                .core
+                .set_query_for_categories(&query, discovered_categories)
+            {
+                AtContextMenuQueryTransition::EnteredAllCategories => {
+                    self.setup_all_categories(&query, ctx);
+                }
+                AtContextMenuQueryTransition::SourcesUnchanged => {
+                    self.refresh_category_rows(ctx);
+                }
+            }
+        }
+        ctx.emit(TuiAtContextMenuEvent);
+    }
+
+    fn input_snapshot(&self, app: &AppContext) -> Option<(String, usize)> {
+        let editor = self.input_editor.as_ref(app);
+        if !editor.selection_is_single_cursor(app) {
+            return None;
+        }
+        let content = editor.content().as_ref(app);
+        let text = if content.is_empty() {
+            String::new()
+        } else {
+            content.text().into_string()
+        };
+        let cursor = editor
+            .buffer_selection_model()
+            .as_ref(app)
+            .first_selection_head()
+            .as_usize()
+            .saturating_sub(1);
+        Some((text, cursor))
+    }
+
+    fn update_working_directory(&mut self, ctx: &mut ModelContext<Self>) {
+        let working_directory = self
+            .active_session
+            .as_ref(ctx)
+            .current_working_directory_location(ctx);
+        if !self.core.set_working_directory(working_directory) || !self.is_open(ctx) {
+            return;
+        }
+        self.core.refresh_categories(ctx);
+        self.core.reset_to_main_menu();
+        self.discovered_categories = None;
+        self.setup_navigation_state("", ctx);
+        ctx.emit(TuiAtContextMenuEvent);
+    }
+
+    fn update_gates(&mut self, app: &AppContext) -> bool {
+        let input_mode = self.input_mode.as_ref(app);
+        let is_ai_or_autodetect_mode =
+            input_mode.input_type().is_ai() || !input_mode.is_input_type_locked();
+        self.core.set_gates(AtContextMenuGates {
+            is_ai_or_autodetect_mode,
+            supports_blocks: false,
+            supports_code_symbols: false,
+            ..Default::default()
+        })
+    }
+
+    fn may_open(&mut self, app: &AppContext) -> bool {
+        if !FeatureFlag::AIContextMenuEnabled.is_enabled() {
+            return false;
+        }
+        self.update_gates(app);
+        let gates = self.core.gates();
+        gates.is_ai_or_autodetect_mode
+            || (FeatureFlag::AtMenuOutsideOfAIMode.is_enabled()
+                && *InputSettings::as_ref(app)
+                    .at_context_menu_in_terminal_mode
+                    .value())
+    }
+
+    fn update_from_input(&mut self, ctx: &mut ModelContext<Self>) {
+        let Some((text, cursor)) = self.input_snapshot(ctx) else {
+            self.close(ctx);
+            return;
+        };
+
+        if !self.has_open_state() {
+            if let Some(dismissed_position) = self.dismissed_at_symbol_position {
+                if text.chars().nth(dismissed_position) == Some('@') {
+                    if cursor.saturating_sub(1) == dismissed_position {
+                        return;
+                    }
+                } else {
+                    self.dismissed_at_symbol_position = None;
+                }
+            }
+            if self.suggestions_mode.as_ref(ctx).mode() != TuiInputSuggestionsMode::Closed
+                || !is_at_menu_trigger(&text, cursor)
+                || !self.may_open(ctx)
+            {
+                return;
+            }
+            self.open(cursor.saturating_sub(1), ctx);
+            return;
+        }
+
+        if !self.is_open(ctx) {
+            self.state = TuiAtContextMenuState::Closed;
+            return;
+        }
+
+        let TuiAtContextMenuState::Open {
+            at_symbol_position,
+            query: previous_query,
+            ..
+        } = &self.state
+        else {
+            return;
+        };
+        let at_symbol_position = *at_symbol_position;
+        let previous_query = previous_query.clone();
+
+        if should_close_at_menu(&text, cursor, at_symbol_position)
+            || text.chars().nth(at_symbol_position) != Some('@')
+        {
+            self.close(ctx);
+            return;
+        }
+        let Some(query) = char_slice(&text, at_symbol_position + 1, cursor).map(str::to_owned)
+        else {
+            self.close(ctx);
+            return;
+        };
+        if !is_valid_at_menu_query(false, &previous_query, &query) {
+            self.close(ctx);
+            return;
+        }
+
+        let visible_results_are_empty = match &self.state {
+            TuiAtContextMenuState::Closed => true,
+            TuiAtContextMenuState::Open { list, .. } => list.rows().is_empty(),
+        };
+        let should_close = self.core.record_results_update(
+            visible_results_are_empty,
+            self.mixer.as_ref(ctx).is_loading(),
+            query.contains(&previous_query),
+        );
+        if should_close {
+            self.close(ctx);
+            return;
+        }
+
+        if let TuiAtContextMenuState::Open {
+            query: current_query,
+            ..
+        } = &mut self.state
+        {
+            *current_query = query.clone();
+        }
+
+        if self.core.navigation_state() == NavigationState::MainMenu
+            && self.discovered_categories.is_none()
+        {
+            // Discovery is still loading. Store the query now; the final
+            // discovery result applies it to the non-empty category set.
+            ctx.emit(TuiAtContextMenuEvent);
+            return;
+        }
+
+        let query_transition = if self.core.navigation_state() == NavigationState::MainMenu {
+            self.core.set_query_for_categories(
+                &query,
+                self.discovered_categories.clone().unwrap_or_default(),
+            )
+        } else {
+            self.core.set_query(&query, ctx)
+        };
+        match query_transition {
+            AtContextMenuQueryTransition::EnteredAllCategories => {
+                self.setup_all_categories(&query, ctx);
+            }
+            AtContextMenuQueryTransition::SourcesUnchanged => {
+                if self.core.navigation_state() == NavigationState::MainMenu {
+                    self.refresh_category_rows(ctx);
+                } else {
+                    self.run_query(&query, ctx);
+                }
+            }
+        }
+        ctx.emit(TuiAtContextMenuEvent);
+    }
+
+    fn open(&mut self, at_symbol_position: usize, ctx: &mut ModelContext<Self>) {
+        let did_open = self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::AtContextMenu, ctx)
+        });
+        if !did_open {
+            return;
+        }
+
+        self.update_gates(ctx);
+        self.core.refresh_categories(ctx);
+        self.core.reset_to_main_menu();
+        self.discovered_categories = None;
+        self.state = TuiAtContextMenuState::Open {
+            at_symbol_position,
+            query: String::new(),
+            list: TuiInlineMenuListState::default(),
+        };
+        self.setup_navigation_state("", ctx);
+        ctx.emit(TuiAtContextMenuEvent);
+    }
+
+    fn setup_navigation_state(&mut self, query: &str, ctx: &mut ModelContext<Self>) {
+        match self.core.navigation_state() {
+            NavigationState::MainMenu => self.setup_category_discovery(ctx),
+            NavigationState::Category(category) => self.setup_category(category, query, ctx),
+            NavigationState::AllCategories => self.setup_all_categories(query, ctx),
+        }
+    }
+
+    /// Runs every potentially available category's zero state through one
+    /// mixer. Once all sources settle, result actions tell us which categories
+    /// actually contain entries.
+    fn setup_category_discovery(&mut self, ctx: &mut ModelContext<Self>) {
+        let categories = self.core.available_categories(ctx);
+        let source_context = self.source_context();
+        self.discovered_categories = None;
+        if let TuiAtContextMenuState::Open { list, .. } = &mut self.state {
+            list.replace_rows(Vec::new(), true, None, MAX_VISIBLE_ROWS, |_| true);
+        }
+        self.mixer.update(ctx, |mixer, ctx| {
+            mixer.reset(ctx);
+            install_sources_for_all_categories(mixer, &categories, &source_context, ctx);
+            mixer.run_query(at_context_menu_query(""), ctx);
+        });
+        self.refresh_result_rows(ctx);
+    }
+
+    fn source_context(&self) -> AtContextMenuSourceContext {
+        AtContextMenuSourceContext {
+            code_symbol_cache: None,
+            working_directory: self.core.working_directory().cloned(),
+        }
+    }
+
+    fn setup_category(
+        &mut self,
+        category: AIContextMenuCategory,
+        query: &str,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let source_context = self.source_context();
+        let query = query.to_owned();
+        self.mixer.update(ctx, |mixer, ctx| {
+            mixer.reset(ctx);
+            install_sources_for_category(mixer, category, &source_context, ctx);
+            mixer.run_query(at_context_menu_query(&query), ctx);
+        });
+        self.refresh_result_rows(ctx);
+    }
+
+    fn setup_all_categories(&mut self, query: &str, ctx: &mut ModelContext<Self>) {
+        let categories = self
+            .discovered_categories
+            .clone()
+            .unwrap_or_else(|| self.core.available_categories(ctx));
+        let source_context = self.source_context();
+        let query = query.to_owned();
+        self.mixer.update(ctx, |mixer, ctx| {
+            mixer.reset(ctx);
+            install_sources_for_all_categories(mixer, &categories, &source_context, ctx);
+            mixer.run_query(at_context_menu_query(&query), ctx);
+        });
+        self.refresh_result_rows(ctx);
+    }
+
+    fn run_query(&mut self, query: &str, ctx: &mut ModelContext<Self>) {
+        self.mixer.update(ctx, |mixer, ctx| {
+            mixer.run_query(at_context_menu_query(query), ctx);
+        });
+        self.refresh_result_rows(ctx);
+    }
+
+    fn refresh_category_rows(&mut self, ctx: &mut ModelContext<Self>) {
+        let categories = self.core.filtered_categories_from(
+            self.discovered_categories
+                .clone()
+                .unwrap_or_else(|| self.core.available_categories(ctx)),
+        );
+        let rows = categories
+            .into_iter()
+            .map(TuiAtContextMenuRow::Category)
+            .collect();
+        let TuiAtContextMenuState::Open { list, .. } = &mut self.state else {
+            return;
+        };
+        let preferred_index = list.selected_index().unwrap_or_default();
+        list.replace_rows(rows, false, Some(preferred_index), MAX_VISIBLE_ROWS, |_| {
+            true
+        });
+    }
+
+    fn refresh_result_rows(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_open(ctx) {
+            return;
+        }
+        if self.core.navigation_state() == NavigationState::MainMenu {
+            self.refresh_discovered_categories(ctx);
+            return;
+        }
+        let (is_loading, rows) = {
+            let mixer = self.mixer.as_ref(ctx);
+            let rows = mixer
+                .results()
+                .iter()
+                .filter(|result| !result.is_static_separator() && !result.is_disabled())
+                .filter_map(|result| {
+                    let detail = result.detail_data()?;
+                    Some(TuiAtContextMenuRow::Result {
+                        title: detail.title,
+                        description: detail.description,
+                        action: result.accept_result(),
+                    })
+                })
+                .collect();
+            (mixer.is_loading(), rows)
+        };
+        let TuiAtContextMenuState::Open { list, .. } = &mut self.state else {
+            return;
+        };
+        let update = list.reconcile_mixer_rows(rows, is_loading, MAX_VISIBLE_ROWS, |_| true);
+        if !matches!(update, InlineMenuResultsUpdate::Loading) {
+            ctx.emit(TuiAtContextMenuEvent);
+        }
+    }
+
+    pub(crate) fn select_previous(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiAtContextMenuState::Open { list, .. } = &mut self.state else {
+            return;
+        };
+        list.select_previous(MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiAtContextMenuEvent);
+    }
+
+    pub(crate) fn select_next(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiAtContextMenuState::Open { list, .. } = &mut self.state else {
+            return;
+        };
+        list.select_next(MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiAtContextMenuEvent);
+    }
+
+    pub(crate) fn select_at_snapshot_index(
+        &mut self,
+        index: usize,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let TuiAtContextMenuState::Open { list, .. } = &mut self.state else {
+            return false;
+        };
+        let selected = list.select_absolute(index, MAX_VISIBLE_ROWS, |_| true);
+        ctx.emit(TuiAtContextMenuEvent);
+        selected
+    }
+
+    pub(crate) fn scroll_by_delta(&mut self, delta: isize, ctx: &mut ModelContext<Self>) {
+        let TuiAtContextMenuState::Open { list, .. } = &mut self.state else {
+            return;
+        };
+        list.scroll_by(delta, MAX_VISIBLE_ROWS);
+        ctx.emit(TuiAtContextMenuEvent);
+    }
+
+    pub(crate) fn accept_selected(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<TuiAtContextMenuAcceptance> {
+        if !self.is_open(ctx) {
+            return None;
+        }
+        let row = match &self.state {
+            TuiAtContextMenuState::Closed => return None,
+            TuiAtContextMenuState::Open { list, .. } => list.selected_row()?.clone(),
+        };
+        match row {
+            TuiAtContextMenuRow::Category(category) => {
+                self.remove_category_filter_from_input(ctx);
+                self.core.enter_category(category);
+                if let TuiAtContextMenuState::Open { query, .. } = &mut self.state {
+                    query.clear();
+                }
+                self.setup_category(category, "", ctx);
+                ctx.emit(TuiAtContextMenuEvent);
+                None
+            }
+            TuiAtContextMenuRow::Result { action, .. } => {
+                let (text, cursor) = self.input_snapshot(ctx)?;
+                let at_symbol_position = self.at_symbol_position()?;
+                let start =
+                    byte_offset_for_char_offset(&text, CharOffset::from(at_symbol_position))?;
+                let end = byte_offset_for_char_offset(&text, CharOffset::from(cursor))?;
+                self.close(ctx);
+                Some(TuiAtContextMenuAcceptance {
+                    action,
+                    replacement_range: start.as_usize()..end.as_usize(),
+                })
+            }
+        }
+    }
+
+    fn remove_category_filter_from_input(&mut self, ctx: &mut ModelContext<Self>) {
+        let Some((_, cursor)) = self.input_snapshot(ctx) else {
+            return;
+        };
+        let Some(at_symbol_position) = self.at_symbol_position() else {
+            return;
+        };
+        let start = at_symbol_position + 2;
+        let end = cursor + 1;
+        if start >= end {
+            return;
+        }
+        self.input_editor.update(ctx, |editor, ctx| {
+            editor.select_at(CharOffset::from(start), false, ctx);
+            editor.set_last_selection_head(CharOffset::from(end), ctx);
+            editor.end_selection(ctx);
+            editor.user_insert("", ctx);
+        });
+    }
+
+    pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
+        self.dismissed_at_symbol_position = self.at_symbol_position();
+        self.close(ctx);
+    }
+
+    fn close(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.has_open_state() {
+            self.state = TuiAtContextMenuState::Closed;
+            self.core.reset_results_progress();
+            self.mixer.update(ctx, |mixer, ctx| mixer.reset(ctx));
+            ctx.emit(TuiAtContextMenuEvent);
+        }
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::AtContextMenu, ctx);
+        });
+    }
+
+    pub(crate) fn snapshot(&self, app: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(app) {
+            return None;
+        }
+        let TuiAtContextMenuState::Open { list, .. } = &self.state else {
+            return None;
+        };
+        let title = match self.core.navigation_state() {
+            NavigationState::MainMenu => "Add context".to_owned(),
+            NavigationState::Category(category) => category.name().to_owned(),
+            NavigationState::AllCategories => "Search context".to_owned(),
+        };
+        let status = if list.rows().is_empty() {
+            Some(if list.is_loading() {
+                TuiInlineMenuStatus::Loading("Loading context…".to_owned())
+            } else {
+                TuiInlineMenuStatus::Empty("No context found".to_owned())
+            })
+        } else {
+            None
+        };
+        Some(TuiInlineMenuSnapshot {
+            header: Some(TuiInlineMenuHeader {
+                title: Some(title),
+                tabs: Vec::new(),
+            }),
+            rows: list
+                .rows()
+                .iter()
+                .map(|row| match row {
+                    TuiAtContextMenuRow::Category(category) => TuiInlineMenuRow {
+                        title: category.name().to_owned(),
+                        prefix: None,
+                        description: None,
+                        state_suffix: Some("›".to_owned()),
+                        is_selectable: true,
+                        style: TuiInlineMenuRowStyle::Default,
+                    },
+                    TuiAtContextMenuRow::Result {
+                        title, description, ..
+                    } => TuiInlineMenuRow {
+                        title: title.clone(),
+                        prefix: None,
+                        description: description.clone(),
+                        state_suffix: None,
+                        is_selectable: true,
+                        style: TuiInlineMenuRowStyle::InlineMenuItem,
+                    },
+                })
+                .collect(),
+            selected_index: list.selected_index(),
+            scroll_offset: list.scroll_offset(),
+            scroll_anchor: list.scroll_anchor(),
+            max_visible_rows: MAX_VISIBLE_ROWS,
+            status,
+        })
+    }
+}
+
+impl TuiInlineMenuHandle for ModelHandle<TuiAtContextMenuModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::AtContextMenu
+    }
+
+    fn is_open(&self, app: &AppContext) -> bool {
+        self.as_ref(app).is_open(app)
+    }
+
+    fn input_highlight_range(&self, _app: &AppContext) -> Option<Range<CharOffset>> {
+        None
+    }
+
+    fn input_argument_hint_text(&self, _app: &AppContext) -> Option<&'static str> {
+        None
+    }
+
+    fn select_previous(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_previous(ctx));
+    }
+
+    fn select_next(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.select_next(ctx));
+    }
+
+    fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
+        self.update(ctx, |model, ctx| model.accept_selected(ctx))
+            .map(TuiInlineMenuAccepted::AtContextMenu)
+    }
+
+    fn dismiss(&self, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.dismiss(ctx));
+    }
+
+    fn snapshot(&self, app: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        self.as_ref(app).snapshot(app)
+    }
+
+    fn select_by_snapshot_index(&self, index: usize, ctx: &mut AppContext) -> bool {
+        self.update(ctx, |model, ctx| model.select_at_snapshot_index(index, ctx))
+    }
+
+    fn scroll_by_delta(&self, delta: isize, ctx: &mut AppContext) {
+        self.update(ctx, |model, ctx| model.scroll_by_delta(delta, ctx));
+    }
+}
+
+impl Entity for TuiAtContextMenuModel {
+    type Event = TuiAtContextMenuEvent;
+}

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -3,21 +3,8 @@ use std::cell::RefCell;
 use std::ops::Range;
 use std::rc::Rc;
 
-use string_offset::CharOffset;
-use warp::tui_export::{
-    AcceptSlashCommandOrSavedPrompt, AgentConversationEntryId, LLMId, TuiMcpAction,
-    TuiUpArrowHistoryItemKind,
-};
-use warp_search_core::inline_menu::{InlineMenuResultsUpdate, InlineMenuSelection};
-use warpui_core::elements::tui::{
-    Modifier, TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiEvent,
-    TuiEventContext, TuiFlex, TuiHoverable, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
-    TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize, TuiText,
-};
-use warpui_core::elements::{CrossAxisAlignment, MouseStateHandle};
-use warpui_core::{AppContext, ModelHandle};
-
 use crate::api_keys_menu::TuiApiKeysMenuModel;
+use crate::at_context_menu::TuiAtContextMenuAcceptance;
 use crate::completion_menu::TuiCompletionAcceptance;
 use crate::conversation_menu::TuiConversationMenuModel;
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
@@ -31,6 +18,19 @@ use crate::tui_builder::TuiUiBuilder;
 use crate::tui_column_layout::{
     TuiTwoColumnConstraints, TuiTwoColumnLayout, format_tui_first_column, tui_two_column_layout,
 };
+use string_offset::CharOffset;
+use warp::tui_export::{
+    AcceptSlashCommandOrSavedPrompt, AgentConversationEntryId, LLMId, TuiMcpAction,
+    TuiUpArrowHistoryItemKind,
+};
+use warp_search_core::inline_menu::{InlineMenuResultsUpdate, InlineMenuSelection};
+use warpui_core::elements::tui::{
+    Modifier, TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiEvent,
+    TuiEventContext, TuiFlex, TuiHoverable, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
+    TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize, TuiText,
+};
+use warpui_core::elements::{CrossAxisAlignment, MouseStateHandle};
+use warpui_core::{AppContext, ModelHandle};
 
 const SLASH_COMMAND_COLUMN_CONSTRAINTS: TuiTwoColumnConstraints = TuiTwoColumnConstraints {
     preferred_first_columns: 29,
@@ -399,6 +399,7 @@ impl<Row> TuiInlineMenuListState<Row> {
 /// Domain action produced by accepting the selected item in an active menu.
 #[derive(Debug, Clone)]
 pub(crate) enum TuiInlineMenuAccepted {
+    AtContextMenu(TuiAtContextMenuAcceptance),
     SlashCommand(AcceptSlashCommandOrSavedPrompt),
     Conversation(AgentConversationEntryId),
     Model(LLMId),

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -28,8 +28,9 @@ use vim::vim::{MotionType, VimMode, VimModel, VimSubscriber as _};
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::AppEditorSettings;
 use warp::tui_export::{
-    AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, InputType,
-    InputTypeAutoDetectionSource, LLMId, TuiMcpAction, TuiUpArrowHistoryItemKind,
+    AIContextMenuSearchableAction, AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel,
+    InputType, InputTypeAutoDetectionSource, LLMId, TuiMcpAction, TuiUpArrowHistoryItemKind,
+    shared_inserted_text,
 };
 use warp_editor::model::CoreEditorModel;
 use warpui::SingletonEntity as _;
@@ -46,6 +47,7 @@ use warpui_core::{
     ViewContext,
 };
 
+use crate::at_context_menu::TuiAtContextMenuAcceptance;
 use crate::completion_menu::TuiCompletionAcceptance;
 use crate::editor_element::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
 use crate::editor_interaction::{
@@ -163,6 +165,12 @@ pub enum TuiInputViewEvent {
     AcceptedMcp(TuiMcpAction),
     /// The user advanced the explicit MCP installation flow.
     AcceptedMcpInstall(TuiMcpInstallFlowAction),
+    /// The user selected a diff set, which the owning session resolves into an
+    /// asynchronous context attachment.
+    AcceptedDiffSet {
+        diff_mode: warp::tui_export::DiffMode,
+        replacement_range: Range<usize>,
+    },
     /// Shift+Up should move focus from the first visual row to the region above.
     MoveFocusUp,
     /// The user accepted an item from the up-arrow prompt-and-command history menu.
@@ -484,6 +492,20 @@ impl TuiInputView {
     ) {
         self.voice_input.update(ctx, |voice_input, ctx| {
             voice_input.handle_hold_key(key, state, available, ctx);
+        });
+    }
+
+    /// Locks the current input to Agent because it now contains context that
+    /// cannot be submitted as a shell command.
+    pub(crate) fn force_agent_mode_for_attachment(&mut self, ctx: &mut ViewContext<Self>) {
+        let is_input_buffer_empty = self.plain_text(ctx).is_empty();
+        self.input_mode.clone().update(ctx, |input_mode, ctx| {
+            input_mode.set_input_config(
+                AI_LOCKED_CONFIG,
+                is_input_buffer_empty,
+                Some(InputTypeAutoDetectionSource::AttachmentForcedAi),
+                ctx,
+            );
         });
     }
 
@@ -1310,6 +1332,9 @@ impl TuiInputView {
         ctx: &mut ViewContext<Self>,
     ) {
         match accepted {
+            TuiInlineMenuAccepted::AtContextMenu(acceptance) => {
+                self.apply_at_context_menu_acceptance(acceptance, ctx);
+            }
             TuiInlineMenuAccepted::SlashCommand(action) => {
                 ctx.emit(TuiInputViewEvent::AcceptedSlashCommand(action));
             }
@@ -1331,6 +1356,44 @@ impl TuiInputView {
             TuiInlineMenuAccepted::Completion(acceptance) => {
                 self.apply_shell_completion(acceptance, ctx);
             }
+        }
+    }
+
+    fn apply_at_context_menu_acceptance(
+        &mut self,
+        acceptance: TuiAtContextMenuAcceptance,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let TuiAtContextMenuAcceptance {
+            action,
+            replacement_range,
+        } = acceptance;
+        let insert_as_shell = {
+            let input_mode = self.input_mode.as_ref(ctx);
+            input_mode.is_input_type_locked() && !input_mode.is_ai_input_enabled()
+        };
+        let replacement = match action {
+            AIContextMenuSearchableAction::InsertFilePath { file_path } => file_path,
+            AIContextMenuSearchableAction::InsertDiffSet { diff_mode } => {
+                ctx.emit(TuiInputViewEvent::AcceptedDiffSet {
+                    diff_mode,
+                    replacement_range,
+                });
+                return;
+            }
+            action => shared_inserted_text(&action)
+                .expect("all non-file, non-diff @ context actions insert shared text"),
+        };
+        self.apply_shell_completion(
+            TuiCompletionAcceptance {
+                replacement,
+                replacement_range,
+                append_space: !insert_as_shell,
+            },
+            ctx,
+        );
+        if !insert_as_shell {
+            self.exit_shell_mode(ctx);
         }
     }
     fn handle_inline_menu_action(

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -14,11 +14,12 @@ use warp::appearance::Appearance;
 use warp::editor::CodeEditorModel;
 use warp::settings::AISettingsChangedEvent;
 use warp::tui_export::{
-    AcceptSlashCommandOrSavedPrompt, BlocklistAIHistoryModel, BlocklistAIInputModel,
-    ConversationSelectionEvent, InputConfig, InputModePolicy, InputType, LLMId, PolicyConfigUpdate,
-    SlashCommandId, SlashCommandMixer, TuiMcpAction, TuiMcpServerId, TuiUpArrowHistoryItemKind,
-    VoiceInput, add_tui_history_test_models, blocklist_ai_history_model_with_queries,
-    register_tui_input_mode_test_settings, register_tui_session_view_test_singletons,
+    AIContextMenuSearchableAction, AcceptSlashCommandOrSavedPrompt, BlocklistAIHistoryModel,
+    BlocklistAIInputModel, ConversationSelectionEvent, InputConfig, InputModePolicy, InputType,
+    LLMId, PolicyConfigUpdate, SlashCommandId, SlashCommandMixer, TuiMcpAction, TuiMcpServerId,
+    TuiUpArrowHistoryItemKind, VoiceInput, add_tui_history_test_models,
+    blocklist_ai_history_model_with_queries, register_tui_input_mode_test_settings,
+    register_tui_session_view_test_singletons,
 };
 use warp_core::features::FeatureFlag;
 use warp_editor::model::CoreEditorModel;
@@ -41,6 +42,7 @@ use super::{
     MCP_MENU_ACTIVE_FLAG, SHELL_COMPLETION_AVAILABLE_FLAG, TuiInputAction, TuiInputView,
     TuiInputViewEvent, input_keymap_context,
 };
+use crate::at_context_menu::TuiAtContextMenuAcceptance;
 use crate::completion_menu::{TuiCompletionAcceptance, TuiCompletionMenuModel};
 use crate::editor_element::{TuiEditorAction, TuiEditorElement};
 use crate::editor_interaction::TuiEditorCommand;
@@ -60,6 +62,41 @@ use crate::tui_builder::TuiUiBuilder;
 use crate::voice_input::{TuiVoiceInputModel, TuiVoiceInputState};
 
 const W: u16 = 80;
+
+#[test]
+fn at_context_acceptance_replaces_the_trigger_and_locks_agent_mode() {
+    App::test((), |mut app| async move {
+        let view = app.update(|ctx| {
+            let view = build_view(ctx);
+            view.update(ctx, |view, ctx| {
+                view.set_text("@cargo", ctx);
+                view.input_mode.update(ctx, |input_mode, ctx| {
+                    input_mode.enable_autodetection(InputType::Shell, ctx);
+                });
+            });
+            view
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.route_inline_menu_acceptance(
+                TuiInlineMenuAccepted::AtContextMenu(TuiAtContextMenuAcceptance {
+                    action: AIContextMenuSearchableAction::InsertFilePath {
+                        file_path: "Cargo.toml".to_owned(),
+                    },
+                    replacement_range: 0..6,
+                }),
+                ctx,
+            );
+        });
+
+        view.read(&app, |input, ctx| {
+            let content = input.model().as_ref(ctx).content().as_ref(ctx);
+            assert_eq!(content.text().into_string(), "Cargo.toml ");
+            assert!(!input.is_shell_mode(ctx));
+            assert!(input.input_mode.as_ref(ctx).is_input_type_locked());
+        });
+    });
+}
 
 struct TestInputModePolicy;
 
@@ -1348,6 +1385,7 @@ fn enter_and_escape_stop_listening_while_escape_cancels_transcribing() {
                 | TuiInputViewEvent::AcceptedModel(_)
                 | TuiInputViewEvent::AcceptedMcp(_)
                 | TuiInputViewEvent::AcceptedMcpInstall(_)
+                | TuiInputViewEvent::AcceptedDiffSet { .. }
                 | TuiInputViewEvent::MoveFocusUp
                 | TuiInputViewEvent::AcceptedPromptAndCommandHistory { .. }
                 | TuiInputViewEvent::RequestShellCompletion
@@ -2227,6 +2265,7 @@ fn multiline_paste_emits_once_and_fallback_inserts_without_submitting() {
                 | TuiInputViewEvent::AcceptedModel(_)
                 | TuiInputViewEvent::AcceptedMcp(_)
                 | TuiInputViewEvent::AcceptedMcpInstall(_)
+                | TuiInputViewEvent::AcceptedDiffSet { .. }
                 | TuiInputViewEvent::AcceptedPromptAndCommandHistory { .. }
                 | TuiInputViewEvent::RequestShellCompletion
                 | TuiInputViewEvent::BackspaceAtEmptyInput

--- a/crates/warp_tui/src/input_suggestions_mode.rs
+++ b/crates/warp_tui/src/input_suggestions_mode.rs
@@ -12,6 +12,7 @@ use crate::read_only_menu::TuiReadOnlyMenuKind;
 pub(crate) enum TuiInputSuggestionsMode {
     #[default]
     Closed,
+    AtContextMenu,
     SlashCommands,
     ApiKeys,
     ConversationMenu,
@@ -33,6 +34,7 @@ impl TuiInputSuggestionsMode {
         match self {
             Self::ReadOnlyMenu(kind) => Some(kind),
             Self::Closed
+            | Self::AtContextMenu
             | Self::SlashCommands
             | Self::ApiKeys
             | Self::ConversationMenu
@@ -90,7 +92,8 @@ impl TuiInputSuggestionsModeModel {
                 true
             }
             active_mode if active_mode == mode => true,
-            TuiInputSuggestionsMode::SlashCommands
+            TuiInputSuggestionsMode::AtContextMenu
+            | TuiInputSuggestionsMode::SlashCommands
             | TuiInputSuggestionsMode::ApiKeys
             | TuiInputSuggestionsMode::ConversationMenu
             | TuiInputSuggestionsMode::ModelSelector

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -12,6 +12,7 @@ mod agent_block_sections;
 mod agent_message;
 mod alt_screen_view;
 mod api_keys_menu;
+mod at_context_menu;
 mod attachment_bar;
 mod autoupdate;
 mod cli_agent_osc_event_publisher;

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -17,22 +17,23 @@ use warp::settings::{
 };
 use warp::tui_export::{
     AIAgentActionId, AIAgentActionResultType, AIAgentContext, AIAgentExchangeId,
-    AIAgentPtyWriteMode, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
-    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AfterBlockCompletedEvent,
-    AgentConversationEntryId, AgentConversationListEntryState, AgentConversationsModel,
-    AgentInteractionMetadata, AgentViewEntryOrigin, Appearance, BlockId, BlockType,
-    BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
-    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel,
+    AIAgentPtyWriteMode, AIContextMenuMixer, AIConversation, AIConversationAutoexecuteMode,
+    AIConversationId, AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent,
+    AfterBlockCompletedEvent, AgentConversationEntryId, AgentConversationListEntryState,
+    AgentConversationsModel, AgentInteractionMetadata, AgentViewEntryOrigin, Appearance, BlockId,
+    BlockType, BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel,
+    BlocklistAIController, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel,
     BlocklistOrchestrationTelemetryEvent, CLISubagentController, CLISubagentEvent,
     CLISubagentTarget, COMMAND_REGISTRY, CancellationReason, ChangelogModel, ChangelogRequestType,
     CloudConversationData, CommandExecutionSource, ConversationFileExport, ConversationSelection,
-    ConversationSelectionHandle, ExecuteCommandEvent, GetRelevantFilesController, GitHubRepoModel,
-    GitRepoStatusModel, LLMId, LLMPreferences, LLMPreferencesEvent,
-    LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, LinkedWorkflowData, ModelEvent,
-    ParsedSlashCommandInput, PersistenceWriter, PillBarActionKind, PillBarInteractionEvent,
-    PillBarPillKind, PillSwitchOutcome, PtyIntent, PtyIntentEvent, QueuedQueryEvent,
-    QueuedQueryModel, RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
-    SessionSettings, Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
+    ConversationSelectionHandle, CurrentHead, DiffBase, DiffMode, DiffSetScope,
+    ExecuteCommandEvent, GetRelevantFilesController, GitHubRepoModel, GitRepoStatusModel, LLMId,
+    LLMPreferences, LLMPreferencesEvent, LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE,
+    LinkedWorkflowData, LocalDiffStateModel, ModelEvent, ParsedSlashCommandInput,
+    PersistenceWriter, PillBarActionKind, PillBarInteractionEvent, PillBarPillKind,
+    PillSwitchOutcome, PtyIntent, PtyIntentEvent, QueuedQueryEvent, QueuedQueryModel,
+    RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken, SessionSettings,
+    Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
     SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
     StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TelemetryEvent, TerminalColorList,
     TerminalColors, TerminalModel, TerminalSurface, TerminalSurfaceInit, TranscriptScope,
@@ -40,10 +41,11 @@ use warp::tui_export::{
     TuiSlashCommandDataSourceArgs, TuiUpArrowHistoryItemKind, TuiUserInfoManager,
     TuiUserInfoManagerEvent, TuiZeroStateDataSource, UserTakeOverReason, WAKEUP_THROTTLE_PERIOD,
     WarpConfig, WarpConfigUpdateEvent, block_context_from_terminal_model,
-    build_slash_command_mixer, detect_possible_git_repo, export_conversation_markdown, log_out_tui,
-    maybe_build_ai_query_upsert_event, prepare_conversation_block_restoration,
+    build_slash_command_mixer, convert_file_diffs_to_diffset_hunks,
+    create_attachment_reference_and_key, detect_possible_git_repo, export_conversation_markdown,
+    log_out_tui, maybe_build_ai_query_upsert_event, prepare_conversation_block_restoration,
     record_autodetection_toggle_from_slash_command, record_saved_prompt_accepted,
-    record_static_slash_command_accepted, saved_prompt_text_for_id,
+    record_static_slash_command_accepted, register_diffset_attachment, saved_prompt_text_for_id,
     slash_command_selection_behavior, slash_commands, throttle,
 };
 use warp_core::channel::{Channel, ChannelState};
@@ -72,6 +74,7 @@ use warpui_core::{
 use crate::agent_block::OUT_OF_CREDITS_URL;
 use crate::alt_screen_view::AltScreenElement;
 use crate::api_keys_menu::{TuiApiKeysMenuEvent, TuiApiKeysMenuModel, render_api_keys_footer};
+use crate::at_context_menu::{TuiAtContextMenuEvent, TuiAtContextMenuModel};
 use crate::attachment_bar::{
     FOCUS_ATTACHMENTS_BINDING_NAME, TuiAttachmentBar, TuiAttachmentBarEvent, TuiAttachmentModel,
     TuiAttachmentPasteDisposition,
@@ -80,7 +83,7 @@ use crate::cli_agent_osc_event_publisher::{
     CliAgentOscEventPublisher, host_supports_cli_agent_notifications,
 };
 use crate::clipboard::copy_to_clipboard;
-use crate::completion_menu::TuiCompletionMenuModel;
+use crate::completion_menu::{TuiCompletionAcceptance, TuiCompletionMenuModel};
 use crate::conversation_menu::{TuiConversationMenuEvent, TuiConversationMenuModel};
 use crate::conversation_selection::TuiConversationSelection;
 use crate::editor_interaction::TuiEditorCommand;
@@ -1592,6 +1595,20 @@ impl TuiTerminalSessionView {
         let input_editor_model =
             ctx.add_model(|ctx| CodeEditorModel::new_tui(INITIAL_INPUT_WIDTH, ctx));
         let suggestions_mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
+        let at_context_menu_mixer = ctx.add_model(|_| AIContextMenuMixer::new());
+        let at_context_menu = ctx.add_model(|ctx| {
+            TuiAtContextMenuModel::new(
+                input_editor_model.clone(),
+                suggestions_mode.clone(),
+                active_session.clone(),
+                ai_input_model.clone(),
+                at_context_menu_mixer,
+                ctx,
+            )
+        });
+        ctx.subscribe_to_model(&at_context_menu, |_, _, _: &TuiAtContextMenuEvent, ctx| {
+            ctx.notify()
+        });
         let suggestions_mode_for_user_info = suggestions_mode.clone();
         ctx.subscribe_to_model(&TuiUserInfoManager::handle(ctx), move |_, _, event, ctx| {
             let TuiUserInfoManagerEvent::Updated = event;
@@ -1753,6 +1770,7 @@ impl TuiTerminalSessionView {
 
         let input_mode_for_input_view = ai_input_model.clone();
         let inline_menus = vec![
+            TuiInlineMenu::new(at_context_menu.clone()),
             TuiInlineMenu::new(slash_commands.clone()),
             TuiInlineMenu::new(api_keys_menu.clone()),
             TuiInlineMenu::new(conversation_menu.clone()),
@@ -1866,6 +1884,12 @@ impl TuiTerminalSessionView {
             }
             TuiInputViewEvent::AcceptedMcpInstall(action) => {
                 view.handle_accepted_mcp_install_action(action.clone(), ctx);
+            }
+            TuiInputViewEvent::AcceptedDiffSet {
+                diff_mode,
+                replacement_range,
+            } => {
+                view.handle_accepted_diff_set(diff_mode.clone(), replacement_range.clone(), ctx);
             }
             TuiInputViewEvent::AcceptedPromptAndCommandHistory { text, kind } => {
                 view.handle_accepted_prompt_and_command_history(text.clone(), kind.clone(), ctx);
@@ -4130,6 +4154,69 @@ impl TuiTerminalSessionView {
             }
         }
         ctx.notify();
+    }
+
+    fn handle_accepted_diff_set(
+        &mut self,
+        diff_mode: DiffMode,
+        replacement_range: std::ops::Range<usize>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(repo_path) = self
+            .current_repo_path
+            .as_ref()
+            .and_then(LocalOrRemotePath::to_local_path)
+            .map(Path::to_path_buf)
+        else {
+            return;
+        };
+
+        let metadata = self.git_status_metadata(ctx);
+        let current =
+            metadata.map(|metadata| CurrentHead::BranchName(metadata.current_branch_name.clone()));
+        let base = match &diff_mode {
+            DiffMode::Head => DiffBase::UncommittedChanges,
+            DiffMode::MainBranch => metadata
+                .map(|metadata| DiffBase::BranchName(metadata.main_branch_name.clone()))
+                .unwrap_or(DiffBase::UncommittedChanges),
+            DiffMode::OtherBranch(branch_name) => DiffBase::BranchName(branch_name.clone()),
+        };
+        let main_branch_name = metadata.map(|metadata| metadata.main_branch_name.clone());
+        let (attachment_reference, diff_set_key) = create_attachment_reference_and_key(
+            &DiffSetScope::All,
+            &diff_mode,
+            main_branch_name.as_deref(),
+        );
+
+        self.input_view.update(ctx, |input, ctx| {
+            input.apply_shell_completion(
+                TuiCompletionAcceptance {
+                    replacement: attachment_reference,
+                    replacement_range,
+                    append_space: true,
+                },
+                ctx,
+            );
+            input.force_agent_mode_for_attachment(ctx);
+        });
+
+        let context_model = self.ai_context_model.clone();
+        ctx.spawn(
+            LocalDiffStateModel::load_diff_data_for_mode(diff_mode, repo_path),
+            move |_, git_diff_data, ctx| {
+                let Some(git_diff_data) = git_diff_data else {
+                    return;
+                };
+                register_diffset_attachment(
+                    &context_model,
+                    diff_set_key.clone(),
+                    convert_file_diffs_to_diffset_hunks(git_diff_data.files.iter()),
+                    current.clone(),
+                    base.clone(),
+                    ctx,
+                );
+            },
+        );
     }
 
     fn handle_accepted_prompt_and_command_history(

--- a/crates/warp_tui/src/terminal_session_view/statusline.rs
+++ b/crates/warp_tui/src/terminal_session_view/statusline.rs
@@ -749,7 +749,10 @@ impl TuiTerminalSessionView {
         ctx.notify();
     }
 
-    fn git_status_metadata<'a>(&self, ctx: &'a AppContext) -> Option<&'a GitStatusMetadata> {
+    pub(super) fn git_status_metadata<'a>(
+        &self,
+        ctx: &'a AppContext,
+    ) -> Option<&'a GitStatusMetadata> {
         self.git_repo_status.as_ref()?.as_ref(ctx).metadata(ctx)
     }
 

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -138,6 +138,56 @@ fn mcp_install_footer_labels_final_value_as_install_and_enable() {
     });
 }
 
+#[test]
+fn at_context_menu_renders_supported_categories_and_enters_the_selected_category() {
+    App::test((), |mut app| async move {
+        let _at_menu = FeatureFlag::AIContextMenuEnabled.override_enabled(true);
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+
+        view.update(&mut app, |view, ctx| {
+            view.input_view.update(ctx, |input, ctx| {
+                input.set_text("@", ctx);
+            });
+        });
+        Timer::after(Duration::from_millis(100)).await;
+        view.read(&app, |view, ctx| {
+            assert_eq!(
+                view.suggestions_mode.as_ref(ctx).mode(),
+                TuiInputSuggestionsMode::AtContextMenu
+            );
+        });
+
+        let rendered = render_session(&mut app, &view, 80, 24).join("\n");
+        assert!(rendered.contains("Add context"), "{rendered}");
+        assert!(rendered.contains("Files and folders"), "{rendered}");
+        // The test fixture has no Drive objects, rules, or conversations; their
+        // empty sources must not produce categories. Skill discovery is
+        // asynchronous and intentionally not asserted here.
+        assert!(!rendered.contains("Workflows"), "{rendered}");
+        assert!(!rendered.contains("Notebooks"), "{rendered}");
+        assert!(!rendered.contains("Plans"), "{rendered}");
+        assert!(!rendered.contains("Conversations"), "{rendered}");
+        assert!(!rendered.contains("Rules"), "{rendered}");
+        assert!(!rendered.contains("Blocks"), "{rendered}");
+        assert!(!rendered.contains("Code"), "{rendered}");
+
+        view.update(&mut app, |view, ctx| {
+            view.input_view.update(ctx, |input, ctx| {
+                input.handle_action(&crate::input::view::TuiInputAction::Submit, ctx);
+            });
+        });
+
+        let rendered = render_session(&mut app, &view, 80, 24).join("\n");
+        assert!(rendered.contains("Files and folders"), "{rendered}");
+        view.read(&app, |view, ctx| {
+            let input = view.input_view.as_ref(ctx);
+            let content = input.model().as_ref(ctx).content().as_ref(ctx);
+            assert_eq!(content.text().into_string(), "@");
+        });
+    });
+}
+
 fn todo(id: &str, title: &str) -> AIAgentTodo {
     AIAgentTodo::new(id.to_owned().into(), title.to_owned(), String::new())
 }


### PR DESCRIPTION
## Description

Final PR in the CODE-1910 stack. Adds the `@` context menu to the headless TUI, reusing the category state, mixer source wiring, input grammar, and insertion format extracted in #14502 and the explicit working-directory seam from #14504.

Typing `@` at a word boundary opens the category list above the TUI composer. The menu first runs the existing zero-state sources and only shows categories that returned at least one entry, so an account with no configured rules does not see Rules. Files and folders stays visible while repo indexing is pending, since pending is not evidence that the category is empty. Up/Down and mouse selection use the existing inline-menu framework; Enter enters a category or accepts its selected result; Escape dismisses the menu and keeps that same trigger dismissed until it is deleted or a new `@` is typed.

### Categories

Parity with the GUI minus exactly two technically blocked categories:

- **Files and folders** — reads the TUI's existing eager `RepoMetadataModel` index inside a repo, or the current folder directly outside one. This PR does not introduce file-tree indexing; repo detection already triggers it as a side effect in the TUI.
- **Workflows, Notebooks, Plans, Rules** — existing `CloudModel`-backed sources.
- **Conversations** — existing conversation source.
- **Diff sets** — Uncommitted changes and Changes vs. main branch.
- **Skills** — included despite the existing `/` skills menu, matching the GUI's parity rule (the GUI also lists Skills in `@` alongside its skills menu, and Conversations alongside its conversations menu).

Excluded:

- **Blocks** — both the source and `find_block_attachment_in_all_terminals` iterate `views_of_type::<TerminalView>`, which does not exist in the TUI. Listing one would produce an unresolved reference.
- **Code symbols** — `LaunchMode::Tui` reports `supports_indexing() == false`, so `RepoOutlines` is built with `new_with_indexing_enabled(false)` and never builds the outlines this category searches. Enabling outlines has agent-context blast radius beyond this menu and is a follow-up.

### Menu model

New `crates/warp_tui/src/at_context_menu.rs` follows the existing `TuiSlashCommandModel` pattern:

- owns `AtContextMenuCoreState`, `AIContextMenuMixer`, the trigger's zero-based character position, and a `TuiInlineMenuListState`
- subscribes to editor content and selection changes, active-session cwd changes, and mixer result changes
- stores `at_symbol_position` in its own open state rather than in `TuiInputSuggestionsMode`, the same ownership split slash commands use for their query
- turns shared `SearchItemDetail` data into TUI rows; category rows enter their source and result rows return an action plus the exact byte span replacing `@filter`
- disables Blocks and Code through explicit surface capabilities in `AtContextMenuGates`, rather than filtering the rendered list after the core computes it
- discovers non-empty categories by running all potentially available zero-state sources through one mixer, then maps accepted actions back to their source category in the core's display order; category-name queries are applied only to that discovered subset

`SearchItemDetail::title_font_family` becomes optional. The seven in-scope GUI search items previously had no neutral row data at all; they now provide title/description with no font opinion. The one existing pixel consumer falls back to the UI font, while the slash-command item keeps its explicit font.

### Acceptance

Text actions replace `@filter` through the same span-replacement primitive used by shell completion:

- files insert the repo-relative path
- Drive objects/rules/plans/conversations insert their existing `<type:id>` reference
- skills insert `/{name}`

Only an explicitly locked Shell input stays Shell. Otherwise acceptance locks the composed input to Agent, preventing a pending NLD classification from treating a selected path like `crates/foo/Cargo.toml` as a shell command. Clearing/submitting restores the normal default afterward.

Diff sets are not text-only. Their TUI path ports `TerminalView::handle_attach_diffset_context`: insert the `<change:…>` reference immediately, force Agent mode, load fresh diff data asynchronously with `LocalDiffStateModel::load_diff_data_for_mode`, convert it to diff-set hunks, and register the attachment on the TUI's existing `BlocklistAIContextModel`.

### Live verification

Verified locally in a real 120×40 tmux PTY using `./script/run-tui`, signed in against a local channel build:

1. `@` rendered `Add context` with Files and folders plus only sources that have entries on the signed-in account (Workflows, Notebooks, Plans, Diff sets, Conversations, Rules, and Skills); Blocks and Code were absent. The empty test fixture independently verifies empty Rules and other configured-object categories are omitted.
2. Enter opened Files and folders and rendered indexed repo paths.
3. Filtering `Cargo.toml` and accepting a result replaced the trigger with a repo-relative path plus a trailing space and left the composer in Agent mode.
4. Navigating to Diff sets rendered both rows with descriptions. Accepting Changes vs. main branch inserted `<change:diffset against origin/master>` and left the composer in Agent mode.

No screenshot artifact is attached because this local agent environment has no artifact-upload tool; the tmux frame was inspected directly. The durable render-level test below covers the category surface in CI.

## Linked Issue

CODE-1910

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo nextest run -p warp_tui --no-fail-fast` — **815/815 passed**
- `cargo nextest run -p warp -E 'test(/ai_context_menu/)' --no-fail-fast` — **78/78 passed**
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `./script/format`

New focused tests:

- full-session render test: typing `@` opens the inline menu, retains Files and folders while indexing may be pending, omits empty Drive/rule/conversation sources plus unsupported Blocks/Code, and Enter moves into the selected Files category while preserving the `@`
- input acceptance test: replacing `@cargo` with a file path appends a space and locks an autodetected Shell input back to Agent

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Added the `@` context menu to Warp Agent CLI for attaching files, Drive objects, plans, diff sets, conversations, rules, and skills.
-->

<!-- WARP_ARTIFACTS_BEGIN -->
Conversation: https://staging.warp.dev/conversation/531c19d5-95a5-4a3c-ac6b-043c74dd4405

Plan: [Scoping: `@` context menu in the Warp TUI](https://staging.warp.dev/drive/notebook/v3yCIHxSRhHwFAOe9KmvdC)
<!-- WARP_ARTIFACTS_END -->
