### PR TITLE
Populate lifecycle event detail from server-provided payloads

### DIFF
--- a/app/src/ai/agent_events/driver_tests.rs
+++ b/app/src/ai/agent_events/driver_tests.rs
@@ -101,6 +101,7 @@ fn make_run_event(
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence,
+        detail: None,
     }
 }
 

--- a/app/src/ai/agent_events/message_hydrator_tests.rs
+++ b/app/src/ai/agent_events/message_hydrator_tests.rs
@@ -23,6 +23,7 @@ fn make_run_event(
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence,
+        detail: None,
     }
 }
 

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -2324,12 +2324,25 @@ fn convert_lifecycle_events(events: &[AgentRunEvent], self_run_id: &str) -> Vec<
         .filter_map(|event| {
             let lifecycle_type = lifecycle_event_type_from_wire(event.event_type.as_str())?;
             let timestamp = parse_occurred_at(&event.occurred_at);
-            // TODO: Parse richer detail payloads (reason, error_message) from
-            // the server event log once the schema supports them.
+            let wire_detail = event.detail.as_ref();
             let detail = match lifecycle_type {
+                api::LifecycleEventType::Failed => LifecycleEventDetailPayload {
+                    reason: wire_detail.and_then(|d| d.reason.clone()),
+                    error_message: wire_detail.and_then(|d| d.error_message.clone()),
+                    ..Default::default()
+                },
                 api::LifecycleEventType::Errored => LifecycleEventDetailPayload {
                     stage: Some(LifecycleEventDetailStage::Runtime),
-                    reason: event.ref_id.clone(),
+                    // Fall back to ref_id for servers that predate structured
+                    // detail, matching the previous wire behavior.
+                    reason: wire_detail
+                        .and_then(|d| d.reason.clone())
+                        .or_else(|| event.ref_id.clone()),
+                    error_message: wire_detail.and_then(|d| d.error_message.clone()),
+                    ..Default::default()
+                },
+                api::LifecycleEventType::Blocked => LifecycleEventDetailPayload {
+                    blocked_action: wire_detail.and_then(|d| d.blocked_action.clone()),
                     ..Default::default()
                 },
                 _ => LifecycleEventDetailPayload::default(),

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -76,7 +76,18 @@ fn make_run_event(event_type: &str, run_id: &str, ref_id: Option<&str>) -> Agent
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 1,
+        detail: None,
     }
+}
+
+fn make_run_event_with_detail(
+    event_type: &str,
+    run_id: &str,
+    detail: crate::server::server_api::ai::AgentRunEventDetail,
+) -> AgentRunEvent {
+    let mut event = make_run_event(event_type, run_id, None);
+    event.detail = Some(detail);
+    event
 }
 
 #[test]
@@ -93,6 +104,115 @@ fn convert_lifecycle_events_includes_run_blocked() {
         panic!("expected blocked detail");
     };
     assert!(blocked.blocked_action.is_empty());
+}
+
+#[test]
+fn convert_lifecycle_events_maps_failed_detail() {
+    let events = vec![make_run_event_with_detail(
+        "run_failed",
+        "child-run",
+        crate::server::server_api::ai::AgentRunEventDetail {
+            reason: Some("environment_setup_failed".to_string()),
+            error_message: Some("Environment setup failed (git clone failed)".to_string()),
+            blocked_action: None,
+        },
+    )];
+    let result = convert_lifecycle_events(&events, "self-run");
+    assert_eq!(result.len(), 1);
+    let Some(api::agent_event::Event::LifecycleEvent(lifecycle)) = &result[0].event else {
+        panic!("expected lifecycle event");
+    };
+    let Some(api::agent_event::lifecycle_event::Detail::Failed(failed)) = &lifecycle.detail else {
+        panic!("expected failed detail");
+    };
+    assert_eq!(failed.reason, "environment_setup_failed");
+    assert_eq!(
+        failed.error_message,
+        "Environment setup failed (git clone failed)"
+    );
+}
+
+#[test]
+fn convert_lifecycle_events_maps_errored_detail() {
+    let events = vec![make_run_event_with_detail(
+        "run_errored",
+        "child-run",
+        crate::server::server_api::ai::AgentRunEventDetail {
+            reason: Some("internal_error".to_string()),
+            error_message: Some("An unexpected error has occurred".to_string()),
+            blocked_action: None,
+        },
+    )];
+    let result = convert_lifecycle_events(&events, "self-run");
+    assert_eq!(result.len(), 1);
+    let Some(api::agent_event::Event::LifecycleEvent(lifecycle)) = &result[0].event else {
+        panic!("expected lifecycle event");
+    };
+    let Some(api::agent_event::lifecycle_event::Detail::Errored(errored)) = &lifecycle.detail
+    else {
+        panic!("expected errored detail");
+    };
+    assert_eq!(errored.stage, "runtime");
+    assert_eq!(errored.reason, "internal_error");
+    assert_eq!(errored.error_message, "An unexpected error has occurred");
+}
+
+#[test]
+fn convert_lifecycle_events_errored_without_detail_falls_back_to_ref_id() {
+    let events = vec![make_run_event(
+        "run_errored",
+        "child-run",
+        Some("legacy-ref"),
+    )];
+    let result = convert_lifecycle_events(&events, "self-run");
+    assert_eq!(result.len(), 1);
+    let Some(api::agent_event::Event::LifecycleEvent(lifecycle)) = &result[0].event else {
+        panic!("expected lifecycle event");
+    };
+    let Some(api::agent_event::lifecycle_event::Detail::Errored(errored)) = &lifecycle.detail
+    else {
+        panic!("expected errored detail");
+    };
+    assert_eq!(errored.reason, "legacy-ref");
+    assert!(errored.error_message.is_empty());
+}
+
+#[test]
+fn convert_lifecycle_events_maps_blocked_action_detail() {
+    let events = vec![make_run_event_with_detail(
+        "run_blocked",
+        "child-run",
+        crate::server::server_api::ai::AgentRunEventDetail {
+            reason: None,
+            error_message: None,
+            blocked_action: Some("waiting for command approval".to_string()),
+        },
+    )];
+    let result = convert_lifecycle_events(&events, "self-run");
+    assert_eq!(result.len(), 1);
+    let Some(api::agent_event::Event::LifecycleEvent(lifecycle)) = &result[0].event else {
+        panic!("expected lifecycle event");
+    };
+    let Some(api::agent_event::lifecycle_event::Detail::Blocked(blocked)) = &lifecycle.detail
+    else {
+        panic!("expected blocked detail");
+    };
+    assert_eq!(blocked.blocked_action, "waiting for command approval");
+}
+
+#[test]
+fn agent_run_event_deserializes_without_detail() {
+    // Backward compat: servers that predate structured detail omit the field.
+    let json = r#"{"id":"evt-1","run_id":"run-1","event_type":"run_failed","sequence":3,"occurred_at":"2026-01-01T00:00:00Z"}"#;
+    let event: AgentRunEvent = serde_json::from_str(json).expect("should deserialize");
+    assert!(event.detail.is_none());
+
+    let json_with_detail = r#"{"id":"evt-2","run_id":"run-1","event_type":"run_failed","sequence":4,"occurred_at":"2026-01-01T00:00:00Z","detail":{"reason":"internal_error","error_message":"boom"}}"#;
+    let event: AgentRunEvent = serde_json::from_str(json_with_detail).expect("should deserialize");
+    let detail = event.detail.expect("detail should parse");
+    assert_eq!(detail.reason.as_deref(), Some("internal_error"));
+    assert_eq!(detail.error_message.as_deref(), Some("boom"));
+    assert!(detail.blocked_action.is_none());
 }
 
 #[test]
