### PR TITLE
Fix agent-dev Docker build: run gpg dearmor non-interactively

### DIFF
--- a/docker/agent-dev/Dockerfile
+++ b/docker/agent-dev/Dockerfile
@@ -91,7 +91,7 @@ RUN cd ./setup && ./script/linux/install_test_deps
 RUN set -eux; \
   install -d -m 0755 /usr/share/keyrings; \
   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg; \
+    | gpg --dearmor --batch --yes -o /usr/share/keyrings/cloud.google.gpg; \
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
     > /etc/apt/sources.list.d/google-cloud-sdk.list; \
   apt-get update; \


### PR DESCRIPTION
## Description
Multi-platform builds of the `docker/agent-dev` image were failing at the Google Cloud SDK install step with:

```
gpg: cannot open '/dev/tty': No such device or address
```

`gpg --dearmor` runs interactively by default and opens `/dev/tty` when it may need to prompt (e.g. to confirm overwriting the output keyring). BuildKit `RUN` steps have no controlling terminal, so the step failed.

This adds `--batch --yes` to the `gpg --dearmor` invocation so it runs fully non-interactively, matching the standard idiom for dearmoring apt keys in Dockerfiles. `--yes` also makes the layer safe to re-run if the keyring file already exists.

## Testing
- [x] Verified `docker buildx build --platform linux/amd64,linux/arm64` now completes all build stages for both platforms (previously failed at the gcloud keyring step).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp Agent <agent@warp.dev>
