### PR TITLE
[QUALITY-1333] Prevent background TUI agents from stealing focus

### DIFF
--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -508,18 +508,21 @@ impl TuiAIBlock {
             &action_model,
             |me, action_model, event: &BlocklistAIActionEvent, ctx| {
                 if me.renders_action(event.action_id()) {
-                    if matches!(
+                    let materialized_active_blocker = if matches!(
                         event,
                         BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(_)
                     ) {
-                        me.sync_action_views(&action_model, ctx);
-                    }
+                        me.sync_action_views(&action_model, ctx)
+                    } else {
+                        false
+                    };
                     if matches!(
                         event,
                         BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(_)
                             | BlocklistAIActionEvent::ExecutingAction(_)
                             | BlocklistAIActionEvent::FinishedAction { .. }
-                    ) {
+                    ) && !materialized_active_blocker
+                    {
                         ctx.emit(TuiAIBlockEvent::BlockingStateChanged);
                     }
                     me.invalidate_action(event.action_id(), ctx);
@@ -647,7 +650,8 @@ impl TuiAIBlock {
         &mut self,
         action_model: &ModelHandle<BlocklistAIActionModel>,
         ctx: &mut ViewContext<Self>,
-    ) {
+    ) -> bool {
+        let mut materialized_active_blocker = false;
         let status = self.block_model.status(ctx);
         let output_streaming = status.is_streaming();
         let mut ask_question_actions = Vec::new();
@@ -726,6 +730,7 @@ impl TuiAIBlock {
             ctx.subscribe_to_view(&view, |me, _, event, ctx| match event {
                 TuiAskQuestionViewEvent::LayoutChanged => me.invalidate_layout(ctx),
             });
+            materialized_active_blocker |= view.as_ref(ctx).is_awaiting_answers(ctx);
             self.action_views
                 .insert(action_id, TuiToolCallView::AskQuestion(view));
             ctx.notify();
@@ -765,6 +770,7 @@ impl TuiAIBlock {
                     });
                 }
             });
+            materialized_active_blocker |= view.as_ref(ctx).active_permission_prompt(ctx).is_some();
             self.action_views
                 .insert(action_id, TuiToolCallView::Generic(view));
             ctx.notify();
@@ -798,6 +804,7 @@ impl TuiAIBlock {
                     });
                 }
             });
+            materialized_active_blocker |= view.as_ref(ctx).active_permission_prompt(ctx).is_some();
             self.action_views
                 .insert(action_id, TuiToolCallView::FileEdits(view));
             ctx.notify();
@@ -856,6 +863,7 @@ impl TuiAIBlock {
                     });
                 }
             });
+            materialized_active_blocker |= view.as_ref(ctx).active_permission_prompt(ctx).is_some();
             self.action_views
                 .insert(action_id, TuiToolCallView::ShellCommand(view));
             ctx.notify();
@@ -924,10 +932,15 @@ impl TuiAIBlock {
                 }
                 TuiOrchestrationBlockEvent::LayoutInvalidated => me.invalidate_layout(ctx),
             });
+            materialized_active_blocker |= view.as_ref(ctx).is_awaiting_confirmation(ctx);
             self.action_views
                 .insert(action_id, TuiToolCallView::OrchestrationBlock(view));
             ctx.notify();
         }
+        if materialized_active_blocker {
+            ctx.emit(TuiAIBlockEvent::BlockingStateChanged);
+        }
+        materialized_active_blocker
     }
 
     /// Cancels a pending or running action as manually cancelled — the

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -19,7 +19,7 @@ use warp::tui_export::{
     GetRelevantFilesController, LLMId, MessageId, ModelEventDispatcher, OutputStatusUpdateCallback,
     ReceivedMessageDisplay, RenderableAIError, RequestCommandOutputResult, ServerOutputId,
     Sessions, Shared, SummarizationType, TaskId, TerminalModel, TodoOperation, TodoStatus,
-    TuiOnboardingMarker, TuiOnboardingMarkers, UserQueryMode,
+    TuiOnboardingMarker, TuiOnboardingMarkers, UserQueryMode, queue_tui_permission_action,
     register_tui_session_view_test_singletons, should_show_failed_output_usage_notice,
 };
 use warp_core::ui::color::blend::Blend;
