### PR TITLE
[QUALITY-1333] Harden TUI focus ownership

### DIFF
--- a/crates/warp_tui/src/attachment_bar/view.rs
+++ b/crates/warp_tui/src/attachment_bar/view.rs
@@ -133,16 +133,8 @@ pub(crate) fn init(app: &mut AppContext) {
 
 impl TuiAttachmentBar {
     pub(crate) fn new(model: ModelHandle<TuiAttachmentModel>, ctx: &mut ViewContext<Self>) -> Self {
-        let model_for_subscription = model.clone();
         ctx.subscribe_to_model(&model, move |_, _, event, ctx| match event {
             TuiAttachmentModelEvent::Updated => {
-                // TUI notifications invalidate the whole window, including the
-                // parent that conditionally renders this attachment bar.
-                // Emit ReturnFocus to prevent holding a stale frame
-                // (ex. showing the image chip after it's removed).
-                if !model_for_subscription.as_ref(ctx).should_render(ctx) {
-                    ctx.emit(TuiAttachmentBarEvent::ReturnFocus);
-                }
                 ctx.notify();
             }
             TuiAttachmentModelEvent::AbortInputDetection => {
@@ -183,6 +175,12 @@ impl TuiAttachmentBar {
     pub(crate) fn paste_from_clipboard(&mut self, ctx: &mut ViewContext<Self>) {
         self.model
             .update(ctx, |model, ctx| model.paste_from_clipboard(ctx));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn emit_model_updated_for_test(&self, ctx: &mut ViewContext<Self>) {
+        self.model
+            .update(ctx, |_, ctx| ctx.emit(TuiAttachmentModelEvent::Updated));
     }
 
     pub(crate) fn remove_selected(&mut self, ctx: &mut ViewContext<Self>) {

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -150,6 +150,8 @@ pub fn init(app: &mut AppContext) {
 /// Events emitted by [`TuiInputView`].
 #[derive(Debug, Clone)]
 pub enum TuiInputViewEvent {
+    /// Pointer interaction requested focus for the session's current input owner.
+    FocusRequested,
     /// The user pressed Enter to submit the current input. Contains the final text.
     Submitted(String),
     /// The terminal delivered one complete bracketed-paste payload.
@@ -791,6 +793,17 @@ impl TypedActionView for TuiInputView {
     type Action = TuiInputAction;
 
     fn handle_action(&mut self, action: &TuiInputAction, ctx: &mut ViewContext<Self>) {
+        if matches!(
+            action,
+            TuiInputAction::Editor(
+                TuiEditorAction::SelectionStartAt { .. }
+                    | TuiEditorAction::SelectionExtendTo { .. }
+                    | TuiEditorAction::SelectWordAt { .. }
+                    | TuiEditorAction::SelectLineAt { .. }
+            ) | TuiInputAction::SetCursor { .. }
+        ) {
+            ctx.emit(TuiInputViewEvent::FocusRequested);
+        }
         if self.handle_inline_menu_action(action, ctx) {
             return;
         }

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -2236,6 +2236,7 @@ fn multiline_paste_emits_once_and_fallback_inserts_without_submitting() {
                 | TuiInputViewEvent::AcceptedPromptAndCommandHistory { .. }
                 | TuiInputViewEvent::RequestShellCompletion
                 | TuiInputViewEvent::BackspaceAtEmptyInput
+                | TuiInputViewEvent::FocusRequested
                 | TuiInputViewEvent::MoveFocusUp
                 | TuiInputViewEvent::ClipboardCopySucceeded
                 | TuiInputViewEvent::ClipboardCopyFailed
@@ -3213,6 +3214,28 @@ fn printable_input_is_accepted_only_while_focused() {
     });
 }
 
+#[test]
+fn mouse_selection_requests_focus() {
+    App::test((), |mut app| async move {
+        let focus_requests = Rc::new(Cell::new(0));
+        let focus_requests_for_subscription = focus_requests.clone();
+        let view = app.update(|ctx| {
+            let view = build_view(ctx);
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiInputViewEvent::FocusRequested) {
+                    focus_requests_for_subscription.set(focus_requests_for_subscription.get() + 1);
+                }
+            });
+            view
+        });
+
+        app.update(|ctx| {
+            assert!(mouse(&view, ctx, &left_down(0, 0, 1, false)));
+        });
+
+        assert_eq!(focus_requests.get(), 1);
+    });
+}
 /// Drives the full mouse path for `event`: lay out the element, map the event to
 /// its editor action, and apply the corresponding [`TuiInputAction`] to the view.
 /// Returns whether an action fired (i.e. the event was not ignored).

--- a/crates/warp_tui/src/orchestration_block.rs
+++ b/crates/warp_tui/src/orchestration_block.rs
@@ -530,9 +530,12 @@ impl TuiOrchestrationBlock {
 
     /// Returns from configuration to the interactive acceptance card.
     fn return_to_acceptance(&mut self, ctx: &mut ViewContext<Self>) {
+        let retain_focus = ctx.is_self_or_child_focused();
         self.mode = CardMode::Acceptance;
         self.pending_page_navigation = None;
-        ctx.focus_self();
+        if retain_focus {
+            ctx.focus_self();
+        }
         ctx.emit(TuiOrchestrationBlockEvent::LayoutInvalidated);
         ctx.notify();
     }

--- a/crates/warp_tui/src/orchestration_block_tests.rs
+++ b/crates/warp_tui/src/orchestration_block_tests.rs
@@ -757,6 +757,29 @@ fn confirming_a_search_result_returns_focus_to_the_acceptance_card() {
         assert_eq!(app.focused_view_id(window_id), Some(block.id()));
     });
 }
+
+#[test]
+fn background_page_invalidation_does_not_take_focus() {
+    App::test((), |mut app| async move {
+        let (block, _) = test_block(&mut app, &request("oz", RunAgentsExecutionMode::Local));
+        block.update(&mut app, |block, ctx| {
+            block.open_page(ConfigPage::Model, ctx);
+        });
+        let window_id = block.read(&app, |_, ctx| block.window_id(ctx));
+        let focus_target = app.update(|ctx| ctx.add_tui_view(window_id, |_| TestHostView));
+        focus_target.update(&mut app, |_, ctx| ctx.focus_self());
+
+        block.update(&mut app, |block, ctx| {
+            block.return_to_acceptance(ctx);
+        });
+
+        assert!(app.read(|ctx| focus_target.is_focused(ctx)));
+        assert_eq!(
+            block.read(&app, |block, _| block.mode),
+            CardMode::Acceptance
+        );
+    });
+}
 #[test]
 fn accepting_dispatches_once_and_releases_focus() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/root_view.rs
+++ b/crates/warp_tui/src/root_view.rs
@@ -11,7 +11,9 @@ use warpui_core::elements::tui::{TuiChildView, TuiElement};
 use warpui_core::keymap::FixedBinding;
 use warpui_core::keymap::macros::*;
 use warpui_core::platform::TerminationMode;
-use warpui_core::{AppContext, Entity, EntityId, TuiView, TypedActionView, ViewContext, keymap};
+use warpui_core::{
+    AppContext, Entity, EntityId, FocusContext, TuiView, TypedActionView, ViewContext, keymap,
+};
 
 use crate::clipboard::copy_to_clipboard;
 use crate::keybindings::TUI_BINDING_GROUP;
@@ -209,6 +211,14 @@ impl TuiView for RootTuiView {
         }
     }
 
+    fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
+        if focus_ctx.is_self_focused()
+            && matches!(self.state, RootTuiState::Terminal)
+            && let Some(view) = self.focused_session_view(ctx)
+        {
+            view.activate(ctx);
+        }
+    }
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
         match self.state {
             RootTuiState::Auth => match TuiLoginModel::as_ref(ctx).phase() {

--- a/crates/warp_tui/src/root_view_tests.rs
+++ b/crates/warp_tui/src/root_view_tests.rs
@@ -52,6 +52,49 @@ fn start_device_login_action_retries_from_failure() {
         });
     });
 }
+
+#[test]
+fn terminal_root_focus_delegates_to_the_selected_session() {
+    App::test((), |mut app| async move {
+        register_tui_session_view_test_singletons(&mut app);
+        add_test_semantic_selection(&mut app);
+        app.update(crate::autoupdate::TuiAutoupdater::register);
+        let (window_id, root) = add_root(&mut app);
+        let sessions = app.add_singleton_model(|_| TuiSessions::new_for_test());
+        let (foreground, foreground_manager) = add_test_terminal_session(&mut app, window_id);
+        let foreground_id = app.update(|ctx| {
+            TuiSessions::register_session(
+                &sessions,
+                foreground.clone(),
+                foreground_manager,
+                true,
+                ctx,
+            )
+        });
+        let (background, background_manager) = add_test_terminal_session(&mut app, window_id);
+        app.update(|ctx| {
+            TuiSessions::register_session(
+                &sessions,
+                background.clone(),
+                background_manager,
+                false,
+                ctx,
+            );
+        });
+        root.update(&mut app, |root, ctx| root.show_terminal(ctx));
+
+        background.update(&mut app, |background, ctx| background.activate(ctx));
+        assert!(app.read(|ctx| { ctx.check_view_or_child_focused(window_id, &background.id()) }));
+        assert_eq!(
+            app.read(|ctx| TuiSessions::as_ref(ctx).focused_session_id()),
+            Some(foreground_id)
+        );
+
+        root.update(&mut app, |_, ctx| ctx.focus_self());
+
+        assert!(app.read(|ctx| { ctx.check_view_or_child_focused(window_id, &foreground.id()) }));
+    });
+}
 #[test]
 fn pending_copy_clears_on_failure_before_url_generation() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -24,7 +24,7 @@ use warp_core::telemetry::TelemetryEvent as _;
 use warp_errors::report_error;
 use warpui::SingletonEntity as _;
 use warpui_core::platform::{TerminationMode, WindowStyle};
-use warpui_core::runtime::spawn_tui_driver;
+use warpui_core::runtime::{TuiFocusPolicy, spawn_tui_driver};
 use warpui_core::{AddWindowOptions, AppContext, ModelHandle, ViewHandle};
 
 use crate::clipboard::copy_to_clipboard;
@@ -265,6 +265,7 @@ fn init(
         ctx,
         window_id,
         root.clone(),
+        TuiFocusPolicy::PresentedTree,
         modifier_key_lifecycle_enabled,
         freeze_repaints_when_unfocused,
     ) {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -1900,6 +1900,7 @@ impl TuiTerminalSessionView {
         });
 
         ctx.subscribe_to_view(&input_view, |view, _, event, ctx| match event {
+            TuiInputViewEvent::FocusRequested => view.reconcile_focus(ctx),
             TuiInputViewEvent::Submitted(text) => view.handle_submitted(text.clone(), None, ctx),
             TuiInputViewEvent::Pasted(text) => view.handle_pasted(text.clone(), ctx),
             TuiInputViewEvent::BackspaceAtEmptyInput => {
@@ -3400,7 +3401,7 @@ impl TuiTerminalSessionView {
             TuiAttachmentBarEvent::ShowHint(text) => {
                 self.show_transient_hint(text.clone(), ctx);
             }
-            TuiAttachmentBarEvent::ReturnFocus => ctx.focus(&self.input_view),
+            TuiAttachmentBarEvent::ReturnFocus => self.reconcile_focus(ctx),
         }
         ctx.notify();
     }

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -7,6 +7,7 @@ use ai::LLMProvider;
 use ai::api_keys::ApiKeyManager;
 use chrono::NaiveDate;
 use instant::Instant;
+use string_offset::CharOffset;
 use tempfile::TempDir;
 use warp::appearance::Appearance;
 #[cfg(feature = "voice_input")]
@@ -84,7 +85,9 @@ use super::{
 };
 use crate::agent_block::{TuiAIBlock, upgrade_url};
 use crate::autoupdate::TuiAutoupdater;
+use crate::editor_element::TuiEditorAction;
 use crate::inline_menu::MAX_INLINE_MENU_ROWS;
+use crate::input::view::TuiInputAction;
 use crate::input_mode_policy::{AI_LOCKED_CONFIG, AI_UNLOCKED_CONFIG};
 use crate::input_suggestions_mode::TuiInputSuggestionsMode;
 use crate::keybindings::{
@@ -5684,6 +5687,81 @@ fn background_focus_reconciliation_does_not_steal_foreground_focus() {
     });
 }
 
+#[test]
+fn empty_background_attachment_update_does_not_steal_foreground_focus() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (foreground, _) = add_focus_test_session(&mut app, &fixture, true);
+        let (background, _) = add_focus_test_session(&mut app, &fixture, false);
+        let foreground_input_id = foreground.read(&app, |view, _| view.input_view.id());
+
+        background.update(&mut app, |view, ctx| {
+            assert!(!view.attachment_bar.as_ref(ctx).should_render(ctx));
+            view.attachment_bar
+                .update(ctx, |bar, ctx| bar.emit_model_updated_for_test(ctx));
+        });
+
+        app.read(|ctx| {
+            assert_eq!(
+                ctx.focused_view_id(fixture.window_id),
+                Some(foreground_input_id),
+                "an empty background context update must not focus its hidden input"
+            );
+        });
+    });
+}
+
+#[test]
+fn foreground_input_pointer_action_recovers_focus_from_background_session() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (foreground, _) = add_focus_test_session(&mut app, &fixture, true);
+        let (background, _) = add_focus_test_session(&mut app, &fixture, false);
+        let foreground_input = foreground.read(&app, |view, _| view.input_view.clone());
+        let background_input = background.read(&app, |view, _| view.input_view.clone());
+
+        background_input.update(&mut app, |_, ctx| ctx.focus_self());
+        foreground_input.update(&mut app, |input, ctx| {
+            input.handle_action(
+                &TuiInputAction::Editor(TuiEditorAction::SelectionStartAt {
+                    offset: CharOffset::from(1),
+                }),
+                ctx,
+            );
+        });
+
+        assert!(app.read(|ctx| foreground_input.is_focused(ctx)));
+    });
+}
+
+#[test]
+fn stale_foreground_input_pointer_action_preserves_new_pty_owner() {
+    App::test((), |mut app| async move {
+        let fixture = focus_test_fixture(&mut app);
+        let (foreground, _) = add_focus_test_session(&mut app, &fixture, true);
+        let (background, _) = add_focus_test_session(&mut app, &fixture, false);
+        let foreground_input = foreground.read(&app, |view, _| view.input_view.clone());
+        let background_input = background.read(&app, |view, _| view.input_view.clone());
+
+        foreground.update(&mut app, |view, _| {
+            view.terminal_model
+                .lock()
+                .simulate_long_running_block("cat", "");
+            assert!(view.input_target().pty_owns_input());
+        });
+        background_input.update(&mut app, |_, ctx| ctx.focus_self());
+        foreground_input.update(&mut app, |input, ctx| {
+            input.handle_action(
+                &TuiInputAction::Editor(TuiEditorAction::SelectionStartAt {
+                    offset: CharOffset::from(1),
+                }),
+                ctx,
+            );
+        });
+
+        assert!(app.read(|ctx| foreground.is_focused(ctx)));
+    });
+}
 struct LateMaterializationBlockModel {
     conversation_id: AIConversationId,
     status: AIBlockOutputStatus,

--- a/crates/warpui_core/src/presenter/tui.rs
+++ b/crates/warpui_core/src/presenter/tui.rs
@@ -45,7 +45,9 @@ use crate::elements::tui::{
     TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
     TuiPresentationContext, TuiRect, TuiScene, TuiScreenPosition, TuiSize,
 };
-use crate::{AppContext, EntityIdMap, TuiView, ViewHandle, WindowId, WindowInvalidation};
+use crate::{
+    AppContext, EntityIdMap, EntityIdSet, TuiView, ViewHandle, WindowId, WindowInvalidation,
+};
 
 /// A painted frame: the composited cell [`TuiBuffer`] plus the absolute cursor
 /// position (in buffer cell coordinates), if a focused element owns the cursor.
@@ -96,6 +98,8 @@ pub struct TuiPresenter {
     pub(crate) last_element: Option<Box<dyn TuiElement>>,
     /// The retained scene painted from `last_element`.
     pub(crate) last_scene: Option<Rc<TuiScene>>,
+    /// View IDs embedded in the most recently presented frame, including the root.
+    pub(crate) presented_views: EntityIdSet,
     /// Whether [`invalidate`](Self::invalidate) ran since the last
     /// [`present`](Self::present). When it did, every changed view was
     /// re-rendered into `rendered_views`, so `last_element` is current and a
@@ -181,6 +185,7 @@ impl TuiPresenter {
         else {
             self.last_element = None;
             self.last_scene = None;
+            self.presented_views.clear();
             return TuiFrame::blank(area);
         };
 
@@ -199,6 +204,8 @@ impl TuiPresenter {
             );
             element.present(&mut present_ctx);
         }
+        self.presented_views = embeddings.keys().copied().collect();
+        self.presented_views.insert(root_view_id);
         ctx.report_view_embeddings(window_id, embeddings);
 
         let (frame, scene) = paint(element.as_mut(), arranged, area, &mut self.rendered_views);
@@ -218,6 +225,7 @@ impl TuiPresenter {
         area: TuiRect,
         app: &AppContext,
     ) -> TuiFrame {
+        self.presented_views.clear();
         let mut layout_ctx = TuiLayoutContext {
             rendered_views: &mut self.rendered_views,
         };

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -139,6 +139,7 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
             self.presenter
                 .invalidate(&invalidation, ctx, self.window_id);
             frame = Some(self.presenter.present(ctx, &self.root_view, area));
+            self.repair_focus_outside_presented_tree(ctx);
             self.replay_mouse_position(ctx);
         }
         let frame = frame.expect("loop always presents at least once");
@@ -147,6 +148,14 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
         self.renderer
             .draw(&mut writer, &frame.buffer, frame.cursor)?;
         Ok(frame.repaint_at)
+    }
+    fn repair_focus_outside_presented_tree(&mut self, ctx: &mut AppContext) {
+        let Some(focused_view_id) = ctx.focused_view_id(self.window_id) else {
+            return;
+        };
+        if !self.presenter.presented_views.contains(&focused_view_id) {
+            self.root_view.update(ctx, |_, ctx| ctx.focus_self());
+        }
     }
 
     /// Redispatches the last known pointer position as a synthetic

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -70,6 +70,17 @@ pub trait TuiTerminal {
     fn writer(&mut self) -> &mut dyn Write;
 }
 
+/// Controls whether a TUI driver constrains keyboard focus to views embedded in
+/// the most recently presented frame.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TuiFocusPolicy {
+    /// Preserve app-managed focus even when its view is not currently presented.
+    #[default]
+    Unrestricted,
+    /// Return focus to the root when the focused view is outside the presented tree.
+    PresentedTree,
+}
+
 /// The rendering half of the TUI: owns the presenter, renderer, and host
 /// terminal for one window and paints that window's view tree. Kept separate
 /// from input dispatch so the invalidation-driven redraw (which paints inside
