### PR TITLE
Report TUI as Warp Agent CLI

### DIFF
--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -24,7 +24,7 @@ impl ExecutionMode {
     pub fn client_id(&self) -> &'static str {
         match self {
             ExecutionMode::App => "warp-app",
-            ExecutionMode::Tui => "warp-agent-cli",
+            ExecutionMode::Tui => "warp-tui",
             ExecutionMode::Sdk => "warp-cli",
             ExecutionMode::RemoteServerDaemon => "warp-remote-server-daemon",
         }

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -24,7 +24,7 @@ impl ExecutionMode {
     pub fn client_id(&self) -> &'static str {
         match self {
             ExecutionMode::App => "warp-app",
-            ExecutionMode::Tui => "warp-tui",
+            ExecutionMode::Tui => "warp-agent-cli",
             ExecutionMode::Sdk => "warp-cli",
             ExecutionMode::RemoteServerDaemon => "warp-remote-server-daemon",
         }

--- a/crates/warp_server_client/src/auth/session.rs
+++ b/crates/warp_server_client/src/auth/session.rs
@@ -21,6 +21,7 @@ use super::UserAuthenticationError;
 const FETCH_ACCESS_TOKEN_TIMEOUT: Duration = Duration::from_secs(5);
 const WARP_AGENT_CLI_CLIENT_ID: &str = "warp-agent-cli";
 const WARP_CLI_CLIENT_ID: &str = "warp-cli";
+const WARP_TUI_CLIENT_ID: &str = "warp-tui";
 
 /// Authentication and authenticated-transport conditions observed by shared client code.
 #[derive(Clone)]
@@ -208,7 +209,7 @@ impl AuthSession {
             .join("/api/v1/oauth/device/auth")
             .expect("Invalid device URL");
 
-        let client_id = if reported_client_id == Some(WARP_AGENT_CLI_CLIENT_ID) {
+        let client_id = if reported_client_id == Some(WARP_TUI_CLIENT_ID) {
             WARP_AGENT_CLI_CLIENT_ID
         } else {
             WARP_CLI_CLIENT_ID

--- a/crates/warp_server_client/src/auth/session.rs
+++ b/crates/warp_server_client/src/auth/session.rs
@@ -8,6 +8,7 @@ use instant::Duration;
 use oauth2::TokenResponse as _;
 use url::Url;
 use warp_core::channel::ChannelState;
+use warp_core::execution_mode::current_client_id;
 use warp_server_auth::auth_state::AuthState;
 use warp_server_auth::credentials::{
     AuthToken, Credentials, FirebaseToken, LoginToken, RefreshToken,
@@ -18,6 +19,8 @@ use warpui_core::r#async::{BoxFuture, Timer};
 use super::UserAuthenticationError;
 
 const FETCH_ACCESS_TOKEN_TIMEOUT: Duration = Duration::from_secs(5);
+const WARP_AGENT_CLI_CLIENT_ID: &str = "warp-agent-cli";
+const WARP_CLI_CLIENT_ID: &str = "warp-cli";
 
 /// Authentication and authenticated-transport conditions observed by shared client code.
 #[derive(Clone)]
@@ -84,7 +87,7 @@ impl AuthSession {
             client,
             auth_state,
             event_sender,
-            oauth_client: Self::create_oauth_client(),
+            oauth_client: Self::create_oauth_client(current_client_id()),
         }
     }
 
@@ -195,7 +198,7 @@ impl AuthSession {
         ))
     }
 
-    fn create_oauth_client() -> OAuth2Client {
+    fn create_oauth_client(reported_client_id: Option<&str>) -> OAuth2Client {
         let server_root =
             Url::parse(&ChannelState::server_root_url()).expect("Server root URL must be valid");
         let token_url = server_root
@@ -205,7 +208,12 @@ impl AuthSession {
             .join("/api/v1/oauth/device/auth")
             .expect("Invalid device URL");
 
-        oauth2::basic::BasicClient::new(oauth2::ClientId::new("warp-agent-cli".to_string()))
+        let client_id = if reported_client_id == Some(WARP_AGENT_CLI_CLIENT_ID) {
+            WARP_AGENT_CLI_CLIENT_ID
+        } else {
+            WARP_CLI_CLIENT_ID
+        };
+        oauth2::basic::BasicClient::new(oauth2::ClientId::new(client_id.to_string()))
             .set_token_uri(oauth2::TokenUrl::from_url(token_url))
             .set_device_authorization_url(oauth2::DeviceAuthorizationUrl::from_url(device_url))
     }

--- a/crates/warp_server_client/src/auth/session_tests.rs
+++ b/crates/warp_server_client/src/auth/session_tests.rs
@@ -2,6 +2,9 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use futures::executor::block_on;
+use mockito::Matcher;
+use warp_core::channel::ChannelState;
+use warp_core::execution_mode::ExecutionMode;
 use warp_server_auth::auth_state::AuthState;
 use warp_server_auth::credentials::{AuthToken, Credentials, LoginToken};
 use warp_server_auth::user::FirebaseAuthTokens;
@@ -11,20 +14,54 @@ use super::AuthSession;
 fn session_with_state(
     auth_state: Arc<AuthState>,
 ) -> (AuthSession, async_channel::Receiver<super::AuthEvent>) {
+    session_with_state_and_oauth_client_id(auth_state, None)
+}
+
+fn session_with_state_and_oauth_client_id(
+    auth_state: Arc<AuthState>,
+    oauth_client_id: Option<&str>,
+) -> (AuthSession, async_channel::Receiver<super::AuthEvent>) {
     let (event_sender, event_receiver) = async_channel::unbounded();
-    let session = AuthSession::new(
-        Arc::new(http_client::Client::new()),
+    let session = AuthSession {
+        client: Arc::new(http_client::Client::new()),
         auth_state,
         event_sender,
-    );
+        oauth_client: AuthSession::create_oauth_client(oauth_client_id),
+    };
     (session, event_receiver)
 }
 
 #[test]
-fn device_authorization_uses_warp_agent_cli_client() {
-    let client = AuthSession::create_oauth_client();
+fn tui_execution_mode_uses_warp_agent_cli_oauth_client() {
+    let client = AuthSession::create_oauth_client(Some(ExecutionMode::Tui.client_id()));
 
     assert_eq!(client.client_id().as_str(), "warp-agent-cli");
+}
+
+#[test]
+fn non_tui_execution_modes_use_warp_cli_oauth_client() {
+    assert_eq!(
+        AuthSession::create_oauth_client(Some(ExecutionMode::Sdk.client_id()))
+            .client_id()
+            .as_str(),
+        "warp-cli"
+    );
+    assert_eq!(
+        AuthSession::create_oauth_client(Some(ExecutionMode::App.client_id()))
+            .client_id()
+            .as_str(),
+        "warp-cli"
+    );
+    assert_eq!(
+        AuthSession::create_oauth_client(Some(ExecutionMode::RemoteServerDaemon.client_id()))
+            .client_id()
+            .as_str(),
+        "warp-cli"
+    );
+    assert_eq!(
+        AuthSession::create_oauth_client(None).client_id().as_str(),
+        "warp-cli"
+    );
 }
 
 #[test]
@@ -71,4 +108,35 @@ fn api_key_exchange_defers_owner_type_until_user_properties_are_fetched() {
             owner_type: None
         } if key == "api-key"
     ));
+}
+
+#[test]
+fn device_code_request_reports_warp_agent_cli_oauth_client() {
+    let auth_state = Arc::new(AuthState::new_logged_out_for_test());
+    let (session, _) =
+        session_with_state_and_oauth_client_id(auth_state, Some(ExecutionMode::Tui.client_id()));
+    let mut server = ChannelState::mock_server();
+    let request = server
+        .mock("POST", "/api/v1/oauth/device/auth")
+        .match_body(Matcher::UrlEncoded(
+            "client_id".to_string(),
+            "warp-agent-cli".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+                "device_code": "device-code",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://app.warp.dev/device",
+                "verification_uri_complete": "https://app.warp.dev/device?user_code=ABCD-EFGH",
+                "expires_in": 600,
+                "interval": 5
+            }"#,
+        )
+        .create();
+
+    block_on(session.request_device_code()).unwrap();
+
+    request.assert();
 }


### PR DESCRIPTION
## Description

Report the native TUI as the dedicated `warp-agent-cli` client for server requests, telemetry, crash reporting, and device OAuth. SDK and other non-TUI device-auth callers continue using the existing `warp-cli` OAuth client.

This is intentionally split from #14620 so onboarding telemetry could land independently.

### Why the OAuth client must be scoped

`AuthSession` is shared by the TUI and generic `warp login` flow. #14670 initially configured that shared session with `warp-agent-cli` unconditionally so TUI device login could use the newly registered OAuth client. This PR selects the OAuth client from the initialized execution mode instead:

- TUI device OAuth: `warp-agent-cli`
- `warp login` and any other non-TUI device OAuth: `warp-cli`

Ordinary authenticated requests do not use the OAuth client ID. They use the execution-mode-derived `X-Warp-Client-ID` header.

### Blast radius

For the TUI, `X-Warp-Client-ID` and related client attribution change from `warp-tui` to `warp-agent-cli`. This relabels:

- client-emitted telemetry
- server request metrics and traces
- server telemetry and client-version check-ins
- Sentry/crash client-type tags

It does not change credentials, authorization headers, API routes, billing, rate limits, feature flags, or the login state machine. Current exact-match server behaviors for `warp-cli` also remain unchanged because neither `warp-tui` nor `warp-agent-cli` matches those branches.

### Server context and merge gate

- warpdotdev/warp-server#13694 registered the `warp-agent-cli` device OAuth client.
- warpdotdev/warp-server#13727 made device OAuth authentication-only rather than enforcing credit eligibility during authorization; warpdotdev/warp-server#13778 carried that behavior to the release line.
- [ ] **Remaining merge gate:** run the full TUI device-login flow against production and confirm device-code issuance, browser authorization, token exchange, and the authenticated TUI state all succeed using `warp-agent-cli`.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Confirmed things still look good: https://www.loom.com/share/021500eb99434321ad412c08e76ec1ca
- [x] `cargo nextest run -p warp_server_client` — 51 passed
- [x] `./script/format`
- [x] `./script/format --check`
- [x] `./script/check_no_inline_test_modules`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] `CARGO_BUILD_JOBS=2 cargo build -p warp_tui --bin warp-tui`
- [ ] Production TUI device-OAuth smoke test described above

Test coverage verifies:

- `ExecutionMode::Tui` selects the `warp-agent-cli` OAuth client.
- app, SDK, daemon, and unset execution modes fall back to `warp-cli`.
- the serialized device authorization request reports `client_id=warp-agent-cli` for the TUI.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/225d9416-8620-43e1-a7c2-e70cad53a171

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
Co-Authored-By: Warp Agent <agent@warp.dev>