@@ -545,6 +665,7 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 7,
+        detail: None,
     };
     assert_eq!(
         consumer.on_event(ignored_event).await.unwrap(),
@@ -559,6 +680,7 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         execution_id: None,
         occurred_at: "2026-01-01T00:00:00Z".to_string(),
         sequence: 7,
+        detail: None,
     };
     assert_eq!(
         consumer.on_event(ignored_same_run_lifecycle).await.unwrap(),
@@ -577,6 +699,7 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         execution_id: None,
         occurred_at: "2026-01-01T00:00:01Z".to_string(),
         sequence: 8,
+        detail: None,
     };
     assert_eq!(
         consumer.on_event(target_event).await.unwrap(),
@@ -792,6 +915,7 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
                 execution_id: None,
                 occurred_at: "2026-01-01T00:00:00Z".to_string(),
                 sequence: 17,
+                detail: None,
             },
             AgentRunEvent {
                 event_type: "unrecognized_event_type".to_string(),
@@ -800,6 +924,7 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
                 execution_id: None,
                 occurred_at: "2026-01-01T00:00:00Z".to_string(),
                 sequence: 42,
+                detail: None,
             },
         ];
 
@@ -880,6 +1005,7 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         execution_id: None,
                         occurred_at: "2026-01-01T00:00:00Z".to_string(),
                         sequence: 17,
