### PR TITLE
Render the full orchestration subtree in shared-session viewers

### DIFF
--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -1651,7 +1651,11 @@ impl OrchestrationEventStreamer {
             self.spawn_ancestor_seed_fetch(parent_task_id, ctx);
         } else {
             // Already seeded: open the SSE immediately if it's not running
-            // (e.g. after a transient teardown).
+            // (e.g. after a transient teardown). The scope resolved by the
+            // original seed is deliberately sticky for the entry's lifetime
+            // — including a DirectChildren fallback from a transient
+            // root-ness fetch failure — and re-resolves only after the last
+            // consumer unregisters and the entry is rebuilt.
             self.start_ancestor_sse_if_seeded(parent_task_id, ctx);
             self.emit_known_viewer_mode_children(parent_task_id, ctx);
         }
@@ -1774,18 +1778,7 @@ impl OrchestrationEventStreamer {
         ctx.spawn(
             async move { ai_client.get_ambient_agent_task(&parent_task_id).await },
             move |me, result, ctx| {
-                let scope = match result {
-                    Ok(task) if task.parent_run_id.is_none() => ViewerAnchorScope::Subtree,
-                    Ok(_) => ViewerAnchorScope::DirectChildren,
-                    Err(err) => {
-                        log::warn!(
-                            "[orch-viewer-streamer] anchor root-ness fetch failed for \
-                             parent_task_id={parent_task_id}: {err:#}; falling back to \
-                             direct-children scope"
-                        );
-                        ViewerAnchorScope::DirectChildren
-                    }
-                };
+                let scope = viewer_scope_from_anchor_fetch(parent_task_id, &result);
                 me.spawn_viewer_seed_list(parent_task_id, scope, ctx);
             },
         );
@@ -3354,6 +3347,28 @@ fn agent_event_filters_equivalent(a: &AgentEventFilter, b: &AgentEventFilter) ->
 pub(crate) fn multi_level_subtree_scope_enabled() -> bool {
     FeatureFlag::MultiLevelOrchestration.is_enabled()
         && FeatureFlag::OrchestrationUnifiedStack.is_enabled()
+}
+
+/// Maps the viewer anchor's root-ness fetch outcome onto a stream scope:
+/// roots (no `parent_run_id`) stream their whole subtree; mid-tree anchors
+/// — and anchors whose root-ness cannot be determined — keep the legacy
+/// direct-children scope.
+fn viewer_scope_from_anchor_fetch(
+    parent_task_id: AmbientAgentTaskId,
+    result: &anyhow::Result<crate::ai::ambient_agents::task::AmbientAgentTask>,
+) -> ViewerAnchorScope {
+    match result {
+        Ok(task) if task.parent_run_id.is_none() => ViewerAnchorScope::Subtree,
+        Ok(_) => ViewerAnchorScope::DirectChildren,
+        Err(err) => {
+            log::warn!(
+                "[orch-viewer-streamer] anchor root-ness fetch failed for \
+                 parent_task_id={parent_task_id}: {err:#}; falling back to \
+                 direct-children scope"
+            );
+            ViewerAnchorScope::DirectChildren
+        }
+    }
 }
 
 pub(crate) fn agent_task_harness(

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -1678,6 +1678,10 @@ impl OrchestrationEventStreamer {
         if remaining == 0 {
             // Last viewer closed: tear down the ancestor SSE and drop any
             // descendants still parked against this entry's placeholder.
+            // With staggered multi-pane closes, entries parked against an
+            // earlier-departing consumer's placeholder linger until that
+            // conversation's own removal prunes them — benign, since a
+            // parked entry only acts when its family materializes.
             if let Some(connection) = entry.sse_connection.take() {
                 connection.abort_handle.abort();
             }

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -239,14 +239,28 @@ struct ConversationStreamState {
     subtree_stream_unavailable: bool,
 }
 
+/// Event scope of a viewer-mode entry's stream and cold-start seed.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum ViewerAnchorScope {
+    /// Direct children only (`?ancestor_run_id=` stream, `ancestor_run_id`
+    /// seed filter). The legacy scope; also the fallback whenever the
+    /// anchor's root-ness cannot be determined.
+    #[default]
+    DirectChildren,
+    /// The anchor's whole descendant subtree (`?subtree_root_run_id=`
+    /// stream, `root_run_id` seed filter). Only valid when the anchor is a
+    /// tree root — the server rejects mid-tree subtree anchors.
+    Subtree,
+}
+
 /// Per-orchestrator SSE stream state. Parallels [`ConversationStreamState`]
 /// but keyed on the orchestrator's `AmbientAgentTaskId` instead of on a
-/// specific conversation, so a single ancestor-scoped SSE connection can
-/// serve every consumer interested in that orchestrator's direct children.
+/// specific conversation, so a single viewer-scoped SSE connection can
+/// serve every consumer interested in that orchestrator's descendants.
 ///
 /// Today the only consumers are shared-session viewer panes (registered via
 /// [`Self::register_viewer_mode_consumer`]), which is why hydration and
-/// server-cursor push are absent on the ancestor path. See the note on
+/// server-cursor push are absent on the viewer path. See the note on
 /// [`AncestorForwardingConsumer`] for the future direction.
 #[derive(Default)]
 struct OrchestratorStreamState {
@@ -256,11 +270,17 @@ struct OrchestratorStreamState {
     /// panes viewing the same orchestrator each register independently and
     /// the entry survives until the last one unregisters.
     consumers: HashMap<EntityId, AIConversationId>,
-    /// Direct child `run_id`s observed via the ancestor SSE. Populated as
-    /// lifecycle events arrive and seeded from the cold-start REST snapshot.
-    /// Used to emit `ChildSpawned` exactly once per child; once a run_id is
-    /// in the set, subsequent observations only emit `ChildStatusChanged`.
+    /// Descendant `run_id`s observed via the viewer SSE (direct children in
+    /// `DirectChildren` scope; the whole subtree in `Subtree` scope).
+    /// Populated as lifecycle events arrive and seeded from the cold-start
+    /// REST snapshot. Used to emit `ChildSpawned` exactly once per run;
+    /// once a run_id is in the set, subsequent observations only emit
+    /// `ChildStatusChanged`.
     known_children: HashSet<String>,
+    /// Scope resolved during the cold-start seed: subtree for root anchors
+    /// (when multi-level subtree scope is enabled), direct children
+    /// otherwise.
+    anchor_scope: ViewerAnchorScope,
     /// Active ancestor SSE connection, if one is open.
     sse_connection: Option<AncestorSseConnectionState>,
     /// In-memory event cursor for the ancestor stream. Mirrors the
@@ -1282,8 +1302,18 @@ impl OrchestrationEventStreamer {
             .max()
             .unwrap_or(cursor);
 
-        // Viewer streams are direct-children scoped, so every child signal
-        // belongs to the anchor family.
+        // The drain scope follows the wire scope the entry's stream was
+        // opened with: subtree anchors attribute descendants to their real
+        // families, direct-children anchors keep anchor-family attribution.
+        let scope = match self
+            .viewer_mode_orchestrators
+            .get(&parent_task_id)
+            .map(|entry| entry.anchor_scope)
+            .unwrap_or_default()
+        {
+            ViewerAnchorScope::Subtree => FamilyDrainScope::Subtree,
+            ViewerAnchorScope::DirectChildren => FamilyDrainScope::AnchorFamily,
+        };
         let trackers = self
             .viewer_mode_orchestrators
             .get_mut(&parent_task_id)
@@ -1294,7 +1324,7 @@ impl OrchestrationEventStreamer {
             &self_run_id,
             parent_task_id,
             FamilyDrainMode::Observer,
-            FamilyDrainScope::AnchorFamily,
+            scope,
             trackers,
             cursor,
             events,
@@ -1724,18 +1754,62 @@ impl OrchestrationEventStreamer {
 
     // ---- Ancestor SSE consumer (viewer-mode driver wiring) -----------
 
-    /// One-shot `?ancestor_run_id=` REST fetch that seeds the per-
-    /// orchestrator entry's known-child set and SSE cursor. The ancestor
-    /// SSE opens automatically once the seed lands.
+    /// Kicks off the cold-start REST seed for `parent_task_id`. With
+    /// multi-level subtree scope enabled, first resolves whether the anchor
+    /// is a tree root (its task has no `parent_run_id`) so root anchors can
+    /// seed and stream their whole subtree; mid-tree anchors — and any
+    /// anchor whose root-ness cannot be determined — keep the legacy
+    /// direct-children scope. The viewer SSE opens automatically once the
+    /// seed lands.
     fn spawn_ancestor_seed_fetch(
         &mut self,
         parent_task_id: AmbientAgentTaskId,
         ctx: &mut ModelContext<Self>,
     ) {
+        if !multi_level_subtree_scope_enabled() {
+            self.spawn_viewer_seed_list(parent_task_id, ViewerAnchorScope::DirectChildren, ctx);
+            return;
+        }
         let ai_client = self.ai_client.clone();
-        let filter = TaskListFilter {
-            ancestor_run_id: Some(parent_task_id.to_string()),
-            ..TaskListFilter::default()
+        ctx.spawn(
+            async move { ai_client.get_ambient_agent_task(&parent_task_id).await },
+            move |me, result, ctx| {
+                let scope = match result {
+                    Ok(task) if task.parent_run_id.is_none() => ViewerAnchorScope::Subtree,
+                    Ok(_) => ViewerAnchorScope::DirectChildren,
+                    Err(err) => {
+                        log::warn!(
+                            "[orch-viewer-streamer] anchor root-ness fetch failed for \
+                             parent_task_id={parent_task_id}: {err:#}; falling back to \
+                             direct-children scope"
+                        );
+                        ViewerAnchorScope::DirectChildren
+                    }
+                };
+                me.spawn_viewer_seed_list(parent_task_id, scope, ctx);
+            },
+        );
+    }
+
+    /// Issues the scope-appropriate task-list fetch (`root_run_id` for
+    /// subtree scope, `ancestor_run_id` for direct children) and routes the
+    /// result through [`Self::finish_ancestor_seed_fetch`].
+    fn spawn_viewer_seed_list(
+        &mut self,
+        parent_task_id: AmbientAgentTaskId,
+        scope: ViewerAnchorScope,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let ai_client = self.ai_client.clone();
+        let filter = match scope {
+            ViewerAnchorScope::DirectChildren => TaskListFilter {
+                ancestor_run_id: Some(parent_task_id.to_string()),
+                ..TaskListFilter::default()
+            },
+            ViewerAnchorScope::Subtree => TaskListFilter {
+                root_run_id: Some(parent_task_id.to_string()),
+                ..TaskListFilter::default()
+            },
         };
         ctx.spawn(
             async move {
@@ -1744,19 +1818,21 @@ impl OrchestrationEventStreamer {
                     .await
             },
             move |me, result, ctx| {
-                me.finish_ancestor_seed_fetch(parent_task_id, result, ctx);
+                me.finish_ancestor_seed_fetch(parent_task_id, scope, result, ctx);
             },
         );
     }
 
-    /// Applies the cold-start REST seed: populates `known_children` from
-    /// the response, advances `event_cursor` to `max(server, local)`, marks
-    /// the entry seeded, and opens the ancestor SSE. Failures are logged
-    /// and retried at registration time (the SSE never opens on a failed
-    /// seed, so re-registering kicks the fetch off again).
+    /// Applies the cold-start REST seed: records the resolved scope,
+    /// populates `known_children` from the response, advances
+    /// `event_cursor` to `max(server, local)`, marks the entry seeded, and
+    /// opens the viewer SSE. Failures are logged and retried at
+    /// registration time (the SSE never opens on a failed seed, so
+    /// re-registering kicks the fetch off again).
     fn finish_ancestor_seed_fetch(
         &mut self,
         parent_task_id: AmbientAgentTaskId,
+        scope: ViewerAnchorScope,
         result: anyhow::Result<Vec<crate::ai::ambient_agents::task::AmbientAgentTask>>,
         ctx: &mut ModelContext<Self>,
     ) {
@@ -1781,7 +1857,7 @@ impl OrchestrationEventStreamer {
                     for task in tasks {
                         if task.task_id == parent_task_id {
                             // The server endpoint may include the parent itself;
-                            // skip it — only direct children are tracked.
+                            // skip it — only descendants are tracked.
                             continue;
                         }
                         let run_id = task.task_id.to_string();
@@ -1792,6 +1868,7 @@ impl OrchestrationEventStreamer {
                         }
                     }
                     entry.event_cursor = seed;
+                    entry.anchor_scope = scope;
                     entry.seeded = true;
                     log::debug!(
                         "[orch-viewer-streamer] ancestor seed applied for parent_task_id={parent_task_id}: \
@@ -1835,7 +1912,7 @@ impl OrchestrationEventStreamer {
         self.start_ancestor_sse(parent_task_id, cursor, ctx);
     }
 
-    /// Opens the ancestor SSE driver for `parent_task_id`. Events are
+    /// Opens the viewer SSE driver for `parent_task_id`. Events are
     /// forwarded through an mpsc channel and drained by a periodic timer
     /// (mirroring the per-conversation pipeline). The driver itself reuses
     /// `run_agent_event_driver::retry_forever` so reconnect / backoff /
@@ -1846,22 +1923,34 @@ impl OrchestrationEventStreamer {
         cursor: i64,
         ctx: &mut ModelContext<Self>,
     ) {
+        let scope = self
+            .viewer_mode_orchestrators
+            .get(&parent_task_id)
+            .map(|entry| entry.anchor_scope)
+            .unwrap_or_default();
         let server_api = self.server_api.clone();
         let (tx, rx) = mpsc::unbounded();
         let generation = self.next_sse_generation;
         self.next_sse_generation += 1;
 
         log::info!(
-            "Opening ancestor SSE for parent_task_id={parent_task_id} \
-             (gen={generation}, since={cursor})"
+            "Opening viewer SSE for parent_task_id={parent_task_id} \
+             (gen={generation}, since={cursor}, scope={scope:?})"
         );
 
-        // Viewer mode subscribes to direct children only: it surfaces child
-        // lifecycle in the pill bar and never needs the orchestrator's inbox,
-        // so `include_self` stays false to preserve the existing contract.
-        let filter = AgentEventFilter::AncestorRunId {
-            ancestor_run_id: parent_task_id.to_string(),
-            include_self: false,
+        // The viewer never needs the orchestrator's inbox: it only surfaces
+        // descendant lifecycle in the pill bar. Direct-children scope keeps
+        // `include_self=false`; subtree scope inherently includes the root's
+        // own events, which the Observer drain classifies as ParentSelf and
+        // drops.
+        let filter = match scope {
+            ViewerAnchorScope::DirectChildren => AgentEventFilter::AncestorRunId {
+                ancestor_run_id: parent_task_id.to_string(),
+                include_self: false,
+            },
+            ViewerAnchorScope::Subtree => AgentEventFilter::SubtreeRootRunId {
+                root_run_id: parent_task_id.to_string(),
+            },
         };
         let config = AgentEventDriverConfig::retry_forever(filter, cursor);
         let source = ServerApiAgentEventSource::new(server_api);

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -1983,6 +1983,7 @@ fn finish_ancestor_seed_fetch_emits_child_spawned_for_each_seeded_child() {
         streamer.update(&mut app, |me, ctx| {
             me.finish_ancestor_seed_fetch(
                 parent_task_id,
+                ViewerAnchorScope::DirectChildren,
                 Ok(vec![
                     make_ambient_task_with_task_id(parent_task_id, Some(5)),
                     make_ambient_task_with_task_id(child_a, Some(11)),
@@ -2064,6 +2065,7 @@ fn register_viewer_mode_consumer_replays_known_children_for_later_panes() {
             me.register_viewer_mode_consumer(parent_task_id, placeholder_a, consumer_a, ctx);
             me.finish_ancestor_seed_fetch(
                 parent_task_id,
+                ViewerAnchorScope::DirectChildren,
                 Ok(vec![make_ambient_task_with_task_id(child_a, Some(3))]),
                 ctx,
             );
@@ -4009,6 +4011,176 @@ fn reparking_a_deduped_descendant_rekicks_the_family_fetch() {
                 me.descendants_waiting_on_family[&mid_run_id].len(),
                 1,
                 "the re-parked descendant must still dedupe"
+            );
+        });
+    });
+}
+
+// ---- Viewer-mode subtree scope ---------------------------------------------
+
+#[test]
+fn viewer_seed_records_subtree_scope_and_tracks_all_descendants() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        let anchor = make_parent_task_id_for_test(0xb1);
+        let child = make_parent_task_id_for_test(0xb2);
+        let grandchild = make_parent_task_id_for_test(0xb3);
+        let consumer_id = warpui::EntityId::new();
+        let placeholder = crate::ai::agent::conversation::AIConversation::new(true, false).id();
+        streamer.update(&mut app, |me, ctx| {
+            let entry = me.viewer_mode_orchestrators.entry(anchor).or_default();
+            entry.consumers.insert(consumer_id, placeholder);
+            me.finish_ancestor_seed_fetch(
+                anchor,
+                ViewerAnchorScope::Subtree,
+                Ok(vec![
+                    make_ambient_task_with_task_id(child, Some(3)),
+                    make_ambient_task_with_task_id(grandchild, Some(4)),
+                ]),
+                ctx,
+            );
+        });
+
+        streamer.read(&app, |me, _| {
+            let entry = me
+                .viewer_mode_orchestrators
+                .get(&anchor)
+                .expect("viewer-mode entry exists after seed");
+            assert_eq!(entry.anchor_scope, ViewerAnchorScope::Subtree);
+            assert!(entry.known_children.contains(&child.to_string()));
+            assert!(
+                entry.known_children.contains(&grandchild.to_string()),
+                "subtree seeds track descendants at every depth"
+            );
+        });
+    });
+}
+
+#[test]
+fn viewer_subtree_drain_drops_anchor_events_and_attributes_families() {
+    // On subtree streams the anchor's own events arrive too; the Observer
+    // drain must drop them (the viewer never surfaces the orchestrator to
+    // itself) while still advancing the cursor, and a grandchild's spawn
+    // broadcast must be attributed to its actual family (the mid-tree
+    // parent), not the anchor.
+    App::test((), |mut app| async move {
+        let _unified = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        // The terminal-lifecycle arm evicts and refetches the child's cached
+        // task row via AgentConversationsModel.
+        app.add_singleton_model(|_ctx| ServerApiProvider::new_for_test());
+        app.add_singleton_model(crate::ai::agent_conversations_model::AgentConversationsModel::new);
+
+        let anchor = make_parent_task_id_for_test(0xb4);
+        let child = make_parent_task_id_for_test(0xb5);
+        let grandchild = make_parent_task_id_for_test(0xb6);
+
+        // Viewer placeholder for the anchor, restored so the Observer
+        // cursor write-through has a conversation row to persist into.
+        let placeholder = AIConversation::new(true, false);
+        let placeholder_id = placeholder.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![placeholder], ctx);
+        });
+
+        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
+        let server_api = ServerApiProvider::new_for_test().get();
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        let (tx, rx) = futures::channel::mpsc::unbounded();
+        let consumer_id = warpui::EntityId::new();
+        streamer.update(&mut app, |me, _| {
+            let entry = me.viewer_mode_orchestrators.entry(anchor).or_default();
+            entry.consumers.insert(consumer_id, placeholder_id);
+            entry.anchor_scope = ViewerAnchorScope::Subtree;
+            entry.seeded = true;
+            let (abort_handle, _) = futures::future::AbortHandle::new_pair();
+            entry.sse_connection = Some(AncestorSseConnectionState {
+                event_receiver: rx,
+                generation: 0,
+                abort_handle,
+            });
+            me.next_sse_generation = 1;
+        });
+
+        type CapturedSpawns = std::sync::Arc<parking_lot::Mutex<Vec<(AmbientAgentTaskId, String)>>>;
+        let captured: CapturedSpawns = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let captured_for_closure = captured.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&streamer, move |_, event, _| {
+                if let OrchestrationEventStreamerEvent::ChildSpawned {
+                    parent_task_id,
+                    run_id,
+                } = event
+                {
+                    captured_for_closure
+                        .lock()
+                        .push((*parent_task_id, run_id.clone()));
+                }
+            })
+        });
+
+        let anchor_event = make_seq_event("run_in_progress", &anchor.to_string(), None, 1);
+        let mut grandchild_event =
+            make_seq_event("run_succeeded", &grandchild.to_string(), None, 2);
+        grandchild_event.parent_run_id = Some(child.to_string());
+        tx.unbounded_send(AncestorSseStreamItem {
+            event: anchor_event,
+        })
+        .unwrap();
+        tx.unbounded_send(AncestorSseStreamItem {
+            event: grandchild_event,
+        })
+        .unwrap();
+
+        streamer.update(&mut app, |me, ctx| {
+            me.drain_viewer_events(anchor, ctx);
+        });
+
+        assert_eq!(
+            captured.lock().clone(),
+            vec![(child, grandchild.to_string())],
+            "only the descendant spawns, attributed to its actual family"
+        );
+        streamer.read(&app, |me, _| {
+            let entry = me
+                .viewer_mode_orchestrators
+                .get(&anchor)
+                .expect("viewer-mode entry exists");
+            assert_eq!(
+                entry.event_cursor, 2,
+                "the cursor advances across dropped anchor events"
+            );
+            // The grandchild's placeholder parks until the mid-tree parent's
+            // own placeholder conversation exists.
+            assert!(
+                me.descendants_waiting_on_family
+                    .contains_key(&child.to_string())
+            );
+        });
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&placeholder_id)
+                    .and_then(|c| c.last_event_sequence()),
+                Some(2),
+                "Observer cursor persists locally on the viewer placeholder"
             );
         });
     });

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -4097,7 +4097,14 @@ fn viewer_subtree_drain_drops_anchor_events_and_attributes_families() {
             model.restore_conversations(terminal_view_id, vec![placeholder], ctx);
         });
 
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
+        // No `expect_update_event_sequence_on_server`: the Observer drain
+        // must never push the server cursor, and any attempt panics the
+        // mock. Placeholder / missing-family fetches fire as side effects
+        // of discovery and parking; their outcome is not under test.
+        let mut mock = MockAIClient::new();
+        mock.expect_get_ambient_agent_task()
+            .returning(|_| Err(anyhow::anyhow!("metadata fetch not under test")));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
         let server_api = ServerApiProvider::new_for_test().get();
         let streamer = app.add_singleton_model(|ctx| {
             OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
@@ -4184,4 +4191,35 @@ fn viewer_subtree_drain_drops_anchor_events_and_attributes_families() {
             );
         });
     });
+}
+
+// ---- Viewer anchor scope resolution -----------------------------------------
+
+#[test]
+fn viewer_scope_resolution_maps_root_rows_to_subtree() {
+    let anchor = make_parent_task_id_for_test(0xb7);
+    assert_eq!(
+        viewer_scope_from_anchor_fetch(anchor, &Ok(make_ambient_task_with_task_id(anchor, None))),
+        ViewerAnchorScope::Subtree
+    );
+}
+
+#[test]
+fn viewer_scope_resolution_maps_mid_tree_rows_to_direct_children() {
+    let anchor = make_parent_task_id_for_test(0xb8);
+    let mut row = make_ambient_task_with_task_id(anchor, None);
+    row.parent_run_id = Some(make_parent_task_id_for_test(0xb9).to_string());
+    assert_eq!(
+        viewer_scope_from_anchor_fetch(anchor, &Ok(row)),
+        ViewerAnchorScope::DirectChildren
+    );
+}
+
+#[test]
+fn viewer_scope_resolution_falls_back_to_direct_children_on_fetch_errors() {
+    let anchor = make_parent_task_id_for_test(0xba);
+    assert_eq!(
+        viewer_scope_from_anchor_fetch(anchor, &Err(anyhow::anyhow!("server unavailable"))),
+        ViewerAnchorScope::DirectChildren
+    );
 }

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -26,7 +26,7 @@ use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAge
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::blocklist::history_model::BlocklistAIHistoryEvent;
 use crate::ai::blocklist::orchestration_event_streamer::{
-    OrchestrationEventStreamer, OrchestrationEventStreamerEvent,
+    OrchestrationEventStreamer, OrchestrationEventStreamerEvent, multi_level_subtree_scope_enabled,
 };
 use crate::features::FeatureFlag;
 use crate::pane_group::{ChildPaneMaterialization, decide_child_pane_materialization};
