### PR TITLE
Adopt root-scoped subtree event streams in the unified orchestration stack

### DIFF
--- a/app/src/ai/agent_events/driver.rs
+++ b/app/src/ai/agent_events/driver.rs
@@ -9,7 +9,9 @@ use instant::Instant;
 use warp_errors::{AnyhowErrorExt as _, report_error};
 use warpui::r#async::Timer;
 
-use crate::server::retry_strategies::{is_auth_error, is_transient_http_error};
+use crate::server::retry_strategies::{
+    is_auth_error, is_permanent_non_auth_4xx_error, is_transient_http_error,
+};
 use crate::server::server_api::ServerApi;
 use crate::server::server_api::ai::AgentRunEvent;
 use crate::server::server_api::presigned_upload::HttpStatusError;
@@ -115,6 +117,13 @@ pub(crate) struct AgentEventDriverConfig {
     /// through auth errors forever (the default for local, interactive
     /// listeners whose credentials refresh in the background).
     pub auth_error_give_up_failures: Option<usize>,
+    /// Consecutive permanent non-auth 4xx failures (400, 404, 405, ...) after
+    /// which the driver stops and returns an error instead of reconnecting.
+    /// Lets callers of filters the server may not accept (for example a
+    /// subtree stream against a server without the endpoint) observe the
+    /// rejection and fall back, instead of retrying a dead filter forever.
+    /// `None` keeps retrying.
+    pub permanent_error_give_up_failures: Option<usize>,
     /// Total wall-clock time the driver keeps retrying after failures begin
     /// (measured from the first failure since the last successful open/event)
     /// before it stops and returns an error. `None` retries without a time
@@ -134,6 +143,7 @@ impl AgentEventDriverConfig {
             proactive_reconnect_after: Some(DEFAULT_AGENT_EVENT_PROACTIVE_RECONNECT),
             failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
             auth_error_give_up_failures: None,
+            permanent_error_give_up_failures: None,
             max_retry_duration: None,
         }
     }
@@ -365,6 +375,9 @@ where
     // of auth failures. Any non-auth failure or success resets it, so a mix like
     // 500, 500, 401 does not trip a "3 consecutive auth failures" policy.
     let mut consecutive_auth_failures = 0usize;
+    // Consecutive permanent non-auth 4xx failures, with the same streak
+    // semantics as `consecutive_auth_failures`.
+    let mut consecutive_permanent_failures = 0usize;
     let mut has_connected_once = false;
     // Start of the current run of consecutive failures. Reset to `None` after any
     // successful open/event so the `max_retry_duration` window only measures
@@ -387,6 +400,7 @@ where
                     err,
                     failures,
                     &mut consecutive_auth_failures,
+                    &mut consecutive_permanent_failures,
                     &mut retry_window_started_at,
                     !has_connected_once,
                 )
@@ -426,6 +440,7 @@ where
                 NextDriverItem::StreamItem(Some(Ok(AgentEventSourceItem::Open))) => {
                     failures = 0;
                     consecutive_auth_failures = 0;
+                    consecutive_permanent_failures = 0;
                     retry_window_started_at = None;
                     has_connected_once = true;
                     notify_driver_state(consumer, AgentEventDriverState::Connected).await;
@@ -437,6 +452,7 @@ where
                 NextDriverItem::StreamItem(Some(Ok(AgentEventSourceItem::Event(event)))) => {
                     failures = 0;
                     consecutive_auth_failures = 0;
+                    consecutive_permanent_failures = 0;
                     retry_window_started_at = None;
                     if event.sequence <= since_sequence {
                         continue;
@@ -464,6 +480,7 @@ where
                         err,
                         failures,
                         &mut consecutive_auth_failures,
+                        &mut consecutive_permanent_failures,
                         &mut retry_window_started_at,
                         false,
                     )
@@ -476,12 +493,15 @@ where
                 NextDriverItem::StreamItem(None) => {
                     failures += 1;
                     // A clean server-side close carries no HTTP status, so it is
-                    // never treated as an auth failure; reset the auth streak and
-                    // let only the time-based backstop trigger a give-up here.
+                    // never treated as an auth or permanent failure; reset both
+                    // streaks and let only the time-based backstop trigger a
+                    // give-up here.
                     consecutive_auth_failures = 0;
+                    consecutive_permanent_failures = 0;
                     if let Some(reason) = agent_event_give_up_reason(
                         &config,
                         consecutive_auth_failures,
+                        consecutive_permanent_failures,
                         &mut retry_window_started_at,
                     ) {
                         return Err(anyhow!(
@@ -516,14 +536,16 @@ enum NextDriverItem {
     ProactiveReconnect,
 }
 
-/// Update the consecutive auth-failure streak for `err` and return a give-up
-/// reason if the driver should stop retrying. Bumps `consecutive_auth_failures`
-/// on an HTTP 401/403 error and resets it otherwise, then defers to
+/// Update the consecutive auth- and permanent-failure streaks for `err` and
+/// return a give-up reason if the driver should stop retrying. Bumps the
+/// matching streak (HTTP 401/403 for auth; other permanent 4xx for
+/// permanent) and resets the other, then defers to
 /// [`agent_event_give_up_reason`].
 fn classify_failure_and_give_up_reason(
     config: &AgentEventDriverConfig,
     err: &anyhow::Error,
     consecutive_auth_failures: &mut usize,
+    consecutive_permanent_failures: &mut usize,
     retry_window_started_at: &mut Option<Instant>,
 ) -> Option<String> {
     if is_auth_error(err) {
@@ -531,7 +553,17 @@ fn classify_failure_and_give_up_reason(
     } else {
         *consecutive_auth_failures = 0;
     }
-    agent_event_give_up_reason(config, *consecutive_auth_failures, retry_window_started_at)
+    if is_permanent_non_auth_4xx_error(err) {
+        *consecutive_permanent_failures += 1;
+    } else {
+        *consecutive_permanent_failures = 0;
+    }
+    agent_event_give_up_reason(
+        config,
+        *consecutive_auth_failures,
+        *consecutive_permanent_failures,
+        retry_window_started_at,
+    )
 }
 
 /// Handles an HTTP error from either `open_stream` or a stream item: checks the
@@ -539,12 +571,14 @@ fn classify_failure_and_give_up_reason(
 /// pending retry, and waits out the backoff delay. Returns `Err` if the driver
 /// should stop — the error is ready to propagate directly — or `Ok(())` once the
 /// retry delay has elapsed.
+#[allow(clippy::too_many_arguments)]
 async fn handle_http_error<C: AgentEventConsumer>(
     config: &AgentEventDriverConfig,
     consumer: &mut C,
     err: anyhow::Error,
     failures: usize,
     consecutive_auth_failures: &mut usize,
+    consecutive_permanent_failures: &mut usize,
     retry_window_started_at: &mut Option<Instant>,
     is_initial_connect: bool,
 ) -> Result<()> {
@@ -552,6 +586,7 @@ async fn handle_http_error<C: AgentEventConsumer>(
         config,
         &err,
         consecutive_auth_failures,
+        consecutive_permanent_failures,
         retry_window_started_at,
     ) {
         return Err(err.context(format!(
@@ -596,6 +631,7 @@ async fn handle_http_error<C: AgentEventConsumer>(
 fn agent_event_give_up_reason(
     config: &AgentEventDriverConfig,
     consecutive_auth_failures: usize,
+    consecutive_permanent_failures: usize,
     retry_window_started_at: &mut Option<Instant>,
 ) -> Option<String> {
     let now = Instant::now();
@@ -606,6 +642,14 @@ fn agent_event_give_up_reason(
     {
         return Some(format!(
             "stopping after {consecutive_auth_failures} consecutive authentication failures"
+        ));
+    }
+
+    if let Some(threshold) = config.permanent_error_give_up_failures
+        && consecutive_permanent_failures >= threshold
+    {
+        return Some(format!(
+            "stopping after {consecutive_permanent_failures} consecutive permanent 4xx failures"
         ));
     }
 

--- a/app/src/ai/agent_events/driver.rs
+++ b/app/src/ai/agent_events/driver.rs
@@ -45,7 +45,11 @@ pub(crate) const DEFAULT_AGENT_EVENT_MAX_RETRY_DURATION: Duration = Duration::fr
 /// child of the supplied parent run (the shared-session viewer's pill bar),
 /// and with `include_self=true` it additionally streams the parent run's
 /// own events so an owner-side orchestrator can receive child lifecycle
-/// events plus its own inbox on one ordered stream.
+/// events plus its own inbox on one ordered stream. `SubtreeRootRunId`
+/// maps to the `?subtree_root_run_id=` shape: it streams events for the
+/// root run itself and its entire descendant subtree (children,
+/// grandchildren, ...), so a tree-root orchestrator can observe runs
+/// spawned by its remote children.
 #[derive(Clone, Debug)]
 pub(crate) enum AgentEventFilter {
     /// One stream per multiplexed set of run IDs. Matches today's
@@ -58,6 +62,11 @@ pub(crate) enum AgentEventFilter {
         ancestor_run_id: String,
         include_self: bool,
     },
+    /// Stream events for the supplied root run and its whole descendant
+    /// subtree. The root is inherently included. Matches the
+    /// `?subtree_root_run_id=` endpoint; only valid for tree roots (the
+    /// server rejects mid-tree anchors with 400).
+    SubtreeRootRunId { root_run_id: String },
 }
 
 impl AgentEventFilter {
@@ -70,6 +79,9 @@ impl AgentEventFilter {
                 ancestor_run_id,
                 include_self,
             } => format!("ancestor_run_id={ancestor_run_id} include_self={include_self}"),
+            AgentEventFilter::SubtreeRootRunId { root_run_id } => {
+                format!("subtree_root_run_id={root_run_id}")
+            }
         }
     }
 }
@@ -258,6 +270,11 @@ impl AgentEventSource for ServerApiAgentEventSource {
                         *include_self,
                         since_sequence,
                     )
+                    .await?
+            }
+            AgentEventFilter::SubtreeRootRunId { root_run_id } => {
+                self.server_api
+                    .stream_agent_events_for_subtree(root_run_id, since_sequence)
                     .await?
             }
         };

--- a/app/src/ai/agent_events/driver_tests.rs
+++ b/app/src/ai/agent_events/driver_tests.rs
@@ -102,7 +102,6 @@ fn make_run_event(
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence,
         parent_run_id: None,
-        depth: None,
     }
 }
 
@@ -148,6 +147,7 @@ async fn driver_skips_duplicate_sequences_and_persists_new_cursor() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -196,6 +196,7 @@ async fn driver_resets_failures_after_successful_event_delivery() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -243,6 +244,7 @@ async fn driver_ignores_persist_cursor_errors() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -279,6 +281,7 @@ async fn driver_ignores_driver_state_errors() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -317,6 +320,7 @@ async fn driver_retries_initial_connection_until_stream_opens() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -457,6 +461,7 @@ async fn driver_uses_slow_backoff_on_permanent_http_error() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -499,6 +504,7 @@ async fn driver_gives_up_after_consecutive_auth_failures() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: Some(3),
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -541,6 +547,7 @@ async fn driver_does_not_give_up_on_non_auth_error_when_only_auth_bounded() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: Some(3),
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -582,6 +589,7 @@ async fn driver_does_not_count_non_auth_failures_toward_auth_give_up() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: Some(3),
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -615,6 +623,7 @@ async fn driver_resets_auth_streak_after_non_auth_failure() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: Some(3),
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 
@@ -647,6 +656,7 @@ async fn driver_gives_up_after_max_retry_duration() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: Some(Duration::from_secs(0)),
     };
 
@@ -690,6 +700,7 @@ async fn driver_uses_fast_backoff_on_transient_http_error() {
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
         auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: None,
         max_retry_duration: None,
     };
 

--- a/app/src/ai/agent_events/driver_tests.rs
+++ b/app/src/ai/agent_events/driver_tests.rs
@@ -101,6 +101,8 @@ fn make_run_event(
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence,
+        parent_run_id: None,
+        depth: None,
     }
 }
 

--- a/app/src/ai/agent_events/driver_tests.rs
+++ b/app/src/ai/agent_events/driver_tests.rs
@@ -639,6 +639,85 @@ async fn driver_resets_auth_streak_after_non_auth_failure() {
 }
 
 #[tokio::test]
+async fn driver_gives_up_after_consecutive_permanent_4xx_failures() {
+    // Every open attempt fails with a 404. With a give-up threshold of 3, the
+    // driver should stop and return an error rather than reconnecting forever.
+    let source = FakeAgentEventSource::new(vec![
+        Err(make_http_status_error(404)),
+        Err(make_http_status_error(404)),
+        Err(make_http_status_error(404)),
+    ]);
+    let mut consumer = RecordingConsumer {
+        stop_after: 1,
+        ..Default::default()
+    };
+
+    let config = AgentEventDriverConfig {
+        filter: AgentEventFilter::RunIds(vec!["child-run".to_string()]),
+        since_sequence: 0,
+        reconnect_backoff_steps: ZERO_BACKOFF_STEPS,
+        permanent_error_backoff_steps: ZERO_BACKOFF_STEPS,
+        proactive_reconnect_after: None,
+        failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: Some(3),
+        max_retry_duration: None,
+    };
+
+    let result = run_agent_event_driver(source, config, &mut consumer).await;
+    assert!(
+        result.is_err(),
+        "driver should give up on persistent permanent 4xx errors"
+    );
+    assert!(consumer.handled_sequences.is_empty());
+}
+
+#[tokio::test]
+async fn driver_resets_permanent_streak_on_other_error_classes() {
+    // Auth (401) and transient (429) failures interleaved with 404s reset the
+    // permanent streak, so a threshold-of-3 policy only trips on a fresh run
+    // of 3 consecutive permanent 4xx failures — which never occurs here.
+    let source = FakeAgentEventSource::new(vec![
+        Err(make_http_status_error(404)),
+        Err(make_http_status_error(404)),
+        Err(make_http_status_error(429)),
+        Err(make_http_status_error(404)),
+        Err(make_http_status_error(404)),
+        Err(make_http_status_error(401)),
+        ok_stream(vec![
+            Ok(AgentEventSourceItem::Open),
+            Ok(AgentEventSourceItem::Event(make_run_event(
+                1,
+                "new_message",
+                "child-run",
+                Some("msg-1"),
+            ))),
+        ]),
+    ]);
+    let mut consumer = RecordingConsumer {
+        stop_after: 1,
+        ..Default::default()
+    };
+
+    let config = AgentEventDriverConfig {
+        filter: AgentEventFilter::RunIds(vec!["child-run".to_string()]),
+        since_sequence: 0,
+        reconnect_backoff_steps: ZERO_BACKOFF_STEPS,
+        permanent_error_backoff_steps: ZERO_BACKOFF_STEPS,
+        proactive_reconnect_after: None,
+        failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: Some(3),
+        max_retry_duration: None,
+    };
+
+    run_agent_event_driver(source, config, &mut consumer)
+        .await
+        .unwrap();
+    assert_eq!(consumer.handled_sequences, vec![1]);
+}
+
+#[tokio::test]
 async fn driver_gives_up_after_max_retry_duration() {
     // A zero-length max retry window means the driver gives up on the first
     // failure regardless of error class.
@@ -720,4 +799,47 @@ async fn driver_uses_fast_backoff_on_transient_http_error() {
         })
         .unwrap();
     assert_eq!(retry_backoff, Duration::from_secs(0));
+}
+
+#[tokio::test]
+async fn driver_resets_permanent_streak_after_clean_stream_close() {
+    // A clean server-side close carries no HTTP status; it must reset the
+    // permanent streak rather than count toward it.
+    let source = FakeAgentEventSource::new(vec![
+        Err(make_http_status_error(404)),
+        Err(make_http_status_error(404)),
+        // Clean close: stream opens, then ends without an error item.
+        ok_stream(vec![Ok(AgentEventSourceItem::Open)]),
+        Err(make_http_status_error(404)),
+        ok_stream(vec![
+            Ok(AgentEventSourceItem::Open),
+            Ok(AgentEventSourceItem::Event(make_run_event(
+                1,
+                "new_message",
+                "child-run",
+                Some("msg-1"),
+            ))),
+        ]),
+    ]);
+    let mut consumer = RecordingConsumer {
+        stop_after: 1,
+        ..Default::default()
+    };
+
+    let config = AgentEventDriverConfig {
+        filter: AgentEventFilter::RunIds(vec!["child-run".to_string()]),
+        since_sequence: 0,
+        reconnect_backoff_steps: ZERO_BACKOFF_STEPS,
+        permanent_error_backoff_steps: ZERO_BACKOFF_STEPS,
+        proactive_reconnect_after: None,
+        failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        auth_error_give_up_failures: None,
+        permanent_error_give_up_failures: Some(3),
+        max_retry_duration: None,
+    };
+
+    run_agent_event_driver(source, config, &mut consumer)
+        .await
+        .unwrap();
+    assert_eq!(consumer.handled_sequences, vec![1]);
 }

--- a/app/src/ai/agent_events/message_hydrator_tests.rs
+++ b/app/src/ai/agent_events/message_hydrator_tests.rs
@@ -24,7 +24,6 @@ fn make_run_event(
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence,
         parent_run_id: None,
-        depth: None,
     }
 }
 

--- a/app/src/ai/agent_events/message_hydrator_tests.rs
+++ b/app/src/ai/agent_events/message_hydrator_tests.rs
@@ -23,6 +23,8 @@ fn make_run_event(
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence,
+        parent_run_id: None,
+        depth: None,
     }
 }
 

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -118,8 +118,7 @@ pub(super) fn filter_from_args(args: &ListTasksArgs) -> TaskListFilter {
         skill_spec: args.skill.clone(),
         schedule_id: args.schedule.clone(),
         ancestor_run_id: args.ancestor_run.clone(),
-        // Not exposed on the CLI yet; the owner-side subtree restore seed is
-        // the only consumer of the root_run_id list filter.
+        // Not exposed on the CLI yet.
         root_run_id: None,
         config_name: args.name.clone(),
         model_id: args.model.clone(),

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -118,6 +118,9 @@ pub(super) fn filter_from_args(args: &ListTasksArgs) -> TaskListFilter {
         skill_spec: args.skill.clone(),
         schedule_id: args.schedule.clone(),
         ancestor_run_id: args.ancestor_run.clone(),
+        // Not exposed on the CLI yet; the owner-side subtree restore seed is
+        // the only consumer of the root_run_id list filter.
+        root_run_id: None,
         config_name: args.name.clone(),
         model_id: args.model.clone(),
         artifact_type: args.artifact_type.map(artifact_type_from_arg),

--- a/app/src/ai/blocklist/orchestration_child_tracker.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker.rs
@@ -56,8 +56,15 @@ pub enum ChildSignal {
     /// UUID directly, so `session_id` can be filled in without a metadata
     /// fetch.
     SessionLinked { session_uuid: String },
-    /// Any recognised lifecycle event on the child run.
-    Lifecycle(api::LifecycleEventType),
+    /// Any recognised lifecycle event on the child run. `sequence` is the
+    /// wire event's sequence number; the tracker drops signals at or below
+    /// the child's last applied lifecycle sequence so replays (e.g. a
+    /// subtree stream resuming from an older cursor) cannot regress a
+    /// child's status.
+    Lifecycle {
+        kind: api::LifecycleEventType,
+        sequence: i64,
+    },
     /// A REST seed row (cold-start seed / restore fetch). Boxed because the
     /// task row dwarfs the other variants.
     #[allow(dead_code)]
@@ -83,6 +90,9 @@ pub struct TrackedChild {
     /// any. Used by the placeholder-completion callback to backfill status
     /// when a lifecycle event arrived before the async metadata fetch finished.
     last_lifecycle: Option<api::LifecycleEventType>,
+    /// Sequence number of the last applied lifecycle signal. Monotonic
+    /// guard: stale replays (sequence <= this) are dropped.
+    last_lifecycle_sequence: Option<i64>,
 }
 
 /// Owns discovery, placeholder bookkeeping, claim-time metadata refetch, and
@@ -162,8 +172,8 @@ impl OrchestrationChildTracker {
             ChildSignal::SessionLinked { session_uuid } => {
                 self.apply_session_linked(task_id, &session_uuid);
             }
-            ChildSignal::Lifecycle(kind) => {
-                self.apply_lifecycle(task_id, child_run_id, kind, ctx);
+            ChildSignal::Lifecycle { kind, sequence } => {
+                self.apply_lifecycle(task_id, child_run_id, kind, sequence, ctx);
             }
             ChildSignal::Seeded(task) => {
                 self.apply_seeded(*task, ctx);
@@ -203,6 +213,7 @@ impl OrchestrationChildTracker {
                 last_state: None,
                 is_remote_child: true,
                 last_lifecycle: None,
+                last_lifecycle_sequence: None,
             },
             ctx,
         );
@@ -221,12 +232,22 @@ impl OrchestrationChildTracker {
         task_id: AmbientAgentTaskId,
         run_id: &str,
         kind: api::LifecycleEventType,
+        sequence: i64,
         ctx: &mut ModelContext<OrchestrationEventStreamer>,
     ) {
         let tracker_known = self.children.contains_key(&task_id);
         if tracker_known {
             if let Some(child) = self.children.get_mut(&task_id) {
+                if child
+                    .last_lifecycle_sequence
+                    .is_some_and(|last| sequence <= last)
+                {
+                    // Stale replay: an equal-or-older lifecycle event must not
+                    // overwrite a status derived from a newer one.
+                    return;
+                }
                 child.last_lifecycle = Some(kind);
+                child.last_lifecycle_sequence = Some(sequence);
             }
             let status = conversation_status_from_lifecycle_event_type(kind);
             // Write status through immediately so the pill bar badge reflects
@@ -269,6 +290,7 @@ impl OrchestrationChildTracker {
         self.apply_started(task_id, run_id, ctx);
         if let Some(child) = self.children.get_mut(&task_id) {
             child.last_lifecycle = Some(kind);
+            child.last_lifecycle_sequence = Some(sequence);
         }
         let status = conversation_status_from_lifecycle_event_type(kind);
         ctx.emit(OrchestrationEventStreamerEvent::ChildStatusChanged {
@@ -306,6 +328,7 @@ impl OrchestrationChildTracker {
                 // never persisted as `is_remote_child` placeholders.
                 is_remote_child: false,
                 last_lifecycle: None,
+                last_lifecycle_sequence: None,
             },
             ctx,
         );
@@ -352,6 +375,7 @@ impl OrchestrationChildTracker {
                 last_state: Some(state),
                 is_remote_child: true,
                 last_lifecycle: None,
+                last_lifecycle_sequence: None,
             },
             ctx,
         );

--- a/app/src/ai/blocklist/orchestration_child_tracker.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker.rs
@@ -356,11 +356,17 @@ impl OrchestrationChildTracker {
 
         self.children_awaiting_metadata.remove(&run_id);
 
+        // The row's `last_event_sequence` floors the lifecycle replay guard:
+        // a stream resuming from an older cursor must not transiently
+        // regress a status the seed snapshot already reflects.
+        let seed_sequence = task.last_event_sequence;
+
         if let Some(existing) = self.children.get_mut(&task_id) {
             existing.last_state = Some(state);
             if existing.session_id.is_none() {
                 existing.session_id = seed_session_id;
             }
+            existing.last_lifecycle_sequence = existing.last_lifecycle_sequence.max(seed_sequence);
             return;
         }
 
@@ -375,7 +381,7 @@ impl OrchestrationChildTracker {
                 last_state: Some(state),
                 is_remote_child: true,
                 last_lifecycle: None,
-                last_lifecycle_sequence: None,
+                last_lifecycle_sequence: seed_sequence,
             },
             ctx,
         );

--- a/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
@@ -399,3 +399,117 @@ fn the_parents_own_seed_row_is_not_tracked_as_a_child() {
         assert!(tracker.children.is_empty());
     });
 }
+
+// ---- Lifecycle sequence guard ----------------------------------------------
+
+#[test]
+fn stale_lifecycle_replays_are_dropped_by_the_sequence_guard() {
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(
+            CHILD_A_RUN_ID,
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::Succeeded,
+                sequence: 20,
+            },
+            &no_killed_runs(),
+            ctx,
+        );
+        // A replay at or below the applied sequence must not regress.
+        tracker.observe_child(
+            CHILD_A_RUN_ID,
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::InProgress,
+                sequence: 19,
+            },
+            &no_killed_runs(),
+            ctx,
+        );
+
+        let child = tracker.children.get(&child_task_id()).expect("tracked");
+        assert_eq!(
+            child.last_lifecycle,
+            Some(api::LifecycleEventType::Succeeded)
+        );
+        assert_eq!(child.last_lifecycle_sequence, Some(20));
+    });
+}
+
+#[test]
+fn terminal_status_is_not_sticky_for_newer_lifecycle_events() {
+    // Runs legitimately go Succeeded -> InProgress on wake; only ORDER is
+    // guarded, not terminal-ness.
+    with_tracker(|tracker, ctx| {
+        tracker.observe_child(
+            CHILD_A_RUN_ID,
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::Succeeded,
+                sequence: 20,
+            },
+            &no_killed_runs(),
+            ctx,
+        );
+        tracker.observe_child(
+            CHILD_A_RUN_ID,
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::InProgress,
+                sequence: 21,
+            },
+            &no_killed_runs(),
+            ctx,
+        );
+
+        let child = tracker.children.get(&child_task_id()).expect("tracked");
+        assert_eq!(
+            child.last_lifecycle,
+            Some(api::LifecycleEventType::InProgress)
+        );
+    });
+}
+
+#[test]
+fn seed_rows_floor_the_lifecycle_sequence_guard() {
+    // A seed snapshot taken at server cursor N already reflects every
+    // lifecycle up to N; replays at or below it must not regress the state.
+    with_tracker(|tracker, ctx| {
+        let mut row = seed_row(child_task_id());
+        row.state = AmbientAgentTaskState::Succeeded;
+        row.last_event_sequence = Some(30);
+        tracker.observe_child(
+            CHILD_A_RUN_ID,
+            ChildSignal::Seeded(row),
+            &no_killed_runs(),
+            ctx,
+        );
+
+        tracker.observe_child(
+            CHILD_A_RUN_ID,
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::InProgress,
+                sequence: 25,
+            },
+            &no_killed_runs(),
+            ctx,
+        );
+        let child = tracker.children.get(&child_task_id()).expect("tracked");
+        assert_eq!(
+            child.last_lifecycle, None,
+            "a replay below the seed snapshot's cursor must be dropped"
+        );
+
+        tracker.observe_child(
+            CHILD_A_RUN_ID,
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::InProgress,
+                sequence: 31,
+            },
+            &no_killed_runs(),
+            ctx,
+        );
+        let child = tracker.children.get(&child_task_id()).expect("tracked");
+        assert_eq!(
+            child.last_lifecycle,
+            Some(api::LifecycleEventType::InProgress),
+            "events newer than the seed snapshot apply normally"
+        );
+    });
+}

--- a/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
@@ -130,7 +130,10 @@ fn lifecycle_discovers_a_child_that_was_never_announced() {
     with_tracker(|tracker, ctx| {
         tracker.observe_child(
             CHILD_A_RUN_ID,
-            ChildSignal::Lifecycle(api::LifecycleEventType::InProgress),
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::InProgress,
+                sequence: 1,
+            },
             &no_killed_runs(),
             ctx,
         );
@@ -148,7 +151,10 @@ fn lifecycle_then_started_does_not_duplicate_discovery() {
     with_tracker(|tracker, ctx| {
         tracker.observe_child(
             CHILD_A_RUN_ID,
-            ChildSignal::Lifecycle(api::LifecycleEventType::InProgress),
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::InProgress,
+                sequence: 1,
+            },
             &no_killed_runs(),
             ctx,
         );
@@ -171,7 +177,10 @@ fn signals_for_a_killed_run_are_dropped() {
 
         tracker.observe_child(
             CHILD_A_RUN_ID,
-            ChildSignal::Lifecycle(api::LifecycleEventType::InProgress),
+            ChildSignal::Lifecycle {
+                kind: api::LifecycleEventType::InProgress,
+                sequence: 1,
+            },
             &killed,
             ctx,
         );

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -220,9 +220,11 @@ struct ConversationStreamState {
     /// Consecutive `get_ambient_agent_task` failure count for the
     /// post-restore retry loop; resets on success.
     restore_fetch_failures: usize,
-    /// Primary-mode child tracker for this orchestrator family. `None` until
-    /// the family drain creates one on the first batch it handles.
-    tracker: Option<OrchestrationChildTracker>,
+    /// Primary-mode child trackers, keyed by each family's parent task id.
+    /// Anchor-scoped streams only ever populate the anchor's own family;
+    /// subtree-scoped streams add one tracker per mid-tree parent as
+    /// descendants are discovered.
+    family_trackers: HashMap<AmbientAgentTaskId, OrchestrationChildTracker>,
 }
 
 /// Per-orchestrator SSE stream state. Parallels [`ConversationStreamState`]
@@ -262,9 +264,9 @@ struct OrchestratorStreamState {
     /// cursor, so a replay does not generate spurious `ChildSpawned` events
     /// for already-known children.
     seeded: bool,
-    /// Observer-mode child tracker for this orchestrator family. `None` until
-    /// the family drain creates one on the first batch it handles.
-    tracker: Option<OrchestrationChildTracker>,
+    /// Observer-mode child trackers, keyed by each family's parent task id.
+    /// Direct-children scope only ever populates the anchor's own family.
+    family_trackers: HashMap<AmbientAgentTaskId, OrchestrationChildTracker>,
 }
 
 /// Async network coordinator for v2 orchestration event delivery via SSE.
@@ -294,6 +296,20 @@ pub struct OrchestrationEventStreamer {
     /// Run IDs killed locally; kept briefly to drop late server events.
     killed_run_ids: HashSet<String>,
     killed_run_id_order: VecDeque<String>,
+    /// Descendant placeholder requests parked until their family parent's
+    /// own placeholder conversation exists, keyed by the missing family run
+    /// id (subtree streams can announce a grandchild while the mid-tree
+    /// parent's placeholder fetch is still in flight). Retried when the
+    /// parent's placeholder materializes.
+    descendants_waiting_on_family: HashMap<String, Vec<ParkedDescendantPlaceholder>>,
+}
+
+/// A descendant whose placeholder creation is deferred until its family
+/// parent's conversation materializes.
+struct ParkedDescendantPlaceholder {
+    anchor_conversation_id: AIConversationId,
+    child_run_id: String,
+    mode: FamilyDrainMode,
 }
 
 #[allow(private_interfaces)]
@@ -341,51 +357,106 @@ enum FamilyDrainMode {
     Observer,
 }
 
+/// Run-attribution scope of a family drain, derived from the wire filter the
+/// stream was opened with.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum FamilyDrainScope {
+    /// Anchor-family streams (`run_ids` / `ancestor_run_id`): every child
+    /// signal is attributed to the anchor's own family.
+    AnchorFamily,
+    /// Whole-subtree streams (`subtree_root_run_id`): signals are attributed
+    /// to each run's actual family — discovery events to the run they fired
+    /// on, session links and lifecycle events to the wire `parent_run_id` —
+    /// so descendants nest under their real parents.
+    Subtree,
+}
+
 /// Classification of a single event from a parent-family (`include_self`)
 /// SSE stream. Produced by [`classify_family_event`] and fanned out by
 /// [`OrchestrationEventStreamer::drain_family_events`].
+///
+/// `family_run_id` names the family (parent run) a child signal belongs to;
+/// on anchor-scoped streams it is always the anchor's own run id.
 #[derive(Debug, PartialEq)]
 enum FamilyEvent {
     /// Inbox message or lifecycle event on the parent's own run. Delivered by
     /// a Primary consumer; dropped by an Observer.
     ParentSelf(AgentRunEvent),
-    /// `child_agent_started` on the parent run; the child run id is the
+    /// `child_agent_started` on a parent run; the child run id is the
     /// event's `ref_id`.
-    ChildStarted { child_run_id: String },
+    ChildStarted {
+        family_run_id: String,
+        child_run_id: String,
+    },
     /// `run_session_linked` on a child run; the session UUID is the event's
     /// `ref_id`, letting the tracker fill in `session_id` without a fetch.
     ChildSessionLinked {
+        family_run_id: String,
         child_run_id: String,
         session_uuid: String,
     },
-    /// A recognised lifecycle event on a child run.
+    /// A recognised lifecycle event on a child run. `sequence` feeds the
+    /// tracker's monotonic per-child replay guard.
     ChildLifecycle {
+        family_run_id: String,
         child_run_id: String,
         kind: api::LifecycleEventType,
+        sequence: i64,
     },
     /// Anything else (unrecognised type, malformed discovery/session event):
     /// advances the cursor only, for forward compatibility.
     Opaque,
 }
 
-/// Classifies one family-stream event relative to the parent's own
-/// `self_run_id`. Discovery (`child_agent_started`) is recognised only on
-/// the parent's own run; session links and lifecycle events are recognised
-/// only on other (child) runs; the parent's own inbox/lifecycle events
-/// become [`FamilyEvent::ParentSelf`]; everything else is
-/// [`FamilyEvent::Opaque`].
-fn classify_family_event(event: &AgentRunEvent, self_run_id: &str) -> FamilyEvent {
+/// Classifies one family-stream event relative to the anchor's own
+/// `self_run_id`.
+///
+/// In `AnchorFamily` scope, discovery (`child_agent_started`) is recognised
+/// only on the anchor's own run and every child signal is attributed to the
+/// anchor family. In `Subtree` scope, discovery is also recognised on
+/// descendant runs (a mid-tree parent starting a grandchild) and child
+/// signals are attributed to the wire event's `parent_run_id` (falling back
+/// to the anchor for old servers that omit it). The anchor's own
+/// inbox/lifecycle events become [`FamilyEvent::ParentSelf`]; everything
+/// else is [`FamilyEvent::Opaque`].
+fn classify_family_event(
+    event: &AgentRunEvent,
+    self_run_id: &str,
+    scope: FamilyDrainScope,
+) -> FamilyEvent {
     let is_self = event.run_id == self_run_id;
+    // The family a signal on a non-anchor run belongs to: its wire-declared
+    // parent in subtree scope, the anchor family otherwise.
+    let child_event_family = || match scope {
+        FamilyDrainScope::Subtree => event
+            .parent_run_id
+            .clone()
+            .unwrap_or_else(|| self_run_id.to_string()),
+        FamilyDrainScope::AnchorFamily => self_run_id.to_string(),
+    };
     match (is_self, event.event_type.as_str()) {
         (true, EVENT_CHILD_AGENT_STARTED) => match event.ref_id.as_deref() {
             Some(child_run_id) if !child_run_id.is_empty() => FamilyEvent::ChildStarted {
+                family_run_id: self_run_id.to_string(),
                 child_run_id: child_run_id.to_string(),
             },
             // A discovery event with no child run id is unusable.
             _ => FamilyEvent::Opaque,
         },
+        (false, EVENT_CHILD_AGENT_STARTED) if scope == FamilyDrainScope::Subtree => {
+            match event.ref_id.as_deref() {
+                // A mid-tree parent started a grandchild: the family is the
+                // run the discovery event fired on.
+                Some(child_run_id) if !child_run_id.is_empty() => FamilyEvent::ChildStarted {
+                    family_run_id: event.run_id.clone(),
+                    child_run_id: child_run_id.to_string(),
+                },
+                _ => FamilyEvent::Opaque,
+            }
+        }
         (false, EVENT_RUN_SESSION_LINKED) => match event.ref_id.as_deref() {
             Some(session_uuid) if !session_uuid.is_empty() => FamilyEvent::ChildSessionLinked {
+                family_run_id: child_event_family(),
                 child_run_id: event.run_id.clone(),
                 session_uuid: session_uuid.to_string(),
             },
@@ -393,8 +464,10 @@ fn classify_family_event(event: &AgentRunEvent, self_run_id: &str) -> FamilyEven
         },
         (false, event_type) => match lifecycle_event_type_from_wire(event_type) {
             Some(kind) => FamilyEvent::ChildLifecycle {
+                family_run_id: child_event_family(),
                 child_run_id: event.run_id.clone(),
                 kind,
+                sequence: event.sequence,
             },
             // A child `new_message` or any unrecognised type: not actionable
             // by the tracker (the viewer drops it, the owner has no delivery
@@ -527,33 +600,54 @@ impl OrchestrationEventStreamer {
     }
 
     /// Fans out one family (`include_self`) SSE batch: classifies each event
-    /// and routes it to the tracker (discovery / session-link / lifecycle) or
-    /// Primary parent-self delivery (`ParentSelf`), then advances the cursor
-    /// with consumer-appropriate authority.
+    /// and routes it to the owning family's tracker (discovery /
+    /// session-link / lifecycle) or Primary parent-self delivery
+    /// (`ParentSelf`), then advances the cursor with consumer-appropriate
+    /// authority.
     ///
-    /// The tracker is passed by value and returned so callers can keep it in
-    /// `self` state without a borrow conflict against `handle_event_batch`
-    /// and `killed_run_ids`. The tracker is the sole status writer for child
-    /// status and emits `ChildStatusChanged`; child lifecycle events are also
-    /// forwarded to `handle_event_batch` in Primary mode so the parent's
+    /// The tracker map is passed by value and returned so callers can keep it
+    /// in `self` state without a borrow conflict against `handle_event_batch`
+    /// and `killed_run_ids`. Anchor-scoped drains only ever touch the
+    /// anchor's own family; subtree-scoped drains create one tracker per
+    /// mid-tree parent as descendants are attributed to their real families.
+    /// The trackers are the sole status writers for child status and emit
+    /// `ChildStatusChanged`; child lifecycle events are also forwarded to
+    /// `handle_event_batch` in Primary mode so the parent's
     /// `OrchestrationEventService` receives them for conversation injection.
     #[allow(clippy::too_many_arguments)]
     fn drain_family_events(
         &mut self,
         cursor_conversation_id: AIConversationId,
         self_run_id: &str,
+        anchor_task_id: AmbientAgentTaskId,
         mode: FamilyDrainMode,
-        mut tracker: OrchestrationChildTracker,
+        scope: FamilyDrainScope,
+        mut trackers: HashMap<AmbientAgentTaskId, OrchestrationChildTracker>,
         previous_cursor: i64,
         events: Vec<AgentRunEvent>,
         messages: Vec<ReceivedMessageInput>,
         ctx: &mut ModelContext<Self>,
-    ) -> OrchestrationChildTracker {
+    ) -> HashMap<AmbientAgentTaskId, OrchestrationChildTracker> {
         let max_seq = events
             .iter()
             .map(|event| event.sequence)
             .max()
             .unwrap_or(previous_cursor);
+
+        /// The tracker owning `family_run_id`, created on first use.
+        /// A malformed family id falls back to the anchor family.
+        fn family_tracker<'a>(
+            trackers: &'a mut HashMap<AmbientAgentTaskId, OrchestrationChildTracker>,
+            family_run_id: &str,
+            anchor_task_id: AmbientAgentTaskId,
+        ) -> &'a mut OrchestrationChildTracker {
+            let family_task_id = family_run_id
+                .parse::<AmbientAgentTaskId>()
+                .unwrap_or(anchor_task_id);
+            trackers
+                .entry(family_task_id)
+                .or_insert_with(|| OrchestrationChildTracker::new(family_task_id))
+        }
 
         let mut parent_self_events = Vec::new();
         // Child lifecycle events are forwarded to `handle_event_batch` as well
@@ -561,19 +655,24 @@ impl OrchestrationEventStreamer {
         // them as orchestration events and not just as status updates.
         let mut child_lifecycle_for_batch = Vec::new();
         for event in events {
-            match classify_family_event(&event, self_run_id) {
+            match classify_family_event(&event, self_run_id, scope) {
                 FamilyEvent::ParentSelf(event) => parent_self_events.push(event),
-                FamilyEvent::ChildStarted { child_run_id } => {
+                FamilyEvent::ChildStarted {
+                    family_run_id,
+                    child_run_id,
+                } => {
                     // Create a local placeholder so the pill bar reflects the new
                     // child immediately, without waiting for the tracker's async
                     // metadata fetch to resolve.
-                    self.ensure_remote_child_placeholder(
+                    self.ensure_family_child_placeholder(
                         cursor_conversation_id,
+                        self_run_id,
+                        &family_run_id,
                         child_run_id.clone(),
                         mode,
                         ctx,
                     );
-                    tracker.observe_child(
+                    family_tracker(&mut trackers, &family_run_id, anchor_task_id).observe_child(
                         &child_run_id,
                         ChildSignal::Started,
                         &self.killed_run_ids,
@@ -581,10 +680,11 @@ impl OrchestrationEventStreamer {
                     );
                 }
                 FamilyEvent::ChildSessionLinked {
+                    family_run_id,
                     child_run_id,
                     session_uuid,
                 } => {
-                    tracker.observe_child(
+                    family_tracker(&mut trackers, &family_run_id, anchor_task_id).observe_child(
                         &child_run_id,
                         ChildSignal::SessionLinked {
                             session_uuid: session_uuid.clone(),
@@ -602,11 +702,18 @@ impl OrchestrationEventStreamer {
                         });
                     }
                 }
-                FamilyEvent::ChildLifecycle { child_run_id, kind } => {
+                FamilyEvent::ChildLifecycle {
+                    family_run_id,
+                    child_run_id,
+                    kind,
+                    sequence,
+                } => {
                     // Backstop: if this lifecycle arrives before (or instead of)
                     // `child_agent_started`, ensure a placeholder still exists.
-                    self.ensure_remote_child_placeholder(
+                    self.ensure_family_child_placeholder(
                         cursor_conversation_id,
+                        self_run_id,
+                        &family_run_id,
                         child_run_id.clone(),
                         mode,
                         ctx,
@@ -614,9 +721,9 @@ impl OrchestrationEventStreamer {
                     if mode == FamilyDrainMode::Primary {
                         child_lifecycle_for_batch.push(event);
                     }
-                    tracker.observe_child(
+                    family_tracker(&mut trackers, &family_run_id, anchor_task_id).observe_child(
                         &child_run_id,
-                        ChildSignal::Lifecycle(kind),
+                        ChildSignal::Lifecycle { kind, sequence },
                         &self.killed_run_ids,
                         ctx,
                     );
@@ -671,15 +778,112 @@ impl OrchestrationEventStreamer {
             }
         }
 
-        tracker
+        trackers
     }
 
     // ---- Remote-child placeholder creation (family path) -----------------
+
+    /// Routes a family child's placeholder to the conversation it nests
+    /// under: the anchor conversation for the anchor's own children, the
+    /// family parent's placeholder conversation for deeper descendants.
+    /// Descendants whose family parent has no local conversation yet (its
+    /// own placeholder fetch may still be in flight) are parked and retried
+    /// when the parent's placeholder materializes.
+    #[allow(clippy::too_many_arguments)]
+    fn ensure_family_child_placeholder(
+        &mut self,
+        anchor_conversation_id: AIConversationId,
+        self_run_id: &str,
+        family_run_id: &str,
+        child_run_id: String,
+        mode: FamilyDrainMode,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let placeholder_parent = if family_run_id == self_run_id {
+            Some(anchor_conversation_id)
+        } else {
+            BlocklistAIHistoryModel::as_ref(ctx).conversation_id_for_agent_id(family_run_id)
+        };
+        match placeholder_parent {
+            Some(parent_conversation_id) => self.ensure_remote_child_placeholder(
+                anchor_conversation_id,
+                parent_conversation_id,
+                child_run_id,
+                mode,
+                ctx,
+            ),
+            None => self.park_descendant_placeholder(
+                family_run_id.to_string(),
+                anchor_conversation_id,
+                child_run_id,
+                mode,
+            ),
+        }
+    }
+
+    /// Parks a descendant placeholder request until `family_run_id`'s own
+    /// placeholder conversation exists. Deduplicated per (anchor, child).
+    fn park_descendant_placeholder(
+        &mut self,
+        family_run_id: String,
+        anchor_conversation_id: AIConversationId,
+        child_run_id: String,
+        mode: FamilyDrainMode,
+    ) {
+        log::info!(
+            "[orch-drain] parking descendant placeholder child_run_id={child_run_id} until \
+             family parent {family_run_id} materializes"
+        );
+        let parked = self
+            .descendants_waiting_on_family
+            .entry(family_run_id)
+            .or_default();
+        if parked.iter().any(|p| {
+            p.child_run_id == child_run_id && p.anchor_conversation_id == anchor_conversation_id
+        }) {
+            return;
+        }
+        parked.push(ParkedDescendantPlaceholder {
+            anchor_conversation_id,
+            child_run_id,
+            mode,
+        });
+    }
+
+    /// Re-drives placeholder creation for descendants parked on
+    /// `family_run_id` once that run's own placeholder conversation exists.
+    fn unpark_descendants_waiting_on(&mut self, family_run_id: &str, ctx: &mut ModelContext<Self>) {
+        let Some(parked) = self.descendants_waiting_on_family.remove(family_run_id) else {
+            return;
+        };
+        let Some(family_conversation_id) =
+            BlocklistAIHistoryModel::as_ref(ctx).conversation_id_for_agent_id(family_run_id)
+        else {
+            // Still no conversation (e.g. the placeholder fetch failed);
+            // leave the entries parked for the next drain to retry.
+            self.descendants_waiting_on_family
+                .insert(family_run_id.to_string(), parked);
+            return;
+        };
+        for parked_child in parked {
+            self.ensure_remote_child_placeholder(
+                parked_child.anchor_conversation_id,
+                family_conversation_id,
+                parked_child.child_run_id,
+                parked_child.mode,
+                ctx,
+            );
+        }
+    }
 
     /// Creates a local `is_remote_child` placeholder for an out-of-band
     /// (cloud) child announced by a `child_agent_started` event on the owner's
     /// family SSE stream, so the orchestrator pill bar renders the child
     /// immediately without waiting for the tracker's async metadata fetch.
+    /// `parent_conversation_id` is the conversation the placeholder nests
+    /// under (the anchor conversation, or a mid-tree parent's placeholder on
+    /// subtree streams); `anchor_conversation_id` identifies the stream the
+    /// request originated from.
     ///
     /// Idempotent: a no-op if the history model already knows this `run_id`
     /// (e.g. an in-band child registered by `StartAgentExecutor`, a restored
@@ -687,6 +891,7 @@ impl OrchestrationEventStreamer {
     /// skipped since they are not the authoritative process for the run.
     fn ensure_remote_child_placeholder(
         &mut self,
+        anchor_conversation_id: AIConversationId,
         parent_conversation_id: AIConversationId,
         child_run_id: String,
         mode: FamilyDrainMode,
@@ -700,9 +905,12 @@ impl OrchestrationEventStreamer {
             return;
         }
         // A Primary passive view must not impersonate the owning process.
-        // Observer is the explicit exception: its local placeholder and cursor
-        // are the representation consumed by the viewer hierarchy.
-        if mode == FamilyDrainMode::Primary && self.is_remote_run_view(parent_conversation_id, ctx)
+        // The check runs against the anchor: on subtree streams the family
+        // parent's conversation is itself a remote-child placeholder that
+        // this process authoritatively owns. Observer is the explicit
+        // exception: its local placeholder and cursor are the representation
+        // consumed by the viewer hierarchy.
+        if mode == FamilyDrainMode::Primary && self.is_remote_run_view(anchor_conversation_id, ctx)
         {
             return;
         }
@@ -718,6 +926,7 @@ impl OrchestrationEventStreamer {
             async move { ai_client.get_ambient_agent_task(&task_id).await },
             move |me, result, ctx| {
                 me.finish_remote_child_placeholder(
+                    anchor_conversation_id,
                     parent_conversation_id,
                     child_run_id,
                     mode,
@@ -732,8 +941,10 @@ impl OrchestrationEventStreamer {
     /// Creates the child `AIConversation` from the fetched task metadata and
     /// marks it `is_remote_child` so no redundant per-child SSE is opened —
     /// the child's events already arrive on the parent's ancestor stream.
+    #[allow(clippy::too_many_arguments)]
     fn finish_remote_child_placeholder(
         &mut self,
+        anchor_conversation_id: AIConversationId,
         parent_conversation_id: AIConversationId,
         child_run_id: String,
         _mode: FamilyDrainMode,
@@ -757,6 +968,9 @@ impl OrchestrationEventStreamer {
             .conversation_id_for_agent_id(&child_run_id)
             .is_some()
         {
+            // Descendants parked on this run can attach now regardless of
+            // which path created its conversation.
+            self.unpark_descendants_waiting_on(&child_run_id, ctx);
             return;
         }
         let Some(terminal_surface_id) = BlocklistAIHistoryModel::as_ref(ctx)
@@ -793,12 +1007,17 @@ impl OrchestrationEventStreamer {
         // If a terminal lifecycle event arrived via SSE before this async fetch
         // resolved, the tracker already processed it but had no conversation to
         // write status to. Apply it now so the pill badge shows the correct
-        // state rather than remaining at the placeholder default.
+        // state rather than remaining at the placeholder default. The child's
+        // family tracker may belong to a mid-tree parent, so scan the anchor
+        // stream's whole tracker map.
         let pending_status = self
             .streams
-            .get(&parent_conversation_id)
-            .and_then(|stream| stream.tracker.as_ref())
-            .and_then(|tracker| tracker.child_conversation_status_from_lifecycle(&child_run_id));
+            .get(&anchor_conversation_id)
+            .and_then(|stream| {
+                stream.family_trackers.values().find_map(|tracker| {
+                    tracker.child_conversation_status_from_lifecycle(&child_run_id)
+                })
+            });
         if let Some(status) = pending_status {
             let child_info = {
                 let history = BlocklistAIHistoryModel::as_ref(ctx);
@@ -816,6 +1035,11 @@ impl OrchestrationEventStreamer {
                 });
             }
         }
+
+        // This run may itself be the missing family parent of parked
+        // descendants (subtree streams announce grandchildren while the
+        // mid-tree parent's placeholder fetch is still in flight).
+        self.unpark_descendants_waiting_on(&child_run_id, ctx);
     }
 
     /// Owner-side family drain: reads the conversation's SSE buffer and routes
@@ -860,23 +1084,38 @@ impl OrchestrationEventStreamer {
             return;
         }
 
-        let tracker = self
+        // The scope follows the wire filter the stream was opened with:
+        // subtree filters attribute descendants to their real families.
+        let scope = self
+            .streams
+            .get(&conversation_id)
+            .and_then(|stream| stream.sse_connection.as_ref())
+            .map(|connection| match connection.connected_filter {
+                AgentEventFilter::SubtreeRootRunId { .. } => FamilyDrainScope::Subtree,
+                AgentEventFilter::RunIds(_) | AgentEventFilter::AncestorRunId { .. } => {
+                    FamilyDrainScope::AnchorFamily
+                }
+            })
+            .unwrap_or(FamilyDrainScope::AnchorFamily);
+        let trackers = self
             .streams
             .get_mut(&conversation_id)
-            .and_then(|stream| stream.tracker.take())
-            .unwrap_or_else(|| OrchestrationChildTracker::new(parent_task_id));
-        let tracker = self.drain_family_events(
+            .map(|stream| std::mem::take(&mut stream.family_trackers))
+            .unwrap_or_default();
+        let trackers = self.drain_family_events(
             conversation_id,
             &self_run_id,
+            parent_task_id,
             FamilyDrainMode::Primary,
-            tracker,
+            scope,
+            trackers,
             cursor,
             events,
             messages,
             ctx,
         );
         if let Some(stream) = self.streams.get_mut(&conversation_id) {
-            stream.tracker = Some(tracker);
+            stream.family_trackers = trackers;
         }
     }
 
@@ -921,23 +1160,27 @@ impl OrchestrationEventStreamer {
             .max()
             .unwrap_or(cursor);
 
-        let tracker = self
+        // Viewer streams are direct-children scoped, so every child signal
+        // belongs to the anchor family.
+        let trackers = self
             .viewer_mode_orchestrators
             .get_mut(&parent_task_id)
-            .and_then(|entry| entry.tracker.take())
-            .unwrap_or_else(|| OrchestrationChildTracker::new(parent_task_id));
-        let tracker = self.drain_family_events(
+            .map(|entry| std::mem::take(&mut entry.family_trackers))
+            .unwrap_or_default();
+        let trackers = self.drain_family_events(
             primary_placeholder,
             &self_run_id,
+            parent_task_id,
             FamilyDrainMode::Observer,
-            tracker,
+            FamilyDrainScope::AnchorFamily,
+            trackers,
             cursor,
             events,
             Vec::new(),
             ctx,
         );
         if let Some(entry) = self.viewer_mode_orchestrators.get_mut(&parent_task_id) {
-            entry.tracker = Some(tracker);
+            entry.family_trackers = trackers;
             entry.event_cursor = entry.event_cursor.max(max_seq);
         }
         // Mirror the advanced cursor onto every registered viewer placeholder.
@@ -1000,6 +1243,7 @@ impl OrchestrationEventStreamer {
             next_wake_generation: 0,
             killed_run_ids: HashSet::new(),
             killed_run_id_order: VecDeque::new(),
+            descendants_waiting_on_family: HashMap::new(),
         }
     }
 
@@ -1025,6 +1269,7 @@ impl OrchestrationEventStreamer {
             next_wake_generation: 0,
             killed_run_ids: HashSet::new(),
             killed_run_id_order: VecDeque::new(),
+            descendants_waiting_on_family: HashMap::new(),
         }
     }
 
@@ -2258,10 +2503,28 @@ impl OrchestrationEventStreamer {
             // be created). Return NoFilter defensively if it's absent so
             // `on_server_token_assigned` re-evaluates when the token arrives.
             return match self.self_run_id(conversation_id, ctx) {
-                Some(self_run_id) => DesiredSseFilter::Filter(AgentEventFilter::AncestorRunId {
-                    ancestor_run_id: self_run_id,
-                    include_self: true,
-                }),
+                Some(self_run_id) => {
+                    // A parent that is not itself a child is an orchestration
+                    // tree root: with multi-level orchestration it streams
+                    // its whole subtree so runs spawned by remote mid-tree
+                    // children are observed too. Mid-tree parents keep the
+                    // direct-family ancestor scope (the server rejects
+                    // non-root subtree anchors).
+                    let is_tree_root = !BlocklistAIHistoryModel::as_ref(ctx)
+                        .conversation(&conversation_id)
+                        .is_some_and(|c| c.is_child_agent_conversation());
+                    let filter = if multi_level_subtree_scope_enabled() && is_tree_root {
+                        AgentEventFilter::SubtreeRootRunId {
+                            root_run_id: self_run_id,
+                        }
+                    } else {
+                        AgentEventFilter::AncestorRunId {
+                            ancestor_run_id: self_run_id,
+                            include_self: true,
+                        }
+                    };
+                    DesiredSseFilter::Filter(filter)
+                }
                 None => {
                     log::warn!(
                         "Parent conversation {conversation_id:?} has watched children \
@@ -2780,8 +3043,21 @@ fn agent_event_filters_equivalent(a: &AgentEventFilter, b: &AgentEventFilter) ->
                 include_self: b_self,
             },
         ) => a_run == b_run && a_self == b_self,
+        (
+            AgentEventFilter::SubtreeRootRunId { root_run_id: a_run },
+            AgentEventFilter::SubtreeRootRunId { root_run_id: b_run },
+        ) => a_run == b_run,
         _ => false,
     }
+}
+
+/// True iff descendant subtrees should be streamed and attributed to their
+/// real families. Multi-level orchestration is only implemented inside the
+/// unified-stack code paths (the legacy drains and seeds are
+/// family-unaware), so both flags must be on.
+pub(crate) fn multi_level_subtree_scope_enabled() -> bool {
+    FeatureFlag::MultiLevelOrchestration.is_enabled()
+        && FeatureFlag::OrchestrationUnifiedStack.is_enabled()
 }
 
 pub(crate) fn agent_task_harness(

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -28,7 +28,7 @@ use crate::ai::agent_events::{
     AgentMessageEventMetadata, MessageHydrator, ServerApiAgentEventSource, run_agent_event_driver,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::server::retry_strategies::is_transient_http_error;
+use crate::server::retry_strategies::{is_permanent_non_auth_4xx_error, is_transient_http_error};
 use crate::server::server_api::ai::{AIClient, AgentRunEvent, TaskListFilter};
 use crate::server::server_api::{ServerApi, ServerApiProvider};
 
@@ -46,6 +46,12 @@ const MAX_KILLED_RUN_IDS: usize = 1024;
 /// Max child runs fetched per cold-start `?ancestor_run_id=` REST seed in
 /// viewer mode. The server caps at 100 regardless.
 const VIEWER_MODE_SEED_FETCH_LIMIT: i32 = 100;
+/// Consecutive permanent 4xx failures on a subtree stream before the
+/// conversation falls back to the ancestor scope. Protects against servers
+/// without the subtree endpoint and against local/server root-ness
+/// disagreement: the parent's own inbox must never stay dark behind an
+/// un-openable subtree stream.
+const SUBTREE_PERMANENT_ERROR_GIVE_UP_FAILURES: usize = 3;
 
 /// Wire `event_type` for a parent's own inbox message events.
 const EVENT_NEW_MESSAGE: &str = "new_message";
@@ -225,6 +231,12 @@ struct ConversationStreamState {
     /// subtree-scoped streams add one tracker per mid-tree parent as
     /// descendants are discovered.
     family_trackers: HashMap<AmbientAgentTaskId, OrchestrationChildTracker>,
+    /// Set once a subtree stream for this conversation has been rejected
+    /// with sustained permanent 4xx failures (server without the endpoint,
+    /// or a root-ness disagreement). Filter selection then falls back to
+    /// the ancestor scope for the rest of the session so the parent's own
+    /// inbox keeps flowing.
+    subtree_stream_unavailable: bool,
 }
 
 /// Per-orchestrator SSE stream state. Parallels [`ConversationStreamState`]
@@ -302,6 +314,9 @@ pub struct OrchestrationEventStreamer {
     /// parent's placeholder fetch is still in flight). Retried when the
     /// parent's placeholder materializes.
     descendants_waiting_on_family: HashMap<String, Vec<ParkedDescendantPlaceholder>>,
+    /// Family run ids with a missing-family placeholder fetch in flight
+    /// (see [`Self::ensure_missing_family_placeholder`]).
+    family_placeholder_fetches_in_flight: HashSet<String>,
 }
 
 /// A descendant whose placeholder creation is deferred until its family
@@ -718,7 +733,16 @@ impl OrchestrationEventStreamer {
                         mode,
                         ctx,
                     );
-                    if mode == FamilyDrainMode::Primary {
+                    // Only DIRECT children's lifecycle events are injected
+                    // into the parent conversation's pending-event queue
+                    // (parity with the anchor-scoped behavior, where every
+                    // family event belongs to the anchor). Deeper
+                    // descendants surface through the tracker's status
+                    // write-through and broadcasts instead — injecting the
+                    // whole tree would flood the root's transcript and
+                    // double-deliver when a local mid-tree parent's own
+                    // family stream also carries the event.
+                    if mode == FamilyDrainMode::Primary && family_run_id == self_run_id {
                         child_lifecycle_for_batch.push(event);
                     }
                     family_tracker(&mut trackers, &family_run_id, anchor_task_id).observe_child(
@@ -817,18 +841,23 @@ impl OrchestrationEventStreamer {
                 anchor_conversation_id,
                 child_run_id,
                 mode,
+                ctx,
             ),
         }
     }
 
     /// Parks a descendant placeholder request until `family_run_id`'s own
     /// placeholder conversation exists. Deduplicated per (anchor, child).
+    /// Also re-kicks the missing family's own placeholder fetch: without
+    /// this, a single failed family fetch would strand every descendant
+    /// parked behind it until an unrelated event for the family arrived.
     fn park_descendant_placeholder(
         &mut self,
         family_run_id: String,
         anchor_conversation_id: AIConversationId,
         child_run_id: String,
         mode: FamilyDrainMode,
+        ctx: &mut ModelContext<Self>,
     ) {
         log::info!(
             "[orch-drain] parking descendant placeholder child_run_id={child_run_id} until \
@@ -836,7 +865,7 @@ impl OrchestrationEventStreamer {
         );
         let parked = self
             .descendants_waiting_on_family
-            .entry(family_run_id)
+            .entry(family_run_id.clone())
             .or_default();
         if parked.iter().any(|p| {
             p.child_run_id == child_run_id && p.anchor_conversation_id == anchor_conversation_id
@@ -848,10 +877,90 @@ impl OrchestrationEventStreamer {
             child_run_id,
             mode,
         });
+        self.ensure_missing_family_placeholder(anchor_conversation_id, family_run_id, mode, ctx);
+    }
+
+    /// Fetches a missing family parent's task row and creates its
+    /// placeholder under its own resolved parent, so descendants parked on
+    /// it can drain. Guarded against duplicate in-flight fetches; a failed
+    /// fetch leaves the parked descendants for the next drain (whose
+    /// parking call re-kicks this fetch).
+    fn ensure_missing_family_placeholder(
+        &mut self,
+        anchor_conversation_id: AIConversationId,
+        family_run_id: String,
+        mode: FamilyDrainMode,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if !self
+            .family_placeholder_fetches_in_flight
+            .insert(family_run_id.clone())
+        {
+            return;
+        }
+        let Ok(family_task_id) = family_run_id.parse::<AmbientAgentTaskId>() else {
+            self.family_placeholder_fetches_in_flight
+                .remove(&family_run_id);
+            return;
+        };
+        let ai_client = self.ai_client.clone();
+        ctx.spawn(
+            async move { ai_client.get_ambient_agent_task(&family_task_id).await },
+            move |me, result, ctx| {
+                me.family_placeholder_fetches_in_flight
+                    .remove(&family_run_id);
+                let task = match result {
+                    Ok(task) => task,
+                    Err(err) => {
+                        log::warn!(
+                            "[orch-drain] missing-family placeholder fetch failed for \
+                             family_run_id={family_run_id}: {err:#}; parked descendants \
+                             retry on the next drain"
+                        );
+                        return;
+                    }
+                };
+                // The family's own placeholder nests under ITS parent: the
+                // anchor conversation when the row names no other parent,
+                // otherwise that run's conversation (parking the family
+                // itself if that is also still missing — the chain resolves
+                // one level per fetch).
+                let family_parent_conversation_id = match task.parent_run_id.as_deref() {
+                    Some(parent) => {
+                        BlocklistAIHistoryModel::as_ref(ctx).conversation_id_for_agent_id(parent)
+                    }
+                    None => Some(anchor_conversation_id),
+                };
+                match family_parent_conversation_id {
+                    Some(parent_conversation_id) => me.finish_remote_child_placeholder(
+                        anchor_conversation_id,
+                        parent_conversation_id,
+                        family_run_id,
+                        mode,
+                        Ok(task),
+                        ctx,
+                    ),
+                    None => {
+                        let grandparent_run_id = task
+                            .parent_run_id
+                            .clone()
+                            .expect("a missing parent conversation implies a named parent");
+                        me.park_descendant_placeholder(
+                            grandparent_run_id,
+                            anchor_conversation_id,
+                            family_run_id,
+                            mode,
+                            ctx,
+                        );
+                    }
+                }
+            },
+        );
     }
 
     /// Re-drives placeholder creation for descendants parked on
     /// `family_run_id` once that run's own placeholder conversation exists.
+    /// Children killed while parked are dropped rather than resurrected.
     fn unpark_descendants_waiting_on(&mut self, family_run_id: &str, ctx: &mut ModelContext<Self>) {
         let Some(parked) = self.descendants_waiting_on_family.remove(family_run_id) else {
             return;
@@ -866,6 +975,9 @@ impl OrchestrationEventStreamer {
             return;
         };
         for parked_child in parked {
+            if self.killed_run_ids.contains(&parked_child.child_run_id) {
+                continue;
+            }
             self.ensure_remote_child_placeholder(
                 parked_child.anchor_conversation_id,
                 family_conversation_id,
@@ -1244,6 +1356,7 @@ impl OrchestrationEventStreamer {
             killed_run_ids: HashSet::new(),
             killed_run_id_order: VecDeque::new(),
             descendants_waiting_on_family: HashMap::new(),
+            family_placeholder_fetches_in_flight: HashSet::new(),
         }
     }
 
@@ -1270,6 +1383,7 @@ impl OrchestrationEventStreamer {
             killed_run_ids: HashSet::new(),
             killed_run_id_order: VecDeque::new(),
             descendants_waiting_on_family: HashMap::new(),
+            family_placeholder_fetches_in_flight: HashSet::new(),
         }
     }
 
@@ -1515,15 +1629,28 @@ impl OrchestrationEventStreamer {
         let Some(entry) = self.viewer_mode_orchestrators.get_mut(&parent_task_id) else {
             return;
         };
-        entry.consumers.remove(&consumer_id);
+        let removed_placeholder = entry.consumers.remove(&consumer_id);
         let remaining = entry.consumers.len();
         if remaining == 0 {
-            // Last viewer closed: tear down the ancestor SSE.
+            // Last viewer closed: tear down the ancestor SSE and drop any
+            // descendants still parked against this entry's placeholder.
             if let Some(connection) = entry.sse_connection.take() {
                 connection.abort_handle.abort();
             }
             self.viewer_mode_orchestrators.remove(&parent_task_id);
+            if let Some(placeholder) = removed_placeholder {
+                self.prune_parked_descendants_for_anchor(placeholder);
+            }
         }
+    }
+
+    /// Drops parked descendant placeholder requests anchored on
+    /// `anchor_conversation_id`.
+    fn prune_parked_descendants_for_anchor(&mut self, anchor_conversation_id: AIConversationId) {
+        self.descendants_waiting_on_family.retain(|_, parked| {
+            parked.retain(|p| p.anchor_conversation_id != anchor_conversation_id);
+            !parked.is_empty()
+        });
     }
 
     /// True iff the viewer-mode entry has previously observed `run_id`
@@ -2149,6 +2276,10 @@ impl OrchestrationEventStreamer {
             }
         }
 
+        // Parked descendants anchored on the removed conversation can never
+        // materialize; drop them so they don't leak or resurrect later.
+        self.prune_parked_descendants_for_anchor(conversation_id);
+
         if let Some(run_id) = removed_run_id.as_deref() {
             let mut affected = Vec::new();
             for (other_id, stream) in self.streams.iter_mut() {
@@ -2378,6 +2509,20 @@ impl OrchestrationEventStreamer {
             .and_then(|c| c.run_id())
     }
 
+    /// Server-side root-ness of `run_id` from the cached task row (`Some`
+    /// only when a row is cached: a root has no `parent_run_id`). Guarded on
+    /// the singleton being registered so test harnesses without an
+    /// `AgentConversationsModel` fall back to local state.
+    fn server_task_row_is_root(&self, run_id: &str, ctx: &warpui::AppContext) -> Option<bool> {
+        if !ctx.has_singleton_model::<AgentConversationsModel>() {
+            return None;
+        }
+        let task_id = run_id.parse::<AmbientAgentTaskId>().ok()?;
+        AgentConversationsModel::as_ref(ctx)
+            .get_task_data(&task_id)
+            .map(|task| task.parent_run_id.is_none())
+    }
+
     /// Parent role: the conversation has at least one watched child
     /// run_id (i.e. a watched run_id that is not its own self_run_id).
     fn is_parent_agent_conversation(
@@ -2509,11 +2654,26 @@ impl OrchestrationEventStreamer {
                     // its whole subtree so runs spawned by remote mid-tree
                     // children are observed too. Mid-tree parents keep the
                     // direct-family ancestor scope (the server rejects
-                    // non-root subtree anchors).
-                    let is_tree_root = !BlocklistAIHistoryModel::as_ref(ctx)
-                        .conversation(&conversation_id)
-                        .is_some_and(|c| c.is_child_agent_conversation());
-                    let filter = if multi_level_subtree_scope_enabled() && is_tree_root {
+                    // non-root subtree anchors). Root-ness prefers the
+                    // server's task row (matching the restore seed) and only
+                    // falls back to local parent linkage when no row is
+                    // cached; a subtree stream the server already rejected
+                    // stays on the ancestor fallback.
+                    let is_tree_root = self
+                        .server_task_row_is_root(&self_run_id, ctx)
+                        .unwrap_or_else(|| {
+                            !BlocklistAIHistoryModel::as_ref(ctx)
+                                .conversation(&conversation_id)
+                                .is_some_and(|c| c.is_child_agent_conversation())
+                        });
+                    let subtree_unavailable = self
+                        .streams
+                        .get(&conversation_id)
+                        .is_some_and(|stream| stream.subtree_stream_unavailable);
+                    let filter = if multi_level_subtree_scope_enabled()
+                        && is_tree_root
+                        && !subtree_unavailable
+                    {
                         AgentEventFilter::SubtreeRootRunId {
                             root_run_id: self_run_id,
                         }
@@ -2745,7 +2905,16 @@ impl OrchestrationEventStreamer {
             filter.log_label()
         );
 
-        let config = AgentEventDriverConfig::retry_forever(filter.clone(), cursor);
+        let mut config = AgentEventDriverConfig::retry_forever(filter.clone(), cursor);
+        if matches!(filter, AgentEventFilter::SubtreeRootRunId { .. }) {
+            // A server without the subtree endpoint (or one that disagrees
+            // about the anchor's root-ness) rejects the stream with a
+            // permanent 4xx. Let the driver give up after a short streak so
+            // the exit callback can fall back to the ancestor scope instead
+            // of blacking out the parent's inbox behind a dead filter.
+            config.permanent_error_give_up_failures =
+                Some(SUBTREE_PERMANENT_ERROR_GIVE_UP_FAILURES);
+        }
         let source = ServerApiAgentEventSource::new(server_api);
         let hydrator = self.message_hydrator_for_run_id(&self_run_id);
 
@@ -2775,6 +2944,7 @@ impl OrchestrationEventStreamer {
                     log::warn!(
                         "SSE driver exited for {conversation_id:?} (gen={generation}): {err:#}"
                     );
+                    me.note_sse_driver_exit_error(conversation_id, &err);
                     me.reconnect_sse(conversation_id, ctx);
                 }
             },
@@ -2790,6 +2960,33 @@ impl OrchestrationEventStreamer {
 
         // Start periodic event drain.
         self.start_sse_drain_timer(conversation_id, generation, ctx);
+    }
+
+    /// Marks the subtree scope unavailable for `conversation_id` when its
+    /// stream driver gave up on a permanent 4xx streak; the subsequent
+    /// reconnect then selects the ancestor fallback via
+    /// [`Self::desired_sse_filter`].
+    fn note_sse_driver_exit_error(
+        &mut self,
+        conversation_id: AIConversationId,
+        err: &anyhow::Error,
+    ) {
+        let Some(stream) = self.streams.get_mut(&conversation_id) else {
+            return;
+        };
+        let subtree_connected = stream.sse_connection.as_ref().is_some_and(|c| {
+            matches!(
+                c.connected_filter,
+                AgentEventFilter::SubtreeRootRunId { .. }
+            )
+        });
+        if subtree_connected && is_permanent_non_auth_4xx_error(err) {
+            log::warn!(
+                "Subtree event stream for {conversation_id:?} was rejected by the server \
+                 ({err:#}); falling back to the ancestor scope"
+            );
+            stream.subtree_stream_unavailable = true;
+        }
     }
 
     /// True iff the open SSE's connected filter is stale relative to the

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -863,9 +863,20 @@ impl OrchestrationEventStreamer {
             "[orch-drain] parking descendant placeholder child_run_id={child_run_id} until \
              family parent {family_run_id} materializes"
         );
+        // Re-kick BEFORE the dedupe return: a re-park of an already-parked
+        // child is exactly the retry path after a failed family fetch. The
+        // in-flight guard bounds this to one fetch per family at a time, so
+        // even a corrupt parent cycle costs at most one fetch per drain
+        // tick.
+        self.ensure_missing_family_placeholder(
+            anchor_conversation_id,
+            family_run_id.clone(),
+            mode,
+            ctx,
+        );
         let parked = self
             .descendants_waiting_on_family
-            .entry(family_run_id.clone())
+            .entry(family_run_id)
             .or_default();
         if parked.iter().any(|p| {
             p.child_run_id == child_run_id && p.anchor_conversation_id == anchor_conversation_id
@@ -877,7 +888,6 @@ impl OrchestrationEventStreamer {
             child_run_id,
             mode,
         });
-        self.ensure_missing_family_placeholder(anchor_conversation_id, family_run_id, mode, ctx);
     }
 
     /// Fetches a missing family parent's task row and creates its

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -81,8 +81,8 @@ fn restored_observer_registration_hydrates_local_cursor() {
                 .expect("Observer must re-register");
             assert_eq!(entry.event_cursor, 27);
             assert!(
-                entry.tracker.is_none(),
-                "tracker is initialized lazily by the family drain"
+                entry.family_trackers.is_empty(),
+                "trackers are initialized lazily by the family drain"
             );
         });
     });
@@ -134,8 +134,10 @@ fn observer_placeholder_completion_creates_one_named_history_mapping() {
                 .viewer_mode_orchestrators
                 .entry(parent_task_id)
                 .or_default()
-                .tracker = Some(tracker);
+                .family_trackers
+                .insert(parent_task_id, tracker);
             streamer.finish_remote_child_placeholder(
+                parent_id,
                 parent_id,
                 child_task_id.to_string(),
                 FamilyDrainMode::Observer,
@@ -143,6 +145,7 @@ fn observer_placeholder_completion_creates_one_named_history_mapping() {
                 ctx,
             );
             streamer.finish_remote_child_placeholder(
+                parent_id,
                 parent_id,
                 child_task_id.to_string(),
                 FamilyDrainMode::Observer,
@@ -196,6 +199,8 @@ fn make_run_event(event_type: &str, run_id: &str, ref_id: Option<&str>) -> Agent
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 1,
+        parent_run_id: None,
+        depth: None,
     }
 }
 
@@ -677,6 +682,8 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 7,
+        parent_run_id: None,
+        depth: None,
     };
     assert_eq!(
         consumer.on_event(ignored_event).await.unwrap(),
@@ -691,6 +698,8 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 7,
+        parent_run_id: None,
+        depth: None,
     };
     assert_eq!(
         consumer.on_event(ignored_same_run_lifecycle).await.unwrap(),
@@ -709,6 +718,8 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         execution_id: None,
         occurred_at: "2026-01-01T00:00:01Z".to_string(),
         sequence: 8,
+        parent_run_id: None,
+        depth: None,
     };
     assert_eq!(
         consumer.on_event(target_event).await.unwrap(),
@@ -924,6 +935,8 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
                 execution_id: None,
                 occurred_at: "2026-01-01T00:00:00Z".to_string(),
                 sequence: 17,
+                parent_run_id: None,
+                depth: None,
             },
             AgentRunEvent {
                 event_type: "unrecognized_event_type".to_string(),
@@ -932,6 +945,8 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
                 execution_id: None,
                 occurred_at: "2026-01-01T00:00:00Z".to_string(),
                 sequence: 42,
+                parent_run_id: None,
+                depth: None,
             },
         ];
 
@@ -1012,6 +1027,8 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         execution_id: None,
                         occurred_at: "2026-01-01T00:00:00Z".to_string(),
                         sequence: 17,
+                        parent_run_id: None,
+                        depth: None,
                     },
                     AgentRunEvent {
                         event_type: "run_cancelled".to_string(),
@@ -1020,6 +1037,8 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         execution_id: None,
                         occurred_at: "2026-01-01T00:00:01Z".to_string(),
                         sequence: 18,
+                        parent_run_id: None,
+                        depth: None,
                     },
                     AgentRunEvent {
                         event_type: "new_message".to_string(),
@@ -1028,6 +1047,8 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         execution_id: None,
                         occurred_at: "2026-01-01T00:00:02Z".to_string(),
                         sequence: 19,
+                        parent_run_id: None,
+                        depth: None,
                     },
                 ],
                 vec![
@@ -2619,8 +2640,9 @@ fn register_parent_on_wait_flag_off_is_noop() {
 fn classify_child_agent_started_on_self_is_child_started() {
     let event = make_run_event(EVENT_CHILD_AGENT_STARTED, "parent-run", Some("child-run"));
     assert_eq!(
-        classify_family_event(&event, "parent-run"),
+        classify_family_event(&event, "parent-run", FamilyDrainScope::AnchorFamily),
         FamilyEvent::ChildStarted {
+            family_run_id: "parent-run".to_string(),
             child_run_id: "child-run".to_string(),
         }
     );
@@ -2631,7 +2653,7 @@ fn classify_child_agent_started_without_ref_id_is_opaque() {
     // A discovery event with no child run id carries nothing actionable.
     let event = make_run_event(EVENT_CHILD_AGENT_STARTED, "parent-run", None);
     assert_eq!(
-        classify_family_event(&event, "parent-run"),
+        classify_family_event(&event, "parent-run", FamilyDrainScope::AnchorFamily),
         FamilyEvent::Opaque
     );
 }
@@ -2640,8 +2662,9 @@ fn classify_child_agent_started_without_ref_id_is_opaque() {
 fn classify_run_session_linked_on_child_is_session_linked() {
     let event = make_run_event(EVENT_RUN_SESSION_LINKED, "child-run", Some("session-uuid"));
     assert_eq!(
-        classify_family_event(&event, "parent-run"),
+        classify_family_event(&event, "parent-run", FamilyDrainScope::AnchorFamily),
         FamilyEvent::ChildSessionLinked {
+            family_run_id: "parent-run".to_string(),
             child_run_id: "child-run".to_string(),
             session_uuid: "session-uuid".to_string(),
         }
@@ -2652,10 +2675,12 @@ fn classify_run_session_linked_on_child_is_session_linked() {
 fn classify_run_in_progress_on_child_is_child_lifecycle() {
     let event = make_run_event("run_in_progress", "child-run", None);
     assert_eq!(
-        classify_family_event(&event, "parent-run"),
+        classify_family_event(&event, "parent-run", FamilyDrainScope::AnchorFamily),
         FamilyEvent::ChildLifecycle {
+            family_run_id: "parent-run".to_string(),
             child_run_id: "child-run".to_string(),
             kind: api::LifecycleEventType::InProgress,
+            sequence: 1,
         }
     );
 }
@@ -2664,7 +2689,7 @@ fn classify_run_in_progress_on_child_is_child_lifecycle() {
 fn classify_new_message_on_self_is_parent_self() {
     let event = make_run_event("new_message", "parent-run", Some("msg-1"));
     assert_eq!(
-        classify_family_event(&event, "parent-run"),
+        classify_family_event(&event, "parent-run", FamilyDrainScope::AnchorFamily),
         FamilyEvent::ParentSelf(event.clone())
     );
 }
@@ -2675,7 +2700,7 @@ fn classify_lifecycle_on_self_is_parent_self() {
     // not the child tracker.
     let event = make_run_event("run_in_progress", "parent-run", None);
     assert_eq!(
-        classify_family_event(&event, "parent-run"),
+        classify_family_event(&event, "parent-run", FamilyDrainScope::AnchorFamily),
         FamilyEvent::ParentSelf(event.clone())
     );
 }
@@ -2684,8 +2709,78 @@ fn classify_lifecycle_on_self_is_parent_self() {
 fn classify_unknown_type_is_opaque() {
     let event = make_run_event("some_unknown_event", "child-run", None);
     assert_eq!(
-        classify_family_event(&event, "parent-run"),
+        classify_family_event(&event, "parent-run", FamilyDrainScope::AnchorFamily),
         FamilyEvent::Opaque
+    );
+}
+
+#[test]
+fn classify_descendant_discovery_is_attributed_to_the_run_it_fired_on_in_subtree_scope() {
+    // A `child_agent_started` on a mid-tree run announces a grandchild; the
+    // family is the run the discovery fired on.
+    let event = make_run_event(EVENT_CHILD_AGENT_STARTED, "mid-run", Some("grandchild-run"));
+    assert_eq!(
+        classify_family_event(&event, "root-run", FamilyDrainScope::Subtree),
+        FamilyEvent::ChildStarted {
+            family_run_id: "mid-run".to_string(),
+            child_run_id: "grandchild-run".to_string(),
+        }
+    );
+}
+
+#[test]
+fn classify_descendant_discovery_is_opaque_in_anchor_scope() {
+    // Anchor-scoped streams only recognise discovery on the anchor's own
+    // run; a descendant's discovery event advances the cursor only.
+    let event = make_run_event(EVENT_CHILD_AGENT_STARTED, "mid-run", Some("grandchild-run"));
+    assert_eq!(
+        classify_family_event(&event, "root-run", FamilyDrainScope::AnchorFamily),
+        FamilyEvent::Opaque
+    );
+}
+
+#[test]
+fn classify_descendant_lifecycle_uses_wire_parent_in_subtree_scope() {
+    let mut event = make_run_event("run_succeeded", "grandchild-run", None);
+    event.parent_run_id = Some("mid-run".to_string());
+    assert_eq!(
+        classify_family_event(&event, "root-run", FamilyDrainScope::Subtree),
+        FamilyEvent::ChildLifecycle {
+            family_run_id: "mid-run".to_string(),
+            child_run_id: "grandchild-run".to_string(),
+            kind: api::LifecycleEventType::Succeeded,
+            sequence: 1,
+        }
+    );
+}
+
+#[test]
+fn classify_descendant_lifecycle_without_wire_parent_falls_back_to_anchor() {
+    // Old servers omit parent_run_id; the anchor family absorbs the child
+    // so behavior degrades to the flat direct-children shape.
+    let event = make_run_event("run_succeeded", "grandchild-run", None);
+    assert_eq!(
+        classify_family_event(&event, "root-run", FamilyDrainScope::Subtree),
+        FamilyEvent::ChildLifecycle {
+            family_run_id: "root-run".to_string(),
+            child_run_id: "grandchild-run".to_string(),
+            kind: api::LifecycleEventType::Succeeded,
+            sequence: 1,
+        }
+    );
+}
+
+#[test]
+fn classify_descendant_session_link_uses_wire_parent_in_subtree_scope() {
+    let mut event = make_run_event(EVENT_RUN_SESSION_LINKED, "grandchild-run", Some("sess-1"));
+    event.parent_run_id = Some("mid-run".to_string());
+    assert_eq!(
+        classify_family_event(&event, "root-run", FamilyDrainScope::Subtree),
+        FamilyEvent::ChildSessionLinked {
+            family_run_id: "mid-run".to_string(),
+            child_run_id: "grandchild-run".to_string(),
+            session_uuid: "sess-1".to_string(),
+        }
     );
 }
 
@@ -2750,17 +2845,21 @@ fn drain_family_events_primary_routes_mixed_batch_and_delivers_inbox() {
         }];
 
         streamer.update(&mut app, |me, ctx| {
-            let tracker = OrchestrationChildTracker::new(parent_task_id);
-            let tracker = me.drain_family_events(
+            let trackers = me.drain_family_events(
                 conversation_id,
                 &parent_run_id,
+                parent_task_id,
                 FamilyDrainMode::Primary,
-                tracker,
+                FamilyDrainScope::AnchorFamily,
+                HashMap::new(),
                 0,
                 events,
                 messages,
                 ctx,
             );
+            let tracker = trackers
+                .get(&parent_task_id)
+                .expect("anchor family tracker is created on demand");
             assert!(
                 tracker.is_awaiting_metadata(&child_a),
                 "ChildStarted / ChildLifecycle must route into the tracker"
@@ -2834,19 +2933,23 @@ fn drain_family_events_observer_advances_cursor_without_server_push() {
         ];
 
         streamer.update(&mut app, |me, ctx| {
-            let tracker = OrchestrationChildTracker::new(parent_task_id);
-            let tracker = me.drain_family_events(
+            let trackers = me.drain_family_events(
                 placeholder_id,
                 &parent_run_id,
+                parent_task_id,
                 FamilyDrainMode::Observer,
-                tracker,
+                FamilyDrainScope::AnchorFamily,
+                HashMap::new(),
                 0,
                 events,
                 Vec::new(),
                 ctx,
             );
             assert!(
-                tracker.is_awaiting_metadata(&child),
+                trackers
+                    .get(&parent_task_id)
+                    .expect("anchor family tracker is created on demand")
+                    .is_awaiting_metadata(&child),
                 "child lifecycle must route into the Observer tracker"
             );
         });
@@ -2861,6 +2964,355 @@ fn drain_family_events_observer_advances_cursor_without_server_push() {
             );
         });
     });
+}
+
+#[test]
+fn drain_family_events_subtree_scope_routes_descendants_to_their_families() {
+    // On a subtree-scoped drain, a mid-tree discovery event and the
+    // grandchild's lifecycle must land in the mid-tree parent's family
+    // tracker, not the anchor's.
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let _event_service = app.add_singleton_model(|_| OrchestrationEventService::default());
+
+        let root_task_id = make_parent_task_id_for_test(0xa1);
+        let root_run_id = root_task_id.to_string();
+        let mid_task_id = make_parent_task_id_for_test(0xa2);
+        let mid_run_id = mid_task_id.to_string();
+        let leaf_run_id = make_parent_task_id_for_test(0xa3).to_string();
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(root_run_id.clone());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mut mock = MockAIClient::new();
+        mock.expect_update_event_sequence_on_server()
+            .returning(|_, _| Ok(()));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        // Root starts mid; mid starts leaf; leaf reports lifecycle with
+        // wire parent attribution.
+        let mut leaf_lifecycle = make_seq_event("run_in_progress", &leaf_run_id, None, 12);
+        leaf_lifecycle.parent_run_id = Some(mid_run_id.clone());
+        let events = vec![
+            make_seq_event(
+                EVENT_CHILD_AGENT_STARTED,
+                &root_run_id,
+                Some(&mid_run_id),
+                10,
+            ),
+            make_seq_event(
+                EVENT_CHILD_AGENT_STARTED,
+                &mid_run_id,
+                Some(&leaf_run_id),
+                11,
+            ),
+            leaf_lifecycle,
+        ];
+
+        streamer.update(&mut app, |me, ctx| {
+            let trackers = me.drain_family_events(
+                conversation_id,
+                &root_run_id,
+                root_task_id,
+                FamilyDrainMode::Primary,
+                FamilyDrainScope::Subtree,
+                HashMap::new(),
+                0,
+                events,
+                Vec::new(),
+                ctx,
+            );
+            assert!(
+                trackers
+                    .get(&root_task_id)
+                    .is_some_and(|t| t.is_awaiting_metadata(&mid_run_id)),
+                "the mid-tree run must be tracked in the anchor's family"
+            );
+            let mid_family = trackers
+                .get(&mid_task_id)
+                .expect("a family tracker must be created for the mid-tree parent");
+            assert!(
+                mid_family.is_awaiting_metadata(&leaf_run_id),
+                "the grandchild must be tracked in the mid-tree parent's family"
+            );
+            assert!(
+                !trackers
+                    .get(&root_task_id)
+                    .is_some_and(|t| t.is_awaiting_metadata(&leaf_run_id)),
+                "the grandchild must not be attributed to the anchor family"
+            );
+            // The mid-tree parent has no local conversation yet, so the
+            // grandchild's placeholder must be parked on it.
+            assert!(
+                me.descendants_waiting_on_family.contains_key(&mid_run_id),
+                "grandchild placeholder must park until the mid-tree placeholder exists"
+            );
+        });
+    });
+}
+
+#[test]
+fn drain_family_events_drops_stale_lifecycle_replays() {
+    // A lifecycle event at or below the child's last applied sequence must
+    // not regress the broadcast status (subtree replays resume from the
+    // root cursor and can re-deliver old descendant events).
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let _event_service = app.add_singleton_model(|_| OrchestrationEventService::default());
+        // The terminal-lifecycle arm evicts and refetches the child's cached
+        // task row via AgentConversationsModel.
+        app.add_singleton_model(|_ctx| ServerApiProvider::new_for_test());
+        app.add_singleton_model(crate::ai::agent_conversations_model::AgentConversationsModel::new);
+
+        let parent_task_id = make_parent_task_id_for_test(0xa4);
+        let parent_run_id = parent_task_id.to_string();
+        let child_run_id = make_parent_task_id_for_test(0xa5).to_string();
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(parent_run_id.clone());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mut mock = MockAIClient::new();
+        mock.expect_update_event_sequence_on_server()
+            .returning(|_, _| Ok(()));
+        // The lifecycle backstop kicks a placeholder metadata fetch for the
+        // unknown child; its outcome is irrelevant to the guard.
+        mock.expect_get_ambient_agent_task()
+            .returning(|_| Err(anyhow::anyhow!("metadata fetch not under test")));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        let statuses: Arc<parking_lot::Mutex<Vec<(String, ConversationStatus)>>> =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let statuses_sink = statuses.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&streamer, move |_, event, _| {
+                if let OrchestrationEventStreamerEvent::ChildStatusChanged {
+                    run_id, status, ..
+                } = event
+                {
+                    statuses_sink.lock().push((run_id.clone(), status.clone()));
+                }
+            })
+        });
+
+        streamer.update(&mut app, |me, ctx| {
+            let trackers = me.drain_family_events(
+                conversation_id,
+                &parent_run_id,
+                parent_task_id,
+                FamilyDrainMode::Primary,
+                FamilyDrainScope::AnchorFamily,
+                HashMap::new(),
+                0,
+                vec![make_seq_event("run_succeeded", &child_run_id, None, 20)],
+                Vec::new(),
+                ctx,
+            );
+            // Replay an older InProgress event for the same run.
+            let _ = me.drain_family_events(
+                conversation_id,
+                &parent_run_id,
+                parent_task_id,
+                FamilyDrainMode::Primary,
+                FamilyDrainScope::AnchorFamily,
+                trackers,
+                0,
+                vec![make_seq_event("run_in_progress", &child_run_id, None, 19)],
+                Vec::new(),
+                ctx,
+            );
+        });
+
+        let recorded = statuses.lock().clone();
+        let child_statuses: Vec<&ConversationStatus> = recorded
+            .iter()
+            .filter(|(run_id, _)| *run_id == child_run_id)
+            .map(|(_, status)| status)
+            .collect();
+        assert_eq!(
+            child_statuses,
+            vec![&ConversationStatus::Success],
+            "the stale InProgress replay must be dropped by the sequence guard"
+        );
+    });
+}
+
+// ---- subtree filter selection ---------------------------------------------
+
+#[test]
+fn root_parent_uses_subtree_filter_when_multi_level_and_unified_stack_are_on() {
+    App::test((), |mut app| async move {
+        let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+        let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440801";
+        let child_run_id = "550e8400-e29b-41d4-a716-446655440802";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.watched_run_ids.insert(child_run_id.to_string());
+        });
+
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(
+                    filter,
+                    AgentEventFilter::SubtreeRootRunId { ref root_run_id }
+                        if root_run_id == own_run_id
+                ),
+                "tree-root parent must stream its whole subtree, got {filter:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn mid_tree_parent_keeps_ancestor_filter_under_subtree_flags() {
+    // A parent that is itself a child (mid-tree node) must not open a
+    // subtree stream: the server rejects non-root subtree anchors.
+    App::test((), |mut app| async move {
+        let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+        let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440803";
+        let child_run_id = "550e8400-e29b-41d4-a716-446655440804";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
+        conversation.set_parent_agent_id("550e8400-e29b-41d4-a716-446655440805".to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.watched_run_ids.insert(child_run_id.to_string());
+        });
+
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(
+                    filter,
+                    AgentEventFilter::AncestorRunId { ref ancestor_run_id, include_self: true }
+                        if ancestor_run_id == own_run_id
+                ),
+                "mid-tree parent must keep the ancestor scope, got {filter:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn root_parent_keeps_ancestor_filter_when_multi_level_is_off() {
+    App::test((), |mut app| async move {
+        let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(false);
+        let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440806";
+        let child_run_id = "550e8400-e29b-41d4-a716-446655440807";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.watched_run_ids.insert(child_run_id.to_string());
+        });
+
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(filter, AgentEventFilter::AncestorRunId { .. }),
+                "subtree scope requires MultiLevelOrchestration, got {filter:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn subtree_filters_equivalence_compares_root_run_ids() {
+    let a = AgentEventFilter::SubtreeRootRunId {
+        root_run_id: "root-1".to_string(),
+    };
+    let b = AgentEventFilter::SubtreeRootRunId {
+        root_run_id: "root-1".to_string(),
+    };
+    let c = AgentEventFilter::SubtreeRootRunId {
+        root_run_id: "root-2".to_string(),
+    };
+    let ancestor = AgentEventFilter::AncestorRunId {
+        ancestor_run_id: "root-1".to_string(),
+        include_self: true,
+    };
+    assert!(agent_event_filters_equivalent(&a, &b));
+    assert!(!agent_event_filters_equivalent(&a, &c));
+    assert!(!agent_event_filters_equivalent(&a, &ancestor));
 }
 
 // ---- should_register_parent_on_wait eligibility ---------------------------

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -200,7 +200,6 @@ fn make_run_event(event_type: &str, run_id: &str, ref_id: Option<&str>) -> Agent
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 1,
         parent_run_id: None,
-        depth: None,
     }
 }
 
@@ -683,7 +682,6 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 7,
         parent_run_id: None,
-        depth: None,
     };
     assert_eq!(
         consumer.on_event(ignored_event).await.unwrap(),
@@ -699,7 +697,6 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 7,
         parent_run_id: None,
-        depth: None,
     };
     assert_eq!(
         consumer.on_event(ignored_same_run_lifecycle).await.unwrap(),
@@ -719,7 +716,6 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         occurred_at: "2026-01-01T00:00:01Z".to_string(),
         sequence: 8,
         parent_run_id: None,
-        depth: None,
     };
     assert_eq!(
         consumer.on_event(target_event).await.unwrap(),
@@ -936,7 +932,6 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
                 occurred_at: "2026-01-01T00:00:00Z".to_string(),
                 sequence: 17,
                 parent_run_id: None,
-                depth: None,
             },
             AgentRunEvent {
                 event_type: "unrecognized_event_type".to_string(),
@@ -946,7 +941,6 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
                 occurred_at: "2026-01-01T00:00:00Z".to_string(),
                 sequence: 42,
                 parent_run_id: None,
-                depth: None,
             },
         ];
 
@@ -1028,7 +1022,6 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         occurred_at: "2026-01-01T00:00:00Z".to_string(),
                         sequence: 17,
                         parent_run_id: None,
-                        depth: None,
                     },
                     AgentRunEvent {
                         event_type: "run_cancelled".to_string(),
@@ -1038,7 +1031,6 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         occurred_at: "2026-01-01T00:00:01Z".to_string(),
                         sequence: 18,
                         parent_run_id: None,
-                        depth: None,
                     },
                     AgentRunEvent {
                         event_type: "new_message".to_string(),
@@ -1048,7 +1040,6 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         occurred_at: "2026-01-01T00:00:02Z".to_string(),
                         sequence: 19,
                         parent_run_id: None,
-                        depth: None,
                     },
                 ],
                 vec![
@@ -2999,6 +2990,10 @@ fn drain_family_events_subtree_scope_routes_descendants_to_their_families() {
         let mut mock = MockAIClient::new();
         mock.expect_update_event_sequence_on_server()
             .returning(|_, _| Ok(()));
+        // Placeholder and missing-family fetches fire as side effects of
+        // discovery/parking; their outcome is not under test here.
+        mock.expect_get_ambient_agent_task()
+            .returning(|_| Err(anyhow::anyhow!("metadata fetch not under test")));
         let ai_client: Arc<dyn AIClient> = Arc::new(mock);
         let server_api = ServerApiProvider::new_for_test().get();
         let streamer = app.add_singleton_model(|ctx| {
@@ -3568,6 +3563,375 @@ fn register_parent_on_wait_without_self_run_id_is_noop() {
         });
         poller.read(&app, |me, _| {
             assert!(connected_filter(me, conversation_id).is_none());
+        });
+    });
+}
+
+// ---- Subtree stream fallback + root-ness resolution -------------------------
+
+/// Builds an anyhow error whose chain carries an `HttpStatusError`, matching
+/// the shape the SSE source produces for a rejected stream open.
+fn http_status_error(status: u16) -> anyhow::Error {
+    anyhow::Error::new(
+        crate::server::server_api::presigned_upload::HttpStatusError {
+            status,
+            body: "rejected".to_string(),
+        },
+    )
+    .context("SSE stream error")
+}
+
+#[test]
+fn subtree_stream_rejection_falls_back_to_the_ancestor_scope() {
+    // A server without the subtree endpoint (or one that disagrees about
+    // root-ness) rejects the stream with a permanent 4xx; the conversation
+    // must fall back to the ancestor scope so the parent's inbox keeps
+    // flowing.
+    App::test((), |mut app| async move {
+        let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+        let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440901";
+        let child_run_id = "550e8400-e29b-41d4-a716-446655440902";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        let (_, rx) = futures::channel::mpsc::unbounded::<SseStreamItem>();
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.watched_run_ids.insert(child_run_id.to_string());
+            let (abort_handle, _) = futures::future::AbortHandle::new_pair();
+            stream.sse_connection = Some(SseConnectionState {
+                event_receiver: rx,
+                generation: 0,
+                abort_handle,
+                connected_filter: AgentEventFilter::SubtreeRootRunId {
+                    root_run_id: own_run_id.to_string(),
+                },
+            });
+        });
+
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(filter, AgentEventFilter::SubtreeRootRunId { .. }),
+                "precondition: the root still prefers the subtree scope"
+            );
+        });
+
+        poller.update(&mut app, |me, _| {
+            me.note_sse_driver_exit_error(conversation_id, &http_status_error(404));
+        });
+
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(
+                    filter,
+                    AgentEventFilter::AncestorRunId { ref ancestor_run_id, include_self: true }
+                        if ancestor_run_id == own_run_id
+                ),
+                "a rejected subtree stream must fall back to the ancestor scope, got {filter:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn transient_subtree_stream_errors_do_not_trigger_the_fallback() {
+    App::test((), |mut app| async move {
+        let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+        let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440903";
+        let child_run_id = "550e8400-e29b-41d4-a716-446655440904";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        let (_, rx) = futures::channel::mpsc::unbounded::<SseStreamItem>();
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.watched_run_ids.insert(child_run_id.to_string());
+            let (abort_handle, _) = futures::future::AbortHandle::new_pair();
+            stream.sse_connection = Some(SseConnectionState {
+                event_receiver: rx,
+                generation: 0,
+                abort_handle,
+                connected_filter: AgentEventFilter::SubtreeRootRunId {
+                    root_run_id: own_run_id.to_string(),
+                },
+            });
+            me.note_sse_driver_exit_error(conversation_id, &http_status_error(503));
+        });
+
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(filter, AgentEventFilter::SubtreeRootRunId { .. }),
+                "5xx failures retry the subtree scope rather than falling back, got {filter:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn filter_root_ness_prefers_the_cached_server_task_row() {
+    // Local linkage and the server row can disagree (e.g. a child whose
+    // local parent linkage never restored). The server row wins, matching
+    // the restore-seed scope selection.
+    App::test((), |mut app| async move {
+        let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+        let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_ctx| ServerApiProvider::new_for_test());
+        app.add_singleton_model(crate::ai::agent_conversations_model::AgentConversationsModel::new);
+
+        let own_task_id = make_parent_task_id_for_test(0xc1);
+        let own_run_id = own_task_id.to_string();
+        let child_run_id = make_parent_task_id_for_test(0xc2).to_string();
+        // Locally the conversation looks like a root (no parent linkage),
+        // but the server row names a parent: the row wins, so the filter
+        // must stay ancestor-scoped.
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.clone());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            let mut row = make_ambient_task_with_task_id(own_task_id, None);
+            row.parent_run_id = Some(make_parent_task_id_for_test(0xc3).to_string());
+            model.insert_task_for_test(row);
+        });
+
+        let poller = streamer_with_no_fetch_expected(&mut app);
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.watched_run_ids.insert(own_run_id.clone());
+            stream.watched_run_ids.insert(child_run_id.clone());
+        });
+
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(filter, AgentEventFilter::AncestorRunId { .. }),
+                "the server row's mid-tree verdict must override local root-ness, got {filter:?}"
+            );
+        });
+
+        // Flip the row to a root: the same locally-ambiguous conversation
+        // now streams its subtree.
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(make_ambient_task_with_task_id(own_task_id, None));
+        });
+        poller.read(&app, |me, ctx| {
+            let DesiredSseFilter::Filter(filter) = me.desired_sse_filter(conversation_id, ctx)
+            else {
+                panic!("parent conversation must produce a filter");
+            };
+            assert!(
+                matches!(filter, AgentEventFilter::SubtreeRootRunId { .. }),
+                "a root server row selects the subtree scope, got {filter:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn grandchild_lifecycle_is_not_injected_into_the_root_conversation() {
+    // Tree-wide status flows via the tracker broadcasts; only DIRECT
+    // children's lifecycle events enter the root conversation's
+    // pending-event queue (parity with the anchor-scoped drain).
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let event_service = app.add_singleton_model(|_| OrchestrationEventService::default());
+        app.add_singleton_model(|_ctx| ServerApiProvider::new_for_test());
+        app.add_singleton_model(crate::ai::agent_conversations_model::AgentConversationsModel::new);
+
+        let root_task_id = make_parent_task_id_for_test(0xc4);
+        let root_run_id = root_task_id.to_string();
+        let mid_run_id = make_parent_task_id_for_test(0xc5).to_string();
+        let leaf_run_id = make_parent_task_id_for_test(0xc6).to_string();
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(root_run_id.clone());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mut mock = MockAIClient::new();
+        mock.expect_update_event_sequence_on_server()
+            .returning(|_, _| Ok(()));
+        mock.expect_get_ambient_agent_task()
+            .returning(|_| Err(anyhow::anyhow!("metadata fetch not under test")));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        // A grandchild terminal lifecycle (family = mid, not the root).
+        let mut leaf_event = make_seq_event("run_succeeded", &leaf_run_id, None, 10);
+        leaf_event.parent_run_id = Some(mid_run_id.clone());
+        streamer.update(&mut app, |me, ctx| {
+            let trackers = me.drain_family_events(
+                conversation_id,
+                &root_run_id,
+                root_task_id,
+                FamilyDrainMode::Primary,
+                FamilyDrainScope::Subtree,
+                HashMap::new(),
+                0,
+                vec![leaf_event],
+                Vec::new(),
+                ctx,
+            );
+            // A direct child's lifecycle in a follow-up batch IS injected.
+            let _ = me.drain_family_events(
+                conversation_id,
+                &root_run_id,
+                root_task_id,
+                FamilyDrainMode::Primary,
+                FamilyDrainScope::Subtree,
+                trackers,
+                10,
+                vec![make_seq_event("run_succeeded", &mid_run_id, None, 11)],
+                Vec::new(),
+                ctx,
+            );
+        });
+
+        event_service.read(&app, |service, _| {
+            assert!(
+                service.has_pending_events(conversation_id),
+                "the direct child's lifecycle must reach the root conversation"
+            );
+        });
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .and_then(|c| c.last_event_sequence()),
+                Some(11),
+                "both batches advance the Primary cursor"
+            );
+        });
+    });
+}
+
+#[test]
+fn parked_descendants_drain_when_their_family_placeholder_materializes() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(16);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+
+        let root_task_id = make_parent_task_id_for_test(0xc7);
+        let root_run_id = root_task_id.to_string();
+        let mid_task_id = make_parent_task_id_for_test(0xc8);
+        let mid_run_id = mid_task_id.to_string();
+        let leaf_run_id = make_parent_task_id_for_test(0xc9).to_string();
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(root_run_id.clone());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mut mock = MockAIClient::new();
+        // Parking kicks the missing family's own fetch, and unparking kicks
+        // the leaf's placeholder fetch; neither outcome is under test here.
+        mock.expect_get_ambient_agent_task()
+            .returning(|_| Err(anyhow::anyhow!("metadata fetch not under test")));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        streamer.update(&mut app, |me, ctx| {
+            // The leaf announces while the mid-tree parent has no local
+            // conversation: it parks.
+            me.ensure_family_child_placeholder(
+                conversation_id,
+                &root_run_id,
+                &mid_run_id,
+                leaf_run_id.clone(),
+                FamilyDrainMode::Primary,
+                ctx,
+            );
+            assert!(me.descendants_waiting_on_family.contains_key(&mid_run_id));
+
+            // The mid-tree parent's own placeholder fetch completes: the
+            // parked leaf drains.
+            me.finish_remote_child_placeholder(
+                conversation_id,
+                conversation_id,
+                mid_run_id.clone(),
+                FamilyDrainMode::Primary,
+                Ok(make_ambient_task_with_task_id(mid_task_id, None)),
+                ctx,
+            );
+            assert!(
+                !me.descendants_waiting_on_family.contains_key(&mid_run_id),
+                "descendants parked on the family must drain once it materializes"
+            );
+        });
+
+        history_model.read(&app, |model, _| {
+            assert!(
+                model.conversation_id_for_agent_id(&mid_run_id).is_some(),
+                "the family placeholder itself must exist after the fetch completes"
+            );
         });
     });
 }

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -3935,3 +3935,81 @@ fn parked_descendants_drain_when_their_family_placeholder_materializes() {
         });
     });
 }
+
+#[test]
+fn reparking_a_deduped_descendant_rekicks_the_family_fetch() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(16);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+
+        let root_run_id = make_parent_task_id_for_test(0xca).to_string();
+        let mid_run_id = make_parent_task_id_for_test(0xcb).to_string();
+        let leaf_run_id = make_parent_task_id_for_test(0xcc).to_string();
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(root_run_id.clone());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mut mock = MockAIClient::new();
+        // Each park kick issues a family metadata fetch; the spawned futures
+        // are never driven here, so fetch completion is simulated by clearing
+        // the in-flight guard directly (what the failure callback does).
+        mock.expect_get_ambient_agent_task()
+            .returning(|_| Err(anyhow::anyhow!("metadata fetch not under test")));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        streamer.update(&mut app, |me, ctx| {
+            me.park_descendant_placeholder(
+                mid_run_id.clone(),
+                conversation_id,
+                leaf_run_id.clone(),
+                FamilyDrainMode::Primary,
+                ctx,
+            );
+            assert!(
+                me.family_placeholder_fetches_in_flight
+                    .contains(&mid_run_id),
+                "the first park must kick the missing family's fetch"
+            );
+            assert_eq!(me.descendants_waiting_on_family[&mid_run_id].len(), 1);
+
+            // Simulate the fetch failing: the spawn callback clears the
+            // in-flight guard and leaves the descendant parked.
+            me.family_placeholder_fetches_in_flight.remove(&mid_run_id);
+
+            // A later drain re-parks the same (anchor, child): the dedupe
+            // must not swallow the re-kick of the family fetch.
+            me.park_descendant_placeholder(
+                mid_run_id.clone(),
+                conversation_id,
+                leaf_run_id.clone(),
+                FamilyDrainMode::Primary,
+                ctx,
+            );
+            assert!(
+                me.family_placeholder_fetches_in_flight
+                    .contains(&mid_run_id),
+                "a re-park after a failed fetch must re-kick the family fetch"
+            );
+            assert_eq!(
+                me.descendants_waiting_on_family[&mid_run_id].len(),
+                1,
+                "the re-parked descendant must still dedupe"
+            );
+        });
+    });
+}

--- a/app/src/pane_group/child_agent/restoration.rs
+++ b/app/src/pane_group/child_agent/restoration.rs
@@ -27,9 +27,12 @@ use crate::terminal::view::load_ai_conversation::{
     RestoreConversationEntryBehavior, RestoredAIConversation,
 };
 
-/// Max direct children fetched per ancestor-list restore seed. The server
-/// caps at 100 regardless, matching the Observer-side ancestor seed fetch.
-const RESTORE_CHILD_SEED_FETCH_LIMIT: i32 = 30;
+/// Max rows fetched per restore seed listing (direct children for mid-tree
+/// parents, the whole subtree for roots), matching the Observer-side seed
+/// fetch. The server caps at 100 regardless; subtrees larger than one page
+/// are not paginated yet, so rows beyond the cap are only discovered
+/// through the live subtree stream.
+const RESTORE_CHILD_SEED_FETCH_LIMIT: i32 = 100;
 
 /// Bounds the recursive ancestor-pane materialization used when revealing a
 /// deep descendant whose intermediate parents have no panes yet.
@@ -146,30 +149,18 @@ impl PaneGroup {
         self.ensure_pending_ambient_restoration_subscription(ctx);
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        // Root-ness comes from the parent's own task row (a root has no
-        // parent_run_id). When the row is not cached yet, stay pending and
-        // let the shared TasksUpdated re-drive retry once the fetch lands —
-        // guessing the scope here could permanently miss grandchildren.
-        let filter = if multi_level_subtree_scope_enabled() {
-            let parent_task = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+        let cached_parent_task = if multi_level_subtree_scope_enabled() {
+            AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
                 model.get_or_async_fetch_task_data(&parent_task_id, ctx)
-            });
-            match parent_task {
-                Some(task) if task.parent_run_id.is_none() => TaskListFilter {
-                    root_run_id: Some(parent_task_id.to_string()),
-                    ..TaskListFilter::default()
-                },
-                Some(_) => TaskListFilter {
-                    ancestor_run_id: Some(parent_task_id.to_string()),
-                    ..TaskListFilter::default()
-                },
-                None => return,
-            }
+            })
         } else {
-            TaskListFilter {
-                ancestor_run_id: Some(parent_task_id.to_string()),
-                ..TaskListFilter::default()
-            }
+            None
+        };
+        let Some(filter) = restore_seed_filter(parent_task_id, cached_parent_task.as_ref()) else {
+            // Scope not determinable yet (parent row still fetching): stay
+            // pending and let the shared TasksUpdated re-drive retry —
+            // guessing the scope here could permanently miss grandchildren.
+            return;
         };
         ctx.spawn(
             async move {
@@ -192,7 +183,7 @@ impl PaneGroup {
     /// `seed_child_conversations_from_task`: links each reported direct child
     /// under `parent_conversation_id` and clears the pending entry once every
     /// child's own task data has resolved.
-    fn finish_seed_child_conversations_from_task(
+    pub(in crate::pane_group) fn finish_seed_child_conversations_from_task(
         &mut self,
         parent_conversation_id: AIConversationId,
         parent_task_id: AmbientAgentTaskId,
@@ -288,11 +279,20 @@ impl PaneGroup {
                 linked_any = true;
             }
             if deferred.is_empty() || !linked_any {
-                // Rows still deferred here reference parents outside the
-                // listing (or ones whose task data is still fetching); keep
-                // the seed pending so TasksUpdated re-drives it.
+                // Rows still deferred after a no-progress pass reference
+                // parents outside the listing (a truncated page or an
+                // out-of-scope ancestor). Deliberately do NOT keep the seed
+                // pending for them: an identical refetch cannot resolve
+                // them, so re-driving on every TasksUpdated would churn
+                // forever. The live subtree stream remains the discovery
+                // path for their families.
                 if !deferred.is_empty() {
-                    all_children_resolved = false;
+                    log::warn!(
+                        "seed_child_conversations_from_task: {} row(s) reference parents \
+                         outside the listing for parent_task_id={parent_task_id} (truncated \
+                         page?); leaving them to live-stream discovery",
+                        deferred.len(),
+                    );
                 }
                 break;
             }
@@ -705,3 +705,37 @@ impl PaneGroup {
         }
     }
 }
+
+/// Selects the restore-seed listing filter for `parent_task_id` from the
+/// parent's cached task row: tree roots (no `parent_run_id`) list their whole
+/// subtree via `root_run_id`; mid-tree parents — and every parent while
+/// multi-level subtree scope is disabled — list direct children via
+/// `ancestor_run_id`. Returns `None` when the scope cannot be determined yet
+/// (subtree scope enabled but no row cached); the caller stays pending and
+/// retries once the row lands.
+fn restore_seed_filter(
+    parent_task_id: AmbientAgentTaskId,
+    cached_parent_task: Option<&crate::ai::ambient_agents::task::AmbientAgentTask>,
+) -> Option<TaskListFilter> {
+    if !multi_level_subtree_scope_enabled() {
+        return Some(TaskListFilter {
+            ancestor_run_id: Some(parent_task_id.to_string()),
+            ..TaskListFilter::default()
+        });
+    }
+    match cached_parent_task {
+        Some(task) if task.parent_run_id.is_none() => Some(TaskListFilter {
+            root_run_id: Some(parent_task_id.to_string()),
+            ..TaskListFilter::default()
+        }),
+        Some(_) => Some(TaskListFilter {
+            ancestor_run_id: Some(parent_task_id.to_string()),
+            ..TaskListFilter::default()
+        }),
+        None => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "restoration_tests.rs"]
+mod tests;

--- a/app/src/pane_group/child_agent/restoration.rs
+++ b/app/src/pane_group/child_agent/restoration.rs
@@ -12,7 +12,9 @@ use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
-use crate::ai::blocklist::orchestration_event_streamer::agent_task_harness;
+use crate::ai::blocklist::orchestration_event_streamer::{
+    agent_task_harness, multi_level_subtree_scope_enabled,
+};
 use crate::ai::restored_conversations::RestoredAgentConversations;
 use crate::features::FeatureFlag;
 use crate::pane_group::{
@@ -27,7 +29,11 @@ use crate::terminal::view::load_ai_conversation::{
 
 /// Max direct children fetched per ancestor-list restore seed. The server
 /// caps at 100 regardless, matching the Observer-side ancestor seed fetch.
-const RESTORE_CHILD_SEED_FETCH_LIMIT: i32 = 100;
+const RESTORE_CHILD_SEED_FETCH_LIMIT: i32 = 30;
+
+/// Bounds the recursive ancestor-pane materialization used when revealing a
+/// deep descendant whose intermediate parents have no panes yet.
+const MAX_ANCESTOR_PANE_CHAIN_DEPTH: usize = 16;
 
 impl PaneGroup {
     /// Lazily restores hidden child panes for the given parent conversation.
@@ -108,11 +114,15 @@ impl PaneGroup {
     }
 
     /// Rebuilds the parent→child conversation index for a restored cloud agent
-    /// parent from the server's `?ancestor_run_id=` listing — the same query
-    /// path the Observer-side ancestor seed (`spawn_ancestor_seed_fetch`) uses
-    /// to discover children on cold start. This is the only pill-bar source
-    /// on clients without cross-session SQLite (web) and on the first restore
-    /// of a run whose parent was never persisted.
+    /// parent from the server's run listing — the same query path the
+    /// Observer-side seed (`spawn_ancestor_seed_fetch`) uses to discover
+    /// children on cold start. Tree roots list their whole subtree
+    /// (`?root_run_id=`) when multi-level orchestration is enabled so
+    /// descendants spawned by remote mid-tree children are restored too;
+    /// mid-tree parents keep the direct-children `?ancestor_run_id=` listing.
+    /// This is the only pill-bar source on clients without cross-session
+    /// SQLite (web) and on the first restore of a run whose parent was never
+    /// persisted.
     ///
     /// Idempotent: children that already resolve locally are left untouched, so
     /// racing the SSE family drain, the local conversation index, or a repeat
@@ -136,9 +146,30 @@ impl PaneGroup {
         self.ensure_pending_ambient_restoration_subscription(ctx);
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        let filter = TaskListFilter {
-            ancestor_run_id: Some(parent_task_id.to_string()),
-            ..TaskListFilter::default()
+        // Root-ness comes from the parent's own task row (a root has no
+        // parent_run_id). When the row is not cached yet, stay pending and
+        // let the shared TasksUpdated re-drive retry once the fetch lands —
+        // guessing the scope here could permanently miss grandchildren.
+        let filter = if multi_level_subtree_scope_enabled() {
+            let parent_task = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+                model.get_or_async_fetch_task_data(&parent_task_id, ctx)
+            });
+            match parent_task {
+                Some(task) if task.parent_run_id.is_none() => TaskListFilter {
+                    root_run_id: Some(parent_task_id.to_string()),
+                    ..TaskListFilter::default()
+                },
+                Some(_) => TaskListFilter {
+                    ancestor_run_id: Some(parent_task_id.to_string()),
+                    ..TaskListFilter::default()
+                },
+                None => return,
+            }
+        } else {
+            TaskListFilter {
+                ancestor_run_id: Some(parent_task_id.to_string()),
+                ..TaskListFilter::default()
+            }
         };
         ctx.spawn(
             async move {
@@ -195,36 +226,77 @@ impl PaneGroup {
         };
 
         // Children whose task data is still being fetched keep the parent
-        // pending.
+        // pending. Root-scoped listings return the whole subtree in
+        // arbitrary order, so rows are linked in passes: each pass links
+        // every row whose parent conversation already exists (direct
+        // children attach to the anchor; deeper rows attach to their
+        // parent's placeholder), unlocking that row's own children for the
+        // next pass.
+        let anchor_run_id = parent_task_id.to_string();
         let mut all_children_resolved = true;
-        for child_run_id in children
+        let mut remaining: Vec<&crate::ai::ambient_agents::task::AmbientAgentTask> = children
             .iter()
-            .map(|task| task.task_id)
-            .filter(|task_id| *task_id != parent_task_id)
-        {
-            let child_task = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-                model.get_or_async_fetch_task_data(&child_run_id, ctx)
-            });
-            let Some(child_task) = child_task else {
-                all_children_resolved = false;
-                continue;
-            };
+            .filter(|task| task.task_id != parent_task_id)
+            .collect();
+        loop {
+            let mut linked_any = false;
+            let mut deferred = Vec::new();
+            for row in remaining {
+                let child_run_id = row.task_id;
+                // The conversation this row nests under: the anchor for
+                // direct children (and rows without parent attribution from
+                // old servers), the parent's placeholder otherwise.
+                let row_parent_conversation_id = match row.parent_run_id.as_deref() {
+                    Some(parent) if parent != anchor_run_id => {
+                        match BlocklistAIHistoryModel::as_ref(ctx)
+                            .conversation_id_for_agent_id(parent)
+                        {
+                            Some(conversation_id) => conversation_id,
+                            None => {
+                                // Parent row not linked yet; retry next pass.
+                                deferred.push(row);
+                                continue;
+                            }
+                        }
+                    }
+                    _ => parent_conversation_id,
+                };
+                let child_task = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.get_or_async_fetch_task_data(&child_run_id, ctx)
+                });
+                let Some(child_task) = child_task else {
+                    all_children_resolved = false;
+                    linked_any = true;
+                    continue;
+                };
 
-            let name = child_task.display_name().to_string();
-            let fallback_title = child_task.title.trim().to_string();
-            let harness = agent_task_harness(&child_task);
-            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-                history.ensure_remote_child_conversation(
-                    terminal_surface_id,
-                    parent_conversation_id,
-                    child_run_id.to_string(),
-                    child_task.task_id,
-                    name,
-                    fallback_title,
-                    harness,
-                    ctx,
-                )
-            });
+                let name = child_task.display_name().to_string();
+                let fallback_title = child_task.title.trim().to_string();
+                let harness = agent_task_harness(&child_task);
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.ensure_remote_child_conversation(
+                        terminal_surface_id,
+                        row_parent_conversation_id,
+                        child_run_id.to_string(),
+                        child_task.task_id,
+                        name,
+                        fallback_title,
+                        harness,
+                        ctx,
+                    )
+                });
+                linked_any = true;
+            }
+            if deferred.is_empty() || !linked_any {
+                // Rows still deferred here reference parents outside the
+                // listing (or ones whose task data is still fetching); keep
+                // the seed pending so TasksUpdated re-drives it.
+                if !deferred.is_empty() {
+                    all_children_resolved = false;
+                }
+                break;
+            }
+            remaining = deferred;
         }
 
         if all_children_resolved {
@@ -321,6 +393,19 @@ impl PaneGroup {
         child_conversation_id: AIConversationId,
         ctx: &mut ViewContext<Self>,
     ) -> bool {
+        self.ensure_hidden_child_agent_pane_for_conversation_at_depth(child_conversation_id, 0, ctx)
+    }
+
+    /// Body of [`Self::ensure_hidden_child_agent_pane_for_conversation`].
+    /// `depth` counts recursive ancestor materializations: revealing a deep
+    /// descendant first materializes each missing ancestor pane, bottoming
+    /// out at [`MAX_ANCESTOR_PANE_CHAIN_DEPTH`].
+    fn ensure_hidden_child_agent_pane_for_conversation_at_depth(
+        &mut self,
+        child_conversation_id: AIConversationId,
+        depth: usize,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
         if self
             .child_agent_panes
             .get(&child_conversation_id)
@@ -357,8 +442,27 @@ impl PaneGroup {
 
         let child_owner_terminal_view_id =
             self.terminal_view_id_for_owned_conversation(child_conversation_id, ctx);
-        let Some(parent_pane_id) = self.pane_id_for_owned_conversation(parent_conversation_id, ctx)
-        else {
+        let mut parent_pane_id = self.pane_id_for_owned_conversation(parent_conversation_id, ctx);
+        if parent_pane_id.is_none()
+            && multi_level_subtree_scope_enabled()
+            && depth < MAX_ANCESTOR_PANE_CHAIN_DEPTH
+            && self.ensure_hidden_child_agent_pane_for_conversation_at_depth(
+                parent_conversation_id,
+                depth + 1,
+                ctx,
+            )
+        {
+            // The parent was itself an unrevealed descendant placeholder:
+            // its pane chain has just been materialized, so retry the
+            // lookup through the child-pane index it registered in.
+            parent_pane_id = self
+                .child_agent_panes
+                .get(&parent_conversation_id)
+                .copied()
+                .filter(|pane_id| self.has_pane_id(*pane_id))
+                .or_else(|| self.pane_id_for_owned_conversation(parent_conversation_id, ctx));
+        }
+        let Some(parent_pane_id) = parent_pane_id else {
             return child_owner_terminal_view_id.is_some();
         };
 

--- a/app/src/pane_group/child_agent/restoration_tests.rs
+++ b/app/src/pane_group/child_agent/restoration_tests.rs
@@ -1,0 +1,92 @@
+//! Tests for the restore-seed scope selection. The listing/link loop and the
+//! ancestor-pane-chain reveal are covered in `pane_group/mod_tests.rs`, which
+//! owns the mock pane-group harness.
+
+use chrono::Utc;
+use warp_core::features::FeatureFlag;
+
+use super::*;
+use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
+
+fn parent_task_id() -> AmbientAgentTaskId {
+    "11111111-1111-1111-1111-111111111111".parse().unwrap()
+}
+
+fn task_row(parent_run_id: Option<&str>) -> AmbientAgentTask {
+    let now = Utc::now();
+    AmbientAgentTask {
+        task_id: parent_task_id(),
+        parent_run_id: parent_run_id.map(str::to_string),
+        title: "parent".to_string(),
+        state: AmbientAgentTaskState::InProgress,
+        prompt: String::new(),
+        created_at: now,
+        started_at: Some(now),
+        updated_at: now,
+        run_time: None,
+        status_message: None,
+        source: None,
+        execution_location: None,
+        session_id: None,
+        session_link: None,
+        creator: None,
+        executor: None,
+        conversation_id: None,
+        request_usage: None,
+        is_sandbox_running: false,
+        agent_config_snapshot: None,
+        artifacts: vec![],
+        last_event_sequence: None,
+        children: vec![],
+    }
+}
+
+#[test]
+fn root_parent_seeds_subtree_listing() {
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+    let filter = restore_seed_filter(parent_task_id(), Some(&task_row(None)))
+        .expect("scope resolvable from a cached root row");
+    assert_eq!(filter.root_run_id, Some(parent_task_id().to_string()));
+    assert_eq!(filter.ancestor_run_id, None);
+}
+
+#[test]
+fn mid_tree_parent_seeds_direct_children_listing() {
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+    let filter = restore_seed_filter(
+        parent_task_id(),
+        Some(&task_row(Some("22222222-2222-2222-2222-222222222222"))),
+    )
+    .expect("scope resolvable from a cached mid-tree row");
+    assert_eq!(filter.ancestor_run_id, Some(parent_task_id().to_string()));
+    assert_eq!(filter.root_run_id, None);
+}
+
+#[test]
+fn unknown_root_ness_defers_the_seed() {
+    // Guessing the scope could permanently miss grandchildren; the seed
+    // stays pending until the parent's row is cached.
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+    assert!(restore_seed_filter(parent_task_id(), None).is_none());
+}
+
+#[test]
+fn subtree_scope_disabled_always_seeds_direct_children() {
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(false);
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+
+    // Even a cached root row keeps the legacy direct-children listing, and
+    // an uncached row does not defer.
+    for cached in [Some(task_row(None)), None] {
+        let filter = restore_seed_filter(parent_task_id(), cached.as_ref())
+            .expect("legacy scope never defers");
+        assert!(filter.ancestor_run_id.is_some());
+        assert_eq!(filter.root_run_id, None);
+    }
+}

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -3603,3 +3603,259 @@ fn test_undo_close_keeps_a_file_pane_watching_its_file() {
         });
     });
 }
+
+// ---- Root restore seed: dependency-ordered subtree linking -------------------
+
+/// Builds a subtree row for the restore-seed listing: a run parented under
+/// `parent_run_id` (the shape a `?root_run_id=` listing returns for
+/// grandchildren and deeper).
+fn subtree_seed_row(
+    task_id: AmbientAgentTaskId,
+    parent_run_id: AmbientAgentTaskId,
+) -> AmbientAgentTask {
+    let mut task = ambient_agent_task_for_current_user(task_id);
+    task.parent_run_id = Some(parent_run_id.to_string());
+    task
+}
+
+#[test]
+fn test_root_seed_links_subtree_rows_in_dependency_order() {
+    // A root_run_id listing returns the whole subtree in arbitrary order;
+    // rows must link under their actual parents (grandchild under the
+    // mid-tree child's placeholder) even when a child row appears after
+    // its own descendants.
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+
+        pane_group.update(&mut app, |panes, ctx| {
+            let parent_pane_id = get_newly_created_pane_id(panes, &[]);
+            let parent_conversation_id = start_parent_conversation(panes, parent_pane_id, ctx);
+            let root_task_id = new_ambient_agent_task_id();
+            let mid_task_id = new_ambient_agent_task_id();
+            let leaf_task_id = new_ambient_agent_task_id();
+            let parent_terminal_view_id = panes
+                .terminal_view_from_pane_id(parent_pane_id, ctx)
+                .expect("parent pane should have a terminal view")
+                .id();
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.assign_run_id_for_conversation(
+                    parent_conversation_id,
+                    root_task_id.to_string(),
+                    Some(root_task_id),
+                    parent_terminal_view_id,
+                    ctx,
+                );
+            });
+            // Cache both rows' task data so linking resolves synchronously.
+            AgentConversationsModel::handle(ctx).update(ctx, |model, _| {
+                model.insert_task_for_test(subtree_seed_row(mid_task_id, root_task_id));
+                model.insert_task_for_test(subtree_seed_row(leaf_task_id, mid_task_id));
+            });
+
+            // Grandchild row FIRST: it must defer one pass, then link under
+            // the mid-tree placeholder created by the second pass.
+            panes.finish_seed_child_conversations_from_task(
+                parent_conversation_id,
+                root_task_id,
+                Ok(vec![
+                    subtree_seed_row(leaf_task_id, mid_task_id),
+                    subtree_seed_row(mid_task_id, root_task_id),
+                ]),
+                ctx,
+            );
+
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            let mid_conversation_id = history
+                .conversation_id_for_agent_id(&mid_task_id.to_string())
+                .expect("the mid-tree row must link");
+            let leaf_conversation_id = history
+                .conversation_id_for_agent_id(&leaf_task_id.to_string())
+                .expect("the grandchild row must link");
+            assert!(
+                history
+                    .child_conversation_ids_of(&parent_conversation_id)
+                    .contains(&mid_conversation_id),
+                "the direct child links under the anchor conversation"
+            );
+            assert!(
+                history
+                    .child_conversation_ids_of(&mid_conversation_id)
+                    .contains(&leaf_conversation_id),
+                "the grandchild links under the mid-tree placeholder, not the anchor"
+            );
+            assert!(
+                !history
+                    .child_conversation_ids_of(&parent_conversation_id)
+                    .contains(&leaf_conversation_id),
+                "the grandchild must not be hard-attributed to the anchor"
+            );
+            assert!(
+                !panes.pending_parent_child_seeds.contains_key(&root_task_id),
+                "a fully-linked seed clears its pending entry"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_root_seed_does_not_respin_on_rows_with_out_of_listing_parents() {
+    // Rows whose parents fall outside the listing (a truncated page) can
+    // never be resolved by refetching the identical listing; the seed must
+    // complete instead of re-driving on every TasksUpdated forever.
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+
+        pane_group.update(&mut app, |panes, ctx| {
+            let parent_pane_id = get_newly_created_pane_id(panes, &[]);
+            let parent_conversation_id = start_parent_conversation(panes, parent_pane_id, ctx);
+            let root_task_id = new_ambient_agent_task_id();
+            let missing_parent_task_id = new_ambient_agent_task_id();
+            let orphan_task_id = new_ambient_agent_task_id();
+            let parent_terminal_view_id = panes
+                .terminal_view_from_pane_id(parent_pane_id, ctx)
+                .expect("parent pane should have a terminal view")
+                .id();
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.assign_run_id_for_conversation(
+                    parent_conversation_id,
+                    root_task_id.to_string(),
+                    Some(root_task_id),
+                    parent_terminal_view_id,
+                    ctx,
+                );
+            });
+            AgentConversationsModel::handle(ctx).update(ctx, |model, _| {
+                model
+                    .insert_task_for_test(subtree_seed_row(orphan_task_id, missing_parent_task_id));
+            });
+
+            // The orphan's parent is not in the listing and has no local
+            // conversation: the row must be left to live-stream discovery.
+            panes.finish_seed_child_conversations_from_task(
+                parent_conversation_id,
+                root_task_id,
+                Ok(vec![subtree_seed_row(
+                    orphan_task_id,
+                    missing_parent_task_id,
+                )]),
+                ctx,
+            );
+
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            assert!(
+                history
+                    .conversation_id_for_agent_id(&orphan_task_id.to_string())
+                    .is_none(),
+                "an out-of-listing-parent row cannot link"
+            );
+            assert!(
+                !panes.pending_parent_child_seeds.contains_key(&root_task_id),
+                "the seed must not stay pending for rows an identical refetch cannot resolve"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_deep_descendant_reveal_materializes_without_a_parent_pane() {
+    // Revealing a grandchild whose mid-tree parent has no pane must still
+    // succeed: the mid-tree placeholder resolves its hosting pane through
+    // the shared root surface, and the leaf's own pane materializes. The
+    // mid-tree parent's pane stays lazy until it is revealed itself.
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+
+        pane_group.update(&mut app, |panes, ctx| {
+            let parent_pane_id = get_newly_created_pane_id(panes, &[]);
+            let parent_conversation_id = start_parent_conversation(panes, parent_pane_id, ctx);
+            let mid_task_id = new_ambient_agent_task_id();
+            let leaf_task_id = new_ambient_agent_task_id();
+            // Mid-tree placeholder under the root, grandchild under it;
+            // neither has a pane.
+            let mid_conversation_id = restore_remote_child_conversation(
+                panes,
+                parent_pane_id,
+                parent_conversation_id,
+                mid_task_id,
+                ctx,
+            );
+            let leaf_conversation_id = restore_remote_child_conversation(
+                panes,
+                parent_pane_id,
+                mid_conversation_id,
+                leaf_task_id,
+                ctx,
+            );
+            AgentConversationsModel::handle(ctx).update(ctx, |model, _| {
+                model.insert_task_for_test(attachable_ambient_agent_task(mid_task_id));
+                model.insert_task_for_test(attachable_ambient_agent_task(leaf_task_id));
+            });
+            assert!(!panes.child_agent_panes.contains_key(&mid_conversation_id));
+            assert!(!panes.child_agent_panes.contains_key(&leaf_conversation_id));
+
+            let revealed =
+                panes.ensure_hidden_child_agent_pane_for_conversation(leaf_conversation_id, ctx);
+
+            assert!(revealed, "the deep reveal must succeed");
+            assert!(
+                panes
+                    .child_agent_panes
+                    .get(&leaf_conversation_id)
+                    .is_some_and(|pane_id| panes.has_pane_id(*pane_id)),
+                "the revealed descendant pane must materialize"
+            );
+
+            // The mid-tree parent stays lazily materializable on its own
+            // reveal.
+            assert!(
+                panes.ensure_hidden_child_agent_pane_for_conversation(mid_conversation_id, ctx,)
+            );
+            assert!(
+                panes
+                    .child_agent_panes
+                    .get(&mid_conversation_id)
+                    .is_some_and(|pane_id| panes.has_pane_id(*pane_id)),
+                "revealing the mid-tree parent materializes its own pane"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_reveal_ancestor_chain_recursion_is_depth_capped() {
+    // A cyclic parent graph (corrupt restore data) must terminate at the
+    // depth cap instead of recursing forever.
+    let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+
+        pane_group.update(&mut app, |panes, ctx| {
+            let conversation_a = AIConversationId::new();
+            let conversation_b = AIConversationId::new();
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
+                history.set_parent_for_conversation(conversation_a, conversation_b);
+                history.set_parent_for_conversation(conversation_b, conversation_a);
+            });
+
+            assert!(
+                !panes.ensure_hidden_child_agent_pane_for_conversation(conversation_a, ctx),
+                "a cyclic ancestor chain must fail the reveal, not hang"
+            );
+        });
+    });
+}

--- a/app/src/server/retry_strategies.rs
+++ b/app/src/server/retry_strategies.rs
@@ -91,6 +91,21 @@ fn is_transient_status(status: u16) -> bool {
     matches!(status, 408 | 429 | 500..=599)
 }
 
+/// Returns `true` if the error chain carries an [`HttpStatusError`] with a
+/// permanent, non-authentication 4xx status (400, 404, 405, ...). Used to
+/// recognise endpoints the server rejects outright (missing route, invalid
+/// anchor) as opposed to transient failures or credential problems.
+pub(crate) fn is_permanent_non_auth_4xx_error(e: &anyhow::Error) -> bool {
+    for cause in e.chain() {
+        if let Some(http_err) = cause.downcast_ref::<HttpStatusError>() {
+            return matches!(http_err.status, 400..=499)
+                && !is_transient_status(http_err.status)
+                && !matches!(http_err.status, 401 | 403);
+        }
+    }
+    false
+}
+
 /// Returns `true` if the error chain carries an [`HttpStatusError`] with an
 /// authentication/authorization status (401 or 403).
 ///

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -604,6 +604,39 @@ impl ServerApi {
         Ok(self.wrap_eventsource_with_iap_detection(request.eventsource()))
     }
 
+    /// Opens an SSE stream against the subtree-scoped agent event endpoint.
+    /// The stream covers the root run itself plus every descendant run
+    /// (children, grandchildren, ...). Only valid for tree roots — the
+    /// server rejects mid-tree anchors with 400.
+    pub async fn stream_agent_events_for_subtree(
+        &self,
+        root_run_id: &str,
+        since_sequence: i64,
+    ) -> Result<http_client::EventSourceStream> {
+        debug_assert!(!root_run_id.is_empty(), "root_run_id must not be empty");
+        let auth_token = self
+            .get_or_refresh_access_token()
+            .await
+            .context("Failed to get access token for SSE stream")?;
+
+        let url = format!(
+            "{}/api/v1/agent/events/stream?subtree_root_run_id={}&since={since_sequence}",
+            ChannelState::rtc_http_url(),
+            urlencoding::encode(root_run_id),
+        );
+
+        let mut request = self.base_client.http_client().get(&url);
+        if let Some(token) = auth_token.as_bearer_token() {
+            request = request.bearer_auth(token);
+        }
+
+        for (name, value) in self.ambient_agent_headers().await? {
+            request = request.header(name, value);
+        }
+
+        Ok(self.wrap_eventsource_with_iap_detection(request.eventsource()))
+    }
+
     pub async fn stream_agent_events_for_task(
         &self,
         task_id: &AmbientAgentTaskId,

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -374,13 +374,11 @@ pub struct AgentRunEvent {
     pub occurred_at: String,
     pub sequence: i64,
     /// The direct parent run of `run_id`, when the run is part of an
-    /// orchestration tree. Absent on old servers and for tree roots.
+    /// orchestration tree. Absent on old servers and for tree roots. The
+    /// wire payload also carries a `depth` field; it is not parsed because
+    /// no client surface consumes it yet.
     #[serde(default)]
     pub parent_run_id: Option<String>,
-    /// Depth of `run_id` in its orchestration tree (roots are 0). Absent
-    /// on old servers.
-    #[serde(default)]
-    pub depth: Option<i64>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -373,6 +373,14 @@ pub struct AgentRunEvent {
     pub execution_id: Option<String>,
     pub occurred_at: String,
     pub sequence: i64,
+    /// The direct parent run of `run_id`, when the run is part of an
+    /// orchestration tree. Absent on old servers and for tree roots.
+    #[serde(default)]
+    pub parent_run_id: Option<String>,
+    /// Depth of `run_id` in its orchestration tree (roots are 0). Absent
+    /// on old servers.
+    #[serde(default)]
+    pub depth: Option<i64>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -722,6 +730,7 @@ pub struct TaskListFilter {
     pub skill_spec: Option<String>,
     pub schedule_id: Option<String>,
     pub ancestor_run_id: Option<String>,
+    pub root_run_id: Option<String>,
     pub config_name: Option<String>,
     pub model_id: Option<String>,
     pub artifact_type: Option<ArtifactType>,
@@ -834,6 +843,9 @@ pub(crate) fn build_list_agent_runs_url(limit: i32, filter: &TaskListFilter) -> 
     }
     if let Some(ancestor_run_id) = filter.ancestor_run_id.as_deref() {
         push("ancestor_run_id", ancestor_run_id);
+    }
+    if let Some(root_run_id) = filter.root_run_id.as_deref() {
+        push("root_run_id", root_run_id);
     }
     if let Some(config_name) = filter.config_name.as_deref() {
         push("name", config_name);

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -1036,6 +1036,7 @@ fn build_list_agent_runs_url_all_fields() {
         skill_spec: Some("owner/repo:SKILL.md".to_string()),
         schedule_id: Some("sched-1".to_string()),
         ancestor_run_id: Some("run-parent".to_string()),
+        root_run_id: Some("run-root".to_string()),
         config_name: Some("nightly".to_string()),
         model_id: Some("claude-4-5".to_string()),
         artifact_type: Some(ArtifactType::PullRequest),
@@ -1061,6 +1062,7 @@ fn build_list_agent_runs_url_all_fields() {
          &skill_spec=owner%2Frepo%3ASKILL.md\
          &schedule_id=sched-1\
          &ancestor_run_id=run-parent\
+         &root_run_id=run-root\
          &name=nightly\
          &model_id=claude-4-5\
          &artifact_type=PULL_REQUEST\
@@ -1108,6 +1110,41 @@ fn build_list_agent_runs_url_routes_to_runs_not_tasks() {
     let url = build_list_agent_runs_url(10, &TaskListFilter::default());
     assert!(url.starts_with("agent/runs?"));
     assert!(!url.starts_with("agent/tasks"));
+}
+
+#[test]
+fn agent_run_event_parses_without_parent_run_id_and_depth() {
+    // Old servers omit the additive orchestration-tree fields.
+    let event: AgentRunEvent = serde_json::from_value(serde_json::json!({
+        "event_type": "run_in_progress",
+        "run_id": "child-run",
+        "ref_id": null,
+        "execution_id": null,
+        "occurred_at": "2026-01-01T00:00:00Z",
+        "sequence": 7,
+    }))
+    .unwrap();
+
+    assert_eq!(event.parent_run_id, None);
+    assert_eq!(event.depth, None);
+}
+
+#[test]
+fn agent_run_event_parses_parent_run_id_and_depth() {
+    let event: AgentRunEvent = serde_json::from_value(serde_json::json!({
+        "event_type": "run_in_progress",
+        "run_id": "grandchild-run",
+        "ref_id": null,
+        "execution_id": null,
+        "occurred_at": "2026-01-01T00:00:00Z",
+        "sequence": 7,
+        "parent_run_id": "child-run",
+        "depth": 2,
+    }))
+    .unwrap();
+
+    assert_eq!(event.parent_run_id.as_deref(), Some("child-run"));
+    assert_eq!(event.depth, Some(2));
 }
 
 #[test]

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -1113,7 +1113,7 @@ fn build_list_agent_runs_url_routes_to_runs_not_tasks() {
 }
 
 #[test]
-fn agent_run_event_parses_without_parent_run_id_and_depth() {
+fn agent_run_event_parses_without_parent_run_id() {
     // Old servers omit the additive orchestration-tree fields.
     let event: AgentRunEvent = serde_json::from_value(serde_json::json!({
         "event_type": "run_in_progress",
@@ -1126,11 +1126,11 @@ fn agent_run_event_parses_without_parent_run_id_and_depth() {
     .unwrap();
 
     assert_eq!(event.parent_run_id, None);
-    assert_eq!(event.depth, None);
 }
 
 #[test]
-fn agent_run_event_parses_parent_run_id_and_depth() {
+fn agent_run_event_parses_parent_run_id_and_ignores_depth() {
+    // `depth` rides the wire payload but has no client consumer yet.
     let event: AgentRunEvent = serde_json::from_value(serde_json::json!({
         "event_type": "run_in_progress",
         "run_id": "grandchild-run",
@@ -1144,7 +1144,6 @@ fn agent_run_event_parses_parent_run_id_and_depth() {
     .unwrap();
 
     assert_eq!(event.parent_run_id.as_deref(), Some("child-run"));
-    assert_eq!(event.depth, Some(2));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Adopts the server's root-scoped subtree event stream (`?subtree_root_run_id=`, warpdotdev/warp-server#14159) on the owner side of the unified orchestration stack, so a tree-root orchestrator observes its **whole** descendant tree — including runs spawned by remote mid-tree children, which previously never appeared in the owner's topology.

This is built on top of the merged unified stack (M1 #14473 / M2 #14480) and nests entirely inside its flag-ON code paths: subtree scope requires **both** `MultiLevelOrchestration` and `OrchestrationUnifiedStack` (the legacy flag-OFF drains and seeds are family-unaware, so they keep their existing direct-family behavior unchanged).

### What

- **Wire**: `AgentEventFilter::SubtreeRootRunId` maps to the server's subtree stream (root plus every descendant at any depth); `AgentRunEvent` parses the additive `parent_run_id` field (the wire's `depth` is left unparsed until a surface consumes it); `TaskListFilter` gains the `root_run_id` descendant listing.
- **Filter selection**: tree-root parents (a parent that is not itself a child) stream their subtree; mid-tree parents keep the `ancestor_run_id` + `include_self` scope — the server rejects non-root subtree anchors.
- **Per-family tracking**: `drain_family_events` generalizes M1's single `OrchestrationChildTracker` into a map keyed by each family's parent task id. On subtree-scoped drains, classification attributes `child_agent_started` to the run it fired on (a mid-tree parent starting a grandchild) and session-link/lifecycle events to the wire `parent_run_id`, so descendants nest under their real families and `ChildSpawned`/`ChildStatusChanged` broadcasts carry correct per-family attribution. Anchor-scoped drains are byte-for-byte unchanged in behavior.
- **Placeholders**: descendants nest under their family parent's placeholder conversation via the existing idempotent `ensure_remote_child_conversation`. A grandchild announced while its parent's placeholder fetch is still in flight parks and is retried when the parent materializes.
- **Replay safety**: the tracker's lifecycle write-through gains a per-child monotonic sequence guard (floored by seed rows' `last_event_sequence`) so subtree replays cannot regress a child's status — order is guarded, not terminal-ness, since runs legitimately go Succeeded → InProgress on wake. Tombstones (`killed_run_ids`) were already enforced by `observe_child` and apply to all depths, including descendants parked mid-discovery.
- **Fail-safe stream selection**: the event driver gains an opt-in consecutive-permanent-4xx give-up streak, enabled for subtree streams. A rejected subtree stream (server without the endpoint, or local/server root-ness disagreement) falls back to the ancestor scope so the parent's own inbox never stays dark behind a dead filter. Filter root-ness prefers the cached server task row (matching the restore seed) with local parent linkage as the fallback.
- **Lifecycle injection semantics**: on subtree drains, only DIRECT children's lifecycle events are injected into the parent conversation's pending-event queue — parity with the anchor-scoped drain and with the TUI's `WatchedRunStatusChanged` consumer, which only accepts direct children of the owner conversation. Tree-wide status still flows to the pill/topology surfaces via the tracker's write-through and broadcasts.
- **Restore**: a restored tree root seeds via the `root_run_id` listing (limit 100, matching the server cap; larger subtrees are not paginated yet — known follow-up, rows beyond the page are discovered via the live stream) and links rows in dependency-ordered passes. Rows referencing parents outside the listing are logged and left to live-stream discovery rather than re-driving the seed forever. The root's resume cursor stays `max(local SQLite, root task server cursor)`; descendant cursors are never merged.
- **Reveal**: revealing a deep descendant resolves its hosting pane through the shared root surface and hydrates through M2's unified `decide_child_pane_materialization` dispatch; a depth-capped ancestor-chain walk backstops parents with no resolvable pane (and terminates on cyclic parent graphs).

Note: an earlier revision of this branch carried a fix for live-attaching revealed child panes; that is now subsumed by the unified `AttachLive` path (`attach_ambient_orchestration_child_session` builds a fresh pane joined to the live session), so it was dropped in the re-port. The flag-OFF hydration path intentionally keeps its legacy behavior.

## Linked Issue
QUALITY-768 / follow-on to QUALITY-928 (M1 #14473, M2 #14480). Server half: warpdotdev/warp-server#14159.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Unit coverage: scope-aware `classify_family_event` (mid-tree discovery, wire-parent attribution, old-server fallback), per-family routing and grandchild park/unpark in `drain_family_events`, the monotonic sequence guard (stale replays dropped; terminal not sticky; seed-row floor), subtree filter selection across flag combinations plus server-row root-ness override, the subtree-stream 4xx fallback (permanent vs transient), direct-children-only lifecycle injection, dependency-ordered restore-seed linking incl. the truncated-listing no-spin case, restore-seed scope selection, deep-descendant reveal, and cyclic-ancestor-chain termination.
- `cargo nextest run -p warp` on all orchestration/streamer/tracker/restoration/hydration modules passes; `./script/format` and all presubmit clippy invocations clean.
- Visual evidence (owner drill-down + mid-run deep reveal joining a live session) pending: the depth-3 E2E against a local warp-server on the subtree branch will be captured during the next manual re-test of this stack.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
