### PR TITLE
Add TUI-specific channel version overrides

### DIFF
--- a/app/src/autoupdate/mod.rs
+++ b/app/src/autoupdate/mod.rs
@@ -571,7 +571,7 @@ impl AutoupdateState {
         }
 
         ctx.emit(AutoupdateStateEvent::CheckComplete {
-            result: update_available,
+            result: Box::new(update_available),
             request_type,
         });
         ctx.notify();
@@ -646,7 +646,7 @@ pub enum AutoupdateStateEvent {
     /// Emitted when an update check has finished.
     CheckComplete {
         /// Result of the check of whether there is an update available.
-        result: Result<UpdateReady>,
+        result: Box<Result<UpdateReady>>,
         /// Type of request that this check references.
         request_type: RequestType,
     },

--- a/app/src/autoupdate/mod_tests.rs
+++ b/app/src/autoupdate/mod_tests.rs
@@ -281,6 +281,7 @@ fn make_version_info(version_string: impl Into<String>, is_rollback: bool) -> Ve
         is_rollback: Some(is_rollback),
         version_for_new_users: None,
         cli_version: None,
+        tui_version: None,
     }
 }
 

--- a/crates/channel_versions/src/lib.rs
+++ b/crates/channel_versions/src/lib.rs
@@ -137,6 +137,9 @@ pub struct VersionInfo {
     /// The version to use for CLI downloads, falling back to `version` if not set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cli_version: Option<String>,
+    /// The version to use for TUI downloads, falling back to `version` if not set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tui_version: Option<String>,
 }
 
 impl VersionInfo {
@@ -149,12 +152,18 @@ impl VersionInfo {
             version_for_new_users: None,
             is_rollback: None,
             cli_version: None,
+            tui_version: None,
         }
     }
 
     /// Returns the CLI version, falling back to the app version if not set.
     pub fn cli_version(&self) -> &str {
         self.cli_version.as_deref().unwrap_or(&self.version)
+    }
+
+    /// Returns the TUI version, falling back to the app version if not set.
+    pub fn tui_version(&self) -> &str {
+        self.tui_version.as_deref().unwrap_or(&self.version)
     }
 }
 

--- a/crates/channel_versions/src/overrides.rs
+++ b/crates/channel_versions/src/overrides.rs
@@ -129,6 +129,9 @@ impl VersionInfo {
         if let Some(cli_version) = other.cli_version {
             self.cli_version = Some(cli_version);
         }
+        if let Some(tui_version) = other.tui_version {
+            self.tui_version = Some(tui_version);
+        }
     }
 }
 

--- a/crates/channel_versions/src/overrides_tests.rs
+++ b/crates/channel_versions/src/overrides_tests.rs
@@ -21,6 +21,7 @@ fn test_only_first_override_is_applied() {
             is_rollback: None,
             version_for_new_users: None,
             cli_version: None,
+            tui_version: None,
         },
         overrides: vec![
             VersionOverride {
@@ -33,6 +34,7 @@ fn test_only_first_override_is_applied() {
                     is_rollback: None,
                     version_for_new_users: None,
                     cli_version: None,
+                    tui_version: None,
                 },
             },
             VersionOverride {
@@ -47,6 +49,7 @@ fn test_only_first_override_is_applied() {
                     is_rollback: None,
                     version_for_new_users: None,
                     cli_version: None,
+                    tui_version: None,
                 },
             },
         ],
@@ -143,6 +146,7 @@ fn test_cli_version_override_is_applied() {
             is_rollback: None,
             version_for_new_users: None,
             cli_version: Some("base_cli_version".to_string()),
+            tui_version: None,
         },
         overrides: vec![VersionOverride {
             predicate,
@@ -154,6 +158,7 @@ fn test_cli_version_override_is_applied() {
                 is_rollback: None,
                 version_for_new_users: None,
                 cli_version: Some("override_cli_version".to_string()),
+                tui_version: None,
             },
         }],
     };
@@ -187,6 +192,7 @@ fn test_cli_version_preserved_when_override_omits_it() {
             is_rollback: None,
             version_for_new_users: None,
             cli_version: Some("base_cli_version".to_string()),
+            tui_version: None,
         },
         overrides: vec![VersionOverride {
             predicate,
@@ -198,6 +204,7 @@ fn test_cli_version_preserved_when_override_omits_it() {
                 is_rollback: None,
                 version_for_new_users: None,
                 cli_version: None,
+                tui_version: None,
             },
         }],
     };
@@ -219,4 +226,79 @@ fn test_cli_version_falls_back_to_version() {
     let info = VersionInfo::new("app_version".to_string());
     assert_eq!(info.cli_version, None);
     assert_eq!(info.cli_version(), "app_version");
+}
+
+#[test]
+fn test_tui_version_override_is_applied() {
+    #[cfg(target_os = "macos")]
+    let predicate = OverridePredicate::TargetOS(TargetOS::MacOS);
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    let predicate = OverridePredicate::TargetOS(TargetOS::Linux);
+    #[cfg(target_os = "windows")]
+    let predicate = OverridePredicate::TargetOS(TargetOS::Windows);
+
+    let mut version_info = VersionInfo::new("base_version".to_string());
+    version_info.tui_version = Some("base_tui_version".to_string());
+    let mut override_version_info = VersionInfo::new("override_version".to_string());
+    override_version_info.tui_version = Some("override_tui_version".to_string());
+    let version = ChannelVersion {
+        version_info,
+        overrides: vec![VersionOverride {
+            predicate,
+            version_info: override_version_info,
+        }],
+    };
+
+    let version_info_with_overrides = version.version_info();
+    assert_eq!(
+        version_info_with_overrides.tui_version(),
+        "override_tui_version"
+    );
+}
+
+#[test]
+fn test_tui_version_preserved_when_override_omits_it() {
+    #[cfg(target_os = "macos")]
+    let predicate = OverridePredicate::TargetOS(TargetOS::MacOS);
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    let predicate = OverridePredicate::TargetOS(TargetOS::Linux);
+    #[cfg(target_os = "windows")]
+    let predicate = OverridePredicate::TargetOS(TargetOS::Windows);
+
+    let mut version_info = VersionInfo::new("base_version".to_string());
+    version_info.tui_version = Some("base_tui_version".to_string());
+    let version = ChannelVersion {
+        version_info,
+        overrides: vec![VersionOverride {
+            predicate,
+            version_info: VersionInfo::new("override_version".to_string()),
+        }],
+    };
+
+    assert_eq!(version.version_info().tui_version(), "base_tui_version");
+}
+
+#[test]
+fn test_tui_version_falls_back_to_effective_version() {
+    #[cfg(target_os = "macos")]
+    let predicate = OverridePredicate::TargetOS(TargetOS::MacOS);
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    let predicate = OverridePredicate::TargetOS(TargetOS::Linux);
+    #[cfg(target_os = "windows")]
+    let predicate = OverridePredicate::TargetOS(TargetOS::Windows);
+
+    let version = ChannelVersion {
+        version_info: VersionInfo::new("base_version".to_string()),
+        overrides: vec![VersionOverride {
+            predicate,
+            version_info: VersionInfo::new("override_version".to_string()),
+        }],
+    };
+
+    let version_info_with_overrides = version.version_info();
+    assert_eq!(version_info_with_overrides.tui_version, None);
+    assert_eq!(
+        version_info_with_overrides.tui_version(),
+        "override_version"
+    );
 }

--- a/crates/warp_tui/src/autoupdate.rs
+++ b/crates/warp_tui/src/autoupdate.rs
@@ -664,7 +664,11 @@ async fn fetch_latest_version(client: &http_client::Client) -> Result<String> {
 
 /// Picks this channel's latest version out of the channel-versions payload.
 fn latest_version_for_channel(versions: &ChannelVersions) -> Result<String> {
-    let channel_version = match ChannelState::channel() {
+    latest_version_for(ChannelState::channel(), versions)
+}
+
+fn latest_version_for(channel: Channel, versions: &ChannelVersions) -> Result<String> {
+    let channel_version = match channel {
         Channel::Dev => &versions.dev,
         Channel::Preview => &versions.preview,
         Channel::Stable => &versions.stable,
@@ -672,7 +676,7 @@ fn latest_version_for_channel(versions: &ChannelVersions) -> Result<String> {
             bail!("no TUI release artifacts exist for the {channel} channel")
         }
     };
-    Ok(channel_version.version_info().version)
+    Ok(channel_version.version_info().tui_version().to_owned())
 }
 
 /// The Warp Agent CLI artifact endpoint for a release channel.

--- a/crates/warp_tui/src/autoupdate_tests.rs
+++ b/crates/warp_tui/src/autoupdate_tests.rs
@@ -4,6 +4,7 @@ use std::process::Child;
 use std::time::Duration;
 use std::{fs, thread};
 
+use channel_versions::{ChannelVersion, ChannelVersions, VersionInfo};
 use command::blocking::Command;
 use instant::Instant;
 use warp_core::channel::Channel;
@@ -11,7 +12,7 @@ use warp_core::channel::Channel;
 use super::{
     CURRENT_LINK_NAME, InstallLayout, InstallLock, LOCK_FILE_NAME, LOCK_OWNER_FILE_NAME,
     VERSION_LEASES_DIR_NAME, VersionDirState, VersionLease, create_unique_staging_dir_with,
-    download_endpoint, is_complete_version_dir, version_dir_state,
+    download_endpoint, is_complete_version_dir, latest_version_for, version_dir_state,
 };
 #[cfg(unix)]
 use super::{
@@ -147,6 +148,49 @@ fn uses_channel_specific_download_endpoints() {
     );
 }
 
+#[test]
+fn uses_channel_specific_tui_versions() {
+    fn channel_version(version: &str, tui_version: Option<&str>) -> ChannelVersion {
+        let mut version_info = VersionInfo::new(version.to_owned());
+        version_info.tui_version = tui_version.map(ToOwned::to_owned);
+        ChannelVersion::new(version_info)
+    }
+
+    let versions = ChannelVersions {
+        dev: channel_version("dev_app", Some("dev_tui")),
+        preview: channel_version("preview_app", Some("preview_tui")),
+        stable: channel_version("stable_app", Some("stable_tui")),
+        changelogs: None,
+    };
+
+    assert_eq!(
+        latest_version_for(Channel::Dev, &versions).unwrap(),
+        "dev_tui"
+    );
+    assert_eq!(
+        latest_version_for(Channel::Preview, &versions).unwrap(),
+        "preview_tui"
+    );
+    assert_eq!(
+        latest_version_for(Channel::Stable, &versions).unwrap(),
+        "stable_tui"
+    );
+}
+
+#[test]
+fn falls_back_to_app_version_when_tui_version_is_omitted() {
+    let versions = ChannelVersions {
+        dev: ChannelVersion::new(VersionInfo::new("dev_app".to_owned())),
+        preview: ChannelVersion::new(VersionInfo::new("preview_app".to_owned())),
+        stable: ChannelVersion::new(VersionInfo::new("stable_app".to_owned())),
+        changelogs: None,
+    };
+
+    assert_eq!(
+        latest_version_for(Channel::Preview, &versions).unwrap(),
+        "preview_app"
+    );
+}
 #[test]
 fn complete_versions_require_real_binary_and_resources() {
     let root = temp_root("complete");


### PR DESCRIPTION
## Description

Add an optional `tui_version` to the channel-version contract so Warp Agent CLI/TUI releases can advance independently from the desktop app.

- Resolve top-level and platform-specific `tui_version` overrides while preserving fallback to the effective app `version`.
- Apply the same override precedence for macOS, Linux, and Windows channel contexts.
- Use the resolved TUI version for TUI autoupdate channel selection, including Windows installer downloads.
- Add regression coverage for override precedence, fallback behavior, and channel selection.
- Box the autoupdate check result to keep the enlarged event variant within Clippy's size limit.

## Cross-repository rollout

- [channel-versions #994](https://github.com/warpdotdev/channel-versions/pull/994) defines and validates the release contract, including both Windows dev installer architectures.
- [warp-server #13606](https://github.com/warpdotdev/warp-server/pull/13606) resolves implicit TUI download versions from the same platform override.
- [Warp #14475](https://github.com/warpdotdev/warp/pull/14475) builds the signed Windows installer.
- [Warp #14477](https://github.com/warpdotdev/warp/pull/14477) uses that installer for Windows TUI autoupdates.
- [Warp #14601](https://github.com/warpdotdev/warp/pull/14601) and [Warp #14574](https://github.com/warpdotdev/warp/pull/14574) publish and verify Windows TUI installers for x86_64 and aarch64.

The currently validated rollout matrix is macOS/Linux dev+preview and Windows dev. Windows preview publishing is not enabled yet. Stable Windows publishing exists, but the current stable channel version predates it and the stable TUI install route remains disabled.

## Linked Issue

None. The related platform-override issue does not specifically cover this TUI release contract.

- [x] Screenshots are not applicable because this changes release resolution and has no user-visible UI.

## Testing

- `./script/presubmit`
  - Rust formatting and inline-test-module checks
  - Workspace/default-GUI Clippy with warnings denied
  - clang-format and WGSL formatting
  - 10,405 workspace tests plus completer feature tests
  - Rust doc tests
- Focused `channel_versions` and TUI autoupdate regression tests
- Windows CI passed for the platform-generic override implementation; later linked PRs exercise native Windows installer bundling and publishing.

- [ ] I have manually tested my changes locally with `./script/run` (not applicable to the release metadata resolver)

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
