### PR TITLE
Display the correct text in the environment selector when no environment is specified

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -247,7 +247,9 @@ impl EnvironmentSelector {
 
         let environments = CloudEnvironmentCatalog::handle(ctx);
         ctx.subscribe_to_model(&environments, |me, _, _, ctx| {
-            me.ensure_default_selection(ctx);
+            if me.should_auto_select_default_environment(ctx) {
+                me.ensure_default_selection(ctx);
+            }
             me.refresh_menu(ctx);
             me.refresh_button(ctx);
             ctx.notify();
@@ -269,7 +271,10 @@ impl EnvironmentSelector {
                             if !me.is_configuring(ctx) {
                                 me.set_menu_visibility(false, ctx);
                             }
-                            me.ensure_default_selection(ctx);
+
+                            if me.should_auto_select_default_environment(ctx) {
+                                me.ensure_default_selection(ctx);
+                            }
                             me.refresh_menu(ctx);
                         }
                         HandoffComposeStateEvent::EnvironmentSelected => {
@@ -290,7 +295,9 @@ impl EnvironmentSelector {
         };
         me.refresh_menu(ctx);
         me.refresh_button(ctx);
-        me.ensure_default_selection(ctx);
+        if me.should_auto_select_default_environment(ctx) {
+            me.ensure_default_selection(ctx);
+        }
         me
     }
 
@@ -344,6 +351,15 @@ impl EnvironmentSelector {
         ctx.notify();
     }
 
+    fn should_auto_select_default_environment(&self, ctx: &AppContext) -> bool {
+        match &self.target {
+            EnvironmentSelectorTarget::CloudPane(model) => {
+                model.as_ref(ctx).is_configuring_ambient_agent()
+            }
+            EnvironmentSelectorTarget::Handoff(state) => state.as_ref(ctx).is_active(),
+        }
+    }
+
     /// Ensures a default environment is selected if none is currently selected.
     fn ensure_default_selection(&mut self, ctx: &mut ViewContext<Self>) {
         let current_selection = self.target.selected_environment_id(ctx);
@@ -384,17 +400,19 @@ impl EnvironmentSelector {
     }
 
     fn refresh_button(&mut self, ctx: &mut ViewContext<Self>) {
+        let is_configuring = self.is_configuring(ctx);
+
         let label = if let Some(id) = self.target.selected_environment_id(ctx) {
             self.environments
                 .as_ref(ctx)
                 .environment(id)
                 .map(|environment| environment.name.clone())
                 .unwrap_or_else(|| "New environment".to_string())
-        } else {
+        } else if is_configuring {
             "New environment".to_string()
+        } else {
+            "No environment selected".to_string()
         };
-
-        let is_configuring = self.is_configuring(ctx);
 
         self.button.update(ctx, |button, ctx| {
             button.set_label(label, ctx);

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -247,9 +247,7 @@ impl EnvironmentSelector {
 
         let environments = CloudEnvironmentCatalog::handle(ctx);
         ctx.subscribe_to_model(&environments, |me, _, _, ctx| {
-            if me.should_auto_select_default_environment(ctx) {
-                me.ensure_default_selection(ctx);
-            }
+            me.auto_select_default_environment_if_new_session(ctx);
             me.refresh_menu(ctx);
             me.refresh_button(ctx);
             ctx.notify();
@@ -272,9 +270,7 @@ impl EnvironmentSelector {
                                 me.set_menu_visibility(false, ctx);
                             }
 
-                            if me.should_auto_select_default_environment(ctx) {
-                                me.ensure_default_selection(ctx);
-                            }
+                            me.auto_select_default_environment_if_new_session(ctx);
                             me.refresh_menu(ctx);
                         }
                         HandoffComposeStateEvent::EnvironmentSelected => {
@@ -295,9 +291,7 @@ impl EnvironmentSelector {
         };
         me.refresh_menu(ctx);
         me.refresh_button(ctx);
-        if me.should_auto_select_default_environment(ctx) {
-            me.ensure_default_selection(ctx);
-        }
+        me.auto_select_default_environment_if_new_session(ctx);
         me
     }
 
@@ -349,6 +343,12 @@ impl EnvironmentSelector {
         }
         ctx.emit(EnvironmentSelectorEvent::MenuVisibilityChanged { open: is_open });
         ctx.notify();
+    }
+
+    fn auto_select_default_environment_if_new_session(&self, ctx: &AppContext) -> bool {
+        if self.should_auto_select_default_environment(ctx) {
+            self.ensure_default_selection(ctx);
+        }
     }
 
     fn should_auto_select_default_environment(&self, ctx: &AppContext) -> bool {
@@ -409,9 +409,9 @@ impl EnvironmentSelector {
                 .map(|environment| environment.name.clone())
                 .unwrap_or_else(|| "New environment".to_string())
         } else if is_configuring {
-            "New environment".to_string()
+            "Choose an environment".to_string()
         } else {
-            "No environment selected".to_string()
+            "Empty environment".to_string()
         };
 
         self.button.update(ctx, |button, ctx| {

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -409,7 +409,7 @@ impl EnvironmentSelector {
                 .map(|environment| environment.name.clone())
                 .unwrap_or_else(|| "New environment".to_string())
         } else if is_configuring {
-            "Choose an environment".to_string()
+            "New environment".to_string()
         } else {
             "Empty environment".to_string()
         };

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -345,7 +345,7 @@ impl EnvironmentSelector {
         ctx.notify();
     }
 
-    fn auto_select_default_environment_if_new_session(&self, ctx: &AppContext) -> bool {
+    fn auto_select_default_environment_if_new_session(&mut self, ctx: &mut ViewContext<Self>) {
         if self.should_auto_select_default_environment(ctx) {
             self.ensure_default_selection(ctx);
         }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

### Problem

Two problems are fixed by this pull request:
- Before the environment data is hydrated, it displays "New Environment", even on completed agent runs
- Once hydrated, the environment selector in the footer displayed the default environment instead of "No environment selected" when no environment is selected. This actually reflects the updated state once the environment catalog is loaded from the backend

### Solution

- Only auto-select the default environment when:
    - Handing off a session without a specified environment to a cloud agent
    - Configuring a new session
- Only show "New Environment" if the session is being configured

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->

https://linear.app/warpdotdev/issue/REV-1926/warp-on-web-footer-shows-wrong-environment-for-empty-environment-cloud

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/wasm/run`



### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

- Existing sessions without an environment show "No environment selected"
https://www.loom.com/share/893ed180ad9045509f708a71f7d9918f

- Environment selector auto-selects default environment when it is available 
https://www.loom.com/share/bc76517f3f5f45398719698ce687567c

- Selected env still displays
<img width="819" height="474" alt="Screenshot 2026-08-07 at 6 36 27 PM" src="https://github.com/user-attachments/assets/b6ab4feb-0991-44e2-bec3-ad654c9f6ed4" />

<!--
## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Warp on Web displays incorrect environment when no environment is selected
-->
