### PR TITLE
Navigate Agent Mode prompts with Cmd-Up

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -989,6 +989,11 @@ pub struct AIBlock {
     /// requested actions and requested commands are completed or cancelled.
     finish_reason: Option<FinishReason>,
 
+    /// `true` while agent-view Cmd-Up/Cmd-Down transcript navigation targets this block's user
+    /// query. Renders a navigation ring around the query row so the stop stays visibly
+    /// identifiable even when the viewport doesn't move.
+    is_agent_transcript_navigation_target: bool,
+
     directory_context: DirectoryContext,
     view_id: EntityId,
 
@@ -1506,6 +1511,7 @@ impl AIBlock {
             num_attached_context_blocks,
             has_attached_context_selected_text,
             finish_reason: None,
+            is_agent_transcript_navigation_target: false,
             directory_context: DirectoryContext { pwd, home_dir },
             view_id: ctx.view_id(),
             detected_links_state,
@@ -4478,6 +4484,23 @@ impl AIBlock {
             .inputs_to_render(app)
             .iter()
             .any(|input| input.display_query().is_some())
+    }
+
+    /// `true` while agent-view transcript navigation targets this block's user query.
+    pub fn is_agent_transcript_navigation_target(&self) -> bool {
+        self.is_agent_transcript_navigation_target
+    }
+
+    /// Flags or unflags this block as the transcript navigation target.
+    pub fn set_agent_transcript_navigation_target(
+        &mut self,
+        is_target: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.is_agent_transcript_navigation_target != is_target {
+            self.is_agent_transcript_navigation_target = is_target;
+            ctx.notify();
+        }
     }
 
     /// `true` if the AI block is "finished".

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1013,6 +1013,8 @@ impl View for AIBlock {
                             state: &self.find_state,
                         },
                     ),
+                    is_agent_transcript_navigation_target: self
+                        .is_agent_transcript_navigation_target(),
                 },
                 app,
             ) {

--- a/app/src/ai/blocklist/block/view_impl/query.rs
+++ b/app/src/ai/blocklist/block/view_impl/query.rs
@@ -3,11 +3,13 @@
 //! Queries are not rendered in blocks corresponding to requested command or requested action responses.
 
 use pathfinder_color::ColorU;
+use pathfinder_geometry::vector::vec2f;
 use warp_core::features::FeatureFlag;
+use warp_core::ui::color::Opacity;
 use warp_core::ui::theme::color::internal_colors;
 use warpui::elements::{
-    Container, CornerRadius, DispatchEventResult, EventHandler, Flex, MainAxisAlignment,
-    MainAxisSize, ParentElement, Radius, Shrinkable, Wrap,
+    Border, Container, CornerRadius, DispatchEventResult, DropShadow, EventHandler, Flex,
+    MainAxisAlignment, MainAxisSize, ParentElement, Radius, Shrinkable, Wrap,
 };
 use warpui::fonts::{Properties, Style, Weight};
 use warpui::ui_components::chip::Chip;
@@ -21,6 +23,16 @@ use crate::ai::blocklist::block::{AIBlockAction, DetectedLinksState, SecretRedac
 use crate::appearance::Appearance;
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
+
+/// Width of the accent ring drawn around the user avatar while agent-view transcript
+/// navigation targets this query.
+const NAVIGATION_RING_BORDER_WIDTH: f32 = 2.;
+/// Blur radius of the accent halo behind the navigation ring.
+const NAVIGATION_HALO_BLUR_RADIUS: f32 = 6.;
+/// How far the accent halo extends beyond the avatar.
+const NAVIGATION_HALO_SPREAD_RADIUS: f32 = 1.5;
+/// Opacity (in percent) of the accent halo.
+const NAVIGATION_HALO_OPACITY: Opacity = 60;
 
 /// Data required to render the AI block query component.
 #[derive(Copy, Clone, Debug)]
@@ -36,6 +48,7 @@ pub(super) struct Props<'a> {
     pub(super) is_ai_input_enabled: bool,
     pub(super) attachments: &'a [(AttachmentType, String)],
     pub(super) find_context: Option<FindContext<'a>>,
+    pub(super) is_agent_transcript_navigation_target: bool,
 }
 
 pub(super) fn maybe_render(props: Props, app: &AppContext) -> Option<Box<dyn Element>> {
@@ -53,6 +66,7 @@ pub(super) fn maybe_render(props: Props, app: &AppContext) -> Option<Box<dyn Ele
             props.is_ai_input_enabled,
             props.attachments,
             props.find_context,
+            props.is_agent_transcript_navigation_target,
             app,
         )
     })
