### PR TITLE
Show server-authored Fable and Opus promotion

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -5,9 +5,7 @@ use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::Fill;
 use warpui::assets::asset_cache::AssetSource;
-use warpui::elements::{
-    CrossAxisAlignment, Element, Empty, Flex, MainAxisSize, MouseStateHandle, ParentElement,
-};
+use warpui::elements::{Element, Empty, MouseStateHandle};
 use warpui::keymap::Keystroke;
 use warpui::platform::OperatingSystem;
 use warpui::{
@@ -402,42 +400,37 @@ impl View for AgentMessageBar {
             return Empty::new().finish();
         };
 
-        let mut right_elements = Vec::new();
-        if !cfg!(target_family = "wasm") {
-            if let Some(message) = PricingPromotionState::as_ref(app)
-                .visible_message(PricingPromotionSurface::AgentMessageBar, app)
-            {
-                right_elements.push(render_dismissible_promo_pill(
-                    message,
-                    appearance.theme().ansi_fg_green(),
-                    Some(self.mouse_states.pricing_promotion.clone()),
-                    Some(AgentMessageBarAction::UpgradePricingPromotion),
-                    self.mouse_states.pricing_promotion_close.clone(),
-                    AgentMessageBarAction::DismissPricingPromotion,
-                    app,
-                ));
-            }
+        let right_element = if cfg!(target_family = "wasm") {
+            None
+        } else if let Some(message) = PricingPromotionState::as_ref(app)
+            .visible_message(PricingPromotionSurface::AgentMessageBar, app)
+        {
+            Some(render_dismissible_promo_pill(
+                message,
+                appearance.theme().ansi_fg_green(),
+                Some(self.mouse_states.pricing_promotion.clone()),
+                Some(AgentMessageBarAction::UpgradePricingPromotion),
+                self.mouse_states.pricing_promotion_close.clone(),
+                AgentMessageBarAction::DismissPricingPromotion,
+                app,
+            ))
+        } else {
             let request_usage_model = AIRequestUsageModel::as_ref(app);
-            if let Some(credits) = request_usage_model.ambient_only_credits_remaining()
-                && credits >= AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD
-                && !request_usage_model.is_ambient_credits_banner_dismissed()
-            {
-                right_elements.push(render_ambient_credits_banner(
-                    credits,
-                    self.mouse_states.ambient_credits_banner_close.clone(),
-                    AgentMessageBarAction::DismissAmbientCreditsBanner,
-                    app,
-                ));
-            }
-        }
-        let right_element = (!right_elements.is_empty()).then(|| {
-            Flex::row()
-                .with_main_axis_size(MainAxisSize::Min)
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_spacing(4.)
-                .with_children(right_elements)
-                .finish()
-        });
+            request_usage_model
+                .ambient_only_credits_remaining()
+                .filter(|credits| {
+                    *credits >= AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD
+                        && !request_usage_model.is_ambient_credits_banner_dismissed()
+                })
+                .map(|credits| {
+                    render_ambient_credits_banner(
+                        credits,
+                        self.mouse_states.ambient_credits_banner_close.clone(),
+                        AgentMessageBarAction::DismissAmbientCreditsBanner,
+                        app,
+                    )
+                })
+        };
 
         // Append a Figma MCP chip to the message if applicable.
         match self.figma_button_status(app) {

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -5,7 +5,9 @@ use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::Fill;
 use warpui::assets::asset_cache::AssetSource;
-use warpui::elements::{Element, Empty, MouseStateHandle};
+use warpui::elements::{
+    CrossAxisAlignment, Element, Empty, Flex, MainAxisSize, MouseStateHandle, ParentElement,
+};
 use warpui::keymap::Keystroke;
 use warpui::platform::OperatingSystem;
 use warpui::{
@@ -19,7 +21,9 @@ use crate::ai::agent::{
     AIAgentExchangeId, AIAgentOutputStatus, FinishedAIAgentOutput, RenderableAIError,
 };
 use crate::ai::blocklist::agent_view::shortcuts::AgentShortcutViewModel;
-use crate::ai::blocklist::agent_view::zero_state_block::render_ambient_credits_banner;
+use crate::ai::blocklist::agent_view::zero_state_block::{
+    render_ambient_credits_banner, render_dismissible_promo_pill,
+};
 use crate::ai::blocklist::agent_view::{
     AgentViewController, AgentViewControllerEvent, is_in_cloud_context,
 };
@@ -30,9 +34,13 @@ use crate::ai::blocklist::{
 use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentModelEvent};
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::ai::mcp::templatable_manager::{FigmaMcpStatus, TemplatableMCPServerManagerEvent};
+use crate::ai::pricing_promotion::{
+    PricingPromotionState, PricingPromotionStateEvent, PricingPromotionSurface,
+};
 use crate::ai::request_usage_model::{
     AIRequestUsageModel, AIRequestUsageModelEvent, AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD,
 };
+use crate::auth::auth_manager::AuthManager;
 use crate::search::slash_command_menu::static_commands::commands;
 use crate::settings::AISettings;
 use crate::terminal::input::buffer_model::{InputBufferModel, InputBufferUpdateEvent};
@@ -77,6 +85,8 @@ pub struct AgentMessageBarMouseStates {
     pub figma_enable_button: MouseStateHandle,
     /// Mouse state handle for dismissing the ambient credits banner.
     pub ambient_credits_banner_close: MouseStateHandle,
+    pub pricing_promotion: MouseStateHandle,
+    pub pricing_promotion_close: MouseStateHandle,
 }
 
 /// Renders contextual hint text at the bottom of the agent view status bar.
@@ -103,6 +113,8 @@ impl Entity for AgentMessageBar {
 #[derive(Clone, Debug)]
 pub enum AgentMessageBarAction {
     DismissAmbientCreditsBanner,
+    UpgradePricingPromotion,
+    DismissPricingPromotion,
 }
 
 impl AgentMessageBar {
@@ -120,12 +132,13 @@ impl AgentMessageBar {
         terminal_model: Arc<FairMutex<TerminalModel>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        ctx.subscribe_to_model(&agent_view_controller, |_, _, event, ctx| {
+        ctx.subscribe_to_model(&agent_view_controller, |me, _, event, ctx| {
             if matches!(
                 event,
                 AgentViewControllerEvent::EnteredAgentView { .. }
                     | AgentViewControllerEvent::ExitedAgentView { .. }
             ) {
+                me.record_visible_promotion(ctx);
                 ctx.notify();
             }
         });
@@ -172,6 +185,7 @@ impl AgentMessageBar {
                     me.ephemeral_message_model
                         .update(ctx, |m, ctx| m.try_dismiss_explicit_message(ctx));
                 }
+                me.record_visible_promotion(ctx);
                 ctx.notify();
             }
         });
@@ -191,7 +205,12 @@ impl AgentMessageBar {
                 ctx.notify();
             }
         });
-
+        ctx.subscribe_to_model(&PricingPromotionState::handle(ctx), |me, _, event, ctx| {
+            if matches!(event, PricingPromotionStateEvent::Updated) {
+                me.record_visible_promotion(ctx);
+                ctx.notify();
+            }
+        });
         ctx.subscribe_to_model(&AIDocumentModel::handle(ctx), |_, _, event, ctx| {
             if matches!(event, AIDocumentModelEvent::DocumentVisibilityChanged(_)) {
                 ctx.notify();
@@ -238,7 +257,7 @@ impl AgentMessageBar {
             }
         });
 
-        Self {
+        let message_bar = Self {
             agent_view_controller,
             ephemeral_message_model,
             shortcut_view_model,
@@ -251,7 +270,9 @@ impl AgentMessageBar {
             terminal_model,
             mouse_states: AgentMessageBarMouseStates::default(),
             figma_detected: false,
-        }
+        };
+        message_bar.record_visible_promotion(ctx);
+        message_bar
     }
 }
 
@@ -290,6 +311,26 @@ impl AgentMessageBar {
         } else {
             None
         }
+    }
+
+    fn record_visible_promotion(&self, ctx: &mut ViewContext<Self>) {
+        if !self.agent_view_controller.as_ref(ctx).is_active()
+            || self
+                .input_suggestions_model
+                .as_ref(ctx)
+                .is_inline_menu_open()
+        {
+            return;
+        }
+        if PricingPromotionState::as_ref(ctx)
+            .visible_message(PricingPromotionSurface::AgentMessageBar, ctx)
+            .is_none()
+        {
+            return;
+        }
+        PricingPromotionState::handle(ctx).update(ctx, |state, ctx| {
+            state.record_displayed(PricingPromotionSurface::AgentMessageBar, ctx);
+        });
     }
 }
 
@@ -361,28 +402,42 @@ impl View for AgentMessageBar {
             return Empty::new().finish();
         };
 
-        // Show credits banner when user has ambient credits remaining.
-        let right_element = if cfg!(target_family = "wasm") {
-            None
-        } else {
-            let request_usage_model = AIRequestUsageModel::as_ref(app);
-            if let Some(credits) = request_usage_model.ambient_only_credits_remaining() {
-                if credits >= AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD
-                    && !request_usage_model.is_ambient_credits_banner_dismissed()
-                {
-                    Some(render_ambient_credits_banner(
-                        credits,
-                        self.mouse_states.ambient_credits_banner_close.clone(),
-                        AgentMessageBarAction::DismissAmbientCreditsBanner,
-                        app,
-                    ))
-                } else {
-                    None
-                }
-            } else {
-                None
+        let mut right_elements = Vec::new();
+        if !cfg!(target_family = "wasm") {
+            if let Some(message) = PricingPromotionState::as_ref(app)
+                .visible_message(PricingPromotionSurface::AgentMessageBar, app)
+            {
+                right_elements.push(render_dismissible_promo_pill(
+                    message,
+                    appearance.theme().ansi_fg_green(),
+                    Some(self.mouse_states.pricing_promotion.clone()),
+                    Some(AgentMessageBarAction::UpgradePricingPromotion),
+                    self.mouse_states.pricing_promotion_close.clone(),
+                    AgentMessageBarAction::DismissPricingPromotion,
+                    app,
+                ));
             }
-        };
+            let request_usage_model = AIRequestUsageModel::as_ref(app);
+            if let Some(credits) = request_usage_model.ambient_only_credits_remaining()
+                && credits >= AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD
+                && !request_usage_model.is_ambient_credits_banner_dismissed()
+            {
+                right_elements.push(render_ambient_credits_banner(
+                    credits,
+                    self.mouse_states.ambient_credits_banner_close.clone(),
+                    AgentMessageBarAction::DismissAmbientCreditsBanner,
+                    app,
+                ));
+            }
+        }
+        let right_element = (!right_elements.is_empty()).then(|| {
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Min)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_spacing(4.)
+                .with_children(right_elements)
+                .finish()
+        });
 
         // Append a Figma MCP chip to the message if applicable.
         match self.figma_button_status(app) {
@@ -426,6 +481,20 @@ impl TypedActionView for AgentMessageBar {
                 AIRequestUsageModel::handle(ctx).update(ctx, |model, ctx| {
                     model.dismiss_ambient_credits_banner(ctx);
                 });
+            }
+            AgentMessageBarAction::UpgradePricingPromotion => {
+                PricingPromotionState::handle(ctx).update(ctx, |state, ctx| {
+                    state.record_clicked(PricingPromotionSurface::AgentMessageBar, ctx);
+                });
+                let upgrade_url = AuthManager::handle(ctx)
+                    .update(ctx, |auth_manager, _| auth_manager.upgrade_url());
+                ctx.open_url(&upgrade_url);
+            }
+            AgentMessageBarAction::DismissPricingPromotion => {
+                PricingPromotionState::handle(ctx).update(ctx, |state, ctx| {
+                    state.dismiss(PricingPromotionSurface::AgentMessageBar, ctx);
+                });
+                ctx.notify();
             }
         }
     }

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -312,7 +312,8 @@ impl AgentMessageBar {
     }
 
     fn record_visible_promotion(&self, ctx: &mut ViewContext<Self>) {
-        if !self.agent_view_controller.as_ref(ctx).is_active()
+        if cfg!(target_family = "wasm")
+            || !self.agent_view_controller.as_ref(ctx).is_active()
             || self
                 .input_suggestions_model
                 .as_ref(ctx)

--- a/app/src/ai/blocklist/agent_view/zero_state_block.rs
+++ b/app/src/ai/blocklist/agent_view/zero_state_block.rs
@@ -6,13 +6,15 @@ use std::sync::Arc;
 use itertools::Itertools as _;
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine, parse_markdown};
 use parking_lot::FairMutex;
