### PR TITLE
Support Homebrew-managed Warp Agent CLI updates

### DIFF
--- a/app/src/settings/tui_autoupdate.rs
+++ b/app/src/settings/tui_autoupdate.rs
@@ -2,7 +2,7 @@ use settings::macros::define_settings_group;
 use settings::{SupportedPlatforms, SyncToCloud};
 
 define_settings_group!(TuiAutoupdateSettings, settings: [
-    // Whether the `warp-tui` background auto-updater is enabled.
+    // Whether the `warp-tui` background update check is enabled.
     //
     // TUI-only (`surface: Tui`): the GUI has its own autoupdater and update
     // preferences, so this key only appears in (and is read from) the TUI's
@@ -16,6 +16,6 @@ define_settings_group!(TuiAutoupdateSettings, settings: [
         surface: settings::SettingSurfaces::TUI,
         private: false,
         toml_path: "general.autoupdate_enabled",
-        description: "Whether Warp Agent CLI automatically installs updates in the background.",
+        description: "Whether Warp Agent CLI checks for updates and automatically installs them when supported by the installation method.",
     },
 ]);

--- a/crates/warp_tui/src/autoupdate.rs
+++ b/crates/warp_tui/src/autoupdate.rs
@@ -19,11 +19,12 @@
 //! lifetime, and cleanup only removes inactive versions whose lease can be
 //! locked exclusively.
 //!
-//! Background updates only run for managed installs (i.e. when the running
-//! executable resolves into a `versions/` directory), so `cargo run` builds
-//! and legacy flat installs are unaffected. Users can opt out with the
-//! file-backed `general.autoupdate_enabled` setting or the
-//! `WARP_TUI_DISABLE_AUTOUPDATE` environment variable; re-running the
+//! Native background updates only run for managed installs (i.e. when the
+//! running executable resolves into a `versions/` directory). Recognized
+//! Homebrew installs check for newer versions but leave installation to
+//! Homebrew, while `cargo run` builds and legacy flat installs are unaffected.
+//! Users can opt out with the file-backed `general.autoupdate_enabled` setting
+//! or the `WARP_TUI_DISABLE_AUTOUPDATE` environment variable; re-running the
 //! install script remains available as a manual escape hatch.
 
 use std::ffi::{OsStr, OsString};
@@ -47,6 +48,13 @@ use crate::telemetry::TuiAutoupdateTelemetryEvent;
 /// auto-updates for a single launch, regardless of the
 /// `general.autoupdate_enabled` setting.
 const DISABLE_ENV_VAR: &str = "WARP_TUI_DISABLE_AUTOUPDATE";
+/// The stable cask token shared by the Warp-managed tap and the planned
+/// official Homebrew package.
+const HOMEBREW_CASK_TOKEN: &str = "warp-agent-cli";
+
+/// User-facing status for Homebrew installations with a newer cask.
+pub(crate) const HOMEBREW_UPDATE_STATUS: &str =
+    "update available — run brew upgrade --cask warp-agent-cli";
 
 /// Name of the directory holding per-version installs under the install root.
 const VERSIONS_DIR_NAME: &str = "versions";
@@ -134,6 +142,56 @@ impl InstallLayout {
             binary_name,
         })
     }
