### PR TITLE
Overlay the hover-revealed tab bar instead of reflowing content

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -572,6 +572,18 @@ pub const TAB_BAR_HEIGHT: f32 = 34.;
 pub const PANEL_HEADER_HEIGHT: f32 = TAB_BAR_HEIGHT;
 /// The hover area height for states where the tab bar is revealed on hover.
 const TAB_BAR_HOVER_HEIGHT: f32 = 12.;
+/// How long the pointer has to rest in the hover area before a hidden tab bar is
+/// revealed. Without a delay, merely sweeping the pointer across the top of the
+/// window pops the bar open.
+///
+/// Do not pair this with a hover-out delay. A delayed transition resolves on the
+/// synthetic [`Event::MouseMoved`] the framework replays after each frame, and
+/// [`Hoverable`] drops the redraw for a state change whose previous change was
+/// also synthetic. With both delays every transition is synthetic, so hiding
+/// would flip the state without scheduling the frame that repaints it and the
+/// bar would linger until something unrelated redrew. Hiding therefore stays
+/// undelayed, resolving on the real mouse move that leaves the bar.
+const TAB_BAR_HOVER_IN_DELAY: Duration = Duration::from_millis(250);
 const TAB_BAR_PADDING_LEFT: f32 = 4.;
 const TAB_BAR_PADDING_RIGHT: f32 = 8.;
 const TITLE_BAR_SEARCH_BAR_MAX_WIDTH: f32 = 320.;
@@ -598,6 +610,13 @@ const THEME_CHOOSER_RATIO: f32 = 3.5;
 
 /// Save position for the tab bar.
 pub(crate) const TAB_BAR_POSITION_ID: &str = "workspace_view:tab_bar";
+/// Save position for the strip that reveals a hidden tab bar on hover. Recorded
+/// so the reveal strip and the revealed bar can be checked against each other.
+pub(crate) const TAB_BAR_HOVER_AREA_POSITION_ID: &str = "workspace_view:tab_bar_hover_area";
+/// Save position for the container holding a hover-revealed tab bar. Unlike the
+/// bar itself, this is the element laid out against the whole window, so its
+/// recorded size is what tells us the overlay stayed a strip at the top.
+pub(crate) const TAB_BAR_OVERLAY_POSITION_ID: &str = "workspace_view:tab_bar_overlay";
 const TEAM_SWITCHER_PILL_POSITION_ID: &str = "workspace_view:team_switcher_pill";
 const TEAM_SWITCHER_DOT_ALPHA: u8 = 204;
 
@@ -839,13 +858,22 @@ enum ShowTabBar {
     /// Show the tab bar stacked on top of the pane group area.
     #[default]
     Stacked,
+    /// Float the tab bar over the top of the window without reserving any
+    /// layout space for it. Used whenever the bar is revealed on hover, for two
+    /// reasons: keeping it out of the content column means revealing it never
+    /// reflows the panes, and anchoring it at the very top of the window keeps
+    /// the hover strip that reveals it inside the revealed bar's own hover area.
+    /// A stacked bar starts below [`WORKSPACE_PADDING`], so the topmost pixel
+    /// row of the window would reveal the bar and then sit outside it, making
+    /// the bar oscillate open and closed under a stationary pointer.
+    Overlay,
     /// Hide the tab bar.
     Hidden,
 }
 
 impl ShowTabBar {
     fn has_tab_bar(self) -> bool {
-        matches!(self, ShowTabBar::Stacked)
+        matches!(self, ShowTabBar::Stacked | ShowTabBar::Overlay)
     }
 }
 
