### PR TITLE
Save and restore tab groups in launch configurations

### DIFF
--- a/app/src/integration_testing/workspace/assertions.rs
+++ b/app/src/integration_testing/workspace/assertions.rs
@@ -1,13 +1,88 @@
-use warpui::async_assert_eq;
 use warpui::integration::AssertionCallback;
+use warpui::{async_assert, async_assert_eq};
 
 use crate::integration_testing::view_getters::workspace_view;
+use crate::tab::SelectedTabColor;
+use crate::themes::theme::AnsiColorIdentifier;
+use crate::workspace::tab_group::TabGroupId;
 
 pub fn assert_focused_tab_index(tab_index: usize) -> AssertionCallback {
     Box::new(move |app, window_id| {
         let workspace = workspace_view(app, window_id);
         workspace.read(app, |view, _ctx| {
             async_assert_eq!(view.active_tab_index(), tab_index)
+        })
+    })
+}
+
+/// Assert how the workspace's tabs are grouped, along with the name and color
+/// of each group.
+///
+/// `expected_memberships` holds one entry per tab, in tab order: `None` for an
+/// ungrouped tab, or an index into `expected_groups`. Groups are numbered by
+/// the order they first appear in the tab list, so this also pins down which
+/// tabs share a single group -- two tabs only get the same index when they
+/// carry the same `TabGroupId`.
+///
+/// Group colors are given the way a launch config writes them -- `None` for a
+/// group that saved no color -- and are compared against the `SelectedTabColor`
+/// restore is expected to produce.
+pub fn assert_tab_groups(
+    expected_memberships: Vec<Option<usize>>,
+    expected_groups: Vec<(Option<&'static str>, Option<AnsiColorIdentifier>)>,
+) -> AssertionCallback {
+    Box::new(move |app, window_id| {
+        let workspace = workspace_view(app, window_id);
+        workspace.read(app, |view, _ctx| {
+            let mut group_order: Vec<TabGroupId> = Vec::new();
+            let memberships: Vec<Option<usize>> = view
+                .tabs
+                .iter()
+                .map(|tab| {
+                    tab.group_id.map(|id| {
+                        group_order
+                            .iter()
+                            .position(|seen| *seen == id)
+                            .unwrap_or_else(|| {
+                                group_order.push(id);
+                                group_order.len() - 1
+                            })
+                    })
+                })
+                .collect();
+
+            if memberships != expected_memberships {
+                return async_assert!(
+                    false,
+                    "Expected tab group memberships {expected_memberships:?}, but there were {memberships:?}"
+                );
+            }
+
+            let groups: Vec<(Option<String>, SelectedTabColor)> = group_order
+                .iter()
+                .map(|id| {
+                    let group = view
+                        .tab_groups
+                        .get(id)
+                        .expect("A grouped tab's group must exist in the workspace");
+                    (group.name.clone(), group.color)
+                })
+                .collect();
+            let expected: Vec<(Option<String>, SelectedTabColor)> = expected_groups
+                .iter()
+                .map(|&(name, color)| {
+                    (
+                        name.map(str::to_owned),
+                        color.map_or(SelectedTabColor::Unset, SelectedTabColor::Color),
+                    )
+                })
+                .collect();
+
+            async_assert_eq!(
+                groups,
+                expected,
+                "Expected restored groups {expected:?}, but there were {groups:?}"
+            )
         })
     })
 }

--- a/app/src/integration_testing/workspace/assertions.rs
+++ b/app/src/integration_testing/workspace/assertions.rs
@@ -27,6 +27,9 @@ pub fn assert_focused_tab_index(tab_index: usize) -> AssertionCallback {
 /// Group colors are given the way a launch config writes them -- `None` for a
 /// group that saved no color -- and are compared against the `SelectedTabColor`
 /// restore is expected to produce.
+///
+/// The workspace must hold exactly the groups listed, so a group that no tab
+/// belongs to is a failure rather than something the caller can omit.
 pub fn assert_tab_groups(
     expected_memberships: Vec<Option<usize>>,
     expected_groups: Vec<(Option<&'static str>, Option<AnsiColorIdentifier>)>,
@@ -55,6 +58,16 @@ pub fn assert_tab_groups(
                 return async_assert!(
                     false,
                     "Expected tab group memberships {expected_memberships:?}, but there were {memberships:?}"
+                );
+            }
+
+            if view.tab_groups.len() != group_order.len() {
+                return async_assert!(
+                    false,
+                    "Expected the workspace to hold exactly {} group(s), the ones its tabs \
+                     belong to, but it holds {} -- the extras have no members",
+                    group_order.len(),
+                    view.tab_groups.len()
                 );
             }
 

--- a/app/src/launch_configs/launch_config.rs
+++ b/app/src/launch_configs/launch_config.rs
@@ -131,6 +131,42 @@ fn is_false(val: &bool) -> bool {
     !*val
 }
 
+/// Resolves each tab's group index for restore, keeping every group to a
+/// single contiguous run.
+///
+/// The tab bar collapses each *contiguous* run of same-group tabs into one
+/// group container (`Workspace::tab_bar_slots`), so interleaved membership --
+/// group 0, an ungrouped tab, group 0 again -- would render as two containers
+/// sharing one id, which no other code path can produce. Configs written by
+/// `From<WindowSnapshot>` are always contiguous because a live window is, so
+/// this only bites on hand-edited YAML.
+///
+/// The first run of each group wins and later stragglers come back ungrouped.
+/// Reordering the tabs would also restore the invariant, but silently moving
+/// tabs the config explicitly ordered is the more surprising of the two.
+/// Out-of-range indices are dropped the same way.
+pub fn resolve_group_memberships(tabs: &[TabTemplate], group_count: usize) -> Vec<Option<usize>> {
+    let mut closed: Vec<bool> = vec![false; group_count];
+    let mut previous: Option<usize> = None;
+
+    tabs.iter()
+        .map(|tab| {
+            let group = tab
+                .group
+                .filter(|index| *index < group_count)
+                .filter(|index| !closed[*index]);
+
+            if previous != group
+                && let Some(previous) = previous
+            {
+                closed[previous] = true;
+            }
+            previous = group;
+            group
+        })
+        .collect()
+}
+
 fn is_falsey(val: &Option<bool>) -> bool {
     val.is_none_or(|v| !v)
 }

--- a/app/src/launch_configs/launch_config.rs
+++ b/app/src/launch_configs/launch_config.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::app_state::{
-    AppState, LeafContents, PaneNodeSnapshot, SplitDirection as StateSplitDirection, TabSnapshot,
-    WindowSnapshot,
+    AppState, LeafContents, PaneNodeSnapshot, SplitDirection as StateSplitDirection,
+    TabGroupSnapshot, TabSnapshot, WindowSnapshot,
 };
 use crate::themes::theme::AnsiColorIdentifier;
 
@@ -39,6 +39,37 @@ pub struct WindowTemplate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub active_tab_index: Option<usize>,
     pub tabs: Vec<TabTemplate>,
+    /// Tab groups in this window, in tab-bar order. A tab joins one by
+    /// index through [`TabTemplate::group`]; runtime `TabGroupId`s are not
+    /// serialized because they are regenerated on every restore.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tab_groups: Vec<TabGroupTemplate>,
+}
+
+/// A tab group as stored in a launch config.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct TabGroupTemplate {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub color: Option<AnsiColorIdentifier>,
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub collapsed: bool,
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub pinned: bool,
+}
+
+impl From<&TabGroupSnapshot> for TabGroupTemplate {
+    fn from(snapshot: &TabGroupSnapshot) -> Self {
+        Self {
+            name: snapshot.name.clone(),
+            // Groups have no default-directory color to fall back to, so the
+            // manual selection is the whole story here.
+            color: snapshot.color.resolve(None),
+            collapsed: snapshot.collapsed,
+            pinned: snapshot.pinned,
+        }
+    }
 }
 
 impl From<WindowSnapshot> for WindowTemplate {
@@ -46,12 +77,16 @@ impl From<WindowSnapshot> for WindowTemplate {
         let mut active_tab_index = None;
         let mut num_valid_tabs = 0;
 
-        let tabs = snapshot
+        // A tab can fail to convert, so group membership has to be carried on
+        // the tab's own `group_id` rather than inferred from its position --
+        // the surviving tabs are renumbered below and the two indices diverge.
+        let tabs_with_groups = snapshot
             .tabs
             .into_iter()
             .enumerate()
             .filter_map(|(i, tab)| {
-                let tab = tab.try_into().ok()?;
+                let group_id = tab.group_id;
+                let tab: TabTemplate = tab.try_into().ok()?;
 
                 if i == snapshot.active_tab_index {
                     active_tab_index = Some(num_valid_tabs);
@@ -59,15 +94,41 @@ impl From<WindowSnapshot> for WindowTemplate {
 
                 num_valid_tabs += 1;
 
-                Some(tab)
+                Some((tab, group_id))
+            })
+            .collect::<Vec<_>>();
+
+        // Keep only groups that still have a member, so a config never
+        // restores an empty group the user cannot see or remove.
+        let tab_groups = snapshot
+            .tab_groups
+            .iter()
+            .filter(|group| {
+                tabs_with_groups
+                    .iter()
+                    .any(|(_, group_id)| *group_id == Some(group.id))
+            })
+            .collect::<Vec<_>>();
+
+        let tabs = tabs_with_groups
+            .into_iter()
+            .map(|(mut tab, group_id)| {
+                tab.group = group_id
+                    .and_then(|group_id| tab_groups.iter().position(|group| group.id == group_id));
+                tab
             })
             .collect::<Vec<TabTemplate>>();
 
         Self {
             active_tab_index,
             tabs,
+            tab_groups: tab_groups.into_iter().map(TabGroupTemplate::from).collect(),
         }
     }
+}
+
+fn is_false(val: &bool) -> bool {
+    !*val
 }
 
 fn is_falsey(val: &Option<bool>) -> bool {
@@ -187,6 +248,9 @@ pub struct TabTemplate {
     pub commands: Vec<CommandTemplate>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub color: Option<AnsiColorIdentifier>,
+    /// Index into [`WindowTemplate::tab_groups`], when this tab is grouped.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub group: Option<usize>,
 }
 
 impl TabTemplate {
@@ -238,6 +302,9 @@ impl TryFrom<TabSnapshot> for TabTemplate {
             layout: snapshot.root.try_into()?,
             commands: Vec::new(),
             color,
+            // Resolved by `From<WindowSnapshot>`, which is the only place
+            // that knows the window's surviving group list.
+            group: None,
         })
     }
 }
@@ -277,9 +344,11 @@ pub fn make_mock_single_window_launch_config() -> LaunchConfig {
         name: "Mocked Config".to_string(),
         active_window_index: Some(0),
         windows: vec![WindowTemplate {
+            tab_groups: vec![],
             active_tab_index: Some(0),
             tabs: vec![
                 TabTemplate {
+                    group: None,
                     title: Some("First Tab".to_string()),
                     layout: PaneTemplateType::PaneTemplate {
                         is_focused: Some(true),
@@ -292,6 +361,7 @@ pub fn make_mock_single_window_launch_config() -> LaunchConfig {
                     color: None,
                 },
                 TabTemplate {
+                    group: None,
                     title: Some("Second Tab".to_string()),
                     layout: PaneTemplateType::PaneTemplate {
                         is_focused: Some(true),

--- a/app/src/launch_configs/launch_config_tests.rs
+++ b/app/src/launch_configs/launch_config_tests.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 
-use super::{CommandTemplate, LaunchConfig, PaneMode, PaneTemplateType};
+use super::{CommandTemplate, LaunchConfig, PaneMode, PaneTemplateType, TabTemplate};
 use crate::app_state::{
     AppState, BranchSnapshot, LeafContents, LeafSnapshot, NotebookPaneSnapshot, PaneFlex,
     PaneNodeSnapshot, SplitDirection, TabGroupSnapshot, TabSnapshot, TerminalPaneSnapshot,
     WindowSnapshot,
 };
-use crate::themes::theme::AnsiColorIdentifier;
-use crate::workspace::tab_group::TabGroupId;
 use crate::drive::OpenWarpDriveObjectSettings;
 use crate::tab::SelectedTabColor;
+use crate::themes::theme::AnsiColorIdentifier;
+use crate::workspace::tab_group::TabGroupId;
 
 fn single_tab_snapshot(root: PaneNodeSnapshot) -> AppState {
     AppState {
@@ -674,4 +674,77 @@ fn test_config_from_snapshot_omits_tab_groups_when_there_are_none() {
     let yaml = serde_yaml::to_string(&config).expect("serializes");
     assert!(!yaml.contains("tab_groups"), "got:\n{yaml}");
     assert!(!yaml.contains("group:"), "got:\n{yaml}");
+}
+
+fn tab_in_group(group: Option<usize>) -> TabTemplate {
+    TabTemplate {
+        title: None,
+        layout: PaneTemplateType::PaneTemplate {
+            cwd: PathBuf::from("/tmp"),
+            commands: vec![],
+            is_focused: None,
+            pane_mode: PaneMode::Terminal,
+            shell: None,
+        },
+        commands: vec![],
+        color: None,
+        group,
+    }
+}
+
+#[test]
+fn test_resolve_group_memberships_keeps_contiguous_runs_intact() {
+    let tabs = vec![
+        tab_in_group(Some(0)),
+        tab_in_group(Some(0)),
+        tab_in_group(None),
+        tab_in_group(Some(1)),
+    ];
+
+    assert_eq!(
+        super::resolve_group_memberships(&tabs, 2),
+        vec![Some(0), Some(0), None, Some(1)]
+    );
+}
+
+#[test]
+fn test_resolve_group_memberships_ungroups_a_split_run() {
+    // The tab bar renders each contiguous run as its own container, so
+    // honoring the second run would draw two containers with one group id.
+    let tabs = vec![
+        tab_in_group(Some(0)),
+        tab_in_group(None),
+        tab_in_group(Some(0)),
+    ];
+
+    assert_eq!(
+        super::resolve_group_memberships(&tabs, 1),
+        vec![Some(0), None, None],
+        "the group's second run must not reopen it"
+    );
+}
+
+#[test]
+fn test_resolve_group_memberships_ungroups_a_run_split_by_another_group() {
+    let tabs = vec![
+        tab_in_group(Some(0)),
+        tab_in_group(Some(1)),
+        tab_in_group(Some(0)),
+    ];
+
+    assert_eq!(
+        super::resolve_group_memberships(&tabs, 2),
+        vec![Some(0), Some(1), None]
+    );
+}
+
+#[test]
+fn test_resolve_group_memberships_drops_out_of_range_indices() {
+    // Hand-edited YAML pointing past the end of `tab_groups`.
+    let tabs = vec![tab_in_group(Some(7)), tab_in_group(Some(0))];
+
+    assert_eq!(
+        super::resolve_group_memberships(&tabs, 1),
+        vec![None, Some(0)]
+    );
 }

--- a/app/src/launch_configs/launch_config_tests.rs
+++ b/app/src/launch_configs/launch_config_tests.rs
@@ -3,8 +3,11 @@ use std::path::PathBuf;
 use super::{CommandTemplate, LaunchConfig, PaneMode, PaneTemplateType};
 use crate::app_state::{
     AppState, BranchSnapshot, LeafContents, LeafSnapshot, NotebookPaneSnapshot, PaneFlex,
-    PaneNodeSnapshot, SplitDirection, TabSnapshot, TerminalPaneSnapshot, WindowSnapshot,
+    PaneNodeSnapshot, SplitDirection, TabGroupSnapshot, TabSnapshot, TerminalPaneSnapshot,
+    WindowSnapshot,
 };
+use crate::themes::theme::AnsiColorIdentifier;
+use crate::workspace::tab_group::TabGroupId;
 use crate::drive::OpenWarpDriveObjectSettings;
 use crate::tab::SelectedTabColor;
 
@@ -527,4 +530,148 @@ fn test_config_with_active_tab_being_filtered() {
 
     let template = LaunchConfig::from_snapshot("Test".into(), &state);
     assert_eq!(template.windows[0].active_tab_index, None)
+}
+
+// ---------------------------------------------------------------------------
+// Tab groups (#13898)
+// ---------------------------------------------------------------------------
+
+fn terminal_tab(cwd: &str, group_id: Option<TabGroupId>) -> TabSnapshot {
+    TabSnapshot {
+        custom_title: None,
+        default_directory_color: None,
+        selected_color: SelectedTabColor::default(),
+        root: PaneNodeSnapshot::Leaf(LeafSnapshot {
+            is_focused: true,
+            custom_vertical_tabs_title: None,
+            contents: LeafContents::Terminal(TerminalPaneSnapshot {
+                uuid: vec![],
+                cwd: Some(cwd.into()),
+                is_active: true,
+                is_read_only: false,
+                shell_launch_data: None,
+                input_config: None,
+                llm_model_override: None,
+                active_profile_id: None,
+                conversation_ids_to_restore: vec![],
+                active_conversation_id: None,
+            }),
+        }),
+        left_panel: None,
+        right_panel: None,
+        group_id,
+        pinned: false,
+    }
+}
+
+/// A tab that cannot be saved into a launch config, so it drops out of the
+/// template and shifts every later tab's index.
+fn unsaveable_tab(group_id: Option<TabGroupId>) -> TabSnapshot {
+    TabSnapshot {
+        custom_title: None,
+        default_directory_color: None,
+        selected_color: SelectedTabColor::default(),
+        root: PaneNodeSnapshot::Leaf(LeafSnapshot {
+            is_focused: true,
+            custom_vertical_tabs_title: None,
+            contents: LeafContents::Notebook(NotebookPaneSnapshot::CloudNotebook {
+                notebook_id: None,
+                settings: OpenWarpDriveObjectSettings::default(),
+            }),
+        }),
+        left_panel: None,
+        right_panel: None,
+        group_id,
+        pinned: false,
+    }
+}
+
+fn grouped_snapshot(tabs: Vec<TabSnapshot>, tab_groups: Vec<TabGroupSnapshot>) -> AppState {
+    let mut state = multi_tab_snapshot(0, tabs);
+    state.windows[0].tab_groups = tab_groups;
+    state
+}
+
+fn group(name: &str, id: TabGroupId) -> TabGroupSnapshot {
+    TabGroupSnapshot {
+        id,
+        name: Some(name.to_string()),
+        color: SelectedTabColor::Color(AnsiColorIdentifier::Blue),
+        collapsed: false,
+        pinned: false,
+    }
+}
+
+#[test]
+fn test_config_from_snapshot_preserves_tab_groups() {
+    let group_id = TabGroupId::new();
+    let state = grouped_snapshot(
+        vec![
+            terminal_tab("/a", Some(group_id)),
+            terminal_tab("/b", None),
+            terminal_tab("/c", Some(group_id)),
+        ],
+        vec![group("backend", group_id)],
+    );
+
+    let config = LaunchConfig::from_snapshot("test".to_string(), &state);
+    let window = &config.windows[0];
+
+    assert_eq!(window.tab_groups.len(), 1);
+    assert_eq!(window.tab_groups[0].name.as_deref(), Some("backend"));
+    assert_eq!(window.tab_groups[0].color, Some(AnsiColorIdentifier::Blue));
+
+    // Membership survives, and an ungrouped tab stays ungrouped.
+    assert_eq!(window.tabs[0].group, Some(0));
+    assert_eq!(window.tabs[1].group, None);
+    assert_eq!(window.tabs[2].group, Some(0));
+}
+
+#[test]
+fn test_config_from_snapshot_remaps_groups_around_unsaveable_tabs() {
+    // The first group's only tab cannot be saved, so that group must not
+    // survive -- and the second group's index must shift down with it.
+    // Membership is carried on each tab's `group_id`, never on its position,
+    // which is what makes this hold once the tab list is renumbered.
+    let dropped_group = TabGroupId::new();
+    let kept_group = TabGroupId::new();
+
+    let state = grouped_snapshot(
+        vec![
+            unsaveable_tab(Some(dropped_group)),
+            terminal_tab("/a", None),
+            terminal_tab("/b", Some(kept_group)),
+        ],
+        vec![group("cloud", dropped_group), group("local", kept_group)],
+    );
+
+    let config = LaunchConfig::from_snapshot("test".to_string(), &state);
+    let window = &config.windows[0];
+
+    assert_eq!(window.tabs.len(), 2);
+    assert_eq!(window.tab_groups.len(), 1, "empty group must be dropped");
+    assert_eq!(window.tab_groups[0].name.as_deref(), Some("local"));
+
+    assert_eq!(window.tabs[0].group, None);
+    assert_eq!(
+        window.tabs[1].group,
+        Some(0),
+        "the surviving group moved from index 1 to 0"
+    );
+}
+
+#[test]
+fn test_config_from_snapshot_omits_tab_groups_when_there_are_none() {
+    // Configs saved from ungrouped windows must serialize exactly as before,
+    // so existing launch configs keep round-tripping unchanged.
+    let state = grouped_snapshot(vec![terminal_tab("/a", None)], vec![]);
+
+    let config = LaunchConfig::from_snapshot("test".to_string(), &state);
+
+    assert!(config.windows[0].tab_groups.is_empty());
+    assert_eq!(config.windows[0].tabs[0].group, None);
+
+    let yaml = serde_yaml::to_string(&config).expect("serializes");
+    assert!(!yaml.contains("tab_groups"), "got:\n{yaml}");
+    assert!(!yaml.contains("group:"), "got:\n{yaml}");
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3858,8 +3858,6 @@ impl Workspace {
         window: WindowTemplate,
         ctx: &mut ViewContext<Self>,
     ) {
-        let start_index = self.tabs.len();
-
         // `tab_bar_slots` turns every *contiguous* run of same-group tabs into
         // one group container, so interleaved membership would render as two
         // containers sharing one id. `resolve_group_memberships` collapses that
@@ -3909,6 +3907,14 @@ impl Workspace {
             })
             .collect();
 
+        // `add_tab_with_pane_layout` honors the `NewTabPlacement` setting, so a
+        // restored tab is not always appended -- opening into the active window
+        // inserts after the current tab by default, which lands before the end
+        // whenever the active tab is not the last one. It activates whatever it
+        // inserted, so read the real index back instead of assuming
+        // `start_index + tab_index`.
+        let mut restored_indices = Vec::with_capacity(window.tabs.len());
+
         window
             .tabs
             .iter()
@@ -3920,22 +3926,24 @@ impl Workspace {
                     tab_template.title.clone(),
                     ctx,
                 );
-                self.tabs[start_index + tab_index].selected_color = tab_template
+                let index = self.active_tab_index;
+                restored_indices.push(index);
+                self.tabs[index].selected_color = tab_template
                     .color
                     .map_or(SelectedTabColor::Unset, SelectedTabColor::Color);
-                self.tabs[start_index + tab_index].group_id = memberships[tab_index]
+                // The config is the authority on membership, so a tab it leaves
+                // ungrouped stays ungrouped even though the insert above may
+                // have had it inherit the active tab's group.
+                self.tabs[index].group_id = memberships[tab_index]
                     .and_then(|group_index| group_ids.get(group_index).copied().flatten());
             });
 
-        if !window.tabs.is_empty() {
-            // Focus the active tab from the launch config.
-
-            let mut index = start_index + window.active_tab_index.unwrap_or_default();
-
-            if index >= self.tab_count() {
-                index = start_index;
-            }
-
+        // Focus the active tab from the launch config.
+        if let Some(&index) = window
+            .active_tab_index
+            .and_then(|active| restored_indices.get(active))
+            .or_else(|| restored_indices.first())
+        {
             self.activate_tab_internal(index, ctx);
         }
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3860,44 +3860,54 @@ impl Workspace {
     ) {
         let start_index = self.tabs.len();
 
-        // Create the groups first so the per-tab assignments below have
-        // something to point at. Ids are minted here rather than restored:
-        // a launch config can be opened repeatedly, and into a workspace that
-        // already holds groups, so reusing saved ids would collide.
-        let group_ids: Vec<TabGroupId> = if FeatureFlag::GroupedTabs.is_enabled() {
-            window
-                .tab_groups
-                .iter()
-                .map(|group_template| {
-                    let group = TabGroup {
-                        id: TabGroupId::new(),
-                        name: group_template.name.clone(),
-                        color: group_template
-                            .color
-                            .map_or(SelectedTabColor::Unset, SelectedTabColor::Color),
-                        collapsed: group_template.collapsed,
-                        draggable_state: Default::default(),
-                        // Mirrors the session-restore path: only honor pinned
-                        // state while the Pinned Tabs feature is enabled.
-                        pinned: FeatureFlag::PinnedTabs.is_enabled() && group_template.pinned,
-                    };
-                    let id = group.id;
-                    self.tab_groups.insert(id, group);
-                    id
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
-
         // `tab_bar_slots` turns every *contiguous* run of same-group tabs into
         // one group container, so interleaved membership would render as two
         // containers sharing one id. `resolve_group_memberships` collapses that
         // to the first run of each group; see its docs for why.
+        let group_count = if FeatureFlag::GroupedTabs.is_enabled() {
+            window.tab_groups.len()
+        } else {
+            0
+        };
         let memberships = crate::launch_configs::launch_config::resolve_group_memberships(
             &window.tabs,
-            group_ids.len(),
+            group_count,
         );
+
+        // Only mint ids for groups that kept a member. A hand-authored config
+        // can name a group no tab joins, and the collapse above can strip a
+        // group's last tab; inserting those anyway would leave empty groups in
+        // workspace state that nothing can reach. This mirrors the save path,
+        // which already drops groups whose members were all unsaveable.
+        //
+        // Ids are minted here rather than restored: a launch config can be
+        // opened repeatedly, and into a workspace that already holds groups, so
+        // reusing saved ids would collide.
+        let group_ids: Vec<Option<TabGroupId>> = window
+            .tab_groups
+            .iter()
+            .enumerate()
+            .map(|(group_index, group_template)| {
+                if !memberships.contains(&Some(group_index)) {
+                    return None;
+                }
+                let group = TabGroup {
+                    id: TabGroupId::new(),
+                    name: group_template.name.clone(),
+                    color: group_template
+                        .color
+                        .map_or(SelectedTabColor::Unset, SelectedTabColor::Color),
+                    collapsed: group_template.collapsed,
+                    draggable_state: Default::default(),
+                    // Mirrors the session-restore path: only honor pinned
+                    // state while the Pinned Tabs feature is enabled.
+                    pinned: FeatureFlag::PinnedTabs.is_enabled() && group_template.pinned,
+                };
+                let id = group.id;
+                self.tab_groups.insert(id, group);
+                Some(id)
+            })
+            .collect();
 
         window
             .tabs
@@ -3914,7 +3924,7 @@ impl Workspace {
                     .color
                     .map_or(SelectedTabColor::Unset, SelectedTabColor::Color);
                 self.tabs[start_index + tab_index].group_id = memberships[tab_index]
-                    .and_then(|group_index| group_ids.get(group_index).copied());
+                    .and_then(|group_index| group_ids.get(group_index).copied().flatten());
             });
 
         if !window.tabs.is_empty() {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3890,6 +3890,15 @@ impl Workspace {
             Vec::new()
         };
 
+        // `tab_bar_slots` turns every *contiguous* run of same-group tabs into
+        // one group container, so interleaved membership would render as two
+        // containers sharing one id. `resolve_group_memberships` collapses that
+        // to the first run of each group; see its docs for why.
+        let memberships = crate::launch_configs::launch_config::resolve_group_memberships(
+            &window.tabs,
+            group_ids.len(),
+        );
+
         window
             .tabs
             .iter()
@@ -3904,10 +3913,7 @@ impl Workspace {
                 self.tabs[start_index + tab_index].selected_color = tab_template
                     .color
                     .map_or(SelectedTabColor::Unset, SelectedTabColor::Color);
-                // An out-of-range index (hand-edited YAML) leaves the tab
-                // ungrouped rather than failing the whole window.
-                self.tabs[start_index + tab_index].group_id = tab_template
-                    .group
+                self.tabs[start_index + tab_index].group_id = memberships[tab_index]
                     .and_then(|group_index| group_ids.get(group_index).copied());
             });
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3860,6 +3860,36 @@ impl Workspace {
     ) {
         let start_index = self.tabs.len();
 
+        // Create the groups first so the per-tab assignments below have
+        // something to point at. Ids are minted here rather than restored:
+        // a launch config can be opened repeatedly, and into a workspace that
+        // already holds groups, so reusing saved ids would collide.
+        let group_ids: Vec<TabGroupId> = if FeatureFlag::GroupedTabs.is_enabled() {
+            window
+                .tab_groups
+                .iter()
+                .map(|group_template| {
+                    let group = TabGroup {
+                        id: TabGroupId::new(),
+                        name: group_template.name.clone(),
+                        color: group_template
+                            .color
+                            .map_or(SelectedTabColor::Unset, SelectedTabColor::Color),
+                        collapsed: group_template.collapsed,
+                        draggable_state: Default::default(),
+                        // Mirrors the session-restore path: only honor pinned
+                        // state while the Pinned Tabs feature is enabled.
+                        pinned: FeatureFlag::PinnedTabs.is_enabled() && group_template.pinned,
+                    };
+                    let id = group.id;
+                    self.tab_groups.insert(id, group);
+                    id
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         window
             .tabs
             .iter()
@@ -3874,6 +3904,11 @@ impl Workspace {
                 self.tabs[start_index + tab_index].selected_color = tab_template
                     .color
                     .map_or(SelectedTabColor::Unset, SelectedTabColor::Color);
+                // An out-of-range index (hand-edited YAML) leaves the tab
+                // ungrouped rather than failing the whole window.
+                self.tabs[start_index + tab_index].group_id = tab_template
+                    .group
+                    .and_then(|group_index| group_ids.get(group_index).copied());
             });
 
         if !window.tabs.is_empty() {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3938,12 +3938,39 @@ impl Workspace {
                     .and_then(|group_index| group_ids.get(group_index).copied().flatten());
             });
 
-        // Focus the active tab from the launch config.
-        if let Some(&index) = window
+        // A pinned group makes its members effectively pinned, and the pinned
+        // region is a prefix of the tab list. The inserts above ran while the
+        // tabs were still ungrouped, so `NewTabPlacement` could leave the block
+        // after the active window's unpinned tabs -- assigning membership is
+        // what pins them, so the repositioning has to happen here, not earlier.
+        // This mirrors `pin_tab_group`: move the group's block to the current
+        // pinned boundary. `restored_indices` goes stale across those moves, so
+        // resolve the tab to focus by its pane group id instead.
+        let active_pane_group_id = window
             .active_tab_index
             .and_then(|active| restored_indices.get(active))
             .or_else(|| restored_indices.first())
-        {
+            .and_then(|&index| self.tabs.get(index))
+            .map(|tab| tab.pane_group.id());
+
+        for group_id in group_ids.iter().flatten() {
+            if self
+                .tab_groups
+                .get(group_id)
+                .is_some_and(|group| group.pinned)
+            {
+                let target = self.pinned_boundary_index(&self.tabs);
+                self.move_group_block(*group_id, target, ctx);
+            }
+        }
+
+        // Focus the active tab from the launch config.
+        let active_index = active_pane_group_id.and_then(|pane_group_id| {
+            self.tabs
+                .iter()
+                .position(|tab| tab.pane_group.id() == pane_group_id)
+        });
+        if let Some(index) = active_index {
             self.activate_tab_internal(index, ctx);
         }
     }

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -255,6 +255,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_with_launch_config_with_active_pane);
     register_test!(test_with_launch_config_with_no_active_pane);
     register_test!(test_launch_config_restores_tab_groups);
+    register_test!(test_launch_config_restores_tab_groups_into_active_window);
     register_test!(test_find_query_not_evaluated_on_terminal_mode_change);
     register_test!(test_bash_bootstraps_with_prompt_command_array);
     register_test!(test_bash_bootstraps_with_prompt_command_array_that_sets_ps1);

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -254,6 +254,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_with_launch_config_with_active_tab_index);
     register_test!(test_with_launch_config_with_active_pane);
     register_test!(test_with_launch_config_with_no_active_pane);
+    register_test!(test_launch_config_restores_tab_groups);
     register_test!(test_find_query_not_evaluated_on_terminal_mode_change);
     register_test!(test_bash_bootstraps_with_prompt_command_array);
     register_test!(test_bash_bootstraps_with_prompt_command_array_that_sets_ps1);

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -256,6 +256,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_with_launch_config_with_no_active_pane);
     register_test!(test_launch_config_restores_tab_groups);
     register_test!(test_launch_config_restores_tab_groups_into_active_window);
+    register_test!(test_launch_config_restores_pinned_tab_group_into_pinned_prefix);
     register_test!(test_find_query_not_evaluated_on_terminal_mode_change);
     register_test!(test_bash_bootstraps_with_prompt_command_array);
     register_test!(test_bash_bootstraps_with_prompt_command_array_that_sets_ps1);

--- a/crates/integration/src/test/launch_configs.rs
+++ b/crates/integration/src/test/launch_configs.rs
@@ -513,3 +513,102 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
                 .add_assertion(assert_focused_pane_index(0, 0)),
         )
 }
+
+/// Opening a launch config that carries tab groups should rebuild those groups
+/// in the new window: names and colors restored, each tab back in the group it
+/// was saved under.
+///
+/// The config here also hand-writes a membership a live window can never
+/// produce -- group "Backend" on both sides of an ungrouped tab. The tab bar
+/// renders each *contiguous* run as one container, so restore keeps the first
+/// run and returns the straggler ungrouped rather than drawing two containers
+/// that share an id.
+pub fn test_launch_config_restores_tab_groups() -> Builder {
+    use warp::integration_testing::workspace::assert_tab_groups;
+    use warp::launch_configs::launch_config::{
+        LaunchConfig, PaneMode, PaneTemplateType, TabGroupTemplate, TabTemplate, WindowTemplate,
+    };
+    use warp::themes::theme::AnsiColorIdentifier;
+
+    FeatureFlag::GroupedTabs.set_enabled(true);
+
+    fn tab(title: &str, group: Option<usize>) -> TabTemplate {
+        TabTemplate {
+            group,
+            title: Some(title.to_owned()),
+            layout: PaneTemplateType::PaneTemplate {
+                is_focused: Some(true),
+                cwd: PathBuf::from("/some/path"),
+                commands: Vec::new(),
+                pane_mode: PaneMode::Terminal,
+                shell: None,
+            },
+            commands: Vec::new(),
+            color: None,
+        }
+    }
+
+    fn create_launch_config() -> LaunchConfig {
+        LaunchConfig {
+            name: "Mocked config".to_owned(),
+            active_window_index: Some(0),
+            windows: vec![WindowTemplate {
+                tab_groups: vec![
+                    TabGroupTemplate {
+                        name: Some("Backend".to_owned()),
+                        color: Some(AnsiColorIdentifier::Blue),
+                        collapsed: false,
+                        pinned: false,
+                    },
+                    TabGroupTemplate {
+                        name: Some("Frontend".to_owned()),
+                        color: None,
+                        collapsed: false,
+                        pinned: false,
+                    },
+                ],
+                active_tab_index: Some(0),
+                tabs: vec![
+                    tab("api", Some(0)),
+                    tab("worker", Some(0)),
+                    tab("scratch", None),
+                    tab("stray", Some(0)),
+                    tab("web", Some(1)),
+                ],
+            }],
+        }
+    }
+
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Assert we have only 1 window open at start")
+                .add_assertion(assert_num_windows_open(1)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Open a launch config carrying tab groups")
+                .with_action(move |app, _, _| {
+                    app.dispatch_global_action(
+                        "root_view:open_launch_config",
+                        warp::root_view::OpenLaunchConfigArg {
+                            launch_config: create_launch_config(),
+                            ui_location: get_launch_config_ui_location(),
+                            open_in_active_window: false,
+                        },
+                    );
+                }),
+        )
+        .with_step(
+            new_step_with_default_assertions("Assert the groups came back with their tabs")
+                .add_assertion(assert_tab_count(5))
+                .add_assertion(assert_tab_groups(
+                    // "stray" asked for "Backend" again after an ungrouped tab,
+                    // so it restores ungrouped.
+                    vec![Some(0), Some(0), None, None, Some(1)],
+                    vec![
+                        (Some("Backend"), Some(AnsiColorIdentifier::Blue)),
+                        (Some("Frontend"), None),
+                    ],
+                )),
+        )
+}

--- a/crates/integration/src/test/launch_configs.rs
+++ b/crates/integration/src/test/launch_configs.rs
@@ -169,8 +169,10 @@ pub fn test_launch_config_single_child_branch() -> Builder {
             name: "Mocked config".to_owned(),
             active_window_index: Some(0),
             windows: vec![WindowTemplate {
+                tab_groups: vec![],
                 active_tab_index: Some(0),
                 tabs: vec![TabTemplate {
+                    group: None,
                     title: Some("First tab".to_owned()),
                     layout: PaneTemplateType::PaneBranchTemplate {
                         split_direction: SplitDirection::Horizontal,
@@ -298,9 +300,11 @@ pub fn test_with_launch_config_with_active_tab_index() -> Builder {
             name: "Mocked config".to_owned(),
             active_window_index: Some(0),
             windows: vec![WindowTemplate {
+                tab_groups: vec![],
                 active_tab_index: Some(1),
                 tabs: vec![
                     TabTemplate {
+                        group: None,
                         title: None,
                         layout: PaneTemplateType::PaneBranchTemplate {
                             split_direction: SplitDirection::Horizontal,
@@ -358,8 +362,10 @@ pub fn test_with_launch_config_with_active_pane() -> Builder {
             name: "Mocked config".to_owned(),
             active_window_index: Some(0),
             windows: vec![WindowTemplate {
+                tab_groups: vec![],
                 active_tab_index: Some(0),
                 tabs: vec![TabTemplate {
+                    group: None,
                     title: None,
                     layout: PaneTemplateType::PaneBranchTemplate {
                         split_direction: SplitDirection::Horizontal,
@@ -437,8 +443,10 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
             name: "Mocked config".to_owned(),
             active_window_index: Some(0),
             windows: vec![WindowTemplate {
+                tab_groups: vec![],
                 active_tab_index: Some(0),
                 tabs: vec![TabTemplate {
+                    group: None,
                     title: None,
                     layout: PaneTemplateType::PaneBranchTemplate {
                         split_direction: SplitDirection::Horizontal,

--- a/crates/integration/src/test/launch_configs.rs
+++ b/crates/integration/src/test/launch_configs.rs
@@ -518,11 +518,14 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
 /// in the new window: names and colors restored, each tab back in the group it
 /// was saved under.
 ///
-/// The config here also hand-writes a membership a live window can never
-/// produce -- group "Backend" on both sides of an ungrouped tab. The tab bar
-/// renders each *contiguous* run as one container, so restore keeps the first
-/// run and returns the straggler ungrouped rather than drawing two containers
-/// that share an id.
+/// The config here also hand-writes two shapes a live window can never produce:
+///
+/// - group "Backend" on both sides of an ungrouped tab. The tab bar renders
+///   each *contiguous* run as one container, so restore keeps the first run and
+///   returns the straggler ungrouped rather than drawing two containers that
+///   share an id.
+/// - group "Orphan", which no tab joins. Restore must not put it in workspace
+///   state, where nothing could reach it.
 pub fn test_launch_config_restores_tab_groups() -> Builder {
     use warp::integration_testing::workspace::assert_tab_groups;
     use warp::launch_configs::launch_config::{
@@ -566,6 +569,12 @@ pub fn test_launch_config_restores_tab_groups() -> Builder {
                         collapsed: false,
                         pinned: false,
                     },
+                    TabGroupTemplate {
+                        name: Some("Orphan".to_owned()),
+                        color: Some(AnsiColorIdentifier::Red),
+                        collapsed: false,
+                        pinned: false,
+                    },
                 ],
                 active_tab_index: Some(0),
                 tabs: vec![
@@ -605,6 +614,9 @@ pub fn test_launch_config_restores_tab_groups() -> Builder {
                     // "stray" asked for "Backend" again after an ungrouped tab,
                     // so it restores ungrouped.
                     vec![Some(0), Some(0), None, None, Some(1)],
+                    // "Orphan" is absent: assert_tab_groups requires the
+                    // workspace to hold exactly these, so a memberless group
+                    // left behind would fail here.
                     vec![
                         (Some("Backend"), Some(AnsiColorIdentifier::Blue)),
                         (Some("Frontend"), None),

--- a/crates/integration/src/test/launch_configs.rs
+++ b/crates/integration/src/test/launch_configs.rs
@@ -624,3 +624,128 @@ pub fn test_launch_config_restores_tab_groups() -> Builder {
                 )),
         )
 }
+
+/// Opening a grouped launch config into the *active* window must put the groups
+/// on the tabs it just created.
+///
+/// `NewTabPlacement` defaults to `AfterCurrentTab`, so restored tabs are only
+/// appended when the active tab happens to be the last one. Here the window
+/// already holds two ungrouped tabs with the first one active, so every
+/// restored tab is inserted ahead of the trailing tab and the old
+/// `start_index + tab_index` arithmetic landed one slot late -- grouping a
+/// pre-existing tab and leaving a restored one out.
+pub fn test_launch_config_restores_tab_groups_into_active_window() -> Builder {
+    use warp::integration_testing::workspace::assert_tab_groups;
+    use warp::launch_configs::launch_config::{
+        LaunchConfig, PaneMode, PaneTemplateType, TabGroupTemplate, TabTemplate, WindowTemplate,
+    };
+    use warp::themes::theme::AnsiColorIdentifier;
+
+    FeatureFlag::GroupedTabs.set_enabled(true);
+
+    fn tab(title: &str, group: Option<usize>) -> TabTemplate {
+        TabTemplate {
+            group,
+            title: Some(title.to_owned()),
+            layout: PaneTemplateType::PaneTemplate {
+                is_focused: Some(true),
+                cwd: PathBuf::from("/some/path"),
+                commands: Vec::new(),
+                pane_mode: PaneMode::Terminal,
+                shell: None,
+            },
+            commands: Vec::new(),
+            color: None,
+        }
+    }
+
+    /// Two ungrouped tabs, opened into a new window, first one left active.
+    fn ungrouped_config() -> LaunchConfig {
+        LaunchConfig {
+            name: "Plain config".to_owned(),
+            active_window_index: Some(0),
+            windows: vec![WindowTemplate {
+                tab_groups: vec![],
+                active_tab_index: Some(0),
+                tabs: vec![tab("first", None), tab("last", None)],
+            }],
+        }
+    }
+
+    fn grouped_config() -> LaunchConfig {
+        LaunchConfig {
+            name: "Grouped config".to_owned(),
+            active_window_index: Some(0),
+            windows: vec![WindowTemplate {
+                tab_groups: vec![
+                    TabGroupTemplate {
+                        name: Some("Backend".to_owned()),
+                        color: Some(AnsiColorIdentifier::Blue),
+                        collapsed: false,
+                        pinned: false,
+                    },
+                    TabGroupTemplate {
+                        name: Some("Frontend".to_owned()),
+                        color: None,
+                        collapsed: false,
+                        pinned: false,
+                    },
+                ],
+                active_tab_index: Some(0),
+                tabs: vec![
+                    tab("api", Some(0)),
+                    tab("worker", Some(0)),
+                    tab("web", Some(1)),
+                ],
+            }],
+        }
+    }
+
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Open two ungrouped tabs in a new window")
+                .with_action(move |app, _, _| {
+                    app.dispatch_global_action(
+                        "root_view:open_launch_config",
+                        warp::root_view::OpenLaunchConfigArg {
+                            launch_config: ungrouped_config(),
+                            ui_location: get_launch_config_ui_location(),
+                            open_in_active_window: false,
+                        },
+                    );
+                }),
+        )
+        .with_step(
+            new_step_with_default_assertions("Assert the first of the two tabs is active")
+                .add_assertion(assert_tab_count(2))
+                .add_assertion(assert_focused_tab_index(0)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Open a grouped launch config into that window")
+                .with_action(move |app, _, _| {
+                    app.dispatch_global_action(
+                        "root_view:open_launch_config",
+                        warp::root_view::OpenLaunchConfigArg {
+                            launch_config: grouped_config(),
+                            ui_location: get_launch_config_ui_location(),
+                            open_in_active_window: true,
+                        },
+                    );
+                })
+                .set_post_step_pause(Duration::from_secs(1)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Assert the groups landed on the restored tabs")
+                .add_assertion(assert_tab_count(5))
+                .add_assertion(assert_tab_groups(
+                    // "first", then the three restored tabs inserted after it,
+                    // then the pre-existing "last" tab -- still ungrouped.
+                    vec![None, Some(0), Some(0), Some(1), None],
+                    vec![
+                        (Some("Backend"), Some(AnsiColorIdentifier::Blue)),
+                        (Some("Frontend"), None),
+                    ],
+                )),
+        )
+}

--- a/crates/integration/src/test/launch_configs.rs
+++ b/crates/integration/src/test/launch_configs.rs
@@ -749,3 +749,134 @@ pub fn test_launch_config_restores_tab_groups_into_active_window() -> Builder {
                 )),
         )
 }
+
+/// A launch config whose group is pinned must restore that group into the
+/// pinned prefix of the tab bar.
+///
+/// Restored tabs are inserted while still ungrouped, so `NewTabPlacement` puts
+/// them wherever the active tab points; the `group_id` assignment that follows
+/// is what makes them effectively pinned. Opening such a config into a window
+/// that already holds unpinned tabs therefore used to leave the pinned group
+/// stranded in the middle of the list, which no other code path can produce.
+pub fn test_launch_config_restores_pinned_tab_group_into_pinned_prefix() -> Builder {
+    use warp::integration_testing::workspace::assert_tab_groups;
+    use warp::launch_configs::launch_config::{
+        LaunchConfig, PaneMode, PaneTemplateType, TabGroupTemplate, TabTemplate, WindowTemplate,
+    };
+    use warp::themes::theme::AnsiColorIdentifier;
+
+    FeatureFlag::GroupedTabs.set_enabled(true);
+    FeatureFlag::PinnedTabs.set_enabled(true);
+
+    fn tab(title: &str, group: Option<usize>) -> TabTemplate {
+        TabTemplate {
+            group,
+            title: Some(title.to_owned()),
+            layout: PaneTemplateType::PaneTemplate {
+                is_focused: Some(true),
+                cwd: PathBuf::from("/some/path"),
+                commands: Vec::new(),
+                pane_mode: PaneMode::Terminal,
+                shell: None,
+            },
+            commands: Vec::new(),
+            color: None,
+        }
+    }
+
+    /// Two ungrouped tabs, opened into a new window, first one left active.
+    fn ungrouped_config() -> LaunchConfig {
+        LaunchConfig {
+            name: "Plain config".to_owned(),
+            active_window_index: Some(0),
+            windows: vec![WindowTemplate {
+                tab_groups: vec![],
+                active_tab_index: Some(0),
+                tabs: vec![tab("first", None), tab("last", None)],
+            }],
+        }
+    }
+
+    /// "Backend" is pinned, "Frontend" is not.
+    fn pinned_group_config() -> LaunchConfig {
+        LaunchConfig {
+            name: "Pinned config".to_owned(),
+            active_window_index: Some(0),
+            windows: vec![WindowTemplate {
+                tab_groups: vec![
+                    TabGroupTemplate {
+                        name: Some("Backend".to_owned()),
+                        color: Some(AnsiColorIdentifier::Blue),
+                        collapsed: false,
+                        pinned: true,
+                    },
+                    TabGroupTemplate {
+                        name: Some("Frontend".to_owned()),
+                        color: None,
+                        collapsed: false,
+                        pinned: false,
+                    },
+                ],
+                active_tab_index: Some(0),
+                tabs: vec![
+                    tab("api", Some(0)),
+                    tab("worker", Some(0)),
+                    tab("web", Some(1)),
+                ],
+            }],
+        }
+    }
+
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Open two ungrouped tabs in a new window")
+                .with_action(move |app, _, _| {
+                    app.dispatch_global_action(
+                        "root_view:open_launch_config",
+                        warp::root_view::OpenLaunchConfigArg {
+                            launch_config: ungrouped_config(),
+                            ui_location: get_launch_config_ui_location(),
+                            open_in_active_window: false,
+                        },
+                    );
+                }),
+        )
+        .with_step(
+            new_step_with_default_assertions("Assert the first of the two tabs is active")
+                .add_assertion(assert_tab_count(2))
+                .add_assertion(assert_focused_tab_index(0)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Open a pinned-group launch config into that window")
+                .with_action(move |app, _, _| {
+                    app.dispatch_global_action(
+                        "root_view:open_launch_config",
+                        warp::root_view::OpenLaunchConfigArg {
+                            launch_config: pinned_group_config(),
+                            ui_location: get_launch_config_ui_location(),
+                            open_in_active_window: true,
+                        },
+                    );
+                })
+                .set_post_step_pause(Duration::from_secs(1)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Assert the pinned group leads the tab list")
+                .add_assertion(assert_tab_count(5))
+                .add_assertion(assert_tab_groups(
+                    // Pinned "Backend" moved ahead of the pre-existing
+                    // "first"; unpinned "Frontend" stayed where it was
+                    // inserted. Without the move this reads
+                    // [None, Some(0), Some(0), Some(1), None].
+                    vec![Some(0), Some(0), None, Some(1), None],
+                    vec![
+                        (Some("Backend"), Some(AnsiColorIdentifier::Blue)),
+                        (Some("Frontend"), None),
+                    ],
+                ))
+                // The config's active tab is "api", which the move carried to
+                // the front of the list.
+                .add_assertion(assert_focused_tab_index(0)),
+        )
+}

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -125,6 +125,7 @@ integration_tests! {
     test_with_launch_config_with_active_pane,
     test_with_launch_config_with_no_active_pane,
     test_launch_config_restores_tab_groups,
+    test_launch_config_restores_tab_groups_into_active_window,
     test_find_query_not_evaluated_on_terminal_mode_change,
     test_custom_open_completions_menu_binding,
     test_ssh_with_shell_override,

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -124,6 +124,7 @@ integration_tests! {
     test_with_launch_config_with_active_tab_index,
     test_with_launch_config_with_active_pane,
     test_with_launch_config_with_no_active_pane,
+    test_launch_config_restores_tab_groups,
     test_find_query_not_evaluated_on_terminal_mode_change,
     test_custom_open_completions_menu_binding,
     test_ssh_with_shell_override,

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -126,6 +126,7 @@ integration_tests! {
     test_with_launch_config_with_no_active_pane,
     test_launch_config_restores_tab_groups,
     test_launch_config_restores_tab_groups_into_active_window,
+    test_launch_config_restores_pinned_tab_group_into_pinned_prefix,
     test_find_query_not_evaluated_on_terminal_mode_change,
     test_custom_open_completions_menu_binding,
     test_ssh_with_shell_override,


### PR DESCRIPTION
Fixes #13898

## Why

Saving a launch config from a window with grouped tabs and reopening it gives you flat tabs — the groups are gone. `impl From<WindowSnapshot> for WindowTemplate` reads `snapshot.tabs` and `snapshot.active_tab_index` and never looks at `snapshot.tab_groups`, and `WindowTemplate` had nowhere to put them.

Worth noting because it narrows the fix: **this is a gap in one path, not a missing capability.** Session restore already round-trips groups end to end — `persistence/sqlite.rs` writes them (`:1012-1038`) and reads them back (`:2538-2703`), covered by `test_sqlite_round_trips_tab_groups`. So the data model was already there; only the launch-config projection ignored it.

## What changed

**Schema** (`launch_config.rs`) — `WindowTemplate` gains `tab_groups: Vec<TabGroupTemplate>` and `TabTemplate` gains `group: Option<usize>`, an index into that list.

```yaml
windows:
  - tabs:
      - layout: {cwd: /srv/api}
        group: 0
      - layout: {cwd: /tmp}          # ungrouped, no `group` key
    tab_groups:
      - name: backend
        color: blue
```

Both fields are `skip_serializing_if` + `default`, so **existing configs are unaffected** — a window with no groups serializes byte-for-byte as before. There is a test asserting neither key appears in that case.

Runtime `TabGroupId`s are deliberately *not* serialized. They are UUIDs minted per session, a config can be opened repeatedly, and it can be opened into a workspace that already holds groups — reusing saved ids would collide. The index indirection sidesteps that.

**Restore** (`workspace/view.rs`) — `open_launch_config_window` resolves each tab's membership first, then creates a group for every index that kept a member and assigns the tabs' `group_id`s through it. Groups no tab joins are never inserted, so hand-authored YAML cannot leave an empty, unreachable group in workspace state — the same posture as the save path, which already drops groups whose members were all unsaveable. This mirrors the session-restore path deliberately, including both feature gates: groups are only created under `FeatureFlag::GroupedTabs`, and `pinned` is only honored under `FeatureFlag::PinnedTabs`.

Two shapes only hand-edited YAML can produce are normalized on the way in:

- A group named on both sides of an ungrouped tab. `tab_bar_slots` collapses each *contiguous* run into one container, so interleaved membership would draw two containers sharing one id. `resolve_group_memberships` keeps the first run and returns later stragglers ungrouped; reordering the tabs would also restore the invariant, but silently moving tabs a config explicitly ordered seemed the more surprising of the two.
- An out-of-range `group` index, which leaves that tab ungrouped rather than failing the window — same posture as session restore, which drops a tab's group reference when the group itself did not restore.

## The part that needed care

The save path filters out tabs that cannot be represented (notebook panes) and **renumbers the survivors** via `num_valid_tabs`. So group membership cannot be derived from tab position — the snapshot index and the template index diverge exactly when a tab drops out. Membership is instead carried on each tab's own `group_id` and resolved against the surviving group list.

Two consequences, both locked by tests:

- A group whose only member failed to convert is **dropped**, rather than restored as an empty group the user can neither see nor remove.
- When that happens, later groups shift down, and the remaining tabs' `group` indices shift with them.

`test_config_from_snapshot_remaps_groups_around_unsaveable_tabs` is the one that guards this, and I checked it actually bites rather than trusting the green run: dropping the "keep only groups that still have a member" filter turns it red with

```
assertion `left == right` failed: empty group must be dropped
  left: 2
 right: 1
```

and restoring the filter returns the suite to 14 passed.

## Tests

Three new tests in `launch_config_tests.rs`:

- `test_config_from_snapshot_preserves_tab_groups` — name/color carried, membership correct, ungrouped tabs stay ungrouped
- `test_config_from_snapshot_remaps_groups_around_unsaveable_tabs` — the re-indexing case above
- `test_config_from_snapshot_omits_tab_groups_when_there_are_none` — backward compatibility of the serialized form

The four existing `WindowTemplate` / `TabTemplate` literals in `crates/integration/src/test/launch_configs.rs` were updated for the new fields; no behavior change there.

End-to-end coverage of the restore half lives in `test_launch_config_restores_tab_groups` (`crates/integration/src/test/launch_configs.rs`), which dispatches the real `root_view:open_launch_config` and asserts the restored window through a new `assert_tab_groups` helper. The helper numbers groups by first appearance in the tab list, so it pins down membership *and* identity — two tabs share an index only when they share a `TabGroupId` — then checks each group's restored name and color, and that the workspace holds exactly those groups and no memberless extras.

I checked it bites rather than trusting the green run; asserting the pre-collapse membership fails on exactly the tab the guard covers:

```
Expected tab group memberships [Some(0), Some(0), None, Some(0), Some(1)],
              but there were   [Some(0), Some(0), None, None,    Some(1)]
```

## Manual validation

![Restoring a launch config with tab groups](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-13898/tab-groups-restore.gif)

Local `./script/run` OSS build, opened via `warposs://launch/Tab%20Groups%20Demo` so the restore path runs exactly as it would from the launch config palette. The tab bar comes back as `[Backend | api  worker]  scratch  stray  [Frontend | web]`: both groups restore with their names and blue/green colors, each tab lands back in its saved group, and `stray` — which asked for `Backend` again after an ungrouped tab — comes back ungrouped rather than opening a second container sharing the same id.

(The GIF is hosted on a branch in my fork because I have no way to attach media to a PR from the CLI; happy to re-upload it wherever you'd prefer.)

`cargo fmt -- --check` is clean, `cargo check -p warp --all-targets` is clean, `cargo test -p warp --lib launch_config` is 18 passed / 0 failed, and the integration test above is 1 passed / 0 failed.

An earlier comment of mine on this PR claimed `GroupedTabs` could not be enabled in a local build. That was wrong — `grouped_tabs` is in `default` in `app/Cargo.toml` and `enabled_features()` turns it on at startup — and the recording above is the correction.

CHANGELOG-BUG-FIX: Add tab group persistence to (legacy) launch configs.
