### PR TITLE
Fix Windows TUI installer signing authentication

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1694,6 +1694,9 @@ jobs:
         env:
           CHANNEL: ${{ steps.get-config.outputs.channel }}
           GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           SIGN_TOOL_CMD: ${{ steps.setup_signing.outputs.sign_tool_cmd }}
 
       - name: Upload Windows TUI installer


### PR DESCRIPTION
## Description
Fix the dev release workflow's Windows TUI installer signing step.

The installer bundling step invokes the Azure Trusted Signing dlib through Inno Setup, but it did not expose the Azure service-principal credentials. As a result, signing stalled after `Submitting digest for signing...` until the release job timed out. Pass the same step-scoped credentials already used by the successful Windows GUI installer path.

Failed run: https://github.com/warpdotdev/warp-internal/actions/runs/30618756994/job/91118776751

Implementation plan: https://staging.warp.dev/drive/notebook/lzKA2EUeURN2B7MajrtOLk

## Linked Issue
No linked issue; this fixes a release workflow regression observed in two consecutive dev release runs.

## Testing
- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- Parsed `.github/workflows/create_release.yml` as YAML and verified the TUI and GUI bundling steps use identical Azure credential sources.
- End-to-end validation requires the next credentialed dev release run.

- [ ] I have manually tested my changes locally with `./script/run` (not applicable to a workflow-only change)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