@@ -80,6 +91,7 @@ struct TuiScreen<T, R: TuiTerminal> {
     presenter: TuiPresenter,
     renderer: TuiFrameRenderer,
     terminal: R,
+    focus_policy: TuiFocusPolicy,
     /// Synthesizes multi-click counts for left mouse presses, which crossterm
     /// does not report.
     click_tracker: ClickTracker,
@@ -100,10 +112,16 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
             presenter: TuiPresenter::new(),
             renderer: TuiFrameRenderer::new(),
             terminal,
+            focus_policy: TuiFocusPolicy::default(),
             click_tracker: ClickTracker::default(),
             shift_key_tracker: ShiftKeyTracker::default(),
             last_mouse_position: None,
         }
+    }
+
+    fn with_focus_policy(mut self, focus_policy: TuiFocusPolicy) -> Self {
+        self.focus_policy = focus_policy;
+        self
     }
 
     fn size(&self) -> io::Result<TuiSize> {
@@ -139,7 +157,9 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
             self.presenter
                 .invalidate(&invalidation, ctx, self.window_id);
             frame = Some(self.presenter.present(ctx, &self.root_view, area));
-            self.repair_focus_outside_presented_tree(ctx);
+            if self.focus_policy == TuiFocusPolicy::PresentedTree {
+                self.repair_focus_outside_presented_tree(ctx);
+            }
             self.replay_mouse_position(ctx);
         }
         let frame = frame.expect("loop always presents at least once");
