### PR TITLE
Simplify TUI auth and credit upgrade links

### DIFF
--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -8,7 +8,6 @@
 mod mcp;
 mod telemetry;
 mod user_info;
-use std::env;
 
 pub use mcp::{
     TuiMcpAction, TuiMcpConfigDiagnostic, TuiMcpFileScope, TuiMcpFileSource, TuiMcpInstallRequest,
@@ -21,7 +20,6 @@ use telemetry::{
 };
 use url::Url;
 pub use user_info::{TuiUserInfoManager, TuiUserInfoManagerEvent, TuiUserInfoSnapshot};
-use warp_core::channel::ChannelState;
 use warp_core::telemetry::TelemetryEvent as _;
 use warpui::{AppContext, Entity, SingletonEntity};
 
@@ -30,7 +28,6 @@ use crate::ai::mcp::FileBasedMCPManager;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::auth_state::AuthState;
 use crate::auth::{self, AuthStateProvider};
-use crate::terminal::focus_env::FOCUS_URL_ENV;
 use crate::tui_onboarding_markers::TuiOnboardingMarkers;
 
 /// Login state of the headless TUI, observed by the `warp_tui` root view to
@@ -338,60 +335,19 @@ fn authorize_device(ctx: &mut AppContext) {
 }
 
 fn tui_verification_url(verification_url: &str, user_code: &str) -> String {
-    let focus_url = env::var(FOCUS_URL_ENV).ok();
-    tui_verification_url_with_return(verification_url, user_code, focus_url.as_deref())
-}
-
-fn tui_verification_url_with_return(
-    verification_url: &str,
-    user_code: &str,
-    focus_url: Option<&str>,
-) -> String {
     let Ok(mut verification_url) = Url::parse(verification_url) else {
         return verification_url.to_owned();
     };
     let has_user_code = verification_url
         .query_pairs()
         .any(|(key, value)| key == "user_code" && !value.is_empty());
-    let return_to = validated_tui_focus_url(focus_url);
     let mut query = verification_url.query_pairs_mut();
     if !has_user_code {
         query.append_pair("user_code", user_code);
     }
     query.append_pair("source", "warp-agent-cli");
-    if let Some(return_to) = return_to {
-        query.append_pair("return_to", &return_to);
-    }
     drop(query);
     verification_url.into()
-}
-
-fn validated_tui_focus_url(focus_url: Option<&str>) -> Option<String> {
-    let mut focus_url = Url::parse(focus_url?).ok()?;
-    if focus_url.scheme() != ChannelState::url_scheme()
-        || focus_url.host_str() != Some("session")
-        || !focus_url.username().is_empty()
-        || focus_url.password().is_some()
-        || focus_url.port().is_some()
-        || focus_url.query().is_some()
-        || focus_url.fragment().is_some()
-    {
-        return None;
-    }
-
-    let session_uuid = {
-        let mut path_segments = focus_url.path_segments()?;
-        let session_uuid = path_segments.next()?.to_ascii_lowercase();
-        if path_segments.next().is_some()
-            || session_uuid.len() != 32
-            || !session_uuid.chars().all(|char| char.is_ascii_hexdigit())
-        {
-            return None;
-        }
-        session_uuid
-    };
-    focus_url.set_path(&format!("/{session_uuid}"));
-    Some(focus_url.into())
 }
 
 fn activate_global_mcp_servers(ctx: &mut AppContext) {

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -9,7 +9,7 @@ use super::telemetry::TuiOnboardingTelemetry;
 use super::{
     TuiAuthBrowserFlow, TuiLoginEvent, TuiLoginModel, TuiLoginPhase, handle_auth_manager_event,
     has_validated_identity, initial_login_phase, set_logged_out_phase, set_login_phase,
-    start_tui_device_login, tui_verification_url_with_return, validated_tui_focus_url,
+    start_tui_device_login, tui_verification_url,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
@@ -65,10 +65,9 @@ fn missing_credentials_and_identity_start_signed_out() {
 
 #[test]
 fn tags_tui_verification_url_without_losing_existing_query_parameters() {
-    let url = tui_verification_url_with_return(
+    let url = tui_verification_url(
         "https://app.warp.dev/device?user_code=ABCD-EFGH&existing=value#fragment",
         "ABCD-EFGH",
-        None,
     );
     let url = url::Url::parse(&url).unwrap();
 
@@ -86,14 +85,14 @@ fn tags_tui_verification_url_without_losing_existing_query_parameters() {
 #[test]
 fn leaves_invalid_verification_url_unchanged() {
     assert_eq!(
-        tui_verification_url_with_return("not a URL", "ABCD-EFGH", None),
+        tui_verification_url("not a URL", "ABCD-EFGH"),
         "not a URL".to_owned()
     );
 }
 
 #[test]
 fn adds_user_code_when_complete_verification_url_is_unavailable() {
-    let url = tui_verification_url_with_return("https://app.warp.dev/device", "ABCD-EFGH", None);
+    let url = tui_verification_url("https://app.warp.dev/device", "ABCD-EFGH");
     let url = url::Url::parse(&url).unwrap();
 
     assert_eq!(
@@ -102,44 +101,13 @@ fn adds_user_code_when_complete_verification_url_is_unavailable() {
             .map(|(_, value)| value.into_owned()),
         Some("ABCD-EFGH".to_owned())
     );
-}
-
-#[test]
-fn adds_valid_focus_url_to_tui_verification_url() {
-    let focus_url = format!(
-        "{}://session/0123456789ABCDEF0123456789ABCDEF",
-        ChannelState::url_scheme()
-    );
-    let verification_url = tui_verification_url_with_return(
-        "https://app.warp.dev/device?user_code=CODE",
-        "CODE",
-        Some(&focus_url),
-    );
-    let verification_url = url::Url::parse(&verification_url).unwrap();
 
     assert_eq!(
-        verification_url
-            .query_pairs()
-            .find(|(key, _)| key == "return_to")
-            .map(|(_, value)| value.into_owned()),
-        Some(format!(
-            "{}://session/0123456789abcdef0123456789abcdef",
-            ChannelState::url_scheme()
-        ))
+        url.query_pairs()
+            .filter(|(key, _)| key == "return_to")
+            .count(),
+        0
     );
-}
-
-#[test]
-fn rejects_invalid_focus_urls() {
-    let scheme = ChannelState::url_scheme();
-    for focus_url in [
-        "https://app.warp.dev/session/0123456789abcdef0123456789abcdef".to_owned(),
-        format!("{scheme}://action/0123456789abcdef0123456789abcdef"),
-        format!("{scheme}://session/not-a-session-id"),
-        format!("{scheme}://session/0123456789abcdef0123456789abcdef?extra=value"),
-    ] {
-        assert_eq!(validated_tui_focus_url(Some(&focus_url)), None);
-    }
 }
 
 #[test]

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -59,7 +59,7 @@ use crate::tui_markdown::{
 };
 use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
 use crate::tui_review_comments::render_review_comments_tool_call;
-pub(crate) const OUT_OF_CREDITS_URL: &str = "https://www.warp.dev/pricing";
+pub(crate) const OUT_OF_CREDITS_URL: &str = "https://app.warp.dev/upgrade?source=warp-agent-cli";
 const OUT_OF_CREDITS_TITLE: &str = "I’m sorry, I couldn’t complete that request.";
 const OUT_OF_CREDITS_DETAIL: &str =
     "In order to use Warp’s AI features, subscribe to a Warp plan or buy packs of credits.";

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -109,7 +109,7 @@ fn restored_out_of_credits_exchange_does_not_consume_first_credit_gate() {
 }
 
 #[test]
-fn first_credit_gate_matches_design_and_opens_pricing() {
+fn first_credit_gate_matches_design_and_opens_upgrade() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let opened_urls = Rc::new(RefCell::new(Vec::new()));
@@ -140,7 +140,7 @@ fn first_credit_gate_matches_design_and_opens_pricing() {
                     "You need AI credits in order to use Warp’s agent.",
                     "Start using AI (ctrl+o).",
                     "",
-                    "https://www.warp.dev/pricing",
+                    "https://app.warp.dev/upgrade?source=warp-agent-cli",
                 ]
             );
             let builder = TuiUiBuilder::from_app(ctx);
@@ -167,7 +167,7 @@ fn first_credit_gate_matches_design_and_opens_pricing() {
 
         assert_eq!(
             &*opened_urls.borrow(),
-            &["https://www.warp.dev/pricing".to_owned()]
+            &["https://app.warp.dev/upgrade?source=warp-agent-cli".to_owned()]
         );
     });
 }
@@ -361,7 +361,7 @@ fn agent_block_renders_context_window_failure() {
 }
 
 #[test]
-fn out_of_credits_failure_matches_tui_design_and_opens_pricing() {
+fn out_of_credits_failure_matches_tui_design_and_opens_upgrade() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let opened_urls = Rc::new(RefCell::new(Vec::new()));
@@ -403,7 +403,7 @@ fn out_of_credits_failure_matches_tui_design_and_opens_pricing() {
                     "",
                     "  Get started with AI (ctrl+o)",
                     "",
-                    "  https://www.warp.dev/pricing",
+                    "  https://app.warp.dev/upgrade?source=warp-agent-cli",
                 ]
             );
             let builder = TuiUiBuilder::from_app(ctx);
@@ -468,7 +468,7 @@ fn out_of_credits_failure_matches_tui_design_and_opens_pricing() {
 
         assert_eq!(
             &*opened_urls.borrow(),
-            &["https://www.warp.dev/pricing".to_owned()]
+            &["https://app.warp.dev/upgrade?source=warp-agent-cli".to_owned()]
         );
     });
 }

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -199,7 +199,7 @@ fn mcp_menu_footer_replaces_status_with_controls() {
 }
 
 #[test]
-fn out_of_credits_ctrl_o_binding_opens_pricing() {
+fn out_of_credits_ctrl_o_binding_opens_upgrade() {
     App::test((), |mut app| async move {
         app.update(crate::keybindings::init);
         app.read(|ctx| {
@@ -239,7 +239,7 @@ fn out_of_credits_ctrl_o_binding_opens_pricing() {
         });
         assert_eq!(
             opened_urls.borrow().as_slice(),
-            &["https://www.warp.dev/pricing".to_owned()]
+            &["https://app.warp.dev/upgrade?source=warp-agent-cli".to_owned()]
         );
     });
 }


### PR DESCRIPTION
## Description

Simplifies Warp Agent CLI authentication URLs and routes TUI credit recovery through the CLI-specific web upgrade flow.

- device URLs retain `user_code` and exact `source=warp-agent-cli`
- device URLs no longer append `return_to` or read terminal focus/deep-link state
- authentication continues to emit `LoggedIn` immediately, create the terminal, and show the existing first zero state
- shell and other non-AI behavior remain usable regardless of AI credit availability
- first and subsequent out-of-credits presentations now display and open `https://app.warp.dev/upgrade?source=warp-agent-cli`
- Ctrl+O on an out-of-credits response opens the same CLI-tagged upgrade URL
- the server route preserves this source through normal checkout to the existing CLI confirmation page
- no native credit polling, pre-terminal credit screen, retry, or bypass behavior is introduced

Design/implementation plan: https://staging.warp.dev/drive/notebook/N9MgLl94GrgcIM3V0JAFKF

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- Confirmed `/upgrade` is registered in the web router
- Existing server tests cover exact `source=warp-agent-cli` upgrade presentation and CLI confirmation routing
- Targeted `rustfmt --check --edition 2024` for all five changed files
- `git diff --check`
- Confirmed `Cargo.lock` is untouched
- Cargo tests and Clippy were not run to avoid touching the shared `Cargo.lock`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Warp Agent <agent@warp.dev>