### PR TITLE
Verify binstall-installed tools instead of trusting install metadata

### DIFF
--- a/script/install_cargo_bundle
+++ b/script/install_cargo_bundle
@@ -19,4 +19,21 @@ CARGO_BUNDLE_VERSION="0.11.0"
 # through cargo-quickinstall, which covers both apple-darwin targets. Where no
 # prebuilt is available binstall compiles from source, which is left enabled: a
 # slow bootstrap is a better outcome than one that can't finish.
-cargo binstall --no-confirm "cargo-bundle@${CARGO_BUNDLE_VERSION}"
+#
+# Check the binary itself rather than trusting binstall's install metadata: CI
+# caches can restore the metadata without the binary (rust-cache prunes
+# $CARGO_HOME/bin), and a plain `cargo binstall` would then skip the install and
+# leave bundling broken. `--force` bypasses that metadata check.
+#
+# The banner's tool name varies across releases (0.11.0 prints
+# "cargo bundle v0.11.0", older versions "cargo-bundle v..."), so compare only
+# the trailing version number.
+INSTALLED_VERSION=""
+if command -v cargo-bundle; then
+    INSTALLED_VERSION="$(cargo-bundle --version)"
+    INSTALLED_VERSION="${INSTALLED_VERSION##* }"
+    INSTALLED_VERSION="${INSTALLED_VERSION#v}"
+fi
+if [ "$INSTALLED_VERSION" != "$CARGO_BUNDLE_VERSION" ]; then
+    cargo binstall --force --no-confirm "cargo-bundle@${CARGO_BUNDLE_VERSION}"
+fi

--- a/script/install_cargo_release_deps
+++ b/script/install_cargo_release_deps
@@ -29,4 +29,16 @@ fi
 "$PWD"/script/install_cargo_binstall
 
 # Install cargo-about for generating third-party license attribution.
-cargo binstall --no-confirm cargo-about@0.8.4
+#
+# Check the binary itself rather than trusting binstall's install metadata: CI caches can
+# restore the metadata without the binary (rust-cache prunes $CARGO_HOME/bin), and a plain
+# `cargo binstall` would then skip the install and leave `cargo about` broken. `--force`
+# bypasses that metadata check.
+CARGO_ABOUT_VERSION="0.8.4"
+INSTALLED_VERSION=""
+if command -v cargo-about; then
+  INSTALLED_VERSION="$(cargo-about --version)"
+fi
+if [ "$INSTALLED_VERSION" != "cargo-about ${CARGO_ABOUT_VERSION}" ]; then
+  cargo binstall --force --no-confirm "cargo-about@${CARGO_ABOUT_VERSION}"
+fi


### PR DESCRIPTION
## Description

All Windows release builds have been failing at the bundle step with:

```
error: no such command: `about`
prepare_bundled_resources.ps1 : Failed to generate third-party licenses
```

(e.g. [this Cut New Releases run](https://github.com/warpdotdev/warp-internal/actions/runs/31578942307)).

Since #14792, `cargo-about` and `cargo-bundle` are installed via `cargo binstall`, which decides whether to install by consulting its install-tracking metadata under `$CARGO_HOME`. On the Windows release runners, `Swatinem/rust-cache` restores that metadata but prunes the binaries in `$CARGO_HOME/bin`. Binstall then reports `cargo-about v0.8.4 is already installed, use --force to override`, skips the install, and license generation fails 40 minutes later. Once a cache is saved in that state it never heals, because the binary is never reinstalled into it.

The install scripts now check the binary itself instead of trusting the metadata: if the pinned version already runs, the install is skipped entirely (no network fetch at all); otherwise the tool is installed with `--force`, which bypasses binstall's metadata check. This preserves #14792's fast prebuilt-binary bootstrap while making poisoned caches self-heal on the next run.

## Linked Issue

N/A — release CI breakage, investigated directly from the failing run.

## Testing

- `bash -n` and `shellcheck` pass on both scripts.
- Dry-ran the decision logic locally: a matching `cargo-about 0.8.4` skips the install; a stale `cargo-bundle` triggers a forced reinstall.
- End-to-end validation is the next scheduled `Cut New Releases` run on master, which will force-reinstall `cargo-about` on the poisoned Windows caches.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/add8648e-657a-4279-866b-338b5026ec86)

CHANGELOG-NONE

Co-Authored-By: Warp Agent <agent@warp.dev>
