### PR TITLE
Show TUI-impacting changelog updates

### DIFF
--- a/.agents/skills/changelog-draft/SKILL.md
+++ b/.agents/skills/changelog-draft/SKILL.md
@@ -54,6 +54,7 @@ The script outputs JSON to stdout with this structure:
       "number": 1234,
       "url": "https://github.com/warpdotdev/warp/pull/1234",
       "title": "...",
+      "commit_subject": "... (#1234)",
       "author": "username",
       "body": "...",
       "labels": ["..."],
@@ -76,7 +77,7 @@ The script outputs JSON to stdout with this structure:
 }
 ```
 
-Use the top-level `number`, `url`, `author`, `body`, `labels`, `changed_files`, and `source_repo` fields as the source of truth. `internal_pr` is audit-only and must never be used for contributor attribution or user-facing changelog links. If `url` is empty, omit the PR link from user-facing markdown rather than synthesizing one.
+Use the top-level `number`, `url`, `commit_subject`, `author`, `body`, `labels`, `changed_files`, and `source_repo` fields as the source of truth. `internal_pr` is audit-only and must never be used for contributor attribution or user-facing changelog links. If `url` is empty, omit the PR link from user-facing markdown rather than synthesizing one.
 
 ### Step 3 — Classify contributors
 
@@ -146,6 +147,7 @@ The `--org` flag checks each reporter's org membership via the GitHub API, filte
 Whenever the markdown draft credits a PR author, contributor, or issue reporter, render the username as a GitHub profile link such as `[@username](https://github.com/username)`.
 
 ### Step 6 — Classify unmarked PRs
+Determine TUI impact independently from the regular changelog category for every PR. Explicit `CHANGELOG-TUI` and `CHANGELOG-OZ` markers are authoritative entries and may coexist with New Feature, Improvement, or Bug Fix entries. When a PR has an explicit TUI entry, preserve its other explicit entries. Otherwise, if `commit_subject` contains `TUI` as a standalone case-insensitive token, route any explicit New Feature, Improvement, or Bug Fix text to `TUI` instead of its regular category. This keeps clearly TUI-labeled changes out of the desktop changelog while allowing explicitly marked shared changes to appear on both surfaces.
 
 For each PR that has no explicit `CHANGELOG-*` entries, decide whether to include it and under which category.
 
@@ -158,6 +160,7 @@ For each unmarked PR, produce a classification:
   "include": true,
   "category": "IMPROVEMENT",
   "text": "Proposed changelog line",
+  "impacts_tui": true,
   "confidence": "high",
   "rationale": "...",
   "feature_flag": null,
@@ -169,6 +172,7 @@ For each unmarked PR, produce a classification:
 - PRs that only touch CI, tests, docs, or internal tooling → `include: false`
 - PRs behind dogfood-only feature flags → `include: false` for stable channel
 - PRs behind preview flags → `include: false` for stable, `include: true` for preview
+- Set `impacts_tui: true` when Warp Agent CLI users observe the change, including shared Agent capabilities such as tool-call or edit-file behavior
 - When in doubt, set `needs_review: true` and `confidence: "low"`
 - Bot PRs (dependabot, renovate, etc.) → `include: false`
 
@@ -183,9 +187,12 @@ Combine explicit entries (Step 2) and inferred entries (Step 6) into the final r
 1. `NEW-FEATURE` — New Features
 2. `IMPROVEMENT` — Improvements
 3. `BUG-FIX` — Bug Fixes
-4. `OZ` — Oz Updates
+4. `TUI` — TUI Updates
+5. `OZ` — Oz Updates
 
 PRs marked with `CHANGELOG-NONE` are explicitly opted out and must never appear in the changelog markdown.
+
+Preserve every explicit entry independently. For an inferred regular entry with `impacts_tui: true`, also create a `TUI` entry with the same user-facing text and PR metadata. Do not duplicate an inferred entry whose category is already `TUI`.
 
 When creating entries, copy `pr_number`, `url`, `author`, `source_repo`, and `internal_pr` from the normalized PR record. The release JSON converter uses `url` directly; do not invent public PR URLs from PR numbers.
 
@@ -209,6 +216,9 @@ Write two files to `output_dir`:
 
 ## Bug Fixes
 - Fixed crash on startup ([#1236](https://github.com/warpdotdev/warp/pull/1236))
+
+## TUI Updates
+- Added inline command menus to Warp Agent CLI ([#1238](https://github.com/warpdotdev/warp/pull/1238))
 
 ## Oz Updates
 - Improved agent memory ([#1237](https://github.com/warpdotdev/warp/pull/1237))

--- a/.agents/skills/changelog-draft/scripts/add_tui_updates.py
+++ b/.agents/skills/changelog-draft/scripts/add_tui_updates.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Add updates that impact TUI users to legacy changelog JSON.
+
+Preview and dev releases use the legacy changelog action, which only parses
+explicit PR-body markers. This post-processor reuses the normalized PR metadata
+collector used by stable releases, copies explicit TUI-impact entries, and moves
+commit-labeled TUI-only entries out of the regular changelog buckets.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+
+from fetch_prs import collect_prs
+
+REGULAR_CATEGORY_KEYS = {
+    "NEW-FEATURE": "newFeatures",
+    "IMPROVEMENT": "improvements",
+    "BUG-FIX": "bugFixes",
+}
+TUI_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9])TUI(?![A-Za-z0-9])", re.IGNORECASE)
+TRAILING_PR_RE = re.compile(r"\s*\(#\d+\)\s*$")
+LEADING_TICKET_RE = re.compile(r"^\s*\[[A-Z]+-\d+\]\s*")
+TUI_PREFIX_RE = re.compile(
+    r"""(?ix)
+    ^\s*
+    (?:
+        (?:\[TUI\]|TUI)\s*(?::|-)\s*
+        |
+        (?:feat|fix|chore|refactor|perf|test|docs)\s*\(\s*TUI\s*\)\s*:\s*
+    )
+    """
+)
+
+
+def run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def previous_release_cut(release_tag: str, channel: str) -> str:
+    """Find the _00 tag from the previous release date."""
+    release_date_prefix = release_tag.rsplit("_", 1)[0]
+    tags = run(
+        [
+            "git",
+            "tag",
+            "--list",
+            f"v0.*.{channel}_00",
+            "--sort=-version:refname",
+        ]
+    )
+    for tag in tags.splitlines():
+        if tag.rsplit("_", 1)[0] != release_date_prefix:
+            return tag
+    raise ValueError(f"could not find a previous {channel} release cut")
+
+
+def is_tui_subject(subject: str) -> bool:
+    return bool(TUI_TOKEN_RE.search(subject))
+
+
+def normalize_subject(subject: str) -> str:
+    """Turn a TUI-labeled commit subject into compact changelog text."""
+    text = TRAILING_PR_RE.sub("", subject).strip()
+    text = LEADING_TICKET_RE.sub("", text)
+    text = TUI_PREFIX_RE.sub("", text).strip()
+    if text:
+        text = text[0].upper() + text[1:]
+    return text
+
+
+def remove_first(items: list, value: str) -> None:
+    try:
+        items.remove(value)
+    except ValueError:
+        pass
+
+
+def append_unique(items: list[str], value: str) -> None:
+    if value and value not in items:
+        items.append(value)
+
+
+def add_tui_updates(changelog: dict, prs: list[dict]) -> dict:
+    """Return a changelog with entries that impact TUI in tui_updates."""
+    tui_updates = list(changelog.get("tui_updates") or [])
+
+    for pr in prs:
+        explicit_entries = pr.get("explicit_entries") or []
+        explicit_categories = {
+            entry.get("category", "") for entry in explicit_entries
+        }
+        if "NONE" in explicit_categories:
+            continue
+
+        regular_entries = [
+            entry
+            for entry in explicit_entries
+            if entry.get("category") in REGULAR_CATEGORY_KEYS
+        ]
+        explicit_tui_entries = [
+            entry for entry in explicit_entries if entry.get("category") == "TUI"
+        ]
+
+        if explicit_tui_entries:
+            selected_text = [
+                entry.get("text", "").strip() for entry in explicit_tui_entries
+            ]
+            move_regular_entries = False
+        else:
+            subject = pr.get("commit_subject") or pr.get("title") or ""
+            title = pr.get("title") or ""
+            tui_headline = subject if is_tui_subject(subject) else title
+            if "OZ" in explicit_categories or not is_tui_subject(tui_headline):
+                continue
+            selected_text = [
+                entry.get("text", "").strip() for entry in regular_entries
+            ]
+            if not selected_text:
+                selected_text = [normalize_subject(tui_headline)]
+            move_regular_entries = True
+
+        if move_regular_entries:
+            for entry in regular_entries:
+                release_key = REGULAR_CATEGORY_KEYS[entry["category"]]
+                values = changelog.get(release_key)
+                if isinstance(values, list):
+                    remove_first(values, entry.get("text", "").strip())
+
+        for text in selected_text:
+            append_unique(tui_updates, text)
+
+    changelog["tui_updates"] = tui_updates
+    return changelog
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Add updates that impact TUI users to legacy changelog JSON"
+    )
+    parser.add_argument("--input", required=True, help="Legacy changelog JSON")
+    parser.add_argument("--output", required=True, help="Updated changelog JSON")
+    parser.add_argument("--repo", required=True, help="GitHub repo (owner/name)")
+    parser.add_argument("--channel", required=True, help="Release channel")
+    parser.add_argument("--release-tag", required=True, help="Current release tag")
+    args = parser.parse_args()
+
+    base_ref = previous_release_cut(args.release_tag, args.channel)
+    release_prs = collect_prs(args.repo, base_ref, args.release_tag)["prs"]
+    with open(args.input) as f:
+        changelog = json.load(f)
+
+    changelog = add_tui_updates(changelog, release_prs)
+    with open(args.output, "w") as f:
+        json.dump(changelog, f, indent=2)
+        f.write("\n")
+
+    print(
+        f"Added {len(changelog['tui_updates'])} TUI updates "
+        f"from {base_ref}..{args.release_tag}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/changelog-draft/scripts/build_slack_payload.py
+++ b/.agents/skills/changelog-draft/scripts/build_slack_payload.py
@@ -20,6 +20,7 @@ SECTION_ORDER = (
     ("improvements", "Improvements"),
     ("bugFixes", "Bug Fixes"),
     ("images", "Image"),
+    ("tui_updates", "TUI Updates"),
     # Keep the existing label stable for compatibility with recent Slack posts.
     ("oz_updates", "oz_updates"),
 )

--- a/.agents/skills/changelog-draft/scripts/convert_to_release_json.py
+++ b/.agents/skills/changelog-draft/scripts/convert_to_release_json.py
@@ -14,7 +14,8 @@ The output schema:
       "improvements": ["..."],
       "bugFixes": ["..."],
       "images": ["..."],
-      "oz_updates": ["..."]
+      "oz_updates": ["..."],
+      "tui_updates": ["..."]
     }
 """
 
@@ -28,6 +29,7 @@ CATEGORY_MAP = {
     "IMPROVEMENT": "improvements",
     "BUG-FIX": "bugFixes",
     "OZ": "oz_updates",
+    "TUI": "tui_updates",
     "IMAGE": "images",
 }
 
@@ -64,6 +66,7 @@ def convert(draft: dict) -> dict:
         "bugFixes": [],
         "images": [],
         "oz_updates": [],
+        "tui_updates": [],
     }
 
     for entry in draft.get("entries", []):

--- a/.agents/skills/changelog-draft/scripts/fetch_prs.py
+++ b/.agents/skills/changelog-draft/scripts/fetch_prs.py
@@ -17,7 +17,7 @@ import sys
 
 # Matches lines like: CHANGELOG-NEW-FEATURE: Added dark mode
 MARKER_RE = re.compile(
-    r"^CHANGELOG-(NEW-FEATURE|IMPROVEMENT|BUG-FIX|IMAGE|OZ|NONE)\s*:?\s*(.*)$",
+    r"^CHANGELOG-(NEW-FEATURE|IMPROVEMENT|BUG-FIX|IMAGE|OZ|TUI|NONE)\s*:?\s*(.*)$",
     re.MULTILINE,
 )
 
@@ -57,6 +57,10 @@ def get_commits(base_ref: str, head_ref: str) -> list[str]:
     if not log:
         return []
     return log.splitlines()
+
+def get_commit_subject(sha: str) -> str:
+    """Return the first line of a commit message."""
+    return run(["git", "log", "-1", "--format=%s", sha])
 
 
 def extract_pr_number(sha: str) -> int | None:
@@ -285,26 +289,20 @@ def extract_markers(body: str) -> list[dict]:
     return entries
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Fetch PRs in a release range")
-    parser.add_argument("--repo", required=True, help="GitHub repo (owner/name)")
-    parser.add_argument("--base-ref", required=True, help="Previous release tag")
-    parser.add_argument("--head-ref", required=True, help="Current release tag")
-    args = parser.parse_args()
-
-    commit_shas = get_commits(args.base_ref, args.head_ref)
-
+def collect_prs(repo: str, base_ref: str, head_ref: str) -> dict:
+    """Collect normalized PR metadata for a release range."""
+    commit_shas = get_commits(base_ref, head_ref)
     seen_prs: set[int] = set()
     prs: list[dict] = []
 
-    def process_pr(pr_num: int) -> None:
+    def process_pr(pr_num: int, commit_sha: str) -> None:
         """Fetch and record a single PR by number."""
-        data = fetch_pr_data(args.repo, pr_num)
+        data = fetch_pr_data(repo, pr_num)
         if data is None:
             return
-        if not should_include_pr(args.repo, data):
+        if not should_include_pr(repo, data):
             return
-        source_repo, data, internal_pr = normalize_pr_data(args.repo, pr_num, data)
+        source_repo, data, internal_pr = normalize_pr_data(repo, pr_num, data)
         author_login = get_author_login(data)
         label_names = get_label_names(data)
 
@@ -317,6 +315,7 @@ def main() -> None:
             "number": data.get("number", pr_num),
             "url": data.get("url", "") if source_repo == PUBLIC_REPO else "",
             "title": data.get("title", ""),
+            "commit_subject": get_commit_subject(commit_sha),
             "author": author_login,
             "body": body,
             "labels": label_names,
@@ -335,7 +334,7 @@ def main() -> None:
         if pr_num is not None and pr_num not in seen_prs:
             # Normal squash-merge commit
             seen_prs.add(pr_num)
-            process_pr(pr_num)
+            process_pr(pr_num, sha)
         else:
             # Merge commit fallback: walk the merged-in commits for PR numbers.
             # This handles branches merged via merge commit (e.g. security-patches)
@@ -344,12 +343,22 @@ def main() -> None:
                 inner_pr = extract_pr_number(merged_sha)
                 if inner_pr is not None and inner_pr not in seen_prs:
                     seen_prs.add(inner_pr)
-                    process_pr(inner_pr)
+                    process_pr(inner_pr, merged_sha)
 
-    output = {
-        "range": {"base": args.base_ref, "head": args.head_ref},
+    return {
+        "range": {"base": base_ref, "head": head_ref},
         "prs": prs,
     }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch PRs in a release range")
+    parser.add_argument("--repo", required=True, help="GitHub repo (owner/name)")
+    parser.add_argument("--base-ref", required=True, help="Previous release tag")
+    parser.add_argument("--head-ref", required=True, help="Current release tag")
+    args = parser.parse_args()
+
+    output = collect_prs(args.repo, args.base_ref, args.head_ref)
     json.dump(output, sys.stdout, indent=2)
     print()  # trailing newline
 

--- a/.agents/skills/changelog-draft/scripts/test_tui_updates.py
+++ b/.agents/skills/changelog-draft/scripts/test_tui_updates.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from add_tui_updates import add_tui_updates, is_tui_subject, normalize_subject
+from convert_to_release_json import convert
+from fetch_prs import extract_markers
+
+
+class TuiUpdatesTest(unittest.TestCase):
+    def test_extract_markers_recognizes_tui(self) -> None:
+        self.assertEqual(
+            extract_markers("CHANGELOG-TUI: Added inline command menus"),
+            [{"category": "TUI", "text": "Added inline command menus"}],
+        )
+
+    def test_tui_subject_requires_a_standalone_token(self) -> None:
+        for subject in [
+            "TUI: add inline menus (#1)",
+            "[TUI] Add inline menus (#1)",
+            "feat(tui): add inline menus (#1)",
+            "Polish the TUI zero state (#1)",
+        ]:
+            self.assertTrue(is_tui_subject(subject), subject)
+        self.assertFalse(is_tui_subject("Make the menu more intuitive (#1)"))
+
+    def test_normalize_subject_removes_internal_prefixes(self) -> None:
+        self.assertEqual(
+            normalize_subject("[CODE-123] TUI: add inline menus (#456)"),
+            "Add inline menus",
+        )
+        self.assertEqual(
+            normalize_subject("feat(tui): add inline menus (#456)"),
+            "Add inline menus",
+        )
+
+    def test_copies_explicit_impacts_and_moves_inferred_tui_entries(self) -> None:
+        changelog = {
+            "newFeatures": [],
+            "improvements": [
+                "Generic TUI text",
+                "Shared apply diff improvement",
+                "Desktop text",
+            ],
+            "bugFixes": [],
+            "images": [],
+            "oz_updates": [],
+        }
+        prs = [
+            {
+                "commit_subject": "TUI: add generic entry (#1)",
+                "explicit_entries": [
+                    {"category": "IMPROVEMENT", "text": "Generic TUI text"}
+                ],
+            },
+            {
+                "commit_subject": "feat(tui): add status menu (#2)",
+                "explicit_entries": [],
+            },
+            {
+                "commit_subject": "Add status details (#22)",
+                "title": "TUI: add status details",
+                "explicit_entries": [],
+            },
+            {
+                "commit_subject": "Improve apply diff behavior (#3)",
+                "explicit_entries": [
+                    {
+                        "category": "TUI",
+                        "text": "Improved apply diff behavior",
+                    },
+                    {
+                        "category": "IMPROVEMENT",
+                        "text": "Shared apply diff improvement",
+                    },
+                ],
+            },
+            {
+                "commit_subject": "TUI: keep this in Oz (#4)",
+                "explicit_entries": [
+                    {"category": "OZ", "text": "Explicit Oz text"}
+                ],
+            },
+        ]
+
+        result = add_tui_updates(changelog, prs)
+
+        self.assertEqual(
+            result["improvements"],
+            ["Shared apply diff improvement", "Desktop text"],
+        )
+        self.assertEqual(
+            result["tui_updates"],
+            [
+                "Generic TUI text",
+                "Add status menu",
+                "Add status details",
+                "Improved apply diff behavior",
+            ],
+        )
+
+    def test_converter_maps_tui_entries(self) -> None:
+        release = convert(
+            {
+                "entries": [
+                    {
+                        "category": "TUI",
+                        "text": "Added inline menus",
+                        "pr_number": 123,
+                        "url": "https://github.com/warpdotdev/warp/pull/123",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(
+            release["tui_updates"],
+            [
+                "Added inline menus "
+                "([#123](https://github.com/warpdotdev/warp/pull/123))"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/classify-changelog-pr/SKILL.md
+++ b/.agents/skills/classify-changelog-pr/SKILL.md
@@ -13,6 +13,7 @@ This document provides classification rules for PRs that lack explicit `CHANGELO
 - **IMPROVEMENT** — Enhances an existing feature in a way users would notice (performance, UX, new options).
 - **BUG-FIX** — Fixes a user-visible bug or regression.
 - **OZ** — Changes to Oz / AI agent capabilities. At most 4 per release in the stable changelog.
+- **TUI** — User-visible changes that impact the Warp Agent CLI/headless TUI, including shared Agent capabilities.
 - **NONE** — Explicitly opt out of changelog inclusion. Handled upstream by `fetch_prs.py` marker extraction.
 
 ## Decision rules
@@ -28,6 +29,14 @@ This document provides classification rules for PRs that lack explicit `CHANGELO
 ### Always include
 - PRs with explicit `CHANGELOG-*` markers (handled before this guidance applies)
 - PRs that fix a crash, data loss, or security issue — even without a marker
+
+### TUI surface classification
+- Treat explicit `CHANGELOG-TUI` and `CHANGELOG-OZ` markers as authoritative entries. They are independent and may coexist with each other or with regular changelog categories.
+- Determine TUI impact independently from the regular New Feature, Improvement, or Bug Fix category. A shared Agent capability may belong in both its regular category and `TUI`.
+- Classify a user-visible entry as impacting `TUI` when `commit_subject` contains `TUI` as a standalone token.
+- For stable releases, also use the PR title/body and TUI-owned paths such as `crates/warp_tui` or `crates/warpui_core/src/elements/tui`. Shared capabilities such as Agent tool-call or edit-file behavior also impact TUI when Warp Agent CLI users observe the change. If metadata is ambiguous, inspect the commit diff.
+- Do not infer TUI impact from file paths alone; confirm that Warp Agent CLI users observe the changed behavior.
+- A TUI-only entry belongs only in the TUI category. An entry that impacts both TUI and another surface should appear in both `TUI` and its regular category.
 
 ### Conditional on channel
 - **Stable channel:** Only include changes that are live for all users. Exclude PRs gated behind `DOGFOOD_FLAGS` or `PREVIEW_FLAGS`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,7 @@ The entries below will be used when constructing a soft-copy of the stable relea
 - BUG-FIX: for fixes related to known bugs or regressions.
 - IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
 - OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
+- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
 - NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.
 
 CHANGELOG-NEW-FEATURE: {{text goes here...}}
@@ -43,5 +44,6 @@ CHANGELOG-BUG-FIX: {{text goes here...}}
 CHANGELOG-BUG-FIX: {{more text goes here...}}
 CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
 CHANGELOG-OZ: {{text goes here...}}
+CHANGELOG-TUI: {{text goes here...}}
 CHANGELOG-NONE
 -->

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1857,6 +1857,31 @@ jobs:
           slack-message: "Failed to create ${{ steps.failed_releases.outputs.failed }} release artifacts for ${{ inputs.channel }}. See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}. cc: <!subteam^S06N82RS7FA>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.ACTION_MONITORING_SLACK }}
+  gate_tui_release_artifacts:
+    name: Gate changelog publication on TUI release artifacts
+    runs-on: ubuntu-latest
+    needs:
+      - prepare_release
+      - release_macos_tui
+      - release_linux_tui
+    if: ${{ always() }}
+    steps:
+      - name: Verify TUI release artifacts
+        shell: bash
+        env:
+          SHOULD_PUBLISH: ${{ needs.prepare_release.outputs.should_publish }}
+          CHANNEL: ${{ inputs.channel }}
+          MACOS_TUI_RESULT: ${{ needs.release_macos_tui.result }}
+          LINUX_TUI_RESULT: ${{ needs.release_linux_tui.result }}
+        run: |
+          if [[ "$SHOULD_PUBLISH" != "true" || ( "$CHANNEL" != "dev" && "$CHANNEL" != "preview" ) ]]; then
+            exit 0
+          fi
+
+          if [[ "$MACOS_TUI_RESULT" != "success" || "$LINUX_TUI_RESULT" != "success" ]]; then
+            echo "::error::TUI release artifacts were not published successfully (macOS: $MACOS_TUI_RESULT, Linux: $LINUX_TUI_RESULT)"
+            exit 1
+          fi
 
   generate_changelogs:
     name: Generate Changelogs
@@ -1872,6 +1897,7 @@ jobs:
       - release_linux_cli_x86
       - release_web
       - release_windows
+      - gate_tui_release_artifacts
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         name: Checkout sources
@@ -1942,36 +1968,40 @@ jobs:
           channel: ${{ inputs.channel }}
           github_auth_token: ${{ steps.github_app_auth.outputs.token }}
           version: ${{ needs.prepare_release.outputs.release_tag }}
+      - name: Add TUI updates to legacy changelog (non-stable only)
+        if: inputs.channel != 'stable'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.github_app_auth.outputs.token }}
+          LEGACY_CHANGELOG: ${{ steps.legacy_changelog.outputs.changelog }}
+        run: |
+          CHANGELOG_DIR="${{ runner.temp }}/changelog-draft"
+          LEGACY_CHANGELOG_FILE="$CHANGELOG_DIR/changelog-legacy.json"
+          mkdir -p "$CHANGELOG_DIR"
+          printf '%s\n' "$LEGACY_CHANGELOG" > "$LEGACY_CHANGELOG_FILE"
+          python3 .agents/skills/changelog-draft/scripts/add_tui_updates.py \
+            --input "$LEGACY_CHANGELOG_FILE" \
+            --output "$CHANGELOG_DIR/changelog-release.json" \
+            --repo "${{ github.repository }}" \
+            --channel "${{ inputs.channel }}" \
+            --release-tag "${{ needs.prepare_release.outputs.release_tag }}"
 
       - name: Load changelog into step output
         id: generate_changelog
         shell: bash
-        env:
-          LEGACY_CHANGELOG: ${{ steps.legacy_changelog.outputs.changelog }}
         run: |
-          # Bridge step: picks whichever generator ran for this channel and
-          # re-emits the changelog as outputs.changelog so downstream Slack/GCS
-          # steps work unchanged.
-          if [[ "${{ inputs.channel }}" == "stable" ]]; then
-            CHANGELOG_FILE="${{ runner.temp }}/changelog-draft/changelog-release.json"
-            if [ ! -f "$CHANGELOG_FILE" ]; then
-              echo "::error::changelog-release.json not found at $CHANGELOG_FILE"
-              exit 1
-            fi
-            jq empty "$CHANGELOG_FILE"
-            {
-              echo "changelog<<CHANGELOG_EOF"
-              cat "$CHANGELOG_FILE"
-              echo "CHANGELOG_EOF"
-            } >> $GITHUB_OUTPUT
-          else
-            echo "$LEGACY_CHANGELOG" | jq empty
-            {
-              echo "changelog<<CHANGELOG_EOF"
-              printf '%s\n' "$LEGACY_CHANGELOG"
-              echo "CHANGELOG_EOF"
-            } >> $GITHUB_OUTPUT
+          # Both generators now write the same release-format file.
+          CHANGELOG_FILE="${{ runner.temp }}/changelog-draft/changelog-release.json"
+          if [ ! -f "$CHANGELOG_FILE" ]; then
+            echo "::error::changelog-release.json not found at $CHANGELOG_FILE"
+            exit 1
           fi
+          jq empty "$CHANGELOG_FILE"
+          {
+            echo "changelog<<CHANGELOG_EOF"
+            cat "$CHANGELOG_FILE"
+            echo "CHANGELOG_EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Build Slack changelog payload
         id: build_slack_payload
@@ -2030,8 +2060,10 @@ jobs:
           IMAGE=$(echo $CHANGELOG | jq -r '.images | if length > 0 then .[-1] else "" end')
           # Extract Oz updates as a JSON array
           OZ_UPDATES=$(echo $CHANGELOG | jq -c '.oz_updates // []')
+          # Extract TUI updates as a JSON array
+          TUI_UPDATES=$(echo $CHANGELOG | jq -c '.tui_updates // []')
           # Tweak the structure of the JSON, add in a top-level date field, and add in the markdown_sections field
-          CHANGELOG=$(echo $CHANGELOG_SECTIONS | jq --arg date "$DATE" --arg new_features "$NEW_FEATURES" --arg improvements "$IMPROVEMENTS" --arg image "$IMAGE" --argjson oz_updates "$OZ_UPDATES" '{"date": $date, "sections": to_entries | map({"title": .key, "items": .value}), "markdown_sections": [{"title": "New features", "markdown": $new_features}, {"title": "Improvements", "markdown": $improvements}, {"title": "Coming soon", "markdown": ""}]} + (if $image != "" then {"image_url": $image} else {} end) + (if ($oz_updates | length) > 0 then {"oz_updates": $oz_updates} else {} end)')
+          CHANGELOG=$(echo $CHANGELOG_SECTIONS | jq --arg date "$DATE" --arg new_features "$NEW_FEATURES" --arg improvements "$IMPROVEMENTS" --arg image "$IMAGE" --argjson oz_updates "$OZ_UPDATES" --argjson tui_updates "$TUI_UPDATES" '{"date": $date, "sections": to_entries | map({"title": .key, "items": .value}), "markdown_sections": [{"title": "New features", "markdown": $new_features}, {"title": "Improvements", "markdown": $improvements}, {"title": "Coming soon", "markdown": ""}]} + (if $image != "" then {"image_url": $image} else {} end) + (if ($oz_updates | length) > 0 then {"oz_updates": $oz_updates} else {} end) + (if ($tui_updates | length) > 0 then {"tui_updates": $tui_updates} else {} end)')
 
           echo $CHANGELOG > changelog.json
           cat changelog.json

--- a/crates/channel_versions/src/channel_versions_tests.rs
+++ b/crates/channel_versions/src/channel_versions_tests.rs
@@ -81,3 +81,24 @@ fn test_ignores_unknown_channels() {
         "v0.2024.01.16.16.31.stable_01"
     );
 }
+
+#[test]
+fn changelog_tui_updates_are_backward_compatible() {
+    let old_payload = r#"{
+        "date": "2026-07-30T12:00:00+00:00",
+        "sections": [],
+        "oz_updates": []
+    }"#;
+    let changelog: Changelog =
+        serde_json::from_str(old_payload).expect("old changelog payload should deserialize");
+    assert!(changelog.tui_updates.is_empty());
+
+    let new_payload = r#"{
+        "date": "2026-07-30T12:00:00+00:00",
+        "sections": [],
+        "tui_updates": ["Added inline TUI menus"]
+    }"#;
+    let changelog: Changelog =
+        serde_json::from_str(new_payload).expect("new changelog payload should deserialize");
+    assert_eq!(changelog.tui_updates, ["Added inline TUI menus"]);
+}

--- a/crates/channel_versions/src/lib.rs
+++ b/crates/channel_versions/src/lib.rs
@@ -176,6 +176,8 @@ pub struct Changelog {
     pub image_url: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub oz_updates: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tui_updates: Vec<String>,
 }
 
 // Default value for when the changelog JSON doesn't have the markdown_sections field

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -582,28 +582,15 @@ fn changelog_bullets(app: &AppContext) -> Vec<String> {
     let ChangelogState::Some(changelog) = &ChangelogModel::as_ref(app).changelog else {
         return Vec::new();
     };
-    let from_sections = changelog
-        .sections
+    changelog_bullets_from_changelog(changelog)
+}
+
+fn changelog_bullets_from_changelog(changelog: &channel_versions::Changelog) -> Vec<String> {
+    changelog
+        .tui_updates
         .iter()
-        .flat_map(|section| section.items.iter())
         .take(MAX_CHANGELOG_BULLETS)
         .cloned()
-        .collect::<Vec<_>>();
-    if !from_sections.is_empty() {
-        return from_sections;
-    }
-    // Newer payloads may only populate the markdown sections; fall back to
-    // their top-level bullet lines.
-    changelog
-        .markdown_sections
-        .iter()
-        .flat_map(|section| section.markdown.lines())
-        .filter_map(|line| {
-            let line = line.trim();
-            line.strip_prefix("* ").or_else(|| line.strip_prefix("- "))
-        })
-        .take(MAX_CHANGELOG_BULLETS)
-        .map(ToOwned::to_owned)
         .collect()
 }
 

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use channel_versions::{Changelog, MarkdownSection, Section};
+use chrono::DateTime;
 use uuid::Uuid;
 use warp::tui_export::{
     TuiMcpConfigState, TuiMcpServerId, TuiMcpServerSnapshot, TuiMcpServerStatus, TuiMcpSnapshot,
@@ -17,7 +19,7 @@ use warpui_core::{App, AppContext};
 
 use super::{
     ANIMATION_PANEL_COLS, LEFT_COLUMN_COLS, build_zero_state_layout, build_zero_state_overlay,
-    mcp_status_label,
+    changelog_bullets_from_changelog, mcp_status_label,
 };
 use crate::tui_builder::TuiUiBuilder;
 use crate::zero_state_animation::{
@@ -36,6 +38,37 @@ fn server(id: u64, status: TuiMcpServerStatus) -> TuiMcpServerSnapshot {
         can_log_out: false,
         authorization_url: None,
     }
+}
+
+fn changelog(tui_updates: Vec<&str>) -> Changelog {
+    Changelog {
+        date: DateTime::parse_from_rfc3339("2026-07-30T12:00:00+00:00").unwrap(),
+        sections: vec![Section {
+            title: "Improvements".to_owned(),
+            items: vec!["Unrelated GUI improvement".to_owned()],
+        }],
+        markdown_sections: vec![MarkdownSection {
+            title: "Improvements".to_owned(),
+            markdown: "* Unrelated GUI improvement\n".to_owned(),
+        }],
+        image_url: None,
+        oz_updates: vec!["Unrelated Oz improvement".to_owned()],
+        tui_updates: tui_updates.into_iter().map(ToOwned::to_owned).collect(),
+    }
+}
+
+#[test]
+fn changelog_bullets_use_only_the_first_three_tui_updates() {
+    let changelog = changelog(vec!["First", "Second", "Third", "Fourth"]);
+    assert_eq!(
+        changelog_bullets_from_changelog(&changelog),
+        ["First", "Second", "Third"]
+    );
+}
+
+#[test]
+fn changelog_bullets_are_empty_when_only_other_surfaces_have_updates() {
+    assert!(changelog_bullets_from_changelog(&changelog(Vec::new())).is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Description

Teach the release changelog pipeline to classify changes that impact Warp Agent CLI users and carry them through a dedicated `tui_updates` payload. Stable releases use semantic impact classification, including shared Agent capabilities; dev and preview releases preserve the legacy generator and use explicit `CHANGELOG-TUI` markers plus deterministic TUI-labeled commit/title inference. Explicit shared impacts can appear in both the regular changelog and `tui_updates`, while inferred TUI-only changes stay out of the desktop changelog.

Changelog publication now waits for successful macOS and Linux TUI artifacts on dev and preview releases. The TUI zero state renders only `tui_updates` and hides “What’s new” when none exist.

```mermaid
flowchart LR
    Artifacts["macOS + Linux<br/>TUI artifacts"] --> Gate{"Artifacts succeeded?"}
    Gate -->|No| Stop["Do not publish changelog"]
    Gate -->|Yes / not a TUI channel| Range["Release range"]
    Range --> Channel{"Stable release?"}
    Channel -->|Yes| Stable["Oz changelog agent<br/>semantic TUI-impact classification"]
    Channel -->|No: Preview / Dev| Legacy["Legacy generator<br/>explicit CHANGELOG markers"]
    Legacy --> Filter["TUI post-processor<br/>copy shared markers / move TUI-only labels"]
    Stable --> Payload["Release payload<br/>tui_updates"]
    Filter --> Payload
    Payload --> Empty{"tui_updates empty?"}
    Empty -->|No| Show["Show up to 3 TUI updates"]
    Empty -->|Yes| Hide["Hide What’s new"]
```

## Linked Issue

N/A

## Testing

We don't have correctly marked new issues for now, so here's proof at least that we don't show the `What's new` section if there's nothing in it.

<img width="1453" height="977" alt="Screenshot 2026-07-30 at 10 57 32 AM" src="https://github.com/user-attachments/assets/c215d4d0-4da8-401e-8674-4acaf30db703" />

- `python3 .agents/skills/changelog-draft/scripts/test_tui_updates.py` (5 passed)
- Parsed `.github/workflows/create_release.yml` with Ruby Psych
- `cargo nextest run -p channel_versions -E 'test(changelog_tui_updates_are_backward_compatible)'`
- `./script/format`
- All three Clippy invocations from `script/presubmit` passed
- Focused TUI render tests were previously skipped at request

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp’s AI Agent Mode

## Artifacts

- [Implementation plan](https://staging.warp.dev/drive/notebook/zydPFn84WDuonNSX1d71Ls)
- [Agent conversation](https://staging.warp.dev/conversation/bc66dda0-c687-42f1-b087-6b0f32fbe191)

CHANGELOG-TUI: Warp Agent CLI now shows updates that impact TUI users in its What’s new section.

Co-Authored-By: Oz <oz-agent@warp.dev>
