### PR TITLE
Show the needs-SSO-link blocker when sign-in completes during new onboarding

### DIFF
--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -4078,11 +4078,10 @@ impl AuthOnboardingState {
                 report_error!("SSO link required after web user import");
             }
             AuthOnboardingState::NeedsSsoLink { .. } => (),
-            AuthOnboardingState::Onboarding { .. }
-            | AuthOnboardingState::LoginSlide { .. }
-            | AuthOnboardingState::PostAuthOnboarding { .. } => {
-                // For onboarding/login slide, we don't have a workspace yet, so we can't convert to SSO link
-                // This case shouldn't normally occur
+            AuthOnboardingState::Onboarding { target, .. }
+            | AuthOnboardingState::LoginSlide { target, .. }
+            | AuthOnboardingState::PostAuthOnboarding { target, .. } => {
+                *self = AuthOnboardingState::NeedsSsoLink(target.clone())
             }
             AuthOnboardingState::Terminal(terminal_view_handle) => {
                 *self = AuthOnboardingState::NeedsSsoLink(AuthOnboardingTarget::Terminal(

--- a/app/src/root_view_tests.rs
+++ b/app/src/root_view_tests.rs
@@ -1,16 +1,32 @@
-use onboarding::{OfferVariant, SelectedSettings, UICustomizationSettings};
+use ai::LLMId;
+use onboarding::{
+    AgentOnboardingView, OfferVariant, OnboardingAuthState, OnboardingIntention, SelectedSettings,
+    UICustomizationSettings,
+};
 use warp_core::features::FeatureFlag;
 use warp_core::user_preferences::GetUserPreferences as _;
-use warpui::{App, SingletonEntity};
+use warpui::elements::Empty;
+use warpui::platform::WindowStyle;
+use warpui::{
+    App, AppContext, Element, Entity, EntityId, SingletonEntity, TypedActionView, View, ViewHandle,
+};
 
 use super::{
-    AccountFirstCompletion, HAS_COMPLETED_ONBOARDING_KEY, RootView, has_completed_local_onboarding,
-    offer_variant_for_account_class, refresh_pending_onboarding_choices,
-    requires_post_onboarding_login,
+    AccountFirstCompletion, AuthOnboardingState, AuthOnboardingTarget,
+    HAS_COMPLETED_ONBOARDING_KEY, NewWorkspaceSource, RootView, WorkspaceArgs,
+    has_completed_local_onboarding, offer_variant_for_account_class,
+    refresh_pending_onboarding_choices, requires_post_onboarding_login,
 };
+use crate::GlobalResourceHandles;
+use crate::appearance::Appearance;
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
+use crate::auth::login_slide::{LoginSlideSource, LoginSlideView};
 use crate::server::server_api::ServerApiProvider;
+use crate::settings_view::keybindings::KeybindingChangedNotifier;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::themes::onboarding_theme_picker_themes;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::workspaces::workspace::FtueAccountClass;
 
 fn initialize_app(app: &mut App) {
@@ -265,5 +281,150 @@ fn test_sync_noop_when_already_onboarded_on_server() {
                 Some(true)
             );
         });
+    });
+}
+
+struct SsoLinkTestHarnessView {
+    login_slide_view: ViewHandle<LoginSlideView>,
+    onboarding_view: ViewHandle<AgentOnboardingView>,
+}
+
+impl Entity for SsoLinkTestHarnessView {
+    type Event = ();
+}
+
+impl View for SsoLinkTestHarnessView {
+    fn ui_name() -> &'static str {
+        "SsoLinkTestHarnessView"
+    }
+
+    fn render(&self, _app: &AppContext) -> Box<dyn Element> {
+        Empty::new().finish()
+    }
+}
+
+impl TypedActionView for SsoLinkTestHarnessView {
+    type Action = ();
+}
+
+/// Regression test: completing browser auth with `needs_sso_link = true` while
+/// a pre-terminal onboarding state was showing (`Onboarding`, `LoginSlide`, or
+/// `PostAuthOnboarding`) used to silently no-op in `show_needs_sso_link_view`,
+/// leaving the UI stuck on the login slide ("Sign in on your browser to
+/// continue") instead of showing the SSO blocker. Each of those states must
+/// convert to `NeedsSsoLink` and preserve its target.
+#[test]
+fn test_show_needs_sso_link_view_blocks_pre_terminal_onboarding_states() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_ctx| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| Appearance::mock());
+        app.add_singleton_model(|_| KeybindingChangedNotifier::new());
+        app.add_singleton_model(UserWorkspaces::default_mock);
+
+        let (_, harness) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let login_slide_view = ctx.add_typed_action_view(|ctx| {
+                LoginSlideView::new(
+                    true,
+                    false,
+                    "Dark",
+                    false,
+                    OnboardingIntention::AgentDrivenDevelopment,
+                    LoginSlideSource::OnboardingFlow,
+                    ctx,
+                )
+            });
+            let onboarding_view = ctx.add_typed_action_view(|ctx| {
+                AgentOnboardingView::new(
+                    onboarding_theme_picker_themes(),
+                    false,
+                    Vec::new(),
+                    LLMId::from("auto"),
+                    false,
+                    false,
+                    OnboardingAuthState::LoggedOut,
+                    ctx,
+                )
+            });
+            SsoLinkTestHarnessView {
+                login_slide_view,
+                onboarding_view,
+            }
+        });
+
+        let (login_slide_view, onboarding_view) = app.read(|ctx| {
+            let harness = harness.as_ref(ctx);
+            (
+                harness.login_slide_view.clone(),
+                harness.onboarding_view.clone(),
+            )
+        });
+
+        fn workspace_target(app: &mut App) -> (AuthOnboardingTarget, EntityId) {
+            let global_resource_handles = GlobalResourceHandles::mock(app);
+            let marker = global_resource_handles.tips_completed.id();
+            let target = AuthOnboardingTarget::Workspace(Box::new(WorkspaceArgs {
+                global_resource_handles,
+                server_time: None,
+                workspace_setting: NewWorkspaceSource::Empty {
+                    previous_active_window: None,
+                    shell: None,
+                },
+            }));
+            (target, marker)
+        }
+
+        fn assert_becomes_needs_sso_link(
+            mut state: AuthOnboardingState,
+            marker: EntityId,
+            case: &str,
+        ) {
+            state.show_needs_sso_link_view();
+            match state {
+                AuthOnboardingState::NeedsSsoLink(AuthOnboardingTarget::Workspace(args)) => {
+                    assert_eq!(
+                        args.global_resource_handles.tips_completed.id(),
+                        marker,
+                        "{case}: the pre-login target must be preserved"
+                    );
+                }
+                _ => panic!("{case}: expected transition to NeedsSsoLink"),
+            }
+        }
+
+        let (target, marker) = workspace_target(&mut app);
+        assert_becomes_needs_sso_link(
+            AuthOnboardingState::LoginSlide {
+                login_slide_view: login_slide_view.clone(),
+                onboarding_view: onboarding_view.clone(),
+                target,
+            },
+            marker,
+            "LoginSlide",
+        );
+
+        let (target, marker) = workspace_target(&mut app);
+        assert_becomes_needs_sso_link(
+            AuthOnboardingState::Onboarding {
+                onboarding_view: onboarding_view.clone(),
+                target,
+            },
+            marker,
+            "Onboarding",
+        );
+
+        let (target, marker) = workspace_target(&mut app);
+        assert_becomes_needs_sso_link(
+            AuthOnboardingState::PostAuthOnboarding {
+                onboarding_view,
+                target,
+                account_class: FtueAccountClass::FreeStandard,
+                upgrade_started: false,
+            },
+            marker,
+            "PostAuthOnboarding",
+        );
     });
 }


