### PR TITLE
Recognize Grok, Qwen Code, and Kimi Code as CLI agents

### DIFF
--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -466,6 +466,9 @@ pub enum CLIAgentType {
     Hermes,
     Vibe,
     Antigravity,
+    Grok,
+    QwenCode,
+    KimiCode,
     /// Warp's own headless TUI, targeted by the code review panel as a CLI-agent-equivalent destination.
     WarpTui,
     Unknown,

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -135,7 +135,31 @@ const MISTRAL_ORANGE: ColorU = ColorU {
     a: 255,
 };
 
-/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid, OpenCode, Copilot, Pi, Auggie, Cursor, Goose, Hermes, Mistral Vibe)
+/// xAI brand color (black, monochrome logo)
+const GROK_COLOR: ColorU = ColorU {
+    r: 0,
+    g: 0,
+    b: 0,
+    a: 255,
+};
+
+/// Qwen brand purple (#615CED)
+const QWEN_COLOR: ColorU = ColorU {
+    r: 97,
+    g: 92,
+    b: 237,
+    a: 255,
+};
+
+/// Moonshot AI brand color (black, monochrome logo)
+const KIMI_COLOR: ColorU = ColorU {
+    r: 0,
+    g: 0,
+    b: 0,
+    a: 255,
+};
+
+/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid, OpenCode, Copilot, Pi, Auggie, Cursor, Goose, Hermes, Mistral Vibe, Grok, Qwen Code, Kimi Code)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Sequence, Serialize, Deserialize)]
 pub enum CLIAgent {
     Claude,
@@ -153,6 +177,9 @@ pub enum CLIAgent {
     Hermes,
     Vibe,
     Antigravity,
+    Grok,
+    QwenCode,
+    KimiCode,
     /// Warp's own headless TUI.
     WarpTui,
     /// Represents an unknown/custom CLI agent matched by user-configured regex patterns.
@@ -178,6 +205,9 @@ impl CLIAgent {
             CLIAgent::Hermes => &["hermes"],
             CLIAgent::Vibe => &["vibe", "vibe-acp"],
             CLIAgent::Antigravity => &["agy"],
+            CLIAgent::Grok => &["grok"],
+            CLIAgent::QwenCode => &["qwen"],
+            CLIAgent::KimiCode => &["kimi"],
             CLIAgent::WarpTui => &[
                 "warp",
                 "warp-preview",
@@ -241,6 +271,9 @@ impl CLIAgent {
             CLIAgent::Hermes => "Hermes",
             CLIAgent::Vibe => "Mistral Vibe",
             CLIAgent::Antigravity => "Antigravity",
+            CLIAgent::Grok => "Grok",
+            CLIAgent::QwenCode => "Qwen Code",
+            CLIAgent::KimiCode => "Kimi Code",
             CLIAgent::WarpTui => "Warp TUI",
             CLIAgent::Unknown => "CLI Agent",
         }
@@ -267,6 +300,13 @@ impl CLIAgent {
             // up in a follow-up once an officially licensed SVG is available.
             CLIAgent::Vibe => None,
             CLIAgent::Antigravity => Some(Icon::AntigravityLogo),
+            // Recognized without brand assets, same as Hermes and Vibe above.
+            // The brand color still drives the toolbar tile; `Icon::GrokLogo` /
+            // `Icon::QwenLogo` / `Icon::KimiLogo` can be wired up in a follow-up
+            // once officially licensed SVGs are available.
+            CLIAgent::Grok => None,
+            CLIAgent::QwenCode => None,
+            CLIAgent::KimiCode => None,
             CLIAgent::WarpTui => Some(Icon::Warp),
             CLIAgent::Unknown => None,
         }
@@ -300,6 +340,11 @@ impl CLIAgent {
             CLIAgent::Hermes => &[SkillProvider::Agents],
             CLIAgent::Vibe => &[SkillProvider::Agents],
             CLIAgent::Antigravity => &[],
+            // Left empty pending confirmation that these read AGENTS.md; claiming
+            // a provider they don't support would surface skills that never load.
+            CLIAgent::Grok => &[],
+            CLIAgent::QwenCode => &[],
+            CLIAgent::KimiCode => &[],
             CLIAgent::WarpTui => &[],
             CLIAgent::Unknown => &[],
         }
@@ -350,6 +395,9 @@ impl CLIAgent {
             CLIAgent::Hermes => Some(HERMES_PURPLE),
             CLIAgent::Vibe => Some(MISTRAL_ORANGE),
             CLIAgent::Antigravity => Some(ANTIGRAVITY_COLOR),
+            CLIAgent::Grok => Some(GROK_COLOR),
+            CLIAgent::QwenCode => Some(QWEN_COLOR),
+            CLIAgent::KimiCode => Some(KIMI_COLOR),
             CLIAgent::WarpTui => Some(ColorU::black()),
             CLIAgent::Unknown => None,
         }
@@ -626,6 +674,9 @@ impl From<CLIAgent> for CLIAgentType {
             CLIAgent::Hermes => CLIAgentType::Hermes,
             CLIAgent::Vibe => CLIAgentType::Vibe,
             CLIAgent::Antigravity => CLIAgentType::Antigravity,
+            CLIAgent::Grok => CLIAgentType::Grok,
+            CLIAgent::QwenCode => CLIAgentType::QwenCode,
+            CLIAgent::KimiCode => CLIAgentType::KimiCode,
             CLIAgent::WarpTui => CLIAgentType::WarpTui,
             CLIAgent::Unknown => CLIAgentType::Unknown,
         }

--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -77,6 +77,9 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         | CLIAgent::Goose
         | CLIAgent::Vibe
         | CLIAgent::Antigravity
+        | CLIAgent::Grok
+        | CLIAgent::QwenCode
+        | CLIAgent::KimiCode
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
@@ -299,6 +299,9 @@ pub(crate) fn plugin_manager_for_with_shell(
         | CLIAgent::Goose
         | CLIAgent::Vibe
         | CLIAgent::Antigravity
+        | CLIAgent::Grok
+        | CLIAgent::QwenCode
+        | CLIAgent::KimiCode
         | CLIAgent::WarpTui
         | CLIAgent::Unknown => None,
     }

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -267,6 +267,9 @@ fn test_detect_known_agents() {
                 ("goose", CLIAgent::Goose),
                 ("vibe", CLIAgent::Vibe),
                 ("agy", CLIAgent::Antigravity),
+                ("grok", CLIAgent::Grok),
+                ("qwen", CLIAgent::QwenCode),
+                ("kimi", CLIAgent::KimiCode),
                 ("omp", CLIAgent::OhMyPi),
                 ("warp", CLIAgent::WarpTui),
                 ("warp-dev", CLIAgent::WarpTui),
@@ -294,6 +297,35 @@ fn test_detect_with_arguments() {
                 CLIAgent::detect("gemini chat", None, None, ctx),
                 Some(CLIAgent::Gemini),
             );
+        });
+    });
+}
+
+#[test]
+fn test_detect_grok_qwen_kimi() {
+    // These three ship as global npm packages whose `bin` entries are `grok`,
+    // `qwen` and `kimi` respectively (@xai-official/grok,
+    // @qwen-code/qwen-code, @moonshot-ai/kimi-code), so plain binary-name
+    // detection is enough. Absolute paths and trailing arguments must not
+    // defeat it, and a longer name that merely starts with one of these
+    // prefixes must not be swallowed.
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            assert_eq!(
+                CLIAgent::detect("grok --model grok-4", None, None, ctx),
+                Some(CLIAgent::Grok),
+            );
+            assert_eq!(
+                CLIAgent::detect("/usr/local/bin/qwen", None, None, ctx),
+                Some(CLIAgent::QwenCode),
+            );
+            assert_eq!(
+                CLIAgent::detect("kimi --resume", None, None, ctx),
+                Some(CLIAgent::KimiCode),
+            );
+            // Distinct binary names should not bleed into these agents.
+            assert_eq!(CLIAgent::detect("grokking", None, None, ctx), None);
+            assert_eq!(CLIAgent::detect("qwen-agent", None, None, ctx), None);
         });
     });
 }

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -137,6 +137,9 @@ fn rich_input_submit_strategy(agent: CLIAgent) -> RichInputSubmitStrategy {
         | CLIAgent::Goose
         | CLIAgent::Vibe
         | CLIAgent::Antigravity
+        | CLIAgent::Grok
+        | CLIAgent::QwenCode
+        | CLIAgent::KimiCode
         | CLIAgent::WarpTui
         | CLIAgent::Unknown => RichInputSubmitStrategy::Inline,
     }


