### PR TITLE
[3/4] TUI: reuse retained text measurements

### DIFF
--- a/crates/warpui_core/src/elements/tui/text.rs
+++ b/crates/warpui_core/src/elements/tui/text.rs
@@ -47,6 +47,11 @@ enum TuiTextOverflow {
     Clip,
     Ellipsis,
 }
+#[derive(Clone, Copy)]
+struct TuiTextMeasurement {
+    available_width: u16,
+    natural_size: TuiSize,
+}
 
 pub struct TuiText {
     /// Styled runs that concatenate into the full text. Runs may contain hard
@@ -56,6 +61,7 @@ pub struct TuiText {
     style: TuiStyle,
     wrap: bool,
     overflow: TuiTextOverflow,
+    cached_measurement: Option<TuiTextMeasurement>,
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
 }
@@ -75,6 +81,7 @@ impl TuiText {
             style: TuiStyle::default(),
             wrap: true,
             overflow: TuiTextOverflow::default(),
+            cached_measurement: None,
             size: None,
             origin: None,
         }
@@ -88,6 +95,7 @@ impl TuiText {
     /// Lays each hard line out as a single (clipped) row instead of wrapping.
     pub fn truncate(mut self) -> Self {
         self.wrap = false;
+        self.cached_measurement = None;
         self
     }
     /// Truncates each hard line at grapheme boundaries and appends `...`
@@ -95,6 +103,7 @@ impl TuiText {
     pub fn truncate_with_ellipsis(mut self) -> Self {
         self.wrap = false;
         self.overflow = TuiTextOverflow::Ellipsis;
+        self.cached_measurement = None;
         self
     }
 
@@ -262,18 +271,30 @@ impl TuiElement for TuiText {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        let size = if self.is_empty() {
-            constraint.clamp(TuiSize::ZERO)
+        let width = constraint.max.width;
+        let natural_size = if self.is_empty() {
+            TuiSize::ZERO
+        } else if let Some(measurement) = self
+            .cached_measurement
+            .filter(|measurement| measurement.available_width == width)
+        {
+            measurement.natural_size
         } else {
             let paragraph = self.paragraph(constraint.max.width);
             let height =
                 u16::try_from(paragraph.line_count(constraint.max.width)).unwrap_or(u16::MAX);
             let content_width = u16::try_from(paragraph.line_width()).unwrap_or(u16::MAX);
-            TuiSize::new(
-                constraint.constrain_width(content_width),
-                constraint.constrain_height(height),
-            )
+            let size = TuiSize::new(content_width, height);
+            self.cached_measurement = Some(TuiTextMeasurement {
+                available_width: width,
+                natural_size: size,
+            });
+            size
         };
+        let size = TuiSize::new(
+            constraint.constrain_width(natural_size.width),
+            constraint.constrain_height(natural_size.height),
+        );
         self.size = Some(size);
         size
     }

--- a/crates/warpui_core/src/elements/tui/text_tests.rs
+++ b/crates/warpui_core/src/elements/tui/text_tests.rs
@@ -70,6 +70,34 @@ fn layout_reports_content_width_and_row_count() {
 }
 
 #[test]
+fn truncation_invalidates_a_cached_wrapped_measurement() {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let constraint = TuiConstraint::loose(TuiSize::new(5, 10));
+            for truncate in [
+                TuiText::truncate as fn(TuiText) -> TuiText,
+                TuiText::truncate_with_ellipsis,
+            ] {
+                let mut text = TuiText::new("hello world");
+                let mut rendered_views = EntityIdMap::default();
+                let mut ctx = TuiLayoutContext {
+                    rendered_views: &mut rendered_views,
+                };
+                assert_eq!(
+                    text.layout(constraint, &mut ctx, app_ctx),
+                    TuiSize::new(5, 2)
+                );
+
+                text = truncate(text);
+                assert_eq!(
+                    text.layout(constraint, &mut ctx, app_ctx),
+                    TuiSize::new(5, 1)
+                );
+            }
+        });
+    });
+}
+#[test]
 fn word_wraps_at_the_width_boundary() {
     let text = TuiText::new("hello world foo");
     assert_eq!(

--- a/crates/warpui_core/src/elements/tui/viewported_list.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list.rs
@@ -147,6 +147,12 @@ where
         let Some(resolved) = self.state.resolved_viewport() else {
             return;
         };
+        let selection_is_valid = selection.validate_width(size.width);
+        let selection_range = selection_is_valid.then(|| selection.range()).flatten();
+        if selection_range.is_none() && !self.trim_selection_line_ends {
+            self.selection_snapshot.borrow_mut().take();
+            return;
+        }
         let visible_height = size.height.saturating_sub(resolved.screen_offset).min(
             resolved
                 .content_height
@@ -171,10 +177,7 @@ where
                 .collect::<Vec<_>>()
         });
         *self.selection_snapshot.borrow_mut() = Some((resolved, snapshot));
-        if !selection.validate_width(size.width) {
-            return;
-        }
-        let Some(range) = selection.range() else {
+        let Some(range) = selection_range else {
             return;
         };
         let viewport_bottom = resolved.window.scroll_top.saturating_add(usize::from(


### PR DESCRIPTION
## Description
Stack 3 of 4. Reuses `TuiText` natural measurements when retained content is laid out again at the same width, and avoids copying a viewport selection snapshot when there is no active selection and line-end trimming is disabled.

This layer targets steady-state frame overhead after stack PR 2 has already bounded paint work. Width changes still recompute text measurement, and selection snapshots remain enabled whenever selection or trimmed line-end behavior needs them.

Benchmark at 120×50 versus stack PR 2:
- Retained rich response, 1,000 rows: 0.925 → 0.129 ms (86% faster).
- Retained rich response, 10,000 rows: 8.56 → 0.598 ms (93% faster).
- Retained middle frame, 10,000 rows: 8.41 → 0.395 ms (95% faster).
- Retained streaming tail at end, 10,000 rows: 17.2 → 9.88 ms (42% faster).
- Invalidated rich response, 10,000 rows: 9.38 → 9.85 ms (~5% slower).
- Many completed blocks, 10,000: 29.2 → 31.6 µs/frame (~8% slower, still flat with history depth).

The next stack layer removes the remaining repeated streaming-height work and owns auto-scroll reconciliation.

Stack: #14575 ← #14582 ← **3/4** → `oz/tui-streaming-height-reconciliation`.

Agent conversation: https://staging.warp.dev/conversation/2b6af7be-b227-4b20-aaf4-23c9a8494b81
Stack plan: https://staging.warp.dev/drive/notebook/yM2YcQsILFsFzwixBDbD9p
Performance plan: https://staging.warp.dev/drive/notebook/LHzsFd1B8XbQ8AnUqB88LS

## Linked Issue
N/A — Warp Agent CLI retained-frame performance.

## Testing
- `cargo nextest run -p warpui_core --features tui` — 555 passed, 7 skipped.
- `cargo nextest run -p warp_tui` — 902 passed.
- Strict Clippy passed for `warpui_core --features tui` and `warp_tui --features test-util`.
- `cargo bench -p warp_tui --features test-util --bench transcript_bench`
- `./script/format`
- Signed-in 120×40 tmux PTY: zero state and unsent input repainted correctly.

- [x] I have manually tested my changes locally with `./script/run-tui`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
