### PR TITLE
Make TUI voice input optional on Linux

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -467,7 +467,7 @@ embed-resource = "3.0"
 
 # Note that we support channel-specific enables for these features
 [features]
-tui = ["warpui_core/tui", "voice_input"]
+tui = ["warpui_core/tui"]
 ai_resume_button = []
 autoupdate = []
 figma_detection = []

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -75,7 +75,6 @@ warp = { workspace = true, features = [
   "nld_classifier_v3",
   "nld_heuristic_v2",
   "tui",
-  "voice_input",
 ] }
 warp_channel_config.workspace = true
 warp_completer.workspace = true
@@ -124,6 +123,9 @@ harness = false
 required-features = ["test-util"]
 
 [features]
+# Enables native microphone capture and transcription support. Keep this
+# opt-in so portable Linux builds do not require the host ALSA runtime.
+voice_input = ["warp/voice_input"]
 # Exposes deterministic, production-shaped transcript fixtures to benchmarks.
 test-util = ["warp/test-util", "warp_core/test-util"]
 # Declared so the `warp_channel_config::load_config!` macro's

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -34,11 +34,14 @@ use warp::tui_export::{
 use warp_editor::model::CoreEditorModel;
 use warpui::SingletonEntity as _;
 use warpui_core::elements::MouseStateHandle;
+#[cfg(feature = "voice_input")]
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiHoverable, TuiText};
+#[cfg(feature = "voice_input")]
 use warpui_core::event::KeyState;
 use warpui_core::keymap::macros::*;
 use warpui_core::keymap::{self, EditableBinding, FixedBinding, Keystroke};
