### PR TITLE
[CODE-1838] Fix TUI focus for long-running command input

### DIFF
--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -3240,6 +3240,12 @@ impl TuiTerminalSessionView {
         }
         let is_focused = self.is_focused_session(ctx);
         if is_focused {
+            let pty_owns_input = self
+                .session_state(ctx)
+                .is_ok_and(|state| state.input_target().pty_owns_input());
+            if pty_owns_input && self.input_view.is_focused(ctx) {
+                self.focus_current_owner(ctx);
+            }
             ctx.notify();
         }
         is_focused

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -5631,6 +5631,37 @@ fn terminal_wakeup_redraws_only_the_focused_session() {
         assert!(!background.update(&mut app, |view, ctx| { view.handle_terminal_wakeup(ctx) }));
     });
 }
+
+#[test]
+fn terminal_wakeup_focuses_a_new_long_running_command() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (view, _) = add_focus_test_session(&mut app, &fixture, true);
+        let input_id = view.read(&app, |view, _| view.input_view.id());
+
+        view.update(&mut app, |view, ctx| {
+            view.terminal_model
+                .lock()
+                .simulate_long_running_block("cat", "");
+            assert!(view.input_target().pty_owns_input());
+            assert_eq!(
+                ctx.focused_view_id(fixture.window_id),
+                Some(input_id),
+                "the composer remains focused until the delayed terminal wakeup"
+            );
+
+            assert!(view.handle_terminal_wakeup(ctx));
+        });
+
+        app.read(|ctx| {
+            assert_eq!(
+                ctx.focused_view_id(fixture.window_id),
+                Some(view.id()),
+                "the PTY-owning session must receive input after the wakeup"
+            );
+        });
+    });
+}
 #[test]
 fn background_focus_reconciliation_does_not_steal_foreground_focus() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

Fixes a TUI focus regression where commands that became long-running could render as PTY-owned while framework focus remained on the hidden composer. Editor-bound keys such as Enter were then intercepted instead of reaching the running process.

Terminal wakeups now move focus to the session only when the PTY owns input and the stale composer is still focused. This preserves nested interaction focus during ordinary terminal redraws.

A regression test covers the delayed composer-to-PTY ownership transition.

## Linked Issue

[CODE-1838](https://linear.app/warpdotdev/issue/CODE-1838/long-running-commands-cant-receive-input-in-tui)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format --check`
- `./script/check_no_inline_test_modules`
- Presubmit Clippy commands for the workspace, `warp`, and `warp_completer`
- `cargo nextest run -p warp_tui` — 993 passed
- Workspace-wide tests intentionally skipped
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/6f6645f5-3f6d-4a0d-ad11-9ae50af406f4

CHANGELOG-BUG-FIX: Fixed long-running commands in Warp Agent CLI not accepting keyboard input.
CHANGELOG-TUI: Fixed keyboard input for long-running commands.

Co-Authored-By: Warp <agent@warp.dev>