@@ -14330,8 +14358,11 @@ impl Workspace {
             .workspace_decoration_visibility
             .value();
 
+        // A bar that comes and goes floats over the content rather than taking a
+        // row in it, so revealing it doesn't shove every pane down by the height
+        // of the bar. See [`ShowTabBar::Overlay`].
         let hovered_visibility = if is_pane_being_dragged || is_hovered || is_tab_menu_open {
-            ShowTabBar::Stacked
+            ShowTabBar::Overlay
         } else {
             ShowTabBar::Hidden
         };
@@ -20728,17 +20759,28 @@ impl Workspace {
 
     /// Renders an invisible rect for detecting hovers over the tab bar.
     fn render_tab_bar_hover_area(&self) -> Box<dyn Element> {
-        self.render_tab_bar_hoverable(
-            ConstrainedBox::new(Empty::new().finish())
-                .with_height(TAB_BAR_HOVER_HEIGHT)
-                .finish(),
+        SavePosition::new(
+            self.render_tab_bar_hoverable(
+                ConstrainedBox::new(Empty::new().finish())
+                    .with_height(TAB_BAR_HOVER_HEIGHT)
+                    .finish(),
+            ),
+            TAB_BAR_HOVER_AREA_POSITION_ID,
         )
+        .finish()
     }
 
     /// Renders the provided content wrapped in the tab bar hover behavior.
+    ///
+    /// The same mouse state backs both the hover strip that reveals a hidden tab
+    /// bar and the revealed bar itself, so this delay governs how long the
+    /// pointer must linger to open the bar. The revealed bar covers the strip,
+    /// so the pointer that opened it stays over it and only a move that leaves
+    /// the bar entirely hides it; see [`TAB_BAR_HOVER_IN_DELAY`] for why that
+    /// direction must stay undelayed.
     fn render_tab_bar_hoverable(&self, content: Box<dyn Element>) -> Box<dyn Element> {
         Hoverable::new(self.tab_bar_hover_state.clone(), |_| content)
-            .with_hover_out_delay(Duration::from_millis(500))
+            .with_hover_in_delay(TAB_BAR_HOVER_IN_DELAY)
             .on_hover(|_is_hovered, ctx, _app, _position| {
                 ctx.dispatch_typed_action(WorkspaceAction::SyncTrafficLights);
             })
@@ -21454,6 +21496,46 @@ impl Workspace {
                 ctx,
             ),
             TAB_BAR_POSITION_ID,
+        )
+        .finish()
+    }
+
+    /// Renders the tab bar for [`ShowTabBar::Overlay`]: the same bar as the
+    /// stacked one, but floated over the content at the very top of the window.
+    ///
+    /// Two things differ from the stacked bar because it no longer sits in the
+    /// content column:
+    /// - It is stretched to the full window width. A positioned stack child is
+    ///   laid out with a zero minimum width, so the bar's flex row would
+    ///   otherwise shrink to its contents instead of spanning the window.
+    /// - It paints its own opaque background. The stacked bar borrows the
+    ///   workspace background painted behind it, which here would let the
+    ///   terminal content underneath show through the tabs. The fill is
+    ///   flattened to a solid color: `background()` may be a gradient, whose
+    ///   stops are normalized to the element it paints, and a full-window ramp
+    ///   squeezed into a tab-bar-tall strip would not match the window behind
+    ///   it.
+    fn render_tab_bar_overlay(
+        &self,
+        appearance: &Appearance,
+        ctx: &AppContext,
+    ) -> Box<dyn Element> {
+        let full_width_bar = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_child(
+                Expanded::new(
+                    1.,
+                    self.render_tab_bar(self.tab_fixed_width, appearance, ctx),
+                )
+                .finish(),
+            )
+            .finish();
+
+        SavePosition::new(
+            Container::new(full_width_bar)
+                .with_background_color(appearance.theme().background().into())
+                .finish(),
+            TAB_BAR_OVERLAY_POSITION_ID,
         )
         .finish()
     }
@@ -26683,6 +26765,25 @@ impl View for Workspace {
                 .finish(),
         );
 
+        // A hover-revealed tab bar floats above the content instead of taking a
+        // row in it, anchored to the very top of the window rather than inset by
+        // `WORKSPACE_PADDING`. That keeps the hover strip which reveals the bar
+        // (also anchored at the window's top-left) fully inside the revealed
+        // bar, so the pointer that opened it stays over it. It is added here,
+        // ahead of the menus below, so the bar's `SavePosition` entries are in
+        // the position cache before anything anchored to them is laid out.
+        if tab_bar_mode == ShowTabBar::Overlay {
+            stack.add_positioned_child(
+                self.render_tab_bar_overlay(appearance, app),
+                OffsetPositioning::offset_from_parent(
+                    Vector2F::zero(),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::TopLeft,
+                    ChildAnchor::TopLeft,
+                ),
+            );
+        }
+
         if !use_simplified_wasm_tab_bar
             && FeatureFlag::VerticalTabs.is_enabled()
             && *TabSettings::as_ref(app).use_vertical_tabs
@@ -26811,6 +26912,7 @@ impl View for Workspace {
 
         match tab_bar_mode {
             ShowTabBar::Stacked => (), // The tab bar was rendered in the content column.
+            ShowTabBar::Overlay => (), // The tab bar was floated above the content column.
             ShowTabBar::Hidden => {
                 // Hide the tab bar, but include a hover area.
                 stack.add_positioned_child(
@@ -26825,10 +26927,10 @@ impl View for Workspace {
             }
         }
 
-        // If the tab bar is being shown in "stacked" mode, we want to render
-        // the traffic lights relative to the full workspace, so they appear
-        // in the top-right corner even if a right-side panel is open.
-        if tab_bar_mode == ShowTabBar::Stacked {
+        // Whenever the tab bar is showing, we want to render the traffic lights
+        // relative to the full workspace, so they appear in the top-right corner
+        // even if a right-side panel is open.
+        if tab_bar_mode.has_tab_bar() {
             self.maybe_render_traffic_lights(&mut stack, app);
         }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -569,6 +569,18 @@ pub const TAB_BAR_HEIGHT: f32 = 34.;
 pub const PANEL_HEADER_HEIGHT: f32 = TAB_BAR_HEIGHT;
 /// The hover area height for states where the tab bar is revealed on hover.
 const TAB_BAR_HOVER_HEIGHT: f32 = 12.;
+/// How long the pointer has to rest in the hover area before a hidden tab bar is
+/// revealed. Without a delay, merely sweeping the pointer across the top of the
+/// window pops the bar open.
+///
+/// Do not pair this with a hover-out delay. A delayed transition resolves on the
+/// synthetic [`Event::MouseMoved`] the framework replays after each frame, and
+/// [`Hoverable`] drops the redraw for a state change whose previous change was
+/// also synthetic. With both delays every transition is synthetic, so hiding
+/// would flip the state without scheduling the frame that repaints it and the
+/// bar would linger until something unrelated redrew. Hiding therefore stays
+/// undelayed, resolving on the real mouse move that leaves the bar.
+const TAB_BAR_HOVER_IN_DELAY: Duration = Duration::from_millis(250);
 const TAB_BAR_PADDING_LEFT: f32 = 4.;
 const TAB_BAR_PADDING_RIGHT: f32 = 8.;
 const TITLE_BAR_SEARCH_BAR_MAX_WIDTH: f32 = 320.;
@@ -595,6 +607,13 @@ const THEME_CHOOSER_RATIO: f32 = 3.5;
 
 /// Save position for the tab bar.
 pub(crate) const TAB_BAR_POSITION_ID: &str = "workspace_view:tab_bar";
+/// Save position for the strip that reveals a hidden tab bar on hover. Recorded
+/// so the reveal strip and the revealed bar can be checked against each other.
+pub(crate) const TAB_BAR_HOVER_AREA_POSITION_ID: &str = "workspace_view:tab_bar_hover_area";
+/// Save position for the container holding a hover-revealed tab bar. Unlike the
+/// bar itself, this is the element laid out against the whole window, so its
+/// recorded size is what tells us the overlay stayed a strip at the top.
+pub(crate) const TAB_BAR_OVERLAY_POSITION_ID: &str = "workspace_view:tab_bar_overlay";
 const TEAM_SWITCHER_PILL_POSITION_ID: &str = "workspace_view:team_switcher_pill";
 const TEAM_SWITCHER_DOT_ALPHA: u8 = 204;
 
@@ -836,13 +855,22 @@ enum ShowTabBar {
     /// Show the tab bar stacked on top of the pane group area.
     #[default]
     Stacked,
+    /// Float the tab bar over the top of the window without reserving any
+    /// layout space for it. Used whenever the bar is revealed on hover, for two
+    /// reasons: keeping it out of the content column means revealing it never
+    /// reflows the panes, and anchoring it at the very top of the window keeps
+    /// the hover strip that reveals it inside the revealed bar's own hover area.
+    /// A stacked bar starts below [`WORKSPACE_PADDING`], so the topmost pixel
+    /// row of the window would reveal the bar and then sit outside it, making
+    /// the bar oscillate open and closed under a stationary pointer.
+    Overlay,
     /// Hide the tab bar.
     Hidden,
 }
 
 impl ShowTabBar {
     fn has_tab_bar(self) -> bool {
-        matches!(self, ShowTabBar::Stacked)
+        matches!(self, ShowTabBar::Stacked | ShowTabBar::Overlay)
     }
 }
 
@@ -14302,8 +14330,11 @@ impl Workspace {
             .workspace_decoration_visibility
             .value();
 
+        // A bar that comes and goes floats over the content rather than taking a
+        // row in it, so revealing it doesn't shove every pane down by the height
+        // of the bar. See [`ShowTabBar::Overlay`].
         let hovered_visibility = if is_pane_being_dragged || is_hovered || is_tab_menu_open {
-            ShowTabBar::Stacked
+            ShowTabBar::Overlay
         } else {
             ShowTabBar::Hidden
         };
@@ -20669,17 +20700,28 @@ impl Workspace {
 
     /// Renders an invisible rect for detecting hovers over the tab bar.
     fn render_tab_bar_hover_area(&self) -> Box<dyn Element> {
-        self.render_tab_bar_hoverable(
-            ConstrainedBox::new(Empty::new().finish())
-                .with_height(TAB_BAR_HOVER_HEIGHT)
-                .finish(),
+        SavePosition::new(
+            self.render_tab_bar_hoverable(
+                ConstrainedBox::new(Empty::new().finish())
+                    .with_height(TAB_BAR_HOVER_HEIGHT)
+                    .finish(),
+            ),
+            TAB_BAR_HOVER_AREA_POSITION_ID,
         )
+        .finish()
     }
 
     /// Renders the provided content wrapped in the tab bar hover behavior.
+    ///
+    /// The same mouse state backs both the hover strip that reveals a hidden tab
+    /// bar and the revealed bar itself, so this delay governs how long the
+    /// pointer must linger to open the bar. The revealed bar covers the strip,
+    /// so the pointer that opened it stays over it and only a move that leaves
+    /// the bar entirely hides it; see [`TAB_BAR_HOVER_IN_DELAY`] for why that
+    /// direction must stay undelayed.
     fn render_tab_bar_hoverable(&self, content: Box<dyn Element>) -> Box<dyn Element> {
         Hoverable::new(self.tab_bar_hover_state.clone(), |_| content)
-            .with_hover_out_delay(Duration::from_millis(500))
+            .with_hover_in_delay(TAB_BAR_HOVER_IN_DELAY)
             .on_hover(|_is_hovered, ctx, _app, _position| {
                 ctx.dispatch_typed_action(WorkspaceAction::SyncTrafficLights);
             })
@@ -21413,6 +21455,46 @@ impl Workspace {
                 ctx,
             ),
             TAB_BAR_POSITION_ID,
+        )
+        .finish()
+    }
+
+    /// Renders the tab bar for [`ShowTabBar::Overlay`]: the same bar as the
+    /// stacked one, but floated over the content at the very top of the window.
+    ///
+    /// Two things differ from the stacked bar because it no longer sits in the
+    /// content column:
+    /// - It is stretched to the full window width. A positioned stack child is
+    ///   laid out with a zero minimum width, so the bar's flex row would
+    ///   otherwise shrink to its contents instead of spanning the window.
+    /// - It paints its own opaque background. The stacked bar borrows the
+    ///   workspace background painted behind it, which here would let the
+    ///   terminal content underneath show through the tabs. The fill is
+    ///   flattened to a solid color: `background()` may be a gradient, whose
+    ///   stops are normalized to the element it paints, and a full-window ramp
+    ///   squeezed into a tab-bar-tall strip would not match the window behind
+    ///   it.
+    fn render_tab_bar_overlay(
+        &self,
+        appearance: &Appearance,
+        ctx: &AppContext,
+    ) -> Box<dyn Element> {
+        let full_width_bar = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_child(
+                Expanded::new(
+                    1.,
+                    self.render_tab_bar(self.tab_fixed_width, appearance, ctx),
+                )
+                .finish(),
+            )
+            .finish();
+
+        SavePosition::new(
+            Container::new(full_width_bar)
+                .with_background_color(appearance.theme().background().into())
+                .finish(),
+            TAB_BAR_OVERLAY_POSITION_ID,
         )
         .finish()
     }
@@ -26694,6 +26776,25 @@ impl View for Workspace {
                 .finish(),
         );
 
+        // A hover-revealed tab bar floats above the content instead of taking a
+        // row in it, anchored to the very top of the window rather than inset by
+        // `WORKSPACE_PADDING`. That keeps the hover strip which reveals the bar
+        // (also anchored at the window's top-left) fully inside the revealed
+        // bar, so the pointer that opened it stays over it. It is added here,
+        // ahead of the menus below, so the bar's `SavePosition` entries are in
+        // the position cache before anything anchored to them is laid out.
+        if tab_bar_mode == ShowTabBar::Overlay {
+            stack.add_positioned_child(
+                self.render_tab_bar_overlay(appearance, app),
+                OffsetPositioning::offset_from_parent(
+                    Vector2F::zero(),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::TopLeft,
+                    ChildAnchor::TopLeft,
+                ),
+            );
+        }
+
         if !use_simplified_wasm_tab_bar
             && FeatureFlag::VerticalTabs.is_enabled()
             && *TabSettings::as_ref(app).use_vertical_tabs
@@ -26822,6 +26923,7 @@ impl View for Workspace {
 
         match tab_bar_mode {
             ShowTabBar::Stacked => (), // The tab bar was rendered in the content column.
+            ShowTabBar::Overlay => (), // The tab bar was floated above the content column.
             ShowTabBar::Hidden => {
                 // Hide the tab bar, but include a hover area.
                 stack.add_positioned_child(
@@ -26836,10 +26938,10 @@ impl View for Workspace {
             }
         }
 
-        // If the tab bar is being shown in "stacked" mode, we want to render
-        // the traffic lights relative to the full workspace, so they appear
-        // in the top-right corner even if a right-side panel is open.
-        if tab_bar_mode == ShowTabBar::Stacked {
+        // Whenever the tab bar is showing, we want to render the traffic lights
+        // relative to the full workspace, so they appear in the top-right corner
+        // even if a right-side panel is open.
+        if tab_bar_mode.has_tab_bar() {
             self.maybe_render_traffic_lights(&mut stack, app);
         }
 

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -4264,8 +4264,82 @@ fn test_standard_tab_context_menu_shows_hover_only_tab_bar() {
             workspace.show_tab_right_click_menu =
                 Some((0, TabContextMenuAnchor::Pointer(Vector2F::zero())));
 
-            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Stacked);
+            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Overlay);
         });
+    });
+}
+
+/// A tab bar that is revealed on hover has to cover the strip that reveals it.
+/// If the strip pokes out above the revealed bar, the pointer that opened the
+/// bar ends up outside of it, the bar hides itself, the strip is put back under
+/// the pointer, and the bar flickers open and closed without the mouse moving.
+#[test]
+fn test_hover_revealed_tab_bar_covers_its_hover_strip() {
+    let _full_screen_zen_mode_guard = FeatureFlag::FullScreenZenMode.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        let window_id = workspace.update(&mut app, |workspace, ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(
+                    settings
+                        .workspace_decoration_visibility
+                        .set_value(WorkspaceDecorationVisibility::OnHover, ctx)
+                );
+            });
+            workspace.should_show_ai_assistant_warm_welcome = false;
+            workspace.window_id
+        });
+
+        // Unhovered: the bar is hidden and only the reveal strip is rendered.
+        // Positions come from the previously rendered frame, so each state has to
+        // be set up in its own update and measured in the next one.
+        let hover_strip = workspace.update(&mut app, |workspace, ctx| {
+            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Hidden);
+            ctx.element_position_by_id_at_last_frame(window_id, TAB_BAR_HOVER_AREA_POSITION_ID)
+                .expect("the hover strip should be rendered while the tab bar is hidden")
+        });
+
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.tab_bar_pinned_by_popup = true;
+            ctx.notify();
+        });
+
+        // Revealed: the bar is rendered where the strip used to be.
+        let (revealed_bar, overlay) = workspace.update(&mut app, |workspace, ctx| {
+            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Overlay);
+            (
+                ctx.element_position_by_id_at_last_frame(window_id, TAB_BAR_POSITION_ID)
+                    .expect("the tab bar should be rendered once revealed"),
+                ctx.element_position_by_id_at_last_frame(window_id, TAB_BAR_OVERLAY_POSITION_ID)
+                    .expect("the overlay container should be rendered once revealed"),
+            )
+        });
+
+        assert!(
+            revealed_bar.min_y() <= hover_strip.min_y()
+                && revealed_bar.max_y() >= hover_strip.max_y(),
+            "the revealed tab bar {revealed_bar:?} must cover the hover strip {hover_strip:?} \
+             vertically, otherwise revealing it moves the bar out from under the pointer"
+        );
+        assert!(
+            revealed_bar.min_x() <= hover_strip.min_x()
+                && revealed_bar.max_x() >= hover_strip.max_x(),
+            "the revealed tab bar {revealed_bar:?} must cover the hover strip {hover_strip:?} \
+             horizontally, otherwise revealing it moves the bar out from under the pointer"
+        );
+        // Covering the strip must not come from the overlay growing to fill the
+        // window. The overlay container, unlike the fixed-height bar inside it,
+        // is laid out against the whole window, so anything in it that sizes to
+        // the maximum constraint would blanket the terminal rather than sit in a
+        // strip at the top.
+        assert!(
+            overlay.height() <= TOTAL_TAB_BAR_HEIGHT,
+            "the revealed tab bar overlay {overlay:?} should be no taller than the tab bar itself \
+             ({TOTAL_TAB_BAR_HEIGHT}); a taller overlay covers the terminal"
+        );
     });
 }
 

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -4096,8 +4096,82 @@ fn test_standard_tab_context_menu_shows_hover_only_tab_bar() {
             workspace.show_tab_right_click_menu =
                 Some((0, TabContextMenuAnchor::Pointer(Vector2F::zero())));
 
-            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Stacked);
+            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Overlay);
         });