+use pathfinder_color::ColorU;
 use settings::Setting;
 use warp_core::features::FeatureFlag;
 use warp_core::ui::Icon;
 use warp_errors::report_if_error;
 use warpui::elements::{
-    Clipped, Container, CornerRadius, CrossAxisAlignment, Flex, FormattedTextElement,
-    HighlightedHyperlink, MainAxisSize, MouseStateHandle, ParentElement, Radius, Shrinkable, Text,
+    Clipped, Container, CornerRadius, CrossAxisAlignment, DispatchEventResult, EventHandler, Flex,
+    FormattedTextElement, HighlightedHyperlink, MainAxisSize, MouseStateHandle, ParentElement,
+    Radius, Shrinkable, Text,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::keymap::Keystroke;
@@ -1233,22 +1235,63 @@ where
     A: Action + Clone + 'static,
 {
     let appearance = Appearance::as_ref(app);
-    let theme = appearance.theme();
+    render_dismissible_promo_pill(
+        format!("{credits} free cloud agent credits"),
+        appearance.theme().terminal_colors().normal.blue.into(),
+        None,
+        None,
+        close_button_mouse_state,
+        dismiss_action,
+        app,
+    )
+}
+
+pub fn render_dismissible_promo_pill<A>(
+    label: String,
+    text_color: ColorU,
+    click_mouse_state: Option<MouseStateHandle>,
+    click_action: Option<A>,
+    close_button_mouse_state: MouseStateHandle,
+    dismiss_action: A,
+    app: &AppContext,
+) -> Box<dyn Element>
+where
+    A: Action + Clone + 'static,
+{
+    let appearance = Appearance::as_ref(app);
     let font_family = appearance.ui_font_family();
     let font_size = styles::CREDITS_BANNER_FONT_SIZE;
-    let text_color = theme.terminal_colors().normal.blue;
-
-    let credits_text = format!("{credits} free cloud agent credits");
-    let text = Text::new(credits_text, font_family, font_size)
-        .with_color(text_color.into())
-        .with_style(Properties::default().weight(Weight::Semibold))
-        .soft_wrap(false)
-        .finish();
+    let label_element: Box<dyn Element> = match (click_mouse_state, click_action) {
+        (Some(mouse_state), Some(action)) => {
+            let label_for_hover = label.clone();
+            let clickable_label = Hoverable::new(mouse_state, move |_| {
+                Text::new(label_for_hover.clone(), font_family, font_size)
+                    .with_color(text_color)
+                    .with_style(Properties::default().weight(Weight::Semibold))
+                    .soft_wrap(false)
+                    .finish()
+            })
+            .with_cursor(Cursor::PointingHand)
+            .finish();
+            EventHandler::new(clickable_label)
+                .on_left_mouse_down(|_, _, _| DispatchEventResult::StopPropagation)
+                .on_left_mouse_up(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(action.clone());
+                    DispatchEventResult::StopPropagation
+                })
+                .finish()
+        }
+        _ => Text::new(label, font_family, font_size)
+            .with_color(text_color)
+            .with_style(Properties::default().weight(Weight::Semibold))
+            .soft_wrap(false)
+            .finish(),
+    };
     let close_button = appearance
         .ui_builder()
         .close_button(12., close_button_mouse_state)
         .with_style(UiComponentStyles {
-            font_color: Some(text_color.into()),
+            font_color: Some(text_color),
             ..Default::default()
         })
         .build()
@@ -1259,12 +1302,12 @@ where
 
     let content = Flex::row()
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_child(text)
+        .with_child(label_element)
         .with_child(Container::new(close_button).with_margin_left(4.).finish())
         .finish();
 
     Container::new(content)
-        .with_border(Border::all(1.).with_border_color(text_color.into()))
+        .with_border(Border::all(1.).with_border_color(text_color))
         .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)))
         .with_vertical_padding(2.)
         .with_horizontal_padding(6.)

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -46,6 +46,7 @@ pub mod onboarding;
 pub(crate) mod orchestration;
 pub(crate) mod persisted_workspace;
 pub(crate) mod predict;
