### PR TITLE
Render TUI agent code blocks without borders

### DIFF
--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -53,7 +53,9 @@ use crate::terminal_session_view::BlockingInputSource;
 use crate::transcript_view::BLOCK_TOP_PADDING_ROWS;
 use crate::tui_builder::TuiUiBuilder;
 use crate::tui_cli_subagent_view::TuiCLISubagentView;
-use crate::tui_code_block_view::{TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent};
+use crate::tui_code_block_view::{
+    TuiCodeBlockChrome, TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent,
+};
 use crate::tui_markdown::{
     TuiMarkdownBlockHooks, TuiMarkdownPalette, render_formatted_table, render_formatted_text,
 };
@@ -1060,7 +1062,9 @@ impl TuiAIBlock {
                 });
                 continue;
             }
-            let view = ctx.add_tui_view(move |ctx| TuiCodeBlockView::new(payload, ctx));
+            let view = ctx.add_tui_view(move |ctx| {
+                TuiCodeBlockView::new(payload, ctx).with_chrome(TuiCodeBlockChrome::Minimal)
+            });
             ctx.subscribe_to_view(&view, |me, _, event, ctx| match event {
                 TuiCodeBlockViewEvent::LayoutChanged | TuiCodeBlockViewEvent::SyntaxUpdated => {
                     me.invalidate_layout(ctx)

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -53,9 +53,7 @@ use crate::terminal_session_view::BlockingInputSource;
 use crate::transcript_view::BLOCK_TOP_PADDING_ROWS;
 use crate::tui_builder::TuiUiBuilder;
 use crate::tui_cli_subagent_view::TuiCLISubagentView;
-use crate::tui_code_block_view::{
-    TuiCodeBlockChrome, TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent,
-};
+use crate::tui_code_block_view::{TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent};
 use crate::tui_markdown::{
     TuiMarkdownBlockHooks, TuiMarkdownPalette, render_formatted_table, render_formatted_text,
 };
@@ -1062,9 +1060,7 @@ impl TuiAIBlock {
                 });
                 continue;
             }
-            let view = ctx.add_tui_view(move |ctx| {
-                TuiCodeBlockView::new(payload, ctx).with_chrome(TuiCodeBlockChrome::Minimal)
-            });
+            let view = ctx.add_tui_view(move |ctx| TuiCodeBlockView::new(payload, ctx));
             ctx.subscribe_to_view(&view, |me, _, event, ctx| match event {
                 TuiCodeBlockViewEvent::LayoutChanged | TuiCodeBlockViewEvent::SyntaxUpdated => {
                     me.invalidate_layout(ctx)

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -1401,12 +1401,15 @@ fn agent_block_preserves_and_renders_code_sections_in_order() {
                 TuiRect::new(0, 0, 40, 3),
                 app_ctx,
             );
-            assert!(
+            assert_eq!(
                 frame
                     .buffer
                     .to_lines()
-                    .iter()
-                    .any(|line| line.contains("println!"))
+                    .into_iter()
+                    .map(|line| line.trim_end().to_owned())
+                    .filter(|line| !line.is_empty())
+                    .collect::<Vec<_>>(),
+                vec!["println!(\"hi\");"]
             );
 
             let rendered = render_block_lines(block, 40, app_ctx);

--- a/crates/warp_tui/src/tui_code_block_view.rs
+++ b/crates/warp_tui/src/tui_code_block_view.rs
@@ -10,9 +10,7 @@ use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::content::version::BufferVersion;
 use warp_editor::model::CoreEditorModel;
-use warpui_core::elements::tui::{
-    Color, TuiContainer, TuiElement, TuiFlex, TuiParentElement, TuiStyle, TuiText,
-};
+use warpui_core::elements::tui::{Color, TuiElement, TuiFlex, TuiParentElement, TuiStyle, TuiText};
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 
 use crate::editor_element::{TuiEditorElement, TuiEditorStyles};
@@ -26,12 +24,6 @@ const TRUNCATION_NOTICE: &str = "… code block truncated …";
 pub(crate) enum TuiCodeBlockViewEvent {
     LayoutChanged,
     SyntaxUpdated,
-}
-#[derive(Clone, Copy, Default)]
-pub(crate) enum TuiCodeBlockChrome {
-    #[default]
-    Bordered,
-    Minimal,
 }
 
 /// Persistent payload identity for one code child.
@@ -57,7 +49,6 @@ pub(crate) struct TuiCodeBlockView {
     expected_syntax_version: Option<BufferVersion>,
     text_overrides: Vec<(std::ops::Range<CharOffset>, TuiStyle)>,
     fallback_text: Option<String>,
-    chrome: TuiCodeBlockChrome,
 }
 
 impl TuiCodeBlockView {
@@ -69,14 +60,9 @@ impl TuiCodeBlockView {
             expected_syntax_version: None,
             text_overrides: Vec::new(),
             fallback_text: None,
-            chrome: TuiCodeBlockChrome::default(),
         };
         view.sync(payload, ctx);
         view
-    }
-    pub(crate) fn with_chrome(mut self, chrome: TuiCodeBlockChrome) -> Self {
-        self.chrome = chrome;
-        self
     }
 
     fn create_editor(ctx: &mut ViewContext<Self>) -> ModelHandle<CodeEditorModel> {
@@ -265,14 +251,7 @@ impl TuiView for TuiCodeBlockView {
             );
         }
         column.add_child(self.render_body(app));
-        let container = TuiContainer::new(column.finish());
-        match self.chrome {
-            TuiCodeBlockChrome::Bordered => container
-                .with_border_style(builder.muted_text_style())
-                .with_padding_x(1)
-                .finish(),
-            TuiCodeBlockChrome::Minimal => container.finish(),
-        }
+        column.finish()
     }
 }
 

--- a/crates/warp_tui/src/tui_code_block_view.rs
+++ b/crates/warp_tui/src/tui_code_block_view.rs
@@ -27,6 +27,12 @@ pub(crate) enum TuiCodeBlockViewEvent {
     LayoutChanged,
     SyntaxUpdated,
 }
+#[derive(Clone, Copy, Default)]
+pub(crate) enum TuiCodeBlockChrome {
+    #[default]
+    Bordered,
+    Minimal,
+}
 
 /// Persistent payload identity for one code child.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -51,6 +57,7 @@ pub(crate) struct TuiCodeBlockView {
     expected_syntax_version: Option<BufferVersion>,
     text_overrides: Vec<(std::ops::Range<CharOffset>, TuiStyle)>,
     fallback_text: Option<String>,
+    chrome: TuiCodeBlockChrome,
 }
 
 impl TuiCodeBlockView {
@@ -62,9 +69,14 @@ impl TuiCodeBlockView {
             expected_syntax_version: None,
             text_overrides: Vec::new(),
             fallback_text: None,
+            chrome: TuiCodeBlockChrome::default(),
         };
         view.sync(payload, ctx);
         view
+    }
+    pub(crate) fn with_chrome(mut self, chrome: TuiCodeBlockChrome) -> Self {
+        self.chrome = chrome;
+        self
     }
 
     fn create_editor(ctx: &mut ViewContext<Self>) -> ModelHandle<CodeEditorModel> {
@@ -253,10 +265,14 @@ impl TuiView for TuiCodeBlockView {
             );
         }
         column.add_child(self.render_body(app));
-        TuiContainer::new(column.finish())
-            .with_border_style(builder.muted_text_style())
-            .with_padding_x(1)
-            .finish()
+        let container = TuiContainer::new(column.finish());
+        match self.chrome {
+            TuiCodeBlockChrome::Bordered => container
+                .with_border_style(builder.muted_text_style())
+                .with_padding_x(1)
+                .finish(),
+            TuiCodeBlockChrome::Minimal => container.finish(),
+        }
     }
 }
 

