### PR TITLE
Show the agent glyph for auto models instead of a host logo

### DIFF
--- a/app/src/ai/execution_profiles/model_menu_items.rs
+++ b/app/src/ai/execution_profiles/model_menu_items.rs
@@ -11,7 +11,8 @@ use warpui::{Action, AppContext, Element};
 
 use crate::ai::custom_model_routers::is_custom_router_id;
 use crate::ai::llms::{
-    DisableReason, LLMId, LLMInfo, should_show_bedrock_icon_for_model,
+    DisableReason, LLMId, LLMInfo, ModelIconFlags, model_leading_icon,
+    should_show_bedrock_icon_for_model,
     should_show_gemini_enterprise_agent_platform_icon_for_model, should_show_key_icon_for_model,
 };
 use crate::menu::{MenuItem, MenuItemFields, MenuTooltipPosition};
@@ -76,7 +77,8 @@ fn make_item_fields<A: Action + Clone>(
     collapse_reasoning_variants: bool,
     app: &AppContext,
 ) -> MenuItem<A> {
-    let label = if collapse_auto && is_auto(llm) {
+    let is_auto_model = is_auto(llm);
+    let label = if collapse_auto && is_auto_model {
         "auto".to_string()
     } else if collapse_reasoning_variants && llm.has_reasoning_level() {
         llm.base_model_name().to_string()
@@ -88,15 +90,15 @@ fn make_item_fields<A: Action + Clone>(
         should_show_gemini_enterprise_agent_platform_icon_for_model(llm, app);
     let is_using_api_key = should_show_key_icon_for_model(llm, app);
     let is_custom_router = is_custom_router_id(llm.id.as_str());
-    let leading_icon = if is_using_bedrock {
-        Icon::Aws
-    } else if is_using_gemini_enterprise_agent_platform {
-        Icon::GeminiEnterpriseAgentPlatform
-    } else if is_custom_router {
-        Icon::Dataflow
-    } else {
-        llm.provider.icon().unwrap_or(Icon::Agent)
-    };
+    let leading_icon = model_leading_icon(
+        llm,
+        ModelIconFlags {
+            is_custom_router,
+            is_auto: is_auto_model,
+            is_using_bedrock,
+            is_using_gemini_enterprise: is_using_gemini_enterprise_agent_platform,
+        },
+    );
     let is_using_cloud_host = is_using_bedrock || is_using_gemini_enterprise_agent_platform;
     let trailing_credential_icon = (!is_using_cloud_host && is_using_api_key).then_some(Icon::Key);
 

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -7,6 +7,7 @@ use anyhow::Context as _;
 use parking_lot::FairMutex;
 use serde::{Deserialize, Serialize, de};
 use warp_core::features::FeatureFlag;
+use warp_core::ui::Icon;
 use warp_core::user_preferences::GetUserPreferences;
 use warp_errors::report_error;
 use warp_multi_agent_api as api;
@@ -162,6 +163,32 @@ pub fn should_show_gemini_enterprise_agent_platform_icon_for_model(
         &LLMModelHost::GeminiEnterprise,
         UserWorkspaces::as_ref(app).is_gemini_enterprise_credentials_enabled(app),
     )
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ModelIconFlags {
+    pub is_custom_router: bool,
+    pub is_auto: bool,
+    pub is_using_bedrock: bool,
+    pub is_using_gemini_enterprise: bool,
+}
+
+/// The leading icon shown next to a model in the model picker and model menus.
+///
+/// Auto models deliberately get the generic agent glyph rather than a host or
+/// provider logo.
+pub fn model_leading_icon(llm: &LLMInfo, flags: ModelIconFlags) -> Icon {
+    if flags.is_custom_router {
+        Icon::Dataflow
+    } else if flags.is_auto {
+        Icon::Agent
+    } else if flags.is_using_bedrock {
+        Icon::Aws
+    } else if flags.is_using_gemini_enterprise {
+        Icon::GeminiEnterpriseAgentPlatform
+    } else {
+        llm.provider.icon().unwrap_or(Icon::Agent)
+    }
 }
 
 /// Key for cached LLM metadata in user preferences.

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -180,6 +180,112 @@ fn host_icon_visibility_requires_enabled_credentials_and_model_host() {
     ));
 }
 
+#[test]
+fn auto_models_show_the_agent_glyph_instead_of_a_host_logo() {
+    // The server reports host availability for auto models from host-level org
+    // settings, without checking whether the auto variant's routing table can
+    // actually reach that host. Badging the row with a host logo would promise a
+    // destination the classifier may never pick, so auto models stay generic.
+    let llm = server_llm("auto-open", None);
+
+    for flags in [
+        ModelIconFlags {
+            is_auto: true,
+            is_using_bedrock: true,
+            ..Default::default()
+        },
+        ModelIconFlags {
+            is_auto: true,
+            is_using_gemini_enterprise: true,
+            ..Default::default()
+        },
+        ModelIconFlags {
+            is_auto: true,
+            is_using_bedrock: true,
+            is_using_gemini_enterprise: true,
+            ..Default::default()
+        },
+    ] {
+        assert_eq!(model_leading_icon(&llm, flags), Icon::Agent);
+    }
+}
+
+#[test]
+fn non_auto_models_keep_their_host_logo() {
+    let llm = server_llm("claude-test", None);
+
+    assert_eq!(
+        model_leading_icon(
+            &llm,
+            ModelIconFlags {
+                is_using_bedrock: true,
+                ..Default::default()
+            }
+        ),
+        Icon::Aws
+    );
+    assert_eq!(
+        model_leading_icon(
+            &llm,
+            ModelIconFlags {
+                is_using_gemini_enterprise: true,
+                ..Default::default()
+            }
+        ),
+        Icon::GeminiEnterpriseAgentPlatform
+    );
+    // Bedrock wins when both hosts are available, matching the server's
+    // AWS_BEDROCK -> GEMINI_ENTERPRISE fallback priority.
+    assert_eq!(
+        model_leading_icon(
+            &llm,
+            ModelIconFlags {
+                is_using_bedrock: true,
+                is_using_gemini_enterprise: true,
+                ..Default::default()
+            }
+        ),
+        Icon::Aws
+    );
+}
+
+#[test]
+fn custom_routers_keep_the_dataflow_icon() {
+    // `is_auto` is a name/id substring match, so a router called "Auto Router"
+    // trips it. The custom-router branch is checked first so those rows keep
+    // their own icon.
+    let llm = server_llm("Auto Router", None);
+
+    assert_eq!(
+        model_leading_icon(
+            &llm,
+            ModelIconFlags {
+                is_custom_router: true,
+                is_auto: true,
+                ..Default::default()
+            }
+        ),
+        Icon::Dataflow
+    );
+}
+
+#[test]
+fn models_without_a_host_fall_back_to_the_provider_icon() {
+    let mut llm = server_llm("gpt-test", None);
+    llm.provider = LLMProvider::OpenAI;
+    assert_eq!(
+        model_leading_icon(&llm, ModelIconFlags::default()),
+        Icon::OpenAILogo
+    );
+
+    // Providers with no logo of their own land on the agent glyph.
+    llm.provider = LLMProvider::Unknown;
+    assert_eq!(
+        model_leading_icon(&llm, ModelIconFlags::default()),
+        Icon::Agent
+    );
+}
+
 // -- build_custom_llm_infos / display label tests --
 
 fn endpoint(

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -22,9 +22,9 @@ use warpui::{
 };
 
 use super::model_spec_scores::{
-    CUSTOM_MODEL_ROUTER_DESCRIPTION, CUSTOM_MODEL_ROUTER_TITLE, CostRow, CostRowTooltip,
-    MODEL_SPECS_DESCRIPTION, MODEL_SPECS_TITLE, ModelSpecScoresLayout, REASONING_LEVEL_DESCRIPTION,
-    REASONING_LEVEL_TITLE, render_model_spec_header, render_model_spec_scores,
+    CUSTOM_MODEL_ROUTER_DESCRIPTION, CUSTOM_MODEL_ROUTER_TITLE, CostRow, MODEL_SPECS_DESCRIPTION,
+    MODEL_SPECS_TITLE, ModelSpecScoresLayout, REASONING_LEVEL_DESCRIPTION, REASONING_LEVEL_TITLE,
+    render_model_spec_header, render_model_spec_scores,
 };
 use crate::ai::custom_model_routers::is_custom_router_id;
 use crate::ai::execution_profiles::model_menu_items::is_auto;
@@ -50,8 +50,8 @@ use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 use crate::workspace::WorkspaceAction;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
-const AUTO_BEDROCK_TOOLTIP: &str = "Warp uses Bedrock when the model Auto selects supports it; otherwise it may use Warp-hosted inference.";
-const AUTO_GEMINI_ENTERPRISE_AGENT_PLATFORM_TOOLTIP: &str = "Warp uses Gemini Enterprise Agent Platform when the model Auto selects supports it; otherwise it may use Warp-hosted inference.";
+/// Auto models pick their concrete model server-side, so the cost line names the
+/// class of inference rather than a host the request may never reach.
 const AUTO_HOSTED_INFERENCE_LABEL: &str = "Inference may use your hosted inference";
 
 #[derive(Clone, Debug)]
@@ -364,7 +364,6 @@ struct ModelSearchItem {
     name_match_result: Option<FuzzyMatchResult>,
     score: OrderedFloat<f64>,
     manage_api_key_mouse_state: MouseStateHandle,
-    cost_row_tooltip_mouse_state: MouseStateHandle,
     reasoning_level: Option<String>,
     discount_percentage: Option<f32>,
 }
@@ -414,7 +413,6 @@ impl ModelSearchItem {
             name_match_result: choice.name_match_result,
             score: choice.score,
             manage_api_key_mouse_state: Default::default(),
-            cost_row_tooltip_mouse_state: Default::default(),
             reasoning_level: llm.reasoning_level(),
             discount_percentage: llm.discount_percentage,
         }
@@ -663,19 +661,6 @@ impl SearchItem for ModelSearchItem {
                     source.inference_label()
                 } else {
                     "Inference via API key"
-                },
-                tooltip: if self.is_using_bedrock && self.is_auto {
-                    Some(CostRowTooltip {
-                        text: AUTO_BEDROCK_TOOLTIP,
-                        mouse_state: self.cost_row_tooltip_mouse_state.clone(),
-                    })
-                } else if self.is_using_gemini_enterprise_agent_platform && self.is_auto {
-                    Some(CostRowTooltip {
-                        text: AUTO_GEMINI_ENTERPRISE_AGENT_PLATFORM_TOOLTIP,
-                        mouse_state: self.cost_row_tooltip_mouse_state.clone(),
-                    })
-                } else {
-                    None
                 },
                 manage_button: Container::new(manage_button).finish(),
             }

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -30,7 +30,8 @@ use crate::ai::custom_model_routers::is_custom_router_id;
 use crate::ai::execution_profiles::model_menu_items::is_auto;
 use crate::ai::llms::{
     ByoKeySource, DisableReason, LLMId, LLMInfo, LLMPreferences, LLMProvider, LLMSpec,
-    byo_key_source_for_model, should_show_bedrock_icon_for_model,
+    ModelIconFlags, byo_key_source_for_model, model_leading_icon,
+    should_show_bedrock_icon_for_model,
     should_show_gemini_enterprise_agent_platform_icon_for_model, should_show_key_icon_for_model,
 };
 use crate::auth::AuthStateProvider;
@@ -51,6 +52,7 @@ use crate::workspaces::user_workspaces::UserWorkspaces;
 
 const AUTO_BEDROCK_TOOLTIP: &str = "Warp uses Bedrock when the model Auto selects supports it; otherwise it may use Warp-hosted inference.";
 const AUTO_GEMINI_ENTERPRISE_AGENT_PLATFORM_TOOLTIP: &str = "Warp uses Gemini Enterprise Agent Platform when the model Auto selects supports it; otherwise it may use Warp-hosted inference.";
+const AUTO_HOSTED_INFERENCE_LABEL: &str = "Inference may use your hosted inference";
 
 #[derive(Clone, Debug)]
 pub struct AcceptModel {
@@ -381,15 +383,15 @@ impl ModelSearchItem {
         let is_using_gemini_enterprise_agent_platform =
             should_show_gemini_enterprise_agent_platform_icon_for_model(llm, app);
         let byo_key_source = byo_key_source_for_model(llm, app);
-        let leading_icon = if is_using_bedrock {
-            Icon::Aws
-        } else if is_using_gemini_enterprise_agent_platform {
-            Icon::GeminiEnterpriseAgentPlatform
-        } else if is_custom_router {
-            Icon::Dataflow
-        } else {
-            llm.provider.icon().unwrap_or(Icon::Agent)
-        };
+        let leading_icon = model_leading_icon(
+            llm,
+            ModelIconFlags {
+                is_custom_router,
+                is_auto,
+                is_using_bedrock,
+                is_using_gemini_enterprise: is_using_gemini_enterprise_agent_platform,
+            },
+        );
         let is_using_cloud_host = is_using_bedrock || is_using_gemini_enterprise_agent_platform;
         let credential_icon =
             (!is_using_cloud_host && byo_key_source.is_some()).then_some(Icon::Key);
@@ -649,12 +651,12 @@ impl SearchItem for ModelSearchItem {
                 })
                 .finish();
             CostRow::BilledToProvider {
-                label: if self.is_using_bedrock && self.is_auto {
-                    "Inference may use Bedrock"
+                label: if self.is_auto
+                    && (self.is_using_bedrock || self.is_using_gemini_enterprise_agent_platform)
+                {
+                    AUTO_HOSTED_INFERENCE_LABEL
                 } else if self.is_using_bedrock {
                     "Inference via Bedrock"
-                } else if self.is_using_gemini_enterprise_agent_platform && self.is_auto {
-                    "Inference may use Gemini Enterprise Agent Platform"
                 } else if self.is_using_gemini_enterprise_agent_platform {
                     "Inference via Gemini Enterprise Agent Platform"
                 } else if let Some(source) = self.byo_key_source {

--- a/app/src/terminal/input/models/model_spec_scores.rs
+++ b/app/src/terminal/input/models/model_spec_scores.rs
@@ -1,14 +1,11 @@
 use pathfinder_color::ColorU;
-use pathfinder_geometry::vector::vec2f;
 use warp_core::ui::theme::color::internal_colors;
 use warpui::elements::{
-    Border, ChildAnchor, ConstrainedBox, Container, CornerRadius, Expanded, Flex, Hoverable,
-    Icon as WarpUiIcon, MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning,
-    ParentAnchor, ParentElement as _, ParentOffsetBounds, Percentage, Radius, Rect, Stack, Text,
+    Border, ConstrainedBox, Container, CornerRadius, Expanded, Flex, MainAxisAlignment,
+    MainAxisSize, ParentElement as _, Percentage, Radius, Rect, Stack, Text,
 };
 use warpui::prelude::{Align, CrossAxisAlignment};
 use warpui::text_layout::ClipConfig;
-use warpui::ui_components::components::UiComponent;
 use warpui::{AppContext, Element, SingletonEntity as _};
 
 use crate::ai::llms::LLMSpec;
@@ -33,13 +30,8 @@ pub enum CostRow {
     },
     BilledToProvider {
         label: &'static str,
-        tooltip: Option<CostRowTooltip>,
         manage_button: Box<dyn Element>,
     },
-}
-pub struct CostRowTooltip {
-    pub text: &'static str,
-    pub mouse_state: MouseStateHandle,
 }
 
 pub struct ModelSpecScoresLayout {
@@ -57,7 +49,6 @@ pub fn render_model_spec_scores(
         ScoreRowKind::Bar {
             value: spec.as_ref().map(|spec| spec.quality),
         },
-        None,
         layout.bg_bar_color,
         app,
     )];
@@ -67,7 +58,6 @@ pub fn render_model_spec_scores(
         ScoreRowKind::Bar {
             value: spec.as_ref().map(|spec| spec.speed),
         },
-        None,
         layout.bg_bar_color,
         app,
     ));
@@ -77,14 +67,12 @@ pub fn render_model_spec_scores(
             rows.push(render_score_row(
                 "Cost",
                 ScoreRowKind::Bar { value },
-                None,
                 layout.bg_bar_color,
                 app,
             ));
         }
         CostRow::BilledToProvider {
             label,
-            tooltip,
             manage_button,
         } => {
             rows.push(render_score_row(
@@ -93,7 +81,6 @@ pub fn render_model_spec_scores(
                     label,
                     manage_button,
                 },
-                tooltip,
                 layout.bg_bar_color,
                 app,
             ));
@@ -119,7 +106,6 @@ enum ScoreRowKind {
 fn render_score_row(
     name: &str,
     kind: ScoreRowKind,
-    label_tooltip: Option<CostRowTooltip>,
     bg_bar_color: ColorU,
     app: &AppContext,
 ) -> Box<dyn Element> {
@@ -134,7 +120,7 @@ fn render_score_row(
         appearance.ui_font_family(),
         appearance.monospace_font_size(),
     ) * 8.;
-    let label = ConstrainedBox::new(render_row_label(name, label_tooltip, appearance, app))
+    let label = ConstrainedBox::new(render_row_label(name, appearance, app))
         .with_width(label_width)
         .finish();
 
@@ -227,13 +213,8 @@ fn render_score_row(
         .finish()
 }
 
-fn render_row_label(
-    label: &str,
-    tooltip: Option<CostRowTooltip>,
-    appearance: &Appearance,
-    app: &AppContext,
-) -> Box<dyn Element> {
-    let label = Text::new(
+fn render_row_label(label: &str, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
+    Text::new(
         label.to_string(),
         appearance.ui_font_family(),
         appearance.monospace_font_size(),
@@ -245,21 +226,7 @@ fn render_row_label(
         )
         .into_solid(),
     )
-    .finish();
-
-    let Some(tooltip) = tooltip else {
-        return label;
-    };
-
-    Flex::row()
-        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_child(label)
-        .with_child(
-            Container::new(render_info_tooltip(tooltip, appearance))
-                .with_margin_left(4.)
-                .finish(),
-        )
-        .finish()
+    .finish()
 }
 
 fn render_provider_label(label: &'static str, appearance: &Appearance) -> Box<dyn Element> {
@@ -268,37 +235,6 @@ fn render_provider_label(label: &'static str, appearance: &Appearance) -> Box<dy
             .with_color(appearance.theme().disabled_ui_text_color().into())
             .finish(),
     )
-    .finish()
-}
-
-fn render_info_tooltip(tooltip: CostRowTooltip, appearance: &Appearance) -> Box<dyn Element> {
-    let icon_color = appearance.theme().disabled_ui_text_color();
-    let ui_builder = appearance.ui_builder();
-    let tooltip_text = tooltip.text.to_string();
-    Hoverable::new(tooltip.mouse_state, move |state| {
-        let info_icon = Container::new(
-            ConstrainedBox::new(WarpUiIcon::new("bundled/svg/info.svg", icon_color).finish())
-                .with_width(13.)
-                .with_height(13.)
-                .finish(),
-        )
-        .finish();
-
-        let mut stack = Stack::new().with_child(info_icon);
-        if state.is_hovered() {
-            let tooltip = ui_builder.tool_tip(tooltip_text.clone()).build();
-            stack.add_positioned_child(
-                tooltip.finish(),
-                OffsetPositioning::offset_from_parent(
-                    vec2f(0., -3.),
-                    ParentOffsetBounds::Unbounded,
-                    ParentAnchor::TopMiddle,
-                    ChildAnchor::BottomMiddle,
-                ),
-            );
-        }
-        stack.finish()
-    })
     .finish()
 }
 


### PR DESCRIPTION
## Description

For auto models we don't show the AWS icon or Gemini icon - we show the Warp icon and messaging that inference may use your provider. 

For concrete models that are supported by Bedrock and GEAP, we still show Bedrock icon / GEAP icon as normal. 

New UI in this loom https://www.loom.com/share/f3ef5f5763524f2599f753a527146d70.

Context in this thread https://warpdev.slack.com/archives/C0A0CGP8F0X/p1785422836324989. 


## Testing

Four unit tests in `app/src/ai/llms_tests.rs`, alongside the existing `host_icon_visibility_*` test and following the same pure-function pattern:

- auto models get the agent glyph with Bedrock, with GEAP, and with both
- non-auto models keep their host logo, with Bedrock winning ties (matching the server's `AWS_BEDROCK → GEMINI_ENTERPRISE` priority)
- custom routers keep `Dataflow` even when named "auto"
- models with no host fall back to the provider icon, and providers without a logo land on the agent glyph

Checks:

- `./script/format` and `cargo fmt --all -- --check` clean
- `cargo clippy -p warp --all-targets -- -D warnings` clean
- `cargo test -p warp --lib ai::llms` — 32 passed

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Auto models in the model picker no longer show an AWS Bedrock or Gemini Enterprise logo, or name a specific host in their cost details, when the model they resolve to may not use that host.
