### PR TITLE
Validate TUI startup API keys before entering signed-in state

### DIFF
--- a/app/src/auth/auth_manager.rs
+++ b/app/src/auth/auth_manager.rs
@@ -15,6 +15,7 @@ use warp_errors::{report_error, report_if_error};
 use warp_graphql::mutations::create_anonymous_user::{
     AnonymousUserType, CreateAnonymousUserResult,
 };
+use warp_server_auth::API_KEY_PREFIX;
 use warp_server_auth::user::persistence::PersistedUser;
 use warpui::r#async::Timer;
 use warpui::clipboard::ClipboardContent;
@@ -304,6 +305,28 @@ impl AuthManager {
             Self::on_user_fetched,
         );
     }
+    /// Validates a startup API key without exposing it through shared auth state.
+    ///
+    /// [`Self::on_user_fetched`] promotes the returned user and credentials only
+    /// after the server accepts the key. A failed request leaves the client
+    /// fully logged out.
+    pub fn authenticate_api_key(&self, api_key: String, ctx: &mut ModelContext<Self>) {
+        log::info!("Authenticating via pending API key");
+        let api_key = if api_key.starts_with(API_KEY_PREFIX) {
+            api_key
+        } else {
+            format!("{API_KEY_PREFIX}{api_key}")
+        };
+        let auth_client = self.auth_client.clone();
+        let _ = ctx.spawn(
+            async move {
+                auth_client
+                    .fetch_user(LoginToken::ApiKey(api_key), false)
+                    .await
+            },
+            Self::on_user_fetched,
+        );
+    }
 
     /// Authenticate asynchronously using the OAuth2 device authorization flow.
     ///
@@ -388,7 +411,7 @@ impl AuthManager {
                     llms,
                 } = user_output.into();
 
-                self.set_and_persist(Some(user.clone()), Some(credentials), ctx);
+                self.complete_authentication(user.clone(), credentials, ctx);
 
                 self.set_needs_reauth(false, ctx);
 
@@ -568,6 +591,14 @@ impl AuthManager {
     /// Sets the user and credentials in auth state and persists to secure storage.
     /// Persistence depends on the credential type - currently, we only persist
     /// state if authenticated via a Firebase token.
+    fn complete_authentication(
+        &self,
+        user: User,
+        credentials: Credentials,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.set_and_persist(Some(user), Some(credentials), ctx);
+    }
     fn set_and_persist(
         &self,
         user: Option<User>,

--- a/app/src/auth/auth_manager_tests.rs
+++ b/app/src/auth/auth_manager_tests.rs
@@ -1,8 +1,8 @@
-use anyhow::anyhow;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
+use anyhow::anyhow;
 use warpui::{App, SingletonEntity};
 
 use super::{AuthManager, AuthManagerEvent, request_device_code_with_timeout};

--- a/app/src/auth/auth_manager_tests.rs
+++ b/app/src/auth/auth_manager_tests.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -7,10 +8,10 @@ use warpui::{App, SingletonEntity};
 use super::{AuthManager, AuthManagerEvent, request_device_code_with_timeout};
 use crate::ServerApiProvider;
 use crate::auth::auth_view_modal::AuthRedirectPayload;
-use crate::auth::credentials::{Credentials, RefreshToken};
-use crate::auth::user::{FirebaseAuthTokens, TEST_USER_UID};
+use crate::auth::credentials::{Credentials, LoginToken, RefreshToken};
+use crate::auth::user::{FirebaseAuthTokens, TEST_USER_UID, User};
 use crate::auth::{AuthStateProvider, UserUid};
-use crate::server::server_api::auth::UserAuthenticationError;
+use crate::server::server_api::auth::{MockAuthClient, UserAuthenticationError};
 
 fn initialize_app(app: &mut App) {
     app.add_singleton_model(|_ctx| ServerApiProvider::new_for_test());
@@ -89,6 +90,79 @@ fn test_duplicate_redirect_for_logged_in_user_is_silently_ignored() {
         AuthManager::handle(&app).update(&mut app, |auth_manager, ctx| {
             auth_manager.initialize_user_from_auth_payload(auth_payload, true, ctx);
         });
+    });
+}
+
+#[test]
+fn pending_api_key_failure_leaves_auth_state_logged_out() {
+    App::test((), |mut app| async move {
+        let mut auth_client = MockAuthClient::new();
+        auth_client
+            .expect_fetch_user()
+            .withf(|token, for_refresh| {
+                matches!(token, LoginToken::ApiKey(key) if key == "wk-inherited-key")
+                    && !for_refresh
+            })
+            .times(1)
+            .return_once(|_, _| Err(UserAuthenticationError::Unexpected(anyhow!("Unauthorized"))));
+
+        initialize_app(&mut app);
+        let auth_state = app.read(|ctx| AuthStateProvider::as_ref(ctx).get().clone());
+        auth_state.set_user(None);
+        auth_state.set_credentials(None);
+        AuthManager::handle(&app).update(&mut app, |auth_manager, _| {
+            auth_manager.auth_client = Arc::new(auth_client);
+        });
+
+        let saw_auth_failure = Arc::new(AtomicBool::new(false));
+        let saw_auth_failure_for_subscription = saw_auth_failure.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&AuthManager::handle(ctx), move |_, event, _| {
+                if matches!(event, AuthManagerEvent::AuthFailed(_)) {
+                    saw_auth_failure_for_subscription.store(true, Ordering::Relaxed);
+                }
+            });
+        });
+
+        AuthManager::handle(&app).update(&mut app, |auth_manager, ctx| {
+            auth_manager.authenticate_api_key("inherited-key".to_owned(), ctx);
+        });
+
+        assert!(auth_state.credentials().is_none());
+        assert!(auth_state.user_id().is_none());
+        assert!(!auth_state.is_logged_in());
+
+        warpui::r#async::Timer::after(Duration::from_millis(100)).await;
+
+        assert!(saw_auth_failure.load(Ordering::Relaxed));
+        assert!(auth_state.credentials().is_none());
+        assert!(auth_state.user_id().is_none());
+        assert!(!auth_state.is_logged_in());
+    });
+}
+
+#[test]
+fn validated_api_key_is_promoted_with_its_user() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let auth_state = app.read(|ctx| AuthStateProvider::as_ref(ctx).get().clone());
+        auth_state.set_user(None);
+        auth_state.set_credentials(None);
+
+        AuthManager::handle(&app).update(&mut app, |auth_manager, ctx| {
+            auth_manager.complete_authentication(
+                User::test(),
+                Credentials::ApiKey {
+                    key: "wk-validated-key".to_owned(),
+                    owner_type: None,
+                },
+                ctx,
+            );
+        });
+
+        assert_eq!(auth_state.api_key().as_deref(), Some("wk-validated-key"));
+        assert_eq!(auth_state.user_id(), Some(UserUid::new(TEST_USER_UID)));
+        assert!(auth_state.is_logged_in());
     });
 }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -451,6 +451,42 @@ impl LaunchMode {
         }
     }
 
