### PR TITLE
add detailed telemetry for the TUI

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -61,6 +61,7 @@ use crate::ai::agent::{
     RequestCommandOutputResult,
 };
 use crate::ai::blocklist::action_model::execute::suggest_new_conversation::SuggestNewConversationExecutor;
+use crate::ai::blocklist::telemetry::send_run_agents_completed_telemetry;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
 use crate::terminal::TerminalModel;
@@ -734,12 +735,15 @@ impl BlocklistAIActionModel {
             );
             return;
         };
+        let result =
+            AIAgentActionResultType::RunAgents(ai::agent::action_result::RunAgentsResult::Denied {
+                reason,
+            });
+        send_run_agents_completed_telemetry(conversation_id, &action.action, &result, ctx);
         let result = Arc::new(AIAgentActionResult {
             id: action.id,
             task_id: action.task_id,
-            result: AIAgentActionResultType::RunAgents(
-                ai::agent::action_result::RunAgentsResult::Denied { reason },
-            ),
+            result,
         });
         self.handle_action_result(conversation_id, result, None, ctx);
     }
@@ -1217,10 +1221,17 @@ impl BlocklistAIActionModel {
             );
         }
 
+        let cancelled_result = pending_action.action.cancelled_result();
+        send_run_agents_completed_telemetry(
+            conversation_id,
+            &pending_action.action,
+            &cancelled_result,
+            ctx,
+        );
         let result = Arc::new(AIAgentActionResult {
             id: pending_action.id,
             task_id: pending_action.task_id,
-            result: pending_action.action.cancelled_result(),
+            result: cancelled_result,
         });
         self.handle_action_result(conversation_id, result, reason, ctx);
     }

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -93,6 +93,7 @@ use crate::ai::agent::{
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::action_model::recording_controller::RecordingController;
+use crate::ai::blocklist::telemetry::send_run_agents_completed_telemetry;
 use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
 #[cfg(feature = "local_fs")]
 use crate::ai::{agent::AnyFileContent, paths::host_native_absolute_path};
@@ -895,11 +896,18 @@ impl BlocklistAIActionExecutor {
                     executor.cancel_execution(&tool_call_id);
                 });
             }
+            let result = running.action.action.cancelled_result();
+            send_run_agents_completed_telemetry(
+                running.conversation_id,
+                &running.action.action,
+                &result,
+                ctx,
+            );
             ctx.emit(BlocklistAIActionExecutorEvent::FinishedAction {
                 result: Arc::new(AIAgentActionResult {
                     id: running.action.id.clone(),
                     task_id: running.action.task_id,
-                    result: running.action.action.cancelled_result(),
+                    result,
                 }),
                 conversation_id: running.conversation_id,
                 cancellation_reason: reason,

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -16,6 +16,8 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use warp_cli::agent::Harness;
 use warp_core::execution_mode::AppExecutionMode;
+use warp_core::telemetry::TelemetryEvent as _;
+use warp_core::{send_telemetry_from_app_ctx, send_telemetry_from_ctx};
 use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use super::start_agent::{StartAgentExecutor, StartAgentOutcome};
@@ -24,6 +26,9 @@ use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType, AIAgentInput,
     StartAgentExecutionMode,
+};
+use crate::ai::blocklist::telemetry::{
+    BlocklistOrchestrationTelemetryEvent, run_agents_completed_event,
 };
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::document::plan_publication::{
@@ -390,21 +395,33 @@ impl RunAgentsExecutor {
             &self.launched_agents,
             ctx,
         ) {
-            return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
-                RunAgentsResult::Denied { reason },
-            ));
+            let result = RunAgentsResult::Denied { reason };
+            send_telemetry_from_ctx!(
+                BlocklistOrchestrationTelemetryEvent::RunAgentsCompleted(
+                    run_agents_completed_event(parent_conversation_id, &request, &result)
+                ),
+                ctx
+            );
+            return ActionExecution::Sync(AIAgentActionResultType::RunAgents(result));
         }
+        let telemetry_request = request.clone();
 
         let receiver =
             self.dispatch_prepared_run_agents(action_id, request, parent_conversation_id, ctx);
 