+pub(crate) mod pricing_promotion;
 #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
 pub(crate) mod remote_agent_context;
 pub(crate) mod remote_context_files;

--- a/app/src/ai/onboarding.rs
+++ b/app/src/ai/onboarding.rs
@@ -70,3 +70,9 @@ pub fn onboarding_credit_packs(ctx: &AppContext) -> Vec<CreditPackOption> {
     };
     onboarding_credit_pack_options(options, policy.effective_premium_bps())
 }
+
+pub fn onboarding_pricing_promotion_message(ctx: &AppContext) -> Option<String> {
+    PricingInfoModel::as_ref(ctx)
+        .promotion_message()
+        .map(str::to_owned)
+}

--- a/app/src/ai/pricing_promotion.rs
+++ b/app/src/ai/pricing_promotion.rs
@@ -1,0 +1,195 @@
+use std::collections::HashSet;
+
+use serde_json::{Value, json};
+use strum_macros::{EnumDiscriminants, EnumIter};
+use warp_core::send_telemetry_from_ctx;
+use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
+use warp_core::user_preferences::GetUserPreferences;
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
+
+use crate::pricing::{PricingInfoModel, PricingInfoModelEvent};
+
+const AGENT_DISMISSED_KEY: &str = "pricing_promotion_agent_dismissed";
+const TERMINAL_DISMISSED_KEY: &str = "pricing_promotion_terminal_dismissed";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PricingPromotionSurface {
+    AgentMessageBar,
+    TerminalMessageBar,
+}
+
+impl PricingPromotionSurface {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::AgentMessageBar => "agent_message_bar",
+            Self::TerminalMessageBar => "terminal_message_bar",
+        }
+    }
+
+    fn dismissal_key(self) -> &'static str {
+        match self {
+            Self::AgentMessageBar => AGENT_DISMISSED_KEY,
+            Self::TerminalMessageBar => TERMINAL_DISMISSED_KEY,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum PricingPromotionStateEvent {
+    Updated,
+}
+
+pub struct PricingPromotionState {
+    agent_dismissed: bool,
+    terminal_dismissed: bool,
+    displayed_surfaces: HashSet<PricingPromotionSurface>,
+}
+
+impl PricingPromotionState {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        ctx.subscribe_to_model(&PricingInfoModel::handle(ctx), |_, _, event, ctx| {
+            if matches!(event, PricingInfoModelEvent::PricingInfoUpdated) {
+                ctx.emit(PricingPromotionStateEvent::Updated);
+                ctx.notify();
+            }
+        });
+
+        Self {
+            agent_dismissed: Self::read_dismissed(AGENT_DISMISSED_KEY, ctx),
+            terminal_dismissed: Self::read_dismissed(TERMINAL_DISMISSED_KEY, ctx),
+            displayed_surfaces: HashSet::new(),
+        }
+    }
+
+    pub fn visible_message(
+        &self,
+        surface: PricingPromotionSurface,
+        app: &AppContext,
+    ) -> Option<String> {
+        if self.is_dismissed(surface) {
+            return None;
+        }
+        PricingInfoModel::as_ref(app)
+            .promotion_message()
+            .map(str::to_owned)
+    }
+
+    pub fn record_displayed(
+        &mut self,
+        surface: PricingPromotionSurface,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.displayed_surfaces.insert(surface) {
+            send_telemetry_from_ctx!(PricingPromotionTelemetryEvent::Shown { surface }, ctx);
+        }
+    }
+
+    pub fn record_clicked(&self, surface: PricingPromotionSurface, ctx: &mut ModelContext<Self>) {
+        send_telemetry_from_ctx!(PricingPromotionTelemetryEvent::Clicked { surface }, ctx);
+    }
+
+    pub fn dismiss(&mut self, surface: PricingPromotionSurface, ctx: &mut ModelContext<Self>) {
+        match surface {
+            PricingPromotionSurface::AgentMessageBar => self.agent_dismissed = true,
+            PricingPromotionSurface::TerminalMessageBar => self.terminal_dismissed = true,
+        }
+        if let Err(error) = ctx
+            .private_user_preferences()
+            .write_value(surface.dismissal_key(), true.to_string())
+        {
+            log::warn!("Failed to persist pricing promotion dismissal: {error:#}");
+        }
+        send_telemetry_from_ctx!(PricingPromotionTelemetryEvent::Dismissed { surface }, ctx);
+        ctx.emit(PricingPromotionStateEvent::Updated);
+        ctx.notify();
+    }
+
+    fn is_dismissed(&self, surface: PricingPromotionSurface) -> bool {
+        match surface {
+            PricingPromotionSurface::AgentMessageBar => self.agent_dismissed,
+            PricingPromotionSurface::TerminalMessageBar => self.terminal_dismissed,
+        }
+    }
+
+    fn read_dismissed(key: &str, ctx: &AppContext) -> bool {
+        ctx.private_user_preferences()
+            .read_value(key)
+            .unwrap_or_default()
+            .is_some_and(|value| value == "true")
+    }
+}
+
+impl Entity for PricingPromotionState {
+    type Event = PricingPromotionStateEvent;
+}
+
+impl SingletonEntity for PricingPromotionState {}
+
+#[derive(Clone, Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
+enum PricingPromotionTelemetryEvent {
+    Shown { surface: PricingPromotionSurface },
+    Clicked { surface: PricingPromotionSurface },
+    Dismissed { surface: PricingPromotionSurface },
+}
+
+impl TelemetryEvent for PricingPromotionTelemetryEvent {
+    fn name(&self) -> &'static str {
+        PricingPromotionTelemetryEventDiscriminants::from(self).name()
+    }
+
+    fn payload(&self) -> Option<Value> {
+        let surface = match self {
+            Self::Shown { surface } | Self::Clicked { surface } | Self::Dismissed { surface } => {
+                surface
+            }
+        };
+        Some(json!({
+            "surface": surface.as_str(),
+        }))
+    }
+
+    fn description(&self) -> &'static str {
+        PricingPromotionTelemetryEventDiscriminants::from(self).description()
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        EnablementState::Always
+    }
+
+    fn contains_ugc(&self) -> bool {
+        false
+    }
+
+    fn event_descs() -> impl Iterator<Item = Box<dyn TelemetryEventDesc>> {
+        warp_core::telemetry::enum_events::<Self>()
+    }
+}
+
+impl TelemetryEventDesc for PricingPromotionTelemetryEventDiscriminants {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Shown => "PricingPromotion.Shown",
+            Self::Clicked => "PricingPromotion.Clicked",
+            Self::Dismissed => "PricingPromotion.Dismissed",
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            Self::Shown => "A pricing promotion was shown",
+            Self::Clicked => "A pricing promotion was clicked",
+            Self::Dismissed => "A pricing promotion was dismissed",
+        }
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        EnablementState::Always
+    }
+}
+
+warp_core::register_telemetry_event!(PricingPromotionTelemetryEvent);
+
+#[cfg(test)]
+#[path = "pricing_promotion_tests.rs"]
+mod tests;