@@ -72,16 +86,36 @@ pub(crate) fn render_query(
     is_ai_input_enabled: bool,
     attachments: &[(AttachmentType, String)],
     find_context: Option<FindContext>,
+    is_agent_transcript_navigation_target: bool,
     app: &AppContext,
 ) -> Box<dyn Element> {
-    let avatar = Container::new(render_user_avatar(
+    let mut avatar_container = Container::new(render_user_avatar(
         user_display_name,
         profile_image_path,
         avatar_color,
         app,
     ))
-    .with_margin_right(16.)
-    .finish();
+    .with_margin_right(16.);
+    if is_agent_transcript_navigation_target {
+        // Cmd-Up/Cmd-Down transcript navigation is stopped on this query: ring the avatar
+        // with the theme accent plus a soft accent halo so the stop is unmistakable even
+        // when the viewport doesn't move. The foreground border and the drop-shadow halo
+        // match the avatar's circular radius, reserve no layout space, and leave the query
+        // text and response untouched.
+        let accent = Appearance::as_ref(app).theme().accent();
+        avatar_container = avatar_container
+            .with_foreground_border(
+                Border::all(NAVIGATION_RING_BORDER_WIDTH).with_border_fill(accent),
+            )
+            .with_drop_shadow(DropShadow {
+                color: accent.with_opacity(NAVIGATION_HALO_OPACITY).into_solid(),
+                offset: vec2f(0., 0.),
+                blur_radius: NAVIGATION_HALO_BLUR_RADIUS,
+                spread_radius: NAVIGATION_HALO_SPREAD_RADIUS,
+            })
+            .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)));
+    }
+    let avatar = avatar_container.finish();
 
     let properties = Properties {
         style: Style::Normal,

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -46,7 +46,9 @@ use crate::terminal::model::ansi::{
     CursorShape, CursorStyle, LineClearMode, Mode, PrecmdValue, PreexecValue, Processor,
     PromptMetadata, StandardCharset, TabulationClearMode,
 };
-use crate::terminal::model::block::{AgentViewVisibility, Block, SerializedBlock, TranscriptScope};
+use crate::terminal::model::block::{
+    AgentViewVisibility, Block, InteractionMode, SerializedBlock, TranscriptScope,
+};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::model::bootstrap::BootstrapStage;
 use crate::terminal::model::grid::Dimensions;
@@ -82,6 +84,10 @@ pub struct RichContentItem {
     /// The conversation ID of the active agent view when this rich content was created, if any.
     pub agent_view_conversation_id: Option<AIConversationId>,
     pub should_hide: bool,
+    /// Whether this AI rich-content item is a navigable user-query/prompt segment for
+    /// agent-view Cmd-Up/Cmd-Down. Agent-reply / tool-result AI blocks mount as separate
+    /// `RichContentType::AIBlock` items and must leave this false.
+    pub is_agent_transcript_user_query: bool,
 }
 
 impl RichContentItem {
@@ -91,12 +97,29 @@ impl RichContentItem {
         agent_view_conversation_id: Option<AIConversationId>,
         should_hide: bool,
     ) -> Self {
+        Self::new_with_agent_transcript_user_query(
+            content_type,
+            view_id,
+            agent_view_conversation_id,
+            should_hide,
+            false,
+        )
+    }
+
+    pub fn new_with_agent_transcript_user_query(
+        content_type: Option<RichContentType>,
+        view_id: EntityId,
+        agent_view_conversation_id: Option<AIConversationId>,
+        should_hide: bool,
+        is_agent_transcript_user_query: bool,
+    ) -> Self {
         Self {
             content_type,
             view_id,
             last_laid_out_height: BlockHeight::from(1.0),
             agent_view_conversation_id,
             should_hide,
+            is_agent_transcript_user_query,
         }
     }
 
@@ -227,6 +250,18 @@ pub struct BlockScrollPosition {
 pub enum RemovableBlocklistItem {
     InlineBanner(InlineBannerId),
     RichContent(EntityId),
+}
+
+/// A chronologically ordered, keyboard-navigable item in an agent-view transcript.
+///
+/// Used by Cmd-Up / Cmd-Down to move across user prompts (AI blocks) and eligible
+/// user-executed shell blocks while skipping agent tool-call/result command blocks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum AgentTranscriptNavigableItem {
+    /// A mounted AI rich-content block (user query / agent exchange prompt).
+    AiBlock { view_id: EntityId },
+    /// A visible user-executed shell command block.
+    ShellBlock(BlockIndex),
 }
 
 pub struct BlockList {
@@ -2126,6 +2161,94 @@ impl BlockList {
         None
     }
 
+    /// Chronological navigable targets for Cmd-Up/Cmd-Down in the active agent view.
+    ///
+    /// Includes mounted AI blocks that represent user prompts/queries and eligible
+    /// user-executed shell command blocks. Skips agent-reply AI segments, tool-call
+    /// results mounted as AI blocks, agent-requested/monitored shell commands, hidden
+    /// items, gaps, banners, and other non-navigable rich content.
+    pub fn agent_transcript_navigable_items(&self) -> Vec<AgentTranscriptNavigableItem> {
+        let mut items = Vec::new();
+        // Match production block_heights traversal: seek left to the first item, then
+        // read `item`/`start` before advancing with `next`. Do not call `next` before the
+        // loop (that invalidates `start` and panics with "Must seek before calling...").
+        let mut cursor = self
+            .block_heights
+            .cursor::<TotalIndex, BlockHeightSummary>();
+        cursor.seek(&TotalIndex(0), SeekBias::Left);
+        while let Some(item) = cursor.item() {
+            match item {
+                BlockHeightItem::RichContent(rich_content)
+                    if !rich_content.should_hide
+                        && rich_content.last_laid_out_height > BlockHeight::zero()
+                        && rich_content
+                            .content_type
+                            .is_some_and(|content_type| content_type.is_ai_block())
+                        // Only user-query AI segments are stops. A single Agent Mode
+                        // tool-call exchange mounts multiple AIBlock rich-content items
+                        // (query + post-tool agent reply); the reply must not stop Cmd-Up.
+                        && rich_content.is_agent_transcript_user_query =>
+                {
+                    items.push(AgentTranscriptNavigableItem::AiBlock {
+                        view_id: rich_content.view_id,
+                    });
+                }
+                BlockHeightItem::Block(_) => {
+                    // `start().block_count` is the index of the current block item.
+                    let block_index = BlockIndex::from(cursor.start().block_count);
+                    if let Some(block) = self.block_at(block_index)
+                        && BlockFilter::commands().matches(block, &self.transcript_scope)
+                        // Agent run-shell / monitored commands use InteractionMode::Agent even
+                        // after unhide or without a requested_command_action_id.
+                        && matches!(block.interaction_mode(), InteractionMode::User(_))
+                    {
+                        items.push(AgentTranscriptNavigableItem::ShellBlock(block_index));
+                    }
+                }
+                BlockHeightItem::RichContent(_)
+                | BlockHeightItem::Gap(_)
+                | BlockHeightItem::RestoredBlockSeparator { .. }
+                | BlockHeightItem::InlineBanner { .. }
+                | BlockHeightItem::SubshellSeparator { .. } => {}
+            }
+            cursor.next();
+        }
+        items
+    }
+
+    /// Updates whether an AI rich-content item is a navigable user-query segment.
+    /// Used when streaming exchange inputs become renderable after initial mount.
+    pub fn set_agent_transcript_user_query_for_rich_content(
+        &mut self,
+        rich_content_view_id: EntityId,
+        is_agent_transcript_user_query: bool,
+    ) {
+        let Some(&index) = self
+            .removable_blocklist_item_positions
+            .get(&RemovableBlocklistItem::RichContent(rich_content_view_id))
+        else {
+            return;
+        };
+
+        self.block_heights = {
+            let mut cursor = self.block_heights.cursor::<TotalIndex, ()>();
+            let mut new_tree = cursor.slice(&index, SeekBias::Right);
+
+            if let Some(BlockHeightItem::RichContent(item)) = cursor.item() {
+                new_tree.push(BlockHeightItem::RichContent(RichContentItem {
+                    is_agent_transcript_user_query,
+                    ..*item
+                }));
+                cursor.next();
+            }
+
+            new_tree.push_tree(cursor.suffix());
+            new_tree
+        };
+
+        self.event_proxy.send_wakeup_event();
+    }
+
     /// Return the height of the last non hidden rich content block after a block index. If there is no non hidden rich content block, return None.
     pub fn last_non_hidden_rich_content_block_after_block(
         &self,
@@ -2265,32 +2388,21 @@ impl BlockList {
                             is_hidden: transcript_scope.is_conversation(),
                         });
                     }
-                    BlockHeightItem::RichContent(RichContentItem {
-                        content_type,
-                        view_id,
-                        agent_view_conversation_id,
-                        last_laid_out_height,
-                        ..
-                    }) => {
+                    BlockHeightItem::RichContent(item) => {
                         let should_hide = RichContentItem {
-                            content_type: *content_type,
-                            view_id: *view_id,
-                            last_laid_out_height: *last_laid_out_height,
-                            agent_view_conversation_id: *agent_view_conversation_id,
                             should_hide: false,
+                            ..*item
                         }
                         .should_hide_for_transcript_scope(transcript_scope);
                         let updated_height = rich_content_heights
-                            .and_then(|heights| heights.get(view_id))
+                            .and_then(|heights| heights.get(&item.view_id))
                             .copied()
-                            .unwrap_or(*last_laid_out_height);
+                            .unwrap_or(item.last_laid_out_height);
 
                         new_sum_tree.push(BlockHeightItem::RichContent(RichContentItem {
-                            content_type: *content_type,
-                            view_id: *view_id,
                             last_laid_out_height: updated_height,
-                            agent_view_conversation_id: *agent_view_conversation_id,
                             should_hide,
+                            ..*item
                         }));
                     }
                     BlockHeightItem::RestoredBlockSeparator {

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -2435,3 +2435,122 @@ fn test_device_status_uses_active_block_if_no_typeahead() {
 
     assert_eq!(writer, "\x1b[1;21R".as_bytes());
 }
+
+#[test]
+fn agent_transcript_navigable_items_include_prompts_and_user_shell_blocks() {
+    let _agent_view_flag = FeatureFlag::AgentView.override_enabled(true);
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+    let conversation_id = AIConversationId::new();
+    block_list.enter_conversation_context(conversation_id, false, false);
+
+    // User-query AI segment (navigable).
+    let prompt_1 = EntityId::new();
+    let mut prompt_1_item = RichContentItem::new_with_agent_transcript_user_query(
+        Some(RichContentType::AIBlock),
+        prompt_1,
+        Some(conversation_id),
+        false,
+        true,
+    );
+    prompt_1_item.last_laid_out_height = BlockHeight::from(2.0);
+    block_list.append_rich_content(prompt_1_item, false);
+
+    // Real agent-requested run-shell shape: hidden initially, then unhidden after execution
+    // via set_visibility_of_block_for_ai_action (production unhide path).
+    let tool_action_id: AIAgentActionId = "tool-action".to_owned().into();
+    let tool_block_index = insert_block(&mut block_list, "tool-call", "tool-result");
+    {
+        let block = &mut block_list.blocks_mut()[tool_block_index.0];
+        block.set_conversation_id(conversation_id);
+        block.set_agent_interaction_mode(AgentInteractionMetadata::new_hidden(
+            tool_action_id.clone(),
+            conversation_id,
+        ));
+    }
+    block_list.set_visibility_of_block_for_ai_action(&tool_action_id, true);
+
+    // Post-tool-call agent-reply AI segment mounted as a separate AIBlock (not navigable).
+    // Production Agent Mode with run-shell mounts query + reply as two AI rich-content items.
+    let agent_reply = EntityId::new();
+    let mut agent_reply_item = RichContentItem::new_with_agent_transcript_user_query(
+        Some(RichContentType::AIBlock),
+        agent_reply,
+        Some(conversation_id),
+        false,
+        false,
+    );
+    agent_reply_item.last_laid_out_height = BlockHeight::from(3.0);
+    block_list.append_rich_content(agent_reply_item, false);
+
+    // Agent-monitored long-running shape: InteractionMode::Agent without requested_command_action_id.
+    let monitored_block_index = insert_block(&mut block_list, "agent-monitored", "still running");
+    {
+        let block = &mut block_list.blocks_mut()[monitored_block_index.0];
+        block.set_conversation_id(conversation_id);
+        block.set_agent_interaction_mode(AgentInteractionMetadata::new(
+            None,
+            conversation_id,
+            None,
+            None,
+            false,
+            false,
+        ));
+    }
+
+    // User-executed shell command in the agent conversation (InteractionMode::User).
+    let user_shell_index = insert_block(&mut block_list, "user-shell", "shell-output");
+    {
+        let block = &mut block_list.blocks_mut()[user_shell_index.0];
+        block.set_conversation_id(conversation_id);
+    }
+
+    let prompt_2 = EntityId::new();
+    let mut prompt_2_item = RichContentItem::new_with_agent_transcript_user_query(
+        Some(RichContentType::AIBlock),
+        prompt_2,
+        Some(conversation_id),
+        false,
+        true,
+    );
+    prompt_2_item.last_laid_out_height = BlockHeight::from(2.0);
+    block_list.append_rich_content(prompt_2_item, false);
+
+    // Another agent-reply segment after prompt 2 must also be skipped.
+    let agent_reply_2 = EntityId::new();
+    let mut agent_reply_2_item = RichContentItem::new_with_agent_transcript_user_query(
+        Some(RichContentType::AIBlock),
+        agent_reply_2,
+        Some(conversation_id),
+        false,
+        false,
+    );
+    agent_reply_2_item.last_laid_out_height = BlockHeight::from(2.0);
+    block_list.append_rich_content(agent_reply_2_item, false);
+
+    block_list.set_transcript_scope(TranscriptScope::Conversation(conversation_id));
+
+    let items = block_list.agent_transcript_navigable_items();
+    assert!(
+        !items.iter().any(|item| {
+            matches!(
+                item,
+                AgentTranscriptNavigableItem::ShellBlock(idx)
+                    if *idx == tool_block_index || *idx == monitored_block_index
+            ) || matches!(
+                item,
+                AgentTranscriptNavigableItem::AiBlock { view_id }
+                    if *view_id == agent_reply || *view_id == agent_reply_2
+            )
+        }),
+        "agent-driven shell/reply blocks must not be navigable: {items:?}"
+    );
+    assert_eq!(
+        items,
+        vec![
+            AgentTranscriptNavigableItem::AiBlock { view_id: prompt_1 },
+            AgentTranscriptNavigableItem::ShellBlock(user_shell_index),
+            AgentTranscriptNavigableItem::AiBlock { view_id: prompt_2 },
+        ]
+    );
+}

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20004,23 +20004,27 @@ impl TerminalView {
                 },
                 None => navigable_items.last().copied(),
             },
-            AgentTranscriptNavigationDirection::Next => match current {
-                Some(current) => {
-                    let next = navigable_items
-                        .iter()
-                        .position(|item| *item == current)
-                        .and_then(|index| navigable_items.get(index + 1).copied());
-                    if next.is_none() {
-                        self.scroll_to_end_of_blocklist_if_not_at_end(ctx);
-                        self.clear_selected_blocks(ctx);
-                        ctx.focus(&self.input);
-                        ctx.notify();
-                        return;
-                    }
-                    next
+            AgentTranscriptNavigationDirection::Next => {
+                // Without a cursor the user is already past the newest stop, so there is
+                // nothing more recent to move to: do nothing, matching ordinary block
+                // navigation. Selecting the newest stop here would make repeated Cmd-Down
+                // presses oscillate between selecting and clearing it.
+                let Some(current) = current else {
+                    return;
+                };
+                let next = navigable_items
+                    .iter()
+                    .position(|item| *item == current)
+                    .and_then(|index| navigable_items.get(index + 1).copied());
+                if next.is_none() {
+                    self.scroll_to_end_of_blocklist_if_not_at_end(ctx);
+                    self.clear_selected_blocks(ctx);
+                    ctx.focus(&self.input);
+                    ctx.notify();
+                    return;
                 }
-                None => navigable_items.last().copied(),
-            },
+                next
+            }
         };
 
         let Some(target) = target else {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -431,8 +431,8 @@ use crate::terminal::model::block::{
 };
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::model::blocks::{
-    BlockHeight, BlockHeightItem, BlockHeightSummary, BlockList, BlockListPoint, Gap,
-    RemovableBlocklistItem,
+    AgentTranscriptNavigableItem, BlockHeight, BlockHeightItem, BlockHeightSummary, BlockList,
+    BlockListPoint, Gap, RemovableBlocklistItem,
 };
 use crate::terminal::model::escape_sequences::{
     self, C1, EscCodes, ToEscapeSequence, alt_screen_scroll_to_pty_bytes,
@@ -500,7 +500,7 @@ use crate::terminal::{
     AudibleBell, BlockListSettings, BlockListSettingsChangedEvent, CellSizeAndWindowPadding,
     History, HistoryEntry, ShellHost, ShellLaunchData, SizeInfo, SizeUpdate, SizeUpdateReason,
     color, element_size_at_last_frame, height_in_range_approx, heights_approx_eq,
-    heights_approx_gt, prompt,
+    heights_approx_gt, heights_approx_gte, prompt,
 };
 use crate::terminal::{
     TerminalModel,
@@ -2431,6 +2431,12 @@ pub(in crate::terminal::view) enum PendingUserQueryKind {
     CloudMode,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AgentTranscriptNavigationDirection {
+    Previous,
+    Next,
+}
+
 #[derive(Debug, Clone)]
 pub struct TerminalDropTargetData {
     pub terminal_view: WeakViewHandle<TerminalView>,
@@ -2503,6 +2509,14 @@ pub struct TerminalView {
     hovered_block_index: Option<BlockIndex>,
 
     selected_blocks: SelectedBlocks,
+
+    /// Focused navigable transcript item in the active agent view (prompt or user shell block).
+    agent_transcript_selection: Option<AgentTranscriptNavigableItem>,
+
+    /// The AI block currently flagged as the transcript navigation target (i.e. rendering the
+    /// user-query navigation ring). Tracked so the flag can be cheaply cleared or moved when the
+    /// navigation cursor changes.
+    agent_transcript_marked_ai_block: Option<EntityId>,
 
     // Whether any session contains blocks from a remote session. Cached to improve performance.
     // Blocks don't necessarily need to be finished for this to be true (e.g. it's true for
@@ -3257,6 +3271,11 @@ impl TerminalView {
                 } => {
                     // Prompt suggestions should not follow the user back to terminal view.
                     me.clear_prompt_suggestions(ctx);
+                    // The transcript navigation cursor is agent-view-scoped; drop it so its
+                    // visual feedback doesn't linger into the terminal view or a re-entered
+                    // agent view.
+                    me.agent_transcript_selection = None;
+                    me.sync_agent_transcript_navigation_target(ctx);
                     // For ambient agent sessions, pop the pane stack to return to the parent terminal.
                     // Skip the pop when this exit is immediately followed by re-entering agent view
                     // for a different conversation (e.g. a restored conversation taking over the
@@ -4275,6 +4294,8 @@ impl TerminalView {
             open_secret_tool_tip: None,
             hovered_block_index: None,
             selected_blocks: Default::default(),
+            agent_transcript_selection: None,
+            agent_transcript_marked_ai_block: None,
             block_list_mouse_states,
             any_session_contains_remote_blocks: false,
             any_session_contains_restored_remote_blocks: false,
@@ -6335,6 +6356,19 @@ impl TerminalView {
                     &ai_block_model,
                     ctx,
                 );
+                // Streaming exchanges can gain a displayable user query after mount (e.g.
+                // cloud-mode queued prompts). Keep the navigable-user-query flag in sync so
+                // Cmd-Up treats the segment as a stop once the query is renderable.
+                if let Some(ai_block) = self.ai_block_for_exchange(exchange_id).cloned() {
+                    let is_user_query = ai_block.as_ref(ctx).has_user_input(ctx);
+                    self.model
+                        .lock()
+                        .block_list_mut()
+                        .set_agent_transcript_user_query_for_rich_content(
+                            ai_block.id(),
+                            is_user_query,
+                        );
+                }
                 self.update_context_blocks_and_exchanges(ctx);
             }
             BlocklistAIHistoryEvent::SetActiveConversation { .. } => {
@@ -19724,6 +19758,11 @@ impl TerminalView {
             self.close_context_menu(ctx, true);
         }
 
+        if !is_shift_down && self.should_use_agent_transcript_navigation(ctx) {
+            self.navigate_agent_transcript(AgentTranscriptNavigationDirection::Previous, ctx);
+            return;
+        }
+
         if let Some(selected_block_index) = self.selected_blocks.tail() {
             let new_block_index = self
                 .model
@@ -19778,6 +19817,12 @@ impl TerminalView {
         if self.is_context_menu_open() {
             self.close_context_menu(ctx, true);
         }
+
+        if !is_shift_down && self.should_use_agent_transcript_navigation(ctx) {
+            self.navigate_agent_transcript(AgentTranscriptNavigationDirection::Next, ctx);
+            return;
+        }
+
         let input_mode = *InputModeSettings::as_ref(ctx).input_mode.value();
         let is_inverted_blocklist = input_mode.is_inverted_blocklist();
         let is_most_recent_block_visible = {
@@ -19901,6 +19946,9 @@ impl TerminalView {
         block_index: BlockIndex,
         ctx: &mut ViewContext<Self>,
     ) {
+        self.agent_transcript_selection =
+            Some(AgentTranscriptNavigableItem::ShellBlock(block_index));
+        self.sync_agent_transcript_navigation_target(ctx);
         self.change_block_selections(
             |selected_blocks| {
                 selected_blocks.reset_to_single(block_index);
@@ -19911,6 +19959,8 @@ impl TerminalView {
     }
 
     fn clear_selected_blocks(&mut self, ctx: &mut ViewContext<Self>) {
+        self.agent_transcript_selection = None;
+        self.sync_agent_transcript_navigation_target(ctx);
         self.change_block_selections(
             |selected_blocks| {
                 selected_blocks.reset();
@@ -19918,6 +19968,183 @@ impl TerminalView {
             ctx,
         );
         ctx.notify();
+    }
+
+    fn should_use_agent_transcript_navigation(&self, ctx: &AppContext) -> bool {
+        FeatureFlag::AgentView.is_enabled() && self.agent_view_controller.as_ref(ctx).is_active()
+    }
+
+    fn navigate_agent_transcript(
+        &mut self,
+        direction: AgentTranscriptNavigationDirection,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let navigable_items = {
+            let model = self.model.lock();
+            model.block_list().agent_transcript_navigable_items()
+        };
+        if navigable_items.is_empty() {
+            return;
+        }
+
+        let current = self.agent_transcript_selection.or_else(|| {
+            self.selected_blocks
+                .tail()
+                .map(AgentTranscriptNavigableItem::ShellBlock)
+        });
+
+        let target = match direction {
+            AgentTranscriptNavigationDirection::Previous => match current {
+                Some(current) => match navigable_items.iter().position(|item| *item == current) {
+                    // Stay on the oldest item, matching ordinary block navigation.
+                    Some(0) => Some(current),
+                    Some(index) => Some(navigable_items[index - 1]),
+                    // Absent/stale cursor: start from the newest navigable item.
+                    None => navigable_items.last().copied(),
+                },
+                None => navigable_items.last().copied(),
+            },
+            AgentTranscriptNavigationDirection::Next => match current {
+                Some(current) => {
+                    let next = navigable_items
+                        .iter()
+                        .position(|item| *item == current)
+                        .and_then(|index| navigable_items.get(index + 1).copied());
+                    if next.is_none() {
+                        self.scroll_to_end_of_blocklist_if_not_at_end(ctx);
+                        self.clear_selected_blocks(ctx);
+                        ctx.focus(&self.input);
+                        ctx.notify();
+                        return;
+                    }
+                    next
+                }
+                None => navigable_items.last().copied(),
+            },
+        };
+
+        let Some(target) = target else {
+            return;
+        };
+        self.apply_agent_transcript_selection(target, direction, ctx);
+    }
+
+    fn apply_agent_transcript_selection(
+        &mut self,
+        target: AgentTranscriptNavigableItem,
+        direction: AgentTranscriptNavigationDirection,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.agent_transcript_selection = Some(target);
+        match target {
+            AgentTranscriptNavigableItem::ShellBlock(block_index) => {
+                self.reset_selection_to_single_block(block_index, ctx);
+                self.scroll_to_if_not_visible(block_index, ctx);
+            }
+            AgentTranscriptNavigableItem::AiBlock { view_id } => {
+                self.change_block_selections(
+                    |selected_blocks| {
+                        selected_blocks.reset();
+                    },
+                    ctx,
+                );
+                self.scroll_to_rich_content_view(view_id, ctx);
+            }
+        }
+        self.sync_agent_transcript_navigation_target(ctx);
+
+        let (delta, is_cmd_down) = match direction {
+            AgentTranscriptNavigationDirection::Previous => (BlockSelectionDelta::Previous, false),
+            AgentTranscriptNavigationDirection::Next => (BlockSelectionDelta::Next, true),
+        };
+        send_telemetry_from_ctx!(
+            TelemetryEvent::BlockSelection(BlockSelectionDetails {
+                cardinality: self.selected_blocks.cardinality(),
+                delta,
+                is_cmd_down,
+                is_shift_down: false,
+            }),
+            ctx
+        );
+
+        self.tips_completed.update(ctx, |tips, ctx| {
+            mark_feature_used_and_write_to_user_defaults(
+                Tip::Hint(TipHint::BlockSelect),
+                tips,
+                ctx,
+            );
+            ctx.notify();
+        });
+        ctx.notify();
+    }
+
+    /// Cmd-Down past the newest navigable transcript item should land the user on the true end
+    /// of the blocklist (latest content), not wherever the last stop left the viewport.
+    fn scroll_to_end_of_blocklist_if_not_at_end(&mut self, ctx: &mut ViewContext<Self>) {
+        let is_at_end = {
+            let input_mode = *InputModeSettings::as_ref(ctx).input_mode.value();
+            let model = self.model.lock();
+            let viewport = self.viewport_state(model.block_list(), input_mode, ctx);
+            heights_approx_gte(
+                viewport.scroll_top_in_lines(),
+                viewport.max_scroll_top_in_lines(),
+            )
+        };
+        if !is_at_end {
+            self.update_scroll_position_locking(ScrollPositionUpdate::AfterEnd, ctx);
+        }
+    }
+
+    /// The AI rich-content view currently targeted by agent-view transcript navigation.
+    /// `None` outside an active agent view or when the cursor is on a shell block.
+    fn agent_transcript_navigated_ai_block(&self, app: &AppContext) -> Option<EntityId> {
+        if !self.should_use_agent_transcript_navigation(app) {
+            return None;
+        }
+        match self.agent_transcript_selection {
+            Some(AgentTranscriptNavigableItem::AiBlock { view_id }) => Some(view_id),
+            _ => None,
+        }
+    }
+
+    /// Propagates the transcript navigation cursor to the targeted [`AIBlock`], which renders a
+    /// navigation ring around its user-query row. Clears the flag from the previously targeted
+    /// block when the cursor moves or resets.
+    fn sync_agent_transcript_navigation_target(&mut self, ctx: &mut ViewContext<Self>) {
+        let target = self.agent_transcript_navigated_ai_block(ctx);
+        if target == self.agent_transcript_marked_ai_block {
+            return;
+        }
+        for rich_content in self.rich_content_views.iter() {
+            let Some(ai_metadata) = rich_content.ai_block_metadata() else {
+                continue;
+            };
+            let handle = &ai_metadata.ai_block_handle;
+            let should_mark = Some(handle.id()) == target;
+            let was_marked = Some(handle.id()) == self.agent_transcript_marked_ai_block;
+            if should_mark != was_marked {
+                handle.update(ctx, |ai_block, ctx| {
+                    ai_block.set_agent_transcript_navigation_target(should_mark, ctx);
+                });
+            }
+        }
+        self.agent_transcript_marked_ai_block = target;
+    }
+
+    fn scroll_to_rich_content_view(&mut self, view_id: EntityId, ctx: &mut ViewContext<Self>) {
+        let Some(index) = self
+            .model
+            .lock()
+            .block_list()
+            .removable_blocklist_item_position(&RemovableBlocklistItem::RichContent(view_id))
+            .copied()
+        else {
+            return;
+        };
+        self.update_scroll_position_locking(
+            ScrollPositionUpdate::ScrollToTopOfRichContent { index },
+            ctx,
+        );
     }
 
     /// Clears selected text across all types of blocks and handles side effects (i.e. Agent Mode
@@ -22663,6 +22890,11 @@ impl TerminalView {
     #[cfg(any(test, feature = "integration_tests"))]
     pub fn selected_blocks_tail_index(&self) -> Option<BlockIndex> {
         self.selected_blocks.tail()
+    }
+
+    #[cfg(any(test, feature = "integration_tests"))]
+    pub fn agent_transcript_selection_for_test(&self) -> Option<AgentTranscriptNavigableItem> {
+        self.agent_transcript_selection
     }
 
     #[cfg(any(test, feature = "integration_tests"))]

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -1029,7 +1029,9 @@ impl TerminalView {
         });
 
         // Insert into block list if command_block_index is provided
-        let item = RichContentItem::new(
+        let is_agent_transcript_user_query =
+            restored_block_view_handle.as_ref(ctx).has_user_input(ctx);
+        let item = RichContentItem::new_with_agent_transcript_user_query(
             Some(RichContentType::AIBlock),
             restored_block_view_handle.id(),
             FeatureFlag::AgentView
@@ -1042,6 +1044,7 @@ impl TerminalView {
                     .agent_view_state()
                     .active_conversation_id()
                     .is_some_and(|id| id == conversation_id),
+            is_agent_transcript_user_query,
         );
         if let Some(cmd_block_index) = command_block_index {
             self.model

--- a/app/src/terminal/view/rich_content.rs
+++ b/app/src/terminal/view/rich_content.rs
@@ -319,11 +319,18 @@ impl TerminalView {
                 false,
             )
         };
-        let item = RichContentItem::new(
+        let is_agent_transcript_user_query = match &metadata {
+            Some(RichContentMetadata::AIBlock(AIBlockMetadata {
+                ai_block_handle, ..
+            })) => ai_block_handle.as_ref(ctx).has_user_input(ctx),
+            _ => false,
+        };
+        let item = RichContentItem::new_with_agent_transcript_user_query(
             content_type,
             handle.id(),
             agent_view_conversation_id,
             should_hide,
+            is_agent_transcript_user_query,
         );
 
         match position {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -488,6 +488,52 @@ fn cmd_down_past_newest_preserves_viewport_when_already_at_end() {
 }
 
 #[test]
+fn cmd_down_without_navigation_cursor_is_a_no_op() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_agent_view_for_navigation(view, ctx);
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![agent_view_user_query_input("prompt 1")],
+                ctx,
+            );
+            simulate_user_shell_block_in_conversation(view, conversation_id, "user-shell");
+
+            // At the end of the transcript with no navigation cursor there is nothing to
+            // move toward, so Cmd-Down must leave the cursor, the selection, the ring and
+            // the viewport untouched.
+            let scroll_position = view.scroll_position();
+            view.select_more_recent_block(
+                true,  /* is_cmd_down */
+                false, /* is_shift_down */
+                ctx,
+            );
+            assert_eq!(view.agent_transcript_selection_for_test(), None);
+            assert_eq!(view.selected_blocks.tail(), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+            assert_eq!(view.scroll_position(), scroll_position);
+
+            // Cmd-Up takes the newest stop and Cmd-Down past it clears the cursor; a
+            // further Cmd-Down must not re-select that stop (no oscillation).
+            view.select_less_recent_block(false /* is_shift_down */, ctx);
+            assert!(view.agent_transcript_selection_for_test().is_some());
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(view.agent_transcript_selection_for_test(), None);
+
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(view.agent_transcript_selection_for_test(), None);
+            assert_eq!(view.selected_blocks.tail(), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+        });
+    })
+}
+
+#[test]
 fn agent_transcript_navigation_marks_target_user_query() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -137,6 +137,21 @@ fn owned_resumable_oz_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
     }
 }
 
+/// The AI blocks currently flagged to render the transcript-navigation ring.
+fn navigation_ring_targets(view: &TerminalView, app: &AppContext) -> Vec<EntityId> {
+    view.rich_content_views
+        .iter()
+        .filter_map(|rich_content| {
+            let ai_metadata = rich_content.ai_block_metadata()?;
+            ai_metadata
+                .ai_block_handle
+                .as_ref(app)
+                .is_agent_transcript_navigation_target()
+                .then(|| ai_metadata.ai_block_handle.id())
+        })
+        .collect()
+}
+
 fn has_pending_user_query_block(view: &TerminalView) -> bool {
     let Some(view_id) = view.pending_user_query_view_id else {
         return false;
@@ -190,6 +205,438 @@ fn agent_view_lifecycle_updates_input_mode() {
             );
         });
     });
+}
+
+#[test]
+fn cmd_up_in_agent_view_navigates_prompts_and_user_shell_blocks() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        let (prompt_view_ids, user_shell_index) = terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_agent_view_for_navigation(view, ctx);
+
+            // prompt 1 (user-query AI block — navigable)
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![agent_view_user_query_input("prompt 1")],
+                ctx,
+            );
+
+            // Agent-requested run-shell (unhidden) and agent-monitored command: not navigable.
+            {
+                let mut model = view.model.lock();
+                model.simulate_block("tool-call", "tool-result");
+                let tool_index = model.block_list().blocks().len() - 2;
+                let action_id = AIAgentActionId::from("tool-action".to_owned());
+                {
+                    let block = &mut model.block_list_mut().blocks_mut()[tool_index];
+                    block.set_conversation_id(conversation_id);
+                    block.set_agent_interaction_mode(
+                        crate::terminal::model::block::AgentInteractionMetadata::new_hidden(
+                            action_id.clone(),
+                            conversation_id,
+                        ),
+                    );
+                }
+                model
+                    .block_list_mut()
+                    .set_visibility_of_block_for_ai_action(&action_id, true);
+
+                model.simulate_block("agent-monitored", "output");
+                let monitored_index = model.block_list().blocks().len() - 2;
+                let block = &mut model.block_list_mut().blocks_mut()[monitored_index];
+                block.set_conversation_id(conversation_id);
+                block.set_agent_interaction_mode(
+                    crate::terminal::model::block::AgentInteractionMetadata::new(
+                        None,
+                        conversation_id,
+                        None,
+                        None,
+                        false,
+                        false,
+                    ),
+                );
+            }
+
+            // Post-tool-call agent-reply AI segment: production mounts this as a second
+            // AIBlock after run-shell. ResumeConversation has no displayable user query,
+            // so has_user_input is false and Cmd-Up must skip it.
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![AIAgentInput::ResumeConversation {
+                    context: Default::default(),
+                }],
+                ctx,
+            );
+
+            // user-executed shell command (navigable)
+            let user_shell_index =
+                simulate_user_shell_block_in_conversation(view, conversation_id, "user-shell");
+
+            // prompt 2 (user-query AI block — navigable)
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![agent_view_user_query_input("prompt 2")],
+                ctx,
+            );
+
+            // Collect AI rich-content blocks and classify via production navigable list.
+            let ai_view_ids: Vec<_> = view
+                .rich_content_views
+                .iter()
+                .filter_map(|rc| rc.ai_block_metadata().map(|meta| meta.ai_block_handle.id()))
+                .collect();
+            assert!(
+                ai_view_ids.len() >= 3,
+                "expected query + agent-reply + query AI blocks, got {}",
+                ai_view_ids.len()
+            );
+
+            let navigable = view
+                .model
+                .lock()
+                .block_list()
+                .agent_transcript_navigable_items();
+            let navigable_ai: Vec<_> = navigable
+                .iter()
+                .filter_map(|item| match item {
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::AiBlock {
+                        view_id,
+                    } => Some(*view_id),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                navigable_ai.len(),
+                2,
+                "only user-query AI segments should be navigable, got {navigable:?}"
+            );
+            // Agent-reply segment must not appear in navigable AI stops.
+            for ai_id in &ai_view_ids {
+                if !navigable_ai.contains(ai_id) {
+                    // Non-navigable AI block present — good (the post-tool reply).
+                    continue;
+                }
+            }
+            assert!(
+                ai_view_ids.iter().any(|id| !navigable_ai.contains(id)),
+                "expected at least one non-navigable agent-reply AI block among {ai_view_ids:?}"
+            );
+
+            (navigable_ai, user_shell_index)
+        });
+
+        let prompt_1 = *prompt_view_ids.first().expect("prompt 1");
+        let prompt_2 = *prompt_view_ids.last().expect("prompt 2");
+
+        terminal.update(&mut app, |view, ctx| {
+            // From the bottom: first Cmd-Up lands on latest prompt.
+            view.select_less_recent_block(false /* is_shift_down */, ctx);
+            assert_eq!(
+                view.agent_transcript_selection_for_test(),
+                Some(
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::AiBlock {
+                        view_id: prompt_2
+                    }
+                )
+            );
+            assert_eq!(view.selected_blocks.tail(), None);
+
+            // Next Cmd-Up lands on the user shell command.
+            view.select_less_recent_block(false, ctx);
+            assert_eq!(
+                view.agent_transcript_selection_for_test(),
+                Some(
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::ShellBlock(
+                        user_shell_index
+                    )
+                )
+            );
+            assert_eq!(view.selected_blocks.tail(), Some(user_shell_index));
+
+            // Next Cmd-Up lands on the first prompt, skipping the tool call.
+            view.select_less_recent_block(false, ctx);
+            assert_eq!(
+                view.agent_transcript_selection_for_test(),
+                Some(
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::AiBlock {
+                        view_id: prompt_1
+                    }
+                )
+            );
+            assert_eq!(view.selected_blocks.tail(), None);
+
+            // Another Cmd-Up at the oldest item stays put.
+            view.select_less_recent_block(false, ctx);
+            assert_eq!(
+                view.agent_transcript_selection_for_test(),
+                Some(
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::AiBlock {
+                        view_id: prompt_1
+                    }
+                )
+            );
+            assert_eq!(view.selected_blocks.tail(), None);
+
+            // Cmd-Down symmetry walks back toward the latest prompt.
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(
+                view.agent_transcript_selection_for_test(),
+                Some(
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::ShellBlock(
+                        user_shell_index
+                    )
+                )
+            );
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(
+                view.agent_transcript_selection_for_test(),
+                Some(
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::AiBlock {
+                        view_id: prompt_2
+                    }
+                )
+            );
+        });
+    })
+}
+
+#[test]
+fn cmd_down_past_newest_transcript_item_scrolls_to_end() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_agent_view_for_navigation(view, ctx);
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![agent_view_user_query_input("prompt 1")],
+                ctx,
+            );
+            // Enough conversation blocks that the transcript is taller than the viewport.
+            for _ in 0..100 {
+                simulate_user_shell_block_in_conversation(view, conversation_id, "user-shell");
+            }
+            assert!(view.is_vertically_scrollable(ctx));
+
+            // Select the newest navigable stop, then scroll the viewport to the top.
+            view.select_less_recent_block(false /* is_shift_down */, ctx);
+            assert!(view.agent_transcript_selection_for_test().is_some());
+            view.update_scroll_position_locking(ScrollPositionUpdate::AfterHome, ctx);
+            assert!(matches!(
+                view.scroll_position(),
+                ScrollPosition::FixedAtPosition { .. }
+            ));
+
+            // Cmd-Down past the newest stop must land the viewport on the true end of
+            // the blocklist and clear the navigation selection.
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(
+                view.scroll_position(),
+                ScrollPosition::FollowsBottomOfMostRecentBlock
+            );
+            assert_eq!(view.agent_transcript_selection_for_test(), None);
+            assert_eq!(view.selected_blocks.tail(), None);
+        });
+    })
+}
+
+#[test]
+fn cmd_down_past_newest_preserves_viewport_when_already_at_end() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_agent_view_for_navigation(view, ctx);
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![agent_view_user_query_input("prompt 1")],
+                ctx,
+            );
+            simulate_user_shell_block_in_conversation(view, conversation_id, "user-shell");
+            assert!(!view.is_vertically_scrollable(ctx));
+
+            view.select_less_recent_block(false /* is_shift_down */, ctx);
+            assert!(view.agent_transcript_selection_for_test().is_some());
+            view.update_scroll_position_locking(ScrollPositionUpdate::AfterHome, ctx);
+            assert!(matches!(
+                view.scroll_position(),
+                ScrollPosition::FixedAtPosition { .. }
+            ));
+
+            // The whole transcript fits in the viewport, so it is already at the end:
+            // Cmd-Down past the newest stop must not touch the scroll position.
+            view.select_more_recent_block(true, false, ctx);
+            assert!(matches!(
+                view.scroll_position(),
+                ScrollPosition::FixedAtPosition { .. }
+            ));
+            assert_eq!(view.agent_transcript_selection_for_test(), None);
+        });
+    })
+}
+
+#[test]
+fn agent_transcript_navigation_marks_target_user_query() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        let (prompt_view_ids, user_shell_index) = terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_agent_view_for_navigation(view, ctx);
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![agent_view_user_query_input("prompt 1")],
+                ctx,
+            );
+            let user_shell_index =
+                simulate_user_shell_block_in_conversation(view, conversation_id, "user-shell");
+            append_inputs_to_conversation_and_handle_event(
+                view,
+                conversation_id,
+                vec![agent_view_user_query_input("prompt 2")],
+                ctx,
+            );
+
+            let navigable = view
+                .model
+                .lock()
+                .block_list()
+                .agent_transcript_navigable_items();
+            let navigable_ai: Vec<_> = navigable
+                .iter()
+                .filter_map(|item| match item {
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::AiBlock {
+                        view_id,
+                    } => Some(*view_id),
+                    crate::terminal::model::blocks::AgentTranscriptNavigableItem::ShellBlock(_) => {
+                        None
+                    }
+                })
+                .collect();
+            assert_eq!(navigable_ai.len(), 2);
+            (navigable_ai, user_shell_index)
+        });
+
+        let prompt_1 = *prompt_view_ids.first().expect("prompt 1");
+        let prompt_2 = *prompt_view_ids.last().expect("prompt 2");
+
+        terminal.update(&mut app, |view, ctx| {
+            // No navigation yet: nothing is marked.
+            assert_eq!(view.agent_transcript_navigated_ai_block(ctx), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+
+            // Every stop on a user query marks exactly that query.
+            view.select_less_recent_block(false /* is_shift_down */, ctx);
+            assert_eq!(
+                view.agent_transcript_navigated_ai_block(ctx),
+                Some(prompt_2)
+            );
+            assert_eq!(navigation_ring_targets(view, ctx), vec![prompt_2]);
+
+            // Stopping on a shell block moves the mark off the query.
+            view.select_less_recent_block(false, ctx);
+            assert_eq!(view.agent_transcript_navigated_ai_block(ctx), None);
+            assert_eq!(view.selected_blocks.tail(), Some(user_shell_index));
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+
+            // The mark follows the cursor to the other query.
+            view.select_less_recent_block(false, ctx);
+            assert_eq!(
+                view.agent_transcript_navigated_ai_block(ctx),
+                Some(prompt_1)
+            );
+            assert_eq!(navigation_ring_targets(view, ctx), vec![prompt_1]);
+
+            // Clamped at the oldest stop: the target stays identifiable even though
+            // neither the cursor nor the viewport moves.
+            view.select_less_recent_block(false, ctx);
+            assert_eq!(
+                view.agent_transcript_navigated_ai_block(ctx),
+                Some(prompt_1)
+            );
+            assert_eq!(navigation_ring_targets(view, ctx), vec![prompt_1]);
+
+            // Cmd-Down back through the stops, then past the newest one, which clears
+            // the mark together with the navigation selection.
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(view.agent_transcript_navigated_ai_block(ctx), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(
+                view.agent_transcript_navigated_ai_block(ctx),
+                Some(prompt_2)
+            );
+            assert_eq!(navigation_ring_targets(view, ctx), vec![prompt_2]);
+            view.select_more_recent_block(true, false, ctx);
+            assert_eq!(view.agent_transcript_navigated_ai_block(ctx), None);
+            assert_eq!(view.agent_transcript_selection_for_test(), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+
+            // Re-mark a query, then exit the agent view below.
+            view.select_less_recent_block(false, ctx);
+            assert_eq!(
+                view.agent_transcript_navigated_ai_block(ctx),
+                Some(prompt_2)
+            );
+            assert_eq!(navigation_ring_targets(view, ctx), vec![prompt_2]);
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.agent_view_controller().update(ctx, |controller, ctx| {
+                controller.exit_agent_view_without_confirmation(ctx)
+            });
+        });
+        terminal.read(&app, |view, ctx| {
+            // Leaving the agent view drops the navigation cursor, its mark, and the ring.
+            assert_eq!(view.agent_transcript_selection_for_test(), None);
+            assert_eq!(view.agent_transcript_navigated_ai_block(ctx), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+        });
+    })
+}
+
+#[test]
+fn ordinary_block_selection_unchanged_outside_agent_view() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.simulate_block("ls", "foo");
+                model.simulate_block("pwd", "bar");
+            }
+
+            // Outside the agent view, Cmd-Up walks ordinary block selection and never
+            // produces a query mark.
+            view.select_less_recent_block(false /* is_shift_down */, ctx);
+            let first = view.selected_blocks.tail().expect("a block gets selected");
+            assert_eq!(view.agent_transcript_navigated_ai_block(ctx), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+
+            view.select_less_recent_block(false, ctx);
+            let second = view.selected_blocks.tail().expect("a block stays selected");
+            assert_eq!(second.0 + 1, first.0);
+            assert_eq!(view.agent_transcript_navigated_ai_block(ctx), None);
+            assert!(navigation_ring_targets(view, ctx).is_empty());
+        });
+    })
 }
 
 #[test]
