### PR TITLE
Reduce TUI zero-state animation CPU usage

### DIFF
--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -123,6 +123,11 @@ name = "transcript_bench"
 harness = false
 required-features = ["test-util"]
 
+[[bench]]
+name = "zero_state_bench"
+harness = false
+required-features = ["test-util"]
+
 [features]
 # Exposes deterministic, production-shaped transcript fixtures to benchmarks.
 test-util = ["warp/test-util", "warp_core/test-util"]

--- a/crates/warp_tui/benches/zero_state_bench.rs
+++ b/crates/warp_tui/benches/zero_state_bench.rs
@@ -1,0 +1,53 @@
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use warp_tui::benchmark_support::{
+    ZeroStateBenchmark, ZeroStateBenchmarkShape, ZeroStateProjectionBenchmark,
+};
+
+fn benchmark_zero_state_frame(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("tui_zero_state/retained_frame");
+    for (width, height) in [(80, 24), (120, 40), (240, 80)] {
+        for shape in [
+            ZeroStateBenchmarkShape::BuiltIn,
+            ZeroStateBenchmarkShape::Ascii,
+        ] {
+            let mut benchmark = ZeroStateBenchmark::new(shape, width, height);
+            group.bench_with_input(
+                BenchmarkId::new(format!("{shape:?}"), format!("{width}x{height}")),
+                &(width, height),
+                |b, _| b.iter(|| black_box(benchmark.present())),
+            );
+        }
+    }
+    group.finish();
+}
+
+fn benchmark_logo_projection(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("tui_zero_state/logo_projection");
+    for (width, height) in [(32, 24), (32, 40), (32, 80)] {
+        for shape in [
+            ZeroStateBenchmarkShape::BuiltIn,
+            ZeroStateBenchmarkShape::Ascii,
+        ] {
+            let mut benchmark = ZeroStateProjectionBenchmark::new(shape, width, height);
+            group.bench_with_input(
+                BenchmarkId::new(format!("{shape:?}"), format!("{width}x{height}")),
+                &(width, height),
+                |b, _| b.iter(|| black_box(benchmark.project())),
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(1));
+    targets = benchmark_zero_state_frame, benchmark_logo_projection
+}
+criterion_main!(benches);

--- a/crates/warp_tui/src/benchmark_support.rs
+++ b/crates/warp_tui/src/benchmark_support.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
@@ -17,9 +18,10 @@ use warpui::{
     AddWindowOptions, App, AppContext, Entity, EntityId, EntityIdSet, TuiView, TypedActionView,
     ViewContext, ViewHandle, WindowInvalidation,
 };
+use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{
-    TuiClipped, TuiElement, TuiRect, TuiViewportPosition, TuiViewportVerticalAlignment,
-    TuiViewportedList, TuiViewportedListState,
+    TuiClipped, TuiElement, TuiRect, TuiSize, TuiStyle, TuiText, TuiViewportPosition,
+    TuiViewportVerticalAlignment, TuiViewportedList, TuiViewportedListState,
 };
 use warpui_core::presenter::tui::TuiPresenter;
 
@@ -30,6 +32,158 @@ use crate::tui_block_list_viewport_source::{
     AgentBlockRegistry, CLISubagentBlockRegistry, HandoffBlockRegistry, TuiBlockListViewportSource,
 };
 use crate::tui_builder::TuiUiBuilder;
+use crate::zero_state::build_zero_state_layout;
+use crate::zero_state_animation::{
+    LogoProjector, WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationElement,
+    ZeroStateInteractionHandle, ZeroStateStarfieldElement, benchmark_logo_projection,
+};
+
+const ZERO_STATE_COPY_COLS: u16 = 48;
+const ZERO_STATE_ANIMATION_COLS: u16 = 32;
+
+#[derive(Clone, Copy, Debug)]
+pub enum ZeroStateBenchmarkShape {
+    BuiltIn,
+    Ascii,
+}
+
+impl ZeroStateBenchmarkShape {
+    fn config(self) -> ZeroStateAnimationConfig {
+        match self {
+            Self::BuiltIn => ZeroStateAnimationConfig::default(),
+            Self::Ascii => ZeroStateAnimationConfig::benchmark_ascii(),
+        }
+    }
+}
+
+pub struct ZeroStateBenchmark {
+    app: App,
+    root: ViewHandle<BenchmarkZeroStateView>,
+    presenter: TuiPresenter,
+    area: TuiRect,
+}
+
+impl ZeroStateBenchmark {
+    pub fn new(shape: ZeroStateBenchmarkShape, width: u16, height: u16) -> Self {
+        let config = Arc::new(shape.config());
+        App::test((), move |mut app| async move {
+            let (_, root) = app.update(|ctx| {
+                ctx.add_tui_window(
+                    AddWindowOptions {
+                        window_style: WindowStyle::NotStealFocus,
+                        ..Default::default()
+                    },
+                    move |_| BenchmarkZeroStateView {
+                        clock: AnimationClock::starting_at(Duration::ZERO),
+                        config,
+                        interaction: ZeroStateInteractionHandle::default(),
+                    },
+                )
+            });
+            let mut benchmark = Self {
+                app,
+                root,
+                presenter: TuiPresenter::new(),
+                area: TuiRect::new(0, 0, width, height),
+            };
+            benchmark.invalidate();
+            benchmark.present();
+            benchmark
+        })
+    }
+
+    pub fn present(&mut self) -> u64 {
+        let frame = self
+            .app
+            .update(|ctx| self.presenter.present(ctx, &self.root, self.area));
+        frame.buffer.content.iter().fold(0u64, |checksum, cell| {
+            checksum.wrapping_add(cell.symbol().len() as u64)
+        })
+    }
+
+    fn invalidate(&mut self) {
+        let invalidation = WindowInvalidation {
+            updated: EntityIdSet::from_iter([self.root.id()]),
+            ..Default::default()
+        };
+        self.app.read(|ctx| {
+            self.presenter
+                .invalidate(&invalidation, ctx, self.root.window_id(ctx));
+        });
+    }
+}
+
+struct BenchmarkZeroStateView {
+    clock: AnimationClock,
+    config: Arc<ZeroStateAnimationConfig>,
+    interaction: ZeroStateInteractionHandle,
+}
+
+impl Entity for BenchmarkZeroStateView {
+    type Event = ();
+}
+
+impl TypedActionView for BenchmarkZeroStateView {
+    type Action = ();
+}
+
+impl TuiView for BenchmarkZeroStateView {
+    fn ui_name() -> &'static str {
+        "BenchmarkZeroStateView"
+    }
+
+    fn render(&self, _app: &AppContext) -> Box<dyn TuiElement> {
+        let style = TuiStyle::default();
+        let starfield = ZeroStateStarfieldElement::new(
+            self.clock,
+            style,
+            ZERO_STATE_COPY_COLS,
+            ZERO_STATE_ANIMATION_COLS,
+        )
+        .finish();
+        let animation = ZeroStateAnimationElement::new(
+            self.clock,
+            self.config.clone(),
+            self.interaction.clone(),
+            WarpLogoStyles {
+                front: style,
+                back: style,
+                side: style,
+                background: style,
+            },
+        )
+        .without_background_stars()
+        .finish();
+        let overlay = TuiText::new(
+            "Warp Agent\nv0.0.0\n\nWhat's new\n• benchmark\n\nProject\nbenchmark fixture",
+        )
+        .finish();
+        build_zero_state_layout(starfield, animation, overlay)
+    }
+}
+
+pub struct ZeroStateProjectionBenchmark {
+    elapsed: Duration,
+    size: TuiSize,
+    config: ZeroStateAnimationConfig,
+    projector: LogoProjector,
+}
+
+impl ZeroStateProjectionBenchmark {
+    pub fn new(shape: ZeroStateBenchmarkShape, width: u16, height: u16) -> Self {
+        Self {
+            elapsed: Duration::ZERO,
+            size: TuiSize::new(width, height),
+            config: shape.config(),
+            projector: LogoProjector::default(),
+        }
+    }
+
+    pub fn project(&mut self) -> u64 {
+        self.elapsed += Duration::from_millis(66);
+        benchmark_logo_projection(self.elapsed, self.size, &self.config, &mut self.projector)
+    }
+}
 
 /// Shape of the retained transcript fixture.
 #[derive(Clone, Copy, Debug)]

--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -890,7 +890,9 @@ impl TuiElement for TuiEditorElement {
                     handler(TuiEditorAction::PasteText(text.clone()), event_ctx);
                     return true;
                 }
-                TuiEvent::ModifierKeyChanged { .. }
+                TuiEvent::FocusGained
+                | TuiEvent::FocusLost
+                | TuiEvent::ModifierKeyChanged { .. }
                 | TuiEvent::ScrollWheel { .. }
                 | TuiEvent::LeftMouseDown { .. }
                 | TuiEvent::LeftMouseUp { .. }

--- a/crates/warp_tui/src/option_selector.rs
+++ b/crates/warp_tui/src/option_selector.rs
@@ -1711,7 +1711,9 @@ impl TuiElement for SelectorInputElement {
                 true
             }
             TuiEvent::Paste { .. } => false,
-            TuiEvent::ModifierKeyChanged { .. }
+            TuiEvent::FocusGained
+            | TuiEvent::FocusLost
+            | TuiEvent::ModifierKeyChanged { .. }
             | TuiEvent::LeftMouseDown { .. }
             | TuiEvent::LeftMouseUp { .. }
             | TuiEvent::LeftMouseDragged { .. }

--- a/crates/warp_tui/src/terminal_content_element.rs
+++ b/crates/warp_tui/src/terminal_content_element.rs
@@ -176,6 +176,7 @@ impl TuiElement for TuiTerminalContentElement {
                         return true;
                     }
                 }