### PR DESCRIPTION
## Description
When a browser sign-in completes during the new onboarding flow for an account with `needs_sso_link=true`, the app never transitions to the "Your organization has enabled SSO for your account" blocker. `AuthOnboardingState::show_needs_sso_link_view()` had a silent no-op arm for the `Onboarding` / `LoginSlide` / `PostAuthOnboarding` states, and because the needs-SSO branch of the `AuthComplete` handler matched first, the normal onboarding advancement was skipped too — leaving the UI stuck on "Sign in on your browser to continue" until an app restart (startup goes through the working `Terminal` arm, which is why the blocker appeared after quit + reopen).

The fix converts those three states to `AuthOnboardingState::NeedsSsoLink(target)`; they all carry the `AuthOnboardingTarget` payload the blocker needs, and everything downstream (focus, render, post-link `complete_sso_link` → Terminal) already works. The stale comment claiming the conversion needs a workspace was removed.

## Linked Issue
N/A — found while testing SSO enforcement flows end to end.

## Testing
- New regression unit test `test_show_needs_sso_link_view_blocks_pre_terminal_onboarding_states` in `app/src/root_view_tests.rs` asserting each pre-terminal onboarding state converts to `NeedsSsoLink` with the target preserved.
- `cargo check -p warp --tests`, `cargo fmt -- --check`, `cargo clippy -p warp --all-targets --tests -- -D warnings`, and `cargo nextest run -p warp -E 'test(root_view::tests)'` (10/10 passed).
- [x] I have manually tested my changes locally with `./script/run` — repro'd with an SSO-required org account (warp.dog on staging): before the fix, onboarding stayed stuck on "Sign in on your browser to continue" after the browser redirect; with the fix, the needs-SSO-link blocker appears immediately.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/79261527-af75-42ad-8b24-ec478e29d88a

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
CHANGELOG-BUG-FIX: Fixed onboarding getting stuck on "Sign in on your browser to continue" when signing in with an account that requires SSO linking.
-->