### PR TITLE
fix: cap unbounded file reads in FileModel to prevent multi-GB memory spikes (APP-4519)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16075,6 +16075,7 @@ name = "warp_util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-fs",
  "command",
  "content_inspector",
  "dirs 6.0.0",
@@ -16094,6 +16095,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.17",
  "typed-path 0.10.0",
  "warp_errors",

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -1333,6 +1333,11 @@ async fn read_binary_file_context(
         Ok(content) => content,
         Err(FileLoadError::DoesNotExist) => return Ok(BinaryFileReadResult::NotFound),
         Err(FileLoadError::IOError(e)) => return Err(anyhow::anyhow!(e)),
+        // `read_file_as_binary` never checks against `MAX_LOADABLE_FILE_SIZE_BYTES`
+        // itself (this function already enforces its own `max_bytes` limit
+        // above), so this arm should be unreachable in practice. Handled
+        // explicitly so the match stays exhaustive as `FileLoadError` grows.
+        Err(err @ FileLoadError::TooLarge { .. }) => return Err(anyhow::anyhow!(err)),
     };
 
     let mime_type = from_path(path).first_or_octet_stream().to_string();

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -127,10 +127,12 @@ pub fn init(app: &mut AppContext) {
 
 const PADDING: f32 = 4.;
 
-/// Renders a byte count in human-readable units (e.g. `8.6 GB`), used for the
-/// "file too large to open" toast message.
+/// Renders a byte count in human-readable binary units (e.g. `8.0 GiB`), used for the "file
+/// too large to open" toast message. Uses `GiB`/`MiB`/etc. (1024-based), matching the divisor
+/// below and [`warp_util::file::MAX_LOADABLE_FILE_SIZE_BYTES`], which is itself defined as a
+/// binary multiple (`100 * 1024 * 1024`).
 fn format_file_size(bytes: u64) -> String {
-    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
     let mut size = bytes as f64;
     let mut unit_index = 0;
     while size >= 1024.0 && unit_index < UNITS.len() - 1 {
@@ -146,26 +148,20 @@ fn format_file_size(bytes: u64) -> String {
 
 /// Renders the "file too large to open" toast message for a [`FileLoadError::TooLarge`].
 ///
-/// The comparative form (e.g. `8.6 GB > 100.0 MB limit`) is only used when the reported size
-/// is [`ReportedSize::Exact`] *and* still reads as larger than the limit after formatting.
-/// [`ReportedSize::AtLeast`] (a lower bound from a capped read, e.g. for a device, FIFO, or a
-/// file that changed size mid-read) isn't presented as if it were the file's true size, and an
-/// exact size that happens to round to the same displayed value as the limit isn't presented as
-/// a comparison that would otherwise read as false.
-fn format_too_large_message(size: warp_util::file::ReportedSize, limit_bytes: u64) -> String {
-    if let warp_util::file::ReportedSize::Exact(size_bytes) = size {
-        let formatted_size = format_file_size(size_bytes);
-        let formatted_limit = format_file_size(limit_bytes);
-        if formatted_size != formatted_limit {
-            return format!(
-                "File is too large to open ({formatted_size} > {formatted_limit} limit)."
-            );
-        }
+/// `size_estimate` (from `stat`) is never authoritative -- a regular file's on-disk size can
+/// change between the `stat` and the read that rejected it finishing, and it's altogether
+/// absent for a device, FIFO, or other non-regular file. It is therefore surfaced only as a
+/// rough, explicitly-labeled estimate, never as a fact and never as one side of a comparison
+/// against `limit_bytes` (which would present both as if they were measured the same way).
+fn format_too_large_message(size_estimate: Option<u64>, limit_bytes: u64) -> String {
+    let limit = format_file_size(limit_bytes);
+    match size_estimate {
+        Some(size_bytes) => format!(
+            "File is larger than the {limit} limit (reported size ~{}).",
+            format_file_size(size_bytes)
+        ),
+        None => format!("File is larger than the {limit} limit."),
     }
-    format!(
-        "File is larger than the {} limit.",
-        format_file_size(limit_bytes)
-    )
 }
 
 pub use crate::util::openable_file_type::is_binary_file;
@@ -990,9 +986,10 @@ impl CodeView {
         ctx: &mut ViewContext<Self>,
     ) {
         let message = match error {
-            warp_util::file::FileLoadError::TooLarge { size, limit_bytes } => {
-                format_too_large_message(*size, *limit_bytes)
-            }
+            warp_util::file::FileLoadError::TooLarge {
+                size_estimate,
+                limit_bytes,
+            } => format_too_large_message(*size_estimate, *limit_bytes),
             warp_util::file::FileLoadError::DoesNotExist
             | warp_util::file::FileLoadError::IOError(_) => "Failed to load file.".to_string(),
         };

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -144,6 +144,30 @@ fn format_file_size(bytes: u64) -> String {
     }
 }
 
+/// Renders the "file too large to open" toast message for a [`FileLoadError::TooLarge`].
+///
+/// The comparative form (e.g. `8.6 GB > 100.0 MB limit`) is only used when the reported size
+/// is [`ReportedSize::Exact`] *and* still reads as larger than the limit after formatting.
+/// [`ReportedSize::AtLeast`] (a lower bound from a capped read, e.g. for a device, FIFO, or a
+/// file that changed size mid-read) isn't presented as if it were the file's true size, and an
+/// exact size that happens to round to the same displayed value as the limit isn't presented as
+/// a comparison that would otherwise read as false.
+fn format_too_large_message(size: warp_util::file::ReportedSize, limit_bytes: u64) -> String {
+    if let warp_util::file::ReportedSize::Exact(size_bytes) = size {
+        let formatted_size = format_file_size(size_bytes);
+        let formatted_limit = format_file_size(limit_bytes);
+        if formatted_size != formatted_limit {
+            return format!(
+                "File is too large to open ({formatted_size} > {formatted_limit} limit)."
+            );
+        }
+    }
+    format!(
+        "File is larger than the {} limit.",
+        format_file_size(limit_bytes)
+    )
+}
+
 pub use crate::util::openable_file_type::is_binary_file;
 /// Determines the `SavePosition` ID for a draggable tab based on its index.
 pub fn tab_position_id(index: usize) -> String {
@@ -966,14 +990,9 @@ impl CodeView {
         ctx: &mut ViewContext<Self>,
     ) {
         let message = match error {
-            warp_util::file::FileLoadError::TooLarge {
-                size_bytes,
-                limit_bytes,
-            } => format!(
-                "File is too large to open ({} > {} limit).",
-                format_file_size(*size_bytes),
-                format_file_size(*limit_bytes)
-            ),
+            warp_util::file::FileLoadError::TooLarge { size, limit_bytes } => {
+                format_too_large_message(*size, *limit_bytes)
+            }
             warp_util::file::FileLoadError::DoesNotExist
             | warp_util::file::FileLoadError::IOError(_) => "Failed to load file.".to_string(),
         };

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -127,6 +127,23 @@ pub fn init(app: &mut AppContext) {
 
 const PADDING: f32 = 4.;
 
+/// Renders a byte count in human-readable units (e.g. `8.6 GB`), used for the
+/// "file too large to open" toast message.
+fn format_file_size(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit_index = 0;
+    while size >= 1024.0 && unit_index < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit_index += 1;
+    }
+    if unit_index == 0 {
+        format!("{bytes} {}", UNITS[unit_index])
+    } else {
+        format!("{size:.1} {}", UNITS[unit_index])
+    }
+}
+
 pub use crate::util::openable_file_type::is_binary_file;
 /// Determines the `SavePosition` ID for a draggable tab based on its index.
 pub fn tab_position_id(index: usize) -> String {
@@ -516,7 +533,7 @@ impl CodeView {
                     return;
                 }
                 log::warn!("Failed to load file. {err:?}");
-                CodeView::display_load_failure(ctx.window_id(), ctx);
+                CodeView::display_load_failure(ctx.window_id(), err, ctx);
             }
             LocalCodeEditorEvent::SelectionAddedAsContext {
                 relative_file_path,
@@ -943,10 +960,26 @@ impl CodeView {
         }
     }
 
-    fn display_load_failure(window_id: WindowId, ctx: &mut ViewContext<Self>) {
+    fn display_load_failure(
+        window_id: WindowId,
+        error: &warp_util::file::FileLoadError,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let message = match error {
+            warp_util::file::FileLoadError::TooLarge {
+                size_bytes,
+                limit_bytes,
+            } => format!(
+                "File is too large to open ({} > {} limit).",
+                format_file_size(*size_bytes),
+                format_file_size(*limit_bytes)
+            ),
+            warp_util::file::FileLoadError::DoesNotExist
+            | warp_util::file::FileLoadError::IOError(_) => "Failed to load file.".to_string(),
+        };
         ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-            let toast = DismissibleToast::error(String::from("Failed to load file."))
-                .with_object_id("failed_to_load_file".to_string());
+            let toast =
+                DismissibleToast::error(message).with_object_id("failed_to_load_file".to_string());
             toast_stack.add_ephemeral_toast(toast, window_id, ctx);
         });
     }

--- a/crates/warp_files/src/lib.rs
+++ b/crates/warp_files/src/lib.rs
@@ -24,7 +24,7 @@ use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
 use repo_metadata::{CanonicalizedPath, Repository, RepositoryUpdate, RepositoryWatchMode};
 use warp_core::HostId;
 use warp_util::content_version::ContentVersion;
-use warp_util::file::{FileId, FileLoadError, FileSaveError};
+use warp_util::file::{FileId, FileLoadError, FileSaveError, MAX_LOADABLE_FILE_SIZE_BYTES};
 use warp_util::standardized_path::StandardizedPath;
 use warpui_core::r#async::SpawnedFutureHandle;
 use warpui_core::{Entity, ModelContext, ModelHandle, SingletonEntity};
@@ -447,9 +447,12 @@ impl FileModel {
         let file_path_buf = file_path.to_owned();
         let future = ctx.spawn(
             async move {
-                let contents = async_fs::read_to_string(&file_path_buf)
-                    .await
-                    .map_err(FileLoadError::from);
+                let contents = match Self::check_not_too_large(&file_path_buf).await {
+                    Ok(()) => async_fs::read_to_string(&file_path_buf)
+                        .await
+                        .map_err(FileLoadError::from),
+                    Err(err) => Err(err),
+                };
                 (file_id, contents)
             },
             move |me, (file_id, load_result), ctx| {
@@ -521,9 +524,35 @@ impl FileModel {
         if !Self::file_exists(file_path).await {
             return Err(FileLoadError::DoesNotExist);
         }
+        Self::check_not_too_large(file_path).await?;
         async_fs::read_to_string(file_path)
             .await
             .map_err(FileLoadError::from)
+    }
+
+    /// Returns `Err(FileLoadError::TooLarge)` if `path`'s on-disk size exceeds
+    /// [`MAX_LOADABLE_FILE_SIZE_BYTES`]. Reading a file's full contents into a
+    /// `String` (as `open`/`read_content_for_file` do) can otherwise trigger a
+    /// single allocation as large as the file itself; an unexpectedly huge
+    /// file (a multi-gigabyte log, database, or binary opened by mistake) can
+    /// then spike process memory by that same amount. Checking the size
+    /// up front avoids ever attempting that allocation.
+    ///
+    /// If `metadata` fails (e.g. the file does not exist or was removed
+    /// concurrently), this returns `Ok(())` so the caller's own read attempt
+    /// surfaces the more specific underlying error.
+    async fn check_not_too_large(path: &Path) -> Result<(), FileLoadError> {
+        let Ok(metadata) = async_fs::metadata(path).await else {
+            return Ok(());
+        };
+        let size_bytes = metadata.len();
+        if size_bytes > MAX_LOADABLE_FILE_SIZE_BYTES {
+            return Err(FileLoadError::TooLarge {
+                size_bytes,
+                limit_bytes: MAX_LOADABLE_FILE_SIZE_BYTES,
+            });
+        }
+        Ok(())
     }
 
     /// Asynchronously reads specific lines from a file using BufReader.
@@ -1145,6 +1174,10 @@ impl FileModel {
             async move {
                 let mut res = Vec::new();
                 for file_path in matching_files {
+                    if let Err(err) = Self::check_not_too_large(&file_path).await {
+                        log::warn!("Skipping auto-reload of {}: {err}", file_path.display());
+                        continue;
+                    }
                     if let Ok(content) = async_fs::read_to_string(&file_path).await {
                         res.push((file_path, content));
                     }

--- a/crates/warp_files/src/lib.rs
+++ b/crates/warp_files/src/lib.rs
@@ -24,7 +24,9 @@ use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
 use repo_metadata::{CanonicalizedPath, Repository, RepositoryUpdate, RepositoryWatchMode};
 use warp_core::HostId;
 use warp_util::content_version::ContentVersion;
-use warp_util::file::{FileId, FileLoadError, FileSaveError, MAX_LOADABLE_FILE_SIZE_BYTES};
+use warp_util::file::{
+    FileId, FileLoadError, FileSaveError, MAX_LOADABLE_FILE_SIZE_BYTES, read_to_string_capped,
+};
 use warp_util::standardized_path::StandardizedPath;
 use warpui_core::r#async::SpawnedFutureHandle;
 use warpui_core::{Entity, ModelContext, ModelHandle, SingletonEntity};
@@ -447,12 +449,8 @@ impl FileModel {
         let file_path_buf = file_path.to_owned();
         let future = ctx.spawn(
             async move {
-                let contents = match Self::check_not_too_large(&file_path_buf).await {
-                    Ok(()) => async_fs::read_to_string(&file_path_buf)
-                        .await
-                        .map_err(FileLoadError::from),
-                    Err(err) => Err(err),
-                };
+                let contents =
+                    read_to_string_capped(&file_path_buf, MAX_LOADABLE_FILE_SIZE_BYTES).await;
                 (file_id, contents)
             },
             move |me, (file_id, load_result), ctx| {
@@ -521,38 +519,13 @@ impl FileModel {
     }
 
     pub async fn read_content_for_file(file_path: &Path) -> Result<String, FileLoadError> {
-        if !Self::file_exists(file_path).await {
-            return Err(FileLoadError::DoesNotExist);
+        match read_to_string_capped(file_path, MAX_LOADABLE_FILE_SIZE_BYTES).await {
+            Ok(content) => Ok(content),
+            Err(FileLoadError::IOError(err)) if err.kind() == io::ErrorKind::NotFound => {
+                Err(FileLoadError::DoesNotExist)
+            }
+            Err(err) => Err(err),
         }
-        Self::check_not_too_large(file_path).await?;
-        async_fs::read_to_string(file_path)
-            .await
-            .map_err(FileLoadError::from)
-    }
-
-    /// Returns `Err(FileLoadError::TooLarge)` if `path`'s on-disk size exceeds
-    /// [`MAX_LOADABLE_FILE_SIZE_BYTES`]. Reading a file's full contents into a
-    /// `String` (as `open`/`read_content_for_file` do) can otherwise trigger a
-    /// single allocation as large as the file itself; an unexpectedly huge
-    /// file (a multi-gigabyte log, database, or binary opened by mistake) can
-    /// then spike process memory by that same amount. Checking the size
-    /// up front avoids ever attempting that allocation.
-    ///
-    /// If `metadata` fails (e.g. the file does not exist or was removed
-    /// concurrently), this returns `Ok(())` so the caller's own read attempt
-    /// surfaces the more specific underlying error.
-    async fn check_not_too_large(path: &Path) -> Result<(), FileLoadError> {
-        let Ok(metadata) = async_fs::metadata(path).await else {
-            return Ok(());
-        };
-        let size_bytes = metadata.len();
-        if size_bytes > MAX_LOADABLE_FILE_SIZE_BYTES {
-            return Err(FileLoadError::TooLarge {
-                size_bytes,
-                limit_bytes: MAX_LOADABLE_FILE_SIZE_BYTES,
-            });
-        }
-        Ok(())
     }
 
     /// Asynchronously reads specific lines from a file using BufReader.
@@ -1170,47 +1143,32 @@ impl FileModel {
         }
 
         // Autoreload modified files.
-        ctx.spawn(
-            async move {
-                let mut res = Vec::new();
-                for file_path in matching_files {
-                    if let Err(err) = Self::check_not_too_large(&file_path).await {
-                        log::warn!("Skipping auto-reload of {}: {err}", file_path.display());
-                        continue;
-                    }
-                    if let Ok(content) = async_fs::read_to_string(&file_path).await {
-                        res.push((file_path, content));
+        ctx.spawn(read_reload_contents(matching_files), move |me, res, ctx| {
+            for (file_path, content) in res {
+                let mut emitted_event = false;
+                for (file_id, file_state) in me.file_state.local_iter_mut() {
+                    // Only set the new version of a file if it has opt-in to receiving updates.
+                    if file_state.should_receive_update_for_path(&file_path) {
+                        let new_version = ContentVersion::new();
+                        ctx.emit(FileModelEvent::FileUpdated {
+                            id: *file_id,
+                            content: content.clone(),
+                            base_version: file_state.version.expect("Version should be some"),
+                            new_version,
+                        });
+                        emitted_event = true;
+                        file_state.version = Some(new_version);
                     }
                 }
-                res
-            },
-            move |me, res, ctx| {
-                for (file_path, content) in res {
-                    let mut emitted_event = false;
-                    for (file_id, file_state) in me.file_state.local_iter_mut() {
-                        // Only set the new version of a file if it has opt-in to receiving updates.
-                        if file_state.should_receive_update_for_path(&file_path) {
-                            let new_version = ContentVersion::new();
-                            ctx.emit(FileModelEvent::FileUpdated {
-                                id: *file_id,
-                                content: content.clone(),
-                                base_version: file_state.version.expect("Version should be some"),
-                                new_version,
-                            });
-                            emitted_event = true;
-                            file_state.version = Some(new_version);
-                        }
-                    }
 
-                    if !emitted_event {
-                        log::warn!(
-                            "{} is changed but there is no handler for the update event",
-                            file_path.display()
-                        );
-                    }
+                if !emitted_event {
+                    log::warn!(
+                        "{} is changed but there is no handler for the update event",
+                        file_path.display()
+                    );
                 }
-            },
-        );
+            }
+        });
     }
 
     /// Falls back to individual file watchers for all files that were expecting to use the given repository.
@@ -1254,6 +1212,20 @@ impl FileModel {
             }
         }
     }
+}
+
+/// Reads the current content of each of `file_paths` for the autoreload loop, silently
+/// omitting any that fail to read (including files rejected by the size cap) so the caller
+/// applies exactly the files that succeeded.
+async fn read_reload_contents(file_paths: Vec<PathBuf>) -> Vec<(PathBuf, String)> {
+    let mut res = Vec::new();
+    for file_path in file_paths {
+        match read_to_string_capped(&file_path, MAX_LOADABLE_FILE_SIZE_BYTES).await {
+            Ok(content) => res.push((file_path, content)),
+            Err(err) => log::warn!("Skipping autoreload of {}: {err}", file_path.display()),
+        }
+    }
+    res
 }
 
 impl Entity for FileModel {

--- a/crates/warp_files/src/lib_tests.rs
+++ b/crates/warp_files/src/lib_tests.rs
@@ -416,4 +416,77 @@ fn test_read_content_for_file_reports_too_large() {
     });
 }
 
+/// [`read_reload_contents`] must skip an oversized file without failing the whole batch,
+/// matching the existing "skip files that fail to read" behavior for other read errors.
+#[test]
+fn test_read_reload_contents_skips_oversized_file() {
+    let directory = tempfile::tempdir().expect("temp dir");
+    let oversized_path = directory.path().join("big.txt");
+    let file = std::fs::File::create(&oversized_path).expect("create file");
+    file.set_len(MAX_LOADABLE_FILE_SIZE_BYTES + 1)
+        .expect("set sparse length");
+    drop(file);
+    let ok_path = directory.path().join("small.txt");
+    std::fs::write(&ok_path, "fine").expect("write small file");
+
+    let contents = block_on(read_reload_contents(vec![oversized_path, ok_path.clone()]));
+
+    assert_eq!(contents, vec![(ok_path, "fine".to_string())]);
+}
+
+/// Regression: the file-watcher autoreload path (`reload_file_paths`) must apply the same size
+/// guard as the initial `open`. A file that grows past the cap between opens is skipped instead
+/// of reloaded, rather than reading it unbounded and emitting `FileUpdated` with its content.
+#[test]
+fn test_reload_file_paths_skips_oversized_replacement() {
+    App::test((), |mut app| async move {
+        let app = &mut app;
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        let files = app.add_singleton_model(FileModel::new);
+        let receiver = setup_event_channel(app, &files);
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let small_path = directory.path().join("small.txt");
+        let big_path = directory.path().join("big.txt");
+        std::fs::write(&small_path, "small").expect("write small file");
+        std::fs::write(&big_path, "placeholder").expect("write big file placeholder");
+
+        let small_id = files.update(app, |model, ctx| model.open(&small_path, true, ctx));
+        await_load(&receiver).await;
+        let big_id = files.update(app, |model, ctx| model.open(&big_path, true, ctx));
+        await_load(&receiver).await;
+
+        let (tracked_small_path, tracked_big_path) = files.read(app, |model, _| {
+            (
+                model.file_path(small_id).expect("small path tracked"),
+                model.file_path(big_id).expect("big path tracked"),
+            )
+        });
+
+        // Grow the big file past the cap, as an external process replacing it with something
+        // huge would, then drive the same reload path the watcher uses for both files at once.
+        std::fs::write(&tracked_small_path, "small, updated").expect("update small file");
+        let file = std::fs::File::create(&tracked_big_path).expect("recreate big file");
+        file.set_len(MAX_LOADABLE_FILE_SIZE_BYTES + 1)
+            .expect("set sparse length");
+        drop(file);
+
+        files.update(app, |model, ctx| {
+            model.reload_file_paths(HashSet::from([tracked_small_path, tracked_big_path]), ctx);
+        });
+
+        // The oversized replacement never reaches `FileUpdated`: the only event delivered for
+        // this reload is the small file's, identified by its FileId.
+        match receiver.recv().await.expect("Could not receive the result") {
+            TestFileModelEvent::FileLoaded { id, .. } => {
+                assert_eq!(
+                    id, small_id,
+                    "expected the small file's update, not the oversized one"
+                );
+            }
+            event => panic!("Expected an update event for the small file, got {event:?}"),
+        }
+    });
+}
+
 static TEST_FILE_CONTENT: &[u8] = include_bytes!("../test_data/test_file.rs");

--- a/crates/warp_files/src/lib_tests.rs
+++ b/crates/warp_files/src/lib_tests.rs
@@ -16,6 +16,10 @@ enum TestFileModelEvent {
         content: String,
         _version: ContentVersion,
     },
+    FileUpdated {
+        id: FileId,
+        content: String,
+    },
     FileSaved,
     FailedToLoad(String),
     FailedToSave,
@@ -33,21 +37,16 @@ impl From<&FileModelEvent> for TestFileModelEvent {
                 content: content.clone(),
                 _version: *version,
             },
+            FileModelEvent::FileUpdated { id, content, .. } => TestFileModelEvent::FileUpdated {
+                id: *id,
+                content: content.clone(),
+            },
             FileModelEvent::FileSaved { .. } => TestFileModelEvent::FileSaved,
             FileModelEvent::FailedToLoad {
                 id: _id,
                 error: err,
             } => TestFileModelEvent::FailedToLoad(format!("{err:?}")),
             FileModelEvent::FailedToSave { .. } => TestFileModelEvent::FailedToSave,
-            FileModelEvent::FileUpdated { .. } => {
-                // For now, we don't handle file updated events in tests
-                // This could be extended to include a FileUpdated variant in TestFileModelEvent if needed
-                TestFileModelEvent::FileLoaded {
-                    id: event.file_id(),
-                    content: String::new(),
-                    _version: ContentVersion::new(),
-                }
-            }
         }
     }
 }
@@ -475,17 +474,27 @@ fn test_reload_file_paths_skips_oversized_replacement() {
             model.reload_file_paths(HashSet::from([tracked_small_path, tracked_big_path]), ctx);
         });
 
-        // The oversized replacement never reaches `FileUpdated`: the only event delivered for
-        // this reload is the small file's, identified by its FileId.
+        // The reload's spawned callback emits every `FileUpdated` for this call in one
+        // synchronous pass before yielding, and the event channel forwards each emit
+        // synchronously too, so by the time the first event is received here, any second
+        // event this reload produced is already sitting in the channel. Checking for one
+        // immediately after the other -- rather than only checking the first -- is what
+        // actually proves the oversized file's id never got an update, instead of merely
+        // being consistent with it having been emitted second.
         match receiver.recv().await.expect("Could not receive the result") {
-            TestFileModelEvent::FileLoaded { id, .. } => {
+            TestFileModelEvent::FileUpdated { id, content } => {
                 assert_eq!(
                     id, small_id,
                     "expected the small file's update, not the oversized one"
                 );
+                assert_eq!(content, "small, updated");
             }
             event => panic!("Expected an update event for the small file, got {event:?}"),
         }
+        assert!(
+            receiver.try_recv().is_err(),
+            "no update should have been emitted for the oversized file's id ({big_id:?})"
+        );
     });
 }
 

--- a/crates/warp_files/src/lib_tests.rs
+++ b/crates/warp_files/src/lib_tests.rs
@@ -356,4 +356,64 @@ fn test_a_failed_open_registers_no_watcher() {
     });
 }
 
+/// Opening a file whose on-disk size exceeds `MAX_LOADABLE_FILE_SIZE_BYTES`
+/// must fail with `FileLoadError::TooLarge` instead of reading the whole file
+/// into memory. A single pathologically large file (a huge log, a binary
+/// opened by mistake, etc.) could otherwise trigger a multi-gigabyte
+/// allocation. Uses a sparse file (`set_len`) so the test doesn't actually
+/// need to write the oversized content to disk.
+#[test]
+fn test_load_oversized_file_reports_too_large() {
+    App::test((), |mut app| async move {
+        let app = &mut app;
+        let files = app.add_singleton_model(FileModel::new);
+        let receiver = setup_event_channel(app, &files);
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("huge.log");
+        let file = std::fs::File::create(&path).expect("create file");
+        file.set_len(MAX_LOADABLE_FILE_SIZE_BYTES + 1)
+            .expect("set sparse length");
+        drop(file);
+
+        files.update(app, |model, ctx| {
+            model.open(&path, false, ctx);
+        });
+
+        match receiver.recv().await.expect("Could not receive the result") {
+            TestFileModelEvent::FailedToLoad(err) => {
+                assert!(
+                    err.contains("TooLarge"),
+                    "expected TooLarge error, got {err}"
+                );
+            }
+            event => panic!("Expected oversized file to fail to load, got {event:?}"),
+        }
+    });
+}
+
+/// [`FileModel::read_content_for_file`] is used for reload/discard flows and
+/// must apply the same size guard as `open`.
+#[test]
+fn test_read_content_for_file_reports_too_large() {
+    App::test((), |mut _app| async move {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("huge.log");
+        let file = std::fs::File::create(&path).expect("create file");
+        file.set_len(MAX_LOADABLE_FILE_SIZE_BYTES + 1)
+            .expect("set sparse length");
+        drop(file);
+
+        let result = FileModel::read_content_for_file(&path).await;
+        assert!(
+            matches!(
+                result,
+                Err(FileLoadError::TooLarge { limit_bytes, .. })
+                    if limit_bytes == MAX_LOADABLE_FILE_SIZE_BYTES
+            ),
+            "expected TooLarge error, got {result:?}"
+        );
+    });
+}
+
 static TEST_FILE_CONTENT: &[u8] = include_bytes!("../test_data/test_file.rs");

--- a/crates/warp_util/Cargo.toml
+++ b/crates/warp_util/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+async-fs.workspace = true
 command.workspace = true
 content_inspector = "0.2.4"
 parking_lot.workspace = true
@@ -28,6 +29,7 @@ event-listener.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 pin-project.workspace = true
+futures-lite.workspace = true
 futures-util.workspace = true
 log.workspace = true
 warp_errors.workspace = true
@@ -39,5 +41,5 @@ windows.workspace = true
 gloo.workspace = true
 
 [dev-dependencies]
-futures-lite.workspace = true
+tempfile.workspace = true
 warpui_core.workspace = true

--- a/crates/warp_util/src/file.rs
+++ b/crates/warp_util/src/file.rs
@@ -41,14 +41,29 @@ register_error!(FileSaveError);
 /// attempting the read.
 pub const MAX_LOADABLE_FILE_SIZE_BYTES: u64 = 100 * 1024 * 1024;
 
+/// A rejected oversized file's reported size: either the file's exact on-disk size, or (when
+/// that can't be trusted) only a lower bound.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ReportedSize {
+    /// The exact on-disk size, from `stat`-ing a regular file.
+    Exact(u64),
+    /// Not necessarily the file's true size: `stat` either failed or (for a FIFO, character
+    /// device, or other non-regular file) cannot be trusted, so this is only known to be a
+    /// lower bound on the actual size.
+    AtLeast(u64),
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum FileLoadError {
     #[error("File does not exist")]
     DoesNotExist,
     #[error("IO error when loading file.")]
     IOError(#[from] io::Error),
-    #[error("File is too large to open ({size_bytes} bytes, limit is {limit_bytes} bytes)")]
-    TooLarge { size_bytes: u64, limit_bytes: u64 },
+    #[error("File is too large to open (limit is {limit_bytes} bytes, reported size: {size:?})")]
+    TooLarge {
+        size: ReportedSize,
+        limit_bytes: u64,
+    },
 }
 
 /// Reads `path` into a `Vec<u8>`, rejecting content exceeding `max_bytes`.
@@ -60,20 +75,29 @@ pub enum FileLoadError {
 /// much data it actually yields, and a regular file's size can change (or the path can be
 /// atomically replaced) between the `stat` and a later, separate open. `metadata` is still
 /// queried here, but only as a best-effort allocation-size hint, capped so an inflated or
-/// unrelated `stat` length can never itself cause an over-cap reservation.
+/// unrelated `stat` length can never itself cause an over-cap reservation, and to report an
+/// exact size in [`FileLoadError::TooLarge`] when it can be trusted.
 pub async fn read_capped(path: &Path, max_bytes: u64) -> Result<Vec<u8>, FileLoadError> {
     let file = async_fs::File::open(path).await?;
     let read_limit = max_bytes.saturating_add(1);
-    let metadata_len = file.metadata().await.map(|m| m.len()).unwrap_or(0);
+    let metadata = file.metadata().await.ok();
+    let metadata_len = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
     let mut buffer = Vec::with_capacity(metadata_len.min(read_limit) as usize);
     file.take(read_limit).read_to_end(&mut buffer).await?;
     if buffer.len() as u64 > max_bytes {
-        // `stat` isn't trusted for the accept/reject decision above, but when it reports a size
-        // at least as large as what was actually read, it's more informative to surface than the
-        // bare "read past the limit" lower bound.
-        let size_bytes = metadata_len.max(buffer.len() as u64);
+        // `stat` isn't trusted for the accept/reject decision above. It's only trusted to
+        // report the file's *size* when it succeeded, the path is a regular file (a FIFO or
+        // character device commonly reports a misleading length, often 0), and it itself
+        // reports something past the limit; otherwise all that's actually known is the lower
+        // bound proven by the capped read.
+        let size = match &metadata {
+            Some(metadata) if metadata.is_file() && metadata.len() > max_bytes => {
+                ReportedSize::Exact(metadata.len())
+            }
+            _ => ReportedSize::AtLeast(buffer.len() as u64),
+        };
         return Err(FileLoadError::TooLarge {
-            size_bytes,
+            size,
             limit_bytes: max_bytes,
         });
     }

--- a/crates/warp_util/src/file.rs
+++ b/crates/warp_util/src/file.rs
@@ -41,27 +41,25 @@ register_error!(FileSaveError);
 /// attempting the read.
 pub const MAX_LOADABLE_FILE_SIZE_BYTES: u64 = 100 * 1024 * 1024;
 
-/// A rejected oversized file's reported size: either the file's exact on-disk size, or (when
-/// that can't be trusted) only a lower bound.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ReportedSize {
-    /// The exact on-disk size, from `stat`-ing a regular file.
-    Exact(u64),
-    /// Not necessarily the file's true size: `stat` either failed or (for a FIFO, character
-    /// device, or other non-regular file) cannot be trusted, so this is only known to be a
-    /// lower bound on the actual size.
-    AtLeast(u64),
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum FileLoadError {
     #[error("File does not exist")]
     DoesNotExist,
     #[error("IO error when loading file.")]
     IOError(#[from] io::Error),
-    #[error("File is too large to open (limit is {limit_bytes} bytes, reported size: {size:?})")]
+    #[error(
+        "File is too large to open (limit is {limit_bytes} bytes; reported size estimate: {size_estimate:?} bytes)"
+    )]
     TooLarge {
-        size: ReportedSize,
+        /// A rough, best-effort estimate of the file's on-disk size from `stat`, present only
+        /// when `stat` succeeded, the path is a regular file, and it itself reported something
+        /// past the limit. Never authoritative: a regular file's size can still change between
+        /// this `stat` and [`read_capped`] finishing its read, so this must never be presented
+        /// as the file's exact size, nor compared against `limit_bytes` as if both were
+        /// measured the same way. `None` when no such estimate is available (`stat` failed, or
+        /// the path is a FIFO, character device, or other non-regular file, which commonly
+        /// report a misleading length — often 0 — regardless of how much data they yield).
+        size_estimate: Option<u64>,
         limit_bytes: u64,
     },
 }
@@ -75,8 +73,9 @@ pub enum FileLoadError {
 /// much data it actually yields, and a regular file's size can change (or the path can be
 /// atomically replaced) between the `stat` and a later, separate open. `metadata` is still
 /// queried here, but only as a best-effort allocation-size hint, capped so an inflated or
-/// unrelated `stat` length can never itself cause an over-cap reservation, and to report an
-/// exact size in [`FileLoadError::TooLarge`] when it can be trusted.
+/// unrelated `stat` length can never itself cause an over-cap reservation, and to offer a
+/// rough size estimate in [`FileLoadError::TooLarge`] — never an exact size, since the file
+/// can still change between this `stat` and the read finishing.
 pub async fn read_capped(path: &Path, max_bytes: u64) -> Result<Vec<u8>, FileLoadError> {
     let file = async_fs::File::open(path).await?;
     let read_limit = max_bytes.saturating_add(1);
@@ -85,19 +84,16 @@ pub async fn read_capped(path: &Path, max_bytes: u64) -> Result<Vec<u8>, FileLoa
     let mut buffer = Vec::with_capacity(metadata_len.min(read_limit) as usize);
     file.take(read_limit).read_to_end(&mut buffer).await?;
     if buffer.len() as u64 > max_bytes {
-        // `stat` isn't trusted for the accept/reject decision above. It's only trusted to
-        // report the file's *size* when it succeeded, the path is a regular file (a FIFO or
-        // character device commonly reports a misleading length, often 0), and it itself
-        // reports something past the limit; otherwise all that's actually known is the lower
-        // bound proven by the capped read.
-        let size = match &metadata {
-            Some(metadata) if metadata.is_file() && metadata.len() > max_bytes => {
-                ReportedSize::Exact(metadata.len())
-            }
-            _ => ReportedSize::AtLeast(buffer.len() as u64),
-        };
+        // Never trusted for the accept/reject decision above, and never presented as an exact
+        // size either -- a regular file's on-disk size can still change between this `stat` and
+        // the read above finishing. Only offered as a rough estimate, and only when `stat`
+        // succeeded, the path is a regular file (a FIFO or character device commonly reports a
+        // misleading length, often 0), and it itself reported something past the limit.
+        let size_estimate = metadata
+            .filter(|metadata| metadata.is_file() && metadata.len() > max_bytes)
+            .map(|metadata| metadata.len());
         return Err(FileLoadError::TooLarge {
-            size,
+            size_estimate,
             limit_bytes: max_bytes,
         });
     }

--- a/crates/warp_util/src/file.rs
+++ b/crates/warp_util/src/file.rs
@@ -32,12 +32,22 @@ impl ErrorExt for FileSaveError {
 }
 register_error!(FileSaveError);
 
+/// Maximum size, in bytes, of a file that can be fully loaded into memory as a
+/// `String` (e.g. to populate an editor buffer). Reading larger files whole
+/// risks multi-gigabyte allocations for pathologically large files (logs,
+/// binaries opened by mistake, etc.); callers should check
+/// [`FileLoadError::TooLarge`] and surface a friendly error instead of
+/// attempting the read.
+pub const MAX_LOADABLE_FILE_SIZE_BYTES: u64 = 100 * 1024 * 1024;
+
 #[derive(thiserror::Error, Debug)]
 pub enum FileLoadError {
     #[error("File does not exist")]
     DoesNotExist,
     #[error("IO error when loading file.")]
     IOError(#[from] io::Error),
+    #[error("File is too large to open ({size_bytes} bytes, limit is {limit_bytes} bytes)")]
+    TooLarge { size_bytes: u64, limit_bytes: u64 },
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/warp_util/src/file.rs
+++ b/crates/warp_util/src/file.rs
@@ -1,7 +1,8 @@
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use futures_lite::io::AsyncReadExt as _;
 use warp_errors::{ErrorExt, register_error};
 
 #[derive(thiserror::Error, Debug)]
@@ -50,6 +51,42 @@ pub enum FileLoadError {
     TooLarge { size_bytes: u64, limit_bytes: u64 },
 }
 
+/// Reads `path` into a `Vec<u8>`, rejecting content exceeding `max_bytes`.
+///
+/// The cap is enforced by the read itself — at most `max_bytes + 1` bytes are read from a
+/// single open handle via [`AsyncReadExt::take`] — rather than by a preceding `stat`. A
+/// `stat`-then-reread-by-path check cannot be trusted as the enforcement boundary: a FIFO,
+/// `/dev/zero`, or other virtual stream commonly reports a length of zero regardless of how
+/// much data it actually yields, and a regular file's size can change (or the path can be
+/// atomically replaced) between the `stat` and a later, separate open. `metadata` is still
+/// queried here, but only as a best-effort allocation-size hint, capped so an inflated or
+/// unrelated `stat` length can never itself cause an over-cap reservation.
+pub async fn read_capped(path: &Path, max_bytes: u64) -> Result<Vec<u8>, FileLoadError> {
+    let file = async_fs::File::open(path).await?;
+    let read_limit = max_bytes.saturating_add(1);
+    let metadata_len = file.metadata().await.map(|m| m.len()).unwrap_or(0);
+    let mut buffer = Vec::with_capacity(metadata_len.min(read_limit) as usize);
+    file.take(read_limit).read_to_end(&mut buffer).await?;
+    if buffer.len() as u64 > max_bytes {
+        // `stat` isn't trusted for the accept/reject decision above, but when it reports a size
+        // at least as large as what was actually read, it's more informative to surface than the
+        // bare "read past the limit" lower bound.
+        let size_bytes = metadata_len.max(buffer.len() as u64);
+        return Err(FileLoadError::TooLarge {
+            size_bytes,
+            limit_bytes: max_bytes,
+        });
+    }
+    Ok(buffer)
+}
+
+/// String counterpart of [`read_capped`]; see its doc comment for the enforcement rationale.
+pub async fn read_to_string_capped(path: &Path, max_bytes: u64) -> Result<String, FileLoadError> {
+    let bytes = read_capped(path, max_bytes).await?;
+    String::from_utf8(bytes)
+        .map_err(|err| FileLoadError::IOError(io::Error::new(io::ErrorKind::InvalidData, err)))
+}
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FileId(usize);
 
@@ -62,3 +99,7 @@ impl FileId {
         FileId(raw)
     }
 }
+
+#[cfg(test)]
+#[path = "file_tests.rs"]
+mod tests;

--- a/crates/warp_util/src/file_tests.rs
+++ b/crates/warp_util/src/file_tests.rs
@@ -1,7 +1,9 @@
 use tempfile::TempDir;
 use warpui_core::r#async::block_on;
 
-use super::{FileLoadError, read_capped, read_to_string_capped};
+#[cfg(unix)]
+use super::read_capped;
+use super::{FileLoadError, read_to_string_capped};
 
 fn write_file(dir: &TempDir, name: &str, contents: &[u8]) -> std::path::PathBuf {
     let path = dir.path().join(name);

--- a/crates/warp_util/src/file_tests.rs
+++ b/crates/warp_util/src/file_tests.rs
@@ -1,7 +1,7 @@
 use tempfile::TempDir;
 use warpui_core::r#async::block_on;
 
-use super::{FileLoadError, read_capped, read_to_string_capped};
+use super::{FileLoadError, ReportedSize, read_capped, read_to_string_capped};
 
 fn write_file(dir: &TempDir, name: &str, contents: &[u8]) -> std::path::PathBuf {
     let path = dir.path().join(name);
@@ -25,9 +25,27 @@ fn read_to_string_capped_rejects_file_over_limit() {
 
     let error = block_on(read_to_string_capped(&path, 1024)).expect_err("should reject");
     assert!(
-        matches!(error, FileLoadError::TooLarge { limit_bytes, .. } if limit_bytes == 1024),
-        "expected TooLarge, got {error:?}"
+        matches!(
+            error,
+            FileLoadError::TooLarge {
+                size: ReportedSize::Exact(2048),
+                limit_bytes: 1024
+            }
+        ),
+        "expected an exact TooLarge(2048) over a 1024 limit, got {error:?}"
     );
+}
+
+#[test]
+fn read_to_string_capped_accepts_a_file_exactly_at_the_limit() {
+    // The cap rejects content *exceeding* `max_bytes`; a file of exactly `max_bytes` is the
+    // boundary and must be accepted, not off-by-one rejected.
+    let dir = TempDir::new().expect("create tempdir");
+    let path = write_file(&dir, "exact.txt", &vec![b'a'; 1024]);
+
+    let contents =
+        block_on(read_to_string_capped(&path, 1024)).expect("exact-limit file should be accepted");
+    assert_eq!(contents.len(), 1024);
 }
 
 #[test]
@@ -56,9 +74,17 @@ fn read_capped_rejects_unbounded_data_from_a_device_reporting_zero_length() {
 
     let error = block_on(read_capped(std::path::Path::new("/dev/zero"), 1024))
         .expect_err("should reject unbounded device data");
+    // The lying `stat` must not be surfaced as the file's exact size -- only the lower bound
+    // actually proven by the capped read is known here.
     assert!(
-        matches!(error, FileLoadError::TooLarge { .. }),
-        "expected TooLarge, got {error:?}"
+        matches!(
+            error,
+            FileLoadError::TooLarge {
+                size: ReportedSize::AtLeast(1025),
+                limit_bytes: 1024
+            }
+        ),
+        "expected an AtLeast(1025) lower bound over a 1024 limit, got {error:?}"
     );
 }
 
@@ -100,9 +126,16 @@ fn read_capped_rejects_content_that_grows_past_the_cap_while_being_read() {
     });
 
     let error = block_on(read_capped(&fifo_path, 1024)).expect_err("should reject");
+    // As above: a FIFO's lying `stat` must not be surfaced as an exact size.
     assert!(
-        matches!(error, FileLoadError::TooLarge { .. }),
-        "expected TooLarge, got {error:?}"
+        matches!(
+            error,
+            FileLoadError::TooLarge {
+                size: ReportedSize::AtLeast(1025),
+                limit_bytes: 1024
+            }
+        ),
+        "expected an AtLeast(1025) lower bound over a 1024 limit, got {error:?}"
     );
 
     writer.join().expect("writer thread should not panic");

--- a/crates/warp_util/src/file_tests.rs
+++ b/crates/warp_util/src/file_tests.rs
@@ -1,0 +1,109 @@
+use tempfile::TempDir;
+use warpui_core::r#async::block_on;
+
+use super::{FileLoadError, read_capped, read_to_string_capped};
+
+fn write_file(dir: &TempDir, name: &str, contents: &[u8]) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    std::fs::write(&path, contents).expect("write temp file");
+    path
+}
+
+#[test]
+fn read_to_string_capped_reads_file_under_limit() {
+    let dir = TempDir::new().expect("create tempdir");
+    let path = write_file(&dir, "small.txt", b"hello world");
+
+    let contents = block_on(read_to_string_capped(&path, 1024)).expect("should read file");
+    assert_eq!(contents, "hello world");
+}
+
+#[test]
+fn read_to_string_capped_rejects_file_over_limit() {
+    let dir = TempDir::new().expect("create tempdir");
+    let path = write_file(&dir, "big.txt", &vec![b'a'; 2048]);
+
+    let error = block_on(read_to_string_capped(&path, 1024)).expect_err("should reject");
+    assert!(
+        matches!(error, FileLoadError::TooLarge { limit_bytes, .. } if limit_bytes == 1024),
+        "expected TooLarge, got {error:?}"
+    );
+}
+
+#[test]
+fn read_to_string_capped_missing_file_reports_io_error() {
+    let dir = TempDir::new().expect("create tempdir");
+    let missing = dir.path().join("does-not-exist.txt");
+
+    let error = block_on(read_to_string_capped(&missing, 1024)).expect_err("should fail");
+    assert!(
+        matches!(error, FileLoadError::IOError(ref err) if err.kind() == std::io::ErrorKind::NotFound),
+        "expected a NotFound IOError, got {error:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn read_capped_rejects_unbounded_data_from_a_device_reporting_zero_length() {
+    // `/dev/zero` is a character device that yields unbounded data while `stat` reports a
+    // length of 0. A stat-then-reread-by-path implementation would see `0 <= max_bytes`, pass
+    // the check, and then hand an effectively unbounded stream to an unbounded read. The cap
+    // must be enforced by the read itself, independent of what `stat` reports.
+    let metadata_len = std::fs::metadata("/dev/zero")
+        .expect("stat /dev/zero")
+        .len();
+    assert_eq!(metadata_len, 0, "/dev/zero should report a length of 0");
+
+    let error = block_on(read_capped(std::path::Path::new("/dev/zero"), 1024))
+        .expect_err("should reject unbounded device data");
+    assert!(
+        matches!(error, FileLoadError::TooLarge { .. }),
+        "expected TooLarge, got {error:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn read_capped_rejects_content_that_grows_past_the_cap_while_being_read() {
+    // A FIFO's content isn't fixed at open time the way a regular file's is -- it arrives (and
+    // can keep growing past the cap) while the read is in progress, the same class of hazard as
+    // a file being mutated or atomically replaced between a `stat` and a later, separate read.
+    // `stat` also reports a fixed length of 0 for a FIFO, doubling as another
+    // zero-length-metadata case.
+    let dir = TempDir::new().expect("create tempdir");
+    let fifo_path = dir.path().join("fifo");
+    let status = command::blocking::Command::new("mkfifo")
+        .arg(&fifo_path)
+        .status()
+        .expect("mkfifo should run");
+    assert!(status.success(), "mkfifo should succeed");
+
+    let metadata_len = std::fs::metadata(&fifo_path).expect("stat fifo").len();
+    assert_eq!(metadata_len, 0, "a FIFO should report a length of 0");
+
+    let writer_path = fifo_path.clone();
+    let writer = std::thread::spawn(move || {
+        use std::io::Write as _;
+        // Opens block until a reader connects; `read_capped` provides the reader below.
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&writer_path)
+            .expect("open fifo for writing");
+        let chunk = vec![b'a'; 4096];
+        // Keep writing well past the cap; a correct reader stops well before this loop ends,
+        // and the loop exits once the reader disconnects and the write returns an error.
+        for _ in 0..256 {
+            if file.write_all(&chunk).is_err() {
+                break;
+            }
+        }
+    });
+
+    let error = block_on(read_capped(&fifo_path, 1024)).expect_err("should reject");
+    assert!(
+        matches!(error, FileLoadError::TooLarge { .. }),
+        "expected TooLarge, got {error:?}"
+    );
+
+    writer.join().expect("writer thread should not panic");
+}

--- a/crates/warp_util/src/file_tests.rs
+++ b/crates/warp_util/src/file_tests.rs
@@ -1,7 +1,7 @@
 use tempfile::TempDir;
 use warpui_core::r#async::block_on;
 
-use super::{FileLoadError, ReportedSize, read_capped, read_to_string_capped};
+use super::{FileLoadError, read_capped, read_to_string_capped};
 
 fn write_file(dir: &TempDir, name: &str, contents: &[u8]) -> std::path::PathBuf {
     let path = dir.path().join(name);
@@ -28,11 +28,11 @@ fn read_to_string_capped_rejects_file_over_limit() {
         matches!(
             error,
             FileLoadError::TooLarge {
-                size: ReportedSize::Exact(2048),
+                size_estimate: Some(2048),
                 limit_bytes: 1024
             }
         ),
-        "expected an exact TooLarge(2048) over a 1024 limit, got {error:?}"
+        "expected a TooLarge estimate of 2048 over a 1024 limit, got {error:?}"
     );
 }
 
@@ -74,17 +74,17 @@ fn read_capped_rejects_unbounded_data_from_a_device_reporting_zero_length() {
 
     let error = block_on(read_capped(std::path::Path::new("/dev/zero"), 1024))
         .expect_err("should reject unbounded device data");
-    // The lying `stat` must not be surfaced as the file's exact size -- only the lower bound
-    // actually proven by the capped read is known here.
+    // `/dev/zero` isn't a regular file, so its (lying) `stat` length must not be surfaced as a
+    // size estimate at all.
     assert!(
         matches!(
             error,
             FileLoadError::TooLarge {
-                size: ReportedSize::AtLeast(1025),
+                size_estimate: None,
                 limit_bytes: 1024
             }
         ),
-        "expected an AtLeast(1025) lower bound over a 1024 limit, got {error:?}"
+        "expected no size estimate over a 1024 limit, got {error:?}"
     );
 }
 
@@ -126,16 +126,17 @@ fn read_capped_rejects_content_that_grows_past_the_cap_while_being_read() {
     });
 
     let error = block_on(read_capped(&fifo_path, 1024)).expect_err("should reject");
-    // As above: a FIFO's lying `stat` must not be surfaced as an exact size.
+    // As above: a FIFO isn't a regular file, so its (lying) `stat` length must not be surfaced
+    // as a size estimate.
     assert!(
         matches!(
             error,
             FileLoadError::TooLarge {
-                size: ReportedSize::AtLeast(1025),
+                size_estimate: None,
                 limit_bytes: 1024
             }
         ),
-        "expected an AtLeast(1025) lower bound over a 1024 limit, got {error:?}"
+        "expected no size estimate over a 1024 limit, got {error:?}"
     );
 
     writer.join().expect("writer thread should not panic");


### PR DESCRIPTION
## Description

`FileModel::open` and `FileModel::read_content_for_file` (`crates/warp_files/src/lib.rs`)
called `async_fs::read_to_string` with no size check, so opening a pathologically large
file (a multi-gigabyte log, database dump, or binary opened by mistake) in the code editor
allocated memory proportional to the file's size.

### Root cause

Sentry issue [7259255054](https://sentry.io/organizations/warpdotdev/issues/7259255054/)
("Excessive memory usage detected", event `8dec8f23a1d94bff9956dda86086450e`, macOS
stable) captured a heap profile sampling **22.9 GB**. The allocation chain starts with
this same unbounded `read_to_string` call, then amplifies through
`GlobalBufferModel::handle_file_model_events` → `populate_buffer_with_read_content` →
`Buffer::replace_all` → `update_content_with_text_fragments` rebuilding the whole
`SumTree<BufferText>` (~15.4 GB) → `sum_tree::SumTree::push_tree_recursive` allocating a
fresh `Arc<Node<BufferText>>` per node (~13.2 GB), plus a downstream `EditDelta` clone in
`CodeEditorModel::handle_content_model_event` (~7.1 GB) and smaller `StyledBufferRun`/
`StyledTextBlock` clones.

Capping the read up front (this PR) means the oversized content never reaches
`replace_all`, so the `SumTree`/`Arc<Node>` amplification is unreachable for a rejected
file. This is deliberately the *whole* fix here — no streaming/chunked buffer
construction is implemented, per triage on APP-4519.

**Verified live** (real Warp client, commit `0c913ab3`, oversized sparse file): opening an
8 GiB file produces the toast, and RSS rises by only ~3 MB (511,176 KB → 514,156 KB) —
flat and unrelated to input size, against the 22.9 GB the Sentry profile sampled. (Baseline
RSS varies between build/run sessions; the delta is the meaningful measurement.)

### Consolidation note

This was one of **nine** open PRs adding an overlapping file-size guard to this same read
path (APP-5343, APP-4519, APP-4801, and six further duplicates: #12060, #12052, #12125,
#12185, #11854, #15052). Triage on APP-4519 designated this PR (originally opened for
APP-5343) as the one to carry forward, since it already guarded both call sites
(`open` and `read_content_for_file`) plus the file-watcher auto-reload path, and already
had a toast UX. Seven of the eight others are closed in favor of this one. #15052
(APP-4801) was reopened after review — its bounded-read hardening for other,
unrelated read paths (MCP config, project rules, skill watcher, Drive import, Alacritty
import) is not duplicated here and remains a separate, live PR; only its read-time-cap
pattern (see "Enforcement fix" below) was adapted into this PR. See APP-4519 for the
consolidation record. Primary tracking issue: [APP-4519](https://linear.app/warpdotdev/issue/APP-4519/memory-spike-globalbuffermodel-loads-large-file-content-into-editor).

### Explicitly out of scope (tracked separately)

- The `EditDelta` clone (APP-4844 / #13508) — still relevant for under-cap files, not
  touched here.
- `GlobalBufferModel::resolve_conflict` — the profile's `resolve_conflict::{closure}`
  symbol is a linker identical-code-folding artifact from a byte-identical closure body
  elsewhere; the real conflict-resolution path is tracked separately under APP-5357 /
  #15094.
- The CoreText layout blowup for a single enormous line (APP-5392, APP-5360) — a byte-size
  cap does not gate a single huge line, so this is a separate, follow-up fix. A very long
  single line inside an otherwise-under-cap file can still hit that path.
- **A rejected file still opens an empty tab** (with an empty content area and "Language
  support is unavailable for this file type" in the status bar — the same generic message
  any file without LSP support shows; it is not specific to, or an explanation of, the
  rejection), with only the toast (which fades after ~1-2s) explaining why. Verified this
  is **pre-existing behavior on
  `master`, not a regression from this PR**: `open_new_tab`/`open_in_preview_or_promote`
  in `app/src/code/view.rs` unconditionally create the tab and its editor view before the
  async load resolves, and the `LocalCodeEditorEvent::FailedToLoad` handler only shows a
  toast — it doesn't touch the tab, for *any* `FileLoadError` (`DoesNotExist`, `IOError`,
  or `TooLarge`). This PR makes that pre-existing rough edge more reachable (oversized
  files now fail cleanly through this same path instead of risking an OOM first), but
  doesn't create it. Left alone here; what should happen to the tab is a product decision
  for the requester, not something this PR should decide.

### Fix

- Add `FileLoadError::TooLarge { size_estimate: Option<u64>, limit_bytes: u64 }` and a
  `MAX_LOADABLE_FILE_SIZE_BYTES` (100 MiB) constant in `warp_util`, so the threshold is a
  single named, well-placed constant.
- Handle the new `FileLoadError` variant in the one place that exhaustively matched on it
  (`app/src/ai/blocklist/action_model/execute.rs`).
- Show a specific, actionable toast in the code editor
  (`CodeView::display_load_failure`) when a file is rejected for being too large, instead
  of the generic "Failed to load file." message. See "Enforcement fix" below for the
  exact strings.

### Enforcement fix (post-review revisions)

The read is capped by `warp_util::file::read_capped`/`read_to_string_capped`, which
enforce the limit **during** the read itself — reading at most `max_bytes + 1` bytes from
a single open handle via `AsyncReadExt::take` — rather than trusting a preceding `stat`.
Applied at all three read sites: `open`, `read_content_for_file`, and the autoreload loop
(extracted into `read_reload_contents` for testability). This closes the gap in an earlier
revision of this PR, where a `stat`-then-read check could be bypassed entirely by a FIFO,
`/dev/zero`, or a file that grows/gets replaced between the `stat` and the read.

A later review pass caught that `metadata()`'s own result — queried on the same open
handle, but still logically a separate observation from the read that follows it — is
subject to the same kind of race: a regular file's on-disk size can change (or the inode
be replaced) between that `metadata()` call and the capped read finishing. So it can never
be presented as an exact size, or compared against the limit as though both were measured
the same way (which would also look like a false comparison whenever both values round to
the same displayed unit, e.g. a file of exactly `limit + 1` byte). `TooLarge` therefore
carries `size_estimate: Option<u64>` — present only when `stat` succeeded, the path is a
regular file, and it itself reported something past the limit — and the toast presents it,
when available, as an explicitly-labeled, non-comparative estimate:

- With a usable estimate: `File is larger than the 100.0 MiB limit (reported size ~8.0 GiB).`
- Without one (`stat` failed, or a non-regular file — the `/dev/zero`/FIFO cases):
  `File is larger than the 100.0 MiB limit.`

Also fixed `format_file_size`'s unit labels: it divides by 1024 but originally labeled the
result `KB`/`MB`/`GB`/`TB` (decimal-looking), so an exactly-8 GiB file rendered as `8.0 GB`
— actually 8.59 GB. Relabeled to `KiB`/`MiB`/`GiB`/`TiB` to match the existing divisor.
This helper is introduced by this PR and has no other callers, so the fix is local to this
PR and doesn't touch any shared byte-formatting code elsewhere in the app.

## Linked Issue

Linear: [APP-4519](https://linear.app/warpdotdev/issue/APP-4519/memory-spike-globalbuffermodel-loads-large-file-content-into-editor)
(also addresses [APP-5343](https://linear.app/warpdotdev/issue/APP-5343/memory-86-gb-unbounded-async-fsread-to-string-in-filemodelopen-allows))

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Captured live in a real, running Warp client on commit `0c913ab3` — see the recording and
screenshots below. Opening the 8 GiB sparse file produces the size-estimate form of the
toast (`File is larger than the 100.0 MiB limit (reported size ~8.0 GiB).`); a boundary
file at `limit + 1` bytes produces the same form with a size that itself rounds to the
limit (`File is larger than the 100.0 MiB limit (reported size ~100.0 MiB).`).

The no-estimate form (`File is larger than the 100.0 MiB limit.`) only fires for a `stat`
failure or a non-regular file. This form could not be captured live: it is not reachable
through any UI affordance in the running app. Neither `/dev/zero` nor a FIFO can be
opened — the terminal's link-click-to-open feature never engages with character devices
or FIFOs at all (no underline on hover, no tooltip, no open option), and the app has no
other way to target an arbitrary path: there is no native Open File dialog, no `Ctrl+O`
binding for one (it just types the literal character into the focused editor), and the
only file-browsing UI — a Tools-panel file tree — is scoped to the current session
directory. This is a genuine reachability limit, not something skipped; the form is
exercised only by the unit tests below.

## Testing

- [x] `crates/warp_files/src/lib_tests.rs`: `test_load_oversized_file_reports_too_large`,
      `test_read_content_for_file_reports_too_large`,
      `test_read_reload_contents_skips_oversized_file`,
      `test_reload_file_paths_skips_oversized_replacement` (autoreload of an already-open
      file that grows past the cap is skipped, not emitted as `FileUpdated`; deterministically
      asserts no update exists for the oversized file's id, not just that the first received
      event belongs to the small one).
- [x] `crates/warp_util/src/file_tests.rs`: under/over/exactly-at-limit boundary cases, a
      missing file, and two read-time-enforcement regressions — `/dev/zero` (reports a
      0-byte length via `stat`) and a FIFO whose writer keeps producing data past the cap
      while the read is in progress — both asserting no size estimate is reported.
- [x] `cargo test -p warp_files --lib` — 37 passed
- [x] `cargo test -p warp_util --lib` — 114 passed
- [x] `cargo test -p warp --features local_fs --lib ai::blocklist::action_model::execute::` — 160 passed
- [x] `cargo clippy -p warp_files -p warp_util --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p warp --features local_fs --lib -- -D warnings` — clean
- [x] `./script/format` applied — no changes
- [x] Live verification in a running Warp client (commit `0c913ab3`): opening an 8 GiB
      sparse file shows the toast and RSS rises by only ~3 MB (511,176 KB → 514,156 KB);
      opening a `limit + 1`-byte file rises a further ~13 MB (→ 527,088 KB). Baseline RSS
      varies between build/run sessions — the delta against the input size is what matters
      (see "Root cause" above).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- warp:pr-description-artifacts start -->
<!-- oz:computer-use-videos start -->
<details>
<summary>Computer-use video recordings (2)</summary>

[![Testing Warp's behavior when opening huge.txt (8GiB sparse), limit\_plus\_one.txt (100MiB+1 byte), and small.txt via terminal links, observing toasts, editor tab states, and memory usage.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a63-a59c-7132-a2c1-141189a10909/download)](https://oz.staging.warp.dev/artifacts/01a02a63-a12f-7e01-ab3b-9789ce180511)
**Warp oversized file open test**: Testing Warp's behavior when opening huge.txt (8GiB sparse), limit\_plus\_one.txt (100MiB+1 byte), and small.txt via terminal links, observing toasts, editor tab states, and memory usage.

[![Closing existing huge.txt tab, running ls -la on huge.txt in terminal, clicking the path link and choosing Open in Warp, then watching closely for a brief toast notification.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a67-04aa-7d6b-981d-442850905bd9/download)](https://oz.staging.warp.dev/artifacts/01a02a67-0137-7321-8a0b-47d87d2d6f2b)
**Re-triggering huge.txt open to catch toast**: Closing existing huge.txt tab, running ls -la on huge.txt in terminal, clicking the path link and choosing Open in Warp, then watching closely for a brief toast notification.

</details>
<!-- oz:computer-use-videos end -->
<!-- oz:computer-use-screenshots start -->
<details>
<summary>Computer-use screenshots (10)</summary>

![Baseline ps aux output showing main warp-oss process (pid 42553): CPU 16.2%, MEM 1.5%, RSS 511176 KB, VSZ 5802344 KB, before opening any oversized files.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a5e-3f97-7264-bb19-188835840556/download)
Baseline ps aux output showing main warp-oss process (pid 42553): CPU 16.2%, MEM 1.5%, RSS 511176 KB, VSZ 5802344 KB, before opening any oversized files.

![huge.txt editor tab opened but shows empty content area (only line number "1", no text/placeholder). No toast/notification appeared. Status bar shows generic "Language support is unavailable for this file type" message.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a5f-2927-780e-b86f-0706a51973a0/download)
huge.txt editor tab opened but shows empty content area (only line number "1", no text/placeholder). No toast/notification appeared. Status bar shows generic "Language support is unavailable for this file type" message.

![ps aux after opening huge.txt: warp-oss pid 42553, CPU 17.1%, MEM 1.5%, RSS 514156 KB (up only \~3MB from baseline 511176 KB) — no significant memory increase from opening the 8GiB sparse file.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a5f-80c2-7d4f-80ee-7110ef40d643/download)
ps aux after opening huge.txt: warp-oss pid 42553, CPU 17.1%, MEM 1.5%, RSS 514156 KB (up only \~3MB from baseline 511176 KB) — no significant memory increase from opening the 8GiB sparse file.

![Toast notification for limit\_plus\_one.txt: salmon/pink background box with circular info icon, text reads 'File is larger than the 100.0 MiB limit (reported size \~100.0 MiB).' positioned at top-right of editor pane overlapping tab bar.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a61-7167-7e02-9b4d-be4a8121ddf9/download)
Toast notification for limit\_plus\_one.txt: salmon/pink background box with circular info icon, text reads 'File is larger than the 100.0 MiB limit (reported size \~100.0 MiB).' positioned at top-right of editor pane overlapping tab bar.

![limit\_plus\_one.txt editor tab after toast disappeared: content area is empty (only line number 1, no text), same empty-state behavior as huge.txt. Toast was visible for roughly 1-2 seconds then vanished.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a61-a2f3-7862-b4a6-10c5d0b7ccd0/download)
limit\_plus\_one.txt editor tab after toast disappeared: content area is empty (only line number 1, no text), same empty-state behavior as huge.txt. Toast was visible for roughly 1-2 seconds then vanished.

![ps aux after opening limit\_plus\_one.txt: warp-oss pid 42553, CPU 18.0%, MEM 1.6%, RSS 527088 KB (up \~13MB from previous 514156 KB) — modest increase, not full 100MB file loaded into memory.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a61-f55b-70cf-b0b6-b5ce57541ea8/download)
ps aux after opening limit\_plus\_one.txt: warp-oss pid 42553, CPU 18.0%, MEM 1.6%, RSS 527088 KB (up \~13MB from previous 514156 KB) — modest increase, not full 100MB file loaded into memory.

![small.txt opened normally in editor, showing exact content: line 1 'Hello world!', line 2 'This is a small control file.', line 3 empty.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a62-4469-79e9-8fbb-ffc6e6f19d12/download)
small.txt opened normally in editor, showing exact content: line 1 'Hello world!', line 2 'This is a small control file.', line 3 empty.

![Right-click context menu on the Tools panel file tree root, showing options (New file, cd to directory, Open in new tab, Reveal in file manager, Attach as context, Copy path, Copy relative path) — no option to browse to arbitrary filesystem paths like /dev/zero. Ctrl+O does not open a file dialog; it inserts the literal character 'o' into the focused editor instead.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a63-6c58-78d9-aa82-5950e7085e7f/download)
Right-click context menu on the Tools panel file tree root, showing options (New file, cd to directory, Open in new tab, Reveal in file manager, Attach as context, Copy path, Copy relative path) — no option to browse to arbitrary filesystem paths like /dev/zero. Ctrl+O does not open a file dialog; it inserts the literal character 'o' into the focused editor instead.

![Toast notification appearing at top of editor pane immediately after clicking "Open in Warp" for huge.txt: "File is larger than the 100.0 MiB limit (reported size \~8.0 GiB)."](https://staging.warp.dev/api/v1/agent/artifacts/01a02a66-aedc-7a23-96db-ecbaf1be97da/download)
Toast notification appearing at top of editor pane immediately after clicking "Open in Warp" for huge.txt: "File is larger than the 100.0 MiB limit (reported size \~8.0 GiB)."

![Resulting huge.txt editor tab state after the toast faded: an empty content pane showing only line number 1 with no text, the app remaining responsive.](https://staging.warp.dev/api/v1/agent/artifacts/01a02a66-eca7-79ac-ac2a-ead604aacd5c/download)
Resulting huge.txt editor tab state after the toast faded: an empty content pane showing only line number 1 with no text, the app remaining responsive.

</details>
<!-- oz:computer-use-screenshots end -->
<!-- warp:pr-description-artifacts end -->

<!--
CHANGELOG-BUG-FIX: Fixed an issue where opening an extremely large file in the code editor could cause a multi-gigabyte memory spike; oversized files now fail to open with a clear error instead.
-->


