### PR TITLE
fix(macos): break infinite titlebar height layout loop

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -412,6 +412,17 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     if (_configuredTitlebarHeight <= 0) return;
     BOOL isFullscreen = (self.styleMask & NSWindowStyleMaskFullScreen) != 0;
     if (isFullscreen) return;
+    // If the titlebar container is already at the configured height, this
+    // notification was caused by our own applyTitlebarHeight: (or the frame is
+    // already correct). Re-applying here would setFrame: again, post another
+    // NSViewFrameDidChangeNotification, and re-enter this handler on the next
+    // layout pass - an infinite apply -> notify -> apply loop that burns CPU
+    // while the window is visible. Skip to break the loop.
+    NSView *containerView = get_titlebar_container_view(self);
+    if (!containerView) return;
+    if (fabs(NSHeight([containerView frame]) - _configuredTitlebarHeight) < 0.5) {
+        return;
+    }
     // Defer to avoid modifying constraints in the middle of an active layout pass.
     dispatch_async(dispatch_get_main_queue(), ^{
       [self applyTitlebarHeight:_configuredTitlebarHeight];
@@ -695,6 +706,17 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     if (_configuredTitlebarHeight <= 0) return;
     BOOL isFullscreen = (self.styleMask & NSWindowStyleMaskFullScreen) != 0;
     if (isFullscreen) return;
+    // If the titlebar container is already at the configured height, this
+    // notification was caused by our own applyTitlebarHeight: (or the frame is
+    // already correct). Re-applying here would setFrame: again, post another
+    // NSViewFrameDidChangeNotification, and re-enter this handler on the next
+    // layout pass - an infinite apply -> notify -> apply loop that burns CPU
+    // while the window is visible. Skip to break the loop.
+    NSView *containerView = get_titlebar_container_view(self);
+    if (!containerView) return;
+    if (fabs(NSHeight([containerView frame]) - _configuredTitlebarHeight) < 0.5) {
+        return;
+    }
     // Defer to avoid modifying constraints in the middle of an active layout pass.
     dispatch_async(dispatch_get_main_queue(), ^{
       [self applyTitlebarHeight:_configuredTitlebarHeight];


### PR DESCRIPTION
## What

Adds a height guard to `titlebarContainerFrameDidChange:` in both `WarpWindow` and `WarpPanel`, so the observer only re-applies the configured titlebar height when the container height actually differs from it.

## Why

The titlebar frame-change observer re-applies the configured titlebar height on every `NSViewFrameDidChangeNotification`, deferring via `dispatch_async`. `applyTitlebarHeight:` then calls `setFrame:` on the titlebar container and updates the height constraint, which marks Auto Layout dirty and posts another frame-change notification on the next layout pass — an infinite apply → notify → apply loop that keeps the main thread busy while the window is visible (~8–10% CPU at idle on macOS). Minimizing the window drops CPU to ~0%.

## How

Skip re-applying when `fabs(NSHeight([containerView frame]) - _configuredTitlebarHeight) < 0.5`. The custom height is still restored when AppKit legitimately changes the container (e.g. after exiting fullscreen).

## Verification

- Before: idle `warp-oss` ~8–10% CPU; main-thread samples dominated by `-[NSView setFrame:]` → `-[NSTitlebarContainerView setFrameSize:]` loops (dozens of dispatch-main-queue callbacks per sample window).
- After: idle CPU 0.0%; the setFrame loop no longer appears in samples; fullscreen enter/exit still restores the configured height; custom titlebar height changes settle after a single apply.