### PR TITLE
fix(macOS): add NSBluetoothAlwaysUsageDescription so BLE CLI tools don't SIGABRT

### DIFF
--- a/script/update_plist
+++ b/script/update_plist
@@ -268,6 +268,7 @@ plutil -insert NSRemindersUsageDescription -string "A program in Warp wants to u
 plutil -insert NSRemindersFullAccessUsageDescription -string "A program in Warp wants full access to your reminders." "$WARP_PLIST_PATH"
 plutil -insert NSLocationUsageDescription -string "A program in Warp wants to use your location information." "$WARP_PLIST_PATH"
 plutil -insert NSPhotoLibraryUsageDescription -string "A program in Warp wants to use your photo library." "$WARP_PLIST_PATH"
+plutil -insert NSBluetoothAlwaysUsageDescription -string "A program in Warp wants to use Bluetooth." "$WARP_PLIST_PATH"
 
 echo "Disabling use of Liquid Glass on macOS Tahoe"
 plutil -insert UIDesignRequiresCompatibility -bool true "$WARP_PLIST_PATH"


### PR DESCRIPTION
## Problem

macOS attributes a child process's TCC privacy request to the **responsible process** — the terminal. When a CLI launched inside Warp calls CoreBluetooth, macOS looks in **Warp's** `Info.plist` for `NSBluetoothAlwaysUsageDescription`; when it's absent the child is killed with `SIGABRT`:

> This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an `NSBluetoothAlwaysUsageDescription` key…

and the user has no way to grant Bluetooth access. This breaks every BLE tool run from Warp (`bleak`/pyobjc scripts, BLE CLIs, etc.).

`script/update_plist` already declares the sibling TCC usage strings — AppleEvents, Camera, Microphone, Contacts, Calendars, Reminders, Location, PhotoLibrary. **Bluetooth is the one omission.**

## Fix

One line, matching the existing pattern:

```sh
plutil -insert NSBluetoothAlwaysUsageDescription -string "A program in Warp wants to use Bluetooth." "$WARP_PLIST_PATH"
```

## Why the string alone is sufficient (no entitlement change)

iTerm2 fixes the identical issue with the string alone (added in iTerm2 3.5.0). Its code-signing posture is the same as Warp's — Developer ID + hardened runtime, shipping `com.apple.security.device.camera` and `com.apple.security.device.audio-input` but **no** `com.apple.security.device.bluetooth` — and BLE tools run from it without SIGABRT. The hardened-runtime device entitlement governs the *entitled process's own* direct access; the hosted CLI is a separate process and only needs the responsible app's usage string. So `script/Entitlements.plist` does not need to change.

The string is inert until a hosted process actually calls CoreBluetooth — it does **not** make Warp itself request Bluetooth on launch.

## References

- Addresses #1183 (requested these keys; Bluetooth specifically was never fixed — see the "core issue persists" comment)
- Addresses #6675 ("can't execute programs using bluetooth")
- Follows #13608 (merged), which added the EventKit/Reminders usage strings to this same file
- Precedent: iTerm2 added `NSBluetoothAlwaysUsageDescription` in 3.5.0 (iTerm2 issues #10353 / #10360)