### PR TITLE
Fix TUI session focus reconciliation

### DIFF
--- a/crates/warp_tui/src/handoff/session.rs
+++ b/crates/warp_tui/src/handoff/session.rs
@@ -61,7 +61,7 @@ impl TuiTerminalSessionView {
             TuiHandoffBlockEvent::LayoutInvalidated => ctx.notify(),
         });
         self.handoff = Some(handoff_block);
-        self.refresh_input_focus(ctx);
+        self.reconcile_focus(ctx);
         record_static_slash_command_accepted("/handoff", true, ctx);
     }
 
@@ -119,6 +119,6 @@ impl TuiTerminalSessionView {
                 self.start_new_conversation(None, ctx);
             }
         }
-        self.refresh_input_focus(ctx);
+        self.reconcile_focus(ctx);
     }
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -19,12 +19,12 @@ use warp::settings::{
 #[cfg(feature = "voice_input")]
 use warp::tui_export::slash_commands;
 use warp::tui_export::{
-    AIAgentActionId, AIAgentActionResultType, AIAgentContext, AIAgentExchangeId,
-    AIAgentPtyWriteMode, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
-    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AfterBlockCompletedEvent,
-    AgentConversationEntryId, AgentConversationListEntryState, AgentConversationsModel,
-    AgentInteractionMetadata, AgentViewEntryOrigin, Appearance, BlockId, BlockType,
-    BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
+    AIAgentActionId, AIAgentContext, AIAgentExchangeId, AIAgentPtyWriteMode, AIConversation,
+    AIConversationAutoexecuteMode, AIConversationId, AcceptSlashCommandOrSavedPrompt,
+    ActiveSession, ActiveSessionEvent, AfterBlockCompletedEvent, AgentConversationEntryId,
+    AgentConversationListEntryState, AgentConversationsModel, AgentInteractionMetadata,
+    AgentViewEntryOrigin, Appearance, BlockId, BlockType, BlocklistAIActionEvent,
+    BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel,
     BlocklistOrchestrationTelemetryEvent, CLISubagentController, CLISubagentEvent,
     CLISubagentTarget, COMMAND_REGISTRY, CancellationReason, ChangelogModel, ChangelogRequestType,
@@ -965,15 +965,6 @@ impl TuiTerminalSessionView {
         })
     }
 
-    fn update_process_input_focus(&mut self, ctx: &mut ViewContext<Self>) {
-        self.focus_current_owner_if_active(ctx);
-    }
-
-    fn refresh_input_focus(&mut self, ctx: &mut ViewContext<Self>) {
-        self.focus_current_owner_if_active(ctx);
-        ctx.notify();
-    }
-
     fn emit_input_buffer_submitted_telemetry(&self, ctx: &mut ViewContext<Self>) {
         let input_model = self.ai_input_model.as_ref(ctx);
         let block_id = self.terminal_model.lock().active_block_id().clone();
@@ -1140,7 +1131,8 @@ impl TuiTerminalSessionView {
         }
     }
 
-    fn focus_current_owner_if_active(&mut self, ctx: &mut ViewContext<Self>) {
+    /// Focuses the active session's immediate interaction owner; child views may delegate further.
+    fn reconcile_focus(&mut self, ctx: &mut ViewContext<Self>) {
         if self.is_focused_session(ctx) {
             let tabs_were_focused = self.orchestration_tabs_focused;
             self.focus_current_owner(ctx);
@@ -1149,12 +1141,7 @@ impl TuiTerminalSessionView {
                 ctx.notify();
             }
         }
-    }
-
-    fn focus_input_if_active(&self, ctx: &mut ViewContext<Self>) {
-        if self.is_focused_session(ctx) {
-            ctx.focus(&self.input_view);
-        }
+        ctx.notify();
     }
 
     fn resume_after_user_controlled_command(
@@ -1192,7 +1179,7 @@ impl TuiTerminalSessionView {
             input.reset_after_agent_control(ctx);
         });
         self.resume_after_user_controlled_command(block_id, ctx);
-        self.refresh_input_focus(ctx);
+        self.reconcile_focus(ctx);
         ctx.notify();
     }
 