@@ -219,15 +219,28 @@ impl OrchestrationViewerModel {
     }
 
     /// True iff a broadcast attributed to `family_task_id` belongs to this
-    /// viewer's tree: the anchor itself, a tracked descendant, or a
-    /// descendant whose own discovery fetch is still pending (its children
-    /// can announce before its metadata resolves).
+    /// viewer's tree: the anchor itself or — with multi-level subtree scope
+    /// enabled — a tracked descendant, a descendant whose discovery fetch is
+    /// still pending, or one parked on a not-yet-registered parent (its own
+    /// children can announce before it resolves). Without the flag only the
+    /// anchor's own broadcasts are accepted, preserving the legacy
+    /// direct-children contract for overlapping viewer panes.
     fn family_in_scope(&self, family_task_id: AmbientAgentTaskId) -> bool {
-        family_task_id == self.parent_task_id
-            || self.children.contains_key(&family_task_id)
+        if family_task_id == self.parent_task_id {
+            return true;
+        }
+        if !multi_level_subtree_scope_enabled() {
+            return false;
+        }
+        self.children.contains_key(&family_task_id)
             || self
                 .pending_task_ids_for_discovery
                 .contains(&family_task_id)
+            || self
+                .children_waiting_on_parent
+                .values()
+                .flatten()
+                .any(|task| task.task_id == family_task_id)
     }
 
     /// Routes broadcast events from the streamer. `parent_task_id` on the