@@ -1200,6 +1200,112 @@ fn ask_user_question_action_registers_a_stateful_child_view() {
     });
 }
 
+#[test]
+fn materializing_an_already_blocked_question_notifies_the_owner() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let action = ask_user_question_action("ask-1", "Which one?");
+        let action_id = action.id.clone();
+        let conversation_id = AIConversationId::new();
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: AIBlockOutputStatus::Pending,
+            },
+        );
+        let blocking_state_changes = Rc::new(Cell::new(0));
+        let changes_for_subscription = blocking_state_changes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&block, move |_, event, _| match event {
+                TuiAIBlockEvent::BlockingStateChanged => {
+                    changes_for_subscription.set(changes_for_subscription.get() + 1);
+                }
+                TuiAIBlockEvent::LayoutInvalidated
+                | TuiAIBlockEvent::ReplacementGuidanceSubmitted { .. } => {}
+            });
+        });
+        let action_model = block.read(&app, |block, _| block.action_model.clone());
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action.clone(), conversation_id, ctx);
+        });
+        assert_eq!(blocking_state_changes.get(), 0);
+
+        block.update(&mut app, |block, ctx| {
+            block.replace_model(
+                block.conversation_id,
+                Rc::new(FakeAgentBlockModel {
+                    inputs: Vec::new(),
+                    status: complete_output_messages(vec![action_message("message-1", action)]),
+                }),
+            );
+            let action_model = block.action_model.clone();
+            block.sync_action_views(&action_model, ctx);
+        });
+
+        assert_eq!(blocking_state_changes.get(), 1);
+        assert!(block.read(&app, |block, ctx| {
+            let Some(TuiToolCallView::AskQuestion(view)) = block.action_views.get(&action_id)
+            else {
+                return false;
+            };
+            view.as_ref(ctx).is_awaiting_answers(ctx)
+        }));
+    });
+}
+
+#[test]
+fn materializing_an_already_blocked_permission_prompt_notifies_the_owner() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let action = test_action("generic-1");
+        let action_id = action.id.clone();
+        let conversation_id = AIConversationId::new();
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: AIBlockOutputStatus::Pending,
+            },
+        );
+        let blocking_state_changes = Rc::new(Cell::new(0));
+        let changes_for_subscription = blocking_state_changes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&block, move |_, event, _| match event {
+                TuiAIBlockEvent::BlockingStateChanged => {
+                    changes_for_subscription.set(changes_for_subscription.get() + 1);
+                }
+                TuiAIBlockEvent::LayoutInvalidated
+                | TuiAIBlockEvent::ReplacementGuidanceSubmitted { .. } => {}
+            });
+        });
+        let action_model = block.read(&app, |block, _| block.action_model.clone());
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action.clone(), conversation_id, ctx);
+        });
+        assert_eq!(blocking_state_changes.get(), 0);
+
+        block.update(&mut app, |block, ctx| {
+            block.replace_model(
+                block.conversation_id,
+                Rc::new(FakeAgentBlockModel {
+                    inputs: Vec::new(),
+                    status: complete_output_messages(vec![action_message("message-1", action)]),
+                }),
+            );
+            let action_model = block.action_model.clone();
+            block.sync_action_views(&action_model, ctx);
+        });
+
+        assert_eq!(blocking_state_changes.get(), 1);
+        assert!(block.read(&app, |block, ctx| {
+            let Some(TuiToolCallView::Generic(view)) = block.action_views.get(&action_id) else {
+                return false;
+            };
+            view.as_ref(ctx).active_permission_prompt(ctx).is_some()
+        }));
+    });
+}
 #[test]
 fn streamed_ask_user_question_payload_replaces_the_initial_empty_child_view() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/handoff/block.rs