@@ -609,6 +629,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     ctx: &mut AppContext,
     window_id: WindowId,
     root_view: ViewHandle<T>,
+    focus_policy: TuiFocusPolicy,
     report_modifier_key_lifecycle: bool,
     freeze_repaints_when_unfocused: bool,
 ) -> io::Result<TuiDriverHandle> {
@@ -617,11 +638,10 @@ pub fn spawn_tui_driver<T: TuiView>(
     // The presenter + renderer + terminal live behind an `Rc<RefCell<_>>` owned
     // by the invalidation callback. The input path never borrows it, so painting
     // inside `flush_effects` can't collide with dispatch.
-    let screen = Rc::new(RefCell::new(TuiScreen::new(
-        window_id,
-        root_view,
-        CrosstermTerminal::new(),
-    )));
+    let screen = Rc::new(RefCell::new(
+        TuiScreen::new(window_id, root_view, CrosstermTerminal::new())
+            .with_focus_policy(focus_policy),
+    ));
 
     // Repaint scheduling: at most one pending timer, held in this slot. Every
     // draw reports the earliest element-requested repaint deadline for the

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -245,7 +245,7 @@ impl TypedActionView for PresentedFocusRoot {
 }
 
 #[test]
-fn draw_repairs_focus_owned_by_a_view_outside_the_presented_tree() {
+fn draw_preserves_focus_outside_the_presented_tree_by_default() {
     App::test((), |mut app| async move {
         let (window_id, _) = app.update(|ctx| ctx.add_tui_window(window_options(), |_| TextView));
         let visible = app.update(|ctx| ctx.add_tui_view(window_id, |_| TextView));
@@ -257,7 +257,32 @@ fn draw_repairs_focus_owned_by_a_view_outside_the_presented_tree() {
             })
         });
         let terminal = TestTerminal::new(TuiSize::new(20, 3));
-        let mut screen = TuiScreen::new(window_id, root.clone(), terminal);
+        let mut screen = TuiScreen::new(window_id, root, terminal);
+
+        visible.update(&mut app, |_, ctx| ctx.focus_self());
+        app.update(|ctx| screen.draw(ctx)).unwrap();
+        hidden.update(&mut app, |_, ctx| ctx.focus_self());
+        app.update(|ctx| screen.draw(ctx)).unwrap();
+
+        assert!(app.read(|ctx| hidden.is_focused(ctx)));
+    });
+}
+
+#[test]
+fn opt_in_draw_repairs_focus_owned_by_a_view_outside_the_presented_tree() {
+    App::test((), |mut app| async move {
+        let (window_id, _) = app.update(|ctx| ctx.add_tui_window(window_options(), |_| TextView));
+        let visible = app.update(|ctx| ctx.add_tui_view(window_id, |_| TextView));
+        let hidden = app.update(|ctx| ctx.add_tui_view(window_id, |_| TextView));
+        let visible_for_root = visible.clone();
+        let root = app.update(|ctx| {
+            ctx.add_tui_view(window_id, move |_| PresentedFocusRoot {
+                visible: visible_for_root,
+            })
+        });
+        let terminal = TestTerminal::new(TuiSize::new(20, 3));
+        let mut screen = TuiScreen::new(window_id, root.clone(), terminal)
+            .with_focus_policy(TuiFocusPolicy::PresentedTree);
 
         visible.update(&mut app, |_, ctx| ctx.focus_self());
         app.update(|ctx| screen.draw(ctx)).unwrap();

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -218,6 +218,59 @@ impl TuiView for TextView {
 impl TypedActionView for TextView {
     type Action = ();
 }
+struct PresentedFocusRoot {
+    visible: crate::ViewHandle<TextView>,
+}
+
+impl Entity for PresentedFocusRoot {
+    type Event = ();
+}
+
+impl TuiView for PresentedFocusRoot {
+    fn ui_name() -> &'static str {
+        "PresentedFocusRoot"
+    }
+
+    fn child_view_ids(&self, _app: &AppContext) -> Vec<crate::EntityId> {
+        vec![self.visible.id()]
+    }
+
+    fn render(&self, _: &AppContext) -> Box<dyn TuiElement> {
+        TuiChildView::new(&self.visible).finish()
+    }
+}
+
+impl TypedActionView for PresentedFocusRoot {
+    type Action = ();
+}
+
+#[test]
+fn draw_repairs_focus_owned_by_a_view_outside_the_presented_tree() {
+    App::test((), |mut app| async move {
+        let (window_id, _) = app.update(|ctx| ctx.add_tui_window(window_options(), |_| TextView));
+        let visible = app.update(|ctx| ctx.add_tui_view(window_id, |_| TextView));
+        let hidden = app.update(|ctx| ctx.add_tui_view(window_id, |_| TextView));
+        let visible_for_root = visible.clone();
+        let root = app.update(|ctx| {
+            ctx.add_tui_view(window_id, move |_| PresentedFocusRoot {
+                visible: visible_for_root,
+            })
+        });
+        let terminal = TestTerminal::new(TuiSize::new(20, 3));
+        let mut screen = TuiScreen::new(window_id, root.clone(), terminal);
+
+        visible.update(&mut app, |_, ctx| ctx.focus_self());
+        app.update(|ctx| screen.draw(ctx)).unwrap();
+        assert!(screen.presenter.presented_views.contains(&root.id()));
+        assert!(screen.presenter.presented_views.contains(&visible.id()));
+        assert!(!screen.presenter.presented_views.contains(&hidden.id()));
+
+        hidden.update(&mut app, |_, ctx| ctx.focus_self());
+        assert!(app.read(|ctx| hidden.is_focused(ctx)));
+        app.update(|ctx| screen.draw(ctx)).unwrap();
+        assert!(app.read(|ctx| root.is_focused(ctx)));
+    });
+}
 
 struct RepaintingElement {
     size: Option<TuiSize>,


### PR DESCRIPTION
## Description
Fixes a class of Warp Agent CLI focus bugs where a retained background subagent session could become the framework keyboard-focus owner while the parent session remained selected and rendered.

This change:
- stops passive attachment-model updates from returning focus to a hidden session
- routes explicit focus returns and prompt clicks through the foreground session's current input owner
- prevents asynchronous RunAgents configuration fallback from taking background focus
- adds an opt-in presented-tree focus policy and enables it only for Warp Agent CLI; generic TUI runtimes preserve unrestricted focus
- records the views rendered in the current TUI frame and repairs focus when the enabled policy detects focus outside that tree
- delegates repaired root focus to the registry-selected session

This also fixes clicks on the visible prompt appearing to move the cursor without restoring keyboard input.

## Linked Issue
- [QUALITY-1333](https://linear.app/warpdotdev/issue/QUALITY-1333/cannot-exit-a-sub-agent-entered-unintentionally-sub-agent-denies-being)
- [x] Regression tests cover passive background updates, pointer recovery, stale PTY ownership, async orchestration fallback, root delegation, default unrestricted focus, and opt-in current-frame focus containment.
- [x] Visual evidence from live Warp Agent CLI verification is included below.

## Testing
- `./script/format`
- `cargo clippy -p warp_tui --all-targets --tests -- -D warnings`
- `cargo clippy -p warpui_core --features tui --all-targets --tests -- -D warnings`
- `cargo nextest run -p warp_tui` — 999 passed
- `cargo nextest run -p warpui_core --features tui` — 562 passed, 7 skipped
- `cargo nextest run -p warpui_core --features tui focus_outside_the_presented_tree` — default unrestricted-focus regression passed
- `cargo nextest run -p warpui_core --features tui opt_in_draw_repairs_focus_owned_by_a_view_outside_the_presented_tree` — opt-in repair regression passed
- `cargo nextest run -p warp_tui terminal_root_focus_delegates_to_the_selected_session` — Warp Agent CLI root delegation passed
- Three authenticated `./script/run-tui` trials with seven untouched background children:
  - parent input remained responsive during creation, running, completion, delayed post-success updates, and cleanup
  - parent prompt clicks restored/reconciled focus
  - Ctrl-C continued routing to the visible parent

- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos
The third live trial after all three children completed. `FIXPROBE3_LATE` was entered after the delayed post-success window that reproduced the bug before this fix.

![Delayed post-completion TUI focus probe](https://github.com/user-attachments/assets/bcc4f548-3ec7-42be-b4f6-2de0f665d67b)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent artifacts
- [Conversation](https://staging.warp.dev/conversation/c1309a65-4b7d-4310-8ddb-5abf3ac76b96)
- [Implementation plan](https://staging.warp.dev/drive/notebook/F1HDwiIN77hN2HxLl0nF74)

CHANGELOG-BUG-FIX: Fixed background subagent sessions stealing focus from the visible Warp Agent CLI input.

Co-Authored-By: Warp <agent@warp.dev>
