### PR TITLE
[APP-5097] Defer startup API key validation

### DIFF
--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1527,6 +1527,23 @@ impl AgentDriverRunner {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CommandAuthentication {
+    PendingApiKey(String),
+    RefreshUser,
+}
+
+fn command_authentication(
+    pending_api_key: Option<String>,
+    is_logged_in: bool,
+) -> Option<CommandAuthentication> {
+    match pending_api_key {
+        Some(api_key) => Some(CommandAuthentication::PendingApiKey(api_key)),
+        None if is_logged_in => Some(CommandAuthentication::RefreshUser),
+        None => None,
+    }
+}
+
 /// Returns `true` if the given CLI command requires authentication.
 fn command_requires_auth(command: &CliCommand) -> bool {
     match command {
@@ -1583,8 +1600,8 @@ fn command_requires_auth(command: &CliCommand) -> bool {
 /// Launch a CLI command, checking authentication first if needed.
 ///
 /// If auth is not required, dispatches the command immediately.
-/// If auth is required and the user is logged in, triggers a user refresh
-/// before launching the command.
+/// If auth is required, validates an explicit API key or refreshes persisted
+/// credentials before launching the command.
 fn launch_command(
     ctx: &mut AppContext,
     command: CliCommand,
@@ -1599,17 +1616,19 @@ fn launch_command(
     let cli_name = warp_cli::binary_name().unwrap_or_else(|| "warp".to_string());
 
     let auth_state = AuthStateProvider::handle(ctx).as_ref(ctx).get();
-    if !auth_state.is_logged_in() {
+    let Some(authentication) =
+        command_authentication(global_options.api_key.clone(), auth_state.is_logged_in())
+    else {
         return Err(anyhow::anyhow!(
             "You are not logged in - please log in with `{cli_name} login` to continue."
         ));
-    }
+    };
 
     // On staging the warp-server is fronted by IAP, so establish an IAP token
     // before *any* warp-server request.
     let iap = IapManager::handle(ctx);
     if !iap.as_ref(ctx).is_enabled() || iap.as_ref(ctx).has_valid_token() {
-        refresh_auth_and_dispatch(ctx, command, global_options);
+        authenticate_and_dispatch(ctx, command, global_options, authentication);
         return Ok(());
     }
 
@@ -1623,7 +1642,12 @@ fn launch_command(
                 if IapManager::handle(ctx).as_ref(ctx).has_valid_token() =>
             {
                 handled = true;
-                refresh_auth_and_dispatch(ctx, command.clone(), global_options.clone());
+                authenticate_and_dispatch(
+                    ctx,
+                    command.clone(),
+                    global_options.clone(),
+                    authentication.clone(),
+                );
             }
             IapManagerEvent::AccessUnavailable => {
                 handled = true;
@@ -1641,18 +1665,17 @@ fn launch_command(
     Ok(())
 }
 
-/// Subscribes to auth events, triggers a user refresh, and dispatches the
-/// command once auth completes. Assumes IAP access (if applicable) is already
-/// established, since the auth refresh is itself an IAP-gated warp-server request.
-fn refresh_auth_and_dispatch(
+/// Subscribes to auth events, authenticates, and dispatches the command once
+/// auth completes. Assumes IAP access (if applicable) is already established.
+fn authenticate_and_dispatch(
     ctx: &mut AppContext,
     command: CliCommand,
     global_options: GlobalOptions,
+    authentication: CommandAuthentication,
 ) {
     let cli_name = warp_cli::binary_name().unwrap_or_else(|| "warp".to_string());
 
-    // User is logged in — subscribe to auth events, trigger a refresh, and wait
-    // for the result before running the command.
+    // Subscribe to auth events and wait for validation before running the command.
     let mut dispatched = false;
     ctx.subscribe_to_model(&AuthManager::handle(ctx), move |_, event, ctx| {
         if dispatched {
@@ -1683,9 +1706,12 @@ fn refresh_auth_and_dispatch(
         }
     });
 
-    // Trigger the user refresh - the subscription above will handle the result.
-    AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
-        auth_manager.refresh_user(ctx);
+    // Trigger authentication - the subscription above will handle the result.
+    AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| match authentication {
+        CommandAuthentication::PendingApiKey(api_key) => {
+            auth_manager.authenticate_api_key(api_key, ctx);
+        }
+        CommandAuthentication::RefreshUser => auth_manager.refresh_user(ctx),
     });
 }
 

--- a/app/src/ai/agent_sdk/mod_tests.rs
+++ b/app/src/ai/agent_sdk/mod_tests.rs
@@ -7,7 +7,10 @@ use warp_cli::artifact::{
 use warp_cli::task::{MessageCommand, MessageSendArgs, MessageWatchArgs, TaskCommand};
 use warp_core::telemetry::TelemetryEvent;
 
-use super::{command_requires_auth, command_to_telemetry_event, reconcile_task_harness};
+use super::{
+    CommandAuthentication, command_authentication, command_requires_auth,
+    command_to_telemetry_event, reconcile_task_harness,
+};
 
 const TASK_ID: &str = "00000000-0000-0000-0000-000000000001";
 
@@ -19,6 +22,35 @@ fn logout_does_not_require_auth() {
 #[test]
 fn login_does_not_require_auth() {
     assert!(!command_requires_auth(&CliCommand::Login));
+}
+
+#[test]
+fn pending_api_key_is_selected_for_command_authentication() {
+    assert_eq!(
+        command_authentication(Some("api-key".to_owned()), false),
+        Some(CommandAuthentication::PendingApiKey("api-key".to_owned()))
+    );
+}
+
+#[test]
+fn pending_api_key_takes_precedence_over_persisted_auth() {
+    assert_eq!(
+        command_authentication(Some("api-key".to_owned()), true),
+        Some(CommandAuthentication::PendingApiKey("api-key".to_owned()))
+    );
+}
+
+#[test]
+fn persisted_auth_is_refreshed_without_pending_api_key() {
+    assert_eq!(
+        command_authentication(None, true),
+        Some(CommandAuthentication::RefreshUser)
+    );
+}
+
+#[test]
+fn logged_out_command_has_no_authentication_source() {
+    assert_eq!(command_authentication(None, false), None);
 }
 
 #[test]

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -439,6 +439,12 @@ enum TuiEntryPoint {
         execute: Box<dyn FnOnce(&mut warpui::AppContext)>,
     },
 }
+
+enum AuthInitialization {
+    Persisted,
+    PendingApiKey(String),
+}
+
 impl LaunchMode {
     fn args(&self) -> Cow<'_, warp_cli::AppArgs> {
         match self {
@@ -467,23 +473,10 @@ impl LaunchMode {
         }
     }
 
-    /// Returns whether a startup API key should be installed before its user is fetched.
-    ///
-    /// The interactive TUI defers the key so its UI cannot treat credential presence as a
-    /// validated identity. Other launch modes retain their existing initialization behavior.
-    fn should_initialize_api_key_eagerly(&self) -> bool {
-        match self {
-            LaunchMode::Tui {
-                entrypoint: TuiEntryPoint::Interactive { .. },
-            } => false,
-            LaunchMode::App { .. }
-            | LaunchMode::CommandLine { .. }
-            | LaunchMode::Test { .. }
-            | LaunchMode::RemoteServerProxy
-            | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::Tui {
-                entrypoint: TuiEntryPoint::CliCommand { .. },
-            } => true,
+    fn auth_initialization(&self) -> AuthInitialization {
+        match self.api_key() {
+            Some(api_key) => AuthInitialization::PendingApiKey(api_key),
+            None => AuthInitialization::Persisted,
         }
     }
 
@@ -1455,16 +1448,14 @@ pub(crate) fn initialize_app(
         ctx.set_zoom_factor(WindowSettings::as_ref(ctx).zoom_level.as_zoom_factor());
     }
 
-    let (api_key, pending_api_key) = if launch_mode.should_initialize_api_key_eagerly() {
-        (launch_mode.api_key(), None)
-    } else {
-        (None, launch_mode.api_key())
+    let (auth_state, pending_api_key) = match launch_mode.auth_initialization() {
+        AuthInitialization::Persisted => (AuthState::initialize(ctx), None),
+        AuthInitialization::PendingApiKey(api_key) => (
+            AuthState::initialize_for_credential_validation(ctx),
+            Some(api_key),
+        ),
     };
-    let auth_state = Arc::new(if pending_api_key.is_some() {
-        AuthState::initialize_for_credential_validation(ctx)
-    } else {
-        AuthState::initialize(ctx, api_key)
-    });
+    let auth_state = Arc::new(auth_state);
     timer.mark_interval_end("AUTH_MANAGER_SET_USER");
 
     let agent_source = determine_agent_source(launch_mode);
@@ -2368,12 +2359,13 @@ pub(crate) fn initialize_app(
     // CLI commands establish IAP access and refresh auth in their dispatch path so they can
     // surface failures synchronously. Interactive clients wait for IAP here before authenticating
     // their startup user, since the request itself calls the IAP-gated warp-server.
-    let startup_authentication = pending_api_key
-        .map(StartupUserAuthentication::ApiKey)
-        .or_else(|| {
-            (user_is_logged_in && !matches!(launch_mode, LaunchMode::CommandLine { .. }))
-                .then_some(StartupUserAuthentication::RefreshUser)
-        });
+    let startup_authentication = if matches!(launch_mode, LaunchMode::CommandLine { .. }) {
+        None
+    } else {
+        pending_api_key
+            .map(StartupUserAuthentication::ApiKey)
+            .or_else(|| user_is_logged_in.then_some(StartupUserAuthentication::RefreshUser))
+    };
     if let Some(authentication) = startup_authentication {
         authenticate_user_after_iap_access(authentication, ctx);
     }

--- a/app/src/lib_tests.rs
+++ b/app/src/lib_tests.rs
@@ -1,11 +1,20 @@
 use super::*;
 
 #[test]
-fn app_and_tui_use_distinct_api_key_initialization_policies() {
+fn app_api_key_requires_validation() {
     let app = LaunchMode::App {
         args: Default::default(),
         api_key: Some("app-api-key".to_owned()),
     };
+
+    assert!(matches!(
+        app.auth_initialization(),
+        AuthInitialization::PendingApiKey(api_key) if api_key == "app-api-key"
+    ));
+}
+
+#[test]
+fn tui_api_key_requires_validation() {
     let tui = LaunchMode::Tui {
         entrypoint: TuiEntryPoint::Interactive {
             mount: Box::new(|_| {}),
@@ -13,10 +22,42 @@ fn app_and_tui_use_distinct_api_key_initialization_policies() {
         },
     };
 
-    assert_eq!(app.api_key().as_deref(), Some("app-api-key"));
-    assert_eq!(tui.api_key().as_deref(), Some("tui-api-key"));
-    assert!(app.should_initialize_api_key_eagerly());
-    assert!(!tui.should_initialize_api_key_eagerly());
+    assert!(matches!(
+        tui.auth_initialization(),
+        AuthInitialization::PendingApiKey(api_key) if api_key == "tui-api-key"
+    ));
+}
+
+#[test]
+fn command_line_api_key_requires_validation() {
+    let command_line = LaunchMode::CommandLine {
+        command: CliCommand::Whoami,
+        global_options: GlobalOptions {
+            api_key: Some("cli-api-key".to_owned()),
+            ..Default::default()
+        },
+        debug: false,
+        is_sandboxed: false,
+        computer_use_override: None,
+    };
+
+    assert!(matches!(
+        command_line.auth_initialization(),
+        AuthInitialization::PendingApiKey(api_key) if api_key == "cli-api-key"
+    ));
+}
+
+#[test]
+fn startup_without_api_key_loads_persisted_auth() {
+    let app = LaunchMode::App {
+        args: Default::default(),
+        api_key: None,
+    };
+
+    assert!(matches!(
+        app.auth_initialization(),
+        AuthInitialization::Persisted
+    ));
 }
 
 #[test]

--- a/crates/warp_server_auth/src/auth_state.rs
+++ b/crates/warp_server_auth/src/auth_state.rs
@@ -10,6 +10,7 @@ use warp_errors::report_error;
 use warp_graphql::object_permissions::OwnerType;
 use warpui_core::{AppContext, Entity, SingletonEntity};
 
+use super::UserUid;
 use super::anonymous_id::get_or_create_anonymous_id;
 use super::credentials::Credentials;
 #[cfg(any(not(target_family = "wasm"), test, feature = "test-util"))]
@@ -18,7 +19,6 @@ use super::user::persistence::PersistedUser;
 use super::user::{
     AnonymousUserType, FirebaseAuthTokens, PersonalObjectLimits, PrincipalType, User,
 };
-use super::{API_KEY_PREFIX, UserUid};
 
 const ANONYMOUS_USER_NOTIFICATION_BLOCK_TIMER: Duration = Duration::days(7);
 
@@ -113,11 +113,10 @@ impl AuthState {
 
     /// Creates and initializes auth state. Checks, in order:
     /// 1. Test user (test/integration/skip_login builds)
-    /// 2. Provided API key
-    /// 3. WARP_USER_SECRET environment variable
-    /// 4. Persisted user from secure storage
+    /// 2. WARP_USER_SECRET environment variable
+    /// 3. Persisted user from secure storage
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
-    pub fn initialize(ctx: &AppContext, api_key: Option<String>) -> Self {
+    pub fn initialize(ctx: &AppContext) -> Self {
         let state = Self::new(ctx);
 
         if Self::should_use_test_user() {
@@ -129,20 +128,6 @@ impl AuthState {
                 feature = "test-util"
             ))]
             state.set_credentials(Some(Self::test_credentials()));
-            return state;
-        }
-
-        if let Some(api_key_value) = api_key {
-            log::info!("Authenticating via API key");
-            let formatted = if api_key_value.starts_with(API_KEY_PREFIX) {
-                api_key_value
-            } else {
-                format!("{API_KEY_PREFIX}{api_key_value}")
-            };
-            state.set_credentials(Some(Credentials::ApiKey {
-                key: formatted,
-                owner_type: None,
-            }));
             return state;
         }
 
@@ -179,11 +164,11 @@ impl AuthState {
     /// Creates auth state for a client that must validate an explicit credential
     /// before making it available to shared authenticated clients.
     ///
-    /// Unlike [`Self::initialize`], this installs neither the supplied credential
-    /// nor persisted identity. The credential remains outside [`AuthState`] until
-    /// its user fetch succeeds, so failed validation leaves the client fully
-    /// logged out. Persisted state is skipped because an explicit credential
-    /// takes precedence over secure storage.
+    /// This installs neither the pending credential nor persisted identity. The
+    /// credential remains outside [`AuthState`] until its user fetch succeeds,
+    /// so failed validation leaves the client fully logged out. Persisted state
+    /// is skipped because an explicit credential takes precedence over secure
+    /// storage.
     pub fn initialize_for_credential_validation(ctx: &AppContext) -> Self {
         let state = Self::new(ctx);
 


### PR DESCRIPTION
## Description

Explicit startup API keys were installed into shared `AuthState` before the server validated them. Credential presence made GUI and TUI startup appear authenticated and allowed unrelated clients to retrieve an unvalidated key.

This change makes GUI, interactive TUI, and Oz CLI hold explicit startup API keys outside shared auth state until `fetch_user` succeeds. GUI and TUI share the deferred startup-auth path, while Oz CLI keeps its separate IAP-gated command lifecycle and validates the pending key before dispatch. The obsolete eager API-key initializer has been removed so failed validation leaves the process fully logged out.

PR with more context: https://github.com/warpdotdev/warp/pull/14620

## Linked Issue

APP-5097

## Testing

- `./script/format`
- Focused `cargo nextest` selection covering launch-mode policy, CLI authentication-source selection, failed pending-key validation, and successful key promotion: 10 passed
- `cargo clippy -p warp --lib --tests -- -D warnings`
- `git diff --check`
- Full workspace/all-features Clippy was not run, per request
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Implementation plan](https://staging.warp.dev/drive/notebook/NsrYAk652rvGYbEjKwVAms)
- [Agent conversation](https://staging.warp.dev/conversation/c78f8f51-e54f-4107-8d94-62d1553b949a)

CHANGELOG-NONE

Co-Authored-By: Warp Agent [agent@warp.dev](mailto:agent@warp.dev)