+++ b/crates/warp_tui/src/handoff/block.rs
@@ -186,11 +186,8 @@ impl TuiHandoffBlock {
     }
 
     fn handle_model_event(&mut self, event: &TuiHandoffModelEvent, ctx: &mut ViewContext<Self>) {
-        if let TuiHandoffModelEvent::Changed { focus_block } = event {
+        if let TuiHandoffModelEvent::Changed { .. } = event {
             self.refresh_selector(ctx);
-            if *focus_block {
-                ctx.focus_self();
-            }
             ctx.notify();
         }
     }

--- a/crates/warp_tui/src/handoff/session.rs
+++ b/crates/warp_tui/src/handoff/session.rs
@@ -91,7 +91,12 @@ impl TuiTerminalSessionView {
         ctx: &mut ViewContext<Self>,
     ) {
         match event {
-            TuiHandoffModelEvent::Changed { .. } => return,
+            TuiHandoffModelEvent::Changed { focus_block } => {
+                if *focus_block {
+                    self.reconcile_focus(ctx);
+                }
+                return;
+            }
             TuiHandoffModelEvent::Cancelled(restoration) => {
                 self.clear_handoff_interaction();
                 if let Some(restoration) = restoration {

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -17,15 +17,18 @@ use warp::settings::{
 };
 use warp::terminal::model::ansi::{Handler, InputBufferValue, Mode};
 use warp::tui_export::{
-    AIAgentActionId, AIAgentExchangeId, AIAgentTodo, AIAgentTodoList,
-    AIConversationAutoexecuteMode, AIConversationId, AgentViewEntryOrigin, BlockPadding,
-    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatus, ConversationUsageTotals,
-    Harness, InputTypeAutoDetectionSource, LLMPreferences, LinkedWorkflowData,
-    LongRunningCommandControlState, ParsedSlashCommandInput, PtyIntent, PtyIntentEvent, Session,
-    SizeInfo, SizeUpdate, SlashCommandDataSource as _, SlashCommandKind, TaskId, TranscriptScope,
-    TuiMcpAction, TuiMcpServerId, TuiOnboardingMarker, TuiOnboardingMarkers,
+    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId, AIAgentInput,
+    AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, AIAgentTodo, AIAgentTodoList,
+    AIBlockModel, AIBlockOutputStatus, AIConversationAutoexecuteMode, AIConversationId,
+    AIRequestType, AgentViewEntryOrigin, AskUserQuestionItem, AskUserQuestionOption,
+    AskUserQuestionType, BlockPadding, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
+    ConversationStatus, ConversationUsageTotals, Harness, InputTypeAutoDetectionSource, LLMId,
+    LLMPreferences, LinkedWorkflowData, LongRunningCommandControlState, MessageId,
+    OutputStatusUpdateCallback, ParsedSlashCommandInput, PtyIntent, PtyIntentEvent, ServerOutputId,
+    Session, Shared, SizeInfo, SizeUpdate, SlashCommandDataSource as _, SlashCommandKind, TaskId,
+    TranscriptScope, TuiMcpAction, TuiMcpServerId, TuiOnboardingMarker, TuiOnboardingMarkers,
     TuiUpArrowHistoryItemKind, UserTakeOverReason, WarpConfig, WarpConfigUpdateEvent,
-    export_conversation_markdown, forkable_tui_conversation_for_test,
+    export_conversation_markdown, forkable_tui_conversation_for_test, queue_tui_permission_action,
     register_tui_session_view_test_singletons, set_tui_default_team_admin_for_test, slash_commands,
 };
 use warp_core::channel::{Channel, ChannelState};
@@ -50,7 +53,7 @@ use warpui_core::keymap::{Context, DescriptionContext, Keystroke, Trigger};
 use warpui_core::platform::keyboard::KeyCode;
 use warpui_core::presenter::tui::{TuiFrame, TuiPresenter};
 use warpui_core::telemetry::{EventPayload, flush_events};
-use warpui_core::{App, AppContext, TuiView, TypedActionView, WindowInvalidation};
+use warpui_core::{App, AppContext, TuiView, TypedActionView, ViewContext, WindowInvalidation};
 
 use super::statusline::{
     ContextWindowUsage, FooterSegment, FooterSegments, format_context_window_usage,
@@ -79,7 +82,7 @@ use super::{
     SESSION_COMPOSER_SHORTCUTS_ACTIVE_FLAG, VOICE_INPUT_BINDING_NAME, VOICE_USAGE_HINT,
     voice_argument_is_empty, voice_command_argument,
 };
-use crate::agent_block::upgrade_url;
+use crate::agent_block::{TuiAIBlock, upgrade_url};
 use crate::autoupdate::TuiAutoupdater;
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
 use crate::input_mode_policy::{AI_LOCKED_CONFIG, AI_UNLOCKED_CONFIG};
@@ -5650,6 +5653,164 @@ fn background_focus_reconciliation_does_not_steal_foreground_focus() {
     });
 }
 
+struct LateMaterializationBlockModel {
+    conversation_id: AIConversationId,
+    status: AIBlockOutputStatus,
+}
+
+impl AIBlockModel for LateMaterializationBlockModel {
+    type View = TuiAIBlock;
+
+    fn status(&self, _app: &AppContext) -> AIBlockOutputStatus {
+        self.status.clone()
+    }
+
+    fn server_output_id(&self, _app: &AppContext) -> Option<ServerOutputId> {
+        None
+    }
+
+    fn model_id(&self, _app: &AppContext) -> Option<LLMId> {
+        None
+    }
+
+    fn base_model<'a>(&'a self, _app: &'a AppContext) -> Option<&'a LLMId> {
+        None
+    }
+
+    fn inputs_to_render<'a>(&'a self, _app: &'a AppContext) -> &'a [AIAgentInput] {
+        &[]
+    }
+
+    fn conversation_id(&self, _app: &AppContext) -> Option<AIConversationId> {
+        Some(self.conversation_id)
+    }
+
+    fn on_updated_output(
+        &self,
+        _callback: OutputStatusUpdateCallback<Self::View>,
+        _ctx: &mut ViewContext<Self::View>,
+    ) {
+    }
+
+    fn request_type(&self, _app: &AppContext) -> AIRequestType {
+        AIRequestType::Active
+    }
+}
+
+fn materialize_already_blocked_action(
+    app: &mut App,
+    session: &ViewHandle<TuiTerminalSessionView>,
+    action: AIAgentAction,
+) -> ViewHandle<TuiAIBlock> {
+    let (conversation_id, action_model, transcript) = session.update(app, |session, ctx| {
+        let conversation_id = session
+            .conversation_selection
+            .update(ctx, |selection, ctx| {
+                selection
+                    .try_start_new_conversation(AgentViewEntryOrigin::Tui, ctx)
+                    .expect("test conversation should start")
+            });
+        ctx.focus(&session.input_view);
+        (
+            conversation_id,
+            session.ai_action_model.clone(),
+            session.transcript.clone(),
+        )
+    });
+    action_model.update(app, |model, ctx| {
+        queue_tui_permission_action(model, action.clone(), conversation_id, ctx);
+    });
+    let status = AIBlockOutputStatus::Complete {
+        output: Shared::new(AIAgentOutput {
+            messages: vec![AIAgentOutputMessage {
+                id: MessageId::new("late-action-message".to_owned()),
+                message: AIAgentOutputMessageType::Action(action),
+                citations: Vec::new(),
+            }],
+            ..Default::default()
+        }),
+    };
+    transcript.update(app, |transcript, ctx| {
+        transcript.append_agent_block_for_test(
+            conversation_id,
+            AIAgentExchangeId::new(),
+            Rc::new(LateMaterializationBlockModel {
+                conversation_id,
+                status,
+            }),
+            ctx,
+        )
+    })
+}
+
+#[test]
+fn foreground_session_focuses_an_already_blocked_question_when_materialized() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (session, _) = add_focus_test_session(&mut app, &fixture, true);
+        let action = AIAgentAction {
+            id: AIAgentActionId::from("late-question".to_owned()),
+            task_id: TaskId::new("task".to_owned()),
+            action: AIAgentActionType::AskUserQuestion {
+                questions: vec![AskUserQuestionItem {
+                    question_id: "question".to_owned(),
+                    question: "Which option?".to_owned(),
+                    question_type: AskUserQuestionType::MultipleChoice {
+                        is_multiselect: false,
+                        options: vec![AskUserQuestionOption {
+                            label: "Alpha".to_owned(),
+                            recommended: false,
+                        }],
+                        supports_other: false,
+                    },
+                }],
+            },
+            requires_result: true,
+        };
+
+        let block = materialize_already_blocked_action(&mut app, &session, action);
+        let question = block.read(&app, |block, ctx| {
+            let Some(BlockingInputSource::AskQuestion(view)) =
+                block.active_blocking_input_source(ctx)
+            else {
+                panic!("materialized question should be the active blocker");
+            };
+            view.clone()
+        });
+
+        app.read(|ctx| {
+            assert!(ctx.check_view_or_child_focused(fixture.window_id, &question.id()));
+        });
+    });
+}
+
+#[test]
+fn foreground_session_focuses_an_already_blocked_permission_when_materialized() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (session, _) = add_focus_test_session(&mut app, &fixture, true);
+        let action = AIAgentAction {
+            id: AIAgentActionId::from("late-permission".to_owned()),
+            task_id: TaskId::new("task".to_owned()),
+            action: AIAgentActionType::InitProject,
+            requires_result: true,
+        };
+
+        let block = materialize_already_blocked_action(&mut app, &session, action);
+        let permission = block.read(&app, |block, ctx| {
+            let Some(BlockingInputSource::Permission(view)) =
+                block.active_blocking_input_source(ctx)
+            else {
+                panic!("materialized permission prompt should be the active blocker");
+            };
+            view.clone()
+        });
+
+        app.read(|ctx| {
+            assert!(ctx.check_view_or_child_focused(fixture.window_id, &permission.id()));
+        });
+    });
+}
 fn tab_focused_context() -> Context {
     let mut context = Context::default();
     context.set.insert(super::TuiTerminalSessionView::ui_name());

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -6,6 +6,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use parking_lot::FairMutex;
+#[cfg(test)]
+use warp::tui_export::AIBlockModel;
 use warp::tui_export::{
     AIAgentActionId, AIAgentExchangeId, AIBlockModelImpl, AIConversationId, BlockHeightItem,
     BlockIndex, BlockPadding, BlockSpacing, BlocklistAIActionModel, BlocklistAIHistoryEvent,
@@ -466,6 +468,15 @@ impl TuiTranscriptView {
                 ctx,
             )
         });
