### PR TITLE
Multi-level orchestration: depth-capable client core and drill-down UI

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -39,6 +39,7 @@ use crate::ai::ambient_agents::{
     AmbientAgentTaskState,
 };
 use crate::ai::artifacts::Artifact;
+use crate::ai::blocklist::orchestration_topology::orchestration_aware_conversation_status;
 use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate,
 };
@@ -416,7 +417,14 @@ impl AgentRunDisplayStatus {
                 let history_model = BlocklistAIHistoryModel::as_ref(app);
                 entry::conversation_id_shadowed_by_task(task, history_model)
                     .and_then(|conversation_id| history_model.conversation(&conversation_id))
-                    .map(|conversation| Self::from_conversation_status(conversation.status()))
+                    .map(|conversation| {
+                        // Roll the whole orchestration subtree (children,
+                        // grandchildren, …) into the root card's status.
+                        Self::from_conversation_status(&orchestration_aware_conversation_status(
+                            history_model,
+                            conversation,
+                        ))
+                    })
                     .unwrap_or_else(|| Self::from_task_state(task))
             }
             AmbientAgentTaskState::Succeeded

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -17,6 +17,7 @@ use crate::ai::ambient_agents::{
 };
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
+use crate::ai::blocklist::orchestration_topology::orchestration_aware_conversation_status;
 use crate::ai::conversation_navigation::ConversationNavigationData;
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::util::time_format::human_readable_precise_duration;
@@ -388,7 +389,13 @@ fn conversation_display_status(
 ) -> AgentRunDisplayStatus {
     history_model
         .conversation(&metadata.nav_data.id)
-        .map(|conversation| AgentRunDisplayStatus::from_conversation_status(conversation.status()))
+        .map(|conversation| {
+            // Roll the whole orchestration subtree (children, grandchildren,
+            // …) into the card's status.
+            AgentRunDisplayStatus::from_conversation_status(
+                &orchestration_aware_conversation_status(history_model, conversation),
+            )
+        })
         .unwrap_or(AgentRunDisplayStatus::ConversationSucceeded)
 }
 

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -39,6 +39,7 @@ use crate::ai::orchestration::{
     OrchestrationConfigState, can_execute_with_auth_secret,
     populate_default_auth_secret_for_execution,
 };
+use crate::features::FeatureFlag;
 
 /// Per-child spawn timeout. If a child agent doesn't report back within
 /// this window (e.g. binary not found, server error), the slot is failed
@@ -436,9 +437,10 @@ impl RunAgentsExecutor {
             return true;
         }
         // Child conversations live in hidden panes where a confirmation card
-        // would be invisible and hang the run. Always auto-execute; the
-        // interactive policy checks in `prepare_request_for_execution` still
-        // fail the call gracefully (Denied result) when launch is blocked.
+        // would be invisible and hang the run. Always auto-execute — even
+        // with `MultiLevelOrchestration` disabled — so the policy checks in
+        // `prepare_request_for_execution` (including the multi-level gate)
+        // fail the call gracefully with a Denied result instead of a card.
         // Children inherit the parent surface's execution profile via
         // `inherit_child_agent_settings`, so run-wide permissions carry over.
         if BlocklistAIHistoryModel::as_ref(ctx)
