### PR TITLE
Use Warp Agent CLI OAuth client for device auth

### DIFF
--- a/crates/warp_server_client/src/auth/session.rs
+++ b/crates/warp_server_client/src/auth/session.rs
@@ -205,7 +205,7 @@ impl AuthSession {
             .join("/api/v1/oauth/device/auth")
             .expect("Invalid device URL");
 
-        oauth2::basic::BasicClient::new(oauth2::ClientId::new("warp-cli".to_string()))
+        oauth2::basic::BasicClient::new(oauth2::ClientId::new("warp-agent-cli".to_string()))
             .set_token_uri(oauth2::TokenUrl::from_url(token_url))
             .set_device_authorization_url(oauth2::DeviceAuthorizationUrl::from_url(device_url))
     }

--- a/crates/warp_server_client/src/auth/session_tests.rs
+++ b/crates/warp_server_client/src/auth/session_tests.rs
@@ -21,6 +21,13 @@ fn session_with_state(
 }
 
 #[test]
+fn device_authorization_uses_warp_agent_cli_client() {
+    let client = AuthSession::create_oauth_client();
+
+    assert_eq!(client.client_id().as_str(), "warp-agent-cli");
+}
+
+#[test]
 fn bearer_credentials_are_returned_without_session_refresh_events() {
     let auth_state = Arc::new(AuthState::new_logged_out_for_test());
     auth_state.set_credentials(Some(Credentials::Bearer("daemon-token".to_string())));


### PR DESCRIPTION
## Description

Use the registered `warp-agent-cli` OAuth client ID for device authorization so warp-server can authoritatively classify TUI device codes and enforce plan/credit eligibility. Add a focused regression test for the configured client ID.

This completes the client half of the server-side classification introduced in warpdotdev/warp-server#13694 and prevents mutable browser query parameters from controlling whether the upgrade gate runs.

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

https://www.loom.com/share/b89587865cfc4e20b7cd388c02201d29

- `cargo test -p warp_server_client auth::session::tests::device_authorization_uses_warp_agent_cli_client`
- `cargo fmt --package warp_server_client -- --check`
- Manually exercised `./script/run-tui` against staging and confirmed an ineligible account reaches the web upgrade flow.
- Clippy was not run before submission at the requester's direction.
- [x] I have manually tested my changes locally with `./script/run-tui`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-TUI: Fixed plan upgrade routing during Warp Agent CLI login.

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)