### PR TITLE
Persist the X11 agent seat for the background computer-use session (fix split-call drags)

### DIFF
--- a/crates/computer_use/src/lib.rs
+++ b/crates/computer_use/src/lib.rs
@@ -114,22 +114,25 @@ pub fn background_supported() -> bool {
 }
 
 /// Ends the background computer-use session owned by `owner` (the client conversation id),
-/// restoring the user's original keyboard focus.
+/// releasing the session state that outlives individual action batches.
 ///
 /// On macOS a background session activates the target window and installs focus-suppression
 /// taps; this tears down only the windows owned by `owner`, deactivates them, and re-activates the
 /// app that was frontmost before the session, so the user's keystrokes return to where they were.
-/// Scoping by owner keeps concurrent background sessions (e.g. another conversation driving a
-/// different window) intact. Idempotent and a no-op when `owner` has no active session, and on
-/// platforms without background per-window control.
+/// On Linux X11 a background session drives a session-scoped agent seat (a second input seat
+/// shared across the session's action batches so state like a held mouse button mid-drag
+/// survives between batches); this removes `owner`'s seat, its on-screen cursor, and any input
+/// state it still holds. Scoping by owner keeps concurrent background sessions (e.g. another
+/// conversation driving a different window) intact. Idempotent and a no-op when `owner` has no
+/// active session, and on platforms without background per-window control.
 ///
 /// Call this whenever a computer-use session ends — normal completion, cancellation, or teardown.
 pub fn end_background_session(owner: &str) {
-    #[cfg(macos)]
+    #[cfg(any(macos, linux))]
     {
         imp::end_background_session(owner);
     }
-    #[cfg(not(macos))]
+    #[cfg(not(any(macos, linux)))]
     {
         let _ = owner;
     }

--- a/crates/computer_use/src/linux/mod.rs
+++ b/crates/computer_use/src/linux/mod.rs
@@ -41,6 +41,17 @@ pub fn background_supported() -> bool {
     *SUPPORTED.get_or_init(x11::probe_background_support)
 }
 
+/// Ends the background computer-use session owned by `owner`. On X11 this removes the
+/// session's shared agent seat (and its on-screen cursor), implicitly releasing any input state
+/// it still holds. Wayland has no background per-window control, so there is nothing to tear
+/// down.
+pub fn end_background_session(owner: &str) {
+    if is_wayland_available() || !is_x11_available() {
+        return;
+    }
+    x11::end_background_session(owner);
+}
+
 /// Enumerates the on-screen windows so a caller can pick one to target. Only supported on X11;
 /// returns an empty list on Wayland or when no display is reachable.
 pub fn enumerate_windows() -> Vec<crate::WindowInfo> {
@@ -106,6 +117,15 @@ impl super::Actor for Actor {
             ActorInner::Wayland(actor) => actor.platform(),
             ActorInner::X11(actor) => actor.platform(),
             ActorInner::Unsupported => None,
+        }
+    }
+
+    fn set_background_session_owner(&mut self, owner: Option<String>) {
+        match &mut self.inner {
+            // The X11 actor keys its shared, session-scoped agent seat by the owner.
+            ActorInner::X11(actor) => actor.set_background_session_owner(owner),
+            // Wayland has no background per-window control; nothing to tag.
+            ActorInner::Wayland(_) | ActorInner::Unsupported => {}
         }
     }
 

--- a/crates/computer_use/src/linux/x11/mod.rs
+++ b/crates/computer_use/src/linux/x11/mod.rs
@@ -12,6 +12,7 @@ mod screenshot;
 mod seat;
 pub(crate) mod windows;
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -43,8 +44,14 @@ pub struct Actor {
     /// character typed.
     keyboard_mapping: xproto::GetKeyboardMappingReply,
     /// The agent seat used for background window targets, created lazily by the first
-    /// window-targeted action and removed when the actor is dropped.
-    agent: Option<seat::AgentSeat>,
+    /// window-targeted action. Owner-tagged actors (the in-app session path) share the
+    /// session-scoped seat from [`seat::shared_for_session`], so input state that spans action
+    /// batches — most importantly a held button mid-drag — survives the per-batch actor
+    /// teardown. Owner-less actors (the developer CLI) hold a private seat removed when the
+    /// actor is dropped.
+    agent: Option<Arc<seat::AgentSeat>>,
+    /// The background-session owner (the client conversation id) keying the shared agent seat.
+    background_session_owner: Option<String>,
 }
 
 impl Actor {
@@ -76,6 +83,7 @@ impl Actor {
             screen_index,
             keyboard_mapping,
             agent: None,
+            background_session_owner: None,
         })
     }
 