--- a/app/src/ai/pricing_promotion.rs
+++ b/app/src/ai/pricing_promotion.rs
@@ -11,6 +11,7 @@ use crate::pricing::{PricingInfoModel, PricingInfoModelEvent};
 
 const AGENT_DISMISSED_KEY: &str = "pricing_promotion_agent_dismissed";
 const TERMINAL_DISMISSED_KEY: &str = "pricing_promotion_terminal_dismissed";
+const DISMISSED_VALUE: &str = "true";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PricingPromotionSurface {
@@ -95,7 +96,7 @@ impl PricingPromotionState {
         }
         if let Err(error) = ctx
             .private_user_preferences()
-            .write_value(surface.dismissal_key(), true.to_string())
+            .write_value(surface.dismissal_key(), DISMISSED_VALUE.to_string())
         {
             log::warn!("Failed to persist pricing promotion dismissal: {error:#}");
         }
@@ -115,7 +116,7 @@ impl PricingPromotionState {
         ctx.private_user_preferences()
             .read_value(key)
             .unwrap_or_default()
-            .is_some_and(|value| value == "true")
+            .is_some_and(|value| value == DISMISSED_VALUE)
     }
 }
 

--- a/app/src/ai/pricing_promotion_tests.rs
+++ b/app/src/ai/pricing_promotion_tests.rs
@@ -1,0 +1,50 @@
+use serde_json::json;
+use warp_core::telemetry::TelemetryEvent;
+
+use super::{PricingPromotionState, PricingPromotionSurface, PricingPromotionTelemetryEvent};
+
+#[test]
+fn promotion_telemetry_payload_includes_surface() {
+    for (event, surface) in [
+        (
+            PricingPromotionTelemetryEvent::Shown {
+                surface: PricingPromotionSurface::AgentMessageBar,
+            },
+            "agent_message_bar",
+        ),
+        (
+            PricingPromotionTelemetryEvent::Clicked {
+                surface: PricingPromotionSurface::AgentMessageBar,
+            },
+            "agent_message_bar",
+        ),
+        (
+            PricingPromotionTelemetryEvent::Dismissed {
+                surface: PricingPromotionSurface::TerminalMessageBar,
+            },
+            "terminal_message_bar",
+        ),
+    ] {
+        assert_eq!(
+            event.payload(),
+            Some(json!({
+                "surface": surface,
+            }))
+        );
+    }
+}
+
+#[test]
+fn agent_and_terminal_dismissals_are_independent() {
+    let mut state = PricingPromotionState {
+        agent_dismissed: true,
+        terminal_dismissed: false,
+        displayed_surfaces: Default::default(),
+    };
+    assert!(state.is_dismissed(PricingPromotionSurface::AgentMessageBar));
+    assert!(!state.is_dismissed(PricingPromotionSurface::TerminalMessageBar));
+
+    state.terminal_dismissed = true;
+    assert!(state.is_dismissed(PricingPromotionSurface::TerminalMessageBar));
+    assert!(state.is_dismissed(PricingPromotionSurface::AgentMessageBar));
+}

--- a/app/src/ai/request_usage_model_tests.rs
+++ b/app/src/ai/request_usage_model_tests.rs
@@ -100,6 +100,7 @@ fn set_addon_credits_pricing_info(app: &mut App) {
                     credits: 1000,
                     price_usd_cents: 1000,
                 }],
