### PR TITLE
Update internal cloud agent dev image

### DIFF
--- a/docker/agent-dev/Dockerfile
+++ b/docker/agent-dev/Dockerfile
@@ -7,7 +7,6 @@ ENV PATH=/usr/local/cargo/bin:/usr/local/go/bin:/usr/local/tfenv/bin:$PATH
 
 # This set of packages is adapted from ./script/bootstrap in warp-internal and warp-server.
 # It doesn't include *everything* (ex. no wgslfmt), but is enough to build and test Warp.
-# Note: currently, only x86_64 builds are supported.
 
 # Install system-level packages. These are needed to build on Linux, and/or to run integration tests.
 RUN set -eux; \
@@ -35,8 +34,8 @@ RUN set -eux; \
 # Install go and go command-line tools we use.
 RUN set -eux; \
   dpkgArch="$(dpkg --print-architecture)"; ARCH="${dpkgArch##*-}"; \
-  curl --proto '=https' --tlsv1.2 -fsSLO https://go.dev/dl/go1.26.1.linux-$ARCH.tar.gz; \
-  tar -C /usr/local -xzf go1.26.1.linux-$ARCH.tar.gz; \
+  curl --proto '=https' --tlsv1.2 -fsSLO https://go.dev/dl/go1.26.5.linux-$ARCH.tar.gz; \
+  tar -C /usr/local -xzf go1.26.5.linux-$ARCH.tar.gz; \
   go version; \
   go env -w "GOPRIVATE=github.com/warpdotdev/*"; \
   CGO_ENABLED=0 go install -tags='no_clickhouse no_libsql no_mssql no_mysql no_sqlite3 no_vertica no_ydb' github.com/pressly/goose/v3/cmd/goose@v3.24.1; \
@@ -47,7 +46,7 @@ RUN set -eux; \
   echo "Installed protoc-gen-go"; \
   go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0; \
   echo "Installed protoc-gen-go-grpc"; \
-  rm go1.26.1.linux-$ARCH.tar.gz
+  rm go1.26.5.linux-$ARCH.tar.gz
 
 # Install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b /usr/local/go/bin v2.6.1 \
@@ -88,7 +87,7 @@ RUN cd ./setup && ./script/linux/install_test_deps
 RUN set -eux; \
   install -d -m 0755 /usr/share/keyrings; \
   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg; \
+    | gpg --batch --yes --dearmor -o /usr/share/keyrings/cloud.google.gpg; \
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
     > /etc/apt/sources.list.d/google-cloud-sdk.list; \
   apt-get update; \

--- a/script/linux/install_test_deps
+++ b/script/linux/install_test_deps
@@ -31,7 +31,7 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
   if [[ ! -x "$(command -v gcloud)" ]]; then
     echo "⬇️  Installing the gcloud CLI..."
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | warp_sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | warp_sudo gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | warp_sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/cloud.google.gpg
     warp_sudo apt-get update -y
     warp_sudo apt-get install google-cloud-cli -y
   fi

--- a/script/push-dev-image
+++ b/script/push-dev-image
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Build and push the base development image for Warp cloud agents.
+# The image supports both x86-64 and AArch64.
+
+exec docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag warpdotdev/warp-internal-dev:latest-dev \
+  --push \
+  --provenance=mode=max --sbom=true \
+  --file docker/agent-dev/Dockerfile .


### PR DESCRIPTION
## Description

This makes a couple updates to our cloud agent dev environment:
1. Explicit support for ARM in addition to x86-64 (this mainly just needed testing)
2. More reliable installation of GCP tooling. Specifically, make sure that we can install Google's keyring even if it's already present. Oddly enough, this caused issues on ARM but not x86-64.
3. Bump the pinned Go version to match what the server currently uses

I also added a script that makes it easier to build and push the image. We're not running it automatically yet - I think it's fine to only do this as needed.

## Testing

Built the image locally for both platforms

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
