### PR TITLE
[APP-3185] Kill generator process groups on cancellation

### DIFF
--- a/app/src/terminal/model/session/command_executor/local_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor.rs
@@ -29,6 +29,8 @@ fn terminate_process_group(process_group_id: u32) {
         }
     }
 }
+#[cfg(not(unix))]
+fn terminate_process_group(_: u32) {}
 
 #[derive(Debug, Default)]
 struct ActiveProcessGroups {
@@ -68,12 +70,9 @@ impl ActiveProcessGroups {
     }
 
     fn cancel(&self, process_group: &Arc<ActiveProcessGroup>) {
-        if !self.remove(process_group) {
-            return;
+        if self.remove(process_group) {
+            terminate_process_group(process_group.id);
         }
-
-        #[cfg(unix)]
-        terminate_process_group(process_group.id);
     }
 
     fn cancel_all(&self) {

--- a/app/src/terminal/model/session/command_executor/local_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor.rs
@@ -90,33 +90,31 @@ impl ActiveProcessGroups {
 }
 
 struct SpawnedChildCleanup {
-    process_group: Arc<ActiveProcessGroup>,
+    process_group: Option<Arc<ActiveProcessGroup>>,
     active_process_groups: Arc<ActiveProcessGroups>,
-    armed: bool,
 }
 
 impl SpawnedChildCleanup {
     fn new(process_group_id: u32, active_process_groups: Arc<ActiveProcessGroups>) -> Self {
         let process_group = active_process_groups.register(process_group_id);
         Self {
-            process_group,
+            process_group: Some(process_group),
             active_process_groups,
-            armed: true,
         }
     }
 
-    fn disarm(mut self) {
-        self.active_process_groups.complete(&self.process_group);
-        self.armed = false;
+    fn complete(mut self) {
+        if let Some(process_group) = self.process_group.take() {
+            self.active_process_groups.complete(&process_group);
+        }
     }
 }
 
 impl Drop for SpawnedChildCleanup {
     fn drop(&mut self) {
-        if !self.armed {
-            return;
+        if let Some(process_group) = self.process_group.take() {
+            self.active_process_groups.cancel(&process_group);
         }
-        self.active_process_groups.cancel(&self.process_group);
     }
 }
 
@@ -319,7 +317,7 @@ impl LocalCommandExecutor {
                 anyhow!(e)
             });
         if output.is_ok() {
-            child_cleanup.disarm();
+            child_cleanup.complete();
         }
         output
     }

--- a/app/src/terminal/model/session/command_executor/local_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -30,24 +30,83 @@ fn terminate_process_group(process_group_id: u32) {
     }
 }
 
+#[derive(Debug, Default)]
+struct ActiveProcessGroups {
+    process_groups: Mutex<HashMap<u32, Arc<ActiveProcessGroup>>>,
+}
+
+#[derive(Debug)]
+struct ActiveProcessGroup {
+    id: u32,
+}
+
+impl ActiveProcessGroups {
+    fn register(&self, process_group_id: u32) -> Arc<ActiveProcessGroup> {
+        let process_group = Arc::new(ActiveProcessGroup {
+            id: process_group_id,
+        });
+        self.process_groups
+            .lock()
+            .insert(process_group_id, process_group.clone());
+        process_group
+    }
+
+    fn remove(&self, process_group: &Arc<ActiveProcessGroup>) -> bool {
+        let mut process_groups = self.process_groups.lock();
+        if !process_groups
+            .get(&process_group.id)
+            .is_some_and(|active| Arc::ptr_eq(active, process_group))
+        {
+            return false;
+        }
+        process_groups.remove(&process_group.id);
+        true
+    }
+
+    fn complete(&self, process_group: &Arc<ActiveProcessGroup>) {
+        self.remove(process_group);
+    }
+
+    fn cancel(&self, process_group: &Arc<ActiveProcessGroup>) {
+        if !self.remove(process_group) {
+            return;
+        }
+
+        #[cfg(unix)]
+        terminate_process_group(process_group.id);
+    }
+
+    fn cancel_all(&self) {
+        let process_groups = self
+            .process_groups
+            .lock()
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for process_group in process_groups {
+            self.cancel(&process_group);
+        }
+    }
+}
+
 struct SpawnedChildCleanup {
-    child_pid: u32,
-    spawned_children_pids: Arc<Mutex<HashSet<u32>>>,
+    process_group: Arc<ActiveProcessGroup>,
+    active_process_groups: Arc<ActiveProcessGroups>,
     armed: bool,
 }
 
 impl SpawnedChildCleanup {
-    fn new(child_pid: u32, spawned_children_pids: Arc<Mutex<HashSet<u32>>>) -> Self {
-        spawned_children_pids.lock().insert(child_pid);
+    fn new(process_group_id: u32, active_process_groups: Arc<ActiveProcessGroups>) -> Self {
+        let process_group = active_process_groups.register(process_group_id);
         Self {
-            child_pid,
-            spawned_children_pids,
+            process_group,
+            active_process_groups,
             armed: true,
         }
     }
 
     fn disarm(mut self) {
-        self.spawned_children_pids.lock().remove(&self.child_pid);
+        self.active_process_groups.complete(&self.process_group);
         self.armed = false;
     }
 }
@@ -57,12 +116,7 @@ impl Drop for SpawnedChildCleanup {
         if !self.armed {
             return;
         }
-
-        let mut spawned_children_pids = self.spawned_children_pids.lock();
-        if spawned_children_pids.remove(&self.child_pid) {
-            #[cfg(unix)]
-            terminate_process_group(self.child_pid);
-        }
+        self.active_process_groups.cancel(&self.process_group);
     }
 }
 
@@ -119,7 +173,7 @@ pub struct LocalCommandExecutor {
     local_shell_path: Option<PathBuf>,
     shell_type: ShellType,
 
-    spawned_children_pids: Arc<Mutex<HashSet<u32>>>,
+    active_process_groups: Arc<ActiveProcessGroups>,
 }
 
 impl LocalCommandExecutor {
@@ -127,7 +181,7 @@ impl LocalCommandExecutor {
         Self {
             local_shell_path,
             shell_type,
-            spawned_children_pids: Arc::new(Mutex::new(HashSet::new())),
+            active_process_groups: Arc::default(),
         }
     }
 
@@ -251,7 +305,7 @@ impl LocalCommandExecutor {
             .spawn()?;
 
         let child_cleanup =
-            SpawnedChildCleanup::new(child.id(), self.spawned_children_pids.clone());
+            SpawnedChildCleanup::new(child.id(), self.active_process_groups.clone());
 
         let output = child
             .output()
@@ -299,14 +353,6 @@ impl CommandExecutor for LocalCommandExecutor {
     }
 
     fn cancel_active_commands(&self) {
-        let mut spawned_children_pids = self.spawned_children_pids.lock();
-        for child_pid in spawned_children_pids.drain() {
-            #[cfg(unix)]
-            terminate_process_group(child_pid);
-
-            // TODO(roland): handle for windows
-            #[cfg(windows)]
-            let _ = child_pid;
-        }
+        self.active_process_groups.cancel_all();
     }
 }

--- a/app/src/terminal/model/session/command_executor/local_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor.rs
@@ -20,6 +20,51 @@ fn kill_all_processes_in_process_group(pid: u32) -> Result<(), nix::Error> {
     // Killing a negative PID kills all processes in this process group
     kill(Pid::from_raw(-(pid as i32)), Signal::SIGKILL)
 }
+#[cfg(unix)]
+fn terminate_process_group(process_group_id: u32) {
+    if let Err(error) = kill_all_processes_in_process_group(process_group_id) {
+        match error {
+            nix::errno::Errno::ESRCH | nix::errno::Errno::EPERM => {}
+            _ => log::warn!("Failed to kill process group {process_group_id}: {error}"),
+        }
+    }
+}
+
+struct SpawnedChildCleanup {
+    child_pid: u32,
+    spawned_children_pids: Arc<Mutex<HashSet<u32>>>,
+    armed: bool,
+}
+
+impl SpawnedChildCleanup {
+    fn new(child_pid: u32, spawned_children_pids: Arc<Mutex<HashSet<u32>>>) -> Self {
+        spawned_children_pids.lock().insert(child_pid);
+        Self {
+            child_pid,
+            spawned_children_pids,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.spawned_children_pids.lock().remove(&self.child_pid);
+        self.armed = false;
+    }
+}
+
+impl Drop for SpawnedChildCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let mut spawned_children_pids = self.spawned_children_pids.lock();
+        if spawned_children_pids.remove(&self.child_pid) {
+            #[cfg(unix)]
+            terminate_process_group(self.child_pid);
+        }
+    }
+}
 
 enum CommandBuilder<'a> {
     #[cfg(windows)]
@@ -61,6 +106,10 @@ impl CommandBuilder<'_> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "local_command_executor_tests.rs"]
+mod tests;
 
 /// `CommandExecutor` implementation that executes the given `command` in a forked subshell process
 /// where the current working directory is set to `current_dir_path` and $PATH is set
@@ -201,8 +250,8 @@ impl LocalCommandExecutor {
             .stderr(Stdio::piped())
             .spawn()?;
 
-        let child_pid = child.id();
-        self.spawned_children_pids.lock().insert(child_pid);
+        let child_cleanup =
+            SpawnedChildCleanup::new(child.id(), self.spawned_children_pids.clone());
 
         let output = child
             .output()
@@ -215,8 +264,9 @@ impl LocalCommandExecutor {
                 );
                 anyhow!(e)
             });
-
-        self.spawned_children_pids.lock().remove(&child_pid);
+        if output.is_ok() {
+            child_cleanup.disarm();
+        }
         output
     }
 }