### PR DESCRIPTION
Closes #14781

## Problem

Three independently distributed coding CLIs aren't recognized as CLI agents: **Grok** (`grok`), **Qwen Code** (`qwen`), and **Kimi Code** (`kimi`). Running any of them yields a plain terminal session — no agent tab icon, no agent toolbar, and none of the toolbar-gated affordances (File Explorer, View Changes).

All three ship as global npm packages with stable, single-word binary names, so they fit the existing `command_prefixes()` model exactly as `claude`, `codex`, and `goose` do:

| Agent | npm package | `bin` | Upstream |
| --- | --- | --- | --- |
| Grok | `@xai-official/grok` | `grok` | https://docs.x.ai/build/overview |
| Qwen Code | `@qwen-code/qwen-code` | `qwen` | https://github.com/QwenLM/qwen-code |
| Kimi Code | `@moonshot-ai/kimi-code` | `kimi` | https://github.com/MoonshotAI/kimi-code |

`bin` names were read from live npm registry metadata (`registry.npmjs.org/<pkg>/latest`), not inferred from docs. The Qwen and Kimi packages declare their repositories in that metadata; `@xai-official/grok` declares none, but is published under the `@xai-official` scope by the `security@x.ai` maintainer account.

`agents.third_party.cli_agent_toolbar_enabled_commands` can force the toolbar on for an arbitrary pattern, but its value is a serialized `CLIAgent` name and no variant exists for these three — so the only honest value deserializes to `Unknown`, whose `icon()` is `None`. That yields a toolbar with no agent identity, and only for users who know the setting exists.

