### PR TITLE
TUI: Add first-run onboarding marker plumbing

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -86,6 +86,8 @@ mod tracing;
 mod tui;
 #[cfg(feature = "tui")]
 pub mod tui_export;
+#[cfg(feature = "tui")]
+mod tui_onboarding_markers;
 #[cfg(all(feature = "tui", any(test, feature = "test-util")))]
 mod tui_test_support;
 mod ui_components;

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -12,6 +12,8 @@ pub mod object;
 pub(crate) mod presigned_upload;
 pub mod referral;
 pub mod team;
+#[cfg(feature = "tui")]
+pub mod tui_onboarding;
 pub mod workspace;
 
 use std::ops::Deref;
@@ -35,6 +37,8 @@ use referral::ReferralsClient;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use team::TeamClient;
+#[cfg(feature = "tui")]
+use tui_onboarding::TuiOnboardingClient;
 use url::Url;
 use warp_core::context_flag::ContextFlag;
 use warp_core::telemetry::TelemetryEvent;
@@ -1363,6 +1367,10 @@ impl ServerApiProvider {
     }
 
     pub fn get_team_client(&self) -> Arc<dyn TeamClient> {
+        self.server_api.clone()
+    }
+    #[cfg(feature = "tui")]
+    pub fn get_tui_onboarding_client(&self) -> Arc<dyn TuiOnboardingClient> {
         self.server_api.clone()
     }
 

--- a/app/src/server/server_api/tui_onboarding.rs
+++ b/app/src/server/server_api/tui_onboarding.rs
@@ -1,0 +1,49 @@
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use cynic::QueryBuilder;
+#[cfg(test)]
+use mockall::automock;
+use warp_graphql::queries::tui_onboarding_markers::{
+    TuiOnboardingMarkers, TuiOnboardingMarkersResult, TuiOnboardingMarkersVariables,
+};
+
+use super::ServerApi;
+use crate::server::graphql::{get_request_context, get_user_facing_error_message};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TuiOnboardingMarkersSnapshot {
+    pub first_zero_state_shown: bool,
+    pub first_credit_gate_shown: bool,
+}
+
+#[cfg_attr(test, automock)]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+pub trait TuiOnboardingClient: 'static + Send + Sync {
+    async fn get_tui_onboarding_markers(&self) -> Result<TuiOnboardingMarkersSnapshot>;
+}
+
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+impl TuiOnboardingClient for ServerApi {
+    async fn get_tui_onboarding_markers(&self) -> Result<TuiOnboardingMarkersSnapshot> {
+        let operation = TuiOnboardingMarkers::build(TuiOnboardingMarkersVariables {
+            request_context: get_request_context(),
+        });
+        let response = self.send_graphql_request(operation, None).await?;
+        match response.tui_onboarding_markers {
+            TuiOnboardingMarkersResult::TuiOnboardingMarkersOutput(output) => {
+                Ok(TuiOnboardingMarkersSnapshot {
+                    first_zero_state_shown: output.first_zero_state_shown,
+                    first_credit_gate_shown: output.first_credit_gate_shown,
+                })
+            }
+            TuiOnboardingMarkersResult::UserFacingError(error) => {
+                Err(anyhow!(get_user_facing_error_message(error)))
+            }
+            TuiOnboardingMarkersResult::Unknown => {
+                Err(anyhow!("Unable to load TUI onboarding markers"))
+            }
+        }
+    }
+}

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -25,6 +25,7 @@ use crate::ai::mcp::FileBasedMCPManager;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::{self, AuthStateProvider};
 use crate::terminal::focus_env::FOCUS_URL_ENV;
+use crate::tui_onboarding_markers::TuiOnboardingMarkers;
 
 /// Login state of the headless TUI, observed by the `warp_tui` root view to
 /// decide whether to show the login placeholder or the input UI.
@@ -180,12 +181,18 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
     });
     ctx.add_singleton_model(TuiMcpManager::new);
     ctx.add_singleton_model(TuiUserInfoManager::new);
