### PR TITLE
fix shift enter

### DIFF
--- a/crates/warpui_core/src/runtime/event_conversion.rs
+++ b/crates/warpui_core/src/runtime/event_conversion.rs
@@ -186,7 +186,8 @@ impl ShiftKeyTracker {
             }
             KeyCode::Char(character)
                 if (self.left_pressed || self.right_pressed)
-                    && !event.modifiers.contains(KeyModifiers::SHIFT) =>
+                    && !event.modifiers.contains(KeyModifiers::SHIFT)
+                    && !is_legacy_line_feed(event) =>
             {
                 event.modifiers.insert(KeyModifiers::SHIFT);
                 if character.is_alphabetic() {
@@ -215,6 +216,13 @@ impl ShiftKeyTracker {
         self.left_pressed = false;
         self.right_pressed = false;
     }
+}
+
+/// Raw LF is indistinguishable from Ctrl+J in terminal input. Some terminals
+/// use it for Shift+Enter even while enhanced modifier reporting is active, so
+/// preserving it as Ctrl+J keeps the standard newline fallback usable.
+fn is_legacy_line_feed(event: &KeyEvent) -> bool {
+    event.code == KeyCode::Char('j') && event.modifiers == KeyModifiers::CONTROL
 }
 
 fn update_pressed(pressed: &mut bool, kind: KeyEventKind) {

--- a/crates/warpui_core/src/runtime/event_conversion.rs
+++ b/crates/warpui_core/src/runtime/event_conversion.rs
@@ -186,8 +186,7 @@ impl ShiftKeyTracker {
             }
             KeyCode::Char(character)
                 if (self.left_pressed || self.right_pressed)
-                    && !event.modifiers.contains(KeyModifiers::SHIFT)
-                    && !is_legacy_line_feed(event) =>
+                    && !event.modifiers.contains(KeyModifiers::SHIFT) =>
             {
                 event.modifiers.insert(KeyModifiers::SHIFT);
                 if character.is_alphabetic() {
@@ -216,13 +215,6 @@ impl ShiftKeyTracker {
         self.left_pressed = false;
         self.right_pressed = false;
     }
-}
-
-/// Raw LF is indistinguishable from Ctrl+J in terminal input. Some terminals
-/// use it for Shift+Enter even while enhanced modifier reporting is active, so
-/// preserving it as Ctrl+J keeps the standard newline fallback usable.
-fn is_legacy_line_feed(event: &KeyEvent) -> bool {
-    event.code == KeyCode::Char('j') && event.modifiers == KeyModifiers::CONTROL
 }
 
 fn update_pressed(pressed: &mut bool, kind: KeyEventKind) {

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -264,6 +264,17 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
     }
 }
 
+/// Crossterm treats the first primary-device-attributes response it reads as a
+/// definitive negative result. Retry that result once because an older queued
+/// response can precede the keyboard-flags response from the current query.
+fn probe_keyboard_enhancement_support(mut probe: impl FnMut() -> io::Result<bool>) -> bool {
+    match probe() {
+        Ok(true) => true,
+        Ok(false) => matches!(probe(), Ok(true)),
+        Err(_) => false,
+    }
+}
+
 /// A **development/test harness** that drives a single [`TuiView`] window with a
 /// *blocking* loop ([`run_until`](Self::run_until)): it redraws when dirty and
 /// polls the terminal for input. It backs the interactive `tui_*` examples and
@@ -464,7 +475,7 @@ impl TuiTerminalGuard {
     /// when the guard is dropped.
     pub fn enter(report_modifier_key_lifecycle: bool) -> io::Result<Self> {
         let keyboard_enhancement_supported =
-            matches!(terminal::supports_keyboard_enhancement(), Ok(true));
+            probe_keyboard_enhancement_support(terminal::supports_keyboard_enhancement);
         Ok(Self {
             _guard: RawModeGuard::enter(CrosstermModeControl {
                 keyboard_enhancement_supported,
@@ -840,16 +851,13 @@ fn enter_terminal_screen(
         Hide
     )?;
 
-    // Opt into the Kitty keyboard protocol so protocol-aware terminals (Ghostty,
-    // kitty, foot, WezTerm) report modified keys distinctly. This only affects
-    // the TUI's own host terminal — the GUI never enters raw mode / the alt
-    // screen and never runs this. The capability query happens before the input
-    // reader starts because crossterm's query cannot run concurrently with
-    // event polling.
-    if keyboard_enhancement_supported {
-        let flags = keyboard_enhancement_flags(report_modifier_key_lifecycle);
-        let _ = execute!(out, PushKeyboardEnhancementFlags(flags));
-    }
+    // Always request the backwards-compatible baseline so modified keys remain
+    // distinct even if capability detection produced a false negative.
+    // Alternate/all-key reporting is more invasive and remains restricted to
+    // confirmed terminals when modifier lifecycle events are required.
+    let flags =
+        keyboard_enhancement_flags(keyboard_enhancement_supported && report_modifier_key_lifecycle);
+    let _ = execute!(out, PushKeyboardEnhancementFlags(flags));
     Ok(())
 }
 
@@ -878,13 +886,8 @@ fn set_terminal_keyboard_enhancement_flags(
     out.flush()
 }
 
-fn leave_terminal_screen(
-    out: &mut impl Write,
-    keyboard_enhancement_supported: bool,
-) -> io::Result<()> {
-    if keyboard_enhancement_supported {
-        let _ = execute!(out, PopKeyboardEnhancementFlags);
-    }
+fn leave_terminal_screen(out: &mut impl Write) -> io::Result<()> {
+    let _ = execute!(out, PopKeyboardEnhancementFlags);
     execute!(
         out,
         Show,
@@ -904,7 +907,7 @@ impl TerminalModeControl for CrosstermModeControl {
             self.keyboard_enhancement_supported,
             self.report_modifier_key_lifecycle,
         ) {
-            let _ = leave_terminal_screen(&mut out, self.keyboard_enhancement_supported);
+            let _ = leave_terminal_screen(&mut out);
             let _ = terminal::disable_raw_mode();
             return Err(error);
         }
@@ -913,7 +916,7 @@ impl TerminalModeControl for CrosstermModeControl {
 
     fn leave(&mut self) {
         let mut out = stdout();
-        let _ = leave_terminal_screen(&mut out, self.keyboard_enhancement_supported);
+        let _ = leave_terminal_screen(&mut out);
         let _ = terminal::disable_raw_mode();
     }
 }

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -346,6 +346,44 @@ fn shift_lifecycle_restores_shift_and_normalizes_symbol_keystrokes() {
 }
 
 #[test]
+fn legacy_ctrl_j_dispatches_while_shift_is_held() {
+    App::test((), |mut app| async move {
+        let (window_id, root) = app.update(|ctx| {
+            ctx.register_fixed_bindings([FixedBinding::new("ctrl-j", Bump, id!("BumpParentView"))]);
+            ctx.add_tui_window(window_options(), |view_ctx| {
+                let child = view_ctx.add_tui_view(|_| BumpChildView);
+                BumpParentView { child, bumps: 0 }
+            })
+        });
+        let terminal = TestTerminal::new(TuiSize::new(20, 3));
+        let mut screen =
+            TuiScreen::new(window_id, root.clone(), terminal, Arc::new(Mutex::new(())));
+        app.update(|ctx| screen.draw(ctx)).unwrap();
+
+        let shift_press = screen
+            .convert_event(CrosstermEvent::Key(KeyEvent::new_with_kind(
+                KeyCode::Modifier(ModifierKeyCode::LeftShift),
+                KeyModifiers::SHIFT,
+                KeyEventKind::Press,
+            )))
+            .expect("shift press");
+        app.update(|ctx| screen.dispatch_event(ctx, &shift_press));
+
+        let ctrl_j = screen
+            .convert_event(CrosstermEvent::Key(KeyEvent::new(
+                KeyCode::Char('j'),
+                KeyModifiers::CONTROL,
+            )))
+            .expect("legacy line feed");
+        let TuiEvent::KeyDown { keystroke, .. } = &ctrl_j else {
+            panic!("expected KeyDown");
+        };
+        assert_eq!(keystroke.normalized(), "ctrl-j");
+        assert!(app.update(|ctx| screen.dispatch_event(ctx, &ctrl_j)));
+        assert_eq!(root.read(&app, |view, _| view.bumps), 1);
+    });
+}
+#[test]
 fn shift_remains_active_until_both_shift_keys_are_released() {
     App::test((), |mut app| async move {
         let (window_id, root) =

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -346,44 +346,6 @@ fn shift_lifecycle_restores_shift_and_normalizes_symbol_keystrokes() {
 }
 
 #[test]
-fn legacy_ctrl_j_dispatches_while_shift_is_held() {
-    App::test((), |mut app| async move {
-        let (window_id, root) = app.update(|ctx| {
-            ctx.register_fixed_bindings([FixedBinding::new("ctrl-j", Bump, id!("BumpParentView"))]);
-            ctx.add_tui_window(window_options(), |view_ctx| {
-                let child = view_ctx.add_tui_view(|_| BumpChildView);
-                BumpParentView { child, bumps: 0 }
-            })
-        });
-        let terminal = TestTerminal::new(TuiSize::new(20, 3));
-        let mut screen =
-            TuiScreen::new(window_id, root.clone(), terminal, Arc::new(Mutex::new(())));
-        app.update(|ctx| screen.draw(ctx)).unwrap();
-
-        let shift_press = screen
-            .convert_event(CrosstermEvent::Key(KeyEvent::new_with_kind(
-                KeyCode::Modifier(ModifierKeyCode::LeftShift),
-                KeyModifiers::SHIFT,
-                KeyEventKind::Press,
-            )))
-            .expect("shift press");
-        app.update(|ctx| screen.dispatch_event(ctx, &shift_press));
-
-        let ctrl_j = screen
-            .convert_event(CrosstermEvent::Key(KeyEvent::new(
-                KeyCode::Char('j'),
-                KeyModifiers::CONTROL,
-            )))
-            .expect("legacy line feed");
-        let TuiEvent::KeyDown { keystroke, .. } = &ctrl_j else {
-            panic!("expected KeyDown");
-        };
-        assert_eq!(keystroke.normalized(), "ctrl-j");
-        assert!(app.update(|ctx| screen.dispatch_event(ctx, &ctrl_j)));
-        assert_eq!(root.read(&app, |view, _| view.bumps), 1);
-    });
-}
-#[test]
 fn shift_remains_active_until_both_shift_keys_are_released() {
     App::test((), |mut app| async move {
         let (window_id, root) =
@@ -738,7 +700,7 @@ fn terminal_screen_lifecycle_toggles_bracketed_paste() {
     );
 
     let mut leave_output = Vec::new();
-    leave_terminal_screen(&mut leave_output, true).unwrap();
+    leave_terminal_screen(&mut leave_output).unwrap();
     assert!(
         leave_output
             .windows(b"\x1b[?2004l".len())
@@ -759,7 +721,7 @@ fn terminal_screen_lifecycle_toggles_focus_reporting() {
     );
 
     let mut leave_output = Vec::new();
-    leave_terminal_screen(&mut leave_output, true).unwrap();
+    leave_terminal_screen(&mut leave_output).unwrap();
     assert!(
         leave_output
             .windows(b"\x1b[?1004l".len())
@@ -809,7 +771,7 @@ fn terminal_screen_lifecycle_toggles_keyboard_enhancement() {
     enter_terminal_screen(&mut enter_output, true, true).unwrap();
 
     let mut leave_output = Vec::new();
-    leave_terminal_screen(&mut leave_output, true).unwrap();
+    leave_terminal_screen(&mut leave_output).unwrap();
 
     #[cfg(not(windows))]
     {
@@ -862,22 +824,63 @@ fn terminal_screen_lifecycle_reconfigures_modifier_reporting() {
 }
 
 #[test]
-fn terminal_screen_lifecycle_skips_unsupported_keyboard_enhancement() {
+fn terminal_screen_lifecycle_uses_baseline_keyboard_enhancement_when_unconfirmed() {
     let mut enter_output = Vec::new();
     enter_terminal_screen(&mut enter_output, false, true).unwrap();
-    assert!(
-        !enter_output
-            .windows(b"\x1b[>15u".len())
-            .any(|window| window == b"\x1b[>15u")
-    );
+
+    #[cfg(not(windows))]
+    {
+        assert!(
+            enter_output
+                .windows(b"\x1b[>3u".len())
+                .any(|window| window == b"\x1b[>3u"),
+            "unconfirmed terminals should still receive safe baseline keyboard enhancements"
+        );
+        assert!(
+            !enter_output
+                .windows(b"\x1b[>15u".len())
+                .any(|window| window == b"\x1b[>15u"),
+            "unconfirmed terminals should not receive all-key reporting"
+        );
+    }
 
     let mut leave_output = Vec::new();
-    leave_terminal_screen(&mut leave_output, false).unwrap();
+    leave_terminal_screen(&mut leave_output).unwrap();
+    #[cfg(not(windows))]
     assert!(
-        !leave_output
+        leave_output
             .windows(b"\x1b[<1u".len())
-            .any(|window| window == b"\x1b[<1u")
+            .any(|window| window == b"\x1b[<1u"),
+        "leaving should pop the baseline keyboard enhancement request"
     );
+}
+
+#[test]
+fn keyboard_enhancement_probe_retries_a_negative_result_once() {
+    let mut results = VecDeque::from([Ok(false), Ok(true)]);
+    assert!(probe_keyboard_enhancement_support(|| {
+        results.pop_front().expect("probe should run at most twice")
+    }));
+    assert!(results.is_empty());
+}
+
+#[test]
+fn keyboard_enhancement_probe_does_not_retry_success_or_error() {
+    let mut successful_results = VecDeque::from([Ok(true), Ok(false)]);
+    assert!(probe_keyboard_enhancement_support(|| {
+        successful_results
+            .pop_front()
+            .expect("successful probe should run once")
+    }));
+    assert_eq!(successful_results.len(), 1);
+
+    let mut failed_results = VecDeque::from([Err(io::Error::other("probe failed")), Ok(true)]);
+    assert!(!probe_keyboard_enhancement_support(|| {
+        failed_results
+            .pop_front()
+            .expect("failed probe should run once")
+    }));
+    assert_eq!(failed_results.len(), 1);
 }
 #[test]
 fn raw_mode_guard_restores_on_drop() {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
Fixes intermittent Shift+Enter handling in the TUI when crossterm incorrectly reports that the host terminal does not support Kitty keyboard enhancements.

Retries a negative capability probe once, always requests the safe baseline Kitty flags (`3`), and keeps full modifier lifecycle reporting (`15`) conditional on confirmed support and push-to-talk configuration.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

