### PR TITLE
TUI: live per-turn pricing breakdown (Detail mode + per-response delta)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -3171,7 +3171,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4510,7 +4510,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4815,7 +4815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7140,7 +7140,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7334,7 +7334,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10577,8 +10577,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.10.5",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph",
@@ -10597,7 +10597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10843,7 +10843,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11834,7 +11834,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11847,7 +11847,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11915,7 +11915,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13605,7 +13605,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15808,7 +15808,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=b40bca688c39c52c6fbc12bd6a6511a95d7b9f54#b40bca688c39c52c6fbc12bd6a6511a95d7b9f54"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=f0028fa6d05db1ba63726eaf6f8d33ab17abe37b#f0028fa6d05db1ba63726eaf6f8d33ab17abe37b"
 dependencies = [
  "prost",
  "prost-reflect",
@@ -17000,7 +17000,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -3171,7 +3171,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4510,7 +4510,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4815,7 +4815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7140,7 +7140,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7334,7 +7334,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9762,7 +9762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -10577,8 +10577,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -10597,7 +10597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10843,7 +10843,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11834,7 +11834,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11847,7 +11847,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11915,7 +11915,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13605,7 +13605,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15808,7 +15808,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=b0886a9523e2e05d102f61bd0a212dc15ade4835#b0886a9523e2e05d102f61bd0a212dc15ade4835"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=b40bca688c39c52c6fbc12bd6a6511a95d7b9f54#b40bca688c39c52c6fbc12bd6a6511a95d7b9f54"
 dependencies = [
  "prost",
  "prost-reflect",
@@ -17000,7 +17000,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "b0886a9523e2e05d102f61bd0a212dc15ade4835" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "b40bca688c39c52c6fbc12bd6a6511a95d7b9f54" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "b40bca688c39c52c6fbc12bd6a6511a95d7b9f54" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "f0028fa6d05db1ba63726eaf6f8d33ab17abe37b" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -29,6 +29,8 @@ fn test_server_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: Some(3.2),
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -66,8 +66,8 @@ use crate::code_review::CodeReviewTelemetryEvent;
 use crate::notebooks::NotebookId;
 use crate::persistence::ModelEvent;
 use crate::persistence::model::{
-    AgentConversationData, ContextWindowSegment, ConversationUsageMetadata, ModelTokenUsage,
-    PersistedAutoexecuteMode, ToolUsageMetadata,
+    AgentConversationData, ChargedUsageTotals, ContextWindowSegment, ConversationUsageMetadata,
+    ModelTokenUsage, PersistedAutoexecuteMode, ToolUsageMetadata,
 };
 use crate::server::ids::ServerId;
 use crate::terminal::general_settings::GeneralSettings;
@@ -193,6 +193,12 @@ pub struct ConversationUsageTotals {
     /// while a restored legacy conversation with real usage but an unknown
     /// historical cost still shows it.
     pub has_usage: bool,
+    /// Cumulative per-category charged-usage breakdown (input/output/
+    /// cache-read/cache-write cost + token counts) for the whole
+    /// conversation so far, from `ConversationUsageMetadata.total_charges`.
+    /// `None` when the server didn't provide it (flag off, or a legacy
+    /// conversation).
+    pub charged_usage: Option<ChargedUsageTotals>,
 }
 
 /// Whether persisted or server usage metadata carries evidence that the
@@ -821,6 +827,18 @@ impl AIConversation {
         self.conversation_usage_metadata
             .credits_spent_for_last_block
             .map(|credits| (credits * 10.0).round() / 10.0)
+    }
+
+    /// Per-category charged-usage breakdown over the last block, where the
+    /// block comprises all agent outputs since the most recent user input
+    /// (mirrors [`Self::credits_spent_for_last_block`], but as a full
+    /// input/output/cache-read/cache-write cost + token breakdown rather
+    /// than a bare credits figure). `None` when the server didn't provide
+    /// `StreamFinished.request_charges` (flag off) or before any block has
+    /// completed.
+    pub fn charged_usage_for_last_block(&self) -> Option<ChargedUsageTotals> {
+        self.conversation_usage_metadata
+            .charged_usage_for_last_block
     }
 
     /// Time to first token for the last completed set of agent responses
@@ -2198,6 +2216,7 @@ impl AIConversation {
     pub fn update_cost_and_usage_for_request(
         &mut self,
         request_cost: Option<RequestCost>,
+        request_charges: Option<stream_finished::RequestCharges>,
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<stream_finished::ConversationUsageMetadata>,
         was_user_initiated_request: bool,
@@ -2245,12 +2264,31 @@ impl AIConversation {
             self.total_request_cost += request_cost;
         }
 
+        if let Some(request_charges) = request_charges {
+            let totals = ChargedUsageTotals::from(&request_charges);
+            let charged_usage_for_last_block = self
+                .conversation_usage_metadata
+                .charged_usage_for_last_block
+                .get_or_insert_with(ChargedUsageTotals::default);
+
+            // Mirrors the `credits_spent_for_last_block` reset above: a
+            // user-initiated request starts a new response block.
+            if was_user_initiated_request {
+                *charged_usage_for_last_block = ChargedUsageTotals::default();
+            }
+            *charged_usage_for_last_block += totals;
+        }
+
         if let Some(usage_metadata) = usage_metadata {
             self.conversation_usage_metadata.context_window_usage =
                 usage_metadata.context_window_usage;
             self.conversation_usage_metadata.credits_spent = usage_metadata.credits_spent;
             self.conversation_usage_metadata.platform_credits_spent =
                 usage_metadata.platform_credits_spent;
+            self.conversation_usage_metadata.total_charged_usage = usage_metadata
+                .total_charges
+                .as_ref()
+                .map(ChargedUsageTotals::from);
             let llm_preferences = LLMPreferences::as_ref(ctx);
             self.conversation_usage_metadata.token_usage =
                 footer_model_token_usage(&usage_metadata, llm_preferences);
@@ -3767,6 +3805,7 @@ impl AIConversation {
             credits_spent: self.inference_credits_spent() + self.platform_credits_spent(),
             cost_in_cents: self.total_provider_cost_in_cents,
             has_usage: self.has_usage_metadata,
+            charged_usage: self.conversation_usage_metadata.total_charged_usage,
         }
     }
 

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -304,6 +304,7 @@ fn custom_endpoint_usage_metadata(
         token_usage: vec![],
         tool_usage_metadata: None,
         total_input_tokens: 0,
+        total_charges: None,
         warp_token_usage: HashMap::new(),
         byok_token_usage: HashMap::new(),
         context_window_segments: Vec::new(),
@@ -867,6 +868,7 @@ fn credits_usage_metadata(
         token_usage: vec![],
         tool_usage_metadata: None,
         total_input_tokens: 0,
+        total_charges: None,
         warp_token_usage: HashMap::new(),
         byok_token_usage: HashMap::new(),
         context_window_segments: Vec::new(),
@@ -960,6 +962,7 @@ fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_label
             token_usage: vec![],
             tool_usage_metadata: None,
             total_input_tokens: 0,
+            total_charges: None,
             warp_token_usage: HashMap::new(),
             byok_token_usage: HashMap::from([(
                 "Resolved custom".to_string(),
@@ -1025,6 +1028,7 @@ fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fall
             token_usage: vec![],
             tool_usage_metadata: None,
             total_input_tokens: 0,
+            total_charges: None,
             warp_token_usage: HashMap::new(),
             byok_token_usage: HashMap::new(),
             custom_endpoint_token_usage: HashMap::from([(

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -666,6 +666,7 @@ fn restored_usage_totals_preserve_server_provider_cost_and_add_follow_up() {
                 conversation
                     .update_cost_and_usage_for_request(
                         None,
+                        None,
                         vec![stream_token_usage("model-a", 10, 2, 1.2)],
                         Some(credits_usage_metadata(1.0, 0.0)),
                         false,
@@ -739,6 +740,7 @@ fn restored_legacy_conversation_keeps_provider_cost_unavailable_after_follow_up(
             conversation
                 .update_cost_and_usage_for_request(
                     None,
+                    None,
                     vec![stream_token_usage("legacy-model", 10, 2, 1.5)],
                     Some(credits_usage_metadata(1.0, 0.0)),
                     false,
@@ -780,6 +782,7 @@ fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
             conversation
                 .update_cost_and_usage_for_request(
                     None,
+                    None,
                     vec![],
                     Some(custom_endpoint_usage_metadata("config-key", 6)),
                     false,
@@ -814,6 +817,7 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    None,
                     None,
                     vec![],
                     Some(custom_endpoint_usage_metadata("missing-config-key", 9)),
@@ -889,12 +893,14 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
                 credits_spent: 0.0,
                 cost_in_cents: Some(0.0),
                 has_usage: false,
+                charged_usage: None,
             }
         );
 
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    None,
                     None,
                     vec![stream_token_usage("model-a", 100, 20, 1.5)],
                     Some(credits_usage_metadata(2.0, 0.5)),
@@ -907,6 +913,7 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
             // summing, while provider cost accumulates per request.
             conversation
                 .update_cost_and_usage_for_request(
+                    None,
                     None,
                     vec![stream_token_usage("model-a", 50, 10, 1.2)],
                     Some(credits_usage_metadata(3.0, 0.5)),

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -928,6 +928,8 @@ fn create_server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/agent_sdk/artifact_upload_tests.rs
+++ b/app/src/ai/agent_sdk/artifact_upload_tests.rs
@@ -41,6 +41,8 @@ fn create_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -3254,6 +3254,7 @@ impl BlocklistAIController {
                     // Total credits charged for this request = inference (`exact`) + platform.
                     RequestCost::new(f64::from(cost.exact) + f64::from(cost.platform_credits))
                 }),
+                finished_event.request_charges.take(),
                 finished_event.token_usage,
                 finished_event.conversation_usage_metadata.take(),
                 did_request_contain_user_query,

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -520,6 +520,7 @@ impl BlocklistAIController {
                     platform_credits_spent: conversation.platform_credits_spent(),
                     summarized: conversation.was_summarized(),
                     total_input_tokens: 0,
+                    total_charges: None,
                     #[allow(deprecated)]
                     token_usage: conversation
                         .token_usage()
@@ -562,6 +563,7 @@ impl BlocklistAIController {
                     token_usage: vec![],
                     should_refresh_model_config: false,
                     request_cost: None,
+                    request_charges: None,
                 },
             )),
         };

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -300,6 +300,7 @@ fn mock_response_stream_updates_history_through_controller() {
                             token_usage: vec![],
                             should_refresh_model_config: false,
                             request_cost: None,
+                            request_charges: None,
                         },
                     )),
                 },

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -17,7 +17,7 @@ use warp_core::features::FeatureFlag;
 use warp_multi_agent_api::client_action::{Action, StartNewConversation};
 use warp_multi_agent_api::message::tool_call::Tool;
 use warp_multi_agent_api::response_event::stream_finished::{
-    ConversationUsageMetadata, TokenUsage,
+    ConversationUsageMetadata, RequestCharges, TokenUsage,
 };
 use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity};
 
@@ -1986,10 +1986,12 @@ impl BlocklistAIHistoryModel {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_conversation_cost_and_usage_for_request(
         &mut self,
         conversation_id: AIConversationId,
         request_cost: Option<RequestCost>,
+        request_charges: Option<RequestCharges>,
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<ConversationUsageMetadata>,
         was_user_initiated_request: bool,
@@ -2000,11 +2002,14 @@ impl BlocklistAIHistoryModel {
         // subscribers (e.g. the orchestration credit rollup or the TUI
         // footer's usage entry). We emit the event only when there's actual
         // data to react to.
-        let emits_usage_event =
-            request_cost.is_some() || usage_metadata.is_some() || !token_usage.is_empty();
+        let emits_usage_event = request_cost.is_some()
+            || request_charges.is_some()
+            || usage_metadata.is_some()
+            || !token_usage.is_empty();
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             if let Err(e) = conversation.update_cost_and_usage_for_request(
                 request_cost,
+                request_charges,
                 token_usage,
                 usage_metadata,
                 was_user_initiated_request,

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1338,6 +1338,8 @@ fn create_server_metadata(
         platform_credits_spent: 0.0,
         total_provider_cost_in_cents: None,
         credits_spent_for_last_block: None,
+        charged_usage_for_last_block: None,
+        total_charged_usage: None,
         token_usage: vec![],
         tool_usage_metadata: Default::default(),
         context_window_segments: Vec::new(),

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -372,6 +372,8 @@ fn make_server_metadata_with_harness(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -187,6 +187,8 @@ fn create_test_server_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -367,6 +367,8 @@ fn test_server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -654,6 +654,10 @@ pub enum TuiUsageDisplayMode {
     Credits,
     /// Provider dollar cost.
     Cost,
+    /// Full pricing-transparency breakdown: dollar cost, token count, and
+    /// the per-category (input/cache-read/cache-write/output) inference
+    /// cost breakdown, condensed onto the single footer line.
+    Detail,
 }
 
 settings::macros::implement_setting_for_enum!(
@@ -807,11 +811,13 @@ impl TuiStatuslineConfig {
 }
 
 impl TuiUsageDisplayMode {
-    /// The other unit — clicking the usage entry flips to this.
+    /// The next unit in the click-to-cycle sequence: credits → cost → full
+    /// breakdown detail → back to credits.
     pub fn toggled(self) -> Self {
         match self {
             TuiUsageDisplayMode::Credits => TuiUsageDisplayMode::Cost,
-            TuiUsageDisplayMode::Cost => TuiUsageDisplayMode::Credits,
+            TuiUsageDisplayMode::Cost => TuiUsageDisplayMode::Detail,
+            TuiUsageDisplayMode::Detail => TuiUsageDisplayMode::Credits,
         }
     }
 }

--- a/app/src/terminal/shared_session/replay_agent_conversations.rs
+++ b/app/src/terminal/shared_session/replay_agent_conversations.rs
@@ -170,6 +170,7 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
             credits_spent: conversation.inference_credits_spent(),
             platform_credits_spent: conversation.platform_credits_spent(),
             summarized: conversation.was_summarized(),
+            total_charges: None,
             #[allow(deprecated)]
             token_usage: conversation
                 .token_usage()
@@ -210,6 +211,7 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
                 token_usage: vec![],
                 should_refresh_model_config: false,
                 request_cost: None,
+                request_charges: None,
             },
         )),
     }

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -305,6 +305,8 @@ fn server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -757,6 +757,8 @@ fn server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -175,6 +175,7 @@ pub use crate::code_review::github_repo_model::GitHubRepoModel;
 pub use crate::completer::SessionContext;
 pub use crate::global_resource_handles::GlobalResourceHandlesProvider;
 pub use crate::persistence::PersistenceWriter;
+pub use crate::persistence::model::ChargedUsageTotals;
 pub use crate::prefix::longest_common_prefix;
 pub use crate::search::slash_command_menu::static_commands::commands::{
     self as slash_commands, COMMAND_REGISTRY,

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -611,6 +611,7 @@ impl ApiKeyManager {
                             |m| api::request::settings::custom_model_providers::CustomModel {
                                 slug: m.name.clone(),
                                 config_key: m.config_key.clone(),
+                                reasoning_effort: String::new(),
                             },
                         )
                         .collect(),

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -217,6 +217,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             platform_credits_spent: gql.platform_credits_spent as f32,
             total_provider_cost_in_cents: gql.total_provider_cost_in_cents.map(|cost| cost as f32),
             credits_spent_for_last_block: None,
+            // Not yet fetched by this GraphQL query (persisted-history
+            // vertical, milestone 3) -- left `None` rather than fabricated.
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -198,6 +198,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             platform_credits_spent: gql.platform_credits_spent as f32,
             total_provider_cost_in_cents: gql.total_provider_cost_in_cents.map(|cost| cost as f32),
             credits_spent_for_last_block: None,
+            // Not yet fetched by this GraphQL query (persisted-history
+            // vertical, milestone 3) -- left `None` rather than fabricated.
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1623,16 +1623,27 @@ pub struct ChargedUsageTotals {
     pub output_tokens: u32,
     pub input_cache_read_tokens: u32,
     pub input_cache_write_tokens: u32,
+    /// Number of web searches performed, summed across every usage category
+    /// and model. `#[serde(default)]` so blobs persisted before this field
+    /// existed still deserialize.
+    #[serde(default)]
+    pub web_search_count: u32,
+    /// Cumulative cost of web searches performed, in US cents. Included in
+    /// [`Self::total_cost_in_cents`] since it's part of the real, actually-
+    /// charged dollar total (see `warp-proto-apis` PR #363).
+    #[serde(default)]
+    pub web_search_cost_in_cents: f32,
 }
 
 impl ChargedUsageTotals {
-    /// Total inference + platform cost, in US cents.
+    /// Total inference + platform + web-search cost, in US cents.
     pub fn total_cost_in_cents(&self) -> f32 {
         self.input_cost_in_cents
             + self.output_cost_in_cents
             + self.input_cache_read_cost_in_cents
             + self.input_cache_write_cost_in_cents
             + self.platform_cost_in_cents
+            + self.web_search_cost_in_cents
     }
 
     /// Total tokens across every category (input + output + cache-read + cache-write).
@@ -1656,6 +1667,8 @@ impl ChargedUsageTotals {
             self.input_cache_read_cost_in_cents += token_cost.input_cache_read_cost_in_cents;
             self.input_cache_write_cost_in_cents += token_cost.input_cache_write_cost_in_cents;
         }
+        self.web_search_count += usage.web_search_count;
+        self.web_search_cost_in_cents += usage.web_search_cost_in_cents;
     }
 }
 
@@ -1670,6 +1683,8 @@ impl std::ops::AddAssign for ChargedUsageTotals {
         self.output_tokens += rhs.output_tokens;
         self.input_cache_read_tokens += rhs.input_cache_read_tokens;
         self.input_cache_write_tokens += rhs.input_cache_write_tokens;
+        self.web_search_count += rhs.web_search_count;
+        self.web_search_cost_in_cents += rhs.web_search_cost_in_cents;
     }
 }
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1605,6 +1605,97 @@ impl From<&ContextWindowSegment> for stream_finished::ContextWindowSegment {
     }
 }
 
+/// A flat breakdown of charged usage — input/output/cache-read/cache-write
+/// inference cost (in US cents) plus platform cost, and the matching token
+/// counts — summed across every usage category and model. Mirrors the Go
+/// `SumChargedUsage` helper (`warp-server` `logic/ai/multi_agent/usage`);
+/// computed client-side from the wire's category/model-keyed
+/// `RequestCharges` map so downstream displays don't need to walk the map
+/// themselves.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq)]
+pub struct ChargedUsageTotals {
+    pub input_cost_in_cents: f32,
+    pub output_cost_in_cents: f32,
+    pub input_cache_read_cost_in_cents: f32,
+    pub input_cache_write_cost_in_cents: f32,
+    pub platform_cost_in_cents: f32,
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub input_cache_read_tokens: u32,
+    pub input_cache_write_tokens: u32,
+}
+
+impl ChargedUsageTotals {
+    /// Total inference + platform cost, in US cents.
+    pub fn total_cost_in_cents(&self) -> f32 {
+        self.input_cost_in_cents
+            + self.output_cost_in_cents
+            + self.input_cache_read_cost_in_cents
+            + self.input_cache_write_cost_in_cents
+            + self.platform_cost_in_cents
+    }
+
+    /// Total tokens across every category (input + output + cache-read + cache-write).
+    pub fn total_tokens(&self) -> u32 {
+        self.input_tokens
+            + self.output_tokens
+            + self.input_cache_read_tokens
+            + self.input_cache_write_tokens
+    }
+
+    fn add_inference_usage(&mut self, usage: &stream_finished::InferenceUsage) {
+        if let Some(token_count) = usage.token_count.as_ref() {
+            self.input_tokens += token_count.input;
+            self.output_tokens += token_count.output;
+            self.input_cache_read_tokens += token_count.input_cache_read;
+            self.input_cache_write_tokens += token_count.input_cache_write;
+        }
+        if let Some(token_cost) = usage.token_cost.as_ref() {
+            self.input_cost_in_cents += token_cost.input_cost_in_cents;
+            self.output_cost_in_cents += token_cost.output_cost_in_cents;
+            self.input_cache_read_cost_in_cents += token_cost.input_cache_read_cost_in_cents;
+            self.input_cache_write_cost_in_cents += token_cost.input_cache_write_cost_in_cents;
+        }
+    }
+}
+
+impl std::ops::AddAssign for ChargedUsageTotals {
+    fn add_assign(&mut self, rhs: Self) {
+        self.input_cost_in_cents += rhs.input_cost_in_cents;
+        self.output_cost_in_cents += rhs.output_cost_in_cents;
+        self.input_cache_read_cost_in_cents += rhs.input_cache_read_cost_in_cents;
+        self.input_cache_write_cost_in_cents += rhs.input_cache_write_cost_in_cents;
+        self.platform_cost_in_cents += rhs.platform_cost_in_cents;
+        self.input_tokens += rhs.input_tokens;
+        self.output_tokens += rhs.output_tokens;
+        self.input_cache_read_tokens += rhs.input_cache_read_tokens;
+        self.input_cache_write_tokens += rhs.input_cache_write_tokens;
+    }
+}
+
+impl From<&stream_finished::RequestCharges> for ChargedUsageTotals {
+    /// Sums a category-keyed `RequestCharges` map (per-turn or cumulative)
+    /// into a single flat breakdown, mirroring the Go `SumChargedUsage`
+    /// helper. Categories and models are summed together; per-category/
+    /// per-model detail is discarded, matching the single
+    /// pricing-breakdown-section display convention (`warp` PR #15015).
+    fn from(charges: &stream_finished::RequestCharges) -> Self {
+        let mut totals = Self::default();
+        for usage in charges.usage_by_category.values() {
+            for inference_usage in usage
+                .direct_api_inference_usage
+                .values()
+                .chain(usage.byok_inference_usage.values())
+                .chain(usage.custom_endpoint_inference_usage.values())
+            {
+                totals.add_inference_usage(inference_usage);
+            }
+            totals.platform_cost_in_cents += usage.platform_usage_in_cents;
+        }
+        totals
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ConversationUsageMetadata {
     pub was_summarized: bool,
@@ -1619,6 +1710,19 @@ pub struct ConversationUsageMetadata {
     pub total_provider_cost_in_cents: Option<f32>,
     #[serde(default)]
     pub credits_spent_for_last_block: Option<f32>,
+    /// Per-category charged-usage breakdown for the most recent block (all
+    /// agent outputs since the last user input), summed via
+    /// [`ChargedUsageTotals::from`] from `StreamFinished.request_charges`.
+    /// `None` when the server didn't provide charges (flag off) or before
+    /// any block has completed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub charged_usage_for_last_block: Option<ChargedUsageTotals>,
+    /// Cumulative per-category charged-usage breakdown summed across the
+    /// whole conversation so far, from
+    /// `ConversationUsageMetadata.total_charges`. `None` when the server
+    /// didn't provide it (flag off, or a legacy conversation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_charged_usage: Option<ChargedUsageTotals>,
     #[serde(default)]
     pub token_usage: Vec<ModelTokenUsage>,
     #[serde(default)]

--- a/crates/persistence/src/model_tests.rs
+++ b/crates/persistence/src/model_tests.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use warp_multi_agent_api as api;
 
 use super::{
-    AgentConversation, AgentConversationData, AgentConversationSummary, ConversationUsageMetadata,
-    ModelTokenUsage,
+    AgentConversation, AgentConversationData, AgentConversationSummary, ChargedUsageTotals,
+    ConversationUsageMetadata, ModelTokenUsage,
 };
 
 fn parentless_task(id: &str, message_count: usize) -> api::Task {
@@ -133,6 +133,100 @@ fn conversation_usage_metadata_preserves_known_zero_provider_cost() {
             .unwrap()
             .contains("\"total_provider_cost_in_cents\":0.0")
     );
+}
+
+fn inference_usage_with_web_search(
+    input: u32,
+    output: u32,
+    input_cost_in_cents: f32,
+    output_cost_in_cents: f32,
+    web_search_count: u32,
+    web_search_cost_in_cents: f32,
+) -> api::response_event::stream_finished::InferenceUsage {
+    api::response_event::stream_finished::InferenceUsage {
+        token_count: Some(api::response_event::stream_finished::TokenCount {
+            input,
+            output,
+            input_cache_read: 0,
+            input_cache_write: 0,
+        }),
+        token_cost: Some(api::response_event::stream_finished::TokenCost {
+            input_cost_in_cents,
+            output_cost_in_cents,
+            input_cache_read_cost_in_cents: 0.0,
+            input_cache_write_cost_in_cents: 0.0,
+        }),
+        web_search_count,
+        web_search_cost_in_cents,
+    }
+}
+
+#[test]
+fn charged_usage_totals_sums_web_search_fields_across_categories_and_models() {
+    let mut usage_by_category = HashMap::new();
+    usage_by_category.insert(
+        "primary_agent".to_string(),
+        api::response_event::stream_finished::ChargedUsage {
+            direct_api_inference_usage: HashMap::from([(
+                "claude-4.5".to_string(),
+                inference_usage_with_web_search(1000, 200, 3.0, 6.0, 2, 5.0),
+            )]),
+            byok_inference_usage: HashMap::new(),
+            custom_endpoint_inference_usage: HashMap::new(),
+            platform_usage_in_cents: 1.0,
+        },
+    );
+    usage_by_category.insert(
+        "compaction".to_string(),
+        api::response_event::stream_finished::ChargedUsage {
+            direct_api_inference_usage: HashMap::from([(
+                "claude-4.5".to_string(),
+                inference_usage_with_web_search(500, 100, 1.5, 3.0, 1, 2.5),
+            )]),
+            byok_inference_usage: HashMap::new(),
+            custom_endpoint_inference_usage: HashMap::new(),
+            platform_usage_in_cents: 0.0,
+        },
+    );
+    let charges = api::response_event::stream_finished::RequestCharges { usage_by_category };
+
+    let totals = ChargedUsageTotals::from(&charges);
+
+    assert_eq!(totals.web_search_count, 3);
+    assert!((totals.web_search_cost_in_cents - 7.5).abs() < 1e-6);
+    // Total cost must include web search cost alongside the token + platform costs.
+    assert!((totals.total_cost_in_cents() - (3.0 + 6.0 + 1.5 + 3.0 + 1.0 + 7.5)).abs() < 1e-6);
+}
+
+#[test]
+fn charged_usage_totals_add_assign_sums_web_search_fields() {
+    let mut a = ChargedUsageTotals {
+        web_search_count: 2,
+        web_search_cost_in_cents: 4.0,
+        ..Default::default()
+    };
+    let b = ChargedUsageTotals {
+        web_search_count: 3,
+        web_search_cost_in_cents: 6.0,
+        ..Default::default()
+    };
+
+    a += b;
+
+    assert_eq!(a.web_search_count, 5);
+    assert!((a.web_search_cost_in_cents - 10.0).abs() < 1e-6);
+}
+
+#[test]
+fn charged_usage_totals_deserializes_legacy_payload_without_web_search_fields() {
+    let totals: ChargedUsageTotals = serde_json::from_str(
+        r#"{"input_cost_in_cents":1.0,"output_cost_in_cents":2.0,"input_cache_read_cost_in_cents":0.0,"input_cache_write_cost_in_cents":0.0,"platform_cost_in_cents":0.0,"input_tokens":10,"output_tokens":5,"input_cache_read_tokens":0,"input_cache_write_tokens":0}"#,
+    )
+    .unwrap();
+
+    assert_eq!(totals.web_search_count, 0);
+    assert_eq!(totals.web_search_cost_in_cents, 0.0);
+    assert!((totals.total_cost_in_cents() - 3.0).abs() < 1e-6);
 }
 
 fn user_query_message(task_id: &str, query: &str, pwd: Option<&str>) -> api::Message {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -28,11 +28,11 @@ use warp::tui_export::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel,
     BlocklistOrchestrationTelemetryEvent, CLISubagentController, CLISubagentEvent,
     CLISubagentTarget, COMMAND_REGISTRY, CancellationReason, ChangelogModel, ChangelogRequestType,
-    CloudConversationData, CommandExecutionSource, ConversationFileExport, ConversationSelection,
-    ConversationSelectionHandle, ExecuteCommandEvent, FORK_PREFIX, ForkConversationError,
-    GetRelevantFilesController, GitHubRepoModel, GitRepoStatusModel, LLMId, LLMPreferences,
-    LLMPreferencesEvent, LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE, LinkedWorkflowData,
-    ModelEvent, ParsedSlashCommandInput, PersistenceWriter, PillBarActionKind,
+    ChargedUsageTotals, CloudConversationData, CommandExecutionSource, ConversationFileExport,
+    ConversationSelection, ConversationSelectionHandle, ExecuteCommandEvent, FORK_PREFIX,
+    ForkConversationError, GetRelevantFilesController, GitHubRepoModel, GitRepoStatusModel, LLMId,
+    LLMPreferences, LLMPreferencesEvent, LOCAL_SKILLS_REMOTE_EXECUTION_ERROR_MESSAGE,
+    LinkedWorkflowData, ModelEvent, ParsedSlashCommandInput, PersistenceWriter, PillBarActionKind,
     PillBarInteractionEvent, PillBarPillKind, PillSwitchOutcome, PtyIntent, PtyIntentEvent,
     QueuedQueryEvent, QueuedQueryModel, RepoDetectionSessionType, RepoDetectionSource,
     ServerConversationToken, SessionSettings, Sessions, SessionsEvent, ShellCommandExecutorEvent,
@@ -3764,12 +3764,13 @@ impl TuiTerminalSessionView {
         exchange_id: AIAgentExchangeId,
         duration: Duration,
         block_credits: Option<f32>,
+        block_charged_usage: Option<ChargedUsageTotals>,
         ctx: &AppContext,
     ) -> Option<Box<dyn TuiElement>> {
         (!self
             .hidden_response_summary_exchange_ids
             .contains(&exchange_id))
-        .then(|| render_response_summary(duration, block_credits, ctx))
+        .then(|| render_response_summary(duration, block_credits, block_charged_usage, ctx))
     }
 
     /// Toggles the inline model picker from the footer's active-model label —
@@ -5387,6 +5388,7 @@ impl TuiTerminalSessionView {
                     exchange_id,
                     duration,
                     conversation.credits_spent_for_last_block(),
+                    conversation.charged_usage_for_last_block(),
                     ctx,
                 ) {
                     content =

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -2449,6 +2449,7 @@ fn response_summary_visibility_is_independent_from_the_footer_usage_mode() {
             credits_spent: 2.5,
             cost_in_cents: Some(3.2),
             has_usage: true,
+            charged_usage: None,
         };
 
         assert_eq!(
@@ -2461,6 +2462,7 @@ fn response_summary_visibility_is_independent_from_the_footer_usage_mode() {
                 exchange_id,
                 Duration::from_secs(2),
                 Some(3.0),
+                None,
                 ctx,
             )
             .map(|summary| render_element(summary, ctx, 60).to_lines())
@@ -2475,6 +2477,7 @@ fn response_summary_visibility_is_independent_from_the_footer_usage_mode() {
                 exchange_id,
                 Duration::from_secs(2),
                 Some(3.0),
+                None,
                 ctx,
             )
         });
@@ -2497,6 +2500,7 @@ fn response_summary_visibility_is_independent_from_the_footer_usage_mode() {
                 exchange_id,
                 Duration::from_secs(2),
                 Some(3.0),
+                None,
                 ctx,
             )
             .map(|summary| render_element(summary, ctx, 60).to_lines())
@@ -4815,6 +4819,7 @@ fn footer_renders_agent_sections_left_aligned() {
                     credits_spent: 2.5,
                     cost_in_cents: Some(0.0),
                     has_usage: true,
+                    charged_usage: None,
                 },
                 ctx,
                 |_, _| {},
@@ -4908,6 +4913,7 @@ fn footer_usage_entry_shows_unknown_cost_even_with_zero_credits() {
                     credits_spent: 0.0,
                     cost_in_cents: None,
                     has_usage: true,
+                    charged_usage: None,
                 },
                 ctx,
                 |_, _| {},

--- a/crates/warp_tui/src/usage.rs
+++ b/crates/warp_tui/src/usage.rs
@@ -92,10 +92,11 @@ fn entry_text(mode: TuiUsageDisplayMode, totals: ConversationUsageTotals) -> Str
 
 /// Condenses the full pricing-transparency breakdown onto a single status
 /// line: total dollar cost, token count, and the per-category inference
-/// cost breakdown (summed across every usage category/model via
-/// `ChargedUsageTotals`). Gracefully degrades (like `Cost` mode) when the
-/// underlying data isn't available -- e.g. a legacy conversation, or a
-/// server response predating the pricing-transparency breakdown fields.
+/// cost breakdown (input/cache-read/cache-write/output plus web search,
+/// summed across every usage category/model via `ChargedUsageTotals`).
+/// Gracefully degrades (like `Cost` mode) when the underlying data isn't
+/// available -- e.g. a legacy conversation, or a server response predating
+/// the pricing-transparency breakdown fields.
 fn format_detail(totals: ConversationUsageTotals) -> String {
     let Some(cost_in_cents) = totals.cost_in_cents else {
         return "Cost unavailable".to_owned();
@@ -107,11 +108,12 @@ fn format_detail(totals: ConversationUsageTotals) -> String {
             text.push_str(&format!(" \u{b7} {total_tokens} tok"));
         }
         text.push_str(&format!(
-            " \u{b7} in {} \u{b7} cr {} \u{b7} cw {} \u{b7} out {}",
+            " \u{b7} in {} \u{b7} cr {} \u{b7} cw {} \u{b7} out {} \u{b7} web {}",
             format_cost(charged_usage.input_cost_in_cents),
             format_cost(charged_usage.input_cache_read_cost_in_cents),
             format_cost(charged_usage.input_cache_write_cost_in_cents),
             format_cost(charged_usage.output_cost_in_cents),
+            format_cost(charged_usage.web_search_cost_in_cents),
         ));
     }
     text

--- a/crates/warp_tui/src/usage.rs
+++ b/crates/warp_tui/src/usage.rs
@@ -77,7 +77,8 @@ impl UsageToggle {
 }
 
 /// The entry's text for `mode`: the GUI-consistent credits total (formatted
-/// with the GUI's own `format_credits`) or the provider dollar cost.
+/// with the GUI's own `format_credits`), the provider dollar cost, or the
+/// full pricing-transparency detail breakdown.
 fn entry_text(mode: TuiUsageDisplayMode, totals: ConversationUsageTotals) -> String {
     match mode {
         TuiUsageDisplayMode::Credits => format_credits(totals.credits_spent),
@@ -85,7 +86,35 @@ fn entry_text(mode: TuiUsageDisplayMode, totals: ConversationUsageTotals) -> Str
             .cost_in_cents
             .map(format_cost)
             .unwrap_or_else(|| "Cost unavailable".to_owned()),
+        TuiUsageDisplayMode::Detail => format_detail(totals),
     }
+}
+
+/// Condenses the full pricing-transparency breakdown onto a single status
+/// line: total dollar cost, token count, and the per-category inference
+/// cost breakdown (summed across every usage category/model via
+/// `ChargedUsageTotals`). Gracefully degrades (like `Cost` mode) when the
+/// underlying data isn't available -- e.g. a legacy conversation, or a
+/// server response predating the pricing-transparency breakdown fields.
+fn format_detail(totals: ConversationUsageTotals) -> String {
+    let Some(cost_in_cents) = totals.cost_in_cents else {
+        return "Cost unavailable".to_owned();
+    };
+    let mut text = format_cost(cost_in_cents);
+    if let Some(charged_usage) = totals.charged_usage {
+        let total_tokens = charged_usage.total_tokens();
+        if total_tokens > 0 {
+            text.push_str(&format!(" \u{b7} {total_tokens} tok"));
+        }
+        text.push_str(&format!(
+            " \u{b7} in {} \u{b7} cr {} \u{b7} cw {} \u{b7} out {}",
+            format_cost(charged_usage.input_cost_in_cents),
+            format_cost(charged_usage.input_cache_read_cost_in_cents),
+            format_cost(charged_usage.input_cache_write_cost_in_cents),
+            format_cost(charged_usage.output_cost_in_cents),
+        ));
+    }
+    text
 }
 
 /// Formats an accumulated cost in US cents as dollars (`3.2` cents → `$0.03`).

--- a/crates/warp_tui/src/usage_tests.rs
+++ b/crates/warp_tui/src/usage_tests.rs
@@ -31,6 +31,8 @@ fn fixture_charged_usage() -> ChargedUsageTotals {
         output_tokens: 50,
         input_cache_read_tokens: 20,
         input_cache_write_tokens: 10,
+        web_search_count: 1,
+        web_search_cost_in_cents: 5.0,
     }
 }
 
@@ -112,15 +114,15 @@ fn detail_mode_explicitly_marks_unknown_historical_cost() {
 }
 
 /// Detail mode renders the total cost, token count, and the per-category
-/// input/cache-read/cache-write/output breakdown, all summed from a
-/// `ChargedUsageTotals` fixture.
+/// input/cache-read/cache-write/output/web-search breakdown, all summed
+/// from a `ChargedUsageTotals` fixture.
 #[test]
 fn detail_mode_renders_full_breakdown() {
     let usage = totals_with_charged_usage(2.5, 3.3, fixture_charged_usage());
     let text = entry_text(TuiUsageDisplayMode::Detail, usage);
     assert_eq!(
         text,
-        "$0.03 \u{b7} 180 tok \u{b7} in $0.01 \u{b7} cr $0.00 \u{b7} cw $0.00 \u{b7} out $0.02"
+        "$0.03 \u{b7} 180 tok \u{b7} in $0.01 \u{b7} cr $0.00 \u{b7} cw $0.00 \u{b7} out $0.02 \u{b7} web $0.05"
     );
 }
 

--- a/crates/warp_tui/src/usage_tests.rs
+++ b/crates/warp_tui/src/usage_tests.rs
@@ -1,6 +1,6 @@
 use warp::appearance::Appearance;
 use warp::settings::TuiUsageDisplayMode;
-use warp::tui_export::ConversationUsageTotals;
+use warp::tui_export::{ChargedUsageTotals, ConversationUsageTotals};
 use warp_core::features::FeatureFlag;
 use warpui_core::App;
 use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
@@ -13,6 +13,35 @@ fn totals(credits_spent: f32, cost_in_cents: f32) -> ConversationUsageTotals {
         credits_spent,
         cost_in_cents: Some(cost_in_cents),
         has_usage: true,
+        charged_usage: None,
+    }
+}
+
+/// A fixture breakdown shared with the GUI-side tests for the same sample
+/// conversation, so Detail mode's rendered text can be cross-checked against
+/// the GUI panels' numbers for identical input data (validation criterion 1).
+fn fixture_charged_usage() -> ChargedUsageTotals {
+    ChargedUsageTotals {
+        input_cost_in_cents: 1.0,
+        output_cost_in_cents: 2.0,
+        input_cache_read_cost_in_cents: 0.2,
+        input_cache_write_cost_in_cents: 0.1,
+        platform_cost_in_cents: 0.0,
+        input_tokens: 100,
+        output_tokens: 50,
+        input_cache_read_tokens: 20,
+        input_cache_write_tokens: 10,
+    }
+}
+
+fn totals_with_charged_usage(
+    credits_spent: f32,
+    cost_in_cents: f32,
+    charged_usage: ChargedUsageTotals,
+) -> ConversationUsageTotals {
+    ConversationUsageTotals {
+        charged_usage: Some(charged_usage),
+        ..totals(credits_spent, cost_in_cents)
     }
 }
 
@@ -38,12 +67,14 @@ fn entry_text_matches_the_gui_credits_formatting() {
 #[test]
 fn entry_text_follows_the_persisted_display_mode() {
     let usage = totals(2.5, 3.2);
-    // Credits is the default mode; a click toggles to cost and back.
+    // Credits is the default mode; a click cycles credits → cost → detail →
+    // back to credits.
     let credits = TuiUsageDisplayMode::default();
     assert_eq!(entry_text(credits, usage), "2.5 credits");
     assert_eq!(entry_text(credits.toggled(), usage), "$0.03");
+    assert_eq!(entry_text(credits.toggled().toggled(), usage), "$0.03");
     assert_eq!(
-        entry_text(credits.toggled().toggled(), usage),
+        entry_text(credits.toggled().toggled().toggled(), usage),
         "2.5 credits"
     );
 }
@@ -57,10 +88,49 @@ fn cost_mode_explicitly_marks_unknown_historical_cost() {
                 credits_spent: 0.0,
                 cost_in_cents: None,
                 has_usage: true,
+                charged_usage: None,
             },
         ),
         "Cost unavailable"
     );
+}
+
+#[test]
+fn detail_mode_explicitly_marks_unknown_historical_cost() {
+    assert_eq!(
+        entry_text(
+            TuiUsageDisplayMode::Detail,
+            ConversationUsageTotals {
+                credits_spent: 0.0,
+                cost_in_cents: None,
+                has_usage: true,
+                charged_usage: None,
+            },
+        ),
+        "Cost unavailable"
+    );
+}
+
+/// Detail mode renders the total cost, token count, and the per-category
+/// input/cache-read/cache-write/output breakdown, all summed from a
+/// `ChargedUsageTotals` fixture.
+#[test]
+fn detail_mode_renders_full_breakdown() {
+    let usage = totals_with_charged_usage(2.5, 3.3, fixture_charged_usage());
+    let text = entry_text(TuiUsageDisplayMode::Detail, usage);
+    assert_eq!(
+        text,
+        "$0.03 \u{b7} 180 tok \u{b7} in $0.01 \u{b7} cr $0.00 \u{b7} cw $0.00 \u{b7} out $0.02"
+    );
+}
+
+/// When the cost is known but no charged-usage breakdown was provided (e.g. a
+/// legacy conversation, or a request predating the breakdown fields), Detail
+/// mode degrades to just the total cost — no fabricated per-category split.
+#[test]
+fn detail_mode_without_charged_usage_shows_cost_only() {
+    let usage = totals(2.5, 3.2);
+    assert_eq!(entry_text(TuiUsageDisplayMode::Detail, usage), "$0.03");
 }
 
 /// The credits⇄dollars toggle is gated behind `PricingTransparency`: with the
@@ -111,6 +181,53 @@ fn footer_usage_entry_gates_the_cost_toggle_behind_the_feature_flag() {
             assert!(
                 line.contains("$0.03"),
                 "flag on must follow the persisted cost mode, got: {line:?}"
+            );
+        });
+    });
+}
+
+/// Same gate, but for the `Detail` mode specifically: with the flag off, a
+/// persisted `Detail` mode (e.g. left over from a session where the flag was
+/// on) must still render as plain static credits, not the breakdown -- byte
+/// identical to pre-saga (Credits/Cost-only) output.
+#[test]
+fn footer_usage_entry_gates_detail_mode_behind_the_feature_flag() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+        });
+        let toggle = UsageToggle::default();
+        let usage = totals_with_charged_usage(2.5, 3.3, fixture_charged_usage());
+
+        app.read(|ctx| {
+            let _guard = FeatureFlag::PricingTransparency.override_enabled(false);
+            let entry = toggle.render_entry(TuiUsageDisplayMode::Detail, usage, ctx, |_, _| {});
+            let line = TuiPresenter::new()
+                .present_element(entry, TuiRect::new(0, 0, 40, 1), ctx)
+                .buffer
+                .to_lines()
+                .join("");
+            assert!(
+                line.contains("2.5 credits"),
+                "flag off must show static credits, got: {line:?}"
+            );
+            assert!(
+                !line.contains("tok") && !line.contains('$'),
+                "flag off must not expose the breakdown, got: {line:?}"
+            );
+        });
+
+        app.read(|ctx| {
+            let _guard = FeatureFlag::PricingTransparency.override_enabled(true);
+            let entry = toggle.render_entry(TuiUsageDisplayMode::Detail, usage, ctx, |_, _| {});
+            let line = TuiPresenter::new()
+                .present_element(entry, TuiRect::new(0, 0, 40, 1), ctx)
+                .buffer
+                .to_lines()
+                .join("");
+            assert!(
+                line.contains("180 tok"),
+                "flag on must follow the persisted detail mode, got: {line:?}"
             );
         });
     });

--- a/crates/warp_tui/src/warping_indicator.rs
+++ b/crates/warp_tui/src/warping_indicator.rs
@@ -15,7 +15,8 @@
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use warp::tui_export::format_credits;
+use warp::tui_export::{ChargedUsageTotals, format_credits};
+use warp_core::features::FeatureFlag;
 use warpui_core::AppContext;
 use warpui_core::elements::animation::{AnimationClock, Keyframe, KeyframeTimeline};
 use warpui_core::elements::shimmer_math::ShimmerConfig;
@@ -134,22 +135,46 @@ pub(crate) fn render_warping_indicator_row(
 
 /// Renders the completed-response summary row shown in the indicator's slot
 /// once the response finishes: the resting glyph, the response's wall-to-wall
-/// duration, and the credits it spent (omitted until any are reported). The
+/// duration, and the credits it spent (omitted until any are reported),
+/// followed by its dollar cost when pricing transparency is enabled. The
 /// row is static — no animation, no repaint scheduling.
 pub(crate) fn render_response_summary(
     duration: Duration,
     block_credits: Option<f32>,
+    block_charged_usage: Option<ChargedUsageTotals>,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
     let mut text = format!("{RESTING_SPINNER} {}s", duration.as_secs());
     if let Some(credits) = block_credits.filter(|credits| *credits > 0.0) {
-        text.push_str(&format!(" • {}", format_credits(credits)));
+        text.push_str(&format!(
+            " \u{2022} {}",
+            format_credits_with_cost(credits, block_charged_usage)
+        ));
     }
     TuiText::new(text)
         .with_style(builder.muted_text_style())
         .truncate()
         .finish()
+}
+
+/// Formats a credits figure with its dollar cost delta appended in parens
+/// (`"0.5 credits ($0.03)"`), gated by `FeatureFlag::PricingTransparency` --
+/// pre-saga behavior (credits only) when the flag is off, matching the
+/// existing Credits/Cost/Detail footer toggle's gate. `charged_usage` is
+/// this response's cost delta, not the conversation cumulative.
+fn format_credits_with_cost(credits: f32, charged_usage: Option<ChargedUsageTotals>) -> String {
+    let credits_text = format_credits(credits);
+    if !FeatureFlag::PricingTransparency.is_enabled() {
+        return credits_text;
+    }
+    let Some(charged_usage) = charged_usage else {
+        return credits_text;
+    };
+    format!(
+        "{credits_text} ({})",
+        crate::usage::format_cost(charged_usage.total_cost_in_cents())
+    )
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/warping_indicator_tests.rs
+++ b/crates/warp_tui/src/warping_indicator_tests.rs
@@ -1,13 +1,22 @@
 use std::time::Duration;
 
 use warp::appearance::Appearance;
+use warp::tui_export::ChargedUsageTotals;
+use warp_core::features::FeatureFlag;
 use warpui_core::App;
 use warpui_core::elements::shimmer_math::ShimmerConfig;
 use warpui_core::elements::tui::{Color, TuiBufferExt, TuiElement, TuiRect, TuiText};
 use warpui_core::presenter::tui::TuiPresenter;
 
-use super::{SPINNER_TIMELINE, render_warping_indicator_row};
+use super::{SPINNER_TIMELINE, render_response_summary, render_warping_indicator_row};
 use crate::tui_builder::TuiUiBuilder;
+
+fn charged_usage(total_cost_in_cents: f32) -> ChargedUsageTotals {
+    ChargedUsageTotals {
+        input_cost_in_cents: total_cost_in_cents,
+        ..Default::default()
+    }
+}
 
 #[test]
 fn spinner_follows_the_prototype_choreography() {
@@ -144,6 +153,99 @@ fn renders_a_custom_progress_label() {
                     .expect("success status should have a foreground")
             );
             assert!(frame.repaint_at.is_some());
+        });
+    });
+}
+
+/// Surface #15: the per-response inline summary row shows a per-response
+/// dollar delta (not the conversation cumulative) alongside credits, gated
+/// by `FeatureFlag::PricingTransparency`. With the flag off, the row is
+/// byte-identical to pre-saga output (credits only, no dollar figure).
+#[test]
+fn response_summary_shows_per_response_dollar_delta_when_flag_is_on() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+        });
+        app.read(|app_ctx| {
+            let _guard = FeatureFlag::PricingTransparency.override_enabled(true);
+            let element = render_response_summary(
+                Duration::from_secs(5),
+                Some(0.5),
+                Some(charged_usage(3.0)),
+                app_ctx,
+            );
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(element, TuiRect::new(0, 0, 40, 1), app_ctx);
+            let line = frame.buffer.to_lines()[0].clone();
+            assert_eq!(line.trim_end(), "∷ 5s • 0.5 credits ($0.03)");
+        });
+    });
+}
+
+#[test]
+fn response_summary_omits_dollar_delta_when_flag_is_off() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+        });
+        app.read(|app_ctx| {
+            let _guard = FeatureFlag::PricingTransparency.override_enabled(false);
+            let element = render_response_summary(
+                Duration::from_secs(5),
+                Some(0.5),
+                Some(charged_usage(3.0)),
+                app_ctx,
+            );
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(element, TuiRect::new(0, 0, 40, 1), app_ctx);
+            let line = frame.buffer.to_lines()[0].clone();
+            assert_eq!(line.trim_end(), "∷ 5s • 0.5 credits");
+        });
+    });
+}
+
+/// The delta changes from response to response within the same conversation
+/// -- it is per-response, not the conversation cumulative.
+#[test]
+fn response_summary_dollar_delta_changes_between_responses() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+        });
+        app.read(|app_ctx| {
+            let _guard = FeatureFlag::PricingTransparency.override_enabled(true);
+            let mut presenter = TuiPresenter::new();
+
+            let first = render_response_summary(
+                Duration::from_secs(2),
+                Some(0.2),
+                Some(charged_usage(3.0)),
+                app_ctx,
+            );
+            let first_line = presenter
+                .present_element(first, TuiRect::new(0, 0, 40, 1), app_ctx)
+                .buffer
+                .to_lines()[0]
+                .trim_end()
+                .to_owned();
+
+            let second = render_response_summary(
+                Duration::from_secs(4),
+                Some(0.8),
+                Some(charged_usage(12.0)),
+                app_ctx,
+            );
+            let second_line = presenter
+                .present_element(second, TuiRect::new(0, 0, 40, 1), app_ctx)
+                .buffer
+                .to_lines()[0]
+                .trim_end()
+                .to_owned();
+
+            assert_eq!(first_line, "∷ 2s • 0.2 credits ($0.03)");
+            assert_eq!(second_line, "∷ 4s • 0.8 credits ($0.12)");
+            assert_ne!(first_line, second_line);
         });
     });
 }


