### PR TITLE
Use a shell retry loop for the binstall download

### DIFF
--- a/script/install_cargo_binstall
+++ b/script/install_cargo_binstall
@@ -96,12 +96,26 @@ if [ "$INSTALLED_VERSION" != "$BINSTALL_VERSION" ]; then
     # shellcheck disable=SC2064 # Expand WORKDIR now so the trap still resolves it later.
     trap "rm -rf \"$WORKDIR\"" EXIT
 
-    # GitHub's release-asset CDN intermittently drops connections mid-transfer,
-    # so retry on all errors rather than only the ones curl considers transient.
-    curl -L --proto '=https' --tlsv1.2 -sSf \
-        --retry 10 --retry-all-errors --retry-delay 2 \
-        "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/${ARCHIVE}" \
-        --output "$WORKDIR/$ARCHIVE"
+    # GitHub's release-asset CDN intermittently fails with errors curl's --retry
+    # won't retry, and its brownouts can last minutes, so retry at the shell level
+    # with exponential backoff.
+    DOWNLOAD_ATTEMPTS=5
+    RETRY_DELAY=10
+    for attempt in $(seq 1 "$DOWNLOAD_ATTEMPTS"); do
+        if curl -L --proto '=https' --tlsv1.2 -sSf \
+            --retry 5 --retry-delay 2 \
+            "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/${ARCHIVE}" \
+            --output "$WORKDIR/$ARCHIVE"; then
+            break
+        fi
+        if [ "$attempt" -eq "$DOWNLOAD_ATTEMPTS" ]; then
+            echo "error: failed to download $ARCHIVE after $DOWNLOAD_ATTEMPTS attempts." >&2
+            exit 1
+        fi
+        echo "Download failed; retrying in ${RETRY_DELAY}s..." >&2
+        sleep "$RETRY_DELAY"
+        RETRY_DELAY=$((RETRY_DELAY * 2))
+    done
 
     ACTUAL_SHA256="$(sha256_of "$WORKDIR/$ARCHIVE")"
     if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then


### PR DESCRIPTION
## Description

#15030 added `--retry-all-errors` to the cargo-binstall download, but the Namespace release runners ship a curl older than 7.71 that doesn't know the flag, so every release job that reached the download path failed with:

```
curl: option --retry-all-errors: is unknown
```

([failing run](https://github.com/warpdotdev/warp-internal/actions/runs/31637909664)). #15030's own CI didn't catch it because its jobs either run on GitHub-hosted images with modern curl or hit the skip path on Namespace runners whose cache already contained binstall.

Replace the flag with a shell-level retry loop around curl. This works on any curl version and covers all failure classes — including the mid-transfer connection drops (curl error 56) that plain `--retry` doesn't classify as transient, which were the original motivation.

The retries also back off exponentially (10s → 20s → 40s → 80s), so the loop spans several minutes rather than a few seconds. The same failing run showed GitHub's release-asset CDN serving errors (503s / empty replies) for a ~5-minute window across independent runner fleets; jobs that exhausted their retries within ~20 seconds never escaped the brownout.

## Linked Issue

N/A — fixes today's release-build breakage introduced by #15030.

## Testing

- `shellcheck` and `bash -n` pass.
- Removed the local binstall binary and ran the script: downloads through the retry loop, verifies the SHA-256, and installs 1.18.1; a second run skips without touching the network.
- The failing runners' old curl only lacked `--retry-all-errors`; the remaining flags (`--retry`, `--retry-delay`) have been supported since curl 7.12.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/add8648e-657a-4279-866b-338b5026ec86)

CHANGELOG-NONE

Co-Authored-By: Warp Agent <agent@warp.dev>