+#[cfg(feature = "voice_input")]
 use warpui_core::platform::keyboard::KeyCode;
 use warpui_core::text::{byte_offset_for_char_offset, count_chars_up_to_byte};
 use warpui_core::{
@@ -64,6 +67,7 @@ use crate::mcp_install_flow::TuiMcpInstallFlowAction;
 use crate::read_only_menu::TuiReadOnlyMenuKind;
 use crate::terminal_session_view::state::TuiTerminalSessionStateModel;
 use crate::tui_builder::TuiUiBuilder;
+#[cfg(feature = "voice_input")]
 use crate::voice_input::{
     TuiVoiceInputEvent, TuiVoiceInputModel, TuiVoiceInputState, VoiceInputStartSource,
 };
@@ -248,6 +252,7 @@ pub struct TuiInputView {
     /// Consults the owner live before an inline-menu Enter can accept an item.
     can_accept_inline_menu: Rc<dyn Fn(&AppContext) -> bool>,
     /// TUI voice state used for Escape routing and shell-gutter suppression.
+    #[cfg(feature = "voice_input")]
     voice_input: ModelHandle<TuiVoiceInputModel>,
     /// Vim model (shared FSA + event dispatch layer). Always present but only
     /// active when `AppEditorSettings::vim_mode_enabled()` returns `true`.
@@ -332,6 +337,7 @@ impl TuiInputView {
         session_state: ModelHandle<TuiTerminalSessionStateModel>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
+        #[cfg(feature = "voice_input")]
         let voice_input = ctx.add_model(|ctx| TuiVoiceInputModel::new(input_mode.clone(), ctx));
         let vim_model = ctx.add_model(|_| VimModel::new());
         // Subscribe to vim events: VimSubscriber blanket impl (TuiInputView: VimHandler)
@@ -346,15 +352,18 @@ impl TuiInputView {
         // on the config (shell-mode gutter/border), so every event re-renders.
         ctx.subscribe_to_model(&input_mode, |_, _, _, ctx| ctx.notify());
         ctx.subscribe_to_model(&suggestions_mode, |_, _, _, ctx| ctx.notify());
-        // Only the voice lifecycle state reaches this view's render (the
-        // suppressed shell gutter and the Escape keymap flag). Transcribed text
-        // arrives through `insert_text`, and failure or cancellation notices
-        // render in the session footer, so neither repaints the input.
-        ctx.subscribe_to_model(&voice_input, |_, _, event, ctx| {
-            if matches!(event, TuiVoiceInputEvent::StateChanged(_)) {
-                ctx.notify();
-            }
-        });
+        #[cfg(feature = "voice_input")]
+        {
+            // Only the voice lifecycle state reaches this view's render (the
+            // suppressed shell gutter and the Escape keymap flag). Transcribed text
+            // arrives through `insert_text`, and failure or cancellation notices
+            // render in the session footer, so neither repaints the input.
+            ctx.subscribe_to_model(&voice_input, |_, _, event, ctx| {
+                if matches!(event, TuiVoiceInputEvent::StateChanged(_)) {
+                    ctx.notify();
+                }
+            });
+        }
 
         Self {
             model,
@@ -368,6 +377,7 @@ impl TuiInputView {
             session_state,
             keyboard_enhancement_supported: false,
             can_accept_inline_menu: Rc::new(|_| true),
+            #[cfg(feature = "voice_input")]
             voice_input,
             vim_model,
             yank_buffer: String::new(),
@@ -397,6 +407,7 @@ impl TuiInputView {
             .resolve(ctx)
             .is_ok_and(|state| state.plan_available())
     }
+
     /// Whether vim mode is enabled in settings.
     ///
     /// Returns `false` when [`AppEditorSettings`] has not been registered in
@@ -432,28 +443,32 @@ impl TuiInputView {
         input_mode_policy::is_shell_mode(self.input_mode.as_ref(ctx))
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn voice_is_active(&self, ctx: &AppContext) -> bool {
         self.voice_input.as_ref(ctx).is_active()
     }
-
+    #[cfg(feature = "voice_input")]
     pub(crate) fn voice_input_model(&self) -> &ModelHandle<TuiVoiceInputModel> {
         &self.voice_input
     }
-
+    #[cfg(feature = "voice_input")]
     pub(crate) fn voice_state(&self, ctx: &AppContext) -> TuiVoiceInputState {
         self.voice_input.as_ref(ctx).state()
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn voice_animation_clock(&self, ctx: &AppContext) -> AnimationClock {
         self.voice_input.as_ref(ctx).animation_clock()
     }
 
     /// The physical modifier holding the current recording open, set only while
     /// a hold-to-talk press started it.
+    #[cfg(feature = "voice_input")]
     pub(crate) fn voice_hold_key(&self, ctx: &AppContext) -> Option<KeyCode> {
         self.voice_input.as_ref(ctx).hold_key()
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn start_voice_input(
         &mut self,
         available: bool,
@@ -465,16 +480,19 @@ impl TuiInputView {
         })
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn stop_voice_input(&mut self, ctx: &mut ViewContext<Self>) {
         self.voice_input
             .update(ctx, |voice_input, ctx| voice_input.stop(ctx));
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn stop_active_voice_hold(&mut self, ctx: &mut ViewContext<Self>) {
         self.voice_input
             .update(ctx, |voice_input, ctx| voice_input.stop_hold(ctx));
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn handle_voice_hold_key(
         &mut self,
         key: KeyCode,
@@ -512,6 +530,7 @@ impl TuiInputView {
     }
 
     /// Inserts normalized text at the current cursor without submitting it.
+    #[cfg(feature = "voice_input")]
     pub(crate) fn insert_text(&mut self, text: &str, ctx: &mut ViewContext<Self>) {
         let text = self.editor_behavior.normalize_text(text);
         if !text.is_empty() {
@@ -651,6 +670,7 @@ impl TuiView for TuiInputView {
         let inline_menu_owns_input = self
             .active_inline_menu_input_ownership(ctx)
             .inline_menu_owns_input();
+        #[cfg(feature = "voice_input")]
         if self.voice_is_active(ctx) && !inline_menu_owns_input {
             return self.render_input(ctx);
         }
@@ -693,7 +713,16 @@ impl TuiView for TuiInputView {
             input_handles_escape: self.active_inline_menu(ctx).is_some()
                 || suggestions_mode.read_only_menu().is_some()
                 || self.is_shell_mode(ctx)
-                || self.voice_is_active(ctx)
+                || {
+                    #[cfg(feature = "voice_input")]
+                    {
+                        self.voice_is_active(ctx)
+                    }
+                    #[cfg(not(feature = "voice_input"))]
+                    {
+                        false
+                    }
+                }
                 || (vim_mode_enabled
                     && (!matches!(vim_state.mode, VimMode::Normal)
                         || !vim_state.showcmd.is_empty())),
@@ -833,7 +862,11 @@ impl TypedActionView for TuiInputView {
                 self.close_read_only_menu(ctx);
                 // In vim normal/visual/replace mode, Enter still submits so the
                 // prompt behaves like a command line (same as bash/zsh vi-mode).
-                if !self.handle_voice_submit(ctx) {
+                #[cfg(feature = "voice_input")]
+                if self.handle_voice_submit(ctx) {
+                    return;
+                }
+                {
                     self.submit(ctx);
                 }
                 TuiEditorInteractionOutcome::FollowCursor
@@ -1292,6 +1325,7 @@ impl TuiInputView {
         ctx.emit(TuiInputViewEvent::Submitted(text));
     }
 
+    #[cfg(feature = "voice_input")]
     fn handle_voice_submit(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         match self.voice_input.as_ref(ctx).state() {
             TuiVoiceInputState::Listening => {
@@ -1406,18 +1440,21 @@ impl TuiInputView {
             return true;
         }
 
-        match self.voice_input.as_ref(ctx).state() {
-            TuiVoiceInputState::Listening => {
-                self.voice_input
-                    .update(ctx, |voice_input, ctx| voice_input.stop(ctx));
-                return true;
+        #[cfg(feature = "voice_input")]
+        {
+            match self.voice_input.as_ref(ctx).state() {
+                TuiVoiceInputState::Listening => {
+                    self.voice_input
+                        .update(ctx, |voice_input, ctx| voice_input.stop(ctx));
+                    return true;
+                }
+                TuiVoiceInputState::Transcribing => {
+                    self.voice_input
+                        .update(ctx, |voice_input, ctx| voice_input.cancel(ctx));
+                    return true;
+                }
+                TuiVoiceInputState::Idle => {}
             }
-            TuiVoiceInputState::Transcribing => {
-                self.voice_input
-                    .update(ctx, |voice_input, ctx| voice_input.cancel(ctx));
-                return true;
-            }
-            TuiVoiceInputState::Idle => {}
         }
 
         // In vim mode, Escape transitions between modes (Insert→Normal,

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -13,11 +13,13 @@ use vim::vim::VimMode;
 use warp::appearance::Appearance;
 use warp::editor::CodeEditorModel;
 use warp::settings::AISettingsChangedEvent;
+#[cfg(feature = "voice_input")]
+use warp::tui_export::VoiceInput;
 use warp::tui_export::{
     AcceptSlashCommandOrSavedPrompt, BlocklistAIHistoryModel, BlocklistAIInputModel,
     ConversationSelectionEvent, InputConfig, InputModePolicy, InputType, LLMId, PolicyConfigUpdate,
     SlashCommandId, SlashCommandMixer, TuiMcpAction, TuiMcpServerId, TuiUpArrowHistoryItemKind,
-    VoiceInput, add_tui_history_test_models, blocklist_ai_history_model_with_queries,
+    add_tui_history_test_models, blocklist_ai_history_model_with_queries,
     register_tui_input_mode_test_settings, register_tui_session_view_test_singletons,
 };
 use warp_core::features::FeatureFlag;
@@ -57,6 +59,7 @@ use crate::read_only_menu::TuiReadOnlyMenuKind;
 use crate::slash_commands::{TuiSlashCommandModel, TuiSlashCommandRow};
 use crate::test_fixtures::{add_test_conversation_selection, add_test_semantic_selection};
 use crate::tui_builder::TuiUiBuilder;
+#[cfg(feature = "voice_input")]
 use crate::voice_input::{TuiVoiceInputModel, TuiVoiceInputState};
 
 const W: u16 = 80;
@@ -1331,6 +1334,7 @@ fn slash_command_argument_hint_renders_after_menu_closes() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn enter_and_escape_stop_listening_while_escape_cancels_transcribing() {
     App::test((), |mut app| async move {
         let (view, voice_input, submissions) = app.update(|ctx| {
@@ -1822,6 +1826,7 @@ fn typeahead_overwrites_incremental_prefix_and_moves_cursor_to_end() {
         });
     });
 }
+#[cfg(feature = "voice_input")]
 fn build_view_with_voice(
     ctx: &mut AppContext,
 ) -> (ViewHandle<TuiInputView>, ModelHandle<TuiVoiceInputModel>) {
@@ -1852,6 +1857,7 @@ fn build_view_with_voice(
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn listening_voice_input_suppresses_shell_gutter() {
     App::test((), |mut app| async move {
         app.update(|ctx| {

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -84,6 +84,7 @@ mod tui_plan_view;
 mod tui_review_comments;
 mod tui_shell_command_view;
 mod usage;
+#[cfg(feature = "voice_input")]
 mod voice_input;
 mod warping_indicator;
 mod zero_state;

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -13,7 +13,9 @@ use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use clap::error::ErrorKind;
 use inquire::{InquireError, Password, PasswordDisplayMode};
-use warp::settings::{TuiThemeSettings, TuiVoiceSettings, TuiVoiceSettingsChangedEvent};
+use warp::settings::TuiThemeSettings;
+#[cfg(feature = "voice_input")]
+use warp::settings::{TuiVoiceSettings, TuiVoiceSettingsChangedEvent};
 use warp::tui_export::{AIConversationAutoexecuteMode, Appearance, ServerConversationToken};
 use warp::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
 use warp_core::channel::ChannelState;
@@ -34,6 +36,7 @@ use crate::terminal_background::TuiHostTerminalBackground;
 use crate::terminal_session_view::{
     TuiConversationRestoreOrigin, TuiConversationRestoreTarget, tui_resume_shell_command,
 };
+#[cfg(feature = "voice_input")]
 use crate::voice_input::requires_modifier_key_reporting;
 
 /// Version string printed by `--version`. Release builds get `GIT_RELEASE_TAG`;
@@ -250,18 +253,24 @@ fn init(
         },
         |_| RootTuiView::new(),
     );
+    #[cfg(feature = "voice_input")]
+    let modifier_key_lifecycle_enabled = requires_modifier_key_reporting(ctx);
+    #[cfg(not(feature = "voice_input"))]
+    let modifier_key_lifecycle_enabled = false;
     match spawn_tui_driver(
         ctx,
         window_id,
         root.clone(),
-        requires_modifier_key_reporting(ctx),
+        modifier_key_lifecycle_enabled,
         Some(probe),
     ) {
         Ok(driver) => {
             let sessions = ctx.add_singleton_model(|_| {
                 TuiSessions::new(driver, exit_summary, resume_token, default_autoexecute_mode)
             });
+            #[cfg(feature = "voice_input")]
             let sessions_for_voice_settings = sessions.clone();
+            #[cfg(feature = "voice_input")]
             ctx.subscribe_to_model(&TuiVoiceSettings::handle(ctx), move |_, event, ctx| {
                 let TuiVoiceSettingsChangedEvent::TuiVoiceInputHoldKeySetting { .. } = event;
                 let enabled = requires_modifier_key_reporting(ctx);

--- a/crates/warp_tui/src/session_registry.rs
+++ b/crates/warp_tui/src/session_registry.rs
@@ -130,6 +130,7 @@ pub(crate) enum TuiSessionsEvent {
 pub(crate) struct TuiSessions {
     /// TUI-specific process driver. Its handle restores terminal mode on
     /// drop, so the app-lifetime session singleton must retain it.
+    #[cfg_attr(not(feature = "voice_input"), allow(dead_code))]
     driver: Option<TuiDriverHandle>,
     keyboard_enhancement_supported: bool,
     exit_summary: TuiExitSummaryHandle,
@@ -602,6 +603,7 @@ impl TuiSessions {
         }
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn set_modifier_key_lifecycle_enabled(
         &mut self,
         enabled: bool,

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -11,10 +11,14 @@ use instant::Instant;
 use parking_lot::FairMutex;
 use warp::appearance::AppearanceEvent;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
+#[cfg(feature = "voice_input")]
+use warp::settings::TuiVoiceSettings;
 use warp::settings::{
     AISettings, AISettingsChangedEvent, AppEditorSettings, SettingsFileError, TuiStatuslineConfig,
-    TuiTheme, TuiThemeSettings, TuiVoiceSettings,
+    TuiTheme, TuiThemeSettings,
 };
+#[cfg(feature = "voice_input")]
+use warp::tui_export::slash_commands;
 use warp::tui_export::{
     AIAgentActionId, AIAgentActionResultType, AIAgentContext, AIAgentExchangeId,
     AIAgentPtyWriteMode, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
@@ -45,7 +49,7 @@ use warp::tui_export::{
     maybe_build_ai_query_upsert_event, prepare_conversation_block_restoration,
     record_autodetection_toggle_from_slash_command, record_saved_prompt_accepted,
     record_static_slash_command_accepted, saved_prompt_text_for_id,
-    slash_command_selection_behavior, slash_commands, throttle,
+    slash_command_selection_behavior, throttle,
 };
 use warp_core::channel::{Channel, ChannelState};
 use warp_core::features::FeatureFlag;
@@ -54,17 +58,20 @@ use warp_editor::model::CoreEditorModel;
 use warp_errors::report_error;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::SingletonEntity;
+#[cfg(feature = "voice_input")]
 use warpui::event::KeyState;
 use warpui_core::r#async::{SpawnedFutureHandle, Timer};
 use warpui_core::elements::MouseStateHandle;
 use warpui_core::elements::tui::{
-    Modifier, TuiAnimated, TuiChildView, TuiConstrainedBox, TuiContainer, TuiDispatchEventResult,
-    TuiElement, TuiEventHandler, TuiFlex, TuiHoverable, TuiSelectionHandle, TuiSize, TuiStyle,
-    TuiText, TuiViewportedListState,
+    Modifier, TuiChildView, TuiConstrainedBox, TuiContainer, TuiElement, TuiFlex, TuiHoverable,
+    TuiSelectionHandle, TuiSize, TuiStyle, TuiText, TuiViewportedListState,
 };
+#[cfg(feature = "voice_input")]
+use warpui_core::elements::tui::{TuiAnimated, TuiDispatchEventResult, TuiEventHandler};
 use warpui_core::keymap::macros::*;
 use warpui_core::keymap::{self, EditableBinding, FixedBinding};
 use warpui_core::platform::TerminationMode;
+#[cfg(feature = "voice_input")]
 use warpui_core::platform::keyboard::KeyCode;
 use warpui_core::{
     AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
@@ -140,6 +147,7 @@ use crate::tui_cli_subagent_view::{HAND_BACK_KEY_BINDING, TuiCLISubagentView};
 use crate::tui_permission_prompt::TuiPermissionPrompt;
 use crate::ui::{abbreviate_home_prefix, conversation_restore_failed, conversation_restoring};
 use crate::usage::UsageToggle;
+#[cfg(feature = "voice_input")]
 use crate::voice_input::{
     TuiVoiceInputEvent, TuiVoiceInputState, VoiceInputStartSource, configured_hold_key,
 };
@@ -173,6 +181,7 @@ const MAX_INPUT_TEXT_ROWS: u16 = 6;
 /// Top and bottom border rows plus one padding row inside each border.
 const BORDERED_INPUT_CHROME_ROWS: u16 = 4;
 const AUTO_APPROVE_FEEDBACK_DURATION: Duration = Duration::from_secs(3);
+#[cfg(feature = "voice_input")]
 const VOICE_INPUT_BORDER_REPAINT_INTERVAL: Duration = Duration::from_millis(33);
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
@@ -229,6 +238,7 @@ pub(crate) const ATTACH_AGENT_TO_RUNNING_COMMAND_BINDING_NAME: &str =
     "tui:session:attach_agent_to_running_command";
 pub(crate) const DETACH_AGENT_FROM_RUNNING_COMMAND_BINDING_NAME: &str =
     "tui:session:detach_agent_from_running_command";
+#[cfg(feature = "voice_input")]
 pub(crate) const VOICE_INPUT_BINDING_NAME: &str = "tui:session:start_voice_input";
 
 /// The current source preventing the normal session composer from owning input.
@@ -357,6 +367,7 @@ const ZERO_STATE_ASCII_INITIAL_LOAD_FAILED_HINT: &str =
     "Could not load custom ASCII art. Using the built-in Warp logo.";
 const ZERO_STATE_ASCII_RELOAD_FAILED_HINT: &str =
     "Could not reload custom ASCII art. Keeping the current object.";
+#[cfg(feature = "voice_input")]
 const VOICE_USAGE_HINT: &str = "Usage: /voice (no arguments)";
 const AUTO_APPROVE_ENABLED_HINT: &str = "Auto approve on";
 const AUTO_APPROVE_DISABLED_HINT: &str = "Auto approve off";
@@ -412,6 +423,7 @@ fn attachment_focus_available(is_shell_mode: bool, attachments_should_render: bo
     !is_shell_mode && attachments_should_render
 }
 
+#[cfg(feature = "voice_input")]
 fn voice_command_argument(input: &str) -> Option<&str> {
     let argument = input.strip_prefix(slash_commands::VOICE.name)?;
     argument
@@ -421,6 +433,7 @@ fn voice_command_argument(input: &str) -> Option<&str> {
         .then_some(argument)
 }
 
+#[cfg(feature = "voice_input")]
 fn voice_argument_is_empty(argument: Option<&String>) -> bool {
     argument.is_none_or(|argument| argument.trim().is_empty())
 }
@@ -618,6 +631,7 @@ pub(crate) enum TuiTerminalSessionAction {
     /// Paste host clipboard text or attach image data and image paths.
     PasteFromClipboard,
     /// Start recording voice input from the session composer.
+    #[cfg(feature = "voice_input")]
     StartVoiceInput,
     /// Left-click on the inline menu at absolute snapshot index `index`:
     /// selects and accepts that row.
@@ -626,8 +640,10 @@ pub(crate) enum TuiTerminalSessionAction {
     /// without changing the selection.
     InlineMenuMouseScrollBy(isize),
     /// Start or stop voice input from the configured statusline control.
+    #[cfg(feature = "voice_input")]
     ToggleVoiceInputFromStatusline,
     /// Route a configured hold-to-talk modifier transition to the input view.
+    #[cfg(feature = "voice_input")]
     VoiceHoldKeyChanged { key: KeyCode, state: KeyState },
     /// A drag selection started inside the shared read-only menu.
     ReadOnlyMenuSelectionStarted,
@@ -691,6 +707,7 @@ pub(crate) struct TuiTerminalSessionView {
     /// Hover and click state for the configured TODO statusline control.
     todo_list_mouse: MouseStateHandle,
     /// Hover and click state for the configured Voice statusline control.
+    #[cfg(feature = "voice_input")]
     voice_input_mouse: MouseStateHandle,
     github_pr_link: TuiLink,
     keyboard_enhancement_supported: bool,
@@ -866,6 +883,7 @@ pub(crate) fn init(app: &mut AppContext) {
         )
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("ctrl-shift-V"),
+        #[cfg(feature = "voice_input")]
         EditableBinding::new(
             VOICE_INPUT_BINDING_NAME,
             "Start voice input",
@@ -1833,7 +1851,9 @@ impl TuiTerminalSessionView {
             })
             .with_keyboard_enhancement_supported(keyboard_enhancement_supported)
         });
+        #[cfg(feature = "voice_input")]
         let voice_input_model = input_view.as_ref(ctx).voice_input_model().clone();
+        #[cfg(feature = "voice_input")]
         ctx.subscribe_to_model(&voice_input_model, |view, _, event, ctx| {
             view.handle_voice_input_event(event, ctx);
         });
@@ -1963,6 +1983,7 @@ impl TuiTerminalSessionView {
                 .scroll_to_rows_from_top(scroll_top);
             ctx.notify();
         });
+        #[cfg(feature = "voice_input")]
         ctx.subscribe_to_model(&TuiVoiceSettings::handle(ctx), |_, _, _, ctx| {
             ctx.notify();
         });
@@ -2205,6 +2226,7 @@ impl TuiTerminalSessionView {
             hidden_response_summary_exchange_ids: HashSet::new(),
             model_label_hover: MouseStateHandle::default(),
             todo_list_mouse: MouseStateHandle::default(),
+            #[cfg(feature = "voice_input")]
             voice_input_mouse: MouseStateHandle::default(),
             github_pr_link: TuiLink::default(),
             keyboard_enhancement_supported,
@@ -2650,6 +2672,7 @@ impl TuiTerminalSessionView {
                 .finish(),
             );
         }
+        #[cfg(feature = "voice_input")]
         let input = if self.input_view.as_ref(ctx).voice_state(ctx) == TuiVoiceInputState::Listening
         {
             let input_view = self.input_view.clone();
@@ -2663,6 +2686,17 @@ impl TuiTerminalSessionView {
             })
             .finish()
         } else {
+            let border_style = if self.api_keys_menu.as_ref(ctx).uses_credential_border(ctx) {
+                builder.credential_entry_accent_style()
+            } else if self.is_shell_mode(ctx) {
+                builder.shell_mode_accent_style()
+            } else {
+                builder.accent_border_style()
+            };
+            bordered_input(&self.input_view, border_style)
+        };
+        #[cfg(not(feature = "voice_input"))]
+        let input = {
             let border_style = if self.api_keys_menu.as_ref(ctx).uses_credential_border(ctx) {
                 builder.credential_entry_accent_style()
             } else if self.is_shell_mode(ctx) {
@@ -3867,6 +3901,7 @@ impl TuiTerminalSessionView {
     /// composer area — a permission prompt or a conversation restore, for
     /// instance — and the release that ends a recording must still reach the
     /// voice model from those states.
+    #[cfg(feature = "voice_input")]
     fn with_voice_hold_handler(
         &self,
         child: Box<dyn TuiElement>,
@@ -3898,6 +3933,7 @@ impl TuiTerminalSessionView {
             .finish()
     }
 
+    #[cfg(feature = "voice_input")]
     pub(crate) fn handle_voice_hold_key_setting_changed(
         &mut self,
         modifier_key_lifecycle_enabled: bool,
@@ -3911,6 +3947,7 @@ impl TuiTerminalSessionView {
     }
 
     /// Asks the input-owned voice model to start recording.
+    #[cfg(feature = "voice_input")]
     fn start_voice_input(
         &mut self,
         source: VoiceInputStartSource,
@@ -3932,6 +3969,7 @@ impl TuiTerminalSessionView {
         started
     }
 
+    #[cfg(feature = "voice_input")]
     fn toggle_voice_input_from_statusline(&mut self, ctx: &mut ViewContext<Self>) {
         match self.input_view.as_ref(ctx).voice_state(ctx) {
             TuiVoiceInputState::Idle => {
@@ -3944,6 +3982,7 @@ impl TuiTerminalSessionView {
             TuiVoiceInputState::Transcribing => {}
         }
     }
+    #[cfg(feature = "voice_input")]
     fn handle_voice_input_event(
         &mut self,
         event: &TuiVoiceInputEvent,
@@ -3972,10 +4011,13 @@ impl TuiTerminalSessionView {
             return;
         }
 
-        if voice_command_argument(input).is_some_and(|argument| !argument.trim().is_empty()) {
-            self.show_transient_hint(VOICE_USAGE_HINT.to_owned(), ctx);
-            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-            return;
+        #[cfg(feature = "voice_input")]
+        {
+            if voice_command_argument(input).is_some_and(|argument| !argument.trim().is_empty()) {
+                self.show_transient_hint(VOICE_USAGE_HINT.to_owned(), ctx);
+                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                return;
+            }
         }
 
         match self
@@ -4397,12 +4439,15 @@ impl TuiTerminalSessionView {
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
             SlashCommandKind::Voice => {
-                if !voice_argument_is_empty(argument) {
-                    self.show_transient_hint(VOICE_USAGE_HINT.to_owned(), ctx);
-                    self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-                    return;
+                #[cfg(feature = "voice_input")]
+                {
+                    if !voice_argument_is_empty(argument) {
+                        self.show_transient_hint(VOICE_USAGE_HINT.to_owned(), ctx);
+                        self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                        return;
+                    }
+                    self.start_voice_input(VoiceInputStartSource::SlashCommand, ctx);
                 }
-                self.start_voice_input(VoiceInputStartSource::SlashCommand, ctx);
             }
             SlashCommandKind::CreateNewProject => {
                 let Some(query) = argument
@@ -4922,7 +4967,15 @@ impl TuiView for TuiTerminalSessionView {
 
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
         let (content, composer_shortcuts_active) = self.render_session_content(ctx);
-        self.with_voice_hold_handler(content, composer_shortcuts_active, ctx)
+        #[cfg(feature = "voice_input")]
+        {
+            self.with_voice_hold_handler(content, composer_shortcuts_active, ctx)
+        }
+        #[cfg(not(feature = "voice_input"))]
+        {
+            let _ = composer_shortcuts_active;
+            content
+        }
     }
 }
 
@@ -5328,6 +5381,7 @@ impl TypedActionView for TuiTerminalSessionView {
                 self.attachment_bar
                     .update(ctx, |bar, ctx| bar.paste_from_clipboard(ctx));
             }
+            #[cfg(feature = "voice_input")]
             TuiTerminalSessionAction::StartVoiceInput => {
                 self.start_voice_input(VoiceInputStartSource::Keybinding, ctx);
             }
@@ -5341,9 +5395,11 @@ impl TypedActionView for TuiTerminalSessionView {
                     ctx.notify();
                 }
             }
+            #[cfg(feature = "voice_input")]
             TuiTerminalSessionAction::ToggleVoiceInputFromStatusline => {
                 self.toggle_voice_input_from_statusline(ctx)
             }
+            #[cfg(feature = "voice_input")]
             TuiTerminalSessionAction::VoiceHoldKeyChanged { key, state } => {
                 let local_skills_available = self
                     .slash_commands_source

--- a/crates/warp_tui/src/terminal_session_view/statusline.rs
+++ b/crates/warp_tui/src/terminal_session_view/statusline.rs
@@ -22,6 +22,7 @@ use super::{
 use crate::transient_hint::TransientHintTone;
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::compact_footer_path;
+#[cfg(feature = "voice_input")]
 use crate::voice_input::TuiVoiceInputState;
 
 const STATUSLINE_DATETIME_REPAINT_INTERVAL: Duration = Duration::from_secs(60);
@@ -35,6 +36,7 @@ enum FooterHintStyle {
     Muted,
     Success,
     Error,
+    #[cfg(feature = "voice_input")]
     VoiceInput,
 }
 
@@ -46,6 +48,7 @@ impl<'a> FooterHint<'a> {
         }
     }
 
+    #[cfg(feature = "voice_input")]
     fn voice_input(text: &'a str) -> Self {
         Self {
             text,
@@ -58,6 +61,7 @@ impl<'a> FooterHint<'a> {
             FooterHintStyle::Muted => builder.muted_text_style(),
             FooterHintStyle::Success => builder.success_glyph_style(),
             FooterHintStyle::Error => builder.error_text_style(),
+            #[cfg(feature = "voice_input")]
             FooterHintStyle::VoiceInput => builder.voice_input_status_style(),
         };
         TuiFlex::row().child(
@@ -132,6 +136,7 @@ pub(super) enum FooterSegment {
     GitHubPullRequest(Box<dyn TuiElement>),
     DateTime(Box<dyn TuiElement>),
     AgentTodoList(Box<dyn TuiElement>),
+    #[cfg(feature = "voice_input")]
     VoiceInput(Box<dyn TuiElement>),
 }
 
@@ -147,6 +152,8 @@ impl FooterSegment {
             | (Self::DateTime(_), Self::DateTime(_))
             | (Self::ShellMode, _)
             | (_, Self::ShellMode) => " • ",
+            #[cfg(feature = "voice_input")]
+            (Self::VoiceInput(_), _) | (_, Self::VoiceInput(_)) => " | ",
             (
                 Self::AutoApproveIndicator(_)
                 | Self::VimIndicator(_)
@@ -159,8 +166,7 @@ impl FooterSegment {
                 | Self::GitBranchStatus(_)
                 | Self::GitHubPullRequest(_)
                 | Self::DateTime(_)
-                | Self::AgentTodoList(_)
-                | Self::VoiceInput(_),
+                | Self::AgentTodoList(_),
                 Self::AutoApproveIndicator(_)
                 | Self::VimIndicator(_)
                 | Self::Model(_)
@@ -172,8 +178,7 @@ impl FooterSegment {
                 | Self::GitBranchStatus(_)
                 | Self::GitHubPullRequest(_)
                 | Self::DateTime(_)
-                | Self::AgentTodoList(_)
-                | Self::VoiceInput(_),
+                | Self::AgentTodoList(_),
             ) => " | ",
         }
     }
@@ -220,8 +225,11 @@ pub(super) fn render_status_footer_row(
             | FooterSegment::GitBranchStatus(element)
             | FooterSegment::GitHubPullRequest(element)
             | FooterSegment::DateTime(element)
-            | FooterSegment::AgentTodoList(element)
-            | FooterSegment::VoiceInput(element) => {
+            | FooterSegment::AgentTodoList(element) => {
+                row = row.child(element);
+            }
+            #[cfg(feature = "voice_input")]
+            FooterSegment::VoiceInput(element) => {
                 row = row.child(element);
             }
             FooterSegment::WorkingDirectory(cwd) => {
@@ -363,23 +371,28 @@ impl TuiTerminalSessionView {
         {
             return Some(FooterHint::muted(RUNNING_COMMAND_DETACH_HINT));
         }
-        if voice_statusline_visible {
-            return None;
-        }
-        match self.input_view.as_ref(ctx).voice_state(ctx) {
-            TuiVoiceInputState::Listening => {
-                let hint = if self.input_view.as_ref(ctx).voice_hold_key(ctx).is_some() {
-                    "listening to voice input... · release key to stop"
-                } else {
-                    "listening to voice input... · esc or enter to stop"
-                };
-                return Some(FooterHint::voice_input(hint));
+        #[cfg(feature = "voice_input")]
+        {
+            if voice_statusline_visible {
+                return None;
             }
-            TuiVoiceInputState::Transcribing => {
-                return Some(FooterHint::voice_input("Transcribing... · esc to cancel"));
+            match self.input_view.as_ref(ctx).voice_state(ctx) {
+                TuiVoiceInputState::Listening => {
+                    let hint = if self.input_view.as_ref(ctx).voice_hold_key(ctx).is_some() {
+                        "listening to voice input... · release key to stop"
+                    } else {
+                        "listening to voice input... · esc or enter to stop"
+                    };
+                    return Some(FooterHint::voice_input(hint));
+                }
+                TuiVoiceInputState::Transcribing => {
+                    return Some(FooterHint::voice_input("Transcribing... · esc to cancel"));
+                }
+                TuiVoiceInputState::Idle => {}
             }
-            TuiVoiceInputState::Idle => {}
         }
+        #[cfg(not(feature = "voice_input"))]
+        let _ = voice_statusline_visible;
         None
     }
 
@@ -586,9 +599,18 @@ impl TuiTerminalSessionView {
                             .finish(),
                         )
                     }),
-                TuiStatuslineItem::VoiceInput => voice_statusline_visible.then(|| {
-                    FooterSegment::VoiceInput(self.render_voice_statusline(&builder, ctx))
-                }),
+                TuiStatuslineItem::VoiceInput => {
+                    #[cfg(feature = "voice_input")]
+                    {
+                        voice_statusline_visible.then(|| {
+                            FooterSegment::VoiceInput(self.render_voice_statusline(&builder, ctx))
+                        })
+                    }
+                    #[cfg(not(feature = "voice_input"))]
+                    {
+                        None
+                    }
+                }
             };
             if let Some(segment) = segment {
                 ordered.push(segment);
@@ -642,10 +664,21 @@ impl TuiTerminalSessionView {
         .finish()
     }
 
+    #[cfg(feature = "voice_input")]
     pub(super) fn voice_statusline_is_available(&self, shell_mode: bool, ctx: &AppContext) -> bool {
         !shell_mode && AISettings::as_ref(ctx).is_voice_input_enabled(ctx)
     }
 
+    #[cfg(not(feature = "voice_input"))]
+    pub(super) fn voice_statusline_is_available(
+        &self,
+        _shell_mode: bool,
+        _ctx: &AppContext,
+    ) -> bool {
+        false
+    }
+
+    #[cfg(feature = "voice_input")]
     fn render_voice_statusline(
         &self,
         builder: &TuiUiBuilder,

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -9,10 +9,11 @@ use chrono::NaiveDate;
 use instant::Instant;
 use tempfile::TempDir;
 use warp::appearance::Appearance;
+#[cfg(feature = "voice_input")]
+use warp::settings::TuiVoiceSettings;
 use warp::settings::{
     AISettings, SettingsFileError, TuiStatuslineConfig, TuiStatuslineItem, TuiTheme,
-    TuiThemeSettings, TuiUsageDisplayMode, TuiVoiceInputHoldKey, TuiVoiceSettings,
-    TuiZeroStateObject,
+    TuiThemeSettings, TuiUsageDisplayMode, TuiVoiceInputHoldKey, TuiZeroStateObject,
 };
 use warp::terminal::model::ansi::{Handler, InputBufferValue, Mode};
 use warp::tui_export::{
@@ -42,7 +43,9 @@ use warpui_core::elements::tui::{
     TuiPoint, TuiRect, TuiScene, TuiScreenPosition, TuiSize, TuiStyle, TuiText,
     TuiViewportPosition,
 };
-use warpui_core::event::{KeyState, ModifiersState};
+#[cfg(feature = "voice_input")]
+use warpui_core::event::KeyState;
+use warpui_core::event::ModifiersState;
 use warpui_core::keymap::{Context, DescriptionContext, Keystroke, Trigger};
 use warpui_core::platform::keyboard::KeyCode;
 use warpui_core::presenter::tui::TuiPresenter;
@@ -66,13 +69,16 @@ use super::{
     LOADING_CONVERSATION_HINT, LOG_BUNDLE_FAILED_HINT, RUNNING_COMMAND_DETACH_HINT,
     SESSION_CAN_ACCEPT_BLOCKED_TERMINAL_USE_ACTION_FLAG,
     SESSION_CAN_ATTACH_AGENT_TO_RUNNING_COMMAND_FLAG,
-    SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG, SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG,
-    SHELL_MODE_HINT, STATUSLINE_RESET_HINT, TuiConversationRestoreOrigin, TuiTerminalSessionAction,
-    TuiTerminalSessionEvent, TuiTerminalSessionView, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
-    attachment_focus_available, cost_command_unavailable_hint, export_file_success_message,
-    log_bundle_success_message, mcp_primary_action_hint, raw_prompt_if_not_blank,
-    render_mcp_install_footer, render_mcp_menu_footer, voice_argument_is_empty,
-    voice_command_argument,
+    SESSION_CAN_DETACH_AGENT_FROM_RUNNING_COMMAND_FLAG, SHELL_MODE_HINT, STATUSLINE_RESET_HINT,
+    TuiConversationRestoreOrigin, TuiTerminalSessionAction, TuiTerminalSessionEvent,
+    TuiTerminalSessionView, attachment_focus_available, cost_command_unavailable_hint,
+    export_file_success_message, log_bundle_success_message, mcp_primary_action_hint,
+    raw_prompt_if_not_blank, render_mcp_install_footer, render_mcp_menu_footer,
+};
+#[cfg(feature = "voice_input")]
+use super::{
+    SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
+    voice_argument_is_empty, voice_command_argument,
 };
 use crate::autoupdate::TuiAutoupdater;
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
@@ -105,6 +111,7 @@ use crate::transcript_view::TRANSCRIPT_BLOCK_SPACING;
 use crate::transient_hint::TransientHintTone;
 use crate::tui_builder::TuiUiBuilder;
 use crate::usage::UsageToggle;
+#[cfg(feature = "voice_input")]
 use crate::voice_input::{TuiVoiceInputState, requires_modifier_key_reporting};
 use crate::zero_state_animation::{
     ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent, ZeroStateAnimationLoadFailure,
@@ -482,6 +489,7 @@ fn footer_supports_arbitrary_order_and_figma_group_dividers() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn footer_uses_pipes_between_figma_groups_and_preserves_within_group_separators() {
     App::test((), |mut app| async move {
         app.update(|ctx| {
@@ -905,6 +913,7 @@ fn nld_reset_only_unlocks_after_agent_control_and_not_on_user_edit() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_accepts_exact_and_whitespace_only_arguments() {
     assert_eq!(voice_command_argument("/voice"), Some(""));
     assert_eq!(voice_command_argument("/voice   "), Some("   "));
@@ -917,6 +926,7 @@ fn voice_accepts_exact_and_whitespace_only_arguments() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_slash_command_rejects_arguments_before_prompt_fallback() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -1251,6 +1261,7 @@ fn startup_settings_parse_failure_renders_as_an_error_footer_hint() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn listening_voice_input_animates_the_input_border() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -3967,6 +3978,7 @@ fn set_enabled_statusline_items(app: &mut App, items: Vec<TuiStatuslineItem>) {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn footer_falls_back_to_replacing_voice_hints_when_voice_item_is_disabled() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -4019,6 +4031,7 @@ fn footer_falls_back_to_replacing_voice_hints_when_voice_item_is_disabled() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn configured_voice_item_renders_idle_listening_and_transcribing_states() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -4085,6 +4098,7 @@ fn configured_voice_item_renders_idle_listening_and_transcribing_states() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_click_is_interactive_only_within_the_segment_bounds() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -4147,6 +4161,7 @@ fn voice_click_is_interactive_only_within_the_segment_bounds() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_toggle_stops_listening_and_ignores_transcribing() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -4736,6 +4751,7 @@ fn voice_hold_keys_preserve_left_and_right_modifiers() {
     }
 }
 
+#[cfg(feature = "voice_input")]
 fn voice_key_event(key: KeyCode, state: KeyState) -> TuiEvent {
     TuiEvent::ModifierKeyChanged {
         key_code: key,
@@ -4743,6 +4759,7 @@ fn voice_key_event(key: KeyCode, state: KeyState) -> TuiEvent {
     }
 }
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_hold_handler_matches_only_the_configured_side() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -4790,6 +4807,7 @@ fn voice_hold_handler_matches_only_the_configured_side() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_hold_handler_keeps_release_after_composer_loses_input() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
@@ -4839,6 +4857,23 @@ fn voice_hold_handler_keeps_release_after_composer_loses_input() {
         ));
     });
 }
+
+#[test]
+#[cfg(not(feature = "voice_input"))]
+fn voice_controls_stay_disabled_without_voice_input_support() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        app.update(crate::keybindings::init);
+        app.read(|ctx| {
+            assert!(
+                ctx.editable_bindings()
+                    .all(|binding| binding.name != "tui:session:start_voice_input")
+            );
+            assert!(!view.as_ref(ctx).voice_statusline_is_available(false, ctx));
+        });
+    });
+}
 #[test]
 fn blocked_terminal_use_action_acceptance_uses_ctrl_enter_without_rebinding_submit() {
     App::test((), |mut app| async move {
@@ -4874,6 +4909,7 @@ fn blocked_terminal_use_action_acceptance_uses_ctrl_enter_without_rebinding_subm
     });
 }
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_input_uses_ctrl_s_only_when_composer_shortcuts_are_active() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -5,7 +5,9 @@
 //! Composition and layout stay with the views and the element library; the
 //! builder only owns styles.
 
+#[cfg(feature = "voice_input")]
 use std::f32::consts::TAU;
+#[cfg(feature = "voice_input")]
 use std::time::Duration;
 
 use pathfinder_color::ColorU;
@@ -310,12 +312,14 @@ impl TuiUiBuilder {
     /// Fixed themed cyan for voice-input status text. Terminal foreground
     /// colors cannot preserve the alpha from `cyan_overlay_2`, so use the
     /// corresponding opaque color instead of pre-blending it into gray.
+    #[cfg(feature = "voice_input")]
     pub(crate) fn voice_input_status_style(&self) -> TuiStyle {
         self.accent_text_style()
     }
 
     /// Smoothly pulsing border between the themed equivalents of
     /// `cyan_overlay_2` and `Lilac-600`.
+    #[cfg(feature = "voice_input")]
     pub(crate) fn voice_input_border_style(&self, elapsed: Duration) -> TuiStyle {
         const PERIOD: Duration = Duration::from_secs(2);
 

--- a/crates/warp_tui/src/tui_builder_tests.rs
+++ b/crates/warp_tui/src/tui_builder_tests.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "voice_input")]
 use std::time::Duration;
 
 use pathfinder_color::ColorU;
@@ -169,6 +170,7 @@ fn selected_state_suffix_midpoint_matches_figma_dark_palette() {
 }
 
 #[test]
+#[cfg(feature = "voice_input")]
 fn voice_input_border_pulses_between_cyan_overlay_2_and_lilac_600() {
     let theme = light_theme();
     let builder = TuiUiBuilder {

--- a/crates/warp_tui/src/voice_input.rs
+++ b/crates/warp_tui/src/voice_input.rs
@@ -378,6 +378,6 @@ impl TuiVoiceInputModel {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "voice_input"))]
 #[path = "voice_input_tests.rs"]
 mod tests;

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -258,7 +258,8 @@ if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
 elif [[ "$ARTIFACT" == "tui" ]]; then
   # The TUI is a separate console crate with its own per-channel bins and a
   # minimal feature set. It uses the native GNU target so the Linux clipboard
-  # backends can link against the host's Wayland/X11 libraries.
+  # backends can link against the host's Wayland/X11 libraries. Deliberately
+  # omit `voice_input` so portable bundles do not require the host ALSA runtime.
   WARP_TUI_FEATURES="release_bundle,standalone"
   if [[ "$RELEASE_CHANNEL" != "oss" ]]; then
     WARP_TUI_FEATURES="$WARP_TUI_FEATURES,crash_reporting"

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -459,7 +459,7 @@ elif [[ "$ARTIFACT" == tui ]]; then
     oss) WARP_BIN="warp-tui-oss" ;;
     *) WARP_BIN="warp-tui-$RELEASE_CHANNEL" ;;
   esac
-  WARP_TUI_FEATURES="release_bundle,standalone"
+  WARP_TUI_FEATURES="release_bundle,standalone,voice_input"
   if [[ "$RELEASE_CHANNEL" != "oss" ]]; then
     WARP_TUI_FEATURES="$WARP_TUI_FEATURES,crash_reporting"
   fi

--- a/script/run-tui
+++ b/script/run-tui
@@ -86,8 +86,13 @@ done
 # Build with the `standalone` feature so `bundled_resources_dir()` resolves the
 # sibling `resources/` directory next to the executable at runtime (matching how
 # the packaged TUI is built in script/macos/bundle). Without it, the app can't
-# locate its bundled skills when run outside a `.app` bundle.
-CARGO_ARGS+=(--features standalone)
+# locate its bundled skills when run outside a `.app` bundle. Keep voice input
+# enabled for local macOS development while leaving Linux builds free of ALSA.
+TUI_FEATURES="standalone"
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  TUI_FEATURES="$TUI_FEATURES,voice_input"
+fi
+CARGO_ARGS+=(--features "$TUI_FEATURES")
 
 # Resolve Cargo's actual target directory rather than assuming ./target
 # (honors CARGO_TARGET_DIR / build.target-dir).

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -165,7 +165,7 @@ if ($IS_TUI) {
         'stable' { 'tui' }
         'oss' { 'tui-oss' }
     }
-    $FEATURES = 'release_bundle,standalone'
+    $FEATURES = 'release_bundle,standalone,voice_input'
     if ("$CHANNEL" -ne 'oss') {
         $FEATURES = "$FEATURES,crash_reporting"
     }


### PR DESCRIPTION
## Description

Makes Warp Agent CLI voice input an explicit `warp_tui/voice_input` feature instead of enabling it through every TUI build.

Linux TUI release bundles deliberately omit the feature, removing the unconditional CPAL → ALSA dependency that prevented the binary from starting on minimal Linux environments without `libasound.so.2`. macOS and Windows bundles explicitly retain voice input through their native audio backends.

No-voice builds now compile the TUI voice integration out entirely rather than substituting a disabled placeholder model. They do not construct or subscribe to a voice model, register voice actions or bindings, enable modifier-key reporting, or render voice input controls. The GUI `gui` feature continues to enable voice input and is unchanged.

## Linked Issue

User-reported Warp Agent CLI preview regression; no issue filed.

## Testing

- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo check -p warp_tui`
- `cargo check -p warp_tui --features voice_input`
- `cargo test -p warp_tui --no-run`
- `cargo test -p warp_tui --features voice_input --no-run`
- `cargo nextest run -p warp_tui` — 936 passed
- `cargo nextest run -p warp_tui --features voice_input` — 955 passed
- `cargo clippy -p warp_tui --all-targets -- -D warnings`
- `cargo clippy -p warp_tui --all-targets --features voice_input -- -D warnings`
- Linux `cargo tree`: default TUI has no `alsa` package; `--features voice_input` restores `warp_tui → warp → voice_input → cpal → alsa`
- Shell syntax validation for the modified Linux/macOS bundle and local TUI scripts

A Linux bundle was not run end-to-end from this macOS host; the Linux-target dependency graph verifies that the startup dependency is absent.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/680c472e-b33f-4a5c-afae-fb98ee9def1a

CHANGELOG-BUG-FIX: Fixed Warp Agent CLI failing to launch on minimal Linux systems without ALSA installed.
CHANGELOG-TUI: Fixed Warp Agent CLI failing to launch on minimal Linux systems without ALSA installed.
