### PR TITLE
TUI: Gate the first out-of-credits response

### DIFF
--- a/crates/warp_graphql_schema/api/client-schema.ts
+++ b/crates/warp_graphql_schema/api/client-schema.ts
@@ -102,6 +102,7 @@ const clientQueries = [
   'task',
   'taskGitCredentials',
   'taskSecrets',
+  'tuiOnboardingMarkers',
   'listAIConversations',
   'suggestCloudEnvironmentImage'
 ];

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -22,7 +22,8 @@ use warp::tui_export::{
     BlocklistAIActionModel, BlocklistAIHistoryModel, CancellationReason,
     FAILED_OUTPUT_USAGE_NOTICE_TEXT, FailedOutputPresentation, MessageId, ModelEvent,
     ModelEventDispatcher, ReceivedMessageDisplay, RenderableAIError, SummarizationType,
-    TelemetryEvent, TerminalModel, TodoOperation, TodoStatus, failed_output_presentation,
+    TelemetryEvent, TerminalModel, TodoOperation, TodoStatus, TuiOnboardingMarker,
+    TuiOnboardingMarkers, TuiOnboardingMarkersEvent, failed_output_presentation,
     should_show_failed_output_usage_notice,
 };
 use warpui::SingletonEntity;
@@ -64,12 +65,66 @@ const OUT_OF_CREDITS_DETAIL: &str =
     "In order to use Warp’s AI features, subscribe to a Warp plan or buy packs of credits.";
 const OUT_OF_CREDITS_ACTION_LABEL: &str = "Get started with AI";
 const OUT_OF_CREDITS_ACTION_HINT: &str = "(ctrl+o)";
