### PR TITLE
Make TUI zero-state focus freeze opt-in

### DIFF
--- a/app/src/settings/tui_zero_state.rs
+++ b/app/src/settings/tui_zero_state.rs
@@ -216,6 +216,16 @@ define_settings_group!(TuiZeroStateSettings, settings: [
         toml_path: "appearance.zero_state.show_animation",
         description: "Whether the Warp Agent CLI zero state shows the rotating object and its starfield.",
     },
+    freeze_animation_when_unfocused: TuiZeroStateFreezeAnimationWhenUnfocusedSetting {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        surface: settings::SettingSurfaces::TUI,
+        private: false,
+        toml_path: "appearance.zero_state.freeze_animation_when_unfocused",
+        description: "Whether the Warp Agent CLI zero-state animation stops repainting while the terminal is unfocused.",
+    },
 ]);
 
 #[cfg(test)]

--- a/app/src/settings/tui_zero_state_tests.rs
+++ b/app/src/settings/tui_zero_state_tests.rs
@@ -7,9 +7,9 @@ use settings_value::SettingsValue;
 use super::{
     MAX_TUI_ZERO_STATE_EXTRUSION_DEPTH, MAX_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
     MIN_TUI_ZERO_STATE_EXTRUSION_DEPTH, MIN_TUI_ZERO_STATE_ROTATION_PERIOD_SECONDS,
-    TuiZeroStateExtrusionDepth, TuiZeroStateExtrusionDepthSetting, TuiZeroStateObject,
-    TuiZeroStateObjectSetting, TuiZeroStateRotationPeriodSeconds,
-    TuiZeroStateRotationPeriodSecondsSetting,
+    TuiZeroStateExtrusionDepth, TuiZeroStateExtrusionDepthSetting,
+    TuiZeroStateFreezeAnimationWhenUnfocusedSetting, TuiZeroStateObject, TuiZeroStateObjectSetting,
+    TuiZeroStateRotationPeriodSeconds, TuiZeroStateRotationPeriodSecondsSetting,
 };
 
 #[test]
@@ -92,6 +92,11 @@ fn zero_state_settings_are_tui_local_file_settings() {
         Some("appearance.zero_state.extrusion_depth")
     );
     assert_eq!(
+        TuiZeroStateFreezeAnimationWhenUnfocusedSetting::toml_path(),
+        Some("appearance.zero_state.freeze_animation_when_unfocused")
+    );
+    assert!(!TuiZeroStateFreezeAnimationWhenUnfocusedSetting::default_value());
+    assert_eq!(
         TuiZeroStateObjectSetting::sync_to_cloud(),
         SyncToCloud::Never
     );
@@ -101,6 +106,10 @@ fn zero_state_settings_are_tui_local_file_settings() {
     );
     assert_eq!(
         TuiZeroStateExtrusionDepthSetting::sync_to_cloud(),
+        SyncToCloud::Never
+    );
+    assert_eq!(
+        TuiZeroStateFreezeAnimationWhenUnfocusedSetting::sync_to_cloud(),
         SyncToCloud::Never
     );
     assert_eq!(TuiZeroStateObjectSetting::max_table_depth(), Some(0));

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -13,12 +13,13 @@ use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use clap::error::ErrorKind;
 use inquire::{InquireError, Password, PasswordDisplayMode};
-use warp::settings::TuiThemeSettings;
+use warp::settings::{TuiThemeSettings, TuiZeroStateSettings, TuiZeroStateSettingsChangedEvent};
 #[cfg(feature = "voice_input")]
 use warp::settings::{TuiVoiceSettings, TuiVoiceSettingsChangedEvent};
 use warp::tui_export::{AIConversationAutoexecuteMode, Appearance, ServerConversationToken};
 use warp::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
 use warp_core::channel::ChannelState;
+use warp_core::settings::Setting as _;
 use warp_core::telemetry::TelemetryEvent as _;
 use warp_errors::report_error;
 use warpui::SingletonEntity as _;
