### PR TITLE
fix(external_editor): enable Cursor file links on Linux

### DIFF
--- a/app/src/util/file/external_editor/linux.rs
+++ b/app/src/util/file/external_editor/linux.rs
@@ -473,6 +473,7 @@ impl Editor {
             VSCode => Some(&["code"]),
             VSCodeInsiders => Some(&["code-insiders"]),
             WebStorm => Some(&["webstorm", "jetbrains-webstorm"]),
+            Cursor => Some(&["cursor", "cursor-url-handler"]),
             Windsurf => Some(&["windsurf"]),
             Zed => Some(&["dev.zed.Zed"]),
             ZedPreview => Some(&["dev.zed.Zed-Preview"]), // both Zed stable and preview use the same binary on Linux
@@ -504,6 +505,15 @@ impl Editor {
                 };
 
                 std::path::Path::new(&binary_path).exists()
+            }
+            // Cursor on Linux is often installed without a .desktop file; fall back to
+            // checking for the CLI binary on PATH.
+            Cursor => {
+                self.installed_editors().contains_key(self)
+                    || std::process::Command::new("sh")
+                        .args(["-c", "command -v cursor >/dev/null 2>&1"])
+                        .status()
+                        .is_ok_and(|status| status.success())
             }
             // For all other editors, just check the desktop file
             _ => self.installed_editors().contains_key(self),
@@ -540,6 +550,15 @@ impl Editor {
                     "vscode-insiders://file{}{suffix}",
                     file_path.display()
                 ));
+                Some(command)
+            }
+            Cursor => {
+                let mut file_arg = file_path.display().to_string();
+                if let Some(line_column_number) = line_column_number {
+                    file_arg.push_str(&line_column_number.to_string_suffix());
+                }
+                let mut command = Command::new("cursor");
+                command.arg(file_arg);
                 Some(command)
             }
             Windsurf => {

--- a/app/src/util/file/external_editor/mod.rs
+++ b/app/src/util/file/external_editor/mod.rs
@@ -51,8 +51,12 @@ pub const SUPPORTED_EDITORS: &[Editor] = &[
     Editor::DataSpell,
     Editor::DataGrip,
     Editor::AndroidStudio,
-    #[cfg(any(target_os = "macos", windows))]
-    // Cursor *can* run on linux, but does not have a .desktop file
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "freebsd",
+        windows
+    ))]
     Editor::Cursor,
     Editor::Windsurf,
 ];


### PR DESCRIPTION
## Description

Fixes #14528 — on Linux, Cursor was excluded from `SUPPORTED_EDITORS` and had no Linux `is_installed` / `command` implementation, so file links could not open in Cursor (dropdown omitted it; manual `open_file_editor: cursor` fell back to the system default app).

Changes:
- Include `Editor::Cursor` in `SUPPORTED_EDITORS` on Linux/FreeBSD (matching macOS/Windows).
- Register Cursor `.desktop` app IDs when present (`cursor`, `cursor-url-handler`).
- Detect Cursor via `cursor` CLI on `PATH` when no `.desktop` entry exists (common install path).
- Launch files with the `cursor` binary and optional `:line` / `:line:col` suffix.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. *(Bug triaged by Oz with `repro:high`; Warp CONTRIBUTING allows actionable bug fixes without `ready-to-implement`.)*
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Fixes warpdotdev/warp#14528

## Testing

**Problem:** On Linux, `Editor::Cursor` was cfg-gated out of `SUPPORTED_EDITORS`, and `linux.rs` had no Cursor `is_installed` / `command` path — matching Oz triage on #14528.

**Root cause:** `mod.rs` excluded Cursor on Linux; `linux.rs` only opened editors discovered via `.desktop` metadata.

**Fix:** Minimal Linux parity with existing Windsurf/VS Code patterns: enable Cursor in the supported list, detect the `cursor` CLI when no desktop entry exists, and invoke `cursor <path>[:line[:col]]`.

**Verification run:**
- `git fetch upstream master` — bug markers present on `upstream/master` at time of branch
- `python3 scripts/preflight_ship.py` — no open/merged duplicate PRs for #14528 (file-level `must-not-contain` false-positives on unrelated `target_os = "linux"` uses in the same module)
- `/home/ubuntu/fleet-ops/scripts/check-existing-pr.sh warpdotdev/warp "linux cursor external editor 14528" --branch fix/linux-cursor-external-editor --issue 14528` — exit 0
- Structural review of `linux.rs` command/`is_installed` paths against Windsurf + Zed patterns

**Not run (environment limits):** `./script/presubmit` / `./script/run` — this contributor host has no Rust toolchain or GUI/Warp runtime. Request maintainer or reviewer validation on Ubuntu 22.04+ with Cursor installed (`cursor` on PATH).

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

N/A from headless CI host — behavior change is in external-editor command dispatch only. Happy to capture a screen recording on request once validated on a Linux desktop with Cursor installed.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: File links can now open in Cursor on Linux when the Cursor CLI is installed.