+        self.attach_agent_block(view, command_block_index, ctx);
+    }
+
+    fn attach_agent_block(
+        &mut self,
+        view: ViewHandle<TuiAIBlock>,
+        command_block_index: Option<BlockIndex>,
+        ctx: &mut ViewContext<Self>,
+    ) {
         let view_id = view.id();
         ctx.subscribe_to_view(&view, move |transcript, _, event, ctx| match event {
             TuiAIBlockEvent::LayoutInvalidated => {
@@ -492,6 +503,7 @@ impl TuiTranscriptView {
                 );
             }
         });
+        let has_initial_blocker = view.as_ref(ctx).active_blocking_input_source(ctx).is_some();
         self.agent_blocks.borrow_mut().insert(view_id, view);
         let item = RichContentItem::new(Some(RichContentType::AIBlock), view_id, None, false);
         let mut model = self.model.lock();
@@ -501,7 +513,37 @@ impl TuiTranscriptView {
                 .insert_rich_content_before_block_index(item, command_block_index),
             None => model.block_list_mut().append_rich_content(item, false),
         }
+        drop(model);
+        if has_initial_blocker {
+            ctx.emit(TuiTranscriptViewEvent::BlockingStateChanged);
+        }
         ctx.notify();
+    }
+
+    #[cfg(test)]
+    pub(super) fn append_agent_block_for_test(
+        &mut self,
+        conversation_id: AIConversationId,
+        exchange_id: AIAgentExchangeId,
+        block_model: Rc<dyn AIBlockModel<View = TuiAIBlock>>,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<TuiAIBlock> {
+        let action_model = self.action_model.clone();
+        let model_events = self.model_events.clone();
+        let terminal_model = self.model.clone();
+        let view = ctx.add_typed_action_tui_view(|ctx| {
+            TuiAIBlock::new(
+                (conversation_id, exchange_id),
+                block_model,
+                action_model,
+                &model_events,
+                terminal_model,
+                false,
+                ctx,
+            )
+        });
+        self.attach_agent_block(view.clone(), None, ctx);
+        view
     }
 
     /// Materializes a shared restoration plan as TUI agent-block views.

--- a/crates/warp_tui/src/tui_ask_question_view.rs
+++ b/crates/warp_tui/src/tui_ask_question_view.rs
@@ -144,20 +144,11 @@ impl TuiAskQuestionView {
             if event.action_id() != &me.action_id {
                 return;
             }
-            if matches!(
-                event,
-                BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(_)
-            ) {
-                ctx.focus(&me.selector);
-            }
             if matches!(event, BlocklistAIActionEvent::FinishedAction { .. }) {
                 me.abort_auto_advance();
             }
             me.invalidate_layout(ctx);
         });