@@ -449,10 +462,13 @@ impl OrchestrationViewerModel {
                              parent run {parent} registers (anchor={})",
                             self.parent_task_id,
                         );
-                        self.children_waiting_on_parent
+                        let parked = self
+                            .children_waiting_on_parent
                             .entry(parent.to_string())
-                            .or_default()
-                            .push(task);
+                            .or_default();
+                        if !parked.iter().any(|parked| parked.task_id == task_id) {
+                            parked.push(task);
+                        }
                         return;
                     }
                 }

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -1,10 +1,13 @@
 //! Drives the orchestration pill bar in shared session viewers.
 //!
 //! After the viewer joins a parent ambient-agent session, this model
-//! discovers and tracks the parent's direct children via the
-//! [`OrchestrationEventStreamer`], which opens an ancestor SSE (seeded
+//! discovers and tracks the parent's descendants via the
+//! [`OrchestrationEventStreamer`], which opens a viewer SSE (subtree-scoped
+//! for tree-root anchors, direct-children ancestor scope otherwise; seeded
 //! by a one-shot REST snapshot) and broadcasts `ChildSpawned` /
-//! `ChildStatusChanged` events.
+//! `ChildStatusChanged` events. Descendants below the direct-child level
+//! are attached under their actual parent's placeholder, so the viewer
+//! renders the same nested topology as the owner.
 //!
 //! Each viewer pane has its own materialization model; durable child identity
 //! is shared through `BlocklistAIHistoryModel`, and the streamer is a shared
