### PR TITLE
Clip a line whose fallback run has no ellipsis glyph

### DIFF
--- a/crates/warpui/src/platform/mac/text_layout_tests.rs
+++ b/crates/warpui/src/platform/mac/text_layout_tests.rs
@@ -1,12 +1,17 @@
 use anyhow::Result;
+use pathfinder_color::ColorU;
+use pathfinder_geometry::rect::RectF;
+use pathfinder_geometry::vector::Vector2F;
 use rand::random;
 
 use super::*;
 use crate::fonts::{
-    FamilyId, Properties, collect_glyph_indices, collect_line_caret_position_starts, init_fonts,
+    Cache as FontCache, FamilyId, Properties, collect_glyph_indices,
+    collect_line_caret_position_starts, init_fonts,
 };
 use crate::platform::FontDB as _;
-use crate::text_layout::DEFAULT_TOP_BOTTOM_RATIO;
+use crate::text_layout::{DEFAULT_TOP_BOTTOM_RATIO, PaintStyleOverride};
+use crate::{Scene, rendering};
 
 pub(crate) fn collect_line_caret_position_pairs(line: &Line) -> Vec<(usize, usize)> {
     line.caret_positions
@@ -694,6 +699,110 @@ fn test_layout_text_last_line_clipped_ligatures() -> Result<()> {
     );
     let first_line = frame.lines().first().unwrap();
     assert!(first_line.width > max_width);
+
+    Ok(())
+}
+
+/// Read the bundled Hack font's bytes from the filesystem.
+fn load_hack_bytes() -> Vec<Vec<u8>> {
+    use std::fs::read;
+    use std::path::PathBuf;
+    let root = env!("CARGO_MANIFEST_DIR");
+    ["Hack-Italic.ttf", "Hack-Bold.ttf", "Hack-Regular.ttf"]
+        .iter()
+        .map(|font_file| {
+            let path = [
+                root, "..", "..", "app", "assets", "bundled", "fonts", "hack", font_file,
+            ]
+            .iter()
+            .collect::<PathBuf>();
+            Ok(read(path)?)
+        })
+        .collect::<Result<Vec<_>>>()
+        .expect("should be able to read hack font bytes from filesystem")
+}
+
+/// Core Text lays a leading `✳` out in its own fallback run because Hack has no U+2733, and the
+/// Zapf Dingbats font it picks carries no '…' either. Resolving the ellipsis from that run alone
+/// leaves the line with neither an ellipsis nor a fade, so it paints past its own bounds onto
+/// whatever the layout placed after it — the vertical-tabs unread dot, in the reported case.
+#[test]
+fn test_ellipsis_resolves_past_a_symbol_fallback_run() -> Result<()> {
+    let mut font_db = FontDB::new();
+    let hack = font_db.load_from_bytes("Hack", load_hack_bytes())?;
+    let font_cache = FontCache::new(Box::new(font_db));
+    let hack_font = font_cache.select_font(hack, Properties::default());
+
+    let text = "✳ Собрать версию с ПРа";
+    let line_style = LineStyle {
+        font_size: 12.,
+        line_height_ratio: 1.,
+        baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+        fixed_width_tab_size: None,
+    };
+    let line = font_cache.text_layout_system().layout_line(
+        text,
+        line_style,
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(hack, Properties::default(), TextStyle::new()),
+        )],
+        f32::MAX,
+        ClipConfig::ellipsis(),
+    );
+
+    let leading_run = line.runs.first().expect("the line should have runs");
+    assert_ne!(
+        leading_run.font_id, hack_font,
+        "expected `✳` to fall back out of Hack into its own run"
+    );
+    assert!(
+        font_cache
+            .glyph_for_char(leading_run.font_id, '…', false)
+            .is_none(),
+        "expected the fallback run's font to have no ellipsis, which is what makes this a test"
+    );
+
+    let (ellipsis_glyph, ellipsis_font) = font_cache
+        .glyph_for_char(hack_font, '…', false)
+        .expect("Hack should have an ellipsis");
+    let bounds = RectF::new(Vector2F::zero(), Vector2F::new(line.width - 20., 20.));
+    let mut scene = Scene::new(1., rendering::Config::default());
+    line.paint(
+        bounds,
+        &PaintStyleOverride::default(),
+        ColorU::black(),
+        &font_cache,
+        &mut scene,
+    );
+
+    let painted = scene
+        .layers()
+        .flat_map(|layer| layer.glyphs.iter())
+        .collect_vec();
+    assert!(
+        painted.iter().any(|glyph| {
+            glyph.glyph_key.glyph_id == ellipsis_glyph && glyph.glyph_key.font_id == ellipsis_font
+        }),
+        "the truncated line painted no ellipsis"
+    );
+    assert!(
+        painted.iter().all(|glyph| glyph.fade.is_none()),
+        "a line that resolved an ellipsis must not also fade"
+    );
+
+    let ellipsis_advance = font_cache
+        .glyph_advance(ellipsis_font, line_style.font_size, ellipsis_glyph)?
+        .x();
+    let rightmost = painted
+        .iter()
+        .map(|glyph| glyph.position.x())
+        .fold(f32::MIN, f32::max);
+    assert!(
+        rightmost + ellipsis_advance <= bounds.upper_right().x(),
+        "the line painted past its bounds: rightmost glyph at {rightmost}, bounds end at {}",
+        bounds.upper_right().x()
+    );
 
     Ok(())
 }

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -97,7 +97,7 @@ impl App {
         log::info!("Starting test app...");
         let platform = Box::new(platform::test::AppDelegate::new().unwrap());
         let window_manager = Box::new(platform::test::WindowManager::new());
-        let font_cache = Box::new(platform::test::FontDB);
+        let font_cache = Box::new(platform::test::FontDB::new());
         let executor = Rc::new(executor::Foreground::test());
         let app = Self(Rc::new(RefCell::new(AppContext::with_foreground_executor(
             executor.clone(),

--- a/crates/warpui_core/src/platform/test/delegate.rs
+++ b/crates/warpui_core/src/platform/test/delegate.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -509,11 +509,30 @@ impl platform::LoadedSystemFonts for LoadedSystemFonts {
 /// A no-op font cache for use in tests that don't want to use full platform
 /// functionality.
 #[derive(Default)]
-pub struct FontDB;
+pub struct FontDB {
+    missing_glyphs: HashSet<(crate::fonts::FontId, char)>,
+    advances: HashMap<crate::fonts::FontId, Vector2I>,
+}
 
 impl FontDB {
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Makes `font_id` report that it cannot draw `ch`. Every font draws every character by
+    /// default, so a test that needs runs to disagree about their coverage — the shape real font
+    /// fallback produces — has to say so.
+    pub fn without_glyph(mut self, font_id: crate::fonts::FontId, ch: char) -> Self {
+        self.missing_glyphs.insert((font_id, ch));
+        self
+    }
+
+    /// Sets the advance `font_id` reports for every glyph, in font units. Fonts advance by zero by
+    /// default, which no real font does, so a test whose subject needs a usable advance has to
+    /// supply one.
+    pub fn with_advance(mut self, font_id: crate::fonts::FontId, advance: Vector2I) -> Self {
+        self.advances.insert(font_id, advance);
+        self
     }
 }
 
@@ -576,10 +595,14 @@ impl platform::FontDB for FontDB {
 
     fn glyph_advance(
         &self,
-        _font_id: crate::fonts::FontId,
+        font_id: crate::fonts::FontId,
         _glyph_id: crate::fonts::GlyphId,
     ) -> Result<Vector2I> {
-        Ok(Vector2I::zero())
+        Ok(self
+            .advances
+            .get(&font_id)
+            .copied()
+            .unwrap_or_else(Vector2I::zero))
     }
 
     fn load_family_name_from_id(&self, _id: crate::fonts::FamilyId) -> Option<String> {
@@ -628,10 +651,10 @@ impl platform::FontDB for FontDB {
 
     fn glyph_for_char(
         &self,
-        _font_id: crate::fonts::FontId,
-        _char: char,
+        font_id: crate::fonts::FontId,
+        char: char,
     ) -> Option<crate::fonts::GlyphId> {
-        Some(0)
+        (!self.missing_glyphs.contains(&(font_id, char))).then_some(0)
     }
 
     fn family_id_for_name(&self, _name: &str) -> Option<FamilyId> {

--- a/crates/warpui_core/src/platform/test/delegate.rs
+++ b/crates/warpui_core/src/platform/test/delegate.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -504,11 +504,30 @@ impl platform::LoadedSystemFonts for LoadedSystemFonts {
 /// A no-op font cache for use in tests that don't want to use full platform
 /// functionality.
 #[derive(Default)]
-pub struct FontDB;
+pub struct FontDB {
+    missing_glyphs: HashSet<(crate::fonts::FontId, char)>,
+    advances: HashMap<crate::fonts::FontId, Vector2I>,
+}
 
 impl FontDB {
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Makes `font_id` report that it cannot draw `ch`. Every font draws every character by
+    /// default, so a test that needs runs to disagree about their coverage — the shape real font
+    /// fallback produces — has to say so.
+    pub fn without_glyph(mut self, font_id: crate::fonts::FontId, ch: char) -> Self {
+        self.missing_glyphs.insert((font_id, ch));
+        self
+    }
+
+    /// Sets the advance `font_id` reports for every glyph, in font units. Fonts advance by zero by
+    /// default, which no real font does, so a test whose subject needs a usable advance has to
+    /// supply one.
+    pub fn with_advance(mut self, font_id: crate::fonts::FontId, advance: Vector2I) -> Self {
+        self.advances.insert(font_id, advance);
+        self
     }
 }
 
@@ -571,10 +590,14 @@ impl platform::FontDB for FontDB {
 
     fn glyph_advance(
         &self,
-        _font_id: crate::fonts::FontId,
+        font_id: crate::fonts::FontId,
         _glyph_id: crate::fonts::GlyphId,
     ) -> Result<Vector2I> {
-        Ok(Vector2I::zero())
+        Ok(self
+            .advances
+            .get(&font_id)
+            .copied()
+            .unwrap_or_else(Vector2I::zero))
     }
 
     fn load_family_name_from_id(&self, _id: crate::fonts::FamilyId) -> Option<String> {
@@ -623,10 +646,10 @@ impl platform::FontDB for FontDB {
 
     fn glyph_for_char(
         &self,
-        _font_id: crate::fonts::FontId,
-        _char: char,
+        font_id: crate::fonts::FontId,
+        char: char,
     ) -> Option<crate::fonts::GlyphId> {
-        Some(0)
+        (!self.missing_glyphs.contains(&(font_id, char))).then_some(0)
     }
 
     fn family_id_for_name(&self, _name: &str) -> Option<FamilyId> {

--- a/crates/warpui_core/src/text_layout.rs
+++ b/crates/warpui_core/src/text_layout.rs
@@ -1412,20 +1412,27 @@ impl Line {
 
         let ellipsis_glyph: Option<(GlyphId, FontId, f32)> =
             if clip_style == ClipStyle::Ellipsis && overflow > MIN_OVERFLOW_FOR_CLIPPING {
-                let ellipsis_run = match clip_direction {
-                    ClipDirection::Start => self.runs.last(),
-                    ClipDirection::End => self.runs.first(),
+                // Start at the run painting starts from — the same run the ellipsis was
+                // previously taken from — and keep walking, because a line whose leading edge is
+                // a single symbol often has that symbol in its own fallback run whose font
+                // carries no '…'. A CLI agent tab title starting with `✳` is one: Hack has no
+                // U+2733, so Core Text splits it into a Zapf Dingbats run, and stopping there
+                // would leave the line unclipped entirely. Keep this starting point: it decides
+                // which font's '…' — and so which advance — a mixed-font line reserves room for.
+                let mut runs = match clip_direction {
+                    ClipDirection::Start => itertools::Either::Left(self.runs.iter().rev()),
+                    ClipDirection::End => itertools::Either::Right(self.runs.iter()),
                 };
 
-                ellipsis_run.and_then(|run| {
-                    font_cache.glyph_for_char(run.font_id, '…', false).and_then(
-                        |(glyph_id, font_id)| {
-                            font_cache
-                                .glyph_advance(font_id, self.font_size, glyph_id)
-                                .ok()
-                                .map(|advance| (glyph_id, font_id, advance.x()))
-                        },
-                    )
+                runs.find_map(|run| {
+                    let (glyph_id, font_id) = font_cache.glyph_for_char(run.font_id, '…', false)?;
+                    let advance = font_cache
+                        .glyph_advance(font_id, self.font_size, glyph_id)
+                        .ok()?
+                        .x();
+                    // A zero-advance ellipsis reserves no room, so the truncation branch below
+                    // would skip it; keep looking for a run that can actually draw one.
+                    (advance > 0.).then_some((glyph_id, font_id, advance))
                 })
             } else {
                 None
@@ -1437,8 +1444,11 @@ impl Line {
 
         // Set the length of the fade based on how much text is overflowing.
         let fade_width = LINE_FADE_MAX_PIXELS.min(overflow * LINE_FADE_SCALE_FACTOR);
+        // An ellipsis replaces the fade, but only once one is actually available: no font on the
+        // line is required to carry '…', and without a fade the glyph loop below paints the glyph
+        // straddling the boundary in full, overhanging whatever the layout placed after the line.
         let fade = if overflow < MIN_OVERFLOW_FOR_CLIPPING
-            || clip_style == ClipStyle::Ellipsis
+            || ellipsis_glyph.is_some()
             || self.clip_config.is_none()
         {
             None

--- a/crates/warpui_core/src/text_layout_tests.rs
+++ b/crates/warpui_core/src/text_layout_tests.rs
@@ -1,4 +1,5 @@
 use float_cmp::assert_approx_eq;
+use pathfinder_geometry::vector::vec2i;
 
 use super::*;
 use crate::fonts::Weight;
@@ -289,25 +290,41 @@ fn test_strip_leading_unicode_bom_with_single_style_run() {
 /// out real text layout so we cannot exercise the paint path through
 /// `layout_line`; instead we hand-roll a single run of fixed-width glyphs.
 fn synthetic_line(glyph_count: usize, glyph_width: f32, clip_config: ClipConfig) -> Line {
-    let glyphs = (0..glyph_count)
-        .map(|i| Glyph {
-            id: 0,
-            position_along_baseline: vec2f(glyph_width * i as f32, 0.),
-            index: i,
-            width: glyph_width,
-        })
-        .collect();
-    let run = Run {
-        font_id: FontId(0),
-        glyphs,
-        styles: TextStyle::default(),
-        width: glyph_width * glyph_count as f32,
-    };
+    synthetic_line_with_runs(&[(FontId(0), glyph_count)], glyph_width, clip_config)
+}
+
+/// Build a synthetic `Line` whose glyphs are split across one run per `(font, glyph count)` pair,
+/// laid out left to right at `glyph_width` each.
+fn synthetic_line_with_runs(
+    runs: &[(FontId, usize)],
+    glyph_width: f32,
+    clip_config: ClipConfig,
+) -> Line {
+    let mut index = 0;
+    let mut line_runs = Vec::with_capacity(runs.len());
+    for (font_id, glyph_count) in runs {
+        let mut glyphs = Vec::with_capacity(*glyph_count);
+        for _ in 0..*glyph_count {
+            glyphs.push(Glyph {
+                id: 0,
+                position_along_baseline: vec2f(glyph_width * index as f32, 0.),
+                index,
+                width: glyph_width,
+            });
+            index += 1;
+        }
+        line_runs.push(Run {
+            font_id: *font_id,
+            glyphs,
+            styles: TextStyle::default(),
+            width: glyph_width * *glyph_count as f32,
+        });
+    }
     Line {
-        width: run.width,
+        width: line_runs.iter().map(|run| run.width).sum(),
         trailing_whitespace_width: 0.,
-        runs: vec![run],
-        font_size: 12.,
+        runs: line_runs,
+        font_size: SYNTHETIC_FONT_SIZE,
         line_height_ratio: 1.,
         baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
         clip_config: Some(clip_config),
@@ -368,6 +385,176 @@ fn test_paint_start_ellipsis_does_not_overlap_leftmost_glyph() {
             }
         });
     });
+}
+
+/// A line asking for `ClipStyle::Ellipsis` must still be clipped when no run on it can draw an
+/// ellipsis, which nothing guarantees: a title starting with `✳` puts that glyph in its own
+/// fallback run, and Zapf Dingbats — the font Core Text picks for U+2733 — has no '…'. Without
+/// either an ellipsis or a fade the glyph loop paints the glyph straddling the boundary in full,
+/// so the line overhangs its own bounds and collides with whatever the layout placed after it.
+/// The platform test `FontDB` reports a zero advance for '…', so it exercises exactly that case.
+#[test]
+fn test_paint_end_ellipsis_fades_when_no_run_can_draw_an_ellipsis() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            const GLYPH_WIDTH: f32 = 12.;
+            let bounds = RectF::new(Vector2F::zero(), Vector2F::new(50., 20.));
+            let line = synthetic_line(10, GLYPH_WIDTH, ClipConfig::ellipsis());
+
+            let mut scene = Scene::new(1., rendering::Config::default());
+            line.paint(
+                bounds,
+                &PaintStyleOverride::default(),
+                ColorU::black(),
+                ctx.font_cache(),
+                &mut scene,
+            );
+
+            let glyphs: Vec<_> = scene
+                .layers()
+                .flat_map(|layer| layer.glyphs.iter())
+                .collect();
+            assert!(
+                glyphs
+                    .iter()
+                    .any(|glyph| glyph.position.x() + GLYPH_WIDTH > bounds.upper_right().x()),
+                "no glyph straddles the right edge, so the fade would go untested"
+            );
+            for glyph in glyphs {
+                let Some(GlyphFade::Horizontal { start, end }) = glyph.fade else {
+                    panic!("glyph at x={} was painted with no fade", glyph.position.x());
+                };
+                assert_approx_eq!(f32, end, bounds.upper_right().x());
+                assert_approx_eq!(f32, start, bounds.upper_right().x() - LINE_FADE_MAX_PIXELS);
+            }
+        });
+    });
+}
+
+/// Font size and per-glyph advance the ellipsis-resolution tests below build their lines from.
+/// `ELLIPSIS_ADVANCE` is in font units, which the test `FontDB`'s 2048 units-per-em turns into
+/// `ELLIPSIS_WIDTH` at `SYNTHETIC_FONT_SIZE`.
+const SYNTHETIC_FONT_SIZE: f32 = 12.;
+const SYNTHETIC_GLYPH_WIDTH: f32 = 10.;
+const ELLIPSIS_ADVANCE: i32 = 2048;
+const ELLIPSIS_WIDTH: f32 = SYNTHETIC_FONT_SIZE;
+
+/// A `FontDB` where `symbol_font` cannot draw '…' and `text_font` can, mirroring a line whose
+/// leading symbol fell back to a font with no ellipsis.
+fn ellipsis_font_cache(symbol_font: FontId, text_font: FontId) -> FontCache {
+    FontCache::new(Box::new(
+        crate::platform::test::FontDB::new()
+            .without_glyph(symbol_font, '…')
+            .with_advance(text_font, vec2i(ELLIPSIS_ADVANCE, 0)),
+    ))
+}
+
+fn painted_glyphs(scene: &Scene) -> Vec<crate::scene::Glyph> {
+    scene
+        .layers()
+        .flat_map(|layer| layer.glyphs.iter())
+        .cloned()
+        .collect()
+}
+
+/// The ellipsis is resolved from whichever run can draw one, not only from the run at the line's
+/// leading edge. A tab title starting with a symbol its font lacks puts that symbol in its own
+/// fallback run, and looking there alone leaves the line unclipped.
+#[test]
+fn test_paint_end_ellipsis_resolves_from_a_later_run() {
+    let symbol_font = FontId(1);
+    let text_font = FontId(2);
+    let font_cache = ellipsis_font_cache(symbol_font, text_font);
+    // 10 glyphs at 10px each = 100px of line painted into 50px of bounds.
+    let line = synthetic_line_with_runs(
+        &[(symbol_font, 1), (text_font, 9)],
+        SYNTHETIC_GLYPH_WIDTH,
+        ClipConfig::ellipsis(),
+    );
+    let bounds = RectF::new(Vector2F::zero(), Vector2F::new(50., 20.));
+
+    let mut scene = Scene::new(1., rendering::Config::default());
+    line.paint(
+        bounds,
+        &PaintStyleOverride::default(),
+        ColorU::black(),
+        &font_cache,
+        &mut scene,
+    );
+
+    // Three 10px glyphs fit in the 38px left over once the ellipsis reserves its 12px, so the
+    // ellipsis lands right after them.
+    let glyphs = painted_glyphs(&scene);
+    assert_eq!(glyphs.len(), 4, "expected 3 glyphs plus an ellipsis");
+    let ellipsis = glyphs
+        .iter()
+        .max_by(|a, b| a.position.x().total_cmp(&b.position.x()))
+        .expect("just asserted the line painted glyphs");
+    assert_approx_eq!(f32, ellipsis.position.x(), 30.);
+    assert_eq!(
+        ellipsis.glyph_key.font_id, text_font,
+        "the ellipsis must come from the run that can draw one"
+    );
+    assert!(
+        ellipsis.position.x() + ELLIPSIS_WIDTH <= bounds.upper_right().x(),
+        "the ellipsis was painted past the line's bounds"
+    );
+    assert!(
+        glyphs.iter().all(|glyph| glyph.fade.is_none()),
+        "a line that resolved an ellipsis must not also fade"
+    );
+}
+
+/// Start-clipping searches the runs from the other end, so the same fallback-run shape has to
+/// resolve when the run that cannot draw '…' is the trailing one.
+#[test]
+fn test_paint_start_ellipsis_resolves_from_an_earlier_run() {
+    let symbol_font = FontId(1);
+    let text_font = FontId(2);
+    let font_cache = ellipsis_font_cache(symbol_font, text_font);
+    let line = synthetic_line_with_runs(
+        &[(text_font, 9), (symbol_font, 1)],
+        SYNTHETIC_GLYPH_WIDTH,
+        ClipConfig {
+            direction: ClipDirection::Start,
+            style: ClipStyle::Ellipsis,
+        },
+    );
+    let bounds = RectF::new(Vector2F::zero(), Vector2F::new(50., 20.));
+
+    let mut scene = Scene::new(1., rendering::Config::default());
+    line.paint(
+        bounds,
+        &PaintStyleOverride::default(),
+        ColorU::black(),
+        &font_cache,
+        &mut scene,
+    );
+
+    let glyphs = painted_glyphs(&scene);
+    assert_eq!(glyphs.len(), 4, "expected 3 glyphs plus an ellipsis");
+    let ellipsis = glyphs
+        .iter()
+        .min_by(|a, b| a.position.x().total_cmp(&b.position.x()))
+        .expect("just asserted the line painted glyphs");
+    assert_eq!(
+        ellipsis.glyph_key.font_id, text_font,
+        "the ellipsis must come from the run that can draw one"
+    );
+    let leftmost_text_glyph = glyphs
+        .iter()
+        .filter(|glyph| glyph.position.x() > ellipsis.position.x())
+        .map(|glyph| glyph.position.x())
+        .fold(f32::MAX, f32::min);
+    assert!(
+        ellipsis.position.x() + ELLIPSIS_WIDTH <= leftmost_text_glyph,
+        "the ellipsis at x={} overlaps the leftmost visible glyph at x={leftmost_text_glyph}",
+        ellipsis.position.x()
+    );
+    assert!(
+        glyphs.iter().all(|glyph| glyph.fade.is_none()),
+        "a line that resolved an ellipsis must not also fade"
+    );
 }
 
 /// Regression test for the "inline-code link underline" bug: a run that has BOTH a


### PR DESCRIPTION
## Description

A line that asks for `ClipStyle::Ellipsis` is not clipped at all when no run on it can draw an ellipsis. It gets neither the ellipsis nor the fade, so the glyph straddling the right edge is painted in full and the text overhangs its own layout box onto whatever was placed after it.

That is reachable in normal use. `Line::paint_internal` looked the ellipsis glyph up in exactly one run — `runs.first()` for end-clipping — with fallback fonts disabled. A title that starts with a symbol its font lacks puts that symbol in its own fallback run, and that run's font usually has no `…`:

```
"✳ Собрать версию с ПРа" laid out in Hack 12pt
run[0] font=ZapfDingbatsITC glyphs=1  advance=8.99  hasEllipsis=false
run[1] font=Hack-Regular    glyphs=21 advance=7.22  hasEllipsis=true
```

Hack has no U+2733, so Core Text splits the leading `✳` into a Zapf Dingbats run, the lookup fails there, and `ellipsis_width` stays 0 — which the glyph loop reads as "no ellipsis to reserve room for", falling back to the bare `remaining_width <= 0.` stop that lets the last glyph overhang. The fade that would have hidden it is disabled unconditionally for `ClipStyle::Ellipsis`.

CLI agent tab titles are prefixed with exactly such a glyph, so in the vertical tabs sidebar a `✳`-prefixed title paints over the unread-activity dot pinned to the right of the title line. The same title with a prefix Hack does have (`◑`, U+25D1) stays a single Hack run, finds the ellipsis, and truncates correctly — same code, same widths, different first-run font.

Two changes:

- **Resolve `…` from any run**, walking from the run painting starts at and continuing through the rest, rather than giving up on the first one. A run whose font reports a zero advance for `…` is skipped too, since the truncation branch would ignore it anyway. The starting point is deliberately unchanged: it decides which font's `…` — and so which advance — a mixed-font line reserves room for.
- **Fall back to the fade when no run can supply one.** `ClipStyle::Ellipsis` now suppresses the fade only when an ellipsis is actually available, so the overhang can no longer paint unmasked.

The fix is in the shared line painter, so it covers every `ClipConfig::ellipsis()` caller, not just the sidebar.

## Testing

Four tests, all verified to fail on the pre-fix code, so none passes vacuously:

| test | failure without the fix |
| --- | --- |
| `warpui_core … test_paint_end_ellipsis_fades_when_no_run_can_draw_an_ellipsis` | `glyph at x=0 was painted with no fade` |
| `warpui_core … test_paint_end_ellipsis_resolves_from_a_later_run` | `expected 3 glyphs plus an ellipsis: 5 != 4` |
| `warpui_core … test_paint_start_ellipsis_resolves_from_an_earlier_run` | `expected 3 glyphs plus an ellipsis: 5 != 4` |
| `warpui platform::mac::… test_ellipsis_resolves_past_a_symbol_fallback_run` | `the truncated line painted no ellipsis` |

The `warpui_core` tests are platform-independent, which matters here: the run walk would otherwise be pinned only by the macOS test, and reverting it to `runs.first()` would stay green everywhere else. To get there the test `FontDB` grew two builder methods — `without_glyph` and `with_advance` — so a test can build a line whose runs disagree about which characters they can draw, which is the shape real font fallback produces. Both default to today's behavior, so existing tests are unaffected.

They assert the ellipsis carries the `font_id` of the run that can draw one, that it lands inside the line's bounds, and that a line which *did* resolve an ellipsis is not also faded — the other half of the changed condition.

The macOS test loads the bundled Hack, lays the reported title out through Core Text, and asserts the premise before the behavior: the leading run is not Hack and its font has no `…`.

`./script/format`, `cargo clippy -p warpui_core -p warpui --all-targets --tests -- -D warnings`, and `cargo nextest run -p warpui_core -p warpui` are clean.

- [x] I have manually tested my changes locally with `./script/run`

Not checked deliberately: `./script/run` builds the OSS channel, and reproducing this needs a CLI agent pane whose title carries the prefix glyph. The measurement above is from the reported build; the scene-level assertions are the evidence here.

### Known coverage limit

The winit font path has no equivalent test. Whether fontdb/rustybuzz splits a symbol-prefixed title into its own fallback run the way Core Text does is unverified, so a test written against it would be speculative about its own premise. The `warpui_core` tests cover the run walk itself on every platform; what stays uncovered is real fallback behavior off macOS.

### Screenshots / Videos

Top: before. Bottom: after. Both halves come from the same capture scenario on the same base commit
(`origin/master` 5071a868c), so the avatar is pixel-identical on either side and the only thing that
changes in frame is the title's clip.

![Vertical-tabs row title, before and after](https://raw.githubusercontent.com/bobrnor/warp/pr-media/media/14967-title-clipping-before-after.png)

The row is a CLI agent tab whose title starts with `✳` (U+2733) — the glyph Hack cannot draw, so
Core Text splits it into its own fallback run and the ellipsis lookup fails there. Full window for
context: [before](https://raw.githubusercontent.com/bobrnor/warp/pr-media/media/14967-full-window-before.png) ·
[after](https://raw.githubusercontent.com/bobrnor/warp/pr-media/media/14967-full-window-after.png).

Captured through the integration harness's own frame capture (`TestStep::with_take_screenshot`),
which reads Warp's Metal texture rather than the screen.

## Linked Issue

Closes #14966.

- [ ] The linked issue is labeled `ready-to-implement`. — #14966 was filed alongside this PR and has not been triaged yet.

## Related

`warpdotdev/warp#14930` fixes a different defect on the same row — the agent avatar sitting in the top-left of the footprint `render_icon_with_status` reserves instead of centered in it. The two are independent: that one moves the icon, this one stops the title from painting past its box.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed truncated text painting past its own bounds — a tab title starting with a symbol its font lacks was drawn over the unread-activity dot beside it instead of being clipped.
-->