+}
+
+/// The installation owner inferred from the canonical running executable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum InstallMethod {
+    /// Installed by Warp's native versioned installer.
+    Native(InstallLayout),
+    /// Installed from the `warp-agent-cli` Homebrew cask.
+    Homebrew,
+    /// A development build, legacy flat install, or unknown package manager.
+    Unmanaged,
+}
+
+impl InstallMethod {
+    fn detect() -> Self {
+        let Ok(exe) = std::env::current_exe() else {
+            return Self::Unmanaged;
+        };
+        let canonical_exe = exe.canonicalize().unwrap_or(exe);
+        Self::from_canonical_exe_path(&canonical_exe)
+    }
+
+    fn from_canonical_exe_path(exe: &Path) -> Self {
+        if let Some(layout) = InstallLayout::from_canonical_exe_path(exe) {
+            return Self::Native(layout);
+        }
+        if is_homebrew_cask_exe_path(exe) {
+            return Self::Homebrew;
+        }
+        Self::Unmanaged
+    }
+}
+
+fn is_homebrew_cask_exe_path(exe: &Path) -> bool {
+    if exe.file_name() != Some(OsStr::new("warp-tui-stable")) {
+        return false;
+    }
+    let components = exe
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(component) => Some(component),
+            std::path::Component::Prefix(_)
+            | std::path::Component::RootDir
+            | std::path::Component::CurDir
+            | std::path::Component::ParentDir => None,
+        })
+        .collect::<Vec<_>>();
+    components.windows(2).any(|components| {
+        components[0] == OsStr::new("Caskroom") && components[1] == OsStr::new(HOMEBREW_CASK_TOKEN)
+    })
 }
 
 fn download_url(version: &str) -> Result<String> {
@@ -273,6 +331,8 @@ enum UpdateOutcome {
     /// A newer version was staged and `current` now points at it. It takes
     /// effect on the next launch.
     Installed { version: String },
+    /// A newer Homebrew cask is available and must be installed by Homebrew.
+    UpdateAvailable { version: String },
 }
 
 impl UpdateOutcome {
@@ -285,6 +345,7 @@ impl UpdateOutcome {
             UpdateOutcome::UpToDate { .. } => "up_to_date",
             UpdateOutcome::PendingRestart { .. } => "pending_restart",
             UpdateOutcome::Installed { .. } => "installed",
+            UpdateOutcome::UpdateAvailable { .. } => "update_available",
         }
     }
 
@@ -295,7 +356,8 @@ impl UpdateOutcome {
             UpdateOutcome::Locked => None,
             UpdateOutcome::UpToDate { version }
             | UpdateOutcome::PendingRestart { version }
-            | UpdateOutcome::Installed { version } => Some(version),
+            | UpdateOutcome::Installed { version }
+            | UpdateOutcome::UpdateAvailable { version } => Some(version),
         }
     }
 }
@@ -317,6 +379,8 @@ pub(crate) enum TuiAutoupdateStatus {
     Failed,
     /// A newer version is staged and takes effect on the next launch.
     PendingRestart,
+    /// A newer Homebrew cask is available.
+    UpdateAvailable,
 }
 
 /// Events emitted by [`TuiAutoupdater`].
@@ -327,11 +391,15 @@ pub(crate) enum TuiAutoupdaterEvent {
 }
 
 /// Whether this process runs the background update loop.
