### PR TITLE
Add TUI fork command support

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -211,6 +211,11 @@ pub enum UpdateHistoryError {
     #[error("Failed to find conversation with ID {0:?}")]
     ConversationNotFound(AIConversationId),
 }
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ForkConversationError {
+    #[error("cannot fork an empty conversation")]
+    EmptyConversation,
+}
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub(crate) enum BeginConversationRenameError {
@@ -1553,6 +1558,16 @@ impl BlocklistAIHistoryModel {
         Ok(new_conversation_id)
     }
 
+    /// Checks whether a conversation can be forked without mutating history.
+    pub fn validate_fork_source(
+        source_conversation: &AIConversation,
+    ) -> Result<(), ForkConversationError> {
+        if source_conversation.is_empty() {
+            return Err(ForkConversationError::EmptyConversation);
+        }
+        Ok(())
+    }
+
     /// Forks an existing conversation by creating a new conversation
     /// and copying the existing conversation's tasks into the new conversation.
     ///
@@ -1572,6 +1587,7 @@ impl BlocklistAIHistoryModel {
         title_override: Option<&str>,
         app: &AppContext,
     ) -> Result<AIConversation, anyhow::Error> {
+        Self::validate_fork_source(source_conversation)?;
         let tasks: Vec<warp_multi_agent_api::Task> = source_conversation
             .all_tasks()
             .filter_map(|t| t.source().cloned())

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -10,8 +10,8 @@ use warpui::{App, EntityId, ModelHandle};
 
 use super::{
     AIConversationMetadata, AIQueryHistoryOutputStatus, BeginConversationRenameError,
-    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, PersistedAIInput, PersistedAIInputType,
-    convert_persisted_conversation_to_ai_conversation_with_metadata,
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ForkConversationError, PersistedAIInput,
+    PersistedAIInputType, convert_persisted_conversation_to_ai_conversation_with_metadata,
 };
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
@@ -3424,6 +3424,25 @@ fn test_set_server_conversation_token_rebinds_reverse_index() {
     });
 }
 
+#[test]
+fn test_fork_conversation_rejects_an_empty_source() {
+    App::test((), |mut app| async move {
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let source = AIConversation::new(false, false);
+
+        let error = history_model.update(&mut app, |model, ctx| {
+            model
+                .fork_conversation(&source, "[Fork] ", false, None, ctx)
+                .expect_err("forking an empty conversation should fail")
+        });
+
+        assert_eq!(
+            error.downcast_ref::<ForkConversationError>(),
+            Some(&ForkConversationError::EmptyConversation),
+        );
+    });
+}
 /// REMOTE-1519 fork-on-chip-click flow.
 /// Forking the local conversation must:
 /// 1. carry the source's server token forward as `forked_from_*` (so the

