### PR TITLE
Retry transient macOS codesign timestamp failures

### DIFF
--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -92,6 +92,33 @@ function relpath() {
   python -c "import os,sys;print(os.path.relpath(*(sys.argv[1:])))" "$@";
 }
 
+# Retry timestamped signing because Apple's timestamp service can fail
+# transiently. All call sites use force signing so retries are idempotent.
+function codesign_with_retry() {
+  local max_attempts="${CODESIGN_MAX_ATTEMPTS:-4}"
+  local initial_retry_delay_seconds="${CODESIGN_INITIAL_RETRY_DELAY_SECONDS:-5}"
+  local retry_delay_seconds="$initial_retry_delay_seconds"
+  local attempt
+  local status
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if codesign "$@"; then
+      return 0
+    else
+      status=$?
+    fi
+
+    if (( attempt == max_attempts )); then
+      echo "Codesigning failed after $attempt attempts."
+      return "$status"
+    fi
+
+    echo "Codesigning failed; retrying in $retry_delay_seconds seconds ($attempt/$max_attempts)."
+    sleep "$retry_delay_seconds"
+    retry_delay_seconds=$((retry_delay_seconds * 2))
+  done
+}
+
 # Submit once so a transient polling failure can resume the same notarization
 # instead of uploading a duplicate artifact.
 function notarize_artifact() {
@@ -842,10 +869,10 @@ elif [[ $CODESIGN = true ]]; then
   if [[ "$ARTIFACT" == app ]]; then
     echo "Codesigning $BUNDLE_DIR/$WARP_APP_NAME.app..."
     # Use --deep so we sign bundled frameworks as well
-    codesign --deep -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$BUNDLE_DIR/$WARP_APP_NAME.app" --entitlements script/Entitlements.plist
+    codesign_with_retry --deep -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$BUNDLE_DIR/$WARP_APP_NAME.app" --entitlements script/Entitlements.plist
   elif [[ "$ARTIFACT" == cli || "$ARTIFACT" == warpctrl || "$ARTIFACT" == tui ]]; then
     echo "Codesigning $OUT_DIR/$WARP_BIN..."
-    codesign -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$OUT_DIR/$WARP_BIN" --entitlements script/Entitlements.plist
+    codesign_with_retry -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$OUT_DIR/$WARP_BIN" --entitlements script/Entitlements.plist
 
     # Create the .zip for notarization in a separate location - otherwise, Apple's codesigning
     # tools decide that it's a sealed resource that belongs to the binary and needs to also be signed.
@@ -917,7 +944,7 @@ if [[ "$ARTIFACT" = app ]]; then
     create_warp_dmg "$DMG_DIR"
 
     echo "Codesigning $DMG_DIR/$DMG_NAME..."
-    codesign -s "$APPLE_TEAM_ID" --timestamp "$DMG_DIR/$DMG_NAME"
+    codesign_with_retry -f -s "$APPLE_TEAM_ID" --timestamp "$DMG_DIR/$DMG_NAME"
 
     NOTARIZATION_ARTIFACT="$DMG_DIR/$DMG_NAME"
     STAPLE_TICKET=true


### PR DESCRIPTION
## Description

Timestamped macOS release signing can fail transiently when Apple's timestamp service does not return a secure timestamp. The failure currently aborts the release after the artifact has already spent most of the job compiling.

This change:
- adds a bounded `codesign_with_retry` helper with four attempts and exponential backoff
- applies it to app, standalone CLI/TUI, and DMG timestamped signing
- preserves the final `codesign` exit status when retries are exhausted
- uses forced DMG signing so a partially signed attempt can be replaced safely
- keeps secure timestamps and notarization requirements enabled

## Linked Issue

Not applicable; this addresses an observed release-infrastructure failure without a corresponding Linear or public GitHub issue.

## Testing

- [x] `./script/presubmit`
  - 10,388 workspace tests passed; 85 skipped
  - 117 `warp_completer` v2 tests passed; 4 skipped
  - formatting, Clippy, clang-format, wgslfmt, and doc tests passed
- [x] `bash -n script/macos/bundle`
- [x] `git diff --check`
- [x] Deterministic fake-`codesign` harness: transient failures succeed on attempt 3
- [x] Deterministic fake-`codesign` harness: persistent failures stop after attempt 4 and preserve exit code 42
- [ ] I have manually tested my changes locally with `./script/run` — not applicable to release codesigning infrastructure

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent artifacts

- [Implementation plan](https://staging.warp.dev/drive/notebook/GpRxMyyvmh4YOOukpgtZEH)
- [Conversation](https://staging.warp.dev/conversation/19e3a899-c2bd-4b29-8787-329da3f3c012)

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
