### PR TITLE
Preserve custom pane names in launch configurations

### DIFF
--- a/app/src/integration_testing/tab/assertion.rs
+++ b/app/src/integration_testing/tab/assertion.rs
@@ -27,6 +27,38 @@ pub fn assert_pane_title(
     })
 }
 
+/// Asserts that the pane at the given index carries the expected custom name,
+/// i.e. the name shown in the vertical tabs panel after the user renames it.
+///
+/// This is distinct from [`assert_pane_title`]: `title` is the terminal-derived
+/// title, while this is `custom_vertical_tabs_title`, which is `None` until the
+/// pane is explicitly renamed.
+pub fn assert_pane_custom_name(
+    tab_index: usize,
+    pane_index: usize,
+    expected_name: Option<&'static str>,
+) -> AssertionCallback {
+    Box::new(move |app, window_id| {
+        let pane_group = pane_group_view(app, window_id, tab_index);
+        pane_group.read(app, |pane_group, ctx| {
+            match pane_group.pane_by_index(pane_index) {
+                Some(pane) => {
+                    let actual = pane
+                        .pane_configuration()
+                        .as_ref(ctx)
+                        .custom_vertical_tabs_title()
+                        .map(str::to_owned);
+                    async_assert!(
+                        actual.as_deref() == expected_name,
+                        "Expected custom name for window_id={window_id}, tab_index={tab_index}, pane_index={pane_index} to be [{expected_name:?}], but got [{actual:?}]"
+                    )
+                },
+                None => panic!("pane should exist for window_id={window_id}, tab_index={tab_index}, pane_index={pane_index}")
+            }
+        })
+    })
+}
+
 /// Asserts that the active pane of the tab has an expected title.
 pub fn assert_tab_title(
     tab_index: usize,

--- a/app/src/launch_configs/launch_config.rs
+++ b/app/src/launch_configs/launch_config.rs
@@ -106,6 +106,11 @@ pub enum PaneTemplateType {
         /// Sourced from the `shell` field of a tab config pane node.
         #[serde(skip_serializing_if = "Option::is_none", default)]
         shell: Option<String>,
+        /// The pane's custom name, as shown in the vertical tabs panel.
+        /// Mirrors `LeafSnapshot::custom_vertical_tabs_title`; `None` means the
+        /// pane was never renamed and falls back to its generated label.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        title: Option<String>,
     },
     PaneBranchTemplate {
         split_direction: SplitDirection,
@@ -144,6 +149,7 @@ impl TryFrom<PaneNodeSnapshot> for PaneTemplateType {
                     is_focused: Some(leaf.is_focused),
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: leaf.custom_vertical_tabs_title,
                 }),
                 // Currently, notebook panes cannot be saved in launch configurations.
                 LeafContents::Notebook(_)
@@ -287,6 +293,7 @@ pub fn make_mock_single_window_launch_config() -> LaunchConfig {
                         commands: vec!["echo test_command".into()],
                         pane_mode: PaneMode::Terminal,
                         shell: None,
+                        title: None,
                     },
                     commands: Vec::new(),
                     color: None,
@@ -299,6 +306,7 @@ pub fn make_mock_single_window_launch_config() -> LaunchConfig {
                         commands: vec!["echo test_command_on_another_tab".into()],
                         pane_mode: PaneMode::Terminal,
                         shell: None,
+                        title: None,
                     },
                     commands: Vec::new(),
                     color: None,

--- a/app/src/launch_configs/launch_config_tests.rs
+++ b/app/src/launch_configs/launch_config_tests.rs
@@ -119,6 +119,7 @@ fn test_config_from_snapshot_flattens_single_pane() {
             commands: vec![],
             pane_mode: PaneMode::Terminal,
             shell: None,
+            title: None,
         },
     )
 }
@@ -192,6 +193,7 @@ fn test_config_from_snapshot_filters_panes() {
                     commands: vec![],
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
                 PaneTemplateType::PaneTemplate {
                     is_focused: Some(false),
@@ -199,6 +201,7 @@ fn test_config_from_snapshot_filters_panes() {
                     commands: vec![],
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
             ]
         }
@@ -255,6 +258,7 @@ windows:
             is_focused: None,
             pane_mode: PaneMode::Terminal,
             shell: None,
+            title: None,
         }
     );
 }
