### PR TITLE
fix windows autoupdate for TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16013,6 +16013,7 @@ dependencies = [
  "command",
  "criterion",
  "dirs 6.0.0",
+ "dunce",
  "fs4",
  "futures",
  "futures-lite 1.13.0",

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -104,6 +104,12 @@ arboard = { workspace = true }
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 arboard = { workspace = true, features = ["wayland-data-control"] }
 
+# `dunce::simplified` strips the Win32 extended-length (`\\?\`) prefix that
+# `Path::canonicalize` produces, which the Inno Setup updater rejects in its
+# `/DIR` argument. Windows-only, so it stays out of the portable dependency set.
+[target.'cfg(windows)'.dependencies]
+dunce.workspace = true
+
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
 tempfile.workspace = true

--- a/crates/warp_tui/src/autoupdate.rs
+++ b/crates/warp_tui/src/autoupdate.rs
@@ -679,12 +679,27 @@ async fn install_update(layout: InstallLayout, latest_version: String) -> Result
     .await
 }
 
+/// Builds the Inno Setup `/DIR` argument naming the install root.
+///
+/// [`InstallLayout::detect`] canonicalizes the running executable, which on
+/// Windows yields a Win32 extended-length path (`\\?\C:\...`). Inno Setup
+/// validates `/DIR` as a plain folder name and rejects the `?` and second `:`
+/// that prefix introduces, reporting "Folder names cannot include any of the
+/// following characters" and exiting with code 3 before installing anything.
+/// `/SUPPRESSMSGBOXES` hides that dialog, so the failure would otherwise
+/// surface only as a bare exit code.
+#[cfg(windows)]
+fn installer_dir_argument(root: &Path) -> OsString {
+    let mut argument = OsString::from("/DIR=");
+    argument.push(dunce::simplified(root));
+    argument
+}
+
 #[cfg(windows)]
 async fn install_update(layout: InstallLayout, latest_version: String) -> Result<UpdateOutcome> {
     let client = http_client::Client::new();
     let installer = download_windows_installer(&layout, &client, &latest_version).await?;
-    let mut install_dir = OsString::from("/DIR=");
-    install_dir.push(&layout.root);
+    let install_dir = installer_dir_argument(&layout.root);
 
     let output = command::r#async::Command::new(&installer.path)
         .args([

--- a/crates/warp_tui/src/autoupdate_tests.rs
+++ b/crates/warp_tui/src/autoupdate_tests.rs
@@ -9,8 +9,6 @@ use command::blocking::Command;
 use instant::Instant;
 use warp_core::channel::Channel;
 
-#[cfg(windows)]
-use super::PREVIOUS_POINTER_NAME;
 use super::{
     CURRENT_POINTER_NAME, InstallLayout, TuiAutoupdateStatus, UpdateOutcome,
     VERSION_LEASES_DIR_NAME, VersionDirState, VersionLease, create_unique_staging_dir_with,
@@ -22,6 +20,8 @@ use super::{
     InstallLock, LOCK_FILE_NAME, LOCK_OWNER_FILE_NAME, StagedUpdate, finalize_staged_version,
     install_update, point_current_at,
 };
+#[cfg(windows)]
+use super::{PREVIOUS_POINTER_NAME, installer_dir_argument};
 
 const BINARY_NAME: &str = "warp-tui-dev";
 const HELPER_MODE_ENV: &str = "WARP_TUI_AUTOUPDATE_HELPER_MODE";
@@ -165,6 +165,29 @@ fn detects_managed_install_layout() {
         Path::new("/home/user/.warp/tui/versions/v0.2026.01.01.00.00.dev_00")
     );
     assert_eq!(layout.binary_name, BINARY_NAME);
+}
+
+/// `Path::canonicalize` hands back `\\?\C:\...` on Windows. Passing that
+/// through to Inno Setup makes it reject `/DIR` and exit with code 3, so the
+/// prefix has to be stripped before the installer sees it.
+#[cfg(windows)]
+#[test]
+fn installer_dir_argument_strips_verbatim_prefix() {
+    assert_eq!(
+        installer_dir_argument(Path::new(r"\\?\C:\Users\dev\AppData\Local\Warp\tui-dev"))
+            .to_string_lossy(),
+        r"/DIR=C:\Users\dev\AppData\Local\Warp\tui-dev"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn installer_dir_argument_preserves_plain_paths() {
+    assert_eq!(
+        installer_dir_argument(Path::new(r"C:\Users\dev\AppData\Local\Warp\tui-dev"))
+            .to_string_lossy(),
+        r"/DIR=C:\Users\dev\AppData\Local\Warp\tui-dev"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`InstallLayout::detect` canonicalizes the running executable, which on Windows yields a verbatim extended-length path (`\\?\C:\...`). That path was passed straight through as the Inno Setup `/DIR` value, and Setup rejects folder names containing `?` or a second `:`. Because `/SUPPRESSMSGBOXES` auto-dismissed the resulting error dialog, the updater aborted with exit code 3 before installing anything and logged only the bare exit code, which made the failure look like a download or timing problem.

Strip the prefix with `dunce::simplified` when building the argument. The verbatim prefix on the installer's own executable path is harmless and is left alone; only `/DIR` is rejected.

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