@@ -527,6 +529,18 @@ fn prepare_request_for_execution(
 
     if AppExecutionMode::as_ref(ctx).is_autonomous() {
         return None;
+    }
+
+    // A child conversation cannot present a confirmation card (hidden pane),
+    // so when the multi-level surfaces are disabled its `run_agents` call
+    // must be denied outright rather than falling through to the
+    // interactive path.
+    if !FeatureFlag::MultiLevelOrchestration.is_enabled()
+        && BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&parent_conversation_id)
+            .is_some_and(|c| c.is_child_agent_conversation())
+    {
+        return Some("Multi-level orchestration is not enabled on this client.".to_string());
     }
 
     if status.is_some_and(|status| status.is_disapproved()) {

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -435,6 +435,18 @@ impl RunAgentsExecutor {
         if AppExecutionMode::as_ref(ctx).is_autonomous() {
             return true;
         }
+        // Child conversations live in hidden panes where a confirmation card
+        // would be invisible and hang the run. Always auto-execute; the
+        // interactive policy checks in `prepare_request_for_execution` still
+        // fail the call gracefully (Denied result) when launch is blocked.
+        // Children inherit the parent surface's execution profile via
+        // `inherit_child_agent_settings`, so run-wide permissions carry over.
+        if BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&input.conversation_id)
+            .is_some_and(|c| c.is_child_agent_conversation())
+        {
+            return true;
+        }
         let mut resolved_request = request.clone();
         resolve_request_from_approved_config(&mut resolved_request, input.conversation_id, ctx);
         populate_default_auth_secret_for_execution(&mut resolved_request, ctx);

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -626,6 +626,39 @@ fn should_not_autoexecute_without_approved_plan_or_always_allow_profile() {
 }
 
 #[test]
+fn should_autoexecute_for_child_conversation_without_plan_or_profile() {
+    // A child conversation lives in a hidden pane where a confirmation card
+    // would be invisible, so its run_agents must auto-execute even without an
+    // approved plan config or an always-allow profile.
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        let child_conversation_id =
+            BlocklistAIHistoryModel::handle(&app).update(&mut app, |history, ctx| {
+                history.start_new_child_conversation(
+                    EntityId::new(),
+                    "mid-tree".to_string(),
+                    state.conversation_id,
+                    None,
+                    ctx,
+                )
+            });
+        let action = remote_run_agents_action("oz");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: child_conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(should_autoexecute);
+    });
+}
+
+#[test]
 fn execute_denies_remote_non_warp_harness_without_default_auth_secret() {
     App::test((), |mut app| async move {
         let state = initialize_run_agents_test(&mut app, ExecutionMode::App);

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -659,6 +659,103 @@ fn should_autoexecute_for_child_conversation_without_plan_or_profile() {
 }
 
 #[test]
+fn child_run_agents_executes_when_multi_level_orchestration_enabled() {
+    let _flag = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        let child_conversation_id =
+            BlocklistAIHistoryModel::handle(&app).update(&mut app, |history, ctx| {
+                history.start_new_child_conversation(
+                    EntityId::new(),
+                    "mid-tree".to_string(),
+                    state.conversation_id,
+                    None,
+                    ctx,
+                )
+            });
+        let action = remote_run_agents_action("oz");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: child_conversation_id,
+                },
+                ctx,
+            )
+        });
+        assert!(should_autoexecute);
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: child_conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+        assert!(matches!(execution, AnyActionExecution::Async { .. }));
+    });
+}
+
+#[test]
+fn execute_denies_child_run_agents_when_multi_level_orchestration_disabled() {
+    let _flag = FeatureFlag::MultiLevelOrchestration.override_enabled(false);
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        let child_conversation_id =
+            BlocklistAIHistoryModel::handle(&app).update(&mut app, |history, ctx| {
+                history.start_new_child_conversation(
+                    EntityId::new(),
+                    "mid-tree".to_string(),
+                    state.conversation_id,
+                    None,
+                    ctx,
+                )
+            });
+        let action = remote_run_agents_action("oz");
+
+        // Auto-execution still bypasses the confirmation card (invisible in a
+        // hidden pane) so the denial below renders instead of hanging the run.
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: child_conversation_id,
+                },
+                ctx,
+            )
+        });
+        assert!(should_autoexecute);
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: child_conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+        let AnyActionExecution::Sync(AIAgentActionResultType::RunAgents(RunAgentsResult::Denied {
+            reason,
+        })) = execution
+        else {
+            panic!("expected synchronous run_agents denial");
+        };
+        assert_eq!(
+            reason,
+            "Multi-level orchestration is not enabled on this client."
+        );
+    });
+}
+
+#[test]
 fn execute_denies_remote_non_warp_harness_without_default_auth_secret() {
     App::test((), |mut app| async move {
         let state = initialize_run_agents_test(&mut app, ExecutionMode::App);

--- a/app/src/ai/blocklist/action_model/execute/wait_for_events_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/wait_for_events_tests.rs
@@ -81,12 +81,12 @@ fn watchdog_timeout_preserves_large_stamped_value() {
 }
 
 #[test]
-fn execute_invokes_parent_registration_and_honors_child_short_circuit() {
+fn execute_invokes_parent_registration_for_child_conversations() {
     // `execute()` must route into the orchestration streamer behind the flag.
-    // For a child conversation (is_child_agent_conversation), the streamer
-    // short-circuits without a server fetch (asserted via the mock's times(0)
-    // expectation), and the wait still flips the conversation into
-    // WaitingForEvents.
+    // A child conversation is eligible for wait-time parent registration —
+    // with multi-level orchestration a mid-tree node may have children of
+    // its own — so the streamer issues a `get_ambient_agent_task` fetch,
+    // and the wait still flips the conversation into WaitingForEvents.
     App::test((), |mut app| async move {
         let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
 
@@ -94,13 +94,15 @@ fn execute_invokes_parent_registration_and_honors_child_short_circuit() {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
 
-        // A streamer whose server fetch must never be called: the child
-        // short-circuit precedes any `get_ambient_agent_task` call.
+        // The registration fetch must be issued exactly once for the child.
+        // Returning an error keeps the rest of the flow a graceful no-op.
         let mut mock = MockAIClient::new();
-        mock.expect_get_ambient_agent_task().times(0);
+        mock.expect_get_ambient_agent_task()
+            .times(1)
+            .returning(|_| Err(anyhow::anyhow!("fetch observed")));
         let ai_client: Arc<dyn AIClient> = Arc::new(mock);
         let server_api = ServerApiProvider::new_for_test().get();
-        // Held for the lifetime of the test so the mock's times(0) expectation
+        // Held for the lifetime of the test so the mock's times(1) expectation
         // is verified on drop; resolved internally by `execute()` via
         // `OrchestrationEventStreamer::handle`.
         let _streamer = app.add_singleton_model(|ctx| {
@@ -147,6 +149,13 @@ fn execute_invokes_parent_registration_and_honors_child_short_circuit() {
             "WaitForEvents should yield an async execution"
         );
 
+        // Drive the spawned registration fetch so the mock observes it; the
+        // times(1) expectation is verified when `_streamer` drops at test
+        // teardown.
+        for _ in 0..3 {
+            futures_lite::future::yield_now().await;
+        }
+
         history_model.read(&app, |model, _| {
             assert!(
                 matches!(
@@ -156,9 +165,5 @@ fn execute_invokes_parent_registration_and_honors_child_short_circuit() {
                 "execute() must flip the conversation into WaitingForEvents"
             );
         });
-        // The child short-circuit is asserted by the mock's times(0)
-        // expectation, verified when `_streamer` drops at test teardown:
-        // a child conversation must never trigger a `get_ambient_agent_task`
-        // fetch.
     });
 }

--- a/app/src/ai/blocklist/action_model/execute/wait_for_events_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/wait_for_events_tests.rs
@@ -94,17 +94,20 @@ fn execute_invokes_parent_registration_for_child_conversations() {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
 
-        // The registration fetch must be issued exactly once for the child.
-        // Returning an error keeps the rest of the flow a graceful no-op.
+        // The registration fetch must be issued for the child (the old code
+        // short-circuited children entirely, i.e. zero fetches). At least
+        // once, not exactly once: the Err return below can also be refetched
+        // by the streamer's restore-retry loop, and whether a retry lands
+        // before test teardown is a platform timing race.
         let mut mock = MockAIClient::new();
         mock.expect_get_ambient_agent_task()
-            .times(1)
+            .times(1..)
             .returning(|_| Err(anyhow::anyhow!("fetch observed")));
         let ai_client: Arc<dyn AIClient> = Arc::new(mock);
         let server_api = ServerApiProvider::new_for_test().get();
-        // Held for the lifetime of the test so the mock's times(1) expectation
-        // is verified on drop; resolved internally by `execute()` via
-        // `OrchestrationEventStreamer::handle`.
+        // Held for the lifetime of the test so the mock's times(1..)
+        // expectation is verified on drop; resolved internally by `execute()`
+        // via `OrchestrationEventStreamer::handle`.
         let _streamer = app.add_singleton_model(|ctx| {
             OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
         });
@@ -150,7 +153,7 @@ fn execute_invokes_parent_registration_for_child_conversations() {
         );
 
         // Drive the spawned registration fetch so the mock observes it; the
-        // times(1) expectation is verified when `_streamer` drops at test
+        // times(1..) expectation is verified when `_streamer` drops at test
         // teardown.
         for _ in 0..3 {
             futures_lite::future::yield_now().await;

--- a/app/src/ai/blocklist/agent_view/orchestration_conversation_links.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_conversation_links.rs
@@ -12,7 +12,6 @@ use warpui::platform::Cursor;
 use warpui::text_layout::ClipConfig;
 use warpui::{AppContext, Element, EntityId, EventContext, SingletonEntity};
 
-use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::agent_conversations_model::entry::AgentConversationEntryId;
 use crate::ai::agent_conversations_model::{
@@ -23,20 +22,6 @@ use crate::terminal::view::TerminalAction;
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::workspace::{RestoreConversationLayout, WorkspaceAction, WorkspaceRegistry};
-
-pub(crate) fn conversation_id_for_agent_id(
-    agent_id: &str,
-    app: &AppContext,
-) -> Option<AIConversationId> {
-    let history_model = BlocklistAIHistoryModel::as_ref(app);
-    history_model
-        .conversation_id_for_agent_id(agent_id)
-        .or_else(|| {
-            history_model.find_conversation_id_by_server_token(&ServerConversationToken::new(
-                agent_id.to_string(),
-            ))
-        })
-}
 
 /// True if the conversation is open in some other visible pane. Hidden
 /// child-agent panes are excluded so unopened children don't look
@@ -107,15 +92,16 @@ pub(crate) fn dispatch_focus_or_open_child_agent_pane(
     ctx.dispatch_typed_action(TerminalAction::OpenChildAgentInNewPane { conversation_id });
 }
 
+/// Thin wrapper over the history model's canonical parent resolution
+/// ([`BlocklistAIHistoryModel::resolved_parent_conversation_id_for_conversation`])
+/// so UI surfaces cannot drift from child indexing, breadcrumbs, or the
+/// orchestration root walk.
 pub(crate) fn parent_conversation_id(
     active_conversation: &AIConversation,
     app: &AppContext,
 ) -> Option<AIConversationId> {
-    active_conversation.parent_conversation_id().or_else(|| {
-        active_conversation
-            .parent_agent_id()
-            .and_then(|id| conversation_id_for_agent_id(id, app))
-    })
+    BlocklistAIHistoryModel::as_ref(app)
+        .resolved_parent_conversation_id_for_conversation(active_conversation)
 }
 
 pub(crate) fn conversation_navigation_action(

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -49,8 +49,8 @@ use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::{
 };
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
 use crate::ai::blocklist::orchestration_topology::{
-    aggregated_orchestrator_status, child_conversations_in_pill_order,
-    descendant_conversation_ids_in_spawn_order, orchestration_root_conversation_id,
+    LoadedSubtreeRollup, aggregated_orchestrator_status, child_conversations_in_pill_order,
+    loaded_subtree_rollup, orchestration_root_conversation_id,
 };
 use crate::ai::blocklist::telemetry::{
     BlocklistOrchestrationTelemetryEvent, PillBarActionKind, PillBarInteractionEvent,
@@ -192,13 +192,7 @@ struct PillSpec {
     is_remote_child: bool,
     /// Present when this child is itself an orchestrator: rolled-up state of
     /// its subtree, rendered as a trailing "group" badge on the pill.
-    subtree_rollup: Option<SubtreeRollup>,
-}
-
-/// Rolled-up state of a child pill's own subtree.
-struct SubtreeRollup {
-    descendant_count: usize,
-    status: ConversationStatus,
+    subtree_rollup: Option<LoadedSubtreeRollup>,
 }
 
 /// Everything `pill_specs` computes for one render of the bar. The bar is a
@@ -325,6 +319,10 @@ pub enum OrchestrationPillBarAction {
     PillClicked {
         conversation_id: AIConversationId,
         pill_kind: PillKind,
+        /// Set for the leading breadcrumb pills so telemetry can tell
+        /// drill-up navigation apart from same-level pill switches
+        /// (navigation itself only depends on `pill_kind`).
+        is_breadcrumb: bool,
     },
 }
 
@@ -640,9 +638,11 @@ impl OrchestrationPillBar {
         let anchor_id = drill_down_anchor_id(active_id, active_conversation, app);
         let anchor = history.conversation(&anchor_id)?;
 
-        // Use the shared canonical pill ordering so the visible row and
-        // keyboard navigation cannot drift. Only DIRECT children render:
-        // deeper levels are reached by drilling into a group pill.
+        // Per-level ordering is shared with keyboard navigation, but the two
+        // consume it differently: cycling walks the whole tree while the bar
+        // renders only the anchor's DIRECT children — deeper levels are
+        // reached by drilling into a group pill, and the bar follows the
+        // keyboard selection by re-anchoring (`drill_down_anchor_id`).
         let children: Vec<_> = child_conversations_in_pill_order(history, anchor_id)
             .into_iter()
             .filter_map(|descendant| history.conversation(&descendant.conversation_id))
@@ -687,12 +687,7 @@ impl OrchestrationPillBar {
             };
             // A child with children of its own renders as a "group" pill:
             // its own status on the avatar plus a rolled-up subtree badge.
-            let descendant_count =
-                descendant_conversation_ids_in_spawn_order(history, child.id()).len();
-            let subtree_rollup = (descendant_count > 0).then(|| SubtreeRollup {
-                descendant_count,
-                status: aggregated_orchestrator_status(history, child.id()),
-            });
+            let subtree_rollup = loaded_subtree_rollup(history, child.id());
             specs.push(PillSpec {
                 conversation_id: child.id(),
                 label: name.to_string(),
@@ -802,14 +797,16 @@ fn orchestrator_label(orchestrator: &AIConversation) -> String {
 }
 
 impl OrchestrationPillBar {
-    /// Resolves the source-conversation / total-pills / total-pinned
-    /// triple used to enrich every `PillBarInteraction` event. Returns
-    /// `None` when there is no active orchestration tree to attribute
-    /// the interaction to.
+    /// Resolves the anchor / root / total-pills / total-pinned tuple used
+    /// to enrich every `PillBarInteraction` event. The anchor becomes the
+    /// payload's `source_conversation_id`; the tree root rides alongside
+    /// so drilled-down interactions stay attributable to their tree.
+    /// Returns `None` when there is no active orchestration tree to
+    /// attribute the interaction to.
     fn pill_bar_telemetry_context(
         &self,
         app: &AppContext,
-    ) -> Option<(AIConversationId, usize, usize)> {
+    ) -> Option<(AIConversationId, AIConversationId, usize, usize)> {
         let contents = self.pill_specs(app)?;
         let total_pills = contents.specs.len();
         let total_pinned = contents
@@ -817,7 +814,8 @@ impl OrchestrationPillBar {
             .iter()
             .filter(|spec| matches!(spec.pin_state, PillPinState::Pinned))
             .count();
-        Some((contents.anchor_id, total_pills, total_pinned))
+        let root_id = contents.breadcrumb_root_id.unwrap_or(contents.anchor_id);
+        Some((contents.anchor_id, root_id, total_pills, total_pinned))
     }
 
     /// Pill kind for `target_id` in the current pill specs. Defaults
@@ -878,7 +876,7 @@ impl OrchestrationPillBar {
         switch_outcome: Option<PillSwitchOutcome>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let Some((source_conversation_id, total_pills, total_pinned)) =
+        let Some((source_conversation_id, root_conversation_id, total_pills, total_pinned)) =
             self.pill_bar_telemetry_context(ctx)
         else {
             return;
@@ -890,6 +888,7 @@ impl OrchestrationPillBar {
                 total_pills,
                 total_pinned,
                 source_conversation_id,
+                root_conversation_id,
                 target_conversation_id,
                 switch_outcome,
             }),
@@ -1087,6 +1086,7 @@ impl TypedActionView for OrchestrationPillBar {
             OrchestrationPillBarAction::PillClicked {
                 conversation_id,
                 pill_kind,
+                is_breadcrumb,
             } => {
                 let id = *conversation_id;
                 let self_terminal_view_id =
@@ -1104,7 +1104,12 @@ impl TypedActionView for OrchestrationPillBar {
                 } else {
                     PillSwitchOutcome::SwitchedInPlace
                 };
-                self.emit_pill_switch(pill_kind.telemetry_kind(), id, outcome, ctx);
+                let telemetry_kind = if *is_breadcrumb {
+                    PillBarPillKind::Breadcrumb
+                } else {
+                    pill_kind.telemetry_kind()
+                };
+                self.emit_pill_switch(telemetry_kind, id, outcome, ctx);
                 if is_open_elsewhere {
                     self.navigate_to_conversation_pane(id, ctx);
                 } else {
@@ -1839,6 +1844,7 @@ fn render_breadcrumb_pill(
         ctx.dispatch_typed_action(OrchestrationPillBarAction::PillClicked {
             conversation_id: target_id,
             pill_kind,
+            is_breadcrumb: true,
         });
     })
     .finish()
@@ -1851,7 +1857,7 @@ const SUBTREE_BADGE_HORIZONTAL_PADDING: f32 = 5.;
 /// and is never narrower than the trailing slice the hover 3-dot overlay
 /// occupies, so swapping the badge out for the dots never resizes the pill.
 fn subtree_rollup_badge_slot_width(
-    rollup: &SubtreeRollup,
+    rollup: &LoadedSubtreeRollup,
     appearance: &Appearance,
     app: &AppContext,
 ) -> f32 {
@@ -1868,7 +1874,7 @@ fn subtree_rollup_badge_slot_width(
 /// Compact trailing badge on a "group" pill: the number of agents in the
 /// child's subtree, tinted with the subtree's aggregated status color.
 fn render_subtree_rollup_badge(
-    rollup: &SubtreeRollup,
+    rollup: &LoadedSubtreeRollup,
     theme: &WarpTheme,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
@@ -2255,6 +2261,7 @@ fn render_pill(
         ctx.dispatch_typed_action(OrchestrationPillBarAction::PillClicked {
             conversation_id,
             pill_kind: kind,
+            is_breadcrumb: false,
         });
     })
     .on_right_click(move |ctx, _app, _| {

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -49,8 +49,8 @@ use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::{
 };
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
 use crate::ai::blocklist::orchestration_topology::{
-    aggregated_orchestrator_status, descendant_conversation_ids_in_spawn_order,
-    descendant_conversations_in_pill_order,
+    aggregated_orchestrator_status, child_conversations_in_pill_order,
+    descendant_conversation_ids_in_spawn_order, orchestration_root_conversation_id,
 };
 use crate::ai::blocklist::telemetry::{
     BlocklistOrchestrationTelemetryEvent, PillBarActionKind, PillBarInteractionEvent,
@@ -190,6 +190,31 @@ struct PillSpec {
     pin_state: PillPinState,
     /// Child running on a remote worker; drives the cloud-shaped badge variant.
     is_remote_child: bool,
+    /// Present when this child is itself an orchestrator: rolled-up state of
+    /// its subtree, rendered as a trailing "group" badge on the pill.
+    subtree_rollup: Option<SubtreeRollup>,
+}
+
+/// Rolled-up state of a child pill's own subtree.
+struct SubtreeRollup {
+    descendant_count: usize,
+    status: ConversationStatus,
+}
+
+/// Everything `pill_specs` computes for one render of the bar. The bar is a
+/// drill-down view: it anchors on one conversation and renders only that
+/// conversation's DIRECT children, with breadcrumbs back up the tree when
+/// the anchored level sits below the root.
+struct PillBarContents {
+    anchor_id: AIConversationId,
+    /// Root of the orchestration tree when the anchor is not itself the
+    /// root; drives the leading breadcrumb pill.
+    breadcrumb_root_id: Option<AIConversationId>,
+    /// The anchor's direct parent when it is neither the anchor nor already
+    /// covered by the root breadcrumb (i.e. the anchor sits 2+ levels below
+    /// the root); rendered after the root breadcrumb.
+    breadcrumb_parent_id: Option<AIConversationId>,
+    specs: Vec<PillSpec>,
 }
 
 #[derive(Clone, Copy)]
@@ -224,6 +249,7 @@ fn pill_body_position_id(conversation_id: AIConversationId) -> String {
 
 fn pill_label_width(
     label: &str,
+    font_size: f32,
     font_properties: Properties,
     appearance: &Appearance,
     app: &AppContext,
@@ -237,7 +263,7 @@ fn pill_label_width(
     let line = text_layout_system.layout_line(
         label,
         LineStyle {
-            font_size: appearance.monospace_font_size() - 1.,
+            font_size,
             line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
             baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
             fixed_width_tab_size: None,
@@ -568,16 +594,18 @@ impl OrchestrationPillBar {
         let Some(active_conversation) = history.conversation(&active_id) else {
             return;
         };
-        let orchestrator_id = parent_conversation_id(active_conversation, ctx).unwrap_or(active_id);
+        let anchor_id = drill_down_anchor_id(active_id, active_conversation, ctx);
         // Track only ids that are still rendered; retain step prevents leaking
         // handles for old orchestrators / children when switching views.
         let mut alive: HashSet<AIConversationId> = HashSet::new();
-        alive.insert(orchestrator_id);
-        if let Some(parent_id) = parent_conversation_id(active_conversation, ctx) {
-            alive.insert(parent_id);
-        }
-        for child_id in descendant_conversation_ids_in_spawn_order(history, orchestrator_id) {
-            alive.insert(child_id);
+        alive.insert(anchor_id);
+        alive.insert(active_id);
+        // The breadcrumb pills anchor on the tree root and the anchor's parent.
+        let (breadcrumb_root_id, breadcrumb_parent_id) = breadcrumb_ids(history, anchor_id);
+        alive.extend(breadcrumb_root_id);
+        alive.extend(breadcrumb_parent_id);
+        for child_id in history.child_conversation_ids_of(&anchor_id) {
+            alive.insert(*child_id);
         }
         let mut mouse_states = self.mouse_states.borrow_mut();
         let mut overflow_states = self.overflow_button_mouse_states.borrow_mut();
@@ -594,10 +622,9 @@ impl OrchestrationPillBar {
         // pane's tree, so pruning here would clobber pins in other panes.
     }
 
-    /// Builds the ordered pill list along with the orchestrator id it was
-    /// built for (used to key the shared horizontal scroll handle), or
-    /// `None` when nothing should render.
-    fn pill_specs(&self, app: &AppContext) -> Option<(AIConversationId, Vec<PillSpec>)> {
+    /// Builds the drill-down pill bar contents for the active conversation,
+    /// or `None` when nothing should render.
+    fn pill_specs(&self, app: &AppContext) -> Option<PillBarContents> {
         let active_id = self
             .agent_view_controller
             .as_ref(app)
@@ -606,39 +633,40 @@ impl OrchestrationPillBar {
         let history = BlocklistAIHistoryModel::as_ref(app);
         let active_conversation = history.conversation(&active_id)?;
 
-        // Anchor the bar on the orchestrator root regardless of which
-        // conversation is active so navigation between siblings is symmetric.
-        let orchestrator_id = parent_conversation_id(active_conversation, app).unwrap_or(active_id);
-        let orchestrator = history.conversation(&orchestrator_id)?;
+        let anchor_id = drill_down_anchor_id(active_id, active_conversation, app);
+        let anchor = history.conversation(&anchor_id)?;
 
         // Use the shared canonical pill ordering so the visible row and
-        // keyboard navigation cannot drift.
-        let children: Vec<_> = descendant_conversations_in_pill_order(history, orchestrator_id)
+        // keyboard navigation cannot drift. Only DIRECT children render:
+        // deeper levels are reached by drilling into a group pill.
+        let children: Vec<_> = child_conversations_in_pill_order(history, anchor_id)
             .into_iter()
             .filter_map(|descendant| history.conversation(&descendant.conversation_id))
             .collect();
 
-        // Nothing to show if the orchestrator has no children yet.
+        // Nothing to show if the anchor has no children yet.
         if children.is_empty() {
             return None;
         }
+        let (breadcrumb_root_id, breadcrumb_parent_id) = breadcrumb_ids(history, anchor_id);
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
         let mut specs = Vec::with_capacity(1 + children.len());
 
-        // Orchestrator pill first; never pinned. Its badge aggregates the tree,
+        // Anchor pill first; never pinned. Its badge aggregates its subtree,
         // while child pills show per-child status.
         specs.push(PillSpec {
-            conversation_id: orchestrator_id,
-            label: orchestrator_label(orchestrator),
+            conversation_id: anchor_id,
+            label: orchestrator_label(anchor),
             avatar_color: theme.ansi_fg_cyan(),
             avatar_glyph: AvatarGlyph::Icon(Icon::Agent),
-            status: Some(aggregated_orchestrator_status(history, orchestrator_id)),
-            is_selected: orchestrator_id == active_id,
+            status: Some(aggregated_orchestrator_status(history, anchor_id)),
+            is_selected: anchor_id == active_id,
             kind: PillKind::Orchestrator,
             pin_state: PillPinState::Unpinned,
-            is_remote_child: false,
+            is_remote_child: anchor.is_remote_child(),
+            subtree_rollup: None,
         });
 
         // Stamp each child's current pin state; partitioning happens at render.
@@ -653,6 +681,14 @@ impl OrchestrationPillBar {
             } else {
                 PillPinState::Unpinned
             };
+            // A child with children of its own renders as a "group" pill:
+            // its own status on the avatar plus a rolled-up subtree badge.
+            let descendant_count =
+                descendant_conversation_ids_in_spawn_order(history, child.id()).len();
+            let subtree_rollup = (descendant_count > 0).then(|| SubtreeRollup {
+                descendant_count,
+                status: aggregated_orchestrator_status(history, child.id()),
+            });
             specs.push(PillSpec {
                 conversation_id: child.id(),
                 label: name.to_string(),
@@ -663,10 +699,52 @@ impl OrchestrationPillBar {
                 kind: PillKind::Child,
                 pin_state,
                 is_remote_child: child.is_remote_child(),
+                subtree_rollup,
             });
         }
 
-        Some((orchestrator_id, specs))
+        Some(PillBarContents {
+            anchor_id,
+            breadcrumb_root_id,
+            breadcrumb_parent_id,
+            specs,
+        })
+    }
+}
+
+/// Resolves the breadcrumb targets shown while the bar is drilled below the
+/// tree root: the root itself, plus the anchor's direct parent when that
+/// parent is a distinct intermediate level (anchor 2+ levels below the
+/// root). When the parent IS the root only the root breadcrumb is returned,
+/// so the bar never shows duplicate affordances.
+fn breadcrumb_ids(
+    history: &BlocklistAIHistoryModel,
+    anchor_id: AIConversationId,
+) -> (Option<AIConversationId>, Option<AIConversationId>) {
+    let root_id = orchestration_root_conversation_id(history, anchor_id)
+        .filter(|root_id| *root_id != anchor_id);
+    let parent_id = history
+        .conversation(&anchor_id)
+        .and_then(|anchor| history.resolved_parent_conversation_id_for_conversation(anchor))
+        .filter(|parent_id| Some(*parent_id) != root_id && *parent_id != anchor_id);
+    (root_id, parent_id)
+}
+
+/// Resolves which conversation's level the drill-down bar shows for
+/// `active_id`: a conversation with children anchors its own level, while a
+/// leaf anchors its parent's level so sibling navigation stays symmetric. At
+/// orchestration depth 1 this matches the historical root-anchored behavior
+/// exactly.
+fn drill_down_anchor_id(
+    active_id: AIConversationId,
+    active_conversation: &AIConversation,
+    app: &AppContext,
+) -> AIConversationId {
+    let history = BlocklistAIHistoryModel::as_ref(app);
+    if history.child_conversation_ids_of(&active_id).is_empty() {
+        parent_conversation_id(active_conversation, app).unwrap_or(active_id)
+    } else {
+        active_id
     }
 }
 
@@ -728,21 +806,23 @@ impl OrchestrationPillBar {
         &self,
         app: &AppContext,
     ) -> Option<(AIConversationId, usize, usize)> {
-        let (orchestrator_id, specs) = self.pill_specs(app)?;
-        let total_pills = specs.len();
-        let total_pinned = specs
+        let contents = self.pill_specs(app)?;
+        let total_pills = contents.specs.len();
+        let total_pinned = contents
+            .specs
             .iter()
             .filter(|spec| matches!(spec.pin_state, PillPinState::Pinned))
             .count();
-        Some((orchestrator_id, total_pills, total_pinned))
+        Some((contents.anchor_id, total_pills, total_pinned))
     }
 
     /// Pill kind for `target_id` in the current pill specs. Defaults
     /// to `Child` if the id is no longer in the bar.
     fn pill_kind_for(&self, target_id: AIConversationId, app: &AppContext) -> PillBarPillKind {
         self.pill_specs(app)
-            .and_then(|(_, specs)| {
-                specs
+            .and_then(|contents| {
+                contents
+                    .specs
                     .into_iter()
                     .find(|spec| spec.conversation_id == target_id)
                     .map(|spec| spec.kind.telemetry_kind())
@@ -1051,7 +1131,13 @@ impl View for OrchestrationPillBar {
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
-        let Some((orchestrator_id, specs)) = self.pill_specs(app) else {
+        let Some(PillBarContents {
+            anchor_id,
+            breadcrumb_root_id,
+            breadcrumb_parent_id,
+            specs,
+        }) = self.pill_specs(app)
+        else {
             return Empty::new().finish();
         };
 
@@ -1088,6 +1174,20 @@ impl View for OrchestrationPillBar {
         let mut orchestrator_pill: Option<Box<dyn Element>> = None;
         let mut pinned_pills: Vec<Box<dyn Element>> = Vec::new();
         let mut unpinned_pills: Vec<Box<dyn Element>> = Vec::new();
+        // Leading breadcrumbs while drilled into a sub-level of the
+        // orchestration tree: the root first, then the anchor's direct
+        // parent when it is an intermediate level of its own.
+        let breadcrumb_pills: Vec<Box<dyn Element>> = [
+            breadcrumb_root_id.map(|root_id| (root_id, PillKind::Orchestrator)),
+            breadcrumb_parent_id.map(|parent_id| (parent_id, PillKind::Child)),
+        ]
+        .into_iter()
+        .flatten()
+        .map(|(target_id, pill_kind)| {
+            let mouse_state = mouse_states.entry(target_id).or_default().clone();
+            render_breadcrumb_pill(target_id, pill_kind, mouse_state, app)
+        })
+        .collect();
         for spec in specs {
             let mouse_state = mouse_states
                 .entry(spec.conversation_id)
@@ -1131,6 +1231,9 @@ impl View for OrchestrationPillBar {
         drop(overflow_states);
         drop(pin_states);
 
+        for pill in breadcrumb_pills {
+            row.add_child(pill);
+        }
         if let Some(pill) = orchestrator_pill {
             row.add_child(pill);
         }
@@ -1153,7 +1256,7 @@ impl View for OrchestrationPillBar {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let horizontal_scroll_state =
-            OrchestrationPillBarModel::as_ref(app).horizontal_scroll_state_for(orchestrator_id);
+            OrchestrationPillBarModel::as_ref(app).horizontal_scroll_state_for(anchor_id);
         let scrollable = NewScrollable::horizontal(
             SingleAxisConfig::Clipped {
                 handle: horizontal_scroll_state,
@@ -1652,6 +1755,140 @@ fn navigation_action_for_pill(kind: PillKind, conversation_id: AIConversationId)
     }
 }
 
+/// Leading breadcrumb pill shown while the bar is drilled into a sub-level
+/// of the orchestration tree. Clicking it navigates to `target_id` — the
+/// tree root (`PillKind::Orchestrator`) or an intermediate parent
+/// (`PillKind::Child`, revealed via its hidden pane like any child pill).
+fn render_breadcrumb_pill(
+    target_id: AIConversationId,
+    pill_kind: PillKind,
+    mouse_state: MouseStateHandle,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    let pill_rest_bg = theme
+        .background()
+        .blend(&internal_colors::fg_overlay_2(theme))
+        .into_solid();
+    let pill_hover_bg = theme
+        .background()
+        .blend(&internal_colors::fg_overlay_3(theme))
+        .into_solid();
+    let text_color = internal_colors::fg_overlay_6(theme).into_solid();
+    let label = BlocklistAIHistoryModel::as_ref(app)
+        .conversation(&target_id)
+        .map(|conversation| match pill_kind {
+            PillKind::Orchestrator => orchestrator_label(conversation),
+            PillKind::Child => conversation
+                .agent_name()
+                .filter(|name| !name.is_empty())
+                .unwrap_or("Agent")
+                .to_string(),
+        })
+        .unwrap_or_else(|| "Orchestrator".to_string());
+
+    Hoverable::new(mouse_state, move |hover_state| {
+        let background = if hover_state.is_hovered() || hover_state.is_clicked() {
+            pill_hover_bg
+        } else {
+            pill_rest_bg
+        };
+        let chevron =
+            ConstrainedBox::new(Icon::ChevronLeft.to_warpui_icon(text_color.into()).finish())
+                .with_width(PILL_ICON_SIZE)
+                .with_height(PILL_ICON_SIZE)
+                .finish();
+        let label_text = Text::new(
+            label,
+            appearance.ui_font_family(),
+            appearance.monospace_font_size() - 1.,
+        )
+        .with_color(text_color)
+        .soft_wrap(false)
+        .with_clip(ClipConfig::ellipsis())
+        .finish();
+        let row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_spacing(PILL_CONTENT_GAP)
+            .with_child(chevron)
+            .with_child(
+                ConstrainedBox::new(label_text)
+                    .with_max_width(PILL_LABEL_MAX_WIDTH)
+                    .finish(),
+            )
+            .finish();
+        ConstrainedBox::new(
+            Container::new(row)
+                .with_padding_left(PILL_HORIZONTAL_PADDING_LEFT)
+                .with_padding_right(PILL_HORIZONTAL_PADDING_RIGHT)
+                .with_background_color(background)
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(PILL_RADIUS)))
+                .finish(),
+        )
+        .with_height(PILL_HEIGHT)
+        .finish()
+    })
+    .with_cursor(Cursor::PointingHand)
+    .on_click(move |ctx, _app, _| {
+        ctx.dispatch_typed_action(OrchestrationPillBarAction::PillClicked {
+            conversation_id: target_id,
+            pill_kind,
+        });
+    })
+    .finish()
+}
+
+/// Horizontal padding inside the subtree badge around its count text.
+const SUBTREE_BADGE_HORIZONTAL_PADDING: f32 = 5.;
+
+/// Fixed slot width for a group pill's subtree badge: fits the count text
+/// and is never narrower than the trailing slice the hover 3-dot overlay
+/// occupies, so swapping the badge out for the dots never resizes the pill.
+fn subtree_rollup_badge_slot_width(
+    rollup: &SubtreeRollup,
+    appearance: &Appearance,
+    app: &AppContext,
+) -> f32 {
+    let text_width = pill_label_width(
+        &rollup.descendant_count.to_string(),
+        appearance.monospace_font_size() - 2.,
+        Properties::default(),
+        appearance,
+        app,
+    );
+    (text_width + 2. * SUBTREE_BADGE_HORIZONTAL_PADDING).max(OVERFLOW_BUTTON_LABEL_RESERVE)
+}
+
+/// Compact trailing badge on a "group" pill: the number of agents in the
+/// child's subtree, tinted with the subtree's aggregated status color.
+fn render_subtree_rollup_badge(
+    rollup: &SubtreeRollup,
+    theme: &WarpTheme,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let (_, color) = rollup
+        .status
+        .status_icon_and_color(theme, StatusColorStyle::Standard);
+    let text = Text::new(
+        rollup.descendant_count.to_string(),
+        appearance.ui_font_family(),
+        appearance.monospace_font_size() - 2.,
+    )
+    .with_color(color)
+    .soft_wrap(false)
+    .finish();
+    Container::new(text)
+        .with_padding_left(SUBTREE_BADGE_HORIZONTAL_PADDING)
+        .with_padding_right(SUBTREE_BADGE_HORIZONTAL_PADDING)
+        .with_padding_top(1.)
+        .with_padding_bottom(1.)
+        .with_background_color(coloru_with_opacity(color, 10))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(PILL_RADIUS)))
+        .finish()
+}
+
 /// 1px vertical divider between the pinned and unpinned sections.
 fn render_pinned_divider(app: &AppContext) -> Box<dyn Element> {
     const DIVIDER_HEIGHT: f32 = 16.;
@@ -1736,6 +1973,7 @@ fn render_pill(
     let avatar_glyph = spec.avatar_glyph;
     let status = spec.status;
     let is_remote_child = spec.is_remote_child;
+    let subtree_rollup = spec.subtree_rollup;
 
     // Per Figma: fg_overlay_2 at rest, fg_overlay_3 on hover, composed over
     // the theme background. Pre-blend to a solid so the avatar cutout ring
@@ -1778,9 +2016,18 @@ fn render_pill(
         };
         // At rest, labels use the full budget. When dots are visible, keep
         // the rest-state slot width but reserve its trailing slice so the
-        // overlay does not cover glyphs or shift sibling pills.
-        let hover_label_slot_width = show_dots.then(|| {
-            pill_label_width(&label, label_style, appearance, app).min(PILL_LABEL_MAX_WIDTH)
+        // overlay does not cover glyphs or shift sibling pills. Group pills
+        // skip the label reserve: their trailing badge slot (below) already
+        // absorbs the overlay.
+        let hover_label_slot_width = (show_dots && subtree_rollup.is_none()).then(|| {
+            pill_label_width(
+                &label,
+                appearance.monospace_font_size() - 1.,
+                label_style,
+                appearance,
+                app,
+            )
+            .min(PILL_LABEL_MAX_WIDTH)
         });
 
         let label_text = Text::new(
@@ -1901,13 +2148,30 @@ fn render_pill(
         // determined by the label alone, and the dots can visually clip
         // the trailing edge of the text when shown without making the
         // pill itself wider or shifting siblings.
-        let row = Flex::row()
+        let mut row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_size(MainAxisSize::Min)
             .with_spacing(leading_label_spacing)
             .with_child(leading)
-            .with_child(label_element)
-            .finish();
+            .with_child(label_element);
+        // Group pills append a rolled-up subtree badge after the label. The
+        // badge occupies a fixed-width slot; while the 3-dot overlay is
+        // shown the slot renders empty so the dots never overlap the badge,
+        // and the pill's width stays constant across the swap.
+        if let Some(rollup) = &subtree_rollup {
+            let slot_width = subtree_rollup_badge_slot_width(rollup, appearance, app);
+            let slot_content: Box<dyn Element> = if show_dots {
+                Empty::new().finish()
+            } else {
+                render_subtree_rollup_badge(rollup, theme, appearance)
+            };
+            row = row.with_child(
+                ConstrainedBox::new(Align::new(slot_content).finish())
+                    .with_width(slot_width)
+                    .finish(),
+            );
+        }
+        let row = row.finish();
 
         // Constrain pill to a fixed height so the half-stadium corner radius
         // renders as a clean continuous shape rather than awkwardly clamping.

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -379,7 +379,11 @@ impl OrchestrationPillBar {
             BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
             | BlocklistAIHistoryEvent::AppendedExchange { .. }
             | BlocklistAIHistoryEvent::SetActiveConversation { .. }
-            | BlocklistAIHistoryEvent::StartedNewConversation { .. } => {
+            | BlocklistAIHistoryEvent::StartedNewConversation { .. }
+            // A remote child's run-id linkage can land after
+            // StartedNewConversation; pill contents and badges keyed on run
+            // linkage must refresh when it does.
+            | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. } => {
                 this.ensure_mouse_states(ctx);
                 ctx.notify();
             }

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -315,3 +315,83 @@ fn navigation_action_for_orchestrator_pill_switches_in_place() {
         } if actual_id == conversation_id
     ));
 }
+
+/// Builds a 3-level tree (root → mid → grandchild) and returns the history
+/// handle plus the ids.
+fn build_three_level_tree(
+    app: &mut warpui::App,
+) -> (
+    ModelHandle<BlocklistAIHistoryModel>,
+    AIConversationId,
+    AIConversationId,
+    AIConversationId,
+) {
+    use warpui::EntityId;
+
+    use crate::test_util::settings::initialize_history_persistence_for_tests;
+
+    initialize_history_persistence_for_tests(app);
+    let terminal_view_id = EntityId::new();
+    let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+    let root_id = history_model.update(app, |history, ctx| {
+        history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+    });
+    let mid_id = history_model.update(app, |history, ctx| {
+        history.start_new_child_conversation(
+            terminal_view_id,
+            "mid".to_string(),
+            root_id,
+            None,
+            ctx,
+        )
+    });
+    let grandchild_id = history_model.update(app, |history, ctx| {
+        history.start_new_child_conversation(
+            terminal_view_id,
+            "grandchild".to_string(),
+            mid_id,
+            None,
+            ctx,
+        )
+    });
+    (history_model, root_id, mid_id, grandchild_id)
+}
+
+#[test]
+fn breadcrumb_ids_show_only_root_when_parent_is_root() {
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let (history_model, root_id, mid_id, _grandchild_id) = build_three_level_tree(&mut app);
+        history_model.read(&app, |history, _| {
+            assert_eq!(breadcrumb_ids(history, mid_id), (Some(root_id), None));
+        });
+    });
+}
+
+#[test]
+fn breadcrumb_ids_show_root_and_parent_when_two_levels_deep() {
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let (history_model, root_id, mid_id, grandchild_id) = build_three_level_tree(&mut app);
+        history_model.read(&app, |history, _| {
+            assert_eq!(
+                breadcrumb_ids(history, grandchild_id),
+                (Some(root_id), Some(mid_id)),
+            );
+        });
+    });
+}
+
+#[test]
+fn breadcrumb_ids_are_empty_at_the_root() {
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let (history_model, root_id, _mid_id, _grandchild_id) = build_three_level_tree(&mut app);
+        history_model.read(&app, |history, _| {
+            assert_eq!(breadcrumb_ids(history, root_id), (None, None));
+        });
+    });
+}

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -396,6 +396,226 @@ fn breadcrumb_ids_are_empty_at_the_root() {
     });
 }
 
+#[test]
+fn drill_down_anchor_is_the_parent_level_for_a_leaf() {
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let (_history_model, _root_id, mid_id, grandchild_id) = build_three_level_tree(&mut app);
+        app.read(|ctx| {
+            let grandchild = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&grandchild_id)
+                .expect("grandchild conversation exists");
+            assert_eq!(
+                drill_down_anchor_id(grandchild_id, grandchild, ctx),
+                mid_id,
+                "a leaf anchors its parent's level so sibling navigation stays symmetric",
+            );
+        });
+    });
+}
+
+#[test]
+fn drill_down_anchor_is_the_node_itself_when_it_has_children() {
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let (_history_model, root_id, mid_id, _grandchild_id) = build_three_level_tree(&mut app);
+        app.read(|ctx| {
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            let root = history
+                .conversation(&root_id)
+                .expect("root conversation exists");
+            let mid = history
+                .conversation(&mid_id)
+                .expect("mid conversation exists");
+            assert_eq!(drill_down_anchor_id(root_id, root, ctx), root_id);
+            assert_eq!(
+                drill_down_anchor_id(mid_id, mid, ctx),
+                mid_id,
+                "a node with children anchors its own level",
+            );
+        });
+    });
+}
+
+/// At orchestration depth 1 the drill-down anchoring must match the
+/// historical root-anchored behavior exactly: both the root and its leaf
+/// children anchor the root's level.
+#[test]
+fn drill_down_anchor_matches_root_anchoring_at_depth_one() {
+    use warpui::{App, EntityId};
+
+    use crate::test_util::settings::initialize_history_persistence_for_tests;
+
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let root_id = history_model.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = history_model.update(&mut app, |history, ctx| {
+            history.start_new_child_conversation(
+                terminal_view_id,
+                "child".to_string(),
+                root_id,
+                None,
+                ctx,
+            )
+        });
+
+        app.read(|ctx| {
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            let root = history
+                .conversation(&root_id)
+                .expect("root conversation exists");
+            let child = history
+                .conversation(&child_id)
+                .expect("child conversation exists");
+            assert_eq!(drill_down_anchor_id(root_id, root, ctx), root_id);
+            assert_eq!(drill_down_anchor_id(child_id, child, ctx), root_id);
+        });
+    });
+}
+
+/// A restored child linked to its parent ONLY via a legacy server
+/// conversation token in `parent_agent_id` (no explicit parent conversation
+/// id, no run id) must index under the parent at restore and resolve
+/// breadcrumbs once the parent is loaded: child indexing, the root walk,
+/// and breadcrumb targets all flow through the history model's canonical
+/// parent resolution (run-id index with a server-token fallback).
+#[test]
+fn breadcrumbs_resolve_token_only_parent_linkage_after_restore() {
+    use chrono::Utc;
+    use warpui::App;
+
+    use crate::ai::blocklist::BlocklistAIHistoryModel;
+    use crate::persistence::model::{
+        AgentConversation, AgentConversationData, AgentConversationRecord,
+    };
+
+    fn user_query_task(
+        conversation_id: AIConversationId,
+        query: &str,
+    ) -> warp_multi_agent_api::Task {
+        warp_multi_agent_api::Task {
+            id: format!("task-{conversation_id}"),
+            messages: vec![warp_multi_agent_api::Message {
+                fetched_memories: vec![],
+                id: format!("msg-{conversation_id}"),
+                task_id: format!("task-{conversation_id}"),
+                server_message_data: String::new(),
+                citations: vec![],
+                message: Some(warp_multi_agent_api::message::Message::UserQuery(
+                    warp_multi_agent_api::message::UserQuery {
+                        query: query.to_string(),
+                        context: None,
+                        referenced_attachments: Default::default(),
+                        mode: None,
+                        intended_agent: Default::default(),
+                    },
+                )),
+                request_id: format!("request-{conversation_id}"),
+                timestamp: None,
+            }],
+            dependencies: None,
+            description: query.to_string(),
+            summary: String::new(),
+            server_data: String::new(),
+        }
+    }
+
+    App::test((), |mut app| async move {
+        let root_id = AIConversationId::new();
+        let child_id = AIConversationId::new();
+        let now = Utc::now().naive_utc();
+
+        let root_data = AgentConversationData {
+            server_conversation_token: Some("root-token".to_string()),
+            conversation_usage_metadata: None,
+            reverted_action_ids: None,
+            forked_from_server_conversation_token: None,
+            artifacts_json: None,
+            parent_agent_id: None,
+            agent_name: None,
+            orchestration_harness_type: None,
+            parent_conversation_id: None,
+            is_remote_child: false,
+            root_task_is_optimistic: None,
+            run_id: None,
+            autoexecute_override: None,
+            last_event_sequence: None,
+            pinned: false,
+        };
+        let child_data = AgentConversationData {
+            server_conversation_token: None,
+            conversation_usage_metadata: None,
+            reverted_action_ids: None,
+            forked_from_server_conversation_token: None,
+            artifacts_json: None,
+            parent_agent_id: Some("root-token".to_string()),
+            agent_name: Some("child".to_string()),
+            orchestration_harness_type: None,
+            parent_conversation_id: None,
+            is_remote_child: false,
+            root_task_is_optimistic: None,
+            run_id: None,
+            autoexecute_override: None,
+            last_event_sequence: None,
+            pinned: false,
+        };
+
+        let conversations = vec![
+            AgentConversation {
+                conversation: AgentConversationRecord {
+                    id: 1,
+                    conversation_id: child_id.to_string(),
+                    conversation_data: serde_json::to_string(&child_data)
+                        .expect("child conversation data should serialize"),
+                    last_modified_at: now,
+                    summary: None,
+                },
+                tasks: vec![user_query_task(child_id, "Child query")],
+            },
+            AgentConversation {
+                conversation: AgentConversationRecord {
+                    id: 2,
+                    conversation_id: root_id.to_string(),
+                    conversation_data: serde_json::to_string(&root_data)
+                        .expect("root conversation data should serialize"),
+                    last_modified_at: now - chrono::Duration::seconds(1),
+                    summary: None,
+                },
+                tasks: vec![user_query_task(root_id, "Root query")],
+            },
+        ];
+
+        let history_model = app
+            .add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &conversations));
+
+        // Token-linked children index under the parent at restore.
+        history_model.read(&app, |history, _| {
+            assert_eq!(history.child_conversation_ids_of(&root_id), &[child_id]);
+        });
+
+        // Load the root (its pane restore normally does this), then confirm
+        // the breadcrumb targets resolve across the token-only linkage.
+        history_model.update(&mut app, |history, _ctx| {
+            history
+                .insert_forked_conversation_from_tasks(
+                    root_id,
+                    vec![user_query_task(root_id, "Root query")],
+                    root_data,
+                )
+                .expect("root conversation should hydrate");
+        });
+        history_model.read(&app, |history, _| {
+            assert_eq!(breadcrumb_ids(history, child_id), (Some(root_id), None));
+        });
+    });
+}
+
 /// The pill bar's history subscription must treat
 /// `ConversationServerTokenAssigned` as a re-render trigger: a remote child's
 /// run-id linkage can land after `StartedNewConversation` (via

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -395,3 +395,133 @@ fn breadcrumb_ids_are_empty_at_the_root() {
         });
     });
 }
+
+/// The pill bar's history subscription must treat
+/// `ConversationServerTokenAssigned` as a re-render trigger: a remote child's
+/// run-id linkage can land after `StartedNewConversation` (via
+/// `assign_run_id_for_conversation`), and pill contents keyed on run linkage
+/// would otherwise stay stale until an unrelated status event fired.
+#[test]
+fn conversation_server_token_assignment_rerenders_the_pill_bar() {
+    use std::sync::Arc;
+
+    use parking_lot::FairMutex;
+    use warpui::App;
+    use warpui::r#async::executor::Background;
+    use warpui::platform::WindowStyle;
+
+    use crate::ai::blocklist::agent_view::{AgentViewEntryOrigin, EphemeralMessageModel};
+    use crate::terminal::TerminalModel;
+    use crate::terminal::color::{self, Colors};
+    use crate::terminal::event_listener::ChannelEventListener;
+    use crate::terminal::model::test_utils::block_size;
+    use crate::test_util::settings::initialize_history_persistence_for_tests;
+
+    /// Hosts the pill bar without embedding it in the rendered element tree,
+    /// so the scene builds triggered by its notifications stay trivial.
+    struct PillBarHost {
+        pill_bar: ViewHandle<OrchestrationPillBar>,
+    }
+
+    impl Entity for PillBarHost {
+        type Event = ();
+    }
+
+    impl View for PillBarHost {
+        fn ui_name() -> &'static str {
+            "PillBarHost"
+        }
+
+        fn render(&self, _app: &AppContext) -> Box<dyn Element> {
+            Empty::new().finish()
+        }
+    }
+
+    impl TypedActionView for PillBarHost {
+        type Action = ();
+    }
+
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        app.add_singleton_model(|_| Appearance::mock());
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        app.add_singleton_model(|ctx| OrchestrationPillBarModel::new(HashSet::new(), ctx));
+
+        let terminal_view_id = EntityId::new();
+        let terminal_model = Arc::new(FairMutex::new(TerminalModel::new_for_test(
+            block_size(),
+            color::List::from(&Colors::default()),
+            ChannelEventListener::new_for_test(),
+            Arc::new(Background::default()),
+            false,
+            None,
+            false,
+            false,
+            None,
+        )));
+        let ephemeral_message_model = app.add_model(|_| EphemeralMessageModel::new());
+        let agent_view_controller = app.add_model(|_| {
+            AgentViewController::new(terminal_model, terminal_view_id, ephemeral_message_model)
+        });
+
+        let root_id = history_model.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = history_model.update(&mut app, |history, ctx| {
+            history.start_new_child_conversation(
+                terminal_view_id,
+                "child".to_string(),
+                root_id,
+                None,
+                ctx,
+            )
+        });
+
+        // Activate the agent view on the root BEFORE the pill bar exists so
+        // the entry events cannot populate its mouse-state cache; the only
+        // event the bar sees below is the token assignment.
+        agent_view_controller.update(&mut app, |controller, ctx| {
+            controller
+                .try_enter_agent_view(
+                    Some(root_id),
+                    AgentViewEntryOrigin::ConversationSelector,
+                    ctx,
+                )
+                .expect("agent view entry should succeed");
+        });
+
+        let (_window_id, host) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let controller = agent_view_controller.clone();
+            let pill_bar =
+                ctx.add_typed_action_view(move |ctx| OrchestrationPillBar::new(controller, ctx));
+            PillBarHost { pill_bar }
+        });
+        let pill_bar = host.read(&app, |host, _| host.pill_bar.clone());
+
+        pill_bar.read(&app, |bar, _| {
+            assert!(
+                bar.mouse_states.borrow().is_empty(),
+                "no history event has reached the pill bar yet",
+            );
+        });
+
+        history_model.update(&mut app, |history, ctx| {
+            history.assign_run_id_for_conversation(
+                child_id,
+                "run-123".to_string(),
+                None,
+                terminal_view_id,
+                ctx,
+            );
+        });
+
+        pill_bar.read(&app, |bar, _| {
+            let mouse_states = bar.mouse_states.borrow();
+            assert!(
+                mouse_states.contains_key(&root_id) && mouse_states.contains_key(&child_id),
+                "ConversationServerTokenAssigned must re-render the pill bar, refreshing \
+                 mouse states for the visible pills",
+            );
+        });
+    });
+}

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -489,6 +489,12 @@ impl BlocklistAIHistoryModel {
             .collect()
     }
 
+    /// Canonical parent resolution for a child's persisted refs: the
+    /// explicit parent conversation id when present, otherwise the parent
+    /// agent id resolved through [`Self::conversation_id_for_agent_id`]
+    /// (run-id index with a legacy server-token fallback). Child indexing,
+    /// the orchestration root walk, breadcrumbs, and UI parent lookups all
+    /// resolve through here so they cannot disagree.
     fn resolved_parent_conversation_id_from_refs(
         &self,
         parent_conversation_id: Option<AIConversationId>,

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -1541,13 +1541,12 @@ fn render_summary(card: &RunAgentsCardFields, appearance: &Appearance) -> Box<dy
     // Multi-level orchestration: the server may grant launched children the
     // run_agents tool, so tell the approver up front. The client cannot
     // cheaply know the server-side depth budget, so this line is gated on
-    // the same dogfood flag as the rest of the client-side multi-level
-    // enablement.
-    if FeatureFlag::WaitForEventsParentRegistration.is_enabled() {
+    // the client-side multi-level enablement flag.
+    if FeatureFlag::MultiLevelOrchestration.is_enabled() {
         column = column.with_child(
             Container::new(
                 Text::new(
-                    "These agents may start their own sub-agents".to_string(),
+                    "These agents may start their own child agents".to_string(),
                     appearance.ui_font_family(),
                     appearance.monospace_font_size() - 1.,
                 )

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -58,6 +58,7 @@ use crate::ai::harness_availability::{
 };
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::appearance::Appearance;
+use crate::features::FeatureFlag;
 use crate::menu::{Event as MenuEvent, Menu, MenuItemFields, MenuVariant};
 use crate::server::experiments::{ServerExperiments, ServerExperimentsEvent};
 use crate::server::server_api::ServerApiProvider;
@@ -1534,7 +1535,31 @@ fn render_summary(card: &RunAgentsCardFields, appearance: &Appearance) -> Box<dy
     .with_selectable(true)
     .finish();
 
-    Container::new(summary_text)
+    let mut column = Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+        .with_child(summary_text);
+    // Multi-level orchestration: the server may grant launched children the
+    // run_agents tool, so tell the approver up front. The client cannot
+    // cheaply know the server-side depth budget, so this line is gated on
+    // the same dogfood flag as the rest of the client-side multi-level
+    // enablement.
+    if FeatureFlag::WaitForEventsParentRegistration.is_enabled() {
+        column = column.with_child(
+            Container::new(
+                Text::new(
+                    "These agents may start their own sub-agents".to_string(),
+                    appearance.ui_font_family(),
+                    appearance.monospace_font_size() - 1.,
+                )
+                .with_color(blended_colors::text_disabled(theme, theme.background()))
+                .finish(),
+            )
+            .with_margin_top(4.)
+            .finish(),
+        );
+    }
+
+    Container::new(column.finish())
         .with_margin_bottom(12.)
         .finish()
 }

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -553,38 +553,40 @@ impl OrchestrationEventStreamer {
         }
     }
 
+    /// Pure eligibility check for [`Self::register_parent_on_wait`]: the
+    /// gating flag must be on; passive views of runs hosted elsewhere
+    /// (shared-session viewers, remote-child placeholders) never register
+    /// because the owning process owns the inbox (mirrors the `is_eligible`
+    /// exclusion); and an established parent needs no re-fetch because the
+    /// live ancestor stream already discovers new children via the server
+    /// `parent_run_id` JOIN. Child conversations ARE eligible: with
+    /// multi-level orchestration a mid-tree node is simultaneously a child
+    /// and a parent candidate, so a child blocked on `wait_for_events` must
+    /// still confirm whether it has children of its own.
+    fn should_register_parent_on_wait(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &warpui::AppContext,
+    ) -> bool {
+        FeatureFlag::WaitForEventsParentRegistration.is_enabled()
+            && !self.is_remote_run_view(conversation_id, ctx)
+            && !self.is_parent_agent_conversation(conversation_id, ctx)
+    }
+
     /// Confirms parent status against the server when an orchestrator blocks
     /// on `wait_for_events`, registering it for the owner-side ancestor
     /// stream. This is the trigger that lets a parent learn about children
     /// created out-of-band (Oz CLI / web API), which never flowed through
     /// [`Self::register_watched_run_id`]. Once the parent role is established
     /// it is permanent for the conversation's life, so subsequent waits
-    /// short-circuit on the already-parent check below.
-    ///
-    /// Child conversations are eligible too: with multi-level orchestration a
-    /// mid-tree node is simultaneously a child and a parent, so a child
-    /// blocked on `wait_for_events` must still confirm whether it has
-    /// children of its own.
+    /// short-circuit in [`Self::should_register_parent_on_wait`]. The fetch
+    /// below exists only to make the initial not-parent -> parent transition.
     pub fn register_parent_on_wait(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) {
-        if !FeatureFlag::WaitForEventsParentRegistration.is_enabled() {
-            return;
-        }
-        // Passive views of a run hosted elsewhere (shared-session viewers,
-        // remote-child placeholders) must not register: the owning process
-        // owns the inbox. Mirrors the `is_eligible` exclusion and avoids a
-        // wasted `get_ambient_agent_task` fetch.
-        if self.is_remote_run_view(conversation_id, ctx) {
-            return;
-        }
-        // Already a known parent: the live ancestor stream already discovers
-        // new children via the server `parent_run_id` JOIN, so no re-fetch is
-        // needed. The fetch below exists only to make the initial
-        // not-parent -> parent transition.
-        if self.is_parent_agent_conversation(conversation_id, ctx) {
+        if !self.should_register_parent_on_wait(conversation_id, ctx) {
             return;
         }
         // No run_id yet (rare): nothing to query the server with; the next

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -560,22 +560,17 @@ impl OrchestrationEventStreamer {
     /// [`Self::register_watched_run_id`]. Once the parent role is established
     /// it is permanent for the conversation's life, so subsequent waits
     /// short-circuit on the already-parent check below.
+    ///
+    /// Child conversations are eligible too: with multi-level orchestration a
+    /// mid-tree node is simultaneously a child and a parent, so a child
+    /// blocked on `wait_for_events` must still confirm whether it has
+    /// children of its own.
     pub fn register_parent_on_wait(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) {
         if !FeatureFlag::WaitForEventsParentRegistration.is_enabled() {
-            return;
-        }
-        // One-level-tree invariant: a child can never also be a parent, so
-        // skip the server fetch. The child still receives its own inbox via
-        // the existing `is_eligible` -> `RunIds(self)` stream, so there is no
-        // regression.
-        let is_child = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&conversation_id)
-            .is_some_and(|c| c.is_child_agent_conversation());
-        if is_child {
             return;
         }
         // Passive views of a run hosted elsewhere (shared-session viewers,

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -2481,6 +2481,113 @@ fn register_parent_on_wait_flag_off_is_noop() {
     });
 }
 
+// ---- should_register_parent_on_wait eligibility ---------------------------
+
+#[test]
+fn wait_registration_eligibility_child_conversation_is_eligible() {
+    // A child conversation must be eligible: with multi-level orchestration
+    // a mid-tree node can have children of its own to discover.
+    App::test((), |mut app| async move {
+        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id("550e8400-e29b-41d4-a716-446655440526".to_string());
+        conversation.set_parent_agent_id("550e8400-e29b-41d4-a716-4466554405fe".to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.read(&app, |me, ctx| {
+            assert!(me.should_register_parent_on_wait(conversation_id, ctx));
+        });
+    });
+}
+
+#[test]
+fn wait_registration_eligibility_requires_the_flag() {
+    App::test((), |mut app| async move {
+        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(false);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id("550e8400-e29b-41d4-a716-446655440527".to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.read(&app, |me, ctx| {
+            assert!(!me.should_register_parent_on_wait(conversation_id, ctx));
+        });
+    });
+}
+
+#[test]
+fn wait_registration_eligibility_excludes_remote_run_views() {
+    // A remote-child placeholder is a passive view of a run executing in
+    // another process; that process owns the inbox and the registration.
+    App::test((), |mut app| async move {
+        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+
+        // `mark_conversation_as_remote_child` persists the conversation,
+        // which needs the settings + persistence singletons wired up.
+        crate::test_util::settings::initialize_history_persistence_for_tests(&mut app);
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id("550e8400-e29b-41d4-a716-446655440528".to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+            model.mark_conversation_as_remote_child(conversation_id, ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.read(&app, |me, ctx| {
+            assert!(!me.should_register_parent_on_wait(conversation_id, ctx));
+        });
+    });
+}
+
+#[test]
+fn wait_registration_eligibility_excludes_established_parents() {
+    // Once the parent role exists (a watched child run_id), the live
+    // ancestor stream discovers new children; no wait-time re-fetch.
+    App::test((), |mut app| async move {
+        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440529";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.watched_run_ids.insert("child-1".to_string());
+        });
+        poller.read(&app, |me, ctx| {
+            assert!(!me.should_register_parent_on_wait(conversation_id, ctx));
+        });
+    });
+}
+
 #[test]
 fn wait_registration_mid_tree_child_with_children_registers_as_parent() {
     // Multi-level orchestration: a mid-tree node is both a child and a

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -2482,13 +2482,12 @@ fn register_parent_on_wait_flag_off_is_noop() {
 }
 
 #[test]
-fn register_parent_on_wait_child_short_circuits() {
-    // One-level-tree invariant: a child (is_child_agent_conversation) can
-    // never be a parent, so no server fetch is issued and no parent role is
-    // taken.
+fn wait_registration_mid_tree_child_with_children_registers_as_parent() {
+    // Multi-level orchestration: a mid-tree node is both a child and a
+    // parent. When its wait-time fetch reports children, it must take the
+    // parent role and open the parent-family ancestor stream just like a
+    // root orchestrator.
     App::test((), |mut app| async move {
-        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440524";
@@ -2507,15 +2506,44 @@ fn register_parent_on_wait_child_short_circuits() {
             );
         });
 
-        let poller = streamer_with_no_fetch_expected(&mut app);
-        poller.update(&mut app, |me, ctx| {
-            me.register_parent_on_wait(conversation_id, ctx);
+        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
+        let server_api = ServerApiProvider::new_for_test().get();
+        let poller = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
         });
+
+        let consumer_id = warpui::EntityId::new();
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.consumers.insert(consumer_id);
+        });
+
+        poller.update(&mut app, |me, ctx| {
+            me.finish_register_parent_on_wait(
+                conversation_id,
+                Ok(make_ambient_task_with_children(vec![
+                    "grandchild-run-1".to_string(),
+                ])),
+                ctx,
+            );
+        });
+
         poller.read(&app, |me, ctx| {
             assert!(
-                !me.is_parent_agent_conversation(conversation_id, ctx),
-                "a child must not take the parent role"
+                me.is_parent_agent_conversation(conversation_id, ctx),
+                "a mid-tree child with children must take the parent role"
             );
+            match connected_filter(me, conversation_id) {
+                Some(AgentEventFilter::AncestorRunId {
+                    ancestor_run_id,
+                    include_self,
+                }) => {
+                    assert_eq!(ancestor_run_id, own_run_id);
+                    assert!(include_self);
+                }
+                other => panic!("expected AncestorRunId include_self filter, got {other:?}"),
+            }
         });
     });
 }

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -5,7 +5,6 @@
 //! orchestration pill bar so other surfaces (e.g. keyboard navigation and
 //! the agent-mode usage footer's credit rollup) can walk and order the same
 //! tree without duplicating the logic.
-#[cfg(feature = "tui")]
 use std::collections::HashSet;
 
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
@@ -106,7 +105,6 @@ pub fn resolve_orchestration_participant(
 ///
 /// Conversations without descendants are not orchestration roots. Malformed
 /// parent cycles and missing ancestors fail closed.
-#[cfg(feature = "tui")]
 pub fn orchestration_root_conversation_id(
     history: &BlocklistAIHistoryModel,
     conversation_id: AIConversationId,
@@ -225,7 +223,30 @@ pub fn descendant_conversations_in_pill_order(
     history: &BlocklistAIHistoryModel,
     parent_id: AIConversationId,
 ) -> Vec<OrderedOrchestrationDescendant> {
-    let mut descendants = descendant_conversation_ids_in_spawn_order(history, parent_id)
+    conversations_in_pill_order(
+        history,
+        descendant_conversation_ids_in_spawn_order(history, parent_id),
+    )
+}
+
+/// Returns only the DIRECT children of `parent_id` in the same canonical pill
+/// order as [`descendant_conversations_in_pill_order`]. Used by the
+/// drill-down pill bar, which renders one level of the tree at a time.
+pub fn child_conversations_in_pill_order(
+    history: &BlocklistAIHistoryModel,
+    parent_id: AIConversationId,
+) -> Vec<OrderedOrchestrationDescendant> {
+    conversations_in_pill_order(
+        history,
+        history.child_conversation_ids_of(&parent_id).to_vec(),
+    )
+}
+
+fn conversations_in_pill_order(
+    history: &BlocklistAIHistoryModel,
+    conversation_ids: Vec<AIConversationId>,
+) -> Vec<OrderedOrchestrationDescendant> {
+    let mut descendants = conversation_ids
         .into_iter()
         .enumerate()
         .filter_map(|(spawn_index, conversation_id)| {
@@ -276,9 +297,10 @@ pub fn adjacent_orchestration_child_conversation_id(
     active_conversation_id: AIConversationId,
     direction: OrchestrationNavigationDirection,
 ) -> Option<AIConversationId> {
-    let active_conversation = history.conversation(&active_conversation_id)?;
-    let orchestration_root_id = history
-        .resolved_parent_conversation_id_for_conversation(active_conversation)
+    history.conversation(&active_conversation_id)?;
+    // Root the cycle at the top of the tree (not one parent hop) so
+    // navigation covers the whole subtree at any orchestration depth.
+    let orchestration_root_id = orchestration_root_conversation_id(history, active_conversation_id)
         .unwrap_or(active_conversation_id);
     let descendants = descendant_conversations_in_pill_order(history, orchestration_root_id);
     if descendants.is_empty() {

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -216,9 +216,11 @@ pub struct OrderedOrchestrationDescendant {
 ///   2) unpinned children
 /// each bucket ordered by status priority, then done-recency, then spawn order.
 ///
-/// This is the single ordering source used by both the pill bar and keyboard
-/// navigation. Callers should preserve the returned order rather than sorting
-/// the conversations again.
+/// The pill bar and keyboard navigation share this per-level ordering but
+/// consume it differently: the bar renders one level at a time (the direct
+/// children of its drill-down anchor) while keyboard cycling walks the whole
+/// tree; the bar follows the selection by re-anchoring. Callers should
+/// preserve the returned order rather than sorting the conversations again.
 pub fn descendant_conversations_in_pill_order(
     history: &BlocklistAIHistoryModel,
     parent_id: AIConversationId,
@@ -297,6 +299,8 @@ pub fn adjacent_orchestration_child_conversation_id(
     active_conversation_id: AIConversationId,
     direction: OrchestrationNavigationDirection,
 ) -> Option<AIConversationId> {
+    // Intentional bail when the active conversation isn't loaded; don't
+    // rely on the downstream walk returning None for it.
     history.conversation(&active_conversation_id)?;
     // Root the cycle at the top of the tree (not one parent hop) so
     // navigation covers the whole subtree at any orchestration depth.
@@ -360,12 +364,49 @@ pub fn aggregated_orchestrator_status(
     history: &BlocklistAIHistoryModel,
     orchestrator_id: AIConversationId,
 ) -> ConversationStatus {
+    aggregate_loaded_subtree(history, orchestrator_id).1
+}
+
+/// Rolled-up state of a conversation's loaded orchestration subtree: the
+/// number of loaded descendants plus the aggregated status
+/// ([`aggregated_orchestrator_status`] semantics) across the node and those
+/// descendants.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoadedSubtreeRollup {
+    pub descendant_count: usize,
+    pub status: ConversationStatus,
+}
+
+/// Returns the rollup for `orchestrator_id`'s subtree in a single walk, or
+/// `None` when no loaded descendant exists. The count deliberately covers
+/// only loaded descendants — the same set the aggregated status inspects —
+/// so a badge never advertises nodes the rollup did not account for (ids
+/// can appear in the parent → children index before their conversations
+/// load).
+pub fn loaded_subtree_rollup(
+    history: &BlocklistAIHistoryModel,
+    orchestrator_id: AIConversationId,
+) -> Option<LoadedSubtreeRollup> {
+    let (descendant_count, status) = aggregate_loaded_subtree(history, orchestrator_id);
+    (descendant_count > 0).then_some(LoadedSubtreeRollup {
+        descendant_count,
+        status,
+    })
+}
+
+/// Single walk over the orchestrator and its loaded descendants, returning
+/// the loaded-descendant count together with the aggregated status.
+fn aggregate_loaded_subtree(
+    history: &BlocklistAIHistoryModel,
+    orchestrator_id: AIConversationId,
+) -> (usize, ConversationStatus) {
     let mut orchestrator_status: Option<ConversationStatus> = None;
     let mut first_blocked: Option<ConversationStatus> = None;
     let mut any_in_progress = false;
     let mut any_waiting = false;
     let mut any_error = false;
     let mut any_cancelled = false;
+    let mut loaded_descendant_count = 0;
 
     for id in std::iter::once(orchestrator_id).chain(descendant_conversation_ids_in_spawn_order(
         history,
@@ -376,6 +417,8 @@ pub fn aggregated_orchestrator_status(
         };
         if id == orchestrator_id {
             orchestrator_status = Some(status.clone());
+        } else {
+            loaded_descendant_count += 1;
         }
         match status {
             // A recovering node counts as still running for aggregation purposes.
@@ -394,36 +437,35 @@ pub fn aggregated_orchestrator_status(
         }
     }
 
-    if any_in_progress {
+    let status = if any_in_progress {
         // Parent's own waiting state outranks descendant in-progress so
         // the pill reflects that THIS conversation is paused.
         if matches!(
             orchestrator_status,
             Some(ConversationStatus::WaitingForEvents)
         ) {
-            return ConversationStatus::WaitingForEvents;
+            ConversationStatus::WaitingForEvents
+        } else {
+            ConversationStatus::InProgress
         }
-        return ConversationStatus::InProgress;
-    }
-    if let Some(blocked) = first_blocked {
-        return blocked;
-    }
-    if any_waiting {
+    } else if let Some(blocked) = first_blocked {
+        blocked
+    } else if any_waiting {
         // Parent's terminal status beats descendant waiting — a
         // finalized run can't resume, so surface the parent's outcome.
         match orchestrator_status {
-            Some(ConversationStatus::Cancelled) => return ConversationStatus::Cancelled,
-            Some(ConversationStatus::Error) => return ConversationStatus::Error,
-            _ => return ConversationStatus::WaitingForEvents,
+            Some(ConversationStatus::Cancelled) => ConversationStatus::Cancelled,
+            Some(ConversationStatus::Error) => ConversationStatus::Error,
+            _ => ConversationStatus::WaitingForEvents,
         }
-    }
-    if any_error {
-        return ConversationStatus::Error;
-    }
-    if any_cancelled {
-        return ConversationStatus::Cancelled;
-    }
-    ConversationStatus::Success
+    } else if any_error {
+        ConversationStatus::Error
+    } else if any_cancelled {
+        ConversationStatus::Cancelled
+    } else {
+        ConversationStatus::Success
+    };
+    (loaded_descendant_count, status)
 }
 
 /// Returns a conversation's direct status, or the aggregated subtree status

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -514,6 +514,112 @@ fn adjacent_orchestration_child_navigation_wraps_within_child_list() {
 }
 
 #[test]
+fn adjacent_orchestration_child_navigation_cycles_whole_tree_from_grandchild() {
+    // Navigation must root at the TOP of the tree (not one parent hop), so
+    // cycling from a grandchild covers the root and every descendant.
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let root_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let mid_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "mid".to_string(),
+                root_id,
+                None,
+                ctx,
+            )
+        });
+        let grandchild_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "grandchild".to_string(),
+                mid_id,
+                None,
+                ctx,
+            )
+        });
+
+        history_model.read(&app, |history_model, _| {
+            // Spawn order is pre-order: [root, mid, grandchild].
+            assert_eq!(
+                adjacent_orchestration_child_conversation_id(
+                    history_model,
+                    grandchild_id,
+                    OrchestrationNavigationDirection::Next,
+                ),
+                Some(root_id),
+                "next from the last descendant wraps to the tree root",
+            );
+            assert_eq!(
+                adjacent_orchestration_child_conversation_id(
+                    history_model,
+                    grandchild_id,
+                    OrchestrationNavigationDirection::Previous,
+                ),
+                Some(mid_id),
+            );
+            assert_eq!(
+                adjacent_orchestration_child_conversation_id(
+                    history_model,
+                    mid_id,
+                    OrchestrationNavigationDirection::Previous,
+                ),
+                Some(root_id),
+            );
+        });
+    });
+}
+
+#[test]
+fn child_conversations_in_pill_order_returns_direct_children_only() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let root_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let mid_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "mid".to_string(),
+                root_id,
+                None,
+                ctx,
+            )
+        });
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "grandchild".to_string(),
+                mid_id,
+                None,
+                ctx,
+            )
+        });
+
+        history_model.read(&app, |history_model, _| {
+            let direct_children: Vec<AIConversationId> =
+                child_conversations_in_pill_order(history_model, root_id)
+                    .into_iter()
+                    .map(|descendant| descendant.conversation_id)
+                    .collect();
+            assert_eq!(
+                direct_children,
+                vec![mid_id],
+                "the drill-down ordering must exclude grandchildren",
+            );
+        });
+    });
+}
+
+#[test]
 fn adjacent_orchestration_child_navigation_noops_for_single_child() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -1201,6 +1201,61 @@ fn aggregated_status_prefers_blocked_over_waiting_for_events() {
 }
 
 #[test]
+fn loaded_subtree_rollup_excludes_unloaded_descendants_from_the_count() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, _child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Register a child id that exists only in the parent → children
+        // index (e.g. discovered remotely before its conversation loads).
+        let unloaded_child = AIConversationId::new();
+        history_model.update(&mut app, |history_model, _ctx| {
+            history_model.set_parent_for_conversation(unloaded_child, orchestrator_id);
+        });
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            let rollup = loaded_subtree_rollup(history_model, orchestrator_id)
+                .expect("two loaded children exist");
+            assert_eq!(
+                rollup.descendant_count, 2,
+                "the badge count must cover exactly the loaded descendants the status aggregates",
+            );
+            assert_eq!(rollup.status, ConversationStatus::InProgress);
+        });
+    });
+}
+
+#[test]
+fn loaded_subtree_rollup_is_none_when_no_descendant_is_loaded() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+        let leaf_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let unloaded_child = AIConversationId::new();
+        history_model.update(&mut app, |history_model, _ctx| {
+            history_model.set_parent_for_conversation(unloaded_child, leaf_id);
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(loaded_subtree_rollup(history_model, leaf_id), None);
+        });
+    });
+}
+
+#[test]
 fn aggregated_status_prefers_waiting_for_events_over_error() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);

--- a/app/src/ai/blocklist/telemetry.rs
+++ b/app/src/ai/blocklist/telemetry.rs
@@ -261,6 +261,9 @@ pub struct AgentProposedConfigEvent {
 pub enum PillBarPillKind {
     Orchestrator,
     Child,
+    /// A leading breadcrumb pill navigating back up the drill-down tree
+    /// (to the tree root or the anchor's parent level).
+    Breadcrumb,
 }
 
 /// Concrete user actions against an orchestration pill bar entry.
@@ -303,8 +306,13 @@ pub struct PillBarInteractionEvent {
     pub pill_kind: PillBarPillKind,
     pub total_pills: usize,
     pub total_pinned: usize,
-    /// The orchestrator that hosts the pill bar.
+    /// The drill-down anchor whose level the bar was rendering when the
+    /// interaction happened. At orchestration depth 1 this is always the
+    /// tree root.
     pub source_conversation_id: AIConversationId,
+    /// Root of the orchestration tree containing the anchor. Equal to
+    /// `source_conversation_id` when the bar is anchored at the root.
+    pub root_conversation_id: AIConversationId,
     /// The pill the action targets.
     pub target_conversation_id: AIConversationId,
     /// Present only when `action == Switch`. Distinguishes whether the

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4214,6 +4214,7 @@ impl TerminalView {
             ActionButton::new("for terminal", AgentViewHeaderTheme)
                 .with_icon(icons::Icon::ArrowLeft)
                 .with_size(ButtonSize::Small)
+                .with_max_label_width(BACK_BUTTON_LABEL_MAX_WIDTH)
                 .with_keybinding(
                     KeystrokeSource::Fixed(Keystroke {
                         key: "escape".to_string(),
@@ -11337,11 +11338,10 @@ impl TerminalView {
             .agent_view_state()
             .active_conversation_id();
         let history = BlocklistAIHistoryModel::as_ref(ctx);
-        let is_child_agent = active_conv_id
-            .and_then(|id| history.conversation(&id))
-            .and_then(|c| history.resolved_parent_conversation_id_for_conversation(c))
-            .is_some();
         let label = agent_view_back_button_label(history, active_conv_id);
+        // The label is "for terminal" exactly when no parent resolved, so
+        // it doubles as the child-agent signal.
+        let is_child_agent = label != "for terminal";
 
         // Never disable for child agents: the swap-back path can't be blocked.
         let disabled_reason = if is_child_agent {
@@ -28622,15 +28622,17 @@ fn is_rich_input_chip_in_cli_toolbar(app: &AppContext) -> bool {
         .any(|item| matches!(item, AgentToolbarItemKind::RichInput))
 }
 
-/// Longest parent-agent name shown verbatim in the back-button label before
-/// it is ellipsized, keeping the pane header compact.
-const BACK_BUTTON_PARENT_NAME_MAX_CHARS: usize = 24;
+/// Maximum pixel width of the back-button label before it ellipsizes
+/// (pixel-based, via the button's label clip), keeping the pane header
+/// compact for long parent-agent names.
+const BACK_BUTTON_LABEL_MAX_WIDTH: f32 = 160.;
 
 /// Returns the agent-view back button label. ESC navigates one level up, so
 /// the label names the direct parent: children of the tree root keep the
 /// classic "for Orchestrator" wording, nested subagents name their parent
 /// agent (falling back to a generic label), and non-child conversations exit
-/// back to the terminal.
+/// back to the terminal. Long parent names are ellipsized pixel-based by the
+/// button itself ([`BACK_BUTTON_LABEL_MAX_WIDTH`]).
 fn agent_view_back_button_label(
     history: &BlocklistAIHistoryModel,
     active_conversation_id: Option<AIConversationId>,
@@ -28655,18 +28657,7 @@ fn agent_view_back_button_label(
         .and_then(|parent| parent.agent_name())
         .filter(|name| !name.is_empty())
     {
-        Some(name) => {
-            let name = if name.chars().count() > BACK_BUTTON_PARENT_NAME_MAX_CHARS {
-                let truncated: String = name
-                    .chars()
-                    .take(BACK_BUTTON_PARENT_NAME_MAX_CHARS - 1)
-                    .collect();
-                format!("{truncated}\u{2026}")
-            } else {
-                name.to_string()
-            };
-            Cow::Owned(format!("for {name}"))
-        }
+        Some(name) => Cow::Owned(format!("for {name}")),
         None => Cow::Borrowed("for parent agent"),
     }
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -220,6 +220,7 @@ use crate::ai::ambient_agents::{
     AmbientAgentTaskId, AmbientConversationStatus, conversation_output_status_from_conversation,
 };
 use crate::ai::blocklist::agent_view::agent_input_footer::toolbar_item::AgentToolbarItemKind;
+use crate::ai::blocklist::agent_view::orchestration_conversation_links::pane_group_id_containing_terminal_view;
 use crate::ai::blocklist::agent_view::{
     AgentViewController, AgentViewControllerEvent, AgentViewConversationSelection,
     AgentViewDisplayMode, AgentViewEntryBlockParams, AgentViewEntryOrigin,
@@ -4834,11 +4835,12 @@ impl TerminalView {
         callback(self, ctx);
     }
 
-    /// If the active conversation is a child agent, navigate to the parent
+    /// If the active conversation is a child agent, navigate to its DIRECT
+    /// parent (one level up, so repeated ESC walks up an orchestration tree)
     /// and return `true`; otherwise return `false` so the caller can run
     /// the normal exit-agent-view flow. Cross-tab and swap-target cases
     /// are handled by the workspace's focus path; falls back to emitting
-    /// a swap event when the parent has no canonical owner. Runs before
+    /// a swap event when the parent has no visible owner. Runs before
     /// any can-exit gating so long-running children can still navigate back.
     fn try_navigate_to_parent_conversation(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         if !FeatureFlag::AgentView.is_enabled() {
@@ -4855,13 +4857,19 @@ impl TerminalView {
         let history = BlocklistAIHistoryModel::as_ref(ctx);
         let parent_id = history
             .conversation(&active_conv_id)
-            .and_then(|c| c.parent_conversation_id());
+            .and_then(|c| history.resolved_parent_conversation_id_for_conversation(c));
         let Some(parent_id) = parent_id else {
             return false;
         };
-        let parent_terminal_view_id = history.terminal_surface_id_for_conversation(&parent_id);
+        // Only focus the parent's terminal view when it is actually visible
+        // in some pane group. A mid-tree parent lives in a *hidden* child
+        // pane (off-tree), which the workspace focus path cannot reach —
+        // swap it into this pane instead, mirroring pill-bar navigation.
+        let visible_parent_view_id = history
+            .terminal_surface_id_for_conversation(&parent_id)
+            .filter(|view_id| pane_group_id_containing_terminal_view(*view_id, ctx).is_some());
 
-        if let Some(parent_terminal_view_id) = parent_terminal_view_id {
+        if let Some(parent_terminal_view_id) = visible_parent_view_id {
             // Defer so it runs after in-flight event handling completes.
             ctx.dispatch_typed_action_deferred(WorkspaceAction::FocusTerminalViewInWorkspace {
                 terminal_view_id: parent_terminal_view_id,
@@ -11319,19 +11327,21 @@ impl TerminalView {
         conversation_id.map(|conversation_id| (conversation_id, command))
     }
 
-    /// Updates the back button's state and label. For child agents the
-    /// label becomes "for Orchestrator" since ESC swaps to the parent
-    /// instead of exiting in place.
+    /// Updates the back button's state and label. For child agents ESC
+    /// navigates one level up instead of exiting in place, so the label
+    /// names the direct parent (see [`agent_view_back_button_label`]).
     pub(crate) fn update_agent_view_back_button_state(&mut self, ctx: &mut ViewContext<Self>) {
         let active_conv_id = self
             .agent_view_controller
             .as_ref(ctx)
             .agent_view_state()
             .active_conversation_id();
+        let history = BlocklistAIHistoryModel::as_ref(ctx);
         let is_child_agent = active_conv_id
-            .and_then(|id| BlocklistAIHistoryModel::as_ref(ctx).conversation(&id))
-            .and_then(|c| c.parent_conversation_id())
+            .and_then(|id| history.conversation(&id))
+            .and_then(|c| history.resolved_parent_conversation_id_for_conversation(c))
             .is_some();
+        let label = agent_view_back_button_label(history, active_conv_id);
 
         // Never disable for child agents: the swap-back path can't be blocked.
         let disabled_reason = if is_child_agent {
@@ -11342,11 +11352,6 @@ impl TerminalView {
                 .can_exit_agent_view()
                 .err()
                 .map(|e| e.to_string())
-        };
-        let label = if is_child_agent {
-            "for Orchestrator"
-        } else {
-            "for terminal"
         };
 
         self.agent_view_back_button.update(ctx, |button, ctx| {
@@ -28615,6 +28620,55 @@ fn is_rich_input_chip_in_cli_toolbar(app: &AppContext) -> bool {
         .iter()
         .chain(sel.right_items().iter())
         .any(|item| matches!(item, AgentToolbarItemKind::RichInput))
+}
+
+/// Longest parent-agent name shown verbatim in the back-button label before
+/// it is ellipsized, keeping the pane header compact.
+const BACK_BUTTON_PARENT_NAME_MAX_CHARS: usize = 24;
+
+/// Returns the agent-view back button label. ESC navigates one level up, so
+/// the label names the direct parent: children of the tree root keep the
+/// classic "for Orchestrator" wording, nested subagents name their parent
+/// agent (falling back to a generic label), and non-child conversations exit
+/// back to the terminal.
+fn agent_view_back_button_label(
+    history: &BlocklistAIHistoryModel,
+    active_conversation_id: Option<AIConversationId>,
+) -> Cow<'static, str> {
+    let parent_id = active_conversation_id
+        .and_then(|id| history.conversation(&id))
+        .and_then(|c| history.resolved_parent_conversation_id_for_conversation(c));
+    let Some(parent_id) = parent_id else {
+        return Cow::Borrowed("for terminal");
+    };
+    let parent = history.conversation(&parent_id);
+    // An unloaded parent can't be classified; keep the classic wording.
+    let parent_is_root = parent.is_none_or(|parent| {
+        history
+            .resolved_parent_conversation_id_for_conversation(parent)
+            .is_none()
+    });
+    if parent_is_root {
+        return Cow::Borrowed("for Orchestrator");
+    }
+    match parent
+        .and_then(|parent| parent.agent_name())
+        .filter(|name| !name.is_empty())
+    {
+        Some(name) => {
+            let name = if name.chars().count() > BACK_BUTTON_PARENT_NAME_MAX_CHARS {
+                let truncated: String = name
+                    .chars()
+                    .take(BACK_BUTTON_PARENT_NAME_MAX_CHARS - 1)
+                    .collect();
+                format!("{truncated}\u{2026}")
+            } else {
+                name.to_string()
+            };
+            Cow::Owned(format!("for {name}"))
+        }
+        None => Cow::Borrowed("for parent agent"),
+    }
 }
 
 #[cfg(test)]

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -8492,3 +8492,84 @@ fn send_review_comments_to_warp_tui_writes_prompt_to_pty() {
         );
     });
 }
+
+#[test]
+fn back_button_label_names_the_direct_parent_at_depth() {
+    App::test((), |mut app| async move {
+        crate::test_util::settings::initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (root_id, mid_id, grandchild_id) = history_model.update(&mut app, |history, ctx| {
+            let root_id =
+                history.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            let mid_id = history.start_new_child_conversation(
+                terminal_view_id,
+                "api-refactor".to_string(),
+                root_id,
+                None,
+                ctx,
+            );
+            let grandchild_id = history.start_new_child_conversation(
+                terminal_view_id,
+                "grandchild".to_string(),
+                mid_id,
+                None,
+                ctx,
+            );
+            (root_id, mid_id, grandchild_id)
+        });
+
+        history_model.read(&app, |history, _| {
+            assert_eq!(agent_view_back_button_label(history, None), "for terminal");
+            assert_eq!(
+                agent_view_back_button_label(history, Some(root_id)),
+                "for terminal",
+            );
+            assert_eq!(
+                agent_view_back_button_label(history, Some(mid_id)),
+                "for Orchestrator",
+            );
+            assert_eq!(
+                agent_view_back_button_label(history, Some(grandchild_id)),
+                "for api-refactor",
+            );
+        });
+    });
+}
+
+#[test]
+fn back_button_label_truncates_long_parent_names() {
+    App::test((), |mut app| async move {
+        crate::test_util::settings::initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let long_name = "a".repeat(BACK_BUTTON_PARENT_NAME_MAX_CHARS + 10);
+        let grandchild_id = history_model.update(&mut app, |history, ctx| {
+            let root_id =
+                history.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            let mid_id = history.start_new_child_conversation(
+                terminal_view_id,
+                long_name.clone(),
+                root_id,
+                None,
+                ctx,
+            );
+            history.start_new_child_conversation(
+                terminal_view_id,
+                "grandchild".to_string(),
+                mid_id,
+                None,
+                ctx,
+            )
+        });
+
+        history_model.read(&app, |history, _| {
+            let label = agent_view_back_button_label(history, Some(grandchild_id));
+            let expected_name: String = long_name
+                .chars()
+                .take(BACK_BUTTON_PARENT_NAME_MAX_CHARS - 1)
+                .collect();
+            assert_eq!(label, format!("for {expected_name}\u{2026}"));
+        });
+    });
+}

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -8519,6 +8519,27 @@ fn back_button_label_names_the_direct_parent_at_depth() {
             (root_id, mid_id, grandchild_id)
         });
 
+        // A nested parent whose agent name is empty falls back to the
+        // generic wording instead of rendering "for ".
+        let (unnamed_mid_id, nested_under_unnamed_id) =
+            history_model.update(&mut app, |history, ctx| {
+                let unnamed_mid_id = history.start_new_child_conversation(
+                    terminal_view_id,
+                    String::new(),
+                    root_id,
+                    None,
+                    ctx,
+                );
+                let nested_id = history.start_new_child_conversation(
+                    terminal_view_id,
+                    "nested".to_string(),
+                    unnamed_mid_id,
+                    None,
+                    ctx,
+                );
+                (unnamed_mid_id, nested_id)
+            });
+
         history_model.read(&app, |history, _| {
             assert_eq!(agent_view_back_button_label(history, None), "for terminal");
             assert_eq!(
@@ -8533,43 +8554,47 @@ fn back_button_label_names_the_direct_parent_at_depth() {
                 agent_view_back_button_label(history, Some(grandchild_id)),
                 "for api-refactor",
             );
+            assert_eq!(
+                agent_view_back_button_label(history, Some(unnamed_mid_id)),
+                "for Orchestrator",
+            );
+            assert_eq!(
+                agent_view_back_button_label(history, Some(nested_under_unnamed_id)),
+                "for parent agent",
+            );
         });
     });
 }
 
+/// A child linked to its parent only via a legacy server conversation token
+/// in `parent_agent_id` (no explicit parent conversation id, no run id) must
+/// still resolve the parent through the history model's canonical
+/// resolution, yielding the same back-button label as an id-linked child.
 #[test]
-fn back_button_label_truncates_long_parent_names() {
+fn back_button_label_resolves_token_only_parent_linkage() {
     App::test((), |mut app| async move {
         crate::test_util::settings::initialize_history_persistence_for_tests(&mut app);
         let terminal_view_id = EntityId::new();
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
-        let long_name = "a".repeat(BACK_BUTTON_PARENT_NAME_MAX_CHARS + 10);
-        let grandchild_id = history_model.update(&mut app, |history, ctx| {
+        let child_id = history_model.update(&mut app, |history, ctx| {
             let root_id =
                 history.start_new_conversation(terminal_view_id, false, false, false, ctx);
-            let mid_id = history.start_new_child_conversation(
-                terminal_view_id,
-                long_name.clone(),
-                root_id,
-                None,
-                ctx,
-            );
-            history.start_new_child_conversation(
-                terminal_view_id,
-                "grandchild".to_string(),
-                mid_id,
-                None,
-                ctx,
-            )
+            history
+                .set_server_conversation_token_for_conversation(root_id, "root-token".to_string());
+            let child_id =
+                history.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            history
+                .conversation_mut(&child_id)
+                .expect("child conversation exists")
+                .set_parent_agent_id("root-token".to_string());
+            child_id
         });
 
         history_model.read(&app, |history, _| {
-            let label = agent_view_back_button_label(history, Some(grandchild_id));
-            let expected_name: String = long_name
-                .chars()
-                .take(BACK_BUTTON_PARENT_NAME_MAX_CHARS - 1)
-                .collect();
-            assert_eq!(label, format!("for {expected_name}\u{2026}"));
+            assert_eq!(
+                agent_view_back_button_label(history, Some(child_id)),
+                "for Orchestrator",
+            );
         });
     });
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -708,6 +708,13 @@ pub enum FeatureFlag {
     /// receives events for children created out-of-band (Oz CLI / web API).
     WaitForEventsParentRegistration,
 
+    /// Gates the client-side multi-level orchestration surfaces: child
+    /// conversations auto-executing their own `run_agents` calls and the
+    /// confirmation-card disclosure that launched agents may start
+    /// children of their own. When disabled, a child's `run_agents` call
+    /// fails gracefully instead of presenting a card in a hidden pane.
+    MultiLevelOrchestration,
+
     /// Shows a pending user query indicator during summarization when a follow-up
     /// prompt is queued via `/fork-and-compact` or `/compact-and`.
     PendingUserQueryIndicator,
@@ -1009,6 +1016,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::PromptCacheExpiryWarning,
     FeatureFlag::JupyterNotebookRendering,
     FeatureFlag::WaitForEventsParentRegistration,
+    FeatureFlag::MultiLevelOrchestration,
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::BoxDrawingGlyphs,
     FeatureFlag::WellKnownMcpIds,

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -2477,7 +2477,10 @@ impl TuiTerminalSessionView {
                     pill_kind,
                     total_pills: snapshot.children.len() + 1,
                     total_pinned: 0,
+                    // The TUI tab bar is root-anchored (no drill-down), so
+                    // the anchor and the tree root coincide.
                     source_conversation_id: snapshot.root_conversation_id,
+                    root_conversation_id: snapshot.root_conversation_id,
                     target_conversation_id: conversation_id,
                     switch_outcome: Some(PillSwitchOutcome::SwitchedInPlace),
                 }),
@@ -2547,7 +2550,10 @@ impl TuiTerminalSessionView {
                     pill_kind: PillBarPillKind::Child,
                     total_pills: snapshot.children.len() + 1,
                     total_pinned: 0,
+                    // The TUI tab bar is root-anchored (no drill-down), so
+                    // the anchor and the tree root coincide.
                     source_conversation_id: snapshot.root_conversation_id,
+                    root_conversation_id: snapshot.root_conversation_id,
                     target_conversation_id: conversation_id,
                     switch_outcome: None,
                 }),


### PR DESCRIPTION
## Description
Client side of multi-level (configurable-depth) agent orchestration. Today only the root "lead" agent can start child agents; the server is making depth configurable via `OrchestrationMaxDepth` (root = depth 0, a run may orchestrate iff `depth < max`, default 1 = today's behavior, dogfood = 2). This PR makes the client behave correctly when a tree is more than one level deep:

- **Mid-tree parents stream their children.** A child conversation blocked on `wait_for_events` now confirms parent status against the server and registers for the ancestor event stream, instead of being short-circuited by the old one-level-tree invariant (still behind the `WaitForEventsParentRegistration` dogfood flag).
- **Children auto-execute `run_agents`.** Child conversations live in hidden panes where a confirmation card would be invisible and hang the run. Their `run_agents` calls auto-execute; interactive policy blocks (never-allow profile, missing harness key, disapproved config) still surface as a graceful `Denied` tool result. The multi-level surfaces are gated on a new `MultiLevelOrchestration` dogfood flag: with the flag off, a child's `run_agents` call is denied outright ("Multi-level orchestration is not enabled on this client.") instead of falling through to the interactive card path. Run-wide settings carry over via the existing per-surface execution-profile inheritance. The server gates tool exposure by depth, so this path is unreachable at depth 1.
- **The pill bar becomes a drill-down.** Each conversation's bar renders only its DIRECT children; a child that is itself an orchestrator renders as a group pill with a rolled-up subtree badge (count and tint computed in a single walk over the loaded subtree, matching exactly what the aggregated status covers). Breadcrumbs lead back to the tree root and, when 2+ levels deep, to the direct parent. At depth 1 this renders exactly what the flattened bar rendered before.
- **Navigation is depth-aware.** ESC and the back button go one level up (repeated ESC walks up the tree) and the label names the direct parent; ESC now also works when the parent lives in a hidden off-tree pane by swapping it in place instead of the unreachable workspace-focus path. Next/prev cycling and the agents-panel root card roll up the whole subtree via the recursive topology walkers. Parent resolution (explicit id → run-id index → legacy server-token index) is unified in one history-model resolver shared by indexing, breadcrumbs, the root walk, and the back button.
- **Disclosure on the confirmation card.** When children may orchestrate, the run_agents card notes "These agents may start their own child agents" (gated on the `MultiLevelOrchestration` flag, since the client cannot cheaply know the server depth budget).

Everything is inert at orchestration depth 1: the server never grants children the `run_agents` tool, trees never exceed one level, and the drill-down anchor resolution matches the old root-anchored behavior exactly.

## Linked Issue
Part of the multi-level orchestration work (client side); pairs with the warp-server `OrchestrationMaxDepth` changes.

## Testing
- Unit tests: mid-tree wait registration (streamer, including the wait-time eligibility predicate), child auto-execute policy under both `MultiLevelOrchestration` flag states, recursive rooting / spawn-order cycling with 3-level fixtures, direct-children pill ordering, drill-down anchor resolution, breadcrumb target resolution (including token-only parent linkage), loaded-subtree rollup counts, and back-button labels at depth (truncation is pixel-based via the button's label clip).
- `cargo check -p warp --lib`, `cargo clippy -p warp --all-targets --tests -- -D warnings`, and `./script/format` are clean at this stack state.
- [x] I have manually tested my changes locally with `./script/run` (depth-2 trees against a server with `OrchestrationMaxDepth=2`)

https://www.loom.com/share/beffa1541c5e4032914442baf93bde1b

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Warp Agent <agent@warp.dev>