@@ -1207,7 +1194,6 @@ impl TuiTerminalSessionView {
                 transcript.detach_cli_subagent(initial_requested_command_action_id, view.id(), ctx);
             });
         }
-        self.focus_input_if_active(ctx);
     }
     fn handle_cli_subagent_event(&mut self, event: &CLISubagentEvent, ctx: &mut ViewContext<Self>) {
         match event {
@@ -1278,8 +1264,16 @@ impl TuiTerminalSessionView {
                 });
             }
         }
-        self.refresh_input_focus(ctx);
-        ctx.notify();
+        if matches!(
+            event,
+            CLISubagentEvent::UpdatedInstruction { .. }
+                | CLISubagentEvent::UpdatedLastSnapshot
+                | CLISubagentEvent::ToggledHideResponses
+        ) {
+            ctx.notify();
+        } else {
+            self.reconcile_focus(ctx);
+        }
     }
 
     fn handle_terminal_use_interrupt(&mut self, ctx: &mut ViewContext<Self>) -> bool {
@@ -1307,7 +1301,7 @@ impl TuiTerminalSessionView {
                         ctx,
                     );
                 });
-                self.refresh_input_focus(ctx);
+                self.reconcile_focus(ctx);
                 true
             }
             TerminalUseInterruptAction::InterruptCommand => {
@@ -1324,7 +1318,7 @@ impl TuiTerminalSessionView {
         self.cli_subagent_controller.update(ctx, |controller, ctx| {
             controller.handoff_active_command_control_to_agent(ctx);
         });
-        self.refresh_input_focus(ctx);
+        self.reconcile_focus(ctx);
     }
     /// Attempts to expose the agent composer for the active user-controlled LRC.
     ///
@@ -1347,7 +1341,7 @@ impl TuiTerminalSessionView {
             input.clear(ctx);
             input.lock_for_agent_control(ctx);
         });
-        self.refresh_input_focus(ctx);
+        self.reconcile_focus(ctx);
         ctx.notify();
         true
     }
@@ -1373,7 +1367,7 @@ impl TuiTerminalSessionView {
         self.input_view.update(ctx, |input, ctx| {
             input.clear(ctx);
         });
-        self.refresh_input_focus(ctx);
+        self.reconcile_focus(ctx);
         ctx.notify();
         true
     }
@@ -1591,29 +1585,17 @@ impl TuiTerminalSessionView {
         });
         // Only action lifecycle transitions can change the blocking input
         // owner. Presentation updates stay within the focused blocker.
-        ctx.subscribe_to_model(
-            &action_model,
-            |view, action_model, event, ctx| match event {
-                BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(_)
-                | BlocklistAIActionEvent::ExecutingAction(_) => view.refresh_input_focus(ctx),
-                BlocklistAIActionEvent::FinishedAction { action_id, .. } => {
-                    view.refresh_input_focus(ctx);
-                    let finished_asking_question = action_model
-                        .as_ref(ctx)
-                        .get_action_result(action_id)
-                        .is_some_and(|result| {
-                            matches!(&result.result, AIAgentActionResultType::AskUserQuestion(_))
-                        });
-                    if finished_asking_question {
-                        ctx.focus(&view.input_view);
-                    }
-                }
-                BlocklistAIActionEvent::QueuedAction(_)
-                | BlocklistAIActionEvent::InitProject(_)
-                | BlocklistAIActionEvent::ToggleCodeReview(_)
-                | BlocklistAIActionEvent::InsertCodeReviewComments { .. } => {}
-            },
-        );
+        ctx.subscribe_to_model(&action_model, |view, _, event, ctx| match event {
+            BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(_)
+            | BlocklistAIActionEvent::ExecutingAction(_)
+            | BlocklistAIActionEvent::FinishedAction { .. } => {
+                view.reconcile_focus(ctx);
+            }
+            BlocklistAIActionEvent::QueuedAction(_)
+            | BlocklistAIActionEvent::InitProject(_)
+            | BlocklistAIActionEvent::ToggleCodeReview(_)
+            | BlocklistAIActionEvent::InsertCodeReviewComments { .. } => {}
+        });
         let input_editor_model =
             ctx.add_model(|ctx| CodeEditorModel::new_tui(INITIAL_INPUT_WIDTH, ctx));
         let suggestions_mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
