### PR TITLE
[APP-5137] Share TUI welcome copy across first-run surfaces

### DIFF
--- a/crates/warp_tui/src/ui.rs
+++ b/crates/warp_tui/src/ui.rs
@@ -137,6 +137,40 @@ pub(crate) fn centered_in_viewport(content: Box<dyn TuiElement>) -> Box<dyn TuiE
         .finish()
 }
 
+pub(crate) fn render_welcome_title(builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
+    TuiText::new("Welcome to Warp")
+        .with_style(builder.brand_primary_style().add_modifier(Modifier::BOLD))
+        .truncate()
+        .finish()
+}
+
+pub(crate) fn append_welcome_capability_section(
+    mut column: TuiFlex,
+    builder: &TuiUiBuilder,
+) -> TuiFlex {
+    column = column.child(
+        TuiText::new("What’s different about Warp")
+            .with_style(builder.muted_text_style())
+            .truncate()
+            .finish(),
+    );
+    for description in [
+        "State of the art coding agents",
+        "Frontier and open-weight models",
+        "Fully customizable model routers",
+        "Orchestration for fleets of agents",
+        "Better shell command support",
+    ] {
+        column = column.child(capability_row(
+            "✶",
+            description,
+            builder.brand_accent_style(),
+            builder.primary_text_style(),
+        ));
+    }
+    column
+}
+
 /// Signed-out welcome shown before browser device authorization begins.
 pub(crate) fn signed_out_welcome(
     clock: AnimationClock,
@@ -150,7 +184,6 @@ pub(crate) fn signed_out_welcome(
     let builder = TuiUiBuilder::from_app(app);
     let primary = builder.primary_text_style();
     let muted = builder.muted_text_style();
-    let title = builder.brand_primary_style().add_modifier(Modifier::BOLD);
     let brand_accent = builder.brand_accent_style();
     let login_style = if login_mouse.lock().is_ok_and(|state| state.is_hovered()) {
         primary
@@ -167,12 +200,7 @@ pub(crate) fn signed_out_welcome(
     let mut on_login_key = on_login.clone();
     let mut on_copy_key = on_copy.clone();
     let content = TuiFlex::column()
-        .child(
-            TuiText::new("Welcome to Warp")
-                .with_style(title)
-                .truncate()
-                .finish(),
-        )
+        .child(render_welcome_title(&builder))
         .child(
             TuiText::from_spans([
                 ("> ".to_owned(), brand_accent),
@@ -208,43 +236,8 @@ pub(crate) fn signed_out_welcome(
             .finish(),
         )
         .child(blank_row())
-        .child(blank_row())
-        .child(
-            TuiText::new("What’s different about Warp")
-                .with_style(muted)
-                .finish(),
-        )
-        .child(capability_row(
-            "⟡",
-            "Prompts or shell commands autodetected",
-            builder.brand_primary_style(),
-            primary,
-        ))
-        .child(capability_row(
-            "⊹",
-            "Set up custom model routers",
-            builder.link_text_style(),
-            primary,
-        ))
-        .child(capability_row(
-            "✶",
-            "Orchestrate fleets of agents",
-            brand_accent,
-            primary,
-        ))
-        .child(capability_row(
-            "*",
-            "Run full-screen terminal apps",
-            builder.credential_entry_accent_style(),
-            primary,
-        ))
-        .child(capability_row(
-            "◊",
-            "Persist sessions through state changes",
-            builder.attention_glyph_style(),
-            primary,
-        ))
-        .finish();
+        .child(blank_row());
+    let content = append_welcome_capability_section(content, &builder).finish();
     TuiEventHandler::new(auth_layout(clock, animation_config, content, &builder))
         .on_key("enter", move |_, event_ctx, app| {
             on_login_key(event_ctx, app);

--- a/crates/warp_tui/src/ui_tests.rs
+++ b/crates/warp_tui/src/ui_tests.rs
@@ -242,11 +242,11 @@ fn signed_out_welcome_matches_designed_copy_and_layout() {
                 "Log in with Warp",
                 "Copy login URL (c)",
                 "What’s different about Warp",
-                "Prompts or shell commands autodetected",
-                "Set up custom model routers",
-                "Orchestrate fleets of agents",
-                "Run full-screen terminal apps",
-                "Persist sessions through state changes",
+                "✶ State of the art coding agents",
+                "✶ Frontier and open-weight models",
+                "✶ Fully customizable model routers",
+                "✶ Orchestration for fleets of agents",
+                "✶ Better shell command support",
             ] {
                 assert!(
                     lines.iter().any(|line| line.contains(expected)),
@@ -324,11 +324,11 @@ fn signed_out_welcome_uses_figma_brand_colors_in_dark_and_light_themes() {
                 assert_eq!(cell_color("> Press enter to get started", 0), brand_accent);
                 assert_eq!(cell_color("> Press enter to get started", 8), brand_accent);
                 assert_eq!(
-                    cell_color("⟡ Prompts or shell commands autodetected", 0),
-                    brand_primary
+                    cell_color("✶ State of the art coding agents", 0),
+                    brand_accent
                 );
                 assert_eq!(
-                    cell_color("✶ Orchestrate fleets of agents", 0),
+                    cell_color("✶ Better shell command support", 0),
                     brand_accent
                 );
             });

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -35,9 +35,7 @@ use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 
 use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent};
 use crate::tui_builder::TuiUiBuilder;
-use crate::ui::{
-    abbreviate_home_prefix, append_welcome_capability_section, render_welcome_title,
-};
+use crate::ui::{abbreviate_home_prefix, append_welcome_capability_section, render_welcome_title};
 use crate::zero_state_animation::{
     WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent,
     ZeroStateAnimationElement, ZeroStateInteractionHandle, ZeroStateStarfieldElement,

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -35,7 +35,9 @@ use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 
 use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent};
 use crate::tui_builder::TuiUiBuilder;
-use crate::ui::abbreviate_home_prefix;
+use crate::ui::{
+    abbreviate_home_prefix, append_welcome_capability_section, render_welcome_title,
+};
 use crate::zero_state_animation::{
     WarpLogoStyles, ZeroStateAnimationConfig, ZeroStateAnimationConfigEvent,
     ZeroStateAnimationElement, ZeroStateInteractionHandle, ZeroStateStarfieldElement,
@@ -686,45 +688,15 @@ fn render_first_run_top_section(
     visibility: ZeroStateSectionVisibility,
     app: &AppContext,
 ) -> TuiFlex {
-    let title_style = builder.brand_primary_style().add_modifier(Modifier::BOLD);
-    let muted = builder.muted_text_style();
     let mut column = TuiFlex::column()
-        .child(
-            TuiText::new("Welcome to Warp")
-                .with_style(title_style)
-                .truncate()
-                .finish(),
-        )
+        .child(render_welcome_title(builder))
         .child(render_version_line(builder, app));
     if visibility.signed_in_user {
         column = column.child(render_login_line_with_prefix("logged in as", builder, app));
     }
-    column = column.child(blank_row()).child(blank_row()).child(
-        TuiText::new("What’s different about Warp")
-            .with_style(muted)
-            .truncate()
-            .finish(),
-    );
-    for description in [
-        "State of the art coding agents",
-        "Frontier and open-weight models",
-        "Fully customizable model routers",
-        "Orchestration for fleets of agents",
-        "Better shell command support",
-    ] {
-        column = column.child(render_first_run_capability(description, builder));
-    }
+    column = column.child(blank_row()).child(blank_row());
+    column = append_welcome_capability_section(column, builder);
     column.child(blank_row())
-}
-
-fn render_first_run_capability(description: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
-    let highlight = builder.brand_accent_style();
-    let primary = builder.primary_text_style();
-    let spans = vec![
-        ("✶ ".to_owned(), highlight),
-        (description.to_owned(), primary),
-    ];
-    TuiText::from_spans(spans).finish()
 }
 
 /// Bottom section of the overlay column: project context body (rules / skills / placeholder)


### PR DESCRIPTION
## Description

Uses one shared welcome presentation for the signed-out auth screen and the post-login first-run zero state.

This follow-up to #14666 updates the signed-out capability copy to match the merged first-run zero state and extracts the shared title, capability strings, glyph, and semantic styles into reusable helpers. Keeping both surfaces on the same rendering path prevents their onboarding copy and visual treatment from drifting again.

## Linked Issue

- APP-5137
- Follow-up to #14666

## Testing

- [x] `git diff --check`
- [ ] Formatting, Clippy, and compilation were not run per request; CI will provide full validation.
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/104cd22f-99f3-4bf5-81b8-dc186b72e070

CHANGELOG-NONE

Co-Authored-By: Warp Agent <agent@warp.dev>