@@ -86,6 +94,13 @@ impl Actor {
     fn screen(&self) -> &xproto::Screen {
         &self.conn.setup().roots[self.screen_index]
     }
+}
+
+/// Ends the background computer-use session owned by `owner`: removes the session's shared
+/// agent seat (and its on-screen cursor), implicitly releasing any input state — held buttons,
+/// the agent keyboard's focus — it still holds.
+pub fn end_background_session(owner: &str) {
+    seat::end_session(owner);
 }
 
 /// Probes whether the display supports the XInput2 device hierarchy required for background,
@@ -171,6 +186,10 @@ impl crate::Actor for Actor {
         Some(crate::Platform::LinuxX11)
     }
 
+    fn set_background_session_owner(&mut self, owner: Option<String>) {
+        self.background_session_owner = owner;
+    }
+
     async fn perform_actions(
         &mut self,
         actions: &[TargetedAction],
@@ -212,8 +231,14 @@ impl crate::Actor for Actor {
             }
         }
         if needs_agent_seat && self.agent.is_none() {
-            let agent_seat = seat::AgentSeat::new()
-                .map_err(|e| format!("Background window control is unavailable: {e}"))?;
+            // In-app sessions (owner-tagged) share the session's seat so a drag that spans
+            // batches keeps its button held; the owner-less CLI gets a private, actor-scoped
+            // seat.
+            let agent_seat = match &self.background_session_owner {
+                Some(owner) => seat::shared_for_session(owner),
+                None => seat::AgentSeat::new().map(Arc::new),
+            }
+            .map_err(|e| format!("Background window control is unavailable: {e}"))?;
             self.agent = Some(agent_seat);
         }
 

--- a/crates/computer_use/src/linux/x11/seat.rs
+++ b/crates/computer_use/src/linux/x11/seat.rs
@@ -15,15 +15,23 @@
 //! drives the agent seat unchanged: events are indistinguishable from real hardware input to
 //! applications, while the user's own pointer, keyboard focus, and modifier state stay put.
 //!
