### PR TITLE
fix(macos): replace the base letter when the accent popup commits

### DIFF
--- a/app/src/editor/view/element.rs
+++ b/app/src/editor/view/element.rs
@@ -625,6 +625,24 @@ impl EditorElement {
         false
     }
 
+    /// Handles a text-input commit that replaces the grapheme before the caret, rather
+    /// than extending the input. See [`Event::ReplacePrecedingCharacters`].
+    fn replace_preceding_characters(&self, chars: &str, ctx: &mut EventContext) -> bool {
+        if self.view_snapshot.is_focused {
+            if self.vim_mode.is_some() {
+                // Vim owns its own insertion state machine, so we leave that path on the
+                // plain insert it has always used rather than reaching around it.
+                ctx.dispatch_typed_action(EditorAction::VimUserInsert(UserInput::new(chars)));
+            } else {
+                ctx.dispatch_typed_action(EditorAction::ReplacePrecedingCharacters(
+                    UserInput::new(chars),
+                ));
+            }
+            return true;
+        }
+        false
+    }
+
     fn set_marked_text(
         &mut self,
         marked_text: &str,
@@ -2176,6 +2194,9 @@ impl Element for EditorElement {
                 key_code, state, ..
             } => self.modifier_key_change(key_code, state, ctx),
             Event::TypedCharacters { chars } => self.typed_characters(chars, ctx),
+            Event::ReplacePrecedingCharacters { chars } => {
+                self.replace_preceding_characters(chars, ctx)
+            }
             Event::DragAndDropFiles { paths, location } => {
                 self.drag_and_drop_file(paths.clone(), *location, ctx)
             }

--- a/app/src/editor/view/marked_text_tests.rs
+++ b/app/src/editor/view/marked_text_tests.rs
@@ -191,3 +191,89 @@ fn test_set_marked_text_vim_insert_mode() {
         });
     });
 }