### PR DESCRIPTION
## What
Task 2.2 of the pricing-transparency-token-breakdown saga (milestone 02-vertical-live-stream). Wires the real per-turn `StreamFinished.charged_usage_by_category` breakdown into the TUI's live usage surfaces:

1. **Shared plumbing** (separable first commit, cherry-pickable by task 2.1/GUI): a new `persistence::model::ChargedUsageTotals` type sums the category/model-keyed `RequestCharges` proto map into a flat input/output/cache-read/cache-write cost + token breakdown (mirrors the Go `SumChargedUsage` helper). Threaded through `AIConversation::update_cost_and_usage_for_request`, exposed via `ConversationUsageTotals.charged_usage` (cumulative) and `AIConversation::charged_usage_for_last_block()` (per-block delta), both re-exported through `warp::tui_export`.
2. **TUI Detail mode** (`crates/warp_tui/src/usage.rs`): extends the footer usage toggle's click-cycle to `Credits -> Cost -> Detail -> Credits` (`TuiUsageDisplayMode::Detail` in `app/src/settings/ai.rs`), rendering total cost, token count, and the input/cache-read/cache-write/output breakdown on one line.
3. **Per-response inline delta** (`crates/warp_tui/src/warping_indicator.rs`, surface #15): the completed-response summary row now appends a per-response dollar delta to the credits figure (e.g. `0.5 credits ($0.03)`), computed from this response's charged usage, not the conversation cumulative.

Both surfaces reuse the existing `FeatureFlag::PricingTransparency` gate; with the flag off, output is byte-identical to pre-saga (Credits/Cost-only cycle, credits-only inline row).

## PR #15015 disposition
Reference-only for the TUI toggle/cycle mechanics (per SAGA.md decision 7, it was built against the superseded flat-field schema). Not rebased or landed as-is — the real data plumbing here is new.

## Validation
- `cargo nextest run -p warp_tui`, `-p persistence`, `-p warp_graphql`, and `-p warp`: all pass (7479 tests, 2 leaky/non-fatal, 0 failed).
- `./script/format` clean.
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`: clean except pre-existing `deprecated` field warnings inherited from the m2t0 proto-pin-bump base branch (unrelated files, not touched by this PR — see conversation in the parent saga for tracking).
- New unit tests cover: Detail mode rendering with/without a breakdown, the Credits/Cost/Detail flag gate, and the per-response dollar delta (shown/hidden by flag, changing between responses).

Co-Authored-By: Warp <agent@warp.dev>