-        if view.is_waiting_on_answers(ctx) {
-            ctx.focus(&selector);
-        }
         view
     }
 

--- a/crates/warp_tui/src/tui_ask_question_view_tests.rs
+++ b/crates/warp_tui/src/tui_ask_question_view_tests.rs
@@ -12,7 +12,7 @@ use warpui_core::{App, TuiView as _, TypedActionView as _, ViewHandle};
 
 use super::{TuiAskQuestionView, TuiAskQuestionViewAction};
 use crate::option_selector::TuiOptionSelectorAction;
-use crate::test_fixtures::add_test_action_model;
+use crate::test_fixtures::{TestHostView, add_test_action_model};
 
 fn question(
     id: &str,
@@ -112,6 +112,8 @@ fn queue_question_action(app: &mut App, view: &ViewHandle<TuiAskQuestionView>) {
     action_model.update(app, |model, ctx| {
         queue_tui_permission_action(model, action, conversation_id, ctx);
     });
+    let selector = app.read(|ctx| view.as_ref(ctx).selector.clone());
+    selector.update(app, |_, ctx| ctx.focus_self());
 }
 
 fn present_active_view(app: &mut App, view: &ViewHandle<TuiAskQuestionView>) {
@@ -206,6 +208,118 @@ fn focusing_an_active_question_delegates_to_the_selector() {
         view.update(&mut app, |_, ctx| ctx.focus_self());
 
         assert!(app.read(|ctx| selector.is_focused(ctx)));
+    });
+}
+
+#[test]
+fn question_blocking_transition_does_not_replace_existing_focus() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let action_model = add_test_action_model(&mut app);
+        let conversation_id = AIConversationId::new();
+        let action_id = AIAgentActionId::from("background-question".to_owned());
+        let questions = vec![question(
+            "single",
+            "Which shell?",
+            false,
+            false,
+            &["zsh", "fish"],
+        )];
+        let action = AIAgentAction {
+            id: action_id.clone(),
+            task_id: TaskId::new("task".to_owned()),
+            action: AIAgentActionType::AskUserQuestion {
+                questions: questions.clone(),
+            },
+            requires_result: true,
+        };
+        let action_model_for_view = action_model.clone();
+        let (window_id, foreground, _question_view) = app.update(|ctx| {
+            let (window_id, foreground) = ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |_| TestHostView,
+            );
+            let question_view = ctx.add_typed_action_tui_view(window_id, move |ctx| {
+                TuiAskQuestionView::new(
+                    action_model_for_view,
+                    conversation_id,
+                    action_id,
+                    questions,
+                    ctx,
+                )
+            });
+            foreground.update(ctx, |_, ctx| ctx.focus_self());
+            (window_id, foreground, question_view)
+        });
+
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action, conversation_id, ctx);
+        });
+
+        assert_eq!(
+            app.read(|ctx| ctx.focused_view_id(window_id)),
+            Some(foreground.id()),
+            "a blocked question in a background session must not replace foreground focus"
+        );
+    });
+}
+
+#[test]
+fn already_blocked_question_does_not_replace_existing_focus_when_materialized() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let action_model = add_test_action_model(&mut app);
+        let conversation_id = AIConversationId::new();
+        let action_id = AIAgentActionId::from("materialized-background-question".to_owned());
+        let questions = vec![question(
+            "single",
+            "Which shell?",
+            false,
+            false,
+            &["zsh", "fish"],
+        )];
+        let action = AIAgentAction {
+            id: action_id.clone(),
+            task_id: TaskId::new("task".to_owned()),
+            action: AIAgentActionType::AskUserQuestion {
+                questions: questions.clone(),
+            },
+            requires_result: true,
+        };
+        let (window_id, foreground) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |_| TestHostView,
+            )
+        });
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action, conversation_id, ctx);
+        });
+        let action_model_for_view = action_model.clone();
+        app.update(|ctx| {
+            foreground.update(ctx, |_, ctx| ctx.focus_self());
+            ctx.add_typed_action_tui_view(window_id, move |ctx| {
+                TuiAskQuestionView::new(
+                    action_model_for_view,
+                    conversation_id,
+                    action_id,
+                    questions,
+                    ctx,
+                )
+            });
+        });
+
+        assert_eq!(
+            app.read(|ctx| ctx.focused_view_id(window_id)),
+            Some(foreground.id()),
+            "materializing an already-blocked background question must preserve foreground focus"
+        );
     });
 }
 #[test]