+
+/// Regression test for #13631: the macOS press-and-hold accent popup commits the base
+/// character first and then commits the accented character as a replacement for it. The
+/// replacement must land as a single grapheme, not appended after the base character.
+#[test]
+fn test_replace_preceding_characters_accent_popup() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            // Typed rather than seeded as base text, so the caret ends up after the
+            // text the way it does when a user is typing a command.
+            let mut editor = EditorView::new_with_base_text("", Default::default(), ctx);
+            editor.user_insert("ech", ctx);
+
+            // Holding `o` commits a literal `o` through the ordinary typed-character path.
+            editor.user_insert("o", ctx);
+            assert_eq!(editor.buffer_text(ctx), "echo");
+
+            // Picking `ò` from the popup replaces that `o` rather than following it.
+            editor.replace_preceding_characters("ò", ctx);
+            assert_eq!(editor.buffer_text(ctx), "echò");
+
+            editor
+        });
+    });
+}
+
+/// The replacement costs no extra undo step: undoing an accented word behaves exactly
+/// like undoing the same word typed directly, rather than first uncovering the
+/// intermediate `echo` state that only existed because of how the popup commits.
+///
+/// The directly-typed editor is the control — without it, a single `undo` reaching an
+/// empty buffer would prove nothing, since that is also what typing coalescing alone
+/// would produce.
+#[test]
+fn test_replace_preceding_characters_costs_no_extra_undo_step() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let mut control = EditorView::new_with_base_text("", Default::default(), ctx);
+            control.user_insert("ech", ctx);
+            control.user_insert("ò", ctx);
+            assert_eq!(control.buffer_text(ctx), "echò");
+            control.undo(ctx);
+            let control_after_one_undo = control.buffer_text(ctx);
+            assert_eq!(control_after_one_undo, "");
+
+            control
+        });
+
+        app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let mut editor = EditorView::new_with_base_text("", Default::default(), ctx);
+            editor.user_insert("ech", ctx);
+            editor.user_insert("o", ctx);
+            editor.replace_preceding_characters("ò", ctx);
+            assert_eq!(editor.buffer_text(ctx), "echò");
+
+            // One undo, same as the control. Two would mean the popup commit left an
+            // extra edit behind, and the second undo would surface `echo`.
+            editor.undo(ctx);
+            assert_eq!(editor.buffer_text(ctx), "");
+
+            editor
+        });
+    });
+}
+
+/// At the start of the buffer there is nothing to replace, so the commit degrades to a
+/// plain insert instead of eating a character that belongs to the user.
+#[test]
+fn test_replace_preceding_characters_at_buffer_start_inserts() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let mut editor = EditorView::new_with_base_text("", Default::default(), ctx);
+
+            editor.replace_preceding_characters("ò", ctx);
+            assert_eq!(editor.buffer_text(ctx), "ò");
+
+            editor
+        });
+    });
+}

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -996,6 +996,10 @@ pub enum EditorAction {
     Scroll(Vector2F),
     Select(SelectAction),
     UserInsert(UserInput<String>),
+    /// Replaces the grapheme before the caret with the given text, as a single edit.
+    /// Produced by the macOS press-and-hold accent popup — see
+    /// [`warpui::Event::ReplacePrecedingCharacters`].
+    ReplacePrecedingCharacters(UserInput<String>),
     VimUserInsert(UserInput<String>),
     DragAndDropFiles(Vec<UserInput<String>>),
     SetMarkedText {
@@ -5032,6 +5036,29 @@ impl EditorView {
         );
     }
 
+    /// Replaces the grapheme before the caret with `text`.
+    ///
+    /// This exists for the macOS press-and-hold accent popup, which commits the base
+    /// character first and then commits the accented character as a replacement for it
+    /// (issue #13631). Both halves run inside one [`Self::edit`] call so the pair is a
+    /// single undo step and the buffer is never briefly in the `oò` state.
+    pub fn replace_preceding_characters(&mut self, text: &str, ctx: &mut ViewContext<Self>) {
+        // Nothing to replace at the start of the buffer, so this degrades to an insert.
+        let has_preceding_grapheme =
+            !self.buffer_text(ctx).is_empty() && !self.single_cursor_at_buffer_start(ctx);
+
+        let action = PlainTextEditorViewAction::from_inserted_str(text);
+        self.edit(
+            ctx,
+            Edits::new().with_update_buffer(action, EditOrigin::UserTyped, |editor_model, ctx| {
+                if has_preceding_grapheme {
+                    editor_model.backspace(ctx);
+                }
+                editor_model.insert_internal(text, None, SelectionInsertion::No, ctx);
+            }),
+        );
+    }
+
     fn voice_input_toggle_key_code(&self, ctx: &AppContext) -> Option<KeyCode> {
         let ai_settings_handle = &AISettings::handle(ctx);
         ai_settings_handle
@@ -8557,6 +8584,9 @@ impl TypedActionView for EditorView {
             Scroll(position) => self.scroll(*position, ctx),
             Select(action) => self.select(action, ctx),
             UserInsert(text) => self.user_insert(text.as_ref(), ctx),
+            ReplacePrecedingCharacters(text) => {
+                self.replace_preceding_characters(text.as_ref(), ctx)
+            }
             #[cfg(feature = "voice_input")]
             ToggleVoiceInput(source) => {
                 self.toggle_voice_input(source, ctx);

--- a/crates/warpui/src/platform/mac/objc/host_view.m
+++ b/crates/warpui/src/platform/mac/objc/host_view.m
@@ -476,8 +476,13 @@ void warp_marked_text_cleared(WarpHostView *);
         // otherwise swallow them. Ordinary dead-key composition (Option-E then `g`)
         // also runs there with marked text, but its setMarkedText: always carries
         // NSNotFound, so it never sets the flag and keeps appending as before.
+        //
+        // The flag is only trusted while the popup's marked text is still standing.
+        // Dismissing the popup clears that marked text, so a flag that outlived its
+        // popup cannot make the next ordinary keystroke eat the character before it.
         BOOL replacesCommittedText =
-            accentPopupReplacingCommittedText || replacementRange.location != NSNotFound;
+            (accentPopupReplacingCommittedText && [self hasMarkedText]) ||
+            replacementRange.location != NSNotFound;
 
         if (replacesCommittedText) {
             accentPopupReplacingCommittedText = NO;
@@ -545,6 +550,9 @@ void warp_marked_text_cleared(WarpHostView *);
     if (interpretingKeyEvents) {
         imeTouchedMarkedTextDuringInterpret = YES;
     }
+    // The accent popup is gone, whether it committed or was cancelled. Either way it
+    // is no longer offering to replace anything.
+    accentPopupReplacingCommittedText = NO;
     [[markedText mutableString] setString:@""];
     if (self.readyForWarp) {
         warp_update_ime_state(self, NO);

--- a/crates/warpui/src/platform/mac/objc/host_view.m
+++ b/crates/warpui/src/platform/mac/objc/host_view.m
@@ -8,6 +8,7 @@ void warp_update_layer(WarpHostView *);
 BOOL warp_handle_view_event(WarpHostView *, NSEvent *, BOOL);
 BOOL warp_handle_first_mouse_event(WarpHostView *, NSEvent *);
 void warp_handle_insert_text(WarpHostView *, id);
+void warp_handle_replace_preceding_text(WarpHostView *, id);
 void warp_update_ime_state(WarpHostView *, BOOL);
 void warp_handle_drag_and_drop(WarpHostView *, NSArray *, NSPoint);
 void warp_handle_file_drag(WarpHostView *, NSPoint);
@@ -55,6 +56,12 @@ void warp_marked_text_cleared(WarpHostView *);
 
     // Whether we're in the middle of a call to interpretKeyEvents.
     BOOL interpretingKeyEvents;
+
+    // Whether the press-and-hold accent popup is currently choosing a replacement for
+    // a character we have already committed. AppKit opens that popup by calling
+    // setMarkedText: with a real replacementRange, which is the one shape ordinary
+    // dead-key composition never takes — see insertText:replacementRange:.
+    BOOL accentPopupReplacingCommittedText;
 
     // Whether the IME modified marked text (via setMarkedText: or unmarkText)
     // during the current interpretKeyEvents: pass. Used to avoid wiping a
@@ -456,7 +463,29 @@ void warp_marked_text_cleared(WarpHostView *);
         // call to `insertText` is not in a call stack underneath `keyDown`
         // (e.g.: when inserting an emoji from the emoji composer), just insert
         // the text directly.
-        if (interpretingKeyEvents) {
+        // The press-and-hold accent popup replaces a character we have already
+        // committed: holding `o` commits a literal `o`, then picking `ò` is meant to
+        // take its place. Appending leaves both, which is issue #13631.
+        //
+        // Two shapes reach us, depending on how the entry is chosen:
+        //   - picking by number  -> insertText with a real replacementRange location
+        //   - arrow keys + Return -> insertText with NSNotFound, but the popup opened
+        //     earlier via setMarkedText: carrying a real replacementRange
+        //
+        // Both run *inside* interpretKeyEvents:, so the batching branch below would
+        // otherwise swallow them. Ordinary dead-key composition (Option-E then `g`)
+        // also runs there with marked text, but its setMarkedText: always carries
+        // NSNotFound, so it never sets the flag and keeps appending as before.
+        BOOL replacesCommittedText =
+            accentPopupReplacingCommittedText || replacementRange.location != NSNotFound;
+
+        if (replacesCommittedText) {
+            accentPopupReplacingCommittedText = NO;
+            // Drop the popup's in-progress marked text first. Otherwise the editor
+            // would delete that ephemeral text instead of the committed character.
+            [self unmarkText];
+            warp_handle_replace_preceding_text(self, (NSString *)characters);
+        } else if (interpretingKeyEvents) {
             [textToInsert appendString:characters];
         } else {
             warp_handle_insert_text(self, (NSString *)characters);
@@ -487,6 +516,13 @@ void warp_marked_text_cleared(WarpHostView *);
      replacementRange:(NSRange)replacementRange {
     if (interpretingKeyEvents) {
         imeTouchedMarkedTextDuringInterpret = YES;
+    }
+
+    // A real replacementRange here means AppKit is offering alternatives for text it
+    // has already handed us — the press-and-hold accent popup. Dead-key composition
+    // always passes NSNotFound, so this cannot be confused with it.
+    if (replacementRange.location != NSNotFound) {
+        accentPopupReplacingCommittedText = YES;
     }
 
     [markedText release];

--- a/crates/warpui/src/platform/mac/window.rs
+++ b/crates/warpui/src/platform/mac/window.rs
@@ -1532,9 +1532,19 @@ extern "C-unwind" fn warp_handle_replace_preceding_text(this: &Object, character
     // SAFETY: `characters` is a valid `NSString` of the inserted text.
     let string = unsafe { &*characters.cast::<NSString>() }.to_string();
     let window = unsafe { get_window_state(this) };
-    app::callback_dispatcher()
-        .for_window(&Window(window.clone()))
-        .dispatch_event(Event::ReplacePrecedingCharacters { chars: string });
+    let event = Event::ReplacePrecedingCharacters { chars: string };
+    let window = Window(window.clone());
+    let mut dispatcher = app::callback_dispatcher().for_window(&window);
+    let handled = dispatcher.dispatch_event(event.clone()).handled;
+    if !handled {
+        // Only surfaces that can delete the grapheme before the caret handle this.
+        // A focused terminal, the alt screen or the code editor do not, and dropping
+        // the commit there would be worse than the doubled character this fixes, so
+        // they keep receiving the plain append they always got.
+        if let Some(fallback) = event.unhandled_fallback() {
+            dispatcher.dispatch_event(fallback);
+        }
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/crates/warpui/src/platform/mac/window.rs
+++ b/crates/warpui/src/platform/mac/window.rs
@@ -1528,6 +1528,16 @@ extern "C-unwind" fn warp_handle_insert_text(this: &Object, characters: id) {
 }
 
 #[unsafe(no_mangle)]
+extern "C-unwind" fn warp_handle_replace_preceding_text(this: &Object, characters: id) {
+    // SAFETY: `characters` is a valid `NSString` of the inserted text.
+    let string = unsafe { &*characters.cast::<NSString>() }.to_string();
+    let window = unsafe { get_window_state(this) };
+    app::callback_dispatcher()
+        .for_window(&Window(window.clone()))
+        .dispatch_event(Event::ReplacePrecedingCharacters { chars: string });
+}
+
+#[unsafe(no_mangle)]
 extern "C-unwind" fn warp_handle_drag_and_drop(this: &Object, paths: id, point: NSPoint) {
     // SAFETY: `paths` is an `NSArray<NSString>` of dropped file paths.
     let paths = unsafe {

--- a/crates/warpui_core/src/event.rs
+++ b/crates/warpui_core/src/event.rs
@@ -200,6 +200,9 @@ pub enum Event {
     /// Handlers should drop the grapheme preceding the caret before inserting `chars`.
     /// The count is fixed at one because the platform layer cannot recover a usable
     /// length — see the comment in `insertText:replacementRange:` in `host_view.m`.
+    ///
+    /// Surfaces that cannot delete backwards need not handle it: an unhandled event
+    /// is redispatched as [`Event::TypedCharacters`], see [`Event::unhandled_fallback`].
     ReplacePrecedingCharacters {
         chars: String,
     },
@@ -256,6 +259,22 @@ impl Event {
             })
         } else {
             None
+        }
+    }
+
+    /// The event a surface should be given instead when it does not handle `self`.
+    ///
+    /// [`Event::ReplacePrecedingCharacters`] only means something to a surface that
+    /// can delete the grapheme before the caret. A focused terminal, the alt screen
+    /// and the code editor cannot, and silently dropping a committed character there
+    /// would be worse than the doubled character the replacement exists to avoid, so
+    /// the commit degrades to the plain append those surfaces have always received.
+    pub fn unhandled_fallback(&self) -> Option<Self> {
+        match self {
+            Event::ReplacePrecedingCharacters { chars } => Some(Event::TypedCharacters {
+                chars: chars.clone(),
+            }),
+            _ => None,
         }
     }
 }
@@ -437,3 +456,7 @@ impl Scale for Event {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "event_tests.rs"]
+mod tests;

--- a/crates/warpui_core/src/event.rs
+++ b/crates/warpui_core/src/event.rs
@@ -38,6 +38,7 @@ impl DispatchedEvent {
             Event::ModifierStateChanged { .. } => Some(&self.event),
             Event::ModifierKeyChanged { .. } => Some(&self.event),
             Event::TypedCharacters { .. } => Some(&self.event),
+            Event::ReplacePrecedingCharacters { .. } => Some(&self.event),
             Event::DragAndDropFiles { .. } => Some(&self.event),
             Event::DragFiles { .. } => Some(&self.event),
             Event::DragFileExit => Some(&self.event),
@@ -191,6 +192,17 @@ pub enum Event {
     TypedCharacters {
         chars: String,
     },
+    /// Gets fired when the text input system commits characters that are meant to
+    /// replace text it has already committed, rather than extend it. The macOS
+    /// press-and-hold accent popup is the only producer today: holding `o` commits a
+    /// literal `o`, and picking `ò` from the popup then commits a replacement for it.
+    ///
+    /// Handlers should drop the grapheme preceding the caret before inserting `chars`.
+    /// The count is fixed at one because the platform layer cannot recover a usable
+    /// length — see the comment in `insertText:replacementRange:` in `host_view.m`.
+    ReplacePrecedingCharacters {
+        chars: String,
+    },
     /// Gets fired when user drags a file or folder into Warp. Note that there could exist
     /// multiple file paths in one event as user could drag and drop multiple targets.
     DragAndDropFiles {
@@ -277,6 +289,7 @@ impl InBoundsExt for Event {
             Event::KeyDown { .. }
             | Event::ModifierKeyChanged { .. }
             | Event::TypedCharacters { .. }
+            | Event::ReplacePrecedingCharacters { .. }
             | Event::DragFileExit
             | Event::SetMarkedText { .. }
             | Event::ClearMarkedText => true,
@@ -410,6 +423,9 @@ impl Scale for Event {
                 Event::ModifierKeyChanged { key_code, state }
             }
             Event::TypedCharacters { chars } => Event::TypedCharacters { chars },
+            Event::ReplacePrecedingCharacters { chars } => {
+                Event::ReplacePrecedingCharacters { chars }
+            }
             Event::SetMarkedText {
                 marked_text,
                 selected_range,

--- a/crates/warpui_core/src/event_tests.rs
+++ b/crates/warpui_core/src/event_tests.rs
@@ -1,0 +1,28 @@
+use super::Event;
+
+/// A replacement commit that no surface handled must still reach that surface as an
+/// ordinary append. Dropping it would lose a character the user typed — the macOS
+/// accent popup produces these in a focused terminal too, not only in an editor
+/// (#13631).
+#[test]
+fn replace_preceding_characters_falls_back_to_an_append() {
+    let event = Event::ReplacePrecedingCharacters {
+        chars: "ò".to_owned(),
+    };
+
+    match event.unhandled_fallback() {
+        Some(Event::TypedCharacters { chars }) => assert_eq!(chars, "ò"),
+        other => panic!("expected a TypedCharacters fallback, got {other:?}"),
+    }
+}
+
+/// Every other event keeps whatever handling it already had; the fallback exists
+/// only for the replacement commit.
+#[test]
+fn other_events_have_no_fallback() {
+    let event = Event::TypedCharacters {
+        chars: "o".to_owned(),
+    };
+
+    assert!(event.unhandled_fallback().is_none());
+}

--- a/crates/warpui_core/src/integration/action_log.rs
+++ b/crates/warpui_core/src/integration/action_log.rs
@@ -22,6 +22,9 @@ pub fn event_description(event: &Event) -> String {
     match event {
         Event::KeyDown { chars, .. } => format!("KeyDown '{chars}'"),
         Event::TypedCharacters { chars } => format!("TypedCharacters '{chars}'"),
+        Event::ReplacePrecedingCharacters { chars } => {
+            format!("ReplacePrecedingCharacters '{chars}'")
+        }
         Event::LeftMouseDown { .. } => "LeftMouseDown".to_string(),
         Event::LeftMouseUp { .. } => "LeftMouseUp".to_string(),
         Event::LeftMouseDragged { .. } => "LeftMouseDragged".to_string(),


### PR DESCRIPTION
## Description

On macOS, selecting a character from the native press-and-hold accent popup inserts **both** the held base letter and the accented character — hold `o`, pick `ò`, and the input reads `oò`.

**Root cause.** Holding the key commits a literal `o` through the ordinary typed-character path. The popup's selection is then meant to *replace* that character, but `insertText:replacementRange:` in `host_view.m` appends unconditionally, so both survive.

### What the input system actually sends

I instrumented `insertText:`, `setMarkedText:` and `unmarkText` on a local OSS build and drove the real popup end to end. **Two different shapes reach us, depending on how the entry is chosen** — and a dead-key control run is included, because that path must keep working:

```
A — hold `o`, arrow keys, Return
   insertText    'o'  loc=NSNotFound              interpreting=1 hasMarked=0
   setMarkedText 'ò'  selLen=1  replLoc=0          interpreting=1 hasMarked=0   ← popup opens
   setMarkedText 'ó'  selLen=1  replLoc=NSNotFound interpreting=1 hasMarked=1
   insertText    'ó'  loc=NSNotFound              interpreting=1 hasMarked=1   ← commit

B — hold `o`, press `1`
   insertText 'o'  loc=NSNotFound  interpreting=1 hasMarked=0
   insertText 'ò'  loc=0           interpreting=1 hasMarked=0                  ← commit

C — Option-E then `g`  (dead-key control, must not change)
   setMarkedText '´'  selLen=0  replLoc=NSNotFound interpreting=1 hasMarked=0
   insertText    '´'  loc=NSNotFound  interpreting=1 hasMarked=1
   insertText    'g'  loc=NSNotFound  interpreting=1 hasMarked=1
```

Three things fall out of this, and each one shaped the patch:

1. **Both commits happen *inside* `interpretKeyEvents:`** (`interpreting=1`). Anything gated on being outside it is dead code.
2. **At `insertText:` time, A is indistinguishable from the dead-key control** — same `NSNotFound`, same `interpreting`, same `hasMarkedText`. B is distinguishable by its real `replacementRange` location.
3. **The discriminator for A is in `setMarkedText:`**: the popup opens with a real `replacementRange` location, a shape dead-key composition never takes.

So the patch sets a flag when `setMarkedText:` arrives with a real `replacementRange`, and treats the next `insertText:` — or any `insertText:` that carries its own real location — as a replacement rather than an append. The popup's in-progress marked text is cleared first, otherwise the editor would delete that ephemeral text instead of the committed character.

The delete and the insert share one `edit()` call, so the pair is a single undo step and the buffer is never briefly in the `oò` state.

## Scope

Sending this as a draft so the scope calls are reviewable on a concrete diff.

1. **Not truthful `selectedRange`.** The general fix is to report the real caret offset so AppKit can compute a proper replacement range itself; I verified that works (a non-degenerate `selectedRange` makes AppKit hand back `{caret-1, 1}`). It needs a caret→UTF-16 offset bridge across the shared text-input surface, which is a much wider change. Happy to build that instead if you'd prefer the general fix.
2. **Editor input only.** `Event::ReplacePrecedingCharacters` is handled in the editor element. The block-list / alt-screen paths still append, because replacing there means writing a DEL byte into the PTY, and that is a behavioral choice I don't think a contributor should make unilaterally. Say the word and I'll extend it.
3. **Vim keeps its existing path.** Vim owns its own insertion state machine, so that branch stays on `VimUserInsert` rather than reaching around it.

## Linked Issue

Fixes #13631

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement` — labeled `ready-to-implement` on 2026-07-16.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

Three regression tests in `app/src/editor/view/marked_text_tests.rs`:

- `test_replace_preceding_characters_accent_popup` — `echo` plus a popup `ò` yields `echò`, not `echoò`.
- `test_replace_preceding_characters_costs_no_extra_undo_step` — compared against a control editor that types the accented word directly, one undo empties both. Without the control this assertion would prove nothing, since typing coalescing alone produces the same result.
- `test_replace_preceding_characters_at_buffer_start_inserts` — with nothing before the caret the commit degrades to a plain insert rather than eating a character that belongs to the user.

The existing `marked_text_tests` IME/dead-key suite stays green (8 passed total).

**What the unit tests cannot cover, and why the manual run matters here.** The detection lives in Objective-C on AppKit callbacks that only a real press-and-hold produces. An earlier revision of this patch had all of these tests passing and still reproduced the bug on a real build, because the detection was gated on being outside `interpretKeyEvents:` and therefore never ran. The measurements above, and the before/after below, come from driving the actual popup on a local OSS build.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Both builds are local OSS builds from this branch; BEFORE differs only by `host_view.m` reverted to `master`. The same synthesized key sequence drives each pair, so the two halves differ by the patch and nothing else.

**A — hold `o`, arrow keys, Return** (the variant the first revision of this patch missed)

![arrow keys and Return](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-13631/13631-A.png)

**B — hold `o`, press `1`**

![number key](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-13631/13631-B.png)

**C — Option-E then `g`, the dead-key control**

Unchanged by the patch. `´g` is `master`'s existing behavior here; the point of this pair is that it stays exactly as it was.

![dead-key control](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-13631/13631-C.png)

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed macOS press-and-hold accent selection inserting both the base letter and the accented character.
