### PR TITLE
Optionally show the switch-to-tab keyboard shortcut on each tab

### DIFF
--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -94,9 +94,9 @@ use crate::workspace::WorkspaceAction;
 use crate::workspace::header_toolbar_editor::HeaderToolbarInlineEditor;
 use crate::workspace::tab_settings::{
     DirectoryTabColor, HideTitleBarSearchBarInVerticalTabs, PreserveActiveTabColor,
-    ShowCodeReviewButton, ShowIndicatorsButton, ShowVerticalTabPanelInRestoredWindows,
-    TabCloseButtonPosition, TabSettings, TabSettingsChangedEvent,
-    UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
+    ShowCodeReviewButton, ShowIndicatorsButton, ShowTabShortcutHint,
+    ShowVerticalTabPanelInRestoredWindows, TabCloseButtonPosition, TabSettings,
+    TabSettingsChangedEvent, UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
     WorkspaceDecorationVisibility, canonical_directory_key,
 };
 use crate::{send_telemetry_from_ctx, themes};
@@ -319,6 +319,22 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
         ),
     );
 
+    toggle_binding_pairs.push(
+        ToggleSettingActionPair::new(
+            "tab shortcut hint",
+            builder(SettingsAction::AppearancePageToggle(
+                AppearancePageAction::ToggleTabShortcutHint,
+            )),
+            context,
+            flags::SHOW_TAB_SHORTCUT_HINT_FLAG,
+        )
+        .is_supported_on_current_platform(
+            TabSettings::as_ref(app)
+                .show_shortcut_hint
+                .is_supported_on_current_platform(),
+        ),
+    );
+
     if !FeatureFlag::OpenWarpNewSettingsModes.is_enabled() {
         toggle_binding_pairs.push(
             ToggleSettingActionPair::custom(
@@ -524,6 +540,7 @@ pub enum AppearancePageAction {
     ToggleMatchNotebookToMonospaceFontSize,
     ToggleMatchAIToTerminalFontFamily,
     ToggleTabIndicators,
+    ToggleTabShortcutHint,
     ToggleShowCodeReviewButton,
     TogglePreserveActiveTabColor,
     ToggleVerticalTabs,
@@ -706,6 +723,7 @@ impl TypedActionView for AppearanceSettingsPageView {
                 ctx.open_url(url);
             }
             ToggleTabIndicators => self.toggle_tab_indicators(ctx),
+            ToggleTabShortcutHint => self.toggle_tab_shortcut_hint(ctx),
             ToggleShowCodeReviewButton => self.toggle_show_code_review_button(ctx),
             TogglePreserveActiveTabColor => self.toggle_preserve_active_tab_color(ctx),
             ToggleVerticalTabs => self.toggle_vertical_tabs(ctx),
@@ -1524,8 +1542,10 @@ impl AppearanceSettingsPageView {
         ));
 
         let tab_settings = TabSettings::as_ref(ctx);
-        let mut tab_settings_widgets: Vec<Box<dyn SettingsWidget<View = Self>>> =
-            vec![Box::new(TabIndicatorWidget::default())];
+        let mut tab_settings_widgets: Vec<Box<dyn SettingsWidget<View = Self>>> = vec![
+            Box::new(TabIndicatorWidget::default()),
+            Box::new(TabShortcutHintWidget::default()),
+        ];
         if !FeatureFlag::OpenWarpNewSettingsModes.is_enabled() {
             tab_settings_widgets.push(Box::new(CodeReviewButtonWidget::default()));
         }
@@ -2486,6 +2506,15 @@ impl AppearanceSettingsPageView {
             TelemetryEvent::ToggleTabIndicators { enabled: new_value },
             ctx
         );
+    }
+
+    fn toggle_tab_shortcut_hint(&mut self, ctx: &mut ViewContext<Self>) {
+        let tab_settings = TabSettings::handle(ctx);
+        let new_value = { !*tab_settings.as_ref(ctx).show_shortcut_hint.value() };
+
+        ctx.update_model(&tab_settings, move |tab_settings, ctx| {
+            report_if_error!(tab_settings.show_shortcut_hint.set_value(new_value, ctx));
+        });
     }
 
     fn toggle_show_code_review_button(&mut self, ctx: &mut ViewContext<Self>) {
@@ -4888,6 +4917,51 @@ impl SettingsWidget for TabIndicatorWidget {
                 .build()
                 .on_click(move |ctx, _, _| {
                     ctx.dispatch_typed_action(AppearancePageAction::ToggleTabIndicators);
+                })
+                .finish(),
+            None,
+        )
+    }
+}
+
+#[derive(Default)]
+struct TabShortcutHintWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for TabShortcutHintWidget {
+    type View = AppearanceSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "tab shortcut"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let tab_settings = TabSettings::as_ref(app);
+
+        render_body_item::<AppearancePageAction>(
+            "Show tab shortcuts".into(),
+            None,
+            LocalOnlyIconState::for_setting(
+                ShowTabShortcutHint::storage_key(),
+                ShowTabShortcutHint::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .switch(self.switch_state.clone())
+                .check(*tab_settings.show_shortcut_hint)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(AppearancePageAction::ToggleTabShortcutHint);
                 })
                 .finish(),
             None,

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -541,6 +541,7 @@ pub mod flags {
     pub const SMART_SELECT_FLAG: &str = "Smart_Select_Enabled";
     pub const ACTIVATION_HOTKEY_FLAG: &str = "Activation_Hotkey_Enabled";
     pub const TAB_INDICATORS_FLAG: &str = "Tab_Indicators_Enabled";
+    pub const SHOW_TAB_SHORTCUT_HINT_FLAG: &str = "Show_Tab_Shortcut_Hint";
     pub const SHOW_CODE_REVIEW_BUTTON_FLAG: &str = "Show_Code_Review_Button_Enabled";
     pub const SHOW_CODE_REVIEW_DIFF_STATS_FLAG: &str = "Show_Code_Review_Diff_Stats_Enabled";
     pub const AUTO_OPEN_CODE_REVIEW_PANE_FLAG: &str = "Auto_Open_Code_Review_Pane_Enabled";

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -44,6 +44,7 @@ use crate::themes::theme::{AnsiColorIdentifier, Fill as ThemeFill, VerticalGradi
 use crate::ui_components::buttons::icon_button;
 use crate::ui_components::color_dot::{TAB_COLOR_OPTIONS, render_color_dot};
 use crate::ui_components::icons::{ICON_DIMENSIONS, Icon};
+use crate::util::bindings::keybinding_name_to_display_string;
 use crate::util::color::{Opacity, coloru_with_opacity};
 use crate::util::truncation::truncate_from_end;
 use crate::window_settings::WindowSettings;
@@ -58,6 +59,19 @@ use crate::workspace::{
 
 pub const TAB_BAR_BORDER_HEIGHT: f32 = 1.0;
 pub(crate) const TAB_INDICATOR_HEIGHT: f32 = 14.0;
+
+/// Binding names for switching to tabs 1–8 (tab index 0–7), used to surface the
+/// effective keystroke (including user overrides) on each tab.
+pub(crate) const TAB_ACTIVATE_BINDING_NAMES: [&str; 8] = [
+    "workspace:activate_first_tab",
+    "workspace:activate_second_tab",
+    "workspace:activate_third_tab",
+    "workspace:activate_fourth_tab",
+    "workspace:activate_fifth_tab",
+    "workspace:activate_sixth_tab",
+    "workspace:activate_seventh_tab",
+    "workspace:activate_eighth_tab",
+];
 
 /// Label for the tab right-click menu's "Move to group" submenu parent.
 pub const MOVE_TO_GROUP_LABEL: &str = "Move to group";
@@ -918,6 +932,7 @@ pub struct TabComponent<'a> {
     /// both the in-selection highlight and the right-click menu dispatch
     /// (multi-tab menu vs single-tab menu).
     is_in_multi_tab_selection: bool,
+    shortcut_hint_label: Option<String>,
 }
 
 /// Structure that holds TabComponent styles.
@@ -1005,6 +1020,13 @@ impl<'a> TabComponent<'a> {
             .as_ref(ctx)
             .is_terminal_pane_being_shared(ctx);
         let should_show_indicators = *TabSettings::as_ref(ctx).show_indicators.value();
+        let shortcut_hint_label = if *TabSettings::as_ref(ctx).show_shortcut_hint.value()
+            && tab_index < TAB_ACTIVATE_BINDING_NAMES.len()
+        {
+            keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[tab_index], ctx)
+        } else {
+            None
+        };
         let are_inputs_synced = SyncedInputState::as_ref(ctx)
             .should_sync_this_pane_group(tab.pane_group.id(), tab.pane_group.window_id(ctx));
 
@@ -1080,6 +1102,7 @@ impl<'a> TabComponent<'a> {
             sole_grouped_member: false,
             locator,
             is_in_multi_tab_selection: false,
+            shortcut_hint_label,
         }
     }
 
@@ -1566,6 +1589,26 @@ impl<'a> TabComponent<'a> {
         })
     }
 
+    fn render_shortcut_hint(&self) -> Option<Box<dyn Element>> {
+        if self.for_drag_ghost {
+            return None;
+        }
+        let label = self.shortcut_hint_label.as_ref()?;
+        let theme = self.appearance.theme();
+        let font_size = self.styles.default.font_size.unwrap_or(12.);
+        let text = Text::new_inline(
+            label.clone(),
+            self.styles
+                .default
+                .font_family_id
+                .expect("Font family defined"),
+            font_size,
+        )
+        .with_color(theme.sub_text_color(theme.background()).into())
+        .finish();
+        Some(Container::new(text).with_margin_right(4.).finish())
+    }
+
     fn render_tab_container(&self, is_hovered: bool) -> Box<dyn Element> {
         let is_tab_dragging = self.is_tab_dragging();
         let is_hovered = is_hovered && !self.tab_bar.is_any_tab_dragging;
@@ -1666,6 +1709,9 @@ impl<'a> TabComponent<'a> {
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_main_axis_alignment(MainAxisAlignment::Center)
                 .with_cross_axis_alignment(warpui::elements::CrossAxisAlignment::Center);
+            if let Some(hint) = self.render_shortcut_hint() {
+                flex_row.add_child(hint);
+            }
             if let Some(indicator) = self.render_indicator() {
                 flex_row.add_child(indicator);
             }

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -467,6 +467,16 @@ define_settings_group!(TabSettings, settings: [
         toml_path: "appearance.tabs.show_indicators_button",
         description: "Whether to show activity indicators on tabs.",
     },
+    show_shortcut_hint: ShowTabShortcutHint {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        surface: settings::SettingSurfaces::GUI,
+        private: false,
+        toml_path: "appearance.tabs.show_shortcut_hint",
+        description: "Whether to show the switch-to-tab keyboard shortcut on each tab.",
+    },
     show_code_review_button: ShowCodeReviewButton {
         type: bool,
         default: true,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3769,6 +3769,7 @@ impl Workspace {
                 ctx.notify();
             }
             TabSettingsChangedEvent::ShowIndicatorsButton { .. }
+            | TabSettingsChangedEvent::ShowTabShortcutHint { .. }
             | TabSettingsChangedEvent::NewTabPlacement { .. }
             | TabSettingsChangedEvent::TabCloseButtonPosition { .. }
             | TabSettingsChangedEvent::PreserveActiveTabColor { .. } => {
@@ -23182,6 +23183,9 @@ impl Workspace {
 
         if *tab_settings.show_indicators.value() {
             context.set.insert(flags::TAB_INDICATORS_FLAG);
+        }
+        if *tab_settings.show_shortcut_hint.value() {
+            context.set.insert(flags::SHOW_TAB_SHORTCUT_HINT_FLAG);
         }
         if *tab_settings.show_code_review_button.value() {
             context.set.insert(flags::SHOW_CODE_REVIEW_BUTTON_FLAG);

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -55,7 +55,10 @@ use crate::pane_group::{
     CodePane, NotebookPane, PaneGroup, PaneId, TabBarHoverIndex, TerminalPane, WorkflowPane,
 };
 use crate::safe_triangle::SafeTriangle;
-use crate::tab::{SelectedTabColor, TAB_INDICATOR_SYNCED_COLOR, TabData, tab_position_id};
+use crate::tab::{
+    SelectedTabColor, TAB_ACTIVATE_BINDING_NAMES, TAB_INDICATOR_SYNCED_COLOR, TabData,
+    tab_position_id,
+};
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::session_settings::SessionSettings;
 use crate::terminal::view::TerminalViewState;
@@ -408,6 +411,7 @@ fn render_pane_row_element(
         pane_rename_editor: _,
         is_pinned,
         container_is_hovered,
+        tab_index: _,
     } = props;
     let is_selected = is_active_tab && is_focused;
     let show_pin = FeatureFlag::PinnedTabs.is_enabled() && is_pinned && !container_is_hovered;
@@ -853,6 +857,7 @@ struct PaneProps<'a> {
     /// True when the tab container containing this pane is hovered.
     /// The pin icon is hidden when a tab is hovered.
     container_is_hovered: bool,
+    tab_index: usize,
 }
 
 struct PaneRowState {
@@ -1235,6 +1240,7 @@ impl VerticalTabsPanelState {
                                 None,
                                 tab.pinned,
                                 false,
+                                *tab_index,
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -1842,6 +1848,7 @@ fn render_groups(
                                     None,
                                     tab.pinned,
                                     false,
+                                    tab_index,
                                     app,
                                 )
                                 .is_some_and(|props| {
@@ -1873,6 +1880,7 @@ fn render_groups(
                                 None,
                                 tab.pinned,
                                 false,
+                                tab_index,
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -2232,6 +2240,7 @@ fn render_tab_group_internal(
                     None,
                     tab.pinned,
                     group_state.is_hovered(),
+                    tab_index,
                     app,
                 ) else {
                     return Empty::new().finish();
@@ -2291,6 +2300,7 @@ fn render_tab_group_internal(
                     is_pane_being_renamed.then_some(workspace.pane_rename_editor.clone()),
                     tab.pinned,
                     group_state.is_hovered(),
+                    tab_index,
                     app,
                 ) else {
                     continue;
@@ -3427,6 +3437,36 @@ fn render_synced_inputs_indicator() -> Box<dyn Element> {
     .finish()
 }
 
+/// Whether a row is eligible to surface the switch-to-tab shortcut hint:
+/// the setting is on and the tab falls within the first 8 (the only tabs with
+/// a default `cmdorctrl-N` binding). Whether a label is actually shown also
+/// depends on the binding being assigned — see [`shortcut_hint_label`].
+fn shows_shortcut_hint(show_setting: bool, tab_index: usize) -> bool {
+    show_setting && tab_index < TAB_ACTIVATE_BINDING_NAMES.len()
+}
+
+/// Resolves the switch-to-tab shortcut label for a row, gated on the setting,
+/// the 8-tab limit, and the binding being assigned. Returns `None` when no hint
+/// should be shown.
+fn shortcut_hint_label(props: &PaneProps<'_>, app: &AppContext) -> Option<String> {
+    if !shows_shortcut_hint(
+        *TabSettings::as_ref(app).show_shortcut_hint.value(),
+        props.tab_index,
+    ) {
+        return None;
+    }
+    keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[props.tab_index], app)
+}
+
+/// Inline label showing the switch-to-tab keyboard shortcut, mirroring the
+/// horizontal tab bar's `TabComponent::render_shortcut_hint`.
+fn render_shortcut_hint(label: &str, appearance: &Appearance) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    Text::new_inline(label.to_string(), appearance.ui_font_family(), 12.)
+        .with_color(theme.sub_text_color(theme.background()).into())
+        .finish()
+}
+
 /// Row title line with its trailing indicators — the synchronized-inputs link
 /// icon followed by the unread-activity dot — pinned to the right edge. Returns
 /// `title` untouched when the row has no indicator to show.
@@ -3434,9 +3474,10 @@ fn render_row_title_line(
     title: Box<dyn Element>,
     shows_synced_inputs: bool,
     shows_activity_indicator: bool,
+    shortcut_hint: Option<Box<dyn Element>>,
     theme: &WarpTheme,
 ) -> Box<dyn Element> {
-    if !shows_synced_inputs && !shows_activity_indicator {
+    if !shows_synced_inputs && !shows_activity_indicator && shortcut_hint.is_none() {
         return title;
     }
 
@@ -3449,6 +3490,9 @@ fn render_row_title_line(
     }
     if shows_activity_indicator {
         indicators.add_child(render_title_indicator(theme));
+    }
+    if let Some(hint) = shortcut_hint {
+        indicators.add_child(hint);
     }
 
     Flex::row()
@@ -3521,6 +3565,13 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
         if has_indicator {
             title_row.add_child(
                 Container::new(render_title_indicator(theme))
+                    .with_margin_left(4.)
+                    .finish(),
+            );
+        }
+        if let Some(label) = shortcut_hint_label(&props, app) {
+            title_row.add_child(
+                Container::new(render_shortcut_hint(&label, appearance))
                     .with_margin_left(4.)
                     .finish(),
             );
@@ -3867,6 +3918,7 @@ impl<'a> PaneProps<'a> {
         pane_rename_editor: Option<ViewHandle<EditorView>>,
         is_pinned: bool,
         container_is_hovered: bool,
+        tab_index: usize,
         app: &AppContext,
     ) -> Option<Self> {
         let pane = pane_group.pane_by_id(pane_id)?;
@@ -3921,6 +3973,7 @@ impl<'a> PaneProps<'a> {
             pane_rename_editor,
             is_pinned,
             container_is_hovered,
+            tab_index,
         })
     }
 
@@ -4484,6 +4537,7 @@ fn render_terminal_row_content(
         first_line,
         row_shows_synced_inputs_indicator(props, app),
         has_unread_activity(&props.typed, app),
+        shortcut_hint_label(props, app).map(|label| render_shortcut_hint(&label, appearance)),
         theme,
     );
 
@@ -4774,6 +4828,7 @@ fn render_summary_tab_item(
         title_region.finish(),
         row_shows_synced_inputs_indicator(&props, app),
         summary.has_unread_activity,
+        shortcut_hint_label(&props, app).map(|label| render_shortcut_hint(&label, appearance)),
         theme,
     ));
 
@@ -6757,6 +6812,9 @@ fn detail_pane_props<'a>(
         None,
         false,
         false,
+        // The detail sidecar never renders a tab shortcut hint, so the tab index
+        // is unused here; pass the active tab as a harmless stand-in.
+        workspace.active_tab_index,
         app,
     )
 }
@@ -7360,6 +7418,7 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
         title_element,
         row_shows_synced_inputs_indicator(&props, app),
         has_indicator,
+        shortcut_hint_label(&props, app).map(|label| render_shortcut_hint(&label, appearance)),
         theme,
     );
 

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -15,7 +15,7 @@ use super::{
     pane_ids_for_display_granularity, pane_search_text_fragments, preferred_agent_tab_titles,
     push_normalized_unique_summary_label, search_fragments_contain_query,
     select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
-    should_show_tab_group_header, shows_synced_inputs_indicator,
+    should_show_tab_group_header, shows_shortcut_hint, shows_synced_inputs_indicator,
     sort_summary_primary_labels_status_first, summary_overflow_count,
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
     terminal_pull_request_badge_label, terminal_search_text_fragments,
@@ -27,6 +27,7 @@ use crate::context_chips::display_chip::GitLineChanges;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
+use crate::tab::TAB_ACTIVATE_BINDING_NAMES;
 use crate::terminal::CLIAgent;
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 
@@ -1165,6 +1166,39 @@ fn synced_inputs_indicator_respects_tab_indicators_setting() {
 #[test]
 fn synced_inputs_indicator_hidden_on_non_terminal_rows() {
     assert!(!shows_synced_inputs_indicator(false, true, true));
+}
+
+#[test]
+fn shortcut_hint_shown_when_setting_on_and_within_first_eight_tabs() {
+    assert!(shows_shortcut_hint(true, 0));
+    assert!(shows_shortcut_hint(true, 7));
+}
+
+#[test]
+fn shortcut_hint_respects_setting() {
+    assert!(!shows_shortcut_hint(false, 0));
+}
+
+#[test]
+fn shortcut_hint_hidden_beyond_eighth_tab() {
+    assert!(!shows_shortcut_hint(true, TAB_ACTIVATE_BINDING_NAMES.len()));
+    assert!(!shows_shortcut_hint(
+        true,
+        TAB_ACTIVATE_BINDING_NAMES.len() + 1
+    ));
+}
+
+#[test]
+fn tab_activate_binding_names_cover_first_eight_tabs_in_order() {
+    assert_eq!(TAB_ACTIVATE_BINDING_NAMES.len(), 8);
+    assert_eq!(
+        TAB_ACTIVATE_BINDING_NAMES[0],
+        "workspace:activate_first_tab"
+    );
+    assert_eq!(
+        TAB_ACTIVATE_BINDING_NAMES[7],
+        "workspace:activate_eighth_tab"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description
Tabs 1–8 have `cmdorctrl-N` bindings (`workspace:activate_*_tab`), but nothing in the UI surfaces them. This adds an opt-in **"Show tab shortcuts"** setting (Settings → Appearance → Tabs, default off) that renders the effective shortcut — e.g. ⌘1 on macOS, Ctrl+1 elsewhere — next to each tab title, in both the horizontal tab bar and the vertical tabs sidebar.

The label is resolved from the binding's current trigger via `keybinding_name_to_display_string`, so it:
- **Respects user overrides** — remapping `workspace:activate_third_tab` to `cmd-shift-3` makes the third tab show `⇧⌘3`.
- **Disappears when a binding is removed** — rather than hinting at a shortcut that does nothing.
- **Uses platform-correct symbols** — `⌘N` on macOS, `Ctrl+N` on Windows/Linux (via `Keystroke::displayed()`).
- **Updates live** — changes take effect immediately through the workspace view's existing `KeybindingChangedNotifier` subscription; no new subscription needed.

Only the first 8 tabs show a hint, since `cmdorctrl-9` activates the *last* tab (not the 9th), so there is no fixed shortcut for index 8+.

The implementation mirrors the existing `show_indicators` (tab indicator) setting end-to-end: same settings-group block, context-flag plumbing, command-palette toggle pair, and Settings > Appearance widget pattern.

## Linked Issue
- [x] N/A — no tracked issue; small self-contained feature.

## Testing
- `./script/format` and `cargo clippy -p warp --tests -- -D warnings` — clean.
- `cargo test -p warp` — 4 new unit tests pass:
  - `shortcut_hint_shown_when_setting_on_and_within_first_eight_tabs`
  - `shortcut_hint_respects_setting`
  - `shortcut_hint_hidden_beyond_eighth_tab`
  - `tab_activate_binding_names_cover_first_eight_tabs_in_order`
- Manually verified in a dev build (`./script/run`) on the vertical tabs layout: hint appears on tabs 1–8, the 9th tab shows none, and the color is readable against the sidebar background.
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- TODO: attach screenshot of ⌘1..⌘8 shown in the tab bar with the setting enabled -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Optionally show the switch-to-tab keyboard shortcut (e.g. ⌘1) on each tab.