### PR TITLE
Avoid throttling of integrated GPUs with uncapped renders

### DIFF
--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -636,6 +636,17 @@ fn mesa_driver_version_is_below_minimum(info_str: &str, min_version: &Version) -
     version < *min_version
 }
 
+/// Returns whether presentation for this adapter should be capped to the
+/// display's refresh rate (vsync) rather than left uncapped.
+///
+/// Warp re-rasterizes the whole window on every redraw. That's cheap on a
+/// discrete GPU, but bursts of small updates (streaming terminal/agent
+/// output, cursor blink, etc.) can request redraws faster than a weak
+/// integrated GPU can keep up with, pegging it for no visible benefit.
+fn should_vsync_present_for_adapter(adapter_info: &wgpu::AdapterInfo) -> bool {
+    adapter_info.device_type == DeviceType::IntegratedGpu
+}
+
 /// Creates a device and command queue for the given adapter that is guaranteed
 /// to be able to create a swapchain for the surface.
 async fn initialize_device(
@@ -893,8 +904,13 @@ fn create_surface_config(
 
     // Use a non-vsync presentation mode for reduced input delay.  This could
     // cause visual tearing on present, but we're ok with paying that cost to
-    // improve responsiveness.
-    config.present_mode = PresentMode::AutoNoVsync;
+    // improve responsiveness.  Integrated GPUs are the exception; see
+    // `should_vsync_present_for_adapter`.
+    config.present_mode = if should_vsync_present_for_adapter(&adapter.get_info()) {
+        PresentMode::AutoVsync
+    } else {
+        PresentMode::AutoNoVsync
+    };
 
     // Explicitly request a non-opaque alpha compositing mode, if available.
     // Without this, transparent surfaces don't work on native Wayland.

--- a/crates/warpui/src/rendering/wgpu/resources_tests.rs
+++ b/crates/warpui/src/rendering/wgpu/resources_tests.rs
@@ -162,3 +162,34 @@ fn test_is_unsupported_intel_uhd_adapter() {
         limit_bucket: None,
     }));
 }
+
+#[test]
+fn test_should_vsync_present_for_adapter() {
+    assert!(should_vsync_present_for_adapter(&wgpu::AdapterInfo {
+        name: String::from("AMD Radeon(TM) Graphics"),
+        vendor: 0,
+        device: 0,
+        device_type: wgpu::DeviceType::IntegratedGpu,
+        driver: String::from("AMD Radeon Graphics driver"),
+        driver_info: String::new(),
+        backend: wgpu::Backend::Dx12,
+        device_pci_bus_id: "01:00.0".to_owned(),
+        subgroup_min_size: wgpu::MINIMUM_SUBGROUP_MIN_SIZE,
+        subgroup_max_size: wgpu::MAXIMUM_SUBGROUP_MAX_SIZE,
+        transient_saves_memory: false,
+    }));
+
+    assert!(!should_vsync_present_for_adapter(&wgpu::AdapterInfo {
+        name: String::from("NVIDIA GeForce RTX 4090"),
+        vendor: 0,
+        device: 0,
+        device_type: wgpu::DeviceType::DiscreteGpu,
+        driver: String::from("NVIDIA"),
+        driver_info: String::new(),
+        backend: wgpu::Backend::Dx12,
+        device_pci_bus_id: "01:00.0".to_owned(),
+        subgroup_min_size: wgpu::MINIMUM_SUBGROUP_MIN_SIZE,
+        subgroup_max_size: wgpu::MAXIMUM_SUBGROUP_MAX_SIZE,
+        transient_saves_memory: false,
+    }));
+}


### PR DESCRIPTION

## Description
This PR Caps the integrated GPUs, so the render loop stops sprinting in place. Discrete GPUs keep the existing uncapped mode for lower input latency, since they can actually afford it.

Every redraw re-rasterizes the entire window, and the code ran integrated adapters with AutoNoVsync just like discrete GPUs. This is fine on a dGPU; but not on a laptop iGPU, as any burst of small updates (streaming agent, cursor blink, etc.) fires off full-window redraws as fast as the driver will allow instead of at the display's refresh rate.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.  
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Fixes  https://github.com/warpdotdev/warp/issues/13158
## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
N/A
## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

<!--+

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
CHANGELOG-BUG-FIX: Avoid throttling of integrated GPUs with uncapped renders