@@ -292,6 +296,7 @@ windows:
                     is_focused: Some(false),
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
                 PaneTemplateType::PaneTemplate {
                     cwd: PathBuf::from("/tmp/right"),
@@ -301,6 +306,7 @@ windows:
                     is_focused: Some(true),
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
             ],
         }
@@ -340,6 +346,7 @@ windows:
                     is_focused: None,
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
                 PaneTemplateType::PaneTemplate {
                     cwd: PathBuf::from("/tmp/right"),
@@ -347,6 +354,7 @@ windows:
                     is_focused: None,
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
             ],
         }
@@ -527,4 +535,104 @@ fn test_config_with_active_tab_being_filtered() {
 
     let template = LaunchConfig::from_snapshot("Test".into(), &state);
     assert_eq!(template.windows[0].active_tab_index, None)
+}
+
+fn named_terminal_leaf(title: Option<&str>, cwd: &str) -> PaneNodeSnapshot {
+    PaneNodeSnapshot::Leaf(LeafSnapshot {
+        is_focused: false,
+        custom_vertical_tabs_title: title.map(str::to_string),
+        contents: LeafContents::Terminal(TerminalPaneSnapshot {
+            uuid: vec![],
+            cwd: Some(cwd.into()),
+            is_active: false,
+            is_read_only: false,
+            shell_launch_data: None,
+            input_config: None,
+            llm_model_override: None,
+            active_profile_id: None,
+            conversation_ids_to_restore: vec![],
+            active_conversation_id: None,
+        }),
+    })
+}
+
+fn pane_title(pane: &PaneTemplateType) -> Option<&str> {
+    match pane {
+        PaneTemplateType::PaneTemplate { title, .. } => title.as_deref(),
+        PaneTemplateType::PaneBranchTemplate { .. } => panic!("expected a leaf pane"),
+    }
+}
+
+#[test]
+fn test_config_from_snapshot_preserves_pane_names() {
+    // Renaming a pane sets `LeafSnapshot::custom_vertical_tabs_title`. Saving a
+    // launch configuration must carry that name across, per-pane, so relaunching
+    // does not reset every pane to its generated label.
+
+    let state = single_tab_snapshot(PaneNodeSnapshot::Branch(BranchSnapshot {
+        direction: SplitDirection::Vertical,
+        children: vec![
+            (PaneFlex(1.), named_terminal_leaf(Some("Build"), "/build")),
+            (PaneFlex(1.), named_terminal_leaf(None, "/unnamed")),
+            (PaneFlex(1.), named_terminal_leaf(Some("Logs"), "/logs")),
+        ],
+    }));
+
+    let template = LaunchConfig::from_snapshot("Test".into(), &state);
+    let PaneTemplateType::PaneBranchTemplate { panes, .. } = &template.windows[0].tabs[0].layout
+    else {
+        panic!("expected a branch layout");
+    };
+
+    assert_eq!(
+        panes.iter().map(pane_title).collect::<Vec<_>>(),
+        vec![Some("Build"), None, Some("Logs")],
+        "each pane must keep its own name, and an unnamed pane must stay unnamed",
+    );
+}
+
+#[test]
+fn test_pane_name_round_trips_through_yaml() {
+    let state = single_tab_snapshot(named_terminal_leaf(Some("Server"), "/srv"));
+    let config = LaunchConfig::from_snapshot("Test".into(), &state);
+
+    let yaml = serde_yaml::to_string(&config).expect("config should serialize");
+    let parsed: LaunchConfig = serde_yaml::from_str(&yaml).expect("config should parse");
+
+    assert_eq!(
+        pane_title(&parsed.windows[0].tabs[0].layout),
+        Some("Server")
+    );
+}
+
+#[test]
+fn test_unnamed_pane_omits_title_key() {
+    // The new field must not appear in configs saved from unnamed panes, so
+    // existing launch configurations keep serializing byte-for-byte as before.
+
+    let state = single_tab_snapshot(named_terminal_leaf(None, "/srv"));
+    let config = LaunchConfig::from_snapshot("Test".into(), &state);
+
+    let yaml = serde_yaml::to_string(&config).expect("config should serialize");
+
+    assert!(
+        !yaml.contains("title"),
+        "unnamed panes must not emit a title key, got:\n{yaml}",
+    );
+}
+
+#[test]
+fn test_legacy_config_without_pane_name_still_parses() {
+    let config: LaunchConfig = serde_yaml::from_str(
+        r#"
+name: Legacy
+windows:
+  - tabs:
+      - layout:
+          cwd: /tmp
+"#,
+    )
+    .expect("a config predating pane names should still parse");
+
+    assert_eq!(pane_title(&config.windows[0].tabs[0].layout), None);
 }

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -1349,6 +1349,7 @@ impl PaneGroup {
                 is_focused,
                 pane_mode,
                 shell,
+                title,
             } => {
                 let uuid = Uuid::new_v4();
 
@@ -1427,6 +1428,18 @@ impl PaneGroup {
                 let terminal_pane_id = pane_data.terminal_pane_id();
                 let pane_id = terminal_pane_id.into();
                 pane_contents.insert(pane_id, Box::new(pane_data));
+
+                // Restore the pane's custom vertical-tabs name, mirroring what
+                // session restoration does in `pane_from_leaf_snapshot`.
+                if let Some(title) = title.as_deref()
+                    && let Some(pane) = pane_contents.get(&pane_id)
+                {
+                    pane.as_pane()
+                        .pane_configuration()
+                        .update(ctx, |configuration, ctx| {
+                            configuration.set_custom_vertical_tabs_title(title, ctx);
+                        });
+                }
 
                 let is_focused = is_focused.unwrap_or_default();
                 let focus = InitialFocus {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -2392,6 +2392,7 @@ fn test_initial_widths_are_computed_correctly() {
                     commands: vec![],
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 }
             };
         }
@@ -2968,6 +2969,7 @@ fn test_pane_focus_does_not_have_an_infinite_event_loop() {
                         commands: vec![],
                         pane_mode: PaneMode::Terminal,
                         shell: None,
+                        title: None,
                     },
                     PaneTemplateType::PaneTemplate {
                         is_focused: None,
@@ -2975,6 +2977,7 @@ fn test_pane_focus_does_not_have_an_infinite_event_loop() {
                         commands: vec![],
                         pane_mode: PaneMode::Terminal,
                         shell: None,
+                        title: None,
                     },
                 ],
             }),
