### PR TITLE
Show TUI autoupdate failures in zero state

### DIFF
--- a/crates/warp_tui/src/autoupdate.rs
+++ b/crates/warp_tui/src/autoupdate.rs
@@ -305,7 +305,7 @@ impl UpdateOutcome {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum TuiAutoupdateStatus {
     /// Nothing to show: updates are disabled for this process, or no check
-    /// has produced a stable result yet (e.g. the first check failed).
+    /// has produced a stable result yet.
     Idle,
     /// Fetching the latest version for this channel.
     Checking,
@@ -313,6 +313,8 @@ pub(crate) enum TuiAutoupdateStatus {
     Updating,
     /// The running build is the channel's latest version.
     UpToDate,
+    /// The most recent check or update attempt failed.
+    Failed,
     /// A newer version is staged and takes effect on the next launch.
     PendingRestart,
 }
@@ -433,8 +435,9 @@ impl TuiAutoupdater {
     /// show progress: a lightweight version check, then — only when a newer
     /// version needs staging — the download/install phase.
     fn check_now(&mut self, layout: InstallLayout, ctx: &mut ModelContext<Self>) {
-        // Where the status settles when this pass fails or is skipped: the
-        // previous pass's stable status, never the transient `Checking`.
+        // Where the status settles when this pass is skipped because another
+        // process is installing, and the status to preserve once an update is
+        // pending restart.
         let fallback_status = self.status;
         self.set_status(TuiAutoupdateStatus::Checking, ctx);
         let check_layout = layout.clone();
@@ -470,29 +473,12 @@ impl TuiAutoupdater {
     ) {
         match &result {
             Ok(outcome) => log::info!("TUI autoupdate check finished: {outcome:?}"),
-            // Fail quietly and let the next poll retry; transient
-            // network errors (e.g. waking from sleep) are common here.
+            // Let the next poll retry; transient network errors (e.g. waking
+            // from sleep) are common here.
             Err(error) => log::warn!("TUI autoupdate check failed: {error:#}"),
         }
         self.report_outcome(&result, ctx);
-        let status = match &result {
-            Ok(UpdateOutcome::UpToDate { .. }) => TuiAutoupdateStatus::UpToDate,
-            Ok(UpdateOutcome::PendingRestart { .. } | UpdateOutcome::Installed { .. }) => {
-                TuiAutoupdateStatus::PendingRestart
-            }
-            #[cfg(unix)]
-            Ok(UpdateOutcome::Locked) => fallback_status,
-            // Failed checks aren't surfaced; settle back on the previous
-            // stable status and let the next poll retry.
-            Err(_) => fallback_status,
-        };
-        // Once an update is staged, only a restart clears it: never downgrade
-        // from `PendingRestart` (e.g. on a server-side version rollback).
-        let status = if fallback_status == TuiAutoupdateStatus::PendingRestart {
-            TuiAutoupdateStatus::PendingRestart
-        } else {
-            status
-        };
+        let status = settled_status(&result, fallback_status);
         self.set_status(status, ctx);
         ctx.spawn(
             async { Timer::after(CHECK_INTERVAL).await },
@@ -523,6 +509,27 @@ impl TuiAutoupdater {
             },
         };
         send_telemetry_from_ctx!(event, ctx);
+    }
+}
+
+fn settled_status(
+    result: &Result<UpdateOutcome>,
+    fallback_status: TuiAutoupdateStatus,
+) -> TuiAutoupdateStatus {
+    // Once an update is staged, only a restart clears it: never downgrade
+    // from `PendingRestart` (e.g. on a failed check or server-side rollback).
+    if fallback_status == TuiAutoupdateStatus::PendingRestart {
+        return TuiAutoupdateStatus::PendingRestart;
+    }
+
+    match result {
+        Ok(UpdateOutcome::UpToDate { .. }) => TuiAutoupdateStatus::UpToDate,
+        Ok(UpdateOutcome::PendingRestart { .. } | UpdateOutcome::Installed { .. }) => {
+            TuiAutoupdateStatus::PendingRestart
+        }
+        #[cfg(unix)]
+        Ok(UpdateOutcome::Locked) => fallback_status,
+        Err(_) => TuiAutoupdateStatus::Failed,
     }
 }
 

--- a/crates/warp_tui/src/autoupdate_tests.rs
+++ b/crates/warp_tui/src/autoupdate_tests.rs
@@ -12,9 +12,10 @@ use warp_core::channel::Channel;
 #[cfg(windows)]
 use super::PREVIOUS_POINTER_NAME;
 use super::{
-    CURRENT_POINTER_NAME, InstallLayout, VERSION_LEASES_DIR_NAME, VersionDirState, VersionLease,
-    create_unique_staging_dir_with, download_endpoint, is_complete_version_dir,
-    is_safe_version_component, latest_version_for, prune_old_versions, version_dir_state,
+    CURRENT_POINTER_NAME, InstallLayout, TuiAutoupdateStatus, UpdateOutcome,
+    VERSION_LEASES_DIR_NAME, VersionDirState, VersionLease, create_unique_staging_dir_with,
+    download_endpoint, is_complete_version_dir, is_safe_version_component, latest_version_for,
+    prune_old_versions, settled_status, version_dir_state,
 };
 #[cfg(unix)]
 use super::{
@@ -34,6 +35,26 @@ fn temp_root(name: &str) -> tempfile::TempDir {
         .prefix(&format!("warp-tui-autoupdate-{name}-"))
         .tempdir()
         .unwrap()
+}
+
+#[test]
+fn failed_check_replaces_stale_up_to_date_status() {
+    let result: anyhow::Result<UpdateOutcome> = Err(anyhow::anyhow!("dns lookup failed"));
+
+    assert_eq!(
+        settled_status(&result, TuiAutoupdateStatus::UpToDate),
+        TuiAutoupdateStatus::Failed
+    );
+}
+
+#[test]
+fn failed_check_preserves_pending_restart_status() {
+    let result: anyhow::Result<UpdateOutcome> = Err(anyhow::anyhow!("dns lookup failed"));
+
+    assert_eq!(
+        settled_status(&result, TuiAutoupdateStatus::PendingRestart),
+        TuiAutoupdateStatus::PendingRestart
+    );
 }
 
 #[test]

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -905,6 +905,18 @@ fn login_line_label(signed_in_prefix: &str, user_info: TuiUserInfoSnapshot) -> O
         .map(|display| format!("{signed_in_prefix} {display}"))
 }
 
+/// User-facing copy for each visible background updater status.
+fn autoupdate_status_label(status: TuiAutoupdateStatus) -> Option<&'static str> {
+    match status {
+        TuiAutoupdateStatus::Idle => None,
+        TuiAutoupdateStatus::Checking => Some("checking for updates…"),
+        TuiAutoupdateStatus::Updating => Some("updating…"),
+        TuiAutoupdateStatus::UpToDate => Some("up to date"),
+        TuiAutoupdateStatus::Failed => Some("automatic update failed"),
+        TuiAutoupdateStatus::PendingRestart => Some("update installed, restart to apply"),
+    }
+}
+
 /// The version line: the release version (or "dev build"), with the
 /// background auto-updater's status appended in parentheses. Dev builds
 /// never run the updater (and have no version), so they render plain; the
@@ -918,20 +930,17 @@ fn render_version_line(builder: &TuiUiBuilder, app: &AppContext) -> Box<dyn TuiE
             .truncate()
             .finish();
     };
-    let suffix = match TuiAutoupdater::as_ref(app).status() {
-        TuiAutoupdateStatus::Idle => None,
-        TuiAutoupdateStatus::Checking => Some(("checking for updates…", muted)),
-        TuiAutoupdateStatus::Updating => Some(("updating…", muted)),
-        TuiAutoupdateStatus::UpToDate => Some(("up to date", muted)),
-        // The one state worth drawing attention to: an update is staged and
-        // a restart picks it up.
-        TuiAutoupdateStatus::PendingRestart => Some((
-            "update installed, restart to apply",
-            builder.success_glyph_style(),
-        )),
-    };
-    let Some((label, style)) = suffix else {
+    let status = TuiAutoupdater::as_ref(app).status();
+    let Some(label) = autoupdate_status_label(status) else {
         return TuiText::new(version).with_style(muted).truncate().finish();
+    };
+    let style = match status {
+        TuiAutoupdateStatus::Idle => unreachable!("idle status has no label"),
+        TuiAutoupdateStatus::Checking
+        | TuiAutoupdateStatus::Updating
+        | TuiAutoupdateStatus::UpToDate => muted,
+        TuiAutoupdateStatus::Failed => builder.error_text_style(),
+        TuiAutoupdateStatus::PendingRestart => builder.success_glyph_style(),
     };
     // Like the bullet rows below: the version reports its natural width and
     // the suffix wraps against the remaining column width.

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -19,10 +19,11 @@ use warpui_core::elements::tui::{
 use warpui_core::{App, AppContext};
 
 use super::{
-    ANIMATION_PANEL_COLS, LEFT_COLUMN_COLS, ZeroStateSectionVisibility, build_zero_state_layout,
-    build_zero_state_overlay, build_zero_state_stack_layout, changelog_bullets_from_changelog,
-    mcp_status_label, render_first_run_top_section,
+    ANIMATION_PANEL_COLS, LEFT_COLUMN_COLS, ZeroStateSectionVisibility, autoupdate_status_label,
+    build_zero_state_layout, build_zero_state_overlay, build_zero_state_stack_layout,
+    changelog_bullets_from_changelog, mcp_status_label, render_first_run_top_section,
 };
+use crate::autoupdate::TuiAutoupdateStatus;
 use crate::tui_builder::TuiUiBuilder;
 use crate::zero_state_animation::{
     WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationElement,
@@ -74,6 +75,14 @@ fn changelog_bullets_use_only_the_first_three_tui_updates() {
 #[test]
 fn changelog_bullets_are_empty_when_only_other_surfaces_have_updates() {
     assert!(changelog_bullets_from_changelog(&changelog(Vec::new())).is_empty());
+}
+
+#[test]
+fn failed_autoupdate_status_has_visible_label() {
+    assert_eq!(
+        autoupdate_status_label(TuiAutoupdateStatus::Failed),
+        Some("automatic update failed")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

TUI autoupdate failures currently restore the previous stable status, which can leave the zero state showing `up to date` after subsequent version checks fail.

This change adds a visible failed updater state, renders `automatic update failed` with the semantic error style, and preserves `PendingRestart` when an already-installed update encounters a later check failure. Automatic retries continue unchanged.

## Linked Issue

No linked issue. This follows an investigation of Windows Warp Agent CLI logs where DNS failures left a stale `up to date` status visible.

## Testing

- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo nextest run -p warp_tui -E 'test(failed_check_replaces_stale_up_to_date_status) | test(failed_check_preserves_pending_restart_status) | test(failed_autoupdate_status_has_visible_label)'` (3 passed)
- Full test suite not rerun; focused updater coverage was requested.

- [ ] I have manually tested my changes locally with `./script/run`

Manual packaged-update testing was not performed because a local development build is ineligible for managed TUI autoupdate.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/d0b35c61-0469-4ae8-a609-7a0a238c5c30

CHANGELOG-TUI: Warp Agent CLI now shows when an automatic update fails instead of displaying stale update status.

Co-Authored-By: Warp <agent@warp.dev>