### PR TITLE
[fix](VA) Keep non-zero wait action groups in computer-use recordings

### DIFF
--- a/crates/computer_use/src/overlay.rs
+++ b/crates/computer_use/src/overlay.rs
@@ -52,15 +52,14 @@ pub enum PointerEventKind {
 }
 
 /// Returns true if a `UseComputer` action batch contains at least one real
-/// interaction — any non-`Wait` action (keyboard, typing, pointer, or scroll).
-/// A wait-only or zero-duration no-op batch (for example a screenshot-only
-/// call, which emits a single `Wait(0)`) is not a qualifying action group and is
-/// not committed to the recording timeline. A pointer-only batch still
-/// qualifies (with empty labels) so its on-screen effects are retained.
+/// interaction — any non-`Wait` action (keyboard, typing, pointer, or scroll)
+/// or an explicit non-zero wait, whose settling time should be kept in the
+/// recording. Only batches made entirely of `Wait(0)` no-ops (for example a
+/// screenshot-only call) fail to qualify and are not committed to the
+/// recording timeline. A pointer-only batch still qualifies (with empty
+/// labels) so its on-screen effects are retained.
 pub fn is_meaningful_action_group(actions: &[TargetedAction]) -> bool {
-    actions
-        .iter()
-        .any(|targeted| !matches!(targeted.action, Action::Wait(_)))
+    actions.iter().any(|targeted| !targeted.action.is_no_op())
 }
 
 enum LabelCandidate {

--- a/crates/computer_use/src/overlay_tests.rs
+++ b/crates/computer_use/src/overlay_tests.rs
@@ -136,12 +136,12 @@ fn is_meaningful_action_group_true_for_real_interactions() {
 }
 
 #[test]
-fn is_meaningful_action_group_false_for_wait_only_or_empty() {
+fn is_meaningful_action_group_keeps_nonzero_waits_but_not_no_ops() {
     let zero_wait = [screen(Action::Wait(Duration::ZERO))];
     assert!(!is_meaningful_action_group(&zero_wait));
 
     let nonzero_wait = [screen(Action::Wait(Duration::from_millis(500)))];
-    assert!(!is_meaningful_action_group(&nonzero_wait));
+    assert!(is_meaningful_action_group(&nonzero_wait));
 
     assert!(!is_meaningful_action_group(&[]));
 }


### PR DESCRIPTION
## Description
Computer-use recordings on Linux are smart-trimmed: only committed action groups produce keep-windows, and everything else is hard-cut. `is_meaningful_action_group` treated every `Wait`-only batch as non-meaningful, so a standalone "wait for the UI to settle" call was never committed and its settling period was cut from the video, even though it plays out in real time on screen.

This changes the predicate to count any non-zero `Wait` as meaningful (via the existing `Action::is_no_op()` helper), while `Wait(0)` no-op batches — emitted for screenshot/zoom/cursor-position-only calls — remain excluded so empty frames are still trimmed. Non-`Wait` actions are unaffected. The commit path already records the full wait duration in the group's `[offset, finish_offset]` span, so no other changes are needed.

## Linked Issue
N/A — recording-quality fix from the CU video trim pipeline work.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Updated the existing `is_meaningful_action_group` unit test: a 500 ms wait-only group now asserts meaningful, while the `Wait(0)` and empty-slice cases keep asserting non-meaningful.

Ran locally (macOS):
- `cargo nextest run -p computer_use` — 62 passed, 0 skipped
- `./script/format --check` — clean
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` — clean
- `cargo clippy -p warp --all-targets --tests -- -D warnings` — clean
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` — clean

Not manually tested with `./script/run`: the trim only runs on Linux recordings, and the change is fully covered by the unit test on the pure predicate.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/df74c6da-5f2a-4a0f-99a6-7b9e8b64cb1f
Run: https://oz.staging.warp.dev/runs/019fb41e-c9c2-778f-844e-afcf68f7bf0e

CHANGELOG-BUG-FIX: Computer-use video recordings now keep real (non-zero) wait periods at real time instead of trimming them out.

Co-Authored-By: Oz <oz-agent@warp.dev>