+    });
+}
+
+/// A tab bar that is revealed on hover has to cover the strip that reveals it.
+/// If the strip pokes out above the revealed bar, the pointer that opened the
+/// bar ends up outside of it, the bar hides itself, the strip is put back under
+/// the pointer, and the bar flickers open and closed without the mouse moving.
+#[test]
+fn test_hover_revealed_tab_bar_covers_its_hover_strip() {
+    let _full_screen_zen_mode_guard = FeatureFlag::FullScreenZenMode.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        let window_id = workspace.update(&mut app, |workspace, ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(
+                    settings
+                        .workspace_decoration_visibility
+                        .set_value(WorkspaceDecorationVisibility::OnHover, ctx)
+                );
+            });
+            workspace.should_show_ai_assistant_warm_welcome = false;
+            workspace.window_id
+        });
+
+        // Unhovered: the bar is hidden and only the reveal strip is rendered.
+        // Positions come from the previously rendered frame, so each state has to
+        // be set up in its own update and measured in the next one.
+        let hover_strip = workspace.update(&mut app, |workspace, ctx| {
+            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Hidden);
+            ctx.element_position_by_id_at_last_frame(window_id, TAB_BAR_HOVER_AREA_POSITION_ID)
+                .expect("the hover strip should be rendered while the tab bar is hidden")
+        });
+
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.tab_bar_pinned_by_popup = true;
+            ctx.notify();
+        });
+
+        // Revealed: the bar is rendered where the strip used to be.
+        let (revealed_bar, overlay) = workspace.update(&mut app, |workspace, ctx| {
+            assert_eq!(workspace.tab_bar_mode(ctx), ShowTabBar::Overlay);
+            (
+                ctx.element_position_by_id_at_last_frame(window_id, TAB_BAR_POSITION_ID)
+                    .expect("the tab bar should be rendered once revealed"),
+                ctx.element_position_by_id_at_last_frame(window_id, TAB_BAR_OVERLAY_POSITION_ID)
+                    .expect("the overlay container should be rendered once revealed"),
+            )
+        });
+
+        assert!(
+            revealed_bar.min_y() <= hover_strip.min_y()
+                && revealed_bar.max_y() >= hover_strip.max_y(),
+            "the revealed tab bar {revealed_bar:?} must cover the hover strip {hover_strip:?} \
+             vertically, otherwise revealing it moves the bar out from under the pointer"
+        );
+        assert!(
+            revealed_bar.min_x() <= hover_strip.min_x()
+                && revealed_bar.max_x() >= hover_strip.max_x(),
+            "the revealed tab bar {revealed_bar:?} must cover the hover strip {hover_strip:?} \
+             horizontally, otherwise revealing it moves the bar out from under the pointer"
+        );
+        // Covering the strip must not come from the overlay growing to fill the
+        // window. The overlay container, unlike the fixed-height bar inside it,
+        // is laid out against the whole window, so anything in it that sizes to
+        // the maximum constraint would blanket the terminal rather than sit in a
+        // strip at the top.
+        assert!(
+            overlay.height() <= TOTAL_TAB_BAR_HEIGHT,
+            "the revealed tab bar overlay {overlay:?} should be no taller than the tab bar itself \
+             ({TOTAL_TAB_BAR_HEIGHT}); a taller overlay covers the terminal"
+        );
     });
 }
 


