### PR TITLE
Remove redundant warp-channel-config install step for Windows releases

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -146,12 +146,6 @@ runs:
           echo "::error::Missing logic to install build dependencies for OS \"${{ inputs.target_os }}\""
           exit 1
         fi
-    - name: Install warp-channel-config for Windows releases
-      if: ${{ github.repository == 'warpdotdev/warp-internal' && inputs.target_os == 'windows' && inputs.install_release_deps == 'true' && inputs.ssh_key != '' }}
-      shell: bash
-      run: |
-        cd "${{ steps.repo-root.outputs.path }}"
-        ./script/install_channel_config
 
     - name: Install Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
The `install_channel_config` install path is already run twice for Windows release builds (once via `install_build_deps.ps1`, and again via `install_cargo_release_deps` -> `install_cargo_build_deps`), both with graceful soft-fail handling so external contributors without repo access can still build. The dedicated Windows-only step added on top of that never installs anything new by the time it runs, and its stricter fail-fast semantics were applied inconsistently (Windows only, not macOS/Linux). This removes it and relies on the existing soft-failing install path, consistent with other platforms.

Co-Authored-By: Oz <oz-agent@warp.dev>