### PR TITLE
TUI: Gate terminal startup on browser authentication

### DIFF
--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -76,9 +76,57 @@ impl TuiLoginModel {
     pub fn start_device_login(ctx: &mut AppContext) {
         start_tui_device_login(ctx);
     }
-    /// Retries opening the exact URL retained after an automatic launch failure.
-    pub fn retry_open_login_url(browser_url: &str, ctx: &mut AppContext) {
-        retry_open_login_url(browser_url, ctx);
+
+    /// Opens the current device-authorization URL.
+    pub fn open_login_url(browser_url: &str, ctx: &mut AppContext) {
+        let is_current_url = matches!(
+            TuiLoginModel::as_ref(ctx).phase(),
+            TuiLoginPhase::AwaitingLogin {
+                browser_url: Some(current_url),
+            } if current_url == browser_url
+        ) || matches!(
+            TuiLoginModel::as_ref(ctx).phase(),
+            TuiLoginPhase::BrowserOpenFailed {
+                browser_url: current_url,
+            } if current_url == browser_url
+        );
+        if !is_current_url {
+            return;
+        }
+
+        let retrying_after_failure = matches!(
+            TuiLoginModel::as_ref(ctx).phase(),
+            TuiLoginPhase::BrowserOpenFailed { .. }
+        );
+        if !ctx.try_open_url(browser_url) {
+            TuiLoginModel::handle(ctx).update(ctx, |model, _| {
+                if model.browser_flow == TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationOpened {
+                    model.browser_flow = TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending;
+                }
+            });
+            set_login_phase(
+                ctx,
+                TuiLoginPhase::BrowserOpenFailed {
+                    browser_url: browser_url.to_owned(),
+                },
+            );
+            log::warn!("Unable to open the device authorization URL in the default browser");
+            return;
+        }
+
+        TuiLoginModel::handle(ctx).update(ctx, |model, _| {
+            if model.browser_flow == TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending {
+                model.browser_flow = TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationOpened;
+            }
+        });
+        if retrying_after_failure {
+            set_login_phase(
+                ctx,
+                TuiLoginPhase::AwaitingLogin {
+                    browser_url: Some(browser_url.to_owned()),
+                },
+            );
+        }
     }
 
     #[cfg(any(test, feature = "test-util"))]
@@ -181,31 +229,31 @@ fn handle_auth_manager_event(event: &AuthManagerEvent, ctx: &mut AppContext) {
                     browser_url: Some(url_to_open.clone()),
                 },
             );
-            let browser_opened = ctx.try_open_url(&url_to_open);
-            handle_browser_launch_result(url_to_open, browser_opened, ctx);
-            if !browser_opened {
-                log::warn!("Unable to open the device authorization URL in the default browser");
-            }
+            TuiLoginModel::open_login_url(&url_to_open, ctx);
         }
         AuthManagerEvent::AuthComplete => {
             set_login_phase(ctx, TuiLoginPhase::LoggedIn);
             activate_global_mcp_servers(ctx);
         }
         AuthManagerEvent::AuthFailed(err) => {
-            let should_finish_web_logout = TuiLoginModel::handle(ctx).update(ctx, |model, _| {
-                let should_finish_web_logout = matches!(
-                    model.browser_flow,
-                    TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending
-                );
-                model.browser_flow = TuiAuthBrowserFlow::DirectDeviceAuthorization;
-                should_finish_web_logout
-            });
-            if should_finish_web_logout {
+            let should_finish_web_logout = matches!(
+                TuiLoginModel::as_ref(ctx).browser_flow,
+                TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending
+            );
+            let browser_flow = if should_finish_web_logout {
                 let logout_url = auth::web_logout_url();
-                if !ctx.try_open_url(&logout_url) {
+                if ctx.try_open_url(&logout_url) {
+                    TuiAuthBrowserFlow::DirectDeviceAuthorization
+                } else {
                     log::warn!("Unable to open the logout URL in the default browser");
+                    TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending
                 }
-            }
+            } else {
+                TuiAuthBrowserFlow::DirectDeviceAuthorization
+            };
+            TuiLoginModel::handle(ctx).update(ctx, |model, _| {
+                model.browser_flow = browser_flow;
+            });
             set_login_phase(
                 ctx,
                 TuiLoginPhase::Failed {
@@ -221,40 +269,6 @@ fn authorize_device(ctx: &mut AppContext) {
     AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
         auth_manager.authorize_device(ctx);
     });
-}
-
-fn handle_browser_launch_result(browser_url: String, browser_opened: bool, ctx: &mut AppContext) {
-    if !browser_opened {
-        set_login_phase(ctx, TuiLoginPhase::BrowserOpenFailed { browser_url });
-    }
-}
-
-fn retry_open_login_url(browser_url: &str, ctx: &mut AppContext) {
-    let is_current_url = matches!(
-        TuiLoginModel::as_ref(ctx).phase(),
-        TuiLoginPhase::AwaitingLogin {
-            browser_url: Some(current_url),
-        } if current_url == browser_url
-    ) || matches!(
-        TuiLoginModel::as_ref(ctx).phase(),
-        TuiLoginPhase::BrowserOpenFailed {
-            browser_url: current_url,
-        } if current_url == browser_url
-    );
-    if !is_current_url {
-        return;
-    }
-
-    if !ctx.try_open_url(browser_url) {
-        log::warn!("Unable to open the device authorization URL in the default browser");
-        return;
-    }
-    set_login_phase(
-        ctx,
-        TuiLoginPhase::AwaitingLogin {
-            browser_url: Some(browser_url.to_owned()),
-        },
-    );
 }
 
 fn tui_verification_url(verification_url: &str, user_code: &str) -> String {
@@ -320,17 +334,19 @@ fn activate_global_mcp_servers(ctx: &mut AppContext) {
     });
 }
 
-/// Starts a fresh direct device-authorization flow from a signed-out screen.
+/// Starts device authorization from a signed-out screen, preserving any required web logout.
 pub fn start_tui_device_login(ctx: &mut AppContext) {
     let should_authorize = TuiLoginModel::handle(ctx).update(ctx, |model, ctx| {
-        if !matches!(
-            model.phase,
-            TuiLoginPhase::SignedOutWelcome | TuiLoginPhase::Failed { .. }
-        ) {
-            return false;
+        match model.phase {
+            TuiLoginPhase::SignedOutWelcome => {
+                model.browser_flow = TuiAuthBrowserFlow::DirectDeviceAuthorization;
+            }
+            TuiLoginPhase::Failed { .. } => {}
+            TuiLoginPhase::AwaitingLogin { .. }
+            | TuiLoginPhase::BrowserOpenFailed { .. }
+            | TuiLoginPhase::LoggedIn => return false,
         }
         model.phase = TuiLoginPhase::AwaitingLogin { browser_url: None };
-        model.browser_flow = TuiAuthBrowserFlow::DirectDeviceAuthorization;
         ctx.notify();
         ctx.emit(TuiLoginEvent::PhaseChanged);
         true

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -3,8 +3,8 @@
 //! `warp_tui` boots the real headless Warp app via [`crate::run_tui`]. Once
 //! shared initialization is done, [`init`] registers the [`TuiLoginModel`] that
 //! the TUI observes, mounts the TUI immediately (so it renders right away), and
-//! leaves device authorization behind an explicit welcome-screen action,
-//! flipping the model to [`TuiLoginPhase::LoggedIn`] when it completes.
+//! leaves device authorization behind an explicit welcome-screen action. The
+//! authentication gate remains visible until the browser flow completes.
 mod mcp;
 mod user_info;
 use std::env;
@@ -35,7 +35,10 @@ pub enum TuiLoginPhase {
     /// exact URL opened in the browser is surfaced once known (the alt screen
     /// hides stdout, so it cannot be printed there).
     AwaitingLogin { browser_url: Option<String> },
-    /// Login failed; the placeholder shows the message so the user can quit.
+    /// The authorization URL could not be opened automatically. The exact URL
+    /// remains available for copy/retry.
+    BrowserOpenFailed { browser_url: String },
+    /// Login failed; the placeholder shows the message if no terminal is active.
     Failed { message: String },
     /// Authenticated — the input UI can be shown.
     LoggedIn,
@@ -69,15 +72,37 @@ impl TuiLoginModel {
     pub fn phase(&self) -> &TuiLoginPhase {
         &self.phase
     }
-    /// Starts device authorization from the signed-out welcome screen.
+    /// Starts or retries device authorization from a signed-out screen.
     pub fn start_device_login(ctx: &mut AppContext) {
         start_tui_device_login(ctx);
+    }
+    /// Retries opening the exact URL retained after an automatic launch failure.
+    pub fn retry_open_login_url(browser_url: &str, ctx: &mut AppContext) {
+        retry_open_login_url(browser_url, ctx);
     }
 
     #[cfg(any(test, feature = "test-util"))]
     pub fn signed_out_for_test() -> Self {
         Self {
             phase: TuiLoginPhase::SignedOutWelcome,
+            browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn failed_for_test(message: impl Into<String>) -> Self {
+        Self {
+            phase: TuiLoginPhase::Failed {
+                message: message.into(),
+            },
+            browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn awaiting_login_for_test(browser_url: Option<String>) -> Self {
+        Self {
+            phase: TuiLoginPhase::AwaitingLogin { browser_url },
             browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
         }
     }
@@ -113,8 +138,8 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
     ctx.subscribe_to_model(&AuthManager::handle(ctx), |_, event, ctx| {
         handle_auth_manager_event(event, ctx);
     });
-    // Mount the TUI now so it renders immediately; the root view shows the
-    // login placeholder until the model flips to `LoggedIn`.
+    // Mount the TUI now so it renders immediately; signed-out users see the
+    // welcome screen before explicitly starting browser authentication.
     mount(ctx);
 
     if logged_in {
@@ -156,7 +181,9 @@ fn handle_auth_manager_event(event: &AuthManagerEvent, ctx: &mut AppContext) {
                     browser_url: Some(url_to_open.clone()),
                 },
             );
-            if !ctx.try_open_url(&url_to_open) {
+            let browser_opened = ctx.try_open_url(&url_to_open);
+            handle_browser_launch_result(url_to_open, browser_opened, ctx);
+            if !browser_opened {
                 log::warn!("Unable to open the device authorization URL in the default browser");
             }
         }
@@ -195,6 +222,41 @@ fn authorize_device(ctx: &mut AppContext) {
         auth_manager.authorize_device(ctx);
     });
 }
+
+fn handle_browser_launch_result(browser_url: String, browser_opened: bool, ctx: &mut AppContext) {
+    if !browser_opened {
+        set_login_phase(ctx, TuiLoginPhase::BrowserOpenFailed { browser_url });
+    }
+}
+
+fn retry_open_login_url(browser_url: &str, ctx: &mut AppContext) {
+    let is_current_url = matches!(
+        TuiLoginModel::as_ref(ctx).phase(),
+        TuiLoginPhase::AwaitingLogin {
+            browser_url: Some(current_url),
+        } if current_url == browser_url
+    ) || matches!(
+        TuiLoginModel::as_ref(ctx).phase(),
+        TuiLoginPhase::BrowserOpenFailed {
+            browser_url: current_url,
+        } if current_url == browser_url
+    );
+    if !is_current_url {
+        return;
+    }
+
+    if !ctx.try_open_url(browser_url) {
+        log::warn!("Unable to open the device authorization URL in the default browser");
+        return;
+    }
+    set_login_phase(
+        ctx,
+        TuiLoginPhase::AwaitingLogin {
+            browser_url: Some(browser_url.to_owned()),
+        },
+    );
+}
+
 fn tui_verification_url(verification_url: &str, user_code: &str) -> String {
     let focus_url = env::var(FOCUS_URL_ENV).ok();
     tui_verification_url_with_return(verification_url, user_code, focus_url.as_deref())
@@ -258,10 +320,13 @@ fn activate_global_mcp_servers(ctx: &mut AppContext) {
     });
 }
 
-/// Starts a fresh direct device-authorization flow from the signed-out welcome screen.
+/// Starts a fresh direct device-authorization flow from a signed-out screen.
 pub fn start_tui_device_login(ctx: &mut AppContext) {
     let should_authorize = TuiLoginModel::handle(ctx).update(ctx, |model, ctx| {
-        if !matches!(model.phase, TuiLoginPhase::SignedOutWelcome) {
+        if !matches!(
+            model.phase,
+            TuiLoginPhase::SignedOutWelcome | TuiLoginPhase::Failed { .. }
+        ) {
             return false;
         }
         model.phase = TuiLoginPhase::AwaitingLogin { browser_url: None };

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -6,8 +6,8 @@ use warpui::{App, SingletonEntity};
 
 use super::{
     TuiAuthBrowserFlow, TuiLoginEvent, TuiLoginModel, TuiLoginPhase, handle_auth_manager_event,
-    handle_browser_launch_result, retry_open_login_url, set_logged_out_phase, set_login_phase,
-    start_tui_device_login, tui_verification_url_with_return, validated_tui_focus_url,
+    set_logged_out_phase, set_login_phase, start_tui_device_login,
+    tui_verification_url_with_return, validated_tui_focus_url,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
@@ -100,7 +100,7 @@ fn rejects_invalid_focus_urls() {
 }
 
 #[test]
-fn explicit_start_device_login_transitions_only_from_welcome() {
+fn explicit_start_device_login_preserves_pending_logout_on_retry() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| ServerApiProvider::new_for_test());
         app.add_singleton_model(|_| AuthStateProvider::new_for_test());
@@ -130,6 +130,26 @@ fn explicit_start_device_login_transitions_only_from_welcome() {
             assert!(matches!(
                 TuiLoginModel::as_ref(ctx).browser_flow,
                 TuiAuthBrowserFlow::DirectDeviceAuthorization
+            ));
+        });
+
+        app.update(|ctx| {
+            TuiLoginModel::handle(ctx).update(ctx, |model, _| {
+                model.phase = TuiLoginPhase::Failed {
+                    message: "Unable to open logout URL".to_owned(),
+                };
+                model.browser_flow = TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending;
+            });
+        });
+        app.update(start_tui_device_login);
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin { browser_url: None }
+            ));
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).browser_flow,
+                TuiAuthBrowserFlow::LogoutThenDeviceAuthorizationPending
             ));
         });
     });
@@ -173,51 +193,7 @@ fn stores_device_fallback_before_opening_browser() {
 }
 
 #[test]
-fn successful_browser_launch_keeps_auth_pending() {
-    App::test((), |mut app| async move {
-        app.add_singleton_model(|_| {
-            login_model(TuiLoginPhase::AwaitingLogin { browser_url: None })
-        });
-        app.update(|ctx| {
-            handle_browser_launch_result(
-                "https://app.warp.dev/device?user_code=ABCD-EFGH".to_owned(),
-                true,
-                ctx,
-            );
-        });
-
-        app.read(|ctx| {
-            assert!(matches!(
-                TuiLoginModel::as_ref(ctx).phase(),
-                TuiLoginPhase::AwaitingLogin { .. }
-            ));
-        });
-    });
-}
-
-#[test]
-fn failed_browser_launch_retains_exact_url_for_recovery() {
-    App::test((), |mut app| async move {
-        app.add_singleton_model(|_| {
-            login_model(TuiLoginPhase::AwaitingLogin { browser_url: None })
-        });
-        let browser_url =
-            "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli".to_owned();
-
-        app.update(|ctx| handle_browser_launch_result(browser_url.clone(), false, ctx));
-
-        app.read(|ctx| {
-            assert!(matches!(
-                TuiLoginModel::as_ref(ctx).phase(),
-                TuiLoginPhase::BrowserOpenFailed {
-                    browser_url: retained_url,
-                } if retained_url == &browser_url
-            ));
-        });
-    });
-}
-#[test]
-fn retry_uses_retained_url_and_keeps_auth_pending() {
+fn opens_only_the_current_retained_url() {
     App::test((), |mut app| async move {
         let browser_url =
             "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli".to_owned();
@@ -234,8 +210,8 @@ fn retry_uses_retained_url_and_keeps_auth_pending() {
                 browser_opened_for_callback.set(true);
                 url.to_owned()
             });
-            retry_open_login_url("https://example.com/wrong", ctx);
-            retry_open_login_url(&browser_url, ctx);
+            TuiLoginModel::open_login_url("https://example.com/wrong", ctx);
+            TuiLoginModel::open_login_url(&browser_url, ctx);
         });
 
         assert!(browser_opened.get());

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -6,8 +6,8 @@ use warpui::{App, SingletonEntity};
 
 use super::{
     TuiAuthBrowserFlow, TuiLoginEvent, TuiLoginModel, TuiLoginPhase, handle_auth_manager_event,
-    set_logged_out_phase, set_login_phase, start_tui_device_login,
-    tui_verification_url_with_return, validated_tui_focus_url,
+    handle_browser_launch_result, retry_open_login_url, set_logged_out_phase, set_login_phase,
+    start_tui_device_login, tui_verification_url_with_return, validated_tui_focus_url,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
@@ -173,6 +173,84 @@ fn stores_device_fallback_before_opening_browser() {
 }
 
 #[test]
+fn successful_browser_launch_keeps_auth_pending() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            login_model(TuiLoginPhase::AwaitingLogin { browser_url: None })
+        });
+        app.update(|ctx| {
+            handle_browser_launch_result(
+                "https://app.warp.dev/device?user_code=ABCD-EFGH".to_owned(),
+                true,
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin { .. }
+            ));
+        });
+    });
+}
+
+#[test]
+fn failed_browser_launch_retains_exact_url_for_recovery() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            login_model(TuiLoginPhase::AwaitingLogin { browser_url: None })
+        });
+        let browser_url =
+            "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli".to_owned();
+
+        app.update(|ctx| handle_browser_launch_result(browser_url.clone(), false, ctx));
+
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::BrowserOpenFailed {
+                    browser_url: retained_url,
+                } if retained_url == &browser_url
+            ));
+        });
+    });
+}
+#[test]
+fn retry_uses_retained_url_and_keeps_auth_pending() {
+    App::test((), |mut app| async move {
+        let browser_url =
+            "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli".to_owned();
+        app.add_singleton_model({
+            let browser_url = browser_url.clone();
+            move |_| login_model(TuiLoginPhase::BrowserOpenFailed { browser_url })
+        });
+        let browser_opened = Rc::new(Cell::new(false));
+        let browser_opened_for_callback = browser_opened.clone();
+        app.update(|ctx| {
+            let expected_url = browser_url.clone();
+            ctx.set_before_open_url(move |url, _| {
+                assert_eq!(url, expected_url);
+                browser_opened_for_callback.set(true);
+                url.to_owned()
+            });
+            retry_open_login_url("https://example.com/wrong", ctx);
+            retry_open_login_url(&browser_url, ctx);
+        });
+
+        assert!(browser_opened.get());
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin {
+                    browser_url: Some(current_url),
+                } if current_url == &browser_url
+            ));
+        });
+    });
+}
+
+#[test]
 fn post_logout_device_auth_opens_logout_with_device_continuation() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| TuiLoginModel {
@@ -245,7 +323,6 @@ fn renders_device_code_request_timeout_without_id_token_prefix() {
         });
     });
 }
