### PR TITLE
Park orchestration events on retry exhaustion instead of dropping them

### DIFF
--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -601,9 +601,13 @@ impl BlocklistAIController {
         // Subscribe to the orchestration event service to inject events
         // (e.g. MessagesReceivedFromAgents) into conversations that receive inter-agent messages.
         let svc = OrchestrationEventService::handle(ctx);
-        ctx.subscribe_to_model(&svc, move |me, _, event, ctx| {
-            let OrchestrationEventServiceEvent::EventsReady { conversation_id } = event;
-            me.handle_pending_events_ready(*conversation_id, ctx);
+        ctx.subscribe_to_model(&svc, move |me, _, event, ctx| match event {
+            OrchestrationEventServiceEvent::EventsReady { conversation_id } => {
+                me.handle_pending_events_ready(*conversation_id, ctx);
+            }
+            OrchestrationEventServiceEvent::EventsDeliveryExhausted { conversation_id } => {
+                me.handle_pending_events_delivery_exhausted(*conversation_id, ctx);
+            }
         });
         let streamer = OrchestrationEventStreamer::handle(ctx);
         ctx.subscribe_to_model(&streamer, move |me, _, event, ctx| match event {
@@ -1928,18 +1932,66 @@ impl BlocklistAIController {
             )
             .is_err()
         {
-            // TODO: surface retry exhaustion. The existing requeue
-            // re-emits `EventsReady` until `MAX_RETRY_ATTEMPTS` is hit,
-            // after which events are dropped silently and the wait has
-            // already been cancelled — the conversation can end up stuck
-            // with no executor pending entry, no watchdog, and no
-            // in-flight stream. Follow-up: park-on-exhaust the events
-            // and transition the conversation to `Error` so the next
-            // user resume can carry them along.
+            // The requeue either re-emits `EventsReady` (retry budget
+            // remaining) or parks the events and emits
+            // `EventsDeliveryExhausted`, which transitions the conversation
+            // to `Error` so the next user resume drains the parked events.
             OrchestrationEventService::handle(ctx).update(ctx, |svc, ctx| {
                 svc.requeue_awaiting_events(conversation_id, ctx);
             });
         }
+    }
+
+    /// Handles the EventsDeliveryExhausted signal. The events themselves are
+    /// parked in the service's pending queue with a fresh retry budget, and
+    /// any in-flight wait_for_events has already been cancelled by the failed
+    /// injection attempt. Without intervention the conversation would sit
+    /// quiescent with no executor entry, no watchdog, and no in-flight
+    /// stream, so transition it to `Error`: the user's resume brings it back
+    /// through `InProgress` to a ready status, which re-fires `EventsReady`
+    /// and carries the parked events along.
+    fn handle_pending_events_delivery_exhausted(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(conversation) =
+            BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
+        else {
+            return;
+        };
+        // An in-flight stream settles the status on its own, and non-ready
+        // statuses (Error, Blocked, Cancelled, InProgress) already require
+        // user or stream activity that re-fires EventsReady on the way back
+        // to a ready status. Only quiescent ready statuses would otherwise
+        // strand the parked events silently.
+        if self
+            .in_flight_response_streams
+            .has_active_stream_for_conversation(conversation_id, ctx)
+            || !matches!(
+                conversation.status(),
+                ConversationStatus::Success | ConversationStatus::WaitingForEvents
+            )
+        {
+            log::info!(
+                "Orchestration event delivery exhausted; leaving conversation status untouched: conversation_id={conversation_id:?} status={:?}",
+                conversation.status()
+            );
+            return;
+        }
+
+        log::warn!(
+            "Orchestration event delivery exhausted; marking conversation errored so a resume can drain parked events: conversation_id={conversation_id:?}"
+        );
+        let terminal_surface_id = self.terminal_surface_id;
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_surface_id,
+                conversation_id,
+                ConversationStatus::Error,
+                ctx,
+            );
+        });
     }
 
     /// Handles the EventsReady signal. Checks readiness, drains

--- a/app/src/ai/blocklist/orchestration_events.rs
+++ b/app/src/ai/blocklist/orchestration_events.rs
@@ -67,6 +67,12 @@ pub enum OrchestrationEventServiceEvent {
     /// Signals that a conversation may have pending orchestration events
     /// ready to drain.
     EventsReady { conversation_id: AIConversationId },
+    /// Delivery attempts for a batch of events exhausted their retry budget.
+    /// The events are parked back in the pending queue with a fresh budget
+    /// and drain on the next `EventsReady` trigger (a status change back to
+    /// a ready state, or new inbound events); the controller surfaces the
+    /// failure to the user instead of retrying immediately.
+    EventsDeliveryExhausted { conversation_id: AIConversationId },
 }
 
 /// Synchronous state manager for orchestration event queuing, delivery tracking, and readiness detection.
@@ -323,8 +329,10 @@ impl OrchestrationEventService {
     }
 
     /// Moves all awaiting events back to pending for retry after a failed
-    /// send attempt. Increments attempt counts and drops events that have
-    /// exhausted their retry limit.
+    /// send attempt. Events that exhaust their retry limit are parked rather
+    /// than dropped: they return to the pending queue with a fresh retry
+    /// budget but do not re-fire `EventsReady`, breaking the immediate retry
+    /// loop while preserving the events for the next drain trigger.
     pub fn requeue_awaiting_events(
         &mut self,
         conversation_id: AIConversationId,
@@ -338,22 +346,22 @@ impl OrchestrationEventService {
             return;
         }
 
-        let (retryable, exhausted) =
-            increment_attempt_and_partition_by_retry_limit(events, MAX_RETRY_ATTEMPTS);
+        let (requeued, any_exhausted) =
+            requeue_events_after_failed_send(events, MAX_RETRY_ATTEMPTS);
 
-        if !exhausted.is_empty() {
-            log::warn!(
-                "Dropping {} orchestration events after exhausting retries",
-                exhausted.len()
-            );
-        }
-
-        if !retryable.is_empty() {
+        if !requeued.is_empty() {
             let queue = self.pending_events.entry(conversation_id).or_default();
-            let mut combined = retryable;
+            let mut combined = requeued;
             combined.append(queue);
             *queue = combined;
+        }
 
+        if any_exhausted {
+            log::warn!(
+                "Orchestration event delivery retries exhausted; parking events for a later drain: conversation_id={conversation_id:?}"
+            );
+            ctx.emit(OrchestrationEventServiceEvent::EventsDeliveryExhausted { conversation_id });
+        } else {
             ctx.emit(OrchestrationEventServiceEvent::EventsReady { conversation_id });
         }
     }
@@ -690,18 +698,27 @@ fn count_pending_lifecycle_events(queue: &[PendingEvent]) -> usize {
         .count()
 }
 
-/// Increment attempt counts and split events into retryable vs exhausted buckets.
-/// Exhaustion is based on `max_retry_attempts` after incrementing this attempt.
-fn increment_attempt_and_partition_by_retry_limit(
-    mut attempted_events: Vec<PendingEvent>,
+/// Increments attempt counts after a failed send and returns the events to
+/// requeue (in their original order) plus whether any exhausted their retry
+/// budget. Exhausted events are parked instead of dropped: their attempt
+/// count resets to zero so a later drain retries them with a fresh budget.
+fn requeue_events_after_failed_send(
+    attempted_events: Vec<PendingEvent>,
     max_retry_attempts: i32,
-) -> (Vec<PendingEvent>, Vec<PendingEvent>) {
-    for event in &mut attempted_events {
-        event.attempt_count += 1;
-    }
-    attempted_events
+) -> (Vec<PendingEvent>, bool) {
+    let mut any_exhausted = false;
+    let requeued = attempted_events
         .into_iter()
-        .partition(|event| event.attempt_count < max_retry_attempts)
+        .map(|mut event| {
+            event.attempt_count += 1;
+            if event.attempt_count >= max_retry_attempts {
+                any_exhausted = true;
+                event.attempt_count = 0;
+            }
+            event
+        })
+        .collect();
+    (requeued, any_exhausted)
 }
 
 impl Default for OrchestrationEventService {

--- a/app/src/ai/blocklist/orchestration_events_tests.rs
+++ b/app/src/ai/blocklist/orchestration_events_tests.rs
@@ -201,7 +201,24 @@ fn test_enforce_lifecycle_queue_cap_keeps_critical_events_even_when_over_limit()
 }
 
 #[test]
-fn test_increment_attempt_and_partition_by_retry_limit() {
+fn test_requeue_events_after_failed_send_increments_attempts_when_under_limit() {
+    let attempted = vec![
+        lifecycle_pending_event("first", "child-a", api::LifecycleEventType::Started, 0),
+        lifecycle_pending_event("second", "child-b", api::LifecycleEventType::Idle, 1),
+    ];
+
+    let (requeued, any_exhausted) = requeue_events_after_failed_send(attempted, 3);
+
+    assert!(!any_exhausted);
+    assert_eq!(requeued.len(), 2);
+    assert_eq!(requeued[0].event_id, "first");
+    assert_eq!(requeued[0].attempt_count, 1);
+    assert_eq!(requeued[1].event_id, "second");
+    assert_eq!(requeued[1].attempt_count, 2);
+}
+
+#[test]
+fn test_requeue_events_after_failed_send_parks_exhausted_events_with_fresh_budget() {
     let attempted = vec![
         lifecycle_pending_event("retryable", "child-a", api::LifecycleEventType::Started, 0),
         lifecycle_pending_event(
@@ -218,17 +235,18 @@ fn test_increment_attempt_and_partition_by_retry_limit() {
         ),
     ];
 
-    let (retryable, exhausted) = increment_attempt_and_partition_by_retry_limit(attempted, 3);
+    let (requeued, any_exhausted) = requeue_events_after_failed_send(attempted, 3);
 
-    assert_eq!(retryable.len(), 1);
-    assert_eq!(retryable[0].event_id, "retryable");
-    assert_eq!(retryable[0].attempt_count, 1);
-
-    assert_eq!(exhausted.len(), 2);
-    assert_eq!(exhausted[0].event_id, "exhausted-at-limit");
-    assert_eq!(exhausted[0].attempt_count, 3);
-    assert_eq!(exhausted[1].event_id, "already-exhausted");
-    assert_eq!(exhausted[1].attempt_count, 4);
+    // Nothing is dropped: exhausted events are parked in place with a fresh
+    // retry budget so a later drain (after user intervention) retries them.
+    assert!(any_exhausted);
+    assert_eq!(requeued.len(), 3);
+    assert_eq!(requeued[0].event_id, "retryable");
+    assert_eq!(requeued[0].attempt_count, 1);
+    assert_eq!(requeued[1].event_id, "exhausted-at-limit");
+    assert_eq!(requeued[1].attempt_count, 0);
+    assert_eq!(requeued[2].event_id, "already-exhausted");
+    assert_eq!(requeued[2].attempt_count, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Problem
Fixes the acknowledged TODO in `controller.rs`: when injecting pending orchestration events (child lifecycle events / inter-agent messages) into an orchestrator conversation failed repeatedly, `requeue_awaiting_events` silently dropped the events after `MAX_RETRY_ATTEMPTS`, with the `wait_for_events` already cancelled. The conversation ended up stuck — no executor pending entry, no watchdog, no in-flight stream — and the orchestrator never learned a child had failed.

## Fix
- `requeue_awaiting_events` now parks exhausted events back in the pending queue with a fresh retry budget instead of dropping them, and emits a new `EventsDeliveryExhausted` signal instead of re-firing `EventsReady` (breaking the immediate retry loop while preserving the events).
- The controller handles `EventsDeliveryExhausted` by transitioning a quiescent (`Success`/`WaitingForEvents`) conversation to `Error`, making the stall visible. The user's resume brings the conversation back through `InProgress` to a ready status, which re-fires `EventsReady` via the existing status-change hook and drains the parked events.
- Conversations with an in-flight stream or in non-ready statuses (`Error`/`Blocked`/`Cancelled`/`InProgress`) are left untouched — their own status transitions re-fire `EventsReady` on the way back to ready, so parked events are no longer stranded in those states either.

Part 2 of 3 of orchestration child-failure reliability fixes (part 1: server-side dormant-parent wake, warpdotdev/warp-server#14180; part 3: lifecycle event failure detail plumbing).

## Testing
- `cargo nextest run -p warp -E 'test(orchestration_events) or test(requeue_events_after_failed_send) or test(orchestration_event_streamer)'` — 70 passed
- New unit tests for `requeue_events_after_failed_send` (attempt increments under the limit; park-with-fresh-budget on exhaustion, nothing dropped)
- `./script/format` clean; `cargo clippy -p warp --all-targets` introduces no new warnings (the `--all-features` build has 6 pre-existing errors on master in unrelated `execution_profiles` code)

Co-Authored-By: Warp Agent <agent@warp.dev>