### PR TITLE
Add Find to file viewer overflow menu

### DIFF
--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -33,7 +33,9 @@ use warpui::{
 };
 
 use super::context_menu::{ContextMenuAction, ContextMenuState, show_rich_editor_context_menu};
-use super::editor::view::{EditorViewEvent, RichTextEditorConfig, RichTextEditorView};
+use super::editor::view::{
+    EditorViewAction, EditorViewEvent, RichTextEditorConfig, RichTextEditorView,
+};
 use super::link::{NotebookLinks, SessionSource};
 use super::telemetry::NotebookTelemetryAction;
 use super::{NotebookLocation, styles};
@@ -55,6 +57,7 @@ use crate::server::telemetry::{NotebookActionEvent, NotebookTelemetryMetadata, T
 use crate::settings::FontSettings;
 use crate::terminal::model::session::Session;
 use crate::ui_components::icons::Icon;
+use crate::util::bindings::keybinding_name_to_display_string;
 #[cfg(feature = "local_fs")]
 use crate::util::openable_file_type::FileTarget;
 // `renders_in_warp_notebook_viewer` is only consumed by non-wasm views
@@ -129,6 +132,7 @@ pub enum FileNotebookAction {
     Focus,
     Close,
     FocusTerminalInput,
+    ShowFindBar,
     ReloadFile,
     #[cfg(feature = "local_fs")]
     CopyFilePath,
@@ -1030,6 +1034,11 @@ impl TypedActionView for FileNotebookView {
             FileNotebookAction::FocusTerminalInput => {
                 ctx.emit(FileNotebookEvent::Pane(PaneEvent::FocusActiveSession))
             }
+            FileNotebookAction::ShowFindBar => {
+                self.editor.update(ctx, |editor, ctx| {
+                    editor.handle_action(&EditorViewAction::ShowFindBar, ctx);
+                });
+            }
             FileNotebookAction::ReloadFile => self.reload_file(ctx),
             #[cfg(feature = "local_fs")]
             FileNotebookAction::CopyFilePath => {
@@ -1129,6 +1138,10 @@ impl BackingView for FileNotebookView {
             .as_ref()
             .is_some_and(|h| h.is_maximized(ctx));
         let mut actions = vec![
+            MenuItemFields::new("Find")
+                .with_on_select_action(FileNotebookAction::ShowFindBar)
+                .with_key_shortcut_label(keybinding_name_to_display_string("editor:find", ctx))
+                .into_item(),
             MenuItemFields::toggle_pane_action(is_maximized)
                 .with_on_select_action(FileNotebookAction::ToggleMaximized)
                 .into_item(),

--- a/app/src/notebooks/file/mod_tests.rs
+++ b/app/src/notebooks/file/mod_tests.rs
@@ -1,4 +1,6 @@
+use std::cell::Cell;
 use std::path::Path;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use pathfinder_geometry::vector::vec2f;
@@ -21,7 +23,9 @@ use crate::auth::auth_manager::AuthManager;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::notebooks::context_menu::MenuSource;
 use crate::notebooks::editor::keys::NotebookKeybindings;
+use crate::notebooks::editor::view::EditorViewEvent;
 use crate::notebooks::file::is_markdown_file;
+use crate::pane_group::BackingView;
 use crate::search::files::model::FileSearchModel;
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::team::MockTeamClient;
@@ -312,6 +316,46 @@ fn test_load_static() {
             // Rendering should not panic.
             file_notebook.render(ctx);
         });
+    });
+}
+
+#[test]
+fn test_pane_header_find_action_opens_editor_find_bar() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let (_, handle) = app.add_window(WindowStyle::NotStealFocus, FileNotebookView::new);
+        handle.update(&mut app, |file_notebook, ctx| {
+            file_notebook.open_static("Test Title", "Searchable content", ctx);
+        });
+
+        let editor = handle.read(&app, |file_notebook, _| file_notebook.editor.clone());
+        let find_bar_opened = Rc::new(Cell::new(false));
+        app.update(|ctx| {
+            let find_bar_opened = find_bar_opened.clone();
+            ctx.subscribe_to_view(&editor, move |_, event, _| {
+                if matches!(event, EditorViewEvent::OpenedFindBar) {
+                    find_bar_opened.set(true);
+                }
+            });
+        });
+
+        let find_action = handle.read(&app, |file_notebook, ctx| {
+            file_notebook
+                .pane_header_overflow_menu_items(ctx)
+                .into_iter()
+                .find(|item| item.fields().is_some_and(|fields| fields.label() == "Find"))
+                .and_then(|item| item.item_on_select_action().cloned())
+                .expect("file viewer overflow menu should expose the Find action")
+        });
+
+        handle.update(&mut app, |file_notebook, ctx| {
+            file_notebook.handle_pane_header_overflow_menu_action(&find_action, ctx);
+        });
+
+        assert!(
+            find_bar_opened.get(),
+            "the overflow action should open the existing editor find bar"
+        );
     });
 }
 

