### PR TITLE
[APP-3185] Run context chips only for active input surfaces

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -11,8 +11,8 @@ use warp_core::user_preferences::GetUserPreferences;
 use warp_errors::report_error;
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{
-    AppContext, Entity, ModelAsRef, ModelContext, ModelHandle, SingletonEntity, ViewHandle,
-    WeakModelHandle,
+    AppContext, Entity, EntityId, ModelAsRef, ModelContext, ModelHandle, SingletonEntity,
+    ViewHandle, WeakModelHandle,
 };
 
 use super::context_chip::{
@@ -23,13 +23,15 @@ use super::context_chip::{
 use super::logging::{ChipCommandLogEntry, PromptChipExecutionPhase, PromptChipLogger};
 use super::prompt::Prompt;
 use super::{ChipResult, ChipValue, ContextChipKind, chips_to_string};
+use crate::CLIAgentSessionsModel;
+use crate::ai::blocklist::agent_view::AgentViewController;
 use crate::code_review::git_repo_model::{GitRepoStatusEvent, GitRepoStatusModel};
 use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
 use crate::context_chips::display_chip::GitLineChanges;
 use crate::editor::EditorView;
 use crate::features::FeatureFlag;
 use crate::menu::{MenuItem, MenuItemFields};
-use crate::settings::{InputSettings, WarpPromptSeparator};
+use crate::settings::{AISettings, AISettingsChangedEvent, InputSettings, WarpPromptSeparator};
 use crate::terminal::event::{BlockType, UserBlockCompleted};
 use crate::terminal::model::block::{Block, BlockMetadata};
 use crate::terminal::model::session::{ExecuteCommandOptions, Session, Sessions, SessionsEvent};
@@ -156,6 +158,8 @@ pub struct CurrentPrompt {
     sessions: ModelHandle<Sessions>,
     prompt_chip_logger: PromptChipLogger,
     update_tx: async_channel::Sender<()>,
+    agent_view_controller: Option<WeakModelHandle<AgentViewController>>,
+    terminal_view_id: Option<EntityId>,
 
     /// When set, branch, branch status, and diff stats are populated from
     /// `GitRepoStatusModel` filesystem events.
@@ -171,6 +175,18 @@ pub struct CurrentPrompt {
 struct PromptContext {
     active_block_metadata: BlockMetadata,
     environment: Environment,
+}
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ActiveChipSurfaces {
+    prompt: bool,
+    agent_footer: bool,
+    cli_agent_footer: bool,
+}
+
+impl ActiveChipSurfaces {
+    fn any(self) -> bool {
+        self.prompt || self.agent_footer || self.cli_agent_footer
+    }
 }
 
 #[derive(Clone)]
@@ -231,6 +247,8 @@ impl CurrentPrompt {
             latest_context: None,
             prompt_chip_logger: PromptChipLogger::default(),
             update_tx,
+            agent_view_controller: None,
+            terminal_view_id: None,
             same_line_prompt_enabled: prompt.as_ref(ctx).same_line_prompt_enabled(),
             separator: prompt.as_ref(ctx).separator(),
             git_repo_status: None,
@@ -241,20 +259,39 @@ impl CurrentPrompt {
     /// This is used to subscribe to an editor view (i.e. in the input) whose buffer
     /// we'd like to use to update chip state.
     pub fn subscribe_to_input_editor(
-        &self,
+        &mut self,
         editor: ViewHandle<EditorView>,
+        agent_view_controller: ModelHandle<AgentViewController>,
+        terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
+        self.agent_view_controller = Some(agent_view_controller.downgrade());
+        self.terminal_view_id = Some(terminal_view_id);
+
+        ctx.subscribe_to_model(&agent_view_controller, |me, _, _, ctx| {
+            me.update_states_with_new_context(ctx);
+        });
+
+        ctx.subscribe_to_model(
+            &CLIAgentSessionsModel::handle(ctx),
+            move |me, _, event, ctx| {
+                if event.terminal_view_id() == terminal_view_id {
+                    me.update_states_with_new_context(ctx);
+                }
+            },
+        );
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |me, _, event, ctx| {
+            if matches!(
+                event,
+                AISettingsChangedEvent::ShouldRenderCLIAgentToolbar { .. }
+            ) {
+                me.update_states_with_new_context(ctx);
+            }
+        });
         // A WeakViewHandle is used here to avoid leaking the terminal model
         let weak_editor_handle = editor.downgrade();
         ctx.subscribe_to_view(&editor, move |me, _, _, ctx| {
-            // CurrentPrompt exists and this fn is called even if we're not using warp prompt.
-            // We don't need to do anything if we're honoring PS1 unless universal developer input
-            // or AgentView is enabled (agent view needs chips regardless of PS1 setting).
-            if *SessionSettings::as_ref(ctx).honor_ps1
-                && !InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx)
-                && !FeatureFlag::AgentView.is_enabled()
-            {
+            if !me.active(ctx) {
                 return;
             }
             let Some(editor) = weak_editor_handle.upgrade(ctx) else {
@@ -278,6 +315,8 @@ impl CurrentPrompt {
                 }
             }
         });
+
+        self.update_states_with_new_context(ctx);
     }
 
     pub fn snapshot(&self) -> HashMap<ContextChipKind, Option<ChipValue>> {
@@ -1047,8 +1086,8 @@ impl CurrentPrompt {
         });
     }
 
-    /// Reads the currently-configured chips from the [`Prompt`] model and filters out any that
-    /// are missing their definition.
+    /// Reads the currently-configured chips from the [`Prompt`] model and filters out any that are
+    /// missing their definition.
     fn configured_chips(&self, ctx: &AppContext) -> Vec<ContextChipKind> {
         let prompt = Prompt::as_ref(ctx);
         prompt
@@ -1058,36 +1097,69 @@ impl CurrentPrompt {
             .collect()
     }
 
-    /// Chips whose values we should actively maintain in state.
-    ///
-    /// When Agent View is enabled, the footer chips should not depend on prompt chip
-    /// customization/ordering/visibility, so we keep their backing values up to date even if they
-    /// are not present in the prompt configuration.
-    fn chips_to_run(&self, ctx: &AppContext) -> Vec<ContextChipKind> {
-        let mut chips = self.configured_chips(ctx);
+    fn active_surfaces(&self, ctx: &AppContext) -> ActiveChipSurfaces {
+        let prompt = !*SessionSettings::as_ref(ctx).honor_ps1
+            || InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx);
+        let agent_footer = FeatureFlag::AgentView.is_enabled()
+            && self
+                .agent_view_controller
+                .as_ref()
+                .and_then(|controller| controller.upgrade(ctx))
+                .is_some_and(|controller| controller.as_ref(ctx).is_active());
+        let cli_agent_footer = self.terminal_view_id.is_some_and(|terminal_view_id| {
+            *AISettings::as_ref(ctx).should_render_cli_agent_footer
+                && CLIAgentSessionsModel::as_ref(ctx)
+                    .session(terminal_view_id)
+                    .is_some_and(|session| session.agent.supports_cli_agent_footer())
+        });
 
-        if FeatureFlag::AgentView.is_enabled() {
-            let footer_chips = SessionSettings::as_ref(ctx)
-                .agent_footer_chip_selection
-                .all_chips();
-            for chip_kind in footer_chips {
+        ActiveChipSurfaces {
+            prompt,
+            agent_footer,
+            cli_agent_footer,
+        }
+    }
+
+    fn chips_to_run_for_surfaces(
+        &self,
+        surfaces: ActiveChipSurfaces,
+        ctx: &AppContext,
+    ) -> Vec<ContextChipKind> {
+        let mut chips = if surfaces.prompt {
+            self.configured_chips(ctx)
+        } else {
+            Vec::new()
+        };
+
+        let mut extend_unique = |new_chips: Vec<ContextChipKind>| {
+            for chip_kind in new_chips {
                 if !chips.contains(&chip_kind) {
                     chips.push(chip_kind);
                 }
             }
+        };
 
-            // Also include chips configured for the CLI agent footer.
-            let cli_footer_chips = SessionSettings::as_ref(ctx)
-                .cli_agent_footer_chip_selection
-                .all_chips();
-            for chip_kind in cli_footer_chips {
-                if !chips.contains(&chip_kind) {
-                    chips.push(chip_kind);
-                }
-            }
+        if surfaces.agent_footer {
+            extend_unique(
+                SessionSettings::as_ref(ctx)
+                    .agent_footer_chip_selection
+                    .all_chips(),
+            );
+        }
+
+        if surfaces.cli_agent_footer {
+            extend_unique(
+                SessionSettings::as_ref(ctx)
+                    .cli_agent_footer_chip_selection
+                    .all_chips(),
+            );
         }
 
         chips
+    }
+    /// Chips whose values we should actively maintain in state.
+    fn chips_to_run(&self, ctx: &AppContext) -> Vec<ContextChipKind> {
+        self.chips_to_run_for_surfaces(self.active_surfaces(ctx), ctx)
     }
 
     /// Resets states (including terminating any in progress spawned operations), and updates the
@@ -1568,13 +1640,7 @@ impl CurrentPrompt {
 
     /// Whether or not context chips are active. If this is false, we can skip running them.
     fn active(&self, ctx: &AppContext) -> bool {
-        // Context chips are active when:
-        // 1. PS1 is not honored (normal case), OR
-        // 2. Universal developer input is enabled (overrides PS1 behavior), OR
-        // 3. AgentView feature is enabled (agent view needs chips regardless of PS1)
-        !*SessionSettings::as_ref(ctx).honor_ps1
-            || InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx)
-            || FeatureFlag::AgentView.is_enabled()
+        self.active_surfaces(ctx).any()
     }
 }
 

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -13,7 +13,9 @@ use warp_core::command::ExitCode;
 use warpui::{App, SingletonEntity};
 use warpui_extras::user_preferences;
 
-use super::{ChipUpdateStatus, CurrentPrompt, PromptContext};
+use super::{ActiveChipSurfaces, ChipUpdateStatus, CurrentPrompt, PromptContext};
+use crate::CLIAgentSessionsModel;
+use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
 #[cfg(feature = "local_fs")]
@@ -34,14 +36,19 @@ use crate::server::telemetry::context_provider::AppTelemetryContextProvider;
 use crate::settings::WarpPromptSeparator;
 #[cfg(windows)]
 use crate::system::SystemInfo;
-use crate::terminal::History;
+use crate::terminal::cli_agent_sessions::{
+    CLIAgentInputState, CLIAgentSession, CLIAgentSessionContext, CLIAgentSessionStatus,
+};
 use crate::terminal::model::block::BlockMetadata;
 use crate::terminal::model::session::{
     CommandExecutor, ExecuteCommandOptions, SessionId, SessionInfo, Sessions,
 };
-use crate::terminal::session_settings::SessionSettings;
+use crate::terminal::session_settings::{
+    AgentToolbarChipSelection, CLIAgentToolbarChipSelection, SessionSettings, ToolbarChipSelection,
+};
 use crate::terminal::shell::Shell;
 use crate::terminal::view::PromptPosition;
+use crate::terminal::{CLIAgent, History};
 #[cfg(feature = "local_fs")]
 use crate::util::git::PrInfo;
 
@@ -497,6 +504,249 @@ fn test_disabling_chips() {
     });
 }
 
+#[test]
+fn test_chips_to_run_only_includes_active_surface_configurations() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [ContextChipKind::Username],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.update(|ctx| {
+            SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings
+                    .agent_footer_chip_selection
+                    .set_value(
+                        AgentToolbarChipSelection::Custom {
+                            left: vec![AgentToolbarItemKind::ContextChip(
+                                ContextChipKind::WorkingDirectory,
+                            )],
+                            right: vec![],
+                        },
+                        ctx,
+                    )
+                    .unwrap();
+                settings
+                    .cli_agent_footer_chip_selection
+                    .set_value(
+                        CLIAgentToolbarChipSelection::Custom {
+                            left: vec![AgentToolbarItemKind::ContextChip(
+                                ContextChipKind::ShellGitBranch,
+                            )],
+                            right: vec![],
+                        },
+                        ctx,
+                    )
+                    .unwrap();
+            });
+        });
+
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        app.read(|ctx| {
+            let current_prompt = current_prompt.as_ref(ctx);
+            let chips_for = |surfaces| current_prompt.chips_to_run_for_surfaces(surfaces, ctx);
+
+            assert!(chips_for(ActiveChipSurfaces::default()).is_empty());
+            assert_eq!(
+                chips_for(ActiveChipSurfaces {
+                    prompt: true,
+                    ..Default::default()
+                }),
+                vec![ContextChipKind::Username]
+            );
+            assert_eq!(
+                chips_for(ActiveChipSurfaces {
+                    agent_footer: true,
+                    ..Default::default()
+                }),
+                vec![ContextChipKind::WorkingDirectory]
+            );
+            assert_eq!(
+                chips_for(ActiveChipSurfaces {
+                    cli_agent_footer: true,
+                    ..Default::default()
+                }),
+                vec![ContextChipKind::ShellGitBranch]
+            );
+            assert_eq!(
+                chips_for(ActiveChipSurfaces {
+                    prompt: true,
+                    agent_footer: true,
+                    cli_agent_footer: true,
+                }),
+                vec![
+                    ContextChipKind::Username,
+                    ContextChipKind::WorkingDirectory,
+                    ContextChipKind::ShellGitBranch,
+                ]
+            );
+        });
+    });
+}
+
+#[test]
+fn test_cli_agent_footer_chips_require_a_visible_supported_footer() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Prompt::mock());
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_| History::new(vec![]));
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| crate::settings::manager::SettingsManager::default());
+        crate::settings::InputSettings::register(&mut app);
+        app.update(crate::settings::AISettings::register_and_subscribe_to_events);
+        app.add_singleton_model(crate::workspaces::user_workspaces::UserWorkspaces::default_mock);
+        app.add_singleton_model(|_| CLIAgentSessionsModel::new());
+        #[cfg(windows)]
+        app.add_singleton_model(SystemInfo::new);
+
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+        let terminal_view_id = current_prompt.id();
+        current_prompt.update(&mut app, |current_prompt, _| {
+            current_prompt.terminal_view_id = Some(terminal_view_id);
+        });
+
+        let cli_footer_chips =
+            |app: &App| app.read(|ctx| current_prompt.as_ref(ctx).chips_to_run(ctx));
+        assert!(cli_footer_chips(&app).is_empty());
+
+        let session_for = |agent| CLIAgentSession {
+            agent,
+            status: CLIAgentSessionStatus::InProgress,
+            session_context: CLIAgentSessionContext::default(),
+            input_state: CLIAgentInputState::Closed,
+            should_auto_toggle_input: false,
+            listener: None,
+            plugin_version: None,
+            remote_host: None,
+            draft_text: None,
+            custom_command_prefix: None,
+            received_rich_notification: false,
+        };
+
+        CLIAgentSessionsModel::handle(&app).update(&mut app, |sessions, ctx| {
+            sessions.set_session(terminal_view_id, session_for(CLIAgent::Claude), ctx);
+        });
+        assert_eq!(
+            cli_footer_chips(&app),
+            app.read(|ctx| {
+                SessionSettings::as_ref(ctx)
+                    .cli_agent_footer_chip_selection
+                    .all_chips()
+            })
+        );
+
+        CLIAgentSessionsModel::handle(&app).update(&mut app, |sessions, ctx| {
+            sessions.set_session(terminal_view_id, session_for(CLIAgent::WarpTui), ctx);
+        });
+        assert!(cli_footer_chips(&app).is_empty());
+
+        CLIAgentSessionsModel::handle(&app).update(&mut app, |sessions, ctx| {
+            sessions.set_session(terminal_view_id, session_for(CLIAgent::Claude), ctx);
+        });
+        crate::settings::AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .should_render_cli_agent_footer
+                .set_value(false, ctx)
+                .unwrap();
+        });
+        assert!(cli_footer_chips(&app).is_empty());
+    });
+}
+
+#[test]
+fn test_ps1_without_active_agent_surface_runs_no_footer_generators() {
+    let _flag_guard = FeatureFlag::AgentView.override_enabled(true);
+    App::test((), |mut app| async move {
+        let session_id = SessionId::from(321);
+        app.add_singleton_model(|_| Prompt::mock());
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_| History::new(vec![]));
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.update(|ctx| {
+            SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
+                settings.honor_ps1.set_value(true, ctx).unwrap();
+            });
+        });
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| crate::settings::manager::SettingsManager::default());
+        crate::settings::InputSettings::register(&mut app);
+        app.update(crate::settings::AISettings::register_and_subscribe_to_events);
+        app.add_singleton_model(crate::workspaces::user_workspaces::UserWorkspaces::default_mock);
+        #[cfg(windows)]
+        app.add_singleton_model(SystemInfo::new);
+
+        let executor = Arc::new(RecordingCommandExecutor::default());
+        let sessions = app.add_model(|ctx| {
+            let mut sessions = Sessions::new_for_test().with_command_executor(executor.clone());
+            sessions.initialize_bootstrapped_session(
+                SessionInfo::new_for_test().with_id(session_id),
+                "test command".to_string(),
+                vec![],
+                None,
+                ctx,
+            );
+            sessions
+        });
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt
+            .update(&mut app, |current_prompt, ctx| {
+                current_prompt.latest_context = Some(PromptContext {
+                    active_block_metadata: BlockMetadata::new(Some(session_id), None),
+                    environment: Environment::default(),
+                });
+                current_prompt.update_states_with_new_context(ctx);
+                current_prompt.await_generators(ctx)
+            })
+            .await;
+
+        assert!(executor.commands.lock().is_empty());
+        app.read(|ctx| {
+            assert!(current_prompt.as_ref(ctx).states.is_empty());
+        });
+    });
+}
 #[cfg(feature = "local_fs")]
 #[test]
 fn test_externally_driven_chip_skips_periodic_timer() {

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -328,7 +328,7 @@ impl CLIAgent {
     }
 
     /// Whether Warp should show its CLI-agent footer for this agent.
-    pub(super) fn supports_cli_agent_footer(&self) -> bool {
+    pub(crate) fn supports_cli_agent_footer(&self) -> bool {
         !matches!(self, CLIAgent::WarpTui)
     }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3238,7 +3238,12 @@ impl Input {
         current_prompt.update(ctx, |prompt_type, ctx| {
             if let PromptType::Dynamic { prompt } = prompt_type {
                 prompt.update(ctx, |current_prompt, ctx| {
-                    current_prompt.subscribe_to_input_editor(editor.clone(), ctx);
+                    current_prompt.subscribe_to_input_editor(
+                        editor.clone(),
+                        agent_view_controller.clone(),
+                        terminal_view_id,
+                        ctx,
+                    );
                 });
             }
         });

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -5795,6 +5795,19 @@ fn agent_footer_updates_chip_groups_when_side_assignment_changes() {
         FeatureFlag::AgentView.set_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            view.agent_view_controller().update(ctx, |controller, ctx| {
+                controller
+                    .try_enter_agent_view(
+                        None,
+                        AgentViewEntryOrigin::Input {
+                            was_prompt_autodetected: false,
+                        },
+                        ctx,
+                    )
+                    .expect("Should be able to enter agent view");
+            });
+        });
 
         terminal.update(&mut app, |view, ctx| {
             let model = view.model.lock();


### PR DESCRIPTION
## Description
Stops inactive prompt and agent-footer configurations from maintaining hidden context-chip generators.

Previously `CurrentPrompt` combined terminal prompt chips, Warp Agent footer chips, and CLI-agent footer chips whenever Agent View was feature-enabled. As a result, PS1 users could still run the CLI footer's default Git diff command every 30 seconds even when no CLI agent or Agent View was active.

This change derives three independent active surfaces from production state: Warp prompt activity follows PS1/UDI settings, the Warp Agent footer follows the pane's live `AgentViewController`, and the CLI footer requires a tracked supported CLI agent plus the footer-rendering setting. `CurrentPrompt` subscribes to those state changes and cancels/recomputes chip work when a surface enters or exits. Agent-context Git metadata remains independent.

Regression tests cover active-surface selection, supported/unsupported/disabled CLI footers, PS1 with no active agent surface launching zero commands, and existing Agent footer chip rearrangement while Agent View is active.

## Linked Issue
- Internal: [APP-3185](https://linear.app/warpdotdev/issue/APP-3185/zombie-git-processes-from-prompt-and-code-review-panel-never-cleaned)
- Related background polling report: [APP-4361](https://linear.app/warpdotdev/issue/APP-4361/github-pr-prompt-chip-drains-github-graphql-api-rate-limit-from)
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (N/A: internal Linear follow-up)
- [x] Where appropriate, screenshots or a short video are included below. (N/A: background scheduling change with no visual UI difference)

## Testing
- `cargo nextest run -p warp --lib context_chips::current_prompt::tests` — 14 passed after merging current `origin/master`
- `cargo nextest run -p warp 'agent_footer_updates_chip_groups_when_side_assignment_changes'` — passed after merging current `origin/master`
- Exact three Clippy commands from `script/presubmit` — passed after merging current `origin/master`
- `./script/format --check` — passed after merging current `origin/master`
- Full `./script/presubmit` — passed before the non-overlapping `origin/master` merge (10,873 workspace tests, 123 completer-v2 tests, and doc tests)

- [ ] I have manually tested my changes locally with `./script/run` (N/A: no visual behavior change)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent artifacts
- [Conversation](https://staging.warp.dev/conversation/59b9c914-a845-4854-a0b6-36f68896ce5b)
- [Implementation plan](https://staging.warp.dev/drive/notebook/dM39SGP1RhWUSCTLvcjEGM)

CHANGELOG-BUG-FIX: Fixed inactive agent toolbelts continuing to run hidden context chip commands.

Co-Authored-By: Warp <agent@warp.dev>