+///
+/// Package-manager-owned installs use explicit variants because each manager
+/// can require different version checks, status copy, and update commands.
 #[derive(Clone, Debug)]
 enum AutoupdateEligibility {
-    /// Eligible: a release build running from the managed versioned install
-    /// layout, without the env opt-out.
-    Enabled(InstallLayout),
+    /// Eligible for native background installation.
+    Native(InstallLayout),
+    /// Eligible for update checks, with installation owned by Homebrew.
+    Homebrew,
     /// Background updates are disabled for this process.
     Disabled {
         /// Why updates are disabled, for logging/debugging.
@@ -365,9 +433,10 @@ impl AutoupdateEligibility {
                 reason: "no TUI release artifacts exist for this platform",
             };
         }
-        match InstallLayout::detect() {
-            Some(layout) => Self::Enabled(layout),
-            None => Self::Disabled {
+        match InstallMethod::detect() {
+            InstallMethod::Native(layout) => Self::Native(layout),
+            InstallMethod::Homebrew => Self::Homebrew,
+            InstallMethod::Unmanaged => Self::Disabled {
                 reason: "not running from a managed install",
             },
         }
@@ -379,7 +448,7 @@ impl AutoupdateEligibility {
 /// Always registered — even when this process isn't eligible for background
 /// updates — so other callsites can safely access the singleton. The polling
 /// loop only runs when [`Self::eligibility`] is
-/// [`AutoupdateEligibility::Enabled`].
+/// [`AutoupdateEligibility::Native`] or [`AutoupdateEligibility::Homebrew`].
 pub(crate) struct TuiAutoupdater {
     /// Whether (and where) this process runs background updates.
     eligibility: AutoupdateEligibility,
@@ -408,7 +477,8 @@ impl TuiAutoupdater {
             last_reported_outcome: None,
         });
         TuiAutoupdater::handle(ctx).update(ctx, |me, ctx| match me.eligibility.clone() {
-            AutoupdateEligibility::Enabled(layout) => me.check_now(layout, ctx),
+            AutoupdateEligibility::Native(layout) => me.check_native_now(layout, ctx),
+            AutoupdateEligibility::Homebrew => me.check_homebrew_now(ctx),
             AutoupdateEligibility::Disabled { reason } => {
                 log::info!("TUI autoupdate disabled: {reason}");
             }
@@ -434,7 +504,7 @@ impl TuiAutoupdater {
     /// [`CHECK_INTERVAL`]. The pass runs in two phases so the zero state can
     /// show progress: a lightweight version check, then — only when a newer
     /// version needs staging — the download/install phase.
-    fn check_now(&mut self, layout: InstallLayout, ctx: &mut ModelContext<Self>) {
+    fn check_native_now(&mut self, layout: InstallLayout, ctx: &mut ModelContext<Self>) {
         // Where the status settles when this pass is skipped because another
         // process is installing, and the status to preserve once an update is
         // pending restart.
@@ -462,6 +532,35 @@ impl TuiAutoupdater {
         );
     }
 
+    /// Checks for a newer Homebrew cask without invoking Homebrew or modifying
+    /// the Caskroom-managed installation.
+    fn check_homebrew_now(&mut self, ctx: &mut ModelContext<Self>) {
+        let fallback_status = self.status;
+        self.set_status(TuiAutoupdateStatus::Checking, ctx);
+        ctx.spawn(check_homebrew_update(), move |me, result, ctx| {
+            me.finish_homebrew_check(result, fallback_status, ctx)
+        });
+    }
+
+    fn finish_homebrew_check(
+        &mut self,
+        result: Result<UpdateOutcome>,
+        fallback_status: TuiAutoupdateStatus,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match &result {
+            Ok(outcome) => log::info!("TUI Homebrew update check finished: {outcome:?}"),
+            Err(error) => log::warn!("TUI Homebrew update check failed: {error:#}"),
+        }
+        self.report_outcome(&result, ctx);
+        let status = settled_status(&result, fallback_status);
+        self.set_status(status, ctx);
+        ctx.spawn(
+            async { Timer::after(CHECK_INTERVAL).await },
+            move |me, _, ctx| me.check_homebrew_now(ctx),
+        );
+    }
+
     /// Logs and reports the final result of an update pass, settles the
     /// user-visible status, and schedules the next check.
     fn finish_check(
@@ -482,7 +581,7 @@ impl TuiAutoupdater {
         self.set_status(status, ctx);
         ctx.spawn(
             async { Timer::after(CHECK_INTERVAL).await },
-            move |me, _, ctx| me.check_now(layout, ctx),
+            move |me, _, ctx| me.check_native_now(layout, ctx),
         );
     }
 
@@ -527,6 +626,7 @@ fn settled_status(
         Ok(UpdateOutcome::PendingRestart { .. } | UpdateOutcome::Installed { .. }) => {
             TuiAutoupdateStatus::PendingRestart
         }
+        Ok(UpdateOutcome::UpdateAvailable { .. }) => TuiAutoupdateStatus::UpdateAvailable,
         #[cfg(unix)]
         Ok(UpdateOutcome::Locked) => fallback_status,
         Err(_) => TuiAutoupdateStatus::Failed,
@@ -551,21 +651,7 @@ async fn check_for_update(layout: InstallLayout) -> Result<CheckDecision> {
 
     let client = http_client::Client::new();
     let latest_version = fetch_latest_version(&client).await?;
-
-    // Version strings become directory names below; reject anything that
-    // doesn't parse as a Warp version outright.
-    let latest_parsed = ParsedVersion::try_from(latest_version.as_str())
-        .with_context(|| format!("invalid latest version {latest_version:?}"))?;
-    if !is_safe_version_component(&latest_version) {
-        bail!("invalid latest version {latest_version:?}");
-    }
-
-    // Only ever move strictly forward. If the server reports an older (or
-    // equal) version — e.g. a rollback — keep the running build; users can
-    // reinstall a pinned version via the install script.
-    let current_parsed = ParsedVersion::try_from(current_version)
-        .with_context(|| format!("invalid current version {current_version:?}"))?;
-    if latest_parsed <= current_parsed {
+    if !is_newer_version(current_version, &latest_version)? {
         return Ok(CheckDecision::Settled(UpdateOutcome::UpToDate {
             version: current_version.to_owned(),
         }));
@@ -594,6 +680,36 @@ async fn check_for_update(layout: InstallLayout) -> Result<CheckDecision> {
     }
 
     Ok(CheckDecision::NeedsInstall { latest_version })
+}
+
+async fn check_homebrew_update() -> Result<UpdateOutcome> {
+    let current_version =
+        ChannelState::app_version().context("no release version tag baked into this build")?;
+    let latest_version = fetch_latest_version(&http_client::Client::new()).await?;
+    homebrew_update_outcome(current_version, latest_version)
+}
+
+fn homebrew_update_outcome(current_version: &str, latest_version: String) -> Result<UpdateOutcome> {
+    if is_newer_version(current_version, &latest_version)? {
+        Ok(UpdateOutcome::UpdateAvailable {
+            version: latest_version,
+        })
+    } else {
+        Ok(UpdateOutcome::UpToDate {
+            version: current_version.to_owned(),
+        })
+    }
+}
+
+fn is_newer_version(current_version: &str, latest_version: &str) -> Result<bool> {
+    let latest_parsed = ParsedVersion::try_from(latest_version)
+        .with_context(|| format!("invalid latest version {latest_version:?}"))?;
+    if !is_safe_version_component(latest_version) {
+        bail!("invalid latest version {latest_version:?}");
+    }
+    let current_parsed = ParsedVersion::try_from(current_version)
+        .with_context(|| format!("invalid current version {current_version:?}"))?;
+    Ok(latest_parsed > current_parsed)
 }
 
 fn is_safe_version_component(version: &str) -> bool {

--- a/crates/warp_tui/src/autoupdate_tests.rs
+++ b/crates/warp_tui/src/autoupdate_tests.rs
@@ -10,10 +10,10 @@ use instant::Instant;
 use warp_core::channel::Channel;
 
 use super::{
-    CURRENT_POINTER_NAME, InstallLayout, TuiAutoupdateStatus, UpdateOutcome,
+    CURRENT_POINTER_NAME, InstallLayout, InstallMethod, TuiAutoupdateStatus, UpdateOutcome,
     VERSION_LEASES_DIR_NAME, VersionDirState, VersionLease, create_unique_staging_dir_with,
-    download_endpoint, is_complete_version_dir, is_safe_version_component, latest_version_for,
-    prune_old_versions, settled_status, version_dir_state,
+    download_endpoint, homebrew_update_outcome, is_complete_version_dir, is_safe_version_component,
+    latest_version_for, prune_old_versions, settled_status, version_dir_state,
 };
 #[cfg(unix)]
 use super::{
@@ -55,6 +55,40 @@ fn failed_check_preserves_pending_restart_status() {
         settled_status(&result, TuiAutoupdateStatus::PendingRestart),
         TuiAutoupdateStatus::PendingRestart
     );
+}
+
+#[test]
+fn homebrew_update_is_presented_without_installing() {
+    let outcome = homebrew_update_outcome(
+        "v0.2026.07.22.18.00.stable_00",
+        "v0.2026.07.29.18.00.stable_00".to_owned(),
+    )
+    .unwrap();
+
+    assert!(matches!(
+        outcome,
+        UpdateOutcome::UpdateAvailable { ref version }
+            if version == "v0.2026.07.29.18.00.stable_00"
+    ));
+    assert_eq!(
+        settled_status(&Ok(outcome), TuiAutoupdateStatus::UpToDate),
+        TuiAutoupdateStatus::UpdateAvailable
+    );
+}
+
+#[test]
+fn homebrew_update_check_never_offers_rollbacks() {
+    let outcome = homebrew_update_outcome(
+        "v0.2026.07.29.18.00.stable_00",
+        "v0.2026.07.22.18.00.stable_00".to_owned(),
+    )
+    .unwrap();
+
+    assert!(matches!(
+        outcome,
+        UpdateOutcome::UpToDate { version }
+            if version == "v0.2026.07.29.18.00.stable_00"
+    ));
 }
 
 #[test]
@@ -165,6 +199,36 @@ fn detects_managed_install_layout() {
         Path::new("/home/user/.warp/tui/versions/v0.2026.01.01.00.00.dev_00")
     );
     assert_eq!(layout.binary_name, BINARY_NAME);
+}
+
+#[test]
+fn detects_homebrew_cask_installations_across_supported_prefixes() {
+    for exe in [
+        "/opt/homebrew/Caskroom/warp-agent-cli/v1/warp-tui-stable",
+        "/usr/local/Caskroom/warp-agent-cli/v1/warp-tui-stable",
+        "/home/linuxbrew/.linuxbrew/Caskroom/warp-agent-cli/v1/warp-tui-stable",
+    ] {
+        assert_eq!(
+            InstallMethod::from_canonical_exe_path(Path::new(exe)),
+            InstallMethod::Homebrew,
+            "{exe}"
+        );
+    }
+}
+
+#[test]
+fn rejects_unrelated_homebrew_casks_and_binary_names() {
+    for exe in [
+        "/opt/homebrew/Caskroom/other/v1/warp-tui-stable",
+        "/opt/homebrew/Caskroom/warp-agent-cli/v1/warp-preview",
+        "/opt/homebrew/bin/warp-tui-stable",
+    ] {
+        assert_eq!(
+            InstallMethod::from_canonical_exe_path(Path::new(exe)),
+            InstallMethod::Unmanaged,
+            "{exe}"
+        );
+    }
 }
 
 /// `Path::canonicalize` hands back `\\?\C:\...` on Windows. Passing that

--- a/crates/warp_tui/src/telemetry.rs
+++ b/crates/warp_tui/src/telemetry.rs
@@ -273,10 +273,11 @@ warp_core::register_telemetry_event!(TuiConversationRestoreTelemetryEvent);
 pub(crate) enum TuiAutoupdateTelemetryEvent {
     /// A background update check completed.
     CheckCompleted {
-        /// `"up_to_date"`, `"installed"`, `"pending_restart"`, or `"locked"`.
+        /// `"up_to_date"`, `"installed"`, `"pending_restart"`,
+        /// `"update_available"`, or `"locked"`.
         outcome: &'static str,
         /// The relevant version: the running version when up to date, or the
-        /// newly installed / staged version.
+        /// newly installed, staged, or available version.
         version: Option<String>,
     },
     /// A background update check failed (e.g. network or install errors).

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -33,7 +33,9 @@ use warpui_core::elements::tui::{
 };
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
 
-use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent};
+use crate::autoupdate::{
+    HOMEBREW_UPDATE_STATUS, TuiAutoupdateStatus, TuiAutoupdater, TuiAutoupdaterEvent,
+};
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::{abbreviate_home_prefix, append_welcome_capability_section, render_welcome_title};
 use crate::zero_state_animation::{
@@ -877,6 +879,7 @@ fn autoupdate_status_label(status: TuiAutoupdateStatus) -> Option<&'static str> 
         TuiAutoupdateStatus::UpToDate => Some("up to date"),
         TuiAutoupdateStatus::Failed => Some("automatic update failed"),
         TuiAutoupdateStatus::PendingRestart => Some("update installed, restart to apply"),
+        TuiAutoupdateStatus::UpdateAvailable => Some(HOMEBREW_UPDATE_STATUS),
     }
 }
 
@@ -901,7 +904,8 @@ fn render_version_line(builder: &TuiUiBuilder, app: &AppContext) -> Box<dyn TuiE
         TuiAutoupdateStatus::Idle => unreachable!("idle status has no label"),
         TuiAutoupdateStatus::Checking
         | TuiAutoupdateStatus::Updating
-        | TuiAutoupdateStatus::UpToDate => muted,
+        | TuiAutoupdateStatus::UpToDate
+        | TuiAutoupdateStatus::UpdateAvailable => muted,
         TuiAutoupdateStatus::Failed => builder.error_text_style(),
         TuiAutoupdateStatus::PendingRestart => builder.success_glyph_style(),
     };

--- a/crates/warp_tui/src/zero_state_tests.rs
+++ b/crates/warp_tui/src/zero_state_tests.rs
@@ -86,6 +86,14 @@ fn failed_autoupdate_status_has_visible_label() {
 }
 
 #[test]
+fn homebrew_update_status_shows_the_upgrade_command() {
+    assert_eq!(
+        autoupdate_status_label(TuiAutoupdateStatus::UpdateAvailable),
+        Some("update available — run brew upgrade --cask warp-agent-cli")
+    );
+}
+
+#[test]
 fn first_zero_state_matches_welcome_design_copy() {
     App::test((), |mut app| async move {
         register_tui_session_view_test_singletons(&mut app);


### PR DESCRIPTION
## Description
Add package-manager-aware update behavior for Warp Agent CLI installations owned by the new Homebrew cask. Native installer layouts keep the existing background installer; recognized `warp-agent-cli` Caskroom installs only check for newer versions and display `brew upgrade --cask warp-agent-cli` without modifying Homebrew-owned files.

Companion PRs:
- Homebrew cask: https://github.com/warpdotdev/homebrew-warp/pull/199
- Automated cask bumps: https://github.com/warpdotdev/channel-versions/pull/999

## Linked Issue
No linked issue; this originated as a high-priority enterprise request.

## Testing
- `./script/format`
- full workspace Clippy through `./script/presubmit`
- `cargo nextest run -p warp_tui` — 970 passed
- focused Homebrew detection/update/render tests — 5 passed
- live stable TUI staged under a Caskroom path and captured through tmux; rendered the expected upgrade command
- macOS Homebrew fetch/install/version/resource/uninstall flow
- Linux x86-64 artifact checksum, runtime library, version, and resource verification

The full presubmit test phase was interrupted by SIGINT in unrelated shell integration tests after 634 tests passed. It was not rerun because this is TUI-only; all relevant TUI suites and the complete formatting/Clippy gates passed.

- [x] I manually tested the user-visible behavior in the live TUI

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

- [Conversation](https://staging.warp.dev/conversation/5b370a36-87ff-455d-9942-1fb2622b9c40)
- [Implementation plan](https://staging.warp.dev/drive/notebook/BpUM6S7gFCUSANuggWBYyS)

CHANGELOG-TUI: Homebrew installations now show the correct `brew upgrade` command when an update is available.

Co-Authored-By: Warp <agent@warp.dev>