+const FIRST_CREDIT_GATE_TITLE: &str = "You need AI credits in order to use Warp’s agent.";
+const FIRST_CREDIT_GATE_ACTION_LABEL: &str = "Start using AI";
+const FIRST_CREDIT_GATE_ACTION_HINT: &str = "(ctrl+o).";
 const FAILURE_WARNING_PREFIX: &str = "⚠ ";
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TuiCodeBlockKey {
     message_id: MessageId,
     section_index: usize,
+}
+
+fn should_consume_first_credit_gate(
+    is_restored: bool,
+    presentation: Option<&FailedOutputPresentation>,
+) -> bool {
+    !is_restored
+        && matches!(
+            presentation,
+            Some(FailedOutputPresentation::OutOfCredits { .. })
+        )
+}
+
+fn render_first_credit_gate(
+    out_of_credits_hover_state: &MouseStateHandle,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    let primary_style = builder.primary_text_style();
+    let action = TuiHoverable::new(
+        out_of_credits_hover_state.clone(),
+        TuiText::new(FIRST_CREDIT_GATE_ACTION_LABEL)
+            .with_style(primary_style.add_modifier(Modifier::UNDERLINED))
+            .finish(),
+    )
+    .on_click(|_, app| app.open_url(OUT_OF_CREDITS_URL))
+    .finish();
+    TuiFlex::column()
+        .child(
+            TuiText::new(FIRST_CREDIT_GATE_TITLE)
+                .with_style(builder.attention_glyph_style())
+                .finish(),
+        )
+        .child(
+            TuiFlex::row()
+                .child(action)
+                .child(TuiText::new(" ").with_style(primary_style).finish())
+                .child(
+                    TuiText::new(FIRST_CREDIT_GATE_ACTION_HINT)
+                        .with_style(builder.accent_text_style())
+                        .finish(),
+                )
+                .finish(),
+        )
+        .child(TuiText::new(" ").finish())
+        .child(
+            TuiText::new(OUT_OF_CREDITS_URL)
+                .with_style(primary_style)
+                .finish(),
+        )
+        .finish()
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -117,6 +172,7 @@ enum TuiAIBlockSection {
     /// A message delivered by another agent in the orchestration.
     AgentMessage(ReceivedMessageDisplay),
     Failure(FailedOutputPresentation),
+    FirstCreditGate,
     UsageNotice,
 }
 
@@ -366,6 +422,7 @@ pub(super) struct TuiAIBlock {
     /// (thinking blocks and task lists).
     collapsible_states: CollapsibleSectionStates,
     out_of_credits_hover_state: MouseStateHandle,
+    first_credit_gate: bool,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -413,6 +470,7 @@ impl TuiAIBlock {
             terminal_model,
             collapsible_states: Default::default(),
             out_of_credits_hover_state: MouseStateHandle::default(),
+            first_credit_gate: false,
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             code_block_views: HashMap::new(),
@@ -425,6 +483,18 @@ impl TuiAIBlock {
         };
         block.sync_action_views(&action_model, ctx);
         block.sync_code_block_views(ctx);
+        block.sync_first_credit_gate(ctx);
+
+        ctx.subscribe_to_model(
+            &TuiOnboardingMarkers::handle(ctx),
+            |block, _, event, ctx| match event {
+                TuiOnboardingMarkersEvent::Loading => {}
+                TuiOnboardingMarkersEvent::Ready => {
+                    block.sync_first_credit_gate(ctx);
+                    block.invalidate_layout(ctx);
+                }
+            },
+        );
 
         ctx.subscribe_to_model(
             &action_model,
@@ -484,6 +554,7 @@ impl TuiAIBlock {
                 me.record_output_telemetry(ctx);
                 me.sync_action_views(&action_model, ctx);
                 me.sync_code_block_views(ctx);
+                me.sync_first_credit_gate(ctx);
                 // The presenter caches this block's rendered element; new
                 // output must invalidate both the view and its canonical
                 // block-list height or scrolling keeps a stale extent after
@@ -493,6 +564,25 @@ impl TuiAIBlock {
             ctx,
         );
         block
+    }
+
+    fn sync_first_credit_gate(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.first_credit_gate {
+            return;
+        }
+        let presentation = {
+            let status = self.block_model.status(ctx);
+            self.visible_failure(&status, ctx)
+                .map(|(_, presentation)| presentation)
+        };
+        let is_out_of_credits =
+            should_consume_first_credit_gate(self.block_model.is_restored(), presentation.as_ref());
+        if is_out_of_credits {
+            self.first_credit_gate = TuiOnboardingMarkers::handle(ctx)
+                .update(ctx, |markers, ctx| {
+                    markers.consume(TuiOnboardingMarker::FirstCreditGate, ctx)
+                });
+        }
     }
 
     fn record_output_telemetry(&mut self, ctx: &mut ViewContext<Self>) {
@@ -1381,6 +1471,9 @@ impl TuiAIBlock {
             TuiAIBlockSection::Failure(presentation) => {
                 render_failure_section(presentation, &self.out_of_credits_hover_state, app)
             }
+            TuiAIBlockSection::FirstCreditGate => {
+                render_first_credit_gate(&self.out_of_credits_hover_state, app)
+            }
             TuiAIBlockSection::UsageNotice => render_usage_notice(app),
         })
     }
@@ -1515,14 +1608,22 @@ impl TuiAIBlock {
         }
 
         if let Some((error, presentation)) = self.visible_failure(&status, app) {
-            sections.push(TuiAIBlockSection::Failure(presentation));
-            if should_show_failed_output_usage_notice(
-                error,
-                self.block_model
-                    .is_latest_visible_exchange_in_root_task(app),
-                self.has_expanded_last_requested_command(app),
-                self.block_model.is_restored(),
-            ) {
+            if self.first_credit_gate
+                && matches!(presentation, FailedOutputPresentation::OutOfCredits { .. })
+            {
+                sections.push(TuiAIBlockSection::FirstCreditGate);
+            } else {
+                sections.push(TuiAIBlockSection::Failure(presentation));
+            }
+            if !self.first_credit_gate
+                && should_show_failed_output_usage_notice(
+                    error,
+                    self.block_model
+                        .is_latest_visible_exchange_in_root_task(app),
+                    self.has_expanded_last_requested_command(app),
+                    self.block_model.is_restored(),
+                )
+            {
                 sections.push(TuiAIBlockSection::UsageNotice);
             }
         }
@@ -1767,6 +1868,9 @@ impl TuiAIBlock {
                 TuiAIBlockSection::Failure(presentation) => {
                     render_failure_section(presentation, &self.out_of_credits_hover_state, app)
                 }
+                TuiAIBlockSection::FirstCreditGate => {
+                    render_first_credit_gate(&self.out_of_credits_hover_state, app)
+                }
                 TuiAIBlockSection::UsageNotice => render_usage_notice(app),
             };
 
@@ -1834,6 +1938,10 @@ fn section_logical_text(section: &TuiAIBlockSection) -> Option<String> {
         | TuiAIBlockSection::CompletedTodos { .. }
         | TuiAIBlockSection::AgentMessage(_) => None,
         TuiAIBlockSection::Failure(presentation) => Some(failure_text(presentation)),
+        TuiAIBlockSection::FirstCreditGate => Some(format!(
+            "{FIRST_CREDIT_GATE_TITLE}\n{FIRST_CREDIT_GATE_ACTION_LABEL} \
+             {FIRST_CREDIT_GATE_ACTION_HINT}\n\n{OUT_OF_CREDITS_URL}"
+        )),
         TuiAIBlockSection::UsageNotice => Some(FAILED_OUTPUT_USAGE_NOTICE_TEXT.to_owned()),
     }
 }

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -2256,9 +2256,6 @@ struct FakeAgentBlockModel {
 /// Builds an agent block with fresh test identity, registered in a fresh TUI
 /// window and backed by a real action model.
 fn test_agent_block(app: &mut App, model: FakeAgentBlockModel) -> ViewHandle<TuiAIBlock> {
-    if !app.read(|ctx| ctx.has_singleton_model::<TuiOnboardingMarkers>()) {
-        app.add_singleton_model(|_| TuiOnboardingMarkers::new_ready_for_test(false, false));
-    }
     let (action_model, model_events) = add_test_action_model_and_events(app);
     let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
     app.update(|ctx| {

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -13,11 +13,13 @@ use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
     AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
     AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIAgentTodo, AIAgentTodoList,
-    AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, AgentOutputImage,
-    AgentOutputImageLayout, AgentOutputMermaidDiagram, AgentOutputTable, Appearance,
-    FailedOutputPresentation, LLMId, MessageId, OutputStatusUpdateCallback, ReceivedMessageDisplay,
-    RenderableAIError, RequestCommandOutputResult, ServerOutputId, Shared, SummarizationType,
-    TaskId, TerminalModel, TodoOperation, TodoStatus, UserQueryMode,
+    AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, ActiveSession,
+    AgentOutputImage, AgentOutputImageLayout, AgentOutputMermaidDiagram, AgentOutputTable,
+    Appearance, BlocklistAIActionModel, FailedOutputPresentation, GetRelevantFilesController,
+    LLMId, MessageId, ModelEventDispatcher, OutputStatusUpdateCallback, ReceivedMessageDisplay,
+    RenderableAIError, RequestCommandOutputResult, ServerOutputId, Sessions, Shared,
+    SummarizationType, TaskId, TerminalModel, TodoOperation, TodoStatus, TuiOnboardingMarker,
+    TuiOnboardingMarkers, UserQueryMode, register_tui_session_view_test_singletons,
     should_show_failed_output_usage_notice,
 };
 use warp_core::ui::color::blend::Blend;
@@ -37,6 +39,7 @@ use warpui_core::{App, AppContext, EntityId, EntityIdMap, TuiView, ViewContext, 
 use super::{
     CollapsibleSectionStates, TuiAIBlock, TuiAIBlockAction, TuiAIBlockEvent, TuiAIBlockSection,
     TuiCodeBlockKey, TuiRichTextSection, TuiToolCallView, render_failure_section,
+    render_first_credit_gate, should_consume_first_credit_gate,
 };
 use crate::agent_block_sections::{
     completed_todos_label, render_fallback_tool_call_section, render_todo_list_section,
@@ -90,6 +93,141 @@ fn agent_block_renders_generic_failure_after_partial_output() {
             ))
             .into();
             assert_eq!(frame.buffer[(0, failure_row as u16)].fg, red);
+        });
+    });
+}
+
+#[test]
+fn restored_out_of_credits_exchange_does_not_consume_first_credit_gate() {
+    let presentation = FailedOutputPresentation::OutOfCredits {
+        message: "out of credits".to_owned(),
+        can_use_own_api_keys: false,
+    };
+    assert!(should_consume_first_credit_gate(false, Some(&presentation)));
+    assert!(!should_consume_first_credit_gate(true, Some(&presentation)));
+    assert!(!should_consume_first_credit_gate(false, None));
+}
+
+#[test]
+fn first_credit_gate_matches_design_and_opens_pricing() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let opened_urls = Rc::new(RefCell::new(Vec::new()));
+        let opened_urls_for_callback = opened_urls.clone();
+        app.update(|ctx| {
+            ctx.set_before_open_url(move |url, _| {
+                opened_urls_for_callback.borrow_mut().push(url.to_owned());
+                url.to_owned()
+            });
+        });
+
+        app.read(|ctx| {
+            let hover_state = MouseStateHandle::default();
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_first_credit_gate(&hover_state, ctx),
+                TuiRect::new(0, 0, 80, 4),
+                ctx,
+            );
+            assert_eq!(
+                frame
+                    .buffer
+                    .to_lines()
+                    .into_iter()
+                    .map(|line| line.trim_end().to_owned())
+                    .collect::<Vec<_>>(),
+                vec![
+                    "You need AI credits in order to use Warp’s agent.",
+                    "Start using AI (ctrl+o).",
+                    "",
+                    "https://www.warp.dev/pricing",
+                ]
+            );
+            let builder = TuiUiBuilder::from_app(ctx);
+            assert_eq!(
+                frame.buffer[(0, 0)].fg,
+                builder
+                    .attention_glyph_style()
+                    .fg
+                    .expect("attention foreground")
+            );
+            assert!(frame.buffer[(0, 1)].modifier.contains(Modifier::UNDERLINED));
+            assert_eq!(
+                frame.buffer[(15, 1)].fg,
+                builder.accent_text_style().fg.expect("accent foreground")
+            );
+            dispatch_click_on_text(
+                render_first_credit_gate(&hover_state, ctx),
+                "Start using AI",
+                80,
+                4,
+                ctx,
+            );
+        });
+
+        assert_eq!(
+            &*opened_urls.borrow(),
+            &["https://www.warp.dev/pricing".to_owned()]
+        );
+    });
+}
+
+#[test]
+fn first_credit_gate_consumes_once_and_reacts_to_delayed_marker_readiness() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        let markers = TuiOnboardingMarkers::handle(&app);
+        let first = test_agent_block_with_registered_singletons(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: failed_output(
+                    Vec::new(),
+                    RenderableAIError::QuotaLimit {
+                        user_display_message: Some("You’ve reached your credit limit.".to_owned()),
+                    },
+                ),
+            },
+        );
+        app.read(|ctx| {
+            assert!(!first.as_ref(ctx).first_credit_gate);
+        });
+
+        markers.update(&mut app, |markers, ctx| {
+            markers.set_ready_for_test(false, true, ctx);
+        });
+        app.read(|ctx| {
+            let lines = render_block_lines(first.as_ref(ctx), 100, ctx);
+            assert!(first.as_ref(ctx).first_credit_gate);
+            assert!(
+                lines
+                    .iter()
+                    .any(|line| line == "You need AI credits in order to use Warp’s agent.")
+            );
+            assert!(
+                lines
+                    .iter()
+                    .all(|line| !line.contains("won't count towards your usage"))
+            );
+        });
+        markers.update(&mut app, |markers, ctx| {
+            assert!(!markers.consume(TuiOnboardingMarker::FirstCreditGate, ctx));
+        });
+
+        let duplicate = test_agent_block_with_registered_singletons(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: failed_output(
+                    Vec::new(),
+                    RenderableAIError::QuotaLimit {
+                        user_display_message: Some("You’ve reached your credit limit.".to_owned()),
+                    },
+                ),
+            },
+        );
+        app.read(|ctx| {
+            assert!(!duplicate.as_ref(ctx).first_credit_gate);
         });
     });
 }