--- a/app/src/global_resource_handles.rs
+++ b/app/src/global_resource_handles.rs
@@ -84,6 +84,10 @@ impl GlobalResourceHandlesProvider {
     pub fn get(&self) -> &GlobalResourceHandles {
         &self.global_resources
     }
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_model_event_sender_for_test(&mut self, sender: SyncSender<ModelEvent>) {
+        self.global_resources.model_event_sender = Some(sender);
+    }
 
     pub(super) fn new(global_resources: GlobalResourceHandles) -> Self {
         Self { global_resources }

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -329,9 +329,9 @@ pub static FORK: LazyLock<StaticCommand> = LazyLock::new(|| {
     let hint_text = "<optional prompt to send in forked conversation>";
     StaticCommand {
         name: "/fork",
-        description: "Fork the current conversation in a new pane or a new tab",
+        description: "Fork the current conversation",
         kind: SlashCommandKind::Fork,
-        supported_surfaces: SlashCommandSurfaces::GuiOnly {
+        supported_surfaces: SlashCommandSurfaces::GuiAndTui {
             icon_path: "bundled/svg/arrow-split.svg",
         },
         availability: Availability::AGENT_VIEW

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -83,7 +83,7 @@ pub use crate::ai::blocklist::handoff::{
 };
 pub use crate::ai::blocklist::history_model::{
     AIQueryHistory, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, CloudConversationData,
-    ConversationStatusUpdate,
+    ConversationStatusUpdate, FORK_PREFIX, ForkConversationError,
 };
 pub use crate::ai::blocklist::inline_action::code_diff_view::convert_file_edits_to_file_diffs;
 pub use crate::ai::blocklist::orchestration_event_streamer::{
@@ -258,8 +258,9 @@ pub use crate::tui_onboarding_markers::{
 #[cfg(any(test, feature = "test-util"))]
 pub use crate::tui_test_support::{
     add_tui_history_test_models, append_tui_history_test_command,
-    blocklist_ai_history_model_with_queries, queue_tui_permission_action,
-    register_tui_input_mode_test_settings, register_tui_session_view_test_singletons,
+    blocklist_ai_history_model_with_queries, forkable_tui_conversation_for_test,
+    queue_tui_permission_action, register_tui_input_mode_test_settings,
+    register_tui_session_view_test_singletons,
 };
 pub use crate::user_config::{WarpConfig, WarpConfigUpdateEvent};
 pub use crate::util::image::{

--- a/app/src/tui_test_support.rs
+++ b/app/src/tui_test_support.rs
@@ -12,7 +12,7 @@ use warpui::{AppContext, ModelContext, ModelHandle, SingletonEntity as _};
 
 use crate::LaunchMode;
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::agent::{AIAgentAction, AIAgentExchangeId};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::blocklist::history_model::AIQueryHistoryOutputStatus;
@@ -88,6 +88,59 @@ pub fn blocklist_ai_history_model_with_queries(queries: Vec<String>) -> Blocklis
         .collect();
 
     BlocklistAIHistoryModel::new(persisted_queries, Vec::new(), &[])
+}
+
+/// Builds a restored conversation with one completed exchange for TUI fork tests.
+pub fn forkable_tui_conversation_for_test(query: &str) -> AIConversation {
+    let task_id = "tui-fork-test-root";
+    let request_id = "tui-fork-test-request";
+    let messages = vec![
+        warp_multi_agent_api::Message {
+            fetched_memories: Vec::new(),
+            id: "tui-fork-test-user".to_owned(),
+            task_id: task_id.to_owned(),
+            server_message_data: String::new(),
+            citations: Vec::new(),
+            message: Some(warp_multi_agent_api::message::Message::UserQuery(
+                warp_multi_agent_api::message::UserQuery {
+                    query: query.to_owned(),
+                    context: None,
+                    referenced_attachments: HashMap::new(),
+                    mode: None,
+                    intended_agent: Default::default(),
+                },
+            )),
+            request_id: request_id.to_owned(),
+            timestamp: None,
+        },
+        warp_multi_agent_api::Message {
+            fetched_memories: Vec::new(),
+            id: "tui-fork-test-agent".to_owned(),
+            task_id: task_id.to_owned(),
+            server_message_data: String::new(),
+            citations: Vec::new(),
+            message: Some(warp_multi_agent_api::message::Message::AgentOutput(
+                warp_multi_agent_api::message::AgentOutput {
+                    text: "Original response".to_owned(),
+                },
+            )),
+            request_id: request_id.to_owned(),
+            timestamp: None,
+        },
+    ];
+    AIConversation::new_restored(
+        AIConversationId::new(),
+        vec![warp_multi_agent_api::Task {
+            id: task_id.to_owned(),
+            messages,
+            dependencies: None,
+            description: String::new(),
+            summary: String::new(),
+            server_data: String::new(),
+        }],
+        None,
+    )
+    .expect("TUI fork test conversation should restore")
 }
 
 /// Registers seeded command history and an active session for focused TUI history tests.

--- a/crates/warp_tui/src/benchmark_support.rs
+++ b/crates/warp_tui/src/benchmark_support.rs
@@ -27,7 +27,8 @@ use crate::agent_block::TuiAIBlock;
 use crate::terminal_block::{TerminalBlockElement, block_content_rows};
 use crate::test_fixtures::add_test_action_model_and_events;
 use crate::tui_block_list_viewport_source::{
-    AgentBlockRegistry, CLISubagentBlockRegistry, HandoffBlockRegistry, TuiBlockListViewportSource,
+    AgentBlockRegistry, CLISubagentBlockRegistry, HandoffBlockRegistry, TranscriptNoticeRegistry,
+    TuiBlockListViewportSource,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -134,10 +135,12 @@ impl TranscriptBenchmark {
             let agent_blocks = AgentBlockRegistry::new(RefCell::new(HashMap::new()));
             let cli_subagent_blocks = CLISubagentBlockRegistry::new(RefCell::new(HashMap::new()));
             let handoff_blocks = HandoffBlockRegistry::new(RefCell::new(HashMap::new()));
+            let notices = TranscriptNoticeRegistry::new(RefCell::new(HashMap::new()));
             let model_for_root = terminal_model.clone();
             let agent_blocks_for_root = agent_blocks.clone();
             let cli_subagent_blocks_for_root = cli_subagent_blocks.clone();
             let handoff_blocks_for_root = handoff_blocks.clone();
+            let notices_for_root = notices.clone();
             let (window_id, root) = app.update(|ctx| {
                 ctx.add_tui_window(
                     AddWindowOptions {
@@ -149,6 +152,7 @@ impl TranscriptBenchmark {
                         agent_blocks: agent_blocks_for_root,
                         cli_subagent_blocks: cli_subagent_blocks_for_root,
                         handoff_blocks: handoff_blocks_for_root,
+                        notices: notices_for_root,
                         viewport: TuiViewportedListState::new_at_end(),
                     },
                 )
@@ -266,6 +270,7 @@ struct BenchmarkTranscriptView {
     agent_blocks: AgentBlockRegistry,
     cli_subagent_blocks: CLISubagentBlockRegistry,
     handoff_blocks: HandoffBlockRegistry,
+    notices: TranscriptNoticeRegistry,
     viewport: TuiViewportedListState,
 }
 
@@ -292,6 +297,7 @@ impl TuiView for BenchmarkTranscriptView {
             self.agent_blocks.clone(),
             self.cli_subagent_blocks.clone(),
             self.handoff_blocks.clone(),
+            self.notices.clone(),
         );
         TuiViewportedList::new(
             self.viewport.clone(),

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -26,21 +26,21 @@ use warp::tui_export::{
     BlocklistOrchestrationTelemetryEvent, CLISubagentController, CLISubagentEvent,
     CLISubagentTarget, COMMAND_REGISTRY, CancellationReason, ChangelogModel, ChangelogRequestType,
     CloudConversationData, CommandExecutionSource, ConversationFileExport, ConversationSelection,
-    ConversationSelectionHandle, ExecuteCommandEvent, GetRelevantFilesController, GitHubRepoModel,
-    GitRepoStatusModel, LLMId, LLMPreferences, LLMPreferencesEvent,
-    LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, LinkedWorkflowData, ModelEvent,
-    ParsedSlashCommandInput, PersistenceWriter, PillBarActionKind, PillBarInteractionEvent,
-    PillBarPillKind, PillSwitchOutcome, PtyIntent, PtyIntentEvent, QueuedQueryEvent,
-    QueuedQueryModel, RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
-    SessionSettings, Sessions, ShellCommandExecutorEvent, SizeInfo, SizeUpdate, SkillReference,
-    SlashCommandDataSource as _, SlashCommandKind, SlashCommandSelectionBehavior,
-    StartAgentExecutorEvent, StartAgentRequest, StaticCommand, TelemetryEvent, TerminalColorList,
-    TerminalColors, TerminalModel, TerminalSurface, TerminalSurfaceInit, TranscriptScope,
-    TuiMcpAction, TuiMcpManager, TuiMcpServerId, TuiMcpVariableValue, TuiOnboardingMarker,
-    TuiOnboardingMarkers, TuiOnboardingMarkersEvent, TuiSlashCommandDataSource,
-    TuiSlashCommandDataSourceArgs, TuiUpArrowHistoryItemKind, TuiUserInfoManager,
-    TuiUserInfoManagerEvent, TuiZeroStateDataSource, UserTakeOverReason, WAKEUP_THROTTLE_PERIOD,
-    WarpConfig, WarpConfigUpdateEvent, block_context_from_terminal_model,
+    ConversationSelectionHandle, ExecuteCommandEvent, FORK_PREFIX, ForkConversationError,
+    GetRelevantFilesController, GitHubRepoModel, GitRepoStatusModel, LLMId, LLMPreferences,
+    LLMPreferencesEvent, LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, LinkedWorkflowData,
+    ModelEvent, ParsedSlashCommandInput, PersistenceWriter, PillBarActionKind,
+    PillBarInteractionEvent, PillBarPillKind, PillSwitchOutcome, PtyIntent, PtyIntentEvent,
+    QueuedQueryEvent, QueuedQueryModel, RepoDetectionSessionType, RepoDetectionSource,
+    ServerConversationToken, SessionSettings, Sessions, ShellCommandExecutorEvent, SizeInfo,
+    SizeUpdate, SkillReference, SlashCommandDataSource as _, SlashCommandKind,
+    SlashCommandSelectionBehavior, StartAgentExecutorEvent, StartAgentRequest, StaticCommand,
+    TelemetryEvent, TerminalColorList, TerminalColors, TerminalModel, TerminalSurface,
+    TerminalSurfaceInit, TranscriptScope, TuiMcpAction, TuiMcpManager, TuiMcpServerId,
+    TuiMcpVariableValue, TuiOnboardingMarker, TuiOnboardingMarkers, TuiOnboardingMarkersEvent,
+    TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs, TuiUpArrowHistoryItemKind,
+    TuiUserInfoManager, TuiUserInfoManagerEvent, TuiZeroStateDataSource, UserTakeOverReason,
+    WAKEUP_THROTTLE_PERIOD, WarpConfig, WarpConfigUpdateEvent, block_context_from_terminal_model,
     build_slash_command_mixer, detect_possible_git_repo, export_conversation_markdown, log_out_tui,
     maybe_build_ai_query_upsert_event, prepare_conversation_block_restoration,
     record_autodetection_toggle_from_slash_command, record_saved_prompt_accepted,
@@ -326,6 +326,10 @@ fn zero_state_ascii_load_failure_hint(failure: ZeroStateAnimationLoadFailure) ->
 const COMMAND_ALREADY_RUNNING_HINT: &str = "cannot run — command already running";
 const NEW_CONVERSATION_COMMAND_RUNNING_HINT: &str =
     "cannot start new conversation while terminal command is running";
+const FORK_NO_ACTIVE_CONVERSATION_HINT: &str = "/fork requires an active conversation";
+const FORK_EMPTY_CONVERSATION_HINT: &str = "Nothing to fork — start a conversation first.";
+const FORK_NO_RESUME_ID_HINT: &str = "This conversation cannot be forked until it has a resume ID.";
+const FORK_FAILED_HINT: &str = "Conversation forking failed.";
 const SWITCH_COMMAND_RUNNING_HINT: &str =
     "Cannot switch conversations while a command is in progress.";
 const SWITCH_CONVERSATION_RUNNING_HINT: &str =
@@ -479,6 +483,7 @@ fn render_mcp_menu_footer(
 pub(crate) enum TuiConversationRestoreOrigin {
     Startup,
     ConversationList,
+    Fork,
 }
 
 impl TuiConversationRestoreOrigin {
@@ -487,6 +492,7 @@ impl TuiConversationRestoreOrigin {
             Self::Startup | Self::ConversationList => {
                 AgentViewEntryOrigin::RestoreExistingConversation
             }
+            Self::Fork => AgentViewEntryOrigin::Tui,
         }
     }
 
@@ -3082,14 +3088,16 @@ impl TuiTerminalSessionView {
             TuiConversationRestoreOrigin::Startup => {
                 self.conversation_restore_state = ConversationRestoreState::Failed(message);
             }
-            TuiConversationRestoreOrigin::ConversationList => {
-                warp::send_telemetry_from_ctx!(
-                    TuiConversationRestoreTelemetryEvent {
-                        state: TuiConversationRestoreTelemetryState::Failed,
-                        target,
-                    },
-                    ctx
-                );
+            TuiConversationRestoreOrigin::ConversationList | TuiConversationRestoreOrigin::Fork => {
+                if origin.records_telemetry() {
+                    warp::send_telemetry_from_ctx!(
+                        TuiConversationRestoreTelemetryEvent {
+                            state: TuiConversationRestoreTelemetryState::Failed,
+                            target,
+                        },
+                        ctx
+                    );
+                }
                 self.conversation_restore_state = ConversationRestoreState::Idle;
                 self.show_transient_hint(message, ctx);
                 self.focus_input_if_active(ctx);
@@ -4283,6 +4291,89 @@ impl TuiTerminalSessionView {
         self.input_view.update(ctx, |input, ctx| input.clear(ctx));
         true
     }
+    fn fork_current_conversation(
+        &mut self,
+        prompt: Option<&String>,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        if !self
+            .ai_context_model
+            .as_ref(ctx)
+            .can_start_new_conversation()
+        {
+            self.show_error_hint(NEW_CONVERSATION_COMMAND_RUNNING_HINT.to_owned(), ctx);
+            return false;
+        }
+        let Some(source_conversation_id) = self
+            .conversation_selection
+            .as_ref(ctx)
+            .selected_conversation_id(ctx)
+        else {
+            self.show_error_hint(FORK_NO_ACTIVE_CONVERSATION_HINT.to_owned(), ctx);
+            return false;
+        };
+        let Some(source_conversation) = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&source_conversation_id)
+            .cloned()
+        else {
+            self.show_error_hint(FORK_NO_ACTIVE_CONVERSATION_HINT.to_owned(), ctx);
+            return false;
+        };
+        if let Err(ForkConversationError::EmptyConversation) =
+            BlocklistAIHistoryModel::validate_fork_source(&source_conversation)
+        {
+            self.show_error_hint(FORK_EMPTY_CONVERSATION_HINT.to_owned(), ctx);
+            return false;
+        }
+        let Some(source_token) = source_conversation.server_conversation_token().cloned() else {
+            self.show_error_hint(FORK_NO_RESUME_ID_HINT.to_owned(), ctx);
+            return false;
+        };
+
+        let forked_conversation =
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.fork_conversation(&source_conversation, FORK_PREFIX, false, None, ctx)
+            });
+        let forked_conversation = match forked_conversation {
+            Ok(conversation) => conversation,
+            Err(error) => {
+                match error.downcast_ref::<ForkConversationError>() {
+                    Some(ForkConversationError::EmptyConversation) => {
+                        self.show_error_hint(FORK_EMPTY_CONVERSATION_HINT.to_owned(), ctx);
+                    }
+                    None => {
+                        report_error!(error.context("TUI conversation forking failed"));
+                        self.show_error_hint(FORK_FAILED_HINT.to_owned(), ctx);
+                    }
+                }
+                return false;
+            }
+        };
+        self.replace_conversation_surface(
+            forked_conversation,
+            TuiConversationRestoreOrigin::Fork,
+            TuiConversationRestoreTelemetryTarget::Local,
+            ctx,
+        );
+        let resume_command =
+            tui_resume_shell_command(ChannelState::channel(), source_token.as_str());
+        self.transcript.update(ctx, |transcript, ctx| {
+            transcript.append_notice(
+                format!(
+                    "Forked conversation. To resume the original in another session, run: {resume_command}"
+                ),
+                ctx,
+            );
+        });
+        if let Some(prompt) = prompt
+            .map(|argument| argument.trim())
+            .filter(|argument| !argument.is_empty())
+        {
+            self.send_prompt(prompt.to_owned(), ctx);
+        }
+        self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+        true
+    }
 
     fn execute_tui_slash_command(
         &mut self,
@@ -4311,6 +4402,11 @@ impl TuiTerminalSessionView {
             }
             SlashCommandKind::MoveToCloud => {
                 self.start_handoff(argument, ctx);
+            }
+            SlashCommandKind::Fork => {
+                if self.fork_current_conversation(argument, ctx) {
+                    record_static_slash_command_accepted(command.name, true, ctx);
+                }
             }
             SlashCommandKind::AutoApprove => {
                 self.toggle_auto_approve(true, ctx);
@@ -4547,7 +4643,6 @@ impl TuiTerminalSessionView {
             | SlashCommandKind::RenameTab
             | SlashCommandKind::RenameConversation
             | SlashCommandKind::SetTabColor
-            | SlashCommandKind::Fork
             | SlashCommandKind::OpenCodeReview
             | SlashCommandKind::Index
             | SlashCommandKind::Init
@@ -4941,6 +5036,10 @@ impl TuiTerminalSessionView {
             } => return (conversation_restoring(ctx), false),
             ConversationRestoreState::Loading {
                 origin: TuiConversationRestoreOrigin::ConversationList,
+                ..
+            }
+            | ConversationRestoreState::Loading {
+                origin: TuiConversationRestoreOrigin::Fork,
                 ..
             } => {}
             ConversationRestoreState::Failed(message) => {

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -24,7 +24,8 @@ use warp::tui_export::{
     SlashCommandDataSource as _, SlashCommandKind, TaskId, TranscriptScope, TuiMcpAction,
     TuiMcpServerId, TuiOnboardingMarker, TuiOnboardingMarkers, TuiUpArrowHistoryItemKind,
     UserTakeOverReason, WarpConfig, WarpConfigUpdateEvent, export_conversation_markdown,
-    light_theme, register_tui_session_view_test_singletons, slash_commands,
+    forkable_tui_conversation_for_test, light_theme, register_tui_session_view_test_singletons,
+    slash_commands,
 };
 use warp_core::channel::Channel;
 use warp_core::features::FeatureFlag;
@@ -119,6 +120,7 @@ struct FocusTestFixture {
 fn only_conversation_list_restores_emit_restore_telemetry() {
     assert!(!TuiConversationRestoreOrigin::Startup.records_telemetry());
     assert!(TuiConversationRestoreOrigin::ConversationList.records_telemetry());
+    assert!(!TuiConversationRestoreOrigin::Fork.records_telemetry());
 }
 
 #[test]
@@ -1970,6 +1972,160 @@ fn cost_slash_command_rejects_an_empty_conversation_like_the_gui() {
                 Some(COST_EMPTY_CONVERSATION_HINT),
             );
         });
+    });
+}
+
+#[test]
+fn fork_slash_command_is_available_on_both_surfaces() {
+    assert_eq!(slash_commands::FORK.name, "/fork");
+    assert!(slash_commands::FORK.supported_surfaces.supports_gui());
+    assert!(slash_commands::FORK.supported_surfaces.supports_tui());
+}
+
+#[test]
+fn fork_slash_command_rejects_an_empty_conversation() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+
+        view.update(&mut app, |view, ctx| {
+            view.execute_tui_slash_command(&slash_commands::FORK, None, ctx);
+        });
+
+        view.read(&app, |view, ctx| {
+            assert_eq!(
+                view.transient_hint.current().map(|(text, _)| text),
+                Some(super::FORK_EMPTY_CONVERSATION_HINT),
+            );
+            assert!(view.input_view.as_ref(ctx).is_empty(ctx));
+        });
+    });
+}
+
+#[test]
+fn fork_slash_command_keeps_a_conversation_without_a_resume_id_selected() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let source_conversation = forkable_tui_conversation_for_test("local-only conversation");
+        let source_conversation_id = source_conversation.id();
+
+        view.update(&mut app, |view, ctx| {
+            view.replace_conversation_surface(
+                source_conversation,
+                TuiConversationRestoreOrigin::ConversationList,
+                TuiConversationRestoreTelemetryTarget::Local,
+                ctx,
+            );
+            view.execute_tui_slash_command(&slash_commands::FORK, None, ctx);
+        });
+
+        view.read(&app, |view, ctx| {
+            assert_eq!(
+                view.conversation_selection
+                    .as_ref(ctx)
+                    .selected_conversation_id(ctx),
+                Some(source_conversation_id),
+            );
+            assert_eq!(
+                view.transient_hint.current().map(|(text, _)| text),
+                Some(super::FORK_NO_RESUME_ID_HINT),
+            );
+        });
+    });
+}
+
+#[test]
+fn fork_slash_command_replaces_the_surface_and_renders_original_resume_guidance() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let (model_event_sender, _model_event_receiver) = std::sync::mpsc::sync_channel(2);
+        app.update(|ctx| {
+            warp::tui_export::GlobalResourceHandlesProvider::handle(ctx).update(
+                ctx,
+                |provider, _| {
+                    provider.set_model_event_sender_for_test(model_event_sender);
+                },
+            );
+        });
+
+        let source_token = "11111111-1111-1111-1111-111111111111";
+        let source_conversation =
+            forkable_tui_conversation_for_test("Original fork boundary prompt");
+        let source_conversation_id = source_conversation.id();
+        let source_root_task_id = source_conversation.get_root_task_id().clone();
+        view.update(&mut app, |view, ctx| {
+            let source_conversation =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.restore_conversations(
+                        view.terminal_surface_id,
+                        vec![source_conversation],
+                        ctx,
+                    );
+                    history.set_server_conversation_token_for_conversation(
+                        source_conversation_id,
+                        source_token.to_owned(),
+                    );
+                    history
+                        .conversation(&source_conversation_id)
+                        .expect("source conversation should be restored")
+                        .clone()
+                });
+            view.replace_conversation_surface(
+                source_conversation,
+                TuiConversationRestoreOrigin::ConversationList,
+                TuiConversationRestoreTelemetryTarget::Local,
+                ctx,
+            );
+            assert!(
+                view.slash_commands_source
+                    .as_ref(ctx)
+                    .active_commands()
+                    .any(|(_, command)| command.kind == SlashCommandKind::Fork)
+            );
+            view.execute_tui_slash_command(&slash_commands::FORK, None, ctx);
+        });
+
+        let forked_conversation_id = view.read(&app, |view, ctx| {
+            view.conversation_selection
+                .as_ref(ctx)
+                .selected_conversation_id(ctx)
+                .expect("fork should select a replacement conversation")
+        });
+        assert_ne!(forked_conversation_id, source_conversation_id);
+        app.read(|ctx| {
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            assert!(history.conversation(&source_conversation_id).is_some());
+            let forked = history
+                .conversation(&forked_conversation_id)
+                .expect("forked conversation should be restored");
+            assert_ne!(forked.get_root_task_id(), &source_root_task_id);
+            assert_eq!(
+                forked
+                    .forked_from_server_conversation_token()
+                    .map(|token| token.as_str()),
+                Some(source_token),
+            );
+            assert_eq!(forked.exchange_count(), 1);
+            assert_eq!(
+                view.as_ref(ctx)
+                    .transcript
+                    .as_ref(ctx)
+                    .agent_blocks_in_canonical_order()
+                    .len(),
+                1,
+            );
+        });
+
+        let rendered = render_session(&mut app, &view, 100, 40).join("\n");
+        let notice = rendered
+            .find("Forked conversation. To resume the original in another session, run:")
+            .unwrap_or_else(|| panic!("fork should render resume guidance:\n{rendered}"));
+        let resume_id = rendered.find(source_token).unwrap_or_else(|| {
+            panic!("resume guidance should contain the original server token:\n{rendered}")
+        });
+        assert!(notice < resume_id);
     });
 }
 

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -27,7 +27,8 @@ use super::handoff::{TuiHandoffBlock, TuiHandoffBlockEvent};
 use super::terminal_block::{block_content_rows, should_render_terminal_block};
 use super::terminal_session_view::BlockingInputSource;
 use super::tui_block_list_viewport_source::{
-    AgentBlockRegistry, CLISubagentBlockRegistry, HandoffBlockRegistry, TuiBlockListViewportSource,
+    AgentBlockRegistry, CLISubagentBlockRegistry, HandoffBlockRegistry, TranscriptNoticeRegistry,
+    TuiBlockListViewportSource, TuiTranscriptNotice,
 };
 use super::tui_builder::TuiUiBuilder;
 use super::tui_cli_subagent_view::{TuiCLISubagentView, TuiCLISubagentViewEvent};
@@ -85,6 +86,7 @@ pub(super) struct TuiTranscriptView {
     agent_blocks: AgentBlockRegistry,
     cli_subagent_blocks: CLISubagentBlockRegistry,
     handoff_blocks: HandoffBlockRegistry,
+    notices: TranscriptNoticeRegistry,
     viewport: TuiViewportedListState,
     selection: TuiSelectionHandle,
 }
@@ -118,6 +120,20 @@ impl TuiTranscriptView {
         ctx.notify();
     }
 
+    pub(super) fn append_notice(&mut self, text: String, ctx: &mut ViewContext<Self>) {
+        let notice_id = EntityId::new();
+        let style = TuiUiBuilder::from_app(ctx).muted_text_style();
+        self.notices
+            .borrow_mut()
+            .insert(notice_id, TuiTranscriptNotice::new(text, style));
+        self.model.lock().block_list_mut().append_rich_content(
+            RichContentItem::new(Some(RichContentType::AIBlock), notice_id, None, false),
+            false,
+        );
+        self.viewport.scroll_to_end();
+        ctx.notify();
+    }
+
     /// Creates a transcript view for one terminal surface.
     pub(super) fn new(
         terminal_surface_id: EntityId,
@@ -139,6 +155,7 @@ impl TuiTranscriptView {
             agent_blocks: Rc::new(RefCell::new(HashMap::new())),
             cli_subagent_blocks: Rc::new(RefCell::new(HashMap::new())),
             handoff_blocks: Rc::new(RefCell::new(HashMap::new())),
+            notices: Rc::new(RefCell::new(HashMap::new())),
             viewport: TuiViewportedListState::new_at_end(),
             selection: TuiSelectionHandle::default(),
         }
@@ -340,6 +357,7 @@ impl TuiTranscriptView {
         if !self.agent_blocks.borrow().is_empty()
             || !self.cli_subagent_blocks.borrow().is_empty()
             || !self.handoff_blocks.borrow().is_empty()
+            || !self.notices.borrow().is_empty()
         {
             return false;
         }
@@ -352,7 +370,7 @@ impl TuiTranscriptView {
         })
     }
 
-    fn agent_blocks_in_canonical_order(&self) -> Vec<ViewHandle<TuiAIBlock>> {
+    pub(super) fn agent_blocks_in_canonical_order(&self) -> Vec<ViewHandle<TuiAIBlock>> {
         let view_ids = {
             let model = self.model.lock();
             model
@@ -686,9 +704,11 @@ impl TuiTranscriptView {
             .collect::<Vec<_>>();
         view_ids.extend(self.cli_subagent_blocks.borrow().keys().copied());
         view_ids.extend(self.handoff_blocks.borrow().keys().copied());
+        view_ids.extend(self.notices.borrow().keys().copied());
         self.agent_blocks.borrow_mut().clear();
         self.cli_subagent_blocks.borrow_mut().clear();
         self.handoff_blocks.borrow_mut().clear();
+        self.notices.borrow_mut().clear();
         self.selection.clear();
         let mut model = self.model.lock();
         for view_id in view_ids {
@@ -725,6 +745,7 @@ impl TuiView for TuiTranscriptView {
             self.agent_blocks.clone(),
             self.cli_subagent_blocks.clone(),
             self.handoff_blocks.clone(),
+            self.notices.clone(),
         );
         let viewport = TuiViewportedList::new(
             self.viewport.clone(),

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -185,6 +185,78 @@ fn agent_block_lookup_uses_canonical_transcript_order() {
 }
 
 #[test]
+fn transcript_notice_preserves_the_fork_boundary_before_a_follow_up_exchange() {
+    App::test((), |mut app| async move {
+        let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+        let model_for_view = terminal_model.clone();
+        let (action_model, model_events) = add_test_action_model_and_events(&mut app);
+        let (_, transcript) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |ctx| {
+                    TuiTranscriptView::new(
+                        EntityId::new(),
+                        model_for_view,
+                        action_model,
+                        &model_events,
+                        ctx,
+                    )
+                },
+            )
+        });
+        let (copied_exchange_id, notice_id, follow_up_exchange_id) =
+            transcript.update(&mut app, |view, ctx| {
+                let copied_exchange_id = append_test_agent_block_with_inputs(
+                    view,
+                    AIConversationId::new(),
+                    AIAgentExchangeId::new(),
+                    vec![query_input("copied history")],
+                    AIBlockOutputStatus::Pending,
+                    ctx,
+                );
+                view.append_notice("resume the original conversation".to_owned(), ctx);
+                let notice_id = *view
+                    .notices
+                    .borrow()
+                    .keys()
+                    .next()
+                    .expect("notice should be registered");
+                let follow_up_exchange_id = append_test_agent_block_with_inputs(
+                    view,
+                    AIConversationId::new(),
+                    AIAgentExchangeId::new(),
+                    vec![query_input("follow-up prompt")],
+                    AIBlockOutputStatus::Pending,
+                    ctx,
+                );
+                (copied_exchange_id, notice_id, follow_up_exchange_id)
+            });
+
+        let rich_content_ids = terminal_model
+            .lock()
+            .block_list()
+            .block_heights()
+            .cursor::<(), ()>()
+            .filter_map(|item| match item {
+                BlockHeightItem::RichContent(item) => Some(item.view_id),
+                BlockHeightItem::Block(_)
+                | BlockHeightItem::Gap(_)
+                | BlockHeightItem::RestoredBlockSeparator { .. }
+                | BlockHeightItem::InlineBanner { .. }
+                | BlockHeightItem::SubshellSeparator { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            rich_content_ids,
+            vec![copied_exchange_id, notice_id, follow_up_exchange_id]
+        );
+    });
+}
+
+#[test]
 fn transcript_clear_event_removes_only_named_conversations() {
     App::test((), |mut app| async move {
         let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));

--- a/crates/warp_tui/src/tui_block_list_viewport_source.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source.rs
@@ -14,8 +14,8 @@ use warp::tui_export::{BlockHeight, BlockHeightItem, BlockHeightSummary, BlockId
 use warpui::{EntityId, ViewHandle};
 use warpui_core::AppContext;
 use warpui_core::elements::tui::{
-    TuiChildView, TuiElement, TuiLayoutContext, TuiRowResize, TuiSelectionSpan, TuiViewportContent,
-    TuiViewportWindow, TuiViewportedElement, TuiVisibleViewportItem,
+    TuiChildView, TuiElement, TuiLayoutContext, TuiRowResize, TuiSelectionSpan, TuiStyle, TuiText,
+    TuiViewportContent, TuiViewportWindow, TuiViewportedElement, TuiVisibleViewportItem,
 };
 
 use super::agent_block::TuiAIBlock;
@@ -27,6 +27,27 @@ pub(super) type AgentBlockRegistry = Rc<RefCell<HashMap<EntityId, ViewHandle<Tui
 pub(super) type CLISubagentBlockRegistry =
     Rc<RefCell<HashMap<EntityId, ViewHandle<TuiCLISubagentView>>>>;
 pub(super) type HandoffBlockRegistry = Rc<RefCell<HashMap<EntityId, ViewHandle<TuiHandoffBlock>>>>;
+pub(super) type TranscriptNoticeRegistry = Rc<RefCell<HashMap<EntityId, TuiTranscriptNotice>>>;
+
+#[derive(Clone)]
+pub(super) struct TuiTranscriptNotice {
+    text: String,
+    style: TuiStyle,
+}
+
+impl TuiTranscriptNotice {
+    pub(super) fn new(text: String, style: TuiStyle) -> Self {
+        Self { text, style }
+    }
+
+    fn element(&self) -> TuiText {
+        TuiText::new(format!("\n{text}", text = self.text)).with_style(self.style)
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.element().desired_height(width)
+    }
+}
 
 /// Extra rows above and below the viewport whose non-dirty agent blocks are
 /// re-measured each frame, so near-off-screen reflow (e.g. a width change) is
@@ -41,6 +62,7 @@ pub(super) enum TuiBlockListViewportItemId {
     Agent(EntityId),
     CLISubagent(EntityId),
     Handoff(EntityId),
+    Notice(EntityId),
 }
 
 struct TuiBlockListVisibleItem {
@@ -55,6 +77,7 @@ enum TuiBlockListVisibleItemKind {
     Agent(ViewHandle<TuiAIBlock>),
     CLISubagent(ViewHandle<TuiCLISubagentView>),
     Handoff(ViewHandle<TuiHandoffBlock>),
+    Notice(TuiTranscriptNotice),
 }
 
 /// Adapts a terminal model's canonical block-list order for TUI viewporting.
@@ -63,6 +86,7 @@ pub(super) struct TuiBlockListViewportSource {
     agent_blocks: AgentBlockRegistry,
     cli_subagent_blocks: CLISubagentBlockRegistry,
     handoff_blocks: HandoffBlockRegistry,
+    notices: TranscriptNoticeRegistry,
     height_changes: RefCell<Vec<TuiRowResize>>,
 }
 
@@ -78,6 +102,7 @@ impl TuiBlockListViewportSource {
             agent_blocks,
             cli_subagent_blocks: Rc::new(RefCell::new(HashMap::new())),
             handoff_blocks: Rc::new(RefCell::new(HashMap::new())),
+            notices: Rc::new(RefCell::new(HashMap::new())),
             height_changes: RefCell::new(Vec::new()),
         }
     }
@@ -86,12 +111,14 @@ impl TuiBlockListViewportSource {
         agent_blocks: AgentBlockRegistry,
         cli_subagent_blocks: CLISubagentBlockRegistry,
         handoff_blocks: HandoffBlockRegistry,
+        notices: TranscriptNoticeRegistry,
     ) -> Self {
         Self {
             model,
             agent_blocks,
             cli_subagent_blocks,
             handoff_blocks,
+            notices,
             height_changes: RefCell::new(Vec::new()),
         }
     }
@@ -121,6 +148,7 @@ impl TuiBlockListViewportSource {
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
         let handoff_blocks = self.handoff_blocks.borrow();
+        let notices = self.notices.borrow();
         let block_list = model.block_list();
         let band_top = window.scroll_top.saturating_sub(OVERHANG_ROWS);
         let band_bottom = window
@@ -158,6 +186,8 @@ impl TuiBlockListViewportSource {
                     && view.as_ref(app).needs_height_measurement(available_width)
                 {
                     view_ids.insert(rich_content.view_id);
+                } else if notices.contains_key(&rich_content.view_id) {
+                    view_ids.insert(rich_content.view_id);
                 }
             }
             cursor.next();
@@ -177,6 +207,7 @@ impl TuiBlockListViewportSource {
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
         let handoff_blocks = self.handoff_blocks.borrow();
+        let notices = self.notices.borrow();
         view_ids
             .into_iter()
             .filter_map(|view_id| {
@@ -190,11 +221,13 @@ impl TuiBlockListViewportSource {
                     let height = view.desired_height(width, ctx, app);
                     view.record_height_measurement(width);
                     height
-                } else {
-                    let view = handoff_blocks.get(&view_id)?.as_ref(app);
+                } else if let Some(view) = handoff_blocks.get(&view_id) {
+                    let view = view.as_ref(app);
                     let height = view.desired_height(width, ctx, app);
                     view.record_height_measurement(width);
                     height
+                } else {
+                    usize::from(notices.get(&view_id)?.desired_height(width))
                 };
                 Some((view_id, BlockHeight::from(height as f64)))
             })
@@ -249,6 +282,7 @@ impl TuiBlockListViewportSource {
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
         let handoff_blocks = self.handoff_blocks.borrow();
+        let notices = self.notices.borrow();
         let viewport_bottom = window
             .scroll_top
             .saturating_add(usize::from(window.viewport_height));
@@ -311,14 +345,20 @@ impl TuiBlockListViewportSource {
                                 height,
                                 kind: TuiBlockListVisibleItemKind::CLISubagent(view.clone()),
                             })
+                        } else if let Some(view) = handoff_blocks.get(&item.view_id) {
+                            Some(TuiBlockListVisibleItem {
+                                origin_y: item_top,
+                                height,
+                                kind: TuiBlockListVisibleItemKind::Handoff(view.clone()),
+                            })
                         } else {
-                            handoff_blocks
-                                .get(&item.view_id)
-                                .map(|view| TuiBlockListVisibleItem {
+                            notices.get(&item.view_id).cloned().map(|notice| {
+                                TuiBlockListVisibleItem {
                                     origin_y: item_top,
                                     height,
-                                    kind: TuiBlockListVisibleItemKind::Handoff(view.clone()),
-                                })
+                                    kind: TuiBlockListVisibleItemKind::Notice(notice),
+                                }
+                            })
                         }
                     }
                 }
@@ -370,6 +410,7 @@ impl TuiBlockListViewportSource {
         let agent_blocks = self.agent_blocks.borrow();
         let cli_subagent_blocks = self.cli_subagent_blocks.borrow();
         let handoff_blocks = self.handoff_blocks.borrow();
+        let notices = self.notices.borrow();
         let mut item_ids = Vec::new();
         let mut cursor = block_list
             .block_heights()
@@ -400,6 +441,11 @@ impl TuiBlockListViewportSource {
                     if !item.should_hide && handoff_blocks.contains_key(&item.view_id) =>
                 {
                     item_ids.push(TuiBlockListViewportItemId::Handoff(item.view_id));
+                }
+                BlockHeightItem::RichContent(item)
+                    if !item.should_hide && notices.contains_key(&item.view_id) =>
+                {
+                    item_ids.push(TuiBlockListViewportItemId::Notice(item.view_id));
                 }
                 BlockHeightItem::RichContent(_)
                 | BlockHeightItem::Gap(_)
@@ -527,7 +573,8 @@ impl TuiBlockListVisibleItem {
             }
             TuiBlockListVisibleItemKind::Agent(_)
             | TuiBlockListVisibleItemKind::CLISubagent(_)
-            | TuiBlockListVisibleItemKind::Handoff(_) => self.origin_y,
+            | TuiBlockListVisibleItemKind::Handoff(_)
+            | TuiBlockListVisibleItemKind::Notice(_) => self.origin_y,
         };
         TuiVisibleViewportItem {
             origin_y,
@@ -550,6 +597,7 @@ impl TuiBlockListVisibleItem {
             TuiBlockListVisibleItemKind::Agent(view) => TuiChildView::new(&view).finish(),
             TuiBlockListVisibleItemKind::CLISubagent(view) => TuiChildView::new(&view).finish(),
             TuiBlockListVisibleItemKind::Handoff(view) => TuiChildView::new(&view).finish(),
+            TuiBlockListVisibleItemKind::Notice(notice) => notice.element().finish(),
         }
     }
 }


### PR DESCRIPTION
## Description
- Enable `/fork` in Warp Agent CLI using the existing shared conversation-fork infrastructure.
- Replace the current TUI conversation with the fork and add a muted transcript marker containing the channel-specific command to resume the original conversation in another session.
- Keep an optional follow-up prompt after the fork marker in canonical transcript order, with clear errors for empty conversations and conversations without a resume ID.

## Linked Issue
N/A

## Testing
- [x] `./script/format`
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- [x] `cargo nextest run -p warp_tui` (940 tests passed)
- [x] Focused `/fork` and transcript-boundary tests (5 tests passed)
- [x] Manually tested with `./script/run-tui`; confirmed `/fork` appears in the slash-command menu and the TUI exits cleanly

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent conversation: https://staging.warp.dev/conversation/d49b4e02-5f3d-4752-ae12-b167e7eb675c

CHANGELOG-TUI: Fork the current Warp Agent CLI conversation with `/fork`.
