### PR TITLE
Add R syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "arborium-php",
  "arborium-powershell",
  "arborium-python",
+ "arborium-r",
  "arborium-ruby",
  "arborium-rust",
  "arborium-scala",
@@ -940,6 +941,17 @@ name = "arborium-python"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec2b0cbb06b6c4901c8b60a91b9ed8b9009c20c3c4a2b4ffefcfae98d92d50"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-r"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aedf681a5e698e93fdd879bc7f07b1c2db90d643259f28463cfea7d9eede82e"
 dependencies = [
  "arborium-sysroot",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,7 @@ arborium = { version = "2", default-features = false, features = [
   "lang-scala",
   "lang-powershell",
   "lang-elixir",
+  "lang-r",
   "lang-sql",
   "lang-starlark",
   "lang-objc",

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -981,6 +981,7 @@ impl ProgrammingLanguage {
                 "kotlin" | "kt" => Some("kt"),
                 "powershell" => Some("ps1"),
                 "elixir" => Some("exs"),
+                "r" => Some("r"),
                 "scala" => Some("scala"),
                 "sql" => Some("sql"),
                 "objective-c" | "objc" => Some("m"),

--- a/app/src/ai/agent/mod_tests.rs
+++ b/app/src/ai/agent/mod_tests.rs
@@ -259,6 +259,8 @@ fn test_programming_language_to_extension() {
         ("kotlin", "kt"),
         ("powershell", "ps1"),
         ("elixir", "exs"),
+        ("r", "r"),
+        ("R", "r"),
         ("scala", "scala"),
         ("sql", "sql"),
         // Languages newly covered by this fix — previously fell through to None and rendered

--- a/crates/languages/grammars/r/config.yaml
+++ b/crates/languages/grammars/r/config.yaml
@@ -1,0 +1,11 @@
+display_name: "R"
+indent_unit:
+  space: 2
+comment_prefix: "#"
+brackets:
+  - start: "{"
+    end: "}"
+  - start: "("
+    end: ")"
+  - start: "["
+    end: "]"

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -18,7 +18,7 @@ lazy_static! {
     static ref LANGUAGE_REGISTRY: LanguageRegistry = LanguageRegistry::new();
 }
 
-pub const SUPPORTED_LANGUAGES: [&str; 35] = [
+pub const SUPPORTED_LANGUAGES: [&str; 36] = [
     "rust",
     "golang",
     "yaml",
@@ -46,6 +46,7 @@ pub const SUPPORTED_LANGUAGES: [&str; 35] = [
     "scala",
     "powershell",
     "elixir",
+    "r",
     "sql",
     "starlark",
     "objective-c",
@@ -116,6 +117,7 @@ fn normalize_language_name(name: &str) -> &str {
         "objc" | "objective_c" => "objective-c",
         "terraform" | "tf" => "hcl",
         "kt" => "kotlin",
+        "R" => "r",
         "docker" | "containerfile" => "dockerfile",
         "md" => "markdown",
         other => other,
@@ -189,6 +191,7 @@ fn language_by_filename_parts(
         "scala" | "sbt" | "sc" => language_by_name("scala"),
         "ps1" | "pwsh" => language_by_name("powershell"),
         "ex" | "exs" => language_by_name("elixir"),
+        "r" | "R" => language_by_name("r"),
         "sql" => language_by_name("sql"),
         "bzl" | "bazel" => language_by_name("starlark"),
         "m" | "mm" => language_by_name("objective-c"),
@@ -287,6 +290,7 @@ fn get_arborium_highlight_query(lang: &str) -> Option<&str> {
         "scala" => Some(arborium::lang_scala::HIGHLIGHTS_QUERY),
         "powershell" => Some(arborium::lang_powershell::HIGHLIGHTS_QUERY),
         "elixir" => Some(arborium::lang_elixir::HIGHLIGHTS_QUERY),
+        "r" => Some(arborium::lang_r::HIGHLIGHTS_QUERY),
         "sql" => Some(arborium::lang_sql::HIGHLIGHTS_QUERY),
         "starlark" => Some(arborium::lang_starlark::HIGHLIGHTS_QUERY),
         "objective-c" => Some(&arborium::lang_objc::HIGHLIGHTS_QUERY),

--- a/crates/languages/src/lib_tests.rs
+++ b/crates/languages/src/lib_tests.rs
@@ -2,7 +2,10 @@ use std::path::Path;
 
 use warp_util::standardized_path::StandardizedPath;
 
-use crate::{SUPPORTED_LANGUAGES, language_by_filename, language_by_local_filename, load_language};
+use crate::{
+    SUPPORTED_LANGUAGES, language_by_filename, language_by_local_filename, language_by_name,
+    load_language,
+};
 
 /// Validate that every supported language can be loaded successfully.
 /// This catches invalid node types, syntax errors, and other issues in .scm query files
@@ -94,4 +97,39 @@ fn markdown_extensions_resolve_to_markdown() {
             "{filename} should resolve to Markdown",
         );
     }
+}
+
+#[test]
+fn r_extensions_resolve_to_r() {
+    for filename in ["analysis.R", "analysis.r"] {
+        let path = StandardizedPath::try_new(&format!("/tmp/{filename}"))
+            .expect("test path should be absolute");
+        let language = language_by_filename(&path)
+            .unwrap_or_else(|| panic!("expected {filename} to resolve to a language"));
+        assert_eq!(
+            language.display_name(),
+            "R",
+            "{filename} should resolve to R"
+        );
+    }
+}
+
+#[test]
+fn local_r_extensions_resolve_to_r() {
+    for filename in ["analysis.R", "analysis.r"] {
+        let language = language_by_local_filename(Path::new(filename))
+            .unwrap_or_else(|| panic!("expected {filename} to resolve to a language"));
+        assert_eq!(
+            language.display_name(),
+            "R",
+            "{filename} should resolve to R"
+        );
+    }
+}
+
+#[test]
+fn uppercase_r_language_name_resolves_to_r() {
+    let language = language_by_name("R").expect("`R` should resolve to a language");
+
+    assert_eq!(language.display_name(), "R");
 }

--- a/crates/syntax_tree/src/queries/highlight_query.rs
+++ b/crates/syntax_tree/src/queries/highlight_query.rs
@@ -87,7 +87,7 @@ fn convert_capture_name_to_color(name: &str, color_map: &ColorMap) -> Option<Col
         _ => {}
     }
     match name.split('.').next() {
-        Some("keyword") => Some(color_map.keyword_color),
+        Some("keyword" | "conditional" | "repeat") => Some(color_map.keyword_color),
         Some("function") => Some(color_map.function_color),
         Some("string") => Some(color_map.string_color),
         Some("type") => Some(color_map.type_color),
@@ -138,3 +138,7 @@ impl<'a> TextProvider<&'a [u8]> for TextBuffer<'a> {
         )
     }
 }
+
+#[cfg(test)]
+#[path = "highlight_query_tests.rs"]
+mod tests;

--- a/crates/syntax_tree/src/queries/highlight_query_tests.rs
+++ b/crates/syntax_tree/src/queries/highlight_query_tests.rs
@@ -1,0 +1,30 @@
+use warpui_core::color::ColorU;
+
+use super::{ColorMap, convert_capture_name_to_color};
+
+fn color_map() -> ColorMap {
+    ColorMap {
+        keyword_color: ColorU::new(1, 2, 3, 255),
+        function_color: ColorU::new(4, 5, 6, 255),
+        string_color: ColorU::new(7, 8, 9, 255),
+        type_color: ColorU::new(10, 11, 12, 255),
+        number_color: ColorU::new(13, 14, 15, 255),
+        comment_color: ColorU::new(16, 17, 18, 255),
+        property_color: ColorU::new(19, 20, 21, 255),
+        tag_color: ColorU::new(22, 23, 24, 255),
+    }
+}
+
+#[test]
+fn control_flow_captures_use_keyword_color() {
+    let colors = color_map();
+
+    assert_eq!(
+        convert_capture_name_to_color("conditional", &colors),
+        Some(colors.keyword_color),
+    );
+    assert_eq!(
+        convert_capture_name_to_color("repeat", &colors),
+        Some(colors.keyword_color),
+    );
+}


### PR DESCRIPTION
## Description

Adds built-in R syntax highlighting to Warp's editor and AI code blocks using Arborium's bundled R grammar and highlight query.

- Recognizes both `.R` and `.r` files.
- Resolves `R` and `r` language tokens used by AI code fences.
- Maps the R query's `conditional` and `repeat` captures to Warp's existing keyword color.
- Keeps R Markdown out of scope because `.Rmd` needs mixed Markdown/R parsing rather than the plain R grammar.

## Linked Issue

Closes #6939

This draft is intentionally ahead of the readiness label. The issue is currently labeled `enhancement` and `triaged`; I requested maintainer reevaluation in [this issue comment](https://github.com/warpdotdev/warp/issues/6939#issuecomment-5269397318).

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format --check`
- `./script/check_no_inline_test_modules`
- All three Clippy commands from `script/presubmit`, with `-D warnings`
- `cargo nextest run -p languages` (9 passed), including the R grammar/query load and `.R`/`.r` resolution tests
- `cargo test --locked -p syntax_tree control_flow_captures_use_keyword_color`
- `cargo test --locked -p warp test_programming_language_to_extension`
- The focused `syntax_tree` test also passed in a Linux container.

The Rust checks used a temporary `xcrun` shim for Metal asset outputs because this Mac has Command Line Tools but not Xcode's `metal` and `metallib` utilities. The change does not touch shaders, but a native app run and visual verification remain outstanding.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Pending a host with the Xcode Metal toolchain.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add syntax highlighting for R files and R code blocks.