@@ -64,6 +67,11 @@ pub struct OrchestrationViewerModel {
     /// yet. Drained on `TasksUpdated`. Only populated while
     /// `OrchestrationUnifiedStack` is enabled.
     pending_task_ids_for_discovery: HashSet<AmbientAgentTaskId>,
+    /// Fetched descendant tasks whose parent run has no placeholder entry
+    /// yet (subtree seeds and events can arrive out of dependency order),
+    /// keyed by the missing parent run_id. Drained when the parent
+    /// registers.
+    children_waiting_on_parent: HashMap<String, Vec<AmbientAgentTask>>,
     /// Periodic timer fetching the claim-time `session_id` for
     /// not-yet-claimed children.
     pending_session_id_poll_handle: Option<SpawnedFutureHandle>,
@@ -125,6 +133,7 @@ impl OrchestrationViewerModel {
             children_by_run_id: HashMap::new(),
             metadata_fetches: HashSet::new(),
             pending_task_ids_for_discovery: HashSet::new(),
+            children_waiting_on_parent: HashMap::new(),
             pending_session_id_poll_handle: None,
             #[cfg(test)]
             metadata_fetch_dispatch_count: 0,
@@ -209,8 +218,22 @@ impl OrchestrationViewerModel {
         });
     }
 
-    /// Routes broadcast events from the streamer, filtered on this model's
-    /// `parent_task_id`.
+    /// True iff a broadcast attributed to `family_task_id` belongs to this
+    /// viewer's tree: the anchor itself, a tracked descendant, or a
+    /// descendant whose own discovery fetch is still pending (its children
+    /// can announce before its metadata resolves).
+    fn family_in_scope(&self, family_task_id: AmbientAgentTaskId) -> bool {
+        family_task_id == self.parent_task_id
+            || self.children.contains_key(&family_task_id)
+            || self
+                .pending_task_ids_for_discovery
+                .contains(&family_task_id)
+    }
+
+    /// Routes broadcast events from the streamer. `parent_task_id` on the
+    /// wire is the run's family (its direct parent): the anchor for direct
+    /// children and seed replays, a tracked descendant for deeper runs on
+    /// subtree-scoped streams.
     fn handle_streamer_event(
         &mut self,
         event: &OrchestrationEventStreamerEvent,
@@ -220,14 +243,14 @@ impl OrchestrationViewerModel {
             OrchestrationEventStreamerEvent::ChildSpawned {
                 parent_task_id,
                 run_id,
-            } if *parent_task_id == self.parent_task_id => {
+            } if self.family_in_scope(*parent_task_id) => {
                 self.handle_child_spawned(run_id.clone(), ctx);
             }
             OrchestrationEventStreamerEvent::ChildStatusChanged {
                 parent_task_id,
                 run_id,
                 status,
-            } if *parent_task_id == self.parent_task_id => {
+            } if self.family_in_scope(*parent_task_id) => {
                 self.handle_child_status_changed(run_id, status.clone(), ctx);
             }
             // Other orchestrators (or non-viewer-mode variants) are ignored.
@@ -405,10 +428,41 @@ impl OrchestrationViewerModel {
             return;
         }
 
-        // New child: register under the orchestrator's local conversation.
-        // Without an active parent conversation, `start_new_child_conversation`
-        // would lose the parent linkage. Drop and try again next cycle/event.
-        let Some(parent_conversation_id) = self.find_parent_conversation_id(ctx) else {
+        // New descendant: resolve the conversation it attaches under. Direct
+        // children of the anchor (and rows without parent attribution from
+        // old servers) attach to the orchestrator's local conversation;
+        // deeper descendants attach under their actual parent's placeholder,
+        // parking until that placeholder registers (subtree seeds and events
+        // can arrive out of dependency order).
+        let anchor_run_id = self.parent_task_id.to_string();
+        let parent_conversation_id = match task.parent_run_id.as_deref() {
+            Some(parent) if parent != anchor_run_id => {
+                let parent_entry = self
+                    .children_by_run_id
+                    .get(parent)
+                    .and_then(|parent_task_id| self.children.get(parent_task_id));
+                match parent_entry {
+                    Some(entry) => Some(entry.conversation_id),
+                    None => {
+                        log::info!(
+                            "[orch-viewer] parking descendant task_id={task_id} until its \
+                             parent run {parent} registers (anchor={})",
+                            self.parent_task_id,
+                        );
+                        self.children_waiting_on_parent
+                            .entry(parent.to_string())
+                            .or_default()
+                            .push(task);
+                        return;
+                    }
+                }
+            }
+            _ => self.find_parent_conversation_id(ctx),
+        };
+        // Without a resolved conversation to attach under,
+        // `start_new_child_conversation` would lose the parent linkage. Drop
+        // and try again next cycle/event.
+        let Some(parent_conversation_id) = parent_conversation_id else {
             log::warn!(
                 "[orch-viewer] no active parent conversation for terminal_view_id={:?} \
                  parent_task_id={}; deferring child registration for task_id={task_id}",
@@ -500,6 +554,20 @@ impl OrchestrationViewerModel {
 
         // Arm the session_id refetch timer if the child arrived pre-claim.
         self.maybe_schedule_pending_session_id_poll(ctx);
+
+        // Descendants parked on this run can attach now.
+        self.drain_children_waiting_on(&task_id.to_string(), ctx);
+    }
+
+    /// Re-enters `register_child` for tasks parked on `parent_run_id` once
+    /// that run's placeholder entry exists.
+    fn drain_children_waiting_on(&mut self, parent_run_id: &str, ctx: &mut ModelContext<Self>) {
+        let Some(waiting) = self.children_waiting_on_parent.remove(parent_run_id) else {
+            return;
+        };
+        for task in waiting {
+            self.register_child(task, ctx);
+        }
     }
 
     // ---- Pending-session_id polling ----------------------------------

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -466,8 +466,14 @@ impl OrchestrationViewerModel {
                             .children_waiting_on_parent
                             .entry(parent.to_string())
                             .or_default();
-                        if !parked.iter().any(|parked| parked.task_id == task_id) {
-                            parked.push(task);
+                        // On duplicate arrival keep the FRESHER snapshot: a
+                        // run can go terminal while parked, and registering
+                        // the stale row later would pin its pill on the old
+                        // status (materialization suppresses the poll that
+                        // would otherwise correct it).
+                        match parked.iter_mut().find(|p| p.task_id == task_id) {
+                            Some(stale) => *stale = task,
+                            None => parked.push(task),
                         }
                         return;
                     }

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -1150,3 +1150,60 @@ fn depth_four_descendants_park_and_drain_bottom_up() {
         });
     });
 }
+
+#[test]
+fn parked_duplicate_keeps_the_fresher_snapshot() {
+    // A run can go terminal while parked behind its unregistered parent; the
+    // dedupe must keep the FRESHER row, otherwise the drain registers the
+    // stale InProgress snapshot and — with materialization already
+    // requested — the poll never arms to correct the pill.
+    let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = setup(&mut app);
+        register_child(
+            &mut app,
+            &fixture,
+            task_with_parent_run(
+                GRANDCHILD_TASK_ID,
+                CHILD_A_TASK_ID,
+                AmbientAgentTaskState::InProgress,
+                "Nested worker",
+            ),
+        );
+        // A fresher snapshot for the same run arrives while still parked.
+        register_child(
+            &mut app,
+            &fixture,
+            task_with_parent_run(
+                GRANDCHILD_TASK_ID,
+                CHILD_A_TASK_ID,
+                AmbientAgentTaskState::Succeeded,
+                "Nested worker",
+            ),
+        );
+        fixture.model.read(&app, |model, _| {
+            let parked = model
+                .children_waiting_on_parent
+                .get(CHILD_A_TASK_ID)
+                .expect("still parked");
+            assert_eq!(parked.len(), 1, "duplicates dedupe to a single row");
+            assert_eq!(
+                parked[0].state,
+                AmbientAgentTaskState::Succeeded,
+                "the fresher snapshot must win"
+            );
+        });
+
+        register_child(&mut app, &fixture, queued_task(CHILD_A_TASK_ID, "Worker"));
+
+        let parked_state = read_child(&app, &fixture, GRANDCHILD_TASK_ID, |entry| {
+            entry.last_state.clone()
+        });
+        assert_eq!(
+            parked_state,
+            AmbientAgentTaskState::Succeeded,
+            "the drained registration must reflect the terminal state"
+        );
+    });
+}

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -718,6 +718,7 @@ fn test_model(
         children_by_run_id: HashMap::new(),
         metadata_fetches: HashSet::new(),
         pending_task_ids_for_discovery: HashSet::new(),
+        children_waiting_on_parent: HashMap::new(),
         pending_session_id_poll_handle: None,
         metadata_fetch_dispatch_count: 0,
     }