### PR DESCRIPTION
## Description

In fullscreen, a hover-revealed tab bar flickered open and closed while the pointer stood still at the top edge of the screen, reflowing every pane by the height of the bar on each flip.

The point that *revealed* the bar was not inside the region that *kept* it revealed. The reveal strip is a positioned stack child anchored at the window's top-left, `TAB_BAR_HOVER_HEIGHT` (12) tall. The revealed bar was added to the content column, which is inset by `WORKSPACE_PADDING`, so it started one pixel lower. Measured from the rendered scene at a 1024x768 window:

| element | before | after |
|---|---|---|
| reveal strip | `RectF(<0, 0, 1024, 12>)` | unchanged |
| revealed bar | `RectF(<1, 1, 1023, 36>)` | `RectF(<0, 0, 1024, 35>)` |

The top pixel row revealed the bar and then sat outside it. In fullscreen the cursor clamps to `y = 0` at the screen edge, which is exactly that band, so the bar oscillated with no mouse movement at all: `build_scene` replays the last pointer position as a synthetic `MouseMoved` after every frame, and there is no mouse-exit event to invalidate that stored position.

This adds `ShowTabBar::Overlay`, used for every hover reveal. The bar is positioned at the window's top-left over the content instead of taking a row in the column, so it now covers a superset of the strip — the pointer that opened it stays over it — and revealing it no longer moves any pane. Two things follow from leaving the column: the overlay stretches itself to the full window width (a positioned stack child is laid out with a zero minimum width), and it paints its own background, flattened to a solid color because `theme.background()` may be a gradient whose stops would otherwise be squeezed into a 35 px strip.