-
 #[test]
 fn post_logout_device_code_failure_still_opens_web_logout() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -32,8 +32,8 @@ pub enum RootTuiAction {
     StartDeviceLogin,
     /// Starts device authorization and copies its exact URL once generated.
     StartDeviceLoginAndCopyUrl,
-    /// Retries the manual browser fallback shown after launch failure.
-    RetryOpenLoginUrl(String),
+    /// Opens the current device-authorization URL.
+    OpenLoginUrl(String),
     /// Copies the manual browser fallback shown while authorization is pending.
     CopyLoginUrl(String),
 }
@@ -89,14 +89,14 @@ impl RootTuiView {
 
     /// Transitions from the authentication gate to the live session container.
     pub(crate) fn show_terminal(&mut self, ctx: &mut ViewContext<Self>) {
-        self.copy_login_url_when_available = false;
+        self.reset_login_copy_state();
         self.state = RootTuiState::Terminal;
         ctx.notify();
     }
 
     /// Returns to the authentication gate after the current user logs out.
     pub(crate) fn show_auth(&mut self, ctx: &mut ViewContext<Self>) {
-        self.copy_login_url_when_available = false;
+        self.reset_login_copy_state();
         self.state = RootTuiState::Auth;
         ctx.focus_self();
         ctx.notify();
@@ -112,11 +112,12 @@ impl RootTuiView {
             .map(|session| session.view().clone())
     }
 
-    pub(crate) fn handle_login_phase_changed(&mut self, ctx: &mut ViewContext<Self>) {
-        self.handle_login_phase_changed_with(ctx, copy_to_clipboard);
+    fn reset_login_copy_state(&mut self) {
+        self.copy_login_url_when_available = false;
+        self.login_copy_hint.clear();
     }
 
-    fn handle_login_phase_changed_with(
+    pub(crate) fn handle_login_phase_changed(
         &mut self,
         ctx: &mut ViewContext<Self>,
         copy: impl FnOnce(&str) -> Result<()>,
@@ -235,7 +236,7 @@ impl TuiView for RootTuiView {
                         let browser_url = browser_url.clone();
                         move |event_ctx, _| {
                             if let Some(browser_url) = browser_url.clone() {
-                                event_ctx.dispatch_typed_action(RootTuiAction::RetryOpenLoginUrl(
+                                event_ctx.dispatch_typed_action(RootTuiAction::OpenLoginUrl(
                                     browser_url,
                                 ));
                             }
@@ -266,7 +267,7 @@ impl TuiView for RootTuiView {
                     {
                         let browser_url = browser_url.clone();
                         move |event_ctx, _| {
-                            event_ctx.dispatch_typed_action(RootTuiAction::RetryOpenLoginUrl(
+                            event_ctx.dispatch_typed_action(RootTuiAction::OpenLoginUrl(
                                 browser_url.clone(),
                             ));
                         }
@@ -321,7 +322,7 @@ impl TypedActionView for RootTuiView {
                     TuiLoginModel::as_ref(ctx).phase(),
                     TuiLoginPhase::SignedOutWelcome | TuiLoginPhase::Failed { .. }
                 ) {
-                    self.copy_login_url_when_available = false;
+                    self.reset_login_copy_state();
                     TuiLoginModel::start_device_login(ctx);
                 }
             }
@@ -330,12 +331,13 @@ impl TypedActionView for RootTuiView {
                     TuiLoginModel::as_ref(ctx).phase(),
                     TuiLoginPhase::SignedOutWelcome | TuiLoginPhase::Failed { .. }
                 ) {
+                    self.reset_login_copy_state();
                     self.copy_login_url_when_available = true;
                     TuiLoginModel::start_device_login(ctx);
                 }
             }
-            RootTuiAction::RetryOpenLoginUrl(url) => {
-                TuiLoginModel::retry_open_login_url(url, ctx);
+            RootTuiAction::OpenLoginUrl(url) => {
+                TuiLoginModel::open_login_url(url, ctx);
             }
             RootTuiAction::CopyLoginUrl(url) => {
                 self.copy_login_url_with(url, ctx, copy_to_clipboard);

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Result;
 use warp::{TuiLoginModel, TuiLoginPhase};
 use warpui::SingletonEntity as _;
 use warpui_core::elements::MouseStateHandle;
@@ -17,7 +18,8 @@ use crate::keybindings::TUI_BINDING_GROUP;
 use crate::session_registry::{TuiSessionView, TuiSessions};
 use crate::transient_hint::TransientHint;
 use crate::ui::{
-    LoginWaitingParams, login_failed, login_waiting, signed_out_welcome, terminal_starting,
+    LoginBrowserOpenFailedParams, LoginFailedParams, LoginWaitingParams, login_browser_open_failed,
+    login_failed, login_waiting, signed_out_welcome, terminal_starting,
 };
 use crate::zero_state_animation::ZeroStateAnimationConfig;
 
@@ -26,10 +28,12 @@ use crate::zero_state_animation::ZeroStateAnimationConfig;
 pub enum RootTuiAction {
     /// Exits the app while no terminal session is focused.
     ExitApp,
-    /// Starts browser device authorization from the signed-out welcome screen.
+    /// Starts or retries browser device authorization from a signed-out screen.
     StartDeviceLogin,
-    /// Opens the manual browser fallback shown while authorization is pending.
-    OpenLoginUrl(String),
+    /// Starts device authorization and copies its exact URL once generated.
+    StartDeviceLoginAndCopyUrl,
+    /// Retries the manual browser fallback shown after launch failure.
+    RetryOpenLoginUrl(String),
     /// Copies the manual browser fallback shown while authorization is pending.
     CopyLoginUrl(String),
 }
@@ -45,8 +49,13 @@ pub struct RootTuiView {
     state: RootTuiState,
     auth_animation_clock: AnimationClock,
     auth_animation_config: Arc<ZeroStateAnimationConfig>,
+    welcome_login_mouse: MouseStateHandle,
+    welcome_copy_mouse: MouseStateHandle,
     waiting_login_mouse: MouseStateHandle,
     waiting_login_copy_mouse: MouseStateHandle,
+    waiting_login_retry_mouse: MouseStateHandle,
+    failed_login_retry_mouse: MouseStateHandle,
+    copy_login_url_when_available: bool,
     login_copy_hint: TransientHint,
 }
 
@@ -67,20 +76,27 @@ impl RootTuiView {
             state: RootTuiState::Auth,
             auth_animation_clock: AnimationClock::starting_at(Duration::ZERO),
             auth_animation_config: Arc::new(ZeroStateAnimationConfig::default()),
+            welcome_login_mouse: MouseStateHandle::default(),
+            welcome_copy_mouse: MouseStateHandle::default(),
             waiting_login_mouse: MouseStateHandle::default(),
             waiting_login_copy_mouse: MouseStateHandle::default(),
+            waiting_login_retry_mouse: MouseStateHandle::default(),
+            failed_login_retry_mouse: MouseStateHandle::default(),
+            copy_login_url_when_available: false,
             login_copy_hint: TransientHint::default(),
         }
     }
 
     /// Transitions from the authentication gate to the live session container.
     pub(crate) fn show_terminal(&mut self, ctx: &mut ViewContext<Self>) {
+        self.copy_login_url_when_available = false;
         self.state = RootTuiState::Terminal;
         ctx.notify();
     }
 
     /// Returns to the authentication gate after the current user logs out.
     pub(crate) fn show_auth(&mut self, ctx: &mut ViewContext<Self>) {
+        self.copy_login_url_when_available = false;
         self.state = RootTuiState::Auth;
         ctx.focus_self();
         ctx.notify();
@@ -94,6 +110,78 @@ impl RootTuiView {
         TuiSessions::as_ref(ctx)
             .focused_session()
             .map(|session| session.view().clone())
+    }
+
+    pub(crate) fn handle_login_phase_changed(&mut self, ctx: &mut ViewContext<Self>) {
+        self.handle_login_phase_changed_with(ctx, copy_to_clipboard);
+    }
+
+    fn handle_login_phase_changed_with(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+        copy: impl FnOnce(&str) -> Result<()>,
+    ) {
+        if !self.copy_login_url_when_available {
+            ctx.notify();
+            return;
+        }
+
+        let browser_url = match TuiLoginModel::as_ref(ctx).phase() {
+            TuiLoginPhase::AwaitingLogin {
+                browser_url: Some(browser_url),
+            }
+            | TuiLoginPhase::BrowserOpenFailed { browser_url } => Some(browser_url.clone()),
+            TuiLoginPhase::AwaitingLogin { browser_url: None } => None,
+            TuiLoginPhase::SignedOutWelcome
+            | TuiLoginPhase::Failed { .. }
+            | TuiLoginPhase::LoggedIn => {
+                self.copy_login_url_when_available = false;
+                None
+            }
+        };
+        if let Some(browser_url) = browser_url {
+            self.copy_login_url_when_available = false;
+            self.copy_login_url_with(&browser_url, ctx, copy);
+        }
+        ctx.notify();
+    }
+
+    fn copy_login_url_with(
+        &mut self,
+        url: &str,
+        ctx: &mut ViewContext<Self>,
+        copy: impl FnOnce(&str) -> Result<()>,
+    ) {
+        let is_current_url = matches!(
+            TuiLoginModel::as_ref(ctx).phase(),
+            TuiLoginPhase::AwaitingLogin {
+                browser_url: Some(current_url),
+            } if current_url == url
+        ) || matches!(
+            TuiLoginModel::as_ref(ctx).phase(),
+            TuiLoginPhase::BrowserOpenFailed {
+                browser_url: current_url,
+            } if current_url == url
+        );
+        if !is_current_url {
+            return;
+        }
+
+        match copy(url) {
+            Ok(()) => self.login_copy_hint.show_success(
+                "Login URL copied to clipboard".to_owned(),
+                ctx,
+                |view| &mut view.login_copy_hint,
+            ),
+            Err(error) => {
+                log::warn!("Failed to copy TUI login URL: {error}");
+                self.login_copy_hint.show_error(
+                    "Unable to copy login URL".to_owned(),
+                    ctx,
+                    |view| &mut view.login_copy_hint,
+                );
+            }
+        }
     }
 }
 
@@ -122,9 +210,14 @@ impl TuiView for RootTuiView {
                 TuiLoginPhase::SignedOutWelcome => signed_out_welcome(
                     self.auth_animation_clock,
                     self.auth_animation_config.clone(),
+                    self.welcome_login_mouse.clone(),
+                    self.welcome_copy_mouse.clone(),
                     ctx,
                     |event_ctx, _| {
                         event_ctx.dispatch_typed_action(RootTuiAction::StartDeviceLogin);
+                    },
+                    |event_ctx, _| {
+                        event_ctx.dispatch_typed_action(RootTuiAction::StartDeviceLoginAndCopyUrl);
                     },
                 ),
                 TuiLoginPhase::LoggedIn => terminal_starting(),
@@ -142,7 +235,7 @@ impl TuiView for RootTuiView {
                         let browser_url = browser_url.clone();
                         move |event_ctx, _| {
                             if let Some(browser_url) = browser_url.clone() {
-                                event_ctx.dispatch_typed_action(RootTuiAction::OpenLoginUrl(
+                                event_ctx.dispatch_typed_action(RootTuiAction::RetryOpenLoginUrl(
                                     browser_url,
                                 ));
                             }
@@ -159,7 +252,46 @@ impl TuiView for RootTuiView {
                         }
                     },
                 ),
-                TuiLoginPhase::Failed { message } => login_failed(message.as_str()),
+                TuiLoginPhase::BrowserOpenFailed { browser_url } => login_browser_open_failed(
+                    self.auth_animation_clock,
+                    self.auth_animation_config.clone(),
+                    LoginBrowserOpenFailedParams {
+                        browser_url,
+                        login_mouse: self.waiting_login_mouse.clone(),
+                        copy_mouse: self.waiting_login_copy_mouse.clone(),
+                        retry_mouse: self.waiting_login_retry_mouse.clone(),
+                        copy_feedback: self.login_copy_hint.current(),
+                    },
+                    ctx,
+                    {
+                        let browser_url = browser_url.clone();
+                        move |event_ctx, _| {
+                            event_ctx.dispatch_typed_action(RootTuiAction::RetryOpenLoginUrl(
+                                browser_url.clone(),
+                            ));
+                        }
+                    },
+                    {
+                        let browser_url = browser_url.clone();
+                        move |event_ctx, _| {
+                            event_ctx.dispatch_typed_action(RootTuiAction::CopyLoginUrl(
+                                browser_url.clone(),
+                            ));
+                        }
+                    },
+                ),
+                TuiLoginPhase::Failed { message } => login_failed(
+                    self.auth_animation_clock,
+                    self.auth_animation_config.clone(),
+                    LoginFailedParams {
+                        message,
+                        retry_mouse: self.failed_login_retry_mouse.clone(),
+                    },
+                    ctx,
+                    |event_ctx, _| {
+                        event_ctx.dispatch_typed_action(RootTuiAction::StartDeviceLogin);
+                    },
+                ),
             },
             RootTuiState::Terminal => self
                 .focused_session_view(ctx)
@@ -187,38 +319,26 @@ impl TypedActionView for RootTuiView {
             RootTuiAction::StartDeviceLogin => {
                 if matches!(
                     TuiLoginModel::as_ref(ctx).phase(),
-                    TuiLoginPhase::SignedOutWelcome
+                    TuiLoginPhase::SignedOutWelcome | TuiLoginPhase::Failed { .. }
                 ) {
+                    self.copy_login_url_when_available = false;
                     TuiLoginModel::start_device_login(ctx);
                 }
             }
-            RootTuiAction::OpenLoginUrl(url) => ctx.open_url(url),
-            RootTuiAction::CopyLoginUrl(url) => {
-                let is_current_url = matches!(
+            RootTuiAction::StartDeviceLoginAndCopyUrl => {
+                if matches!(
                     TuiLoginModel::as_ref(ctx).phase(),
-                    TuiLoginPhase::AwaitingLogin {
-                        browser_url: Some(current_url),
-                    } if current_url == url
-                );
-                if !is_current_url {
-                    return;
+                    TuiLoginPhase::SignedOutWelcome | TuiLoginPhase::Failed { .. }
+                ) {
+                    self.copy_login_url_when_available = true;
+                    TuiLoginModel::start_device_login(ctx);
                 }
-
-                match copy_to_clipboard(url) {
-                    Ok(()) => self.login_copy_hint.show_success(
-                        "Login URL copied to clipboard".to_owned(),
-                        ctx,
-                        |view| &mut view.login_copy_hint,
-                    ),
-                    Err(error) => {
-                        log::warn!("Failed to copy TUI login URL: {error}");
-                        self.login_copy_hint.show_error(
-                            "Unable to copy login URL".to_owned(),
-                            ctx,
-                            |view| &mut view.login_copy_hint,
-                        );
-                    }
-                }
+            }
+            RootTuiAction::RetryOpenLoginUrl(url) => {
+                TuiLoginModel::retry_open_login_url(url, ctx);
+            }
+            RootTuiAction::CopyLoginUrl(url) => {
+                self.copy_login_url_with(url, ctx, copy_to_clipboard);
             }
         }
     }

--- a/crates/warp_tui/src/root_view_tests.rs
+++ b/crates/warp_tui/src/root_view_tests.rs
@@ -1,3 +1,7 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use anyhow::Result;
 use warp::tui_export::register_tui_session_view_test_singletons;
 use warp::{TuiLoginModel, TuiLoginPhase};
 use warpui::platform::WindowStyle;
@@ -19,6 +23,122 @@ fn add_root(app: &mut App) -> (WindowId, warpui_core::ViewHandle<RootTuiView>) {
             |_| RootTuiView::new(),
         )
     })
+}
+#[test]
+fn start_device_login_action_retries_from_failure() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        app.add_singleton_model(|_| {
+            TuiLoginModel::failed_for_test("Failed to generate device code")
+        });
+        let (_, root) = add_root(&mut app);
+
+        root.update(&mut app, |root, ctx| {
+            root.handle_action(&RootTuiAction::StartDeviceLogin, ctx);
+        });
+
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin { browser_url: None }
+            ));
+            assert!(!root.as_ref(ctx).copy_login_url_when_available);
+        });
+    });
+}
+#[test]
+fn pending_copy_clears_on_failure_before_url_generation() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        app.add_singleton_model(|_| {
+            TuiLoginModel::failed_for_test("Failed to generate device code")
+        });
+        let (_, root) = add_root(&mut app);
+
+        root.update(&mut app, |root, ctx| {
+            root.copy_login_url_when_available = true;
+            root.handle_login_phase_changed_with(ctx, |_| -> Result<()> {
+                panic!("failure has no URL to copy")
+            });
+        });
+        app.read(|ctx| {
+            assert!(!root.as_ref(ctx).copy_login_url_when_available);
+        });
+    });
+}
+
+#[test]
+fn start_and_copy_action_waits_for_generated_url() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        app.add_singleton_model(|_| TuiLoginModel::signed_out_for_test());
+        let (_, root) = add_root(&mut app);
+
+        root.update(&mut app, |root, ctx| {
+            root.handle_action(&RootTuiAction::StartDeviceLoginAndCopyUrl, ctx);
+        });
+
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::AwaitingLogin { browser_url: None }
+            ));
+            assert!(root.as_ref(ctx).copy_login_url_when_available);
+        });
+    });
+}
+
+#[test]
+fn pending_copy_consumes_exact_generated_url_once() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        let browser_url =
+            "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli".to_owned();
+        app.add_singleton_model({
+            let browser_url = browser_url.clone();
+            move |_| TuiLoginModel::awaiting_login_for_test(Some(browser_url))
+        });
+        let (_, root) = add_root(&mut app);
+        let copied = Rc::new(RefCell::new(None));
+        let copied_for_action = copied.clone();
+
+        root.update(&mut app, |root, ctx| {
+            root.copy_login_url_when_available = true;
+            root.handle_login_phase_changed_with(ctx, move |url| {
+                copied_for_action.replace(Some(url.to_owned()));
+                Ok(())
+            });
+        });
+
+        assert_eq!(copied.borrow().as_deref(), Some(browser_url.as_str()));
+        app.read(|ctx| {
+            assert!(!root.as_ref(ctx).copy_login_url_when_available);
+        });
+        root.update(&mut app, |root, ctx| {
+            root.handle_login_phase_changed_with(ctx, |_| -> Result<()> {
+                panic!("generated URL must only be copied once")
+            });
+        });
+    });
+}
+
+#[test]
+fn pending_copy_waits_without_url() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        app.add_singleton_model(|_| TuiLoginModel::awaiting_login_for_test(None));
+        let (_, root) = add_root(&mut app);
+
+        root.update(&mut app, |root, ctx| {
+            root.copy_login_url_when_available = true;
+            root.handle_login_phase_changed_with(ctx, |_| -> Result<()> {
+                panic!("copy must wait until an exact URL exists")
+            });
+        });
+        app.read(|ctx| {
+            assert!(root.as_ref(ctx).copy_login_url_when_available);
+        });
+    });
 }
 
 #[test]