-        ActionExecution::new_async(
-            async move { receiver.recv().await },
-            |result, _| match result {
-                Ok(r) => AIAgentActionResultType::RunAgents(r),
-                Err(_) => AIAgentActionResultType::RunAgents(RunAgentsResult::Cancelled),
-            },
-        )
+        ActionExecution::new_async(async move { receiver.recv().await }, move |result, ctx| {
+            let result = match result {
+                Ok(result) => result,
+                Err(_) => RunAgentsResult::Cancelled,
+            };
+            send_telemetry_from_app_ctx!(
+                BlocklistOrchestrationTelemetryEvent::RunAgentsCompleted(
+                    run_agents_completed_event(parent_conversation_id, &telemetry_request, &result,)
+                ),
+                ctx
+            );
+            AIAgentActionResultType::RunAgents(result)
+        })
     }
 
     pub(super) fn should_autoexecute(

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -168,6 +168,7 @@ fn execute_denies_duplicate_launched_agent() {
 
 fn initialize_run_agents_test(app: &mut App, mode: ExecutionMode) -> RunAgentsTestState {
     initialize_settings_for_tests_with_mode(app, mode, false);
+    app.update(warp_core::telemetry::testing::MockTelemetryContextProvider::register);
     let global_resource_handles = GlobalResourceHandles::mock(app);
     app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
     let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));

--- a/app/src/ai/blocklist/handoff/mod.rs
+++ b/app/src/ai/blocklist/handoff/mod.rs
@@ -36,7 +36,7 @@ pub use pipeline::{
     HandoffCommitFailure, HandoffCommitOutcome, HandoffCreated, HandoffPrepareError,
     HandoffPrepareInput, HandoffPresentationSnapshot, HandoffRestoration,
     HandoffTargetMaterialization, MaterializeHandoffTarget, PendingHandoff, execute_handoff,
-    prepare_handoff,
+    handoff_dispatch_error, prepare_handoff,
 };
 #[cfg(feature = "local_fs")]
 #[cfg_attr(not(feature = "tui"), allow(unused_imports))]

--- a/app/src/ai/blocklist/handoff/pipeline.rs
+++ b/app/src/ai/blocklist/handoff/pipeline.rs
@@ -48,8 +48,9 @@ use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::resolve_cloud_agent_computer_use_state;
 use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::ai::orchestration::{
-    CloudAgentStartupIssue, classify_cloud_agent_startup_error, oz_run_url,
-    resolve_default_environment_id, resolve_default_host_slug, should_disable_snapshot,
+    CloudAgentStartupBlocker, CloudAgentStartupFailure, CloudAgentStartupIssue,
+    classify_cloud_agent_startup_error, oz_run_url, resolve_default_environment_id,
+    resolve_default_host_slug, should_disable_snapshot,
 };
 use crate::cloud_object::CloudObjectLookup as _;
 use crate::server::ids::{ServerId, SyncId};
@@ -637,6 +638,21 @@ pub enum HandoffCommitOutcome {
     Cancelled,
     /// The cloud run was created and is ready for frontend monitoring.
     Created(HandoffCreated),
+}
+
+pub fn handoff_dispatch_error(issue: &CloudAgentStartupIssue) -> String {
+    match issue {
+        CloudAgentStartupIssue::Blocked(CloudAgentStartupBlocker::GitHubAuthRequired {
+            message,
+            ..
+        })
+        | CloudAgentStartupIssue::Failed(
+            CloudAgentStartupFailure::Capacity { message }
+            | CloudAgentStartupFailure::OutOfCredits { message }
+            | CloudAgentStartupFailure::ServerOverloaded { message }
+            | CloudAgentStartupFailure::Other { message },
+        ) => message.clone(),
+    }
 }
 
 /// State after selecting or creating the server-side conversation fork.

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -47,9 +47,8 @@ use crate::ai::blocklist::inline_action::requested_action::{
     CTRL_C_KEYSTROKE, ENTER_KEYSTROKE, render_requested_action_row_for_text,
 };
 use crate::ai::blocklist::telemetry::{
-    BlocklistOrchestrationTelemetryEvent, OrchestrationApprovalStatus, OrchestrationEnteredEvent,
-    OrchestrationEntrySource, OrchestrationExecutionModeKind, OrchestrationHarnessKind,
-    RunAgentsCardDecision, RunAgentsCardDecisionEvent, orchestration_modified_field,
+    BlocklistOrchestrationTelemetryEvent, OrchestrationEnteredEvent, OrchestrationEntrySource,
+    RunAgentsCardDecision, run_agents_card_decision_event,
 };
 use crate::ai::connected_self_hosted_workers::{
     ConnectedSelfHostedWorkersEvent, ConnectedSelfHostedWorkersModel,
@@ -759,57 +758,17 @@ impl RunAgentsCardView {
         let Some(conversation_id) = self.block_model.conversation_id(ctx) else {
             return;
         };
-        let modified_fields_from_tool_call = diverged_orch_fields(
+        let event = run_agents_card_decision_event(
+            conversation_id,
+            (!self.card.plan_id.is_empty()).then(|| self.card.plan_id.clone()),
+            decision,
+            self.card.agent_run_configs.len(),
             &self.orchestration_edit_state.orchestration_config_state,
             &self.original_tool_call_request,
+            self.active_config.as_ref(),
         );
-        let (had_active_config, active_config_status, modified_fields_from_active_config) =
-            match &self.active_config {
-                Some((cfg, status)) => {
-                    let status_enum = if status.is_approved() {
-                        Some(OrchestrationApprovalStatus::Approved)
-                    } else if status.is_disapproved() {
-                        Some(OrchestrationApprovalStatus::Disapproved)
-                    } else {
-                        None
-                    };
-                    let diff = if status.is_approved() {
-                        diverged_orch_fields_against_config(
-                            &self.orchestration_edit_state.orchestration_config_state,
-                            cfg,
-                        )
-                    } else {
-                        Vec::new()
-                    };
-                    (true, status_enum, diff)
-                }
-                None => (false, None, Vec::new()),
-            };
         send_telemetry_from_ctx!(
-            BlocklistOrchestrationTelemetryEvent::RunAgentsCardDecision(
-                RunAgentsCardDecisionEvent {
-                    conversation_id,
-                    plan_id: (!self.card.plan_id.is_empty()).then(|| self.card.plan_id.clone()),
-                    decision,
-                    agent_count: self.card.agent_run_configs.len(),
-                    harness: OrchestrationHarnessKind::from_str(
-                        &self
-                            .orchestration_edit_state
-                            .orchestration_config_state
-                            .harness_type
-                    ),
-                    execution_mode: OrchestrationExecutionModeKind::from_run_agents(
-                        &self
-                            .orchestration_edit_state
-                            .orchestration_config_state
-                            .execution_mode,
-                    ),
-                    modified_fields_from_tool_call,
-                    modified_fields_from_active_config,
-                    had_active_config,
-                    active_config_status,
-                }
-            ),
+            BlocklistOrchestrationTelemetryEvent::RunAgentsCardDecision(event),
             ctx
         );
     }
@@ -1483,95 +1442,6 @@ impl TypedActionView for RunAgentsCardView {
             }
         }
     }
-}
-
-/// Field names from [`orchestration_modified_field`] that differ
-/// between the user-edited `state` and the LLM's original
-/// `RunAgentsRequest`.
-fn diverged_orch_fields(
-    state: &oc::OrchestrationConfigState,
-    original: &RunAgentsRequest,
-) -> Vec<&'static str> {
-    let mut fields = Vec::new();
-    if state.model_id != original.model_id {
-        fields.push(orchestration_modified_field::MODEL_ID);
-    }
-    if state.harness_type != original.harness_type {
-        fields.push(orchestration_modified_field::HARNESS);
-    }
-    let state_remote = state.execution_mode.is_remote();
-    let original_remote = original.execution_mode.is_remote();
-    if state_remote != original_remote {
-        fields.push(orchestration_modified_field::EXECUTION_MODE);
-    } else if let (
-        RunAgentsExecutionMode::Remote {
-            environment_id: state_env,
-            worker_host: state_host,
-            ..
-        },
-        RunAgentsExecutionMode::Remote {
-            environment_id: orig_env,
-            worker_host: orig_host,
-            ..
-        },
-    ) = (&state.execution_mode, &original.execution_mode)
-    {
-        if state_env != orig_env {
-            fields.push(orchestration_modified_field::ENVIRONMENT_ID);
-        }
-        if state_host != orig_host {
-            fields.push(orchestration_modified_field::WORKER_HOST);
-        }
-    }
-    if state.auth_secret_name() != original.harness_auth_secret_name.as_deref() {
-        fields.push(orchestration_modified_field::AUTH_SECRET);
-    }
-    fields
-}
-
-/// Same shape as [`diverged_orch_fields`] but compares against an
-/// approved `OrchestrationConfig`. auth_secret is omitted: managed
-/// secrets are per-user, not stored on the config.
-fn diverged_orch_fields_against_config(
-    state: &oc::OrchestrationConfigState,
-    config: &OrchestrationConfig,
-) -> Vec<&'static str> {
-    use ai::agent::orchestration_config::OrchestrationExecutionMode;
-    let mut fields = Vec::new();
-    if state.model_id != config.model_id {
-        fields.push(orchestration_modified_field::MODEL_ID);
-    }
-    if state.harness_type != config.harness_type {
-        fields.push(orchestration_modified_field::HARNESS);
-    }
-    let state_remote = state.execution_mode.is_remote();
-    let config_remote = matches!(
-        config.execution_mode,
-        OrchestrationExecutionMode::Remote { .. }
-    );
-    if state_remote != config_remote {
-        fields.push(orchestration_modified_field::EXECUTION_MODE);
-    } else if let (
-        RunAgentsExecutionMode::Remote {
-            environment_id: state_env,
-            worker_host: state_host,
-            ..
-        },
-        OrchestrationExecutionMode::Remote {
-            environment_id: cfg_env,
-            worker_host: cfg_host,
-            ..
-        },
-    ) = (&state.execution_mode, &config.execution_mode)
-    {
-        if state_env != cfg_env {
-            fields.push(orchestration_modified_field::ENVIRONMENT_ID);
-        }
-        if state_host != cfg_host {
-            fields.push(orchestration_modified_field::WORKER_HOST);
-        }
-    }
-    fields
 }
 
 fn render_confirmation_card(

--- a/app/src/ai/blocklist/telemetry.rs
+++ b/app/src/ai/blocklist/telemetry.rs
@@ -1,16 +1,28 @@
+use ai::agent::action::{RunAgentsExecutionMode, RunAgentsRequest};
+use ai::agent::action_result::{
+    RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode, RunAgentsResult,
+};
+use ai::agent::orchestration_config::{
+    OrchestrationConfig, OrchestrationConfigStatus, OrchestrationExecutionMode,
+};
 use serde::Serialize;
 use serde_json::{Value, json};
 use strum_macros::{EnumDiscriminants, EnumIter};
+use warp_core::send_telemetry_from_app_ctx;
 use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
+use warpui::AppContext;
 
 use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::{AIAgentActionResultType, AIAgentActionType};
+use crate::ai::orchestration::OrchestrationConfigState;
 
 #[derive(Debug, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumIter))]
-pub(crate) enum BlocklistOrchestrationTelemetryEvent {
+pub enum BlocklistOrchestrationTelemetryEvent {
     TeamAgentCommunicationFailed(TeamAgentCommunicationFailedEvent),
     PlanConfigApprovalToggled(PlanConfigApprovalToggledEvent),
     RunAgentsCardDecision(RunAgentsCardDecisionEvent),
+    RunAgentsCompleted(RunAgentsCompletedEvent),
     PillBarInteraction(PillBarInteractionEvent),
     OrchestrationEntered(OrchestrationEnteredEvent),
     AgentProposedConfig(AgentProposedConfigEvent),
@@ -19,7 +31,7 @@ pub(crate) enum BlocklistOrchestrationTelemetryEvent {
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
-pub(crate) enum TeamAgentCommunicationKind {
+pub enum TeamAgentCommunicationKind {
     Message,
     LifecycleEvent,
 }
@@ -27,14 +39,14 @@ pub(crate) enum TeamAgentCommunicationKind {
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
-pub(crate) enum TeamAgentCommunicationTransport {
+pub enum TeamAgentCommunicationTransport {
     Local,
     ServerApi,
 }
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
-pub(crate) enum TeamAgentOrchestrationVersion {
+pub enum TeamAgentOrchestrationVersion {
     V1,
     V2,
 }
@@ -42,7 +54,7 @@ pub(crate) enum TeamAgentOrchestrationVersion {
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
-pub(crate) enum TeamAgentCommunicationFailureReason {
+pub enum TeamAgentCommunicationFailureReason {
     InvalidLifecycleEventType,
     MissingSourceConversation,
     MissingSourceIdentifier,
@@ -52,7 +64,7 @@ pub(crate) enum TeamAgentCommunicationFailureReason {
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct TeamAgentCommunicationFailedEvent {
+pub struct TeamAgentCommunicationFailedEvent {
     pub communication_kind: TeamAgentCommunicationKind,
     pub transport: TeamAgentCommunicationTransport,
     pub orchestration_version: TeamAgentOrchestrationVersion,
@@ -72,7 +84,7 @@ pub(crate) struct TeamAgentCommunicationFailedEvent {
 /// `Use orchestration` toggle.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum OrchestrationApprovalStatus {
+pub enum OrchestrationApprovalStatus {
     Approved,
     Disapproved,
 }
@@ -82,13 +94,13 @@ pub(crate) enum OrchestrationApprovalStatus {
 /// environment id or worker host.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum OrchestrationExecutionModeKind {
+pub enum OrchestrationExecutionModeKind {
     Local,
     Remote,
 }
 
 impl OrchestrationExecutionModeKind {
-    pub(crate) fn from_run_agents(mode: &ai::agent::action::RunAgentsExecutionMode) -> Self {
+    pub fn from_run_agents(mode: &RunAgentsExecutionMode) -> Self {
         if mode.is_remote() {
             Self::Remote
         } else {
@@ -102,7 +114,7 @@ impl OrchestrationExecutionModeKind {
 /// low-cardinality.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum OrchestrationHarnessKind {
+pub enum OrchestrationHarnessKind {
     Oz,
     ClaudeCode,
     Codex,
@@ -112,7 +124,7 @@ pub(crate) enum OrchestrationHarnessKind {
 }
 
 impl OrchestrationHarnessKind {
-    pub(crate) fn from_str(harness_type: &str) -> Self {
+    pub fn from_str(harness_type: &str) -> Self {
         match harness_type {
             "oz" | "" => Self::Oz,
             "claude" | "claude-code" | "claude_code" => Self::ClaudeCode,
@@ -138,7 +150,7 @@ pub(crate) mod orchestration_modified_field {
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct PlanConfigApprovalToggledEvent {
+pub struct PlanConfigApprovalToggledEvent {
     pub conversation_id: AIConversationId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_id: Option<String>,
@@ -156,14 +168,14 @@ pub(crate) struct PlanConfigApprovalToggledEvent {
 /// Decision a user took on the run_agents confirmation card.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum RunAgentsCardDecision {
+pub enum RunAgentsCardDecision {
     Accept,
     AcceptWithoutOrchestration,
     Reject,
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct RunAgentsCardDecisionEvent {
+pub struct RunAgentsCardDecisionEvent {
     pub conversation_id: AIConversationId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_id: Option<String>,
@@ -184,6 +196,28 @@ pub(crate) struct RunAgentsCardDecisionEvent {
     pub active_config_status: Option<OrchestrationApprovalStatus>,
 }
 
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunAgentsResultKind {
+    Launched,
+    Failure,
+    Denied,
+    Cancelled,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunAgentsCompletedEvent {
+    pub conversation_id: AIConversationId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    pub requested_agent_count: usize,
+    pub launched_agent_count: usize,
+    pub failed_agent_count: usize,
+    pub result: RunAgentsResultKind,
+    pub harness: OrchestrationHarnessKind,
+    pub execution_mode: OrchestrationExecutionModeKind,
+}
+
 /// Surface that first introduced orchestration into a conversation.
 ///
 /// Plan-card surfacing is intentionally NOT a variant here — that signal
@@ -192,7 +226,7 @@ pub(crate) struct RunAgentsCardDecisionEvent {
 /// [`PlanConfigApprovalToggledEvent`] (the user's approval toggle).
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum OrchestrationEntrySource {
+pub enum OrchestrationEntrySource {
     /// `/orchestrate` slash-command mode on a user query.
     SlashCommandOrchestrate,
     /// `run_agents` confirmation card was shown (not auto-launched).
@@ -200,7 +234,7 @@ pub(crate) enum OrchestrationEntrySource {
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct OrchestrationEnteredEvent {
+pub struct OrchestrationEnteredEvent {
     pub conversation_id: AIConversationId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_id: Option<String>,
@@ -211,7 +245,7 @@ pub(crate) struct OrchestrationEnteredEvent {
 /// becomes visible to the user on a plan card. One emission per
 /// `OrchestrationConfigBlockView` instance.
 #[derive(Debug, Serialize)]
-pub(crate) struct AgentProposedConfigEvent {
+pub struct AgentProposedConfigEvent {
     pub conversation_id: AIConversationId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_id: Option<String>,
@@ -224,7 +258,7 @@ pub(crate) struct AgentProposedConfigEvent {
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum PillBarPillKind {
+pub enum PillBarPillKind {
     Orchestrator,
     Child,
 }
@@ -232,7 +266,7 @@ pub(crate) enum PillBarPillKind {
 /// Concrete user actions against an orchestration pill bar entry.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum PillBarActionKind {
+pub enum PillBarActionKind {
     /// User clicked the pill body. See `switch_outcome` for what
     /// happened next.
     Switch,
@@ -255,7 +289,7 @@ pub(crate) enum PillBarActionKind {
 /// action variants again.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum PillSwitchOutcome {
+pub enum PillSwitchOutcome {
     /// Pill click navigated within the current pane.
     SwitchedInPlace,
     /// Target conversation was already owned by another visible
@@ -264,7 +298,7 @@ pub(crate) enum PillSwitchOutcome {
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct PillBarInteractionEvent {
+pub struct PillBarInteractionEvent {
     pub action: PillBarActionKind,
     pub pill_kind: PillBarPillKind,
     pub total_pills: usize,
@@ -280,6 +314,220 @@ pub(crate) struct PillBarInteractionEvent {
     pub switch_outcome: Option<PillSwitchOutcome>,
 }
 
+pub fn run_agents_card_decision_event(
+    conversation_id: AIConversationId,
+    plan_id: Option<String>,
+    decision: RunAgentsCardDecision,
+    agent_count: usize,
+    state: &OrchestrationConfigState,
+    original: &RunAgentsRequest,
+    active_config: Option<&(OrchestrationConfig, OrchestrationConfigStatus)>,
+) -> RunAgentsCardDecisionEvent {
+    let modified_fields_from_tool_call = diverged_orchestration_fields(state, original);
+    let (had_active_config, active_config_status, modified_fields_from_active_config) =
+        match active_config {
+            Some((config, status)) => {
+                let telemetry_status = if status.is_approved() {
+                    Some(OrchestrationApprovalStatus::Approved)
+                } else if status.is_disapproved() {
+                    Some(OrchestrationApprovalStatus::Disapproved)
+                } else {
+                    None
+                };
+                let modified_fields = if status.is_approved() {
+                    diverged_orchestration_fields_from_config(state, config)
+                } else {
+                    Vec::new()
+                };
+                (true, telemetry_status, modified_fields)
+            }
+            None => (false, None, Vec::new()),
+        };
+    RunAgentsCardDecisionEvent {
+        conversation_id,
+        plan_id,
+        decision,
+        agent_count,
+        harness: OrchestrationHarnessKind::from_str(&state.harness_type),
+        execution_mode: OrchestrationExecutionModeKind::from_run_agents(&state.execution_mode),
+        modified_fields_from_tool_call,
+        modified_fields_from_active_config,
+        had_active_config,
+        active_config_status,
+    }
+}
+
+pub fn run_agents_completed_event(
+    conversation_id: AIConversationId,
+    request: &RunAgentsRequest,
+    result: &RunAgentsResult,
+) -> RunAgentsCompletedEvent {
+    let (result_kind, harness, execution_mode, launched_agent_count, failed_agent_count) =
+        match result {
+            RunAgentsResult::Launched {
+                harness_type,
+                execution_mode,
+                agents,
+                ..
+            } => {
+                let launched_agent_count = agents
+                    .iter()
+                    .filter(|agent| {
+                        matches!(&agent.kind, RunAgentsAgentOutcomeKind::Launched { .. })
+                    })
+                    .count();
+                let failed_agent_count = agents.len().saturating_sub(launched_agent_count);
+                let execution_mode = match execution_mode {
+                    RunAgentsLaunchedExecutionMode::Local => OrchestrationExecutionModeKind::Local,
+                    RunAgentsLaunchedExecutionMode::Remote { .. } => {
+                        OrchestrationExecutionModeKind::Remote
+                    }
+                };
+                (
+                    RunAgentsResultKind::Launched,
+                    OrchestrationHarnessKind::from_str(harness_type),
+                    execution_mode,
+                    launched_agent_count,
+                    failed_agent_count,
+                )
+            }
+            RunAgentsResult::Failure { .. } => (
+                RunAgentsResultKind::Failure,
+                OrchestrationHarnessKind::from_str(&request.harness_type),
+                OrchestrationExecutionModeKind::from_run_agents(&request.execution_mode),
+                0,
+                request.agent_run_configs.len(),
+            ),
+            RunAgentsResult::Denied { .. } => (
+                RunAgentsResultKind::Denied,
+                OrchestrationHarnessKind::from_str(&request.harness_type),
+                OrchestrationExecutionModeKind::from_run_agents(&request.execution_mode),
+                0,
+                0,
+            ),
+            RunAgentsResult::Cancelled => (
+                RunAgentsResultKind::Cancelled,
+                OrchestrationHarnessKind::from_str(&request.harness_type),
+                OrchestrationExecutionModeKind::from_run_agents(&request.execution_mode),
+                0,
+                0,
+            ),
+        };
+    RunAgentsCompletedEvent {
+        conversation_id,
+        plan_id: (!request.plan_id.is_empty()).then(|| request.plan_id.clone()),
+        requested_agent_count: request.agent_run_configs.len(),
+        launched_agent_count,
+        failed_agent_count,
+        result: result_kind,
+        harness,
+        execution_mode,
+    }
+}
+
+pub(crate) fn send_run_agents_completed_telemetry(
+    conversation_id: AIConversationId,
+    action: &AIAgentActionType,
+    result: &AIAgentActionResultType,
+    ctx: &mut AppContext,
+) {
+    let (AIAgentActionType::RunAgents(request), AIAgentActionResultType::RunAgents(result)) =
+        (action, result)
+    else {
+        return;
+    };
+    send_telemetry_from_app_ctx!(
+        BlocklistOrchestrationTelemetryEvent::RunAgentsCompleted(run_agents_completed_event(
+            conversation_id,
+            request,
+            result,
+        )),
+        ctx
+    );
+}
+
+fn diverged_orchestration_fields(
+    state: &OrchestrationConfigState,
+    original: &RunAgentsRequest,
+) -> Vec<&'static str> {
+    let mut fields = Vec::new();
+    if state.model_id != original.model_id {
+        fields.push(orchestration_modified_field::MODEL_ID);
+    }
+    if state.harness_type != original.harness_type {
+        fields.push(orchestration_modified_field::HARNESS);
+    }
+    let state_remote = state.execution_mode.is_remote();
+    let original_remote = original.execution_mode.is_remote();
+    if state_remote != original_remote {
+        fields.push(orchestration_modified_field::EXECUTION_MODE);
+    } else if let (
+        RunAgentsExecutionMode::Remote {
+            environment_id: state_environment,
+            worker_host: state_host,
+            ..
+        },
+        RunAgentsExecutionMode::Remote {
+            environment_id: original_environment,
+            worker_host: original_host,
+            ..
+        },
+    ) = (&state.execution_mode, &original.execution_mode)
+    {
+        if state_environment != original_environment {
+            fields.push(orchestration_modified_field::ENVIRONMENT_ID);
+        }
+        if state_host != original_host {
+            fields.push(orchestration_modified_field::WORKER_HOST);
+        }
+    }
+    if state.auth_secret_name() != original.harness_auth_secret_name.as_deref() {
+        fields.push(orchestration_modified_field::AUTH_SECRET);
+    }
+    fields
+}
+
+fn diverged_orchestration_fields_from_config(
+    state: &OrchestrationConfigState,
+    config: &OrchestrationConfig,
+) -> Vec<&'static str> {
+    let mut fields = Vec::new();
+    if state.model_id != config.model_id {
+        fields.push(orchestration_modified_field::MODEL_ID);
+    }
+    if state.harness_type != config.harness_type {
+        fields.push(orchestration_modified_field::HARNESS);
+    }
+    let state_remote = state.execution_mode.is_remote();
+    let config_remote = matches!(
+        config.execution_mode,
+        OrchestrationExecutionMode::Remote { .. }
+    );
+    if state_remote != config_remote {
+        fields.push(orchestration_modified_field::EXECUTION_MODE);
+    } else if let (
+        RunAgentsExecutionMode::Remote {
+            environment_id: state_environment,
+            worker_host: state_host,
+            ..
+        },
+        OrchestrationExecutionMode::Remote {
+            environment_id: config_environment,
+            worker_host: config_host,
+            ..
+        },
+    ) = (&state.execution_mode, &config.execution_mode)
+    {
+        if state_environment != config_environment {
+            fields.push(orchestration_modified_field::ENVIRONMENT_ID);
+        }
+        if state_host != config_host {
+            fields.push(orchestration_modified_field::WORKER_HOST);
+        }
+    }
+    fields
+}
+
 impl TelemetryEvent for BlocklistOrchestrationTelemetryEvent {
     fn name(&self) -> &'static str {
         BlocklistOrchestrationTelemetryEventDiscriminants::from(self).name()
@@ -290,6 +538,7 @@ impl TelemetryEvent for BlocklistOrchestrationTelemetryEvent {
             Self::TeamAgentCommunicationFailed(event) => Some(json!(event)),
             Self::PlanConfigApprovalToggled(event) => Some(json!(event)),
             Self::RunAgentsCardDecision(event) => Some(json!(event)),
+            Self::RunAgentsCompleted(event) => Some(json!(event)),
             Self::PillBarInteraction(event) => Some(json!(event)),
             Self::OrchestrationEntered(event) => Some(json!(event)),
             Self::AgentProposedConfig(event) => Some(json!(event)),
@@ -321,6 +570,7 @@ impl TelemetryEventDesc for BlocklistOrchestrationTelemetryEventDiscriminants {
             }
             Self::PlanConfigApprovalToggled => "AgentMode.Orchestration.PlanConfigApprovalToggled",
             Self::RunAgentsCardDecision => "AgentMode.Orchestration.RunAgentsCardDecision",
+            Self::RunAgentsCompleted => "AgentMode.Orchestration.RunAgentsCompleted",
             Self::PillBarInteraction => "AgentMode.Orchestration.PillBarInteraction",
             Self::OrchestrationEntered => "AgentMode.Orchestration.Entered",
             Self::AgentProposedConfig => "AgentMode.Orchestration.AgentProposedConfig",
@@ -337,6 +587,9 @@ impl TelemetryEventDesc for BlocklistOrchestrationTelemetryEventDiscriminants {
             }
             Self::RunAgentsCardDecision => {
                 "User accepted, accepted-without-orchestration, or rejected a run_agents confirmation card. Reports which config fields diverged from the original tool call and/or the active approved config."
+            }
+            Self::RunAgentsCompleted => {
+                "A run_agents request completed with actual launched and failed child counts"
             }
             Self::PillBarInteraction => {
                 "User interacted with the orchestration pill bar (switch, pin, open in pane/tab, stop, kill, etc.)"
@@ -356,3 +609,7 @@ impl TelemetryEventDesc for BlocklistOrchestrationTelemetryEventDiscriminants {
 }
 
 warp_core::register_telemetry_event!(BlocklistOrchestrationTelemetryEvent);
+
+#[cfg(test)]
+#[path = "telemetry_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/telemetry_tests.rs
+++ b/app/src/ai/blocklist/telemetry_tests.rs
@@ -1,0 +1,100 @@
+use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
+use ai::agent::action_result::{
+    RunAgentsAgentOutcome, RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode,
+    RunAgentsResult,
+};
+use warp_core::telemetry::TelemetryEvent as _;
+
+use super::*;
+
+fn request() -> RunAgentsRequest {
+    RunAgentsRequest {
+        summary: "summary".to_string(),
+        base_prompt: "base".to_string(),
+        skills: Vec::new(),
+        model_id: "auto".to_string(),
+        harness_type: "oz".to_string(),
+        execution_mode: RunAgentsExecutionMode::Local,
+        agent_run_configs: ["one", "two", "three"]
+            .into_iter()
+            .map(|name| RunAgentsAgentRunConfig {
+                name: name.to_string(),
+                prompt: String::new(),
+                title: String::new(),
+                agent_identity_uid: String::new(),
+                model_id: String::new(),
+            })
+            .collect(),
+        plan_id: "plan-id".to_string(),
+        harness_auth_secret_name: None,
+    }
+}
+
+#[test]
+fn run_agents_completed_counts_actual_launches() {
+    let request = request();
+    let result = RunAgentsResult::Launched {
+        model_id: "auto".to_string(),
+        harness_type: "oz".to_string(),
+        execution_mode: RunAgentsLaunchedExecutionMode::Local,
+        agents: vec![
+            RunAgentsAgentOutcome {
+                name: "one".to_string(),
+                kind: RunAgentsAgentOutcomeKind::Launched {
+                    agent_id: "agent-one".to_string(),
+                },
+                resolved_model_id: String::new(),
+            },
+            RunAgentsAgentOutcome {
+                name: "two".to_string(),
+                kind: RunAgentsAgentOutcomeKind::Failed {
+                    error: "failed".to_string(),
+                },
+                resolved_model_id: String::new(),
+            },
+            RunAgentsAgentOutcome {
+                name: "three".to_string(),
+                kind: RunAgentsAgentOutcomeKind::Launched {
+                    agent_id: "agent-three".to_string(),
+                },
+                resolved_model_id: String::new(),
+            },
+        ],
+    };
+
+    let event = BlocklistOrchestrationTelemetryEvent::RunAgentsCompleted(
+        run_agents_completed_event(AIConversationId::new(), &request, &result),
+    );
+
+    assert_eq!(event.name(), "AgentMode.Orchestration.RunAgentsCompleted");
+    assert_eq!(
+        event.payload(),
+        Some(json!({
+            "conversation_id": event.payload().unwrap()["conversation_id"],
+            "plan_id": "plan-id",
+            "requested_agent_count": 3,
+            "launched_agent_count": 2,
+            "failed_agent_count": 1,
+            "result": "launched",
+            "harness": "oz",
+            "execution_mode": "local",
+        }))
+    );
+}
+
+#[test]
+fn run_agents_failure_counts_every_requested_agent_as_failed() {
+    let request = request();
+    let event = run_agents_completed_event(
+        AIConversationId::new(),
+        &request,
+        &RunAgentsResult::Failure {
+            error: "invalid".to_string(),
+        },
+    );
+
+    assert_eq!(event.requested_agent_count, 3);
+    assert_eq!(event.launched_agent_count, 0);
+    assert_eq!(event.failed_agent_count, 3);
+    assert!(matches!(event.result, RunAgentsResultKind::Failure));
+}

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -4,6 +4,7 @@ use ai::LLMProvider;
 use ai::api_keys::{ApiKeyManager, GrokTokens};
 use chrono::Duration;
 use warp_core::features::FeatureFlag;
+use warp_core::telemetry::testing::MockTelemetryContextProvider;
 use warp_graphql::billing::{AddonCreditsOption, OveragesPricing, PricingInfo};
 use warpui::{App, ModelHandle};
 
@@ -65,6 +66,7 @@ fn add_request_usage_model_without_auth(app: &mut App) -> ModelHandle<AIRequestU
     register_user_preferences_for_tests(app);
     app.update(|ctx| {
         warpui_extras::secure_storage::register_noop("test", ctx);
+        MockTelemetryContextProvider::register(ctx);
         ctx.add_singleton_model(ApiKeyManager::new);
     });
     app.add_singleton_model(|_| PricingInfoModel::new());

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -25,7 +25,7 @@ use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
 use crate::ai::ambient_agents::{AgentSource, AmbientAgentTaskId};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::handoff::{HandoffCommitFailure, HandoffCreated};
+use crate::ai::blocklist::handoff::{HandoffCommitFailure, HandoffCreated, handoff_dispatch_error};
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::{
     CloudAgentComputerUseState, resolve_cloud_agent_computer_use_state,
@@ -586,18 +586,7 @@ impl AmbientAgentViewModel {
                 return;
             }
         }
-        let error = match &failure.issue {
-            CloudAgentStartupIssue::Blocked(CloudAgentStartupBlocker::GitHubAuthRequired {
-                message,
-                ..
-            })
-            | CloudAgentStartupIssue::Failed(
-                CloudAgentStartupFailure::Capacity { message }
-                | CloudAgentStartupFailure::OutOfCredits { message }
-                | CloudAgentStartupFailure::ServerOverloaded { message }
-                | CloudAgentStartupFailure::Other { message },
-            ) => message.clone(),
-        };
+        let error = handoff_dispatch_error(&failure.issue);
         send_telemetry_from_ctx!(CloudAgentTelemetryEvent::DispatchFailed { error }, ctx);
         if let Some(derived_workspace_had_content) = failure.derived_workspace_had_content {
             send_telemetry_from_ctx!(

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -49,7 +49,9 @@ pub use crate::ai::agent_conversations_model::{
     query_conversation_entries,
 };
 pub use crate::ai::ambient_agents::AmbientAgentTaskId;
-pub use crate::ai::ambient_agents::telemetry::{HandoffEntryPoint, HandoffSurface};
+pub use crate::ai::ambient_agents::telemetry::{
+    CloudAgentTelemetryEvent, HandoffEntryPoint, HandoffSurface,
+};
 pub use crate::ai::blocklist::agent_view::{
     AgentViewController, AgentViewDisplayMode, AgentViewEntryOrigin, EnterAgentViewError,
     EphemeralMessageModel,
@@ -76,7 +78,8 @@ pub use crate::ai::blocklist::handoff::{
     HandoffCommitFailure, HandoffCommitOutcome, HandoffCreated, HandoffLaunchAttachments,
     HandoffPrepareError, HandoffPrepareInput, HandoffPresentationSnapshot, HandoffRestoration,
     HandoffTargetMaterialization, MaterializeHandoffTarget, PendingCloudLaunch, PendingHandoff,
-    SnapshotUploadTarget, execute_handoff, prepare_handoff, suggest_handoff_environment,
+    SnapshotUploadTarget, execute_handoff, handoff_dispatch_error, prepare_handoff,
+    suggest_handoff_environment,
 };
 pub use crate::ai::blocklist::history_model::{
     AIQueryHistory, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, CloudConversationData,
@@ -92,6 +95,11 @@ pub use crate::ai::blocklist::orchestration_topology::{
     descendant_conversation_ids_in_spawn_order, descendant_conversations_in_pill_order,
     orchestration_root_conversation_id, orchestrator_agent_id_for_conversation,
     resolve_orchestration_participant,
+};
+pub use crate::ai::blocklist::telemetry::{
+    BlocklistOrchestrationTelemetryEvent, OrchestrationEnteredEvent, OrchestrationEntrySource,
+    PillBarActionKind, PillBarInteractionEvent, PillBarPillKind, PillSwitchOutcome,
+    RunAgentsCardDecision, run_agents_card_decision_event,
 };
 pub use crate::ai::blocklist::view_util::{
     FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, OUT_OF_CREDITS_SUBSCRIBE_LABEL,
@@ -178,14 +186,15 @@ pub use crate::server::server_api::TranscribeError;
 pub use crate::server::server_api::ai::{
     AIClient, AgentConfigSnapshot, AttachmentInput, SpawnAgentRequest, SpawnAgentResponse,
 };
-pub use crate::settings::AISettingsChangedEvent;
+pub use crate::server::telemetry::{SlashMenuSource, TelemetryEvent};
+pub use crate::settings::{AISettingsChangedEvent, InputSettings};
 pub use crate::terminal::alt_screen::{should_intercept_mouse, should_intercept_scroll};
 pub use crate::terminal::color::{Colors as TerminalColors, List as TerminalColorList};
 pub use crate::terminal::conversation_restoration::{
     ConversationBlockRestorationPlan, RestoredConversationExchange,
     prepare_conversation_block_restoration,
 };
-pub use crate::terminal::event::AfterBlockCompletedEvent;
+pub use crate::terminal::event::{AfterBlockCompletedEvent, BlockType, UserBlockCompleted};
 pub use crate::terminal::input::CommandExecutionSource;
 pub use crate::terminal::input::decorations::parse_current_commands_and_tokens;
 pub use crate::terminal::input::models::{ModelPickerChoice, query_model_picker_choices};
@@ -224,6 +233,7 @@ pub use crate::terminal::model::session::Sessions;
 pub use crate::terminal::model::session::active_session::{ActiveSession, ActiveSessionEvent};
 pub use crate::terminal::model::terminal_model::BlockIndex;
 pub use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
+pub use crate::terminal::session_settings::SessionSettings;
 pub use crate::terminal::shared_session::IsSharedSessionCreator;
 pub use crate::terminal::terminal_manager::BlockSpacing;
 pub use crate::terminal::view::blocklist_filter::should_show_task_in_blocklist;

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, SystemTime};
 use futures::channel::oneshot;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use warp_core::send_telemetry_from_ctx;
 use warp_errors::report_error;
 use warp_multi_agent_api as api;
 use warpui_core::{Entity, ModelContext, SingletonEntity};
@@ -16,6 +17,10 @@ pub use crate::geap_credentials::GeapRefreshOutcome;
 pub use crate::geap_credentials::{
     GEAP_MINT_FAILURE_COOLDOWN, GEAP_REFRESH_LEAD_TIME, GeapCredentials, GeapCredentialsState,
     GeapFederation, GeapMintBinding, LoadGeapCredentialsError,
+};
+use crate::telemetry::{
+    AITelemetryEvent, ProviderCredentialTelemetryAction, ProviderCredentialTelemetryKind,
+    ProviderCredentialTelemetryProvider,
 };
 
 const SECURE_STORAGE_KEY: &str = "AiApiKeys";
@@ -277,6 +282,44 @@ pub struct CustomEndpointParams {
     pub models: Vec<(String, Option<String>, Option<String>)>,
     pub schema: CustomEndpointSchema,
 }
+fn provider_credential_action(is_present: bool) -> ProviderCredentialTelemetryAction {
+    if is_present {
+        ProviderCredentialTelemetryAction::Added
+    } else {
+        ProviderCredentialTelemetryAction::Removed
+    }
+}
+
+fn provider_telemetry_provider(
+    provider: LLMProvider,
+) -> Option<ProviderCredentialTelemetryProvider> {
+    match provider {
+        LLMProvider::OpenAI => Some(ProviderCredentialTelemetryProvider::OpenAi),
+        LLMProvider::Anthropic => Some(ProviderCredentialTelemetryProvider::Anthropic),
+        LLMProvider::Google => Some(ProviderCredentialTelemetryProvider::Google),
+        LLMProvider::Xai => Some(ProviderCredentialTelemetryProvider::Xai),
+        LLMProvider::Unknown => None,
+    }
+}
+
+fn send_provider_credential_telemetry(
+    provider: LLMProvider,
+    credential_kind: ProviderCredentialTelemetryKind,
+    action: ProviderCredentialTelemetryAction,
+    ctx: &mut ModelContext<ApiKeyManager>,
+) {
+    let Some(provider) = provider_telemetry_provider(provider) else {
+        return;
+    };
+    send_telemetry_from_ctx!(
+        AITelemetryEvent::ProviderCredentialChanged {
+            provider,
+            credential_kind,
+            action,
+        },
+        ctx
+    );
+}
 
 impl ApiKeyManager {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
@@ -326,6 +369,7 @@ impl ApiKeyManager {
         key: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) -> anyhow::Result<()> {
+        let was_present = provider.api_key(&self.keys).is_some();
         let mut keys = self.keys.clone();
         if !provider.set_api_key(&mut keys, key) {
             return Err(anyhow::anyhow!(
@@ -341,8 +385,17 @@ impl ApiKeyManager {
                 anyhow::Error::new(error).context("Failed to write API keys to secure storage")
             })?;
         if self.keys != keys {
+            let is_present = provider.api_key(&keys).is_some();
             self.keys = keys;
             ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+            if was_present != is_present {
+                send_provider_credential_telemetry(
+                    provider,
+                    ProviderCredentialTelemetryKind::PastedKey,
+                    provider_credential_action(is_present),
+                    ctx,
+                );
+            }
         }
         Ok(())
     }
@@ -375,9 +428,19 @@ impl ApiKeyManager {
         if self.grok_tokens == tokens {
             return;
         }
+        let was_connected = self.grok_tokens.is_some();
+        let is_connected = tokens.is_some();
         self.grok_tokens = tokens;
         ctx.emit(ApiKeyManagerEvent::KeysUpdated);
         self.write_grok_tokens_to_secure_storage(ctx);
+        if was_connected != is_connected {
+            send_provider_credential_telemetry(
+                LLMProvider::Xai,
+                ProviderCredentialTelemetryKind::Oauth,
+                provider_credential_action(is_connected),
+                ctx,
+            );
+        }
     }
 
     pub fn set_provider_key(
@@ -386,11 +449,21 @@ impl ApiKeyManager {
         key: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) {
+        let was_present = provider.api_key(&self.keys).is_some();
         if !provider.set_api_key(&mut self.keys, key) {
             return;
         }
         ctx.emit(ApiKeyManagerEvent::KeysUpdated);
         self.write_keys_to_secure_storage(ctx);
+        let is_present = provider.api_key(&self.keys).is_some();
+        if was_present != is_present {
+            send_provider_credential_telemetry(
+                provider,
+                ProviderCredentialTelemetryKind::PastedKey,
+                provider_credential_action(is_present),
+                ctx,
+            );
+        }
     }
 
     pub fn add_custom_endpoint(

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -31,6 +31,7 @@ fn persisted_provider_api_key_updates_request_state() {
     warpui_core::App::test((), |mut app| async move {
         app.update(|ctx| {
             warpui_extras::secure_storage::register_noop("test", ctx);
+            warp_core::telemetry::testing::MockTelemetryContextProvider::register(ctx);
         });
         let manager = app.add_singleton_model(ApiKeyManager::new);
 
@@ -58,6 +59,7 @@ fn persisted_provider_api_key_can_be_cleared() {
     warpui_core::App::test((), |mut app| async move {
         app.update(|ctx| {
             warpui_extras::secure_storage::register_noop("test", ctx);
+            warp_core::telemetry::testing::MockTelemetryContextProvider::register(ctx);
         });
         let manager = app.add_singleton_model(ApiKeyManager::new);
 

--- a/crates/ai/src/telemetry.rs
+++ b/crates/ai/src/telemetry.rs
@@ -11,6 +11,11 @@ use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
 #[derive(Clone, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumIter))]
 pub enum AITelemetryEvent {
+    ProviderCredentialChanged {
+        provider: ProviderCredentialTelemetryProvider,
+        credential_kind: ProviderCredentialTelemetryKind,
+        action: ProviderCredentialTelemetryAction,
+    },
     MerkleTreeSnapshotRebuildSuccess {
         duration: Duration,
     },
@@ -44,6 +49,29 @@ pub enum AITelemetryEvent {
     },
 }
 
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProviderCredentialTelemetryProvider {
+    OpenAi,
+    Anthropic,
+    Google,
+    Xai,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProviderCredentialTelemetryKind {
+    PastedKey,
+    Oauth,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProviderCredentialTelemetryAction {
+    Added,
+    Removed,
+}
+
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 #[derive(Clone, Serialize)]
 pub enum CodebaseContextSyncType {
@@ -67,6 +95,15 @@ impl TelemetryEvent for AITelemetryEvent {
 
     fn payload(&self) -> Option<Value> {
         match self {
+            Self::ProviderCredentialChanged {
+                provider,
+                credential_kind,
+                action,
+            } => Some(json!({
+                "provider": provider,
+                "credential_kind": credential_kind,
+                "action": action,
+            })),
             Self::MerkleTreeSnapshotRebuildSuccess { duration } => Some(json!({
                 "duration": duration,
             })),
@@ -113,7 +150,8 @@ impl TelemetryEvent for AITelemetryEvent {
 
     fn contains_ugc(&self) -> bool {
         match self {
-            Self::MerkleTreeSnapshotRebuildSuccess { .. }
+            Self::ProviderCredentialChanged { .. }
+            | Self::MerkleTreeSnapshotRebuildSuccess { .. }
             | Self::MerkleTreeSnapshotRebuildFailed { .. }
             | Self::MerkleTreeSnapshotDiffSuccess { .. }
             | Self::MerkleTreeSnapshotDiffFailed { .. }
@@ -132,6 +170,7 @@ impl TelemetryEvent for AITelemetryEvent {
 impl TelemetryEventDesc for AITelemetryEventDiscriminants {
     fn name(&self) -> &'static str {
         match self {
+            Self::ProviderCredentialChanged => "AI.ProviderCredential.Changed",
             Self::MerkleTreeSnapshotRebuildSuccess => {
                 "AgentMode.MerkleTreeSnapshot.Rebuild.Success"
             }
@@ -147,6 +186,9 @@ impl TelemetryEventDesc for AITelemetryEventDiscriminants {
 
     fn description(&self) -> &'static str {
         match self {
+            Self::ProviderCredentialChanged => {
+                "A user added or removed a model-provider credential"
+            }
             Self::MerkleTreeSnapshotRebuildSuccess => {
                 "Successfully rebuilt merkle tree from snapshot"
             }
@@ -162,6 +204,7 @@ impl TelemetryEventDesc for AITelemetryEventDiscriminants {
 
     fn enablement_state(&self) -> EnablementState {
         match self {
+            Self::ProviderCredentialChanged => EnablementState::Always,
             Self::MerkleTreeSnapshotRebuildSuccess
             | Self::MerkleTreeSnapshotRebuildFailed
             | Self::MerkleTreeSnapshotDiffSuccess
@@ -175,3 +218,7 @@ impl TelemetryEventDesc for AITelemetryEventDiscriminants {
 }
 
 register_telemetry_event!(AITelemetryEvent);
+
+#[cfg(test)]
+#[path = "telemetry_tests.rs"]
+mod tests;

--- a/crates/ai/src/telemetry_tests.rs
+++ b/crates/ai/src/telemetry_tests.rs
@@ -1,0 +1,23 @@
+use warp_core::telemetry::TelemetryEvent as _;
+
+use super::*;
+
+#[test]
+fn provider_credential_payload_contains_only_classification_metadata() {
+    let event = AITelemetryEvent::ProviderCredentialChanged {
+        provider: ProviderCredentialTelemetryProvider::Anthropic,
+        credential_kind: ProviderCredentialTelemetryKind::PastedKey,
+        action: ProviderCredentialTelemetryAction::Added,
+    };
+
+    assert_eq!(event.name(), "AI.ProviderCredential.Changed");
+    assert_eq!(
+        event.payload(),
+        Some(json!({
+            "provider": "anthropic",
+            "credential_kind": "pasted_key",
+            "action": "added",
+        }))
+    );
+    assert!(!event.contains_ugc());
+}

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -5,12 +5,13 @@
 //! composition ([`TuiAIBlock::render_element`]); the per-section render
 //! functions live in [`crate::agent_block_sections`].
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::TimeDelta;
 use itertools::Itertools;
 use markdown_parser::{FormattedTable, FormattedText};
 use parking_lot::FairMutex;
@@ -21,7 +22,7 @@ use warp::tui_export::{
     BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason,
     FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, MessageId, ModelEvent,
     ModelEventDispatcher, ReceivedMessageDisplay, RenderableAIError, SummarizationType,
-    TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
+    TelemetryEvent, TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
     should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
@@ -381,6 +382,10 @@ pub(super) struct TuiAIBlock {
     /// conversation-wide todo/status invalidations to the blocks whose
     /// rendering can actually change.
     renders_todos: bool,
+    is_restored_for_telemetry: bool,
+    time_to_first_token: OnceCell<TimeDelta>,
+    time_to_last_token: Option<TimeDelta>,
+    terminal_telemetry_emitted: bool,
     last_measured_width: Cell<Option<u16>>,
 }
 
@@ -391,14 +396,15 @@ impl TuiAIBlock {
     /// child views for tool calls already present, then re-syncs whenever the
     /// exchange's output updates (via `on_updated_output`).
     pub(super) fn new(
-        conversation_id: AIConversationId,
-        exchange_id: AIAgentExchangeId,
+        identity: (AIConversationId, AIAgentExchangeId),
         block_model: Rc<dyn AIBlockModel<View = Self>>,
         action_model: ModelHandle<BlocklistAIActionModel>,
         model_events: &ModelHandle<ModelEventDispatcher>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
+        is_restored_for_telemetry: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
+        let (conversation_id, exchange_id) = identity;
         let mut block = Self {
             conversation_id,
             exchange_id,
@@ -411,6 +417,10 @@ impl TuiAIBlock {
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
             renders_todos: false,
+            is_restored_for_telemetry,
+            time_to_first_token: OnceCell::new(),
+            time_to_last_token: None,
+            terminal_telemetry_emitted: false,
             last_measured_width: Cell::new(None),
         };
         block.sync_action_views(&action_model, ctx);
@@ -471,6 +481,7 @@ impl TuiAIBlock {
         });
         block.block_model.on_updated_output(
             Box::new(move |me, ctx| {
+                me.record_output_telemetry(ctx);
                 me.sync_action_views(&action_model, ctx);
                 me.sync_code_block_views(ctx);
                 // The presenter caches this block's rendered element; new
@@ -482,6 +493,53 @@ impl TuiAIBlock {
             ctx,
         );
         block
+    }
+
+    fn record_output_telemetry(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.is_restored_for_telemetry || self.terminal_telemetry_emitted {
+            return;
+        }
+        let status = self.block_model.status(ctx);
+        if status.output_to_render().is_some()
+            && let Some(latency) = self.block_model.time_since_request_start(ctx)
+        {
+            if self.time_to_first_token.set(latency).is_ok() {
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
+                    history.set_exchange_time_to_first_token(
+                        self.conversation_id,
+                        self.exchange_id,
+                        latency.num_milliseconds(),
+                    );
+                });
+            }
+            self.time_to_last_token = Some(latency);
+        }
+        let (was_user_facing_error, cancelled) = match status {
+            AIBlockOutputStatus::Pending | AIBlockOutputStatus::PartiallyReceived { .. } => return,
+            AIBlockOutputStatus::Complete { .. } => (false, false),
+            AIBlockOutputStatus::Cancelled { .. } => (false, true),
+            AIBlockOutputStatus::Failed { .. } => (true, false),
+        };
+        self.terminal_telemetry_emitted = true;
+        warp::send_telemetry_from_ctx!(
+            TelemetryEvent::AgentModeCreatedAIBlock {
+                client_exchange_id: self.exchange_id.to_string(),
+                server_output_id: self.block_model.server_output_id(ctx),
+                was_autodetected_ai_query: self.block_model.was_autodetected_ai_query(ctx),
+                time_to_first_token_ms: self
+                    .time_to_first_token
+                    .get()
+                    .map(|duration| duration.num_milliseconds() as u128),
+                time_to_last_token_ms: self
+                    .time_to_last_token
+                    .map(|duration| duration.num_milliseconds() as u128),
+                was_user_facing_error,
+                cancelled,
+                conversation_id: self.conversation_id,
+                is_udi_enabled: false,
+            },
+            ctx
+        );
     }
 
     /// Records the exchange's tool-call action ids and todo presence, and
@@ -741,9 +799,11 @@ impl TuiAIBlock {
             let card_action_model = action_model.clone();
             let run_agents_executor = action_model.as_ref(ctx).run_agents_executor(ctx);
             let fallback_base_model_id = self.block_model.base_model(ctx).map(|id| id.to_string());
-            let is_restored = self.block_model.is_restored();
+            let is_restored = self.is_restored_for_telemetry;
+            let conversation_id = self.conversation_id;
             let view = ctx.add_typed_action_tui_view(move |ctx| {
                 TuiOrchestrationBlock::new(
+                    conversation_id,
                     action,
                     &request,
                     active_config,

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -2118,12 +2118,12 @@ fn test_agent_block(app: &mut App, model: FakeAgentBlockModel) -> ViewHandle<Tui
         );
         ctx.add_typed_action_tui_view(window_id, move |ctx| {
             TuiAIBlock::new(
-                AIConversationId::new(),
-                AIAgentExchangeId::new(),
+                (AIConversationId::new(), AIAgentExchangeId::new()),
                 Rc::new(model),
                 action_model,
                 &model_events,
                 terminal_model,
+                false,
                 ctx,
             )
         })

--- a/crates/warp_tui/src/conversation_menu.rs
+++ b/crates/warp_tui/src/conversation_menu.rs
@@ -19,6 +19,7 @@ use crate::inline_menu::{
     TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, result_row_capacity,
 };
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
+use crate::telemetry::TuiConversationMenuTelemetryEvent;
 
 const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
 
@@ -112,6 +113,7 @@ impl TuiConversationMenuModel {
         let mut list = TuiInlineMenuListState::default();
         list.set_loading(true);
         self.state = TuiConversationMenuState::Open { list };
+        warp::send_telemetry_from_ctx!(TuiConversationMenuTelemetryEvent::Opened, ctx);
         self.cloud_warning_shown = false;
         let window_id = self.window_id;
         let model_id = ctx.model_id();

--- a/crates/warp_tui/src/handoff/model.rs
+++ b/crates/warp_tui/src/handoff/model.rs
@@ -15,11 +15,12 @@ use parking_lot::FairMutex;
 use warp::settings::{AISettings, PrivacySettings, PrivacySettingsChangedEvent};
 use warp::tui_export::{
     AIConversationId, AISettingsChangedEvent, AttachmentInput, BlocklistAIContextModel,
-    BlocklistAIController, BlocklistAIHistoryModel, CloudEnvironmentCatalog, HandoffCommitOutcome,
-    HandoffEntryPoint, HandoffLaunchAttachments, HandoffPrepareError, HandoffPrepareInput,
-    HandoffRestoration, HandoffSurface, LLMId, LLMPreferences, LLMPreferencesEvent, OptionRow,
-    OptionSnapshot, OptionSourceStatus, PendingCloudLaunch, PendingHandoff, ServerApiProvider,
-    SnapshotUploadTarget, TerminalModel, UserWorkspaces, UserWorkspacesEvent, execute_handoff,
+    BlocklistAIController, BlocklistAIHistoryModel, CloudAgentTelemetryEvent,
+    CloudEnvironmentCatalog, HandoffCommitOutcome, HandoffEntryPoint, HandoffLaunchAttachments,
+    HandoffPrepareError, HandoffPrepareInput, HandoffRestoration, HandoffSurface, LLMId,
+    LLMPreferences, LLMPreferencesEvent, OptionRow, OptionSnapshot, OptionSourceStatus,
+    PendingCloudLaunch, PendingHandoff, ServerApiProvider, SnapshotUploadTarget, TerminalModel,
+    UserWorkspaces, UserWorkspacesEvent, execute_handoff, handoff_dispatch_error,
     oz_model_snapshot, prepare_handoff, suggest_handoff_environment,
 };
 use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity as _};
@@ -627,6 +628,22 @@ impl TuiHandoffModel {
                     ctx.notify();
                 }
                 HandoffCommitOutcome::Failed(failure) => {
+                    warp::send_telemetry_from_ctx!(
+                        CloudAgentTelemetryEvent::DispatchFailed {
+                            error: handoff_dispatch_error(&failure.issue),
+                        },
+                        ctx
+                    );
+                    if let Some(derived_workspace_had_content) =
+                        failure.derived_workspace_had_content
+                    {
+                        warp::send_telemetry_from_ctx!(
+                            CloudAgentTelemetryEvent::HandoffSnapshotPrepared {
+                                derived_workspace_had_content,
+                            },
+                            ctx
+                        );
+                    }
                     model.dismissed = true;
                     ctx.emit(TuiHandoffModelEvent::Failed {
                         restoration: failure.restoration,
@@ -642,6 +659,13 @@ impl TuiHandoffModel {
                     ctx.notify();
                 }
                 HandoffCommitOutcome::Created(created) => {
+                    warp::send_telemetry_from_ctx!(
+                        CloudAgentTelemetryEvent::HandoffSnapshotPrepared {
+                            derived_workspace_had_content: created
+                                .derived_workspace_had_content,
+                        },
+                        ctx
+                    );
                     model.phase = TuiHandoffPhase::Created {
                         url: created.url,
                         completed_at: Local::now()

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -329,7 +329,7 @@ impl TuiInputView {
         session_state: ModelHandle<TuiTerminalSessionStateModel>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let voice_input = ctx.add_model(TuiVoiceInputModel::new);
+        let voice_input = ctx.add_model(|ctx| TuiVoiceInputModel::new(input_mode.clone(), ctx));
         let vim_model = ctx.add_model(|_| VimModel::new());
         // Subscribe to vim events: VimSubscriber blanket impl (TuiInputView: VimHandler)
         // dispatches each VimEvent to the appropriate VimHandler method.

--- a/crates/warp_tui/src/orchestration_block.rs
+++ b/crates/warp_tui/src/orchestration_block.rs
@@ -14,14 +14,16 @@
 use std::rc::Rc;
 
 use warp::tui_export::{
-    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionType, AuthSecretSelection,
-    BlocklistAIActionEvent, BlocklistAIActionModel, Harness, HarnessAvailabilityEvent,
+    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionType, AIConversationId,
+    AuthSecretSelection, BlocklistAIActionEvent, BlocklistAIActionModel,
+    BlocklistOrchestrationTelemetryEvent, Harness, HarnessAvailabilityEvent,
     HarnessAvailabilityModel, LLMPreferences, LLMPreferencesEvent, ORCHESTRATION_WARP_WORKER_HOST,
     OptionSnapshot, OrchestrationConfig, OrchestrationConfigState, OrchestrationConfigStatus,
-    OrchestrationEditState, RunAgentsExecutionMode, RunAgentsExecutor, RunAgentsExecutorEvent,
+    OrchestrationEditState, OrchestrationEnteredEvent, OrchestrationEntrySource,
+    RunAgentsCardDecision, RunAgentsExecutionMode, RunAgentsExecutor, RunAgentsExecutorEvent,
     RunAgentsRequest, RunAgentsSpawningSnapshot, persist_host_selection,
     resolve_auth_secret_selection_for_harness, resolve_default_environment_id,
-    resolve_default_host_slug, should_show_auth_secret_picker,
+    resolve_default_host_slug, run_agents_card_decision_event, should_show_auth_secret_picker,
 };
 use warpui::SingletonEntity;
 use warpui_core::elements::tui::TuiElement;
@@ -131,6 +133,7 @@ pub(crate) enum TuiOrchestrationBlockAction {
 /// The TUI orchestration confirmation block. See the module docs.
 pub(crate) struct TuiOrchestrationBlock {
     // Request and action identity.
+    conversation_id: AIConversationId,
     action_id: AIAgentActionId,
     /// The latest streamed tool call, kept in sync by
     /// [`Self::update_request`]; terminal/streaming states render from it
@@ -159,6 +162,8 @@ pub(crate) struct TuiOrchestrationBlock {
     spawning: Option<RunAgentsSpawningSnapshot>,
     /// Set once the request is accepted or rejected.
     decided: bool,
+    entered_event_emitted: bool,
+    decision_event_emitted: bool,
     /// Identity palette pinned at construction so identities stay stable
     /// across re-renders, edits, and theme switches.
     identity_palette: Vec<AgentIdentity>,
@@ -169,6 +174,7 @@ impl TuiOrchestrationBlock {
     /// subscriptions.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        conversation_id: AIConversationId,
         action: AIAgentAction,
         request: &RunAgentsRequest,
         active_config: Option<(OrchestrationConfig, OrchestrationConfigStatus)>,
@@ -221,6 +227,7 @@ impl TuiOrchestrationBlock {
                 // "Configuring agents…" placeholder to the interactive
                 // acceptance card, so resolve display defaults now.
                 me.resolve_interactive_defaults(ctx);
+                me.emit_orchestration_entered_once(ctx);
                 ctx.emit(TuiOrchestrationBlockEvent::BlockingStateChanged);
                 ctx.notify();
             }
@@ -274,6 +281,7 @@ impl TuiOrchestrationBlock {
         let controller = Rc::new(ModelOrchestrationBlockController { action_model });
         let identity_palette = TuiUiBuilder::from_app(ctx).agent_identity_palette();
         let mut view = Self::from_parts(
+            conversation_id,
             action,
             request,
             active_config,
@@ -290,6 +298,7 @@ impl TuiOrchestrationBlock {
     /// Constructs the block from injected external behavior.
     #[allow(clippy::too_many_arguments)]
     fn from_parts(
+        conversation_id: AIConversationId,
         action: AIAgentAction,
         request: &RunAgentsRequest,
         active_config: Option<(OrchestrationConfig, OrchestrationConfigStatus)>,
@@ -307,6 +316,7 @@ impl TuiOrchestrationBlock {
             Self::config_state_from_request(request, active_config.as_ref()),
         );
         Self {
+            conversation_id,
             action_id: action.id.clone(),
             action,
             request_fields: request.clone(),
@@ -321,6 +331,8 @@ impl TuiOrchestrationBlock {
             controller,
             spawning: None,
             decided: false,
+            entered_event_emitted: false,
+            decision_event_emitted: false,
             identity_palette,
         }
     }
@@ -413,6 +425,42 @@ impl TuiOrchestrationBlock {
         self.refresh_active_page(ctx);
         ctx.emit(TuiOrchestrationBlockEvent::LayoutInvalidated);
         ctx.notify();
+    }
+
+    fn emit_orchestration_entered_once(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.entered_event_emitted || self.is_restored {
+            return;
+        }
+        self.entered_event_emitted = true;
+        warp::send_telemetry_from_ctx!(
+            BlocklistOrchestrationTelemetryEvent::OrchestrationEntered(OrchestrationEnteredEvent {
+                conversation_id: self.conversation_id,
+                plan_id: (!self.request_fields.plan_id.is_empty())
+                    .then(|| self.request_fields.plan_id.clone()),
+                entry_source: OrchestrationEntrySource::RunAgentsCardShown,
+            }),
+            ctx
+        );
+    }
+
+    fn emit_decision(&mut self, decision: RunAgentsCardDecision, ctx: &mut ViewContext<Self>) {
+        if self.decision_event_emitted || self.is_restored {
+            return;
+        }
+        self.decision_event_emitted = true;
+        let event = run_agents_card_decision_event(
+            self.conversation_id,
+            (!self.request_fields.plan_id.is_empty()).then(|| self.request_fields.plan_id.clone()),
+            decision,
+            self.request_fields.agent_run_configs.len(),
+            &self.orchestration_edit_state.orchestration_config_state,
+            &self.request_fields,
+            self.active_config.as_ref(),
+        );
+        warp::send_telemetry_from_ctx!(
+            BlocklistOrchestrationTelemetryEvent::RunAgentsCardDecision(event),
+            ctx
+        );
     }
 
     /// Whether this card still awaits a user decision.
@@ -639,9 +687,7 @@ impl TuiOrchestrationBlock {
         }
         let request = self.to_request();
         let action_id = self.action_id.clone();
-        if let Err(reason) = self.controller.accept(
-            &action_id,
-            request,
+        if let Some(reason) = self.controller.accept_disabled_reason(
             &self.orchestration_edit_state.orchestration_config_state,
             ctx,
         ) {
@@ -650,6 +696,8 @@ impl TuiOrchestrationBlock {
             ctx.notify();
             return;
         }
+        self.emit_decision(RunAgentsCardDecision::Accept, ctx);
+        self.controller.accept(&action_id, request, ctx);
         self.decided = true;
         self.accept_error = None;
         self.mode = CardMode::Acceptance;
@@ -663,6 +711,7 @@ impl TuiOrchestrationBlock {
         if self.decided || self.spawning.is_some() || !self.is_awaiting_confirmation(ctx) {
             return;
         }
+        self.emit_decision(RunAgentsCardDecision::Reject, ctx);
         self.decided = true;
         self.mode = CardMode::Acceptance;
         ctx.emit(TuiOrchestrationBlockEvent::RejectRequested);

--- a/crates/warp_tui/src/orchestration_block/configuration.rs
+++ b/crates/warp_tui/src/orchestration_block/configuration.rs
@@ -100,15 +100,15 @@ pub(super) trait OrchestrationBlockController {
         ctx: &mut AppContext,
     );
 
-    /// Validates and dispatches an accepted request, returning the blocking
-    /// reason when the edited configuration cannot launch.
-    fn accept(
+    /// Returns the blocking reason when the edited configuration cannot launch.
+    fn accept_disabled_reason(
         &self,
-        action_id: &AIAgentActionId,
-        request: RunAgentsRequest,
         state: &OrchestrationConfigState,
-        ctx: &mut AppContext,
-    ) -> Result<(), String>;
+        ctx: &AppContext,
+    ) -> Option<String>;
+
+    /// Dispatches a request that has already passed validation.
+    fn accept(&self, action_id: &AIAgentActionId, request: RunAgentsRequest, ctx: &mut AppContext);
 }
 
 /// Production controller backed by the shared orchestration models.
@@ -189,19 +189,17 @@ impl OrchestrationBlockController for ModelOrchestrationBlockController {
         }
     }
 
-    fn accept(
+    fn accept_disabled_reason(
         &self,
-        action_id: &AIAgentActionId,
-        request: RunAgentsRequest,
         state: &OrchestrationConfigState,
-        ctx: &mut AppContext,
-    ) -> Result<(), String> {
-        if let Some(reason) = accept_disabled_reason_with_auth(state, ctx) {
-            return Err(reason);
-        }
+        ctx: &AppContext,
+    ) -> Option<String> {
+        accept_disabled_reason_with_auth(state, ctx)
+    }
+
+    fn accept(&self, action_id: &AIAgentActionId, request: RunAgentsRequest, ctx: &mut AppContext) {
         self.action_model.update(ctx, |action_model, ctx| {
             action_model.execute_run_agents(action_id, request, ctx);
         });
-        Ok(())
     }
 }

--- a/crates/warp_tui/src/orchestration_block_tests.rs
+++ b/crates/warp_tui/src/orchestration_block_tests.rs
@@ -5,10 +5,10 @@ use ai::agent::orchestration_config::{
     OrchestrationConfig, OrchestrationConfigStatus, OrchestrationExecutionMode,
 };
 use warp::tui_export::{
-    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionType, Appearance,
-    AuthSecretSelection, OptionRow, OptionSnapshot, OptionSourceStatus, OrchestrationConfigState,
-    OrchestrationEditState, RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest,
-    TaskId,
+    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionType, AIConversationId,
+    Appearance, AuthSecretSelection, OptionRow, OptionSnapshot, OptionSourceStatus,
+    OrchestrationConfigState, OrchestrationEditState, RunAgentsAgentRunConfig,
+    RunAgentsExecutionMode, RunAgentsRequest, TaskId,
 };
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, App, ViewHandle};
@@ -313,18 +313,21 @@ impl OrchestrationBlockController for TestController {
         }
     }
 
+    fn accept_disabled_reason(
+        &self,
+        _state: &OrchestrationConfigState,
+        _ctx: &warpui::AppContext,
+    ) -> Option<String> {
+        self.accept_error.borrow().clone()
+    }
+
     fn accept(
         &self,
         _action_id: &AIAgentActionId,
         request: RunAgentsRequest,
-        _state: &OrchestrationConfigState,
         _ctx: &mut warpui::AppContext,
-    ) -> Result<(), String> {
-        if let Some(reason) = self.accept_error.borrow().clone() {
-            return Err(reason);
-        }
+    ) {
         self.executed_requests.borrow_mut().push(request);
-        Ok(())
     }
 }
 
@@ -345,6 +348,7 @@ fn test_block(
     request: &RunAgentsRequest,
 ) -> (ViewHandle<TuiOrchestrationBlock>, Rc<TestController>) {
     app.add_singleton_model(|_| Appearance::mock());
+    app.update(warp_core::telemetry::testing::MockTelemetryContextProvider::register);
     let action = AIAgentAction {
         id: AIAgentActionId::from("run-agents-1".to_string()),
         task_id: TaskId::new("task-1".to_string()),
@@ -364,6 +368,7 @@ fn test_block(
         );
         ctx.add_typed_action_tui_view(window_id, move |ctx| {
             TuiOrchestrationBlock::from_parts(
+                AIConversationId::new(),
                 action,
                 &request,
                 None,

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -220,7 +220,7 @@ fn init(
     exit_summary: TuiExitSummaryHandle,
     ctx: &mut AppContext,
 ) {
-    warp_core::send_telemetry_from_app_ctx!(TuiStartupTelemetryEvent, ctx);
+    warp_core::send_telemetry_from_app_ctx!(TuiStartupTelemetryEvent::from_environment(), ctx);
     // Register the TUI views' keybindings (and, in debug builds, the
     // cross-surface binding validators) before any input can be dispatched.
     crate::keybindings::init(ctx);

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -13,8 +13,8 @@ use warp::search::mixer::SearchMixerEvent;
 use warp::settings::{AISettings, AppEditorSettings, TuiTheme, TuiThemeSettings};
 use warp::tui_export::{
     AcceptSlashCommandOrSavedPrompt, Appearance, ConversationSelectionHandle,
-    ParsedSlashCommandInput, SlashCommandDataSource as _, SlashCommandMixer,
-    TuiSlashCommandDataSource, UpdatedActiveCommands,
+    ParsedSlashCommandInput, SlashCommandDataSource as _, SlashCommandMixer, SlashMenuSource,
+    TelemetryEvent, TuiSlashCommandDataSource, UpdatedActiveCommands,
     should_close_slash_command_menu_for_exact_match, slash_command_query, slash_commands,
 };
 use warp_editor::model::CoreEditorModel;
@@ -88,6 +88,7 @@ pub(crate) struct TuiSlashCommandModel {
     mixer: ModelHandle<SlashCommandMixer>,
     state: TuiSlashCommandState,
     lifecycle: InputDrivenInlineMenuLifecycle,
+    opened_telemetry_emitted: bool,
     highlighted_prefix_len: Option<usize>,
     argument_hint_text: Option<&'static str>,
     conversation_selection: ConversationSelectionHandle,
@@ -126,6 +127,7 @@ impl TuiSlashCommandModel {
             mixer,
             state: TuiSlashCommandState::Closed,
             lifecycle: InputDrivenInlineMenuLifecycle::default(),
+            opened_telemetry_emitted: false,
             highlighted_prefix_len: None,
             argument_hint_text: None,
             conversation_selection,
@@ -157,6 +159,7 @@ impl TuiSlashCommandModel {
                 list,
             },
             lifecycle: InputDrivenInlineMenuLifecycle::default(),
+            opened_telemetry_emitted: false,
             highlighted_prefix_len: None,
             argument_hint_text: None,
             conversation_selection,
@@ -346,6 +349,9 @@ impl TuiSlashCommandModel {
 
     fn update_from_input(&mut self, force_query: bool, ctx: &mut ModelContext<Self>) {
         let input = input_text(&self.input_editor, ctx);
+        if input.is_empty() || !input.starts_with('/') {
+            self.opened_telemetry_emitted = false;
+        }
         if matches!(
             self.suggestions_mode.as_ref(ctx).mode(),
             TuiInputSuggestionsMode::ApiKeys
@@ -418,6 +424,17 @@ impl TuiSlashCommandModel {
                     query: query.clone(),
                     list,
                 };
+                if !self.opened_telemetry_emitted {
+                    self.opened_telemetry_emitted = true;
+                    warp::send_telemetry_from_ctx!(
+                        TelemetryEvent::OpenSlashMenu {
+                            source: SlashMenuSource::UserTyped,
+                            is_inline_ui_enabled: true,
+                            is_in_agent_view: true,
+                        },
+                        ctx
+                    );
+                }
             }
             TuiSlashCommandState::Open {
                 query: current_query,

--- a/crates/warp_tui/src/telemetry.rs
+++ b/crates/warp_tui/src/telemetry.rs
@@ -1,10 +1,78 @@
 //! Telemetry for the `warp-tui` front-end.
+use std::ffi::{OsStr, OsString};
 
 use serde_json::{Value, json};
 use strum_macros::{EnumDiscriminants, EnumIter};
 use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
+const MAX_TERM_PROGRAM_CHARS: usize = 64;
+
+#[derive(Clone, Copy, Debug)]
+enum TuiHostMultiplexer {
+    None,
+    Tmux,
+    Screen,
+    Zellij,
+}
+
+impl TuiHostMultiplexer {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Tmux => "tmux",
+            Self::Screen => "screen",
+            Self::Zellij => "zellij",
+        }
+    }
+}
+
 #[derive(Debug)]
-pub(crate) struct TuiStartupTelemetryEvent;
+pub(crate) struct TuiStartupTelemetryEvent {
+    term_program: Option<String>,
+    multiplexer: TuiHostMultiplexer,
+}
+
+impl TuiStartupTelemetryEvent {
+    pub(crate) fn from_environment() -> Self {
+        Self {
+            term_program: sanitize_term_program(std::env::var_os("TERM_PROGRAM")),
+            multiplexer: detect_multiplexer(
+                std::env::var_os("TMUX").as_deref(),
+                std::env::var_os("STY").as_deref(),
+                std::env::var_os("ZELLIJ").as_deref(),
+                std::env::var_os("ZELLIJ_SESSION_NAME").as_deref(),
+            ),
+        }
+    }
+}
+
+fn sanitize_term_program(value: Option<OsString>) -> Option<String> {
+    let value = value?.into_string().ok()?;
+    let sanitized = value
+        .trim()
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(MAX_TERM_PROGRAM_CHARS)
+        .collect::<String>();
+    (!sanitized.is_empty()).then_some(sanitized)
+}
+
+fn detect_multiplexer(
+    tmux: Option<&OsStr>,
+    screen: Option<&OsStr>,
+    zellij: Option<&OsStr>,
+    zellij_session_name: Option<&OsStr>,
+) -> TuiHostMultiplexer {
+    let is_present = |value: Option<&OsStr>| value.is_some_and(|value| !value.is_empty());
+    if is_present(tmux) {
+        TuiHostMultiplexer::Tmux
+    } else if is_present(screen) {
+        TuiHostMultiplexer::Screen
+    } else if is_present(zellij) || is_present(zellij_session_name) {
+        TuiHostMultiplexer::Zellij
+    } else {
+        TuiHostMultiplexer::None
+    }
+}
 
 impl TelemetryEvent for TuiStartupTelemetryEvent {
     fn name(&self) -> &'static str {
@@ -12,7 +80,10 @@ impl TelemetryEvent for TuiStartupTelemetryEvent {
     }
 
     fn payload(&self) -> Option<Value> {
-        None
+        Some(json!({
+            "term_program": self.term_program,
+            "multiplexer": self.multiplexer.as_str(),
+        }))
     }
 
     fn description(&self) -> &'static str {
@@ -28,7 +99,10 @@ impl TelemetryEvent for TuiStartupTelemetryEvent {
     }
 
     fn event_descs() -> impl Iterator<Item = Box<dyn TelemetryEventDesc>> {
-        std::iter::once(Box::new(Self) as Box<dyn TelemetryEventDesc>)
+        std::iter::once(Box::new(Self {
+            term_program: None,
+            multiplexer: TuiHostMultiplexer::None,
+        }) as Box<dyn TelemetryEventDesc>)
     }
 }
 
@@ -47,6 +121,149 @@ impl TelemetryEventDesc for TuiStartupTelemetryEvent {
 }
 
 warp_core::register_telemetry_event!(TuiStartupTelemetryEvent);
+
+#[derive(Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
+pub(crate) enum TuiConversationMenuTelemetryEvent {
+    Opened,
+    ItemSelected,
+}
+
+impl TelemetryEvent for TuiConversationMenuTelemetryEvent {
+    fn name(&self) -> &'static str {
+        TuiConversationMenuTelemetryEventDiscriminants::from(self).name()
+    }
+
+    fn payload(&self) -> Option<Value> {
+        None
+    }
+
+    fn description(&self) -> &'static str {
+        TuiConversationMenuTelemetryEventDiscriminants::from(self).description()
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        TuiConversationMenuTelemetryEventDiscriminants::from(self).enablement_state()
+    }
+
+    fn contains_ugc(&self) -> bool {
+        false
+    }
+
+    fn event_descs() -> impl Iterator<Item = Box<dyn TelemetryEventDesc>> {
+        warp_core::telemetry::enum_events::<Self>()
+    }
+}
+
+impl TelemetryEventDesc for TuiConversationMenuTelemetryEventDiscriminants {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Opened => "TUI.ConversationMenu.Opened",
+            Self::ItemSelected => "TUI.ConversationMenu.ItemSelected",
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            Self::Opened => "The conversation menu opened in the headless Warp TUI",
+            Self::ItemSelected => "A conversation-menu item was selected in the headless Warp TUI",
+        }
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        EnablementState::Always
+    }
+}
+
+warp_core::register_telemetry_event!(TuiConversationMenuTelemetryEvent);
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TuiConversationRestoreTelemetryState {
+    Started,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl TuiConversationRestoreTelemetryState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Started => "started",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TuiConversationRestoreTelemetryTarget {
+    Local,
+    Server,
+}
+
+impl TuiConversationRestoreTelemetryTarget {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Server => "server",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TuiConversationRestoreTelemetryEvent {
+    pub state: TuiConversationRestoreTelemetryState,
+    pub target: TuiConversationRestoreTelemetryTarget,
+}
+
+impl TelemetryEvent for TuiConversationRestoreTelemetryEvent {
+    fn name(&self) -> &'static str {
+        "TUI.ConversationRestore"
+    }
+
+    fn payload(&self) -> Option<Value> {
+        Some(json!({
+            "state": self.state.as_str(),
+            "target": self.target.as_str(),
+        }))
+    }
+
+    fn description(&self) -> &'static str {
+        "A conversation-list restore changed lifecycle state in the headless Warp TUI"
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        EnablementState::Always
+    }
+
+    fn contains_ugc(&self) -> bool {
+        false
+    }
+
+    fn event_descs() -> impl Iterator<Item = Box<dyn TelemetryEventDesc>> {
+        std::iter::once(Box::new(Self {
+            state: TuiConversationRestoreTelemetryState::Started,
+            target: TuiConversationRestoreTelemetryTarget::Local,
+        }) as Box<dyn TelemetryEventDesc>)
+    }
+}
+
+impl TelemetryEventDesc for TuiConversationRestoreTelemetryEvent {
+    fn name(&self) -> &'static str {
+        "TUI.ConversationRestore"
+    }
+
+    fn description(&self) -> &'static str {
+        "A conversation-list restore changed lifecycle state in the headless Warp TUI"
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        EnablementState::Always
+    }
+}
+
+warp_core::register_telemetry_event!(TuiConversationRestoreTelemetryEvent);
 
 /// Health signals for the TUI auto-updater. Sent when the outcome of a
 /// background update check *changes* (not on every poll), so repeated
@@ -135,3 +352,7 @@ impl TelemetryEventDesc for TuiAutoupdateTelemetryEventDiscriminants {
 }
 
 warp_core::register_telemetry_event!(TuiAutoupdateTelemetryEvent);
+
+#[cfg(test)]
+#[path = "telemetry_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/telemetry_tests.rs
+++ b/crates/warp_tui/src/telemetry_tests.rs
@@ -1,0 +1,80 @@
+use warp_core::telemetry::TelemetryEvent as _;
+
+use super::*;
+
+#[test]
+fn startup_payload_reports_sanitized_terminal_metadata() {
+    let event = TuiStartupTelemetryEvent {
+        term_program: sanitize_term_program(Some("  ghost\u{1b}ty  ".into())),
+        multiplexer: TuiHostMultiplexer::Tmux,
+    };
+
+    assert_eq!(
+        event.payload(),
+        Some(json!({
+            "term_program": "ghostty",
+            "multiplexer": "tmux",
+        }))
+    );
+}
+
+#[test]
+fn terminal_program_is_bounded_and_empty_values_are_omitted() {
+    assert_eq!(sanitize_term_program(Some("   ".into())), None);
+    assert_eq!(
+        sanitize_term_program(Some("x".repeat(MAX_TERM_PROGRAM_CHARS + 10).into()))
+            .unwrap()
+            .len(),
+        MAX_TERM_PROGRAM_CHARS
+    );
+}
+
+#[test]
+fn multiplexer_detection_uses_stable_precedence() {
+    let value = std::ffi::OsStr::new("present");
+    assert_eq!(
+        detect_multiplexer(Some(value), Some(value), Some(value), Some(value)).as_str(),
+        "tmux"
+    );
+    assert_eq!(
+        detect_multiplexer(None, Some(value), Some(value), Some(value)).as_str(),
+        "screen"
+    );
+    assert_eq!(
+        detect_multiplexer(None, None, Some(value), None).as_str(),
+        "zellij"
+    );
+    assert_eq!(detect_multiplexer(None, None, None, None).as_str(), "none");
+}
+
+#[test]
+fn conversation_menu_events_use_tui_native_names() {
+    let opened = TuiConversationMenuTelemetryEvent::Opened;
+    let selected = TuiConversationMenuTelemetryEvent::ItemSelected;
+
+    assert_eq!(TelemetryEvent::name(&opened), "TUI.ConversationMenu.Opened");
+    assert_eq!(
+        TelemetryEvent::name(&selected),
+        "TUI.ConversationMenu.ItemSelected"
+    );
+    assert_eq!(opened.payload(), None);
+    assert_eq!(selected.payload(), None);
+}
+
+#[test]
+fn conversation_restore_payload_is_low_cardinality_and_non_ugc() {
+    let event = TuiConversationRestoreTelemetryEvent {
+        state: TuiConversationRestoreTelemetryState::Failed,
+        target: TuiConversationRestoreTelemetryTarget::Server,
+    };
+
+    assert_eq!(TelemetryEvent::name(&event), "TUI.ConversationRestore");
+    assert_eq!(
+        event.payload(),
+        Some(json!({
+            "state": "failed",
+            "target": "server",
+        }))
+    );
+    assert!(!event.contains_ugc());
+}

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -18,23 +18,25 @@ use warp::settings::{
 use warp::tui_export::{
     AIAgentActionId, AIAgentActionResultType, AIAgentContext, AIAgentExchangeId,
     AIAgentPtyWriteMode, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
-    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AgentConversationEntryId,
-    AgentConversationListEntryState, AgentConversationsModel, AgentInteractionMetadata,
-    AgentViewEntryOrigin, Appearance, BlockId, BlocklistAIActionEvent, BlocklistAIActionModel,
-    BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
-    BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController, CLISubagentEvent,
+    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AfterBlockCompletedEvent,
+    AgentConversationEntryId, AgentConversationListEntryState, AgentConversationsModel,
+    AgentInteractionMetadata, AgentViewEntryOrigin, Appearance, BlockId, BlockType,
+    BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel,
+    BlocklistOrchestrationTelemetryEvent, CLISubagentController, CLISubagentEvent,
     CLISubagentTarget, COMMAND_REGISTRY, CancellationReason, ChangelogModel, ChangelogRequestType,
     CloudConversationData, CommandExecutionSource, ConversationFileExport, ConversationSelection,
     ConversationSelectionHandle, ExecuteCommandEvent, GetRelevantFilesController, GitHubRepoModel,
     GitRepoStatusModel, LLMId, LLMPreferences, LLMPreferencesEvent,
     LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, LinkedWorkflowData, ModelEvent,
-    ParsedSlashCommandInput, PersistenceWriter, PtyIntent, PtyIntentEvent, QueuedQueryEvent,
+    ParsedSlashCommandInput, PersistenceWriter, PillBarActionKind, PillBarInteractionEvent,
+    PillBarPillKind, PillSwitchOutcome, PtyIntent, PtyIntentEvent, QueuedQueryEvent,
     QueuedQueryModel, RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
-    Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
+    SessionSettings, Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
     SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
-    StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TerminalColorList, TerminalColors,
-    TerminalModel, TerminalSurface, TerminalSurfaceInit, TranscriptScope, TuiMcpAction,
-    TuiMcpManager, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
+    StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TelemetryEvent, TerminalColorList,
+    TerminalColors, TerminalModel, TerminalSurface, TerminalSurfaceInit, TranscriptScope,
+    TuiMcpAction, TuiMcpManager, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
     TuiUpArrowHistoryItemKind, TuiUserInfoManager, TuiUserInfoManagerEvent, TuiZeroStateDataSource,
     UserTakeOverReason, WAKEUP_THROTTLE_PERIOD, WarpConfig, WarpConfigUpdateEvent,
     block_context_from_terminal_model, build_slash_command_mixer, detect_possible_git_repo,
@@ -115,6 +117,10 @@ use crate::skills_menu::{TuiSkillMenuEvent, TuiSkillMenuModel};
 use crate::slash_commands::TuiSlashCommandModel;
 use crate::statusline_config_view::{TuiStatuslineConfigEvent, TuiStatuslineConfigView};
 use crate::tab_bar::{TuiTabBarConfig, TuiTabBarEvent, TuiTabBarView};
+use crate::telemetry::{
+    TuiConversationMenuTelemetryEvent, TuiConversationRestoreTelemetryEvent,
+    TuiConversationRestoreTelemetryState, TuiConversationRestoreTelemetryTarget,
+};
 use crate::terminal_background::TuiHostTerminalBackground;
 use crate::terminal_content_element::TuiTerminalContentElement;
 use crate::terminal_use::{
@@ -456,6 +462,10 @@ impl TuiConversationRestoreOrigin {
             }
         }
     }
+
+    fn records_telemetry(self) -> bool {
+        matches!(self, Self::ConversationList)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -464,12 +474,22 @@ pub(crate) enum TuiConversationRestoreTarget {
     Server(ServerConversationToken),
 }
 
+impl TuiConversationRestoreTarget {
+    fn telemetry_target(&self) -> TuiConversationRestoreTelemetryTarget {
+        match self {
+            Self::Local(_) => TuiConversationRestoreTelemetryTarget::Local,
+            Self::Server(_) => TuiConversationRestoreTelemetryTarget::Server,
+        }
+    }
+}
+
 #[derive(Default)]
 enum ConversationRestoreState {
     #[default]
     Idle,
     Loading {
         origin: TuiConversationRestoreOrigin,
+        target: TuiConversationRestoreTelemetryTarget,
         request_id: u64,
         future: Option<SpawnedFutureHandle>,
     },
@@ -899,6 +919,79 @@ impl TuiTerminalSessionView {
     fn refresh_input_focus(&mut self, ctx: &mut ViewContext<Self>) {
         self.focus_current_owner_if_active(ctx);
         ctx.notify();
+    }
+
+    fn emit_input_buffer_submitted_telemetry(&self, ctx: &mut ViewContext<Self>) {
+        let input_model = self.ai_input_model.as_ref(ctx);
+        let block_id = self.terminal_model.lock().active_block_id().clone();
+        warp::send_telemetry_from_ctx!(
+            TelemetryEvent::InputBufferSubmitted {
+                input_type: input_model.input_type(),
+                is_locked: input_model.is_input_type_locked(),
+                input_type_decision_source: input_model.last_ai_autodetection_source(),
+                was_lock_set_with_empty_buffer: input_model.was_lock_set_with_empty_buffer(),
+                block_id,
+            },
+            ctx
+        );
+    }
+
+    fn emit_block_completed_telemetry(
+        &self,
+        completed: &AfterBlockCompletedEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(delay) = completed.command_finished_to_precmd_delay else {
+            return;
+        };
+        let honor_ps1_enabled = match &completed.block_type {
+            BlockType::User(user_block) => user_block.serialized_block.honor_ps1,
+            BlockType::BootstrapVisible(serialized_block) => serialized_block.honor_ps1,
+            BlockType::BootstrapHidden
+            | BlockType::Restored
+            | BlockType::InBandCommand
+            | BlockType::Background(_)
+            | BlockType::Static => *SessionSettings::as_ref(ctx).honor_ps1,
+        };
+        let BlockType::User(user_block) = &completed.block_type else {
+            return;
+        };
+        warp::send_telemetry_from_ctx!(
+            TelemetryEvent::BlockCompleted {
+                block_finished_to_precmd_delay_ms: delay.as_millis() as u64,
+                honor_ps1_enabled,
+                num_secrets_redacted: completed.num_secrets_obfuscated,
+                num_output_lines: user_block.num_output_lines,
+                num_output_lines_truncated: user_block.num_output_lines_truncated,
+                terminal_session_id: user_block.serialized_block.session_id,
+                is_udi_enabled: false,
+                is_in_agent_view: true,
+            },
+            ctx
+        );
+        if ChannelState::channel().is_dogfood() {
+            let duration = match (
+                user_block.serialized_block.start_ts,
+                user_block.serialized_block.completed_ts,
+            ) {
+                (Some(start), Some(completed)) => (completed - start).to_std().unwrap_or_default(),
+                (None, _) | (_, None) => Duration::default(),
+            };
+            warp::send_telemetry_from_ctx!(
+                TelemetryEvent::BlockCompletedOnDogfoodOnly {
+                    block_finished_to_precmd_delay_ms: delay.as_millis() as u64,
+                    honor_ps1_enabled,
+                    num_secrets_redacted: completed.num_secrets_obfuscated,
+                    num_output_lines: user_block.num_output_lines,
+                    num_output_lines_truncated: user_block.num_output_lines_truncated,
+                    command: user_block.command_with_obfuscated_secrets.clone(),
+                    duration,
+                    exit_code: user_block.serialized_block.exit_code,
+                    terminal_session_id: user_block.serialized_block.session_id,
+                },
+                ctx
+            );
+        }
     }
 
     fn focus_blocking_input_source(source: BlockingInputSource, ctx: &mut ViewContext<Self>) {
@@ -1810,6 +1903,9 @@ impl TuiTerminalSessionView {
             ModelEvent::BlockCompleted(completed) => {
                 view.handle_block_completed(&completed.block_id, ctx);
             }
+            ModelEvent::AfterBlockCompleted(completed) => {
+                view.emit_block_completed_telemetry(completed, ctx);
+            }
             ModelEvent::AfterBlockStarted { .. } => {
                 view.refresh_input_focus(ctx);
                 ctx.notify();
@@ -1825,11 +1921,14 @@ impl TuiTerminalSessionView {
             ModelEvent::Typeahead => view.handle_typeahead_event(ctx),
             ModelEvent::BlockMetadataReceived(_)
             | ModelEvent::BlockWorkingDirectoryUpdated(_)
-            | ModelEvent::BackgroundBlockStarted
             | ModelEvent::TerminalClear
             | ModelEvent::PromptUpdated
             | ModelEvent::Handler(_)
             | ModelEvent::FinishUpdate(_) => ctx.notify(),
+            ModelEvent::BackgroundBlockStarted => {
+                warp::send_telemetry_from_ctx!(TelemetryEvent::BackgroundBlockStarted, ctx);
+                ctx.notify();
+            }
             _ => {}
         });
         // Re-render when the configured statusline or usage-display mode
@@ -2219,6 +2318,25 @@ impl TuiTerminalSessionView {
         let Some(session_id) = session_id else {
             return;
         };
+        if let Some(snapshot) = self.compute_orchestration_tab_snapshot(ctx) {
+            let pill_kind = if conversation_id == snapshot.root_conversation_id {
+                PillBarPillKind::Orchestrator
+            } else {
+                PillBarPillKind::Child
+            };
+            warp::send_telemetry_from_ctx!(
+                BlocklistOrchestrationTelemetryEvent::PillBarInteraction(PillBarInteractionEvent {
+                    action: PillBarActionKind::Switch,
+                    pill_kind,
+                    total_pills: snapshot.children.len() + 1,
+                    total_pinned: 0,
+                    source_conversation_id: snapshot.root_conversation_id,
+                    target_conversation_id: conversation_id,
+                    switch_outcome: Some(PillSwitchOutcome::SwitchedInPlace),
+                }),
+                ctx
+            );
+        }
         if session_id.surface_id() == self.terminal_surface_id {
             self.refresh_orchestration_tab_state(ctx);
             self.set_orchestration_tab_focus(keep_tab_focus, ctx);
@@ -2275,6 +2393,20 @@ impl TuiTerminalSessionView {
     /// from history, removes its retained TUI session, and returns focus to the
     /// root/main orchestration agent. Equivalent to the GUI's Kill agent path.
     fn kill_child_agent(&mut self, conversation_id: AIConversationId, ctx: &mut ViewContext<Self>) {
+        if let Some(snapshot) = self.compute_orchestration_tab_snapshot(ctx) {
+            warp::send_telemetry_from_ctx!(
+                BlocklistOrchestrationTelemetryEvent::PillBarInteraction(PillBarInteractionEvent {
+                    action: PillBarActionKind::Kill,
+                    pill_kind: PillBarPillKind::Child,
+                    total_pills: snapshot.children.len() + 1,
+                    total_pinned: 0,
+                    source_conversation_id: snapshot.root_conversation_id,
+                    target_conversation_id: conversation_id,
+                    switch_outcome: None,
+                }),
+                ctx
+            );
+        }
         // Clear any armed kill or exit window.
         self.exit_confirmation.disarm();
         self.child_kill_armed_conversation = None;
@@ -2512,11 +2644,22 @@ impl TuiTerminalSessionView {
         }
         self.next_restore_request_id = self.next_restore_request_id.wrapping_add(1);
         let request_id = self.next_restore_request_id;
+        let telemetry_target = target.telemetry_target();
         self.conversation_restore_state = ConversationRestoreState::Loading {
             origin,
+            target: telemetry_target,
             request_id,
             future: None,
         };
+        if origin.records_telemetry() {
+            warp::send_telemetry_from_ctx!(
+                TuiConversationRestoreTelemetryEvent {
+                    state: TuiConversationRestoreTelemetryState::Started,
+                    target: telemetry_target,
+                },
+                ctx
+            );
+        }
 
         ctx.notify();
         let future =
@@ -2596,7 +2739,7 @@ impl TuiTerminalSessionView {
             return;
         }
 
-        self.replace_conversation_surface(*conversation, origin, ctx);
+        self.replace_conversation_surface(*conversation, origin, target.telemetry_target(), ctx);
     }
 
     /// Discards the retained child-agent sessions of a previously restored
@@ -2656,6 +2799,7 @@ impl TuiTerminalSessionView {
         &mut self,
         conversation: AIConversation,
         origin: TuiConversationRestoreOrigin,
+        telemetry_target: TuiConversationRestoreTelemetryTarget,
         ctx: &mut ViewContext<Self>,
     ) {
         let previous_conversation_id = self
@@ -2727,6 +2871,15 @@ impl TuiTerminalSessionView {
         self.conversation_restore_state = ConversationRestoreState::Idle;
         self.refresh_exit_summary(ctx);
         self.focus_input_if_active(ctx);
+        if origin.records_telemetry() {
+            warp::send_telemetry_from_ctx!(
+                TuiConversationRestoreTelemetryEvent {
+                    state: TuiConversationRestoreTelemetryState::Succeeded,
+                    target: telemetry_target,
+                },
+                ctx
+            );
+        }
         ctx.notify();
     }
 
@@ -2749,7 +2902,13 @@ impl TuiTerminalSessionView {
 
     fn cancel_conversation_restore(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         let state = std::mem::take(&mut self.conversation_restore_state);
-        let ConversationRestoreState::Loading { future, .. } = state else {
+        let ConversationRestoreState::Loading {
+            origin,
+            target,
+            future,
+            ..
+        } = state
+        else {
             self.conversation_restore_state = state;
             return false;
         };
@@ -2757,6 +2916,15 @@ impl TuiTerminalSessionView {
             future.abort();
         }
         self.next_restore_request_id = self.next_restore_request_id.wrapping_add(1);
+        if origin.records_telemetry() {
+            warp::send_telemetry_from_ctx!(
+                TuiConversationRestoreTelemetryEvent {
+                    state: TuiConversationRestoreTelemetryState::Cancelled,
+                    target,
+                },
+                ctx
+            );
+        }
         self.focus_input_if_active(ctx);
         ctx.notify();
         true
@@ -2768,12 +2936,13 @@ impl TuiTerminalSessionView {
         message: String,
         ctx: &mut ViewContext<Self>,
     ) {
-        let origin = match &self.conversation_restore_state {
+        let (origin, target) = match &self.conversation_restore_state {
             ConversationRestoreState::Loading {
                 origin,
+                target,
                 request_id: active_request_id,
                 ..
-            } if *active_request_id == request_id => *origin,
+            } if *active_request_id == request_id => (*origin, *target),
             ConversationRestoreState::Idle
             | ConversationRestoreState::Failed(_)
             | ConversationRestoreState::Loading { .. } => return,
@@ -2783,6 +2952,13 @@ impl TuiTerminalSessionView {
                 self.conversation_restore_state = ConversationRestoreState::Failed(message);
             }
             TuiConversationRestoreOrigin::ConversationList => {
+                warp::send_telemetry_from_ctx!(
+                    TuiConversationRestoreTelemetryEvent {
+                        state: TuiConversationRestoreTelemetryState::Failed,
+                        target,
+                    },
+                    ctx
+                );
                 self.conversation_restore_state = ConversationRestoreState::Idle;
                 self.show_transient_hint(message, ctx);
                 self.focus_input_if_active(ctx);
@@ -3507,6 +3683,7 @@ impl TuiTerminalSessionView {
                 source: CommandExecutionSource::User,
             },
         )));
+        self.emit_input_buffer_submitted_telemetry(ctx);
 
         // The submission was accepted: clear the input and return to the
         // setting-derived agent default.
@@ -3543,6 +3720,9 @@ impl TuiTerminalSessionView {
             self.cli_subagent_controller.update(ctx, |controller, ctx| {
                 controller.set_latest_instruction(block_id, prompt, ctx);
             });
+        }
+        if dispatched {
+            self.emit_input_buffer_submitted_telemetry(ctx);
         }
     }
 
@@ -3806,6 +3986,7 @@ impl TuiTerminalSessionView {
             }
         };
 
+        warp::send_telemetry_from_ctx!(TuiConversationMenuTelemetryEvent::ItemSelected, ctx);
         self.conversation_menu
             .update(ctx, |menu, ctx| menu.dismiss(ctx));
         self.restore_conversation(target, TuiConversationRestoreOrigin::ConversationList, ctx);

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -91,6 +91,7 @@ use crate::read_only_menu::TuiReadOnlyMenuKind;
 use crate::root_view::RootTuiView;
 use crate::session_registry::{TuiSessionId, TuiSessions};
 use crate::statusline_config_view::TuiStatuslineConfigEvent;
+use crate::telemetry::TuiConversationRestoreTelemetryTarget;
 use crate::terminal_background::TuiHostTerminalBackground;
 use crate::terminal_block::{block_content_rows, should_render_terminal_block};
 use crate::terminal_use::TuiInputTarget;
@@ -110,6 +111,12 @@ use crate::zero_state_animation::{
 struct FocusTestFixture {
     window_id: warpui_core::WindowId,
     sessions: ModelHandle<TuiSessions>,
+}
+
+#[test]
+fn only_conversation_list_restores_emit_restore_telemetry() {
+    assert!(!TuiConversationRestoreOrigin::Startup.records_telemetry());
+    assert!(TuiConversationRestoreOrigin::ConversationList.records_telemetry());
 }
 
 fn todo(id: &str, title: &str) -> AIAgentTodo {
@@ -4231,6 +4238,7 @@ fn footer_transient_state_replaces_all_sections() {
             view.exit_confirmation.disarm();
             view.conversation_restore_state = ConversationRestoreState::Loading {
                 origin: TuiConversationRestoreOrigin::ConversationList,
+                target: TuiConversationRestoreTelemetryTarget::Local,
                 request_id: 0,
                 future: None,
             };
@@ -4254,6 +4262,7 @@ fn footer_transient_state_replaces_all_sections() {
             view.exit_confirmation.arm(Instant::now());
             view.conversation_restore_state = ConversationRestoreState::Loading {
                 origin: TuiConversationRestoreOrigin::ConversationList,
+                target: TuiConversationRestoreTelemetryTarget::Local,
                 request_id: 1,
                 future: None,
             };

--- a/crates/warp_tui/src/test_fixtures.rs
+++ b/crates/warp_tui/src/test_fixtures.rs
@@ -101,6 +101,9 @@ pub(crate) fn add_test_action_model_and_events(
     if !app.read(|ctx| ctx.has_singleton_model::<Appearance>()) {
         app.add_singleton_model(|_| Appearance::mock());
     }
+    if !app.read(|ctx| ctx.has_singleton_model::<warp_core::telemetry::TelemetryContextModel>()) {
+        app.update(warp_core::telemetry::testing::MockTelemetryContextProvider::register);
+    }
     add_test_semantic_selection(app);
     // Read as a singleton by the action model's executors.
     if !app.read(|ctx| ctx.has_singleton_model::<BlocklistAIHistoryModel>()) {

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -255,7 +255,7 @@ impl TuiTranscriptView {
                     .and_then(|conversation| conversation.get_task(task_id))
                     .is_some_and(should_show_task_in_blocklist);
                 if should_show {
-                    self.insert_agent_block(*conversation_id, *exchange_id, None, ctx);
+                    self.insert_agent_block(*conversation_id, *exchange_id, None, false, ctx);
                 }
             }
             BlocklistAIHistoryEvent::UpdatedStreamingExchange { exchange_id, .. } => {
@@ -417,6 +417,7 @@ impl TuiTranscriptView {
         conversation_id: AIConversationId,
         exchange_id: AIAgentExchangeId,
         command_block_index: Option<BlockIndex>,
+        is_restored: bool,
         ctx: &mut ViewContext<Self>,
     ) {
         if self.view_id_for_exchange(exchange_id, ctx).is_some() {
@@ -438,12 +439,12 @@ impl TuiTranscriptView {
         let terminal_model = self.model.clone();
         let view = ctx.add_typed_action_tui_view(|ctx| {
             TuiAIBlock::new(
-                conversation_id,
-                exchange_id,
+                (conversation_id, exchange_id),
                 block_model,
                 action_model,
                 &model_events,
                 terminal_model,
+                is_restored,
                 ctx,
             )
         });
@@ -497,6 +498,7 @@ impl TuiTranscriptView {
                 conversation_id,
                 restored_exchange.exchange().id,
                 restored_exchange.command_block_index(),
+                true,
                 ctx,
             );
         }

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -870,8 +870,7 @@ fn insert_test_agent_block(
         let terminal_model = view.model.clone();
         let agent_block = ctx.add_typed_action_tui_view(|ctx| {
             TuiAIBlock::new(
-                conversation_id,
-                exchange_id,
+                (conversation_id, exchange_id),
                 Rc::new(FakeAgentBlockModel {
                     inputs,
                     status: AIBlockOutputStatus::Pending,
@@ -879,6 +878,7 @@ fn insert_test_agent_block(
                 action_model,
                 &model_events,
                 terminal_model,
+                false,
                 ctx,
             )
         });
@@ -1058,12 +1058,12 @@ fn append_test_agent_block_with_inputs(
     let terminal_model = view.model.clone();
     let agent_block = ctx.add_tui_view(|ctx| {
         TuiAIBlock::new(
-            conversation_id,
-            exchange_id,
+            (conversation_id, exchange_id),
             Rc::new(FakeAgentBlockModel { inputs, status }),
             action_model,
             &model_events,
             terminal_model,
+            false,
             ctx,
         )
     });

--- a/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
@@ -878,12 +878,12 @@ fn add_agent_block_with(
         );
         ctx.add_typed_action_tui_view(window_id, move |ctx| {
             TuiAIBlock::new(
-                AIConversationId::new(),
-                AIAgentExchangeId::new(),
+                (AIConversationId::new(), AIAgentExchangeId::new()),
                 Rc::new(QueryAgentBlockModel { inputs, status }),
                 action_model,
                 &model_events,
                 terminal_model,
+                false,
                 ctx,
             )
         })
@@ -917,12 +917,12 @@ fn updating_agent_block_source(
         );
         ctx.add_typed_action_tui_view(window_id, move |ctx| {
             TuiAIBlock::new(
-                AIConversationId::new(),
-                AIAgentExchangeId::new(),
+                (AIConversationId::new(), AIAgentExchangeId::new()),
                 block_model_for_block,
                 action_model,
                 &model_events,
                 terminal_model_for_block,
+                false,
                 ctx,
             )
         })

--- a/crates/warp_tui/src/voice_input.rs
+++ b/crates/warp_tui/src/voice_input.rs
@@ -5,8 +5,9 @@ use std::time::Duration;
 use warp::settings::{AISettings, TuiVoiceSettings};
 pub(crate) use warp::tui_export::VoiceInputLifecycleState as TuiVoiceInputState;
 use warp::tui_export::{
-    AIRequestUsageModel, StartListeningError, TranscribeError, UserWorkspaces, VoiceInput,
-    VoiceInputToggledFrom, VoiceSessionResult, VoiceTranscriber,
+    AIRequestUsageModel, BlocklistAIInputModel, StartListeningError, TelemetryEvent,
+    TranscribeError, UserWorkspaces, VoiceInput, VoiceInputToggledFrom, VoiceSessionResult,
+    VoiceTranscriber,
 };
 use warp_core::settings::Setting as _;
 use warp_errors::report_error;
@@ -14,7 +15,7 @@ use warpui::event::KeyState;
 use warpui_core::r#async::SpawnedFutureHandle;
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::platform::keyboard::KeyCode;
-use warpui_core::{AppContext, Entity, ModelContext, SingletonEntity};
+use warpui_core::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TuiVoiceInputEvent {
@@ -69,6 +70,7 @@ impl VoiceInputStartSource {
 
 pub(crate) struct TuiVoiceInputModel {
     state: TuiVoiceInputState,
+    input_mode: ModelHandle<BlocklistAIInputModel>,
     /// The physical modifier holding the current recording open. Only ever set
     /// while a hold-to-talk press owns a `Listening` session, so a release can
     /// never stop a recording another entry point started.
@@ -83,9 +85,13 @@ impl Entity for TuiVoiceInputModel {
 }
 
 impl TuiVoiceInputModel {
-    pub(crate) fn new(_ctx: &mut ModelContext<Self>) -> Self {
+    pub(crate) fn new(
+        input_mode: ModelHandle<BlocklistAIInputModel>,
+        _ctx: &mut ModelContext<Self>,
+    ) -> Self {
         Self {
             state: TuiVoiceInputState::Idle,
+            input_mode,
             hold_key: None,
             animation_clock: AnimationClock::starting_at(Duration::ZERO),
             recording_handle: None,
@@ -150,6 +156,15 @@ impl TuiVoiceInputModel {
         self.hold_key = source.hold_key();
         self.animation_clock = AnimationClock::starting_at(Duration::ZERO);
         self.set_state(TuiVoiceInputState::Listening, ctx);
+        warp::send_telemetry_from_ctx!(
+            TelemetryEvent::VoiceInputUsed {
+                action: "start".to_owned(),
+                session_duration_ms: None,
+                is_udi_enabled: false,
+                current_input_mode: self.input_mode.as_ref(ctx).input_type(),
+            },
+            ctx
+        );
         self.recording_handle = Some(ctx.spawn(
             async move { session.await_result().await },
             Self::handle_session_result,
@@ -263,9 +278,37 @@ impl TuiVoiceInputModel {
             return;
         }
 
-        let VoiceSessionResult::Audio { wav_base64, .. } = result else {
-            self.fail("Voice input stopped", ctx);
-            return;
+        let wav_base64 = match result {
+            VoiceSessionResult::Audio {
+                wav_base64,
+                session_duration_ms,
+            } => {
+                warp::send_telemetry_from_ctx!(
+                    TelemetryEvent::VoiceInputUsed {
+                        action: "stop".to_owned(),
+                        session_duration_ms: Some(session_duration_ms),
+                        is_udi_enabled: false,
+                        current_input_mode: self.input_mode.as_ref(ctx).input_type(),
+                    },
+                    ctx
+                );
+                wav_base64
+            }
+            VoiceSessionResult::Aborted {
+                session_duration_ms,
+            } => {
+                warp::send_telemetry_from_ctx!(
+                    TelemetryEvent::VoiceInputUsed {
+                        action: "cancel".to_owned(),
+                        session_duration_ms,
+                        is_udi_enabled: false,
+                        current_input_mode: self.input_mode.as_ref(ctx).input_type(),
+                    },
+                    ctx
+                );
+                self.fail("Voice input stopped", ctx);
+                return;
+            }
         };
         let Some(transcriber) = VoiceTranscriber::as_ref(ctx).transcriber().cloned() else {
             self.fail("Voice transcription is unavailable", ctx);

--- a/crates/warp_tui/src/voice_input_tests.rs
+++ b/crates/warp_tui/src/voice_input_tests.rs
@@ -1,15 +1,65 @@
-use warp::tui_export::VoiceInput;
-use warpui_core::App;
+use std::rc::Rc;
+
+use warp::settings::AISettingsChangedEvent;
+use warp::tui_export::{
+    BlocklistAIInputModel, ConversationSelectionEvent, InputConfig, InputModePolicy, InputType,
+    PolicyConfigUpdate, VoiceInput,
+};
 use warpui_core::event::KeyState;
 use warpui_core::platform::keyboard::KeyCode;
+use warpui_core::{App, AppContext, ModelHandle};
 
 use super::{TuiVoiceInputModel, TuiVoiceInputState, VoiceInputStartSource};
+
+struct TestInputModePolicy;
+
+impl InputModePolicy for TestInputModePolicy {
+    fn initial_config(&self, _app: &AppContext) -> InputConfig {
+        InputConfig {
+            input_type: InputType::AI,
+            is_locked: true,
+        }
+    }
+
+    fn allows_locked_ai_input(&self, _app: &AppContext) -> bool {
+        true
+    }
+
+    fn is_autodetection_enabled(&self, _app: &AppContext) -> bool {
+        false
+    }
+
+    fn config_on_conversation_selection_changed(
+        &self,
+        _event: &ConversationSelectionEvent,
+        _current: InputConfig,
+        _app: &AppContext,
+    ) -> Option<PolicyConfigUpdate> {
+        None
+    }
+
+    fn config_on_ai_settings_changed(
+        &self,
+        _event: &AISettingsChangedEvent,
+        _current: InputConfig,
+        _is_autodetection_enabled_for_current_context: bool,
+        _app: &AppContext,
+    ) -> Option<PolicyConfigUpdate> {
+        None
+    }
+}
+
+fn add_voice_model(app: &mut App) -> ModelHandle<TuiVoiceInputModel> {
+    let input_mode =
+        app.update(|ctx| BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx));
+    app.add_model(|ctx| TuiVoiceInputModel::new(input_mode, ctx))
+}
 
 #[test]
 fn start_does_not_replace_an_active_session() {
     App::test((), |mut app| async move {
         app.add_singleton_model(VoiceInput::new);
-        let model = app.add_model(TuiVoiceInputModel::new);
+        let model = add_voice_model(&mut app);
         model.update(&mut app, |voice, ctx| {
             voice.set_state_for_test(TuiVoiceInputState::Listening, ctx);
             assert!(!voice.start(false, VoiceInputStartSource::Keybinding, ctx));
@@ -22,7 +72,7 @@ fn start_does_not_replace_an_active_session() {
 fn stop_transitions_the_model_to_transcribing() {
     App::test((), |mut app| async move {
         app.add_singleton_model(VoiceInput::new);
-        let model = app.add_model(TuiVoiceInputModel::new);
+        let model = add_voice_model(&mut app);
         model.update(&mut app, |voice, ctx| {
             voice.set_state_for_test(TuiVoiceInputState::Listening, ctx);
             voice.stop(ctx);
@@ -35,7 +85,7 @@ fn stop_transitions_the_model_to_transcribing() {
 fn cancel_returns_the_model_to_idle() {
     App::test((), |mut app| async move {
         app.add_singleton_model(VoiceInput::new);
-        let model = app.add_model(TuiVoiceInputModel::new);
+        let model = add_voice_model(&mut app);
         model.update(&mut app, |voice, ctx| {
             voice.set_state_for_test(TuiVoiceInputState::Transcribing, ctx);
             voice.cancel(ctx);
@@ -48,7 +98,7 @@ fn cancel_returns_the_model_to_idle() {
 fn hold_release_stops_only_a_recording_the_hold_started() {
     App::test((), |mut app| async move {
         app.add_singleton_model(VoiceInput::new);
-        let model = app.add_model(TuiVoiceInputModel::new);
+        let model = add_voice_model(&mut app);
         model.update(&mut app, |voice, ctx| {
             voice.set_state_for_test(TuiVoiceInputState::Listening, ctx);
             voice.set_hold_key_for_test(Some(KeyCode::ControlLeft));
@@ -77,7 +127,7 @@ fn hold_release_stops_only_a_recording_the_hold_started() {
 fn stop_hold_only_ends_a_held_recording() {
     App::test((), |mut app| async move {
         app.add_singleton_model(VoiceInput::new);
-        let model = app.add_model(TuiVoiceInputModel::new);
+        let model = add_voice_model(&mut app);
         model.update(&mut app, |voice, ctx| {
             voice.set_state_for_test(TuiVoiceInputState::Listening, ctx);
             voice.stop_hold(ctx);
@@ -99,7 +149,7 @@ fn stop_hold_only_ends_a_held_recording() {
 fn the_hold_key_clears_when_its_recording_ends_by_another_path() {
     App::test((), |mut app| async move {
         app.add_singleton_model(VoiceInput::new);
-        let model = app.add_model(TuiVoiceInputModel::new);
+        let model = add_voice_model(&mut app);
         model.update(&mut app, |voice, ctx| {
             voice.set_state_for_test(TuiVoiceInputState::Listening, ctx);
             voice.set_hold_key_for_test(Some(KeyCode::ControlLeft));


### PR DESCRIPTION
## Description

Adds detailed product telemetry for the headless TUI while preserving the existing GUI behavior and shared telemetry envelope. Covered flows include:

- **TUI identification and startup:** distinguishes TUI events through `client_id=warp-tui`, records release channel/version, and reports sanitized `TERM_PROGRAM` plus terminal multiplexer context on `TUI.Startup`.
- **Launch and meaningful-use signals:** keeps `TUI.Startup` as a launch metric and records prompt submission, completed commands, and agent exchanges as separate interaction signals. This PR does not connect TUI interaction to the shared `Active App Usage` heartbeat. It also does not add the GUI retention check-in: the GUI calls `/client_version/daily`, which emits the server-side `Checked For Updated Client Version` event used for retention, while the TUI updater continues to call the non-instrumented `/client_version` endpoint. Consequently, this PR does not establish GUI-parity DAU/WAU/MAU measurement.
- **Agent and prompt lifecycle:** records completed, cancelled, and failed responses, response latency, request errors/retries, and defensive failed-submission paths.
- **Terminal use:** covers PTY/bootstrap lifecycle, completed user command blocks, background blocks, and Local/Dev input-classification details. It intentionally does not emit GUI `Tab Creation` telemetry.
- **Handoff and orchestration:** covers handoff initiation/snapshot/failure, orchestration entry and card decisions, local-vs-remote configuration, supported child navigation, and final requested/launched/failed child counts per parent conversation.
- **Conversation menu:** records menu opens, item selections, and local/server restore started/succeeded/failed/cancelled outcomes through TUI-native event names.
- **Voice input:** matches the GUI recording lifecycle with start, stop, cancel, duration, and current TUI input-mode metadata, without audio or transcript content.
- **Slash commands, models, and credentials:** records slash-menu/command use, model selection, natural-language detection changes, and provider credential add/remove transitions without secret values.
- **Shared agent tools:** attributes existing grep, file glob, code edit, MCP, computer-use, and autoexecution telemetry to the TUI through the common client identifier.
- **Updater health:** records transition-deduplicated TUI update-check outcomes and failures. These are updater diagnostics, not equivalents of the GUI retention check-in.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Also ran w/ the `warpui_core/log_named_telemetry_events` feature and confirmed events were being emitted correctly.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode