### PR TITLE
TUI: Restore authentication after /logout

### DIFF
--- a/app/src/auth/mod.rs
+++ b/app/src/auth/mod.rs
@@ -20,6 +20,8 @@ pub use auth_manager::AuthManager;
 pub use auth_state::AuthStateProvider;
 use itertools::Itertools;
 pub use login_failure_notification::LoginFailureReason;
+#[cfg(feature = "tui")]
+use url::Url;
 pub use user_uid::UserUid;
 use warp_core::channel::ChannelState;
 use warp_core::user_preferences::GetUserPreferences as _;
@@ -74,6 +76,37 @@ pub fn web_logout_url() -> String {
         "{}/logout",
         ChannelState::server_root_url().trim_end_matches('/')
     )
+}
+
+/// Returns the configured Warp web logout URL with a validated browser continuation.
+///
+/// TUI logout only continues to the same Warp web origin's device page. This
+/// keeps the logout endpoint from becoming an open redirect if an unexpected
+/// device-authorization response reaches the client.
+#[cfg(feature = "tui")]
+pub fn web_logout_url_with_continue(continue_url: &str) -> Option<String> {
+    let mut logout_url =
+        Url::parse(&web_logout_url()).expect("configured Warp web logout URL must be valid");
+    let continue_url = Url::parse(continue_url).ok()?;
+    let has_required_query = continue_url
+        .query_pairs()
+        .any(|(key, value)| key == "user_code" && !value.is_empty())
+        && continue_url
+            .query_pairs()
+            .any(|(key, value)| key == "source" && value == "warp-agent-cli");
+    if continue_url.origin() != logout_url.origin()
+        || continue_url.path() != "/device"
+        || !continue_url.username().is_empty()
+        || continue_url.password().is_some()
+        || continue_url.fragment().is_some()
+        || !has_required_query
+    {
+        return None;
+    }
+    logout_url
+        .query_pairs_mut()
+        .append_pair("continue", continue_url.as_str());
+    Some(logout_url.into())
 }
 
 /// If the app has running processes or dirty objects, we'll show a confirmation modal before logging out.

--- a/app/src/auth/mod_tests.rs
+++ b/app/src/auth/mod_tests.rs
@@ -1,6 +1,8 @@
 use warp_core::channel::ChannelState;
 
 use super::web_logout_url;