@@ -1900,7 +1882,7 @@ impl TuiTerminalSessionView {
                 }
             },
             TuiTranscriptViewEvent::BlockingStateChanged => {
-                view.refresh_input_focus(ctx);
+                view.reconcile_focus(ctx);
             }
             TuiTranscriptViewEvent::PermissionReplacementGuidanceSubmitted {
                 conversation_id,
@@ -2064,15 +2046,15 @@ impl TuiTerminalSessionView {
                 view.emit_block_completed_telemetry(completed, ctx);
             }
             ModelEvent::AfterBlockStarted { .. } => {
-                view.refresh_input_focus(ctx);
+                view.reconcile_focus(ctx);
                 ctx.notify();
             }
             ModelEvent::VisibleBootstrapBlock | ModelEvent::BootstrapPrecmdDone => {
-                view.refresh_input_focus(ctx);
+                view.reconcile_focus(ctx);
                 ctx.notify();
             }
             ModelEvent::TerminalModeSwapped(_) => {
-                view.update_process_input_focus(ctx);
+                view.reconcile_focus(ctx);
                 ctx.notify();
             }
             ModelEvent::Typeahead => view.handle_typeahead_event(ctx),
@@ -2405,7 +2387,7 @@ impl TuiTerminalSessionView {
         if !tabs_are_available && self.orchestration_tabs_focused {
             self.orchestration_tabs_focused = false;
             focus_changed = true;
-            self.focus_current_owner(ctx);
+            self.reconcile_focus(ctx);
         }
         // Disarm the child-kill window when the child is no longer reachable.
         if !tabs_are_available && self.child_kill_armed_conversation.is_some() {
@@ -2433,7 +2415,7 @@ impl TuiTerminalSessionView {
         ctx: &mut ViewContext<Self>,
     ) {
         self.orchestration_tabs_focused = focused;
-        self.focus_current_owner(ctx);
+        self.reconcile_focus(ctx);
         self.refresh_orchestration_tab_bar(ctx);
         ctx.notify();
     }
@@ -3038,7 +3020,7 @@ impl TuiTerminalSessionView {
 
         self.conversation_restore_state = ConversationRestoreState::Idle;
         self.refresh_exit_summary(ctx);
-        self.focus_input_if_active(ctx);
+        self.reconcile_focus(ctx);
         if origin.records_telemetry() {
             warp::send_telemetry_from_ctx!(
                 TuiConversationRestoreTelemetryEvent {
@@ -3093,7 +3075,7 @@ impl TuiTerminalSessionView {
                 ctx
             );
         }
-        self.focus_input_if_active(ctx);
+        self.reconcile_focus(ctx);
         ctx.notify();
         true
     }
@@ -3131,7 +3113,7 @@ impl TuiTerminalSessionView {
                 }
                 self.conversation_restore_state = ConversationRestoreState::Idle;
                 self.show_transient_hint(message, ctx);
-                self.focus_input_if_active(ctx);
+                self.reconcile_focus(ctx);
             }
         }
         ctx.notify();
@@ -3191,7 +3173,6 @@ impl TuiTerminalSessionView {
         }
         let is_focused = self.is_focused_session(ctx);
         if is_focused {
-            self.refresh_input_focus(ctx);
             ctx.notify();
         }
         is_focused
@@ -4728,7 +4709,7 @@ impl TuiTerminalSessionView {
         self.statusline_config_view = Some(statusline_config_view);
         self.input_view.update(ctx, |input, ctx| input.clear(ctx));
         self.orchestration_tabs_focused = false;
-        self.focus_current_owner_if_active(ctx);
+        self.reconcile_focus(ctx);
         record_static_slash_command_accepted(command_name, true, ctx);
         ctx.notify();
     }
@@ -4744,7 +4725,7 @@ impl TuiTerminalSessionView {
             }
             TuiStatuslineConfigEvent::Cancelled => {
                 self.statusline_config_view = None;
-                self.focus_current_owner_if_active(ctx);
+                self.reconcile_focus(ctx);
                 ctx.notify();
             }
             TuiStatuslineConfigEvent::LayoutChanged => ctx.notify(),
@@ -4761,7 +4742,7 @@ impl TuiTerminalSessionView {
             settings.tui_statusline.set_value(config.normalized(), ctx)
         });
         self.statusline_config_view = None;
-        self.focus_current_owner_if_active(ctx);
+        self.reconcile_focus(ctx);
         match result {
             Ok(()) => self.show_success_hint(success_hint.to_owned(), ctx),
             Err(error) => {

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -47,7 +47,7 @@ use warpui_core::event::KeyState;
 use warpui_core::event::ModifiersState;
 use warpui_core::keymap::{Context, DescriptionContext, Keystroke, Trigger};
 use warpui_core::platform::keyboard::KeyCode;
-use warpui_core::presenter::tui::TuiPresenter;
+use warpui_core::presenter::tui::{TuiFrame, TuiPresenter};
 use warpui_core::telemetry::{EventPayload, flush_events};
 use warpui_core::{App, AppContext, TuiView, TypedActionView, WindowInvalidation};
 
@@ -1897,7 +1897,7 @@ fn theme_slash_command_rejects_a_missing_argument() {
 }
 
 #[test]
-fn statusline_slash_command_clears_input_focuses_one_picker_and_cancels_cleanly() {
+fn statusline_slash_command_preserves_nested_focus_and_restores_the_input_cursor() {
     App::test((), |mut app| async move {
         let fixture = focus_test_fixture(&mut app);
         let (view, _) = add_focus_test_session(&mut app, &fixture, true);
@@ -1908,7 +1908,7 @@ fn statusline_slash_command_clears_input_focuses_one_picker_and_cancels_cleanly(
             view.execute_tui_slash_command(&slash_commands::STATUSLINE, None, ctx);
         });
 
-        let picker_id = view.read(&app, |view, ctx| {
+        let (picker_id, picker_focus_id) = view.read(&app, |view, ctx| {
             let picker = view
                 .statusline_config_view
                 .as_ref()
@@ -1925,9 +1925,21 @@ fn statusline_slash_command_clears_input_focuses_one_picker_and_cancels_cleanly(
                 ""
             );
             assert!(ctx.check_view_or_child_focused(fixture.window_id, &picker.id()));
-            picker.id()
+            (
+                picker.id(),
+                ctx.focused_view_id(fixture.window_id)
+                    .expect("the statusline picker should delegate focus to a child"),
+            )
         });
 
+        assert!(view.update(&mut app, |view, ctx| { view.handle_terminal_wakeup(ctx) }));
+        app.read(|ctx| {
+            assert_eq!(
+                ctx.focused_view_id(fixture.window_id),
+                Some(picker_focus_id),
+                "a redraw must preserve the interaction surface's delegated child focus"
+            );
+        });
         view.update(&mut app, |view, ctx| {
             view.execute_tui_slash_command(&slash_commands::STATUSLINE, None, ctx);
         });
@@ -1945,6 +1957,12 @@ fn statusline_slash_command_clears_input_focuses_one_picker_and_cancels_cleanly(
             assert!(view.statusline_config_view.is_none());
             assert!(ctx.check_view_or_child_focused(fixture.window_id, &view.input_view.id()));
         });
+        assert!(
+            render_session_frame(&mut app, &view, 80, 24)
+                .cursor
+                .is_some(),
+            "dismissing the interaction surface should restore the input cursor"
+        );
     });
 }
 
@@ -2612,6 +2630,15 @@ fn render_session_buffer(
     width: u16,
     height: u16,
 ) -> TuiBuffer {
+    render_session_frame(app, view, width, height).buffer
+}
+
+fn render_session_frame(
+    app: &mut App,
+    view: &ViewHandle<super::TuiTerminalSessionView>,
+    width: u16,
+    height: u16,
+) -> TuiFrame {
     let mut presenter = TuiPresenter::new();
     app.update(|ctx| {
         let mut invalidation = WindowInvalidation::default();
@@ -2620,9 +2647,7 @@ fn render_session_buffer(
             .updated
             .extend(view.as_ref(ctx).child_view_ids(ctx));
         presenter.invalidate(&invalidation, ctx, view.window_id(ctx));
-        presenter
-            .present(ctx, view, TuiRect::new(0, 0, width, height))
-            .buffer
+        presenter.present(ctx, view, TuiRect::new(0, 0, width, height))
     })
 }
 
@@ -5445,6 +5470,27 @@ fn terminal_wakeup_redraws_only_the_focused_session() {
 
         assert!(foreground.update(&mut app, |view, ctx| { view.handle_terminal_wakeup(ctx) }));
         assert!(!background.update(&mut app, |view, ctx| { view.handle_terminal_wakeup(ctx) }));
+    });
+}
+#[test]
+fn background_focus_reconciliation_does_not_steal_foreground_focus() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (foreground, _) = add_focus_test_session(&mut app, &fixture, true);
+        let (background, _) = add_focus_test_session(&mut app, &fixture, false);
+        let foreground_input_id = foreground.read(&app, |view, _| view.input_view.id());
+
+        background.update(&mut app, |view, ctx| {
+            view.reconcile_focus(ctx);
+        });
+
+        app.read(|ctx| {
+            assert_eq!(
+                ctx.focused_view_id(fixture.window_id),
+                Some(foreground_input_id),
+                "background ownership transitions must not change framework focus"
+            );
+        });
     });
 }
 


### PR DESCRIPTION
## Description

Fixes an intermittent Warp Agent CLI state where the input remains visible but has no cursor after a temporary interaction owns focus.

Session-level lifecycle transitions now reconcile focus through one state-derived path. The session chooses only the immediate interaction surface—session/PTY, input, blocker, or statusline configuration—and WarpUI's existing nested focus handling lets that surface delegate to its internal child. This also removes direct input-focus restoration workarounds, prevents background sessions from stealing foreground focus, and stops ordinary PTY redraws from overriding nested interaction focus.

## Linked Issue

N/A

## Testing

- [x] I have manually tested my changes locally with `./script/run-tui`
- [x] Verified the input cursor is initially visible
- [x] Opened `/statusline`, verified focus moved to its nested selector, then pressed Escape and verified the input cursor returned
- [x] `./script/format --check`
- [x] All Clippy invocations from `./script/presubmit`
- [x] Workspace nextest: 10,739 passed
- [x] `warp_completer` v2 nextest: 117 passed
- [x] Doc tests passed

Added regression coverage for nested focus preservation across redraws, cursor restoration after an interaction closes, and background-session focus isolation.

### Screenshots / Videos

Not included: this is a keyboard-focus lifecycle fix without a persistent visual change. The end-to-end focus transition was verified in the live TUI and the regression test asserts presenter-level terminal cursor publication.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Warp Agent conversation: https://staging.warp.dev/conversation/0cdf14ab-4d3b-4419-a548-49e5fb9331ac

CHANGELOG-BUG-FIX: Fixed the Warp Agent CLI input occasionally rendering without a cursor after temporary interactions.
CHANGELOG-TUI: Fixed the input occasionally rendering without a cursor after temporary interactions.

Co-Authored-By: Warp Agent <agent@warp.dev>
