### PR TITLE
Fix built-in Factory MCP server vanishing after credential-rotation respawn

### DIFF
--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -17,6 +17,8 @@ use mcp::oauth;
 pub use native::McpIntegration;
 #[cfg(not(target_family = "wasm"))]
 use parking_lot::Mutex;
+#[cfg(not(target_family = "wasm"))]
+use simple_logger::SimpleLogger;
 use uuid::Uuid;
 #[cfg(not(target_family = "wasm"))]
 use warpui::ModelSpawner;
@@ -99,6 +101,15 @@ pub struct TemplatableMCPServerManager {
     /// spawned, so the field would be dead code there.
     #[cfg(not(target_family = "wasm"))]
     builtin_server_token: Option<String>,
+    /// Log-file handles for spawned server instances, keyed by installation
+    /// UUID. `LogManager` reserves one log path per template UUID and rejects
+    /// re-registration while an unclosed logger holds it, so shutdown paths
+    /// close the outgoing instance's logger eagerly instead of waiting for
+    /// async teardown to drop the remaining clones. Without this, an
+    /// immediate respawn (e.g. the built-in Factory MCP picking up a rotated
+    /// token) loses the race and fails to spawn.
+    #[cfg(not(target_family = "wasm"))]
+    server_loggers: HashMap<Uuid, SimpleLogger>,
 }
 
 /// Information about a spawned server task.

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -411,6 +411,7 @@ impl TemplatableMCPServerManager {
             cli_spawned_server_uuids: Default::default(),
             builtin_server_uuids: Default::default(),
             builtin_server_token: Default::default(),
+            server_loggers: Default::default(),
         };
 
         me.fetch_cloud_servers(ctx);
@@ -989,9 +990,18 @@ impl TemplatableMCPServerManager {
                     safe: ("Failed to register MCP log file: {}", e.safe_message()),
                     full: ("Failed to register MCP log file for {template_uuid}: {e}")
                 );
+                self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
+                if mode.is_reconnect() {
+                    self.notify_reconnect_waiters(
+                        installation_uuid,
+                        Err("Failed to register MCP log file".to_string()),
+                    );
+                }
                 return;
             }
         };
+        self.server_loggers
+            .insert(installation_uuid, logger.clone());
         let logger_clone = logger.clone();
 
         // Create channel that we can use to send OAuth callback results
@@ -1157,6 +1167,7 @@ impl TemplatableMCPServerManager {
                             .log(format!("[error] MCP: Failed to connect to server: {e:#}"));
                         // Close the logger to make sure we flush any remaining data.
                         logger_clone.close();
+                        me.server_loggers.remove(&installation_uuid);
                         log::warn!("Failed to spawn MCP server: {e:#}");
 
                         // Store user-friendly error message.
@@ -1223,6 +1234,12 @@ impl TemplatableMCPServerManager {
         // We do both to avoid race conditions and have to do it in this order to avoid the server connecting between the shutdown_server and cancel_spawn calls
         if let Some(spawned_info) = self.spawned_servers.remove(&installation_uuid) {
             spawned_info.abort_handle.abort();
+        }
+        // Close the log stream now rather than when async teardown drops the
+        // last logger clone, so an immediate respawn of the same server can
+        // re-register its log path.
+        if let Some(logger) = self.server_loggers.remove(&installation_uuid) {
+            logger.close();
         }
         self.pending_oauth_csrf
             .retain(|_, v| *v != installation_uuid);
@@ -1856,6 +1873,11 @@ impl TemplatableMCPServerManager {
         // Cancel any in-flight spawn.
         if let Some(spawned_info) = self.spawned_servers.remove(&installation_uuid) {
             spawned_info.abort_handle.abort();
+        }
+        // Release the old instance's log path so the respawn below can
+        // re-register it.
+        if let Some(logger) = self.server_loggers.remove(&installation_uuid) {
+            logger.close();
         }
         self.pending_oauth_csrf
             .retain(|_, v| *v != installation_uuid);


### PR DESCRIPTION
## Description

### The bug

The built-in Factory MCP server (`warp-factory`, dogfood-gated via `FeatureFlag::FactoryMcp`) would silently vanish mid-session and stay gone. Agents saw its tools disappear from discovery and direct calls fail with `MCP server "fac70a11-…" not found`, even though the server-side endpoint (`/api/v1/mcp/factory` on staging) was healthy the whole time.

Repro from a real session log:

```
23:25:07 [INFO]  Spawning the built-in Factory MCP server
23:25:12 [INFO]  Spawning the built-in Factory MCP server
23:25:12 [ERROR] Failed to register MCP log file for fac70a11-…f002:
                 A logger is already active for this path: …/mcp/fac70a11-…f002.log
```

### Root cause

`sync_builtin_servers` respawns the built-in server whenever the bearer token rotates (`AccessTokenRefreshed`, which reliably fires a few seconds after launch and roughly hourly thereafter). The respawn is `shutdown_server(uuid)` followed immediately by `spawn_ephemeral_server(...)` under the **same installation/template UUID**:

1. `shutdown_server` tears the old instance down **asynchronously** — its `SimpleLogger` clones (held by the transport tasks) are only dropped when the shutdown future completes.
2. `LogManager` reserves one log path per template UUID and rejects re-registration while an unclosed logger holds it.
3. The replacement spawn therefore raced the old instance's teardown for the log path and lost: `spawn_server_impl` hit `LoggerAlreadyActive` and **silently `return`ed** — no server spawned, no state transition, no error surfaced, and no retry until the *next* token rotation (up to ~1h away, which then re-enters the same race).

Net effect: a healthy, connected server was shut down and its replacement never started.

### The fix

Uses the eager-release contract `LogManager`/`SimpleLogger` were designed around (`SimpleLogger::close()` marks a stream finished so the path is reclaimable even while clones are still alive):

- Track each spawned instance's `SimpleLogger` in the manager (`server_loggers`, keyed by installation UUID).
- In `shutdown_server` and `reconnect_server`, `close()` the outgoing instance's logger **synchronously** before returning, so an immediate respawn can re-register the log path deterministically instead of racing async teardown.
- In `spawn_server_impl`, stop silently aborting when log registration fails: transition to `FailedToStart` and notify reconnect waiters, mirroring the sibling failure arms.
- Drop the map entry on connect failure (the logger is already closed there).

## Linked Issue

N/A — root-caused from a live dogfood session (built-in Factory MCP disappearing for agents on dev builds).

## Testing

- `cargo check -p warp`, `cargo clippy -p warp --all-targets -- -D warnings`, `cargo fmt --check`, and wasm clippy (`--target wasm32-unknown-unknown --profile release-wasm-debug_assertions --no-deps`) all pass.
- `cargo nextest run -p simple_logger`: 20/20 pass — `register_reclaims_closed_logger` pins the close-to-reclaim semantics this fix relies on.
- [x] I have manually tested my changes locally with `./script/run`

**End-to-end validation:** launched the patched build (Local channel → staging); it organically hit the exact trigger — second spawn 5s after the first on `AccessTokenRefreshed`:

```
00:01:46 [INFO] Spawning the built-in Factory MCP server
00:01:51 [INFO] Spawning the built-in Factory MCP server
```

This time there is no `Failed to register MCP log file` error; the respawned instance re-registered the log path (fresh, truncated `fac70a11-…f002.log`), completed the streamable-HTTP handshake, and listed all four factory tools (`list_factories`, `list_tasks`, `get_task`, `send_task`).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
