### PR TITLE
feat: promote context window usage breakdown to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -600,6 +600,7 @@ default = [
     "mcp_grouped_server_context",
     "fork_from_command",
     "context_window_usage_v2",
+    "context_window_usage_breakdown",
     "ambient_agents_command_line",
     "ambient_agents_image_upload",
     "scheduled_ambient_agents",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -519,8 +519,8 @@ pub enum FeatureFlag {
     /// Enables v2 of the context window usage UI.
     ContextWindowUsageV2,
 
-    /// Dev-only: enables the expandable per-segment context window usage
-    /// breakdown in the conversation usage card.
+    /// Enables the expandable per-segment context window usage breakdown in
+    /// the conversation usage card.
     ContextWindowUsageBreakdown,
 
     /// Enables global search
@@ -1000,7 +1000,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::WarpControlCli,
     FeatureFlag::TerminalLifecycleRecovery,
     FeatureFlag::PromptCacheExpiryWarning,
-    FeatureFlag::ContextWindowUsageBreakdown,
     FeatureFlag::JupyterNotebookRendering,
     FeatureFlag::WaitForEventsParentRegistration,
     FeatureFlag::McpJsonTreeView,


### PR DESCRIPTION
## Description
Promotes the detailed context-window usage breakdown to Stable in the Warp client.

- Enables the `context_window_usage_breakdown` Cargo feature by default.
- Removes `ContextWindowUsageBreakdown` from `DOGFOOD_FLAGS` because Stable builds now compile and enable it through the existing feature bridge.
- Keeps the feature flag and compile-time bridge in place for a one-line rollback during stabilization.
- Updates the feature comment to remove the stale dev-only designation.

This complements the server-side production rollout and addresses [REMOTE-2390](https://linear.app/warpdotdev/issue/REMOTE-2390/context-breakdown-for-conversations-system-prompt-tools-agentsmd).

## Validation
- `./script/format`
- `cargo check -p warp_features`
- `cargo clippy -p warp_features --all-targets -- -D warnings`
- Confirmed via `cargo metadata` that `context_window_usage_breakdown` is present in the default feature set.

No new integration test is included because this PR only promotes the existing, already-tested implementation through configuration; it does not change rendering behavior.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/058394b3-c0e4-4edd-a6af-3f2ee8405276_
_Run: https://oz.staging.warp.dev/runs/019fb027-7a76-7053-834f-5ba35407e63b_
_This PR was generated with [Oz](https://warp.dev/oz)._
