### PR TITLE
Clone the Factory definition repo as a run-scoped setup command

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2455,10 +2455,14 @@ impl AgentDriver {
         let additional_source_repos = foreground
             .spawn(|me, _| me.additional_source_repos.clone())
             .await?;
-        let setup_commands = environment_opt
+        let mut setup_commands = environment_opt
             .as_ref()
             .map(|environment| environment.setup_commands.clone())
             .unwrap_or_default();
+        // The Factory definition checkout is run-scoped: the dispatch decides
+        // whether this run gets one by attaching the clone variables,
+        // independent of which environment the run executes in.
+        environment::prepend_factory_definition_clone(&mut setup_commands);
         let source_repos = environment::merge_repos_deduped(
             environment_opt
                 .as_ref()
@@ -2467,7 +2471,7 @@ impl AgentDriver {
             additional_source_repos,
         )?;
 
-        if environment_opt.is_some() || !source_repos.is_empty() {
+        if environment_opt.is_some() || !source_repos.is_empty() || !setup_commands.is_empty() {
             log::info!("Loading environment...");
             environment_skill_repos = source_repos.clone();
 

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -147,6 +147,52 @@ pub(super) fn merge_repos_deduped(
     Ok(merged)
 }
 
+/// Environment variable carrying the authenticated remote URL of a Factory's
+/// code.storage definition repository. Attached to the run by the server only
+/// for Factory-agent runs.
+const FACTORY_REPO_CLONE_URL_ENV_VAR: &str = "WARP_FACTORY_REPO_CLONE_URL";
+
+/// Environment variable carrying the directory, relative to the working
+/// directory, that the Factory definition repository is cloned into.
+const FACTORY_REPO_DIR_ENV_VAR: &str = "WARP_FACTORY_REPO_DIR";
+
+/// Prepends the setup command that clones a Factory's definition repository
+/// when the dispatch attached the clone variables to this run, so the checkout
+/// exists before user-declared setup commands run.
+pub(super) fn prepend_factory_definition_clone(setup_commands: &mut Vec<String>) {
+    let clone_url = std::env::var(FACTORY_REPO_CLONE_URL_ENV_VAR).unwrap_or_default();
+    let clone_dir = std::env::var(FACTORY_REPO_DIR_ENV_VAR).unwrap_or_default();
+    prepend_factory_definition_clone_for_values(&clone_url, &clone_dir, setup_commands);
+}
+
+fn prepend_factory_definition_clone_for_values(
+    clone_url: &str,
+    clone_dir: &str,
+    setup_commands: &mut Vec<String>,
+) {
+    if clone_url.trim().is_empty() || clone_dir.trim().is_empty() {
+        return;
+    }
+    // Environments provisioned before run-scoped cloning still persist their
+    // own copy of the clone command; leave that copy in charge rather than
+    // attempting the checkout twice.
+    if setup_commands
+        .iter()
+        .any(|command| command.contains(FACTORY_REPO_CLONE_URL_ENV_VAR))
+    {
+        return;
+    }
+    // The command expands the variables in the session shell instead of
+    // inlining their values so the credential-bearing URL never appears in
+    // command text, and the existence guard makes it idempotent.
+    setup_commands.insert(
+        0,
+        format!(
+            "[ -e \"${FACTORY_REPO_DIR_ENV_VAR}\" ] || git clone \"${FACTORY_REPO_CLONE_URL_ENV_VAR}\" \"${FACTORY_REPO_DIR_ENV_VAR}\""
+        ),
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn prepare_environment_impl(
     spawner: &ModelSpawner<TerminalDriver>,

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -614,3 +614,42 @@ fn no_checkout_ref_leaves_clone_on_default_branch() {
         fixture.base_sha
     );
 }
+
+#[test]
+fn factory_clone_is_prepended_when_clone_values_are_present() {
+    let mut setup_commands = vec!["make setup".to_string()];
+    super::prepend_factory_definition_clone_for_values(
+        "https://t:token@org.code.storage/team/factory.git",
+        "acme_factory_repo",
+        &mut setup_commands,
+    );
+    assert_eq!(
+        setup_commands,
+        vec![
+            "[ -e \"$WARP_FACTORY_REPO_DIR\" ] || git clone \"$WARP_FACTORY_REPO_CLONE_URL\" \"$WARP_FACTORY_REPO_DIR\"".to_string(),
+            "make setup".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn factory_clone_is_skipped_without_clone_values() {
+    let mut setup_commands = vec!["make setup".to_string()];
+    super::prepend_factory_definition_clone_for_values("", "", &mut setup_commands);
+    super::prepend_factory_definition_clone_for_values("url", "  ", &mut setup_commands);
+    super::prepend_factory_definition_clone_for_values("  ", "dir", &mut setup_commands);
+    assert_eq!(setup_commands, vec!["make setup".to_string()]);
+}
+
+#[test]
+fn factory_clone_defers_to_a_persisted_environment_copy() {
+    let persisted =
+        "git clone \"$WARP_FACTORY_REPO_CLONE_URL\" \"$WARP_FACTORY_REPO_DIR\"".to_string();
+    let mut setup_commands = vec![persisted.clone(), "make setup".to_string()];
+    super::prepend_factory_definition_clone_for_values(
+        "https://t:token@org.code.storage/team/factory.git",
+        "acme_factory_repo",
+        &mut setup_commands,
+    );
+    assert_eq!(setup_commands, vec![persisted, "make setup".to_string()]);
+}


### PR DESCRIPTION
## Description
Makes the Factory definition-repo checkout **run-scoped** instead of environment-persisted.

**What:** When a dispatch attaches `WARP_FACTORY_REPO_CLONE_URL` / `WARP_FACTORY_REPO_DIR` to a run (which warp-server does only for Factory-agent runs), the agent driver now prepends a guarded clone ahead of the environment's setup commands:

```
[ -e "$WARP_FACTORY_REPO_DIR" ] || git clone "$WARP_FACTORY_REPO_CLONE_URL" "$WARP_FACTORY_REPO_DIR"
```

**Why:** Today the clone command is persisted into the Factory's *managed* environment's `setup_commands` by the server-side projector. That design has two defects:
- Factories whose default environment is **external** (user-owned, declared via `agentDefaults.environmentId` in factory.yaml) never get the clone command — the projector must not rewrite a user-owned environment — so those runs silently get no definition checkout and no skills.
- The persisted command runs for **every** run in the environment, including non-Factory runs where the env vars are absent (`git clone "" ""` setup failures; mitigated server-side by making the persisted command self-guarding).

**How:** The prepend is keyed purely off the presence of the per-run env vars, so "is this a Factory run" is decided by the dispatch, independent of which environment the run uses. Three safety properties:
- The command expands the variables in the session shell, so the credential-bearing clone URL never appears in command text.
- `[ -e ]` makes it idempotent.
- If the environment still persists its own copy of the clone command (all managed environments today), the driver defers to it — no double clone. This makes rollout order-independent; once this ships broadly, the server-side projector stamping can be removed and reconciles will strip the persisted copies (follow-up in warp-server).

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

No linked issue — this fixes a defect found during a QA pass of the Factory code.storage feature (see warp-server PR #14136 review thread).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

Unit tests (`cargo nextest run -p warp -E 'test(factory_clone)'`, all passing after merging master):
- `factory_clone_is_prepended_when_clone_values_are_present`
- `factory_clone_is_skipped_without_clone_values`
- `factory_clone_defers_to_a_persisted_environment_copy`

End-to-end verification against a local oz-local stack (direct worker backend, code.storage-backed factory `uT0VjUDyDFmuEeNE1ZJqlH`):
1. Rebuilt the WarpLocal debug bundle from this branch and pointed the local worker's `--oz-path` at it.
2. Simulated the post-cleanup state by setting the factory's managed environment to `"setup_commands": []` in the local DB (verified before and after the run — the environment persisted **no** clone command at any point).
3. Dispatched a run as the factory's foreman agent into that environment; run SUCCEEDED.
4. Proof the run-scoped clone performed the checkout:
   - `qa-storage-test_factory_repo/.git` created at 11:05:26 during the run (task claimed 11:05:12), with `origin` = `https://t:<jwt>@warp-local.code.storage/UwFjztsVETHaLyHFs8jJyy/uT0VjUDyDFmuEeNE1ZJqlH.git` and HEAD at the definition repo's latest commit.
   - The agent reported all 5 factory skills (`code-review`, `github`, `linear`, `slack`, `ui-verification`) injected into context with run-scoped absolute paths under the per-run workspace.
   - `cargo clippy -p warp --all-targets -- -D warnings` and `./script/format` clean.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