--- a/crates/warp_tui/src/root_view_tests.rs
+++ b/crates/warp_tui/src/root_view_tests.rs
@@ -34,6 +34,11 @@ fn start_device_login_action_retries_from_failure() {
         let (_, root) = add_root(&mut app);
 
         root.update(&mut app, |root, ctx| {
+            root.login_copy_hint.show_success(
+                "Login URL copied to clipboard".to_owned(),
+                ctx,
+                |view| &mut view.login_copy_hint,
+            );
             root.handle_action(&RootTuiAction::StartDeviceLogin, ctx);
         });
 
@@ -43,6 +48,7 @@ fn start_device_login_action_retries_from_failure() {
                 TuiLoginPhase::AwaitingLogin { browser_url: None }
             ));
             assert!(!root.as_ref(ctx).copy_login_url_when_available);
+            assert!(root.as_ref(ctx).login_copy_hint.current().is_none());
         });
     });
 }
@@ -57,7 +63,7 @@ fn pending_copy_clears_on_failure_before_url_generation() {
 
         root.update(&mut app, |root, ctx| {
             root.copy_login_url_when_available = true;
-            root.handle_login_phase_changed_with(ctx, |_| -> Result<()> {
+            root.handle_login_phase_changed(ctx, |_| -> Result<()> {
                 panic!("failure has no URL to copy")
             });
         });
@@ -104,7 +110,7 @@ fn pending_copy_consumes_exact_generated_url_once() {
 
         root.update(&mut app, |root, ctx| {
             root.copy_login_url_when_available = true;
-            root.handle_login_phase_changed_with(ctx, move |url| {
+            root.handle_login_phase_changed(ctx, move |url| {
                 copied_for_action.replace(Some(url.to_owned()));
                 Ok(())
             });
@@ -115,7 +121,7 @@ fn pending_copy_consumes_exact_generated_url_once() {
             assert!(!root.as_ref(ctx).copy_login_url_when_available);
         });
         root.update(&mut app, |root, ctx| {
-            root.handle_login_phase_changed_with(ctx, |_| -> Result<()> {
+            root.handle_login_phase_changed(ctx, |_| -> Result<()> {
                 panic!("generated URL must only be copied once")
             });
         });
@@ -131,7 +137,7 @@ fn pending_copy_waits_without_url() {
 
         root.update(&mut app, |root, ctx| {
             root.copy_login_url_when_available = true;
-            root.handle_login_phase_changed_with(ctx, |_| -> Result<()> {
+            root.handle_login_phase_changed(ctx, |_| -> Result<()> {
                 panic!("copy must wait until an exact URL exists")
             });
         });

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -2,7 +2,8 @@
 //!
 //! [`run`] boots the real headless Warp app via [`warp::run_tui`]. Once shared
 //! initialization is done, the mount built here starts the TUI driver and
-//! defers creating the first terminal session until login.
+//! creates the first terminal session once browser authentication starts, while
+//! allowing authentication to complete in the background.
 
 use std::io::{self, IsTerminal as _, Read as _};
 
@@ -286,10 +287,12 @@ fn init(
             let login_model = TuiLoginModel::handle(ctx);
             ctx.subscribe_to_model(&login_model, move |_, event, ctx| match event {
                 TuiLoginEvent::PhaseChanged => {
-                    root_for_login.update(ctx, |_, ctx| ctx.notify());
+                    root_for_login.update(ctx, |root, ctx| {
+                        root.handle_login_phase_changed(ctx);
+                    });
                 }
                 TuiLoginEvent::LoggedIn => {
-                    create_terminal_session_after_login(&sessions_for_login, &root_for_login, ctx)
+                    ensure_terminal_session(&sessions_for_login, &root_for_login, ctx)
                 }
                 TuiLoginEvent::LoggedOut => {
                     root_for_login.update(ctx, |root, ctx| root.show_auth(ctx));
@@ -298,7 +301,7 @@ fn init(
             });
             if matches!(TuiLoginModel::as_ref(ctx).phase(), TuiLoginPhase::LoggedIn) {
                 // Already authenticated at mount: create the first session now.
-                create_terminal_session_after_login(&sessions, &root, ctx);
+                ensure_terminal_session(&sessions, &root, ctx);
             }
         }
         Err(error) => {
@@ -310,7 +313,7 @@ fn init(
 }
 
 /// Creates the focused bootstrap session and restores the requested conversation.
-fn create_terminal_session_after_login(
+fn ensure_terminal_session(
     sessions: &ModelHandle<TuiSessions>,
     root: &ViewHandle<RootTuiView>,
     ctx: &mut AppContext,

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -24,6 +24,7 @@ use warpui_core::platform::{TerminationMode, WindowStyle};
 use warpui_core::runtime::spawn_tui_driver;
 use warpui_core::{AddWindowOptions, AppContext, ModelHandle, ViewHandle};
 
+use crate::clipboard::copy_to_clipboard;
 use crate::orchestration_model::TuiOrchestrationModel;
 use crate::resume::TuiExitSummaryHandle;
 use crate::root_view::RootTuiView;
@@ -288,7 +289,7 @@ fn init(
             ctx.subscribe_to_model(&login_model, move |_, event, ctx| match event {
                 TuiLoginEvent::PhaseChanged => {
                     root_for_login.update(ctx, |root, ctx| {
-                        root.handle_login_phase_changed(ctx);
+                        root.handle_login_phase_changed(ctx, copy_to_clipboard);
                     });
                 }
                 TuiLoginEvent::LoggedIn => {

--- a/crates/warp_tui/src/session_tests.rs
+++ b/crates/warp_tui/src/session_tests.rs
@@ -1,7 +1,14 @@
 use ai::LLMProvider;
 use clap::Parser;
+use warp::tui_export::register_tui_session_view_test_singletons;
+use warpui::platform::WindowStyle;
+use warpui::{AddWindowOptions, SingletonEntity};
+use warpui_core::App;
 
-use super::{TuiArgs, parse_resume_token};
+use super::{TuiArgs, ensure_terminal_session, parse_resume_token};
+use crate::root_view::RootTuiView;
+use crate::session_registry::TuiSessions;
+use crate::test_fixtures::{add_test_semantic_selection, add_test_terminal_session};
 
 #[test]
 fn parses_provider_api_key_setup_flag() {
@@ -76,6 +83,33 @@ fn parses_resume_server_token() {
             .as_str(),
         token
     );
+}
+
+#[test]
+fn terminal_bootstrap_is_idempotent_after_background_terminal_exists() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        add_test_semantic_selection(&mut app);
+        app.update(crate::autoupdate::TuiAutoupdater::register);
+        let (window_id, root) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |_| RootTuiView::new(),
+            )
+        });
+        let sessions = app.add_singleton_model(|_| TuiSessions::new_for_test());
+        let (surface, manager) = add_test_terminal_session(&mut app, window_id);
+        app.update(|ctx| {
+            TuiSessions::register_session(&sessions, surface, manager, true, ctx);
+            ensure_terminal_session(&sessions, &root, ctx);
+            ensure_terminal_session(&sessions, &root, ctx);
+        });
+
+        app.read(|ctx| assert_eq!(TuiSessions::as_ref(ctx).len(), 1));
+    });
 }
 
 #[test]

--- a/crates/warp_tui/src/transient_hint.rs
+++ b/crates/warp_tui/src/transient_hint.rs
@@ -102,6 +102,14 @@ impl TransientHint {
         }
     }
 
+    /// Clears the current notice and cancels its pending expiry.
+    pub(crate) fn clear(&mut self) {
+        self.content = None;
+        if let Some(timer) = self.timer.take() {
+            timer.abort();
+        }
+    }
+
     /// The currently displayed notice, if any.
     pub(crate) fn current(&self) -> Option<(&str, TransientHintTone)> {
         self.content

--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -140,8 +140,11 @@ pub(crate) fn centered_in_viewport(content: Box<dyn TuiElement>) -> Box<dyn TuiE
 pub(crate) fn signed_out_welcome(
     clock: AnimationClock,
     animation_config: Arc<ZeroStateAnimationConfig>,
+    login_mouse: MouseStateHandle,
+    copy_mouse: MouseStateHandle,
     app: &AppContext,
-    mut on_login: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
+    on_login: impl FnMut(&mut TuiEventContext, &AppContext) + Clone + 'static,
+    on_copy: impl FnMut(&mut TuiEventContext, &AppContext) + Clone + 'static,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
     let primary = builder.primary_text_style();
@@ -150,6 +153,20 @@ pub(crate) fn signed_out_welcome(
         .credential_entry_accent_style()
         .add_modifier(Modifier::BOLD);
     let success = builder.success_glyph_style();
+    let login_style = if login_mouse.lock().is_ok_and(|state| state.is_hovered()) {
+        primary
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::UNDERLINED)
+    } else {
+        builder.link_text_style().add_modifier(Modifier::UNDERLINED)
+    };
+    let copy_style = if copy_mouse.lock().is_ok_and(|state| state.is_hovered()) {
+        primary.add_modifier(Modifier::BOLD)
+    } else {
+        builder.link_text_style()
+    };
+    let mut on_login_key = on_login.clone();
+    let mut on_copy_key = on_copy.clone();
     let content = TuiFlex::column()
         .child(
             TuiText::new("Welcome to Warp")
@@ -164,6 +181,28 @@ pub(crate) fn signed_out_welcome(
                 ("enter".to_owned(), success.add_modifier(Modifier::BOLD)),
                 (" to get started".to_owned(), muted),
             ])
+            .finish(),
+        )
+        .child(
+            TuiHoverable::new(
+                login_mouse,
+                TuiText::new("Log in with Warp")
+                    .with_style(login_style)
+                    .truncate()
+                    .finish(),
+            )
+            .on_click(on_login)
+            .finish(),
+        )
+        .child(
+            TuiHoverable::new(
+                copy_mouse,
+                TuiText::new("Copy login URL (c)")
+                    .with_style(copy_style)
+                    .truncate()
+                    .finish(),
+            )
+            .on_click(on_copy)
             .finish(),
         )
         .child(blank_row())
@@ -206,7 +245,10 @@ pub(crate) fn signed_out_welcome(
         .finish();
     TuiEventHandler::new(auth_layout(clock, animation_config, content, &builder))
         .on_key("enter", move |_, event_ctx, app| {
-            on_login(event_ctx, app);
+            on_login_key(event_ctx, app);
+        })
+        .on_key("c", move |_, event_ctx, app| {
+            on_copy_key(event_ctx, app);
         })
         .finish()
 }
@@ -216,6 +258,20 @@ pub(crate) struct LoginWaitingParams<'a> {
     pub(crate) browser_url: Option<&'a str>,
     pub(crate) login_mouse: MouseStateHandle,
     pub(crate) copy_mouse: MouseStateHandle,
+    pub(crate) copy_feedback: Option<(&'a str, TransientHintTone)>,
+}
+/// Device-authorization request failure with no verification URL available yet.
+pub(crate) struct LoginFailedParams<'a> {
+    pub(crate) message: &'a str,
+    pub(crate) retry_mouse: MouseStateHandle,
+}
+
+/// Browser-launch recovery controls retain the exact device URL.
+pub(crate) struct LoginBrowserOpenFailedParams<'a> {
+    pub(crate) browser_url: &'a str,
+    pub(crate) login_mouse: MouseStateHandle,
+    pub(crate) copy_mouse: MouseStateHandle,
+    pub(crate) retry_mouse: MouseStateHandle,
     pub(crate) copy_feedback: Option<(&'a str, TransientHintTone)>,
 }
 
@@ -329,6 +385,120 @@ pub(crate) fn login_waiting(
     }
 }
 
+/// Recovery state shown when the default browser rejects the launch request.
+pub(crate) fn login_browser_open_failed(
+    clock: AnimationClock,
+    animation_config: Arc<ZeroStateAnimationConfig>,
+    params: LoginBrowserOpenFailedParams<'_>,
+    app: &AppContext,
+    on_retry: impl FnMut(&mut TuiEventContext, &AppContext) + Clone + 'static,
+    on_copy: impl FnMut(&mut TuiEventContext, &AppContext) + Clone + 'static,
+) -> Box<dyn TuiElement> {
+    let LoginBrowserOpenFailedParams {
+        browser_url,
+        login_mouse,
+        copy_mouse,
+        retry_mouse,
+        copy_feedback,
+    } = params;
+    let builder = TuiUiBuilder::from_app(app);
+    let primary = builder.primary_text_style();
+    let muted = builder.muted_text_style();
+    let title = builder
+        .credential_entry_accent_style()
+        .add_modifier(Modifier::BOLD);
+    let link_style = if login_mouse.lock().is_ok_and(|state| state.is_hovered()) {
+        primary
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::UNDERLINED)
+    } else {
+        primary.add_modifier(Modifier::UNDERLINED)
+    };
+    let copy_hovered = copy_mouse.lock().is_ok_and(|state| state.is_hovered());
+    let (copy_label, copy_style) = match copy_feedback {
+        Some((message, TransientHintTone::Muted)) => (message.to_owned(), muted),
+        Some((message, TransientHintTone::Success)) => {
+            (message.to_owned(), builder.success_glyph_style())
+        }
+        Some((message, TransientHintTone::Error)) => {
+            (message.to_owned(), builder.error_text_style())
+        }
+        None => {
+            let style = if copy_hovered {
+                primary.add_modifier(Modifier::BOLD)
+            } else {
+                builder.link_text_style()
+            };
+            ("Copy URL (c)".to_owned(), style)
+        }
+    };
+    let retry_style = if retry_mouse.lock().is_ok_and(|state| state.is_hovered()) {
+        primary.add_modifier(Modifier::BOLD)
+    } else {
+        builder.link_text_style()
+    };
+    let mut on_retry_key = on_retry.clone();
+    let mut on_copy_key = on_copy.clone();
+    let content = TuiFlex::column()
+        .child(
+            TuiText::new("Welcome to Warp")
+                .with_style(title)
+                .truncate()
+                .finish(),
+        )
+        .child(
+            TuiText::new("We couldn’t open your browser.")
+                .with_style(builder.attention_glyph_style())
+                .finish(),
+        )
+        .child(blank_row())
+        .child(
+            TuiText::new("Open this exact URL manually:")
+                .with_style(muted)
+                .finish(),
+        )
+        .child(
+            TuiHoverable::new(
+                login_mouse,
+                TuiText::new(browser_url).with_style(link_style).finish(),
+            )
+            .on_click(on_retry.clone())
+            .finish(),
+        )
+        .child(
+            TuiHoverable::new(
+                copy_mouse,
+                TuiText::new(copy_label)
+                    .with_style(copy_style)
+                    .truncate()
+                    .finish(),
+            )
+            .on_click(on_copy)
+            .finish(),
+        )
+        .child(blank_row())
+        .child(
+            TuiHoverable::new(
+                retry_mouse,
+                TuiText::new("Retry opening browser (r)")
+                    .with_style(retry_style)
+                    .truncate()
+                    .finish(),
+            )
+            .on_click(on_retry)
+            .finish(),
+        )
+        .finish();
+    TuiEventHandler::new(auth_layout(clock, animation_config, content, &builder))
+        .on_key("c", move |_, event_ctx, app| {
+            on_copy_key(event_ctx, app);
+        })
+        .on_key("r", move |_, event_ctx, app| {
+            on_retry_key(event_ctx, app);
+        })
+        .finish()
+}
+
 fn capability_row(
     glyph: &str,
     label: &str,
@@ -422,22 +592,70 @@ pub(crate) fn terminal_starting() -> Box<dyn TuiElement> {
     )
 }
 
-/// Placeholder shown when login fails; the user can quit with `Ctrl-C`.
-pub(crate) fn login_failed(message: &str) -> Box<dyn TuiElement> {
-    let dim = TuiStyle::default().add_modifier(Modifier::DIM);
+/// Retryable failure shown when device authorization fails before login completes.
+pub(crate) fn login_failed(
+    clock: AnimationClock,
+    animation_config: Arc<ZeroStateAnimationConfig>,
+    params: LoginFailedParams<'_>,
+    app: &AppContext,
+    on_retry: impl FnMut(&mut TuiEventContext, &AppContext) + Clone + 'static,
+) -> Box<dyn TuiElement> {
+    let LoginFailedParams {
+        message,
+        retry_mouse,
+    } = params;
+    let builder = TuiUiBuilder::from_app(app);
+    let primary = builder.primary_text_style();
+    let muted = builder.muted_text_style();
+    let title = builder
+        .credential_entry_accent_style()
+        .add_modifier(Modifier::BOLD);
+    let retry_style = if retry_mouse.lock().is_ok_and(|state| state.is_hovered()) {
+        primary.add_modifier(Modifier::BOLD)
+    } else {
+        builder.link_text_style()
+    };
+    let mut on_retry_key = on_retry.clone();
+    let mut on_retry_enter = on_retry.clone();
     let content = TuiFlex::column()
         .child(
-            TuiText::new(format!("Login failed: {message}"))
+            TuiText::new("Welcome to Warp")
+                .with_style(title)
                 .truncate()
                 .finish(),
         )
         .child(
-            TuiText::new("Press Ctrl-C to exit.")
-                .with_style(dim)
+            TuiText::new(format!("Login failed: {message}"))
+                .with_style(builder.error_text_style())
                 .truncate()
                 .finish(),
-        );
-    vertically_centered(content)
+        )
+        .child(
+            TuiHoverable::new(
+                retry_mouse,
+                TuiText::new("Retry login (r)")
+                    .with_style(retry_style)
+                    .truncate()
+                    .finish(),
+            )
+            .on_click(on_retry)
+            .finish(),
+        )
+        .child(
+            TuiText::new("Press enter or r to retry · Ctrl-C to exit")
+                .with_style(muted)
+                .truncate()
+                .finish(),
+        )
+        .finish();
+    TuiEventHandler::new(auth_layout(clock, animation_config, content, &builder))
+        .on_key("r", move |_, event_ctx, app| {
+            on_retry_key(event_ctx, app);
+        })
+        .on_key("enter", move |_, event_ctx, app| {
+            on_retry_enter(event_ctx, app);
+        })
+        .finish()
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -17,7 +17,8 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, EntityId, EntityIdMap};
 
 use super::{
-    LoginWaitingParams, compact_footer_path, conversation_restoring, horizontally_centered,
+    LoginBrowserOpenFailedParams, LoginFailedParams, LoginWaitingParams, compact_footer_path,
+    conversation_restoring, horizontally_centered, login_browser_open_failed, login_failed,
     login_waiting, signed_out_welcome,
 };
 use crate::transient_hint::TransientHintTone;
@@ -26,6 +27,90 @@ use crate::zero_state_animation::ZeroStateAnimationConfig;
 #[test]
 fn compact_footer_path_preserves_short_paths() {
     assert_eq!(compact_footer_path("/erica/project"), "/erica/project");
+}
+#[test]
+fn failed_login_renders_clickable_retry_and_handles_retry_keys() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let retry_count = Rc::new(Cell::new(0));
+            let retry_count_for_action = retry_count.clone();
+            let mut element = login_failed(
+                AnimationClock::starting_at(Duration::ZERO),
+                Arc::new(ZeroStateAnimationConfig::default()),
+                LoginFailedParams {
+                    message: "Failed to generate device code",
+                    retry_mouse: MouseStateHandle::default(),
+                },
+                app_ctx,
+                move |_, _| retry_count_for_action.set(retry_count_for_action.get() + 1),
+            );
+            let area = TuiRect::new(0, 0, 80, 24);
+            let mut rendered_views = EntityIdMap::default();
+            let mut layout_ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            element.layout(
+                TuiConstraint::tight(TuiSize::new(area.width, area.height)),
+                &mut layout_ctx,
+                app_ctx,
+            );
+            element.after_layout(&mut layout_ctx, app_ctx);
+            let mut buffer = TuiBuffer::empty(area);
+            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+            {
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+            }
+            let lines = buffer.to_lines();
+            let rendered = lines.join("\n");
+            assert!(rendered.contains("Login failed: Failed to generate device code"));
+            assert!(rendered.contains("Retry login (r)"));
+            assert!(rendered.contains("Press enter or r to retry · Ctrl-C to exit"));
+            assert!(!rendered.contains("Copy URL (c)"));
+
+            let row = lines
+                .iter()
+                .position(|line| line.contains("Retry login (r)"))
+                .expect("retry action renders") as u16;
+            let col = lines[usize::from(row)]
+                .find("Retry login (r)")
+                .expect("retry action offset") as u16;
+            let scene = Rc::new(paint_ctx.scene.clone());
+            drop(paint_ctx);
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+            event_ctx.set_origin_view(Some(EntityId::new()));
+            for event in [
+                TuiEvent::LeftMouseDown {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                    click_count: 1,
+                    is_first_mouse: false,
+                },
+                TuiEvent::LeftMouseUp {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                },
+            ] {
+                assert!(element.dispatch_event(&event, &mut event_ctx, app_ctx));
+            }
+            assert_eq!(retry_count.get(), 1);
+
+            let key_down = |key: &str| TuiEvent::KeyDown {
+                keystroke: Keystroke {
+                    key: key.to_owned(),
+                    ..Default::default()
+                },
+                chars: String::new(),
+                details: Default::default(),
+                is_composing: false,
+            };
+            assert!(element.dispatch_event(&key_down("r"), &mut event_ctx, app_ctx));
+            assert!(element.dispatch_event(&key_down("enter"), &mut event_ctx, app_ctx));
+            assert!(!element.dispatch_event(&key_down("c"), &mut event_ctx, app_ctx));
+            assert_eq!(retry_count.get(), 3);
+        });
+    });
 }
 
 #[test]
@@ -138,7 +223,10 @@ fn signed_out_welcome_matches_designed_copy_and_layout() {
                 signed_out_welcome(
                     AnimationClock::starting_at(Duration::ZERO),
                     Arc::new(ZeroStateAnimationConfig::default()),
+                    MouseStateHandle::default(),
+                    MouseStateHandle::default(),
                     app_ctx,
+                    |_, _| {},
                     |_, _| {},
                 ),
                 TuiRect::new(0, 0, 80, 24),
@@ -149,6 +237,8 @@ fn signed_out_welcome_matches_designed_copy_and_layout() {
             for expected in [
                 "Welcome to Warp",
                 "> Press enter to get started",
+                "Log in with Warp",
+                "Copy login URL (c)",
                 "What’s different about Warp",
                 "Prompts or shell commands autodetected",
                 "Set up custom model routers",
@@ -335,17 +425,22 @@ fn waiting_login_copy_control_handles_click_and_key() {
     });
 }
 #[test]
-fn signed_out_welcome_handles_enter() {
+fn signed_out_welcome_handles_enter_and_copy_shortcuts() {
     App::test((), |app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         app.read(|app_ctx| {
-            let activated = Rc::new(Cell::new(false));
-            let activated_for_enter = activated.clone();
+            let login_count = Rc::new(Cell::new(0));
+            let copy_count = Rc::new(Cell::new(0));
+            let login_count_for_enter = login_count.clone();
+            let copy_count_for_key = copy_count.clone();
             let mut element = signed_out_welcome(
                 AnimationClock::starting_at(Duration::ZERO),
                 Arc::new(ZeroStateAnimationConfig::default()),
+                MouseStateHandle::default(),
+                MouseStateHandle::default(),
                 app_ctx,
-                move |_, _| activated_for_enter.set(true),
+                move |_, _| login_count_for_enter.set(login_count_for_enter.get() + 1),
+                move |_, _| copy_count_for_key.set(copy_count_for_key.get() + 1),
             );
             let mut rendered_views = EntityIdMap::default();
             let scene = Rc::new(Default::default());
@@ -362,9 +457,170 @@ fn signed_out_welcome_handles_enter() {
             };
 
             assert!(!element.dispatch_event(&key_down("a"), &mut event_ctx, app_ctx));
-            assert!(!activated.get());
+            assert_eq!(login_count.get(), 0);
+            assert_eq!(copy_count.get(), 0);
             assert!(element.dispatch_event(&key_down("enter"), &mut event_ctx, app_ctx));
+            assert_eq!(login_count.get(), 1);
+            assert_eq!(copy_count.get(), 0);
+            assert!(element.dispatch_event(&key_down("c"), &mut event_ctx, app_ctx));
+            assert_eq!(login_count.get(), 1);
+            assert_eq!(copy_count.get(), 1);
+        });
+    });
+}
+
+#[test]
+fn signed_out_welcome_handles_login_link_click() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let activated = Rc::new(Cell::new(false));
+            let activated_for_click = activated.clone();
+            let mut element = signed_out_welcome(
+                AnimationClock::starting_at(Duration::ZERO),
+                Arc::new(ZeroStateAnimationConfig::default()),
+                MouseStateHandle::default(),
+                MouseStateHandle::default(),
+                app_ctx,
+                move |_, _| activated_for_click.set(true),
+                |_, _| {},
+            );
+            let area = TuiRect::new(0, 0, 80, 24);
+            let mut rendered_views = EntityIdMap::default();
+            let mut layout_ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            element.layout(
+                TuiConstraint::tight(TuiSize::new(area.width, area.height)),
+                &mut layout_ctx,
+                app_ctx,
+            );
+            element.after_layout(&mut layout_ctx, app_ctx);
+            let mut buffer = TuiBuffer::empty(area);
+            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+            {
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+            }
+            let lines = buffer.to_lines();
+            let row = lines
+                .iter()
+                .position(|line| line.contains("Log in with Warp"))
+                .expect("login action renders") as u16;
+            let col = lines[usize::from(row)]
+                .find("Log in with Warp")
+                .expect("login action offset") as u16;
+            let scene = Rc::new(paint_ctx.scene.clone());
+            drop(paint_ctx);
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+            event_ctx.set_origin_view(Some(EntityId::new()));
+            for event in [
+                TuiEvent::LeftMouseDown {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                    click_count: 1,
+                    is_first_mouse: false,
+                },
+                TuiEvent::LeftMouseUp {
+                    position: (col, row).into(),
+                    modifiers: ModifiersState::default(),
+                },
+            ] {
+                assert!(element.dispatch_event(&event, &mut event_ctx, app_ctx));
+            }
             assert!(activated.get());
+        });
+    });
+}
+
+#[test]
+fn browser_open_failure_renders_exact_fallback_and_handles_recovery_keys() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let browser_url =
+                "https://app.warp.dev/device?user_code=ABCD-EFGH&source=warp-agent-cli";
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                login_browser_open_failed(
+                    AnimationClock::starting_at(Duration::ZERO),
+                    Arc::new(ZeroStateAnimationConfig::default()),
+                    LoginBrowserOpenFailedParams {
+                        browser_url,
+                        login_mouse: MouseStateHandle::default(),
+                        copy_mouse: MouseStateHandle::default(),
+                        retry_mouse: MouseStateHandle::default(),
+                        copy_feedback: None,
+                    },
+                    app_ctx,
+                    |_, _| {},
+                    |_, _| {},
+                ),
+                TuiRect::new(0, 0, 80, 24),
+                app_ctx,
+            );
+            let rendered = frame.buffer.to_lines().join("\n");
+            for expected in [
+                "We couldn’t open your browser.",
+                "Open this exact URL manually:",
+                "https://app.warp.dev/device?user_code=ABCD-EF",
+                "GH&source=warp-agent-cli",
+                "Copy URL (c)",
+                "Retry opening browser (r)",
+            ] {
+                assert!(
+                    rendered.contains(expected),
+                    "browser failure should render {expected:?}: {rendered:?}"
+                );
+            }
+            assert!(!rendered.contains("Continue to terminal"));
+
+            let retry_count = Rc::new(Cell::new(0));
+            let copy_count = Rc::new(Cell::new(0));
+            let retry_count_for_action = retry_count.clone();
+            let copy_count_for_action = copy_count.clone();
+            let mut element = login_browser_open_failed(
+                AnimationClock::starting_at(Duration::ZERO),
+                Arc::new(ZeroStateAnimationConfig::default()),
+                LoginBrowserOpenFailedParams {
+                    browser_url,
+                    login_mouse: MouseStateHandle::default(),
+                    copy_mouse: MouseStateHandle::default(),
+                    retry_mouse: MouseStateHandle::default(),
+                    copy_feedback: None,
+                },
+                app_ctx,
+                move |_, _| retry_count_for_action.set(retry_count_for_action.get() + 1),
+                move |_, _| copy_count_for_action.set(copy_count_for_action.get() + 1),
+            );
+            let mut rendered_views = EntityIdMap::default();
+            let scene = Rc::new(Default::default());
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+            event_ctx.set_origin_view(Some(EntityId::new()));
+            for key in ["r", "c"] {
+                let event = TuiEvent::KeyDown {
+                    keystroke: Keystroke {
+                        key: key.to_owned(),
+                        ..Default::default()
+                    },
+                    chars: String::new(),
+                    details: Default::default(),
+                    is_composing: false,
+                };
+                assert!(element.dispatch_event(&event, &mut event_ctx, app_ctx));
+            }
+            let enter = TuiEvent::KeyDown {
+                keystroke: Keystroke {
+                    key: "enter".to_owned(),
+                    ..Default::default()
+                },
+                chars: String::new(),
+                details: Default::default(),
+                is_composing: false,
+            };
+            assert!(!element.dispatch_event(&enter, &mut event_ctx, app_ctx));
+            assert_eq!(retry_count.get(), 1);
+            assert_eq!(copy_count.get(), 1);
         });
     });
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Gate Warp Agent CLI terminal creation on completed browser authentication. This keeps the Figma-aligned waiting screen visible through device-code confirmation, retains exact generated URLs for retry/copy recovery, adds retry for device-code request failures, and exposes `Copy login URL (c)` on the initial screen. Pressing `c` starts login and copies the exact URL once it is generated; Enter and mouse click continue to start login without auto-copy.

Design: https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1779-21723&m=dev

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Implementation plan: https://staging.warp.dev/drive/notebook/VEDTJkrbVxEnFZIwM5uC3A

## Testing
- `./script/format`
- `cargo check -p warp_tui --tests`
- Focused login rendering/action tests passed before the final auto-copy follow-up.
- The cumulative W3 and W4 tips passed the repository-prescribed Clippy configurations.
- Remaining test execution was skipped at request before PR creation.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Manual verification and screenshots are available in the implementation conversation:
https://staging.warp.dev/conversation/b543d79e-e3d9-4f48-9516-50c2372eabc8

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-TUI: Improved Warp Agent CLI browser sign-in with retry and copyable login URLs.

Co-Authored-By: Oz <oz-agent@warp.dev>
