### PR TITLE
Auto-bundle the built-in Factory MCP server into Oz cloud/CLI agent runs

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -71,13 +71,14 @@ use crate::ai::mcp::parsing::{ParsedTemplatableMCPServerResult, normalize_mcp_js
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManagerEvent;
 use crate::ai::mcp::{
     JSONMCPServer, MCPServerState, TemplatableMCPServerInstallation, TemplatableMCPServerManager,
-    VariableType, VariableValue,
+    VariableType, VariableValue, builtin,
 };
 use crate::ai::skills::{
     SkillManager, SkillWatcher, filter_skills_by_spec, read_skills_from_directories,
     resolve_skill_repos,
 };
 use crate::auth::AuthStateProvider;
+use crate::auth::credentials::Credentials;
 use crate::cloud_object::{CloudObject, CloudObjectLookup as _};
 use crate::send_telemetry_from_app_ctx;
 use crate::server::ids::{ServerId, SyncId};
@@ -1286,6 +1287,39 @@ impl AgentDriver {
         Ok(resolved)
     }
 
+    /// Returns the built-in Factory MCP server installation to attach to this
+    /// run, or `None` when it should not be attached.
+    ///
+    /// Interactive clients (GUI/TUI) attach built-in Warp-hosted servers via
+    /// [`TemplatableMCPServerManager::sync_builtin_servers`], which skips CLI
+    /// agent runs. The driver mirrors the same eligibility rules for its
+    /// run-scoped ephemeral startup path: the `FactoryMcp` feature flag, a
+    /// usable bearer token, and no configured server already named
+    /// `warp-factory` (an explicit configuration wins over the built-in).
+    ///
+    /// The token is pinned into the transport at spawn time and is not
+    /// refreshed mid-run: cloud runs authenticate with API keys, which do not
+    /// rotate, so only Firebase-authenticated local runs that outlive their
+    /// token would see factory tool calls start failing.
+    fn builtin_factory_mcp_for_run(
+        credentials: Option<&Credentials>,
+        taken_server_names: &HashSet<String>,
+    ) -> Option<TemplatableMCPServerInstallation> {
+        if !FeatureFlag::FactoryMcp.is_enabled() {
+            return None;
+        }
+        if taken_server_names.contains(builtin::FACTORY_MCP_SERVER_NAME) {
+            log::info!(
+                "Skipping the built-in Factory MCP server: a server named '{}' is already configured for this run",
+                builtin::FACTORY_MCP_SERVER_NAME
+            );
+            return None;
+        }
+        let token = builtin::builtin_bearer_token(credentials?)?;
+        log::info!("Attaching the built-in Factory MCP server to this agent run");
+        Some(builtin::factory_mcp_installation(&token))
+    }
+
     fn installations_from_user_mcp_json(
         json_str: &str,
     ) -> Result<Vec<TemplatableMCPServerInstallation>, AgentDriverError> {
@@ -2226,7 +2260,45 @@ impl AgentDriver {
                         Self::resolve_mcp_specs(&mcp_specs, managed_mcp_client, &foreground)
                             .await?;
                     let existing_uuids = resolved_mcp_specs.local_uuids;
-                    let ephemeral_installations = resolved_mcp_specs.ephemeral_installations;
+                    let mut ephemeral_installations = resolved_mcp_specs.ephemeral_installations;
+
+                    // Attach the built-in Factory MCP server. Interactive
+                    // clients attach built-ins via
+                    // `TemplatableMCPServerManager::sync_builtin_servers`,
+                    // which skips CLI agent runs, so the driver injects the
+                    // same code-owned installation here, scoped to this run.
+                    let local_uuids = existing_uuids.clone();
+                    let mut taken_server_names: HashSet<String> = ephemeral_installations
+                        .iter()
+                        .map(|installation| installation.templatable_mcp_server().name.clone())
+                        .collect();
+                    let credentials = foreground
+                        .spawn(move |_, ctx| {
+                            let manager = TemplatableMCPServerManager::as_ref(ctx);
+                            let local_names = local_uuids
+                                .iter()
+                                .filter_map(|uuid| {
+                                    manager.get_installed_server(uuid).map(|installation| {
+                                        installation.templatable_mcp_server().name.clone()
+                                    })
+                                })
+                                .collect::<Vec<_>>();
+                            let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
+                            let credentials = (!auth_state.is_anonymous_or_logged_out())
+                                .then(|| auth_state.credentials())
+                                .flatten();
+                            (credentials, local_names)
+                        })
+                        .await
+                        .map(|(credentials, local_names)| {
+                            taken_server_names.extend(local_names);
+                            credentials
+                        })?;
+                    if let Some(installation) =
+                        Self::builtin_factory_mcp_for_run(credentials.as_ref(), &taken_server_names)
+                    {
+                        ephemeral_installations.push(installation);
+                    }
 
                     log::info!(
                         "Starting {} existing and {} ephemeral MCP servers",

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -26,6 +26,7 @@ use warp_cli::agent::{Harness, OutputFormat};
 use warp_cli::mcp::MCPSpec;
 use warp_cli::share::ShareRequest;
 use warp_cli::skill::SkillSpec;
+use warp_core::execution_mode::AppExecutionMode;
 use warp_core::features::FeatureFlag;
 use warp_core::{safe_debug, safe_error, safe_info};
 use warp_errors::{ErrorExt, register_error, report_error, report_if_error};
@@ -2274,19 +2275,35 @@ impl AgentDriver {
                         .collect();
                     let credentials = foreground
                         .spawn(move |_, ctx| {
-                            let manager = TemplatableMCPServerManager::as_ref(ctx);
-                            let local_names = local_uuids
-                                .iter()
-                                .filter_map(|uuid| {
-                                    manager.get_installed_server(uuid).map(|installation| {
-                                        installation.templatable_mcp_server().name.clone()
+                            let (local_names, builtin_already_active) = {
+                                let manager = TemplatableMCPServerManager::as_ref(ctx);
+                                let local_names = local_uuids
+                                    .iter()
+                                    .filter_map(|uuid| {
+                                        manager.get_installed_server(uuid).map(|installation| {
+                                            installation.templatable_mcp_server().name.clone()
+                                        })
                                     })
-                                })
-                                .collect::<Vec<_>>();
+                                    .collect::<Vec<_>>();
+                                let builtin_already_active = manager.is_server_active_or_pending(
+                                    builtin::FACTORY_MCP_INSTALLATION_UUID,
+                                );
+                                (local_names, builtin_already_active)
+                            };
+                            // Interactive clients (GUI/TUI) attach built-ins
+                            // through `sync_builtin_servers`, under the same
+                            // stable installation UUID. The driver currently
+                            // only runs in SDK mode, where that path never
+                            // spawns, but guard anyway so this injection can
+                            // never double-spawn the built-in if the driver
+                            // is ever hosted in an interactive process.
+                            let builtin_owned_by_manager = builtin_already_active
+                                || AppExecutionMode::as_ref(ctx).can_autostart_mcp_servers();
                             let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
-                            let credentials = (!auth_state.is_anonymous_or_logged_out())
-                                .then(|| auth_state.credentials())
-                                .flatten();
+                            let credentials = (!builtin_owned_by_manager
+                                && !auth_state.is_anonymous_or_logged_out())
+                            .then(|| auth_state.credentials())
+                            .flatten();
                             (credentials, local_names)
                         })
                         .await

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -42,8 +42,10 @@ use crate::ai::agent_sdk::task_env_vars;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::cloud_environments::{GithubRepo, SourceRepo};
 use crate::ai::mcp::JSONTransportType;
+use crate::ai::mcp::builtin::{FACTORY_MCP_INSTALLATION_UUID, FACTORY_MCP_SERVER_NAME};
 use crate::ai::mcp::parsing::normalize_mcp_json;
 use crate::ai::skills::SkillManager;
+use crate::auth::credentials::Credentials;
 use crate::server::server_api::managed_mcp::MockManagedMcpClient;
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
 
@@ -436,6 +438,59 @@ fn managed_command_config_missing_secret_leaves_placeholder() {
         }
         other => panic!("expected CLI server, got {other:?}"),
     }
+}
+
+// ── Built-in Factory MCP injection tests ────────────────────────────────────
+
+fn api_key_credentials() -> Credentials {
+    Credentials::ApiKey {
+        key: "wk-test-key".to_string(),
+        owner_type: None,
+    }
+}
+
+#[test]
+fn builtin_factory_mcp_attaches_with_api_key_credentials() {
+    let _flag = FeatureFlag::FactoryMcp.override_enabled(true);
+
+    let installation =
+        AgentDriver::builtin_factory_mcp_for_run(Some(&api_key_credentials()), &HashSet::new())
+            .expect("built-in Factory MCP should attach when eligible");
+
+    assert_eq!(installation.uuid(), FACTORY_MCP_INSTALLATION_UUID);
+    assert_eq!(
+        installation.templatable_mcp_server().name,
+        FACTORY_MCP_SERVER_NAME
+    );
+}
+
+#[test]
+fn builtin_factory_mcp_skipped_when_flag_disabled() {
+    let _flag = FeatureFlag::FactoryMcp.override_enabled(false);
+
+    assert!(
+        AgentDriver::builtin_factory_mcp_for_run(Some(&api_key_credentials()), &HashSet::new())
+            .is_none()
+    );
+}
+
+#[test]
+fn builtin_factory_mcp_skipped_without_credentials() {
+    let _flag = FeatureFlag::FactoryMcp.override_enabled(true);
+
+    assert!(AgentDriver::builtin_factory_mcp_for_run(None, &HashSet::new()).is_none());
+}
+
+#[test]
+fn builtin_factory_mcp_skipped_on_name_collision() {
+    let _flag = FeatureFlag::FactoryMcp.override_enabled(true);
+    // A user-configured server named `warp-factory` wins over the built-in.
+    let taken_server_names = HashSet::from([FACTORY_MCP_SERVER_NAME.to_string()]);
+
+    assert!(
+        AgentDriver::builtin_factory_mcp_for_run(Some(&api_key_credentials()), &taken_server_names)
+            .is_none()
+    );
 }
 
 #[test]

--- a/app/src/ai/mcp/builtin.rs
+++ b/app/src/ai/mcp/builtin.rs
@@ -10,6 +10,12 @@
 //! (attach on login, re-attach on token rotation, detach on logout), gated by
 //! [`warp_core::features::FeatureFlag::FactoryMcp`].
 //!
+//! CLI agent runs (`oz agent run`, including the cloud workers behind
+//! `oz agent run-cloud`) bypass that manager path; the agent driver attaches
+//! the same installation per-run instead (see
+//! `AgentDriver::builtin_factory_mcp_for_run`), with the token pinned for the
+//! duration of the run.
+//!
 //! [`TemplatableMCPServerManager::sync_builtin_servers`]: super::TemplatableMCPServerManager::sync_builtin_servers
 
 use std::collections::HashMap;

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -784,7 +784,13 @@ impl TemplatableMCPServerManager {
         let is_active = self.is_server_active_or_pending(installation_uuid);
 
         if !eligible {
-            if is_active {
+            // Only tear down a built-in this manager attached itself
+            // (tracked in `builtin_server_uuids`). CLI agent runs spawn a
+            // run-scoped installation with the same UUID through the
+            // AgentDriver (see `AgentDriver::builtin_factory_mcp_for_run`),
+            // and auth events delivered in SDK mode (e.g. a mid-run token
+            // refresh) must not shut that driver-owned server down.
+            if is_active && self.builtin_server_uuids.contains(&installation_uuid) {
                 log::info!("Shutting down the built-in Factory MCP server (no longer eligible)");
                 self.shutdown_server(installation_uuid, ctx);
             }


### PR DESCRIPTION
## Description

Auto-bundles the built-in Warp-hosted Factory MCP server (`warp-factory`, `/api/v1/mcp/factory`) into CLI agent runs, so Oz cloud runs (`oz agent run-cloud` → worker running `warp agent run --task-id …`) get factory tools automatically, matching the existing GUI/TUI behavior.

**What:**
- `AgentDriver::run_internal` (Oz harness, `SetupStep::McpServerStartup`) now appends the built-in Factory MCP installation to the run's ephemeral MCP set when eligible:
  - `FeatureFlag::FactoryMcp` is enabled (currently dogfood)
  - the user is logged in with a usable bearer token (`builtin::builtin_bearer_token`)
  - no user-configured server named `warp-factory` exists in the run's resolved MCP specs (explicit config wins)
- Startup failures flow through the existing strict/degraded MCP startup handling, same as any user-configured server.
- `builtin.rs` is reused unchanged as the single source of truth for the server definition; its module docs now describe both attach paths.

**Why:** cloud runs execute in `ExecutionMode::Sdk`, where `TemplatableMCPServerManager::sync_builtin_servers` never runs (`can_autostart_mcp_servers()` is app/TUI-only), so cloud agents had no factory tools without manual MCP config.

### Why per-run driver injection instead of reusing `sync_builtin_servers`

We considered relaxing `sync_builtin_servers`' eligibility gate to cover Sdk mode, but rejected it:

1. **It fires for every CLI command, not just agent runs.** The manager triggers it from auth events, and the CLI refreshes auth before dispatching *any* command — `oz secret list` would open a server-side MCP session for no reason.
2. **Manager-side spawns bypass the driver's setup barrier.** The driver deliberately sequences MCP startup after terminal bootstrap and waits for servers to reach a terminal state before submitting the prompt; a background auth-event spawn could race the first turn.
3. **They bypass setup observability and failure semantics.** Driver MCP startup is recorded via `SetupClientEventReporter` and honors `--strict-mcp-startup` / degraded handling; manager spawns would be invisible to both.
4. **The gate is shared with unrelated behavior.** `can_autostart_mcp_servers()` also gates restoring previously-running persisted servers at manager construction — relaxing it wholesale would auto-start stale local servers in every CLI run.

Both paths feed the same `builtin::factory_mcp_installation` + ephemeral spawn machinery, so there's no duplicated server definition.

### Scope notes (v0)

- **No token refresh:** cloud runs authenticate with API keys, which don't rotate mid-run. Local Firebase-authenticated runs that outlive their ~1h token would see 401s on factory tool calls only (run continues); `builtin_bearer_token` already refuses near-expiry tokens at spawn. A respawn on `AuthEvent::AccessTokenRefreshed` is a possible follow-up if long local runs become a pattern.
- **Oz harness only:** third-party harnesses (claude-code/codex) render MCP config into harness-native format in `prepare_harness`; extending the built-in there is deferred pending a product call.

Plan: https://staging.warp.dev/drive/notebook/FRzSHRZoEmujvTY2bYl6bY
Conversation: https://staging.warp.dev/conversation/f5b5d499-f12f-4070-ad4f-efd15630b548

## Linked Issue
N/A

## Testing

- 4 new unit tests in `driver_tests.rs` covering the eligibility helper: attaches with API-key credentials, skipped when flag disabled, skipped without credentials, skipped on `warp-factory` name collision.
- Full `ai::agent_sdk::driver::tests` + `ai::mcp::builtin::tests` modules pass (59/59) via `cargo nextest`.
- `./script/format` and `cargo clippy -p warp --all-targets --tests -- -D warnings` pass.

**E2E validation (branch-built CLI, Sdk mode — the same code path the cloud worker executes):**
- Positive: `./target/debug/warp agent run -p "List the MCP tools available to you from the warp-factory MCP server..."` — agent listed the factory tools (`create_factory`, `get_task`, `list_factories`, `list_tasks`, `send_task`); log shows `Attaching the built-in Factory MCP server to this agent run` followed by `Starting 0 existing and 1 ephemeral MCP servers`.
- Collision: same run with `--mcp '{"warp-factory": {"url": "http://127.0.0.1:1/unreachable"}}'` — log shows `Skipping the built-in Factory MCP server: a server named 'warp-factory' is already configured for this run`, only the user's server is started (degrades as expected), and no attach line appears.
- A true `oz agent run-cloud` spot-check requires this change to ship in the worker build; to follow once it lands in dogfood.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