--- a/crates/warp_tui/src/tui_code_block_view_tests.rs
+++ b/crates/warp_tui/src/tui_code_block_view_tests.rs
@@ -7,8 +7,8 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{TuiView, ViewHandle};
 
 use super::{
-    MAX_CODE_LINES, MAX_HIGHLIGHT_BYTES, TRUNCATION_NOTICE, TuiCodeBlockPayload, TuiCodeBlockView,
-    TuiCodeBlockViewEvent, bounded_fallback_text,
+    MAX_CODE_LINES, MAX_HIGHLIGHT_BYTES, TRUNCATION_NOTICE, TuiCodeBlockChrome,
+    TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent, bounded_fallback_text,
 };
 use crate::test_fixtures::TestHostView;
 
@@ -56,6 +56,47 @@ fn renders_read_only_code_with_language_and_wrapping() {
     });
 }
 
+#[test]
+fn renders_minimal_code_with_language_and_wrapping() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let view = add_code_view(&mut app, |ctx| {
+            TuiCodeBlockView::new(
+                TuiCodeBlockPayload::new(
+                    "fn main() {\n    println!(\"hello world\");\n}",
+                    Some("rust".to_owned()),
+                ),
+                ctx,
+            )
+            .with_chrome(TuiCodeBlockChrome::Minimal)
+        });
+        app.read(|ctx| {
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                view.as_ref(ctx).render(ctx),
+                TuiRect::new(0, 0, 18, 10),
+                ctx,
+            );
+            let lines = frame
+                .buffer
+                .to_lines()
+                .into_iter()
+                .map(|line| line.trim_end().to_owned())
+                .take_while(|line| !line.is_empty())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                lines,
+                vec![
+                    "rust",
+                    "fn main() {",
+                    "    println!",
+                    "(\"hello world\");",
+                    "}",
+                ]
+            );
+        });
+    });
+}
 fn add_code_view(
     app: &mut App,
     build: impl FnOnce(&mut warpui_core::ViewContext<TuiCodeBlockView>) -> TuiCodeBlockView + 'static,

--- a/crates/warp_tui/src/tui_code_block_view_tests.rs
+++ b/crates/warp_tui/src/tui_code_block_view_tests.rs
@@ -7,8 +7,8 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{TuiView, ViewHandle};
 
 use super::{
-    MAX_CODE_LINES, MAX_HIGHLIGHT_BYTES, TRUNCATION_NOTICE, TuiCodeBlockChrome,
-    TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent, bounded_fallback_text,
+    MAX_CODE_LINES, MAX_HIGHLIGHT_BYTES, TRUNCATION_NOTICE, TuiCodeBlockPayload, TuiCodeBlockView,
+    TuiCodeBlockViewEvent, bounded_fallback_text,
 };
 use crate::test_fixtures::TestHostView;
 
@@ -24,51 +24,6 @@ fn renders_read_only_code_with_language_and_wrapping() {
                 ),
                 ctx,
             )