@@ -3094,6 +3097,7 @@ fn test_focused_pane_is_synchronized_with_application_focus() {
                     commands: vec![],
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
                 PaneTemplateType::PaneTemplate {
                     is_focused: None,
@@ -3101,6 +3105,7 @@ fn test_focused_pane_is_synchronized_with_application_focus() {
                     commands: vec![],
                     pane_mode: PaneMode::Terminal,
                     shell: None,
+                    title: None,
                 },
             ],
         });

--- a/app/src/tab_configs/tab_config.rs
+++ b/app/src/tab_configs/tab_config.rs
@@ -234,6 +234,7 @@ pub fn render_tab_config(
                 is_focused: Some(true),
                 pane_mode: PaneMode::Terminal,
                 shell: None,
+                title: None,
             }
         }
     };
@@ -400,6 +401,9 @@ fn resolve_pane_node(
                 is_focused: Some(is_focused),
                 pane_mode,
                 shell: node.shell.clone(),
+                // Tab configs have no pane-name field of their own; panes they
+                // open fall back to their generated label.
+                title: None,
             },
             explicitly_focused || did_consume,
         ))

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -254,6 +254,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_with_launch_config_with_active_tab_index);
     register_test!(test_with_launch_config_with_active_pane);
     register_test!(test_with_launch_config_with_no_active_pane);
