### PR TITLE
Fix Circular view update when opening settings from GE credentials error

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -4135,7 +4135,9 @@ impl AIBlock {
                 ctx.emit(AIBlockEvent::RunAwsLoginCommand);
             }
             AwsBedrockCredentialsErrorEvent::ConfigureLoginCommand => {
-                ctx.dispatch_typed_action(&WorkspaceAction::ShowSettingsPageWithSearch {
+                // Defer so Workspace is not opened while AIBlock is still mid-subscription.
+                // Synchronous dispatch here can panic with "Circular view update".
+                ctx.dispatch_typed_action_deferred(WorkspaceAction::ShowSettingsPageWithSearch {
                     search_query: "aws bedrock".to_string(),
                     section: Some(SettingsSection::WarpAgent),
                 });
@@ -4175,7 +4177,9 @@ impl AIBlock {
                 }
             }
             GeminiEnterpriseCredentialsErrorEvent::OpenSettings => {
-                ctx.dispatch_typed_action(&WorkspaceAction::ShowSettingsPageWithSearch {
+                // Defer so Workspace is not opened while AIBlock is still mid-subscription.
+                // Synchronous dispatch here can panic with "Circular view update".
+                ctx.dispatch_typed_action_deferred(WorkspaceAction::ShowSettingsPageWithSearch {
                     search_query: "gemini enterprise".to_string(),
                     section: Some(SettingsSection::WarpAgent),
                 });


### PR DESCRIPTION
## Description
Fixes a macOS GUI crash (`Circular view update`) when clicking **Manage** on the Gemini Enterprise credentials error card (and the equivalent AWS Bedrock configure path).

**What**
- Defer `WorkspaceAction::ShowSettingsPageWithSearch` from the `AIBlock` subscription handlers for:
  - Gemini Enterprise credentials error → Manage / OpenSettings
  - AWS Bedrock credentials error → ConfigureLoginCommand

**Why**
Those handlers run while `AIBlock` is mid-subscription (`emit_event` has removed the view). A synchronous typed-action dispatch opens Settings and re-enters `Workspace` before the current update finishes, which panics at `crates/warpui_core/src/core/app.rs` (`Circular view update`).

A bad GEAP audience still correctly fails the request and shows the error card; Manage should open Settings, not crash the app.

**How**
Use `ctx.dispatch_typed_action_deferred(...)` so the settings open runs after effects flush and views are reinserted.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Static root-cause trace of Manage → OpenSettings → `WorkspaceAction::ShowSettingsPageWithSearch` re-entrancy.
- `./script/format`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- No automated regression test added (UI subscription re-entrancy). Manual verification: trigger GE credentials error card → Manage → Settings opens without crash.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — crash fix; no intentional UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a crash when opening Settings from the Gemini Enterprise or AWS Bedrock credentials error Manage/Configure actions.

Co-Authored-By: Oz <oz-agent@warp.dev>