-        });
-        app.read(|ctx| {
-            let mut presenter = TuiPresenter::new();
-            let frame = presenter.present_element(
-                view.as_ref(ctx).render(ctx),
-                TuiRect::new(0, 0, 18, 10),
-                ctx,
-            );
-            let lines = frame
-                .buffer
-                .to_lines()
-                .into_iter()
-                .map(|line| line.trim_end().to_owned())
-                .take_while(|line| !line.is_empty() || line.starts_with('▏'))
-                .collect::<Vec<_>>();
-            assert_eq!(
-                lines,
-                vec![
-                    "▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁",
-                    "▏ rust           ▕",
-                    "▏ fn main() {    ▕",
-                    "▏     println!   ▕",
-                    "▏ (\"hello        ▕",
-                    "▏ world\");       ▕",
-                    "▏ }              ▕",
-                    "▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔",
-                ]
-            );
-        });
-    });
-}
-
-#[test]
-fn renders_minimal_code_with_language_and_wrapping() {
-    App::test((), |mut app| async move {
-        app.add_singleton_model(|_| Appearance::mock());
-        let view = add_code_view(&mut app, |ctx| {
-            TuiCodeBlockView::new(
-                TuiCodeBlockPayload::new(
-                    "fn main() {\n    println!(\"hello world\");\n}",
-                    Some("rust".to_owned()),
-                ),
-                ctx,
-            )
-            .with_chrome(TuiCodeBlockChrome::Minimal)
         });
         app.read(|ctx| {
             let mut presenter = TuiPresenter::new();


### PR DESCRIPTION
## Description

Agent-generated code blocks in the TUI currently render inside a full box. The vertical border characters make terminal selection and copying unnecessarily awkward.

This change removes the border and container padding from the reusable TUI code-block view. Agent output, plan documents, and other editor-backed code blocks retain their language label, syntax highlighting, wrapping, and streaming behavior while using the same minimal presentation.

Design exploration and comparison with Codex CLI and Claude Code: [Warp Agent conversation](https://staging.warp.dev/conversation/6465587d-c46b-4030-a8bf-a46c9fd03e1c)

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] Manually tested locally with `./script/run-tui`
- [x] `./script/format`
- [x] `cargo nextest run -p warp_tui` — 949 tests passed
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- [x] Added render-to-lines coverage for labeled borderless code blocks
- [x] Added agent-block coverage confirming borderless output

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

The linked Warp Agent conversation contains the side-by-side design variants. The selected labeled-minimal treatment was verified in the local TUI.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-TUI: Code blocks no longer include box borders, making code easier to select and copy.

Co-Authored-By: Warp Agent <agent@warp.dev>