@@ -876,4 +877,146 @@ fn only_child_conversation(app: &App, fixture: &Fixture) -> AIConversation {
     let mut children = child_conversations(app, fixture);
     assert_eq!(children.len(), 1, "expected exactly one child conversation");
     children.remove(0)
+}
+
+// ---- Nested descendant placement (subtree streams) ---------------------------
+
+const GRANDCHILD_TASK_ID: &str = "55555555-5555-5555-5555-555555555555";
+
+/// Like [`task`], but parented under an arbitrary run instead of the anchor —
+/// the shape of a grandchild (or deeper) row on subtree streams.
+fn task_with_parent_run(
+    id: &str,
+    parent_run_id: &str,
+    state: AmbientAgentTaskState,
+    title: &str,
+) -> AmbientAgentTask {
+    let mut task = task(id, state, title);
+    task.parent_run_id = Some(parent_run_id.to_string());
+    task
+}
+
+#[test]
+fn registers_grandchild_under_its_parent_placeholder() {
+    let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = setup(&mut app);
+        register_child(&mut app, &fixture, queued_task(CHILD_A_TASK_ID, "Worker"));
+        register_child(
+            &mut app,
+            &fixture,
+            task_with_parent_run(
+                GRANDCHILD_TASK_ID,
+                CHILD_A_TASK_ID,
+                AmbientAgentTaskState::InProgress,
+                "Nested worker",
+            ),
+        );
+
+        let child_conv_id = read_child(&app, &fixture, CHILD_A_TASK_ID, |entry| {
+            entry.conversation_id
+        });
+        let grandchild_conv_id = read_child(&app, &fixture, GRANDCHILD_TASK_ID, |entry| {
+            entry.conversation_id
+        });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert!(
+                history
+                    .child_conversation_ids_of(&child_conv_id)
+                    .contains(&grandchild_conv_id),
+                "the grandchild must attach under its actual parent's placeholder"
+            );
+            assert!(
+                !history
+                    .child_conversation_ids_of(&fixture.parent_conv_id)
+                    .contains(&grandchild_conv_id),
+                "the grandchild must not be hard-attributed to the stream anchor"
+            );
+        });
+    });
+}
+
+#[test]
+fn parks_grandchild_until_parent_registers_then_drains() {
+    // Subtree seeds and events can arrive out of dependency order: a
+    // grandchild observed before its parent parks until the parent's
+    // placeholder registers, then drains under it.
+    let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = setup(&mut app);
+        register_child(
+            &mut app,
+            &fixture,
+            task_with_parent_run(
+                GRANDCHILD_TASK_ID,
+                CHILD_A_TASK_ID,
+                AmbientAgentTaskState::InProgress,
+                "Nested worker",
+            ),
+        );
+        fixture.model.read(&app, |model, _| {
+            assert!(
+                !model.children.contains_key(&task_id(GRANDCHILD_TASK_ID)),
+                "the grandchild must park while its parent run is unknown"
+            );
+            assert_eq!(
+                model
+                    .children_waiting_on_parent
+                    .get(CHILD_A_TASK_ID)
+                    .map(|tasks| tasks.len()),
+                Some(1)
+            );
+        });
+
+        register_child(&mut app, &fixture, queued_task(CHILD_A_TASK_ID, "Worker"));
+
+        fixture.model.read(&app, |model, _| {
+            assert!(model.children_waiting_on_parent.is_empty());
+            assert!(model.children.contains_key(&task_id(GRANDCHILD_TASK_ID)));
+        });
+        let child_conv_id = read_child(&app, &fixture, CHILD_A_TASK_ID, |entry| {
+            entry.conversation_id
+        });
+        let grandchild_conv_id = read_child(&app, &fixture, GRANDCHILD_TASK_ID, |entry| {
+            entry.conversation_id
+        });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert!(
+                history
+                    .child_conversation_ids_of(&child_conv_id)
+                    .contains(&grandchild_conv_id),
+                "the drained grandchild must attach under its parent's placeholder"
+            );
+        });
+    });
+}
+
+#[test]
+fn family_scope_covers_anchor_descendants_and_pending_discoveries() {
+    let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = setup(&mut app);
+        register_child(&mut app, &fixture, queued_task(CHILD_A_TASK_ID, "Worker"));
+        fixture.model.update(&mut app, |model, _| {
+            model
+                .pending_task_ids_for_discovery
+                .insert(task_id(CHILD_B_TASK_ID));
+        });
+
+        fixture.model.read(&app, |model, _| {
+            assert!(model.family_in_scope(task_id(PARENT_TASK_ID)));
+            assert!(
+                model.family_in_scope(task_id(CHILD_A_TASK_ID)),
+                "a tracked descendant is a family for its own children"
+            );
+            assert!(
+                model.family_in_scope(task_id(CHILD_B_TASK_ID)),
+                "a descendant awaiting discovery metadata can already parent grandchildren"
+            );
+            assert!(
+                !model.family_in_scope(task_id(GRANDCHILD_TASK_ID)),
+                "unknown families belong to other orchestrators"
+            );
+        });
+    });
 }

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -994,6 +994,7 @@ fn parks_grandchild_until_parent_registers_then_drains() {
 #[test]
 fn family_scope_covers_anchor_descendants_and_pending_discoveries() {
     let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
     App::test((), |mut app| async move {
         let fixture = setup(&mut app);
         register_child(&mut app, &fixture, queued_task(CHILD_A_TASK_ID, "Worker"));
@@ -1016,6 +1017,135 @@ fn family_scope_covers_anchor_descendants_and_pending_discoveries() {
             assert!(
                 !model.family_in_scope(task_id(GRANDCHILD_TASK_ID)),
                 "unknown families belong to other orchestrators"
+            );
+        });
+    });
+}
+
+#[test]
+fn family_scope_covers_descendants_parked_on_unregistered_parents() {
+    // A descendant parked behind a not-yet-registered parent can already be
+    // announcing children of its own; dropping those broadcasts as foreign
+    // would permanently lose already-terminal grandchildren.
+    let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+    App::test((), |mut app| async move {
+        let fixture = setup(&mut app);
+        register_child(
+            &mut app,
+            &fixture,
+            task_with_parent_run(
+                GRANDCHILD_TASK_ID,
+                CHILD_A_TASK_ID,
+                AmbientAgentTaskState::InProgress,
+                "Nested worker",
+            ),
+        );
+
+        fixture.model.read(&app, |model, _| {
+            assert!(
+                !model.children.contains_key(&task_id(GRANDCHILD_TASK_ID)),
+                "precondition: the descendant is parked, not registered"
+            );
+            assert!(
+                model.family_in_scope(task_id(GRANDCHILD_TASK_ID)),
+                "a parked descendant must still be an acceptable family"
+            );
+        });
+    });
+}
+
+#[test]
+fn family_scope_is_anchor_only_without_multi_level_orchestration() {
+    // Without multi-level subtree scope, overlapping viewer panes (for
+    // example a second top-level pane anchored on a child run) must keep
+    // the legacy contract: only the anchor's own broadcasts are accepted.
+    let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(false);
+    App::test((), |mut app| async move {
+        let fixture = setup(&mut app);
+        register_child(&mut app, &fixture, queued_task(CHILD_A_TASK_ID, "Worker"));
+
+        fixture.model.read(&app, |model, _| {
+            assert!(model.family_in_scope(task_id(PARENT_TASK_ID)));
+            assert!(
+                !model.family_in_scope(task_id(CHILD_A_TASK_ID)),
+                "a tracked child is not a family without multi-level orchestration"
+            );
+        });
+    });
+}
+
+#[test]
+fn depth_four_descendants_park_and_drain_bottom_up() {
+    // A depth-4 chain arriving fully out of dependency order: each level
+    // parks on its missing parent, and registrations drain the chain.
+    let _unified_stack = FeatureFlag::OrchestrationUnifiedStack.override_enabled(true);
+    let _multi_level = FeatureFlag::MultiLevelOrchestration.override_enabled(true);
+    App::test((), |mut app| async move {
+        const GREAT_GRANDCHILD_TASK_ID: &str = "66666666-6666-6666-6666-666666666666";
+        let fixture = setup(&mut app);
+
+        // Deepest first: great-grandchild parks on the grandchild, then the
+        // grandchild parks on the child.
+        register_child(
+            &mut app,
+            &fixture,
+            task_with_parent_run(
+                GREAT_GRANDCHILD_TASK_ID,
+                GRANDCHILD_TASK_ID,
+                AmbientAgentTaskState::InProgress,
+                "Depth four",
+            ),
+        );
+        register_child(
+            &mut app,
+            &fixture,
+            task_with_parent_run(
+                GRANDCHILD_TASK_ID,
+                CHILD_A_TASK_ID,
+                AmbientAgentTaskState::InProgress,
+                "Depth three",
+            ),
+        );
+        fixture.model.read(&app, |model, _| {
+            assert!(
+                model.children.is_empty(),
+                "everything parks until the child lands"
+            );
+            assert!(
+                model.family_in_scope(task_id(GRANDCHILD_TASK_ID)),
+                "parked mid levels stay in scope for their own children"
+            );
+        });
+
+        // The direct child registers: the whole chain drains bottom-up.
+        register_child(&mut app, &fixture, queued_task(CHILD_A_TASK_ID, "Worker"));
+
+        fixture.model.read(&app, |model, _| {
+            assert!(model.children_waiting_on_parent.is_empty());
+            assert!(model.children.contains_key(&task_id(CHILD_A_TASK_ID)));
+            assert!(model.children.contains_key(&task_id(GRANDCHILD_TASK_ID)));
+            assert!(
+                model
+                    .children
+                    .contains_key(&task_id(GREAT_GRANDCHILD_TASK_ID)),
+                "the depth-4 leaf drains once its whole ancestor chain registers"
+            );
+        });
+        let grandchild_conv_id = read_child(&app, &fixture, GRANDCHILD_TASK_ID, |entry| {
+            entry.conversation_id
+        });
+        let great_grandchild_conv_id =
+            read_child(&app, &fixture, GREAT_GRANDCHILD_TASK_ID, |entry| {
+                entry.conversation_id
+            });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert!(
+                history
+                    .child_conversation_ids_of(&grandchild_conv_id)
+                    .contains(&great_grandchild_conv_id),
+                "each drained level attaches under its actual parent"
             );
         });
     });