Revealing now takes a 250 ms hover-in delay, so a sweep across the top of the window no longer pops the bar open. Hiding deliberately stays undelayed: `Hoverable` drops the redraw for a state change whose previous change was also synthetic, and with both delays set every transition resolves on the synthetic `MouseMoved` replayed after a frame — the bar would flip to hidden without scheduling the frame that repaints it. That constraint is recorded next to the constant.

## Linked Issue

Fixes #14945.

Related: #10784 is the same mechanism seen from the other side — the reveal pushing content down made a tmux top status line escape the cursor, so chasing it re-triggered the bar. This removes that chase: content no longer moves when the bar appears, and the 250 ms hover-in delay means a deliberate move to click the status line lands before the bar reveals at all. It is not a complete fix for that report, though — once the bar *is* revealed it sits over the terminal's top row, so a tmux status line there is covered while the bar is up. Leaving #10784 open for that remainder.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. — #14945 was filed alongside this PR and has not been triaged yet.
- [x] Screenshots or a short video are included.

### Screenshots / Videos

Fullscreen, pointer parked at the top edge and not moved, with a colour grid filling the viewport so
any vertical movement is readable straight off the row numbers.

**Before** — revealing the bar reflows the whole column: the grid and the vertical-tabs sidebar jump
by the bar's height every time it flips.

