### PR TITLE
Install cargo-binstall in CI via the pinned, verified repo script

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -87,10 +87,15 @@ runs:
           rust
           ${{ inputs.target_os == 'macos' && 'brew' || '' }}
 
+    # The script pins the binstall version, verifies the archive against an
+    # in-repo SHA-256, retries transient download failures, and skips the
+    # download entirely when the pinned version is already present (e.g.
+    # restored from a runner cache).
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
-      env:
-        BINSTALL_VERSION: 1.14.4
+      shell: bash
+      run: |
+        cd "${{ steps.repo-root.outputs.path }}"
+        ./script/install_cargo_binstall
 
     # Load the SSH key needed to clone the private warp-channel-config repo. Only
     # run in warpdotdev/warp-internal; elsewhere (mirrors, fork PRs) this is a no-op

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
+        run: ./script/install_cargo_binstall
 
       - name: Install diesel_cli
         run: |
@@ -658,7 +658,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
+        run: ./script/install_cargo_binstall
 
       - name: Check licenses for dependencies
         run: |

--- a/script/install_cargo_binstall
+++ b/script/install_cargo_binstall
@@ -6,8 +6,8 @@
 
 set -eo pipefail
 
-# Keep in sync with the cargo-bins/cargo-binstall action pin in .github/workflows/ci.yml
-# so local bootstraps and CI resolve binaries with the same binstall version.
+# Local bootstraps and CI both install binstall through this script, so this is
+# the single pinned version everywhere.
 BINSTALL_VERSION="1.18.1"
 
 # Every archive this script may run, keyed by asset name, with the SHA-256 that
@@ -96,7 +96,10 @@ if [ "$INSTALLED_VERSION" != "$BINSTALL_VERSION" ]; then
     # shellcheck disable=SC2064 # Expand WORKDIR now so the trap still resolves it later.
     trap "rm -rf \"$WORKDIR\"" EXIT
 
+    # GitHub's release-asset CDN intermittently drops connections mid-transfer,
+    # so retry on all errors rather than only the ones curl considers transient.
     curl -L --proto '=https' --tlsv1.2 -sSf \
+        --retry 10 --retry-all-errors --retry-delay 2 \
         "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/${ARCHIVE}" \
         --output "$WORKDIR/$ARCHIVE"
 

--- a/script/wasm/install_build_deps
+++ b/script/wasm/install_build_deps
@@ -12,6 +12,8 @@ set -e
 # Make sure the wasm Rust toolchain target is available.
 rustup target add wasm32-unknown-unknown
 
+"$PWD"/script/install_cargo_binstall
+
 # Install cargo-managed dependencies required to build for wasm.
 # The wasm-bindgen version installed here must be kept in sync with the version
 # used in the project.


### PR DESCRIPTION
## Description

CI had two independent ways of installing cargo-binstall, run serially:

1. The upstream `cargo-bins/cargo-binstall` action in `prepare_environment` (and two standalone `ci.yml` jobs), which downloads on every run with no pinning honored (its `BINSTALL_VERSION` env doesn't reach the inner install script, so it fetches `releases/latest`) and no verification.
2. `script/install_cargo_binstall` (from #14792), invoked later by the `install_cargo_*_deps` scripts: pinned to 1.18.1, SHA-256-verified against digests committed in-repo, and skipped when the pinned version is already present.

This gave the overlapping jobs double the download-flake exposure with no redundancy benefit — the steps run serially, so either one failing kills the job. The action's download flaked twice today on transient GitHub CDN errors ([release re-run](https://github.com/warpdotdev/warp-internal/actions/runs/31578942307), [PR CI](https://github.com/warpdotdev/warp/actions/runs/31622450016/job/94200479128)), and on Windows release jobs the action's unpinned copy was overwritten by the script's 1.18.1 five seconds later.

This PR consolidates on the script as the single provider:

- `prepare_environment` and the `database-migration` / `general-lint` jobs now run `./script/install_cargo_binstall` instead of the action.
- `script/wasm/install_build_deps` calls the script explicitly, since it previously relied on the action being run beforehand.
- The script's curl now retries transient failures (`--retry 10 --retry-all-errors`), addressing the mid-transfer connection drops observed today.

Deliberately **not** adding a fallback installer: falling back to an unpinned, unverified download on network flakiness would defeat the SHA-pinning. If flakes outlive the retries, the next step is a second *source* (a Warp-owned GCS mirror of the pinned archives) inside the script, where the SHA-256 check still gates execution.

## Linked Issue

N/A — follow-up to today's CI flakiness, investigated directly from the failing runs.

## Testing

- `bash -n` + `shellcheck` on the edited scripts (clean, aside from a pre-existing warning on an untouched line); both YAML files parse.
- Ran `./script/install_cargo_binstall` locally end to end: downloaded with the new retry flags, verified the SHA-256, and self-installed 1.18.1.
- The script already runs in CI on all three OSes (including under Git Bash on Windows release jobs), so the risk here is wiring, which CI on this PR exercises directly.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/add8648e-657a-4279-866b-338b5026ec86)

CHANGELOG-NONE

Co-Authored-By: Warp Agent <agent@warp.dev>