+                TuiEvent::FocusGained | TuiEvent::FocusLost => {}
                 TuiEvent::ScrollWheel { .. }
                 | TuiEvent::LeftMouseDown { .. }
                 | TuiEvent::LeftMouseUp { .. }
@@ -257,7 +258,9 @@ fn forwarded_pty_input_for_event<'a>(
                 possible_typeahead: Some(Cow::Owned(normalized)),
             })
         }
-        TuiEvent::KeyDown {
+        TuiEvent::FocusGained
+        | TuiEvent::FocusLost
+        | TuiEvent::KeyDown {
             is_composing: true, ..
         }
         | TuiEvent::ModifierKeyChanged { .. }

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -24,7 +24,10 @@ use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::SingletonEntity;
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{
-    Color, Modifier, TuiConstrainedBox, TuiContainer, TuiElement, TuiFlex, TuiStack, TuiText,
+    Cell, Color, Modifier, TuiClipBounds, TuiConstrainedBox, TuiConstraint, TuiContainer,
+    TuiElement, TuiEvent, TuiEventContext, TuiFlex, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiScreenRect,
+    TuiSize, TuiText,
 };
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 
@@ -201,7 +204,7 @@ impl TuiView for TuiZeroStateView {
 /// opaque copy block vertically. Reserving the copy column before measuring
 /// the animation also hides the artwork when a narrow terminal cannot display
 /// both regions.
-fn build_zero_state_layout(
+pub(crate) fn build_zero_state_layout(
     starfield: Box<dyn TuiElement>,
     animation: Box<dyn TuiElement>,
     overlay: Box<dyn TuiElement>,
@@ -223,6 +226,39 @@ fn build_zero_state_layout(
         .flex_child(animation_region)
         .finish();
 
+    let overlay = opaque_zero_state_overlay(overlay);
+    let overlay_layer = TuiFlex::column()
+        .flex_child(TuiText::new("").finish())
+        .child(overlay)
+        .flex_child(TuiText::new("").finish())
+        .finish();
+
+    ZeroStateLayers::new(starfield, animation_layer, overlay_layer).finish()
+}
+#[cfg(test)]
+fn build_zero_state_stack_layout(
+    starfield: Box<dyn TuiElement>,
+    animation: Box<dyn TuiElement>,
+    overlay: Box<dyn TuiElement>,
+) -> Box<dyn TuiElement> {
+    use warpui_core::elements::tui::TuiStack;
+
+    let copy_column_reservation = TuiConstrainedBox::new(TuiText::new("").finish())
+        .with_min_cols(LEFT_COLUMN_COLS)
+        .with_max_cols(LEFT_COLUMN_COLS)
+        .finish();
+    let animation = TuiConstrainedBox::new(animation)
+        .with_max_cols(ANIMATION_PANEL_COLS)
+        .finish();
+    let animation_region = TuiFlex::row()
+        .flex_child(TuiText::new("").finish())
+        .child(animation)
+        .flex_child(TuiText::new("").finish())
+        .finish();
+    let animation_layer = TuiFlex::row()
+        .child(copy_column_reservation)
+        .flex_child(animation_region)
+        .finish();
     let overlay = TuiContainer::new(overlay)
         .with_background(Color::Reset)
         .finish();
@@ -231,12 +267,193 @@ fn build_zero_state_layout(
         .child(overlay)
         .flex_child(TuiText::new("").finish())
         .finish();
-
     TuiStack::new()
         .child(starfield)
         .child(animation_layer)
         .child(overlay_layer)
         .finish()
+}
+
+fn opaque_zero_state_overlay(overlay: Box<dyn TuiElement>) -> Box<dyn TuiElement> {
+    ZeroStateOpaqueOverlay::new(
+        TuiContainer::new(overlay)
+            .with_background(Color::Reset)
+            .finish(),
+    )
+    .finish()
+}
+
+struct ZeroStateOpaqueOverlay {
+    child: Box<dyn TuiElement>,
+    size: Option<TuiSize>,
+}
+
+impl ZeroStateOpaqueOverlay {
+    fn new(child: Box<dyn TuiElement>) -> Self {
+        Self { child, size: None }
+    }
+}
+
+impl TuiElement for ZeroStateOpaqueOverlay {
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        ctx: &mut TuiLayoutContext,
+        app: &AppContext,
+    ) -> TuiSize {
+        let size = self.child.layout(constraint, ctx, app);
+        self.size = Some(size);
+        size
+    }
+
+    fn after_layout(&mut self, ctx: &mut TuiLayoutContext, app: &AppContext) {
+        self.child.after_layout(ctx, app);
+    }
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        if let Some(size) = self.size {
+            for y in 0..size.height {
+                for x in 0..size.width {
+                    surface.set_cell(origin.offset(i32::from(x), i32::from(y)), Cell::default());
+                }
+            }
+        }
+        self.child.render(origin, surface, ctx);
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.child.origin()
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        self.child.present(ctx);
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &TuiEvent,
+        event_ctx: &mut TuiEventContext<'_>,
+        app: &AppContext,
+    ) -> bool {
+        self.child.dispatch_event(event, event_ctx, app)
+    }
+}
+
+/// A zero-state-specific stack whose children are known to paint sparsely or
+/// explicitly fill their visible rectangle. Painting them directly avoids the
+/// generic stack's full-screen scratch buffers and transparency scans.
+struct ZeroStateLayers {
+    children: [Box<dyn TuiElement>; 3],
+    child_sizes: [TuiSize; 3],
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
+}
+
+impl ZeroStateLayers {
+    fn new(
+        starfield: Box<dyn TuiElement>,
+        animation: Box<dyn TuiElement>,
+        overlay: Box<dyn TuiElement>,
+    ) -> Self {
+        Self {
+            children: [starfield, animation, overlay],
+            child_sizes: [TuiSize::ZERO; 3],
+            size: None,
+            origin: None,
+        }
+    }
+}
+
+impl TuiElement for ZeroStateLayers {
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        ctx: &mut TuiLayoutContext,
+        app: &AppContext,
+    ) -> TuiSize {
+        let mut content_size = TuiSize::ZERO;
+        for (child, child_size) in self.children.iter_mut().zip(&mut self.child_sizes) {
+            *child_size = child.layout(constraint, ctx, app);
+            content_size = TuiSize::new(
+                content_size.width.max(child_size.width),
+                content_size.height.max(child_size.height),
+            );
+        }
+        let size = constraint.clamp(content_size);
+        self.size = Some(size);
+        size
+    }
+
+    fn after_layout(&mut self, ctx: &mut TuiLayoutContext, app: &AppContext) {
+        for child in &mut self.children {
+            child.after_layout(ctx, app);
+        }
+    }
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        let screen_origin = ctx.scene_point(origin);
+        self.origin = Some(screen_origin);
+        let Some(size) = self.size else {
+            return;
+        };
+        if size.width == 0 || size.height == 0 {
+            return;
+        }
+
+        for (child, child_size) in self.children.iter_mut().zip(self.child_sizes) {
+            let child_size = TuiSize::new(
+                child_size.width.min(size.width),
+                child_size.height.min(size.height),
+            );
+            let child_bounds = TuiScreenRect::new(screen_origin, child_size);
+            ctx.with_scene_layer(
+                TuiClipBounds::BoundedByActiveLayerAnd(child_bounds),
+                |ctx| child.render(origin, surface, ctx),
+            );
+        }
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        for child in &mut self.children {
+            child.present(ctx);
+        }
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &TuiEvent,
+        event_ctx: &mut TuiEventContext<'_>,
+        app: &AppContext,
+    ) -> bool {
+        for child in self.children.iter_mut().rev() {
+            if child.dispatch_event(event, event_ctx, app) {
+                return true;
+            }
+        }
+        false
+    }
 }
 /// Assembles the text-overlay column placed on top of the animation layer.
 ///

--- a/crates/warp_tui/src/zero_state_animation.rs
+++ b/crates/warp_tui/src/zero_state_animation.rs
@@ -675,19 +675,18 @@ impl TuiElement for ZeroStateStarfieldElement {
     ) {
         self.origin = Some(ctx.scene_point(origin));
         let Some(size) = self.size else { return };
-        let mut frame = LogoFrame::new(size);
-        draw_background_stars_from(
-            &mut frame,
+        for_each_background_star(
+            size,
             self.clock.elapsed(),
             starfield_emitter_x(size, self.leading_reserved_cols, self.logo_panel_cols),
+            |x, y, cell| {
+                if let Some(destination) = surface.cell_mut(origin.offset(x as i32, y as i32)) {
+                    destination
+                        .set_symbol(cell.glyph.as_str())
+                        .set_style(self.style);
+                }
+            },
         );
-        for (x, y, cell) in frame.iter_cells() {
-            if let Some(destination) = surface.cell_mut(origin.offset(x as i32, y as i32)) {
-                destination
-                    .set_symbol(cell.glyph.as_str())
-                    .set_style(self.style);
-            }
-        }
         ctx.repaint_after(REPAINT_INTERVAL);
     }
 
@@ -711,7 +710,7 @@ struct ProjectedSample {
     cell: LogoCell,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct LogoFrame {
     size: TuiSize,
     cells: Vec<Option<LogoCell>>,
@@ -727,6 +726,13 @@ impl LogoFrame {
 
     fn set(&mut self, x: usize, y: usize, cell: LogoCell) {
         self.cells[y * usize::from(self.size.width) + x] = Some(cell);
+    }
+
+    fn clear_and_resize(&mut self, size: TuiSize) {
+        self.size = size;
+        self.cells.clear();
+        self.cells
+            .resize(usize::from(size.width) * usize::from(size.height), None);
     }
 
     fn iter_cells(&self) -> impl Iterator<Item = (usize, usize, LogoCell)> + '_ {
@@ -780,6 +786,7 @@ pub struct ZeroStateAnimationElement {
     size: Option<TuiSize>,
     origin: Option<TuiScreenPoint>,
     object_bounds: Option<ObjectBounds>,
+    projector: LogoProjector,
 }
 
 impl ZeroStateAnimationElement {
@@ -798,6 +805,7 @@ impl ZeroStateAnimationElement {
             size: None,
             origin: None,
             object_bounds: None,
+            projector: LogoProjector::default(),
         }
     }
 
@@ -839,7 +847,7 @@ impl TuiElement for ZeroStateAnimationElement {
             .interaction
             .resolve_at(elapsed, idle_velocity, Instant::now());
         debug_assert!(resolved.velocity.is_finite());
-        let Some(frame) = object_frame_at_angle_with_background(
+        let Some(frame) = self.projector.project(
             elapsed,
             size,
             &self.config,
@@ -956,6 +964,184 @@ fn object_frame_at_with_background(
     )
 }
 
+#[derive(Clone, Copy)]
+struct CachedSourceSample {
+    model_x: f64,
+    model_y: f64,
+    normal_x: f64,
+    normal_y: f64,
+    is_side_stitch: bool,
+}
+
+struct CachedLogoGeometry {
+    shape: Arc<ZeroStateShape>,
+    logo_cols: u16,
+    logo_rows: u16,
+    samples: Vec<CachedSourceSample>,
+}
+
+impl CachedLogoGeometry {
+    fn new(shape: Arc<ZeroStateShape>, logo_cols: u16, logo_rows: u16) -> Self {
+        let source_cols = usize::from(logo_cols) * SURFACE_SAMPLES;
+        let source_rows = usize::from(logo_rows) * SURFACE_SAMPLES;
+        let dx = 2.0 / source_cols as f64;
+        let dy = 2.0 / source_rows as f64;
+        let mut samples = Vec::new();
+        for source_y in 0..source_rows {
+            let model_y = sample_coordinate(source_y, source_rows);
+            for source_x in 0..source_cols {
+                let model_x = sample_coordinate(source_x, source_cols);
+                if !shape.contains(model_x, model_y) {
+                    continue;
+                }
+                let left = shape.contains(model_x - dx, model_y);
+                let right = shape.contains(model_x + dx, model_y);
+                let above = shape.contains(model_x, model_y - dy);
+                let below = shape.contains(model_x, model_y + dy);
+                samples.push(CachedSourceSample {
+                    model_x,
+                    model_y,
+                    normal_x: bool_as_scalar(left) - bool_as_scalar(right),
+                    normal_y: bool_as_scalar(above) - bool_as_scalar(below),
+                    is_side_stitch: (source_x * 13 + source_y * 7) % SIDE_STITCH_MODULUS == 0,
+                });
+            }
+        }
+        Self {
+            shape,
+            logo_cols,
+            logo_rows,
+            samples,
+        }
+    }
+
+    fn matches(&self, shape: &Arc<ZeroStateShape>, logo_cols: u16, logo_rows: u16) -> bool {
+        Arc::ptr_eq(&self.shape, shape)
+            && self.logo_cols == logo_cols
+            && self.logo_rows == logo_rows
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct LogoProjector {
+    geometry: Option<CachedLogoGeometry>,
+    frame: Option<LogoFrame>,
+    z_buffer: Vec<Option<ProjectedSample>>,
+}
+
+impl LogoProjector {
+    fn project(
+        &mut self,
+        elapsed: Duration,
+        size: TuiSize,
+        config: &ZeroStateAnimationConfig,
+        angle: f64,
+        draw_stars: bool,
+    ) -> Option<&LogoFrame> {
+        let cell_aspect_ratio = config.shape.cell_aspect_ratio();
+        let (logo_cols, logo_rows) = fitted_logo_size(size, cell_aspect_ratio)?;
+        if self
+            .geometry
+            .as_ref()
+            .is_none_or(|geometry| !geometry.matches(&config.shape, logo_cols, logo_rows))
+        {
+            self.geometry = Some(CachedLogoGeometry::new(
+                config.shape.clone(),
+                logo_cols,
+                logo_rows,
+            ));
+        }
+        let geometry = self
+            .geometry
+            .as_ref()
+            .expect("logo geometry was initialized above");
+
+        let angle = face_linger_angle(angle);
+        let (sin, cos) = angle.sin_cos();
+        let frame = self.frame.get_or_insert_with(|| LogoFrame::new(size));
+        frame.clear_and_resize(size);
+        if draw_stars {
+            draw_background_stars(frame, elapsed);
+        }
+        self.z_buffer.clear();
+        self.z_buffer
+            .resize(usize::from(size.width) * usize::from(size.height), None);
+
+        let center_x = (f64::from(size.width) - 1.0) / 2.0;
+        let center_y = (f64::from(size.height) - 1.0) / 2.0;
+        let scale_x = (f64::from(logo_cols) - 1.0) / 2.0;
+        let scale_y = (f64::from(logo_rows) - 1.0) / 2.0;
+
+        for source in &geometry.samples {
+            let outline_glyph =
+                glyph_for_tangent(-source.normal_y * cos * cell_aspect_ratio, source.normal_x);
+            for depth_index in 0..=DEPTH_SAMPLES {
+                let is_face = depth_index == 0 || depth_index == DEPTH_SAMPLES;
+                if !is_face && (outline_glyph.is_none() || !source.is_side_stitch) {
+                    continue;
+                }
+                let model_z = -config.extrusion_depth
+                    + 2.0 * config.extrusion_depth * depth_index as f64 / DEPTH_SAMPLES as f64;
+                let rotated_x = source.model_x * cos + model_z * sin;
+                let rotated_depth = -source.model_x * sin + model_z * cos;
+                let projected_x = (center_x + rotated_x * scale_x).round() as i32;
+                let projected_y = (center_y + source.model_y * scale_y).round() as i32;
+                if projected_x < 0
+                    || projected_y < 0
+                    || projected_x >= i32::from(size.width)
+                    || projected_y >= i32::from(size.height)
+                {
+                    continue;
+                }
+                if is_face
+                    && outline_glyph.is_none()
+                    && !is_ghost_stipple_cell(projected_x as usize, projected_y as usize)
+                {
+                    continue;
+                }
+
+                let cell = if !is_face {
+                    LogoCell {
+                        surface: LogoSurface::Side,
+                        glyph: LogoGlyph::Dot,
+                    }
+                } else if let Some(glyph) = outline_glyph {
+                    let surface = if depth_index == DEPTH_SAMPLES {
+                        LogoSurface::Front
+                    } else {
+                        LogoSurface::Back
+                    };
+                    LogoCell { surface, glyph }
+                } else {
+                    LogoCell {
+                        surface: LogoSurface::Ghost,
+                        glyph: LogoGlyph::Dot,
+                    }
+                };
+                let index = projected_y as usize * usize::from(size.width) + projected_x as usize;
+                let sample = ProjectedSample {
+                    depth: rotated_depth,
+                    cell,
+                };
+                if self.z_buffer[index].is_none_or(|current| sample.depth > current.depth) {
+                    self.z_buffer[index] = Some(sample);
+                }
+            }
+        }
+
+        for (index, sample) in self.z_buffer.iter().copied().enumerate() {
+            if let Some(sample) = sample {
+                frame.set(
+                    index % usize::from(size.width),
+                    index / usize::from(size.width),
+                    sample.cell,
+                );
+            }
+        }
+        Some(frame)
+    }
+}
+#[cfg(test)]
 fn object_frame_at_angle_with_background(
     elapsed: Duration,
     size: TuiSize,
@@ -1073,6 +1259,31 @@ fn object_frame_at_angle_with_background(
     Some(frame)
 }
 
+#[cfg(feature = "test-util")]
+pub(crate) fn benchmark_logo_projection(
+    elapsed: Duration,
+    size: TuiSize,
+    config: &ZeroStateAnimationConfig,
+    projector: &mut LogoProjector,
+) -> u64 {
+    projector
+        .project(
+            elapsed,
+            size,
+            config,
+            idle_angle(elapsed, configured_idle_velocity(config)),
+            true,
+        )
+        .map_or(0, |frame| {
+            frame.iter_cells().fold(0u64, |checksum, (x, y, cell)| {
+                checksum
+                    .wrapping_add(x as u64)
+                    .wrapping_add((y as u64).rotate_left(7))
+                    .wrapping_add(cell.glyph.as_str().as_bytes()[0] as u64)
+            })
+        })
+}
+
 /// Eases a rotation phase so the object dwells on its readable front and back
 /// poses. The mapping is strictly increasing and satisfies
 /// `face_linger_angle(phase + PI) == face_linger_angle(phase) + PI`, so it
@@ -1101,10 +1312,22 @@ fn draw_background_stars(frame: &mut LogoFrame, elapsed: Duration) {
 }
 
 fn draw_background_stars_from(frame: &mut LogoFrame, elapsed: Duration, center_x: f64) {
-    let width = usize::from(frame.size.width);
-    let height = usize::from(frame.size.height);
-    let star_count = star_count_for_size(frame.size);
-    let center_y = (f64::from(frame.size.height) - 1.0) / 2.0;
+    let size = frame.size;
+    for_each_background_star(size, elapsed, center_x, |x, y, cell| {
+        frame.set(x, y, cell);
+    });
+}
+
+fn for_each_background_star(
+    size: TuiSize,
+    elapsed: Duration,
+    center_x: f64,
+    mut paint: impl FnMut(usize, usize, LogoCell),
+) {
+    let width = usize::from(size.width);
+    let height = usize::from(size.height);
+    let star_count = star_count_for_size(size);
+    let center_y = (f64::from(size.height) - 1.0) / 2.0;
     let elapsed = elapsed.as_secs_f64();
 
     for index in 0..star_count {
@@ -1132,7 +1355,7 @@ fn draw_background_stars_from(frame: &mut LogoFrame, elapsed: Duration, center_x
         } else {
             LogoGlyph::Star
         };
-        frame.set(
+        paint(
             x,
             y,
             LogoCell {
@@ -1188,6 +1411,7 @@ fn fitted_logo_size(size: TuiSize, cell_aspect_ratio: f64) -> Option<(u16, u16)>
 fn sample_coordinate(index: usize, sample_count: usize) -> f64 {
     ((index as f64 + 0.5) / sample_count as f64) * 2.0 - 1.0
 }
+#[cfg(test)]
 fn logo_outline_glyph(
     shape: &ZeroStateShape,
     x: f64,

--- a/crates/warp_tui/src/zero_state_animation_config.rs
+++ b/crates/warp_tui/src/zero_state_animation_config.rs
@@ -218,6 +218,19 @@ impl Entity for ZeroStateAnimationConfig {
 impl SingletonEntity for ZeroStateAnimationConfig {}
 
 impl ZeroStateAnimationConfig {
+    #[cfg(feature = "test-util")]
+    pub(crate) fn benchmark_ascii() -> Self {
+        Self {
+            active_object: TuiZeroStateObject::BuiltIn,
+            shape: Arc::new(ZeroStateShape::Ascii(
+                AsciiArtMask::parse("    #\n   ###\n  #####\n #######\n   ###\n  #   #\n")
+                    .expect("benchmark ASCII art is valid"),
+            )),
+            rotation_period: Duration::from_secs(5),
+            extrusion_depth: 0.18,
+            load_failure: None,
+        }
+    }
     pub(crate) fn register(ctx: &mut AppContext) {
         let config_dir = warp_core::paths::tui_config_local_dir();
         let (object, rotation_period, extrusion_depth) = {

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -29,18 +29,50 @@ use super::config::{
 };
 use super::{
     ActivePress, BUILT_IN_LOGO_CELL_ASPECT_RATIO, FLICK_RELEASE_VELOCITY_GAIN, LogoCell, LogoGlyph,
-    LogoSurface, MAX_INTERACTIVE_RADIANS_PER_SECOND, MIN_ANIMATION_COLS, MIN_ANIMATION_ROWS,
-    MOMENTUM_SETTLE_DURATION, REPAINT_INTERVAL, WarpLogoStyles, ZeroStateAnimationElement,
-    ZeroStateInteractionHandle, configured_idle_velocity, face_linger_angle, fitted_logo_size,
-    glyph_for_tangent, idle_angle, is_ghost_stipple_cell, logo_frame_at, object_frame_at,
-    object_frame_at_angle, object_frame_at_with_background, rotation_angle, star_count_for_size,
-    starfield_emitter_x, warp_logo_contains,
+    LogoProjector, LogoSurface, MAX_INTERACTIVE_RADIANS_PER_SECOND, MIN_ANIMATION_COLS,
+    MIN_ANIMATION_ROWS, MOMENTUM_SETTLE_DURATION, REPAINT_INTERVAL, WarpLogoStyles,
+    ZeroStateAnimationElement, ZeroStateInteractionHandle, configured_idle_velocity,
+    face_linger_angle, fitted_logo_size, glyph_for_tangent, idle_angle, is_ghost_stipple_cell,
+    logo_frame_at, object_frame_at, object_frame_at_angle, object_frame_at_angle_with_background,
+    object_frame_at_with_background, rotation_angle, star_count_for_size, starfield_emitter_x,
+    warp_logo_contains,
 };
 
 const PANEL_SIZE: TuiSize = TuiSize::new(52, 20);
 const DIAMOND_ART: &str = "   #\n  ###\n #####\n  ###\n   #\n";
 const ROCKET_ART: &str = "    #\n   ###\n  ####\n #####\n   ###\n  #  #\n";
 const WARP_W_ART: &str = "#       #\n#       #\n#   #   #\n#  # #  #\n ##   ##\n";
+
+#[test]
+fn idle_animation_uses_a_fifteen_frame_per_second_cadence() {
+    assert_eq!(REPAINT_INTERVAL, Duration::from_millis(66));
+}
+
+#[test]
+fn retained_projector_matches_reference_across_resizes_and_shape_changes() {
+    let mut projector = LogoProjector::default();
+    let configs = [
+        ZeroStateAnimationConfig::default(),
+        custom_config(ROCKET_ART, 4.0, 0.18),
+    ];
+    for config in &configs {
+        for size in [PANEL_SIZE, TuiSize::new(32, 12), TuiSize::new(52, 30)] {
+            for elapsed in [
+                Duration::ZERO,
+                Duration::from_millis(850),
+                Duration::from_secs(2),
+            ] {
+                let angle = idle_angle(elapsed, configured_idle_velocity(config));
+                let retained = projector
+                    .project(elapsed, size, config, angle, true)
+                    .cloned();
+                let reference =
+                    object_frame_at_angle_with_background(elapsed, size, config, angle, true);
+                assert_eq!(retained, reference);
+            }
+        }
+    }
+}
 
 fn custom_config(
     art: &str,

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -19,7 +19,8 @@ use warpui_core::{App, AppContext};
 
 use super::{
     ANIMATION_PANEL_COLS, LEFT_COLUMN_COLS, build_zero_state_layout, build_zero_state_overlay,
-    changelog_bullets_from_changelog, mcp_status_label, render_first_run_top_section,
+    build_zero_state_stack_layout, changelog_bullets_from_changelog, mcp_status_label,
+    render_first_run_top_section,
 };
 use crate::tui_builder::TuiUiBuilder;
 use crate::zero_state_animation::{
@@ -231,6 +232,50 @@ fn render_element_lines(
     height: u16,
 ) -> Vec<String> {
     render_to_buffer(element, ctx, width, height).to_lines()
+}
+
+fn static_zero_state_layers(
+    width: u16,
+    height: u16,
+) -> (
+    Box<dyn TuiElement>,
+    Box<dyn TuiElement>,
+    Box<dyn TuiElement>,
+) {
+    let stars = (0..height)
+        .map(|_| "*".repeat(usize::from(width)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (
+        TuiText::new(stars).finish(),
+        TuiText::new("animation").finish(),
+        TuiText::new("copy here\n\nsecond line").finish(),
+    )
+}
+
+#[test]
+fn direct_zero_state_layers_match_scratch_composition() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            for (width, height) in [(60, 12), (80, 24), (120, 40), (240, 80)] {
+                let (stars, animation, overlay) = static_zero_state_layers(width, height);
+                let direct = render_to_buffer(
+                    build_zero_state_layout(stars, animation, overlay),
+                    ctx,
+                    width,
+                    height,
+                );
+                let (stars, animation, overlay) = static_zero_state_layers(width, height);
+                let scratch = render_to_buffer(
+                    build_zero_state_stack_layout(stars, animation, overlay),
+                    ctx,
+                    width,
+                    height,
+                );
+                assert_eq!(direct, scratch, "layout differs at {width}x{height}");
+            }
+        });
+    });
 }
 
 #[test]

--- a/crates/warpui_core/src/elements/tui/event.rs
+++ b/crates/warpui_core/src/elements/tui/event.rs
@@ -27,6 +27,8 @@ pub type TuiScrollDelta = (isize, isize);
 /// Input events dispatched through TUI elements.
 #[derive(Clone, Debug)]
 pub enum TuiEvent {
+    FocusGained,
+    FocusLost,
     KeyDown {
         keystroke: Keystroke,
         chars: String,
@@ -88,7 +90,11 @@ impl TuiEvent {
             | Self::MiddleMouseDown { position, .. }
             | Self::RightMouseDown { position, .. }
             | Self::MouseMoved { position, .. } => Some(*position),
-            Self::KeyDown { .. } | Self::ModifierKeyChanged { .. } | Self::Paste { .. } => None,
+            Self::FocusGained
+            | Self::FocusLost
+            | Self::KeyDown { .. }
+            | Self::ModifierKeyChanged { .. }
+            | Self::Paste { .. } => None,
         }
     }
 

--- a/crates/warpui_core/src/elements/tui/selectable.rs
+++ b/crates/warpui_core/src/elements/tui/selectable.rs
@@ -420,7 +420,9 @@ where
                 event_ctx.notify();
                 true
             }
-            TuiEvent::LeftMouseDown { .. }
+            TuiEvent::FocusGained
+            | TuiEvent::FocusLost
+            | TuiEvent::LeftMouseDown { .. }
             | TuiEvent::LeftMouseDragged { .. }
             | TuiEvent::LeftMouseUp { .. }
             | TuiEvent::ScrollWheel { .. }

--- a/crates/warpui_core/src/runtime/event_conversion.rs
+++ b/crates/warpui_core/src/runtime/event_conversion.rs
@@ -21,11 +21,9 @@ pub fn crossterm_event_to_tui_event(event: CrosstermEvent) -> Option<TuiEvent> {
         CrosstermEvent::Key(key_event) => key_event_to_tui_event(key_event),
         CrosstermEvent::Mouse(mouse_event) => TuiEvent::try_from(mouse_event).ok(),
         CrosstermEvent::Paste(text) => Some(TuiEvent::Paste { text }),
-        // TODO: FocusGained and FocusLost have no TUI equivalents yet.
-        // If these are needed in the future, consider adding matching TuiEvent variants.
-        CrosstermEvent::FocusGained | CrosstermEvent::FocusLost | CrosstermEvent::Resize(_, _) => {
-            None
-        }
+        CrosstermEvent::FocusGained => Some(TuiEvent::FocusGained),
+        CrosstermEvent::FocusLost => Some(TuiEvent::FocusLost),
+        CrosstermEvent::Resize(_, _) => None,
     }
 }
 

--- a/crates/warpui_core/src/runtime/event_conversion_tests.rs
+++ b/crates/warpui_core/src/runtime/event_conversion_tests.rs
@@ -304,9 +304,16 @@ fn unsupported_modifier_keys_have_no_tui_equivalent() {
 }
 
 #[test]
-fn resize_and_focus_events_are_ignored() {
+fn resize_is_ignored_and_focus_events_are_preserved() {
     assert!(crossterm_event_to_tui_event(CrosstermEvent::Resize(80, 24)).is_none());
-    assert!(crossterm_event_to_tui_event(CrosstermEvent::FocusGained).is_none());
+    assert!(matches!(
+        crossterm_event_to_tui_event(CrosstermEvent::FocusGained),
+        Some(TuiEvent::FocusGained)
+    ));
+    assert!(matches!(
+        crossterm_event_to_tui_event(CrosstermEvent::FocusLost),
+        Some(TuiEvent::FocusLost)
+    ));
 }
 
 #[test]

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -292,6 +292,9 @@ where
     /// The earliest element-requested repaint deadline from the last draw; the
     /// loop marks itself dirty once it passes.
     pending_repaint: Option<Instant>,
+    /// Whether the host terminal currently has focus. Timed animation repaints
+    /// are suspended while false, but ordinary invalidations may still draw.
+    focused: bool,
     /// Restores the terminal when the runtime is dropped (the `enter` path).
     /// Held only for its `Drop`.
     _terminal_guard: Option<TuiTerminalGuard>,
@@ -333,6 +336,7 @@ where
             dirty,
             last_size: None,
             pending_repaint: None,
+            focused: true,
             _terminal_guard: None,
         }
     }
@@ -380,9 +384,10 @@ where
         if self.last_size != Some(size) {
             self.dirty.set(true);
         }
-        if self
-            .pending_repaint
-            .is_some_and(|deadline| deadline <= Instant::now())
+        if self.focused
+            && self
+                .pending_repaint
+                .is_some_and(|deadline| deadline <= Instant::now())
         {
             self.pending_repaint = None;
             self.dirty.set(true);
@@ -391,7 +396,12 @@ where
             return Ok(());
         }
         let screen = &mut self.screen;
-        self.pending_repaint = app.update(|ctx| screen.draw(ctx))?;
+        let requested_repaint = app.update(|ctx| screen.draw(ctx))?;
+        self.pending_repaint = if self.focused {
+            requested_repaint
+        } else {
+            None
+        };
         self.last_size = Some(size);
         Ok(())
     }
@@ -404,6 +414,17 @@ where
         match event {
             CrosstermEvent::Resize(_, _) => self.dirty.set(true),
             event => {
+                match &event {
+                    CrosstermEvent::FocusGained => {
+                        self.focused = true;
+                        self.dirty.set(true);
+                    }
+                    CrosstermEvent::FocusLost => {
+                        self.focused = false;
+                        self.pending_repaint = None;
+                    }
+                    _ => {}
+                }
                 let screen = &mut self.screen;
                 if let Some(tui_event) = screen.convert_event(event) {
                     let handled = app.update(|ctx| screen.dispatch_event(ctx, &tui_event));
@@ -615,6 +636,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     // whole frame, so each draw replaces (cancelling) the previous timer with
     // one for its own deadline — or clears it when nothing is animating.
     let repaint_timer: Rc<RefCell<Option<ForegroundTask>>> = Rc::default();
+    let focused = Rc::new(Cell::new(true));
 
     // Redraw whenever the window is invalidated. `update_windows` invokes this at
     // the end of every `flush_effects`, so any `notify()` repaints. (The callback
@@ -623,8 +645,9 @@ pub fn spawn_tui_driver<T: TuiView>(
     {
         let screen = screen.clone();
         let repaint_timer = repaint_timer.clone();
+        let focused = focused.clone();
         ctx.on_window_invalidated(window_id, move |_, ctx| {
-            if let Err(error) = draw_and_schedule_repaint(&screen, &repaint_timer, ctx) {
+            if let Err(error) = draw_and_schedule_repaint(&screen, &repaint_timer, &focused, ctx) {
                 report_error!(anyhow::Error::new(error).context("failed to draw a TUI frame"));
             }
         });
@@ -637,7 +660,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     // returning `Err` here drops `guard` (restoring the terminal) and lets the
     // caller surface the error, rather than leaving a live raw-mode session with
     // no usable frame.
-    draw_and_schedule_repaint(&screen, &repaint_timer, ctx)?;
+    draw_and_schedule_repaint(&screen, &repaint_timer, &focused, ctx)?;
 
     let weak_app = ctx.weak_app();
     let (sender, receiver) = async_channel::unbounded::<CrosstermEvent>();
@@ -663,12 +686,16 @@ pub fn spawn_tui_driver<T: TuiView>(
         })?;
 
     let dispatch_screen = screen.clone();
+    let dispatch_repaint_timer = repaint_timer.clone();
+    let dispatch_focused = focused.clone();
     let task = ctx.foreground_executor().spawn(async move {
         while let Ok(event) = receiver.recv().await {
             let Some(mut app) = weak_app.upgrade() else {
                 break;
             };
             let screen = dispatch_screen.clone();
+            let repaint_timer = dispatch_repaint_timer.clone();
+            let focused = dispatch_focused.clone();
             // Dispatch reuses the shared screen's cached element tree (so embedded
             // child views resolve their elements). Edits queue effects that flush
             // when this `update` returns — firing the invalidation callback to
@@ -676,6 +703,17 @@ pub fn spawn_tui_driver<T: TuiView>(
             app.update(move |ctx| match event {
                 CrosstermEvent::Resize(_, _) => ctx.invalidate_all_views(),
                 event => {
+                    match &event {
+                        CrosstermEvent::FocusGained => {
+                            focused.set(true);
+                            ctx.invalidate_all_views();
+                        }
+                        CrosstermEvent::FocusLost => {
+                            focused.set(false);
+                            repaint_timer.borrow_mut().take();
+                        }
+                        _ => {}
+                    }
                     let mut screen = screen.borrow_mut();
                     if let Some(tui_event) = screen.convert_event(event) {
                         screen.dispatch_event(ctx, &tui_event);
@@ -792,11 +830,13 @@ fn should_probe_after_event(
 fn draw_and_schedule_repaint<T: TuiView, R: TuiTerminal + 'static>(
     screen: &Rc<RefCell<TuiScreen<T, R>>>,
     timer_slot: &Rc<RefCell<Option<ForegroundTask>>>,
+    focused: &Rc<Cell<bool>>,
     ctx: &mut AppContext,
 ) -> io::Result<()> {
     let deadline = screen.borrow_mut().draw(ctx)?;
-    let timer = deadline.map(|deadline| {
+    let timer = deadline.filter(|_| focused.get()).map(|deadline| {
         let screen = screen.clone();
+        let focused = Rc::clone(focused);
         // Weak, or the slot (held by the task) and the task (held by the slot)
         // would keep each other alive.
         let weak_slot = Rc::downgrade(timer_slot);
@@ -814,7 +854,7 @@ fn draw_and_schedule_repaint<T: TuiView, R: TuiTerminal + 'static>(
                 // The draw below replaces the slot, dropping this task's own
                 // handle; `async_task` defers destruction, so this in-flight
                 // poll completes normally.
-                if let Err(error) = draw_and_schedule_repaint(&screen, &timer_slot, ctx) {
+                if let Err(error) = draw_and_schedule_repaint(&screen, &timer_slot, &focused, ctx) {
                     report_error!("failed to draw a TUI frame", extra: { "error" => %error });
                 }
             });

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -28,6 +28,71 @@ struct TextElement {
     origin: Option<TuiScreenPoint>,
 }
 
+#[test]
+fn blocking_runtime_suspends_and_resumes_repaint_deadlines_with_focus() {
+    App::test((), |mut app| async move {
+        let (window_id, root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| RepaintingView));
+        let terminal = TestTerminal::new(TuiSize::new(20, 3));
+        let mut runtime = TuiRuntime::with_terminal(&app, window_id, root, terminal);
+
+        runtime.draw_if_dirty(&mut app).unwrap();
+        assert!(runtime.pending_repaint.is_some());
+
+        runtime
+            .screen
+            .terminal
+            .events
+            .push_back(CrosstermEvent::FocusLost);
+        runtime.poll_and_dispatch(&mut app, Duration::ZERO).unwrap();
+        assert!(!runtime.focused);
+        assert!(runtime.pending_repaint.is_none());
+
+        runtime.dirty.set(true);
+        runtime.draw_if_dirty(&mut app).unwrap();
+        assert!(
+            runtime.pending_repaint.is_none(),
+            "ordinary invalidations may draw while blurred but must not restart animation"
+        );
+
+        runtime
+            .screen
+            .terminal
+            .events
+            .push_back(CrosstermEvent::FocusGained);
+        runtime.poll_and_dispatch(&mut app, Duration::ZERO).unwrap();
+        assert!(runtime.focused);
+        assert!(runtime.dirty.get());
+        runtime.draw_if_dirty(&mut app).unwrap();
+        assert!(runtime.pending_repaint.is_some());
+    });
+}
+
+#[test]
+fn invalidation_driver_does_not_schedule_repaints_while_unfocused() {
+    App::test((), |mut app| async move {
+        let (window_id, root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| RepaintingView));
+        let screen = Rc::new(RefCell::new(TuiScreen::new(
+            window_id,
+            root,
+            TestTerminal::new(TuiSize::new(20, 3)),
+            Arc::new(Mutex::new(())),
+        )));
+        let timer = Rc::new(RefCell::new(None));
+        let focused = Rc::new(Cell::new(true));
+
+        app.update(|ctx| draw_and_schedule_repaint(&screen, &timer, &focused, ctx))
+            .unwrap();
+        assert!(timer.borrow().is_some());
+
+        focused.set(false);
+        app.update(|ctx| draw_and_schedule_repaint(&screen, &timer, &focused, ctx))
+            .unwrap();
+        assert!(timer.borrow().is_none());
+    });
+}
+
 impl TuiElement for TextElement {
     fn layout(
         &mut self,
@@ -89,6 +154,59 @@ impl TuiView for TextView {
 }
 
 impl TypedActionView for TextView {
+    type Action = ();
+}
+
+struct RepaintingElement {
+    size: Option<TuiSize>,
+}
+
+impl TuiElement for RepaintingElement {
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        _ctx: &mut TuiLayoutContext,
+        _app: &AppContext,
+    ) -> TuiSize {
+        let size = constraint.clamp(TuiSize::new(1, 1));
+        self.size = Some(size);
+        size
+    }
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        if let Some(cell) = surface.cell_mut(origin) {
+            cell.set_char('*');
+        }
+        ctx.repaint_after(Duration::from_secs(1));
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+}
+
+struct RepaintingView;
+
+impl Entity for RepaintingView {
+    type Event = ();
+}
+
+impl TuiView for RepaintingView {
+    fn ui_name() -> &'static str {
+        "RepaintingView"
+    }
+
+    fn render(&self, _: &AppContext) -> Box<dyn TuiElement> {
+        Box::new(RepaintingElement { size: None })
+    }
+}
+
+impl TypedActionView for RepaintingView {
     type Action = ();
 }
 


### PR DESCRIPTION
## Description

Reduces the CPU cost of the TUI zero-state animation while preserving its original 66 ms (~15 FPS) visual cadence.

- Suspends animation repaint scheduling while the terminal is unfocused and resumes immediately on focus gain.
- Caches logo geometry, reuses projection buffers, and paints the starfield directly.
- Replaces generic stack composition in the zero state with a specialized direct compositor while preserving opaque-overlay semantics.
- Adds production-shaped Criterion benchmarks and rendering/focus regression coverage.

At 120×40, the retained-frame benchmarks improved by approximately 68% for the built-in logo and 73% for the ASCII logo. Larger terminal sizes showed greater savings.

Implementation plan: https://staging.warp.dev/drive/notebook/NHie0i2bcU6ge5gHne0EEC

## Linked Issue

None.

## Testing

- [x] Manually tested the TUI locally with `./script/run-tui`
- [x] `cargo nextest run -p warpui_core --features tui --no-fail-fast` (559 passed, 7 skipped)
- [x] `cargo nextest run -p warp_tui --features test-util --no-fail-fast` (947 passed)
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] `./script/format --check`
- [x] `git diff --check`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-TUI: Reduced CPU usage while the zero-state animation is active.