### PR TITLE
TUI: Add the first-session zero state

### DIFF
--- a/app/src/tui_onboarding_markers.rs
+++ b/app/src/tui_onboarding_markers.rs
@@ -105,6 +105,7 @@ impl TuiOnboardingMarkers {
             load_timeout: MARKER_LOAD_TIMEOUT,
         }
     }
+
     #[cfg(test)]
     fn new_loading_for_test(
         onboarding_client: Arc<dyn TuiOnboardingClient>,
@@ -140,6 +141,7 @@ impl TuiOnboardingMarkers {
         );
         ctx.notify();
     }
+
     /// Invalidates the previous account snapshot before a signed-out terminal
     /// can be created for the next browser authentication flow.
     pub fn reset_for_account_transition(&mut self, ctx: &mut ModelContext<Self>) {

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -325,10 +325,12 @@ fn ensure_terminal_session(
 
     let resume_token = sessions.update(ctx, |sessions, _| sessions.take_resume_token());
     let window_id = root.window_id(ctx);
+    let handles_first_run_onboarding = resume_token.is_none();
     let (_, surface) = TuiSessions::create_local_terminal_session(
         sessions,
         window_id,
         true,
+        handles_first_run_onboarding,
         std::env::current_dir().ok(),
         ctx,
     );

--- a/crates/warp_tui/src/session_registry.rs
+++ b/crates/warp_tui/src/session_registry.rs
@@ -151,6 +151,7 @@ impl TuiSessions {
         sessions: &ModelHandle<Self>,
         window_id: WindowId,
         focus: bool,
+        handles_first_run_onboarding: bool,
         startup_directory: Option<PathBuf>,
         ctx: &mut AppContext,
     ) -> (TuiSessionId, ViewHandle<TuiTerminalSessionView>) {
@@ -197,6 +198,7 @@ impl TuiSessions {
                         exit_summary,
                         keyboard_enhancement_supported,
                         default_autoexecute_mode,
+                        handles_first_run_onboarding,
                         initial_settings_file_error,
                         ctx,
                     )
@@ -268,8 +270,14 @@ impl TuiSessions {
         conversation: AIConversation,
         ctx: &mut AppContext,
     ) -> (TuiSessionId, ViewHandle<TuiTerminalSessionView>) {
-        let (session_id, surface) =
-            Self::create_local_terminal_session(sessions, window_id, false, startup_directory, ctx);
+        let (session_id, surface) = Self::create_local_terminal_session(
+            sessions,
+            window_id,
+            false,
+            false,
+            startup_directory,
+            ctx,
+        );
         surface.update(ctx, |view, ctx| {
             view.restore_orchestrated_child_conversation(conversation, ctx);
         });
@@ -433,6 +441,7 @@ impl TuiSessions {
                 let (session_id, session_view) = Self::create_local_terminal_session(
                     &sessions,
                     window_id,
+                    false,
                     false,
                     working_directory.clone(),
                     ctx,

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -36,7 +36,8 @@ use warp::tui_export::{
     SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
     StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TelemetryEvent, TerminalColorList,
     TerminalColors, TerminalModel, TerminalSurface, TerminalSurfaceInit, TranscriptScope,
-    TuiMcpAction, TuiMcpManager, TuiMcpServerId, TuiMcpVariableValue, TuiSlashCommandDataSource,
+    TuiMcpAction, TuiMcpManager, TuiMcpServerId, TuiMcpVariableValue, TuiOnboardingMarker,
+    TuiOnboardingMarkers, TuiOnboardingMarkersEvent, TuiSlashCommandDataSource,
     TuiSlashCommandDataSourceArgs, TuiUpArrowHistoryItemKind, TuiUserInfoManager,
     TuiUserInfoManagerEvent, TuiZeroStateDataSource, UserTakeOverReason, WAKEUP_THROTTLE_PERIOD,
     WarpConfig, WarpConfigUpdateEvent, block_context_from_terminal_model,
@@ -1767,6 +1768,14 @@ impl TuiTerminalSessionView {
         let suggestions_mode_for_input = suggestions_mode.clone();
         let terminal_model_for_input = model.clone();
         let orchestration_tab_bar = ctx.add_typed_action_tui_view(|_| TuiTabBarView::empty());
+        let onboarding_markers = TuiOnboardingMarkers::handle(ctx);
+        let show_first_zero_state = onboarding_markers.update(ctx, |markers, ctx| {
+            if markers.is_ready() {
+                markers.consume(TuiOnboardingMarker::FirstZeroState, ctx)
+            } else {
+                true
+            }
+        });
         let session_state = ctx.add_model(|_| {
             TuiTerminalSessionStateModel::new(
                 &model,
@@ -1775,8 +1784,30 @@ impl TuiTerminalSessionView {
                 &ai_input_model,
                 &suggestions_mode,
                 &orchestration_tab_bar,
+                show_first_zero_state,
             )
         });
+        let session_state_for_markers = session_state.clone();
+        ctx.subscribe_to_model(
+            &onboarding_markers,
+            move |_, markers, event, ctx| match event {
+                TuiOnboardingMarkersEvent::Loading => {
+                    session_state_for_markers.update(ctx, |state, ctx| {
+                        state.set_show_first_zero_state(true, ctx);
+                    });
+                }
+                TuiOnboardingMarkersEvent::Ready => {
+                    let keep_showing = markers.update(ctx, |markers, ctx| {
+                        markers.consume(TuiOnboardingMarker::FirstZeroState, ctx)
+                    });
+                    session_state_for_markers.update(ctx, |state, ctx| {
+                        if state.show_first_zero_state() {
+                            state.set_show_first_zero_state(keep_showing, ctx);
+                        }
+                    });
+                }
+            },
+        );
         let input_editor_for_input = input_editor_model.clone();
         let session_state_for_input = session_state.clone();
         let input_view = ctx.add_typed_action_tui_view(move |ctx| {
@@ -3677,6 +3708,9 @@ impl TuiTerminalSessionView {
         linked_workflow_data: Option<LinkedWorkflowData>,
         ctx: &mut ViewContext<Self>,
     ) {
+        self.session_state.update(ctx, |state, ctx| {
+            state.set_show_first_zero_state(false, ctx);
+        });
         // A stale editor frame must not submit into a shell that is still
         // bootstrapping or has handed input to a foreground process.
         if !self.input_target().agent_editor_owns_input() {
@@ -5022,7 +5056,9 @@ impl TuiTerminalSessionView {
         let mut content = TuiFlex::column();
         let transcript_is_empty = self.transcript.as_ref(ctx).is_empty();
         self.zero_state_interaction.set_visible(transcript_is_empty);
-        if transcript_is_empty {
+        if transcript_is_empty && self.session_state.as_ref(ctx).show_first_zero_state() {
+            content = content.flex_child(self.zero_state_view.as_ref(ctx).render_first_run(ctx));
+        } else if transcript_is_empty {
             content = content.flex_child(TuiChildView::new(&self.zero_state_view).finish());
         } else {
             content = content.flex_child(TuiChildView::new(&self.transcript).finish());

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -1434,6 +1434,7 @@ impl TuiTerminalSessionView {
         exit_summary: TuiExitSummaryHandle,
         keyboard_enhancement_supported: bool,
         default_autoexecute_mode: AIConversationAutoexecuteMode,
+        handles_first_run_onboarding: bool,
         initial_settings_file_error: Option<SettingsFileError>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
@@ -1768,13 +1769,16 @@ impl TuiTerminalSessionView {
         let suggestions_mode_for_input = suggestions_mode.clone();
         let terminal_model_for_input = model.clone();
         let orchestration_tab_bar = ctx.add_typed_action_tui_view(|_| TuiTabBarView::empty());
-        let onboarding_markers = TuiOnboardingMarkers::handle(ctx);
-        let show_first_zero_state = onboarding_markers.update(ctx, |markers, ctx| {
-            if markers.is_ready() {
-                markers.consume(TuiOnboardingMarker::FirstZeroState, ctx)
-            } else {
-                true
-            }
+        let onboarding_markers =
+            handles_first_run_onboarding.then(|| TuiOnboardingMarkers::handle(ctx));
+        let show_first_zero_state = onboarding_markers.as_ref().is_some_and(|markers| {
+            markers.update(ctx, |markers, ctx| {
+                if markers.is_ready() {
+                    markers.consume(TuiOnboardingMarker::FirstZeroState, ctx)
+                } else {
+                    true
+                }
+            })
         });
         let session_state = ctx.add_model(|_| {
             TuiTerminalSessionStateModel::new(
@@ -1787,27 +1791,29 @@ impl TuiTerminalSessionView {
                 show_first_zero_state,
             )
         });
-        let session_state_for_markers = session_state.clone();
-        ctx.subscribe_to_model(
-            &onboarding_markers,
-            move |_, markers, event, ctx| match event {
-                TuiOnboardingMarkersEvent::Loading => {
-                    session_state_for_markers.update(ctx, |state, ctx| {
-                        state.set_show_first_zero_state(true, ctx);
-                    });
-                }
-                TuiOnboardingMarkersEvent::Ready => {
-                    let keep_showing = markers.update(ctx, |markers, ctx| {
-                        markers.consume(TuiOnboardingMarker::FirstZeroState, ctx)
-                    });
-                    session_state_for_markers.update(ctx, |state, ctx| {
-                        if state.show_first_zero_state() {
-                            state.set_show_first_zero_state(keep_showing, ctx);
-                        }
-                    });
-                }
-            },
-        );
+        if let Some(onboarding_markers) = onboarding_markers {
+            let session_state_for_markers = session_state.clone();
+            ctx.subscribe_to_model(
+                &onboarding_markers,
+                move |_, markers, event, ctx| match event {
+                    TuiOnboardingMarkersEvent::Loading => {
+                        session_state_for_markers.update(ctx, |state, ctx| {
+                            state.set_show_first_zero_state(true, ctx);
+                        });
+                    }
+                    TuiOnboardingMarkersEvent::Ready => {
+                        let keep_showing = markers.update(ctx, |markers, ctx| {
+                            markers.consume(TuiOnboardingMarker::FirstZeroState, ctx)
+                        });
+                        session_state_for_markers.update(ctx, |state, ctx| {
+                            if state.show_first_zero_state() {
+                                state.set_show_first_zero_state(keep_showing, ctx);
+                            }
+                        });
+                    }
+                },
+            );
+        }
         let input_editor_for_input = input_editor_model.clone();
         let session_state_for_input = session_state.clone();
         let input_view = ctx.add_typed_action_tui_view(move |ctx| {

--- a/crates/warp_tui/src/terminal_session_view/state.rs
+++ b/crates/warp_tui/src/terminal_session_view/state.rs
@@ -6,7 +6,9 @@ use std::{error, fmt};
 use parking_lot::FairMutex;
 use warp::tui_export::{BlocklistAIInputModel, CLISubagentController, TerminalModel};
 use warpui_core::keymap::Context;
-use warpui_core::{AppContext, Entity, ModelHandle, ViewHandle, WeakModelHandle, WeakViewHandle};
+use warpui_core::{
+    AppContext, Entity, ModelContext, ModelHandle, ViewHandle, WeakModelHandle, WeakViewHandle,
+};
 
 use super::{
     AUTO_APPROVE_TOGGLE_BINDING_NAME, BlockingInputSource,
@@ -54,6 +56,7 @@ enum TuiTerminalSessionStateSource {
 /// presentation components one shared state source.
 pub(crate) struct TuiTerminalSessionStateModel {
     source: TuiTerminalSessionStateSource,
+    show_first_zero_state: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -101,6 +104,7 @@ impl TuiTerminalSessionStateModel {
         input_mode: &ModelHandle<BlocklistAIInputModel>,
         suggestions_mode: &ModelHandle<TuiInputSuggestionsModeModel>,
         orchestration_tab_bar: &ViewHandle<TuiTabBarView>,
+        show_first_zero_state: bool,
     ) -> Self {
         Self {
             source: TuiTerminalSessionStateSource::Session {
@@ -111,6 +115,18 @@ impl TuiTerminalSessionStateModel {
                 suggestions_mode: suggestions_mode.downgrade(),
                 orchestration_tab_bar: orchestration_tab_bar.downgrade(),
             },
+            show_first_zero_state,
+        }
+    }
+
+    pub(crate) fn show_first_zero_state(&self) -> bool {
+        self.show_first_zero_state
+    }
+
+    pub(crate) fn set_show_first_zero_state(&mut self, show: bool, ctx: &mut ModelContext<Self>) {
+        if self.show_first_zero_state != show {
+            self.show_first_zero_state = show;
+            ctx.notify();
         }
     }
     #[cfg(test)]
@@ -125,6 +141,7 @@ impl TuiTerminalSessionStateModel {
                 suggestions_mode: suggestions_mode.downgrade(),
                 orchestration_tabs_available: Rc::new(orchestration_tabs_available),
             },
+            show_first_zero_state: false,
         }
     }
 

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -98,6 +98,7 @@ use crate::terminal_block::{block_content_rows, should_render_terminal_block};
 use crate::terminal_use::TuiInputTarget;
 use crate::test_fixtures::{
     add_test_semantic_selection, add_test_terminal_session,
+    add_test_terminal_session_with_first_run_onboarding,
     add_test_terminal_session_with_settings_file_error,
 };
 use crate::transcript_view::TRANSCRIPT_BLOCK_SPACING;
@@ -2282,6 +2283,19 @@ fn add_focus_test_session(
     (view, session_id)
 }
 
+fn add_first_run_onboarding_test_session(
+    app: &mut App,
+    fixture: &FocusTestFixture,
+    focus: bool,
+) -> (ViewHandle<super::TuiTerminalSessionView>, TuiSessionId) {
+    let (view, manager) =
+        add_test_terminal_session_with_first_run_onboarding(app, fixture.window_id);
+    let session_id = app.update(|ctx| {
+        TuiSessions::register_session(&fixture.sessions, view.clone(), manager, focus, ctx)
+    });
+    (view, session_id)
+}
+
 fn add_focus_test_session_with_settings_file_error(
     app: &mut App,
     fixture: &FocusTestFixture,
@@ -3680,7 +3694,7 @@ fn first_zero_state_is_provisional_and_reconciles_without_replacing_the_session(
                 markers.reset_for_account_transition(ctx);
             });
         });
-        let (view, session_id) = add_focus_test_session(&mut app, &fixture, true);
+        let (view, session_id) = add_first_run_onboarding_test_session(&mut app, &fixture, true);
 
         app.read(|ctx| {
             assert!(
@@ -3730,7 +3744,7 @@ fn dismissed_provisional_zero_state_stays_hidden_but_consumes_ready_marker() {
                 markers.reset_for_account_transition(ctx);
             });
         });
-        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let (view, _) = add_first_run_onboarding_test_session(&mut app, &fixture, true);
 
         view.update(&mut app, |view, ctx| {
             view.session_state.update(ctx, |state, ctx| {
@@ -3762,10 +3776,62 @@ fn dismissed_provisional_zero_state_stays_hidden_but_consumes_ready_marker() {
 }
 
 #[test]
+fn background_session_does_not_receive_first_run_onboarding() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        app.update(|ctx| {
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.reset_for_account_transition(ctx);
+            });
+        });
+        let (onboarding_view, _) = add_first_run_onboarding_test_session(&mut app, &fixture, true);
+        let (background_view, _) = add_focus_test_session(&mut app, &fixture, false);
+
+        app.read(|ctx| {
+            assert!(
+                onboarding_view
+                    .as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+            assert!(
+                !background_view
+                    .as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+        });
+        app.update(|ctx| {
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.set_ready_for_test(true, false, ctx);
+            });
+        });
+        app.read(|ctx| {
+            assert!(
+                onboarding_view
+                    .as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+            assert!(
+                !background_view
+                    .as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+        });
+    });
+}
+
+#[test]
 fn account_transition_restores_provisional_zero_state_on_existing_session() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
-        let (view, session_id) = add_focus_test_session(&mut app, &fixture, true);
+        let (view, session_id) = add_first_run_onboarding_test_session(&mut app, &fixture, true);
         app.read(|ctx| {
             assert!(
                 !view

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -22,9 +22,9 @@ use warp::tui_export::{
     Harness, InputTypeAutoDetectionSource, LLMPreferences, LinkedWorkflowData,
     LongRunningCommandControlState, PtyIntent, PtyIntentEvent, SizeInfo, SizeUpdate,
     SlashCommandDataSource as _, SlashCommandKind, TaskId, TranscriptScope, TuiMcpAction,
-    TuiMcpServerId, TuiUpArrowHistoryItemKind, UserTakeOverReason, WarpConfig,
-    WarpConfigUpdateEvent, export_conversation_markdown, light_theme,
-    register_tui_session_view_test_singletons, slash_commands,
+    TuiMcpServerId, TuiOnboardingMarker, TuiOnboardingMarkers, TuiUpArrowHistoryItemKind,
+    UserTakeOverReason, WarpConfig, WarpConfigUpdateEvent, export_conversation_markdown,
+    light_theme, register_tui_session_view_test_singletons, slash_commands,
 };
 use warp_core::channel::Channel;
 use warp_core::features::FeatureFlag;
@@ -3668,6 +3668,132 @@ fn zero_state_renders_with_only_zero_height_bootstrap_blocks() {
             "starfield content should extend beyond the centered logo panel:\n{}",
             lines.join("\n")
         );
+    });
+}
+
+#[test]
+fn first_zero_state_is_provisional_and_reconciles_without_replacing_the_session() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        app.update(|ctx| {
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.reset_for_account_transition(ctx);
+            });
+        });
+        let (view, session_id) = add_focus_test_session(&mut app, &fixture, true);
+
+        app.read(|ctx| {
+            assert!(
+                view.as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+        });
+        let lines = render_session(&mut app, &view, 100, 24);
+        assert!(lines.iter().any(|line| line.contains("Welcome to Warp")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("What’s different about Warp"))
+        );
+        assert!(lines.iter().all(|line| !line.contains("████")));
+
+        app.update(|ctx| {
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.set_ready_for_test(false, false, ctx);
+            });
+        });
+        app.read(|ctx| {
+            assert!(
+                !view
+                    .as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+            assert_eq!(
+                TuiSessions::as_ref(ctx).focused_session_id(),
+                Some(session_id)
+            );
+            assert!(TuiSessions::as_ref(ctx).session(session_id).is_some());
+        });
+    });
+}
+
+#[test]
+fn dismissed_provisional_zero_state_stays_hidden_but_consumes_ready_marker() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        app.update(|ctx| {
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.reset_for_account_transition(ctx);
+            });
+        });
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+
+        view.update(&mut app, |view, ctx| {
+            view.session_state.update(ctx, |state, ctx| {
+                state.set_show_first_zero_state(false, ctx);
+            });
+        });
+        app.update(|ctx| {
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.set_ready_for_test(true, false, ctx);
+            });
+        });
+
+        app.read(|ctx| {
+            assert!(
+                !view
+                    .as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+        });
+        app.update(|ctx| {
+            let consumed_again = TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.consume(TuiOnboardingMarker::FirstZeroState, ctx)
+            });
+            assert!(!consumed_again);
+        });
+    });
+}
+
+#[test]
+fn account_transition_restores_provisional_zero_state_on_existing_session() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, session_id) = add_focus_test_session(&mut app, &fixture, true);
+        app.read(|ctx| {
+            assert!(
+                !view
+                    .as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+        });
+
+        app.update(|ctx| {
+            TuiOnboardingMarkers::handle(ctx).update(ctx, |markers, ctx| {
+                markers.reset_for_account_transition(ctx);
+            });
+        });
+        app.read(|ctx| {
+            assert!(
+                view.as_ref(ctx)
+                    .session_state
+                    .as_ref(ctx)
+                    .show_first_zero_state()
+            );
+            assert_eq!(
+                TuiSessions::as_ref(ctx).focused_session_id(),
+                Some(session_id)
+            );
+            assert!(TuiSessions::as_ref(ctx).session(session_id).is_some());
+        });
     });
 }
 

--- a/crates/warp_tui/src/test_fixtures.rs
+++ b/crates/warp_tui/src/test_fixtures.rs
@@ -142,12 +142,34 @@ pub(crate) fn add_test_terminal_session(
     ViewHandle<TuiTerminalSessionView>,
     ModelHandle<Box<dyn TerminalManagerTrait>>,
 ) {
-    add_test_terminal_session_with_settings_file_error(app, window_id, None)
+    add_test_terminal_session_with_options(app, window_id, false, None)
+}
+
+pub(crate) fn add_test_terminal_session_with_first_run_onboarding(
+    app: &mut App,
+    window_id: WindowId,
+) -> (
+    ViewHandle<TuiTerminalSessionView>,
+    ModelHandle<Box<dyn TerminalManagerTrait>>,
+) {
+    add_test_terminal_session_with_options(app, window_id, true, None)
 }
 
 pub(crate) fn add_test_terminal_session_with_settings_file_error(
     app: &mut App,
     window_id: WindowId,
+    initial_settings_file_error: Option<SettingsFileError>,
+) -> (
+    ViewHandle<TuiTerminalSessionView>,
+    ModelHandle<Box<dyn TerminalManagerTrait>>,
+) {
+    add_test_terminal_session_with_options(app, window_id, false, initial_settings_file_error)
+}
+
+fn add_test_terminal_session_with_options(
+    app: &mut App,
+    window_id: WindowId,
+    handles_first_run_onboarding: bool,
     initial_settings_file_error: Option<SettingsFileError>,
 ) -> (
     ViewHandle<TuiTerminalSessionView>,
@@ -165,6 +187,7 @@ pub(crate) fn add_test_terminal_session_with_settings_file_error(
                 TuiExitSummaryHandle::default(),
                 false,
                 AIConversationAutoexecuteMode::RespectUserSettings,
+                handles_first_run_onboarding,
                 initial_settings_file_error,
                 ctx,
             )

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -1,6 +1,6 @@
 //! The pre-first-interaction "zero state" filling the transcript area: the
-//! Warp Agent CLI title and version, a "What's new" changelog section, and the
-//! session's project context (rules and skills discovered).
+//! Warp title and version, either first-run guidance or a "What's new"
+//! changelog section, and the session's project context.
 //!
 //! The session view owns visibility: the zero state fills the transcript
 //! slot while the transcript has no visible content, so it dismisses once
@@ -50,6 +50,12 @@ const LEFT_COLUMN_COLS: u16 = 48;
 /// Width of the right-aligned animation region. This keeps the logo secondary
 /// to the copy and input while leaving enough cells for its wireframe detail.
 const ANIMATION_PANEL_COLS: u16 = 32;
+
+#[derive(Clone, Copy)]
+enum ZeroStateVariant {
+    Standard,
+    FirstRun,
+}
 // ---------------------------------------------------------------------------
 // TuiZeroStateView
 // ---------------------------------------------------------------------------
@@ -131,18 +137,12 @@ impl TuiZeroStateView {
             active_session,
         }
     }
-}
 
-impl Entity for TuiZeroStateView {
-    type Event = ();
-}
-
-impl TuiView for TuiZeroStateView {
-    fn ui_name() -> &'static str {
-        "TuiZeroStateView"
+    pub(crate) fn render_first_run(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
+        self.render_variant(ZeroStateVariant::FirstRun, ctx)
     }
 
-    fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
+    fn render_variant(&self, variant: ZeroStateVariant, ctx: &AppContext) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(ctx);
         let session = self.active_session.as_ref(ctx);
         let cwd = session.current_working_directory().cloned().or_else(|| {
@@ -170,8 +170,30 @@ impl TuiView for TuiZeroStateView {
             ANIMATION_PANEL_COLS,
         )
         .finish();
-        let overlay = build_zero_state_overlay(cwd.as_deref(), &builder, ctx);
+        let overlay = match variant {
+            ZeroStateVariant::Standard => build_zero_state_overlay(cwd.as_deref(), &builder, ctx),
+            ZeroStateVariant::FirstRun => build_zero_state_overlay_with_variant(
+                cwd.as_deref(),
+                &builder,
+                ZeroStateVariant::FirstRun,
+                ctx,
+            ),
+        };
         build_zero_state_layout(starfield, animation, overlay)
+    }
+}
+
+impl Entity for TuiZeroStateView {
+    type Event = ();
+}
+
+impl TuiView for TuiZeroStateView {
+    fn ui_name() -> &'static str {
+        "TuiZeroStateView"
+    }
+
+    fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
+        self.render_variant(ZeroStateVariant::Standard, ctx)
     }
 }
 
@@ -226,6 +248,15 @@ fn build_zero_state_overlay(
     builder: &TuiUiBuilder,
     ctx: &AppContext,
 ) -> Box<dyn TuiElement> {
+    build_zero_state_overlay_with_variant(cwd, builder, ZeroStateVariant::Standard, ctx)
+}
+
+fn build_zero_state_overlay_with_variant(
+    cwd: Option<&str>,
+    builder: &TuiUiBuilder,
+    variant: ZeroStateVariant,
+    ctx: &AppContext,
+) -> Box<dyn TuiElement> {
     // Compute project context once — find_applicable_project_rules walks the
     // directory tree and clones rule file contents, so resolving it once
     // avoids a redundant allocation on every zero-state re-render (pwd change,
@@ -242,10 +273,11 @@ fn build_zero_state_overlay(
 
     // Title, version, and changelog — constrained to LEFT_COLUMN_COLS so changelog
     // bullets (which lack `.truncate()`) do not wrap against the full terminal width.
-    let constrained_top = TuiConstrainedBox::new(render_top_section(builder, ctx).finish())
-        .with_min_cols(LEFT_COLUMN_COLS)
-        .with_max_cols(LEFT_COLUMN_COLS)
-        .finish();
+    let constrained_top =
+        TuiConstrainedBox::new(render_top_section(builder, variant, ctx).finish())
+            .with_min_cols(LEFT_COLUMN_COLS)
+            .with_max_cols(LEFT_COLUMN_COLS)
+            .finish();
 
     // Project context body (rules / skills / placeholder) and MCP — also constrained
     // to LEFT_COLUMN_COLS, keeping those rows stable.
@@ -287,7 +319,18 @@ fn build_zero_state_overlay(
 /// This is wrapped in a [`TuiConstrainedBox`] with `min = max = LEFT_COLUMN_COLS` by the
 /// caller so that changelog bullets (which lack `.truncate()`) do not word-wrap against
 /// the full terminal width while still rendering stably during async content loads.
-fn render_top_section(builder: &TuiUiBuilder, app: &AppContext) -> TuiFlex {
+fn render_top_section(
+    builder: &TuiUiBuilder,
+    variant: ZeroStateVariant,
+    app: &AppContext,
+) -> TuiFlex {
+    match variant {
+        ZeroStateVariant::Standard => render_standard_top_section(builder, app),
+        ZeroStateVariant::FirstRun => render_first_run_top_section(builder, app),
+    }
+}
+
+fn render_standard_top_section(builder: &TuiUiBuilder, app: &AppContext) -> TuiFlex {
     let title_style = builder.accent_text_style().add_modifier(Modifier::BOLD);
     let header_style = builder.primary_text_style().add_modifier(Modifier::BOLD);
     let muted = builder.muted_text_style();
@@ -322,6 +365,58 @@ fn render_top_section(builder: &TuiUiBuilder, app: &AppContext) -> TuiFlex {
         }
     }
     column
+}
+
+fn render_first_run_top_section(builder: &TuiUiBuilder, app: &AppContext) -> TuiFlex {
+    let title_style = builder.accent_text_style().add_modifier(Modifier::BOLD);
+    let muted = builder.muted_text_style();
+    let mut column = TuiFlex::column()
+        .child(
+            TuiText::new("Welcome to Warp")
+                .with_style(title_style)
+                .truncate()
+                .finish(),
+        )
+        .child(render_version_line(builder, app))
+        .child(render_login_line_with_prefix("logged in as", builder, app))
+        .child(blank_row())
+        .child(blank_row())
+        .child(
+            TuiText::new("What’s different about Warp")
+                .with_style(muted)
+                .truncate()
+                .finish(),
+        );
+    for (command, description) in [
+        (
+            Some("/natural-language-detection"),
+            "to autodetect prompts or shell commands",
+        ),
+        (Some("/modify-settings"), "to set up custom model routers"),
+        (Some("/orchestrate"), "to spawn fleets of agents"),
+        (
+            None,
+            "Run full-screen terminal apps and cd into other directories",
+        ),
+    ] {
+        column = column.child(render_first_run_capability(command, description, builder));
+    }
+    column.child(blank_row())
+}
+
+fn render_first_run_capability(
+    command: Option<&str>,
+    description: &str,
+    builder: &TuiUiBuilder,
+) -> Box<dyn TuiElement> {
+    let highlight = builder.success_glyph_style();
+    let primary = builder.primary_text_style();
+    let mut spans = vec![("✶ ".to_owned(), highlight)];
+    if let Some(command) = command {
+        spans.push((format!("{command} "), highlight));
+    }
+    spans.push((description.to_owned(), primary));
+    TuiText::from_spans(spans).finish()
 }
 
 /// Bottom section of the overlay column: project context body (rules / skills / placeholder)
@@ -459,6 +554,14 @@ fn mcp_status_label(snapshot: &warp::tui_export::TuiMcpSnapshot) -> (String, boo
 /// not. The zero state is normally only shown after login, but the unauthenticated
 /// branch keeps the surface honest if it is ever rendered before auth completes.
 fn render_login_line(builder: &TuiUiBuilder, app: &AppContext) -> Box<dyn TuiElement> {
+    render_login_line_with_prefix("Signed in as", builder, app)
+}
+
+fn render_login_line_with_prefix(
+    signed_in_prefix: &str,
+    builder: &TuiUiBuilder,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
     let muted = builder.muted_text_style();
     let dim = builder.dim_text_style();
     let user_info = TuiUserInfoManager::as_ref(app).snapshot(app);
@@ -467,7 +570,7 @@ fn render_login_line(builder: &TuiUiBuilder, app: &AppContext) -> Box<dyn TuiEle
         .filter(|email| !email.is_empty())
         .or(user_info.username.filter(|username| !username.is_empty()));
     let (label, style) = if let Some(display) = display {
-        (format!("Signed in as {display}"), muted)
+        (format!("{signed_in_prefix} {display}"), muted)
     } else if user_info.is_logged_in {
         ("Signed in".to_owned(), muted)
     } else {

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -19,7 +19,7 @@ use warpui_core::{App, AppContext};
 
 use super::{
     ANIMATION_PANEL_COLS, LEFT_COLUMN_COLS, build_zero_state_layout, build_zero_state_overlay,
-    changelog_bullets_from_changelog, mcp_status_label,
+    changelog_bullets_from_changelog, mcp_status_label, render_first_run_top_section,
 };
 use crate::tui_builder::TuiUiBuilder;
 use crate::zero_state_animation::{
@@ -72,6 +72,43 @@ fn changelog_bullets_use_only_the_first_three_tui_updates() {
 #[test]
 fn changelog_bullets_are_empty_when_only_other_surfaces_have_updates() {
     assert!(changelog_bullets_from_changelog(&changelog(Vec::new())).is_empty());
+}
+
+#[test]
+fn first_zero_state_matches_welcome_design_copy() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+
+        let lines = app.read(|ctx| {
+            let builder = TuiUiBuilder::from_app(ctx);
+            render_element_lines(
+                render_first_run_top_section(&builder, ctx).finish(),
+                ctx,
+                LEFT_COLUMN_COLS,
+                16,
+            )
+        });
+        let rendered = lines.join("\n");
+        for expected in [
+            "Welcome to Warp",
+            "What’s different about Warp",
+            "✶ /natural-language-detection",
+            "to autodetect",
+            "prompts or shell commands",
+            "✶ /modify-settings to set up custom model",
+            "routers",
+            "✶ /orchestrate to spawn fleets of agents",
+            "✶ Run full-screen terminal apps and cd into",
+            "other directories",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "first zero state should contain {expected:?}:\n{rendered}"
+            );
+        }
+        assert!(!rendered.contains("What's new"));
+        assert!(!rendered.contains("████"));
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Add the once-per-account first-session zero state. The first-run variant reuses the existing zero-state layout, animation, starfield, project context, input, and footer while presenting the Figma-aligned "What's different about Warp" guidance.

Design: https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1768-18320&m=dev

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Implementation plan: https://staging.warp.dev/drive/notebook/VEDTJkrbVxEnFZIwM5uC3A

## Testing
- `./script/format`
- `cargo check -p warp_tui --tests`
- Previously passed focused coverage: `first_zero_state_matches_welcome_design_copy` and `first_zero_state_is_provisional_and_reconciles_without_replacing_the_session`.
- Full test execution and Clippy were skipped as requested.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Manual verification screenshot and discussion:
https://staging.warp.dev/conversation/b543d79e-e3d9-4f48-9516-50c2372eabc8

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-TUI: Added first-run guidance to the Warp Agent CLI welcome screen.

Co-Authored-By: Oz <oz-agent@warp.dev>
