### PR TITLE
Align TUI dark and light colors with Figma

### DIFF
--- a/crates/warp_tui/src/orchestrated_agent_identity_styling.rs
+++ b/crates/warp_tui/src/orchestrated_agent_identity_styling.rs
@@ -4,7 +4,7 @@
 //! policy that keep identities stable across re-renders and edits.
 
 use pathfinder_color::ColorU;
-use warp_core::ui::theme::{Fill as ThemeFill, TerminalColors};
+use warp_core::ui::theme::Fill as ThemeFill;
 use warpui_core::elements::Fill as CoreFill;
 use warpui_core::elements::tui::TuiStyle;
 
@@ -27,19 +27,9 @@ impl Default for AgentIdentity {
     }
 }
 
-/// Builds the identity palette from the seven color roles in the design:
-/// themed cyan, blue, magenta, lilac, pink, green, and yellow. Lilac uses
-/// bright magenta while the remaining roles use their normal ANSI slots.
-pub(crate) fn agent_identity_palette(colors: &TerminalColors) -> Vec<AgentIdentity> {
-    let colors: [ColorU; 7] = [
-        colors.normal.cyan.into(),
-        colors.normal.blue.into(),
-        colors.normal.magenta.into(),
-        colors.bright.magenta.into(),
-        colors.normal.red.into(),
-        colors.normal.green.into(),
-        colors.normal.yellow.into(),
-    ];
+/// Builds the identity palette from the theme's seven design colors: cyan,
+/// blue, magenta, Lilac, pink, green, and yellow.
+pub(crate) fn agent_identity_palette(colors: &[ColorU; 7]) -> Vec<AgentIdentity> {
     // Vary the color fastest so adjacent palette indices differ in color
     // before repeating a glyph.
     AGENT_IDENTITY_GLYPHS

--- a/crates/warp_tui/src/orchestrated_agent_identity_styling_tests.rs
+++ b/crates/warp_tui/src/orchestrated_agent_identity_styling_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
-use warp::tui_export::{dark_theme, light_theme};
-use warp_core::ui::theme::{Fill as ThemeFill, WarpTheme};
+use pathfinder_color::ColorU;
+use warp_core::ui::theme::Fill as ThemeFill;
 use warpui_core::elements::Fill as CoreFill;
 use warpui_core::elements::tui::Color;
 
@@ -9,34 +9,32 @@ use super::{
     AGENT_IDENTITY_GLYPHS, agent_identity_palette, assign_agent_identity_indices, stable_hash,
 };
 
-fn palette_len(theme: &WarpTheme) -> usize {
-    agent_identity_palette(theme.terminal_colors()).len()
+fn test_colors() -> [ColorU; 7] {
+    [
+        ColorU::from_u32(0x010101FF),
+        ColorU::from_u32(0x020202FF),
+        ColorU::from_u32(0x030303FF),
+        ColorU::from_u32(0x040404FF),
+        ColorU::from_u32(0x050505FF),
+        ColorU::from_u32(0x060606FF),
+        ColorU::from_u32(0x070707FF),
+    ]
 }
 
 #[test]
 fn palette_crosses_the_seven_design_glyphs_and_colors() {
     assert_eq!(AGENT_IDENTITY_GLYPHS, ["⊹", "⟡", "✶", "◊", "⊛", "*", "✠"]);
-    assert_eq!(palette_len(&dark_theme()), 49);
-    assert_eq!(palette_len(&light_theme()), 49);
+    assert_eq!(agent_identity_palette(&test_colors()).len(), 49);
 }
 
 #[test]
 fn palette_uses_the_themed_design_color_roles_in_order() {
-    let theme = dark_theme();
-    let colors = theme.terminal_colors();
-    let expected: Vec<Option<Color>> = [
-        colors.normal.cyan,
-        colors.normal.blue,
-        colors.normal.magenta,
-        colors.bright.magenta,
-        colors.normal.red,
-        colors.normal.green,
-        colors.normal.yellow,
-    ]
-    .into_iter()
-    .map(|color| Some(CoreFill::from(ThemeFill::from(color)).into()))
-    .collect();
-    let palette = agent_identity_palette(colors);
+    let colors = test_colors();
+    let expected: Vec<Option<Color>> = colors
+        .into_iter()
+        .map(|color| Some(CoreFill::from(ThemeFill::Solid(color)).into()))
+        .collect();
+    let palette = agent_identity_palette(&colors);
 
     assert_eq!(
         palette[..expected.len()]
@@ -49,8 +47,7 @@ fn palette_uses_the_themed_design_color_roles_in_order() {
 
 #[test]
 fn palette_entries_are_distinct_glyph_color_pairs() {
-    let theme = dark_theme();
-    let palette = agent_identity_palette(theme.terminal_colors());
+    let palette = agent_identity_palette(&test_colors());
     let unique: HashSet<String> = palette
         .iter()
         .map(|identity| format!("{}-{:?}", identity.glyph, identity.style.fg))

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -15,7 +15,7 @@ use warp::tui_export::Appearance;
 use warp_core::ui::color::Opacity;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::color::internal_colors;
-use warp_core::ui::theme::{Fill as ThemeFill, WarpTheme};
+use warp_core::ui::theme::{ColorScheme, Fill as ThemeFill, WarpTheme};
 use warpui::SingletonEntity;
 use warpui_core::AppContext;
 use warpui_core::elements::tui::{
@@ -37,6 +37,12 @@ pub(crate) struct CloudRunMarkStyles {
     pub(crate) brightest: TuiStyle,
     pub(crate) ansi_bright: TuiStyle,
 }
+#[derive(Clone, Copy, Debug)]
+struct TuiDesignPalette {
+    brand_primary: ColorU,
+    brand_accent: ColorU,
+    agent_colors: [ColorU; 7],
+}
 
 /// Theme-derived styles and components for the TUI, mirroring the GUI's
 /// `UiBuilder` (minus fonts, which terminal cells don't have). Cheap to
@@ -57,6 +63,37 @@ impl TuiUiBuilder {
         Self {
             warp_theme: Appearance::as_ref(app).theme().clone(),
             terminal_background,
+        }
+    }
+
+    fn design_palette(&self) -> TuiDesignPalette {
+        match self.warp_theme.inferred_color_scheme() {
+            ColorScheme::LightOnDark => TuiDesignPalette {
+                brand_primary: ColorU::from_u32(0xD2B5FFFF),
+                brand_accent: ColorU::from_u32(0xE2FFD4FF),
+                agent_colors: [
+                    ColorU::from_u32(0xD0D1FEFF),
+                    ColorU::from_u32(0xA5D5FEFF),
+                    ColorU::from_u32(0xFF8FFDFF),
+                    ColorU::from_u32(0xD2B5FFFF),
+                    ColorU::from_u32(0xFF8AA6FF),
+                    ColorU::from_u32(0xE2FFD4FF),
+                    ColorU::from_u32(0xFBDC79FF),
+                ],
+            },
+            ColorScheme::DarkOnLight => TuiDesignPalette {
+                brand_primary: ColorU::from_u32(0x9C58F0FF),
+                brand_accent: ColorU::from_u32(0x33770BFF),
+                agent_colors: [
+                    ColorU::from_u32(0x20A5BAFF),
+                    ColorU::from_u32(0x008EC4FF),
+                    ColorU::from_u32(0x523C79FF),
+                    ColorU::from_u32(0x9C58F0FF),
+                    ColorU::from_u32(0xFF8AA6FF),
+                    ColorU::from_u32(0x33770BFF),
+                    ColorU::from_u32(0xC79A18FF),
+                ],
+            },
         }
     }
 
@@ -313,7 +350,21 @@ impl TuiUiBuilder {
         TuiStyle::default().fg(cell_color(self.cyan_overlay_2()))
     }
 
-    /// Lilac credential-entry accent used by the API-key input states.
+    /// Scheme-aware Lilac brand color used by branded titles and progress.
+    pub(crate) fn brand_primary_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::Solid(
+            self.design_palette().brand_primary,
+        )))
+    }
+
+    /// Scheme-aware green brand accent used by branded prompts and actions.
+    pub(crate) fn brand_accent_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::Solid(
+            self.design_palette().brand_accent,
+        )))
+    }
+
+    /// Magenta credential-entry accent used by the API-key input states.
     pub(crate) fn credential_entry_accent_style(&self) -> TuiStyle {
         TuiStyle::default().fg(cell_color(ThemeFill::from(
             self.warp_theme.terminal_colors().normal.magenta,
@@ -351,10 +402,10 @@ impl TuiUiBuilder {
         TuiStyle::default().fg(cell_color(ThemeFill::Solid(self.warp_theme.ansi_fg_blue())))
     }
 
-    /// The warping indicator's base fill: the terminal palette's bright
-    /// magenta, corresponding to the design's Lilac-200.
+    /// The warping indicator's base fill: Lilac-200 in dark themes and
+    /// Lilac-600 in light themes.
     fn warping_base_fill(&self) -> ThemeFill {
-        ThemeFill::from(self.warp_theme.terminal_colors().bright.magenta)
+        ThemeFill::Solid(self.design_palette().brand_primary)
     }
 
     /// The warping indicator's base color as a solid color, for per-glyph
@@ -459,7 +510,7 @@ impl TuiUiBuilder {
     /// The deterministic agent identity palette for this theme. See
     /// [`crate::orchestrated_agent_identity_styling`].
     pub(crate) fn agent_identity_palette(&self) -> Vec<AgentIdentity> {
-        agent_identity_palette(self.warp_theme.terminal_colors())
+        agent_identity_palette(&self.design_palette().agent_colors)
     }
     /// Bold cyan option text for the ask-question card.
     pub(crate) fn question_option_selected_style(&self) -> TuiStyle {

--- a/crates/warp_tui/src/tui_builder_tests.rs
+++ b/crates/warp_tui/src/tui_builder_tests.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 
 use pathfinder_color::ColorU;
-use warp::tui_export::light_theme;
+use warp::tui_export::{dark_theme, light_theme};
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill as ThemeFill;
 use warp_core::ui::theme::color::internal_colors;
@@ -11,6 +11,57 @@ use warpui_core::elements::tui::{Color, Modifier};
 use warpui_core::runtime::ProbedRgb;
 
 use super::{TuiUiBuilder, rounded_midpoint_color};
+
+fn rgb(value: u32) -> Color {
+    let color = ColorU::from_u32(value);
+    Color::Rgb(color.r, color.g, color.b)
+}
+
+#[test]
+fn design_palettes_match_figma_in_dark_and_light_themes() {
+    for (theme, brand_primary, brand_accent, agent_colors) in [
+        (
+            dark_theme(),
+            0xD2B5FFFF,
+            0xE2FFD4FF,
+            [
+                0xD0D1FEFF, 0xA5D5FEFF, 0xFF8FFDFF, 0xD2B5FFFF, 0xFF8AA6FF, 0xE2FFD4FF, 0xFBDC79FF,
+            ],
+        ),
+        (
+            light_theme(),
+            0x9C58F0FF,
+            0x33770BFF,
+            [
+                0x20A5BAFF, 0x008EC4FF, 0x523C79FF, 0x9C58F0FF, 0xFF8AA6FF, 0x33770BFF, 0xC79A18FF,
+            ],
+        ),
+    ] {
+        let builder = TuiUiBuilder {
+            warp_theme: theme,
+            terminal_background: None,
+        };
+
+        assert_eq!(builder.brand_primary_style().fg, Some(rgb(brand_primary)));
+        assert_eq!(builder.brand_accent_style().fg, Some(rgb(brand_accent)));
+        assert_eq!(
+            builder.warping_base_color(),
+            ColorU::from_u32(brand_primary)
+        );
+        assert_eq!(
+            builder
+                .agent_identity_palette()
+                .into_iter()
+                .take(agent_colors.len())
+                .map(|identity| identity.style.fg)
+                .collect::<Vec<_>>(),
+            agent_colors
+                .into_iter()
+                .map(|color| Some(rgb(color)))
+                .collect::<Vec<_>>()
+        );
+    }
+}
 
 #[test]
 fn text_styles_follow_light_theme_foreground() {

--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -150,10 +150,8 @@ pub(crate) fn signed_out_welcome(
     let builder = TuiUiBuilder::from_app(app);
     let primary = builder.primary_text_style();
     let muted = builder.muted_text_style();
-    let title = builder
-        .credential_entry_accent_style()
-        .add_modifier(Modifier::BOLD);
-    let success = builder.success_glyph_style();
+    let title = builder.brand_primary_style().add_modifier(Modifier::BOLD);
+    let brand_accent = builder.brand_accent_style();
     let login_style = if login_mouse.lock().is_ok_and(|state| state.is_hovered()) {
         primary
             .add_modifier(Modifier::BOLD)
@@ -177,9 +175,12 @@ pub(crate) fn signed_out_welcome(
         )
         .child(
             TuiText::from_spans([
-                ("> ".to_owned(), success),
+                ("> ".to_owned(), brand_accent),
                 ("Press ".to_owned(), muted),
-                ("enter".to_owned(), success.add_modifier(Modifier::BOLD)),
+                (
+                    "enter".to_owned(),
+                    brand_accent.add_modifier(Modifier::BOLD),
+                ),
                 (" to get started".to_owned(), muted),
             ])
             .finish(),
@@ -216,7 +217,7 @@ pub(crate) fn signed_out_welcome(
         .child(capability_row(
             "⟡",
             "Prompts or shell commands autodetected",
-            builder.credential_entry_accent_style(),
+            builder.brand_primary_style(),
             primary,
         ))
         .child(capability_row(
@@ -228,7 +229,7 @@ pub(crate) fn signed_out_welcome(
         .child(capability_row(
             "✶",
             "Orchestrate fleets of agents",
-            success,
+            brand_accent,
             primary,
         ))
         .child(capability_row(

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use warp::appearance::Appearance;
+use warp::tui_export::{dark_theme, light_theme};
+use warpui::SingletonEntity;
 use warpui_core::elements::MouseStateHandle;
 use warpui_core::elements::animation::AnimationClock;
 use warpui_core::elements::tui::{
-    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    Color, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
     TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize,
     TuiText,
 };
@@ -270,6 +272,67 @@ fn signed_out_welcome_matches_designed_copy_and_layout() {
                 "welcome must not render a URL before device authorization: {lines:?}"
             );
         });
+    });
+}
+
+#[test]
+fn signed_out_welcome_uses_figma_brand_colors_in_dark_and_light_themes() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+
+        for (theme, brand_primary, brand_accent) in [
+            (
+                dark_theme(),
+                Color::Rgb(210, 181, 255),
+                Color::Rgb(226, 255, 212),
+            ),
+            (
+                light_theme(),
+                Color::Rgb(156, 88, 240),
+                Color::Rgb(51, 119, 11),
+            ),
+        ] {
+            Appearance::handle(&app).update(&mut app, |appearance, ctx| {
+                appearance.set_theme(theme, ctx);
+            });
+            app.read(|app_ctx| {
+                let mut presenter = TuiPresenter::new();
+                let frame = presenter.present_element(
+                    signed_out_welcome(
+                        AnimationClock::starting_at(Duration::ZERO),
+                        Arc::new(ZeroStateAnimationConfig::default()),
+                        MouseStateHandle::default(),
+                        MouseStateHandle::default(),
+                        app_ctx,
+                        |_, _| {},
+                        |_, _| {},
+                    ),
+                    TuiRect::new(0, 0, 80, 24),
+                    app_ctx,
+                );
+                let lines = frame.buffer.to_lines();
+                let cell_color = |text: &str, offset: usize| {
+                    let row = lines
+                        .iter()
+                        .position(|line| line.contains(text))
+                        .expect("designed text renders");
+                    let column = lines[row].find(text).expect("designed text offset") + offset;
+                    frame.buffer[(u16::try_from(column).unwrap(), u16::try_from(row).unwrap())].fg
+                };
+
+                assert_eq!(cell_color("Welcome to Warp", 0), brand_primary);
+                assert_eq!(cell_color("> Press enter to get started", 0), brand_accent);
+                assert_eq!(cell_color("> Press enter to get started", 8), brand_accent);
+                assert_eq!(
+                    cell_color("⟡ Prompts or shell commands autodetected", 0),
+                    brand_primary
+                );
+                assert_eq!(
+                    cell_color("✶ Orchestrate fleets of agents", 0),
+                    brand_accent
+                );
+            });
+        }
     });
 }
 

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -683,7 +683,7 @@ fn render_first_run_top_section(
     visibility: ZeroStateSectionVisibility,
     app: &AppContext,
 ) -> TuiFlex {
-    let title_style = builder.accent_text_style().add_modifier(Modifier::BOLD);
+    let title_style = builder.brand_primary_style().add_modifier(Modifier::BOLD);
     let muted = builder.muted_text_style();
     let mut column = TuiFlex::column()
         .child(
@@ -724,7 +724,7 @@ fn render_first_run_capability(
     description: &str,
     builder: &TuiUiBuilder,
 ) -> Box<dyn TuiElement> {
-    let highlight = builder.success_glyph_style();
+    let highlight = builder.brand_accent_style();
     let primary = builder.primary_text_style();
     let mut spans = vec![("✶ ".to_owned(), highlight)];
     if let Some(command) = command {


### PR DESCRIPTION
## Description

Aligns Warp Agent CLI's dark and light semantic colors with the latest [TUI Figma palette](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=1911-18426).

The existing functional ANSI colors already matched the design, so this keeps those shared theme values unchanged and adds a TUI-specific, color-scheme-aware palette for brand primary, brand accent, and orchestrated-agent identity colors. Welcome, first-run, and warping surfaces now consume the brand roles, while agent identities use the exact seven-color arrays declared by the design.

The Figma palette legend is treated as authoritative for agent pink (`#FF8AA6`) over the illustrative light-mode orchestration frame.

## Linked Issue

N/A

## Testing

- [x] `./script/format`
- [x] `cargo nextest run -p warp_tui` (956 tests passed)
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- [x] Rendered-cell tests cover the exact dark/light brand and agent palettes.
- [x] Manually switched the real TUI through `/theme light`, `/theme dark`, and `/theme auto` under tmux and inspected the emitted ANSI colors.
- [x] I have manually tested my changes locally with `./script/run-tui`

Dark theme:
<img width="1556" height="1167" alt="image" src="https://github.com/user-attachments/assets/164189ea-4ef4-4f3a-a64b-5bb2888ea78b" />

Light theme:
<img width="1360" height="998" alt="image" src="https://github.com/user-attachments/assets/0129332f-6423-4a25-a43a-3aa87ba66f22" />


## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent artifacts

- [Implementation plan](https://staging.warp.dev/drive/notebook/QrAjBXBuhwx2kgENjmncAx)
- [Agent conversation](https://staging.warp.dev/conversation/eecd0959-c99e-4a59-829d-fa3d6fb0ed09)

CHANGELOG-TUI: Updated dark and light theme colors to match the latest Warp Agent CLI design palette.

Co-Authored-By: Warp <agent@warp.dev>