+                promotion_message: None,
             },
             ctx,
         );

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1807,6 +1807,7 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(|_| ExecutionProfileEditorManager::default());
     ctx.add_singleton_model(|_| NetworkLogPaneManager::default());
     ctx.add_singleton_model(|_| pricing::PricingInfoModel::new());
+    ctx.add_singleton_model(ai::pricing_promotion::PricingPromotionState::new);
     ctx.add_singleton_model(|ctx| {
         // Not using the *Provider types isn't ideal, but it's worth it for the ability to move managed secrets to a separate crate.
         ManagedSecretManager::new(

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -215,6 +215,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(UndoCloseStack::new);
     app.add_singleton_model(|_| IgnoredSuggestionsModel::new(vec![]));
     app.add_singleton_model(|_| PricingInfoModel::new());
+    app.add_singleton_model(crate::ai::pricing_promotion::PricingPromotionState::new);
     app.add_singleton_model(AIDocumentModel::new);
     app.add_singleton_model(|_| History::new(vec![]));
     app.add_singleton_model(|_| GitHubAuthNotifier::new());

--- a/app/src/pricing/mod.rs
+++ b/app/src/pricing/mod.rs
@@ -99,6 +99,10 @@ impl PricingInfoModel {
             .as_ref()
             .map(|info| info.addon_credits_options.as_slice())
     }
+
+    pub fn promotion_message(&self) -> Option<&str> {
+        self.pricing_info.as_ref()?.promotion_message.as_deref()
+    }
 }
 
 impl Default for PricingInfoModel {

--- a/app/src/pricing/pricing_tests.rs
+++ b/app/src/pricing/pricing_tests.rs
@@ -1,6 +1,6 @@
-use warp_graphql::billing::AddonCreditsOption;
+use warp_graphql::billing::{AddonCreditsOption, OveragesPricing, PricingInfo};
 
-use super::onboarding_credit_pack_options;
+use super::{PricingInfoModel, onboarding_credit_pack_options};
 
 /// The production add-on credit packs (`GetAddonCreditsOptions` on the server).
 fn production_packs() -> Vec<AddonCreditsOption> {
@@ -86,4 +86,20 @@ fn packs_worse_than_the_base_rate_show_no_savings() {
         .map(|pack| pack.savings_percent)
         .collect();
     assert_eq!(savings, [0, 0]);
+}
+
+#[test]
+fn promotion_message_is_exposed_verbatim() {
+    let model = PricingInfoModel {
+        pricing_info: Some(PricingInfo {
+            plans: vec![],
+            overages: OveragesPricing {
+                price_per_request_usd_cents: 0,
+            },
+            addon_credits_options: vec![],
+            promotion_message: Some("50% off Fable and Opus 5".to_string()),
+        }),
+    };
+
+    assert_eq!(model.promotion_message(), Some("50% off Fable and Opus 5"));
 }

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -43,6 +43,7 @@ use crate::ai::blocklist::SerializedBlockListItem;
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::ai::onboarding::{
     build_onboarding_models, current_onboarding_auth_state, onboarding_credit_packs,
+    onboarding_pricing_promotion_message,
 };
 use crate::ai::request_usage_model::AIRequestUsageModelEvent;
 use crate::app_state::{AppState, PaneUuid, WindowSnapshot};
@@ -2207,18 +2208,20 @@ impl RootView {
                 ctx,
             );
             view.set_credit_pack_options(onboarding_credit_packs(ctx), ctx);
+            view.set_pricing_promotion_message(onboarding_pricing_promotion_message(ctx), ctx);
             view
         });
-
-        // Keep the offer slide's credit packs in sync with server pricing.
+        // Keep the offer slide's credit packs and promotion in sync with server pricing.
         let onboarding_view_for_pricing = onboarding_view.clone();
         ctx.subscribe_to_model(
             &PricingInfoModel::handle(ctx),
             move |_, _pricing, event, ctx| {
                 let PricingInfoModelEvent::PricingInfoUpdated = event;
                 let options = onboarding_credit_packs(ctx);
+                let promotion_message = onboarding_pricing_promotion_message(ctx);
                 onboarding_view_for_pricing.update(ctx, |onboarding_view, ctx| {
                     onboarding_view.set_credit_pack_options(options, ctx);
+                    onboarding_view.set_pricing_promotion_message(promotion_message, ctx);
                 });
             },
         );

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3222,7 +3222,7 @@ impl Input {
             None
         };
 
-        let terminal_input_message_bar = ctx.add_view(|ctx| {
+        let terminal_input_message_bar = ctx.add_typed_action_view(|ctx| {
             TerminalInputMessageBar::new(
                 model.clone(),
                 ai_input_model.clone(),

--- a/app/src/terminal/input/terminal_message_bar.rs
+++ b/app/src/terminal/input/terminal_message_bar.rs
@@ -2,16 +2,22 @@ use std::sync::Arc;
 
 use parking_lot::FairMutex;
 use pathfinder_color::ColorU;
+use warp_core::ui::Icon;
 use warp_core::ui::theme::WarpTheme;
-use warpui::elements::{Container, Element};
+use warpui::elements::{Container, Element, MouseStateHandle};
 use warpui::keymap::Keystroke;
-use warpui::{AppContext, Entity, ModelHandle, SingletonEntity, View, ViewContext};
+use warpui::{
+    AppContext, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
+};
 
 use super::buffer_model::InputBufferModel;
 use super::message_bar::common::render_terminal_message;
 use super::message_bar::{Message, MessageItem, MessageProvider, truncated_command_for_block};
 use crate::ai::blocklist::{
     BlocklistAIContextEvent, BlocklistAIContextModel, BlocklistAIInputModel,
+};
+use crate::ai::pricing_promotion::{
+    PricingPromotionState, PricingPromotionStateEvent, PricingPromotionSurface,
 };
 use crate::appearance::Appearance;
 use crate::search::slash_command_menu::static_commands::commands;
@@ -35,10 +41,15 @@ pub struct TerminalInputMessageBar {
     context_model: ModelHandle<BlocklistAIContextModel>,
     suggestions_mode_model: ModelHandle<InputSuggestionsModeModel>,
     inline_history_model: ModelHandle<InlineMenuModel<AcceptHistoryItem, HistoryTab>>,
+    promotion_close_mouse_state: MouseStateHandle,
 }
 
 impl Entity for TerminalInputMessageBar {
     type Event = ();
+}
+#[derive(Clone, Debug)]
+pub enum TerminalInputMessageBarAction {
+    DismissPricingPromotion,
 }
 
 impl TerminalInputMessageBar {
@@ -71,15 +82,35 @@ impl TerminalInputMessageBar {
                 ctx.notify();
             }
         });
-
-        Self {
+        ctx.subscribe_to_model(&PricingPromotionState::handle(ctx), |me, _, event, ctx| {
+            if matches!(event, PricingPromotionStateEvent::Updated) {
+                me.record_visible_promotion(ctx);
+                ctx.notify();
+            }
+        });
+        let message_bar = Self {
             terminal_model,
             ai_input_model,
             input_buffer_model,
             context_model,
             suggestions_mode_model,
             inline_history_model,
+            promotion_close_mouse_state: MouseStateHandle::default(),
+        };
+        message_bar.record_visible_promotion(ctx);
+        message_bar
+    }
+
+    fn record_visible_promotion(&self, ctx: &mut ViewContext<Self>) {
+        if PricingPromotionState::as_ref(ctx)
+            .visible_message(PricingPromotionSurface::TerminalMessageBar, ctx)
+            .is_none()
+        {
+            return;
         }
+        PricingPromotionState::handle(ctx).update(ctx, |state, ctx| {
+            state.record_displayed(PricingPromotionSurface::TerminalMessageBar, ctx);
+        });
     }
 }
 
@@ -115,6 +146,7 @@ impl View for TerminalInputMessageBar {
             context_model,
             input_model,
             app,
+            promotion_close_mouse_state: &self.promotion_close_mouse_state,
         };
 
         let mut message = ErroredBlockMessageProducer
@@ -149,6 +181,7 @@ pub struct TerminalMessageArgs<'a> {
     context_model: &'a BlocklistAIContextModel,
     input_model: &'a BlocklistAIInputModel,
     app: &'a AppContext,
+    promotion_close_mouse_state: &'a MouseStateHandle,
 }
 
 impl<'a> TerminalMessageArgs<'a> {
@@ -340,14 +373,45 @@ impl MessageProvider<TerminalMessageArgs<'_>> for DefaultMessageProducer {
         };
 
         if let Some(keystroke) = keystroke {
-            Some(Message::new(vec![
-                MessageItem::keystroke(keystroke),
-                MessageItem::text(" new /agent conversation"),
-            ]))
+            let promotion_message = PricingPromotionState::as_ref(args.app)
+                .visible_message(PricingPromotionSurface::TerminalMessageBar, args.app);
+            let mut text = " new /agent conversation".to_string();
+            if let Some(promotion_message) = &promotion_message {
+                text.push_str(" · ");
+                text.push_str(promotion_message);
+            }
+            let mut items = vec![MessageItem::keystroke(keystroke), MessageItem::text(text)];
+            if promotion_message.is_some() {
+                items.push(MessageItem::text(" "));
+                items.push(MessageItem::clickable(
+                    vec![MessageItem::icon(Icon::X)],
+                    |ctx| {
+                        ctx.dispatch_typed_action(
+                            TerminalInputMessageBarAction::DismissPricingPromotion,
+                        );
+                    },
+                    args.promotion_close_mouse_state.clone(),
+                ));
+            }
+            Some(Message::new(items))
         } else {
             Some(Message::new(vec![MessageItem::text(
                 "/agent for new conversation",
             )]))
+        }
+    }
+}
+
+impl TypedActionView for TerminalInputMessageBar {
+    type Action = TerminalInputMessageBarAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            TerminalInputMessageBarAction::DismissPricingPromotion => {
+                PricingPromotionState::handle(ctx).update(ctx, |state, ctx| {
+                    state.dismiss(PricingPromotionSurface::TerminalMessageBar, ctx);
+                });
+            }
         }
     }
 }

