### PR TITLE
Avoid Git probes for filesystem-only directory watchers

### DIFF
--- a/app/src/ai/mcp/file_mcp_watcher.rs
+++ b/app/src/ai/mcp/file_mcp_watcher.rs
@@ -8,6 +8,7 @@ use async_channel::Sender;
 use futures::Future;
 use futures::stream::AbortHandle;
 use regex::Regex;
+use repo_metadata::RepositoryWatchMode;
 use repo_metadata::repositories::{
     DetectedRepositories, DetectedRepositoriesEvent, RepoDetectionSource,
 };
@@ -261,6 +262,7 @@ impl FileMCPWatcher {
 
         let start = repo_handle.update(ctx, |repo, ctx| {
             repo.start_watching(
+                RepositoryWatchMode::FilesystemOnly,
                 Box::new(FileMCPSubscriber {
                     stored_dir: repo_path.clone(),
                     message_tx: file_mcp_tx,
@@ -323,7 +325,9 @@ impl FileMCPWatcher {
             stored_dir: home_dir,
             message_tx: file_mcp_tx,
         });
-        let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
+        let start = repo_handle.update(ctx, |repo, ctx| {
+            repo.start_watching(RepositoryWatchMode::FilesystemOnly, subscriber, ctx)
+        });
         let subscriber_id = start.subscriber_id;
         // Store optimistically; removed in the error callback below if registration fails.
         home_provider_watchers.insert(

--- a/app/src/ai/outline/native.rs
+++ b/app/src/ai/outline/native.rs
@@ -11,7 +11,9 @@ use repo_metadata::repositories::{DetectedRepositories, DetectedRepositoriesEven
 use repo_metadata::repository::{
     BufferingRepositorySubscriber, RepositorySubscriber, SubscriberId,
 };
-use repo_metadata::{CanonicalizedPath, DirectoryWatcher, Repository, RepositoryUpdate};
+use repo_metadata::{
+    CanonicalizedPath, DirectoryWatcher, Repository, RepositoryUpdate, RepositoryWatchMode,
+};
 use settings::Setting as _;
 use warp_errors::report_error;
 use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity};
@@ -322,7 +324,11 @@ impl RepoOutlines {
             };
             let debounced =
                 BufferingRepositorySubscriber::new(inner, REPO_WATCHER_DEBOUNCE_DURATION);
-            repo.start_watching(Box::new(debounced), ctx)
+            repo.start_watching(
+                RepositoryWatchMode::FilesystemOnly,
+                Box::new(debounced),
+                ctx,
+            )
         });
         let subscriber_id = start.subscriber_id;
 

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -10,7 +10,10 @@ use async_channel::Sender;
 use futures::future::BoxFuture;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repository::{Repository, SubscriberId};
-use repo_metadata::{DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate};
+use repo_metadata::{
+    DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate,
+    RepositoryWatchMode,
+};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 use watcher::{BulkFilesystemWatcherEvent, HomeDirectoryWatcher, HomeDirectoryWatcherEvent};
@@ -314,7 +317,9 @@ impl SkillWatcher {
         let subscriber = Box::new(ProjectSkillSubscriber {
             message_tx: self.repository_message_tx.clone(),
         });
-        let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
+        let start = repo_handle.update(ctx, |repo, ctx| {
+            repo.start_watching(RepositoryWatchMode::FilesystemOnly, subscriber, ctx)
+        });
         let subscriber_id = start.subscriber_id;
         self.failed_local_project_watchers
             .insert(repo_path.clone(), (repo_handle.clone(), subscriber_id));
@@ -772,7 +777,9 @@ impl SkillWatcher {
             let subscriber = Box::new(SymlinkSkillSubscriber {
                 message_tx: self.repository_message_tx.clone(),
             });
-            let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
+            let start = repo_handle.update(ctx, |repo, ctx| {
+                repo.start_watching(RepositoryWatchMode::FilesystemOnly, subscriber, ctx)
+            });
             let subscriber_id = start.subscriber_id;
             self.symlink_target_watchers
                 .insert(canonical_dir.clone(), (repo_handle.clone(), subscriber_id));
@@ -1018,7 +1025,9 @@ impl SkillWatcher {
             }
         };
 
-        let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
+        let start = repo_handle.update(ctx, |repo, ctx| {
+            repo.start_watching(RepositoryWatchMode::FilesystemOnly, subscriber, ctx)
+        });
         let subscriber_id = start.subscriber_id;
 
         // Store the watcher so it can be cleaned up if the directory is deleted.

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -52,7 +52,7 @@ cfg_if::cfg_if! {
         use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
         use repo_metadata::{
             repository::{RepositorySubscriber, SubscriberId},
-            RepoMetadataError, Repository, RepositoryUpdate,
+            RepoMetadataError, Repository, RepositoryUpdate, RepositoryWatchMode,
         };
         use async_channel::Sender;
         use warpui::ModelHandle;
@@ -976,6 +976,7 @@ impl LocalDiffStateModel {
             async_channel::unbounded();
         let start = new_repository.update(ctx, |new_repository, ctx| {
             new_repository.start_watching(
+                RepositoryWatchMode::GitRepository,
                 Box::new(LocalDiffStateModelRepositorySubscriber {
                     repository_update_tx,
                 }),

--- a/app/src/code_review/git_repo_model/local.rs
+++ b/app/src/code_review/git_repo_model/local.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use async_channel::Sender;
 use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
-use repo_metadata::{Repository, RepositoryUpdate};
+use repo_metadata::{Repository, RepositoryUpdate, RepositoryWatchMode};
 use warpui::r#async::SpawnedFutureHandle;
 use warpui::{Entity, ModelContext, ModelHandle};
 
@@ -55,6 +55,7 @@ impl LocalGitRepoStatusModel {
         let (throttled_tx, throttled_rx) = async_channel::unbounded();
         let start = repository_model.update(ctx, |repo, ctx| {
             repo.start_watching(
+                RepositoryWatchMode::GitRepository,
                 Box::new(GitStatusRepositorySubscriber {
                     repository_update_tx,
                 }),

--- a/crates/ai/src/project_context/global_rules.rs
+++ b/crates/ai/src/project_context/global_rules.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use async_channel::Sender;
 use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
-use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate};
+use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate, RepositoryWatchMode};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use warp_core::safe_warn;
@@ -236,7 +236,9 @@ impl GlobalRules {
 
         let subscriber = Box::new(GlobalRulesRepositorySubscriber { source, update_tx });
 
-        let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
+        let start = repo_handle.update(ctx, |repo, ctx| {
+            repo.start_watching(RepositoryWatchMode::FilesystemOnly, subscriber, ctx)
+        });
         let subscriber_id = start.subscriber_id;
         let subdir_path_owned = subdir_path.to_path_buf();
 

--- a/crates/lsp/src/server_repo_watcher.rs
+++ b/crates/lsp/src/server_repo_watcher.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use async_channel::Sender;
 use lsp_types::FileChangeType;
 use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
-use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate};
+use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate, RepositoryWatchMode};
 use warp_util::standardized_path::StandardizedPath;
 use warpui_core::{ModelContext, SingletonEntity, WeakModelHandle};
 
@@ -83,7 +83,11 @@ impl LspRepoWatcher {
         };
 
         let start = repository.update(ctx, |repo, ctx| {
-            repo.start_watching(Box::new(LspRepoSubscriber { tx }), ctx)
+            repo.start_watching(
+                RepositoryWatchMode::FilesystemOnly,
+                Box::new(LspRepoSubscriber { tx }),
+                ctx,
+            )
         });
 
         let repository_for_spawn = repository.downgrade();

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -52,7 +52,7 @@ pub use entry::{
 };
 // Re-export the local model's event under its original name for backward compatibility.
 pub use local_model::RepositoryMetadataEvent;
-pub use repository::Repository;
+pub use repository::{Repository, RepositoryWatchMode};
 pub use watcher::{DirectoryWatcher, RepositoryUpdate, TargetFile};
 
 #[cfg(not(target_family = "wasm"))]

--- a/crates/repo_metadata/src/repository.rs
+++ b/crates/repo_metadata/src/repository.rs
@@ -49,10 +49,22 @@ pub trait RepositorySubscriber: Send + Sync {
 
 /// A unique identifier for repository subscribers.
 pub type SubscriberId = usize;
+/// Controls which repository changes a subscriber receives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepositoryWatchMode {
+    /// Watch ordinary filesystem content without activating Git metadata tracking.
+    FilesystemOnly,
+    /// Watch filesystem content and Git metadata such as commits, index locks, and upstream refs.
+    GitRepository,
+}
 
 pub struct StartWatching {
     pub subscriber_id: SubscriberId,
     pub registration_future: BoxFuture<'static, Result<(), RepoMetadataError>>,
+}
+struct RepositorySubscription {
+    mode: RepositoryWatchMode,
+    subscriber: Box<dyn RepositorySubscriber>,
 }
 
 /// Model for tracking a code repository that Warp is aware of.
@@ -68,7 +80,7 @@ pub struct Repository {
     /// the `.git` component. `None` when the repo is not a linked worktree.
     common_git_directory: Option<StandardizedPath>,
     /// Collection of subscribers interested in file changes.
-    subscribers: HashMap<SubscriberId, Box<dyn RepositorySubscriber>>,
+    subscribers: HashMap<SubscriberId, RepositorySubscription>,
     /// Counter for generating unique subscriber IDs.
     next_subscriber_id: SubscriberId,
     /// Cached gitignore patterns for this repository.
@@ -77,6 +89,8 @@ pub struct Repository {
     /// Cached loose remote-tracking ref tracked by the active branch.
     #[cfg(feature = "local_fs")]
     tracked_remote_ref: Option<TrackedRemoteRef>,
+    #[cfg(test)]
+    tracked_remote_ref_refresh_count: usize,
 
     task_queue: ModelHandle<TaskQueue>,
 }
@@ -141,6 +155,8 @@ impl Repository {
             gitignores,
             #[cfg(feature = "local_fs")]
             tracked_remote_ref: None,
+            #[cfg(test)]
+            tracked_remote_ref_refresh_count: 0,
             task_queue,
         }
     }
@@ -184,9 +200,11 @@ impl Repository {
     /// Directory registrations can be created from a raw path before git detection completes.
     /// Preserve any metadata already associated with the repository, since later raw-path
     /// registrations must not downgrade a known linked worktree.
+    #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
     pub(super) fn enrich_external_git_directory(
         &mut self,
         external_git_directory: StandardizedPath,
+        ctx: &mut ModelContext<Self>,
     ) {
         if self.external_git_directory.is_some() {
             return;
@@ -194,6 +212,19 @@ impl Repository {
 
         self.common_git_directory = Self::derive_common_git_directory(&external_git_directory);
         self.external_git_directory = Some(external_git_directory);
+
+        #[cfg(feature = "local_fs")]
+        if self.has_git_repository_subscribers() {
+            let git_paths = self.git_watch_paths();
+            if !git_paths.is_empty() {
+                let gitignores = self.gitignores.clone();
+                let registration_future =
+                    DirectoryWatcher::handle(ctx).update(ctx, move |watcher, ctx| {
+                        watcher.start_watching_directories(git_paths, gitignores, ctx)
+                    });
+                ctx.spawn(registration_future, |_, _, _| {});
+            }
+        }
     }
 
     /// Returns the path to the actual `.git` directory for this repository.
@@ -270,10 +301,21 @@ impl Repository {
         notify: bool,
         ctx: &mut ModelContext<Self>,
     ) {
+        if !self.has_git_repository_subscribers() {
+            return;
+        }
+
+        #[cfg(test)]
+        {
+            self.tracked_remote_ref_refresh_count += 1;
+        }
         let root_dir = self.root_dir().to_local_path_lossy();
         ctx.spawn(
             Repository::resolve_tracked_remote_ref(root_dir),
             move |repository, tracked_remote_ref, ctx| {
+                if !repository.has_git_repository_subscribers() {
+                    return;
+                }
                 let tracked_remote_ref_changed =
                     repository.update_tracked_remote_ref(tracked_remote_ref);
                 if notify && tracked_remote_ref_changed {
@@ -286,7 +328,7 @@ impl Repository {
     #[cfg(feature = "local_fs")]
     fn enqueue_remote_ref_update(&mut self, ctx: &mut ModelContext<Self>) {
         let repository_handle = ctx.handle();
-        let subscriber_ids = self.get_subscriber_ids();
+        let subscriber_ids = self.get_git_repository_subscriber_ids();
         let update = RepositoryUpdate {
             remote_ref_updated: true,
             ..Default::default()
@@ -304,8 +346,8 @@ impl Repository {
     }
 
     #[cfg(feature = "local_fs")]
-    fn watch_paths(&self) -> Vec<StandardizedPath> {
-        let mut paths = vec![self.root_dir.clone()];
+    fn git_watch_paths(&self) -> Vec<StandardizedPath> {
+        let mut paths = Vec::new();
         if let Some(external_git_dir) = &self.external_git_directory {
             paths.push(external_git_dir.clone());
         }
@@ -324,6 +366,12 @@ impl Repository {
         paths
     }
 
+    pub(crate) fn has_git_repository_subscribers(&self) -> bool {
+        self.subscribers
+            .values()
+            .any(|subscription| subscription.mode == RepositoryWatchMode::GitRepository)
+    }
+
     /// Returns the current watcher count.
     pub fn watcher_count(&self) -> usize {
         self.subscribers.len()
@@ -336,6 +384,7 @@ impl Repository {
     #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
     pub fn start_watching(
         &mut self,
+        mode: RepositoryWatchMode,
         subscriber: Box<dyn RepositorySubscriber>,
         ctx: &mut ModelContext<Self>,
     ) -> StartWatching {
@@ -344,14 +393,27 @@ impl Repository {
 
         // If this is the first subscriber, we need to start watching the repository
         #[cfg(feature = "local_fs")]
-        let should_start_watching = self.subscribers.is_empty();
+        let should_start_filesystem_watching = self.subscribers.is_empty();
+        #[cfg(feature = "local_fs")]
+        let should_start_git_watching =
+            mode == RepositoryWatchMode::GitRepository && !self.has_git_repository_subscribers();
 
-        self.subscribers.insert(subscriber_id, subscriber);
+        self.subscribers
+            .insert(subscriber_id, RepositorySubscription { mode, subscriber });
 
         #[cfg(feature = "local_fs")]
-        let registration_future: BoxFuture<'static, Result<(), RepoMetadataError>> =
-            if should_start_watching {
-                let directories_to_watch = self.watch_paths();
+        let registration_future: BoxFuture<'static, Result<(), RepoMetadataError>> = {
+            let mut directories_to_watch = Vec::new();
+            if should_start_filesystem_watching {
+                directories_to_watch.push(self.root_dir.clone());
+            }
+            if should_start_git_watching {
+                directories_to_watch.extend(self.git_watch_paths());
+            }
+
+            if directories_to_watch.is_empty() {
+                Box::pin(ready(Ok(())))
+            } else {
                 // Reuse the gitignores we already built at construction so the
                 // watch descend filter doesn't re-read `.gitignore` from disk.
                 let gitignores = self.gitignores.clone();
@@ -361,9 +423,8 @@ impl Repository {
                         watcher.start_watching_directories(directories_to_watch, gitignores, ctx)
                     }),
                 )
-            } else {
-                Box::pin(ready(Ok(())))
-            };
+            }
+        };
 
         #[cfg(not(feature = "local_fs"))]
         let registration_future: BoxFuture<'static, Result<(), RepoMetadataError>> =
@@ -374,7 +435,9 @@ impl Repository {
             queue.enqueue_scan(self_handle, subscriber_id, ctx);
         });
         #[cfg(feature = "local_fs")]
-        self.refresh_tracked_remote_ref(false, ctx);
+        if should_start_git_watching {
+            self.refresh_tracked_remote_ref(false, ctx);
+        }
 
         StartWatching {
             subscriber_id,
@@ -388,11 +451,20 @@ impl Repository {
     /// RepositoryWatcher's set of watched paths.
     #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
     pub fn stop_watching(&mut self, subscriber_id: SubscriberId, ctx: &mut ModelContext<Self>) {
-        let Some(mut subscriber) = self.subscribers.remove(&subscriber_id) else {
+        let Some(mut subscription) = self.subscribers.remove(&subscriber_id) else {
             return;
         };
 
-        subscriber.on_unsubscribe(ctx);
+        subscription.subscriber.on_unsubscribe(ctx);
+
+        #[cfg(feature = "local_fs")]
+        let should_stop_git_watching = subscription.mode == RepositoryWatchMode::GitRepository
+            && !self.has_git_repository_subscribers();
+
+        #[cfg(feature = "local_fs")]
+        if should_stop_git_watching {
+            self.tracked_remote_ref = None;
+        }
 
         if self.subscribers.is_empty() {
             // If this was the last subscriber, notify the RepWatcher to stop watching.
@@ -403,8 +475,22 @@ impl Repository {
 
             #[cfg(feature = "local_fs")]
             {
+                let mut paths = vec![self.root_dir.clone()];
+                if should_stop_git_watching {
+                    paths.extend(self.git_watch_paths());
+                }
                 DirectoryWatcher::handle(ctx).update(ctx, |watcher, ctx| {
-                    for path in self.watch_paths() {
+                    for path in paths {
+                        std::mem::drop(watcher.stop_watching_directory(&path, ctx));
+                    }
+                });
+            }
+        } else {
+            #[cfg(feature = "local_fs")]
+            if should_stop_git_watching {
+                let git_paths = self.git_watch_paths();
+                DirectoryWatcher::handle(ctx).update(ctx, |watcher, ctx| {
+                    for path in git_paths {
                         std::mem::drop(watcher.stop_watching_directory(&path, ctx));
                     }
                 });
@@ -418,9 +504,9 @@ impl Repository {
         subscriber_id: SubscriberId,
         ctx: &mut ModelContext<Self>,
     ) -> Option<Pin<Box<dyn Future<Output = ()> + Send + 'static>>> {
-        if let Some(mut subscriber) = self.subscribers.remove(&subscriber_id) {
-            let future = subscriber.on_scan(self, ctx);
-            self.subscribers.insert(subscriber_id, subscriber);
+        if let Some(mut subscription) = self.subscribers.remove(&subscriber_id) {
+            let future = subscription.subscriber.on_scan(self, ctx);
+            self.subscribers.insert(subscriber_id, subscription);
             Some(future)
         } else {
             None
@@ -435,19 +521,43 @@ impl Repository {
         update: &RepositoryUpdate,
         ctx: &mut ModelContext<Self>,
     ) -> Option<Pin<Box<dyn Future<Output = ()> + Send + 'static>>> {
-        if let Some(mut subscriber) = self.subscribers.remove(&subscriber_id) {
-            let future = subscriber.on_files_updated(self, update, ctx);
-            self.subscribers.insert(subscriber_id, subscriber);
+        if let Some(mut subscription) = self.subscribers.remove(&subscriber_id) {
+            let future = subscription.subscriber.on_files_updated(self, update, ctx);
+            self.subscribers.insert(subscriber_id, subscription);
             Some(future)
         } else {
             None
         }
     }
 
-    /// Returns the subscriber IDs for this repository.
+    /// Returns updates filtered for each subscriber's watch mode.
     #[cfg(feature = "local_fs")]
-    pub(crate) fn get_subscriber_ids(&self) -> Vec<SubscriberId> {
-        self.subscribers.keys().cloned().collect()
+    pub(crate) fn subscriber_updates(
+        &self,
+        update: &RepositoryUpdate,
+    ) -> Vec<(SubscriberId, RepositoryUpdate)> {
+        self.subscribers
+            .iter()
+            .filter_map(|(&subscriber_id, subscription)| {
+                let mut update = update.clone();
+                if subscription.mode == RepositoryWatchMode::FilesystemOnly {
+                    update.commit_updated = false;
+                    update.index_lock_detected = false;
+                    update.remote_ref_updated = false;
+                }
+                (!update.is_empty()).then_some((subscriber_id, update))
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn get_git_repository_subscriber_ids(&self) -> Vec<SubscriberId> {
+        self.subscribers
+            .iter()
+            .filter_map(|(&subscriber_id, subscription)| {
+                (subscription.mode == RepositoryWatchMode::GitRepository).then_some(subscriber_id)
+            })
+            .collect()
     }
 
     /// Checks if a path is gitignored within this repository.

--- a/crates/repo_metadata/src/repository.rs
+++ b/crates/repo_metadata/src/repository.rs
@@ -63,6 +63,7 @@ pub struct StartWatching {
     pub registration_future: BoxFuture<'static, Result<(), RepoMetadataError>>,
 }
 struct RepositorySubscription {
+    #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     mode: RepositoryWatchMode,
     subscriber: Box<dyn RepositorySubscriber>,
 }
@@ -366,6 +367,7 @@ impl Repository {
         paths
     }
 
+    #[cfg(feature = "local_fs")]
     pub(crate) fn has_git_repository_subscribers(&self) -> bool {
         self.subscribers
             .values()

--- a/crates/repo_metadata/src/repository.rs
+++ b/crates/repo_metadata/src/repository.rs
@@ -346,7 +346,7 @@ impl Repository {
     }
 
     #[cfg(feature = "local_fs")]
-    fn git_watch_paths(&self) -> Vec<StandardizedPath> {
+    pub(crate) fn git_watch_paths(&self) -> Vec<StandardizedPath> {
         let mut paths = Vec::new();
         if let Some(external_git_dir) = &self.external_git_directory {
             paths.push(external_git_dir.clone());
@@ -466,35 +466,29 @@ impl Repository {
             self.tracked_remote_ref = None;
         }
 
-        if self.subscribers.is_empty() {
+        let should_stop_filesystem_watching = self.subscribers.is_empty();
+        if should_stop_filesystem_watching {
             // If this was the last subscriber, notify the RepWatcher to stop watching.
             log::debug!(
                 "All subscribers removed for {}, stopping watcher",
                 self.root_dir
             );
+        }
 
-            #[cfg(feature = "local_fs")]
-            {
-                let mut paths = vec![self.root_dir.clone()];
-                if should_stop_git_watching {
-                    paths.extend(self.git_watch_paths());
+        #[cfg(feature = "local_fs")]
+        if should_stop_filesystem_watching || should_stop_git_watching {
+            let root_dir = self.root_dir.clone();
+            let git_paths = if should_stop_git_watching {
+                self.git_watch_paths()
+            } else {
+                Vec::new()
+            };
+            DirectoryWatcher::handle(ctx).update(ctx, |watcher, ctx| {
+                if should_stop_filesystem_watching {
+                    std::mem::drop(watcher.stop_watching_directory(&root_dir, ctx));
                 }
-                DirectoryWatcher::handle(ctx).update(ctx, |watcher, ctx| {
-                    for path in paths {
-                        std::mem::drop(watcher.stop_watching_directory(&path, ctx));
-                    }
-                });
-            }
-        } else {
-            #[cfg(feature = "local_fs")]
-            if should_stop_git_watching {
-                let git_paths = self.git_watch_paths();
-                DirectoryWatcher::handle(ctx).update(ctx, |watcher, ctx| {
-                    for path in git_paths {
-                        std::mem::drop(watcher.stop_watching_directory(&path, ctx));
-                    }
-                });
-            }
+                watcher.stop_watching_unused_git_directories(&root_dir, git_paths, ctx);
+            });
         }
     }
 

--- a/crates/repo_metadata/src/repository_tests.rs
+++ b/crates/repo_metadata/src/repository_tests.rs
@@ -10,7 +10,10 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui_core::r#async::Timer;
 use warpui_core::{App, ModelContext};
 
-use super::{Repository, RepositorySubscriber, TrackedRemoteRef, merge_repository_updates};
+use super::{
+    Repository, RepositorySubscriber, RepositorySubscription, RepositoryWatchMode,
+    TrackedRemoteRef, merge_repository_updates,
+};
 use crate::repositories::stub_git_repository;
 use crate::watcher::DirectoryWatcher;
 use crate::{RepositoryUpdate, TargetFile};
@@ -44,13 +47,19 @@ impl RepositorySubscriber for RecordingSubscriber {
 
 fn add_recording_subscriber(
     repository: &mut Repository,
+    mode: RepositoryWatchMode,
     update_tx: mpsc::UnboundedSender<RepositoryUpdate>,
-) {
+) -> usize {
     let subscriber_id = repository.next_subscriber_id;
     repository.next_subscriber_id += 1;
-    repository
-        .subscribers
-        .insert(subscriber_id, Box::new(RecordingSubscriber { update_tx }));
+    repository.subscribers.insert(
+        subscriber_id,
+        RepositorySubscription {
+            mode,
+            subscriber: Box::new(RecordingSubscriber { update_tx }),
+        },
+    );
+    subscriber_id
 }
 #[test]
 fn tracked_remote_ref_validates_full_ref_names() {
@@ -190,6 +199,198 @@ fn merge_repository_updates_preserves_remote_ref_updates() {
 }
 
 #[test]
+fn filesystem_only_subscription_does_not_activate_git_tracking() {
+    VirtualFS::test(
+        "filesystem_only_subscription_does_not_activate_git_tracking",
+        |dirs, mut vfs| {
+            stub_git_repository(&mut vfs, "repo");
+            let repo_path = dirs.tests().join("repo");
+
+            App::test((), |mut app| async move {
+                let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+                let repo_handle = watcher_handle
+                    .update(&mut app, |watcher, ctx| {
+                        watcher.add_directory(
+                            StandardizedPath::from_local_canonicalized(&repo_path).unwrap(),
+                            ctx,
+                        )
+                    })
+                    .unwrap();
+
+                let (update_tx, _) = mpsc::unbounded::<RepositoryUpdate>();
+                let start = repo_handle.update(&mut app, |repo, ctx| {
+                    repo.start_watching(
+                        RepositoryWatchMode::FilesystemOnly,
+                        Box::new(RecordingSubscriber { update_tx }),
+                        ctx,
+                    )
+                });
+                std::mem::drop(start.registration_future);
+
+                repo_handle.read(&app, |repo, _| {
+                    assert!(!repo.has_git_repository_subscribers());
+                    assert_eq!(repo.tracked_remote_ref_refresh_count, 0);
+                });
+            });
+        },
+    );
+}
+
+#[test]
+fn git_tracking_activates_once_for_concurrent_git_subscriptions() {
+    VirtualFS::test(
+        "git_tracking_activates_once_for_concurrent_git_subscriptions",
+        |dirs, mut vfs| {
+            stub_git_repository(&mut vfs, "repo");
+            let repo_path = dirs.tests().join("repo");
+
+            App::test((), |mut app| async move {
+                let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+                let repo_handle = watcher_handle
+                    .update(&mut app, |watcher, ctx| {
+                        watcher.add_directory(
+                            StandardizedPath::from_local_canonicalized(&repo_path).unwrap(),
+                            ctx,
+                        )
+                    })
+                    .unwrap();
+
+                let mut subscriber_ids = Vec::new();
+                for _ in 0..2 {
+                    let (update_tx, _) = mpsc::unbounded::<RepositoryUpdate>();
+                    let start = repo_handle.update(&mut app, |repo, ctx| {
+                        repo.start_watching(
+                            RepositoryWatchMode::GitRepository,
+                            Box::new(RecordingSubscriber { update_tx }),
+                            ctx,
+                        )
+                    });
+                    subscriber_ids.push(start.subscriber_id);
+                    std::mem::drop(start.registration_future);
+                }
+
+                repo_handle.read(&app, |repo, _| {
+                    assert!(repo.has_git_repository_subscribers());
+                    assert_eq!(repo.tracked_remote_ref_refresh_count, 1);
+                });
+
+                for subscriber_id in subscriber_ids {
+                    repo_handle.update(&mut app, |repo, ctx| {
+                        repo.stop_watching(subscriber_id, ctx);
+                    });
+                }
+
+                repo_handle.read(&app, |repo, _| {
+                    assert!(!repo.has_git_repository_subscribers());
+                    assert!(repo.tracked_remote_ref.is_none());
+                });
+            });
+        },
+    );
+}
+
+#[test]
+fn mixed_watch_modes_filter_git_flags_per_subscriber() {
+    VirtualFS::test(
+        "mixed_watch_modes_filter_git_flags_per_subscriber",
+        |dirs, mut vfs| {
+            stub_git_repository(&mut vfs, "repo");
+            let repo_path = dirs.tests().join("repo");
+
+            App::test((), |mut app| async move {
+                let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+                let repo_handle = watcher_handle
+                    .update(&mut app, |watcher, ctx| {
+                        watcher.add_directory(
+                            StandardizedPath::from_local_canonicalized(&repo_path).unwrap(),
+                            ctx,
+                        )
+                    })
+                    .unwrap();
+
+                let (filesystem_tx, _) = mpsc::unbounded::<RepositoryUpdate>();
+                let (git_tx, _) = mpsc::unbounded::<RepositoryUpdate>();
+                let (filesystem_id, git_id) = repo_handle.update(&mut app, |repo, _| {
+                    (
+                        add_recording_subscriber(
+                            repo,
+                            RepositoryWatchMode::FilesystemOnly,
+                            filesystem_tx,
+                        ),
+                        add_recording_subscriber(repo, RepositoryWatchMode::GitRepository, git_tx),
+                    )
+                });
+                let changed_file = TargetFile::new(repo_path.join("file.txt"), false);
+                let update = RepositoryUpdate {
+                    modified: [changed_file.clone()].into(),
+                    commit_updated: true,
+                    index_lock_detected: true,
+                    remote_ref_updated: true,
+                    ..Default::default()
+                };
+
+                let subscriber_updates =
+                    repo_handle.read(&app, |repo, _| repo.subscriber_updates(&update));
+                let filesystem_update = subscriber_updates
+                    .iter()
+                    .find_map(|(id, update)| (*id == filesystem_id).then_some(update))
+                    .unwrap();
+                let git_update = subscriber_updates
+                    .iter()
+                    .find_map(|(id, update)| (*id == git_id).then_some(update))
+                    .unwrap();
+
+                assert_eq!(filesystem_update.modified, [changed_file.clone()].into());
+                assert!(!filesystem_update.commit_updated);
+                assert!(!filesystem_update.index_lock_detected);
+                assert!(!filesystem_update.remote_ref_updated);
+                assert_eq!(git_update.modified, [changed_file].into());
+                assert!(git_update.commit_updated);
+                assert!(git_update.index_lock_detected);
+                assert!(git_update.remote_ref_updated);
+            });
+        },
+    );
+}
+
+#[test]
+fn filesystem_only_subscription_drops_git_only_updates() {
+    VirtualFS::test(
+        "filesystem_only_subscription_drops_git_only_updates",
+        |dirs, mut vfs| {
+            stub_git_repository(&mut vfs, "repo");
+            let repo_path = dirs.tests().join("repo");
+
+            App::test((), |mut app| async move {
+                let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+                let repo_handle = watcher_handle
+                    .update(&mut app, |watcher, ctx| {
+                        watcher.add_directory(
+                            StandardizedPath::from_local_canonicalized(&repo_path).unwrap(),
+                            ctx,
+                        )
+                    })
+                    .unwrap();
+
+                let (update_tx, _) = mpsc::unbounded::<RepositoryUpdate>();
+                repo_handle.update(&mut app, |repo, _| {
+                    add_recording_subscriber(repo, RepositoryWatchMode::FilesystemOnly, update_tx);
+                });
+                let update = RepositoryUpdate {
+                    commit_updated: true,
+                    ..Default::default()
+                };
+
+                let subscriber_updates =
+                    repo_handle.read(&app, |repo, _| repo.subscriber_updates(&update));
+
+                assert!(subscriber_updates.is_empty());
+            });
+        },
+    );
+}
+
+#[test]
 fn tracked_remote_ref_change_notifies_subscribers() {
     VirtualFS::test("tracked_remote_ref_change_notifies", |dirs, mut vfs| {
         stub_git_repository(&mut vfs, "repo");
@@ -209,7 +410,7 @@ fn tracked_remote_ref_change_notifies_subscribers() {
 
             let (update_tx, mut update_rx) = mpsc::unbounded::<RepositoryUpdate>();
             repo_handle.update(&mut app, |repo, _| {
-                add_recording_subscriber(repo, update_tx);
+                add_recording_subscriber(repo, RepositoryWatchMode::GitRepository, update_tx);
             });
 
             repo_handle.update(&mut app, |repo, ctx| {
@@ -254,7 +455,7 @@ fn unchanged_tracked_remote_ref_does_not_notify_subscribers() {
 
                 let (update_tx, mut update_rx) = mpsc::unbounded::<RepositoryUpdate>();
                 repo_handle.update(&mut app, |repo, _| {
-                    add_recording_subscriber(repo, update_tx);
+                    add_recording_subscriber(repo, RepositoryWatchMode::GitRepository, update_tx);
                 });
 
                 repo_handle.update(&mut app, |repo, _| {

--- a/crates/repo_metadata/src/watcher.rs
+++ b/crates/repo_metadata/src/watcher.rs
@@ -293,8 +293,8 @@ impl DirectoryWatcher {
         if let Some(repository_handle) = self.directories.get(&repository_path).cloned() {
             log::debug!("Using already-registered repository");
             if let Some(external_git_directory) = external_git_directory {
-                repository_handle.update(ctx, |repository, _ctx| {
-                    repository.enrich_external_git_directory(external_git_directory)
+                repository_handle.update(ctx, |repository, ctx| {
+                    repository.enrich_external_git_directory(external_git_directory, ctx)
                 });
             }
             return Ok(repository_handle);
@@ -453,7 +453,12 @@ impl DirectoryWatcher {
         repos_to_refresh_tracked_remote_ref: &mut HashSet<ModelHandle<Repository>>,
         ctx: &ModelContext<Self>,
     ) {
-        let affected = self.find_repos_for_git_event(path, ctx);
+        let mut affected = self.find_repos_for_git_event(path, ctx);
+        affected.retain(|repository| {
+            repository.read(ctx, |repository, _| {
+                repository.has_git_repository_subscribers()
+            })
+        });
         let is_commit = is_commit_related_git_file(path);
         let is_lock = is_index_lock_file(path);
         let is_remote_ref = is_remote_tracking_ref(path);
@@ -609,12 +614,13 @@ impl DirectoryWatcher {
 
         self.processing_queue.update(ctx, |queue, ctx| {
             for (repo_handle, repo_update) in repo_updates {
-                let subscriber_ids = repo_handle.read(ctx, |repo, _| repo.get_subscriber_ids());
-                for subscriber_id in subscriber_ids {
+                let subscriber_updates =
+                    repo_handle.read(ctx, |repo, _| repo.subscriber_updates(&repo_update));
+                for (subscriber_id, subscriber_update) in subscriber_updates {
                     queue.enqueue_incremental_update(
                         repo_handle.downgrade(),
                         subscriber_id,
-                        repo_update.clone(),
+                        subscriber_update,
                         ctx,
                     );
                 }

--- a/crates/repo_metadata/src/watcher.rs
+++ b/crates/repo_metadata/src/watcher.rs
@@ -38,6 +38,8 @@ pub struct DirectoryWatcher {
     /// The filesystem watcher for monitoring changes.
     #[cfg(feature = "local_fs")]
     watcher: Option<ModelHandle<BulkFilesystemWatcher>>,
+    #[cfg(test)]
+    stopped_watching_paths: Vec<StandardizedPath>,
 
     /// Handle to the internal processing queue model that orders scan & update tasks.
     processing_queue: ModelHandle<TaskQueue>,
@@ -73,6 +75,8 @@ impl DirectoryWatcher {
             directories: Default::default(),
             #[cfg(feature = "local_fs")]
             watcher: Some(fs_watcher),
+            #[cfg(test)]
+            stopped_watching_paths: Vec::new(),
             processing_queue,
             force_included_paths: Vec::new(),
         }
@@ -98,6 +102,8 @@ impl DirectoryWatcher {
             directories: Default::default(),
             #[cfg(feature = "local_fs")]
             watcher: Some(fs_watcher),
+            #[cfg(test)]
+            stopped_watching_paths: Vec::new(),
             processing_queue,
             force_included_paths: Vec::new(),
         }
@@ -397,6 +403,8 @@ impl DirectoryWatcher {
         directory_path: &StandardizedPath,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = Result<(), anyhow::Error>> {
+        #[cfg(test)]
+        self.stopped_watching_paths.push(directory_path.clone());
         cfg_if::cfg_if! {
             if #[cfg(feature = "local_fs")] {
                 let local_path = directory_path.to_local_path();
@@ -428,6 +436,29 @@ impl DirectoryWatcher {
                 })
             } else {
                 async { Ok(()) }
+            }
+        }
+    }
+    #[cfg(feature = "local_fs")]
+    pub(crate) fn stop_watching_unused_git_directories(
+        &mut self,
+        repository_root_to_stop: &StandardizedPath,
+        directory_paths: Vec<StandardizedPath>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        for path in directory_paths {
+            let is_still_used = self
+                .directories
+                .iter()
+                .any(|(root_dir, repository_handle)| {
+                    root_dir != repository_root_to_stop
+                        && repository_handle.read(ctx, |repository, _| {
+                            repository.has_git_repository_subscribers()
+                                && repository.git_watch_paths().contains(&path)
+                        })
+                });
+            if !is_still_used {
+                std::mem::drop(self.stop_watching_directory(&path, ctx));
             }
         }
     }

--- a/crates/repo_metadata/src/watcher_tests.rs
+++ b/crates/repo_metadata/src/watcher_tests.rs
@@ -103,6 +103,97 @@ fn test_existing_directory_registration_is_enriched_with_external_git_directory(
         },
     );
 }
+#[test]
+fn test_shared_git_paths_remain_watched_until_last_worktree_stops() {
+    VirtualFS::test("shared_git_paths_remain_watched", |dirs, mut vfs| {
+        stub_git_repository(&mut vfs, "repo");
+        vfs.mkdir("repo/.git/refs");
+        vfs.mkdir("repo/.git/worktrees/worktree-1");
+        vfs.mkdir("repo/.git/worktrees/worktree-2");
+        vfs.mkdir("worktree-1");
+        vfs.mkdir("worktree-2");
+
+        let worktree_1_path = dirs.tests().join("worktree-1");
+        let worktree_2_path = dirs.tests().join("worktree-2");
+        let external_git_dir_1 = dirs.tests().join("repo/.git/worktrees/worktree-1");
+        let external_git_dir_2 = dirs.tests().join("repo/.git/worktrees/worktree-2");
+        let shared_refs_dir = dirs.tests().join("repo/.git/refs");
+        let shared_config = dirs.tests().join("repo/.git/config");
+
+        App::test((), |mut app| async move {
+            let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+            let worktree_1_handle = watcher_handle
+                .update(&mut app, |watcher, ctx| {
+                    watcher.add_directory_with_git_dir(
+                        StandardizedPath::from_local_canonicalized(&worktree_1_path).unwrap(),
+                        Some(
+                            StandardizedPath::from_local_canonicalized(&external_git_dir_1)
+                                .unwrap(),
+                        ),
+                        ctx,
+                    )
+                })
+                .unwrap();
+            let worktree_2_handle = watcher_handle
+                .update(&mut app, |watcher, ctx| {
+                    watcher.add_directory_with_git_dir(
+                        StandardizedPath::from_local_canonicalized(&worktree_2_path).unwrap(),
+                        Some(
+                            StandardizedPath::from_local_canonicalized(&external_git_dir_2)
+                                .unwrap(),
+                        ),
+                        ctx,
+                    )
+                })
+                .unwrap();
+
+            let (scan_tx, _) = mpsc::unbounded();
+            let (update_tx, _) = mpsc::unbounded();
+            let active_tasks = Arc::new(AtomicUsize::new(0));
+            let worktree_1_start = worktree_1_handle.update(&mut app, |repository, ctx| {
+                repository.start_watching(
+                    RepositoryWatchMode::GitRepository,
+                    Box::new(TestSubscriber::new(
+                        scan_tx.clone(),
+                        update_tx.clone(),
+                        active_tasks.clone(),
+                    )),
+                    ctx,
+                )
+            });
+            let worktree_2_start = worktree_2_handle.update(&mut app, |repository, ctx| {
+                repository.start_watching(
+                    RepositoryWatchMode::GitRepository,
+                    Box::new(TestSubscriber::new(scan_tx, update_tx, active_tasks)),
+                    ctx,
+                )
+            });
+            std::mem::drop(worktree_1_start.registration_future);
+            std::mem::drop(worktree_2_start.registration_future);
+
+            worktree_1_handle.update(&mut app, |repository, ctx| {
+                repository.stop_watching(worktree_1_start.subscriber_id, ctx);
+            });
+
+            let shared_refs_dir =
+                StandardizedPath::from_local_canonicalized(&shared_refs_dir).unwrap();
+            let shared_config = StandardizedPath::from_local_canonicalized(&shared_config).unwrap();
+            watcher_handle.read(&app, |watcher, _| {
+                assert!(!watcher.stopped_watching_paths.contains(&shared_refs_dir));
+                assert!(!watcher.stopped_watching_paths.contains(&shared_config));
+            });
+
+            worktree_2_handle.update(&mut app, |repository, ctx| {
+                repository.stop_watching(worktree_2_start.subscriber_id, ctx);
+            });
+
+            watcher_handle.read(&app, |watcher, _| {
+                assert!(watcher.stopped_watching_paths.contains(&shared_refs_dir));
+                assert!(watcher.stopped_watching_paths.contains(&shared_config));
+            });
+        });
+    });
+}
 
 #[test]
 fn test_add_repository_non_existent() {

--- a/crates/repo_metadata/src/watcher_tests.rs
+++ b/crates/repo_metadata/src/watcher_tests.rs
@@ -13,7 +13,7 @@ use warpui_core::r#async::Timer;
 use warpui_core::{App, ModelContext, ModelHandle};
 
 use crate::repositories::stub_git_repository;
-use crate::repository::{RepositorySubscriber, TrackedRemoteRef};
+use crate::repository::{RepositorySubscriber, RepositoryWatchMode, TrackedRemoteRef};
 use crate::watcher::{DirectoryWatcher, TaskQueue};
 use crate::{CanonicalizedPath, RepoMetadataError, Repository, RepositoryUpdate};
 
@@ -249,7 +249,11 @@ fn test_task_queue_processes_all_tasks() {
                     TestSubscriber::new(scan_tx.clone(), update_tx.clone(), active_tasks.clone());
 
                 let start = repo1_handle.update(&mut app, |repo, ctx| {
-                    repo.start_watching(Box::new(subscriber1), ctx)
+                    repo.start_watching(
+                        RepositoryWatchMode::FilesystemOnly,
+                        Box::new(subscriber1),
+                        ctx,
+                    )
                 });
                 start
                     .registration_future
@@ -257,7 +261,11 @@ fn test_task_queue_processes_all_tasks() {
                     .expect("Failed to add subscriber");
 
                 let start = repo2_handle.update(&mut app, |repo, ctx| {
-                    repo.start_watching(Box::new(subscriber2), ctx)
+                    repo.start_watching(
+                        RepositoryWatchMode::FilesystemOnly,
+                        Box::new(subscriber2),
+                        ctx,
+                    )
                 });
                 start
                     .registration_future
@@ -319,7 +327,11 @@ fn test_scan_queue_handles_nonexistent_subscriber() {
             let subscriber = TestSubscriber::new(tx, update_tx, active_scans.clone());
 
             std::mem::drop(repo_handle.update(&mut app, |repo, ctx| {
-                repo.start_watching(Box::new(subscriber), ctx)
+                repo.start_watching(
+                    RepositoryWatchMode::FilesystemOnly,
+                    Box::new(subscriber),
+                    ctx,
+                )
             }));
 
             // Wait for processing to complete
@@ -372,7 +384,11 @@ fn test_file_updates_delivered() {
                 let subscriber =
                     TestSubscriber::new(scan_tx.clone(), update_tx.clone(), task_count.clone());
                 let start = repo_handle.update(&mut app, |repo, ctx| {
-                    repo.start_watching(Box::new(subscriber), ctx)
+                    repo.start_watching(
+                        RepositoryWatchMode::FilesystemOnly,
+                        Box::new(subscriber),
+                        ctx,
+                    )
                 });
                 start
                     .registration_future
@@ -609,7 +625,11 @@ fn test_commit_related_files_excluded_from_update_lists() {
 
             log::info!("Start setting up watcher");
             let start = repo_handle.update(&mut app, |repo, ctx| {
-                repo.start_watching(Box::new(subscriber), ctx)
+                repo.start_watching(
+                    RepositoryWatchMode::GitRepository,
+                    Box::new(subscriber),
+                    ctx,
+                )
             });
             start
                 .registration_future

--- a/crates/warp_files/src/lib.rs
+++ b/crates/warp_files/src/lib.rs
@@ -21,7 +21,7 @@ use notify_debouncer_full::notify::{RecursiveMode, WatchFilter};
 use remote_server::manager::RemoteServerManager;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
-use repo_metadata::{CanonicalizedPath, Repository, RepositoryUpdate};
+use repo_metadata::{CanonicalizedPath, Repository, RepositoryUpdate, RepositoryWatchMode};
 use warp_core::HostId;
 use warp_util::content_version::ContentVersion;
 use warp_util::file::{FileId, FileLoadError, FileSaveError};
@@ -963,6 +963,7 @@ impl FileModel {
         let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
         let start = repository.update(ctx, |repo, ctx| {
             repo.start_watching(
+                RepositoryWatchMode::FilesystemOnly,
                 Box::new(FileRepositorySubscriber {
                     repository_update_tx,
                 }),


### PR DESCRIPTION
## Description

Fixes a startup process storm where filesystem-only `DirectoryWatcher` consumers could launch Git upstream probes for every watched directory. Global skill installations with many symlink-resolved skill directories could therefore create hundreds of concurrent `git rev-parse --symbolic-full-name @{u}` processes, affecting both desktop Warp and Warp Agent CLI.

This adds explicit per-subscriber `RepositoryWatchMode::{FilesystemOnly, GitRepository}` modes. Shared repository handles now activate Git metadata tracking only while at least one Git-aware subscriber exists, resolve the tracked upstream once per activation, and filter Git-only updates from filesystem-only consumers. Skills, MCP, LSP, global rules, outlines, and file autoreload use filesystem-only mode; code-review diff state and Git status retain Git-aware behavior.

Regression tests cover filesystem-only probe suppression, one-time Git activation, deactivation, mixed-mode update filtering, and Git-only update suppression.

## Linked Issue

Internal bug report; no linked public issue.

## Testing

- `./script/presubmit` — passed, including full formatting, Clippy, unit/integration tests, and doctests.
- Local `cargo nextest run -p repo_metadata --features local_fs` — 135 passed, 2 skipped.
- Local `cargo check -p warp --lib` — passed.
- Targeted rerun of the five environment-dependent SSH integration tests — 5 passed.

### Cloud verification

Verified exact commit `e60ad6384918917bc405237af0c7c8d78e5d2073` on Linux x86_64 (8 CPUs):

- `cargo nextest run -p repo_metadata --features local_fs` — 135 passed, 2 pre-existing ignored tests skipped.
- `cargo check -p warp_tui` — passed with 0 warnings/errors.
- `cargo check -p repo_metadata` without `local_fs` — passed.
- Static audit — all 11 production subscriptions pass an explicit mode; exactly 9 use `FilesystemOnly` and the intended code-review diff/status consumers use `GitRepository`.
- Checkout remained clean; no cloud-side changes were created.

The installed Oz CLI did not expose runner discovery, so an exact Intel macOS cloud runner could not be selected without guessing an ID.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not applicable; this changes repository/filesystem watcher behavior without a visual UI change.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent artifacts

- [Conversation](https://staging.warp.dev/conversation/c0f3c219-89ab-4316-bf95-68df75b320bd)
- [Implementation plan](https://staging.warp.dev/drive/notebook/obpTQZwzdFwIMt7nE8zGpH)

CHANGELOG-BUG-FIX: Fixed excessive Git process creation when loading global skills.
CHANGELOG-TUI: Fixed excessive Git process creation when loading global skills.

Co-Authored-By: Warp <agent@warp.dev>