+#[cfg(feature = "tui")]
+use super::web_logout_url_with_continue;
 
 #[test]
 fn web_logout_url_uses_configured_server_root() {
@@ -8,5 +10,48 @@ fn web_logout_url_uses_configured_server_root() {
     assert_eq!(
         web_logout_url(),
         format!("{}/logout", server_root_url.trim_end_matches('/'))
+    );
+}
+
+#[test]
+#[cfg(feature = "tui")]
+fn web_logout_url_rejects_unsafe_device_auth_continuations() {
+    let server_root_url = ChannelState::server_root_url();
+    for continue_url in [
+        "https://example.com/device?user_code=ABCD-EFGH&source=warp-agent-cli".to_owned(),
+        format!(
+            "{}/login?user_code=ABCD-EFGH&source=warp-agent-cli",
+            server_root_url.trim_end_matches('/')
+        ),
+        format!(
+            "{}/device?source=warp-agent-cli",
+            server_root_url.trim_end_matches('/')
+        ),
+        format!(
+            "{}/device?user_code=ABCD-EFGH",
+            server_root_url.trim_end_matches('/')
+        ),
+    ] {
+        assert_eq!(web_logout_url_with_continue(&continue_url), None);
+    }
+}
+
+#[test]
+#[cfg(feature = "tui")]
+fn web_logout_url_encodes_device_auth_continuation() {
+    let continue_url = format!(
+        "{}/device?user_code=ABCD-EFGH&source=warp-agent-cli",
+        ChannelState::server_root_url().trim_end_matches('/')
+    );
+    let logout_url =
+        url::Url::parse(&web_logout_url_with_continue(&continue_url).unwrap()).unwrap();
+
+    assert_eq!(logout_url.path(), "/logout");
+    assert_eq!(
+        logout_url
+            .query_pairs()
+            .find(|(key, _)| key == "continue")
+            .map(|(_, value)| value.into_owned()),
+        Some(continue_url)
     );
 }

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -3,10 +3,11 @@
 //! `warp_tui` boots the real headless Warp app via [`crate::run_tui`]. Once
 //! shared initialization is done, [`init`] registers the [`TuiLoginModel`] that
 //! the TUI observes, mounts the TUI immediately (so it renders right away), and
-//! — when the user isn't logged in yet — drives the device-authorization login
-//! flow, flipping the model to [`TuiLoginPhase::LoggedIn`] when it completes.
+//! leaves device authorization behind an explicit welcome-screen action,
+//! flipping the model to [`TuiLoginPhase::LoggedIn`] when it completes.
 mod mcp;
 mod user_info;
+use std::env;
 
 pub use mcp::{
     TuiMcpAction, TuiMcpConfigDiagnostic, TuiMcpFileScope, TuiMcpFileSource, TuiMcpInstallRequest,
@@ -16,23 +17,24 @@ pub use mcp::{
 };
 use url::Url;
 pub use user_info::{TuiUserInfoManager, TuiUserInfoManagerEvent, TuiUserInfoSnapshot};
+use warp_core::channel::ChannelState;
 use warpui::{AppContext, Entity, SingletonEntity};
 
 use crate::TuiMountFn;
 use crate::ai::mcp::FileBasedMCPManager;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::{self, AuthStateProvider};
+use crate::terminal::focus_env::FOCUS_URL_ENV;
 
 /// Login state of the headless TUI, observed by the `warp_tui` root view to
 /// decide whether to show the login placeholder or the input UI.
 pub enum TuiLoginPhase {
+    /// Logged out and waiting for the user to explicitly begin browser login.
+    SignedOutWelcome,
     /// Waiting for the user to finish the device-authorization login. The
-    /// verification URL/code are surfaced in the placeholder once known (the
-    /// alt screen hides stdout, so they can't be printed there).
-    AwaitingLogin {
-        verification_uri: Option<String>,
-        user_code: Option<String>,
-    },
+    /// exact URL opened in the browser is surfaced once known (the alt screen
+    /// hides stdout, so it cannot be printed there).
+    AwaitingLogin { browser_url: Option<String> },
     /// Login failed; the placeholder shows the message so the user can quit.
     Failed { message: String },
     /// Authenticated — the input UI can be shown.
@@ -48,17 +50,36 @@ pub enum TuiLoginEvent {
     /// The current user logged out and the TUI should return to authentication.
     LoggedOut,
 }
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TuiAuthBrowserFlow {
+    DirectDeviceAuthorization,
+    LogoutThenDeviceAuthorizationPending,
+    LogoutThenDeviceAuthorizationOpened,
+}
 
 /// Singleton holding the TUI's [`TuiLoginPhase`]. Updated by [`init`]'s auth
 /// flow and read by the `warp_tui` root view.
 pub struct TuiLoginModel {
     phase: TuiLoginPhase,
+    browser_flow: TuiAuthBrowserFlow,
 }
 
 impl TuiLoginModel {
     /// The current login phase.
     pub fn phase(&self) -> &TuiLoginPhase {
         &self.phase
+    }
+    /// Starts device authorization from the signed-out welcome screen.
+    pub fn start_device_login(ctx: &mut AppContext) {
+        start_tui_device_login(ctx);
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn signed_out_for_test() -> Self {
+        Self {
+            phase: TuiLoginPhase::SignedOutWelcome,
+            browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
+        }
     }
 }
 
@@ -70,21 +91,19 @@ impl SingletonEntity for TuiLoginModel {}
 
 /// Entry point invoked from `run_internal` once the headless app is initialized.
 ///
-/// Registers the [`TuiLoginModel`], mounts the TUI immediately, and runs the
-/// device-authorization login flow when the user isn't already logged in.
+/// Registers the [`TuiLoginModel`], mounts the TUI immediately, and shows an
+/// explicit welcome screen when the user isn't already logged in.
 pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
     let logged_in = AuthStateProvider::as_ref(ctx).get().is_logged_in();
 
     let initial_phase = if logged_in {
         TuiLoginPhase::LoggedIn
     } else {
-        TuiLoginPhase::AwaitingLogin {
-            verification_uri: None,
-            user_code: None,
-        }
+        TuiLoginPhase::SignedOutWelcome
     };
     ctx.add_singleton_model(move |_| TuiLoginModel {
         phase: initial_phase,
+        browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
     });
     ctx.add_singleton_model(TuiMcpManager::new);
     ctx.add_singleton_model(TuiUserInfoManager::new);
@@ -100,8 +119,6 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
 
     if logged_in {
         activate_global_mcp_servers(ctx);
-    } else {
-        authorize_device(ctx);
     }
 }
 
@@ -116,12 +133,27 @@ fn handle_auth_manager_event(event: &AuthManagerEvent, ctx: &mut AppContext) {
             let url_to_open = verification_url_complete
                 .as_deref()
                 .unwrap_or(verification_url.as_str());
-            let url_to_open = tui_verification_url(url_to_open);
+            let verification_url = tui_verification_url(url_to_open, user_code);
+            let url_to_open =
+                TuiLoginModel::handle(ctx).update(ctx, |model, _| match model.browser_flow {
+                    TuiAuthBrowserFlow::DirectDeviceAuthorization => Some(verification_url.clone()),
+                    TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending => {
+                        model.browser_flow =
+                            TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationOpened;
+                        Some(
+                            auth::web_logout_url_with_continue(&verification_url)
+                                .unwrap_or_else(auth::web_logout_url),
+                        )
+                    }
+                    TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationOpened => None,
+                });
+            let Some(url_to_open) = url_to_open else {
+                return;
+            };
             set_login_phase(
                 ctx,
                 TuiLoginPhase::AwaitingLogin {
-                    verification_uri: Some(url_to_open.clone()),
-                    user_code: Some(user_code.clone()),
+                    browser_url: Some(url_to_open.clone()),
                 },
             );
             if !ctx.try_open_url(&url_to_open) {
@@ -132,12 +164,28 @@ fn handle_auth_manager_event(event: &AuthManagerEvent, ctx: &mut AppContext) {
             set_login_phase(ctx, TuiLoginPhase::LoggedIn);
             activate_global_mcp_servers(ctx);
         }
-        AuthManagerEvent::AuthFailed(err) => set_login_phase(
-            ctx,
-            TuiLoginPhase::Failed {
-                message: format!("{err:#}"),
-            },
-        ),
+        AuthManagerEvent::AuthFailed(err) => {
+            let should_finish_web_logout = TuiLoginModel::handle(ctx).update(ctx, |model, _| {
+                let should_finish_web_logout = matches!(
+                    model.browser_flow,
+                    TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending
+                );
+                model.browser_flow = TuiAuthBrowserFlow::DirectDeviceAuthorization;
+                should_finish_web_logout
+            });
+            if should_finish_web_logout {
+                let logout_url = auth::web_logout_url();
+                if !ctx.try_open_url(&logout_url) {
+                    log::warn!("Unable to open the logout URL in the default browser");
+                }
+            }
+            set_login_phase(
+                ctx,
+                TuiLoginPhase::Failed {
+                    message: format!("{err:#}"),
+                },
+            );
+        }
         _ => {}
     }
 }
@@ -147,14 +195,61 @@ fn authorize_device(ctx: &mut AppContext) {
         auth_manager.authorize_device(ctx);
     });
 }
-fn tui_verification_url(verification_url: &str) -> String {
+fn tui_verification_url(verification_url: &str, user_code: &str) -> String {
+    let focus_url = env::var(FOCUS_URL_ENV).ok();
+    tui_verification_url_with_return(verification_url, user_code, focus_url.as_deref())
+}
+
+fn tui_verification_url_with_return(
+    verification_url: &str,
+    user_code: &str,
+    focus_url: Option<&str>,
+) -> String {
     let Ok(mut verification_url) = Url::parse(verification_url) else {
         return verification_url.to_owned();
     };
-    verification_url
-        .query_pairs_mut()
-        .append_pair("source", "warp-agent-cli");
+    let has_user_code = verification_url
+        .query_pairs()
+        .any(|(key, value)| key == "user_code" && !value.is_empty());
+    let return_to = validated_tui_focus_url(focus_url);
+    let mut query = verification_url.query_pairs_mut();
+    if !has_user_code {
+        query.append_pair("user_code", user_code);
+    }
+    query.append_pair("source", "warp-agent-cli");
+    if let Some(return_to) = return_to {
+        query.append_pair("return_to", &return_to);
+    }
+    drop(query);
     verification_url.into()
+}
+
+fn validated_tui_focus_url(focus_url: Option<&str>) -> Option<String> {
+    let mut focus_url = Url::parse(focus_url?).ok()?;
+    if focus_url.scheme() != ChannelState::url_scheme()
+        || focus_url.host_str() != Some("session")
+        || !focus_url.username().is_empty()
+        || focus_url.password().is_some()
+        || focus_url.port().is_some()
+        || focus_url.query().is_some()
+        || focus_url.fragment().is_some()
+    {
+        return None;
+    }
+
+    let session_uuid = {
+        let mut path_segments = focus_url.path_segments()?;
+        let session_uuid = path_segments.next()?.to_ascii_lowercase();
+        if path_segments.next().is_some()
+            || session_uuid.len() != 32
+            || !session_uuid.chars().all(|char| char.is_ascii_hexdigit())
+        {
+            return None;
+        }
+        session_uuid
+    };
+    focus_url.set_path(&format!("/{session_uuid}"));
+    Some(focus_url.into())
 }
 
 fn activate_global_mcp_servers(ctx: &mut AppContext) {
@@ -163,18 +258,33 @@ fn activate_global_mcp_servers(ctx: &mut AppContext) {
     });
 }
 
+/// Starts a fresh direct device-authorization flow from the signed-out welcome screen.
+pub fn start_tui_device_login(ctx: &mut AppContext) {
+    let should_authorize = TuiLoginModel::handle(ctx).update(ctx, |model, ctx| {
+        if !matches!(model.phase, TuiLoginPhase::SignedOutWelcome) {
+            return false;
+        }
+        model.phase = TuiLoginPhase::AwaitingLogin { browser_url: None };
+        model.browser_flow = TuiAuthBrowserFlow::DirectDeviceAuthorization;
+        ctx.notify();
+        ctx.emit(TuiLoginEvent::PhaseChanged);
+        true
+    });
+    if should_authorize {
+        authorize_device(ctx);
+    }
+}
 /// Logs out the current TUI user and sends them to Warp web's logged-out flow.
 pub fn log_out_tui(ctx: &mut AppContext) {
-    auth::log_out_and_open_web(ctx);
+    auth::log_out(ctx);
     set_logged_out_phase(ctx);
+    authorize_device(ctx);
 }
 
 fn set_logged_out_phase(ctx: &mut AppContext) {
     TuiLoginModel::handle(ctx).update(ctx, |model, ctx| {
-        model.phase = TuiLoginPhase::AwaitingLogin {
-            verification_uri: None,
-            user_code: None,
-        };
+        model.phase = TuiLoginPhase::AwaitingLogin { browser_url: None };
+        model.browser_flow = TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending;
         ctx.notify();
         ctx.emit(TuiLoginEvent::PhaseChanged);
         ctx.emit(TuiLoginEvent::LoggedOut);
@@ -188,6 +298,9 @@ fn set_login_phase(ctx: &mut AppContext, phase: TuiLoginPhase) {
     TuiLoginModel::handle(ctx).update(ctx, |model, ctx| {
         let logged_in = matches!(phase, TuiLoginPhase::LoggedIn);
         model.phase = phase;
+        if logged_in {
+            model.browser_flow = TuiAuthBrowserFlow::DirectDeviceAuthorization;
+        }
         ctx.notify();
         ctx.emit(TuiLoginEvent::PhaseChanged);
         if logged_in {

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -1,19 +1,31 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
+use warp_core::channel::ChannelState;
 use warpui::{App, SingletonEntity};
 
 use super::{
-    TuiLoginEvent, TuiLoginModel, TuiLoginPhase, handle_auth_manager_event, set_logged_out_phase,
-    set_login_phase, tui_verification_url,
+    TuiAuthBrowserFlow, TuiLoginEvent, TuiLoginModel, TuiLoginPhase, handle_auth_manager_event,
+    set_logged_out_phase, set_login_phase, start_tui_device_login,
+    tui_verification_url_with_return, validated_tui_focus_url,
 };
-use crate::auth::auth_manager::AuthManagerEvent;
+use crate::auth::AuthStateProvider;
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::auth::UserAuthenticationError;
+fn login_model(phase: TuiLoginPhase) -> TuiLoginModel {
+    TuiLoginModel {
+        phase,
+        browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
+    }
+}
 
 #[test]
 fn tags_tui_verification_url_without_losing_existing_query_parameters() {
-    let url = tui_verification_url(
+    let url = tui_verification_url_with_return(
         "https://app.warp.dev/device?user_code=ABCD-EFGH&existing=value#fragment",
+        "ABCD-EFGH",
+        None,
     );
     let url = url::Url::parse(&url).unwrap();
 
@@ -30,17 +42,103 @@ fn tags_tui_verification_url_without_losing_existing_query_parameters() {
 
 #[test]
 fn leaves_invalid_verification_url_unchanged() {
-    assert_eq!(tui_verification_url("not a URL"), "not a URL".to_owned());
+    assert_eq!(
+        tui_verification_url_with_return("not a URL", "ABCD-EFGH", None),
+        "not a URL".to_owned()
+    );
 }
 
 #[test]
+fn adds_user_code_when_complete_verification_url_is_unavailable() {
+    let url = tui_verification_url_with_return("https://app.warp.dev/device", "ABCD-EFGH", None);
+    let url = url::Url::parse(&url).unwrap();
+
+    assert_eq!(
+        url.query_pairs()
+            .find(|(key, _)| key == "user_code")
+            .map(|(_, value)| value.into_owned()),
+        Some("ABCD-EFGH".to_owned())
+    );
+}
+
+#[test]
+fn adds_valid_focus_url_to_tui_verification_url() {
+    let focus_url = format!(
+        "{}://session/0123456789ABCDEF0123456789ABCDEF",
+        ChannelState::url_scheme()
+    );
+    let verification_url = tui_verification_url_with_return(
+        "https://app.warp.dev/device?user_code=CODE",
+        "CODE",
+        Some(&focus_url),
+    );
+    let verification_url = url::Url::parse(&verification_url).unwrap();
+
+    assert_eq!(
+        verification_url
+            .query_pairs()
+            .find(|(key, _)| key == "return_to")
+            .map(|(_, value)| value.into_owned()),
+        Some(format!(
+            "{}://session/0123456789abcdef0123456789abcdef",
+            ChannelState::url_scheme()
+        ))
+    );
+}
+
+#[test]
+fn rejects_invalid_focus_urls() {
+    let scheme = ChannelState::url_scheme();
+    for focus_url in [
+        "https://app.warp.dev/session/0123456789abcdef0123456789abcdef".to_owned(),
+        format!("{scheme}://action/0123456789abcdef0123456789abcdef"),
+        format!("{scheme}://session/not-a-session-id"),
+        format!("{scheme}://session/0123456789abcdef0123456789abcdef?extra=value"),
+    ] {
+        assert_eq!(validated_tui_focus_url(Some(&focus_url)), None);
+    }
+}
+
+#[test]
+fn explicit_start_device_login_transitions_only_from_welcome() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| TuiLoginModel::signed_out_for_test());
+
+        let phase_changed_events = Rc::new(Cell::new(0));
+        let phase_changed_events_for_subscription = phase_changed_events.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&TuiLoginModel::handle(ctx), move |_, event, _| {
+                if matches!(event, TuiLoginEvent::PhaseChanged) {
+                    phase_changed_events_for_subscription
+                        .set(phase_changed_events_for_subscription.get() + 1);
+                }
+            });
+        });
+
+        app.update(start_tui_device_login);
+        app.update(start_tui_device_login);
+
+        assert_eq!(phase_changed_events.get(), 1);
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin { browser_url: None }
+            ));
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).browser_flow,
+                TuiAuthBrowserFlow::DirectDeviceAuthorization
+            ));
+        });
+    });
+}
+#[test]
 fn stores_device_fallback_before_opening_browser() {
     App::test((), |mut app| async move {
-        app.add_singleton_model(|_| TuiLoginModel {
-            phase: TuiLoginPhase::AwaitingLogin {
-                verification_uri: None,
-                user_code: None,
-            },
+        app.add_singleton_model(|_| {
+            login_model(TuiLoginPhase::AwaitingLogin { browser_url: None })
         });
 
         let browser_opened = Rc::new(Cell::new(false));
@@ -50,19 +148,20 @@ fn stores_device_fallback_before_opening_browser() {
                 assert!(matches!(
                     TuiLoginModel::as_ref(ctx).phase(),
                     TuiLoginPhase::AwaitingLogin {
-                        verification_uri: Some(verification_uri),
-                        user_code: Some(user_code),
-                    } if verification_uri == url && user_code == "ABCD-EFGH"
+                        browser_url: Some(browser_url),
+                    } if browser_url == url
                 ));
                 browser_opened_for_callback.set(true);
                 url.to_owned()
             });
+            let verification_url = format!(
+                "{}/device",
+                ChannelState::server_root_url().trim_end_matches('/')
+            );
             handle_auth_manager_event(
                 &AuthManagerEvent::ReceivedDeviceAuthorizationCode {
-                    verification_url: "https://app.warp.dev/device".to_owned(),
-                    verification_url_complete: Some(
-                        "https://app.warp.dev/device?user_code=ABCD-EFGH".to_owned(),
-                    ),
+                    verification_url,
+                    verification_url_complete: None,
                     user_code: "ABCD-EFGH".to_owned(),
                 },
                 ctx,
@@ -74,13 +173,57 @@ fn stores_device_fallback_before_opening_browser() {
 }
 
 #[test]
-fn renders_device_code_request_timeout_without_id_token_prefix() {
+fn post_logout_device_auth_opens_logout_with_device_continuation() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| TuiLoginModel {
-            phase: TuiLoginPhase::AwaitingLogin {
-                verification_uri: None,
-                user_code: None,
-            },
+            phase: TuiLoginPhase::AwaitingLogin { browser_url: None },
+            browser_flow: TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending,
+        });
+
+        app.update(|ctx| {
+            ctx.set_before_open_url(|url, ctx| {
+                let logout_url = url::Url::parse(url).unwrap();
+                assert_eq!(logout_url.path(), "/logout");
+                let continuation = logout_url
+                    .query_pairs()
+                    .find(|(key, _)| key == "continue")
+                    .map(|(_, value)| value.into_owned())
+                    .unwrap();
+                let continuation = url::Url::parse(&continuation).unwrap();
+                assert_eq!(continuation.path(), "/device");
+                assert_eq!(
+                    continuation
+                        .query_pairs()
+                        .find(|(key, _)| key == "source")
+                        .map(|(_, value)| value.into_owned()),
+                    Some("warp-agent-cli".to_owned())
+                );
+                assert!(matches!(
+                    TuiLoginModel::as_ref(ctx).browser_flow,
+                    TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationOpened
+                ));
+                url.to_owned()
+            });
+            let verification_url = format!(
+                "{}/device",
+                ChannelState::server_root_url().trim_end_matches('/')
+            );
+            handle_auth_manager_event(
+                &AuthManagerEvent::ReceivedDeviceAuthorizationCode {
+                    verification_url,
+                    verification_url_complete: None,
+                    user_code: "ABCD-EFGH".to_owned(),
+                },
+                ctx,
+            );
+        });
+    });
+}
+#[test]
+fn renders_device_code_request_timeout_without_id_token_prefix() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            login_model(TuiLoginPhase::AwaitingLogin { browser_url: None })
         });
 
         app.update(|ctx| {
@@ -102,14 +245,45 @@ fn renders_device_code_request_timeout_without_id_token_prefix() {
         });
     });
 }