+    let onboarding_markers = ctx.add_singleton_model(TuiOnboardingMarkers::new);
 
     // Keep the auth subscription alive for the full process lifetime so a
     // logged-in TUI can complete device authorization again after logout.
     ctx.subscribe_to_model(&AuthManager::handle(ctx), |_, event, ctx| {
         handle_auth_manager_event(event, ctx);
     });
+    if logged_in {
+        onboarding_markers.update(ctx, |markers, ctx| {
+            markers.load_current_account(ctx);
+        });
+    }
     // Mount the TUI now so it renders immediately; signed-out users see the
     // welcome screen before explicitly starting browser authentication.
     mount(ctx);
@@ -233,6 +240,9 @@ fn handle_auth_manager_event(event: &AuthManagerEvent, ctx: &mut AppContext) {
         }
         AuthManagerEvent::AuthComplete => {
             set_login_phase(ctx, TuiLoginPhase::LoggedIn);
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.load_current_account(ctx);
+            });
             activate_global_mcp_servers(ctx);
         }
         AuthManagerEvent::AuthFailed(err) => {
@@ -358,6 +368,9 @@ pub fn start_tui_device_login(ctx: &mut AppContext) {
 /// Logs out the current TUI user and sends them to Warp web's logged-out flow.
 pub fn log_out_tui(ctx: &mut AppContext) {
     auth::log_out(ctx);
+    TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+        markers.reset_for_account_transition(ctx);
+    });
     set_logged_out_phase(ctx);
     authorize_device(ctx);
 }

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -252,6 +252,9 @@ pub use crate::tui::{
     TuiMcpTransport, TuiMcpVariableValue, TuiUserInfoManager, TuiUserInfoManagerEvent,
     TuiUserInfoSnapshot, log_out_tui,
 };