@@ -257,17 +258,39 @@ fn init(
     let modifier_key_lifecycle_enabled = requires_modifier_key_reporting(ctx);
     #[cfg(not(feature = "voice_input"))]
     let modifier_key_lifecycle_enabled = false;
+    let freeze_repaints_when_unfocused = *TuiZeroStateSettings::as_ref(ctx)
+        .freeze_animation_when_unfocused
+        .value();
     match spawn_tui_driver(
         ctx,
         window_id,
         root.clone(),
         modifier_key_lifecycle_enabled,
+        freeze_repaints_when_unfocused,
         Some(probe),
     ) {
         Ok(driver) => {
             let sessions = ctx.add_singleton_model(|_| {
                 TuiSessions::new(driver, exit_summary, resume_token, default_autoexecute_mode)
             });
+            let sessions_for_zero_state_settings = sessions.clone();
+            ctx.subscribe_to_model(
+                &TuiZeroStateSettings::handle(ctx),
+                move |settings, event, ctx| {
+                    let TuiZeroStateSettingsChangedEvent::TuiZeroStateFreezeAnimationWhenUnfocusedSetting {
+                        ..
+                    } = event
+                    else {
+                        return;
+                    };
+                    let freeze =
+                        *settings.as_ref(ctx).freeze_animation_when_unfocused.value();
+                    sessions_for_zero_state_settings.update(ctx, |sessions, _| {
+                        sessions.set_freeze_repaints_when_unfocused(freeze);
+                    });
+                    ctx.invalidate_all_views();
+                },
+            );
             #[cfg(feature = "voice_input")]
             let sessions_for_voice_settings = sessions.clone();
             #[cfg(feature = "voice_input")]

--- a/crates/warp_tui/src/session_registry.rs
+++ b/crates/warp_tui/src/session_registry.rs
@@ -130,7 +130,6 @@ pub(crate) enum TuiSessionsEvent {
 pub(crate) struct TuiSessions {
     /// TUI-specific process driver. Its handle restores terminal mode on
     /// drop, so the app-lifetime session singleton must retain it.
-    #[cfg_attr(not(feature = "voice_input"), allow(dead_code))]
     driver: Option<TuiDriverHandle>,
     keyboard_enhancement_supported: bool,
     exit_summary: TuiExitSummaryHandle,
@@ -600,6 +599,12 @@ impl TuiSessions {
             focused_session_id: None,
             resume_token: None,
             default_autoexecute_mode: AIConversationAutoexecuteMode::RespectUserSettings,
+        }
+    }
+
+    pub(crate) fn set_freeze_repaints_when_unfocused(&mut self, freeze: bool) {
+        if let Some(driver) = self.driver.as_mut() {
+            driver.set_freeze_repaints_when_unfocused(freeze);
         }
     }
 

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -197,6 +197,9 @@ impl TuiZeroStateView {
                     }
                     | TuiZeroStateSettingsChangedEvent::TuiZeroStateExtrusionDepthSetting {
                         ..
+                    }
+                    | TuiZeroStateSettingsChangedEvent::TuiZeroStateFreezeAnimationWhenUnfocusedSetting {
+                        ..
                     } => {}
                 }
             });

--- a/crates/warp_tui/src/zero_state_animation_tests.rs
+++ b/crates/warp_tui/src/zero_state_animation_tests.rs
@@ -7,11 +7,11 @@ use std::time::Duration;
 use instant::Instant;
 use tempfile::TempDir;
 use warp::settings::{
-    TuiZeroStateExtrusionDepthSetting, TuiZeroStateObject, TuiZeroStateObjectSetting,
-    TuiZeroStateRotationPeriodSeconds, TuiZeroStateRotationPeriodSecondsSetting,
-    TuiZeroStateSettings, TuiZeroStateShowAnimationSetting, TuiZeroStateShowChangelogSetting,
-    TuiZeroStateShowMcpSetting, TuiZeroStateShowProjectInfoSetting,
-    TuiZeroStateShowSignedInUserSetting,
+    TuiZeroStateExtrusionDepthSetting, TuiZeroStateFreezeAnimationWhenUnfocusedSetting,
+    TuiZeroStateObject, TuiZeroStateObjectSetting, TuiZeroStateRotationPeriodSeconds,
+    TuiZeroStateRotationPeriodSecondsSetting, TuiZeroStateSettings,
+    TuiZeroStateShowAnimationSetting, TuiZeroStateShowChangelogSetting, TuiZeroStateShowMcpSetting,
+    TuiZeroStateShowProjectInfoSetting, TuiZeroStateShowSignedInUserSetting,
 };
 use warp_core::settings::Setting as _;
 use warpui::{EntityIdMap, SingletonEntity as _};
@@ -616,6 +616,8 @@ fn settings_model_reloads_only_object_changes() {
                 show_project_info: TuiZeroStateShowProjectInfoSetting::new(None),
                 show_mcp: TuiZeroStateShowMcpSetting::new(None),
                 show_animation: TuiZeroStateShowAnimationSetting::new(None),
+                freeze_animation_when_unfocused:
+                    TuiZeroStateFreezeAnimationWhenUnfocusedSetting::new(None),
             });
             ZeroStateAnimationConfig::register(ctx);
         });

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -293,8 +293,11 @@ where
     /// loop marks itself dirty once it passes.
     pending_repaint: Option<Instant>,
     /// Whether the host terminal currently has focus. Timed animation repaints
