### PR TITLE
Remove stable gating for TUI bundling

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -515,8 +515,7 @@ jobs:
     name: Build Release (macOS TUI ${{ matrix.arch }})
     runs-on: macos-26-xlarge
     needs: prepare_release
-    # The Warp TUI is available on the dev, preview, and stable channels.
-    if: ${{ inputs.build_macos != false && (inputs.channel == 'dev' || inputs.channel == 'preview' || inputs.channel == 'stable') }}
+    if: ${{ inputs.build_macos != false }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -631,7 +630,7 @@ jobs:
     name: Build Release (Linux TUI ${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     needs: prepare_release
-    if: ${{ inputs.build_linux != false && (inputs.channel == 'dev' || inputs.channel == 'preview' || inputs.channel == 'stable') }}
+    if: ${{ inputs.build_linux != false }}
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -1628,7 +1627,7 @@ jobs:
     name: Build Release (Windows TUI ${{ matrix.arch }})
     runs-on: windows-latest-large
     needs: prepare_release
-    if: ${{ inputs.build_windows != false && (inputs.channel == 'dev' || inputs.channel == 'stable') }}
+    if: ${{ inputs.build_windows != false }}
     timeout-minutes: 150
     strategy:
       fail-fast: false
@@ -1935,12 +1934,10 @@ jobs:
           if [[ ${{ needs.release_macos_cli.result }} != 'success' ]]; then
             FAILED+=('MacOS CLI')
           fi
-          # The TUI jobs only run on supported release channels, so only treat
-          # them as failures where they are expected to produce artifacts.
-          if [[ ${{ needs.release_macos_tui.result }} != 'success' && ( ${{ inputs.channel }} == 'dev' || ${{ inputs.channel }} == 'preview' || ${{ inputs.channel }} == 'stable' ) ]]; then
+          if [[ ${{ needs.release_macos_tui.result }} != 'success' ]]; then
             FAILED+=('MacOS TUI')
           fi
-          if [[ ${{ needs.release_linux_tui.result }} != 'success' && ( ${{ inputs.channel }} == 'dev' || ${{ inputs.channel }} == 'preview' || ${{ inputs.channel }} == 'stable' ) ]]; then
+          if [[ ${{ needs.release_linux_tui.result }} != 'success' ]]; then
             FAILED+=('Linux TUI')
           fi
           if [[ ${{ needs.release_linux_x86.result }} != 'success' ]]; then
@@ -1958,7 +1955,7 @@ jobs:
           if [[ ${{ needs.release_windows.result }} != 'success' ]]; then
               FAILED+=("Windows")
           fi
-          if [[ ${{ needs.release_windows_tui.result }} != 'success' && ( ${{ inputs.channel }} == 'dev' || ${{ inputs.channel }} == 'stable' ) ]]; then
+          if [[ ${{ needs.release_windows_tui.result }} != 'success' ]]; then
               FAILED+=("Windows TUI")
           fi
 
@@ -1991,19 +1988,17 @@ jobs:
         shell: bash
         env:
           SHOULD_PUBLISH: ${{ needs.prepare_release.outputs.should_publish }}
-          CHANNEL: ${{ inputs.channel }}
           MACOS_TUI_RESULT: ${{ needs.release_macos_tui.result }}
           LINUX_TUI_RESULT: ${{ needs.release_linux_tui.result }}
           WINDOWS_TUI_RESULT: ${{ needs.release_windows_tui.result }}
         run: |
-          if [[ "$SHOULD_PUBLISH" != "true" || ( "$CHANNEL" != "dev" && "$CHANNEL" != "preview" && "$CHANNEL" != "stable" ) ]]; then
+          if [[ "$SHOULD_PUBLISH" != "true" ]]; then
             exit 0
           fi
           if [[ "$MACOS_TUI_RESULT" != "success" ||
                 "$LINUX_TUI_RESULT" != "success" ||
-                ( ( "$CHANNEL" == "dev" || "$CHANNEL" == "stable" ) && "$WINDOWS_TUI_RESULT" != "success" ) ]]; then
+                "$WINDOWS_TUI_RESULT" != "success" ]]; then
             echo "::error::TUI release artifacts were not published successfully (macOS: $MACOS_TUI_RESULT, Linux: $LINUX_TUI_RESULT, Windows: $WINDOWS_TUI_RESULT)"
-            echo "::error::TUI release artifacts were not published successfully (macOS: $MACOS_TUI_RESULT, Linux: $LINUX_TUI_RESULT)"
             exit 1
           fi
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