+    fn api_key(&self) -> Option<String> {
+        match self {
+            LaunchMode::CommandLine { global_options, .. } => global_options.api_key.clone(),
+            LaunchMode::App { api_key, .. }
+            | LaunchMode::Tui {
+                entrypoint: TuiEntryPoint::Interactive { api_key, .. },
+            } => api_key.clone(),
+            LaunchMode::Test { .. }
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon { .. }
+            | LaunchMode::Tui {
+                entrypoint: TuiEntryPoint::CliCommand { .. },
+            } => None,
+        }
+    }
+
+    /// Returns whether a startup API key should be installed before its user is fetched.
+    ///
+    /// The interactive TUI defers the key so its UI cannot treat credential presence as a
+    /// validated identity. Other launch modes retain their existing initialization behavior.
+    fn should_initialize_api_key_eagerly(&self) -> bool {
+        match self {
+            LaunchMode::Tui {
+                entrypoint: TuiEntryPoint::Interactive { .. },
+            } => false,
+            LaunchMode::App { .. }
+            | LaunchMode::CommandLine { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon { .. }
+            | LaunchMode::Tui {
+                entrypoint: TuiEntryPoint::CliCommand { .. },
+            } => true,
+        }
+    }
+
     /// Returns `true` if this process is running an integration test.
     fn is_integration_test(&self) -> bool {
         match self {
@@ -1366,37 +1402,6 @@ fn authenticate_user_after_iap_access(
     iap_manager.update(ctx, |manager, ctx| manager.ensure_access(ctx));
 }
 
-fn api_key_from_launch_mode(launch_mode: &LaunchMode) -> Option<String> {
-    match launch_mode {
-        LaunchMode::CommandLine { global_options, .. } => global_options.api_key.clone(),
-        LaunchMode::App { api_key, .. }
-        | LaunchMode::Tui {
-            entrypoint: TuiEntryPoint::Interactive { api_key, .. },
-        } => api_key.clone(),
-        LaunchMode::Test { .. }
-        | LaunchMode::RemoteServerProxy
-        | LaunchMode::RemoteServerDaemon { .. }
-        | LaunchMode::Tui {
-            entrypoint: TuiEntryPoint::CliCommand { .. },
-        } => None,
-    }
-}
-
-fn pending_tui_api_key_from_launch_mode(launch_mode: &LaunchMode) -> Option<String> {
-    match launch_mode {
-        LaunchMode::Tui {
-            entrypoint: TuiEntryPoint::Interactive { api_key, .. },
-        } => api_key.clone(),
-        LaunchMode::App { .. }
-        | LaunchMode::CommandLine { .. }
-        | LaunchMode::Test { .. }
-        | LaunchMode::RemoteServerProxy
-        | LaunchMode::RemoteServerDaemon { .. }
-        | LaunchMode::Tui {
-            entrypoint: TuiEntryPoint::CliCommand { .. },
-        } => None,
-    }
-}
 #[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 pub(crate) fn initialize_app(
     launch_mode: &LaunchMode,
@@ -1450,13 +1455,15 @@ pub(crate) fn initialize_app(
         ctx.set_zoom_factor(WindowSettings::as_ref(ctx).zoom_level.as_zoom_factor());
     }
 
-    // Interactive TUI API keys remain outside shared auth state until the server accepts them.
-    // Other launch modes retain their existing eager credential initialization semantics.
-    let pending_tui_api_key = pending_tui_api_key_from_launch_mode(launch_mode);
-    let auth_state = Arc::new(if pending_tui_api_key.is_some() {
-        AuthState::initialize_for_pending_api_key(ctx)
+    let (api_key, pending_api_key) = if launch_mode.should_initialize_api_key_eagerly() {
+        (launch_mode.api_key(), None)
     } else {
-        AuthState::initialize(ctx, api_key_from_launch_mode(launch_mode))
+        (None, launch_mode.api_key())
+    };
+    let auth_state = Arc::new(if pending_api_key.is_some() {
+        AuthState::initialize_for_credential_validation(ctx)
+    } else {
+        AuthState::initialize(ctx, api_key)
     });
     timer.mark_interval_end("AUTH_MANAGER_SET_USER");
 
@@ -2339,7 +2346,7 @@ pub(crate) fn initialize_app(
     // CLI commands establish IAP access and refresh auth in their dispatch path so they can
     // surface failures synchronously. Interactive clients wait for IAP here before authenticating
     // their startup user, since the request itself calls the IAP-gated warp-server.
-    let startup_authentication = pending_tui_api_key
+    let startup_authentication = pending_api_key
         .map(StartupUserAuthentication::ApiKey)
         .or_else(|| {
             (user_is_logged_in && !matches!(launch_mode, LaunchMode::CommandLine { .. }))

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1321,25 +1321,39 @@ pub struct UpdateQuakeModeEventArg {
     active_window_id: Option<WindowId>,
 }
 
-fn refresh_user_after_iap_access(ctx: &mut AppContext) {
+enum StartupUserAuthentication {
+    RefreshUser,
+    ApiKey(String),
+}
+
+impl StartupUserAuthentication {
+    fn start(self, ctx: &mut AppContext) {
+        AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| match self {
+            Self::RefreshUser => auth_manager.refresh_user(ctx),
+            Self::ApiKey(api_key) => auth_manager.authenticate_api_key(api_key, ctx),
+        });
+    }
+}
+
+fn authenticate_user_after_iap_access(
+    authentication: StartupUserAuthentication,
+    ctx: &mut AppContext,
+) {
     let iap_manager = IapManager::handle(ctx);
     if !iap_manager.as_ref(ctx).is_enabled() || iap_manager.as_ref(ctx).has_valid_token() {
-        AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
-            auth_manager.refresh_user(ctx);
-        });
+        authentication.start(ctx);
         return;
     }
 
-    let mut refresh_started = false;
+    let mut pending_authentication = Some(authentication);
     ctx.subscribe_to_model(&iap_manager, move |iap_manager, event, ctx| match event {
         IapManagerEvent::StateChanged => {
-            if refresh_started || !iap_manager.as_ref(ctx).has_valid_token() {
+            if !iap_manager.as_ref(ctx).has_valid_token() {
                 return;
             }
-            refresh_started = true;
-            AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
-                auth_manager.refresh_user(ctx);
-            });
+            if let Some(authentication) = pending_authentication.take() {
+                authentication.start(ctx);
+            }
         }
         IapManagerEvent::AccessUnavailable => {
             report_error!("Staging IAP access unavailable before startup user refresh");
@@ -1368,6 +1382,21 @@ fn api_key_from_launch_mode(launch_mode: &LaunchMode) -> Option<String> {
     }
 }
 
+fn pending_tui_api_key_from_launch_mode(launch_mode: &LaunchMode) -> Option<String> {
+    match launch_mode {
+        LaunchMode::Tui {
+            entrypoint: TuiEntryPoint::Interactive { api_key, .. },
+        } => api_key.clone(),
+        LaunchMode::App { .. }
+        | LaunchMode::CommandLine { .. }
+        | LaunchMode::Test { .. }
+        | LaunchMode::RemoteServerProxy
+        | LaunchMode::RemoteServerDaemon { .. }
+        | LaunchMode::Tui {
+            entrypoint: TuiEntryPoint::CliCommand { .. },
+        } => None,
+    }
+}
 #[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 pub(crate) fn initialize_app(
     launch_mode: &LaunchMode,
@@ -1421,10 +1450,14 @@ pub(crate) fn initialize_app(
         ctx.set_zoom_factor(WindowSettings::as_ref(ctx).zoom_level.as_zoom_factor());
     }
 
-    // Extract API key from command line options, if applicable.
-    let api_key = api_key_from_launch_mode(launch_mode);
-
-    let auth_state = Arc::new(AuthState::initialize(ctx, api_key));
+    // Interactive TUI API keys remain outside shared auth state until the server accepts them.
+    // Other launch modes retain their existing eager credential initialization semantics.
+    let pending_tui_api_key = pending_tui_api_key_from_launch_mode(launch_mode);
+    let auth_state = Arc::new(if pending_tui_api_key.is_some() {
+        AuthState::initialize_for_pending_api_key(ctx)
+    } else {
+        AuthState::initialize(ctx, api_key_from_launch_mode(launch_mode))
+    });
     timer.mark_interval_end("AUTH_MANAGER_SET_USER");
 
     let agent_source = determine_agent_source(launch_mode);
@@ -2304,10 +2337,16 @@ pub(crate) fn initialize_app(
     });
 
     // CLI commands establish IAP access and refresh auth in their dispatch path so they can
-    // surface failures synchronously. Interactive clients wait for IAP here before refreshing
-    // their persisted user, since the refresh itself calls the IAP-gated warp-server.
-    if user_is_logged_in && !matches!(launch_mode, LaunchMode::CommandLine { .. }) {
-        refresh_user_after_iap_access(ctx);
+    // surface failures synchronously. Interactive clients wait for IAP here before authenticating
+    // their startup user, since the request itself calls the IAP-gated warp-server.
+    let startup_authentication = pending_tui_api_key
+        .map(StartupUserAuthentication::ApiKey)
+        .or_else(|| {
+            (user_is_logged_in && !matches!(launch_mode, LaunchMode::CommandLine { .. }))
+                .then_some(StartupUserAuthentication::RefreshUser)
+        });
+    if let Some(authentication) = startup_authentication {
+        authenticate_user_after_iap_access(authentication, ctx);
     }
 
     // Add a singleton model that holds the current prompt configuration.

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1356,7 +1356,7 @@ fn authenticate_user_after_iap_access(
             }
         }
         IapManagerEvent::AccessUnavailable => {
-            report_error!("Staging IAP access unavailable before startup user refresh");
+            report_error!("Staging IAP access unavailable before startup user authentication");
         }
         IapManagerEvent::RefreshFailed {
             message: _,

--- a/app/src/lib_tests.rs
+++ b/app/src/lib_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn app_and_tui_accept_api_keys() {
+fn app_and_tui_use_distinct_api_key_initialization_policies() {
     let app = LaunchMode::App {
         args: Default::default(),
         api_key: Some("app-api-key".to_owned()),
@@ -13,19 +13,10 @@ fn app_and_tui_accept_api_keys() {
         },
     };
 
-    assert_eq!(
-        api_key_from_launch_mode(&app).as_deref(),
-        Some("app-api-key")
-    );
-    assert_eq!(
-        api_key_from_launch_mode(&tui).as_deref(),
-        Some("tui-api-key")
-    );
-    assert!(pending_tui_api_key_from_launch_mode(&app).is_none());
-    assert_eq!(
-        pending_tui_api_key_from_launch_mode(&tui).as_deref(),
-        Some("tui-api-key")
-    );
+    assert_eq!(app.api_key().as_deref(), Some("app-api-key"));
+    assert_eq!(tui.api_key().as_deref(), Some("tui-api-key"));
+    assert!(app.should_initialize_api_key_eagerly());
+    assert!(!tui.should_initialize_api_key_eagerly());
 }
 
 #[test]

--- a/app/src/lib_tests.rs
+++ b/app/src/lib_tests.rs
@@ -21,6 +21,11 @@ fn app_and_tui_accept_api_keys() {
         api_key_from_launch_mode(&tui).as_deref(),
         Some("tui-api-key")
     );
+    assert!(pending_tui_api_key_from_launch_mode(&app).is_none());
+    assert_eq!(
+        pending_tui_api_key_from_launch_mode(&tui).as_deref(),
+        Some("tui-api-key")
+    );
 }
 
 #[test]

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -23,6 +23,7 @@ use warpui::{AppContext, Entity, SingletonEntity};
 use crate::TuiMountFn;
 use crate::ai::mcp::FileBasedMCPManager;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::auth::auth_state::AuthState;
 use crate::auth::{self, AuthStateProvider};
 use crate::terminal::focus_env::FOCUS_URL_ENV;
 use crate::tui_onboarding_markers::TuiOnboardingMarkers;
@@ -30,7 +31,7 @@ use crate::tui_onboarding_markers::TuiOnboardingMarkers;
 /// Login state of the headless TUI, observed by the `warp_tui` root view to
 /// decide whether to show the login placeholder or the input UI.
 pub enum TuiLoginPhase {
-    /// Logged out and waiting for the user to explicitly begin browser login.
+    /// No validated user identity is available, so the login welcome remains visible.
     SignedOutWelcome,
     /// Waiting for the user to finish the device-authorization login. The
     /// exact URL opened in the browser is surfaced once known (the alt screen
@@ -168,13 +169,8 @@ impl SingletonEntity for TuiLoginModel {}
 /// Registers the [`TuiLoginModel`], mounts the TUI immediately, and shows an
 /// explicit welcome screen when the user isn't already logged in.
 pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
-    let logged_in = AuthStateProvider::as_ref(ctx).get().is_logged_in();
-
-    let initial_phase = if logged_in {
-        TuiLoginPhase::LoggedIn
-    } else {
-        TuiLoginPhase::SignedOutWelcome
-    };
+    let initial_phase = initial_login_phase(AuthStateProvider::as_ref(ctx).get());
+    let logged_in = matches!(&initial_phase, TuiLoginPhase::LoggedIn);
     ctx.add_singleton_model(move |_| TuiLoginModel {
         phase: initial_phase,
         browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
@@ -199,6 +195,18 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
 
     if logged_in {
         activate_global_mcp_servers(ctx);
+    }
+}
+
+fn has_validated_identity(auth_state: &AuthState) -> bool {
+    auth_state.is_logged_in() && auth_state.user_id().is_some()
+}
+
+fn initial_login_phase(auth_state: &AuthState) -> TuiLoginPhase {
+    if has_validated_identity(auth_state) {
+        TuiLoginPhase::LoggedIn
+    } else {
+        TuiLoginPhase::SignedOutWelcome
     }
 }
 

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -6,11 +6,13 @@ use warpui::{App, SingletonEntity};
 
 use super::{
     TuiAuthBrowserFlow, TuiLoginEvent, TuiLoginModel, TuiLoginPhase, handle_auth_manager_event,
-    set_logged_out_phase, set_login_phase, start_tui_device_login,
-    tui_verification_url_with_return, validated_tui_focus_url,
+    has_validated_identity, initial_login_phase, set_logged_out_phase, set_login_phase,
+    start_tui_device_login, tui_verification_url_with_return, validated_tui_focus_url,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::auth::auth_state::AuthState;
+use crate::auth::credentials::Credentials;
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::auth::UserAuthenticationError;
 fn login_model(phase: TuiLoginPhase) -> TuiLoginModel {
@@ -18,6 +20,43 @@ fn login_model(phase: TuiLoginPhase) -> TuiLoginModel {
         phase,
         browser_flow: TuiAuthBrowserFlow::DirectDeviceAuthorization,
     }
+}
+
+#[test]
+fn credential_only_auth_stays_on_signed_out_welcome() {
+    let auth_state = AuthState::new_logged_out_for_test();
+    auth_state.set_credentials(Some(Credentials::ApiKey {
+        key: "wk-api-test".to_owned(),
+        owner_type: None,
+    }));
+
+    assert!(!has_validated_identity(&auth_state));
+    assert!(matches!(
+        initial_login_phase(&auth_state),
+        TuiLoginPhase::SignedOutWelcome
+    ));
+}
+
+#[test]
+fn credentials_with_user_identity_start_logged_in() {
+    let auth_state = AuthState::new_for_test();
+
+    assert!(has_validated_identity(&auth_state));
+    assert!(matches!(
+        initial_login_phase(&auth_state),
+        TuiLoginPhase::LoggedIn
+    ));
+}
+
+#[test]
+fn missing_credentials_and_identity_start_signed_out() {
+    let auth_state = AuthState::new_logged_out_for_test();
+
+    assert!(!has_validated_identity(&auth_state));
+    assert!(matches!(
+        initial_login_phase(&auth_state),
+        TuiLoginPhase::SignedOutWelcome
+    ));
 }
 
 #[test]
@@ -295,6 +334,29 @@ fn renders_device_code_request_timeout_without_id_token_prefix() {
                 TuiLoginPhase::Failed { message }
                     if message == "Timed out requesting a sign-in link after 2 attempts"
                         && !message.contains("ID token")
+            ));
+        });
+    });
+}
+
+#[test]
+fn credential_validation_failure_stays_on_auth_flow() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| TuiLoginModel::signed_out_for_test());
+
+        app.update(|ctx| {
+            handle_auth_manager_event(
+                &AuthManagerEvent::AuthFailed(UserAuthenticationError::Unexpected(
+                    anyhow::anyhow!("API key rejected"),
+                )),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            assert!(matches!(
+                TuiLoginModel::as_ref(ctx).phase(),
+                TuiLoginPhase::Failed { message } if message.contains("API key rejected")
             ));
         });
     });

--- a/app/src/tui/user_info.rs
+++ b/app/src/tui/user_info.rs
@@ -73,7 +73,7 @@ impl TuiUserInfoManager {
             .current_workspace()
             .map(|workspace| workspace.name.clone());
         TuiUserInfoSnapshot {
-            is_logged_in: auth.is_logged_in(),
+            is_logged_in: super::has_validated_identity(auth),
             username: auth.username_for_display(),
             email: auth.user_email(),
             user_id: auth.user_id().map(|uid| uid.as_string()),

--- a/crates/warp_server_auth/src/auth_state.rs
+++ b/crates/warp_server_auth/src/auth_state.rs
@@ -176,6 +176,30 @@ impl AuthState {
         state
     }
 
+    /// Creates auth state for an interactive client that still needs to validate
+    /// its startup API key.
+    ///
+    /// The pending key intentionally remains outside [`AuthState`] so it cannot
+    /// authorize unrelated requests or make [`Self::is_logged_in`] true before
+    /// the user fetch succeeds. Persisted user state is also skipped because an
+    /// explicitly supplied API key takes precedence over secure storage.
+    pub fn initialize_for_pending_api_key(ctx: &AppContext) -> Self {
+        let state = Self::new(ctx);
+
+        if Self::should_use_test_user() {
+            state.set_user(Some(User::test()));
+            #[cfg(any(
+                test,
+                feature = "integration_tests",
+                feature = "skip_login",
+                feature = "test-util"
+            ))]
+            state.set_credentials(Some(Self::test_credentials()));
+        }
+
+        state
+    }
+
     fn should_use_test_user() -> bool {
         cfg!(any(test, feature = "skip_login", feature = "test-util"))
             || ChannelState::channel() == Channel::Integration

--- a/crates/warp_server_auth/src/auth_state.rs
+++ b/crates/warp_server_auth/src/auth_state.rs
@@ -176,14 +176,15 @@ impl AuthState {
         state
     }
 
-    /// Creates auth state for an interactive client that still needs to validate
-    /// its startup API key.
+    /// Creates auth state for a client that must validate an explicit credential
+    /// before making it available to shared authenticated clients.
     ///
-    /// The pending key intentionally remains outside [`AuthState`] so it cannot
-    /// authorize unrelated requests or make [`Self::is_logged_in`] true before
-    /// the user fetch succeeds. Persisted user state is also skipped because an
-    /// explicitly supplied API key takes precedence over secure storage.
-    pub fn initialize_for_pending_api_key(ctx: &AppContext) -> Self {
+    /// Unlike [`Self::initialize`], this installs neither the supplied credential
+    /// nor persisted identity. The credential remains outside [`AuthState`] until
+    /// its user fetch succeeds, so failed validation leaves the client fully
+    /// logged out. Persisted state is skipped because an explicit credential
+    /// takes precedence over secure storage.
+    pub fn initialize_for_credential_validation(ctx: &AppContext) -> Self {
         let state = Self::new(ctx);
 
         if Self::should_use_test_user() {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -197,7 +197,6 @@ const STATUS_UNAVAILABLE: &str = "\u{2014}"; // em dash
 const STATUS_UNTITLED_SESSION: &str = "Untitled";
 const STATUS_DEV_BUILD: &str = "dev build";
 const STATUS_NOT_SIGNED_IN: &str = "Not signed in";
-const STATUS_SIGNED_IN: &str = "Signed in";
 
 fn status_menu_is_open(mode: TuiInputSuggestionsMode) -> bool {
     matches!(
@@ -542,23 +541,22 @@ fn export_file_success_message(export: &ConversationFileExport) -> String {
 /// chain as `render_login_line`:
 /// 1. `email` when non-empty
 /// 2. `username` when non-empty (display name or email fallback from auth)
-/// 3. `STATUS_SIGNED_IN` when `is_logged_in` is true but no identifier
-/// 4. `STATUS_NOT_SIGNED_IN` when fully logged out
+/// 3. `user_id` when non-empty
+/// 4. `STATUS_NOT_SIGNED_IN` when no validated identity is available
 fn resolve_status_email(
     email: Option<String>,
     username: Option<String>,
+    user_id: Option<String>,
     is_logged_in: bool,
 ) -> String {
+    if !is_logged_in {
+        return STATUS_NOT_SIGNED_IN.to_owned();
+    }
     email
         .filter(|e| !e.is_empty())
         .or_else(|| username.filter(|u| !u.is_empty()))
-        .unwrap_or_else(|| {
-            if is_logged_in {
-                STATUS_SIGNED_IN.to_owned()
-            } else {
-                STATUS_NOT_SIGNED_IN.to_owned()
-            }
-        })
+        .or_else(|| user_id.filter(|id| !id.is_empty()))
+        .unwrap_or_else(|| STATUS_NOT_SIGNED_IN.to_owned())
 }
 
 fn format_status_conversation_id(conversation_id: Option<AIConversationId>) -> String {
@@ -2750,8 +2748,12 @@ impl TuiTerminalSessionView {
         let org = user_info
             .org
             .unwrap_or_else(|| STATUS_UNAVAILABLE.to_owned());
-        let email =
-            resolve_status_email(user_info.email, user_info.username, user_info.is_logged_in);
+        let email = resolve_status_email(
+            user_info.email,
+            user_info.username,
+            user_info.user_id,
+            user_info.is_logged_in,
+        );
         status_menu::TuiStatusInfo {
             version,
             session: session_name,

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -6394,38 +6394,55 @@ fn killing_child_does_not_exit_tui_parent_session_remains_alive() {
 }
 
 #[test]
-fn status_email_fallback_chain_covers_username_and_signed_in_arms() {
+fn status_email_fallback_chain_requires_a_validated_identity() {
     // Arm 1: non-empty email wins regardless of username.
     assert_eq!(
         super::resolve_status_email(
             Some("user@example.com".to_owned()),
             Some("display_name".to_owned()),
+            Some("user-123".to_owned()),
             true,
         ),
         "user@example.com"
     );
     // Arm 2a: empty email falls back to a non-empty username.
     assert_eq!(
-        super::resolve_status_email(Some(String::new()), Some("display_name".to_owned()), true,),
+        super::resolve_status_email(
+            Some(String::new()),
+            Some("display_name".to_owned()),
+            Some("user-123".to_owned()),
+            true,
+        ),
         "display_name"
     );
     // Arm 2b: None email falls back to a non-empty username.
     assert_eq!(
-        super::resolve_status_email(None, Some("display_name".to_owned()), true),
+        super::resolve_status_email(
+            None,
+            Some("display_name".to_owned()),
+            Some("user-123".to_owned()),
+            true,
+        ),
         "display_name"
     );
-    // Arm 3: both email and username absent/empty but logged in → "Signed in".
+    // Arm 3: user ID is the final validated identity fallback.
     assert_eq!(
-        super::resolve_status_email(None, None, true),
-        super::STATUS_SIGNED_IN
+        super::resolve_status_email(None, None, Some("user-123".to_owned()), true),
+        "user-123"
     );
+    // Arm 4: a missing identity never degrades to bare "Signed in".
     assert_eq!(
-        super::resolve_status_email(Some(String::new()), Some(String::new()), true,),
-        super::STATUS_SIGNED_IN
+        super::resolve_status_email(Some(String::new()), Some(String::new()), None, true),
+        super::STATUS_NOT_SIGNED_IN
     );
-    // Arm 4: fully logged out → "Not signed in".
+    // Arm 5: an identity is ignored unless auth has been validated.
     assert_eq!(
-        super::resolve_status_email(None, None, false),
+        super::resolve_status_email(
+            Some("user@example.com".to_owned()),
+            Some("display_name".to_owned()),
+            Some("user-123".to_owned()),
+            false,
+        ),
         super::STATUS_NOT_SIGNED_IN
     );
 }

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -17,7 +17,7 @@ use ai::project_context::model::{
 use warp::tui_export::{
     ActiveSession, ActiveSessionEvent, ChangelogModel, ChangelogModelEvent, ChangelogState,
     SkillManager, SkillManagerEvent, TuiMcpManager, TuiMcpServerStatus, TuiUserInfoManager,
-    TuiUserInfoManagerEvent,
+    TuiUserInfoManagerEvent, TuiUserInfoSnapshot,
 };
 use warp_core::channel::ChannelState;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -782,18 +782,24 @@ fn render_login_line_with_prefix(
     let muted = builder.muted_text_style();
     let dim = builder.dim_text_style();
     let user_info = TuiUserInfoManager::as_ref(app).snapshot(app);
-    let display = user_info
-        .email
-        .filter(|email| !email.is_empty())
-        .or(user_info.username.filter(|username| !username.is_empty()));
-    let (label, style) = if let Some(display) = display {
-        (format!("{signed_in_prefix} {display}"), muted)
-    } else if user_info.is_logged_in {
-        ("Signed in".to_owned(), muted)
+    let (label, style) = if let Some(label) = login_line_label(signed_in_prefix, user_info) {
+        (label, muted)
     } else {
         ("Not signed in".to_owned(), dim)
     };
     TuiText::new(label).with_style(style).truncate().finish()
+}
+
+fn login_line_label(signed_in_prefix: &str, user_info: TuiUserInfoSnapshot) -> Option<String> {
+    if !user_info.is_logged_in {
+        return None;
+    }
+    user_info
+        .email
+        .filter(|email| !email.is_empty())
+        .or(user_info.username.filter(|username| !username.is_empty()))
+        .or(user_info.user_id.filter(|user_id| !user_id.is_empty()))
+        .map(|display| format!("{signed_in_prefix} {display}"))
 }
 
 /// The version line: the release version (or "dev build"), with the

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -7,7 +7,8 @@ use chrono::DateTime;
 use uuid::Uuid;
 use warp::tui_export::{
     TuiMcpConfigDiagnostic, TuiMcpServerId, TuiMcpServerSnapshot, TuiMcpServerSource,
-    TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport, register_tui_session_view_test_singletons,
+    TuiMcpServerStatus, TuiMcpSnapshot, TuiMcpTransport, TuiUserInfoSnapshot,
+    register_tui_session_view_test_singletons,
 };
 use warpui::{EntityIdMap, SingletonEntity};
 use warpui_core::elements::animation::AnimationClock;
@@ -490,6 +491,30 @@ fn login_line_shows_signed_in_account_email() {
             lines.join("\n")
         );
     });
+}
+
+#[test]
+fn login_line_never_claims_signed_in_without_an_identity() {
+    let snapshot = TuiUserInfoSnapshot {
+        is_logged_in: true,
+        ..Default::default()
+    };
+
+    assert_eq!(super::login_line_label("Signed in as", snapshot), None);
+}
+
+#[test]
+fn login_line_falls_back_to_validated_user_id() {
+    let snapshot = TuiUserInfoSnapshot {
+        is_logged_in: true,
+        user_id: Some("user-123".to_owned()),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        super::login_line_label("Signed in as", snapshot),
+        Some("Signed in as user-123".to_owned())
+    );
 }
 
 /// At a narrow terminal the complete displayed path must wrap across rows


### PR DESCRIPTION
## Description

Interactive Warp Agent CLI startup API keys could previously enter shared `AuthState` before the server had validated them or returned the associated user. Credential presence made `AuthState::is_logged_in()` true and allowed unrelated clients to use the key while identity loading was still pending. If validation then failed, the TUI could create a terminal and render a bare **Signed in** state with no validated identity.

This change fixes both parts of that lifecycle:
- `LaunchMode` now owns the decision that interactive TUI startup keys require deferred validation;
- interactive TUI startup keys remain pending outside shared `AuthState`;
- the pending key is used only by `AuthClient::fetch_user(LoginToken::ApiKey(...), false)`, after staging IAP access is ready;
- successful validation atomically promotes the returned credentials and user through the existing authentication-completion path;
- failed validation leaves shared auth state with neither credentials nor a user and remains in the retryable login flow;
- an explicitly supplied TUI key still takes precedence over persisted identity without exposing the unvalidated key to other clients;
- command-line and desktop-app API-key initialization behavior is unchanged;
- the TUI requires credentials plus a fetched user ID before entering its logged-in phase or creating a terminal; and
- account labels fall back through email, username, and stable user ID, otherwise reporting **Not signed in** instead of bare **Signed in**.

The SSH environment exposed the partial state but was not the root cause. API keys are not persisted by Warp; a key present at startup comes from the launch arguments or `WARP_API_KEY` environment inherited by that process.

## Linked Issue

N/A — this was identified from logs for an SSH-launched Warp Agent CLI session.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Added regression coverage for:
- distinct desktop-app and interactive-TUI startup-key initialization policy;
- pending API-key normalization and validation with `for_refresh = false`;
- failed validation emitting `AuthFailed` while leaving shared auth state fully logged out;
- successful promotion installing the API-key credentials together with the fetched user;
- credential-only startup, validated identity startup, zero-state labels, stable user-ID fallback, and `/status` identity resolution.

Manual full-terminal validation:
- Ran `WARP_API_KEY=wk-invalid-pending-key ./script/run-tui` in a real PTY.
- The TUI built and launched successfully.
- The invalid key was rejected and displayed the login failure/retry flow.
- The TUI never entered a signed-in state and did not create a shell terminal.

Previously completed for the original TUI state-gating patch:
- App TUI authentication module: 17 tests passed.
- Full `warp_tui` suite: 966 tests passed.
- `./script/format` passed.
- Relevant workspace, app, and completer Clippy commands passed.

No additional automated suite, Clippy, presubmit, or formatting run was performed after the pending-key lifecycle follow-up; validation of that follow-up used the real TUI terminal flow above.

No process-level integration test was added because the headless TUI does not use the GUI integration harness; state-transition and render-to-lines unit tests cover the regression directly.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/f0184211-8c6c-4695-8ca1-6b0972449c78

CHANGELOG-BUG-FIX: Fixed Warp Agent CLI treating startup API keys as authenticated before validation completed.

Co-Authored-By: Oz <oz-agent@warp.dev>