## Changes

Adds `Grok`, `QwenCode`, and `KimiCode` to `CLIAgent` and fills in every arm the enum requires:

- `command_prefixes()` — `grok` / `qwen` / `kimi`
- `display_name()` — `Grok` / `Qwen Code` / `Kimi Code`
- `brand_color()` — new `GROK_COLOR` (xAI black), `QWEN_COLOR` (#615CED), `KIMI_COLOR` (Moonshot black)
- `icon()` — `None`, see below
- `CLIAgentType` + its `From<CLIAgent>` arm, for telemetry parity

No prefix collisions: none of `grok`, `qwen`, `kimi` appears in any existing variant's `command_prefixes()`. Detection runs through `enum_iterator::all::<CLIAgent>()` in `detect()`, so the new variants participate automatically.

### Deliberately conservative choices

I only claimed behavior I could verify from the packages themselves. Three arms are intentionally minimal, and each is a one-line change if a maintainer confirms otherwise:

- **`icon()` returns `None`** — I don't have officially licensed brand SVGs. This follows the precedent set by `Hermes` and `Vibe`, and the comment on `Vibe` documenting the "recognized now, licensed asset later" path. `brand_color()` still drives the toolbar tile, so the agents are visually distinct without an icon.
- **`supported_skill_providers()` returns `&[]`** — I haven't confirmed these read `AGENTS.md`. Claiming `SkillProvider::Agents` would surface skills that never load.
- **Session listener / plugin manager / rich-input strategy** — grouped with the "no OSC 777 plugin, inline submit" cohort, since I haven't verified they emit session events.

## Testing

`test_detect_known_agents` gains the three binaries, and a new `test_detect_grok_qwen_kimi` covers arguments (`grok --model grok-4`), absolute paths (`/usr/local/bin/qwen`), and negative cases (`grokking`, `qwen-agent` must not match).

```
cargo check -p warp    clean (0 errors)
rustfmt --check        clean on all six changed files
```

Two existing all-variants tests pick the new agents up automatically and pass: `test_serialized_name_round_trips_known_agents` (no `#[serde(rename_all)]` on the enum, so the names round-trip as `Grok` / `QwenCode` / `KimiCode`) and the `all::<CLIAgent>()` dropdown loop in `settings_view/ai_page.rs`, which lists them and skips the icon via its existing `if let Some(icon)`.

**On manual testing:** CONTRIBUTING.md asks for proof of manual testing, and I want to be straight about what I have and haven't done. I verified the binary names against live npm registry metadata, confirmed the crate type-checks, and ran the `cli_agent` tests. I have **not** run a locally built Warp with these three agents attached, so I can't personally attest to the tab icon and toolbar rendering end to end. Happy to do that round if you can point me at the expected local run setup, or to hand it off if you'd rather validate internally.

## Notes

Filed per CONTRIBUTING.md's bug-fix path since the fix is mechanical and the report is self-contained; if you'd rather treat this as a feature request needing `ready-to-spec` first, I'm glad to convert it to an issue and wait for triage.
