### PR TITLE
REMOTE-2111: enable PeriodicHandoffCheckpoints for dogfood builds

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -1036,6 +1036,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::WellKnownMcpIds,
     FeatureFlag::FactoryMcp,
     FeatureFlag::PricingTransparency,
+    FeatureFlag::PeriodicHandoffCheckpoints,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## What this does
First stage of a staged rollout for the periodic workspace-handoff checkpoint coordinator (#14589, #14573, #14588). Adds `FeatureFlag::PeriodicHandoffCheckpoints` to `DOGFOOD_FLAGS` so the coordinator is exercised on internal dogfood builds before promoting to `PREVIEW_FLAGS`/`RELEASE_FLAGS`.

`OzHandoff` (the other prerequisite flag) is already enabled by default for all builds via the `oz_handoff` Cargo default feature, so no additional change is needed there.

## Validation
`cargo check -p warp_features`, `cargo clippy -p warp_features --all-targets --all-features -- -D warnings`, `cargo test -p warp_features`, and `cargo fmt --check -p warp_features` all pass.

Co-Authored-By: Warp Agent <agent@warp.dev>