### PR TITLE
Add syntax highlighting and LSP support for Solidity (.sol) files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "arborium"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7e6876037a5e3be1d34920a78bf31ca623fe559d56c2dbad3b67a9464c8870"
+checksum = "abb7a99c146e42da48d5783335814d9bd0f088143aa51fb5ea5b59855df5ca70"
 dependencies = [
  "arborium-bash",
  "arborium-c",
@@ -672,6 +672,7 @@ dependencies = [
  "arborium-ruby",
  "arborium-rust",
  "arborium-scala",
+ "arborium-solidity",
  "arborium-sql",
  "arborium-starlark",
  "arborium-swift",
@@ -688,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-bash"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efa85fb0db07418b867b4a92decd1cc6124a29712ca324ab84741c7874ec4f1"
+checksum = "5aa5ef1fa9c298d071d0817b068880a22c86f11202508215bdfddc3386aae643"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -699,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-c"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccda810d178c6a605849627487d8e43817c61290831dd1879d7c77e69524269"
+checksum = "3d44b533ac7c14da8a26dfb8f7b4bfa29da969a7f01015d63a3ed4097af14c9d"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -710,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-c-sharp"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744c7b320c4b42757ce136b1b011aab619ecd8a2e84f12ba487f776fdb898648"
+checksum = "74247ec493c8d377fe9b905c33650742ffd6a3bce87849df656bbb34ec4e3c78"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -721,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-cpp"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c1c426b4c60bc0b57ef35ef08a66887e6feeb04ad72833793087ec8e5a39af"
+checksum = "8f307d299c2089784e11c6a93374b80c0d5f42c46bdc9f10bcd02163a1fd30bb"
 dependencies = [
  "arborium-c",
  "arborium-sysroot",
@@ -733,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-css"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f38e4a1fbceafce1853134db903f09c8bc4cefe627a1cca3ac62d4d4dad5b"
+checksum = "040085bd355e439915eaeca9ed9db316a8dc3795f36c23948f216a808192376f"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -744,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-dockerfile"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ddfdd2c91c570d5fa7b16beb5c0513bb1a079c0be1a6ca68ac85c77c4ef8ea"
+checksum = "168968cacf937c51bb8ed785780467547a5158141d2c53c0d8f6fb64a60d86c9"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -755,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-elixir"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83642c9163db915db820ba0d8e0546d76f30c4c4afedc04d4108c6a496834d9"
+checksum = "5523d0749ec7f0b020cab4e0a37d64f5bf52096b6851cca516f0c07941fbf256"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -766,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-go"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdedc9ea8ba852f3e4d5514ac73a146087b347476e4a5292cc88c71d560bfd7"
+checksum = "ab9a45c7deab55b1dfed13074fe9cbc0bfa8d4a40e4bc509f4295291e53efdec"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -777,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-hcl"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f131ed1d40c891bcaabd919f3342be428dec0f3aaa074b4f25a58f94c60b7b"
+checksum = "c9b1c28c0abb1030dc2f82b9b1f51bbec933571375261bddccae8c4a996e8231"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -788,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-highlight"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e371b139629b82f07e426efb305bc3e481c71f8f63ebf7d45962c56c7b1459"
+checksum = "65635c663883cb887d52abce06650f81e4abeb7bfd8e79a555f6a0d8e8f0a31b"
 dependencies = [
  "arborium-theme",
  "arborium-tree-sitter",
@@ -799,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-html"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdcc798603a9ebd4d0c0f91165d6610b2e4d239c1e41f427c2a0727891f85367"
+checksum = "0b109985d29a842c1fe328b567ac48f8d2211bce778dfe12da6297dd58adac2a"
 dependencies = [
  "arborium-css",
  "arborium-javascript",
@@ -812,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-java"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0830b9cc627513c491f29e8a1c599dc71151381c5052611fa8d010932adc9af"
+checksum = "98e14774819787b842be24f7979f527f4a1cf8a60a231a66aef9bb8e31811ae9"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -823,10 +824,11 @@ dependencies = [
 
 [[package]]
 name = "arborium-javascript"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b04390f79e704f411fec9f11acd1ee7e6bc3c4e1941ca6af41d31efad78582"
+checksum = "424c648bf3075e137a5620318a7f865cf320c5f43163d3094764d4cc050e7cc0"
 dependencies = [
+ "arborium-jsdoc",
  "arborium-sysroot",
  "cc",
  "tree-sitter-language",
@@ -834,9 +836,20 @@ dependencies = [
 
 [[package]]
 name = "arborium-jq"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdce2ce4dabcff7626fb09fcb2a6915ce4714d2f6a190dc8c54dac1bd2072da"
+checksum = "f738b957b80adb9b479d5edd3afd86658337a06fd4b4d998a6856c9cf818678b"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-jsdoc"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f06a77e65f79ded95575bbc9b48a3f213e82ba1a23e5bc64ee5df77f14166cf4"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -845,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-json"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3de7588e3bab5753eb216ec27b15a9d343b46ee260cce6a7652f9197a4471aa"
+checksum = "bcbd847461cd81d50cd34454870359bc73ac1b96512eb8a33943fe54cba82d9f"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -856,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-kotlin"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df5f4afbaad12c54ee732957c4db19f2fbcde4e0f25440cb313f473cd0b13d"
+checksum = "39795ff23c1d15c870e4173d580f4188f78814ab919b9b01566a422426b9b697"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -867,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-lua"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0132cce1b343560a26ae8a9af8da70bcec44432106c9670399ac9c59c61f2dee"
+checksum = "672db35847456504a89c9882092c04b659d9c65e92272dd4383a15f4cddcc57b"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -878,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-markdown"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3705547b4e843b1caaf8b690be09a54094ee888faa260f6333189dc7b9b9b7f7"
+checksum = "5bd7c263aeb25a87a0b9eb0d90d2f559eb4e7ec4bce2a305271893902201a6e1"
 dependencies = [
  "arborium-html",
  "arborium-sysroot",
@@ -892,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-nix"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a703d5502526e68f7ad8dbffd303537d6828005bed0ef0fc7d37e45bf7078"
+checksum = "b56328852b01793707818ed971ae42129693ad0026d330a0fd42a600a54bd7aa"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -903,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-objc"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2889b5a0cc3fa2accded8bf40bfab575d1ad6d8d3dbedd6b3264d79546f22e"
+checksum = "fd492b0f4a5478a5799c2b9b81c72e1be909ded9136b442a95e85f9f1f987c8c"
 dependencies = [
  "arborium-c",
  "arborium-sysroot",
@@ -915,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-php"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc8dc435097077e3a74faed79e6d17c66bb64fc99ae00065650b6277cc3e2d0"
+checksum = "570bbca1ecf73c659650db6d7be73bdf996691055afc63f5c4eb1ef3e9a52d05"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -926,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-powershell"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211257c0ad8c94150db5a8cff4698c58d7350187c284993af4a6cc4eb249d7e"
+checksum = "13e9c67ce414f1c898f6999b02226419ee81c11757c86045b9cc850930b7f83c"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -937,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-python"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec2b0cbb06b6c4901c8b60a91b9ed8b9009c20c3c4a2b4ffefcfae98d92d50"
+checksum = "5ade74ad0c312807b2f4c439c7e416c6de41f5a6a638cdea1d5e93470d87ba91"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -948,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-ruby"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0901190cc2c700063668e727343c3b3dc7bf86e2f83477995e2be4de9ba26fb5"
+checksum = "b9ff559db56a1a46e34d289e1076a89c4babc75fd06a9c30cfe54ab63307088c"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -959,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-rust"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1feaf2984af48c8066f9eb9f2e381daa1d06cde717725739d16f6312b5afeb"
+checksum = "a291f443c124244ff7dea2248a1f2bf60a3b4d6ab0585784ea680dc33fd7cd47"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -970,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-scala"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374bd0959a654159766c43135a4bc57de803730b932a093997affe1ee0b1abb5"
+checksum = "87cfeb6d01db8a42af104161a2ec7e2a8585072689195bdc5d3511929ce465ae"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -981,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-scss"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ec43c8cbb9326eda4c63d190084379742bc9c6e167adc46c1bee1c7a1f4e4"
+checksum = "2e63936c6eddc6fa79a9106c0910b52069ec9d74eba5e8234acc4374c2ab733c"
 dependencies = [
  "arborium-css",
  "arborium-sysroot",
@@ -992,10 +1005,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "arborium-sql"
-version = "2.13.0"
+name = "arborium-solidity"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06c5820b032879818e31e627d2252fc83534b5fd97976c62fefb7b1fd8fad6c"
+checksum = "45a8dd0eba3acdb3686e11472dfe2e05d3a26fdae0288035922728429b9d6a80"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-sql"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f790fcca922217312f9e4c03d7423d74e37d4c5eec41a0b774019debd73be8"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -1004,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-starlark"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f510abda8b94d9322c162c8e70aa91fa023fa8962dca36624168241ac0cbed40"
+checksum = "57f562d7734124b4894babd2450d3709668ddf6309415ed405c6e2565c2188d0"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -1015,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-swift"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b329b137a5df5b2a2db1a9306deeec5946f3111dc6c7239b81466d569ffa573"
+checksum = "8251ab4f0af5b08e0439fb02e7e4e229cb814e75d145cbe26e0afabacfba3863"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -1026,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-sysroot"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce9624bea89e41ab45de48c1e94d4a8587f9ed429801314c91255149a852cc9"
+checksum = "59d99d80550b726f9dec7ee6d07118c31e08b10e729ac488eabd4c10603dc841"
 dependencies = [
  "cc",
  "dlmalloc",
@@ -1036,15 +1060,15 @@ dependencies = [
 
 [[package]]
 name = "arborium-theme"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fc2e080b8021373c7ea15cc489dbb7961a874c2ad33dfcea78922d28e74916"
+checksum = "a00a8f02b994f454d9703dd6a8b6075ba778320550d699198faff1882594c0f7"
 
 [[package]]
 name = "arborium-toml"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d27803c540a96afb4495b4ae4ffe8a1e45f3e2a2e9c96bcb6dea606689068c"
+checksum = "102a80466c8afd64c0c05c57cae30e5ff5ddbf3f943065fdd8fbe64331b49952"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -1053,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-tree-sitter"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5949db89cff33854500be88107ec38e125aa22ec82d2bfbefe96172014b2bf"
+checksum = "b27f3bd6bb7192e4a19dc177748532b305e9052839b34e55705f53e5eea2d5ca"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -1067,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-tsx"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4743664693d6ca201d34daf376ec4156f8f47755b1020d2fdce4fea24c356fd3"
+checksum = "459b71b663c89d3e03beb0226bdd1faac2ae5d5b36dbfcddbe4c631fd062b19e"
 dependencies = [
  "arborium-javascript",
  "arborium-sysroot",
@@ -1079,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-typescript"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc62ebc9766afcda0699641c368cf1df9f3f0d4537768cb1e0dd53d13f17537c"
+checksum = "72a226449c2081a153662af88ac5db08d6ee2654ac9022bdc1bacb8a2769053d"
 dependencies = [
  "arborium-javascript",
  "arborium-sysroot",
@@ -1091,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-vue"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52efb91c3196ad8cdb84dffb186d1111cfb589f6584fcd2361fd7ab1742db514"
+checksum = "ffce50016451cdbd77d6c7ab15ef96bc419c7842feff67e0fb27b19cef744749"
 dependencies = [
  "arborium-css",
  "arborium-html",
@@ -1107,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-xml"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5d887ca19a9019b1130b268d1b1bb586067b167028cca71f3163f29186c254"
+checksum = "d2ab75e92a76a01cfbbc7720944c9436bbed931e7b3c5e397a94f088f05acc17"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -1118,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-yaml"
-version = "2.13.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d369177e823663b47a26c83fd3503db86ba278c4e734844fee6cb85caf17ff"
+checksum = "d83a224e870912490905c2cb21fa1d0b055ae9f88a47329f5849662cb9fe656f"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -10577,7 +10601,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,7 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
   "registry",
   "std",
 ] }
-arborium = { version = "2", default-features = false, features = [
+arborium = { version = "2.18.1", default-features = false, features = [
   "lang-rust",
   "lang-go",
   "lang-yaml",
@@ -334,6 +334,7 @@ arborium = { version = "2", default-features = false, features = [
   "lang-vue",
   "lang-dockerfile",
   "lang-markdown",
+  "lang-solidity",
 ] }
 unicode-general-category = "1.1.0"
 unicode-linebreak = "0.1.5"

--- a/crates/languages/grammars/solidity/config.yaml
+++ b/crates/languages/grammars/solidity/config.yaml
@@ -1,0 +1,11 @@
+display_name: "Solidity"
+indent_unit:
+  space: 4
+comment_prefix: "//"
+brackets:
+  - start: "{"
+    end: "}"
+  - start: "("
+    end: ")"
+  - start: "["
+    end: "]"

--- a/crates/languages/grammars/solidity/identifiers.scm
+++ b/crates/languages/grammars/solidity/identifiers.scm
@@ -1,0 +1,21 @@
+(comment) @comment
+
+; Contract, interface, and library declarations
+(contract_declaration (identifier) @definition.class)
+(interface_declaration (identifier) @definition.class)
+(library_declaration (identifier) @definition.class)
+
+; Function and modifier declarations
+(function_definition (identifier) @definition.fn)
+(modifier_definition (identifier) @definition.method)
+
+; Event and error declarations
+(event_definition (identifier) @definition.method)
+(error_declaration (identifier) @definition.method)
+
+; Struct and enum declarations
+(struct_declaration (identifier) @definition.struct)
+(enum_declaration (identifier) @definition.enum)
+
+; State variables
+(state_variable_declaration (identifier) @definition)

--- a/crates/languages/grammars/solidity/indents.scm
+++ b/crates/languages/grammars/solidity/indents.scm
@@ -1,0 +1,45 @@
+[
+  (contract_declaration)
+  (interface_declaration)
+  (library_declaration)
+  (constructor_definition)
+  (fallback_receive_definition)
+  (function_definition)
+  (modifier_definition)
+  (event_definition)
+  (error_declaration)
+  (struct_declaration)
+  (enum_declaration)
+  (block_statement)
+  (contract_body)
+  (function_body)
+  (struct_body)
+  (enum_body)
+  (parenthesized_expression)
+  (inline_array_expression)
+  (struct_expression)
+  (call_expression)
+  (call_argument)
+  (parameter)
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (do_while_statement)
+  (try_statement)
+  (catch_clause)
+  (import_directive)
+  (member_expression)
+  (binary_expression)
+  (assignment_expression)
+  (augmented_assignment_expression)
+  (return_statement)
+  (revert_statement)
+  (variable_declaration_statement)
+  (variable_declaration_tuple)
+] @indent
+
+[
+  "}"
+  "]"
+  ")"
+] @outdent

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -18,7 +18,7 @@ lazy_static! {
     static ref LANGUAGE_REGISTRY: LanguageRegistry = LanguageRegistry::new();
 }
 
-pub const SUPPORTED_LANGUAGES: [&str; 35] = [
+pub const SUPPORTED_LANGUAGES: [&str; 36] = [
     "rust",
     "golang",
     "yaml",
@@ -54,6 +54,7 @@ pub const SUPPORTED_LANGUAGES: [&str; 35] = [
     "dockerfile",
     "nix",
     "markdown",
+    "solidity",
 ];
 
 /// Registry that holds all of the supported languages.
@@ -196,6 +197,7 @@ fn language_by_filename_parts(
         "vue" => language_by_name("vue"),
         "dockerfile" => language_by_name("dockerfile"),
         "md" | "markdown" => language_by_name("markdown"),
+        "sol" => language_by_name("solidity"),
         _ => None,
     }
 }
@@ -294,6 +296,7 @@ fn get_arborium_highlight_query(lang: &str) -> Option<&str> {
         "vue" => Some(&arborium::lang_vue::HIGHLIGHTS_QUERY),
         "dockerfile" => Some(arborium::lang_dockerfile::HIGHLIGHTS_QUERY),
         "markdown" => Some(arborium::lang_markdown::HIGHLIGHTS_QUERY),
+        "solidity" => Some(arborium::lang_solidity::HIGHLIGHTS_QUERY),
         _ => None,
     }
 }

--- a/crates/languages/src/lib_tests.rs
+++ b/crates/languages/src/lib_tests.rs
@@ -95,3 +95,20 @@ fn markdown_extensions_resolve_to_markdown() {
         );
     }
 }
+
+/// `.sol` files should resolve to the Solidity language so the editor applies
+/// syntax highlighting and LSP support to Solidity smart contracts.
+#[test]
+fn solidity_extensions_resolve_to_solidity() {
+    for filename in ["Contract.sol", "Token.sol"] {
+        let path = StandardizedPath::try_new(&format!("/tmp/{filename}"))
+            .expect("test path should be absolute");
+        let language = language_by_filename(&path)
+            .unwrap_or_else(|| panic!("expected {filename} to resolve to a language"));
+        assert_eq!(
+            language.display_name(),
+            "Solidity",
+            "{filename} should resolve to Solidity",
+        );
+    }
+}

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -32,6 +32,7 @@ pub enum LanguageId {
     JavaScriptReact,
     C,
     Cpp,
+    Solidity,
 }
 
 impl LanguageId {
@@ -52,6 +53,7 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
+            "sol" => Some(Self::Solidity),
             _ => None,
         }
     }
@@ -69,6 +71,7 @@ impl LanguageId {
             LanguageId::JavaScriptReact => "javascriptreact",
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
+            LanguageId::Solidity => "solidity",
         }
     }
 
@@ -83,6 +86,7 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
+            LanguageId::Solidity => LSPServerType::SolidityLanguageServer,
         }
     }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use lsp_types::Uri;
 
-use crate::config::{lsp_uri_to_path, path_to_lsp_uri};
+use crate::config::{LanguageId, lsp_uri_to_path, path_to_lsp_uri};
 
 // Unix-specific tests use Unix paths
 #[cfg(not(windows))]
@@ -127,6 +127,13 @@ mod unix_tests {
         let uri = path_to_lsp_uri(&original_path).unwrap();
         let roundtrip_path = lsp_uri_to_path(&uri).unwrap();
         assert_eq!(original_path, roundtrip_path);
+    }
+
+    #[test]
+    fn test_solidity_file_resolves_to_solidity_language_id() {
+        let path = PathBuf::from("/Users/test/project/contract.sol");
+        assert_eq!(LanguageId::from_path(&path), Some(LanguageId::Solidity));
+        assert_eq!(LanguageId::Solidity.lsp_language_identifier(), "solidity");
     }
 }
 

--- a/crates/lsp/src/servers/mod.rs
+++ b/crates/lsp/src/servers/mod.rs
@@ -2,4 +2,5 @@ pub mod clangd;
 pub mod go;
 pub mod pyright;
 pub mod rust;
+pub mod solidity_language_server;
 pub mod typescript_language_server;

--- a/crates/lsp/src/servers/solidity_language_server.rs
+++ b/crates/lsp/src/servers/solidity_language_server.rs
@@ -4,13 +4,18 @@ use std::sync::Arc;
 #[cfg(feature = "local_fs")]
 use anyhow::Context;
 use async_trait::async_trait;
-#[cfg(feature = "local_fs")]
-use command::r#async::Command;
 
 use crate::CommandBuilder;
 use crate::language_server_candidate::{LanguageServerCandidate, LanguageServerMetadata};
 #[cfg(feature = "local_fs")]
 use crate::supported_servers::CustomBinaryConfig;
+
+#[cfg(feature = "local_fs")]
+const SOLIDITY_SERVER_BINARY_NAME: &str = "nomicfoundation-solidity-language-server";
+
+/// Minimum Node.js version required by `@nomicfoundation/solidity-language-server`.
+#[cfg(feature = "local_fs")]
+const SOLIDITY_MIN_NODE_VERSION: (u64, u64, u64) = (20, 9, 0);
 
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 pub struct SolidityLanguageServerCandidate {
@@ -48,36 +53,12 @@ impl SolidityLanguageServerCandidate {
             return None;
         }
 
-        let node_binary = node_runtime::find_working_node_binary(path_env_var).await?;
+        let node_binary = find_node_binary_for_solidity(path_env_var).await?;
 
-        let mut cmd = Command::new(&node_binary);
-        if let Some(path) = path_env_var {
-            cmd.env("PATH", path);
-        }
-        cmd.arg(&server_js).arg("--version");
-        match cmd.output().await {
-            Ok(output) if output.status.success() => {
-                let version = String::from_utf8_lossy(&output.stdout);
-                log::info!(
-                    "Verified Solidity language server installation: {}",
-                    version.trim()
-                );
-            }
-            Ok(output) => {
-                log::warn!(
-                    "Solidity language server version check failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
-                return None;
-            }
-            Err(e) => {
-                log::warn!(
-                    "Failed to run Solidity language server version check: {}",
-                    e
-                );
-                return None;
-            }
-        }
+        log::info!(
+            "Found Solidity language server JS file at {}",
+            server_js.display()
+        );
 
         Some(CustomBinaryConfig {
             binary_path: node_binary,
@@ -106,13 +87,7 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
     }
 
     async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
-        executor
-            .command("nomicfoundation-solidity-language-server")
-            .arg("--version")
-            .output()
-            .await
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        binary_exists_on_path(executor.path_env_var(), SOLIDITY_SERVER_BINARY_NAME)
     }
 
     async fn install(
@@ -131,10 +106,7 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
             .await
             .context("Failed to create Solidity language server installation directory")?;
 
-        let use_system_node = match executor.path_env_var() {
-            Some(path) => node_runtime::detect_system_node(path).await.is_ok(),
-            None => false,
-        };
+        let use_system_node = system_node_meets_solidity_requirement(executor.path_env_var()).await;
 
         let custom_node_paths = if use_system_node {
             log::info!("Using system Node.js for Solidity language server installation");
@@ -199,6 +171,135 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
             digest: None,
         })
     }
+}
+
+/// Finds a Node.js binary that can run the Solidity language server.
+///
+/// Prefers Warp's pinned custom Node install, then falls back to system Node only when it
+/// satisfies the package's `engines` requirement (`>=20.9.0`).
+#[cfg(feature = "local_fs")]
+async fn find_node_binary_for_solidity(path_env_var: Option<&str>) -> Option<std::path::PathBuf> {
+    if let Ok(custom_node) = node_runtime::node_binary_path()
+        && custom_node.is_file()
+    {
+        log::info!(
+            "Using custom node installation for Solidity language server at {}",
+            custom_node.display()
+        );
+        return Some(custom_node);
+    }
+
+    if system_node_meets_solidity_requirement(path_env_var).await {
+        log::info!("Using system node for Solidity language server");
+        return Some(std::path::PathBuf::from("node"));
+    }
+
+    None
+}
+
+/// Returns true when system Node.js is available and meets the Solidity server's engine requirement.
+#[cfg(feature = "local_fs")]
+async fn system_node_meets_solidity_requirement(path_env_var: Option<&str>) -> bool {
+    let Some(path) = path_env_var else {
+        return false;
+    };
+
+    // Still require Warp's generic minimum first so we share the same PATH resolution path.
+    if node_runtime::detect_system_node(path).await.is_err() {
+        return false;
+    }
+
+    let mut cmd = command::r#async::Command::new("node");
+    cmd.env("PATH", path).arg("--version");
+    match cmd.output().await {
+        Ok(output) if output.status.success() => {
+            let version_str = String::from_utf8_lossy(&output.stdout);
+            let version_str = version_str.trim().trim_start_matches('v');
+            match parse_semver_tuple(version_str) {
+                Some(version) if version >= SOLIDITY_MIN_NODE_VERSION => {
+                    log::info!(
+                        "System Node.js {} meets Solidity language server requirement (>= {}.{}.{})",
+                        version_str,
+                        SOLIDITY_MIN_NODE_VERSION.0,
+                        SOLIDITY_MIN_NODE_VERSION.1,
+                        SOLIDITY_MIN_NODE_VERSION.2
+                    );
+                    true
+                }
+                Some(_) => {
+                    log::info!(
+                        "System Node.js {} is below Solidity language server requirement (>= {}.{}.{})",
+                        version_str,
+                        SOLIDITY_MIN_NODE_VERSION.0,
+                        SOLIDITY_MIN_NODE_VERSION.1,
+                        SOLIDITY_MIN_NODE_VERSION.2
+                    );
+                    false
+                }
+                None => {
+                    log::warn!("Failed to parse system Node.js version: {version_str}");
+                    false
+                }
+            }
+        }
+        Ok(output) => {
+            log::warn!(
+                "node --version failed while checking Solidity requirement: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            false
+        }
+        Err(e) => {
+            log::warn!("Failed to run node --version for Solidity requirement check: {e}");
+            false
+        }
+    }
+}
+
+/// Returns true if `binary_name` exists somewhere on PATH.
+///
+/// The Solidity language server only accepts LSP transport flags such as `--stdio`,
+/// so we cannot probe it with `--version` the way we do for other Node-based servers.
+#[cfg(feature = "local_fs")]
+fn binary_exists_on_path(path_env_var: Option<&str>, binary_name: &str) -> bool {
+    let Some(path_env_var) = path_env_var else {
+        return false;
+    };
+
+    for dir in std::env::split_paths(path_env_var) {
+        let candidate = dir.join(binary_name);
+        if candidate.is_file() {
+            return true;
+        }
+
+        #[cfg(windows)]
+        {
+            for extension in ["cmd", "bat", "exe"] {
+                let windows_candidate = dir.join(format!("{binary_name}.{extension}"));
+                if windows_candidate.is_file() {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(feature = "local_fs")]
+fn parse_semver_tuple(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts
+        .next()
+        .unwrap_or("0")
+        .split(|c: char| !c.is_ascii_digit())
+        .next()
+        .unwrap_or("0")
+        .parse()
+        .ok()?;
+    Some((major, minor, patch))
 }
 
 #[async_trait]

--- a/crates/lsp/src/servers/solidity_language_server.rs
+++ b/crates/lsp/src/servers/solidity_language_server.rs
@@ -14,8 +14,12 @@ use crate::supported_servers::CustomBinaryConfig;
 const SOLIDITY_SERVER_BINARY_NAME: &str = "nomicfoundation-solidity-language-server";
 
 /// Minimum Node.js version required by `@nomicfoundation/solidity-language-server`.
+///
+/// Matches the package's published `engines.node` field. Node itself does not enforce
+/// engines, but Warp gates PATH installs and system-Node selection on this floor so a
+/// stale global install cannot block the managed-install fallback.
 #[cfg(feature = "local_fs")]
-const SOLIDITY_MIN_NODE_VERSION: (u64, u64, u64) = (20, 9, 0);
+const SOLIDITY_MIN_NODE_VERSION: node_runtime::Version = node_runtime::Version::new(20, 9, 0);
 
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 pub struct SolidityLanguageServerCandidate {
@@ -36,6 +40,10 @@ impl SolidityLanguageServerCandidate {
     /// Instead of running the wrapper script (which has a shebang requiring node in PATH),
     /// we run node directly with the packaged JS entrypoint.
     ///
+    /// The published entrypoint only accepts LSP transport flags such as `--stdio`; it does
+    /// not implement `--version`. Custom-install verification therefore checks that the JS
+    /// entrypoint exists and that a usable Node binary is available.
+    ///
     /// # Arguments
     /// * `path_env_var` - The PATH environment variable to use when checking for system node.
     #[cfg(feature = "local_fs")]
@@ -53,7 +61,11 @@ impl SolidityLanguageServerCandidate {
             return None;
         }
 
-        let node_binary = find_node_binary_for_solidity(path_env_var).await?;
+        let node_binary = node_runtime::find_working_node_binary_with_min(
+            path_env_var,
+            SOLIDITY_MIN_NODE_VERSION,
+        )
+        .await?;
 
         log::info!(
             "Found Solidity language server JS file at {}",
@@ -87,7 +99,28 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
     }
 
     async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
-        binary_exists_on_path(executor.path_env_var(), SOLIDITY_SERVER_BINARY_NAME)
+        // The published server only accepts LSP transport flags such as `--stdio`, so we
+        // cannot probe it with `--version` the way we do for pyright/typescript-language-server.
+        // PATH must still only win when the wrapper is actually runnable: the binary has to
+        // exist/be executable, and system Node must satisfy the package engines floor.
+        // Otherwise Warp would skip the managed-install fallback for a broken global install.
+        if !executable_exists_on_path(executor.path_env_var(), SOLIDITY_SERVER_BINARY_NAME) {
+            return false;
+        }
+
+        let Some(path) = executor.path_env_var() else {
+            return false;
+        };
+
+        match node_runtime::detect_system_node_with_min(path, SOLIDITY_MIN_NODE_VERSION).await {
+            Ok(()) => true,
+            Err(err) => {
+                log::info!(
+                    "Ignoring PATH install of {SOLIDITY_SERVER_BINARY_NAME} because system Node does not meet >= {SOLIDITY_MIN_NODE_VERSION}: {err}"
+                );
+                false
+            }
+        }
     }
 
     async fn install(
@@ -106,7 +139,14 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
             .await
             .context("Failed to create Solidity language server installation directory")?;
 
-        let use_system_node = system_node_meets_solidity_requirement(executor.path_env_var()).await;
+        let use_system_node = match executor.path_env_var() {
+            Some(path) => {
+                node_runtime::detect_system_node_with_min(path, SOLIDITY_MIN_NODE_VERSION)
+                    .await
+                    .is_ok()
+            }
+            None => false,
+        };
 
         let custom_node_paths = if use_system_node {
             log::info!("Using system Node.js for Solidity language server installation");
@@ -173,102 +213,19 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
     }
 }
 
-/// Finds a Node.js binary that can run the Solidity language server.
-///
-/// Prefers Warp's pinned custom Node install, then falls back to system Node only when it
-/// satisfies the package's `engines` requirement (`>=20.9.0`).
-#[cfg(feature = "local_fs")]
-async fn find_node_binary_for_solidity(path_env_var: Option<&str>) -> Option<std::path::PathBuf> {
-    if let Ok(custom_node) = node_runtime::node_binary_path()
-        && custom_node.is_file()
-    {
-        log::info!(
-            "Using custom node installation for Solidity language server at {}",
-            custom_node.display()
-        );
-        return Some(custom_node);
-    }
-
-    if system_node_meets_solidity_requirement(path_env_var).await {
-        log::info!("Using system node for Solidity language server");
-        return Some(std::path::PathBuf::from("node"));
-    }
-
-    None
-}
-
-/// Returns true when system Node.js is available and meets the Solidity server's engine requirement.
-#[cfg(feature = "local_fs")]
-async fn system_node_meets_solidity_requirement(path_env_var: Option<&str>) -> bool {
-    let Some(path) = path_env_var else {
-        return false;
-    };
-
-    // Still require Warp's generic minimum first so we share the same PATH resolution path.
-    if node_runtime::detect_system_node(path).await.is_err() {
-        return false;
-    }
-
-    let mut cmd = command::r#async::Command::new("node");
-    cmd.env("PATH", path).arg("--version");
-    match cmd.output().await {
-        Ok(output) if output.status.success() => {
-            let version_str = String::from_utf8_lossy(&output.stdout);
-            let version_str = version_str.trim().trim_start_matches('v');
-            match parse_semver_tuple(version_str) {
-                Some(version) if version >= SOLIDITY_MIN_NODE_VERSION => {
-                    log::info!(
-                        "System Node.js {} meets Solidity language server requirement (>= {}.{}.{})",
-                        version_str,
-                        SOLIDITY_MIN_NODE_VERSION.0,
-                        SOLIDITY_MIN_NODE_VERSION.1,
-                        SOLIDITY_MIN_NODE_VERSION.2
-                    );
-                    true
-                }
-                Some(_) => {
-                    log::info!(
-                        "System Node.js {} is below Solidity language server requirement (>= {}.{}.{})",
-                        version_str,
-                        SOLIDITY_MIN_NODE_VERSION.0,
-                        SOLIDITY_MIN_NODE_VERSION.1,
-                        SOLIDITY_MIN_NODE_VERSION.2
-                    );
-                    false
-                }
-                None => {
-                    log::warn!("Failed to parse system Node.js version: {version_str}");
-                    false
-                }
-            }
-        }
-        Ok(output) => {
-            log::warn!(
-                "node --version failed while checking Solidity requirement: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-            false
-        }
-        Err(e) => {
-            log::warn!("Failed to run node --version for Solidity requirement check: {e}");
-            false
-        }
-    }
-}
-
-/// Returns true if `binary_name` exists somewhere on PATH.
+/// Returns true if an executable named `binary_name` exists somewhere on PATH.
 ///
 /// The Solidity language server only accepts LSP transport flags such as `--stdio`,
 /// so we cannot probe it with `--version` the way we do for other Node-based servers.
 #[cfg(feature = "local_fs")]
-fn binary_exists_on_path(path_env_var: Option<&str>, binary_name: &str) -> bool {
+fn executable_exists_on_path(path_env_var: Option<&str>, binary_name: &str) -> bool {
     let Some(path_env_var) = path_env_var else {
         return false;
     };
 
     for dir in std::env::split_paths(path_env_var) {
         let candidate = dir.join(binary_name);
-        if candidate.is_file() {
+        if is_executable_file(&candidate) {
             return true;
         }
 
@@ -276,7 +233,7 @@ fn binary_exists_on_path(path_env_var: Option<&str>, binary_name: &str) -> bool 
         {
             for extension in ["cmd", "bat", "exe"] {
                 let windows_candidate = dir.join(format!("{binary_name}.{extension}"));
-                if windows_candidate.is_file() {
+                if is_executable_file(&windows_candidate) {
                     return true;
                 }
             }
@@ -287,19 +244,19 @@ fn binary_exists_on_path(path_env_var: Option<&str>, binary_name: &str) -> bool 
 }
 
 #[cfg(feature = "local_fs")]
-fn parse_semver_tuple(version: &str) -> Option<(u64, u64, u64)> {
-    let mut parts = version.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts
-        .next()
-        .unwrap_or("0")
-        .split(|c: char| !c.is_ascii_digit())
-        .next()
-        .unwrap_or("0")
-        .parse()
-        .ok()?;
-    Some((major, minor, patch))
+fn is_executable_file(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
 }
 
 #[async_trait]
@@ -329,3 +286,7 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
         todo!()
     }
 }
+
+#[cfg(all(test, feature = "local_fs"))]
+#[path = "solidity_language_server_tests.rs"]
+mod tests;

--- a/crates/lsp/src/servers/solidity_language_server.rs
+++ b/crates/lsp/src/servers/solidity_language_server.rs
@@ -1,0 +1,230 @@
+use std::path::Path;
+use std::sync::Arc;
+
+#[cfg(feature = "local_fs")]
+use anyhow::Context;
+use async_trait::async_trait;
+#[cfg(feature = "local_fs")]
+use command::r#async::Command;
+
+use crate::CommandBuilder;
+use crate::language_server_candidate::{LanguageServerCandidate, LanguageServerMetadata};
+#[cfg(feature = "local_fs")]
+use crate::supported_servers::CustomBinaryConfig;
+
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+pub struct SolidityLanguageServerCandidate {
+    client: Arc<http_client::Client>,
+}
+
+impl SolidityLanguageServerCandidate {
+    /// Path to the language server entrypoint relative to the install directory.
+    #[cfg(feature = "local_fs")]
+    const SERVER_PATH: &str = "node_modules/@nomicfoundation/solidity-language-server/out/index.js";
+
+    pub fn new(client: Arc<http_client::Client>) -> Self {
+        Self { client }
+    }
+
+    /// Finds the configuration for running the Solidity language server from our custom installation.
+    ///
+    /// Instead of running the wrapper script (which has a shebang requiring node in PATH),
+    /// we run node directly with the packaged JS entrypoint.
+    ///
+    /// # Arguments
+    /// * `path_env_var` - The PATH environment variable to use when checking for system node.
+    #[cfg(feature = "local_fs")]
+    pub async fn find_installed_binary_config(
+        path_env_var: Option<&str>,
+    ) -> Option<CustomBinaryConfig> {
+        let install_dir = warp_core::paths::data_dir().join("solidity-language-server");
+        let server_js = install_dir.join(Self::SERVER_PATH);
+
+        if !server_js.is_file() {
+            log::info!(
+                "Solidity language server JS file not found at {}",
+                server_js.display()
+            );
+            return None;
+        }
+
+        let node_binary = node_runtime::find_working_node_binary(path_env_var).await?;
+
+        let mut cmd = Command::new(&node_binary);
+        if let Some(path) = path_env_var {
+            cmd.env("PATH", path);
+        }
+        cmd.arg(&server_js).arg("--version");
+        match cmd.output().await {
+            Ok(output) if output.status.success() => {
+                let version = String::from_utf8_lossy(&output.stdout);
+                log::info!(
+                    "Verified Solidity language server installation: {}",
+                    version.trim()
+                );
+            }
+            Ok(output) => {
+                log::warn!(
+                    "Solidity language server version check failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                return None;
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to run Solidity language server version check: {}",
+                    e
+                );
+                return None;
+            }
+        }
+
+        Some(CustomBinaryConfig {
+            binary_path: node_binary,
+            prepend_args: vec![server_js.to_string_lossy().to_string()],
+        })
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "local_fs")]
+impl LanguageServerCandidate for SolidityLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, path: &Path, _executor: &CommandBuilder) -> bool {
+        // Check for common Solidity project indicators
+        path.join("hardhat.config.js").exists()
+            || path.join("hardhat.config.ts").exists()
+            || path.join("foundry.toml").exists()
+            || path.join("truffle.js").exists()
+            || path.join("truffle-config.js").exists()
+            || path.join("ape-config.yaml").exists()
+    }
+
+    async fn is_installed_in_data_dir(&self, executor: &CommandBuilder) -> bool {
+        Self::find_installed_binary_config(executor.path_env_var())
+            .await
+            .is_some()
+    }
+
+    async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
+        executor
+            .command("nomicfoundation-solidity-language-server")
+            .arg("--version")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    async fn install(
+        &self,
+        metadata: LanguageServerMetadata,
+        executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        log::info!(
+            "Installing @nomicfoundation/solidity-language-server version {}",
+            metadata.version
+        );
+
+        let install_dir = warp_core::paths::data_dir().join("solidity-language-server");
+
+        async_fs::create_dir_all(&install_dir)
+            .await
+            .context("Failed to create Solidity language server installation directory")?;
+
+        let use_system_node = match executor.path_env_var() {
+            Some(path) => node_runtime::detect_system_node(path).await.is_ok(),
+            None => false,
+        };
+
+        let custom_node_paths = if use_system_node {
+            log::info!("Using system Node.js for Solidity language server installation");
+            None
+        } else {
+            log::info!("System Node.js not found or too old, installing custom Node.js");
+            node_runtime::install_npm(&self.client).await?;
+            Some((
+                node_runtime::node_binary_path()?,
+                node_runtime::npm_binary_path()?,
+            ))
+        };
+
+        log::info!(
+            "Installing @nomicfoundation/solidity-language-server@{} using npm",
+            metadata.version
+        );
+
+        let mut cmd = if let Some((node_path, npm_path)) = &custom_node_paths {
+            let mut c = executor.command(node_path);
+            c.arg(npm_path);
+            c
+        } else {
+            executor.command("npm")
+        };
+
+        cmd.arg("install")
+            .arg("--ignore-scripts")
+            .arg(format!(
+                "@nomicfoundation/solidity-language-server@{}",
+                metadata.version
+            ))
+            .current_dir(&install_dir);
+
+        let output = cmd.output().await.context("Failed to run npm install")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "Failed to install @nomicfoundation/solidity-language-server via npm: {}",
+                stderr
+            );
+        }
+
+        log::info!("@nomicfoundation/solidity-language-server installed successfully");
+        Ok(())
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        let version = node_runtime::fetch_npm_package_version(
+            &self.client,
+            "@nomicfoundation/solidity-language-server",
+        )
+        .await
+        .context(
+            "Failed to fetch @nomicfoundation/solidity-language-server version from npm registry",
+        )?;
+
+        Ok(LanguageServerMetadata {
+            version,
+            url: None,
+            digest: None,
+        })
+    }
+}
+
+#[async_trait]
+#[cfg(not(feature = "local_fs"))]
+impl LanguageServerCandidate for SolidityLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, _path: &Path, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_on_path(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn install(
+        &self,
+        _metadata: LanguageServerMetadata,
+        _executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        todo!()
+    }
+}

--- a/crates/lsp/src/servers/solidity_language_server.rs
+++ b/crates/lsp/src/servers/solidity_language_server.rs
@@ -287,6 +287,6 @@ impl LanguageServerCandidate for SolidityLanguageServerCandidate {
     }
 }
 
-#[cfg(all(test, feature = "local_fs"))]
+#[cfg(all(test, feature = "local_fs", unix))]
 #[path = "solidity_language_server_tests.rs"]
 mod tests;

--- a/crates/lsp/src/servers/solidity_language_server_tests.rs
+++ b/crates/lsp/src/servers/solidity_language_server_tests.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use super::{executable_exists_on_path, is_executable_file};
+
+#[test]
+fn executable_exists_on_path_finds_executable_file() {
+    let dir = tempfile_dir("solidity-lsp-exec");
+    let binary = dir.join("nomicfoundation-solidity-language-server");
+    fs::write(&binary, "#!/bin/sh\n").unwrap();
+    let mut perms = fs::metadata(&binary).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&binary, perms).unwrap();
+
+    let path = dir.to_string_lossy().into_owned();
+    assert!(executable_exists_on_path(
+        Some(&path),
+        "nomicfoundation-solidity-language-server"
+    ));
+}
+
+#[test]
+fn executable_exists_on_path_ignores_non_executable_file() {
+    let dir = tempfile_dir("solidity-lsp-nonexec");
+    let binary = dir.join("nomicfoundation-solidity-language-server");
+    fs::write(&binary, "not executable").unwrap();
+    let mut perms = fs::metadata(&binary).unwrap().permissions();
+    perms.set_mode(0o644);
+    fs::set_permissions(&binary, perms).unwrap();
+
+    let path = dir.to_string_lossy().into_owned();
+    assert!(!executable_exists_on_path(
+        Some(&path),
+        "nomicfoundation-solidity-language-server"
+    ));
+    assert!(!is_executable_file(&binary));
+}
+
+#[test]
+fn executable_exists_on_path_returns_false_when_missing() {
+    let dir = tempfile_dir("solidity-lsp-missing");
+    let path = dir.to_string_lossy().into_owned();
+    assert!(!executable_exists_on_path(
+        Some(&path),
+        "nomicfoundation-solidity-language-server"
+    ));
+    assert!(!executable_exists_on_path(
+        None,
+        "nomicfoundation-solidity-language-server"
+    ));
+}
+
+fn tempfile_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -15,6 +15,7 @@ use crate::servers::clangd::ClangdCandidate;
 use crate::servers::go::GoPlsCandidate;
 use crate::servers::pyright::PyrightCandidate;
 use crate::servers::rust::RustAnalyzerCandidate;
+use crate::servers::solidity_language_server::SolidityLanguageServerCandidate;
 use crate::servers::typescript_language_server::TypeScriptLanguageServerCandidate;
 use crate::{LanguageId, LanguageServerCandidate};
 
@@ -43,6 +44,7 @@ pub enum LSPServerType {
     Pyright,
     TypeScriptLanguageServer,
     Clangd,
+    SolidityLanguageServer,
 }
 
 /// Provides server-specific configuration for each LSP server type.
@@ -110,6 +112,9 @@ impl LSPServerType {
                     binary_path: path,
                     prepend_args: vec![],
                 }),
+            LSPServerType::SolidityLanguageServer => {
+                SolidityLanguageServerCandidate::find_installed_binary_config(path_env_var).await
+            }
         }
     }
 
@@ -133,6 +138,7 @@ impl LSPServerType {
             LSPServerType::Pyright => "pyright-langserver",
             LSPServerType::TypeScriptLanguageServer => "typescript-language-server",
             LSPServerType::Clangd => "clangd",
+            LSPServerType::SolidityLanguageServer => "nomicfoundation-solidity-language-server",
         }
     }
 
@@ -141,7 +147,9 @@ impl LSPServerType {
     fn args(&self) -> Vec<&'static str> {
         match self {
             LSPServerType::RustAnalyzer | LSPServerType::GoPls | LSPServerType::Clangd => vec![],
-            LSPServerType::Pyright | LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
+            LSPServerType::Pyright
+            | LSPServerType::TypeScriptLanguageServer
+            | LSPServerType::SolidityLanguageServer => vec!["--stdio"],
         }
     }
 
@@ -155,6 +163,7 @@ impl LSPServerType {
             LSPServerType::Pyright => vec!["--stdio"],
             LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
             LSPServerType::Clangd => vec![],
+            LSPServerType::SolidityLanguageServer => vec!["--stdio"],
         }
     }
 
@@ -173,6 +182,7 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
+            LSPServerType::SolidityLanguageServer => vec![LanguageId::Solidity],
         }
     }
 
@@ -206,6 +216,9 @@ impl LSPServerType {
                 Box::new(TypeScriptLanguageServerCandidate::new(client))
             }
             LSPServerType::Clangd => Box::new(ClangdCandidate::new(client)),
+            LSPServerType::SolidityLanguageServer => {
+                Box::new(SolidityLanguageServerCandidate::new(client))
+            }
         }
     }
 

--- a/crates/node_runtime/src/lib.rs
+++ b/crates/node_runtime/src/lib.rs
@@ -5,6 +5,9 @@
 //! (x64, arm64).
 
 use anyhow::{Context, Result, bail};
+// Re-export so callers can pass package-specific engine floors without depending on `semver` directly.
+#[cfg(feature = "local_fs")]
+pub use semver::Version;
 use serde::Deserialize;
 
 cfg_if::cfg_if! {
@@ -16,7 +19,6 @@ cfg_if::cfg_if! {
         use std::path::{Path, PathBuf};
         use tar::Archive;
         use command::r#async::Command;
-        use semver::Version;
     }
 }
 
@@ -404,6 +406,18 @@ where
 /// For system node, returns `PathBuf::from("node")` to let PATH resolution handle it.
 #[cfg(feature = "local_fs")]
 pub async fn find_working_node_binary(path_env_var: Option<&str>) -> Option<PathBuf> {
+    find_working_node_binary_with_min(path_env_var, MIN_NODE_VERSION).await
+}
+
+/// Same as [`find_working_node_binary`], but enforces a caller-supplied minimum system Node version.
+///
+/// Custom installs are still preferred and validated with `node --version`. System Node is only
+/// used when it satisfies `min_version`.
+#[cfg(feature = "local_fs")]
+pub async fn find_working_node_binary_with_min(
+    path_env_var: Option<&str>,
+    min_version: Version,
+) -> Option<PathBuf> {
     // First, try our custom node installation
     if let Ok(custom_node) = node_binary_path()
         && custom_node.is_file()
@@ -423,7 +437,9 @@ pub async fn find_working_node_binary(path_env_var: Option<&str>) -> Option<Path
 
     // Fall back to system node if available
     if let Some(path_env_var) = path_env_var
-        && detect_system_node(path_env_var).await.is_ok()
+        && detect_system_node_with_min(path_env_var, min_version)
+            .await
+            .is_ok()
     {
         // System node is available and meets version requirements.
         // Use "node" and let the PATH resolve it.
@@ -435,7 +451,7 @@ pub async fn find_working_node_binary(path_env_var: Option<&str>) -> Option<Path
     None
 }
 
-/// Detects and validates the system-installed Node.js meets the minimum version requirement.
+/// Detects and validates the system-installed Node.js meets Warp's baseline minimum.
 ///
 /// This function runs `node --version` using the provided PATH environment variable
 /// and verifies that the installed version meets the minimum requirement.
@@ -447,6 +463,17 @@ pub async fn find_working_node_binary(path_env_var: Option<&str>) -> Option<Path
 /// Returns an error if Node.js is not found or doesn't meet the minimum version.
 #[cfg(feature = "local_fs")]
 pub async fn detect_system_node(path_env_var: impl AsRef<OsStr>) -> Result<()> {
+    detect_system_node_with_min(path_env_var, MIN_NODE_VERSION).await
+}
+
+/// Same as [`detect_system_node`], but enforces a caller-supplied minimum version.
+///
+/// Used by servers whose npm `engines` field is stricter than Warp's baseline.
+#[cfg(feature = "local_fs")]
+pub async fn detect_system_node_with_min(
+    path_env_var: impl AsRef<OsStr>,
+    min_version: Version,
+) -> Result<()> {
     let path_env_var = path_env_var.as_ref();
 
     // On Windows, we must use `cmd.exe /c node` so that the provided PATH
@@ -482,11 +509,11 @@ pub async fn detect_system_node(path_env_var: impl AsRef<OsStr>) -> Result<()> {
     let version = Version::parse(version_str)
         .with_context(|| format!("Failed to parse Node.js version: {}", version_str))?;
 
-    if version < MIN_NODE_VERSION {
+    if version < min_version {
         bail!(
             "System Node.js version {} is too old. Minimum required: {}",
             version,
-            MIN_NODE_VERSION
+            min_version
         );
     }
 


### PR DESCRIPTION
## Description
Adds syntax highlighting and LSP support for Solidity (`.sol`) files.

Changes include:
- Upgrade `arborium` to `2.18.1` to pick up the `lang-solidity` grammar.
- Register `solidity` in `crates/languages` with a highlight query, indent/identifier `.scm` files, and a `.sol` extension mapping.
- Add `nomicfoundation-solidity-language-server` support in `crates/lsp` with PATH-based detection and a custom npm-install fallback.
- Add unit tests for `.sol` extension resolution and LSP language-id resolution.

## Linked Issue
Closes #14845

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo test -p languages -p lsp --no-fail-fast` passes.
- `cargo clippy -p languages -p lsp --all-targets --all-features --tests -- -D warnings` passes.
- `./script/format` was run.
- Manually tested by running `./script/run`, opening a sample `/tmp/solidity-proof/Counter.sol` file, and confirming in the app logs that the Solidity LSP candidate was attempted.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Screenshot of `Counter.sol` open in Warp, showing Solidity syntax highlighting and the LSP install prompt for `nomicfoundation-solidity-language-server`:

<img width="1034" height="577" alt="Screenshot 2026-08-10 at 01 58 48" src="https://github.com/user-attachments/assets/b1c56209-f8a5-4d97-ac6d-25aead953d24" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NEW-FEATURE: Add syntax highlighting and LSP support for Solidity (.sol) files.