+
+#[test]
+fn post_logout_device_code_failure_still_opens_web_logout() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| TuiLoginModel {
+            phase: TuiLoginPhase::AwaitingLogin { browser_url: None },
+            browser_flow: TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending,
+        });
+        let browser_opened = Rc::new(Cell::new(false));
+        let browser_opened_for_callback = browser_opened.clone();
+
+        app.update(|ctx| {
+            ctx.set_before_open_url(move |url, _| {
+                assert_eq!(url::Url::parse(url).unwrap().path(), "/logout");
+                browser_opened_for_callback.set(true);
+                url.to_owned()
+            });
+            handle_auth_manager_event(
+                &AuthManagerEvent::AuthFailed(UserAuthenticationError::DeviceCodeRequestTimedOut {
+                    attempts: 2,
+                }),
+                ctx,
+            );
+        });
+
+        assert!(browser_opened.get());
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).browser_flow,
+                TuiAuthBrowserFlow::DirectDeviceAuthorization
+            ));
+        });
+    });
+}
 #[test]
 fn emits_logged_in_event_when_login_completes() {
     App::test((), |mut app| async move {
-        app.add_singleton_model(|_| TuiLoginModel {
-            phase: TuiLoginPhase::AwaitingLogin {
-                verification_uri: None,
-                user_code: None,
-            },
+        app.add_singleton_model(|_| {
+            login_model(TuiLoginPhase::AwaitingLogin { browser_url: None })
         });
 
         let logged_in_events = Rc::new(Cell::new(0));
@@ -136,8 +310,7 @@ fn emits_logged_in_event_when_login_completes() {
             set_login_phase(
                 ctx,
                 TuiLoginPhase::AwaitingLogin {
-                    verification_uri: Some("https://example.com".to_owned()),
-                    user_code: Some("CODE".to_owned()),
+                    browser_url: Some("https://example.com".to_owned()),
                 },
             );
         });
@@ -153,9 +326,7 @@ fn emits_logged_in_event_when_login_completes() {
 #[test]
 fn emits_logged_out_event_and_resets_login_details() {
     App::test((), |mut app| async move {
-        app.add_singleton_model(|_| TuiLoginModel {
-            phase: TuiLoginPhase::LoggedIn,
-        });
+        app.add_singleton_model(|_| login_model(TuiLoginPhase::LoggedIn));
 
         let logged_out_events = Rc::new(Cell::new(0));
         let logged_out_events_for_subscription = logged_out_events.clone();
@@ -179,10 +350,11 @@ fn emits_logged_out_event_and_resets_login_details() {
         app.read(|ctx| {
             assert!(matches!(
                 TuiLoginModel::as_ref(ctx).phase(),
-                TuiLoginPhase::AwaitingLogin {
-                    verification_uri: None,
-                    user_code: None,
-                }
+                TuiLoginPhase::AwaitingLogin { browser_url: None }
+            ));
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).browser_flow,
+                TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending
             ));
         });
     });

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -1,7 +1,11 @@
 //! [`RootTuiView`]: the login-gated root view of the `warp-tui` front-end.
+use std::sync::Arc;
+use std::time::Duration;
 
 use warp::{TuiLoginModel, TuiLoginPhase};
 use warpui::SingletonEntity as _;
+use warpui_core::elements::MouseStateHandle;
+use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{TuiChildView, TuiElement};
 use warpui_core::keymap::FixedBinding;
 use warpui_core::keymap::macros::*;
@@ -10,13 +14,18 @@ use warpui_core::{AppContext, Entity, EntityId, TuiView, TypedActionView, ViewCo
 
 use crate::keybindings::TUI_BINDING_GROUP;
 use crate::session_registry::{TuiSessionView, TuiSessions};
-use crate::ui::{login_failed, login_placeholder, terminal_starting};
+use crate::ui::{login_failed, login_waiting, signed_out_welcome, terminal_starting};
+use crate::zero_state_animation::ZeroStateAnimationConfig;
 
 /// Typed actions handled by [`RootTuiView`].
 #[derive(Debug, Clone)]
 pub enum RootTuiAction {
     /// Exits the app while no terminal session is focused.
     ExitApp,
+    /// Starts browser device authorization from the signed-out welcome screen.
+    StartDeviceLogin,
+    /// Opens the manual browser fallback shown while authorization is pending.
+    OpenLoginUrl(String),
 }
 
 /// Whether the root is presenting authentication or the live session container.
@@ -28,6 +37,9 @@ enum RootTuiState {
 /// The app-level TUI shell, projecting only the focused full session view.
 pub struct RootTuiView {
     state: RootTuiState,
+    auth_animation_clock: AnimationClock,
+    auth_animation_config: Arc<ZeroStateAnimationConfig>,
+    waiting_login_mouse: MouseStateHandle,
 }
 
 /// Registers the root view's keybindings.
@@ -45,6 +57,9 @@ impl RootTuiView {
     pub(crate) fn new() -> Self {
         Self {
             state: RootTuiState::Auth,
+            auth_animation_clock: AnimationClock::starting_at(Duration::ZERO),
+            auth_animation_config: Arc::new(ZeroStateAnimationConfig::default()),
+            waiting_login_mouse: MouseStateHandle::default(),
         }
     }
 
@@ -94,11 +109,32 @@ impl TuiView for RootTuiView {
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
         match self.state {
             RootTuiState::Auth => match TuiLoginModel::as_ref(ctx).phase() {
+                TuiLoginPhase::SignedOutWelcome => signed_out_welcome(
+                    self.auth_animation_clock,
+                    self.auth_animation_config.clone(),
+                    ctx,
+                    |event_ctx, _| {
+                        event_ctx.dispatch_typed_action(RootTuiAction::StartDeviceLogin);
+                    },
+                ),
                 TuiLoginPhase::LoggedIn => terminal_starting(),
-                TuiLoginPhase::AwaitingLogin {
-                    verification_uri,
-                    user_code,
-                } => login_placeholder(verification_uri.as_deref(), user_code.as_deref()),
+                TuiLoginPhase::AwaitingLogin { browser_url } => login_waiting(
+                    self.auth_animation_clock,
+                    self.auth_animation_config.clone(),
+                    browser_url.as_deref(),
+                    self.waiting_login_mouse.clone(),
+                    ctx,
+                    {
+                        let browser_url = browser_url.clone();
+                        move |event_ctx, _| {
+                            if let Some(browser_url) = browser_url.clone() {
+                                event_ctx.dispatch_typed_action(RootTuiAction::OpenLoginUrl(
+                                    browser_url,
+                                ));
+                            }
+                        }
+                    },
+                ),
                 TuiLoginPhase::Failed { message } => login_failed(message.as_str()),
             },
             RootTuiState::Terminal => self
@@ -124,6 +160,15 @@ impl TypedActionView for RootTuiView {
     fn handle_action(&mut self, action: &RootTuiAction, ctx: &mut ViewContext<Self>) {
         match action {
             RootTuiAction::ExitApp => ctx.terminate_app(TerminationMode::ForceTerminate, None),
+            RootTuiAction::StartDeviceLogin => {
+                if matches!(
+                    TuiLoginModel::as_ref(ctx).phase(),
+                    TuiLoginPhase::SignedOutWelcome
+                ) {
+                    TuiLoginModel::start_device_login(ctx);
+                }
+            }
+            RootTuiAction::OpenLoginUrl(url) => ctx.open_url(url),
         }
     }
 }

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -14,6 +14,8 @@ use warpui_core::{AppContext, Entity, EntityId, TuiView, TypedActionView, ViewCo
 
 use crate::keybindings::TUI_BINDING_GROUP;
 use crate::session_registry::{TuiSessionView, TuiSessions};
+use crate::clipboard::copy_to_clipboard;
+use crate::transient_hint::TransientHint;
 use crate::ui::{login_failed, login_waiting, signed_out_welcome, terminal_starting};
 use crate::zero_state_animation::ZeroStateAnimationConfig;
 
@@ -26,6 +28,8 @@ pub enum RootTuiAction {
     StartDeviceLogin,
     /// Opens the manual browser fallback shown while authorization is pending.
     OpenLoginUrl(String),
+    /// Copies the manual browser fallback shown while authorization is pending.
+    CopyLoginUrl(String),
 }
 
 /// Whether the root is presenting authentication or the live session container.
@@ -40,6 +44,8 @@ pub struct RootTuiView {
     auth_animation_clock: AnimationClock,
     auth_animation_config: Arc<ZeroStateAnimationConfig>,
     waiting_login_mouse: MouseStateHandle,
+    waiting_login_copy_mouse: MouseStateHandle,
+    login_copy_hint: TransientHint,
 }
 
 /// Registers the root view's keybindings.
@@ -60,6 +66,8 @@ impl RootTuiView {
             auth_animation_clock: AnimationClock::starting_at(Duration::ZERO),
             auth_animation_config: Arc::new(ZeroStateAnimationConfig::default()),
             waiting_login_mouse: MouseStateHandle::default(),
+            waiting_login_copy_mouse: MouseStateHandle::default(),
+            login_copy_hint: TransientHint::default(),
         }
     }
 
@@ -123,12 +131,24 @@ impl TuiView for RootTuiView {
                     self.auth_animation_config.clone(),
                     browser_url.as_deref(),
                     self.waiting_login_mouse.clone(),
+                    self.waiting_login_copy_mouse.clone(),
+                    self.login_copy_hint.current(),
                     ctx,
                     {
                         let browser_url = browser_url.clone();
                         move |event_ctx, _| {
                             if let Some(browser_url) = browser_url.clone() {
                                 event_ctx.dispatch_typed_action(RootTuiAction::OpenLoginUrl(
+                                    browser_url,
+                                ));
+                            }
+                        }
+                    },
+                    {
+                        let browser_url = browser_url.clone();
+                        move |event_ctx, _| {
+                            if let Some(browser_url) = browser_url.clone() {
+                                event_ctx.dispatch_typed_action(RootTuiAction::CopyLoginUrl(
                                     browser_url,
                                 ));
                             }
@@ -169,6 +189,33 @@ impl TypedActionView for RootTuiView {
                 }
             }
             RootTuiAction::OpenLoginUrl(url) => ctx.open_url(url),
+            RootTuiAction::CopyLoginUrl(url) => {
+                let is_current_url = matches!(
+                    TuiLoginModel::as_ref(ctx).phase(),
+                    TuiLoginPhase::AwaitingLogin {
+                        browser_url: Some(current_url),
+                    } if current_url == url
+                );
+                if !is_current_url {
+                    return;
+                }
+
+                match copy_to_clipboard(url) {
+                    Ok(()) => self.login_copy_hint.show_success(
+                        "Login URL copied to clipboard".to_owned(),
+                        ctx,
+                        |view| &mut view.login_copy_hint,
+                    ),
+                    Err(error) => {
+                        log::warn!("Failed to copy TUI login URL: {error}");
+                        self.login_copy_hint.show_error(
+                            "Unable to copy login URL".to_owned(),
+                            ctx,
+                            |view| &mut view.login_copy_hint,
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -12,9 +12,9 @@ use warpui_core::keymap::macros::*;
 use warpui_core::platform::TerminationMode;
 use warpui_core::{AppContext, Entity, EntityId, TuiView, TypedActionView, ViewContext, keymap};
 
+use crate::clipboard::copy_to_clipboard;
 use crate::keybindings::TUI_BINDING_GROUP;
 use crate::session_registry::{TuiSessionView, TuiSessions};
-use crate::clipboard::copy_to_clipboard;
 use crate::transient_hint::TransientHint;
 use crate::ui::{login_failed, login_waiting, signed_out_welcome, terminal_starting};
 use crate::zero_state_animation::ZeroStateAnimationConfig;

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -16,7 +16,9 @@ use crate::clipboard::copy_to_clipboard;
 use crate::keybindings::TUI_BINDING_GROUP;
 use crate::session_registry::{TuiSessionView, TuiSessions};
 use crate::transient_hint::TransientHint;
-use crate::ui::{login_failed, login_waiting, signed_out_welcome, terminal_starting};
+use crate::ui::{
+    LoginWaitingParams, login_failed, login_waiting, signed_out_welcome, terminal_starting,
+};
 use crate::zero_state_animation::ZeroStateAnimationConfig;
 
 /// Typed actions handled by [`RootTuiView`].
@@ -129,10 +131,12 @@ impl TuiView for RootTuiView {
                 TuiLoginPhase::AwaitingLogin { browser_url } => login_waiting(
                     self.auth_animation_clock,
                     self.auth_animation_config.clone(),
-                    browser_url.as_deref(),
-                    self.waiting_login_mouse.clone(),
-                    self.waiting_login_copy_mouse.clone(),
-                    self.login_copy_hint.current(),
+                    LoginWaitingParams {
+                        browser_url: browser_url.as_deref(),
+                        login_mouse: self.waiting_login_mouse.clone(),
+                        copy_mouse: self.waiting_login_copy_mouse.clone(),
+                        copy_feedback: self.login_copy_hint.current(),
+                    },
                     ctx,
                     {
                         let browser_url = browser_url.clone();

--- a/crates/warp_tui/src/root_view_tests.rs
+++ b/crates/warp_tui/src/root_view_tests.rs
@@ -1,9 +1,10 @@
 use warp::tui_export::register_tui_session_view_test_singletons;
+use warp::{TuiLoginModel, TuiLoginPhase};
 use warpui::platform::WindowStyle;
-use warpui::{AddWindowOptions, UpdateModel};
-use warpui_core::{App, TuiView as _, WindowId};
+use warpui::{AddWindowOptions, SingletonEntity, UpdateModel};
+use warpui_core::{App, TuiView as _, TypedActionView as _, WindowId};
 
-use super::RootTuiView;
+use super::{RootTuiAction, RootTuiView};
 use crate::cloud_run::TuiCloudRunState;
 use crate::session_registry::{TuiSessions, TuiSessionsEvent};
 use crate::test_fixtures::{add_test_semantic_selection, add_test_terminal_session};
@@ -18,6 +19,26 @@ fn add_root(app: &mut App) -> (WindowId, warpui_core::ViewHandle<RootTuiView>) {
             |_| RootTuiView::new(),
         )
     })
+}
+
+#[test]
+fn start_device_login_action_transitions_from_welcome() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        app.add_singleton_model(|_| TuiLoginModel::signed_out_for_test());
+        let (_, root) = add_root(&mut app);
+
+        root.update(&mut app, |root, ctx| {
+            root.handle_action(&RootTuiAction::StartDeviceLogin, ctx);
+        });
+
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin { browser_url: None }
+            ));
+        });
+    });
 }
 
 #[test]

--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -9,8 +9,8 @@ use warpui_core::elements::tui::{
     TuiFlex, TuiHoverable, TuiStack, TuiStyle, TuiText,
 };
 use warpui_core::elements::{CrossAxisAlignment, MouseStateHandle};
-use crate::transient_hint::TransientHintTone;
 
+use crate::transient_hint::TransientHintTone;
 use crate::tui_builder::TuiUiBuilder;
 use crate::warping_indicator::render_spinner;
 use crate::zero_state_animation::{

--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -211,18 +211,29 @@ pub(crate) fn signed_out_welcome(
         .finish()
 }
 
+/// Browser interaction state for the waiting login screen.
+pub(crate) struct LoginWaitingParams<'a> {
+    pub(crate) browser_url: Option<&'a str>,
+    pub(crate) login_mouse: MouseStateHandle,
+    pub(crate) copy_mouse: MouseStateHandle,
+    pub(crate) copy_feedback: Option<(&'a str, TransientHintTone)>,
+}
+
 /// Waiting state shown after device authorization starts.
 pub(crate) fn login_waiting(
     clock: AnimationClock,
     animation_config: Arc<ZeroStateAnimationConfig>,
-    browser_url: Option<&str>,
-    login_mouse: MouseStateHandle,
-    copy_mouse: MouseStateHandle,
-    copy_feedback: Option<(&str, TransientHintTone)>,
+    params: LoginWaitingParams<'_>,
     app: &AppContext,
     on_open: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
     on_copy: impl FnMut(&mut TuiEventContext, &AppContext) + Clone + 'static,
 ) -> Box<dyn TuiElement> {
+    let LoginWaitingParams {
+        browser_url,
+        login_mouse,
+        copy_mouse,
+        copy_feedback,
+    } = params;
     let builder = TuiUiBuilder::from_app(app);
     let primary = builder.primary_text_style();
     let muted = builder.muted_text_style();

--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -1,15 +1,23 @@
 //! Small presentation helpers for the `warp-tui` front-end's TUI views.
+use std::sync::Arc;
 use std::time::Duration;
 
 use warpui_core::AppContext;
-use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{
-    Modifier, TuiConstrainedBox, TuiElement, TuiFlex, TuiStyle, TuiText,
+    Color, Modifier, TuiConstrainedBox, TuiContainer, TuiElement, TuiEventContext, TuiEventHandler,
+    TuiFlex, TuiHoverable, TuiStack, TuiStyle, TuiText,
 };
+use warpui_core::elements::{CrossAxisAlignment, MouseStateHandle};
 
 use crate::tui_builder::TuiUiBuilder;
 use crate::warping_indicator::render_spinner;
+use crate::zero_state_animation::{
+    WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationElement, ZeroStateStarfieldElement,
+};
+
+const AUTH_COPY_COLS: u16 = 48;
+const AUTH_ANIMATION_COLS: u16 = 32;
 
 /// Abbreviates a leading home-directory prefix of `path` to `~`.
 pub(crate) fn abbreviate_home_prefix(path: &str) -> String {
@@ -127,53 +135,223 @@ pub(crate) fn centered_in_viewport(content: Box<dyn TuiElement>) -> Box<dyn TuiE
         .finish()
 }
 
-/// Placeholder shown while the user completes device-authorization login. The
-/// verification URL/code are surfaced once known (the browser also auto-opens).
-pub(crate) fn login_placeholder(
-    verification_uri: Option<&str>,
-    user_code: Option<&str>,
+/// Signed-out welcome shown before browser device authorization begins.
+pub(crate) fn signed_out_welcome(
+    clock: AnimationClock,
+    animation_config: Arc<ZeroStateAnimationConfig>,
+    app: &AppContext,
+    mut on_login: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
 ) -> Box<dyn TuiElement> {
-    let dim = TuiStyle::default().add_modifier(Modifier::DIM);
-    let mut content =
-        TuiFlex::column().child(TuiText::new("Sign in to continue").truncate().finish());
-    match (verification_uri, user_code) {
-        (Some(uri), Some(code)) => {
-            content = content
-                .child(
-                    TuiText::new(format!("Open {uri} in your browser"))
-                        .with_style(dim)
-                        .truncate()
-                        .finish(),
-                )
-                .child(
-                    TuiText::new(format!("and enter code: {code}"))
-                        .with_style(dim)
-                        .truncate()
-                        .finish(),
-                );
-        }
-        (Some(uri), None) => {
-            content = content.child(
-                TuiText::new(format!("Open {uri} in your browser"))
-                    .with_style(dim)
-                    .truncate()
-                    .finish(),
-            );
-        }
-        _ => {
-            content = content.child(
-                TuiText::new("Requesting a sign-in link…")
-                    .with_style(dim)
-                    .truncate()
-                    .finish(),
-            );
-        }
-    }
-    centered_in_viewport(
-        content
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+    let builder = TuiUiBuilder::from_app(app);
+    let primary = builder.primary_text_style();
+    let muted = builder.muted_text_style();
+    let title = builder
+        .credential_entry_accent_style()
+        .add_modifier(Modifier::BOLD);
+    let success = builder.success_glyph_style();
+    let content = TuiFlex::column()
+        .child(
+            TuiText::new("Welcome to Warp")
+                .with_style(title)
+                .truncate()
+                .finish(),
+        )
+        .child(
+            TuiText::from_spans([
+                ("> ".to_owned(), success),
+                ("Press ".to_owned(), muted),
+                ("enter".to_owned(), success.add_modifier(Modifier::BOLD)),
+                (" to get started".to_owned(), muted),
+            ])
             .finish(),
+        )
+        .child(blank_row())
+        .child(blank_row())
+        .child(
+            TuiText::new("What’s different about Warp")
+                .with_style(muted)
+                .finish(),
+        )
+        .child(capability_row(
+            "⟡",
+            "Prompts or shell commands autodetected",
+            builder.credential_entry_accent_style(),
+            primary,
+        ))
+        .child(capability_row(
+            "⊹",
+            "Set up custom model routers",
+            builder.link_text_style(),
+            primary,
+        ))
+        .child(capability_row(
+            "✶",
+            "Orchestrate fleets of agents",
+            success,
+            primary,
+        ))
+        .child(capability_row(
+            "*",
+            "Run full-screen terminal apps",
+            builder.credential_entry_accent_style(),
+            primary,
+        ))
+        .child(capability_row(
+            "◊",
+            "Persist sessions through state changes",
+            builder.attention_glyph_style(),
+            primary,
+        ))
+        .finish();
+    TuiEventHandler::new(auth_layout(clock, animation_config, content, &builder))
+        .on_key("enter", move |_, event_ctx, app| {
+            on_login(event_ctx, app);
+        })
+        .finish()
+}
+
+/// Waiting state shown after device authorization starts.
+pub(crate) fn login_waiting(
+    clock: AnimationClock,
+    animation_config: Arc<ZeroStateAnimationConfig>,
+    browser_url: Option<&str>,
+    login_mouse: MouseStateHandle,
+    app: &AppContext,
+    on_open: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    let primary = builder.primary_text_style();
+    let muted = builder.muted_text_style();
+    let title = builder
+        .credential_entry_accent_style()
+        .add_modifier(Modifier::BOLD);
+    let mut content = TuiFlex::column()
+        .child(
+            TuiText::new("Welcome to Warp")
+                .with_style(title)
+                .truncate()
+                .finish(),
+        )
+        .child(
+            TuiText::from_spans([
+                ("● ".to_owned(), builder.attention_glyph_style()),
+                ("Waiting for login...".to_owned(), primary),
+            ])
+            .finish(),
+        )
+        .child(blank_row())
+        .child(blank_row());
+
+    if let Some(browser_url) = browser_url {
+        let link_style = if login_mouse.lock().is_ok_and(|state| state.is_hovered()) {
+            primary
+                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::UNDERLINED)
+        } else {
+            primary.add_modifier(Modifier::UNDERLINED)
+        };
+        content = content.child(
+            TuiHoverable::new(
+                login_mouse,
+                TuiText::from_spans([
+                    ("Visit ".to_owned(), muted),
+                    (browser_url.to_owned(), link_style),
+                    (" to get started, then come back here.".to_owned(), muted),
+                ])
+                .finish(),
+            )
+            .on_click(on_open)
+            .finish(),
+        );
+    } else {
+        content = content.child(
+            TuiText::new("Requesting a secure sign-in link...")
+                .with_style(muted)
+                .finish(),
+        );
+    }
+
+    auth_layout(clock, animation_config, content.finish(), &builder)
+}
+
+fn capability_row(
+    glyph: &str,
+    label: &str,
+    glyph_style: TuiStyle,
+    text_style: TuiStyle,
+) -> Box<dyn TuiElement> {
+    TuiText::from_spans([
+        (format!("{glyph} "), glyph_style),
+        (label.to_owned(), text_style),
+    ])
+    .finish()
+}
+
+fn auth_layout(
+    clock: AnimationClock,
+    animation_config: Arc<ZeroStateAnimationConfig>,
+    content: Box<dyn TuiElement>,
+    builder: &TuiUiBuilder,
+) -> Box<dyn TuiElement> {
+    let starfield = ZeroStateStarfieldElement::new(
+        clock,
+        builder.muted_text_style(),
+        AUTH_COPY_COLS,
+        AUTH_ANIMATION_COLS,
     )
+    .finish();
+    let animation = ZeroStateAnimationElement::new(
+        clock,
+        animation_config,
+        WarpLogoStyles {
+            front: builder.accent_text_style(),
+            back: builder.primary_text_style(),
+            side: builder.dim_text_style(),
+            background: builder.muted_text_style(),
+        },
+    )
+    .without_background_stars()
+    .finish();
+    let copy_reservation = TuiConstrainedBox::new(TuiText::new("").finish())
+        .with_min_cols(AUTH_COPY_COLS)
+        .with_max_cols(AUTH_COPY_COLS)
+        .finish();
+    let animation = TuiConstrainedBox::new(animation)
+        .with_max_cols(AUTH_ANIMATION_COLS)
+        .finish();
+    let animation_region = TuiFlex::row()
+        .flex_child(TuiText::new("").finish())
+        .child(animation)
+        .flex_child(TuiText::new("").finish())
+        .finish();
+    let animation_layer = TuiFlex::row()
+        .child(copy_reservation)
+        .flex_child(animation_region)
+        .finish();
+
+    let content = TuiContainer::new(content)
+        .with_padding_left(3)
+        .with_background(Color::Reset)
+        .finish();
+    let content = TuiConstrainedBox::new(content)
+        .with_min_cols(AUTH_COPY_COLS)
+        .with_max_cols(AUTH_COPY_COLS)
+        .finish();
+    let content_layer = TuiFlex::column()
+        .flex_child(TuiText::new("").finish())
+        .child(content)
+        .flex_child(TuiText::new("").finish())
+        .finish();
+
+    TuiStack::new()
+        .child(starfield)
+        .child(animation_layer)
+        .child(content_layer)
+        .finish()
+}
+
+fn blank_row() -> Box<dyn TuiElement> {
+    TuiText::new(" ").truncate().finish()
 }
 
 /// Placeholder shown between login completion and terminal session creation.

--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -9,6 +9,7 @@ use warpui_core::elements::tui::{
     TuiFlex, TuiHoverable, TuiStack, TuiStyle, TuiText,
 };
 use warpui_core::elements::{CrossAxisAlignment, MouseStateHandle};
+use crate::transient_hint::TransientHintTone;
 
 use crate::tui_builder::TuiUiBuilder;
 use crate::warping_indicator::render_spinner;
@@ -216,8 +217,11 @@ pub(crate) fn login_waiting(
     animation_config: Arc<ZeroStateAnimationConfig>,
     browser_url: Option<&str>,
     login_mouse: MouseStateHandle,
+    copy_mouse: MouseStateHandle,
+    copy_feedback: Option<(&str, TransientHintTone)>,
     app: &AppContext,
     on_open: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
+    on_copy: impl FnMut(&mut TuiEventContext, &AppContext) + Clone + 'static,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
     let primary = builder.primary_text_style();
@@ -242,6 +246,8 @@ pub(crate) fn login_waiting(
         .child(blank_row())
         .child(blank_row());
 
+    let has_browser_url = browser_url.is_some();
+    let mut on_copy_key = on_copy.clone();
     if let Some(browser_url) = browser_url {
         let link_style = if login_mouse.lock().is_ok_and(|state| state.is_hovered()) {
             primary
@@ -263,6 +269,35 @@ pub(crate) fn login_waiting(
             .on_click(on_open)
             .finish(),
         );
+        let copy_hovered = copy_mouse.lock().is_ok_and(|state| state.is_hovered());
+        let (copy_label, copy_style) = match copy_feedback {
+            Some((message, TransientHintTone::Muted)) => (message.to_owned(), muted),
+            Some((message, TransientHintTone::Success)) => {
+                (message.to_owned(), builder.success_glyph_style())
+            }
+            Some((message, TransientHintTone::Error)) => {
+                (message.to_owned(), builder.error_text_style())
+            }
+            None => {
+                let style = if copy_hovered {
+                    primary.add_modifier(Modifier::BOLD)
+                } else {
+                    builder.link_text_style()
+                };
+                ("Copy URL (c)".to_owned(), style)
+            }
+        };
+        content = content.child(
+            TuiHoverable::new(
+                copy_mouse,
+                TuiText::new(copy_label)
+                    .with_style(copy_style)
+                    .truncate()
+                    .finish(),
+            )
+            .on_click(on_copy)
+            .finish(),
+        );
     } else {
         content = content.child(
             TuiText::new("Requesting a secure sign-in link...")
@@ -271,7 +306,16 @@ pub(crate) fn login_waiting(
         );
     }
 
-    auth_layout(clock, animation_config, content.finish(), &builder)
+    let content = auth_layout(clock, animation_config, content.finish(), &builder);
+    if has_browser_url {
+        TuiEventHandler::new(content)
+            .on_key("c", move |_, event_ctx, app| {
+                on_copy_key(event_ctx, app);
+            })
+            .finish()
+    } else {
+        content
+    }
 }
 
 fn capability_row(

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -17,8 +17,8 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, EntityId, EntityIdMap};
 
 use super::{
-    compact_footer_path, conversation_restoring, horizontally_centered, login_waiting,
-    signed_out_welcome,
+    LoginWaitingParams, compact_footer_path, conversation_restoring, horizontally_centered,
+    login_waiting, signed_out_welcome,
 };
 use crate::transient_hint::TransientHintTone;
 use crate::zero_state_animation::ZeroStateAnimationConfig;
@@ -62,10 +62,12 @@ fn waiting_login_renders_copy_feedback() {
                     login_waiting(
                         AnimationClock::starting_at(Duration::ZERO),
                         Arc::new(ZeroStateAnimationConfig::default()),
-                        Some(browser_url),
-                        MouseStateHandle::default(),
-                        MouseStateHandle::default(),
-                        Some((message, tone)),
+                        LoginWaitingParams {
+                            browser_url: Some(browser_url),
+                            login_mouse: MouseStateHandle::default(),
+                            copy_mouse: MouseStateHandle::default(),
+                            copy_feedback: Some((message, tone)),
+                        },
                         app_ctx,
                         |_, _| {},
                         |_, _| {},
@@ -193,10 +195,12 @@ fn waiting_login_generated_url_handles_click() {
             let mut element = login_waiting(
                 AnimationClock::starting_at(Duration::ZERO),
                 Arc::new(ZeroStateAnimationConfig::default()),
-                Some(browser_url),
-                MouseStateHandle::default(),
-                MouseStateHandle::default(),
-                None,
+                LoginWaitingParams {
+                    browser_url: Some(browser_url),
+                    login_mouse: MouseStateHandle::default(),
+                    copy_mouse: MouseStateHandle::default(),
+                    copy_feedback: None,
+                },
                 app_ctx,
                 move |_, _| activated_for_click.set(true),
                 |_, _| {},
@@ -261,10 +265,12 @@ fn waiting_login_copy_control_handles_click_and_key() {
             let mut element = login_waiting(
                 AnimationClock::starting_at(Duration::ZERO),
                 Arc::new(ZeroStateAnimationConfig::default()),
-                Some(browser_url),
-                MouseStateHandle::default(),
-                MouseStateHandle::default(),
-                None,
+                LoginWaitingParams {
+                    browser_url: Some(browser_url),
+                    login_mouse: MouseStateHandle::default(),
+                    copy_mouse: MouseStateHandle::default(),
+                    copy_feedback: None,
+                },
                 app_ctx,
                 |_, _| {},
                 move |_, _| copy_count_for_action.set(copy_count_for_action.get() + 1),
@@ -376,10 +382,12 @@ fn waiting_login_renders_actual_browser_url_and_requesting_fallback() {
                     login_waiting(
                         AnimationClock::starting_at(Duration::ZERO),
                         Arc::new(ZeroStateAnimationConfig::default()),
-                        url,
-                        MouseStateHandle::default(),
-                        MouseStateHandle::default(),
-                        None,
+                        LoginWaitingParams {
+                            browser_url: url,
+                            login_mouse: MouseStateHandle::default(),
+                            copy_mouse: MouseStateHandle::default(),
+                            copy_feedback: None,
+                        },
                         app_ctx,
                         |_, _| {},
                         |_, _| {},

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -54,10 +54,7 @@ fn waiting_login_renders_copy_feedback() {
             let browser_url =
                 "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli";
             for (message, tone) in [
-                (
-                    "Login URL copied to clipboard",
-                    TransientHintTone::Success,
-                ),
+                ("Login URL copied to clipboard", TransientHintTone::Success),
                 ("Unable to copy login URL", TransientHintTone::Error),
             ] {
                 let mut presenter = TuiPresenter::new();

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -20,6 +20,7 @@ use super::{
     compact_footer_path, conversation_restoring, horizontally_centered, login_waiting,
     signed_out_welcome,
 };
+use crate::transient_hint::TransientHintTone;
 use crate::zero_state_animation::ZeroStateAnimationConfig;
 
 #[test]
@@ -41,6 +42,46 @@ fn horizontally_centered_balances_available_space() {
             let left = line.find("center").expect("centered text renders");
             let right = 20 - left - "center".len();
             assert!(left.abs_diff(right) <= 1, "{line:?}");
+        });
+    });
+}
+
+#[test]
+fn waiting_login_renders_copy_feedback() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let browser_url =
+                "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli";
+            for (message, tone) in [
+                (
+                    "Login URL copied to clipboard",
+                    TransientHintTone::Success,
+                ),
+                ("Unable to copy login URL", TransientHintTone::Error),
+            ] {
+                let mut presenter = TuiPresenter::new();
+                let frame = presenter.present_element(
+                    login_waiting(
+                        AnimationClock::starting_at(Duration::ZERO),
+                        Arc::new(ZeroStateAnimationConfig::default()),
+                        Some(browser_url),
+                        MouseStateHandle::default(),
+                        MouseStateHandle::default(),
+                        Some((message, tone)),
+                        app_ctx,
+                        |_, _| {},
+                        |_, _| {},
+                    ),
+                    TuiRect::new(0, 0, 80, 24),
+                    app_ctx,
+                );
+                let lines = frame.buffer.to_lines();
+                assert!(
+                    lines.iter().any(|line| line.contains(message)),
+                    "waiting state should render copy feedback: {lines:?}"
+                );
+            }
         });
     });
 }
@@ -157,8 +198,11 @@ fn waiting_login_generated_url_handles_click() {
                 Arc::new(ZeroStateAnimationConfig::default()),
                 Some(browser_url),
                 MouseStateHandle::default(),
+                MouseStateHandle::default(),
+                None,
                 app_ctx,
                 move |_, _| activated_for_click.set(true),
+                |_, _| {},
             );
             let area = TuiRect::new(0, 0, 80, 24);
             let mut rendered_views = EntityIdMap::default();
@@ -209,6 +253,85 @@ fn waiting_login_generated_url_handles_click() {
 }
 
 #[test]
+fn waiting_login_copy_control_handles_click_and_key() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let copy_count = Rc::new(Cell::new(0));
+            let copy_count_for_action = copy_count.clone();
+            let browser_url =
+                "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli";
+            let mut element = login_waiting(
+                AnimationClock::starting_at(Duration::ZERO),
+                Arc::new(ZeroStateAnimationConfig::default()),
+                Some(browser_url),
+                MouseStateHandle::default(),
+                MouseStateHandle::default(),
+                None,
+                app_ctx,
+                |_, _| {},
+                move |_, _| copy_count_for_action.set(copy_count_for_action.get() + 1),
+            );
+            let area = TuiRect::new(0, 0, 80, 24);
+            let mut rendered_views = EntityIdMap::default();
+            let mut layout_ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            element.layout(
+                TuiConstraint::tight(TuiSize::new(area.width, area.height)),
+                &mut layout_ctx,
+                app_ctx,
+            );
+            element.after_layout(&mut layout_ctx, app_ctx);
+            let mut buffer = TuiBuffer::empty(area);
+            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+            {
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+            }
+            let lines = buffer.to_lines();
+            let row = lines
+                .iter()
+                .position(|line| line.contains("Copy URL (c)"))
+                .expect("copy control renders") as u16;
+            let col = lines[usize::from(row)]
+                .find("Copy URL (c)")
+                .expect("copy control offset") as u16;
+            let scene = Rc::new(paint_ctx.scene.clone());
+            drop(paint_ctx);
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+            event_ctx.set_origin_view(Some(EntityId::new()));
+            for event in [
+                TuiEvent::LeftMouseDown {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                    click_count: 1,
+                    is_first_mouse: false,
+                },
+                TuiEvent::LeftMouseUp {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                },
+            ] {
+                assert!(element.dispatch_event(&event, &mut event_ctx, app_ctx));
+            }
+            assert_eq!(copy_count.get(), 1);
+
+            let copy_key = TuiEvent::KeyDown {
+                keystroke: Keystroke {
+                    key: "c".to_owned(),
+                    ..Default::default()
+                },
+                chars: String::new(),
+                details: Default::default(),
+                is_composing: false,
+            };
+            assert!(element.dispatch_event(&copy_key, &mut event_ctx, app_ctx));
+            assert_eq!(copy_count.get(), 2);
+        });
+    });
+}
+#[test]
 fn signed_out_welcome_handles_enter() {
     App::test((), |app| async move {
         app.add_singleton_model(|_| Appearance::mock());
@@ -258,7 +381,10 @@ fn waiting_login_renders_actual_browser_url_and_requesting_fallback() {
                         Arc::new(ZeroStateAnimationConfig::default()),
                         url,
                         MouseStateHandle::default(),
+                        MouseStateHandle::default(),
+                        None,
                         app_ctx,
+                        |_, _| {},
                         |_, _| {},
                     ),
                     TuiRect::new(0, 0, 80, 24),
@@ -273,6 +399,10 @@ fn waiting_login_renders_actual_browser_url_and_requesting_fallback() {
                 );
                 if url.is_some() {
                     assert!(
+                        lines.iter().any(|line| line.contains("Copy URL (c)")),
+                        "waiting state should render the copy control: {lines:?}"
+                    );
+                    assert!(
                         lines.iter().any(|line| {
                             line.contains("https://app.warp.dev/device?user_code=ABCD-EF")
                         }),
@@ -285,6 +415,10 @@ fn waiting_login_renders_actual_browser_url_and_requesting_fallback() {
                         "waiting state should render the rest of the real URL: {lines:?}"
                     );
                 } else {
+                    assert!(
+                        lines.iter().all(|line| !line.contains("Copy URL (c)")),
+                        "requesting state must not render the copy control: {lines:?}"
+                    );
                     assert!(
                         lines
                             .iter()

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -1,11 +1,26 @@
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
 use warp::appearance::Appearance;
-use warpui_core::App;
-use warpui_core::elements::tui::{TuiBufferExt, TuiElement, TuiRect, TuiText};
+use warpui_core::elements::MouseStateHandle;
+use warpui_core::elements::animation::AnimationClock;
+use warpui_core::elements::tui::{
+    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize,
+    TuiText,
+};
+use warpui_core::event::ModifiersState;
+use warpui_core::keymap::Keystroke;
 use warpui_core::presenter::tui::TuiPresenter;
+use warpui_core::{App, EntityId, EntityIdMap};
 
 use super::{
-    compact_footer_path, conversation_restoring, horizontally_centered, login_placeholder,
+    compact_footer_path, conversation_restoring, horizontally_centered, login_waiting,
+    signed_out_welcome,
 };
+use crate::zero_state_animation::ZeroStateAnimationConfig;
 
 #[test]
 fn compact_footer_path_preserves_short_paths() {
@@ -74,86 +89,207 @@ fn conversation_loader_is_centered_and_animated() {
 }
 
 #[test]
-fn login_placeholder_is_centered_for_all_states() {
-    const VIEWPORT_COLS: usize = 60;
-    const VIEWPORT_ROWS: usize = 8;
-
+fn signed_out_welcome_matches_designed_copy_and_layout() {
     App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
         app.read(|app_ctx| {
-            // Every line the placeholder renders for each login substate, so
-            // per-line centering is checked — not just the longest line. The
-            // shorter lines (e.g. the URI-only and URI+code substates' "Sign in
-            // to continue" and "and enter code" lines) are the ones a
-            // start-aligned column leaves flush with the block's left edge.
-            let states: Vec<(Option<&str>, Option<&str>, Vec<&str>)> = vec![
-                (
-                    None,
-                    None,
-                    vec!["Sign in to continue", "Requesting a sign-in link…"],
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                signed_out_welcome(
+                    AnimationClock::starting_at(Duration::ZERO),
+                    Arc::new(ZeroStateAnimationConfig::default()),
+                    app_ctx,
+                    |_, _| {},
                 ),
-                (
-                    Some("https://warp.dev/device"),
-                    None,
-                    vec![
-                        "Sign in to continue",
-                        "Open https://warp.dev/device in your browser",
-                    ],
-                ),
-                (
-                    Some("https://warp.dev/device"),
-                    Some("ABC-123"),
-                    vec![
-                        "Sign in to continue",
-                        "Open https://warp.dev/device in your browser",
-                        "and enter code: ABC-123",
-                    ],
-                ),
-            ];
+                TuiRect::new(0, 0, 80, 24),
+                app_ctx,
+            );
+            let lines = frame.buffer.to_lines();
 
-            for (verification_uri, user_code, expected_lines) in states {
-                let element = login_placeholder(verification_uri, user_code);
+            for expected in [
+                "Welcome to Warp",
+                "> Press enter to get started",
+                "What’s different about Warp",
+                "Prompts or shell commands autodetected",
+                "Set up custom model routers",
+                "Orchestrate fleets of agents",
+                "Run full-screen terminal apps",
+                "Persist sessions through state changes",
+            ] {
+                assert!(
+                    lines.iter().any(|line| line.contains(expected)),
+                    "welcome should render {expected:?}: {lines:?}"
+                );
+            }
+            let title_row = lines
+                .iter()
+                .position(|line| line.contains("Welcome to Warp"))
+                .expect("welcome title renders");
+            assert!(title_row > 0 && title_row < 12);
+            assert_eq!(
+                lines[title_row]
+                    .find("Welcome to Warp")
+                    .expect("welcome title offset"),
+                3
+            );
+            assert!(frame.repaint_at.is_some());
+            assert!(
+                lines
+                    .iter()
+                    .all(|line| !line.contains("https://app.warp.dev/login")),
+                "welcome must not render a URL before device authorization: {lines:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn waiting_login_generated_url_handles_click() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let activated = Rc::new(Cell::new(false));
+            let activated_for_click = activated.clone();
+            let browser_url =
+                "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli";
+            let mut element = login_waiting(
+                AnimationClock::starting_at(Duration::ZERO),
+                Arc::new(ZeroStateAnimationConfig::default()),
+                Some(browser_url),
+                MouseStateHandle::default(),
+                app_ctx,
+                move |_, _| activated_for_click.set(true),
+            );
+            let area = TuiRect::new(0, 0, 80, 24);
+            let mut rendered_views = EntityIdMap::default();
+            let mut layout_ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            element.layout(
+                TuiConstraint::tight(TuiSize::new(area.width, area.height)),
+                &mut layout_ctx,
+                app_ctx,
+            );
+            element.after_layout(&mut layout_ctx, app_ctx);
+            let mut buffer = TuiBuffer::empty(area);
+            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+            {
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+            }
+            let lines = buffer.to_lines();
+            let row = lines
+                .iter()
+                .position(|line| line.contains("https://app.warp.dev/device?user_code="))
+                .expect("generated URL renders") as u16;
+            let col = lines[usize::from(row)]
+                .find("https://app.warp.dev/device?user_code=")
+                .expect("generated URL offset") as u16;
+            let scene = Rc::new(paint_ctx.scene.clone());
+            drop(paint_ctx);
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+            event_ctx.set_origin_view(Some(EntityId::new()));
+            for event in [
+                TuiEvent::LeftMouseDown {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                    click_count: 1,
+                    is_first_mouse: false,
+                },
+                TuiEvent::LeftMouseUp {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                },
+            ] {
+                assert!(element.dispatch_event(&event, &mut event_ctx, app_ctx));
+            }
+            assert!(activated.get());
+        });
+    });
+}
+
+#[test]
+fn signed_out_welcome_handles_enter() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let activated = Rc::new(Cell::new(false));
+            let activated_for_enter = activated.clone();
+            let mut element = signed_out_welcome(
+                AnimationClock::starting_at(Duration::ZERO),
+                Arc::new(ZeroStateAnimationConfig::default()),
+                app_ctx,
+                move |_, _| activated_for_enter.set(true),
+            );
+            let mut rendered_views = EntityIdMap::default();
+            let scene = Rc::new(Default::default());
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+            event_ctx.set_origin_view(Some(EntityId::new()));
+            let key_down = |key: &str| TuiEvent::KeyDown {
+                keystroke: Keystroke {
+                    key: key.to_owned(),
+                    ..Default::default()
+                },
+                chars: String::new(),
+                details: Default::default(),
+                is_composing: false,
+            };
+
+            assert!(!element.dispatch_event(&key_down("a"), &mut event_ctx, app_ctx));
+            assert!(!activated.get());
+            assert!(element.dispatch_event(&key_down("enter"), &mut event_ctx, app_ctx));
+            assert!(activated.get());
+        });
+    });
+}
+
+#[test]
+fn waiting_login_renders_actual_browser_url_and_requesting_fallback() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let browser_url =
+                "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli";
+            for url in [Some(browser_url), None] {
                 let mut presenter = TuiPresenter::new();
                 let frame = presenter.present_element(
-                    element,
-                    TuiRect::new(0, 0, VIEWPORT_COLS as u16, VIEWPORT_ROWS as u16),
+                    login_waiting(
+                        AnimationClock::starting_at(Duration::ZERO),
+                        Arc::new(ZeroStateAnimationConfig::default()),
+                        url,
+                        MouseStateHandle::default(),
+                        app_ctx,
+                        |_, _| {},
+                    ),
+                    TuiRect::new(0, 0, 80, 24),
                     app_ctx,
                 );
                 let lines = frame.buffer.to_lines();
-
-                for expected_line in expected_lines {
-                    let row = lines
+                assert!(
+                    lines
                         .iter()
-                        .position(|line| line.contains(expected_line))
-                        .unwrap_or_else(|| {
-                            panic!("login state should render {expected_line:?}: {lines:?}")
-                        });
-                    let rendered_line = &lines[row];
-                    let left = rendered_line
-                        .find(expected_line)
-                        .map(|byte_offset| rendered_line[..byte_offset].chars().count())
-                        .unwrap_or_else(|| {
-                            panic!("expected login text should be present: {rendered_line:?}")
-                        });
-                    let text_width = expected_line.chars().count();
-                    let right = VIEWPORT_COLS
-                        .saturating_sub(left)
-                        .saturating_sub(text_width);
-
-                    // Centered means symmetric horizontal padding: the blank
-                    // columns on either side of the text differ by at most one
-                    // cell (the flex layout's integer-division slack). A
-                    // start-aligned column leaves shorter lines flush with the
-                    // block's left edge, producing lopsided padding, so this
-                    // catches the per-line centering the ticket requires.
+                        .any(|line| line.contains("Waiting for login...")),
+                    "{lines:?}"
+                );
+                if url.is_some() {
                     assert!(
-                        left.abs_diff(right) <= 1,
-                        "{expected_line:?} should be horizontally centered with symmetric padding \
-                         (left={left}, right={right}, width={text_width}, viewport={VIEWPORT_COLS}): \
-                         {rendered_line:?}"
+                        lines.iter().any(|line| {
+                            line.contains("https://app.warp.dev/device?user_code=ABCD-EF")
+                        }),
+                        "waiting state should render the start of the real URL: {lines:?}"
                     );
                     assert!(
-                        row > 0 && row < VIEWPORT_ROWS,
-                        "{expected_line:?} should remain vertically centered: row={row}, lines={lines:?}"
+                        lines
+                            .iter()
+                            .any(|line| line.contains("GH&source=warp-agent-cli")),
+                        "waiting state should render the rest of the real URL: {lines:?}"
+                    );
+                } else {
+                    assert!(
+                        lines
+                            .iter()
+                            .any(|line| line.contains("Requesting a secure sign-in link...")),
+                        "{lines:?}"
                     );
                 }
             }


### PR DESCRIPTION
## Description

Restores a complete authentication path after `/logout` in the headless TUI.

- Shows an explicit signed-out welcome state and starts device authorization only after user input.
- Starts fresh device authorization after local logout, then opens a validated `/logout?continue=…` browser URL so the prior web session is cleared first.
- Keeps the exact browser URL visible as a manual fallback and returns to the authenticated TUI without requiring a restart.
- Validates the device continuation as same-origin, exact-path, and CLI-sourced before passing it to the browser.

This is the client half of the auth-return handshake; the browser implementation is in warpdotdev/warp-server#13620.

## Linked Issue

None.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Manual end-to-end verification is documented below.

## Testing

https://www.loom.com/share/2c6d09cb0d0c41658e5a97514f8f347b

- [x] `./script/format --check`
- [x] `./script/check_no_inline_test_modules`
- [x] Presubmit workspace Clippy, default `warp` Clippy, and `warp_completer` Clippy with warnings denied
- [x] `cargo nextest run -p warp_tui` (906/906 tests passed)
- [x] Full terminal verification: signed-out welcome, unrelated input ignored, Enter starts device auth, wrapped logout continuation opens, browser completion returns to the authenticated TUI
- [ ] I have manually tested my changes locally with `./script/run`

The changed surface is the headless TUI, so manual verification used the real TUI in a full terminal rather than the GUI `./script/run` path.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)