### PR TITLE
Block zero-length computer-use recording uploads and surface capture failures

### DIFF
--- a/app/src/ai/blocklist/action_model/recording_finalize.rs
+++ b/app/src/ai/blocklist/action_model/recording_finalize.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use ai::agent::action_result::{RecordingStopped, StopRecordingResult};
@@ -48,6 +48,17 @@ impl RecordingFinalization {
             }),
             RecordingFinalization::Ready(ready) => ready,
         }
+    }
+}
+
+/// Removes the capture and every intermediate file produced while finalizing it.
+/// Local recording files are ephemeral regardless of outcome; retrying a failed
+/// upload or retaining its file requires a separate persistence policy.
+fn remove_local_recording_files(local_path: &Path, intermediates: &[Option<PathBuf>]) {
+    let _ = std::fs::remove_file(local_path);
+    let _ = std::fs::remove_file(local_path.with_extension("log"));
+    for intermediate in intermediates.iter().flatten() {
+        let _ = std::fs::remove_file(intermediate);
     }
 }
 
@@ -142,11 +153,12 @@ async fn finalize_recording(
 
     // Apply the post-stop smart cut (keep real action windows at 1x, drop
     // blocked/thinking gaps) and burn the remapped overlay pills into the video
-    // before upload. Best-effort: on any failure the original 1x capture is
-    // uploaded unannotated (a no-cut video beats no video). The cut/overlay
-    // file, when produced, is a sibling of the mp4.
-    let mut upload_path = local_path.clone();
-    let mut overlay_path: Option<std::path::PathBuf> = None;
+    // before upload. The cut/overlay file, when produced, is a sibling of the
+    // mp4. A failure here means the finalized video is not the one the agent
+    // asked for, so it is reported instead of silently publishing the raw
+    // capture.
+    let mut processed_path = local_path.clone();
+    let mut overlay_path: Option<PathBuf> = None;
     match computer_use::post_process_recording(
         &local_path,
         &actions,
@@ -158,22 +170,34 @@ async fn finalize_recording(
     {
         Ok(path) if path != local_path => {
             overlay_path = Some(path.clone());
-            upload_path = path;
+            processed_path = path;
         }
         Ok(_) => {}
         Err(error) => {
-            log::warn!("Recording cut/overlay burn-in failed; uploading original: {error}");
+            remove_local_recording_files(&local_path, &[]);
+            return StopRecordingResult::Error(format!(
+                "Recording cut/overlay processing failed, so no video artifact was published: \
+                 {error}"
+            ));
         }
     }
-    let duration = match computer_use::finalized_video_duration(&upload_path).await {
-        Ok(duration) => duration,
+
+    // Only a duration the container itself reports makes a recording
+    // publishable: a capture can hold every frame yet declare a near-zero
+    // timeline, which plays back as an empty video. The wall-clock capture
+    // duration is deliberately not a fallback, since it would report that broken
+    // file as a normal one.
+    let (upload_path, duration) = match computer_use::playable_recording(&processed_path).await {
+        Ok(playable) => playable,
         Err(error) => {
-            log::warn!(
-                "Failed to inspect finalized recording duration; using capture duration: {error}"
-            );
-            output.duration
+            remove_local_recording_files(&local_path, &[overlay_path]);
+            return StopRecordingResult::Error(format!(
+                "Recording has no playable video timeline, so no video artifact was published; \
+                 retry the recording: {error}"
+            ));
         }
     };
+    let remux_path = (upload_path != processed_path).then(|| upload_path.clone());
 
     // Keep a handle on the finalized video path for thumbnail extraction before
     // it is moved into the upload request; the thumbnail reads this file with
@@ -209,13 +233,7 @@ async fn finalize_recording(
     {
         log::warn!("PR video thumbnail capture failed; video upload unaffected: {error}");
     }
-    // Local files are ephemeral regardless of upload outcome. Retrying failed
-    // uploads or retaining their files requires a separate persistence policy.
-    let _ = std::fs::remove_file(&local_path);
-    let _ = std::fs::remove_file(local_path.with_extension("log"));
-    if let Some(overlay_path) = overlay_path.as_ref() {
-        let _ = std::fs::remove_file(overlay_path);
-    }
+    remove_local_recording_files(&local_path, &[overlay_path, remux_path]);
 
     match upload_result {
         Ok(upload) => StopRecordingResult::Success(RecordingStopped {

--- a/crates/computer_use/src/lib.rs
+++ b/crates/computer_use/src/lib.rs
@@ -303,11 +303,14 @@ pub async fn post_process_recording(
         Ok(input.to_path_buf())
     }
 }
-/// Reads the duration encoded in a finalized recording's media timeline.
-pub async fn finalized_video_duration(input: &Path) -> Result<Duration, RecordingError> {
+/// Resolves the finalized recording that may be published: the file whose media
+/// timeline is playable, plus that duration. Repairs a mis-written container
+/// duration with a stream copy, and errors when no playable timeline can be
+/// established, so a zero-length video is never uploaded.
+pub async fn playable_recording(input: &Path) -> Result<(PathBuf, Duration), RecordingError> {
     #[cfg(any(macos, linux))]
     {
-        recording_metadata::video_duration(input).await
+        recording_metadata::playable_video(input).await
     }
     #[cfg(not(any(macos, linux)))]
     {

--- a/crates/computer_use/src/linux/recording.rs
+++ b/crates/computer_use/src/linux/recording.rs
@@ -23,6 +23,7 @@ use x11rb::protocol::xproto;
 use x11rb::rust_connection::RustConnection;
 
 use super::x11::windows;
+use crate::recording_metadata::ffmpeg_error_tail;
 use crate::{
     RecordingCompletionStatus, RecordingConfig, RecordingError, RecordingHandle, RecordingOutput,
     Target,
@@ -381,7 +382,7 @@ async fn cut_to_segments(
 ) -> Result<PathBuf, RecordingError> {
     let output_path = input.with_extension("cut.mp4");
     let filter = build_cut_only_filtergraph(segments);
-    let status = Command::new("ffmpeg")
+    let output = Command::new("ffmpeg")
         .arg("-y")
         .arg("-i")
         .arg(input)
@@ -402,15 +403,19 @@ async fn cut_to_segments(
         .arg(&output_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+        .stderr(Stdio::piped())
+        .output()
         .await;
-    match status {
-        Ok(status) if status.success() => Ok(output_path),
-        Ok(status) => {
+    match output {
+        Ok(output) if output.status.success() => Ok(output_path),
+        Ok(output) => {
             let _ = std::fs::remove_file(&output_path);
+            let detail = ffmpeg_error_tail(&String::from_utf8_lossy(&output.stderr));
             Err(RecordingError::Finalize {
-                reason: format!("ffmpeg segment cut exited with status {status}"),
+                reason: format!(
+                    "ffmpeg segment cut exited with status {}{detail}",
+                    output.status
+                ),
             })
         }
         Err(e) => {
@@ -434,7 +439,7 @@ async fn burn_overlays_into_cut(
 ) -> Result<PathBuf, RecordingError> {
     let output_path = input.with_extension("overlay.mp4");
     let subtitles_filter = format!("subtitles=filename='{}'", ass_path.display());
-    let status = Command::new("ffmpeg")
+    let output = Command::new("ffmpeg")
         .arg("-y")
         .arg("-i")
         .arg(input)
@@ -447,15 +452,19 @@ async fn burn_overlays_into_cut(
         .arg(&output_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+        .stderr(Stdio::piped())
+        .output()
         .await;
-    match status {
-        Ok(status) if status.success() => Ok(output_path),
-        Ok(status) => {
+    match output {
+        Ok(output) if output.status.success() => Ok(output_path),
+        Ok(output) => {
             let _ = std::fs::remove_file(&output_path);
+            let detail = ffmpeg_error_tail(&String::from_utf8_lossy(&output.stderr));
             Err(RecordingError::Finalize {
-                reason: format!("ffmpeg overlay burn-in exited with status {status}"),
+                reason: format!(
+                    "ffmpeg overlay burn-in exited with status {}{detail}",
+                    output.status
+                ),
             })
         }
         Err(e) => {
@@ -477,9 +486,9 @@ async fn burn_overlays_into_cut(
 /// The two steps are independent: `cut_to_segments` knows nothing about
 /// overlays, and `burn_overlays_into_cut` knows nothing about segment
 /// boundaries. A recording whose committed actions yield no qualifying segment
-/// returns an error rather than producing a video; the caller falls back to
-/// uploading the untouched source for an unexpected processing failure after at
-/// least one committed action.
+/// has nothing to cut or annotate and returns the untouched source; every error
+/// is a real processing failure that the caller surfaces rather than publishing
+/// an unprocessed video.
 pub async fn post_process_recording(
     input: &Path,
     entries: &[crate::ActionLogEntry],
@@ -489,9 +498,7 @@ pub async fn post_process_recording(
 ) -> Result<PathBuf, RecordingError> {
     let segments = crate::overlay::build_keep_segments(entries, source_duration, frame_rate);
     if segments.is_empty() {
-        return Err(RecordingError::Finalize {
-            reason: "recording has no qualifying action segments to keep".to_string(),
-        });
+        return Ok(input.to_path_buf());
     }
 
     // Step 1: cut the source to retained segments only.
@@ -577,22 +584,6 @@ async fn wait_for_first_output(path: &Path, process: &mut Child) -> Result<(), S
             return Err("timed out waiting for capture to begin".to_string());
         }
         tokio::time::sleep(POLL_INTERVAL).await;
-    }
-}
-
-/// Returns a short, parenthesized tail of ffmpeg's stderr log for diagnostics.
-fn ffmpeg_error_tail(log: &str) -> String {
-    let lines: Vec<&str> = log
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .collect();
-    let start = lines.len().saturating_sub(3);
-    let tail = lines[start..].join(" ");
-    if tail.is_empty() {
-        String::new()
-    } else {
-        format!(" ({tail})")
     }
 }
 

--- a/crates/computer_use/src/mac/recording.rs
+++ b/crates/computer_use/src/mac/recording.rs
@@ -11,8 +11,8 @@
 //! bounded-capture (`-t` input option / `-fs`) and playback-speed (`-vf setpts`)
 //! handling are identical to Linux; see the
 //! code-split note in the REMOTE-2160 spec for why the
-//! `wait_for_first_output` / `ffmpeg_error_tail` / SIGINT-finalize logic is
-//! duplicated between the two recorder modules.
+//! `wait_for_first_output` / SIGINT-finalize logic is duplicated between the two
+//! recorder modules.
 
 use std::path::Path;
 use std::process::Stdio;
@@ -26,6 +26,7 @@ use nix::unistd::Pid;
 use tokio::process::{Child, Command};
 
 use super::util::main_display_dimensions;
+use crate::recording_metadata::ffmpeg_error_tail;
 use crate::{
     RecordingCompletionStatus, RecordingConfig, RecordingError, RecordingHandle, RecordingOutput,
 };
@@ -253,22 +254,6 @@ async fn wait_for_first_output(path: &Path, process: &mut Child) -> Result<(), S
             return Err("timed out waiting for capture to begin".to_string());
         }
         tokio::time::sleep(POLL_INTERVAL).await;
-    }
-}
-
-/// Returns a short, parenthesized tail of ffmpeg's stderr log for diagnostics.
-fn ffmpeg_error_tail(log: &str) -> String {
-    let lines: Vec<&str> = log
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .collect();
-    let start = lines.len().saturating_sub(3);
-    let tail = lines[start..].join(" ");
-    if tail.is_empty() {
-        String::new()
-    } else {
-        format!(" ({tail})")
     }
 }
 

--- a/crates/computer_use/src/recording_metadata.rs
+++ b/crates/computer_use/src/recording_metadata.rs
@@ -1,10 +1,100 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
 use tokio::process::Command;
 
 use crate::RecordingError;
+
+/// Shortest media timeline a finalized recording may report and still be
+/// treated as playable. A capture whose container duration is written near zero
+/// plays back as an empty video even when every frame is present, so anything
+/// under roughly a couple of frames is treated as unplayable.
+const MIN_PLAYABLE_DURATION: Duration = Duration::from_millis(100);
+
+/// Resolves the file that may be published for `input`: the path whose
+/// container reports a playable timeline, together with that duration.
+///
+/// A mis-written container duration is recoverable without re-encoding, so a
+/// single stream copy is attempted before giving up. The wall-clock capture
+/// duration is deliberately never used as a fallback here: it cannot
+/// distinguish a playable file from an unplayable one, which is exactly how a
+/// zero-length recording reaches an upload.
+pub(super) async fn playable_video(input: &Path) -> Result<(PathBuf, Duration), RecordingError> {
+    let probe_failure = match video_duration(input).await {
+        Ok(duration) if duration >= MIN_PLAYABLE_DURATION => {
+            return Ok((input.to_path_buf(), duration));
+        }
+        Ok(duration) => format!("finalized video reported a {duration:?} timeline"),
+        Err(error) => error.to_string(),
+    };
+
+    let remuxed = remux(input)
+        .await
+        .map_err(|error| RecordingError::Finalize {
+            reason: format!("{probe_failure}; stream-copy repair failed: {error}"),
+        })?;
+    match video_duration(&remuxed).await {
+        Ok(duration) if duration >= MIN_PLAYABLE_DURATION => Ok((remuxed, duration)),
+        repaired => {
+            let _ = std::fs::remove_file(&remuxed);
+            let repaired = match repaired {
+                Ok(duration) => format!("a {duration:?} timeline"),
+                Err(error) => error.to_string(),
+            };
+            Err(RecordingError::Finalize {
+                reason: format!("{probe_failure}; stream-copy repair still reported {repaired}"),
+            })
+        }
+    }
+}
+
+/// Rewrites `input`'s container without re-encoding, rebuilding the media
+/// timeline from the elementary stream's own timestamps.
+async fn remux(input: &Path) -> Result<PathBuf, RecordingError> {
+    let output_path = input.with_extension("remux.mp4");
+    let output = Command::new("ffmpeg")
+        .args(["-y", "-hide_banner", "-i"])
+        .arg(input)
+        .args(["-c", "copy"])
+        .args(["-movflags", "+faststart"])
+        .arg(&output_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|error| RecordingError::Finalize {
+            reason: format!("failed to run ffmpeg for stream copy: {error}"),
+        })?;
+    if !output.status.success() {
+        let _ = std::fs::remove_file(&output_path);
+        let detail = ffmpeg_error_tail(&String::from_utf8_lossy(&output.stderr));
+        return Err(RecordingError::Finalize {
+            reason: format!(
+                "ffmpeg stream copy exited with status {}{detail}",
+                output.status
+            ),
+        });
+    }
+    Ok(output_path)
+}
+
+/// Returns a short, parenthesized tail of ffmpeg's stderr for diagnostics.
+pub(crate) fn ffmpeg_error_tail(log: &str) -> String {
+    let lines: Vec<&str> = log
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    let start = lines.len().saturating_sub(3);
+    let tail = lines[start..].join(" ");
+    if tail.is_empty() {
+        String::new()
+    } else {
+        format!(" ({tail})")
+    }
+}
 
 pub(super) async fn video_duration(input: &Path) -> Result<Duration, RecordingError> {
     let output = Command::new("ffmpeg")

--- a/crates/computer_use/src/recording_metadata_tests.rs
+++ b/crates/computer_use/src/recording_metadata_tests.rs
@@ -26,14 +26,17 @@ fn rejects_missing_or_invalid_duration() {
     }
 }
 
-#[tokio::test]
-async fn probes_duration_after_timestamp_rescaling() {
-    if !Command::new("ffmpeg")
+async fn ffmpeg_available() -> bool {
+    Command::new("ffmpeg")
         .arg("-version")
         .output()
         .await
         .is_ok_and(|output| output.status.success())
-    {
+}
+
+#[tokio::test]
+async fn probes_duration_after_timestamp_rescaling() {
+    if !ffmpeg_available().await {
         return;
     }
 
@@ -74,5 +77,62 @@ async fn probes_duration_after_timestamp_rescaling() {
     assert!(
         (Duration::from_millis(800)..=Duration::from_millis(1200)).contains(&duration),
         "expected a roughly 1-second final timeline, got {duration:?}"
+    );
+}
+
+/// A capture holding real frames whose container declares a near-zero timeline
+/// plays back as an empty video. A stream copy cannot recover a timeline the
+/// frames themselves don't carry, so the recording is rejected instead of
+/// becoming an upload candidate off the capture's wall-clock duration.
+#[tokio::test]
+async fn rejects_a_capture_whose_container_reports_no_timeline() {
+    if !ffmpeg_available().await {
+        return;
+    }
+
+    let path = std::env::temp_dir().join(format!(
+        "warp-zero-length-recording-test-{}.mp4",
+        uuid::Uuid::new_v4()
+    ));
+    // Twenty real frames spanning a ~0.02s container timeline, matching the
+    // frames-present / duration-near-zero capture this guard exists for.
+    let output = Command::new("ffmpeg")
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=black:size=16x16:rate=1000:duration=1",
+            "-frames:v",
+            "20",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+        ])
+        .arg(&path)
+        .output()
+        .await
+        .expect("run ffmpeg");
+    assert!(
+        output.status.success(),
+        "ffmpeg failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result = playable_video(&path).await;
+    let remux_path = path.with_extension("remux.mp4");
+    let remux_left_behind = remux_path.exists();
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(&remux_path);
+
+    assert!(
+        matches!(result, Err(RecordingError::Finalize { .. })),
+        "a zero-length timeline should not be publishable, got {result:?}"
+    );
+    assert!(
+        !remux_left_behind,
+        "the failed repair file should be removed"
     );
 }


### PR DESCRIPTION
## Description
Never upload a zero-length computer-use recording, and make capture failures surface descriptive, retryable errors instead of silently publishing a broken artifact.

Motivating regression: Oz conversation `e993f489` / GH #13326. That recording contained 16,667 real frames and ~9.1 MB of data, but its mp4 `mdhd` duration was written as ~0.02s, so it played back as zero-length and was only salvageable with a manual `ffmpeg -c copy` remux. #14172 added a `finalized_video_duration` probe, but it only *reported* the duration and fell back to the wall-clock capture duration on probe failure — nothing blocked the bad upload.

What changed:
- **Zero-length guard.** `computer_use::playable_recording` (replacing `finalized_video_duration`) requires the container to report a timeline of at least 100 ms before a recording can be uploaded. There is no wall-clock fallback for the upload decision: only a duration the container itself reports proves the file plays. On failure it attempts one `ffmpeg -c copy` remux and re-probes; if the repaired file still has no valid timeline, the repair artifact is removed and the finalize returns `StopRecordingResult::Error(..)` with the original probe failure and the repair result in the message.
- **Descriptive, agent-visible errors.** `recording_finalize.rs` no longer swallows failures. The duration-probe / near-zero-duration case and cut/overlay post-processing failures now return `StopRecordingResult::Error(..)` (previously `log::warn!` fallbacks the agent never saw), telling the agent to retry rather than handing back an empty or unprocessed video. Existing clear errors (finalize timeout, empty file, start-failure tail, no committed actions) are untouched.
- **ffmpeg stderr is no longer discarded.** The Linux segment-cut and overlay burn-in steps piped stderr to `/dev/null`; they now capture it and include the same short tail already used for start failures. Because the "no qualifying action segments" case is expected rather than a failure, `post_process_recording` returns the untouched source for it, so every remaining `Err` is a genuine processing failure worth surfacing.
- The stderr-tail helper, previously duplicated per platform recorder, now lives next to the probe in `recording_metadata.rs` and is shared by the Linux, macOS, and remux paths.

## Linked Issue
GH #13326 (zero-length computer-use recording); reproduced in Oz conversation `e993f489`.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
One scoped regression test in `crates/computer_use/src/recording_metadata_tests.rs`: a capture with 20 real frames whose container declares a ~0.02s timeline — the shape of the reported regression — is rejected rather than becoming an upload candidate, and the failed stream-copy repair file is cleaned up. It skips when ffmpeg is unavailable, matching the existing ffmpeg-dependent tests in that file.

Commands run (Linux, ffmpeg 6.1.1 installed in the sandbox):
- `cargo test -p computer_use` — 64 passed, 0 failed, 2 ignored (includes the new test; verified it fails against the pre-change behavior, which returned `Ok(20ms)`).
- `cargo test -p warp --lib recording_finalize` — 3 passed (existing finalize tests).
- `cargo check -p warp --lib --tests` — clean.
- `cargo clippy -p computer_use -p warp --all-targets --tests -- -D warnings` — clean. (`--all-features` was not used for the clippy run because it enables `warp_completer`'s `v2` feature, which fails on pre-existing lints unrelated to this change; presubmit runs that package separately.)
- `./script/format` / `cargo fmt -- --check` — clean.

Not run: the full `./script/presubmit` workspace suite and a GUI run of the app — building the whole app test binary OOMs at default settings in this sandbox (it succeeded only with debug info disabled). Recording capture itself needs a real X11 display, so end-to-end capture was not exercised here.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Computer-use recordings that finalized with a zero-length video timeline are now repaired or reported as an error instead of being uploaded as an unplayable artifact.
-->

_Conversation: https://staging.warp.dev/conversation/77d8d138-076f-46bb-bd35-ce766e22cec3_
_Run: https://oz.staging.warp.dev/runs/019fc9cc-edbd-7d79-9809-6812ce750003_

_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
