### PR TITLE
Make vertical tabs search match tab group names

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1,7 +1,7 @@
 pub mod telemetry;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -1781,7 +1781,7 @@ fn render_groups(
             .collect()
     } else {
         let query_lower = query.to_lowercase();
-        workspace
+        let own_matches: Vec<(usize, Option<Vec<PaneId>>)> = workspace
             .tabs
             .iter()
             .enumerate()
@@ -1882,7 +1882,24 @@ fn render_groups(
                     }
                 }
             })
-            .collect()
+            .collect();
+
+        // A query matching a group's name reveals every tab under that group,
+        // even members whose own text does not match.
+        let matched_groups: HashSet<TabGroupId> = workspace
+            .tab_groups
+            .iter()
+            .filter(|(_, group)| {
+                group_display_name(group)
+                    .to_lowercase()
+                    .contains(&query_lower)
+            })
+            .map(|(group_id, _)| *group_id)
+            .collect();
+        let tab_group_ids: Vec<Option<TabGroupId>> =
+            workspace.tabs.iter().map(|tab| tab.group_id).collect();
+
+        merge_group_name_matches(&tab_group_ids, &matched_groups, own_matches)
     };
 
     if visible_tabs.is_empty() {
@@ -1930,7 +1947,14 @@ fn render_groups(
                 .get(&gid)
                 .map(|group| (gid, group.clone()))
         }) {
-            Some((group_id, group)) => {
+            Some((group_id, mut group)) => {
+                // While a search is active, render every surviving group
+                // expanded so its matches are visible without a click. This
+                // only mutates the local clone — the stored `collapsed` flag is
+                // untouched, so clearing the query restores the real state.
+                if !query.is_empty() {
+                    group.collapsed = false;
+                }
                 // Members are a contiguous subslice of `visible_tabs`.
                 let run_len = visible_tabs[i..]
                     .iter()
@@ -2788,10 +2812,7 @@ fn render_grouped_tabs_header(
         if let Some(editor) = rename_editor.filter(|_| is_being_renamed) {
             render_inline_tab_rename_editor(editor, appearance, app)
         } else {
-            let title_text = group
-                .name
-                .clone()
-                .unwrap_or_else(|| "New Group".to_string());
+            let title_text = group_display_name(group);
             Text::new_inline(title_text, font_family, 12.)
                 .with_clip(ClipConfig::ellipsis())
                 .with_color(main_text_color.into())
@@ -3929,6 +3950,59 @@ fn should_show_tab_group_header(
     visible_pane_count: usize,
 ) -> bool {
     has_custom_title || is_being_renamed || visible_pane_count > 1
+}
+
+/// Header text for a tab group the user has never named.
+const UNTITLED_GROUP_NAME: &str = "New Group";
+
+/// The group title as displayed in the panel header, including the fallback
+/// used for a group the user has never named. Search matches against this so a
+/// query matches what is actually on screen.
+fn group_display_name(group: &TabGroup) -> String {
+    group
+        .name
+        .clone()
+        .unwrap_or_else(|| UNTITLED_GROUP_NAME.to_string())
+}
+
+/// Force-includes every member of a name-matched tab group into the search
+/// results, so matching a group by name reveals all the tabs under it.
+///
+/// `own_matches` holds the tabs that matched the query on their own text, as
+/// `(tab index, matching pane ids)` where `None` means "render all pane rows".
+/// Output stays ordered by tab index: `render_groups` collapses a group's
+/// members into one container by scanning a contiguous run, so an out-of-order
+/// entry would split the group across several rendered containers.
+///
+/// A member already present from its own text match is upgraded to `None`
+/// rather than duplicated — a group-name match shows whole tabs, not
+/// pane-filtered slices of them.
+fn merge_group_name_matches(
+    tab_group_ids: &[Option<TabGroupId>],
+    matched_groups: &HashSet<TabGroupId>,
+    own_matches: Vec<(usize, Option<Vec<PaneId>>)>,
+) -> Vec<(usize, Option<Vec<PaneId>>)> {
+    if matched_groups.is_empty() {
+        return own_matches;
+    }
+
+    let mut merged: Vec<(usize, Option<Vec<PaneId>>)> = Vec::with_capacity(own_matches.len());
+    let mut own_matches = own_matches.into_iter().peekable();
+
+    for (tab_index, group_id) in tab_group_ids.iter().enumerate() {
+        let in_matched_group = group_id.is_some_and(|id| matched_groups.contains(&id));
+        let own_match = own_matches.next_if(|(index, _)| *index == tab_index);
+
+        match (in_matched_group, own_match) {
+            // The group name matched, so the whole tab is shown regardless of
+            // whether it also matched on its own text.
+            (true, _) => merged.push((tab_index, None)),
+            (false, Some(own_match)) => merged.push(own_match),
+            (false, None) => {}
+        }
+    }
+
+    merged
 }
 
 fn search_fragments_contain_query(fragments: &[String], query_lower: &str) -> bool {

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use pathfinder_geometry::rect::RectF;
@@ -11,11 +12,12 @@ use super::{
     VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
     VerticalTabsSummaryPrimaryLabel, branch_label_display, coalesce_summary_branch_entries,
     code_detail_kind_label, compact_branch_subtitle_display, detail_sidecar_width_and_bounds,
-    detail_target_for_hovered_row, non_terminal_search_text_fragments,
-    pane_ids_for_display_granularity, pane_search_text_fragments, preferred_agent_tab_titles,
-    push_normalized_unique_summary_label, search_fragments_contain_query,
-    select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
-    should_show_tab_group_header, sort_summary_primary_labels_status_first, summary_overflow_count,
+    detail_target_for_hovered_row, group_display_name, merge_group_name_matches,
+    non_terminal_search_text_fragments, pane_ids_for_display_granularity,
+    pane_search_text_fragments, preferred_agent_tab_titles, push_normalized_unique_summary_label,
+    search_fragments_contain_query, select_summary_pane_kind_icons,
+    should_keep_detail_sidecar_visible_for_mouse_position, should_show_tab_group_header,
+    sort_summary_primary_labels_status_first, summary_overflow_count,
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
     terminal_pull_request_badge_label, terminal_search_text_fragments,
     terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
@@ -27,6 +29,7 @@ use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
 use crate::terminal::CLIAgent;
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 
 fn label(text: &str) -> VerticalTabsSummaryPrimaryLabel {
@@ -1206,4 +1209,114 @@ fn summary_search_fragments_include_hidden_overflow_values() {
     assert!(search_fragments_contain_query(&fragments, "#789"));
     assert!(search_fragments_contain_query(&fragments, "+2"));
     assert!(search_fragments_contain_query(&fragments, "-3"));
+}
+
+fn tab_group(name: Option<&str>) -> TabGroup {
+    TabGroup {
+        name: name.map(str::to_string),
+        ..TabGroup::new()
+    }
+}
+
+#[test]
+fn group_display_name_uses_the_group_name_when_set() {
+    assert_eq!(group_display_name(&tab_group(Some("backend"))), "backend");
+}
+
+#[test]
+fn group_display_name_falls_back_to_the_untitled_header_text() {
+    assert_eq!(group_display_name(&tab_group(None)), "New Group");
+}
+
+#[test]
+fn group_name_match_includes_members_that_did_not_match_on_their_own() {
+    let group = TabGroupId::new();
+    let tab_group_ids = vec![Some(group), Some(group), None];
+
+    let merged = merge_group_name_matches(
+        &tab_group_ids,
+        &HashSet::from([group]),
+        // Only the second tab matched on its own title.
+        vec![(1, None)],
+    );
+
+    assert_eq!(merged, vec![(0, None), (1, None)]);
+}
+
+#[test]
+fn group_name_match_keeps_results_ordered_by_tab_index() {
+    let group = TabGroupId::new();
+    // Ungrouped tabs on either side of the group.
+    let tab_group_ids = vec![None, Some(group), Some(group), None];
+
+    let merged = merge_group_name_matches(
+        &tab_group_ids,
+        &HashSet::from([group]),
+        vec![(0, None), (3, None)],
+    );
+
+    assert_eq!(
+        merged,
+        vec![(0, None), (1, None), (2, None), (3, None)],
+        "group members must be interleaved in tab order, not appended"
+    );
+}
+
+#[test]
+fn group_name_match_upgrades_a_pane_filtered_member_to_all_panes() {
+    let group = TabGroupId::new();
+    let tab_group_ids = vec![Some(group)];
+
+    let merged = merge_group_name_matches(
+        &tab_group_ids,
+        &HashSet::from([group]),
+        // The tab matched on one pane row only.
+        vec![(0, Some(vec![pane_id()]))],
+    );
+
+    assert_eq!(
+        merged,
+        vec![(0, None)],
+        "a group-name match shows the whole tab, not a pane-filtered slice"
+    );
+}
+
+#[test]
+fn group_name_match_for_a_group_with_no_members_changes_nothing() {
+    let empty_group = TabGroupId::new();
+    let tab_group_ids = vec![None, None];
+
+    let merged = merge_group_name_matches(
+        &tab_group_ids,
+        &HashSet::from([empty_group]),
+        vec![(1, None)],
+    );
+
+    assert_eq!(merged, vec![(1, None)]);
+}
+
+#[test]
+fn group_name_match_leaves_tabs_outside_the_group_filtered() {
+    let matched = TabGroupId::new();
+    let other = TabGroupId::new();
+    let tab_group_ids = vec![Some(matched), Some(other), None];
+
+    let merged = merge_group_name_matches(&tab_group_ids, &HashSet::from([matched]), vec![]);
+
+    assert_eq!(
+        merged,
+        vec![(0, None)],
+        "only members of the name-matched group are force-included"
+    );
+}
+
+#[test]
+fn no_group_name_match_leaves_the_filtered_tabs_untouched() {
+    let group = TabGroupId::new();
+    let tab_group_ids = vec![Some(group), None];
+    let own_matches = vec![(1, Some(vec![pane_id()]))];
+
+    let merged = merge_group_name_matches(&tab_group_ids, &HashSet::new(), own_matches.clone());
+
+    assert_eq!(merged, own_matches);
 }

--- a/docs/superpowers/specs/2026-08-03-tab-search-group-matching-design.md
+++ b/docs/superpowers/specs/2026-08-03-tab-search-group-matching-design.md
@@ -1,0 +1,165 @@
+# Tab search matches tab groups
+
+Date: 2026-08-03
+Status: Approved, ready for implementation planning
+
+## Problem
+
+The vertical tabs panel has a search field that filters the tab list in place
+(`app/src/workspace/view/vertical_tabs.rs`, `render_groups`). It matches against
+pane and tab text only. Tab group names — `TabGroup::name`, the feature gated
+behind `FeatureFlag::GroupedTabs` — are never consulted, so a user who organizes
+work into a group named `backend` cannot find that group by typing its name, and
+cannot use the search field to pull up everything inside it.
+
+## Goal
+
+Typing a query that matches a tab group's displayed name surfaces that group and
+every tab under it, regardless of whether the individual tab titles match.
+
+## Scope
+
+In scope: the vertical tabs panel search field only.
+
+Out of scope: the Ctrl+Tab command palette tab switcher
+(`app/src/search/command_palette/tabs/`). It is a flat MRU list of
+`TabNavigationData` with no group concept; adding group awareness there would
+require new item types and grouped result rendering, and is a separate project.
+
+No data-model changes. `TabGroup` already carries `name`, `collapsed`, and
+`pinned`; `TabData::group_id` already links members to their group.
+
+## Design
+
+### 1. Where the change lands
+
+Entirely within `render_groups` (`vertical_tabs.rs:1748`), plus two extracted
+helpers.
+
+`render_groups` builds:
+
+```rust
+let visible_tabs: Vec<(usize, Option<Vec<PaneId>>)>
+```
+
+where the first element is the index into `workspace.tabs` and the second is
+`None` (render all of the tab's pane rows) or `Some(ids)` (render only the pane
+rows that matched). Everything downstream of line 1906 — group container runs,
+drop targets, ghost slots, the empty state — consumes this vector and needs no
+change. Group matching is therefore purely a matter of adding entries to it.
+
+### 2. Matching rule
+
+A new helper, shared with the group header renderer so the two cannot drift:
+
+```rust
+/// The group title as displayed in the panel header, including the
+/// untitled fallback.
+fn group_display_name(group: &TabGroup) -> String {
+    group.name.clone().unwrap_or_else(|| "New Group".to_string())
+}
+```
+
+`vertical_tabs.rs:2791`, which currently inlines the same
+`unwrap_or_else(|| "New Group".to_string())`, switches to calling it.
+
+A group matches when:
+
+```rust
+group_display_name(group).to_lowercase().contains(query_lower)
+```
+
+This is the same case-insensitive substring rule the existing tab filter uses,
+so no new matching concept enters the code.
+
+Matching the *displayed* name — fallback included — means an untitled group
+matches the query "new group". This is deliberate: the user is searching for
+what is on screen.
+
+The rule applies in all three resolved modes (`Summary`, `FocusedSession`,
+`Panes`), since group headers render in each.
+
+### 3. Merging group hits with tab hits
+
+A second helper, pure and unit-testable without an `AppContext`:
+
+```rust
+/// Force-includes every member of a name-matched group, preserving original
+/// tab order. A tab that also matched on its own title is upgraded to the
+/// group entry (`None` = all pane rows shown), never duplicated.
+fn merge_group_name_matches(
+    tab_group_ids: &[Option<TabGroupId>],
+    matched_groups: &HashSet<TabGroupId>,
+    own_matches: Vec<(usize, Option<Vec<PaneId>>)>,
+) -> Vec<(usize, Option<Vec<PaneId>>)>
+```
+
+Two properties are load-bearing:
+
+- **Ordering.** The output must stay sorted ascending by tab index. The `while`
+  loop at `vertical_tabs.rs:1921` computes a group's member run with
+  `take_while` over consecutive `visible_tabs` entries sharing a `group_id`.
+  Injecting members out of order would split one group across several rendered
+  containers.
+- **Upgrade, not duplicate.** In `Panes`/`FocusedSession` mode a member tab may
+  already appear as `Some(vec![pane_a])` from its own title match. Under a
+  group-name match that entry becomes `None` so every pane row shows. "All the
+  tabs under the group" means whole tabs, not pane-filtered slices of them.
+
+Tabs outside any matched group keep their existing filter behavior unchanged.
+
+### 4. Collapsed groups
+
+`TabGroup::collapsed` is persisted state, and `render_grouped_tab_container`
+hides members when it is set (`vertical_tabs.rs:3059`). The group value at the
+call site (`vertical_tabs.rs:1927-1932`) is already a clone, so the override is:
+
+```rust
+// While a search is active, expand every rendered group so matches are
+// visible without a click. The stored `collapsed` flag is untouched;
+// clearing the query restores the real state on the next frame.
+if !query.is_empty() {
+    group.collapsed = false;
+}
+```
+
+This expands *any* group surviving the filter, not only name-matched ones. A
+collapsed group holding a title-matching tab would otherwise render as a bare
+header with the match hidden inside it — worse than the alternative. Because the
+override is applied at render time to a clone, there is no persistence, no undo
+state, and no restore logic that can get out of sync.
+
+Accepted side effect: `is_header_selected` (`vertical_tabs.rs:3005`) and the
+collapsed-member icon collage (`vertical_tabs.rs:3012`) both key off
+`is_collapsed`, so during a search a previously-collapsed group renders with a
+chevron and expanded members rather than the collage. This is the intended
+appearance.
+
+## Testing
+
+Unit tests in `app/src/workspace/view/vertical_tabs_tests.rs`, matching the
+existing pure-function style in that file:
+
+- `group_display_name` returns the name when set, and `"New Group"` when `None`.
+- `merge_group_name_matches`:
+  - a group-name match pulls in members whose own titles do not match
+  - output stays ordered by tab index
+  - a member already present as `Some(pane_ids)` is upgraded to `None`
+  - a matched group with no members is a no-op
+  - ungrouped tabs are unaffected
+- A query matching neither any tab nor any group name still reaches the
+  `"No tabs match your search."` empty state.
+
+The collapsed override and the end-to-end filter are render-path behavior not
+covered by this test file today. Verify those by running the app with the
+`GroupedTabs` flag enabled rather than by adding a new integration test.
+
+## Risks
+
+- Group contiguity in `workspace.tabs` is an existing assumption of the render
+  loop, not an invariant this design introduces. If tabs in one group are ever
+  non-contiguous, the group already renders as multiple containers; group-name
+  matching inherits that behavior without making it worse.
+- The "New Group" fallback string is duplicated today. Extracting
+  `group_display_name` removes the duplication; anyone adding a third call site
+  should use the helper.


### PR DESCRIPTION
## Description

The vertical tabs panel search field only matched against pane and tab text, so a tab group could not be found by its name. Typing `backend` would surface tabs whose own titles happened to contain it, but not the group named `backend`, and there was no way to pull up everything inside that group.

This makes a query that matches a group's displayed name surface that group and every tab under it, regardless of whether the individual tab titles match.

Two helpers carry the behavior, both in `app/src/workspace/view/vertical_tabs.rs`:

- **`group_display_name()`** returns the header title including the `"New Group"` fallback. The group header renderer now calls it too, so the text being searched and the text on screen cannot drift apart.
- **`merge_group_name_matches()`** folds members of name-matched groups into the filtered results. Two properties are load-bearing: output stays ordered by tab index (the render loop collapses a group into one container by scanning a contiguous run, so an out-of-order entry would split it across containers), and a member already present from its own text match is upgraded to "all panes" rather than duplicated — a group-name match shows whole tabs, not pane-filtered slices of them.

While a query is active, every surviving group renders expanded so matches aren't hidden behind a collapsed header. This mutates only the local clone that `render_groups` already makes, so the persisted `collapsed` flag is untouched and clearing the query restores the real state on the next frame.

Matching uses the *displayed* name, fallback included, so an unnamed group matches the query "new group" — the user is searching for what's on screen.

Behavior is unchanged when the query matches no group name: `merge_group_name_matches` returns the input untouched.

Scope note: this covers the vertical tabs panel search only. The Ctrl+Tab command palette switcher (`app/src/search/command_palette/tabs/`) is a flat MRU list with no group concept; adding group awareness there needs new item types and grouped result rendering, and is left for separate work.

## Linked Issue

None — this is a self-contained improvement to the `GroupedTabs` preview feature.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Eight unit tests added to `app/src/workspace/view/vertical_tabs_tests.rs`, following the pure-function style already in that file. Each was written first and watched fail before any implementation existed.

`group_display_name`:
- returns the name when set
- falls back to `"New Group"` when unnamed

`merge_group_name_matches`:
- a group-name match pulls in members whose own titles do not match
- results stay ordered by tab index rather than appended
- a member present as `Some(pane_ids)` is upgraded to all-panes
- a matched group with no members is a no-op
- tabs outside the matched group stay filtered
- no group match leaves the filtered results untouched

```
running 8 tests
test ...::group_display_name_uses_the_group_name_when_set ... ok
test ...::group_display_name_falls_back_to_the_untitled_header_text ... ok
test ...::no_group_name_match_leaves_the_filtered_tabs_untouched ... ok
test ...::group_name_match_for_a_group_with_no_members_changes_nothing ... ok
test ...::group_name_match_keeps_results_ordered_by_tab_index ... ok
test ...::group_name_match_includes_members_that_did_not_match_on_their_own ... ok
test ...::group_name_match_upgrades_a_pane_filtered_member_to_all_panes ... ok
test ...::group_name_match_leaves_tabs_outside_the_group_filtered ... ok

test result: ok. 8 passed; 0 failed
```

Full `vertical_tabs` suite: `68 passed; 0 failed`. `cargo clippy -p warp --lib --all-targets` clean, `cargo fmt --check` clean.

The collapse-during-search override and the end-to-end filter are render-path behavior that the unit test file doesn't reach; those were confirmed by running the app locally with `grouped_tabs` enabled.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not captured — happy to add a short recording of the search-matches-group flow if that's wanted before review.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Tab search in the vertical tabs panel now matches tab group names, showing all tabs in a matching group.
