### PR TITLE
[CODE-1876] Polish TUI zero-state presentation

### DIFF
--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -291,10 +291,6 @@ impl TuiUiBuilder {
         }
     }
 
-    /// Solid form of the transcript's base background for opaque overlays.
-    pub(crate) fn transcript_background(&self) -> Color {
-        cell_color(self.base_background())
-    }
     fn cyan_overlay_2(&self) -> ThemeFill {
         let cyan = ThemeFill::from(self.warp_theme.terminal_colors().normal.cyan);
         self.base_background().blend(&cyan.with_opacity(50))

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -167,12 +167,7 @@ impl TuiView for TuiZeroStateView {
         )
         .finish();
         let overlay = build_zero_state_overlay(cwd.as_deref(), &builder, ctx);
-        build_zero_state_layout(
-            starfield,
-            animation,
-            overlay,
-            builder.transcript_background(),
-        )
+        build_zero_state_layout(starfield, animation, overlay)
     }
 }
 
@@ -184,7 +179,6 @@ fn build_zero_state_layout(
     starfield: Box<dyn TuiElement>,
     animation: Box<dyn TuiElement>,
     overlay: Box<dyn TuiElement>,
-    background: Color,
 ) -> Box<dyn TuiElement> {
     let copy_column_reservation = TuiConstrainedBox::new(TuiText::new("").finish())
         .with_min_cols(LEFT_COLUMN_COLS)
@@ -204,7 +198,7 @@ fn build_zero_state_layout(
         .finish();
 
     let overlay = TuiContainer::new(overlay)
-        .with_background(background)
+        .with_background(Color::Reset)
         .finish();
     let overlay_layer = TuiFlex::column()
         .flex_child(TuiText::new("").finish())

--- a/crates/warp_tui/src/zero_state_animation.rs
+++ b/crates/warp_tui/src/zero_state_animation.rs
@@ -35,8 +35,17 @@ const MIN_OBJECT_ROWS: u16 = 5;
 const BUILT_IN_LOGO_CELL_ASPECT_RATIO: f64 = 2.5;
 const SURFACE_SAMPLES: usize = 3;
 const DEPTH_SAMPLES: usize = 6;
-const GHOST_STIPPLE_MODULUS: usize = 97;
-const SIDE_STITCH_MODULUS: usize = 29;
+/// Slows the rotation at the readable front and back poses while preserving
+/// the configured revolution period and exact cardinal angles.
+const FACE_LINGER_STRENGTH: f64 = 0.2;
+/// `1 + sqrt(2)` divides the four terminal line glyphs into equal 45-degree
+/// sectors instead of favoring horizontal and vertical strokes.
+const CARDINAL_GLYPH_TANGENT_RATIO: f64 = 2.414_213_562_373_095;
+/// Screen-space ghost stippling stays visually anchored while the source
+/// geometry rotates. One cell in nineteen keeps the interior deliberately
+/// quieter than the outline.
+const GHOST_STIPPLE_MODULUS: usize = 19;
+const SIDE_STITCH_MODULUS: usize = 43;
 const STARFIELD_REFERENCE_AREA: usize = 52 * 20;
 const STARFIELD_REFERENCE_COUNT: usize = 36;
 const STARFIELD_MIN_COUNT: usize = 18;
@@ -366,8 +375,7 @@ fn object_frame_at_with_background(
 ) -> Option<LogoFrame> {
     let cell_aspect_ratio = config.shape.cell_aspect_ratio();
     let (logo_cols, logo_rows) = fitted_logo_size(size, cell_aspect_ratio)?;
-    let revolution_secs = config.rotation_period.as_secs_f64();
-    let angle = (elapsed.as_secs_f64() % revolution_secs) / revolution_secs * std::f64::consts::TAU;
+    let angle = rotation_angle(elapsed, config.rotation_period);
     let (sin, cos) = angle.sin_cos();
     let mut frame = LogoFrame::new(size);
     if draw_stars {
@@ -398,11 +406,7 @@ fn object_frame_at_with_background(
                 cos,
                 cell_aspect_ratio,
             );
-            let is_ghost_sample = (source_x * 17 + source_y * 31) % GHOST_STIPPLE_MODULUS == 0;
             let is_side_stitch = (source_x * 13 + source_y * 7) % SIDE_STITCH_MODULUS == 0;
-            if outline_glyph.is_none() && !is_ghost_sample {
-                continue;
-            }
 
             for depth_index in 0..=DEPTH_SAMPLES {
                 let is_face = depth_index == 0 || depth_index == DEPTH_SAMPLES;
@@ -419,6 +423,12 @@ fn object_frame_at_with_background(
                     || projected_y < 0
                     || projected_x >= i32::from(size.width)
                     || projected_y >= i32::from(size.height)
+                {
+                    continue;
+                }
+                if is_face
+                    && outline_glyph.is_none()
+                    && !is_ghost_stipple_cell(projected_x as usize, projected_y as usize)
                 {
                     continue;
                 }
@@ -467,6 +477,16 @@ fn object_frame_at_with_background(
     Some(frame)
 }
 
+fn rotation_angle(elapsed: Duration, rotation_period: Duration) -> f64 {
+    let revolution_secs = rotation_period.as_secs_f64();
+    let linear_angle =
+        (elapsed.as_secs_f64() % revolution_secs) / revolution_secs * std::f64::consts::TAU;
+    linear_angle - FACE_LINGER_STRENGTH * (2.0 * linear_angle).sin() / 2.0
+}
+
+fn is_ghost_stipple_cell(x: usize, y: usize) -> bool {
+    (x * 17 + y * 31).is_multiple_of(GHOST_STIPPLE_MODULUS)
+}
 fn draw_background_stars(frame: &mut LogoFrame, elapsed: Duration) {
     let center_x = (f64::from(frame.size.width) - 1.0) / 2.0;
     draw_background_stars_from(frame, elapsed, center_x);
@@ -583,9 +603,15 @@ fn logo_outline_glyph(
     let normal_y = bool_as_scalar(above) - bool_as_scalar(below);
     let tangent_x = -normal_y * rotation_cos * cell_aspect_ratio;
     let tangent_y = normal_x;
-    if tangent_x.abs() > tangent_y.abs() * 1.8 {
+    glyph_for_tangent(tangent_x, tangent_y)
+}
+
+fn glyph_for_tangent(tangent_x: f64, tangent_y: f64) -> Option<LogoGlyph> {
+    if tangent_x == 0.0 && tangent_y == 0.0 {
+        None
+    } else if tangent_x.abs() > tangent_y.abs() * CARDINAL_GLYPH_TANGENT_RATIO {
         Some(LogoGlyph::Horizontal)
-    } else if tangent_y.abs() > tangent_x.abs() * 1.8 {
+    } else if tangent_y.abs() > tangent_x.abs() * CARDINAL_GLYPH_TANGENT_RATIO {
         Some(LogoGlyph::Vertical)
     } else if tangent_x.signum() == tangent_y.signum() {
         Some(LogoGlyph::Backslash)

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -20,9 +20,10 @@ use super::config::{
     ZeroStateAnimationLoadFailure, ZeroStateShape, resolve_ascii_art_path,
 };
 use super::{
-    BUILT_IN_LOGO_CELL_ASPECT_RATIO, LogoCell, LogoSurface, WarpLogoStyles,
-    ZeroStateAnimationElement, fitted_logo_size, logo_frame_at, object_frame_at,
-    object_frame_at_with_background, star_count_for_size, starfield_emitter_x, warp_logo_contains,
+    BUILT_IN_LOGO_CELL_ASPECT_RATIO, LogoCell, LogoGlyph, LogoSurface, REPAINT_INTERVAL,
+    WarpLogoStyles, ZeroStateAnimationElement, fitted_logo_size, glyph_for_tangent,
+    is_ghost_stipple_cell, logo_frame_at, object_frame_at, object_frame_at_with_background,
+    rotation_angle, star_count_for_size, starfield_emitter_x, warp_logo_contains,
 };
 
 const PANEL_SIZE: TuiSize = TuiSize::new(52, 20);
@@ -121,6 +122,55 @@ fn logo_mask_preserves_the_offset_warp_faces() {
 }
 
 #[test]
+fn rotation_lingers_on_faces_and_preserves_cardinal_angles() {
+    let period = Duration::from_secs(5);
+    for (elapsed, expected) in [
+        (Duration::ZERO, 0.0),
+        (Duration::from_millis(1_250), std::f64::consts::FRAC_PI_2),
+        (Duration::from_millis(2_500), std::f64::consts::PI),
+        (
+            Duration::from_millis(3_750),
+            3.0 * std::f64::consts::FRAC_PI_2,
+        ),
+    ] {
+        let actual = rotation_angle(elapsed, period);
+        assert!(
+            (actual - expected).abs() < f64::EPSILON * 4.0,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    let face_step =
+        rotation_angle(Duration::from_millis(100), period) - rotation_angle(Duration::ZERO, period);
+    let edge_step = rotation_angle(Duration::from_millis(1_350), period)
+        - rotation_angle(Duration::from_millis(1_250), period);
+    assert!(
+        face_step < edge_step,
+        "the logo should move more slowly near a face ({face_step}) than near an edge ({edge_step})"
+    );
+}
+
+#[test]
+fn tangent_glyphs_use_equal_angular_sectors() {
+    assert_eq!(glyph_for_tangent(0.0, 0.0), None);
+    assert_eq!(glyph_for_tangent(2.5, 1.0), Some(LogoGlyph::Horizontal));
+    assert_eq!(glyph_for_tangent(2.0, 1.0), Some(LogoGlyph::Backslash));
+    assert_eq!(glyph_for_tangent(1.0, 2.0), Some(LogoGlyph::Backslash));
+    assert_eq!(glyph_for_tangent(1.0, 2.5), Some(LogoGlyph::Vertical));
+    assert_eq!(glyph_for_tangent(1.0, -1.0), Some(LogoGlyph::ForwardSlash));
+}
+
+#[test]
+fn screen_space_ghost_stipple_is_sparse_and_deterministic() {
+    let stippled_cells = (0..32)
+        .flat_map(|x| (0..17).map(move |y| (x, y)))
+        .filter(|(x, y)| is_ghost_stipple_cell(*x, *y))
+        .count();
+
+    assert_eq!(stippled_cells, 29);
+}
+
+#[test]
 fn full_face_frame_is_recognizable_and_centered() {
     let frame = logo_frame_at(Duration::ZERO, PANEL_SIZE).unwrap();
     let lines = frame.to_lines();
@@ -169,31 +219,42 @@ fn background_stars_move_between_frames() {
 }
 
 #[test]
-fn adjacent_builtin_frames_have_bounded_cell_churn() {
+fn adjacent_builtin_frames_have_bounded_occupancy_and_content_churn() {
     let config = ZeroStateAnimationConfig::default();
     let size = TuiSize::new(32, 28);
     let frames = (0..=76)
         .map(|frame| {
-            object_frame_at_with_background(Duration::from_millis(frame * 66), size, &config, false)
-                .unwrap()
+            object_frame_at_with_background(REPAINT_INTERVAL * frame, size, &config, false).unwrap()
         })
         .collect::<Vec<_>>();
-    let max_changed_cells = frames
+    let (max_occupancy_changes, max_content_changes) = frames
         .windows(2)
         .map(|frames| {
-            frames[0]
+            let occupancy_changes = frames[0]
                 .cells
                 .iter()
                 .zip(&frames[1].cells)
                 .filter(|(before, after)| before.is_some() != after.is_some())
-                .count()
+                .count();
+            let content_changes = frames[0]
+                .cells
+                .iter()
+                .zip(&frames[1].cells)
+                .filter(|(before, after)| before != after)
+                .count();
+            (occupancy_changes, content_changes)
         })
-        .max()
-        .unwrap();
+        .fold((0, 0), |maximums, changes| {
+            (maximums.0.max(changes.0), maximums.1.max(changes.1))
+        });
 
     assert!(
-        max_changed_cells <= 80,
-        "adjacent built-in frames changed occupancy in {max_changed_cells} cells"
+        max_occupancy_changes <= 80,
+        "adjacent built-in frames changed occupancy in {max_occupancy_changes} cells"
+    );
+    assert!(
+        max_content_changes <= 120,
+        "adjacent built-in frames changed glyph or surface content in {max_content_changes} cells"
     );
 }
 

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -154,23 +154,31 @@ fn render_element_lines(
 }
 
 #[test]
-fn zero_state_copy_content_rectangle_is_centered_and_opaque_without_covering_margins() {
+fn zero_state_copy_rectangle_is_opaque_without_changing_the_background_color() {
     App::test((), |app| async move {
         app.read(|ctx| {
+            let stars = (0..9)
+                .map(|_| "*".repeat(80))
+                .collect::<Vec<_>>()
+                .join("\n");
             let layout = build_zero_state_layout(
-                TuiText::new("").finish(),
+                TuiText::new(stars).finish(),
                 TuiText::new("").finish(),
                 TuiText::new("copy here\n\nline").finish(),
-                Color::Red,
             );
             let buffer = render_to_buffer(layout, ctx, 80, 9);
             let lines = buffer.to_lines();
-            assert_eq!(lines[3].trim_end(), "copy here");
-            assert_eq!(lines[5].trim_end(), "line");
-            assert_eq!(buffer[(1, 3)].bg, Color::Red);
-            assert_eq!(buffer[(4, 3)].bg, Color::Red);
-            assert_eq!(buffer[(1, 4)].bg, Color::Red);
-            assert_eq!(buffer[(8, 5)].bg, Color::Red);
+            assert_eq!(&lines[3][..9], "copy here");
+            assert_eq!(&lines[5][..4], "line");
+            for y in 3..=5 {
+                for x in 0..9 {
+                    assert_ne!(buffer[(x, y)].symbol(), "*");
+                    assert_eq!(buffer[(x, y)].bg, Color::Reset);
+                }
+            }
+            assert_eq!(buffer[(1, 2)].symbol(), "*");
+            assert_eq!(buffer[(1, 6)].symbol(), "*");
+            assert_eq!(buffer[(9, 3)].symbol(), "*");
             assert_eq!(buffer[(1, 2)].bg, Color::Reset);
             assert_eq!(buffer[(1, 6)].bg, Color::Reset);
             assert_eq!(buffer[(9, 3)].bg, Color::Reset);
@@ -191,7 +199,6 @@ fn zero_state_starfield_spans_the_full_width() {
                 .finish(),
                 TuiText::new("").finish(),
                 TuiText::new("").finish(),
-                Color::Reset,
             );
             let buffer = render_to_buffer(layout, ctx, 120, 20);
             let occupied_columns = buffer
@@ -232,7 +239,6 @@ fn zero_state_animation_is_centered_in_remaining_space_and_hidden_when_space_is_
                 TuiText::new("").finish(),
                 animation(),
                 TuiText::new("").finish(),
-                Color::Reset,
             );
             let wide_width = 120;
             let wide = render_to_buffer(layout, ctx, wide_width, 20);
@@ -260,7 +266,6 @@ fn zero_state_animation_is_centered_in_remaining_space_and_hidden_when_space_is_
                 TuiText::new("").finish(),
                 animation(),
                 TuiText::new("").finish(),
-                Color::Reset,
             );
             assert!(
                 render_to_buffer(layout, ctx, 60, 20)

--- a/crates/warpui_core/src/elements/tui/container.rs
+++ b/crates/warpui_core/src/elements/tui/container.rs
@@ -26,8 +26,8 @@ use ratatui::style::Color;
 
 use super::{
     TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
-    TuiPaintSurface, TuiPresentationContext, TuiRect, TuiScreenPoint, TuiScreenPosition, TuiSize,
-    TuiStyle,
+    TuiPaintSurface, TuiPresentationContext, TuiRect, TuiScreenPoint, TuiScreenPosition,
+    TuiScreenRect, TuiSize, TuiStyle,
 };
 use crate::AppContext;
 
@@ -235,6 +235,7 @@ impl TuiElement for TuiContainer {
 
         if let Some(background) = self.background {
             surface.set_style(origin, size, TuiStyle::default().bg(background));
+            ctx.record_opaque_region(TuiScreenRect::new(ctx.scene_point(origin), size));
         }
 
         if self.border {

--- a/crates/warpui_core/src/elements/tui/mod.rs
+++ b/crates/warpui_core/src/elements/tui/mod.rs
@@ -146,6 +146,9 @@ pub struct TuiPaintContext<'a> {
     repaint_at: Option<Instant>,
     /// Hardware terminal cursor submitted during paint.
     terminal_cursor: Option<TuiScreenPoint>,
+    /// Stack-local captures of explicitly opaque paint regions. These regions
+    /// are compositing metadata only and never enter the terminal cell buffer.
+    opaque_region_captures: Vec<Vec<TuiScreenRect>>,
 }
 
 /// The soonest an element may request a repaint after the current paint.
@@ -162,6 +165,7 @@ impl<'a> TuiPaintContext<'a> {
             scene: TuiScene::default(),
             repaint_at: None,
             terminal_cursor: None,
+            opaque_region_captures: Vec::new(),
         }
     }
     /// Attaches the active scene layer to an absolute screen position.
@@ -212,6 +216,28 @@ impl<'a> TuiPaintContext<'a> {
     /// Makes the active scene layer transparent to hit testing.
     pub fn set_active_layer_click_through(&mut self) {
         self.scene.set_active_layer_click_through();
+    }
+
+    /// Captures explicit background fills painted by one stack child.
+    pub(crate) fn capture_opaque_regions<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> (R, Vec<TuiScreenRect>) {
+        self.opaque_region_captures.push(Vec::new());
+        let result = f(self);
+        let regions = self
+            .opaque_region_captures
+            .pop()
+            .expect("an opaque-region capture is active");
+        (result, regions)
+    }
+
+    /// Records an explicit background fill for the innermost containing stack.
+    /// Painting outside a stack needs no retained compositing metadata.
+    pub(crate) fn record_opaque_region(&mut self, region: TuiScreenRect) {
+        if let Some(regions) = self.opaque_region_captures.last_mut() {
+            regions.push(region);
+        }
     }
 
     /// Requests a repaint after `delay` (floored to [`MIN_REPAINT_DELAY`]),

--- a/crates/warpui_core/src/elements/tui/stack.rs
+++ b/crates/warpui_core/src/elements/tui/stack.rs
@@ -115,14 +115,24 @@ impl TuiElement for TuiStack {
             let child_area = TuiRect::new(0, 0, child_size.width, child_size.height);
             let mut layer = TuiBuffer::empty(child_area);
             let child_bounds = TuiScreenRect::new(screen_origin, child_size);
-            ctx.with_scene_layer(
+            let mut opaque_regions = ctx.with_scene_layer(
                 TuiClipBounds::BoundedByActiveLayerAnd(child_bounds),
                 |ctx| {
-                    let mut child_surface = TuiPaintSurface::mapped(&mut layer, origin);
-                    child.render(origin, &mut child_surface, ctx);
+                    let (_, opaque_regions) = ctx.capture_opaque_regions(|ctx| {
+                        let mut child_surface = TuiPaintSurface::mapped(&mut layer, origin);
+                        child.render(origin, &mut child_surface, ctx);
+                    });
+                    opaque_regions
                 },
             );
-            composite_buffer(&layer, origin, child_size, size, surface);
+            opaque_regions = opaque_regions
+                .into_iter()
+                .filter_map(|region| region.intersection(child_bounds))
+                .collect();
+            composite_buffer(&layer, &opaque_regions, origin, child_size, size, surface);
+            for region in opaque_regions {
+                ctx.record_opaque_region(region);
+            }
         }
     }
 
@@ -158,6 +168,7 @@ impl TuiElement for TuiStack {
 /// Paints the opaque cells in `source` onto `destination`.
 fn composite_buffer(
     source: &TuiBuffer,
+    opaque_regions: &[TuiScreenRect],
     origin: TuiScreenPosition,
     source_size: TuiSize,
     destination_size: TuiSize,
@@ -167,7 +178,12 @@ fn composite_buffer(
         let mut x = 0;
         while x < source_size.width {
             let cell = &source[(x, y)];
-            if is_transparent(cell) {
+            let screen_x = origin.x.saturating_add(i32::from(x));
+            let screen_y = origin.y.saturating_add(i32::from(y));
+            let explicitly_opaque = opaque_regions
+                .iter()
+                .any(|region| region.contains_xy(screen_x, screen_y));
+            if is_transparent(cell) && !explicitly_opaque {
                 x = x.saturating_add(1);
                 continue;
             }

--- a/crates/warpui_core/src/elements/tui/stack_tests.rs
+++ b/crates/warpui_core/src/elements/tui/stack_tests.rs
@@ -10,7 +10,7 @@ use crate::elements::tui::test_support::{
     render_to_frame, render_to_lines, with_event_context, with_paint_surface,
 };
 use crate::elements::tui::{
-    TuiBuffer, TuiBufferExt, TuiConstrainedBox, TuiConstraint, TuiElement, TuiEvent,
+    TuiBuffer, TuiBufferExt, TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiEvent,
     TuiEventHandler, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScreenPoint,
     TuiScreenPosition, TuiSize, TuiText,
 };
@@ -81,6 +81,45 @@ fn blank_cells_with_a_background_are_opaque() {
 
     assert_eq!(frame.buffer.to_lines(), vec!["A    "]);
     assert_eq!(frame.buffer[(4, 0)].bg, Color::Red);
+}
+
+#[test]
+fn blank_reset_background_fill_is_opaque_without_changing_color() {
+    let background = TuiText::new("stars").finish();
+    let foreground = TuiContainer::new(
+        TuiConstrainedBox::new(TuiText::new("A").finish())
+            .with_min_cols(5)
+            .with_max_cols(5)
+            .finish(),
+    )
+    .with_background(Color::Reset)
+    .finish();
+    let stack = TuiStack::new().child(background).child(foreground);
+
+    let frame = render_to_frame(stack, TuiSize::new(5, 1));
+
+    assert_eq!(frame.buffer.to_lines(), vec!["A    "]);
+    assert_eq!(frame.buffer[(4, 0)].bg, Color::Reset);
+}
+#[test]
+fn reset_background_opacity_propagates_through_nested_stacks() {
+    let background = TuiText::new("stars").finish();
+    let foreground = TuiStack::new().child(
+        TuiContainer::new(
+            TuiConstrainedBox::new(TuiText::new("A").finish())
+                .with_min_cols(5)
+                .with_max_cols(5)
+                .finish(),
+        )
+        .with_background(Color::Reset)
+        .finish(),
+    );
+    let stack = TuiStack::new().child(background).child(foreground.finish());
+
+    let frame = render_to_frame(stack, TuiSize::new(5, 1));
+
+    assert_eq!(frame.buffer.to_lines(), vec!["A    "]);
+    assert_eq!(frame.buffer[(4, 0)].bg, Color::Reset);
 }
 
 #[test]


### PR DESCRIPTION
## Description
Polishes the Warp Agent CLI zero state by smoothing the rotating logo animation, improving glyph transitions, and reducing visual noise from ghost stippling and side stitches.

The zero-state copy now clears stars beneath it without introducing a concrete RGB background. Explicit container background fills are retained as stack-local opaque rectangles, so `Color::Reset` continues to inherit the host terminal background while clearing lower layers. This avoids per-cell opacity masks and their extra allocation and marking pass.

## Linked Issue
https://linear.app/warpdotdev/issue/CODE-1876/zero-state-animation

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] Manually tested the TUI locally with `./script/run-tui` and tmux captures.
- [x] `cargo nextest run -p warpui_core --features tui -E 'test(stack)'` — 33 passed.
- [x] `cargo nextest run -p warp_tui -E 'test(zero_state)'` — 47 passed.
- [x] `./script/format`
- [x] All three Clippy configurations from `./script/presubmit` with warnings denied.
- [ ] Full workspace nextest was interrupted during unrelated GUI integration tests after formatting and linting passed.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/f10c4f69-37bb-4ef6-ae3e-2f7108e2de4f

CHANGELOG-IMPROVEMENT: Polished the Warp Agent CLI zero-state animation and text presentation.

Co-Authored-By: Warp <agent@warp.dev>