-    /// are suspended while false, but ordinary invalidations may still draw.
+    /// may be suspended while false, but ordinary invalidations may still draw.
     focused: bool,
+    /// Whether timed repaints should be suspended while the host terminal is
+    /// unfocused. Disabled by default so focus-based suspension is opt-in.
+    freeze_repaints_when_unfocused: bool,
     /// Restores the terminal when the runtime is dropped (the `enter` path).
     /// Held only for its `Drop`.
     _terminal_guard: Option<TuiTerminalGuard>,
@@ -337,6 +340,7 @@ where
             last_size: None,
             pending_repaint: None,
             focused: true,
+            freeze_repaints_when_unfocused: false,
             _terminal_guard: None,
         }
     }
@@ -384,7 +388,7 @@ where
         if self.last_size != Some(size) {
             self.dirty.set(true);
         }
-        if self.focused
+        if should_schedule_repaints(self.focused, self.freeze_repaints_when_unfocused)
             && self
                 .pending_repaint
                 .is_some_and(|deadline| deadline <= Instant::now())
@@ -397,11 +401,12 @@ where
         }
         let screen = &mut self.screen;
         let requested_repaint = app.update(|ctx| screen.draw(ctx))?;
-        self.pending_repaint = if self.focused {
-            requested_repaint
-        } else {
-            None
-        };
+        self.pending_repaint =
+            if should_schedule_repaints(self.focused, self.freeze_repaints_when_unfocused) {
+                requested_repaint
+            } else {
+                None
+            };
         self.last_size = Some(size);
         Ok(())
     }
@@ -421,7 +426,9 @@ where
                     }
                     CrosstermEvent::FocusLost => {
                         self.focused = false;
-                        self.pending_repaint = None;
+                        if self.freeze_repaints_when_unfocused {
+                            self.pending_repaint = None;
+                        }
                     }
                     _ => {}
                 }
@@ -556,7 +563,9 @@ pub struct TuiDriverHandle {
     _task: ForegroundTask,
     /// The pending element-requested repaint timer, if any (see
     /// [`draw_and_schedule_repaint`]). Dropping it cancels the timer.
-    _repaint_timer: Rc<RefCell<Option<ForegroundTask>>>,
+    repaint_timer: Rc<RefCell<Option<ForegroundTask>>>,
+    focused: Rc<Cell<bool>>,
+    freeze_repaints_when_unfocused: Rc<Cell<bool>>,
     _reader: thread::JoinHandle<()>,
     reader_shutdown: Arc<AtomicBool>,
     probe_lifecycle_lock: Arc<Mutex<()>>,
@@ -581,6 +590,14 @@ impl TuiDriverHandle {
     ) -> io::Result<()> {
         self.guard
             .set_modifier_key_lifecycle_enabled(report_modifier_key_lifecycle)
+    }
+
+    /// Controls whether timed repaints stop while the host terminal is unfocused.
+    pub fn set_freeze_repaints_when_unfocused(&mut self, freeze: bool) {
+        self.freeze_repaints_when_unfocused.set(freeze);
+        if freeze && !self.focused.get() {
+            self.repaint_timer.borrow_mut().take();
+        }
     }
 }
 