--- a/app/src/notebooks/file/mod_tests.rs
+++ b/app/src/notebooks/file/mod_tests.rs
@@ -1,6 +1,4 @@
-use std::cell::Cell;
 use std::path::Path;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use pathfinder_geometry::vector::vec2f;
@@ -23,9 +21,7 @@ use crate::auth::auth_manager::AuthManager;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::notebooks::context_menu::MenuSource;
 use crate::notebooks::editor::keys::NotebookKeybindings;
-use crate::notebooks::editor::view::EditorViewEvent;
 use crate::notebooks::file::is_markdown_file;
-use crate::pane_group::BackingView;
 use crate::search::files::model::FileSearchModel;
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::team::MockTeamClient;
@@ -316,46 +312,6 @@ fn test_load_static() {
             // Rendering should not panic.
             file_notebook.render(ctx);
         });
-    });
-}
-
-#[test]
-fn test_pane_header_find_action_opens_editor_find_bar() {
-    App::test((), |mut app| async move {
-        init_app(&mut app);
-        let (_, handle) = app.add_window(WindowStyle::NotStealFocus, FileNotebookView::new);
-        handle.update(&mut app, |file_notebook, ctx| {
-            file_notebook.open_static("Test Title", "Searchable content", ctx);
-        });
-
-        let editor = handle.read(&app, |file_notebook, _| file_notebook.editor.clone());
-        let find_bar_opened = Rc::new(Cell::new(false));
-        app.update(|ctx| {
-            let find_bar_opened = find_bar_opened.clone();
-            ctx.subscribe_to_view(&editor, move |_, event, _| {
-                if matches!(event, EditorViewEvent::OpenedFindBar) {
-                    find_bar_opened.set(true);
-                }
-            });
-        });
-
-        let find_action = handle.read(&app, |file_notebook, ctx| {
-            file_notebook
-                .pane_header_overflow_menu_items(ctx)
-                .into_iter()
-                .find(|item| item.fields().is_some_and(|fields| fields.label() == "Find"))
-                .and_then(|item| item.item_on_select_action().cloned())
-                .expect("file viewer overflow menu should expose the Find action")
-        });
-
-        handle.update(&mut app, |file_notebook, ctx| {
-            file_notebook.handle_pane_header_overflow_menu_action(&find_action, ctx);
-        });
-
-        assert!(
-            find_bar_opened.get(),
-            "the overflow action should open the existing editor find bar"
-        );
     });
 }
 


### PR DESCRIPTION
## Description

Adds a **Find** entry to the rendered file viewer's pane overflow menu. The new menu item reuses the existing editor find action and displays the currently configured `editor:find` shortcut, so the menu and keyboard paths stay in sync without introducing a second search implementation.

## Linked Issue

Closes #9659

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `env MACOSX_DEPLOYMENT_TARGET=10.14 cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2 -E 'not test(/(_ssh_|remote_server)/)'` (10,882 passed)
- `env MACOSX_DEPLOYMENT_TARGET=10.14 cargo nextest run -p warp_completer --features v2` (123 passed, 4 skipped)
- `env MACOSX_DEPLOYMENT_TARGET=10.14 cargo test --doc`
- Full `./script/presubmit`: all formatting and Clippy profiles passed; 11,006 of 11,011 tests passed. The only failures were the five private SSH-fixture tests that timed out waiting for a password prompt and are excluded from fork PR CI (`test_ssh_into_sh`, `test_ssh_into_ash`, `test_ssh_wrapper_into_bash`, `test_ssh_wrapper_into_zsh`, and `test_ssh_with_shell_override`).
- Manual comparison used the same rendered `README.md` and window layout on base `69254d73d` and this branch. The new **Find ⌘F** item opened the existing file viewer find bar.

### Screenshots / Videos

#### Before

<img width="1001" height="723" alt="before-file-viewer-overflow" src="https://github.com/user-attachments/assets/8705455c-862d-4231-b6f1-b660532cfd4e" />

#### After: Find in the overflow menu

<img width="1001" height="723" alt="after-file-viewer-overflow" src="https://github.com/user-attachments/assets/8aeb7e42-8541-44b0-9a54-2d07bff81942" />

#### After: existing find bar opened from the new action

<img width="1001" height="723" alt="after-find-bar-open" src="https://github.com/user-attachments/assets/3bebb7ba-361d-40e8-8d91-a6428b31cbb8" />

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a visible Find action to rendered file viewer pane menus.
