### PR TITLE
Fix SSH bootstrap output appearing in command history

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -3039,6 +3039,9 @@ macro_rules! delegate {
                     Default::default()
                 }
             },
+            _ if $self.bootstrap_stage == BootstrapStage::ScriptExecution => {
+                $self.output_grid.$method($( $arg ),*)
+            },
             _ => {
                 if $self.state == BlockState::BeforeExecution {
                     $self.header_grid.$method($( $arg ),*)

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -3040,6 +3040,9 @@ macro_rules! delegate {
                 }
             },
             _ if $self.bootstrap_stage == BootstrapStage::ScriptExecution => {
+                if !$self.output_grid.started() {
+                    $self.output_grid.start();
+                }
                 $self.output_grid.$method($( $arg ),*)
             },
             _ => {

--- a/app/src/terminal/model/block_tests.rs
+++ b/app/src/terminal/model/block_tests.rs
@@ -383,6 +383,21 @@ pub fn test_image_completion_before_execution_routes_to_output_grid() {
 }
 
 #[test]
+pub fn script_execution_text_is_not_serialized_as_a_command() {
+    let mut block = TestBlockBuilder::new()
+        .with_bootstrap_stage(BootstrapStage::ScriptExecution)
+        .build();
+    block.start();
+
+    for c in "motd".chars() {
+        block.input(c);
+    }
+
+    assert_eq!(block.command_to_string(), "");
+    assert_eq!(block.output_grid().contents_to_string(false, None), "motd");
+}
+
+#[test]
 pub fn test_image_completion_drops_in_warp_input_stage() {
     let _iterm_images = FeatureFlag::ITermImages.override_enabled(true);
     let mut block = TestBlockBuilder::new()

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -3691,6 +3691,7 @@ impl BlockList {
             match block.bootstrap_stage() {
                 BootstrapStage::WarpInput | BootstrapStage::ScriptExecution => {
                     contents.push_str(&block.command_to_string());
+                    contents.push_str(&block.output_grid().contents_to_string(false, None));
                     contents.push('\n');
                 }
                 // We stop at the first block that is after the bootstrapping stage.

--- a/app/src/terminal/model/blocks/selection_tests.rs
+++ b/app/src/terminal/model/blocks/selection_tests.rs
@@ -1270,18 +1270,6 @@ pub fn test_selection_to_string_hidden_blocks() {
                 1
             );
 
-            assert_eq!(
-                block_list.blocks[bootstrapped_block_list_len + 2]
-                    .prompt_and_command_number_of_rows(),
-                1
-            );
-            assert_eq!(
-                block_list.blocks[bootstrapped_block_list_len + 2]
-                    .output_grid()
-                    .len(),
-                1
-            );
-
             let semantic_selection = SemanticSelection::mock(false, "");
             // Create a selection that spans from command grid of the before block to output grid of the
             // after block.

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -221,6 +221,17 @@ fn test_iterm_image_renders_in_script_execution_block() {
 }
 
 #[test]
+fn bootstrap_contents_include_script_execution_output() {
+    let mut block_list = TestBlockListBuilder::new().build();
+    advance_to_script_execution(&mut block_list);
+
+    input_string(&mut block_list, "motd");
+
+    assert_eq!(block_list.active_block().command_to_string(), "");
+    assert_eq!(block_list.bootstrap_block_contents(), "motd");
+}
+
+#[test]
 fn test_invalid_iterm_image_does_not_render_in_script_execution_block() {
     let _iterm_images = FeatureFlag::ITermImages.override_enabled(true);
     let mut block_list = TestBlockListBuilder::new().build();

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -4092,6 +4092,7 @@ fn zero_state_renders_with_only_zero_height_bootstrap_blocks() {
                 .mut_block_from_id(&bootstrap_block_id)
                 .expect("bootstrap block should remain in the block list");
             bootstrap_block.set_should_hide_command_grid(true);
+            bootstrap_block.set_should_hide_output_grid(true);
             terminal_model.update_blockheight_items(
                 BlockPadding {
                     bottom: 1.0,


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

SSH/session bootstrap output can arrive while the active block is still in `BeforeExecution`.
During `BootstrapStage::ScriptExecution`, that output was routed through the command grid and could be serialized as the command for the block. If Warp was quit during the SSH session and restored later, the remote MOTD/welcome text could then appear in command history.

This changes script-execution bootstrap output to be handled as output rather than command text, while preserving hidden bootstrap block semantics: routing bytes away from the command grid does not automatically make the bootstrap block visible.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Fixes #3523

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

Manual testing:
- Built and launched `target/debug/warp-oss` on macOS.
- Ran `tsh ssh htz-p6m-salt-master-stg` into a warpified SSH session.
- Quit Warp through the Dock while the SSH session was active.
- Relaunched `target/debug/warp-oss`.
- Verified the Ubuntu MOTD/welcome output was not restored as a command history entry.

## Result

Login banner message is not shown in the restored command history
Manual verification was performed with a real macOS build and warpified SSH session. No UI layout change is included.

### Screenshots / Videos
<img width="1274" height="182" alt="image" src="https://github.com/user-attachments/assets/7e0c3925-a8e2-40d4-a689-95097e195b0c" />