@@ -249,19 +299,14 @@ impl CommandExecutor for LocalCommandExecutor {
     }
 
     fn cancel_active_commands(&self) {
-        let spawned_children_pids = std::mem::take(&mut *self.spawned_children_pids.lock());
-        for _pid in spawned_children_pids {
-            // TODO(roland): handle for windows
+        let mut spawned_children_pids = self.spawned_children_pids.lock();
+        for child_pid in spawned_children_pids.drain() {
             #[cfg(unix)]
-            if let Err(e) = kill_all_processes_in_process_group(_pid) {
-                match e {
-                    // Ignore errors that occur when the process is no longer running,
-                    // or if we cannot kill all processes in the process group.  These
-                    // are expected to happen occasionally.
-                    nix::errno::Errno::ESRCH | nix::errno::Errno::EPERM => {}
-                    _ => log::warn!("Failed to kill process {_pid}: {e}"),
-                }
-            }
+            terminate_process_group(child_pid);
+
+            // TODO(roland): handle for windows
+            #[cfg(windows)]
+            let _ = child_pid;
         }
     }
 }

--- a/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
@@ -147,6 +147,42 @@ mod unix {
     }
 
     #[test]
+    fn cancel_active_commands_kills_descendant_process() {
+        futures_lite::future::block_on(async {
+            let temp_dir = tempfile::tempdir().expect("create temp dir");
+            let mut release_fifo = create_release_fifo(temp_dir.path());
+            let ready_file = temp_dir.path().join("ready");
+            let side_effect_file = temp_dir.path().join("side-effect");
+            let executor = executor();
+            let command = executor.execute_local_command(
+                descendant_command(),
+                None,
+                Some(command_environment(temp_dir.path())),
+                ExecuteCommandOptions::default(),
+            );
+
+            let task_executor = async_executor::LocalExecutor::new();
+            task_executor
+                .run(async {
+                    let command_task = task_executor.spawn(command);
+                    let descendant_pid = wait_for_descendant_pid(&ready_file).await;
+
+                    executor.cancel_active_commands();
+                    let _ = command_task.await;
+
+                    writeln!(release_fifo, "continue").expect("release descendant");
+                    wait_for_process_exit(descendant_pid).await;
+                    assert!(
+                        !side_effect_file.exists(),
+                        "canceled descendant unexpectedly created {}",
+                        side_effect_file.display()
+                    );
+                })
+                .await;
+        });
+    }
+
+    #[test]
     fn completed_command_is_not_canceled_later() {
         futures_lite::future::block_on(async {
             let temp_dir = tempfile::tempdir().expect("create temp dir");

--- a/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
@@ -1,0 +1,178 @@
+#[cfg(unix)]
+mod unix {
+    use std::collections::HashMap;
+    use std::fs::{self, File, OpenOptions};
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+    use std::path::Path;
+    use std::time::Duration;
+
+    use async_io::Timer;
+    use futures_util::future::{AbortHandle, Abortable, Aborted};
+    use instant::Instant;
+    use nix::sys::signal::kill;
+    use nix::sys::stat::Mode;
+    use nix::unistd::{Pid, mkfifo};
+
+    use super::super::*;
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    fn executor() -> LocalCommandExecutor {
+        LocalCommandExecutor::new(Some("/bin/bash".into()), ShellType::Bash)
+    }
+
+    fn descendant_command() -> &'static str {
+        "/bin/sh -c 'printf %s \"$$\" > \"$READY_FILE\"; \
+         IFS= read -r _ < \"$RELEASE_FIFO\"; \
+         printf descendant-ran > \"$SIDE_EFFECT_FILE\"' \
+         </dev/null >/dev/null 2>&1 & wait"
+    }
+
+    fn detached_descendant_command() -> &'static str {
+        "/bin/sh -c 'printf %s \"$$\" > \"$READY_FILE\"; \
+         IFS= read -r _ < \"$RELEASE_FIFO\"; \
+         printf descendant-ran > \"$SIDE_EFFECT_FILE\"' \
+         </dev/null >/dev/null 2>&1 &"
+    }
+
+    fn command_environment(temp_dir: &Path) -> HashMap<String, String> {
+        HashMap::from([
+            (
+                "READY_FILE".into(),
+                temp_dir.join("ready").to_string_lossy().into_owned(),
+            ),
+            (
+                "RELEASE_FIFO".into(),
+                temp_dir.join("release-fifo").to_string_lossy().into_owned(),
+            ),
+            (
+                "SIDE_EFFECT_FILE".into(),
+                temp_dir.join("side-effect").to_string_lossy().into_owned(),
+            ),
+        ])
+    }
+
+    fn create_release_fifo(temp_dir: &Path) -> File {
+        let path = temp_dir.join("release-fifo");
+        mkfifo(&path, Mode::S_IRUSR | Mode::S_IWUSR).expect("create release FIFO");
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(path)
+            .expect("open release FIFO")
+    }
+
+    async fn wait_for_file(path: &Path) {
+        let deadline = Instant::now() + TIMEOUT;
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            Timer::after(Duration::from_millis(10)).await;
+        }
+    }
+    async fn wait_for_process_exit(pid: Pid) {
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            match kill(pid, None) {
+                Err(nix::errno::Errno::ESRCH) => return,
+                Ok(()) | Err(nix::errno::Errno::EPERM) => {}
+                Err(error) => panic!("failed to inspect descendant {pid}: {error}"),
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for descendant {pid} to exit"
+            );
+            Timer::after(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn wait_for_descendant_pid(path: &Path) -> Pid {
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            if let Ok(contents) = fs::read_to_string(path)
+                && let Ok(pid) = contents.parse()
+            {
+                return Pid::from_raw(pid);
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for descendant PID in {}",
+                path.display()
+            );
+            Timer::after(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[test]
+    fn dropping_command_future_kills_descendant_process() {
+        futures_lite::future::block_on(async {
+            let temp_dir = tempfile::tempdir().expect("create temp dir");
+            let mut release_fifo = create_release_fifo(temp_dir.path());
+            let ready_file = temp_dir.path().join("ready");
+            let side_effect_file = temp_dir.path().join("side-effect");
+            let executor = executor();
+            let (abort_handle, abort_registration) = AbortHandle::new_pair();
+            let command = executor.execute_local_command(
+                descendant_command(),
+                None,
+                Some(command_environment(temp_dir.path())),
+                ExecuteCommandOptions::default(),
+            );
+            let command = Abortable::new(command, abort_registration);
+
+            let task_executor = async_executor::LocalExecutor::new();
+            task_executor
+                .run(async {
+                    let command_task = task_executor.spawn(command);
+                    let descendant_pid = wait_for_descendant_pid(&ready_file).await;
+
+                    abort_handle.abort();
+                    assert!(matches!(command_task.await, Err(Aborted)));
+
+                    writeln!(release_fifo, "continue").expect("release descendant");
+                    wait_for_process_exit(descendant_pid).await;
+                    assert!(
+                        !side_effect_file.exists(),
+                        "canceled descendant unexpectedly created {}",
+                        side_effect_file.display()
+                    );
+                })
+                .await;
+        });
+    }
+
+    #[test]
+    fn completed_command_is_not_canceled_later() {
+        futures_lite::future::block_on(async {
+            let temp_dir = tempfile::tempdir().expect("create temp dir");
+            let mut release_fifo = create_release_fifo(temp_dir.path());
+            let ready_file = temp_dir.path().join("ready");
+            let side_effect_file = temp_dir.path().join("side-effect");
+            let executor = executor();
+
+            executor
+                .execute_local_command(
+                    detached_descendant_command(),
+                    None,
+                    Some(command_environment(temp_dir.path())),
+                    ExecuteCommandOptions::default(),
+                )
+                .await
+                .expect("complete wrapper command");
+            wait_for_file(&ready_file).await;
+
+            executor.cancel_active_commands();
+            writeln!(release_fifo, "continue").expect("release descendant");
+            wait_for_file(&side_effect_file).await;
+            assert_eq!(
+                fs::read_to_string(side_effect_file).expect("read side effect"),
+                "descendant-ran"
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Description
Fixes per-command cancellation for local generator commands so Warp terminates the entire owned process group rather than only the immediate shell or wrapper process.

### Why the existing process-group kill did not cover this path

`LocalCommandExecutor::cancel_active_commands()` already killed every tracked process group with `kill(-pgid, SIGKILL)`. That behavior was correct, but it is an explicit **session-wide bulk cancellation API**: a caller has to invoke it, and doing so cancels all generator commands running through the session's executor.

Prompt chips use a different cancellation mechanism. Each chip owns a `SpawnedFutureHandle`; when a refresh replaces an in-flight generator, a chip is disabled, or a shell-command timeout wins, Warp aborts that one handle and drops its individual `Session::execute_command()` future. This path intentionally does not call `session.cancel_active_commands()`, because local executors support parallel commands and a single Git chip refresh must not also cancel unrelated completions, autosuggestions, or other chips.

Before this PR, dropping that command future relied on `kill_on_drop(true)`. That kills only the immediate child PID. It does not call `LocalCommandExecutor::cancel_active_commands()` and does not signal the child's process group. Because the future is dropped while awaiting `child.output()`, execution also never reaches the normal post-`await` bookkeeping removal.

### How that causes the enterprise failure

In the reported environment, the command resolves through an internal Git wrapper which launches the real Git process. The wrapper and real Git child inherit the dedicated process group created by Warp, but the old future-drop path only sent `SIGKILL` to the immediate leader/wrapper PID.

Since `SIGKILL` cannot be caught or forwarded:

1. Warp aborts the periodic Git chip's command future.
2. `kill_on_drop` kills the immediate shell or wrapper.
3. The real Git child receives no signal, becomes orphaned, and continues scanning the large repository.
4. The next periodic refresh starts another wrapper and Git child.
5. Repeating this produces hundreds of expensive Git processes and unbounded CPU/memory growth.

The existing bulk `cancel_active_commands()` path would have killed the whole group, but prompt refresh cancellation never invoked it.

### How this PR fixes it

Each spawned command now registers a stable process-group record in `ActiveProcessGroups`. Both cancellation entry points converge on the same idempotent operation:

- Dropping one command future drops its `SpawnedChildCleanup`, which calls `ActiveProcessGroups::cancel(&record)`.
- `cancel_active_commands()` calls `ActiveProcessGroups::cancel_all()`, which snapshots the active records and calls that same `cancel(&record)` operation for each one.
- Successful command completion calls `complete(&record)`, removing it without sending a signal.

`cancel(&record)` claims the registration exactly once and sends `SIGKILL` to `-pgid`, so the wrapper and all descendants still in its process group are terminated directly. The wrapper no longer needs to catch or forward a signal. Stable record identity also prevents an old bulk-cancellation snapshot from targeting a later process that reused the same numeric PGID.

This preserves per-command cancellation for prompt refreshes without using the session-wide bulk API, while ensuring both paths share the same process-tree termination behavior.

### Regression coverage

Real-process tests start shell descendants behind FIFOs and verify:

- Dropping an individual command future kills its descendant before it can perform a side effect.
- Calling `cancel_active_commands()` kills its descendant through the same registry path.
- Normal completion unregisters the command, so later bulk cancellation does not affect its detached descendant.

## Linked Issue
- Internal: [APP-3185](https://linear.app/warpdotdev/issue/APP-3185/zombie-git-processes-from-prompt-and-code-review-panel-never-cleaned)
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (N/A: internal Linear follow-up)
- [x] Where appropriate, screenshots or a short video are included below. (N/A: process-lifecycle change with no UI)

## Testing
- `cargo nextest run -p warp 'local_command_executor::tests::unix'` — 3 passed
- Exact three Clippy commands from `script/presubmit` — passed after merging current `origin/master`
- `./script/format --check` — passed after merging current `origin/master`
- Full `./script/presubmit` — passed before the non-overlapping `origin/master` merge (10,872 workspace tests plus completer-v2 and doc tests)
- Local platform: macOS
- Linux cloud verification was not run because `oz-dev` is unavailable in the submitting environment; the new implementation and tests are Unix-gated

- [ ] I have manually tested my changes locally with `./script/run` (N/A: no interactive UI behavior)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent artifacts
- [Conversation](https://staging.warp.dev/conversation/59b9c914-a845-4854-a0b6-36f68896ce5b)
- [Implementation plan](https://staging.warp.dev/drive/notebook/dM39SGP1RhWUSCTLvcjEGM)

CHANGELOG-BUG-FIX: Fixed canceled background commands leaving wrapped child processes running.

Co-Authored-By: Warp <agent@warp.dev>