--- a/app/src/terminal/input/terminal_message_bar.rs
+++ b/app/src/terminal/input/terminal_message_bar.rs
@@ -82,13 +82,12 @@ impl TerminalInputMessageBar {
                 ctx.notify();
             }
         });
-        ctx.subscribe_to_model(&PricingPromotionState::handle(ctx), |me, _, event, ctx| {
+        ctx.subscribe_to_model(&PricingPromotionState::handle(ctx), |_, _, event, ctx| {
             if matches!(event, PricingPromotionStateEvent::Updated) {
-                me.record_visible_promotion(ctx);
                 ctx.notify();
             }
         });
-        let message_bar = Self {
+        Self {
             terminal_model,
             ai_input_model,
             input_buffer_model,
@@ -96,21 +95,7 @@ impl TerminalInputMessageBar {
             suggestions_mode_model,
             inline_history_model,
             promotion_close_mouse_state: MouseStateHandle::default(),
-        };
-        message_bar.record_visible_promotion(ctx);
-        message_bar
-    }
-
-    fn record_visible_promotion(&self, ctx: &mut ViewContext<Self>) {
-        if PricingPromotionState::as_ref(ctx)
-            .visible_message(PricingPromotionSurface::TerminalMessageBar, ctx)
-            .is_none()
-        {
-            return;
         }
-        PricingPromotionState::handle(ctx).update(ctx, |state, ctx| {
-            state.record_displayed(PricingPromotionSurface::TerminalMessageBar, ctx);
-        });
     }
 }
 

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -331,6 +331,7 @@ pub fn initialize_app(app: &mut App) {
     app.add_singleton_model(|_| WorkspaceRegistry::new());
     app.add_singleton_model(|_| ToastStack);
     app.add_singleton_model(|_| PricingInfoModel::new());
+    app.add_singleton_model(crate::ai::pricing_promotion::PricingPromotionState::new);
     app.add_singleton_model(ByoLlmAuthBannerSessionState::new);
     app.add_singleton_model(|_| {
         crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier::new()

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -34,6 +34,7 @@ use crate::ai::mcp::gallery::MCPGalleryManager;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
 use crate::ai::outline::RepoOutlines;
 use crate::ai::persisted_workspace::PersistedWorkspace;
+use crate::ai::pricing_promotion::PricingPromotionState;
 use crate::ai::restored_conversations::RestoredAgentConversations;
 use crate::ai::skills::SkillManager;
 use crate::auth::AuthStateProvider;
@@ -179,6 +180,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(|_| WorkspaceRegistry::new());
     app.add_singleton_model(|_| IgnoredSuggestionsModel::new(vec![]));
     app.add_singleton_model(|_| PricingInfoModel::new());
+    app.add_singleton_model(PricingPromotionState::new);
     app.add_singleton_model(AIDocumentModel::new);
     app.add_singleton_model(ByoLlmAuthBannerSessionState::new);
     app.add_singleton_model(|_| GitHubAuthNotifier::new());

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -239,6 +239,7 @@ pub(crate) fn initialize_app(app: &mut App) {
     app.add_singleton_model(|ctx| PersistedWorkspace::new(vec![], HashMap::new(), None, ctx));
     app.add_singleton_model(|_| ProjectContextModel::default());
     app.add_singleton_model(|_| PricingInfoModel::new());
+    app.add_singleton_model(crate::ai::pricing_promotion::PricingPromotionState::new);
     app.add_singleton_model(AIDocumentModel::new);
     app.add_singleton_model(|_| History::new(vec![]));
 

--- a/crates/graphql/src/api/billing.rs
+++ b/crates/graphql/src/api/billing.rs
@@ -306,6 +306,7 @@ pub struct PricingInfo {
     pub plans: Vec<PlanPricing>,
     pub overages: OveragesPricing,
     pub addon_credits_options: Vec<AddonCreditsOption>,
+    pub promotion_message: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]

--- a/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
+++ b/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
@@ -203,6 +203,7 @@ query GetWorkspacesMetadataForUser($requestContext: RequestContext!) {
         overages {
           pricePerRequestUsdCents
         }
+        promotionMessage
       }
     }
   }

--- a/crates/onboarding/src/agent_onboarding_view.rs
+++ b/crates/onboarding/src/agent_onboarding_view.rs
@@ -356,6 +356,17 @@ impl AgentOnboardingView {
         ctx.notify();
     }
 
+    pub fn set_pricing_promotion_message(
+        &mut self,
+        message: Option<String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.onboarding_state.update(ctx, |state, ctx| {
+            state.set_pricing_promotion_message(message, ctx);
+        });
+        ctx.notify();
+    }
+
     pub fn set_workspace_enforces_autonomy(&mut self, value: bool, ctx: &mut ViewContext<Self>) {
         self.onboarding_state.update(ctx, |state, ctx| {
             state.set_workspace_enforces_autonomy(value, ctx);

--- a/crates/onboarding/src/model.rs
+++ b/crates/onboarding/src/model.rs
@@ -292,6 +292,7 @@ pub(crate) struct OnboardingStateModel {
     /// supplied by the app crate from server pricing. Empty until pricing has
     /// been fetched, which hides the buy-credits option entirely.
     credit_pack_options: Vec<CreditPackOption>,
+    pricing_promotion_message: Option<String>,
     /// Index into `credit_pack_options` of the pack the user has selected.
     selected_credit_pack_index: usize,
     /// Progress of a credit purchase started from the offer slide.
@@ -322,6 +323,7 @@ impl OnboardingStateModel {
             offer_variant: None,
             no_ai_confirmation: None,
             credit_pack_options: Vec::new(),
+            pricing_promotion_message: None,
             selected_credit_pack_index: 0,
             credit_purchase_state: CreditPurchaseState::default(),
         }
@@ -480,6 +482,22 @@ impl OnboardingStateModel {
     /// (smallest first). Empty until the app supplies server pricing.
     pub(crate) fn credit_pack_options(&self) -> &[CreditPackOption] {
         &self.credit_pack_options
+    }
+
+    pub(crate) fn pricing_promotion_message(&self) -> Option<&str> {
+        self.pricing_promotion_message.as_deref()
+    }
+
+    pub(crate) fn set_pricing_promotion_message(
+        &mut self,
+        message: Option<String>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.pricing_promotion_message == message {
+            return;
+        }
+        self.pricing_promotion_message = message;
+        ctx.notify();
     }
 
     /// Replaces the offered credit packs. Keeps the user's selection when it

--- a/crates/onboarding/src/model_tests.rs
+++ b/crates/onboarding/src/model_tests.rs
@@ -16,6 +16,33 @@ fn add_test_model(app: &mut App) -> ModelHandle<OnboardingStateModel> {
     add_model(app)
 }
 
+#[test]
+fn pricing_promotion_message_can_be_replaced_and_cleared() {
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+        model.read(&app, |model, _| {
+            assert_eq!(model.pricing_promotion_message(), None);
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.set_pricing_promotion_message(Some("50% off Fable and Opus 5".to_string()), ctx)
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(
+                model.pricing_promotion_message(),
+                Some("50% off Fable and Opus 5")
+            );
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.set_pricing_promotion_message(None, ctx)
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(model.pricing_promotion_message(), None);
+        });
+    });
+}
+
 fn add_model(app: &mut App) -> ModelHandle<OnboardingStateModel> {
     app.add_model(|_| {
         OnboardingStateModel::new(

--- a/crates/onboarding/src/slides/offer_slide.rs
+++ b/crates/onboarding/src/slides/offer_slide.rs
@@ -52,8 +52,9 @@ impl OfferVariant {
 
     pub(crate) fn primary_badge_label(self, pricing_promotion_message: Option<&str>) -> &str {
         match self {
-            OfferVariant::ChooseHowToStart => pricing_promotion_message.unwrap_or("Recommended"),
-            OfferVariant::HeadStart => "Recommended",
+            OfferVariant::HeadStart | OfferVariant::ChooseHowToStart => {
+                pricing_promotion_message.unwrap_or("Recommended")
+            }
         }
     }
 

--- a/crates/onboarding/src/slides/offer_slide.rs
+++ b/crates/onboarding/src/slides/offer_slide.rs
@@ -50,6 +50,13 @@ impl OfferVariant {
         }
     }
 
+    pub(crate) fn primary_badge_label(self, pricing_promotion_message: Option<&str>) -> &str {
+        match self {
+            OfferVariant::ChooseHowToStart => pricing_promotion_message.unwrap_or("Recommended"),
+            OfferVariant::HeadStart => "Recommended",
+        }
+    }
+
     pub(crate) fn subtitle(self) -> Option<&'static str> {
         match self {
             OfferVariant::HeadStart => {
@@ -402,7 +409,7 @@ impl OfferSlide {
                 variant.primary_label(),
                 variant.primary_description(shows_credit_packs),
                 selected_choice == OfferChoice::Primary,
-                Some("Recommended"),
+                Some("Recommended".to_string()),
                 self.primary_mouse_state.clone(),
                 OfferSlideAction::SelectPrimary,
                 None,
@@ -468,11 +475,17 @@ impl OfferSlide {
             })
             .build()
             .finish();
+        let badge_label = {
+            let state = self.onboarding_state.as_ref(app);
+            variant
+                .primary_badge_label(state.pricing_promotion_message())
+                .to_owned()
+        };
         let green = theme.ansi_fg_green();
         let badge = Container::new(
             appearance
                 .ui_builder()
-                .paragraph("Recommended")
+                .paragraph(badge_label)
                 .with_style(UiComponentStyles {
                     font_size: Some(12.),
                     font_color: Some(green),
@@ -897,7 +910,7 @@ impl OfferSlide {
         label: &'static str,
         description: &'static str,
         selected: bool,
-        badge_label: Option<&'static str>,
+        badge_label: Option<String>,
         mouse_state: MouseStateHandle,
         action: OfferSlideAction,
         extra_content: Option<Box<dyn Element>>,

--- a/crates/onboarding/src/slides/offer_slide.rs
+++ b/crates/onboarding/src/slides/offer_slide.rs
@@ -259,6 +259,13 @@ impl OfferSlide {
         !self.credit_packs(variant, app).is_empty()
     }
 
+    fn primary_badge_label(&self, variant: OfferVariant, app: &AppContext) -> String {
+        let state = self.onboarding_state.as_ref(app);
+        variant
+            .primary_badge_label(state.pricing_promotion_message())
+            .to_owned()
+    }
+
     /// The selectable options, top to bottom. Also the order the arrow keys
     /// move through.
     fn choices(&self, variant: OfferVariant, app: &AppContext) -> Vec<OfferChoice> {
@@ -410,7 +417,7 @@ impl OfferSlide {
                 variant.primary_label(),
                 variant.primary_description(shows_credit_packs),
                 selected_choice == OfferChoice::Primary,
-                Some("Recommended".to_string()),
+                Some(self.primary_badge_label(variant, app)),
                 self.primary_mouse_state.clone(),
                 OfferSlideAction::SelectPrimary,
                 None,
@@ -476,12 +483,7 @@ impl OfferSlide {
             })
             .build()
             .finish();
-        let badge_label = {
-            let state = self.onboarding_state.as_ref(app);
-            variant
-                .primary_badge_label(state.pricing_promotion_message())
-                .to_owned()
-        };
+        let badge_label = self.primary_badge_label(variant, app);
         let green = theme.ansi_fg_green();
         let badge = Container::new(
             appearance

--- a/crates/onboarding/src/slides/offer_slide_tests.rs
+++ b/crates/onboarding/src/slides/offer_slide_tests.rs
@@ -131,6 +131,24 @@ fn choose_how_to_start_copy_and_telemetry_names_match_spec() {
     assert_eq!(variant.credits_action(), "buy_ai_credits");
 }
 
+#[test]
+fn promotion_replaces_recommended_only_on_choose_how_to_start() {
+    let promotion = Some("50% off Fable and Opus 5");
+
+    assert_eq!(
+        OfferVariant::ChooseHowToStart.primary_badge_label(promotion),
+        "50% off Fable and Opus 5"
+    );
+    assert_eq!(
+        OfferVariant::ChooseHowToStart.primary_badge_label(None),
+        "Recommended"
+    );
+    assert_eq!(
+        OfferVariant::HeadStart.primary_badge_label(promotion),
+        "Recommended"
+    );
+}
+
 /// The subscribe card must frame the add-on discount as a saving (matching the
 /// web copy), never as a surcharge on the free plan.
 #[test]

--- a/crates/onboarding/src/slides/offer_slide_tests.rs
+++ b/crates/onboarding/src/slides/offer_slide_tests.rs
@@ -153,6 +153,29 @@ fn promotion_replaces_recommended_on_both_offer_variants() {
     );
 }
 
+#[test]
+fn both_rendered_offer_paths_read_the_promotion_from_onboarding_state() {
+    App::test((), |mut app| async move {
+        let onboarding_state = add_onboarding_state(&mut app);
+        onboarding_state.update(&mut app, |model, ctx| {
+            model
+                .set_pricing_promotion_message(Some("50% off Fable 5 and Opus 5".to_string()), ctx);
+        });
+        let slide = OfferSlide::new(onboarding_state);
+
+        app.read(|ctx| {
+            assert_eq!(
+                slide.primary_badge_label(OfferVariant::HeadStart, ctx),
+                "50% off Fable 5 and Opus 5"
+            );
+            assert_eq!(
+                slide.primary_badge_label(OfferVariant::ChooseHowToStart, ctx),
+                "50% off Fable 5 and Opus 5"
+            );
+        });
+    });
+}
+
 /// The subscribe card must frame the add-on discount as a saving (matching the
 /// web copy), never as a surcharge on the free plan.
 #[test]

--- a/crates/onboarding/src/slides/offer_slide_tests.rs
+++ b/crates/onboarding/src/slides/offer_slide_tests.rs
@@ -132,7 +132,7 @@ fn choose_how_to_start_copy_and_telemetry_names_match_spec() {
 }
 
 #[test]
-fn promotion_replaces_recommended_only_on_choose_how_to_start() {
+fn promotion_replaces_recommended_on_both_offer_variants() {
     let promotion = Some("50% off Fable and Opus 5");
 
     assert_eq!(
@@ -145,6 +145,10 @@ fn promotion_replaces_recommended_only_on_choose_how_to_start() {
     );
     assert_eq!(
         OfferVariant::HeadStart.primary_badge_label(promotion),
+        "50% off Fable and Opus 5"
+    );
+    assert_eq!(
+        OfferVariant::HeadStart.primary_badge_label(None),
         "Recommended"
     );
 }

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -2690,6 +2690,7 @@ type PricingInfo {
   addonCreditsOptions: [AddonCreditsOption!]!
   overages: OveragesPricing!
   plans: [PlanPricing!]!
+  promotionMessage: String
 }
 
 type PricingInfoOutput implements Response {


### PR DESCRIPTION
## Description

Consume the nullable `PricingInfo.promotionMessage` introduced by [warp-server PR #13900](https://github.com/warpdotdev/warp-server/pull/13900) and render the exact server-authored copy in three desktop surfaces:

- A dismissible, clickable green pill in the Agent message bar that opens the existing upgrade flow. Almost exact same behaviour as the blue cloud agent pill (except clicking this one takes you to /upgrade). 
- Dismissible copy appended to the terminal's default `new /agent conversation` hint.
- The existing green badge on both account-first onboarding offers: `HeadStart` / `You've got a head start` and `ChooseHowToStart` / `Use Warp with AI`, replacing `Recommended` while the server message is present and restoring it for `None`.

Loom: https://www.loom.com/share/f1081d94a426480bb59a47c0a3dc8a9b

The client owns only separate persisted Agent/terminal dismissals and shown/clicked/dismissed telemetry. Campaign activity, eligibility, and copy remain server-owned; `None` renders no Agent/terminal promotion and restores the onboarding fallback badge. Onboarding intentionally does not share the Agent or terminal dismissal state.


## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Screenshots or a short video are included below.

## Testing

- [x] `./script/format`
- [x] `cargo clippy -p onboarding --all-targets -- -D warnings`
- [x] `cargo clippy -p warp --lib -- -D warnings`
- [x] `cargo test -p warp pricing_promotion --lib`
- [x] `cargo test -p warp promotion_message_is_exposed_verbatim --lib`
- [x] `cargo nextest run -p onboarding -E 'test(pricing_promotion_message_can_be_replaced_and_cleared) | test(promotion_replaces_recommended_on_both_offer_variants)'`
- [x] `git diff origin/master...HEAD --check`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Pending local end-to-end verification against the server branch.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp Agent <agent@warp.dev>