### PR TITLE
Add "Screen with Mouse" option for the Global Hotkey window (#2886)

### DIFF
--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -86,8 +86,8 @@ use crate::settings::cloud_preferences_syncer::{
     CloudPreferencesSyncer, CloudPreferencesSyncerEvent,
 };
 use crate::settings::{
-    AISettings, QuakeModeSettings, ThemeSettings, apply_account_first_onboarding_settings,
-    apply_onboarding_settings,
+    AISettings, QuakeModeScreen, QuakeModeSettings, ThemeSettings,
+    apply_account_first_onboarding_settings, apply_onboarding_settings,
 };
 use crate::settings_view::mcp_servers_page::MCPServersSettingsPage;
 use crate::settings_view::{OpenTeamsSettingsModalArgs, SettingsSection, flags};
@@ -1417,9 +1417,12 @@ fn fit_quake_mode_window_within_active_screen(
         let active_id = ctx.windows().active_display_id();
 
         // When there is no screen config and active screen id change, we don't need to reposition
-        // the quake mode window as its position should still be valid.
+        // the quake mode window as its position should still be valid. This shortcut doesn't
+        // apply when the window follows the mouse: the mouse can move to another screen without
+        // the active display changing.
         if matches!(trigger, QuakeModeMoveTrigger::ActiveScreenSetting)
             && active_id == state.active_display_id
+            && !matches!(settings.pin_screen, Some(QuakeModeScreen::Mouse))
         {
             return;
         }
@@ -1533,12 +1536,12 @@ fn toggle_quake_mode_window(global_resource_handles: &GlobalResourceHandles, ctx
         Some(state) if matches!(state.window_state, WindowState::Hidden) => {
             send_telemetry_from_app_ctx!(TelemetryEvent::OpenQuakeModeWindow, ctx);
 
-            // If quake mode does not have a set pin screen -- move it to the current active screen.
-            if KeysSettings::as_ref(ctx)
-                .quake_mode_settings
-                .pin_screen
-                .is_none()
-            {
+            // If quake mode does not have a fixed pin screen -- move it to the current active
+            // screen (or the screen with the mouse, when configured to follow the mouse).
+            if !matches!(
+                KeysSettings::as_ref(ctx).quake_mode_settings.pin_screen,
+                Some(QuakeModeScreen::Display(_))
+            ) {
                 fit_quake_mode_window_within_active_screen(
                     &KeysSettings::as_ref(ctx)
                         .quake_mode_settings

--- a/app/src/settings/import/view.rs
+++ b/app/src/settings/import/view.rs
@@ -19,8 +19,8 @@ use super::config::{QuakeModeWindow, ThemeType};
 use crate::settings::import::config::{Config, ParsedTerminalSetting, SettingType};
 use crate::settings::import::model::{ImportedConfigModel, TerminalTypeAndProfile};
 use crate::settings::{
-    AppEditorSettings, CursorBlink, FontSettings, GlobalHotkeyMode, SelectionSettings,
-    ThemeSettings,
+    AppEditorSettings, CursorBlink, FontSettings, GlobalHotkeyMode, QuakeModeScreen,
+    SelectionSettings, ThemeSettings,
 };
 use crate::terminal::alt_screen_reporting::AltScreenReporting;
 use crate::terminal::keys_settings::KeysSettings;
@@ -850,7 +850,10 @@ impl SettingsImportView {
             .set_global_hotkey_mode_and_write_to_user_defaults(&GlobalHotkeyMode::QuakeMode, ctx);
         keys_settings
             .set_quake_mode_pin_position_and_write_to_user_defaults(window.pin_position, ctx);
-        keys_settings.set_quake_mode_pin_screen_and_write_to_user_defaults(window.screen, ctx);
+        keys_settings.set_quake_mode_pin_screen_and_write_to_user_defaults(
+            window.screen.map(QuakeModeScreen::Display),
+            ctx,
+        );
         keys_settings.set_hide_quake_mode_window_when_unfocused_and_write_to_user_defaults(
             window.autohide,
             ctx,

--- a/app/src/settings/mod.rs
+++ b/app/src/settings/mod.rs
@@ -331,6 +331,53 @@ impl Mul<Vector2F> for SizePercentages {
     }
 }
 
+/// Which screen the hotkey window opens on.
+///
+/// Serialization is backward compatible with the previous `Option<DisplayIdx>`
+/// representation of `pin_screen`: `Display` is untagged, so existing values
+/// like `"primary"` or `{ external = 0 }` keep deserializing as before, while
+/// the new mouse-follow mode serializes as `"mouse"`.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
+#[schemars(description = "Which screen the hotkey window opens on.")]
+pub enum QuakeModeScreen {
+    /// The screen containing the mouse cursor at the time the window is shown.
+    #[serde(rename = "mouse")]
+    #[schemars(
+        rename = "mouse",
+        description = "The screen containing the mouse cursor."
+    )]
+    Mouse,
+    /// A fixed display.
+    #[serde(untagged)]
+    #[schemars(description = "A fixed display.")]
+    Display(DisplayIdx),
+}
+
+impl std::fmt::Display for QuakeModeScreen {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mouse => write!(f, "Screen with Mouse"),
+            Self::Display(idx) => write!(f, "{idx}"),
+        }
+    }
+}
+
+impl settings_value::SettingsValue for QuakeModeScreen {
+    fn to_file_value(&self) -> serde_json::Value {
+        match self {
+            Self::Mouse => serde_json::Value::String("mouse".to_string()),
+            Self::Display(idx) => idx.to_file_value(),
+        }
+    }
+
+    fn from_file_value(value: &serde_json::Value) -> Option<Self> {
+        if value.as_str() == Some("mouse") {
+            return Some(Self::Mouse);
+        }
+        DisplayIdx::from_file_value(value).map(Self::Display)
+    }
+}
+
 #[derive(
     Clone,
     Debug,
@@ -350,8 +397,10 @@ pub struct QuakeModeSettings {
     pub active_pin_position: QuakeModePinPosition,
     #[schemars(description = "Window size percentages for each pin position.")]
     pub pin_position_to_size_percentages: HashMap<QuakeModePinPosition, SizePercentages>,
-    #[schemars(description = "Display to pin the hotkey window to.")]
-    pub pin_screen: Option<DisplayIdx>,
+    #[schemars(
+        description = "Screen the hotkey window opens on: \"mouse\" for the screen containing the mouse cursor, or a fixed display. Defaults to the screen with the active window."
+    )]
+    pub pin_screen: Option<QuakeModeScreen>,
     /// Whether we should hide quake mode window when it loses focus, this could happen either when
     /// user focuses on another warp window or another app.
     #[schemars(description = "Whether to hide the hotkey window when it loses focus.")]
@@ -406,10 +455,14 @@ impl QuakeModeSettings {
     /// Resolves the display bounds for quake mode (respecting the pinned screen setting)
     /// and calculates the window bounds.
     pub fn resolve_quake_mode_bounds(&self, ctx: &mut AppContext) -> RectF {
-        let display_bounds = self
-            .pin_screen
-            .and_then(|display_idx| ctx.windows().bounds_for_display_idx(display_idx))
-            .unwrap_or_else(|| ctx.windows().active_display_bounds());
+        let display_bounds = match self.pin_screen {
+            Some(QuakeModeScreen::Mouse) => ctx.windows().display_bounds_containing_mouse(),
+            Some(QuakeModeScreen::Display(display_idx)) => {
+                ctx.windows().bounds_for_display_idx(display_idx)
+            }
+            None => None,
+        }
+        .unwrap_or_else(|| ctx.windows().active_display_bounds());
         self.calculate_quake_mode_bounds_from_settings(display_bounds)
     }
 
@@ -614,4 +667,72 @@ pub fn user_preferences_toml_file_path() -> PathBuf {
         settings::SettingsMode::Tui => warp_core::paths::tui_config_local_dir(),
     };
     config_dir.join("settings.toml")
+}
+
+#[cfg(test)]
+mod quake_mode_screen_tests {
+    use settings_value::SettingsValue as _;
+
+    use super::*;
+
+    /// Values stored before `QuakeModeScreen` existed (serde format of
+    /// `Option<DisplayIdx>`, used by UserDefaults and cloud sync) must keep
+    /// deserializing unchanged.
+    #[test]
+    fn serde_format_is_backward_compatible_with_display_idx() {
+        let primary: QuakeModeScreen =
+            serde_json::from_value(serde_json::json!("Primary")).unwrap();
+        assert_eq!(primary, QuakeModeScreen::Display(DisplayIdx::Primary));
+
+        let external: QuakeModeScreen =
+            serde_json::from_value(serde_json::json!({"External": 1})).unwrap();
+        assert_eq!(external, QuakeModeScreen::Display(DisplayIdx::External(1)));
+
+        // The `Display` variant is untagged, so it serializes exactly like the
+        // wrapped `DisplayIdx` used to.
+        assert_eq!(
+            serde_json::to_value(QuakeModeScreen::Display(DisplayIdx::Primary)).unwrap(),
+            serde_json::to_value(DisplayIdx::Primary).unwrap()
+        );
+    }
+
+    #[test]
+    fn serde_round_trips_mouse() {
+        let value = serde_json::to_value(QuakeModeScreen::Mouse).unwrap();
+        assert_eq!(value, serde_json::json!("mouse"));
+        let parsed: QuakeModeScreen = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed, QuakeModeScreen::Mouse);
+    }
+
+    /// Values written to `settings.toml` before `QuakeModeScreen` existed
+    /// (`SettingsValue` file format of `Option<DisplayIdx>`) must keep
+    /// deserializing unchanged.
+    #[test]
+    fn file_format_is_backward_compatible_with_display_idx() {
+        assert_eq!(
+            QuakeModeScreen::from_file_value(&DisplayIdx::Primary.to_file_value()),
+            Some(QuakeModeScreen::Display(DisplayIdx::Primary))
+        );
+        assert_eq!(
+            QuakeModeScreen::from_file_value(&DisplayIdx::External(0).to_file_value()),
+            Some(QuakeModeScreen::Display(DisplayIdx::External(0)))
+        );
+
+        // The `Display` variant writes exactly what the wrapped `DisplayIdx`
+        // used to.
+        assert_eq!(
+            QuakeModeScreen::Display(DisplayIdx::External(2)).to_file_value(),
+            DisplayIdx::External(2).to_file_value()
+        );
+    }
+
+    #[test]
+    fn file_format_round_trips_mouse() {
+        let value = QuakeModeScreen::Mouse.to_file_value();
+        assert_eq!(value, serde_json::Value::String("mouse".to_string()));
+        assert_eq!(
+            QuakeModeScreen::from_file_value(&value),
+            Some(QuakeModeScreen::Mouse)
+        );
+    }
 }

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -71,7 +71,7 @@ use crate::settings::{
     EnableSlashCommandsInTerminal, ErrorUnderliningEnabled, ExtraMetaKeys, GPUSettings,
     GlobalHotkeyMode, InputSettings, InputSettingsChangedEvent, LinuxSelectionClipboard,
     MiddleClickPasteEnabled, MouseScrollMultiplier, OutlineCodebaseSymbolsForAtContextMenu,
-    PreferLowPowerGPU, PreferredGraphicsBackend, QUAKE_WINDOW_AUTOHIDE_SUPPORTED,
+    PreferLowPowerGPU, PreferredGraphicsBackend, QUAKE_WINDOW_AUTOHIDE_SUPPORTED, QuakeModeScreen,
     QuakeModeSettings, ScrollSettings, ScrollSettingsChangedEvent, SelectionSettings,
     ShowAutosuggestionIgnoreButton, ShowChangelogAfterUpdate, ShowTerminalInputMessageBar,
     SshSettings, SyntaxHighlighting, TabBehavior, UserNativeRedirectPreference, VimModeEnabled,
@@ -759,7 +759,7 @@ pub enum FeaturesPageAction {
     QuakeKeybindEditorCancel,
     QuakeKeybindEditorSave,
     QuakeEditorSetPinPosition(QuakeModePinPosition),
-    QuakeEditorSetPinScreen(Option<DisplayIdx>),
+    QuakeEditorSetPinScreen(Option<QuakeModeScreen>),
     QuakeEditorSetWidthPercentage,
     QuakeEditorSetHeightPercentage,
     QuakeEditorResetWidthHeight,
@@ -1053,7 +1053,7 @@ impl FeaturesPageAction {
             Self::QuakeEditorSetPinScreen(screen) => TelemetryEvent::FeaturesPageAction {
                 action: "QuakeEditorSetPinScreen".to_string(),
                 value: screen
-                    .map(|idx| format!("{idx}"))
+                    .map(|screen| format!("{screen}"))
                     .unwrap_or_else(|| "Active Screen".into()),
             },
             Self::QuakeEditorResetWidthHeight => TelemetryEvent::FeaturesPageAction {
@@ -4526,22 +4526,33 @@ fn init_display_count_dropdown(
     );
     let mut items = vec![no_preference];
     items.push(DropdownItem::new(
+        format!("{}", QuakeModeScreen::Mouse),
+        FeaturesPageAction::QuakeEditorSetPinScreen(Some(QuakeModeScreen::Mouse)),
+    ));
+    items.push(DropdownItem::new(
         format!("{}", DisplayIdx::Primary),
         //move ||
-        FeaturesPageAction::QuakeEditorSetPinScreen(Some(DisplayIdx::Primary)),
+        FeaturesPageAction::QuakeEditorSetPinScreen(Some(QuakeModeScreen::Display(
+            DisplayIdx::Primary,
+        ))),
     ));
 
     (1..display_count).for_each(|idx| {
         items.push(DropdownItem::new(
             format!("{}", DisplayIdx::External(idx - 1)),
             //move || {
-            FeaturesPageAction::QuakeEditorSetPinScreen(Some(DisplayIdx::External(idx - 1))), //},
+            FeaturesPageAction::QuakeEditorSetPinScreen(Some(QuakeModeScreen::Display(
+                DisplayIdx::External(idx - 1),
+            ))), //},
         ));
     });
 
     dropdown.set_items(items, ctx);
     match quake_mode_settings.pin_screen {
-        Some(idx) if idx.is_valid_given_display_count(display_count) => {
+        Some(QuakeModeScreen::Mouse) => {
+            dropdown.set_selected_by_name(format!("{}", QuakeModeScreen::Mouse), ctx)
+        }
+        Some(QuakeModeScreen::Display(idx)) if idx.is_valid_given_display_count(display_count) => {
             dropdown.set_selected_by_name(format!("{idx}"), ctx)
         }
         _ => dropdown.set_selected_by_name("Active Screen", ctx),

--- a/app/src/terminal/keys_settings.rs
+++ b/app/src/terminal/keys_settings.rs
@@ -2,12 +2,12 @@ use settings::macros::define_settings_group;
 use settings::{RespectUserSyncSetting, Setting, SupportedPlatforms, SyncToCloud};
 use warp_errors::{report_error, report_if_error};
 use warpui::keymap::Keystroke;
-use warpui::{AppContext, DisplayIdx, ModelContext};
+use warpui::{AppContext, ModelContext};
 
 use crate::root_view::{QuakeModePinPosition, update_quake_window_bounds};
 use crate::settings::{
     CtrlTabBehavior, DEFAULT_QUAKE_MODE_SIZE_PERCENTAGES, ExtraMetaKeys as ExtraMetaKeysEnum,
-    GlobalHotkeyMode, SizePercentages,
+    GlobalHotkeyMode, QuakeModeScreen, SizePercentages,
 };
 
 define_settings_group!(KeysSettings, settings: [
@@ -118,7 +118,7 @@ impl KeysSettings {
 
     pub fn set_quake_mode_pin_screen_and_write_to_user_defaults(
         &mut self,
-        pin_screen: Option<DisplayIdx>,
+        pin_screen: Option<QuakeModeScreen>,
         ctx: &mut ModelContext<Self>,
     ) {
         let mut quake_mode_settings = self.quake_mode_settings.value().clone();

--- a/crates/warpui/src/platform/mac/window.rs
+++ b/crates/warpui/src/platform/mac/window.rs
@@ -15,7 +15,9 @@ use objc::runtime::Object;
 use objc2::rc::{Retained, autoreleasepool};
 use objc2::runtime::{AnyObject, Bool, ProtocolObject};
 use objc2::{MainThreadMarker, msg_send};
-use objc2_app_kit::{NSApplication, NSScreen, NSView, NSWindow, NSWindowButton, NSWindowStyleMask};
+use objc2_app_kit::{
+    NSApplication, NSEvent, NSScreen, NSView, NSWindow, NSWindowButton, NSWindowStyleMask,
+};
 use objc2_foundation::{
     NSArray, NSInteger, NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger,
 };
@@ -204,6 +206,34 @@ impl platform::WindowManager for WindowManager {
             transform_origin_from_frame_coord_to_rect_coord(point, size),
             size,
         ))
+    }
+
+    fn display_bounds_containing_mouse(&self) -> Option<RectF> {
+        // SAFETY: `WindowManager` methods run on the main thread.
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        let mouse_location = NSEvent::mouseLocation();
+        let screens = NSScreen::screens(mtm);
+
+        // `NSEvent::mouseLocation` and `NSScreen::frame` share AppKit's global
+        // bottom-left-origin coordinate space. Match `NSMouseInRect`'s
+        // convention for points on shared edges: min-inclusive on x,
+        // max-inclusive on y.
+        screens.iter().find_map(|screen| {
+            let rect = screen.frame();
+            let contains = mouse_location.x >= rect.origin.x
+                && mouse_location.x < rect.origin.x + rect.size.width
+                && mouse_location.y > rect.origin.y
+                && mouse_location.y <= rect.origin.y + rect.size.height;
+
+            contains.then(|| {
+                let point = Vector2F::new(rect.origin.x as f32, rect.origin.y as f32);
+                let size = Vector2F::new(rect.size.width as f32, rect.size.height as f32);
+                RectF::new(
+                    transform_origin_from_frame_coord_to_rect_coord(point, size),
+                    size,
+                )
+            })
+        })
     }
 
     fn active_cursor_position_updated(&self) {

--- a/crates/warpui_core/src/platform/mod.rs
+++ b/crates/warpui_core/src/platform/mod.rs
@@ -612,6 +612,12 @@ pub trait WindowManager {
     fn active_display_id(&self) -> DisplayId;
     fn display_count(&self) -> usize;
     fn bounds_for_display_idx(&self, idx: DisplayIdx) -> Option<RectF>;
+    /// Returns the bounds of the display containing the mouse cursor, or `None`
+    /// if the platform cannot determine it. Callers should fall back to
+    /// `active_display_bounds`.
+    fn display_bounds_containing_mouse(&self) -> Option<RectF> {
+        None
+    }
 
     fn active_cursor_position_updated(&self);
 

--- a/crates/warpui_core/src/windowing/state.rs
+++ b/crates/warpui_core/src/windowing/state.rs
@@ -168,6 +168,12 @@ impl WindowManager {
         self.platform.bounds_for_display_idx(idx)
     }
 
+    // Get the rect of the screen containing the mouse cursor, if the platform
+    // can determine it.
+    pub fn display_bounds_containing_mouse(&self) -> Option<RectF> {
+        self.platform.display_bounds_containing_mouse()
+    }
+
     pub fn display_count(&self) -> usize {
         self.platform.display_count()
     }


### PR DESCRIPTION
Fixes #2886

## Summary

Adds a **"Screen with Mouse"** option to the Global Hotkey (Quake Mode) *Pin to screen* dropdown. When selected, the hotkey window opens on the screen containing the mouse cursor — matching iTerm2's hotkey window and Raycast's "Screen containing mouse" behavior — instead of always opening on the screen with the active window.

## Implementation

- **Settings** (`app/src/settings/mod.rs`): `QuakeModeSettings.pin_screen` changes from `Option<DisplayIdx>` to `Option<QuakeModeScreen>`, where `QuakeModeScreen` is `Mouse | Display(DisplayIdx)`.
  - **Serialization is fully backward compatible**: the `Display` variant is `#[serde(untagged)]` and the manual `SettingsValue` impl delegates to `DisplayIdx`, so existing stored values (`"primary"`, `{ external = 0 }` in `settings.toml`; `"Primary"`, `{"External": 0}` in UserDefaults/cloud sync) keep deserializing unchanged. The new mode serializes as `"mouse"`. Unit tests cover both formats.
- **Platform** (`crates/warpui_core/src/platform/mod.rs`): new `WindowManager::display_bounds_containing_mouse()` with a default `None` implementation, so all platforms compile and fall back to the current active-screen behavior.
- **macOS** (`crates/warpui/src/platform/mac/window.rs`): implemented via `NSEvent::mouseLocation()` + iterating `NSScreen::screens`, using the same frame→rect coordinate transform as `bounds_for_display_idx`.
- **Resolution** (`resolve_quake_mode_bounds`): `Mouse` resolves the mouse screen's bounds, falling back to the active display when unavailable.
- **Show-from-hidden path** (`app/src/root_view.rs`): the reposition-on-show logic now also runs for `Mouse` (previously only when `pin_screen` was unset), and skips the "active display unchanged" early-return in mouse mode, since the mouse can move between screens without the active display changing.
- **UI** (`features_page.rs`): "Screen with Mouse" appears in the existing *Pin to screen* dropdown between "Active Screen" and "Main Screen".

Windows/Linux keep their current behavior (default trait impl returns `None`); the option can be wired up per-platform in follow-ups.

## Testing

- [x] Serialization backward-compat unit tests added in `app/src/settings/mod.rs` (`quake_mode_screen_tests`) — all pass (`cargo test -p warp quake_mode_screen`)
- [x] `cargo check -p warp`, `cargo clippy -p warp -p warpui -p warpui_core` (no warnings), and `cargo fmt --check` clean on touched crates
- [ ] Manual test on macOS with 2 displays — not yet run: my machine only has Command Line Tools (no full Xcode), so the Metal shader build step fails locally and I can't run the GUI. Happy to follow up once that's sorted; the expected behavior to verify: with *Pin to screen = Screen with Mouse*, the hotkey window opens on whichever screen contains the cursor (including when the focused window is on the other screen), and existing `settings.toml` values for `pin_screen` load unchanged.

## Note on readiness labels

I'm aware #2886 is not yet marked `ready-to-spec`/`ready-to-implement`. The change turned out to be small and self-contained, so I'm submitting it directly as a proposed implementation — happy to convert this into a spec PR (product.md + tech.md) instead if the team prefers, or park it until the issue is triaged for contribution.