+//! A seat must outlive any single `perform_actions` batch: the actor is rebuilt for every
+//! batch, and a drag routinely spans batches (press in one, moves and release in later ones).
+//! Removing a master device implicitly releases the buttons its XTEST slave holds — which would
+//! end an in-progress drag (the application sees the selection drop and subsequent moves as
+//! plain hover) — so seats used by in-app sessions are shared per session owner via
+//! [`shared_for_session`] and live until [`end_session`]. Owner-less actors (the developer CLI)
+//! keep a private seat dropped with the actor.
+//!
 //! Unlike most X resources, master devices are server-global and outlive the connection that
 //! created them, so the pair is removed explicitly on drop, and every seat creation reaps
 //! leaked pairs: pairs of this process not owned by a live [`AgentSeat`] (per a process-local
 //! registry), and pairs whose owning process (identified by the pid embedded in the seat name)
 //! no longer exists.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use x11rb::connection::Connection;
 use x11rb::protocol::xinput::{
@@ -150,6 +158,33 @@ impl AgentSeat {
             .map_err(|e| format!("Failed to focus target window {window}: {e}"))?;
         Ok(())
     }
+}
+
+/// The shared seats of active background computer-use sessions, keyed by session owner (the
+/// client conversation id).
+fn session_seats() -> &'static Mutex<HashMap<String, Arc<AgentSeat>>> {
+    static SESSION_SEATS: OnceLock<Mutex<HashMap<String, Arc<AgentSeat>>>> = OnceLock::new();
+    SESSION_SEATS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Returns `owner`'s session seat, creating it on first use. The seat is shared by every actor
+/// of the session so input state spanning batches — a held button mid-drag, the agent
+/// keyboard's focus — survives actor teardown between batches.
+pub fn shared_for_session(owner: &str) -> Result<Arc<AgentSeat>, String> {
+    let mut seats = session_seats().lock().unwrap();
+    if let Some(seat) = seats.get(owner) {
+        return Ok(seat.clone());
+    }
+    let seat = Arc::new(AgentSeat::new()?);
+    seats.insert(owner.to_string(), seat.clone());
+    Ok(seat)
+}
+
+/// Ends `owner`'s background session: drops its shared seat, removing the master pair (and its
+/// on-screen cursor) and implicitly releasing any input state it still holds. An actor mid-batch
+/// keeps the seat alive until its batch completes. Idempotent; a no-op for unknown owners.
+pub fn end_session(owner: &str) {
+    session_seats().lock().unwrap().remove(owner);
 }
 
 impl Drop for AgentSeat {

--- a/specs/x11-background-computer-use/TECH.md
+++ b/specs/x11-background-computer-use/TECH.md
@@ -44,8 +44,15 @@ drives the agent seat completely unchanged. Consequences:
 - The user's cursor position, keyboard focus, and modifier state are properties of the user's
   own master pair and are never touched. Agent typing follows the agent keyboard's focus, set
   per action with `XISetFocus`, even while the target window is covered.
-- A second visible cursor exists while a window-targeted batch runs (the seat lives for the
-  `Actor`'s lifetime, i.e. one tool call).
+- A second visible cursor exists while a window-targeted batch runs. Post-ship amendment: the
+  seat originally lived for the `Actor`'s lifetime (one tool call), but the X server holds
+  input state on the seat that must span tool calls — removing a master pair implicitly
+  releases the buttons its XTEST slave holds, which ended split-call drags (press in one
+  `use_computer` call, moves/release in later ones) and broke e.g. drag-to-select. Seats used
+  by in-app sessions are therefore shared per session owner (the client conversation id) and
+  live until `computer_use::end_background_session(owner)` runs at session completion or
+  cancellation, so the second cursor persists for the session, not one call. The owner-less
+  `use_computer` CLI keeps a per-actor seat.
 
 Rejected alternatives: `XSendEvent` synthetic events (silently ignored by major toolkits);
 focus/pointer save-restore juggling on the user's seat (races with concurrent user input, not


### PR DESCRIPTION
## Description

On Linux, window-scoped (background) drags didn't actually drag: the cursor moved, but e.g. drag-to-select never selected any text. Screen-scoped drags were fine.

**Root cause:** each `use_computer` call creates and drops its own `Actor`, and on Linux dropping the actor removed the MPX "agent seat". Removing a master device implicitly releases the buttons it holds. Since the model splits drags across calls (press in one call, moves/release in later ones), the button was dropped at the first call boundary and the rest of the drag became plain hover motion.

**Fix:** the agent seat now lives for the whole background session instead of one call.

- Sessions share one seat, keyed by the owning conversation id, so held buttons (and the agent keyboard's focus) survive between calls.
- The existing `end_background_session()` teardown hook (previously macOS-only) now also removes the Linux seat; it already runs on completion and cancellation. This mirrors how #13752 solved the same problem on macOS.
- The `use_computer` dev CLI and the existing leak-safety (stale-seat reaping) are unchanged.

Trade-off: on a real desktop, the agent's second cursor now stays visible for the session rather than one call. The spec (`specs/x11-background-computer-use/TECH.md`) is amended.

## Linked Issue

Follow-up to QUALITY-1169; found while reviewing drag recordings from #14681.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Reproduced at the X11 level in a container: press on a seat, remove it (what `Actor::drop` did), and the button reads released on every later move; a persistent seat selects text correctly.
- E2E via a local Oz worker: drag-to-select in Chromium now highlights text in both window- and screen-scoped recordings.
- `cargo nextest run -p computer_use` (75/75), format + clippy clean; Linux build verified via the sidecar image.
- [ ] I have manually tested my changes locally with `./script/run` — not applicable: Linux-only paths, exercised via the local worker runs above.


https://github.com/user-attachments/assets/cab590c2-99c2-4f1a-a333-21eb278afb5b


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Fixed background (window-scoped) computer use on Linux dropping the mouse button between actions, which broke drag gestures like text selection.

Co-Authored-By: Warp Agent <agent@warp.dev>