@@ -616,6 +633,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     window_id: WindowId,
     root_view: ViewHandle<T>,
     report_modifier_key_lifecycle: bool,
+    freeze_repaints_when_unfocused: bool,
     probe: Option<TuiProbe>,
 ) -> io::Result<TuiDriverHandle> {
     let guard = TuiTerminalGuard::enter(report_modifier_key_lifecycle)?;
@@ -637,6 +655,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     // one for its own deadline — or clears it when nothing is animating.
     let repaint_timer: Rc<RefCell<Option<ForegroundTask>>> = Rc::default();
     let focused = Rc::new(Cell::new(true));
+    let freeze_repaints_when_unfocused = Rc::new(Cell::new(freeze_repaints_when_unfocused));
 
     // Redraw whenever the window is invalidated. `update_windows` invokes this at
     // the end of every `flush_effects`, so any `notify()` repaints. (The callback
@@ -646,8 +665,15 @@ pub fn spawn_tui_driver<T: TuiView>(
         let screen = screen.clone();
         let repaint_timer = repaint_timer.clone();
         let focused = focused.clone();
+        let freeze_repaints_when_unfocused = freeze_repaints_when_unfocused.clone();
         ctx.on_window_invalidated(window_id, move |_, ctx| {
-            if let Err(error) = draw_and_schedule_repaint(&screen, &repaint_timer, &focused, ctx) {
+            if let Err(error) = draw_and_schedule_repaint(
+                &screen,
+                &repaint_timer,
+                &focused,
+                &freeze_repaints_when_unfocused,
+                ctx,
+            ) {
                 report_error!(anyhow::Error::new(error).context("failed to draw a TUI frame"));
             }
         });
@@ -660,7 +686,13 @@ pub fn spawn_tui_driver<T: TuiView>(
     // returning `Err` here drops `guard` (restoring the terminal) and lets the
     // caller surface the error, rather than leaving a live raw-mode session with
     // no usable frame.
-    draw_and_schedule_repaint(&screen, &repaint_timer, &focused, ctx)?;
+    draw_and_schedule_repaint(
+        &screen,
+        &repaint_timer,
+        &focused,
+        &freeze_repaints_when_unfocused,
+        ctx,
+    )?;
 
     let weak_app = ctx.weak_app();
     let (sender, receiver) = async_channel::unbounded::<CrosstermEvent>();
@@ -688,6 +720,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     let dispatch_screen = screen.clone();
     let dispatch_repaint_timer = repaint_timer.clone();
     let dispatch_focused = focused.clone();
+    let dispatch_freeze_repaints_when_unfocused = freeze_repaints_when_unfocused.clone();
     let task = ctx.foreground_executor().spawn(async move {
         while let Ok(event) = receiver.recv().await {
             let Some(mut app) = weak_app.upgrade() else {
@@ -696,6 +729,7 @@ pub fn spawn_tui_driver<T: TuiView>(
             let screen = dispatch_screen.clone();
             let repaint_timer = dispatch_repaint_timer.clone();
             let focused = dispatch_focused.clone();
+            let freeze_repaints_when_unfocused = dispatch_freeze_repaints_when_unfocused.clone();
             // Dispatch reuses the shared screen's cached element tree (so embedded
             // child views resolve their elements). Edits queue effects that flush
             // when this `update` returns — firing the invalidation callback to
@@ -710,7 +744,9 @@ pub fn spawn_tui_driver<T: TuiView>(
                         }
                         CrosstermEvent::FocusLost => {
                             focused.set(false);
-                            repaint_timer.borrow_mut().take();
+                            if freeze_repaints_when_unfocused.get() {
+                                repaint_timer.borrow_mut().take();
+                            }
                         }
                         _ => {}
                     }
@@ -725,7 +761,9 @@ pub fn spawn_tui_driver<T: TuiView>(
 
     Ok(TuiDriverHandle {
         _task: task,
-        _repaint_timer: repaint_timer,
+        repaint_timer,
+        focused,
+        freeze_repaints_when_unfocused,
         _reader: reader,
         reader_shutdown,
         probe_lifecycle_lock,
@@ -831,37 +869,51 @@ fn draw_and_schedule_repaint<T: TuiView, R: TuiTerminal + 'static>(
     screen: &Rc<RefCell<TuiScreen<T, R>>>,
     timer_slot: &Rc<RefCell<Option<ForegroundTask>>>,
     focused: &Rc<Cell<bool>>,
+    freeze_repaints_when_unfocused: &Rc<Cell<bool>>,
     ctx: &mut AppContext,
 ) -> io::Result<()> {
     let deadline = screen.borrow_mut().draw(ctx)?;
-    let timer = deadline.filter(|_| focused.get()).map(|deadline| {
-        let screen = screen.clone();
-        let focused = Rc::clone(focused);
-        // Weak, or the slot (held by the task) and the task (held by the slot)
-        // would keep each other alive.
-        let weak_slot = Rc::downgrade(timer_slot);
-        let weak_app = ctx.weak_app();
-        ctx.foreground_executor().spawn(async move {
-            let now = Instant::now();
-            if deadline > now {
-                Timer::after(deadline - now).await;
-            }
-            let (Some(mut app), Some(timer_slot)) = (weak_app.upgrade(), weak_slot.upgrade())
-            else {
-                return;
-            };
-            app.update(move |ctx| {
-                // The draw below replaces the slot, dropping this task's own
-                // handle; `async_task` defers destruction, so this in-flight
-                // poll completes normally.
-                if let Err(error) = draw_and_schedule_repaint(&screen, &timer_slot, &focused, ctx) {
-                    report_error!("failed to draw a TUI frame", extra: { "error" => %error });
+    let timer = deadline
+        .filter(|_| should_schedule_repaints(focused.get(), freeze_repaints_when_unfocused.get()))
+        .map(|deadline| {
+            let screen = screen.clone();
+            let focused = Rc::clone(focused);
+            let freeze_repaints_when_unfocused = Rc::clone(freeze_repaints_when_unfocused);
+            // Weak, or the slot (held by the task) and the task (held by the slot)
+            // would keep each other alive.
+            let weak_slot = Rc::downgrade(timer_slot);
+            let weak_app = ctx.weak_app();
+            ctx.foreground_executor().spawn(async move {
+                let now = Instant::now();
+                if deadline > now {
+                    Timer::after(deadline - now).await;
                 }
-            });
-        })
-    });
+                let (Some(mut app), Some(timer_slot)) = (weak_app.upgrade(), weak_slot.upgrade())
+                else {
+                    return;
+                };
+                app.update(move |ctx| {
+                    // The draw below replaces the slot, dropping this task's own
+                    // handle; `async_task` defers destruction, so this in-flight
+                    // poll completes normally.
+                    if let Err(error) = draw_and_schedule_repaint(
+                        &screen,
+                        &timer_slot,
+                        &focused,
+                        &freeze_repaints_when_unfocused,
+                        ctx,
+                    ) {
+                        report_error!("failed to draw a TUI frame", extra: { "error" => %error });
+                    }
+                });
+            })
+        });
     *timer_slot.borrow_mut() = timer;
     Ok(())
+}
+
+fn should_schedule_repaints(focused: bool, freeze_repaints_when_unfocused: bool) -> bool {
+    focused || !freeze_repaints_when_unfocused
 }
 
 /// The alternate-screen + raw-mode operations a [`RawModeGuard`] toggles.

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -29,12 +29,42 @@ struct TextElement {
 }
 
 #[test]
-fn blocking_runtime_suspends_and_resumes_repaint_deadlines_with_focus() {
+fn blocking_runtime_continues_repaint_deadlines_while_unfocused_by_default() {
     App::test((), |mut app| async move {
         let (window_id, root) =
             app.update(|ctx| ctx.add_tui_window(window_options(), |_| RepaintingView));
         let terminal = TestTerminal::new(TuiSize::new(20, 3));
         let mut runtime = TuiRuntime::with_terminal(&app, window_id, root, terminal);
+
+        runtime.draw_if_dirty(&mut app).unwrap();
+        assert!(runtime.pending_repaint.is_some());
+
+        runtime
+            .screen
+            .terminal
+            .events
+            .push_back(CrosstermEvent::FocusLost);
+        runtime.poll_and_dispatch(&mut app, Duration::ZERO).unwrap();
+        assert!(!runtime.focused);
+        assert!(
+            runtime.pending_repaint.is_some(),
+            "unfocused repaint suspension should be opt-in"
+        );
+
+        runtime.dirty.set(true);
+        runtime.draw_if_dirty(&mut app).unwrap();
+        assert!(runtime.pending_repaint.is_some());
+    });
+}
+
+#[test]
+fn blocking_runtime_suspends_and_resumes_repaint_deadlines_when_enabled() {
+    App::test((), |mut app| async move {
+        let (window_id, root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| RepaintingView));
+        let terminal = TestTerminal::new(TuiSize::new(20, 3));
+        let mut runtime = TuiRuntime::with_terminal(&app, window_id, root, terminal);
+        runtime.freeze_repaints_when_unfocused = true;
 
         runtime.draw_if_dirty(&mut app).unwrap();
         assert!(runtime.pending_repaint.is_some());
@@ -81,15 +111,48 @@ fn invalidation_driver_does_not_schedule_repaints_while_unfocused() {
         )));
         let timer = Rc::new(RefCell::new(None));
         let focused = Rc::new(Cell::new(true));
+        let freeze_repaints_when_unfocused = Rc::new(Cell::new(true));
 
-        app.update(|ctx| draw_and_schedule_repaint(&screen, &timer, &focused, ctx))
-            .unwrap();
+        app.update(|ctx| {
+            draw_and_schedule_repaint(
+                &screen,
+                &timer,
+                &focused,
+                &freeze_repaints_when_unfocused,
+                ctx,
+            )
+        })
+        .unwrap();
         assert!(timer.borrow().is_some());
 
         focused.set(false);
-        app.update(|ctx| draw_and_schedule_repaint(&screen, &timer, &focused, ctx))
-            .unwrap();
+        app.update(|ctx| {
+            draw_and_schedule_repaint(
+                &screen,
+                &timer,
+                &focused,
+                &freeze_repaints_when_unfocused,
+                ctx,
+            )
+        })
+        .unwrap();
         assert!(timer.borrow().is_none());
+
+        freeze_repaints_when_unfocused.set(false);
+        app.update(|ctx| {
+            draw_and_schedule_repaint(
+                &screen,
+                &timer,
+                &focused,
+                &freeze_repaints_when_unfocused,
+                ctx,
+            )
+        })
+        .unwrap();
+        assert!(
+            timer.borrow().is_some(),
+            "disabling the opt-in should resume repaint scheduling while unfocused"
+        );
     });
 }
 


### PR DESCRIPTION
## Description

Makes focus-based zero-state animation freezing opt-in through `appearance.zero_state.freeze_animation_when_unfocused`.

The TUI runtime previously suspended timed repaints whenever the terminal lost focus. The new setting defaults to `false`, preserving continuous animation by default, while retaining the lower-CPU behavior for users who explicitly enable it. Startup and live settings changes are wired into the repaint scheduler.

## Linked Issue

N/A

## Testing

- [x] `./script/format`
- [x] `cargo clippy -p warpui_core --features tui --all-targets -- -D warnings`
- [x] `cargo clippy -p warp_tui --all-targets -- -D warnings`
- [x] `cargo nextest run -p warpui_core --features tui runtime::tests` (24 passed)
- [x] `cargo nextest run -p warp settings::tui_zero_state::tests` (4 passed)
- [x] `cargo nextest run -p warp_tui zero_state` (86 passed)
- [x] Manually verified the built TUI in tmux with terminal focus-out/focus-in sequences; default unfocused frames continued updating.

### Screenshots / Videos

No visual layout changes. Live verification used text frame captures before and during terminal focus loss.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/739763b6-c99b-4fec-9582-de5b486c3bed

CHANGELOG-TUI: Zero-state animations now continue while Warp Agent CLI is unfocused unless freezing is explicitly enabled in settings.

Co-Authored-By: Warp <agent@warp.dev>
