### PR TITLE
[APP-4908] Scope TUI model selection to the session

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -1452,15 +1452,8 @@ impl LLMPreferences {
         terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
-        let profile =
-            AIExecutionProfilesModel::as_ref(ctx).active_profile(Some(terminal_view_id), ctx);
-
-        let profile_default_model_id = profile
-            .data()
-            .base_model
-            .as_ref()
-            .and_then(|id| self.models_by_feature.agent_mode.info_for_id(id))
-            .unwrap_or_else(|| self.models_by_feature.agent_mode.default_llm_info())
+        let profile_default_model_id = self
+            .get_active_profile_base_model(ctx, Some(terminal_view_id))
             .id
             .clone();
 

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -830,11 +830,11 @@ impl LLMPreferences {
     }
 
     /// Returns `LLMInfo` for the currently selected LLM to be used for Agent Mode.
-    fn get_preferred_base_model(
-        &self,
-        app: &AppContext,
+    fn get_preferred_base_model<'a>(
+        &'a self,
+        app: &'a AppContext,
         terminal_view_id: Option<EntityId>,
-    ) -> &LLMInfo {
+    ) -> &'a LLMInfo {
         if let Some(terminal_view_id) = terminal_view_id {
             let raw_override = self.base_llm_for_terminal_view.get(&terminal_view_id);
             if let Some(llm_id) = raw_override
@@ -844,6 +844,17 @@ impl LLMPreferences {
                 return llm_info;
             }
         }
+
+        self.get_active_profile_base_model(app, terminal_view_id)
+    }
+
+    /// Returns the active execution profile's effective base model without applying a
+    /// terminal-view override.
+    pub fn get_active_profile_base_model<'a>(
+        &'a self,
+        app: &'a AppContext,
+        terminal_view_id: Option<EntityId>,
+    ) -> &'a LLMInfo {
         let profile = AIExecutionProfilesModel::as_ref(app).active_profile(terminal_view_id, app);
 
         profile
@@ -948,6 +959,11 @@ impl LLMPreferences {
             })
             .chain(self.custom_llm_choices(app))
             .chain(self.custom_router_choices())
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn add_agent_mode_model_for_test(&mut self, llm: LLMInfo) {
+        self.models_by_feature.agent_mode.choices.push(llm);
     }
 
     /// Returns the set of LLMs available for coding.

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -1158,6 +1158,64 @@ fn updating_active_profile_base_model_persists_and_updates_resolution() {
 }
 
 #[test]