+                        detail: None,
                     },
                     AgentRunEvent {
                         event_type: "run_cancelled".to_string(),
@@ -888,6 +1014,7 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         execution_id: None,
                         occurred_at: "2026-01-01T00:00:01Z".to_string(),
                         sequence: 18,
+                        detail: None,
                     },
                     AgentRunEvent {
                         event_type: "new_message".to_string(),
@@ -896,6 +1023,7 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
                         execution_id: None,
                         occurred_at: "2026-01-01T00:00:02Z".to_string(),
                         sequence: 19,
+                        detail: None,
                     },
                 ],
                 vec![

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -373,6 +373,25 @@ pub struct AgentRunEvent {
     pub execution_id: Option<String>,
     pub occurred_at: String,
     pub sequence: i64,
+    /// Optional structured lifecycle detail. Servers that predate the field
+    /// omit it, so deserialization must default to `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<AgentRunEventDetail>,
+}
+
+/// Structured detail attached to lifecycle events by the server:
+/// `reason` (stable error code for run_failed/run_errored, cancellation
+/// reason for run_cancelled), `error_message` (user-facing description for
+/// run_failed/run_errored), and `blocked_action` (what a run_blocked run is
+/// waiting on).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct AgentRunEventDetail {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_action: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]


### PR DESCRIPTION
## Description
Companion to warpdotdev/warp-server#14181 (fix #3 of the orchestration child-failure visibility work).

The server now attaches an optional structured `detail` object to orchestration lifecycle events:

```json
"detail": {"reason": "...", "error_message": "...", "blocked_action": "..."}
```

This PR consumes it on the client:
- `AgentRunEvent` (`app/src/server/server_api/ai.rs`) gains an optional `detail: Option<AgentRunEventDetail>` field, deserialized with `serde(default)` so servers that omit it keep working.
- `convert_lifecycle_events` (`app/src/ai/blocklist/orchestration_event_streamer.rs`) now fills `LifecycleEventDetailPayload` with real values instead of defaults:
  - `Failed` → `reason` + `error_message` from the wire detail.
  - `Errored` → `stage=runtime` + `reason`/`error_message`, falling back to the legacy `ref_id`-as-reason behavior when detail is absent.
  - `Blocked` → `blocked_action`.

The proto (`api::agent_event::lifecycle_event::Detail::{Failed,Errored,Blocked}`) already supported these fields, so orchestrators now see actionable `reason`/`error_message`/`blocked_action` in their `<lifecycle_events>` blocks instead of empty strings.

**Rollout ordering**: the server PR must land/deploy first. This change is fully backward compatible with servers that omit `detail` (behavior is unchanged in that case), and old clients ignore the new field.

## Linked Issue
Part of the orchestration lifecycle-failure-detail work coordinated in warpdotdev/warp-server#14181.

## Testing
- New unit tests in `orchestration_event_streamer_tests.rs`: failed/errored/blocked detail mapping, errored `ref_id` fallback when detail is absent, and wire deserialization with and without `detail`.
- `cargo nextest run -p warp` for the touched modules (`convert_lifecycle_events`, `agent_run_event_deserializes`, hydrator, driver tests): 32 passed.
- `cargo clippy -p warp --tests -- -D warnings`: clean.
- `./script/format` run.
- Not manually testable end-to-end yet: requires a server with warpdotdev/warp-server#14181 deployed; behavior against current servers is unchanged (verified by the fallback tests).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Orchestrator agents now see the failure reason and error message in child-agent lifecycle events (failed, errored, blocked) instead of empty placeholders.

Co-Authored-By: Warp Agent <agent@warp.dev>