+pub use crate::tui_onboarding_markers::{
+    TuiOnboardingMarker, TuiOnboardingMarkers, TuiOnboardingMarkersEvent,
+};
 #[cfg(any(test, feature = "test-util"))]
 pub use crate::tui_test_support::{
     add_tui_history_test_models, append_tui_history_test_command,

--- a/app/src/tui_onboarding_markers.rs
+++ b/app/src/tui_onboarding_markers.rs
@@ -1,0 +1,378 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use cloud_object_models::JsonSerializer;
+use settings::{RespectUserSyncSetting, SyncToCloud};
+use warpui::r#async::Timer;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use crate::cloud_object::CloudObjectEventEntrypoint;
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::server::cloud_objects::update_manager::{
+    GenericStringObjectInput, UpdateManager, UpdateManagerEvent,
+};
+use crate::server::ids::ClientId;
+use crate::server::server_api::ServerApiProvider;
+use crate::server::server_api::tui_onboarding::{
+    TuiOnboardingClient, TuiOnboardingMarkersSnapshot,
+};
+use crate::settings::cloud_preferences::{CloudPreference, CloudPreferenceModel, Preference};
+use crate::workspaces::user_workspaces::UserWorkspaces;
+
+const FIRST_ZERO_STATE_STORAGE_KEY: &str = "TuiFirstZeroStateShown";
+const FIRST_CREDIT_GATE_STORAGE_KEY: &str = "TuiFirstCreditGateShown";
+const MARKER_LOAD_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Account-scoped, monotonic TUI onboarding markers stored as separate global
+/// cloud preferences so concurrent devices cannot overwrite unrelated state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TuiOnboardingMarker {
+    FirstZeroState,
+    FirstCreditGate,
+}
+
+impl TuiOnboardingMarker {
+    fn storage_key(self) -> &'static str {
+        match self {
+            Self::FirstZeroState => FIRST_ZERO_STATE_STORAGE_KEY,
+            Self::FirstCreditGate => FIRST_CREDIT_GATE_STORAGE_KEY,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TuiOnboardingMarkersState {
+    Loading,
+    Ready {
+        first_zero_state_available: bool,
+        first_credit_gate_available: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MarkerPersistenceAction {
+    None,
+    Create,
+    Update,
+}
+
+fn marker_persistence_action(existing_value: Option<bool>) -> MarkerPersistenceAction {
+    match existing_value {
+        Some(true) => MarkerPersistenceAction::None,
+        Some(false) => MarkerPersistenceAction::Update,
+        None => MarkerPersistenceAction::Create,
+    }
+}
+
+/// Events emitted as the current account's marker snapshot is invalidated and resolved.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TuiOnboardingMarkersEvent {
+    Loading,
+    Ready,
+}
+
+/// Dedicated cloud-preference model for the TUI's once-per-account surfaces.
+pub struct TuiOnboardingMarkers {
+    state: TuiOnboardingMarkersState,
+    load_generation: u64,
+    persist_markers: bool,
+    onboarding_client: Option<Arc<dyn TuiOnboardingClient>>,
+    load_timeout: Duration,
+}
+
+impl TuiOnboardingMarkers {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        let onboarding_client = ServerApiProvider::as_ref(ctx).get_tui_onboarding_client();
+        ctx.subscribe_to_model(&UpdateManager::handle(ctx), |markers, _, event, ctx| {
+            let UpdateManagerEvent::CloudPreferencesUpdated { updated } = event else {
+                return;
+            };
+            let mut changed = false;
+            for preference in updated {
+                if preference.value.as_bool() == Some(true) {
+                    changed |= markers.mark_consumed_by_storage_key(&preference.storage_key);
+                }
+            }
+            if changed {
+                ctx.notify();
+            }
+        });
+        Self {
+            state: TuiOnboardingMarkersState::Loading,
+            load_generation: 0,
+            persist_markers: true,
+            onboarding_client: Some(onboarding_client),
+            load_timeout: MARKER_LOAD_TIMEOUT,
+        }
+    }
+    #[cfg(test)]
+    fn new_loading_for_test(
+        onboarding_client: Arc<dyn TuiOnboardingClient>,
+        load_timeout: Duration,
+    ) -> Self {
+        Self {
+            state: TuiOnboardingMarkersState::Loading,
+            load_generation: 0,
+            persist_markers: false,
+            onboarding_client: Some(onboarding_client),
+            load_timeout,
+        }
+    }
+
+    /// Starts a fresh, account-scoped load. Terminal creation never waits for
+    /// this request; consumers reconcile provisional one-time UI on
+    /// [`TuiOnboardingMarkersEvent::Ready`].
+    pub fn load_current_account(&mut self, ctx: &mut ModelContext<Self>) {
+        self.state = TuiOnboardingMarkersState::Loading;
+        self.load_generation = self.load_generation.wrapping_add(1);
+        ctx.emit(TuiOnboardingMarkersEvent::Loading);
+        let load_generation = self.load_generation;
+        let onboarding_client = self
+            .onboarding_client
+            .clone()
+            .expect("production TUI onboarding marker model must have an API client");
+        let load_timeout = self.load_timeout;
+        ctx.spawn(
+            load_markers_with_timeout(onboarding_client, load_timeout),
+            move |markers, result, ctx| {
+                markers.handle_load_result(load_generation, result, ctx);
+            },
+        );
+        ctx.notify();
+    }
+    /// Invalidates the previous account snapshot before a signed-out terminal
+    /// can be created for the next browser authentication flow.
+    pub fn reset_for_account_transition(&mut self, ctx: &mut ModelContext<Self>) {
+        self.state = TuiOnboardingMarkersState::Loading;
+        self.load_generation = self.load_generation.wrapping_add(1);
+        ctx.emit(TuiOnboardingMarkersEvent::Loading);
+        ctx.notify();
+    }
+
+    pub fn is_ready(&self) -> bool {
+        matches!(self.state, TuiOnboardingMarkersState::Ready { .. })
+    }
+
+    /// Consumes a marker immediately in memory, then queues the monotonic
+    /// cloud write. Returning `false` means the marker was loading or had
+    /// already been consumed in this process/account snapshot.
+    pub fn consume(&mut self, marker: TuiOnboardingMarker, ctx: &mut ModelContext<Self>) -> bool {
+        if !self.take_available(marker) {
+            return false;
+        }
+        if self.persist_markers {
+            self.persist_consumed_marker(marker, ctx);
+        }
+        ctx.notify();
+        true
+    }
+
+    fn resolve_from_snapshot(
+        &mut self,
+        snapshot: TuiOnboardingMarkersSnapshot,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.state = TuiOnboardingMarkersState::Ready {
+            first_zero_state_available: !snapshot.first_zero_state_shown,
+            first_credit_gate_available: !snapshot.first_credit_gate_shown,
+        };
+        ctx.emit(TuiOnboardingMarkersEvent::Ready);
+        ctx.notify();
+    }
+    fn resolve_unavailable(&mut self, ctx: &mut ModelContext<Self>) {
+        self.state = TuiOnboardingMarkersState::Ready {
+            first_zero_state_available: false,
+            first_credit_gate_available: false,
+        };
+        ctx.emit(TuiOnboardingMarkersEvent::Ready);
+        ctx.notify();
+    }
+    fn handle_load_result(
+        &mut self,
+        load_generation: u64,
+        result: MarkerLoadResult,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.load_generation != load_generation {
+            return;
+        }
+        match result {
+            MarkerLoadResult::Loaded(Ok(snapshot)) => {
+                self.resolve_from_snapshot(snapshot, ctx);
+            }
+            MarkerLoadResult::Loaded(Err(error)) => {
+                log::warn!(
+                    "Unable to load TUI onboarding markers; continuing without one-time onboarding surfaces: {error:#}"
+                );
+                self.resolve_unavailable(ctx);
+            }
+            MarkerLoadResult::TimedOut => {
+                log::warn!(
+                    "Timed out loading TUI onboarding markers; continuing without one-time onboarding surfaces"
+                );
+                self.resolve_unavailable(ctx);
+            }
+        }
+    }
+
+    fn take_available(&mut self, marker: TuiOnboardingMarker) -> bool {
+        let TuiOnboardingMarkersState::Ready {
+            first_zero_state_available,
+            first_credit_gate_available,
+        } = &mut self.state
+        else {
+            return false;
+        };
+        let available = match marker {
+            TuiOnboardingMarker::FirstZeroState => first_zero_state_available,
+            TuiOnboardingMarker::FirstCreditGate => first_credit_gate_available,
+        };
+        std::mem::take(available)
+    }
+
+    fn mark_consumed_by_storage_key(&mut self, storage_key: &str) -> bool {
+        let TuiOnboardingMarkersState::Ready {
+            first_zero_state_available,
+            first_credit_gate_available,
+        } = &mut self.state
+        else {
+            return false;
+        };
+        match storage_key {
+            FIRST_ZERO_STATE_STORAGE_KEY => std::mem::take(first_zero_state_available),
+            FIRST_CREDIT_GATE_STORAGE_KEY => std::mem::take(first_credit_gate_available),
+            _ => false,
+        }
+    }
+
+    fn persist_consumed_marker(&self, marker: TuiOnboardingMarker, ctx: &mut ModelContext<Self>) {
+        let storage_key = marker.storage_key();
+        let existing = CloudModel::as_ref(ctx)
+            .get_all_cloud_preferences_by_storage_key()
+            .get(storage_key)
+            .map(|preference| (*preference).clone());
+        let existing_value = existing
+            .as_ref()
+            .and_then(|preference| preference.model().string_model.value.as_bool());
+        match marker_persistence_action(existing_value) {
+            MarkerPersistenceAction::None => {}
+            MarkerPersistenceAction::Update => {
+                let Some(preference) = existing else {
+                    return;
+                };
+                self.update_marker(storage_key, preference, ctx);
+            }
+            MarkerPersistenceAction::Create => self.create_marker(storage_key, ctx),
+        }
+    }
+
+    fn update_marker(
+        &self,
+        storage_key: &str,
+        cloud_preference: CloudPreference,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Ok(preference) = Preference::new(
+            storage_key.to_owned(),
+            "true",
+            SyncToCloud::Globally(RespectUserSyncSetting::No),
+        ) else {
+            log::warn!("Unable to serialize consumed TUI onboarding marker {storage_key}");
+            return;
+        };
+        let mut model = cloud_preference.model().clone();
+        model.string_model = preference;
+        let revision = CloudModel::as_ref(ctx)
+            .current_revision(&cloud_preference.id)
+            .cloned();
+        UpdateManager::handle(ctx).update(ctx, move |update_manager, ctx| {
+            update_manager.update_object(model, cloud_preference.id, revision, ctx);
+        });
+    }
+
+    fn create_marker(&self, storage_key: &str, ctx: &mut ModelContext<Self>) {
+        let Some(personal_drive) = UserWorkspaces::as_ref(ctx).personal_drive(ctx) else {
+            log::warn!(
+                "Unable to create consumed TUI onboarding marker {storage_key}: personal drive is unavailable"
+            );
+            return;
+        };
+        let Ok(preference) = Preference::new(
+            storage_key.to_owned(),
+            "true",
+            SyncToCloud::Globally(RespectUserSyncSetting::No),
+        ) else {
+            log::warn!("Unable to serialize consumed TUI onboarding marker {storage_key}");
+            return;
+        };
+        let input = GenericStringObjectInput::<Preference, JsonSerializer> {
+            id: ClientId::new(),
+            model: CloudPreferenceModel::new(preference),
+            initial_folder_id: None,
+            entrypoint: CloudObjectEventEntrypoint::Unknown,
+        };
+        UpdateManager::handle(ctx).update(ctx, move |update_manager, ctx| {
+            update_manager.bulk_create_generic_string_objects(personal_drive, vec![input], ctx);
+        });
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn new_ready_for_test(
+        first_zero_state_available: bool,
+        first_credit_gate_available: bool,
+    ) -> Self {
+        Self {
+            state: TuiOnboardingMarkersState::Ready {
+                first_zero_state_available,
+                first_credit_gate_available,
+            },
+            load_generation: 0,
+            persist_markers: false,
+            onboarding_client: None,
+            load_timeout: MARKER_LOAD_TIMEOUT,
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_ready_for_test(
+        &mut self,
+        first_zero_state_available: bool,
+        first_credit_gate_available: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.state = TuiOnboardingMarkersState::Ready {
+            first_zero_state_available,
+            first_credit_gate_available,
+        };
+        ctx.emit(TuiOnboardingMarkersEvent::Ready);
+        ctx.notify();
+    }
+}
+
+impl Entity for TuiOnboardingMarkers {
+    type Event = TuiOnboardingMarkersEvent;
+}
+impl SingletonEntity for TuiOnboardingMarkers {}
+
+enum MarkerLoadResult {
+    Loaded(anyhow::Result<TuiOnboardingMarkersSnapshot>),
+    TimedOut,
+}
+
+async fn load_markers_with_timeout(
+    onboarding_client: Arc<dyn TuiOnboardingClient>,
+    timeout: Duration,
+) -> MarkerLoadResult {
+    let load = onboarding_client.get_tui_onboarding_markers();
+    let timeout = Timer::after(timeout);
+    futures::pin_mut!(load);
+    futures::pin_mut!(timeout);
+    match futures::future::select(load, timeout).await {
+        futures::future::Either::Left((result, _)) => MarkerLoadResult::Loaded(result),
+        futures::future::Either::Right(_) => MarkerLoadResult::TimedOut,
+    }
+}
+
+#[cfg(test)]
+#[path = "tui_onboarding_markers_tests.rs"]
+mod tests;

--- a/app/src/tui_onboarding_markers_tests.rs
+++ b/app/src/tui_onboarding_markers_tests.rs
@@ -1,0 +1,207 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use warpui::App;
+
+use super::{
+    MarkerLoadResult, MarkerPersistenceAction, TuiOnboardingMarker, TuiOnboardingMarkers,
+    TuiOnboardingMarkersState, load_markers_with_timeout, marker_persistence_action,
+};
+use crate::server::server_api::tui_onboarding::{
+    MockTuiOnboardingClient, TuiOnboardingClient, TuiOnboardingMarkersSnapshot,
+};
+
+struct PendingTuiOnboardingClient;
+
+#[async_trait]
+impl TuiOnboardingClient for PendingTuiOnboardingClient {
+    async fn get_tui_onboarding_markers(&self) -> anyhow::Result<TuiOnboardingMarkersSnapshot> {
+        futures::future::pending().await
+    }
+}
+
+#[test]
+fn markers_are_unavailable_until_initial_load_resolves() {
+    let mut markers = TuiOnboardingMarkers {
+        state: TuiOnboardingMarkersState::Loading,
+        load_generation: 0,
+        persist_markers: false,
+        onboarding_client: None,
+        load_timeout: Duration::from_secs(3),
+    };
+
+    assert!(!markers.is_ready());
+    assert!(!markers.take_available(TuiOnboardingMarker::FirstZeroState));
+    assert!(!markers.take_available(TuiOnboardingMarker::FirstCreditGate));
+}
+
+#[test]
+fn absent_or_false_cloud_markers_are_available_and_true_markers_are_consumed() {
+    let marker_is_available = |value: Option<bool>| value != Some(true);
+
+    assert!(marker_is_available(None));
+    assert!(marker_is_available(Some(false)));
+    assert!(!marker_is_available(Some(true)));
+}
+
+#[test]
+fn marker_consumption_is_monotonic_and_independent() {
+    let mut markers = TuiOnboardingMarkers::new_ready_for_test(true, true);
+
+    assert!(markers.take_available(TuiOnboardingMarker::FirstZeroState));
+    assert!(!markers.take_available(TuiOnboardingMarker::FirstZeroState));
+    assert!(markers.take_available(TuiOnboardingMarker::FirstCreditGate));
+    assert!(!markers.take_available(TuiOnboardingMarker::FirstCreditGate));
+}
+
+#[test]
+fn marker_persistence_creates_updates_or_skips_without_writing_false() {
+    assert_eq!(
+        marker_persistence_action(None),
+        MarkerPersistenceAction::Create
+    );
+    assert_eq!(
+        marker_persistence_action(Some(false)),
+        MarkerPersistenceAction::Update
+    );
+    assert_eq!(
+        marker_persistence_action(Some(true)),
+        MarkerPersistenceAction::None
+    );
+}
+
+#[test]
+fn targeted_marker_load_returns_the_server_snapshot() {
+    App::test((), |_app| async move {
+        let snapshot = TuiOnboardingMarkersSnapshot {
+            first_zero_state_shown: true,
+            first_credit_gate_shown: false,
+        };
+        let mut client = MockTuiOnboardingClient::new();
+        client
+            .expect_get_tui_onboarding_markers()
+            .once()
+            .return_once(move || Ok(snapshot));
+
+        let result = load_markers_with_timeout(Arc::new(client), Duration::from_millis(100)).await;
+
+        let MarkerLoadResult::Loaded(Ok(loaded)) = result else {
+            panic!("expected successful targeted marker load");
+        };
+        assert_eq!(loaded, snapshot);
+    });
+}
+
+#[test]
+fn targeted_marker_load_preserves_request_failures_for_fail_open_handling() {
+    App::test((), |_app| async move {
+        let mut client = MockTuiOnboardingClient::new();
+        client
+            .expect_get_tui_onboarding_markers()
+            .once()
+            .return_once(|| Err(anyhow!("request failed")));
+
+        let result = load_markers_with_timeout(Arc::new(client), Duration::from_millis(100)).await;
+
+        let MarkerLoadResult::Loaded(Err(error)) = result else {
+            panic!("expected targeted marker request failure");
+        };
+        assert_eq!(error.to_string(), "request failed");
+    });
+}
+
+#[test]
+fn targeted_marker_load_times_out_when_the_request_never_resolves() {
+    App::test((), |_app| async move {
+        let result = load_markers_with_timeout(
+            Arc::new(PendingTuiOnboardingClient),
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert!(matches!(result, MarkerLoadResult::TimedOut));
+    });
+}
+
+#[test]
+fn successful_snapshot_controls_marker_availability() {
+    App::test((), |mut app| async move {
+        let markers =
+            app.add_singleton_model(|_| TuiOnboardingMarkers::new_ready_for_test(false, false));
+
+        markers.update(&mut app, |markers, ctx| {
+            markers.load_generation = 1;
+            markers.handle_load_result(
+                1,
+                MarkerLoadResult::Loaded(Ok(TuiOnboardingMarkersSnapshot {
+                    first_zero_state_shown: false,
+                    first_credit_gate_shown: true,
+                })),
+                ctx,
+            );
+        });
+
+        markers.update(&mut app, |markers, _| {
+            assert!(markers.take_available(TuiOnboardingMarker::FirstZeroState));
+            assert!(!markers.take_available(TuiOnboardingMarker::FirstCreditGate));
+        });
+    });
+}
+
+#[test]
+fn failed_marker_load_allows_startup_without_one_time_surfaces() {
+    App::test((), |mut app| async move {
+        let markers = app.add_singleton_model(|_| {
+            TuiOnboardingMarkers::new_loading_for_test(
+                Arc::new(PendingTuiOnboardingClient),
+                Duration::from_millis(1),
+            )
+        });
+
+        markers.update(&mut app, |markers, ctx| {
+            markers.handle_load_result(
+                0,
+                MarkerLoadResult::Loaded(Err(anyhow!("request failed"))),
+                ctx,
+            );
+        });
+
+        markers.read(&app, |markers, _| {
+            assert!(markers.is_ready());
+        });
+        markers.update(&mut app, |markers, _| {
+            assert!(!markers.take_available(TuiOnboardingMarker::FirstZeroState));
+            assert!(!markers.take_available(TuiOnboardingMarker::FirstCreditGate));
+        });
+    });
+}
+
+#[test]
+fn stale_account_load_result_is_ignored() {
+    App::test((), |mut app| async move {
+        let markers = app.add_singleton_model(|_| {
+            TuiOnboardingMarkers::new_loading_for_test(
+                Arc::new(PendingTuiOnboardingClient),
+                Duration::from_secs(1),
+            )
+        });
+
+        markers.update(&mut app, |markers, ctx| {
+            markers.load_generation = 2;
+            markers.handle_load_result(
+                1,
+                MarkerLoadResult::Loaded(Ok(TuiOnboardingMarkersSnapshot {
+                    first_zero_state_shown: false,
+                    first_credit_gate_shown: false,
+                })),
+                ctx,
+            );
+        });
+
+        markers.read(&app, |markers, _| {
+            assert!(!markers.is_ready());
+        });
+    });
+}

--- a/app/src/tui_test_support.rs
+++ b/app/src/tui_test_support.rs
@@ -59,6 +59,7 @@ use crate::terminal::safe_mode_settings::SafeModeSettings;
 use crate::terminal::session_settings::SessionSettings;
 use crate::terminal::shell::{Shell, ShellType};
 use crate::terminal::{History, HistoryEntry, HistoryEvent};
+use crate::tui_onboarding_markers::TuiOnboardingMarkers;
 use crate::user_config::WarpConfig;
 #[cfg(feature = "voice_input")]
 use crate::voice::transcriber::VoiceTranscriber;
@@ -241,6 +242,7 @@ pub fn register_tui_session_view_test_singletons(app: &mut warpui::App) {
     app.add_singleton_model(|_| ServerApiProvider::new_for_test());
     app.add_singleton_model(|_| AuthStateProvider::new_for_test());
     app.add_singleton_model(AuthManager::new_for_test);
+    app.add_singleton_model(|_| TuiOnboardingMarkers::new_ready_for_test(false, false));
     app.add_singleton_model(PrivacySettings::mock);
     app.add_singleton_model(|ctx| {
         let (team_client, workspace_client) = {

--- a/crates/graphql/src/api/queries/mod.rs
+++ b/crates/graphql/src/api/queries/mod.rs
@@ -33,5 +33,6 @@ pub mod sync_merkle_tree;
 pub mod task_attachments;
 pub mod task_git_credentials;
 pub mod task_secrets;
+pub mod tui_onboarding_markers;
 pub mod user_github_info;
 pub mod user_repo_auth_status;

--- a/crates/graphql/src/api/queries/tui_onboarding_markers.rs
+++ b/crates/graphql/src/api/queries/tui_onboarding_markers.rs
@@ -1,0 +1,36 @@
+use crate::error::UserFacingError;
+use crate::request_context::RequestContext;
+use crate::schema;
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct TuiOnboardingMarkersVariables {
+    pub request_context: RequestContext,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct TuiOnboardingMarkersOutput {
+    pub first_zero_state_shown: bool,
+    pub first_credit_gate_shown: bool,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum TuiOnboardingMarkersResult {
+    TuiOnboardingMarkersOutput(TuiOnboardingMarkersOutput),
+    UserFacingError(UserFacingError),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "RootQuery",
+    variables = "TuiOnboardingMarkersVariables"
+)]
+pub struct TuiOnboardingMarkers {
+    #[arguments(requestContext: $request_context)]
+    pub tui_onboarding_markers: TuiOnboardingMarkersResult,
+}
+
+crate::client::define_operation! {
+    tui_onboarding_markers(TuiOnboardingMarkersVariables) -> TuiOnboardingMarkers;
+}

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -2908,6 +2908,13 @@ type ResetInviteLinksOutput implements Response {
 }
 
 union ResetInviteLinksResult = ResetInviteLinksOutput | UserFacingError
+type TuiOnboardingMarkersOutput implements Response {
+  firstZeroStateShown: Boolean!
+  firstCreditGateShown: Boolean!
+  responseContext: ResponseContext!
+}
+
+union TuiOnboardingMarkersResult = TuiOnboardingMarkersOutput | UserFacingError
 
 interface Response {
   responseContext: ResponseContext!
@@ -3220,6 +3227,7 @@ type RootQuery {
   task(input: TaskInput!, requestContext: RequestContext!): TaskResult!
   taskGitCredentials(input: TaskGitCredentialsInput!, requestContext: RequestContext!): TaskGitCredentialsResult!
   taskSecrets(input: TaskSecretsInput!, requestContext: RequestContext!): TaskSecretsResult!
+  tuiOnboardingMarkers(requestContext: RequestContext!): TuiOnboardingMarkersResult!
   updatedCloudObjects(input: UpdatedCloudObjectsInput!, requestContext: RequestContext!): UpdatedCloudObjectsResult!
   user(requestContext: RequestContext!): UserResult!
   userGithubInfo(requestContext: RequestContext!): UserGithubInfoResult!


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Add account-scoped onboarding marker plumbing for Warp Agent CLI. The client loads only the two targeted marker values, reconciles provisional UI without waiting for bulk Drive sync, and persists each consumed marker monotonically as a separate cloud preference.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Implementation plan: https://staging.warp.dev/drive/notebook/oIi5YUnOvj4YXlV019cGl6

## Testing
- `./script/format`
- Focused marker model and persistence tests passed before stack submission.
- Default-GUI and TUI workspace Clippy configurations passed after feature-gating the TUI-only API surface.
- Remaining test execution was skipped at request before PR creation.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