### PR DESCRIPTION
## Description

Follows the owner-side subtree adoption (#14856): a shared-session viewer of a tree-root orchestrator previously rendered only the root's direct children, because its stream, replay, and cold-start seed were all direct-children scoped. Deeper descendants never appeared in the pill bar, and their transcript references resolved to "Unknown agent".

With `MultiLevelOrchestration` + `OrchestrationUnifiedStack` enabled, the viewer now renders the same nested topology as the owner. This collapses almost entirely into Observer-mode wiring over the shared per-family drain that #14856 introduced.

### What

- **Anchor scope resolution**: the viewer streamer resolves the anchor's root-ness during the cold-start seed (a root task has no `parent_run_id`). Root anchors seed via the `root_run_id` list filter and stream via `subtree_root_run_id`; mid-tree anchors — and anchors whose root-ness can't be determined — keep the existing direct-children ancestor scope.
- **Observer family drain**: the viewer drain follows the entry's resolved scope, so descendant signals on subtree anchors route to per-family trackers and spawn/status broadcasts carry each run's actual family. The anchor's own events (subtree streams include the root) classify as ParentSelf and are dropped — the viewer never surfaces the orchestrator to itself — while still advancing the cursor. Viewer cursor semantics are unchanged (local-only persistence, never pushes the server cursor).
- **Nested placement**: `OrchestrationViewerModel` accepts broadcasts for any family in its tree — the anchor, tracked descendants, descendants whose discovery metadata is still resolving, and descendants parked on a not-yet-registered parent — and attaches each descendant under its actual parent's placeholder, parking out-of-dependency-order rows until the parent registers (duplicates dedupe per task, keeping the freshest snapshot). Non-anchor family acceptance is gated on the multi-level subtree flags, preserving the legacy direct-children contract for overlapping viewer panes. Pane materialization reuses the unified `EnsureUnifiedViewerChildPane` dispatch unchanged.

## Linked Issue
QUALITY-768 / follow-on to QUALITY-928 (M1 #14473, M2 #14480). Server half: warpdotdev/warp-server#14159. Owner half: #14856.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Unit coverage: anchor scope resolution (root / mid-tree / fetch-error paths); subtree seed records scope and tracks descendants at every depth; the Observer subtree drain drops anchor-self events while advancing the local cursor (mock panics on any server-cursor push) and attributes a grandchild's spawn to its mid-tree family; grandchildren register under their parent's placeholder (never hard-attributed to the anchor); out-of-order chains down to depth 4 park and drain bottom-up; family-scope acceptance covers the anchor, tracked/pending/parked descendants, ignores foreign orchestrators, and collapses to anchor-only without the multi-level flag.
- `cargo nextest run -p warp` on all orchestration/streamer/viewer-model modules passes; `./script/format` and all presubmit clippy invocations clean.
- Visual evidence (viewer nested pill bar + named grandchild chips) pending: the browser-viewer E2E against a local warp-server on the subtree branch will be captured during the next manual re-test of this stack.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