![Fullscreen hover reveal before the fix](https://raw.githubusercontent.com/bobrnor/warp/pr-media/media/14947-before.gif)

**After** — the bar fades in over the content and nothing underneath moves.

![Fullscreen hover reveal after the fix](https://raw.githubusercontent.com/bobrnor/warp/pr-media/media/14947-after.gif)

Measured rather than eyeballed: taking the lower half of the screen — which the bar never covers —
and cross-correlating every consecutive frame pair at 10 fps gives

| | vertical content jumps | jump size |
|---|---|---|
| before | 16 | ±70px, i.e. the bar's 35pt at 2x |
| after | **0** of 132 frame pairs | — |

Full clips: [before](https://raw.githubusercontent.com/bobrnor/warp/pr-media/media/14947-before.mp4) · [after](https://raw.githubusercontent.com/bobrnor/warp/pr-media/media/14947-after.mp4). The "before" half is a
released build (0.2026.08.05) and the "after" is an OSS build carrying this branch, since the change
is not in any channel yet; the scenario and the machine are otherwise identical.

One thing the clips show that this PR does *not* claim to change: the macOS menu bar still slides in
whenever the pointer touches the very top of the screen. That is the system's own behaviour, and it
happens in both halves.

## Testing

Added `test_hover_revealed_tab_bar_covers_its_hover_strip`, which renders both states and asserts the invariant the bug violated: the revealed bar must cover the strip that reveals it. It also asserts the overlay stays a strip at the top rather than growing into the full-window constraint it is now laid out against.

Both assertions were verified to be capable of failing, not just passing:

- With `hovered_visibility` reverted to `Stacked`, the coverage assertion fails with `revealed tab bar RectF(<1, 1, 1023, 36>) must cover the hover strip RectF(<0, 0, 1024, 12>)` — this is where the measurements above come from.
- Tightening the height bound reports the overlay as `RectF(<0, 0, 1024, 35>)`, confirming it is a top strip and that the bound is not vacuous.

Existing coverage only asserted the `tab_bar_mode` enum, never the geometry, which is why this survived.

Also run: `cargo test -p warp --lib workspace::` (209 passed), the full `cargo test -p warp --lib` suite compared against a clean-tree baseline (identical failure set; the one extra failure floats between different tests in `secret_redaction` across runs on unchanged code), `cargo clippy -p warp --all-targets --tests -- -D warnings`, and `cargo fmt`.

- [x] I have manually tested my changes locally with `./script/run`.

**Not manually verified in the GUI** — this needs a human pass before merge. Worth checking specifically: the revealed bar looks right over a transparent background and under a gradient theme, hiding feels right now that it is immediate rather than delayed by 500 ms, and dragging a tab out of the revealed bar still behaves.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed the tab bar flickering open and closed, and jolting terminal content, when the pointer reached the top of the screen in fullscreen. It now fades in over the content without moving your panes, and only after the pointer rests there briefly.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoefEcZFpauaaUcSVANoMn

