### PR TITLE
Update TUI out-of-credits upgrade state

### DIFF
--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -62,7 +62,6 @@ const OUT_OF_CREDITS_DETAIL: &str =
     "In order to use Warp’s AI features, subscribe to a Warp plan or buy packs of credits.";
 const OUT_OF_CREDITS_ACTION_LABEL: &str = "Get started with AI";
 const OUT_OF_CREDITS_ACTION_HINT: &str = "(ctrl+o)";
-const OUT_OF_CREDITS_WARNING_PREFIX: &str = "! ";
 const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -226,15 +225,19 @@ fn render_failure_section(
             let content = TuiFlex::column()
                 .child(
                     TuiText::from_spans([
-                        (OUT_OF_CREDITS_WARNING_PREFIX.to_owned(), error_style),
+                        (FAILURE_WARNING_PREFIX.to_owned(), error_style),
                         (OUT_OF_CREDITS_TITLE.to_owned(), primary_style),
                     ])
                     .finish(),
                 )
                 .child(
-                    TuiText::new(format!("  {OUT_OF_CREDITS_DETAIL}"))
-                        .with_style(primary_style)
-                        .finish(),
+                    TuiContainer::new(
+                        TuiText::new(OUT_OF_CREDITS_DETAIL)
+                            .with_style(primary_style)
+                            .finish(),
+                    )
+                    .with_padding_left(2)
+                    .finish(),
                 )
                 .child(TuiText::new(" ").finish())
                 .child(actions)
@@ -1082,6 +1085,9 @@ impl TuiAIBlock {
     }
 
     pub(super) fn has_out_of_credits_failure(&self, app: &AppContext) -> bool {
+        if !self.block_model.request_type(app).is_active() {
+            return false;
+        }
         let status = self.block_model.status(app);
         let AIBlockOutputStatus::Failed { error, .. } = &status else {
             return false;

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -223,7 +223,7 @@ fn render_failure_section(
                         .finish(),
                 )
                 .finish();
-            let content = TuiFlex::column()
+            TuiFlex::column()
                 .child(
                     TuiText::from_spans([
                         (FAILURE_WARNING_PREFIX.to_owned(), error_style),
@@ -248,8 +248,7 @@ fn render_failure_section(
                         .with_style(primary_style)
                         .finish(),
                 )
-                .finish();
-            content
+                .finish()
         }
         FailedOutputPresentation::ContextWindowExceeded { message } => TuiText::from_spans([
             ("× ".to_owned(), error_style),

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -56,11 +56,13 @@ use crate::tui_markdown::{
 };
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
 use crate::tui_review_comments::render_review_comments_tool_call;
-const PLANS_URL: &str = "https://www.warp.dev/pricing";
-const BYOK_DOCS_URL: &str =
-    "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/";
-const COMPARE_PLANS_LABEL: &str = "Compare plans";
-const USE_YOUR_OWN_API_KEYS_LABEL: &str = "Use your own API keys";
+pub(crate) const OUT_OF_CREDITS_URL: &str = "https://www.warp.dev/pricing";
+const OUT_OF_CREDITS_TITLE: &str = "I’m sorry, I couldn’t complete that request.";
+const OUT_OF_CREDITS_DETAIL: &str =
+    "In order to use Warp’s AI features, subscribe to a Warp plan or buy packs of credits.";
+const OUT_OF_CREDITS_ACTION_LABEL: &str = "Get started with AI";
+const OUT_OF_CREDITS_ACTION_HINT: &str = "(ctrl+o)";
+const OUT_OF_CREDITS_WARNING_PREFIX: &str = "! ";
 const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -172,8 +174,7 @@ impl CollapsibleSectionStates {
 
 fn render_failure_section(
     presentation: &FailedOutputPresentation,
-    compare_plans_hover_state: &MouseStateHandle,
-    byok_hover_state: &MouseStateHandle,
+    out_of_credits_hover_state: &MouseStateHandle,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
@@ -201,60 +202,50 @@ fn render_failure_section(
             (detail.clone(), body_style),
         ])
         .finish(),
-        FailedOutputPresentation::OutOfCredits {
-            message,
-            can_use_own_api_keys,
-        } => {
+        FailedOutputPresentation::OutOfCredits { .. } => {
             let primary_style = builder.primary_text_style();
             let link_style = primary_style.add_modifier(Modifier::UNDERLINED);
-            let (title, detail) = message.split_once("\n\n").unwrap_or((message.as_str(), ""));
-            let compare_plans = TuiHoverable::new(
-                compare_plans_hover_state.clone(),
-                TuiText::new(COMPARE_PLANS_LABEL)
+            let action = TuiHoverable::new(
+                out_of_credits_hover_state.clone(),
+                TuiText::new(OUT_OF_CREDITS_ACTION_LABEL)
                     .with_style(link_style)
                     .finish(),
             )
-            .on_click(|_, app| app.open_url(PLANS_URL))
+            .on_click(|_, app| app.open_url(OUT_OF_CREDITS_URL))
             .finish();
-            let mut actions = TuiFlex::row()
+            let actions = TuiFlex::row()
                 .child(TuiText::new("  ").with_style(primary_style).finish())
-                .child(compare_plans);
-            if *can_use_own_api_keys {
-                actions = actions
-                    .child(
-                        TuiText::new("  or  ")
-                            .with_style(builder.muted_text_style())
-                            .finish(),
-                    )
-                    .child(
-                        TuiHoverable::new(
-                            byok_hover_state.clone(),
-                            TuiText::new(USE_YOUR_OWN_API_KEYS_LABEL)
-                                .with_style(link_style)
-                                .finish(),
-                        )
-                        .on_click(|_, app| app.open_url(BYOK_DOCS_URL))
+                .child(action)
+                .child(TuiText::new(" ").with_style(primary_style).finish())
+                .child(
+                    TuiText::new(OUT_OF_CREDITS_ACTION_HINT)
+                        .with_style(builder.accent_text_style())
                         .finish(),
-                    );
-            }
-            let mut content = TuiFlex::column().child(
-                TuiText::from_spans([
-                    (FAILURE_WARNING_PREFIX.to_owned(), error_style),
-                    (title.to_owned(), primary_style),
-                ])
-                .finish(),
-            );
-            if !detail.is_empty() {
-                content = content.child(
-                    TuiText::new(format!("  {detail}"))
+                )
+                .finish();
+            let content = TuiFlex::column()
+                .child(
+                    TuiText::from_spans([
+                        (OUT_OF_CREDITS_WARNING_PREFIX.to_owned(), error_style),
+                        (OUT_OF_CREDITS_TITLE.to_owned(), primary_style),
+                    ])
+                    .finish(),
+                )
+                .child(
+                    TuiText::new(format!("  {OUT_OF_CREDITS_DETAIL}"))
                         .with_style(primary_style)
                         .finish(),
-                );
-            }
-            content
+                )
                 .child(TuiText::new(" ").finish())
-                .child(actions.finish())
-                .finish()
+                .child(actions)
+                .child(TuiText::new(" ").finish())
+                .child(
+                    TuiText::new(format!("  {OUT_OF_CREDITS_URL}"))
+                        .with_style(primary_style)
+                        .finish(),
+                )
+                .finish();
+            content
         }
         FailedOutputPresentation::ContextWindowExceeded { message } => TuiText::from_spans([
             ("× ".to_owned(), error_style),
@@ -280,17 +271,9 @@ fn failure_text(presentation: &FailedOutputPresentation) -> String {
             fallback_message: message,
         }
         | FailedOutputPresentation::ContextWindowExceeded { message } => message.clone(),
-        FailedOutputPresentation::OutOfCredits {
-            message,
-            can_use_own_api_keys,
-        } => {
-            let actions = if *can_use_own_api_keys {
-                format!("{COMPARE_PLANS_LABEL}  or  {USE_YOUR_OWN_API_KEYS_LABEL}")
-            } else {
-                COMPARE_PLANS_LABEL.to_owned()
-            };
-            format!("{message}\n\n{actions}")
-        }
+        FailedOutputPresentation::OutOfCredits { .. } => format!(
+            "{OUT_OF_CREDITS_TITLE}\n  {OUT_OF_CREDITS_DETAIL}\n\n  {OUT_OF_CREDITS_ACTION_LABEL} {OUT_OF_CREDITS_ACTION_HINT}\n\n  {OUT_OF_CREDITS_URL}"
+        ),
         FailedOutputPresentation::InvalidApiKey { title, detail } => {
             format!("{title}\n{detail}")
         }
@@ -378,8 +361,7 @@ pub(super) struct TuiAIBlock {
     /// Per-message UI state for this exchange's collapsible sections
     /// (thinking blocks and task lists).
     collapsible_states: CollapsibleSectionStates,
-    compare_plans_hover_state: MouseStateHandle,
-    byok_hover_state: MouseStateHandle,
+    out_of_credits_hover_state: MouseStateHandle,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -421,8 +403,7 @@ impl TuiAIBlock {
             action_model: action_model.clone(),
             terminal_model,
             collapsible_states: Default::default(),
-            compare_plans_hover_state: MouseStateHandle::default(),
-            byok_hover_state: MouseStateHandle::default(),
+            out_of_credits_hover_state: MouseStateHandle::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
@@ -1100,6 +1081,17 @@ impl TuiAIBlock {
         self.last_measured_width.set(Some(width));
     }
 
+    pub(super) fn has_out_of_credits_failure(&self, app: &AppContext) -> bool {
+        let status = self.block_model.status(app);
+        let AIBlockOutputStatus::Failed { error, .. } = &status else {
+            return false;
+        };
+        matches!(
+            failed_output_presentation(error, app),
+            Some(FailedOutputPresentation::OutOfCredits { .. })
+        )
+    }
+
     /// Returns this block's wrapped height using the live layout context.
     pub(super) fn desired_height(
         &self,
@@ -1307,12 +1299,9 @@ impl TuiAIBlock {
                 )
             }
             TuiAIBlockSection::AgentMessage(_) => return None,
-            TuiAIBlockSection::Failure(presentation) => render_failure_section(
-                presentation,
-                &self.compare_plans_hover_state,
-                &self.byok_hover_state,
-                app,
-            ),
+            TuiAIBlockSection::Failure(presentation) => {
+                render_failure_section(presentation, &self.out_of_credits_hover_state, app)
+            }
             TuiAIBlockSection::UsageNotice => render_usage_notice(app),
         })
     }
@@ -1699,12 +1688,9 @@ impl TuiAIBlock {
                     self.conversation_id,
                     app,
                 ),
-                TuiAIBlockSection::Failure(presentation) => render_failure_section(
-                    presentation,
-                    &self.compare_plans_hover_state,
-                    &self.byok_hover_state,
-                    app,
-                ),
+                TuiAIBlockSection::Failure(presentation) => {
+                    render_failure_section(presentation, &self.out_of_credits_hover_state, app)
+                }
                 TuiAIBlockSection::UsageNotice => render_usage_notice(app),
             };
 

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -20,8 +20,9 @@ use warp::tui_export::{
     AIBlockModelHelper, AIBlockOutputStatus, AIConversationId, BlockId, BlocklistAIActionEvent,
     BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason,
     FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, MessageId, ModelEvent,
-    ModelEventDispatcher, ReceivedMessageDisplay, SummarizationType, TerminalModel, TodoOperation,
-    TodoStatus, failed_output_presentation, should_show_failed_output_usage_notice,
+    ModelEventDispatcher, ReceivedMessageDisplay, RenderableAIError, SummarizationType,
+    TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
+    should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
 use warpui_core::elements::MouseStateHandle;
@@ -1084,17 +1085,30 @@ impl TuiAIBlock {
         self.last_measured_width.set(Some(width));
     }
 
-    pub(super) fn has_out_of_credits_failure(&self, app: &AppContext) -> bool {
+    /// Returns the failure that is visible in this block.
+    ///
+    /// This is the single source of truth for both failure rendering and
+    /// contextual failure actions. Restored active failures remain visible;
+    /// restoration only suppresses the separate usage notice.
+    fn visible_failure<'a>(
+        &self,
+        status: &'a AIBlockOutputStatus,
+        app: &AppContext,
+    ) -> Option<(&'a RenderableAIError, FailedOutputPresentation)> {
         if !self.block_model.request_type(app).is_active() {
-            return false;
+            return None;
         }
-        let status = self.block_model.status(app);
-        let AIBlockOutputStatus::Failed { error, .. } = &status else {
-            return false;
+        let AIBlockOutputStatus::Failed { error, .. } = status else {
+            return None;
         };
+        failed_output_presentation(error, app).map(|presentation| (error, presentation))
+    }
+
+    pub(super) fn has_out_of_credits_failure(&self, app: &AppContext) -> bool {
+        let status = self.block_model.status(app);
         matches!(
-            failed_output_presentation(error, app),
-            Some(FailedOutputPresentation::OutOfCredits { .. })
+            self.visible_failure(&status, app),
+            Some((_, FailedOutputPresentation::OutOfCredits { .. }))
         )
     }
 
@@ -1441,10 +1455,7 @@ impl TuiAIBlock {
             }
         }
 
-        if self.block_model.request_type(app).is_active()
-            && let AIBlockOutputStatus::Failed { error, .. } = &status
-            && let Some(presentation) = failed_output_presentation(error, app)
-        {
+        if let Some((error, presentation)) = self.visible_failure(&status, app) {
             sections.push(TuiAIBlockSection::Failure(presentation));
             if should_show_failed_output_usage_notice(
                 error,

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -260,7 +260,7 @@ fn out_of_credits_failure_matches_tui_design_and_opens_pricing() {
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
                 vec![
-                    "! I’m sorry, I couldn’t complete that request.",
+                    "⚠ I’m sorry, I couldn’t complete that request.",
                     "  In order to use Warp’s AI features, subscribe to a Warp plan or buy packs of credits.",
                     "",
                     "  Get started with AI (ctrl+o)",
@@ -292,6 +292,20 @@ fn out_of_credits_failure_matches_tui_design_and_opens_pricing() {
                 frame.buffer[(2, 3)]
                     .modifier
                     .contains(Modifier::UNDERLINED)
+            );
+            let narrow_frame = presenter.present_element(
+                render_failure_section(
+                    &presentation,
+                    &out_of_credits_hover_state,
+                    ctx,
+                ),
+                TuiRect::new(0, 0, 64, 7),
+                ctx,
+            );
+            let narrow_lines = narrow_frame.buffer.to_lines();
+            assert!(
+                narrow_lines[2].starts_with("  "),
+                "wrapped detail should preserve its two-column indent: {narrow_lines:?}"
             );
 
             dispatch_click_on_text(

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -223,7 +223,7 @@ fn agent_block_renders_context_window_failure() {
 }
 
 #[test]
-fn out_of_credits_failure_uses_shared_copy_warning_style_and_tui_actions() {
+fn out_of_credits_failure_matches_tui_design_and_opens_pricing() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let opened_urls = Rc::new(RefCell::new(Vec::new()));
@@ -241,17 +241,15 @@ fn out_of_credits_failure_uses_shared_copy_warning_style_and_tui_actions() {
                     .to_owned(),
                 can_use_own_api_keys: true,
             };
-            let compare_plans_hover_state = MouseStateHandle::default();
-            let byok_hover_state = MouseStateHandle::default();
+            let out_of_credits_hover_state = MouseStateHandle::default();
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
                 render_failure_section(
                     &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
+                    &out_of_credits_hover_state,
                     ctx,
                 ),
-                TuiRect::new(0, 0, 100, 4),
+                TuiRect::new(0, 0, 100, 6),
                 ctx,
             );
             assert_eq!(
@@ -262,10 +260,12 @@ fn out_of_credits_failure_uses_shared_copy_warning_style_and_tui_actions() {
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
                 vec![
-                    "⚠ I'm sorry, I couldn't complete that request.",
-                    "  In order to use Warp's AI features, subscribe to a Warp plan, or bring your own inference.",
+                    "! I’m sorry, I couldn’t complete that request.",
+                    "  In order to use Warp’s AI features, subscribe to a Warp plan or buy packs of credits.",
                     "",
-                    "  Compare plans  or  Use your own API keys",
+                    "  Get started with AI (ctrl+o)",
+                    "",
+                    "  https://www.warp.dev/pricing",
                 ]
             );
             let builder = TuiUiBuilder::from_app(ctx);
@@ -281,71 +281,42 @@ fn out_of_credits_failure_uses_shared_copy_warning_style_and_tui_actions() {
             assert_eq!(frame.buffer[(2, 1)].fg, primary_foreground);
             assert_eq!(frame.buffer[(2, 3)].fg, primary_foreground);
             assert_eq!(
-                frame.buffer[(17, 3)].fg,
-                builder.muted_text_style().fg.expect("muted foreground")
+                frame.buffer[(22, 3)].fg,
+                builder
+                    .accent_text_style()
+                    .fg
+                    .expect("accent foreground")
             );
-            assert_eq!(frame.buffer[(21, 3)].fg, primary_foreground);
+            assert_eq!(frame.buffer[(2, 5)].fg, primary_foreground);
             assert!(
                 frame.buffer[(2, 3)]
                     .modifier
                     .contains(Modifier::UNDERLINED)
             );
+
+            dispatch_click_on_text(
+                render_failure_section(
+                    &presentation,
+                    &out_of_credits_hover_state,
+                    ctx,
+                ),
+                "Get started with AI",
+                100,
+                6,
+                ctx,
+            );
             assert!(
-                frame.buffer[(21, 3)]
-                    .modifier
-                    .contains(Modifier::UNDERLINED)
+                frame
+                    .buffer
+                    .to_lines()
+                    .iter()
+                    .all(|line| !line.contains("API keys"))
             );
-
-            dispatch_click_on_text(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                "Compare plans",
-                100,
-                4,
-                ctx,
-            );
-            dispatch_click_on_text(
-                render_failure_section(
-                    &presentation,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                "Use your own API keys",
-                100,
-                4,
-                ctx,
-            );
-
-            let without_byok = FailedOutputPresentation::OutOfCredits {
-                message: "I'm sorry, I couldn't complete that request.\n\nOut of credits."
-                    .to_owned(),
-                can_use_own_api_keys: false,
-            };
-            let mut presenter = TuiPresenter::new();
-            let frame = presenter.present_element(
-                render_failure_section(
-                    &without_byok,
-                    &compare_plans_hover_state,
-                    &byok_hover_state,
-                    ctx,
-                ),
-                TuiRect::new(0, 0, 100, 4),
-                ctx,
-            );
-            assert_eq!(frame.buffer.to_lines()[3].trim_end(), "  Compare plans");
         });
 
         assert_eq!(
             &*opened_urls.borrow(),
-            &[
-                "https://www.warp.dev/pricing".to_owned(),
-                "https://docs.warp.dev/agent-platform/inference/bring-your-own-api-key/".to_owned(),
-            ]
+            &["https://www.warp.dev/pricing".to_owned()]
         );
     });
 }
@@ -2559,11 +2530,11 @@ fn dispatch_click_on_text(
         app,
     );
 }
-
 fn render_tui_view_lines(
     view: &impl TuiView,
     width: u16,
     height: u16,
+
     app: &AppContext,
 ) -> Vec<String> {
     let mut presenter = TuiPresenter::new();

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::agent_block::OUT_OF_CREDITS_URL;
 use async_channel::Sender;
 use instant::Instant;
 use parking_lot::FairMutex;
@@ -195,6 +196,7 @@ const SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG: &str =
     "TuiSessionCanDetachAgentFromRunningCommand";
 const SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG: &str =
     "TuiSessionCanAcceptBlockedTerminalUseAction";
+const SESSION_CAN_OPEN_OUT_OF_CREDITS_URL_FLAG: &str = "TuiSessionCanOpenOutOfCreditsUrl";
 pub(crate) const SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG: &str = "TuiSessionComposerShortcutsActive";
 pub(crate) const PASTE_IMAGE_BINDING_NAME: &str = "tui:session:paste_image";
 pub(crate) const AUTO_APPROVE_TOGGLE_BINDING_NAME: &str = "tui:session:toggle_auto_approve";
@@ -509,6 +511,8 @@ pub(crate) enum TuiTerminalSessionAction {
     /// conversation, else clear the input; a second press within
     /// [`CTRL_C_EXIT_WINDOW`] exits the TUI.
     Interrupt,
+    /// Open the out-of-credits upgrade and credit-pack flow.
+    OpenOutOfCreditsUrl,
     /// Cancel an in-flight conversation restore.
     CancelRestore,
     /// Return a user-controlled terminal-use command to the agent.
@@ -695,6 +699,13 @@ pub(crate) fn init(app: &mut AppContext) {
             HAND_BACK_KEY_BINDING,
             TuiTerminalSessionAction::HandBackTerminalUseControl,
             id!(SESSION_CAN_HAND_BACK_CONTROL_FLAG),
+        )
+        .with_group(TUI_BINDING_GROUP),
+        FixedBinding::new(
+            "ctrl-o",
+            TuiTerminalSessionAction::OpenOutOfCreditsUrl,
+            (id!(TuiInputView::ui_name()) | view_context.clone())
+                & id!(SESSION_CAN_OPEN_OUT_OF_CREDITS_URL_FLAG),
         )
         .with_group(TUI_BINDING_GROUP),
     ]);
@@ -4513,6 +4524,13 @@ impl TuiView for TuiTerminalSessionView {
                 .set
                 .insert(SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG);
         }
+        if self
+            .transcript
+            .as_ref(ctx)
+            .latest_agent_block_is_out_of_credits(ctx)
+        {
+            context.set.insert(SESSION_CAN_OPEN_OUT_OF_CREDITS_URL_FLAG);
+        }
         if state.as_ref().is_some_and(|state| state.plan_available()) {
             context.set.insert(PLAN_TOGGLE_AVAILABLE_FLAG);
         }
@@ -4874,6 +4892,7 @@ impl TypedActionView for TuiTerminalSessionView {
     fn handle_action(&mut self, action: &TuiTerminalSessionAction, ctx: &mut ViewContext<Self>) {
         match action {
             TuiTerminalSessionAction::Interrupt => self.handle_interrupt(ctx),
+            TuiTerminalSessionAction::OpenOutOfCreditsUrl => ctx.open_url(OUT_OF_CREDITS_URL),
             TuiTerminalSessionAction::Eof => self.handle_eof(ctx),
             TuiTerminalSessionAction::CancelRestore => {
                 self.cancel_conversation_restore(ctx);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::agent_block::OUT_OF_CREDITS_URL;
 use async_channel::Sender;
 use instant::Instant;
 use parking_lot::FairMutex;
@@ -67,6 +66,7 @@ use warpui_core::{
     AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
 };
 
+use crate::agent_block::OUT_OF_CREDITS_URL;
 use crate::alt_screen_view::AltScreenElement;
 use crate::api_keys_menu::{TuiApiKeysMenuEvent, TuiApiKeysMenuModel, render_api_keys_footer};
 use crate::attachment_bar::{

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -162,6 +162,52 @@ fn mcp_menu_footer_replaces_status_with_controls() {
 }
 
 #[test]
+fn out_of_credits_ctrl_o_binding_opens_pricing() {
+    App::test((), |mut app| async move {
+        app.update(crate::keybindings::init);
+        app.read(|ctx| {
+            let ctrl_o = Trigger::Keystrokes(vec![Keystroke::parse("ctrl-o").unwrap()]);
+            assert!(
+                ctx.get_key_bindings().any(|binding| {
+                    *binding.trigger == ctrl_o
+                        && binding.name.is_empty()
+                        && binding.group == Some(TUI_BINDING_GROUP)
+                }),
+                "out-of-credits ctrl-o binding should be registered"
+            );
+        });
+
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        app.read(|ctx| {
+            let ctrl_o = Trigger::Keystrokes(vec![Keystroke::parse("ctrl-o").unwrap()]);
+            let input_view_id = view.as_ref(ctx).input_view.id();
+            assert!(
+                !ctx.key_bindings_for_view(fixture.window_id, input_view_id)
+                    .iter()
+                    .any(|binding| *binding.trigger == ctrl_o),
+                "ctrl-o should not be active without an out-of-credits failure"
+            );
+        });
+        let opened_urls = Rc::new(RefCell::new(Vec::new()));
+        let opened_urls_for_callback = opened_urls.clone();
+        app.update(|ctx| {
+            ctx.set_before_open_url(move |url, _| {
+                opened_urls_for_callback.borrow_mut().push(url.to_owned());
+                url.to_owned()
+            });
+        });
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiTerminalSessionAction::OpenOutOfCreditsUrl, ctx);
+        });
+        assert_eq!(
+            opened_urls.borrow().as_slice(),
+            &["https://www.warp.dev/pricing".to_owned()]
+        );
+    });
+}
+
+#[test]
 fn mcp_menu_footer_hides_unavailable_primary_control() {
     App::test((), |mut app| async move {
         app.update(|ctx| {

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -392,6 +392,12 @@ impl TuiTranscriptView {
             .any(|block| block.as_ref(ctx).has_exposed_plan(ctx))
     }
 
+    pub(super) fn latest_agent_block_is_out_of_credits(&self, ctx: &AppContext) -> bool {
+        self.agent_blocks_in_canonical_order()
+            .last()
+            .is_some_and(|block| block.as_ref(ctx).has_out_of_credits_failure(ctx))
+    }
+
     /// Returns the view id of the agent block rendering `exchange_id`, if any.
     fn view_id_for_exchange(
         &self,

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -8,9 +8,9 @@ use warp::tui_export::{
     AIAgentText, AIAgentTextSection, AIAgentTodo, AIBlockModel, AIBlockOutputStatus,
     AIConversation, AIConversationId, AIRequestType, Appearance, BlockHeightItem,
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatus, ConversationStatusUpdate,
-    LLMId, MessageId, OutputStatusUpdateCallback, ReceivedMessageDisplay, RichContentItem,
-    RichContentType, ServerOutputId, Shared, TerminalModel, TodoOperation, UserQueryMode,
-    register_tui_session_view_test_singletons,
+    LLMId, MessageId, OutputStatusUpdateCallback, ReceivedMessageDisplay, RenderableAIError,
+    RichContentItem, RichContentType, ServerOutputId, Shared, TerminalModel, TodoOperation,
+    UserQueryMode, register_tui_session_view_test_singletons,
 };
 use warpui::event::ModifiersState;
 use warpui::platform::WindowStyle;
@@ -69,6 +69,64 @@ fn transcript_view_renders_terminal_blocks_from_canonical_order() {
             text.contains('1'),
             "transcript should render command output:\n{text}"
         );
+    });
+}
+
+#[test]
+fn out_of_credits_shortcut_tracks_the_latest_agent_block() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+        let model_for_view = terminal_model.clone();
+        let (action_model, model_events) = add_test_action_model_and_events(&mut app);
+        let (_, transcript) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |ctx| {
+                    TuiTranscriptView::new(
+                        EntityId::new(),
+                        model_for_view,
+                        action_model,
+                        &model_events,
+                        ctx,
+                    )
+                },
+            )
+        });
+
+        transcript.update(&mut app, |view, ctx| {
+            append_test_agent_block(
+                view,
+                AIConversationId::new(),
+                AIAgentExchangeId::new(),
+                AIBlockOutputStatus::Failed {
+                    partial_output: None,
+                    error: RenderableAIError::QuotaLimit {
+                        user_display_message: Some("Out of credits.".to_owned()),
+                    },
+                },
+                ctx,
+            );
+        });
+        assert!(transcript.read(&app, |view, ctx| {
+            view.latest_agent_block_is_out_of_credits(ctx)
+        }));
+
+        transcript.update(&mut app, |view, ctx| {
+            append_test_agent_block(
+                view,
+                AIConversationId::new(),
+                AIAgentExchangeId::new(),
+                AIBlockOutputStatus::Pending,
+                ctx,
+            );
+        });
+        assert!(!transcript.read(&app, |view, ctx| {
+            view.latest_agent_block_is_out_of_credits(ctx)
+        }));
     });
 }
 


### PR DESCRIPTION
## Description
- Update the TUI insufficient-AI-credits state to match the Figma copy and layout, including credit packs and a visible pricing URL fallback.
- Keep this presentation TUI-specific and remove the GUI-oriented BYOK callout from the TUI state.
- Make “Get started with AI” clickable and route `ctrl+o` through the focused terminal-session keymap so it reliably opens the pricing flow.
- Scope the shortcut to transcripts whose latest agent block is the out-of-credits failure state.

## Linked Issue
N/A — implementation follows the linked TUI Figma design.

## Testing
- [x] Focused `warp_tui` render/click regression for the out-of-credits state.
- [x] Focused `warp_tui` regression for latest-agent-block shortcut scoping.
- [x] Focused `warp_tui` regression for the session-level `ctrl+o` binding and pricing action.
- [x] Manually launched the TUI with `./script/run-tui`.
- [x] I have manually tested my changes locally with `./script/run` (not applicable; this change is TUI-specific).

### Screenshots / Videos
Mocks on left, local build on right
<img width="1921" height="918" alt="Screenshot 2026-07-30 at 12 54 47 PM" src="https://github.com/user-attachments/assets/0c2a0afa-9046-4c3d-95e6-785660cc2e7f" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent conversation: https://staging.warp.dev/conversation/9cd32f82-1d36-4ddf-83c9-56825cabf608

CHANGELOG-BUG-FIX: Updated the TUI out-of-credits guidance and fixed its upgrade shortcut.

Co-Authored-By: Oz <oz-agent@warp.dev>
