### PR TITLE
Improve cloud agent setup trace spans.

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -25,6 +25,7 @@ use oneshot::{Canceled, Receiver};
 use repo_metadata::local_model::IndexedRepoState;
 use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
 use session_sharing_protocol::sharer::SessionRetentionReason;
+use tracing::Instrument as _;
 use uuid::Uuid;
 use warp_cli::agent::{Harness, OutputFormat};
 use warp_cli::mcp::MCPSpec;
@@ -2379,7 +2380,15 @@ impl AgentDriver {
             safe: ("Running agent driver"),
             full: ("Running agent driver for query `{:?}`", task.prompt)
         );
-        let setup_events = foreground
+
+        let setup_span = tracing::info_span!("agent_run_setup", tags.cloud_agent = true);
+        let (
+            setup_events,
+            task_id_for_refresh,
+            ai_client_for_refresh,
+            oidc_strategy_for_refresh,
+        ) = async {
+            let setup_events = foreground
             .spawn(|me, ctx| {
                 let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client().clone();
                 match me.task_id {
@@ -2766,6 +2775,16 @@ impl AgentDriver {
                 (task_id, ai_client, oidc_strategy)
             })
             .await?;
+
+            Ok::<_, AgentDriverError>((
+                setup_events,
+                task_id_for_refresh,
+                ai_client_for_refresh,
+                oidc_strategy_for_refresh,
+            ))
+        }
+        .instrument(setup_span)
+        .await?;
 
         // Run the harness with a prompt, racing it against optional background refresh
         // loops for git credentials and Bedrock OIDC credentials via
@@ -3947,6 +3966,8 @@ impl AgentDriver {
 
         // Submit the AI query.
         if !self.skip_initial_turn {
+            tracing::info!("Submitting initial AI query");
+
             self.terminal_driver.update(ctx, |td, ctx| {
                 td.with_terminal_view(ctx, |terminal, ctx| match task_prompt {
                     AgentRunPrompt::Local(prompt_str) => {

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -362,6 +362,9 @@ fn record_codebase_indexing(
             log::warn!(
                 "Timed out waiting for codebase index sync; continuing without guaranteed codebase context",
             );
+            tracing::warn!(
+                "Timed out waiting for codebase index sync; continuing without guaranteed codebase context",
+            );
         }
         let _ = spawner
             .spawn(|_, ctx| {

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1514,7 +1514,9 @@ impl AgentDriverRunner {
             }
             let span =
                 tracing::info_span!("AgentDriver::run", tags.cloud_agent = true, ?task.model, ?task.harness);
-            let agent_future = driver.run(task, ctx).instrument(span);
+            let agent_future = span
+                .in_scope(|| driver.run(task, ctx))
+                .instrument(span);
 
             ctx.spawn(agent_future, |_, result, ctx| match result {
                 Ok(()) => {
@@ -1608,6 +1610,7 @@ fn launch_command(
     command: CliCommand,
     global_options: GlobalOptions,
 ) -> anyhow::Result<()> {
+    let parent_span = tracing::Span::current();
     let requires_auth = command_requires_auth(&command);
 
     if !requires_auth {
@@ -1629,12 +1632,14 @@ fn launch_command(
     // before *any* warp-server request.
     let iap = IapManager::handle(ctx);
     if !iap.as_ref(ctx).is_enabled() || iap.as_ref(ctx).has_valid_token() {
-        authenticate_and_dispatch(ctx, command, global_options, authentication);
+        authenticate_and_dispatch(ctx, command, global_options, authentication, parent_span);
         return Ok(());
     }
 
     let mut handled = false;
+    let parent_span_for_iap = parent_span.clone();
     ctx.subscribe_to_model(&iap, move |_, event, ctx| {
+        let _guard = parent_span_for_iap.enter();
         if handled {
             return;
         }
@@ -1648,6 +1653,7 @@ fn launch_command(
                     command.clone(),
                     global_options.clone(),
                     authentication.clone(),
+                    parent_span.clone(),
                 );
             }
             IapManagerEvent::AccessUnavailable => {
@@ -1673,12 +1679,14 @@ fn authenticate_and_dispatch(
     command: CliCommand,
     global_options: GlobalOptions,
     authentication: CommandAuthentication,
+    parent_span: tracing::Span,
 ) {
     let cli_name = warp_cli::binary_name().unwrap_or_else(|| "warp".to_string());
 
     // Subscribe to auth events and wait for validation before running the command.
     let mut dispatched = false;
     ctx.subscribe_to_model(&AuthManager::handle(ctx), move |_, event, ctx| {
+        let _guard = parent_span.enter();
         if dispatched {
             return;
         }


### PR DESCRIPTION
## Description
Cloud-agent traces could lose their parent context while command dispatch waited for IAP or authentication. The driver also spawned its worker before the `AgentDriver::run` span became active, which left the real work outside that span. Setup operations had individual spans but no enclosing span with a clear end boundary.

This change:
- Preserves the `agent_sdk::run` context through the IAP and authentication callbacks.
- Activates `AgentDriver::run` before the driver eagerly spawns its worker.
- Adds an `agent_run_setup` span around the setup portion of `run_internal`. The span uses future instrumentation, so it exits on suspension and ends before harness execution begins.
- Adds trace events for initial query submission and codebase-index synchronization timeouts.

## Linked Issue
No linked issue.

## Testing
- [x] Ran `./script/format`.
- [x] Ran `cargo check -p warp --lib`.
- [x] Ran `cargo clippy -p warp --lib -- -D warnings`.
- [x] Ran `WITH_LOCAL_SERVER=1 ./script/run -- secret list` and confirmed that the local CLI command returned the secret list.

No automated tests were added because this change adjusts tracing context propagation and span boundaries without changing application behavior.

- [x] I have manually tested my changes locally with `./script/run`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode.
- [Agent conversation](https://staging.warp.dev/conversation/e67b6d50-2da4-4329-88b8-f2b315b2971b)

CHANGELOG-NONE

Co-Authored-By: Warp Agent <agent@warp.dev>