--- a/crates/warp_tui/src/tui_file_edits_view_tests.rs
+++ b/crates/warp_tui/src/tui_file_edits_view_tests.rs
@@ -529,6 +529,8 @@ fn e_key_dispatches_toggle_expand_all_on_blocked_card() {
                 ctx,
             );
         });
+        let permission_prompt = app.read(|ctx| view.as_ref(ctx).permission_prompt.clone());
+        permission_prompt.update(&mut app, |_, ctx| ctx.focus_self());
         // Seed two real diffs so ToggleExpandAll operates on actual sections.
         seed_two_file_diffs(&mut app, &view);
 

--- a/crates/warp_tui/src/tui_permission_prompt.rs
+++ b/crates/warp_tui/src/tui_permission_prompt.rs
@@ -148,12 +148,6 @@ impl TuiPermissionPrompt {
             if matches!(
                 event,
                 BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(_)
-            ) {
-                prompt.focus(ctx);
-            }
-            if matches!(
-                event,
-                BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(_)
                     | BlocklistAIActionEvent::ExecutingAction(_)
                     | BlocklistAIActionEvent::FinishedAction { .. }
             ) {

--- a/crates/warp_tui/src/tui_permission_prompt_tests.rs
+++ b/crates/warp_tui/src/tui_permission_prompt_tests.rs
@@ -20,17 +20,24 @@ use crate::editor_view::TuiEditorView;
 use crate::option_selector::{TuiOptionSelectorAction, TuiOptionSelectorEvent};
 use crate::test_fixtures::{TestHostView, add_test_action_model};
 fn add_prompt(app: &mut App, body_editable: bool) -> ViewHandle<TuiPermissionPrompt> {
+    add_prompt_with_host(app, body_editable).1
+}
+
+fn add_prompt_with_host(
+    app: &mut App,
+    body_editable: bool,
+) -> (ViewHandle<TestHostView>, ViewHandle<TuiPermissionPrompt>) {
     app.add_singleton_model(|_| Appearance::mock());
     let action_model = add_test_action_model(app);
     app.update(|ctx| {
-        let (window_id, _) = ctx.add_tui_window(
+        let (window_id, host) = ctx.add_tui_window(
             AddWindowOptions {
                 window_style: WindowStyle::NotStealFocus,
                 ..Default::default()
             },
             |_| TestHostView,
         );
-        ctx.add_typed_action_tui_view(window_id, move |ctx| {
+        let prompt = ctx.add_typed_action_tui_view(window_id, move |ctx| {
             let body_editor =
                 body_editable.then(|| ctx.add_typed_action_tui_view(TuiEditorView::single_line));
             TuiPermissionPrompt::new(
@@ -39,10 +46,14 @@ fn add_prompt(app: &mut App, body_editable: bool) -> ViewHandle<TuiPermissionPro
                 body_editor,
                 ctx,
             )
-        })
+        });
+        (host, prompt)
     })
 }
 
+fn focus_prompt(app: &mut App, prompt: &ViewHandle<TuiPermissionPrompt>) {
+    prompt.update(app, |_, ctx| ctx.focus_self());
+}
 fn dispatch_focused_key(
     app: &mut App,
     prompt: &ViewHandle<TuiPermissionPrompt>,
@@ -147,11 +158,34 @@ fn focusing_an_active_prompt_delegates_to_the_selector() {
         action_model.update(&mut app, |model, ctx| {
             queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
         });
+        focus_prompt(&mut app, &prompt);
         let selector = app.read(|ctx| prompt.as_ref(ctx).selector.clone());
 
         prompt.update(&mut app, |_, ctx| ctx.focus_self());
 
         assert!(app.read(|ctx| selector.is_focused(ctx)));
+    });
+}
+
+#[test]
+fn permission_blocking_transition_does_not_replace_existing_focus() {
+    App::test((), |mut app| async move {
+        let (foreground, prompt) = add_prompt_with_host(&mut app, false);
+        let (action_model, action) = app.read(|ctx| {
+            let prompt = prompt.as_ref(ctx);
+            (prompt.action_model.clone(), pending_action(prompt))
+        });
+        foreground.update(&mut app, |_, ctx| ctx.focus_self());
+
+        action_model.update(&mut app, |model, ctx| {
+            queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
+        });
+
+        assert_eq!(
+            app.read(|ctx| ctx.focused_view_id(prompt.window_id(ctx))),
+            Some(foreground.id()),
+            "a blocked permission prompt in a background session must not replace foreground focus"
+        );
     });
 }
 #[test]
@@ -166,6 +200,7 @@ fn leading_editor_participates_in_selector_focus_cycle() {
         action_model.update(&mut app, |model, ctx| {
             queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
         });
+        focus_prompt(&mut app, &prompt);
         render_lines(&mut app, &prompt);
 
         assert!(dispatch_focused_key(&mut app, &prompt, "up"));
@@ -214,6 +249,7 @@ fn e_focuses_the_body_editor_without_interfering_with_other() {
         action_model.update(&mut app, |model, ctx| {
             queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
         });
+        focus_prompt(&mut app, &prompt);
         let selector = app.read(|ctx| prompt.as_ref(ctx).selector.clone());
         assert!(dispatch_focused_key(&mut app, &prompt, "e"));
         assert!(app.read(|ctx| {
@@ -278,6 +314,7 @@ fn footer_shows_exit_editor_hint_while_body_editor_is_focused() {
         action_model.update(&mut app, |model, ctx| {
             queue_tui_permission_action(model, action, AIConversationId::new(), ctx);
         });
+        focus_prompt(&mut app, &prompt);
         // Focus the body editor via EditBody so body_editor_is_focused returns true.
         dispatch_focused_key(&mut app, &prompt, "e");
         // Render and assert the footer reflects the editor-focus state.


### PR DESCRIPTION
## Description

Prevents background Warp Agent CLI orchestration sessions from taking window focus when a child agent becomes blocked on a question, permission prompt, or handoff.

Passive child-view callbacks no longer focus themselves directly. Instead, blocking-state events bubble to the owning terminal session, whose existing focus reconciler verifies that the session is foreground before delegating focus. Regression tests cover both newly blocked and already-blocked background interactions while preserving foreground interaction behavior.

## Linked Issue

- [QUALITY-1333](https://linear.app/warpdotdev/issue/QUALITY-1333/cannot-exit-a-sub-agent-entered-unintentionally-sub-agent-denies-being)
- [x] The linked Linear issue is in progress.
- [x] Automated focus regressions cover the user-visible behavior.

## Testing

- [x] `./script/presubmit`
  - Formatting, workspace Clippy, clang-format, wgslfmt, and PowerShell analysis passed.
  - 10,815 tests across 92 binaries passed; 87 tests skipped.
- [x] `cargo nextest run -p warp_tui --no-fail-fast`
  - 965/965 tests passed after the review follow-up.
- [x] Focus regression matrix
  - 10/10 targeted tests passed, including late materialization of already-blocked questions and permission prompts through owner notification, transcript propagation, foreground session reconciliation, and WarpUI focus delegation.
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- [x] I have manually tested my changes locally with `./script/run-tui`
  - Launched an authenticated local-channel TUI under tmux and kept the orchestrator selected while a local child blocked on `ask_user_question`.
  - Typed `FOCUS_SENTINEL_14829` into the visible orchestrator composer while the child was blocked; the text remained in the orchestrator input.
  - Switched to the child through the orchestration tab bar and pressed `2`; the focused question selected Beta and completed.
  - Triggered a top-level `sudo -n true` permission card and pressed `2`; the focused prompt selected No and cancelled the command.
  - Local child agents use an unsupervised execution policy, so their shell commands did not sustain a background permission prompt; the background permission path remains covered by deterministic WarpUI tests.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent conversation: https://staging.warp.dev/conversation/26ea7771-9bbe-4e06-b521-2ad343970401

CHANGELOG-BUG-FIX: Fixed background orchestrated agents stealing input focus in Warp Agent CLI when they need user interaction.
CHANGELOG-TUI: Background orchestrated agents no longer take focus away from the session you are using.

Co-Authored-By: Warp <agent@warp.dev>