@@ -2118,6 +2256,9 @@ struct FakeAgentBlockModel {
 /// Builds an agent block with fresh test identity, registered in a fresh TUI
 /// window and backed by a real action model.
 fn test_agent_block(app: &mut App, model: FakeAgentBlockModel) -> ViewHandle<TuiAIBlock> {
+    if !app.read(|ctx| ctx.has_singleton_model::<TuiOnboardingMarkers>()) {
+        app.add_singleton_model(|_| TuiOnboardingMarkers::new_ready_for_test(false, false));
+    }
     let (action_model, model_events) = add_test_action_model_and_events(app);
     let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
     app.update(|ctx| {
@@ -2142,6 +2283,52 @@ fn test_agent_block(app: &mut App, model: FakeAgentBlockModel) -> ViewHandle<Tui
     })
 }
 
+/// Builds an agent block after the full session fixture has registered the app
+/// models needed by out-of-credits presentation.
+fn test_agent_block_with_registered_singletons(
+    app: &mut App,
+    model: FakeAgentBlockModel,
+) -> ViewHandle<TuiAIBlock> {
+    let action_terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+    let sessions = app.add_model(|_| Sessions::new_for_test());
+    let (_tx, model_events_rx) = async_channel::unbounded();
+    let model_events =
+        app.add_model(|ctx| ModelEventDispatcher::new(model_events_rx, sessions.clone(), ctx));
+    let active_session =
+        app.add_model(|ctx| ActiveSession::new(sessions, model_events.clone(), ctx));
+    let get_relevant_files = app.add_model(|_| GetRelevantFilesController::default());
+    let action_model = app.add_model(|ctx| {
+        BlocklistAIActionModel::new(
+            action_terminal_model,
+            active_session,
+            &model_events,
+            get_relevant_files,
+            EntityId::new(),
+            ctx,
+        )
+    });
+    let block_terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+    app.update(|ctx| {
+        let (window_id, _) = ctx.add_tui_window(
+            AddWindowOptions {
+                window_style: WindowStyle::NotStealFocus,
+                ..Default::default()
+            },
+            |_| TestHostView,
+        );
+        ctx.add_typed_action_tui_view(window_id, move |ctx| {
+            TuiAIBlock::new(
+                (AIConversationId::new(), AIAgentExchangeId::new()),
+                Rc::new(model),
+                action_model,
+                &model_events,
+                block_terminal_model,
+                false,
+                ctx,
+            )
+        })
+    })
+}
 fn ask_user_question_action(id: &str, question: &str) -> AIAgentAction {
     AIAgentAction {
         id: AIAgentActionId::from(id.to_owned()),

--- a/crates/warp_tui/src/test_fixtures.rs
+++ b/crates/warp_tui/src/test_fixtures.rs
@@ -9,7 +9,7 @@ use warp::tui_export::{
     AIConversationAutoexecuteMode, ActiveSession, Appearance, BlocklistAIActionModel,
     BlocklistAIHistoryModel, ConversationSelection, ConversationSelectionHandle,
     GetRelevantFilesController, ModelEventDispatcher, Sessions, TerminalManagerTrait,
-    TerminalModel, TerminalSurfaceInit, TranscriptScope,
+    TerminalModel, TerminalSurfaceInit, TranscriptScope, TuiOnboardingMarkers,
 };
 use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
 use warp_core::semantic_selection::SemanticSelection;
@@ -99,6 +99,9 @@ pub(crate) fn add_test_action_model_and_events(
     ModelHandle<BlocklistAIActionModel>,
     ModelHandle<ModelEventDispatcher>,
 ) {
+    if !app.read(|ctx| ctx.has_singleton_model::<TuiOnboardingMarkers>()) {
+        app.add_singleton_model(|_| TuiOnboardingMarkers::new_ready_for_test(false, false));
+    }
     if !app.read(|ctx| ctx.has_singleton_model::<Appearance>()) {
         app.add_singleton_model(|_| Appearance::mock());
     }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Gate the first out-of-credits response behind the account-scoped onboarding marker. The first eligible response shows the upgrade guidance once, persists consumption, and leaves subsequent credit failures on the standard response path.

Also add `tuiOnboardingMarkers` to the generated GraphQL client schema allowlist after warp-server #13645 merged. The query binding and compatible SDL definitions already landed in #14579; this closes the generator input gap so future schema refreshes retain the endpoint. A full staging refresh was generated and compile-checked, but its unrelated removals are not included because they remove schema types still consumed by the client.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Implementation plan: https://staging.warp.dev/drive/notebook/VEDTJkrbVxEnFZIwM5uC3A

## Testing
- `./script/format`
- `cargo check -p warp_graphql -p warp_tui --tests`
- Added focused coverage in `agent_block_tests.rs`.
- Full test execution and Clippy were skipped as requested.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-TUI: Added a one-time upgrade explanation when Warp Agent CLI first runs out of credits.

Co-Authored-By: Oz <oz-agent@warp.dev>