+fn selecting_a_custom_profile_default_clears_the_session_override() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+        let profiles = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let custom_model_id = LLMId::from("custom-endpoint");
+        let preferences = app.add_singleton_model(|_| {
+            let mut preferences = preferences_for_profile_model_tests();
+            preferences
+                .custom_llms
+                .push(agent_llm(custom_model_id.as_str(), "Custom Endpoint"));
+            preferences
+        });
+        let surface_id = EntityId::new();
+        let profile_id = profiles.read(&app, |profiles, ctx| {
+            profiles.active_profile(Some(surface_id), ctx).id().clone()
+        });
+        profiles.update(&mut app, |profiles, ctx| {
+            profiles.set_base_model(&profile_id, Some(custom_model_id.clone()), ctx);
+        });
+        preferences.update(&mut app, |preferences, ctx| {
+            preferences.set_agent_mode_llm_override(surface_id, LLMId::from("claude-opus"), ctx);
+            preferences.update_preferred_agent_mode_llm(&custom_model_id, surface_id, ctx);
+        });
+
+        preferences.read(&app, |preferences, _| {
+            assert_eq!(
+                preferences.base_llm_for_terminal_view.get(&surface_id),
+                None
+            );
+        });
+        profiles.update(&mut app, |profiles, ctx| {
+            profiles.set_base_model(&profile_id, Some(LLMId::from("auto")), ctx);
+        });
+        preferences.read(&app, |preferences, ctx| {
+            assert_eq!(
+                preferences
+                    .get_active_base_model(ctx, Some(surface_id))
+                    .id
+                    .as_str(),
+                "auto"
+            );
+        });
+    });
+}
+
+#[test]
 fn explicit_child_model_pin_preserves_gui_behavior_and_only_emits_for_effective_changes() {
     App::test((), |mut app| async move {
         initialize_settings_for_tests(&mut app);

--- a/crates/warp_tui/src/model_menu.rs
+++ b/crates/warp_tui/src/model_menu.rs
@@ -1,13 +1,14 @@
 //! Searchable TUI model picker state.
 
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
+use warp::settings::AISettings;
 use warp::tui_export::{
-    LLMId, LLMPreferences, LLMPreferencesEvent, ModelPickerChoice, query_model_picker_choices,
-    should_show_bedrock_icon_for_model,
+    AISettingsChangedEvent, LLMId, LLMPreferences, LLMPreferencesEvent, ModelPickerChoice,
+    query_model_picker_choices, should_show_bedrock_icon_for_model,
     should_show_gemini_enterprise_agent_platform_icon_for_model, should_show_key_icon_for_model,
 };
 use warp_editor::model::CoreEditorModel;
-use warpui_core::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
+use warpui_core::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use crate::inline_menu::{
     MAX_INLINE_MENU_ROWS, TuiInlineMenuHeader, TuiInlineMenuListState, TuiInlineMenuRow,
@@ -23,6 +24,7 @@ struct TuiModelMenuRow {
     title: String,
     is_selectable: bool,
     is_key_connected: bool,
+    is_profile_default: bool,
     discount_percentage: Option<f32>,
 }
 
@@ -41,6 +43,7 @@ pub(crate) struct TuiModelMenuEvent;
 pub(crate) struct TuiModelMenuModel {
     input_editor: ModelHandle<CodeEditorModel>,
     suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+    terminal_view_id: EntityId,
     state: TuiModelMenuState,
 }
 
@@ -48,6 +51,7 @@ impl TuiModelMenuModel {
     pub(crate) fn new(
         input_editor: ModelHandle<CodeEditorModel>,
         suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
+        terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&input_editor, |model, _, event, ctx| {
@@ -66,9 +70,17 @@ impl TuiModelMenuModel {
                 model.refresh_rows(ctx);
             }
         });
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |model, _, event, ctx| {
+            if model.is_open(ctx)
+                && matches!(event, AISettingsChangedEvent::ExecutionProfiles { .. })
+            {
+                model.refresh_rows(ctx);
+            }
+        });
         Self {
             input_editor,
             suggestions_mode,
+            terminal_view_id,
             state: TuiModelMenuState::Closed,
         }
     }
@@ -88,6 +100,7 @@ impl TuiModelMenuModel {
                     id,
                     is_selectable,
                     is_key_connected: false,
+                    is_profile_default: false,
                     discount_percentage: None,
                 })
                 .collect(),
@@ -99,6 +112,7 @@ impl TuiModelMenuModel {
         Self {
             input_editor,
             suggestions_mode,
+            terminal_view_id: EntityId::new(),
             state: TuiModelMenuState::Open { list },
         }
     }
@@ -225,7 +239,14 @@ impl TuiModelMenuModel {
         }
         let query = input_text(&self.input_editor, ctx);
         let preferences = LLMPreferences::as_ref(ctx);
-        let active_id = preferences.get_active_base_model(ctx, None).id.clone();
+        let active_id = preferences
+            .get_active_base_model(ctx, Some(self.terminal_view_id))
+            .id
+            .clone();
+        let profile_default_id = preferences
+            .get_active_profile_base_model(ctx, Some(self.terminal_view_id))
+            .id
+            .clone();
         let choices = query_model_picker_choices(
             preferences,
             preferences.get_base_llm_choices_for_agent_mode(ctx),
@@ -234,7 +255,7 @@ impl TuiModelMenuModel {
         );
         let rows = choices
             .into_iter()
-            .map(|choice| model_menu_row(choice, ctx))
+            .map(|choice| model_menu_row(choice, &profile_default_id, ctx))
             .collect::<Vec<_>>();
         let preferred_index = preferred_selection_index(&rows, &active_id, query.trim().is_empty());
         let TuiModelMenuState::Open { list } = &mut self.state else {
@@ -247,7 +268,11 @@ impl TuiModelMenuModel {
     }
 }
 
-fn model_menu_row(choice: ModelPickerChoice, app: &AppContext) -> TuiModelMenuRow {
+fn model_menu_row(
+    choice: ModelPickerChoice,
+    profile_default_id: &LLMId,
+    app: &AppContext,
+) -> TuiModelMenuRow {
     let uses_external_inference = should_show_key_icon_for_model(&choice.llm, app)
         || should_show_bedrock_icon_for_model(&choice.llm, app)
         || should_show_gemini_enterprise_agent_platform_icon_for_model(&choice.llm, app);
@@ -258,17 +283,24 @@ fn model_menu_row(choice: ModelPickerChoice, app: &AppContext) -> TuiModelMenuRo
             .llm
             .discount_percentage
             .filter(|_| !uses_external_inference),
+        is_profile_default: choice.llm.id == *profile_default_id,
         id: choice.llm.id,
         title: choice.llm.display_name,
     }
 }
 
 fn snapshot_row(row: &TuiModelMenuRow) -> TuiInlineMenuRow {
+    let state_suffix = match (row.is_profile_default, row.is_key_connected) {
+        (true, true) => Some("(default) (key connected)".to_owned()),
+        (true, false) => Some("(default)".to_owned()),
+        (false, true) => Some("(key connected)".to_owned()),
+        (false, false) => None,
+    };
     TuiInlineMenuRow {
         title: row.title.clone(),
         prefix: None,
         description: (!row.is_selectable).then(|| "disabled".to_owned()),
-        state_suffix: row.is_key_connected.then(|| "(key connected)".to_owned()),
+        state_suffix,
         promotional_suffix: discount_label(row.discount_percentage),
         is_selectable: row.is_selectable,
         style: TuiInlineMenuRowStyle::Default,

--- a/crates/warp_tui/src/model_menu_tests.rs
+++ b/crates/warp_tui/src/model_menu_tests.rs
@@ -7,12 +7,18 @@ use warpui_core::App;
 
 use super::*;
 
-fn row(id: &str, is_selectable: bool, is_key_connected: bool) -> TuiModelMenuRow {
+fn row(
+    id: &str,
+    is_selectable: bool,
+    is_key_connected: bool,
+    is_profile_default: bool,
+) -> TuiModelMenuRow {
     TuiModelMenuRow {
         id: id.into(),
         title: id.to_owned(),
         is_selectable,
         is_key_connected,
+        is_profile_default,
         discount_percentage: None,
     }
 }
@@ -20,9 +26,9 @@ fn row(id: &str, is_selectable: bool, is_key_connected: bool) -> TuiModelMenuRow
 #[test]
 fn empty_query_prefers_active_model_and_filtered_query_prefers_best_match() {
     let rows = vec![
-        row("auto", true, false),
-        row("gpt-4", true, false),
-        row("gpt-5", true, false),
+        row("auto", true, false, false),
+        row("gpt-4", true, false, false),
+        row("gpt-5", true, false, false),
     ];
 
     assert_eq!(
@@ -38,9 +44,9 @@ fn empty_query_prefers_active_model_and_filtered_query_prefers_best_match() {
 #[test]
 fn model_selection_skips_disabled_rows() {
     let rows = vec![
-        row("auto", true, false),
-        row("gpt-5", true, false),
-        row("disabled", false, false),
+        row("auto", true, false, false),
+        row("gpt-5", true, false, false),
+        row("disabled", false, false, false),
     ];
 
     assert_eq!(
@@ -55,11 +61,21 @@ fn model_selection_skips_disabled_rows() {
 
 #[test]
 fn snapshot_marks_only_key_connected_models() {
-    let connected = snapshot_row(&row("gpt-5", true, true));
+    let connected = snapshot_row(&row("gpt-5", true, true, false));
     assert_eq!(connected.state_suffix.as_deref(), Some("(key connected)"));
-
-    let hosted = snapshot_row(&row("auto", true, false));
+    let hosted = snapshot_row(&row("auto", true, false, false));
     assert_eq!(hosted.state_suffix, None);
+}
+#[test]
+fn snapshot_marks_the_profile_default_model() {
+    let default = snapshot_row(&row("auto", true, false, true));
+    assert_eq!(default.state_suffix.as_deref(), Some("(default)"));
+
+    let connected_default = snapshot_row(&row("gpt-5", true, true, true));
+    assert_eq!(
+        connected_default.state_suffix.as_deref(),
+        Some("(default) (key connected)")
+    );
 }
 
 #[test]
@@ -82,7 +98,7 @@ fn provider_key_controls_key_connected_callout() {
         let connected_row = app.read(|ctx| {
             let choice =
                 query_model_picker_choices(LLMPreferences::as_ref(ctx), [&llm], "", ctx).remove(0);
-            model_menu_row(choice, ctx)
+            model_menu_row(choice, &LLMId::from("profile-default"), ctx)
         });
         assert_eq!(
             snapshot_row(&connected_row).state_suffix.as_deref(),
@@ -97,7 +113,7 @@ fn provider_key_controls_key_connected_callout() {
         let disconnected_row = app.read(|ctx| {
             let choice =
                 query_model_picker_choices(LLMPreferences::as_ref(ctx), [&llm], "", ctx).remove(0);
-            model_menu_row(choice, ctx)
+            model_menu_row(choice, &LLMId::from("profile-default"), ctx)
         });
         assert_eq!(snapshot_row(&disconnected_row).state_suffix, None);
     });

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -349,7 +349,6 @@ const SWITCH_CONVERSATION_RUNNING_HINT: &str =
 const SWITCH_LOADING_HINT: &str = "Another conversation is already loading.";
 const SWITCH_UNAVAILABLE_HINT: &str = "That conversation is no longer available.";
 const LOADING_CONVERSATION_HINT: &str = "Loading conversation…";
-const MODEL_PERSISTENCE_FAILED_HINT: &str = "Could not save the selected model.";
 const THEME_INVALID_ARGUMENT_HINT: &str = "Theme must be auto, light, or dark.";
 
 /// Footer label shown while the input is in `!` shell mode. The how-to-exit
@@ -1681,7 +1680,12 @@ impl TuiTerminalSessionView {
             }
         });
         let model_menu = ctx.add_model(|ctx| {
-            TuiModelMenuModel::new(input_editor_model.clone(), suggestions_mode.clone(), ctx)
+            TuiModelMenuModel::new(
+                input_editor_model.clone(),
+                suggestions_mode.clone(),
+                terminal_surface_id,
+                ctx,
+            )
         });
         ctx.subscribe_to_model(&model_menu, |_, _, _: &TuiModelMenuEvent, ctx| {
             ctx.notify();
@@ -2094,6 +2098,7 @@ impl TuiTerminalSessionView {
                 AISettingsChangedEvent::TuiUsageDisplayMode { .. }
                     | AISettingsChangedEvent::TuiStatusline { .. }
                     | AISettingsChangedEvent::VoiceInputEnabled { .. }
+                    | AISettingsChangedEvent::ExecutionProfiles { .. }
             ) {
                 ctx.notify();
             }
@@ -4169,14 +4174,9 @@ impl TuiTerminalSessionView {
     }
 
     fn handle_accepted_model(&mut self, id: &LLMId, ctx: &mut ViewContext<Self>) {
-        let terminal_view_id = ctx.view_id();
-        let persisted = LLMPreferences::handle(ctx).update(ctx, |preferences, ctx| {
-            preferences.update_active_profile_base_model(id, Some(terminal_view_id), ctx)
+        LLMPreferences::handle(ctx).update(ctx, |preferences, ctx| {
+            preferences.update_preferred_agent_mode_llm(id, self.terminal_surface_id, ctx);
         });
-        if !persisted {
-            self.show_transient_hint(MODEL_PERSISTENCE_FAILED_HINT.to_owned(), ctx);
-            return;
-        }
         self.model_menu.update(ctx, |menu, ctx| menu.dismiss(ctx));
     }
     fn handle_accepted_mcp_action(&mut self, action: TuiMcpAction, ctx: &mut ViewContext<Self>) {

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -1450,6 +1450,109 @@ fn toggle_model_menu_action_opens_and_closes_the_inline_model_menu() {
         });
     });
 }
+
+#[test]
+fn accepted_model_only_changes_the_current_session() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        LLMPreferences::handle(&app).update(&mut app, |preferences, ctx| {
+            let mut alternate = preferences.get_default_base_model(ctx).clone();
+            alternate.id = "tui-session-override".into();
+            alternate.display_name = "TUI session override".to_owned();
+            preferences.add_agent_mode_model_for_test(alternate);
+        });
+        let (first_view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let (second_view, _) = add_focus_test_session(&mut app, &fixture, false);
+        let (profile_default_id, alternate_id) = app.read(|ctx| {
+            let preferences = LLMPreferences::as_ref(ctx);
+            let profile_default_id = preferences
+                .get_active_profile_base_model(ctx, None)
+                .id
+                .clone();
+            let alternate_id = preferences
+                .get_base_llm_choices_for_agent_mode(ctx)
+                .find(|model| model.id != profile_default_id && model.disable_reason.is_none())
+                .expect("test model catalog should include an alternate model")
+                .id
+                .clone();
+            (profile_default_id, alternate_id)
+        });
+
+        first_view.update(&mut app, |view, ctx| {
+            view.handle_accepted_model(&alternate_id, ctx);
+        });
+
+        app.read(|ctx| {
+            let preferences = LLMPreferences::as_ref(ctx);
+            let first_surface_id = first_view.as_ref(ctx).terminal_surface_id;
+            let second_surface_id = second_view.as_ref(ctx).terminal_surface_id;
+            assert_eq!(
+                preferences
+                    .get_active_base_model(ctx, Some(first_surface_id))
+                    .id,
+                alternate_id
+            );
+            assert_eq!(
+                preferences
+                    .get_active_base_model(ctx, Some(second_surface_id))
+                    .id,
+                profile_default_id
+            );
+            assert_eq!(
+                preferences
+                    .get_active_profile_base_model(ctx, Some(first_surface_id))
+                    .id,
+                profile_default_id
+            );
+        });
+    });
+}
+
+#[test]
+fn model_menu_labels_the_profile_default_model() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        view.update(&mut app, |view, ctx| {
+            view.model_menu.update(ctx, |menu, ctx| menu.open(ctx));
+        });
+
+        view.read(&app, |view, ctx| {
+            let default_name = LLMPreferences::as_ref(ctx)
+                .get_active_profile_base_model(ctx, Some(view.terminal_surface_id))
+                .display_name
+                .clone();
+            let snapshot = view
+                .model_menu
+                .as_ref(ctx)
+                .snapshot(ctx)
+                .expect("model menu should be open");
+            let default_row = snapshot
+                .rows
+                .iter()
+                .find(|row| row.title == default_name)
+                .expect("profile default model should be listed");
+            assert!(
+                default_row
+                    .state_suffix
+                    .as_deref()
+                    .is_some_and(|suffix| suffix.contains("(default)"))
+            );
+            assert_eq!(
+                snapshot
+                    .rows
+                    .iter()
+                    .filter(|row| {
+                        row.state_suffix
+                            .as_deref()
+                            .is_some_and(|suffix| suffix.contains("(default)"))
+                    })
+                    .count(),
+                1
+            );
+        });
+    });
+}
 #[test]
 fn todo_menu_renders_active_list_and_toggles_through_shared_suggestions_mode() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description
Fixes the Warp Agent CLI model picker so choosing a model creates a session-scoped override instead of changing the active execution profile for every session.

The picker now resolves selection state for its terminal surface, labels the profile model with `(default)`, and refreshes the statusline and open picker when execution-profile settings change. Sessions without an override follow a newly configured profile default, while sessions with an override remain pinned.

## Linked Issue
[APP-4908](https://linear.app/warpdotdev/issue/APP-4908/tui-clicking-model-name-in-footer-should-open-model-inline-menu)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo nextest run -p warp_tui` — 952 passed; one existing test reported as leaky.
- Focused session-isolation and default-label tests passed.
- `./script/format --check` passed.
- Clippy passed for `warp_tui` and `warp` with warnings denied.
- Manually verified with `./script/run-tui` under tmux:
  - the profile model rendered with `(default)`;
  - selecting another model updated the current session statusline;
  - reopening the picker preserved the profile's `(default)` marker.
- Additional full presubmit run skipped per request.

- [x] I have manually tested my changes locally with `./script/run-tui`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Conversation](https://staging.warp.dev/conversation/62c43d38-231d-41cf-b4b5-2680c88f5279)

CHANGELOG-BUG-FIX: Fixed the Warp Agent CLI model picker changing the default model for every session.
CHANGELOG-TUI: Model selection now applies only to the current session and identifies the profile default.

Co-Authored-By: Warp Agent <agent@warp.dev>