+    register_test!(test_launch_config_restores_pane_names);
     register_test!(test_find_query_not_evaluated_on_terminal_mode_change);
     register_test!(test_bash_bootstraps_with_prompt_command_array);
     register_test!(test_bash_bootstraps_with_prompt_command_array_that_sets_ps1);

--- a/crates/integration/src/test/launch_configs.rs
+++ b/crates/integration/src/test/launch_configs.rs
@@ -5,6 +5,7 @@ use warp::features::FeatureFlag;
 use warp::integration_testing::pane_group::assert_focused_pane_index;
 use warp::integration_testing::settings::set_window_custom_size;
 use warp::integration_testing::step::new_step_with_default_assertions;
+use warp::integration_testing::tab::assert_pane_custom_name;
 use warp::integration_testing::terminal::{
     validate_block_output, wait_until_bootstrapped_single_pane_for_tab,
 };
@@ -180,6 +181,7 @@ pub fn test_launch_config_single_child_branch() -> Builder {
                             commands: Vec::new(),
                             pane_mode: PaneMode::Terminal,
                             shell: None,
+                            title: None,
                         }],
                     },
                     commands: Vec::new(),
@@ -310,6 +312,7 @@ pub fn test_with_launch_config_with_active_tab_index() -> Builder {
                                 commands: Vec::new(),
                                 pane_mode: PaneMode::Terminal,
                                 shell: None,
+                                title: None,
                             }],
                         },
                         commands: Vec::new(),
@@ -370,6 +373,7 @@ pub fn test_with_launch_config_with_active_pane() -> Builder {
                                 commands: Vec::new(),
                                 pane_mode: PaneMode::Terminal,
                                 shell: None,
+                                title: None,
                             },
                             PaneTemplateType::PaneBranchTemplate {
                                 split_direction: SplitDirection::Vertical,
@@ -380,6 +384,7 @@ pub fn test_with_launch_config_with_active_pane() -> Builder {
                                         commands: Vec::new(),
                                         pane_mode: PaneMode::Terminal,
                                         shell: None,
+                                        title: None,
                                     },
                                     PaneTemplateType::PaneTemplate {
                                         is_focused: Some(true),
@@ -387,6 +392,7 @@ pub fn test_with_launch_config_with_active_pane() -> Builder {
                                         commands: Vec::new(),
                                         pane_mode: PaneMode::Terminal,
                                         shell: None,
+                                        title: None,
                                     },
                                 ],
                             },
@@ -449,6 +455,7 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
                                 commands: Vec::new(),
                                 pane_mode: PaneMode::Terminal,
                                 shell: None,
+                                title: None,
                             },
                             PaneTemplateType::PaneBranchTemplate {
                                 split_direction: SplitDirection::Vertical,
@@ -459,6 +466,7 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
                                         commands: Vec::new(),
                                         pane_mode: PaneMode::Terminal,
                                         shell: None,
+                                        title: None,
                                     },
                                     PaneTemplateType::PaneTemplate {
                                         is_focused: Some(false),
@@ -466,6 +474,7 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
                                         commands: Vec::new(),
                                         pane_mode: PaneMode::Terminal,
                                         shell: None,
+                                        title: None,
                                     },
                                 ],
                             },
@@ -503,5 +512,70 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
                 .add_assertion(assert_tab_count(1))
                 .add_assertion(assert_focused_tab_index(0))
                 .add_assertion(assert_focused_pane_index(0, 0)),