@@ -357,6 +804,85 @@ fn update_exchange_input_and_handle_event(
         },
         ctx,
     );
+}
+
+fn enter_agent_view_for_navigation(
+    view: &mut TerminalView,
+    ctx: &mut ViewContext<TerminalView>,
+) -> AIConversationId {
+    view.agent_view_controller().update(ctx, |controller, ctx| {
+        controller
+            .try_enter_agent_view(
+                None,
+                AgentViewEntryOrigin::Input {
+                    was_prompt_autodetected: false,
+                },
+                ctx,
+            )
+            .expect("agent view entry should succeed")
+    })
+}
+
+fn append_inputs_to_conversation_and_handle_event(
+    view: &mut TerminalView,
+    conversation_id: AIConversationId,
+    inputs: Vec<AIAgentInput>,
+    ctx: &mut ViewContext<TerminalView>,
+) {
+    let history_model = BlocklistAIHistoryModel::handle(ctx);
+    let (exchange_id, task_id, response_stream_id) =
+        history_model.update(ctx, |history_model, ctx| {
+            let response_stream_id = ResponseStreamId::new_for_test();
+            let exchange = exchange_with_inputs(inputs);
+            let exchange_id = exchange.id;
+            let task_id = history_model
+                .conversation(&conversation_id)
+                .expect("conversation should exist")
+                .get_root_task_id()
+                .clone();
+            history_model
+                .conversation_mut(&conversation_id)
+                .expect("conversation should exist")
+                .append_reassigned_exchange(&response_stream_id, exchange, view.view_id, ctx)
+                .expect("exchange should append");
+            (exchange_id, task_id, response_stream_id)
+        });
+    view.handle_ai_history_model_event(
+        history_model,
+        &BlocklistAIHistoryEvent::AppendedExchange {
+            exchange_id,
+            task_id,
+            terminal_surface_id: view.view_id,
+            conversation_id,
+            is_hidden: false,
+            response_stream_id: Some(response_stream_id),
+        },
+        ctx,
+    );
+}
+
+fn agent_view_user_query_input(query: &str) -> AIAgentInput {
+    AIAgentInput::UserQuery {
+        query: query.to_owned(),
+        context: Default::default(),
+        static_query_type: None,
+        referenced_attachments: Default::default(),
+        user_query_mode: UserQueryMode::Normal,
+        running_command: None,
+        intended_agent: None,
+    }
+}
+
+fn simulate_user_shell_block_in_conversation(
+    view: &mut TerminalView,
+    conversation_id: AIConversationId,
+    command: &str,
+) -> BlockIndex {
+    let mut model = view.model.lock();
+    model.simulate_block(command, "shell-output");
+    let index = model.block_list().blocks().len() - 2;
+    model.block_list_mut().blocks_mut()[index].set_conversation_id(conversation_id);
+    index.into()
 }
 
 fn ai_block_count(view: &TerminalView) -> usize {


### PR DESCRIPTION
## Description

Update Cmd-Up and Cmd-Down navigation in Agent Mode to move chronologically across user prompts and user-executed shell commands. Agent-requested/monitored command blocks, tool results, and agent-reply rich-content segments are skipped.

The implementation reuses block-list transcript ordering, identifies prompt segments using `AIBlock::has_user_input()`, and preserves existing block-only navigation outside Agent Mode.

Additional navigation feedback:
- The focused prompt's user avatar receives a clear 2px theme-accent ring plus a soft accent halo, so navigation is visible even when the viewport cannot move. Query text, tool calls, and responses are not tinted or outlined.
- Cmd-Down past the newest navigable stop scrolls to the true end of the blocklist before clearing the navigation cursor and refocusing input.
- Cmd-Down with no active navigation cursor is a no-op: it never selects a prompt, so repeated presses at the end of the transcript cannot oscillate between selecting and clearing the newest stop. This matches ordinary block navigation, which does nothing without a selection. Cmd-Up is unchanged.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format`
- All three presubmit Clippy configurations from `script/presubmit`
- `cargo check -p warp --lib`
- `cargo check -p warp --bin warp`
- Focused navigation tests plus broader terminal/AI-block coverage (252 tests)
- `cargo nextest run -p warp -E 'test(/terminal::view::tests/)'` (150 tests, all passing) after the Cmd-Down no-op fix
- New regression test `cmd_down_without_navigation_cursor_is_a_no_op`, which fails before the fix (Cmd-Down selects the newest stop) and passes after it
- Remote GUI verification on Linux at commit `11e6c76d385edc4678e1717c4ef88124b5d95ebd` using the Ctrl-Up/Ctrl-Down variants of the same `cmdorctrl` actions
  - Natural Agent Mode transcript with an older prompt, real agent-requested run-shell command/result, user-executed shell command, and newer prompt
  - Confirmed exactly three navigation stops: newer prompt → user shell command → older prompt
  - Confirmed agent command/result and post-tool agent reply are skipped
  - Confirmed the 2px accent ring and halo are limited to the focused prompt's circular user avatar and clear/move correctly
  - Confirmed Cmd-Down past newest reaches the true blocklist end and refocuses input
  - Confirmed symmetric navigation and no crash

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

#### Original feature verification (recorded at `11e6c76`, before the Cmd-Down no-op fix)

[![Cmd-Up/Cmd-Down Agent Mode navigation with avatar accent ring and halo](https://staging.warp.dev/api/v1/agent/artifacts/019fcdd7-67fd-755c-81e1-c947646cd0df/download)](https://oz.staging.warp.dev/artifacts/019fcdd7-649d-7f40-b309-8e65c4ed2bfb)

*Video: Ctrl-Up (Cmd-Up on macOS) steps through the newer user prompt, the user-run shell command, and the older user prompt. A 2px theme-accent ring plus soft halo marks only the focused prompt's circular avatar, with no row border or tint. Agent-run command/results and agent replies are skipped. Ctrl-Down steps back; past the newest stop, it scrolls to the true end, clears the ring and halo, and refocuses input.*

[Agent conversation](https://staging.warp.dev/conversation/e087938e-e3cb-4033-adbc-4e3e7269c46c)

**This recording predates the Cmd-Down no-op fix and does not demonstrate it.** The fix itself is covered by the `cmd_down_without_navigation_cursor_is_a_no_op` unit test, which fails on the pre-fix code and passes after.

#### Post-fix GUI verification: attempted, not obtained

A fresh recording of the fixed behavior could not be captured in the Linux cloud sandbox. Details, so this is not mistaken for verified UI behavior:

- The internal-channel GUI build (`cargo build --bin warp --features gui`, with `warp-channel-config` installed) launches authenticated under Xvfb with software Vulkan, and a real Agent Mode conversation with two user prompts was created against staging.
- Control test: in plain terminal mode, Ctrl-Up/Ctrl-Down select and move between command blocks exactly as expected, so keystrokes do reach the app.
- Inside the full-screen agent view, however, **neither** Ctrl-Down **nor** Ctrl-Up produces any visible effect — no ring, no selection, no scroll — with the caret in the follow-up input, after clicking prompt or reply text, or after Ctrl-Shift-Up. The pre-existing Cmd-Up behavior from `11e6c76` is equally inert there, so this is not a regression from the fix (which does not touch Cmd-Up).
- Likely cause, unconfirmed: `terminal:select_previous_block` / `terminal:select_next_block` are gated on the `Terminal` keymap context (`app/src/terminal/view/init.rs`), and the repo's own note at `app/src/terminal/view/init.rs` (jump-to-latest-agent-message binding) says that in the agent view the rich input holds focus and its context "lacks `Terminal` but carries `Input`". Whether that differs on macOS or by agent-view mode was not determined here and may be worth a look.

Captures from those attempts (they document the attempt and the terminal-mode control test — they do not show the fixed behavior):

<!-- oz:computer-use-videos start -->
<details>
<summary>Computer-use video recordings (2)</summary>

[![Recording the keyboard navigation behavior in a Warp Agent Mode transcript: three Ctrl+Down presses with nothing selected, then Ctrl+Up, then Ctrl+Down twice, observing the user-prompt avatars and viewport after each press.](https://staging.warp.dev/api/v1/agent/artifacts/019fd43c-9a18-7956-a0e3-e2234f59c58c/download)](https://oz.staging.warp.dev/artifacts/019fd43c-9714-7dbb-8a06-7a495a3be55f)
**Ctrl+Up/Ctrl+Down navigation in Warp agent transcript**: Recording the keyboard navigation behavior in a Warp Agent Mode transcript: three Ctrl+Down presses with nothing selected, then Ctrl+Up, then Ctrl+Down twice, observing the user-prompt avatars and viewport after each press.

[![Recording of six keypresses (Ctrl+Down x3, Ctrl+Up, Ctrl+Down x2) in Warp's Agent Mode transcript, showing the two user-prompt avatars and viewport after each press.](https://staging.warp.dev/api/v1/agent/artifacts/019fd444-9a69-7791-8e34-4fd53f1edc88/download)](https://oz.staging.warp.dev/artifacts/019fd444-96ec-7484-accc-9c5e76888c93)
**Ctrl+Down/Up sequence in Agent Mode transcript**: Recording of six keypresses (Ctrl+Down x3, Ctrl+Up, Ctrl+Down x2) in Warp's Agent Mode transcript, showing the two user-prompt avatars and viewport after each press.

</details>
<!-- oz:computer-use-videos end -->

<!-- oz:computer-use-screenshots start -->
<details>
<summary>Computer-use screenshots (6)</summary>

![Warp agent transcript right after the first Ctrl+Down press: both user prompts show plain blue circular avatars with no highlight, nothing selected, caret in the input box.](https://staging.warp.dev/api/v1/agent/artifacts/019fd43a-fc62-78d5-9394-85f3dd134402/download)
Warp agent transcript right after the first Ctrl+Down press: both user prompts show plain blue circular avatars with no highlight, nothing selected, caret in the input box.

![Warp agent transcript right after the Ctrl+Up press: both user prompt avatars remain plain blue circles with no ring/halo/outline, nothing selected, caret in the input box.](https://staging.warp.dev/api/v1/agent/artifacts/019fd43b-dcad-7e2d-8852-569c1464e90d/download)
Warp agent transcript right after the Ctrl+Up press: both user prompt avatars remain plain blue circles with no ring/halo/outline, nothing selected, caret in the input box.

![Terminal-mode control test after first Ctrl+Up: the pwd command block is highlighted (selected) with a teal background spanning the whole block.](https://staging.warp.dev/api/v1/agent/artifacts/019fd440-9372-70e3-a24a-517ff454a4c7/download)
Terminal-mode control test after first Ctrl+Up: the pwd command block is highlighted (selected) with a teal background spanning the whole block.

![Agent Mode transcript right after Ctrl+Up: no ring/halo/outline appears around either user prompt's circular blue avatar; the newest prompt ("what is 5 plus 5?") and its avatar are visible.](https://staging.warp.dev/api/v1/agent/artifacts/019fd443-117b-787c-93eb-27763a53c69f/download)
Agent Mode transcript right after Ctrl+Up: no ring/halo/outline appears around either user prompt's circular blue avatar; the newest prompt ("what is 5 plus 5?") and its avatar are visible.

![Warp terminal tab with finished ls and pwd blocks; after Ctrl+Up/Down probing, the pwd block is selected (teal highlight) with hint 'new /agent conversation with pwd attached'.](https://staging.warp.dev/api/v1/agent/artifacts/019fd44b-1e85-76b8-be52-b5f717095757/download)
Warp terminal tab with finished ls and pwd blocks; after Ctrl+Up/Down probing, the pwd block is selected (teal highlight).

![Agent conversation "Simple Arithmetic Question" after all focus attempts, showing both user prompts with solid blue circular avatars (no ring/halo/outline) and the replies "4" and "10".](https://staging.warp.dev/api/v1/agent/artifacts/019fd44f-b914-7711-9501-6a07b77424a2/download)
Agent conversation "Simple Arithmetic Question" after all focus attempts, showing both user prompts with solid blue circular avatars (no ring/halo/outline) and the replies "4" and "10".

</details>
<!-- oz:computer-use-screenshots end -->


## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Cmd-Up in Agent Mode now navigates user prompts and skips agent-run commands.

Co-Authored-By: Warp Agent <agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/00fb5ef8-d747-44e9-9cf2-10bf62e282e6_
_Run: https://oz.staging.warp.dev/runs/019fd3d6-e43e-7e68-a2a5-c99ec5ac0dcc_
