### PR TITLE
Coalesce adjacent identical style runs before Core Text layout (APP-5342)

### DIFF
--- a/crates/warpui/src/platform/mac/text_layout.rs
+++ b/crates/warpui/src/platform/mac/text_layout.rs
@@ -447,6 +447,44 @@ fn apply_paragraph_style_settings(
     }
 }
 
+/// Merges adjacent style runs that are contiguous (no gap between them) and share an identical
+/// [`StyleAndFont`] into a single run.
+///
+/// Some callers (for example, character-by-character diff or syntax highlighting) can produce a
+/// very large number of small, contiguous runs that all resolve to the same style. Feeding each
+/// of those runs to Core Text individually means one (or several) `set_attribute` calls per run.
+/// Core Text's own attribute-range bookkeeping can become extremely costly, in both time and
+/// memory, when a single attributed string carries a very large number of distinct ranges, even
+/// when those ranges are stylistically identical. Coalescing identical, adjacent runs up front
+/// keeps the visual output identical while bounding the number of ranges we ask Core Text to
+/// track.
+fn merge_adjacent_identical_runs(
+    style_runs: &[(Range<usize>, StyleAndFont)],
+) -> Cow<'_, [(Range<usize>, StyleAndFont)]> {
+    // Fast path: bail out at the first opportunity to merge, so that the common case (already
+    // maximally-coalesced runs) doesn't need to allocate a new Vec at all.
+    let first_mergeable = style_runs
+        .windows(2)
+        .position(|pair| pair[0].0.end == pair[1].0.start && pair[0].1 == pair[1].1);
+    let Some(first_mergeable) = first_mergeable else {
+        return Cow::Borrowed(style_runs);
+    };
+
+    let mut merged: Vec<(Range<usize>, StyleAndFont)> = Vec::with_capacity(style_runs.len());
+    merged.extend_from_slice(&style_runs[..first_mergeable]);
+    for (range, style) in &style_runs[first_mergeable..] {
+        if let Some(last) = merged.last_mut()
+            && last.0.end == range.start
+            && last.1 == *style
+        {
+            last.0.end = range.end;
+        } else {
+            merged.push((range.clone(), *style));
+        }
+    }
+    Cow::Owned(merged)
+}
+
 /// Creates a `CFAttributedString` out of `text` with the correct font ranges based on `runs`.
 fn create_attributed_string(
     text: &str,
@@ -464,6 +502,9 @@ fn create_attributed_string(
     unsafe {
         CFAttributedStringBeginEditing(attributed_string.as_concrete_TypeRef());
     }
+
+    let style_runs = merge_adjacent_identical_runs(style_runs);
+    let style_runs = style_runs.as_ref();
 
     let mut utf16_lens = text.chars().map(|c| c.len_utf16());
     let mut prev_char_ix: usize = 0;

--- a/crates/warpui/src/platform/mac/text_layout_tests.rs
+++ b/crates/warpui/src/platform/mac/text_layout_tests.rs
@@ -3,7 +3,7 @@ use rand::random;
 
 use super::*;
 use crate::fonts::{
-    Properties, collect_glyph_indices, collect_line_caret_position_starts, init_fonts,
+    FamilyId, Properties, collect_glyph_indices, collect_line_caret_position_starts, init_fonts,
 };
 use crate::platform::FontDB as _;
 use crate::text_layout::DEFAULT_TOP_BOTTOM_RATIO;
@@ -13,6 +13,53 @@ pub(crate) fn collect_line_caret_position_pairs(line: &Line) -> Vec<(usize, usiz
         .iter()
         .map(|pos| (pos.start_offset, pos.last_offset))
         .collect_vec()
+}
+
+#[test]
+fn test_merge_adjacent_identical_runs_noop_when_already_distinct() {
+    let style_a = StyleAndFont::new(FamilyId(0), Properties::default(), TextStyle::new());
+    let style_b = StyleAndFont::new(FamilyId(1), Properties::default(), TextStyle::new());
+    let runs = vec![(0..5, style_a), (5..10, style_b)];
+
+    let merged = merge_adjacent_identical_runs(&runs);
+
+    assert!(matches!(merged, std::borrow::Cow::Borrowed(_)));
+    assert_eq!(merged.as_ref(), runs.as_slice());
+}
+
+#[test]
+fn test_merge_adjacent_identical_runs_combines_contiguous_identical_styles() {
+    let style_a = StyleAndFont::new(FamilyId(0), Properties::default(), TextStyle::new());
+    let style_b = StyleAndFont::new(FamilyId(1), Properties::default(), TextStyle::new());
+    // Many small, contiguous runs sharing the same style, as could be produced by
+    // character-by-character diff or syntax highlighting.
+    let runs = vec![
+        (0..1, style_a),
+        (1..2, style_a),
+        (2..3, style_a),
+        (3..5, style_b),
+        (5..6, style_a),
+        (6..7, style_a),
+    ];
+
+    let merged = merge_adjacent_identical_runs(&runs);
+
+    assert_eq!(
+        merged.as_ref(),
+        &[(0..3, style_a), (3..5, style_b), (5..7, style_a)]
+    );
+}
+
+#[test]
+fn test_merge_adjacent_identical_runs_does_not_merge_across_gaps() {
+    let style_a = StyleAndFont::new(FamilyId(0), Properties::default(), TextStyle::new());
+    // A gap between the two runs (2..3 is unstyled) should prevent merging even though the
+    // styles are identical, since merging would silently apply styling to the gap.
+    let runs = vec![(0..2, style_a), (3..5, style_a)];
+
+    let merged = merge_adjacent_identical_runs(&runs);
+
+    assert_eq!(merged.as_ref(), runs.as_slice());
 }
 
 #[test]


### PR DESCRIPTION
## Description
Fixes a ~11.98 GB memory spike reported in Sentry issue [7259255054](https://warpdotdev.sentry.io/issues/7259255054/) (event `4bd8353d1d5c46dbbe3430cb6ab4a93a`, macOS stable). See [APP-5342](https://linear.app/warpdotdev/issue/APP-5342/memory-1198-gb-core-text-attributed-string-cost-scales-with-un) for the full investigation.

Symbolizing the heap profile (via the Sentry event's `debugmeta` image info + the matching dSYM downloaded from Sentry) showed essentially the entire sampled heap funneling through the editor's macOS text-layout pipeline:

```
RenderState::layout_pending_edit -> EditDelta::layout_delta
  -> TextLayout::layout_text -> warpui::platform::mac::text_layout::layout_text
  -> create_attributed_string (CFMutableAttributedString::set_attribute)
  -> Core Text internals (deeply repeating, unresolved system frames)
  -> line_from_ct_line / caret_positions_for_line (our own per-line Vecs)
```

`create_attributed_string` applies one (or several) `set_attribute` calls per style run passed to it, without ever coalescing adjacent runs that share an identical style. A caller that produces many small, contiguous, identically-styled runs (e.g. fine-grained diff/syntax highlighting) causes Core Text's own attribute-range bookkeeping to become extremely costly in both time and memory as the number of distinct ranges grows — even though merging those runs would have zero visual effect.

This PR adds `merge_adjacent_identical_runs`, which coalesces contiguous runs with an identical `StyleAndFont` before constructing the `CFAttributedString`. It has a fast path that returns the original slice unmodified (no allocation) when there's nothing to merge, so the common case is unaffected. This is a behavior-preserving optimization — rendered output is unchanged — that directly bounds the pathological case driving this alert.

## Linked Issue
- [x] N/A — filed from automated Sentry memory-alert triage as [APP-5342](https://linear.app/warpdotdev/issue/APP-5342/memory-1198-gb-core-text-attributed-string-cost-scales-with-un).

## Testing
This is macOS-only code (`#[cfg(target_os = "macos")]`) and could not be compiled or run in the (Linux) sandbox this fix was authored in. I validated it with:
- `rustfmt --check` on both changed files (parses cleanly).
- Careful manual review of the merge logic against the existing (unchanged) utf16-offset bookkeeping in `create_attributed_string`.
- New unit tests for `merge_adjacent_identical_runs` covering the no-op, coalescing, and gap-preservation cases. These don't require Core Text or font loading, so they should run in CI, but I was not able to run `cargo test -p warpui` / `cargo clippy` myself in this environment.

A maintainer with macOS CI access should confirm `cargo test -p warpui` and `cargo clippy --workspace --all-targets --all-features --tests` pass before merging.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