+        )
+}
+
+/// Opening a launch config whose panes carry names must restore those names on
+/// the live panes, and must leave panes without a name unnamed.
+pub fn test_launch_config_restores_pane_names() -> Builder {
+    use warp::launch_configs::launch_config::{
+        LaunchConfig, PaneMode, PaneTemplateType, SplitDirection, TabTemplate, WindowTemplate,
+    };
+
+    fn named_pane(title: Option<&str>) -> PaneTemplateType {
+        PaneTemplateType::PaneTemplate {
+            is_focused: Some(false),
+            cwd: PathBuf::from("/some/path"),
+            commands: Vec::new(),
+            pane_mode: PaneMode::Terminal,
+            shell: None,
+            title: title.map(str::to_owned),
+        }
+    }
+
+    fn create_launch_config() -> LaunchConfig {
+        LaunchConfig {
+            name: "Named panes".to_owned(),
+            active_window_index: Some(0),
+            windows: vec![WindowTemplate {
+                active_tab_index: Some(0),
+                tabs: vec![TabTemplate {
+                    title: None,
+                    layout: PaneTemplateType::PaneBranchTemplate {
+                        split_direction: SplitDirection::Horizontal,
+                        panes: vec![
+                            named_pane(Some("Build")),
+                            named_pane(None),
+                            named_pane(Some("Logs")),
+                        ],
+                    },
+                    commands: Vec::new(),
+                    color: None,
+                }],
+            }],
+        }
+    }
+
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Opening a configuration template with named panes")
+                .with_action(move |app, _, _| {
+                    app.dispatch_global_action(
+                        "root_view:open_launch_config",
+                        warp::root_view::OpenLaunchConfigArg {
+                            launch_config: create_launch_config(),
+                            ui_location: get_launch_config_ui_location(),
+                            open_in_active_window: false,
+                        },
+                    );
+                }),
+        )
+        .with_step(
+            new_step_with_default_assertions("Assert each pane kept its own name")
+                .add_assertion(assert_tab_count(1))
+                .add_assertion(assert_pane_custom_name(0, 0, Some("Build")))
+                .add_assertion(assert_pane_custom_name(0, 1, None))
+                .add_assertion(assert_pane_custom_name(0, 2, Some("Logs"))),
         )
 }

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -124,6 +124,7 @@ integration_tests! {
     test_with_launch_config_with_active_tab_index,
     test_with_launch_config_with_active_pane,
     test_with_launch_config_with_no_active_pane,
+    test_launch_config_restores_pane_names,
     test_find_query_not_evaluated_on_terminal_mode_change,
     test_custom_open_completions_menu_binding,
     test_ssh_with_shell_override,


### PR DESCRIPTION
## Description

Fixes #14817

Saving a launch configuration drops each pane's custom name. Relaunching brings every pane back unnamed, showing its generated label (`New session` for a fresh terminal). Reported by @derekneely on #13898.

**This is a gap in one path, not a missing capability.** `LeafSnapshot::custom_vertical_tabs_title` already exists and session restore round-trips it end to end — `persistence/sqlite.rs` writes it to `pane_leaves` (`:1232`) and reads it back (`:2423`). Only the launch-config projection ignored it: `PaneTemplateType::PaneTemplate` had nowhere to put a name, and `TryFrom<PaneNodeSnapshot>` read just `leaf.is_focused` and `terminal.cwd`, letting the rest of the leaf fall on the floor.

Same shape as #13898 / #14624 (tab groups), but a different field with a different fix, which is why it is filed and fixed separately.

## What changed

**Schema** (`launch_config.rs`) — `PaneTemplate` gains `title: Option<String>`:

```yaml
windows:
  - tabs:
      - layout:
          split_direction: vertical
          panes:
            - cwd: /srv/api
              title: Build
            - cwd: /tmp          # never renamed, no `title` key
```

`skip_serializing_if` + `default`, so **a config saved from unnamed panes serializes byte-for-byte as before**. There is a test asserting the key is absent in that case, and another asserting a config written before this change still parses.

**Save** (`launch_config.rs`) — carries `leaf.custom_vertical_tabs_title` into the template, per pane.

**Restore** (`pane_group/mod.rs`) — after the pane is inserted into `pane_contents`, its name is applied through `pane_configuration().set_custom_vertical_tabs_title(...)`. This deliberately reuses the exact mechanism session restore already uses in `pane_from_leaf_snapshot` (`mod.rs:2004-2013`) rather than introducing a second way to name a pane.

**Tab configs** (`tab_configs/tab_config.rs`) — `TabConfigPaneNode` has no name field of its own, so panes opened from a tab config pass `title: None` and keep falling back to their generated label. No behavior change there; noted in a comment so the `None` does not read as an oversight.

## Testing

Four new tests in `launch_config_tests.rs`; `cargo test -p warp --lib launch_config` is **15 passed / 0 failed**, `cargo fmt -- --check` clean, `cargo check -p warp --all-targets` 0 errors / 0 warnings.

- `test_config_from_snapshot_preserves_pane_names` — three panes, named / unnamed / named, each keeps its own name and the unnamed one stays unnamed
- `test_pane_name_round_trips_through_yaml` — survives serialize + deserialize
- `test_unnamed_pane_omits_title_key` — backward compatibility of the serialized form
- `test_legacy_config_without_pane_name_still_parses` — configs predating this change still load

I checked the first two actually bite rather than trusting the green run. Dropping the name on the save side (`title: None`) turns them red with

```
assertion `left == right` failed: each pane must keep its own name, and an unnamed pane must stay unnamed
  left: [None, None, None]
 right: [Some("Build"), None, Some("Logs")]
```

and restoring the line returns the suite to 15 passed.

### Integration coverage for the restore half

The unit tests above only reach the save side and the serialized form, so the restore half — applying the name back onto a live pane — is covered separately by `test_launch_config_restores_pane_names` in `crates/integration/src/test/launch_configs.rs`. It opens a launch config with three panes (named / unnamed / named) and asserts each live pane comes back with its own name. **1 passed.**

`assert_pane_custom_name` is new: the existing `assert_pane_title` reads the terminal-derived `title`, which is a different field from `custom_vertical_tabs_title` and would pass whether or not this fix works.

Red-armed the same way — disabling the restore-side application turns it red with

```
Expected custom name for window_id=1, tab_index=0, pane_index=0
  to be [Some("Build")], but got [None]
```

and restoring it returns to 1 passed.

### Manual validation

Built with `./script/run` and exercised end to end through the URI handler — `warposs://launch/Pane%20Names%20Demo` against this launch config:

```yaml
name: Pane Names Demo
windows:
  - active_tab_index: 0
    tabs:
      - title: services
        layout:
          split_direction: horizontal
          panes:
            - {cwd: ~/side, title: Build}
            - {cwd: ~/side}            # never renamed
            - {cwd: ~/side, title: Logs}
```

Both shots are the vertical tabs panel of the relaunched window, same config, same geometry — the only difference is whether the restore-side application is in place. Cropped to the panel because that is where pane names render; the terminal panes themselves are empty in both.

**Before — every pane comes back unnamed**

All three fall back to the terminal-derived title, and `Build` / `Logs` are gone.

![before](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-14818/pr-assets/before.png)

**After (this PR) — each pane keeps its own name**

`Build` and `Logs` are restored, and the middle pane — which was never renamed — correctly stays unnamed rather than inheriting a neighbour's name.

![after](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-14818/pr-assets/after.png)

Stills rather than a recording: the difference here is a static state (a name is present or it isn't), not a flow, so a video would show the same two frames. Screenshots are hosted on a branch of my fork; happy to re-upload them wherever a maintainer prefers.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

  #14817 is triaged (`bug`, `triaged`, `repro:high`, `area:launch-configs`) but carries **no readiness label**, because its second auto-triage run failed to set up rather than completed (`warp-agent-staging`, Aug 7: `Environment setup failed: Failed to clone warpdotdev-demos/agent-eval-kit, warpdotdev/warp`). I flagged that on the issue on Aug 28; there has been no response in the two weeks since.

  Checking this box on the basis of `CONTRIBUTING.md`, which scopes readiness labels to feature requests: "Bug fixes are welcome once the report is actionable from the provided details or maintainer triage" (TL;DR) and "Bug fixes can go straight to a code PR once the report is reproducible or otherwise actionable; they do not require spec PRs." #14817 is a `bug` with `repro:high`, and Oz's own triage reads "This looks actionable from the provided steps." Happy to move this back to draft if the team reads the gate differently.

- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing checklist

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Launch configurations now preserve custom pane names.

