### PR TITLE
Wire live per-category pricing breakdown into GUI usage surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -3171,7 +3171,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4510,7 +4510,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4815,7 +4815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7141,7 +7141,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7335,7 +7335,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10578,8 +10578,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.10.5",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph",
@@ -10598,7 +10598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10844,7 +10844,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11836,7 +11836,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11849,7 +11849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11917,7 +11917,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13613,7 +13613,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15818,7 +15818,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=b40bca688c39c52c6fbc12bd6a6511a95d7b9f54#b40bca688c39c52c6fbc12bd6a6511a95d7b9f54"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=f0028fa6d05db1ba63726eaf6f8d33ab17abe37b#f0028fa6d05db1ba63726eaf6f8d33ab17abe37b"
 dependencies = [
  "prost",
  "prost-reflect",
@@ -17010,7 +17010,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "b40bca688c39c52c6fbc12bd6a6511a95d7b9f54" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "f0028fa6d05db1ba63726eaf6f8d33ab17abe37b" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -29,6 +29,8 @@ fn test_server_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: Some(3.2),
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -66,8 +66,8 @@ use crate::code_review::CodeReviewTelemetryEvent;
 use crate::notebooks::NotebookId;
 use crate::persistence::ModelEvent;
 use crate::persistence::model::{
-    AgentConversationData, ContextWindowSegment, ConversationUsageMetadata, ModelTokenUsage,
-    PersistedAutoexecuteMode, ToolUsageMetadata,
+    AgentConversationData, ChargedUsageTotals, ContextWindowSegment, ConversationUsageMetadata,
+    ModelTokenUsage, PersistedAutoexecuteMode, ToolUsageMetadata,
 };
 use crate::server::ids::ServerId;
 use crate::terminal::general_settings::GeneralSettings;
@@ -193,6 +193,12 @@ pub struct ConversationUsageTotals {
     /// while a restored legacy conversation with real usage but an unknown
     /// historical cost still shows it.
     pub has_usage: bool,
+    /// Cumulative per-category charged-usage breakdown (input/output/
+    /// cache-read/cache-write cost + token counts) for the whole
+    /// conversation so far, from `ConversationUsageMetadata.total_charges`.
+    /// `None` when the server didn't provide it (flag off, or a legacy
+    /// conversation).
+    pub charged_usage: Option<ChargedUsageTotals>,
 }
 
 /// Whether persisted or server usage metadata carries evidence that the
@@ -833,6 +839,18 @@ impl AIConversation {
         self.conversation_usage_metadata
             .credits_spent_for_last_block
             .map(|credits| (credits * 10.0).round() / 10.0)
+    }
+
+    /// Per-category charged-usage breakdown over the last block, where the
+    /// block comprises all agent outputs since the most recent user input
+    /// (mirrors [`Self::credits_spent_for_last_block`], but as a full
+    /// input/output/cache-read/cache-write cost + token breakdown rather
+    /// than a bare credits figure). `None` when the server didn't provide
+    /// `StreamFinished.request_charges` (flag off) or before any block has
+    /// completed.
+    pub fn charged_usage_for_last_block(&self) -> Option<ChargedUsageTotals> {
+        self.conversation_usage_metadata
+            .charged_usage_for_last_block
     }
 
     /// Time to first token for the last completed set of agent responses
@@ -2210,6 +2228,7 @@ impl AIConversation {
     pub fn update_cost_and_usage_for_request(
         &mut self,
         request_cost: Option<RequestCost>,
+        request_charges: Option<stream_finished::RequestCharges>,
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<stream_finished::ConversationUsageMetadata>,
         was_user_initiated_request: bool,
@@ -2257,6 +2276,21 @@ impl AIConversation {
             self.total_request_cost += request_cost;
         }
 
+        if let Some(request_charges) = request_charges {
+            let totals = ChargedUsageTotals::from(&request_charges);
+            let charged_usage_for_last_block = self
+                .conversation_usage_metadata
+                .charged_usage_for_last_block
+                .get_or_insert_with(ChargedUsageTotals::default);
+
+            // Mirrors the `credits_spent_for_last_block` reset above: a
+            // user-initiated request starts a new response block.
+            if was_user_initiated_request {
+                *charged_usage_for_last_block = ChargedUsageTotals::default();
+            }
+            *charged_usage_for_last_block += totals;
+        }
+
         if let Some(usage_metadata) = usage_metadata {
             self.conversation_usage_metadata.context_window_usage =
                 usage_metadata.context_window_usage;
@@ -2266,6 +2300,10 @@ impl AIConversation {
                 self.conversation_usage_metadata.platform_credits_spent =
                     usage_metadata.platform_credits_spent;
             }
+            self.conversation_usage_metadata.total_charged_usage = usage_metadata
+                .total_charges
+                .as_ref()
+                .map(ChargedUsageTotals::from);
             let llm_preferences = LLMPreferences::as_ref(ctx);
             self.conversation_usage_metadata.token_usage =
                 footer_model_token_usage(&usage_metadata, llm_preferences);
@@ -3782,6 +3820,7 @@ impl AIConversation {
             credits_spent: self.inference_credits_spent() + self.platform_credits_spent(),
             cost_in_cents: self.total_provider_cost_in_cents,
             has_usage: self.has_usage_metadata,
+            charged_usage: self.conversation_usage_metadata.total_charged_usage,
         }
     }
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -819,6 +819,20 @@ impl AIConversation {
         self.conversation_usage_metadata.total_charged_usage = charged_usage;
     }
 
+    /// Test-only helper that sets (or clears) the conversation's last-block
+    /// charged-usage breakdown directly, mirroring what a real
+    /// `StreamFinished.request_charges` update would populate. Used to set
+    /// up a "stale" precondition for regression tests covering the reset
+    /// behavior in `update_cost_and_usage_for_request`.
+    #[cfg(test)]
+    pub(crate) fn set_charged_usage_for_last_block_for_test(
+        &mut self,
+        charged_usage: Option<ChargedUsageTotals>,
+    ) {
+        self.conversation_usage_metadata
+            .charged_usage_for_last_block = charged_usage;
+    }
+
     /// Test-only helper that simulates the root-task upgrade performed by the
     /// `Action::CreateTask` branch of `apply_client_action` when the server
     /// confirms the root for a newly started conversation. Replaces the
@@ -2287,18 +2301,23 @@ impl AIConversation {
             self.total_request_cost += request_cost;
         }
 
+        // Mirrors the `credits_spent_for_last_block` reset above: a
+        // user-initiated request starts a new response block. Reset
+        // unconditionally (not only inside the `Some(request_charges)`
+        // branch below) so a later request in the same turn that happens
+        // to carry no charges (e.g. the flag is off for it) doesn't leave
+        // the previous block's stale totals in place, which would pair a
+        // fresh credits figure with stale token/cost details.
+        if was_user_initiated_request {
+            self.conversation_usage_metadata
+                .charged_usage_for_last_block = None;
+        }
         if let Some(request_charges) = request_charges {
             let totals = ChargedUsageTotals::from(&request_charges);
             let charged_usage_for_last_block = self
                 .conversation_usage_metadata
                 .charged_usage_for_last_block
                 .get_or_insert_with(ChargedUsageTotals::default);
-
-            // Mirrors the `credits_spent_for_last_block` reset above: a
-            // user-initiated request starts a new response block.
-            if was_user_initiated_request {
-                *charged_usage_for_last_block = ChargedUsageTotals::default();
-            }
             *charged_usage_for_last_block += totals;
         }
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -808,6 +808,17 @@ impl AIConversation {
             .total_provider_cost_in_cents = cost_in_cents;
     }
 
+    /// Test-only helper that sets (or clears) the conversation's cumulative
+    /// charged-usage breakdown directly, mirroring what a real
+    /// `ConversationUsageMetadata.total_charges` update would populate. Used
+    /// by unit tests that exercise downstream token-count-aware logic (e.g.
+    /// the orchestration credit rollup's token figure) without wiring up a
+    /// full `StreamFinished` event.
+    #[cfg(test)]
+    pub(crate) fn set_charged_usage_for_test(&mut self, charged_usage: Option<ChargedUsageTotals>) {
+        self.conversation_usage_metadata.total_charged_usage = charged_usage;
+    }
+
     /// Test-only helper that simulates the root-task upgrade performed by the
     /// `Action::CreateTask` branch of `apply_client_action` when the server
     /// confirms the root for a newly started conversation. Replaces the

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -790,6 +790,18 @@ impl AIConversation {
         self.conversation_usage_metadata.platform_credits_spent = 0.0;
     }
 
+    /// Test-only helper that sets (or clears) the conversation's dollar-cost
+    /// baseline directly, mirroring what `set_server_metadata` would derive
+    /// from a real snapshot. Used by unit tests that exercise downstream
+    /// cost-aware logic (e.g. the orchestration credit rollup's dollar
+    /// figure) without wiring up a full server metadata snapshot.
+    #[cfg(test)]
+    pub(crate) fn set_cost_in_cents_for_test(&mut self, cost_in_cents: Option<f32>) {
+        self.total_provider_cost_in_cents = cost_in_cents;
+        self.conversation_usage_metadata
+            .total_provider_cost_in_cents = cost_in_cents;
+    }
+
     /// Test-only helper that simulates the root-task upgrade performed by the
     /// `Action::CreateTask` branch of `apply_client_action` when the server
     /// confirms the root for a newly started conversation. Replaces the

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -786,10 +786,8 @@ impl AIConversation {
         self.conversation_usage_metadata.platform_credits_spent
     }
 
-    /// Test-only helper that sets the conversation's credit total directly.
-    /// Used by unit tests that exercise downstream credit-aware logic
-    /// (e.g. the orchestration credit rollup) without having to wire up a
-    /// full `StreamFinished` event.
+    /// Test-only helper that sets the conversation's credit total directly,
+    /// without wiring up a full `StreamFinished` event.
     #[cfg(test)]
     pub(crate) fn set_credits_spent_for_test(&mut self, credits: f32) {
         self.conversation_usage_metadata.credits_spent = credits;
@@ -798,9 +796,7 @@ impl AIConversation {
 
     /// Test-only helper that sets (or clears) the conversation's dollar-cost
     /// baseline directly, mirroring what `set_server_metadata` would derive
-    /// from a real snapshot. Used by unit tests that exercise downstream
-    /// cost-aware logic (e.g. the orchestration credit rollup's dollar
-    /// figure) without wiring up a full server metadata snapshot.
+    /// from a real snapshot, without wiring up a full snapshot.
     #[cfg(test)]
     pub(crate) fn set_cost_in_cents_for_test(&mut self, cost_in_cents: Option<f32>) {
         self.total_provider_cost_in_cents = cost_in_cents;
@@ -810,10 +806,8 @@ impl AIConversation {
 
     /// Test-only helper that sets (or clears) the conversation's cumulative
     /// charged-usage breakdown directly, mirroring what a real
-    /// `ConversationUsageMetadata.total_charges` update would populate. Used
-    /// by unit tests that exercise downstream token-count-aware logic (e.g.
-    /// the orchestration credit rollup's token figure) without wiring up a
-    /// full `StreamFinished` event.
+    /// `ConversationUsageMetadata.total_charges` update would populate,
+    /// without wiring up a full `StreamFinished` event.
     #[cfg(test)]
     pub(crate) fn set_charged_usage_for_test(&mut self, charged_usage: Option<ChargedUsageTotals>) {
         self.conversation_usage_metadata.total_charged_usage = charged_usage;
@@ -821,9 +815,7 @@ impl AIConversation {
 
     /// Test-only helper that sets (or clears) the conversation's last-block
     /// charged-usage breakdown directly, mirroring what a real
-    /// `StreamFinished.request_charges` update would populate. Used to set
-    /// up a "stale" precondition for regression tests covering the reset
-    /// behavior in `update_cost_and_usage_for_request`.
+    /// `StreamFinished.request_charges` update would populate.
     #[cfg(test)]
     pub(crate) fn set_charged_usage_for_last_block_for_test(
         &mut self,

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -666,6 +666,7 @@ fn restored_usage_totals_preserve_server_provider_cost_and_add_follow_up() {
                 conversation
                     .update_cost_and_usage_for_request(
                         None,
+                        None,
                         vec![stream_token_usage("model-a", 10, 2, 1.2)],
                         Some(credits_usage_metadata(1.0, 0.0)),
                         false,
@@ -739,6 +740,7 @@ fn restored_legacy_conversation_keeps_provider_cost_unavailable_after_follow_up(
             conversation
                 .update_cost_and_usage_for_request(
                     None,
+                    None,
                     vec![stream_token_usage("legacy-model", 10, 2, 1.5)],
                     Some(credits_usage_metadata(1.0, 0.0)),
                     false,
@@ -780,6 +782,7 @@ fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
             conversation
                 .update_cost_and_usage_for_request(
                     None,
+                    None,
                     vec![],
                     Some(custom_endpoint_usage_metadata("config-key", 6)),
                     false,
@@ -814,6 +817,7 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    None,
                     None,
                     vec![],
                     Some(custom_endpoint_usage_metadata("missing-config-key", 9)),
@@ -889,12 +893,14 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
                 credits_spent: 0.0,
                 cost_in_cents: Some(0.0),
                 has_usage: false,
+                charged_usage: None,
             }
         );
 
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    None,
                     None,
                     vec![stream_token_usage("model-a", 100, 20, 1.5)],
                     Some(credits_usage_metadata(2.0, 0.5)),
@@ -907,6 +913,7 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
             // summing, while provider cost accumulates per request.
             conversation
                 .update_cost_and_usage_for_request(
+                    None,
                     None,
                     vec![stream_token_usage("model-a", 50, 10, 1.2)],
                     Some(credits_usage_metadata(3.0, 0.5)),

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -15,7 +15,9 @@ use crate::ai::llms::LLMPreferences;
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
 use crate::network::NetworkStatus;
-use crate::persistence::model::{AgentConversationData, ConversationUsageMetadata};
+use crate::persistence::model::{
+    AgentConversationData, ChargedUsageTotals, ConversationUsageMetadata,
+};
 use crate::server::server_api::ServerApiProvider;
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -932,6 +934,36 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
                 - 2.7)
                 .abs()
                 < 1e-6
+        );
+    });
+}
+
+#[test]
+fn update_cost_and_usage_resets_stale_charged_usage_for_last_block_on_new_user_turn() {
+    App::test((), |mut app| async move {
+        initialize_custom_endpoint_usage_test_app(&mut app);
+        app.add_singleton_model(LLMPreferences::new);
+
+        let mut conversation = AIConversation::new(false, false);
+        // Simulate a stale last-block breakdown left over from a previous
+        // response, as would happen if this turn's request carries no
+        // `request_charges` (e.g. the flag is off for it).
+        conversation.set_charged_usage_for_last_block_for_test(Some(ChargedUsageTotals {
+            input_tokens: 500,
+            ..Default::default()
+        }));
+
+        app.read(|ctx| {
+            conversation
+                .update_cost_and_usage_for_request(None, None, vec![], None, true, ctx)
+                .expect("usage should update");
+        });
+
+        assert_eq!(
+            conversation.charged_usage_for_last_block(),
+            None,
+            "a new user-initiated turn must clear the previous block's stale charged usage, \
+             even when this turn's request itself carries no charges"
         );
     });
 }

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -928,6 +928,8 @@ fn create_server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/agent_sdk/artifact_upload_tests.rs
+++ b/app/src/ai/agent_sdk/artifact_upload_tests.rs
@@ -41,6 +41,8 @@ fn create_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -104,7 +104,7 @@ use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
 use crate::ai::blocklist::view_util::{
-    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits_with_cost,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits_with_cost, format_usage_parenthetical,
     should_show_failed_output_usage_notice,
 };
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
@@ -3735,15 +3735,25 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
             && props.model.status(app).error().is_none()
         {
             // If the first part of the decimal is 0, we just display the whole number.
-            if credits_spent_for_last_block.fract() < 0.1 {
-                credit_usage_text = format!(
-                    "{credit_usage_text} (+{})",
-                    credits_spent_for_last_block.trunc() as i32
-                );
+            let last_block_credits_text = if credits_spent_for_last_block.fract() < 0.1 {
+                format!("{}", credits_spent_for_last_block.trunc() as i32)
             } else {
-                credit_usage_text =
-                    format!("{credit_usage_text} (+{credits_spent_for_last_block:.1})");
-            }
+                format!("{credits_spent_for_last_block:.1}")
+            };
+            // The last-block figure has no rollup equivalent: it stays
+            // bound to the orchestrator's own last block, same as
+            // `credits_spent_for_last_block` above.
+            let last_block_charged_usage = conversation.charged_usage_for_last_block();
+            let last_block_detail = format_usage_parenthetical(
+                last_block_charged_usage.map(|usage| usage.total_tokens()),
+                last_block_charged_usage.map(|usage| usage.total_cost_in_cents()),
+            );
+            credit_usage_text = match last_block_detail {
+                Some(detail) => {
+                    format!("{credit_usage_text} (+{last_block_credits_text}, {detail})")
+                }
+                None => format!("{credit_usage_text} (+{last_block_credits_text})"),
+            };
         }
     }
 

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -104,7 +104,8 @@ use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
 use crate::ai::blocklist::view_util::{
-    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits, should_show_failed_output_usage_notice,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits_with_cost,
+    should_show_failed_output_usage_notice,
 };
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
@@ -3689,6 +3690,13 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
         .as_ref()
         .map(|r| r.total_credits)
         .unwrap_or_else(|| conversation.credits_spent());
+    // Only the rollup path (summed across sub-agents) has a matching
+    // aggregated cost figure; a non-orchestrator conversation's own dollar
+    // cost comes from its usage totals directly.
+    let headline_cost_in_cents = rollup
+        .as_ref()
+        .map(|r| r.total_cost_in_cents)
+        .unwrap_or_else(|| conversation.usage_totals().cost_in_cents);
     let has_any_usage = headline_credits > 0.0
         || conversation.credits_spent_for_last_block().is_some()
         || !conversation.token_usage().is_empty()
@@ -3707,7 +3715,8 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
     };
 
     let total_credits_spent = headline_credits;
-    let mut credit_usage_text = format_credits(total_credits_spent);
+    let mut credit_usage_text =
+        format_credits_with_cost(total_credits_spent, headline_cost_in_cents);
     if let Some(credits_spent_for_last_block) = conversation.credits_spent_for_last_block() {
         // Only show the credits spent for the last block if it is different from the total credits spent
         // and we spent a non-zero amount of credits for the last block.

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3697,6 +3697,14 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
         .as_ref()
         .map(|r| r.total_cost_in_cents)
         .unwrap_or_else(|| conversation.usage_totals().cost_in_cents);
+    // Same rollup-vs-own-totals split as `headline_cost_in_cents`, for the
+    // token count shown alongside it.
+    let headline_tokens = rollup.as_ref().map(|r| r.total_tokens).unwrap_or_else(|| {
+        conversation
+            .usage_totals()
+            .charged_usage
+            .map(|usage| usage.total_tokens())
+    });
     let has_any_usage = headline_credits > 0.0
         || conversation.credits_spent_for_last_block().is_some()
         || !conversation.token_usage().is_empty()
@@ -3716,7 +3724,7 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
 
     let total_credits_spent = headline_credits;
     let mut credit_usage_text =
-        format_credits_with_cost(total_credits_spent, headline_cost_in_cents);
+        format_credits_with_cost(total_credits_spent, headline_tokens, headline_cost_in_cents);
     if let Some(credits_spent_for_last_block) = conversation.credits_spent_for_last_block() {
         // Only show the credits spent for the last block if it is different from the total credits spent
         // and we spent a non-zero amount of credits for the last block.

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -3287,6 +3287,7 @@ impl BlocklistAIController {
             history_model.update_conversation_cost_and_usage_for_request(
                 conversation_id,
                 request_cost,
+                finished_event.request_charges.take(),
                 finished_event.token_usage,
                 finished_event.conversation_usage_metadata.take(),
                 did_request_contain_user_query,

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -17,7 +17,7 @@ use warp_core::features::FeatureFlag;
 use warp_multi_agent_api::client_action::{Action, StartNewConversation};
 use warp_multi_agent_api::message::tool_call::Tool;
 use warp_multi_agent_api::response_event::stream_finished::{
-    ConversationUsageMetadata, TokenUsage,
+    ConversationUsageMetadata, RequestCharges, TokenUsage,
 };
 use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity};
 
@@ -1986,10 +1986,12 @@ impl BlocklistAIHistoryModel {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_conversation_cost_and_usage_for_request(
         &mut self,
         conversation_id: AIConversationId,
         request_cost: Option<RequestCost>,
+        request_charges: Option<RequestCharges>,
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<ConversationUsageMetadata>,
         was_user_initiated_request: bool,
@@ -2000,11 +2002,14 @@ impl BlocklistAIHistoryModel {
         // subscribers (e.g. the orchestration credit rollup or the TUI
         // footer's usage entry). We emit the event only when there's actual
         // data to react to.
-        let emits_usage_event =
-            request_cost.is_some() || usage_metadata.is_some() || !token_usage.is_empty();
+        let emits_usage_event = request_cost.is_some()
+            || request_charges.is_some()
+            || usage_metadata.is_some()
+            || !token_usage.is_empty();
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             if let Err(e) = conversation.update_cost_and_usage_for_request(
                 request_cost,
+                request_charges,
                 token_usage,
                 usage_metadata,
                 was_user_initiated_request,

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1338,6 +1338,8 @@ fn create_server_metadata(
         platform_credits_spent: 0.0,
         total_provider_cost_in_cents: None,
         credits_spent_for_last_block: None,
+        charged_usage_for_last_block: None,
+        total_charged_usage: None,
         token_usage: vec![],
         tool_usage_metadata: Default::default(),
         context_window_segments: Vec::new(),

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -372,6 +372,8 @@ fn make_server_metadata_with_harness(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -29,8 +29,8 @@ use crate::ai::blocklist::view_util::format_credits;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
-    ContextWindowSegment, ContextWindowSegmentType, FULL_TERMINAL_USE_CATEGORY, ModelTokenUsage,
-    PRIMARY_AGENT_CATEGORY, token_usage_category_display_name,
+    ChargedUsageTotals, ContextWindowSegment, ContextWindowSegmentType, FULL_TERMINAL_USE_CATEGORY,
+    ModelTokenUsage, PRIMARY_AGENT_CATEGORY, token_usage_category_display_name,
 };
 use crate::ui_components::blended_colors;
 
@@ -56,6 +56,14 @@ pub struct ConversationUsageInfo {
     pub lines_added: i32,
     pub lines_removed: i32,
     pub commands_executed: i32,
+    /// Cumulative per-category charged-usage breakdown (input/output/
+    /// cache-read/cache-write cost + token counts) for the whole
+    /// conversation so far, gated by `FeatureFlag::PricingTransparency`.
+    /// `None` when the server didn't provide it (flag off, or the source
+    /// doesn't yet carry it — e.g. the settings usage-history surface,
+    /// which sources this view from a GraphQL query that doesn't yet
+    /// expose the breakdown; documented gap, see `gql_convert.rs`).
+    pub charged_usage: Option<ChargedUsageTotals>,
 }
 
 /// Timing information for the last set of agent responses
@@ -367,6 +375,21 @@ impl ConversationUsageView {
         // existing flex spacing handles indentation.
         self.append_per_agent_rows(&mut labels, &mut values, rollup.as_ref(), appearance);
 
+        // Total token count, gated by `FeatureFlag::PricingTransparency`. Computed
+        // locally from the per-model breakdown so it's available regardless of
+        // whether the underlying source is the live streaming protocol or a
+        // GraphQL usage-history entry.
+        let total_tokens: u32 = self
+            .usage_info
+            .models
+            .iter()
+            .map(|model| model.warp_tokens + model.byok_tokens + model.custom_endpoint_tokens)
+            .sum();
+        if FeatureFlag::PricingTransparency.is_enabled() && total_tokens > 0 {
+            labels.push(render_label_text("Tokens used", appearance));
+            values.push(render_value_text(total_tokens.to_string(), appearance));
+        }
+
         labels.push(render_label_text("Tool calls", appearance));
         values.push(render_value_text(
             format_value_text(self.usage_info.tool_calls, "call"),
@@ -513,6 +536,8 @@ impl ConversationUsageView {
             context_window_breakdown_enabled,
             appearance,
         );
+
+        self.append_pricing_breakdown_section(&mut labels, &mut values, appearance);
 
         // Space between sections
         labels.push(
@@ -781,6 +806,56 @@ impl ConversationUsageView {
                 .with_color(value_color)
                 .finish(),
             );
+        }
+    }
+
+    /// Pushes a "PRICING BREAKDOWN" section with a row per inference
+    /// token category (input, cache read, cache write, output), gated by
+    /// `FeatureFlag::PricingTransparency`. Absent entirely when the flag is
+    /// off or the breakdown is unavailable (e.g. the settings usage-history
+    /// surface, which sources this view from a GraphQL query that doesn't
+    /// yet expose a per-category cost breakdown — documented gap).
+    fn append_pricing_breakdown_section(
+        &self,
+        labels: &mut Vec<Box<dyn Element>>,
+        values: &mut Vec<Box<dyn Element>>,
+        appearance: &Appearance,
+    ) {
+        if !FeatureFlag::PricingTransparency.is_enabled() {
+            return;
+        }
+        let Some(charged_usage) = self.usage_info.charged_usage else {
+            return;
+        };
+
+        labels.push(
+            Container::new(Empty::new().finish())
+                .with_margin_top(12.)
+                .finish(),
+        );
+        values.push(
+            Container::new(Empty::new().finish())
+                .with_margin_top(12.)
+                .finish(),
+        );
+        labels.push(render_section_header(
+            "PRICING BREAKDOWN".to_string(),
+            appearance,
+        ));
+        values.push(render_section_header("".to_string(), appearance));
+
+        let rows: [(&str, f32); 4] = [
+            ("Input", charged_usage.input_cost_in_cents),
+            ("Cache read", charged_usage.input_cache_read_cost_in_cents),
+            ("Cache write", charged_usage.input_cache_write_cost_in_cents),
+            ("Output", charged_usage.output_cost_in_cents),
+        ];
+        for (label, cost_in_cents) in rows {
+            labels.push(render_label_text(label, appearance));
+            values.push(render_value_text(
+                format!("${:.2}", cost_in_cents / 100.0),
+                appearance,
+            ));
         }
     }
 

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -810,11 +810,12 @@ impl ConversationUsageView {
     }
 
     /// Pushes a "PRICING BREAKDOWN" section with a row per inference
-    /// token category (input, cache read, cache write, output), gated by
-    /// `FeatureFlag::PricingTransparency`. Absent entirely when the flag is
-    /// off or the breakdown is unavailable (e.g. the settings usage-history
-    /// surface, which sources this view from a GraphQL query that doesn't
-    /// yet expose a per-category cost breakdown — documented gap).
+    /// token category (input, cache read, cache write, output) plus web
+    /// search cost, gated by `FeatureFlag::PricingTransparency`. Absent
+    /// entirely when the flag is off or the breakdown is unavailable (e.g.
+    /// the settings usage-history surface, which sources this view from a
+    /// GraphQL query that doesn't yet expose a per-category cost breakdown
+    /// — documented gap).
     fn append_pricing_breakdown_section(
         &self,
         labels: &mut Vec<Box<dyn Element>>,
@@ -844,11 +845,12 @@ impl ConversationUsageView {
         ));
         values.push(render_section_header("".to_string(), appearance));
 
-        let rows: [(&str, f32); 4] = [
+        let rows: [(&str, f32); 5] = [
             ("Input", charged_usage.input_cost_in_cents),
             ("Cache read", charged_usage.input_cache_read_cost_in_cents),
             ("Cache write", charged_usage.input_cache_write_cost_in_cents),
             ("Output", charged_usage.output_cost_in_cents),
+            ("Web search", charged_usage.web_search_cost_in_cents),
         ];
         for (label, cost_in_cents) in rows {
             labels.push(render_label_text(label, appearance));

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -29,8 +29,8 @@ use crate::ai::blocklist::view_util::format_credits;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
-    ChargedUsageTotals, ContextWindowSegment, ContextWindowSegmentType, FULL_TERMINAL_USE_CATEGORY,
-    ModelTokenUsage, PRIMARY_AGENT_CATEGORY, token_usage_category_display_name,
+    ContextWindowSegment, ContextWindowSegmentType, FULL_TERMINAL_USE_CATEGORY, ModelTokenUsage,
+    PRIMARY_AGENT_CATEGORY, token_usage_category_display_name,
 };
 use crate::ui_components::blended_colors;
 
@@ -56,14 +56,6 @@ pub struct ConversationUsageInfo {
     pub lines_added: i32,
     pub lines_removed: i32,
     pub commands_executed: i32,
-    /// Cumulative per-category charged-usage breakdown (input/output/
-    /// cache-read/cache-write cost + token counts) for the whole
-    /// conversation so far, gated by `FeatureFlag::PricingTransparency`.
-    /// `None` when the server didn't provide it (flag off, or the source
-    /// doesn't yet carry it — e.g. the settings usage-history surface,
-    /// which sources this view from a GraphQL query that doesn't yet
-    /// expose the breakdown; documented gap, see `gql_convert.rs`).
-    pub charged_usage: Option<ChargedUsageTotals>,
 }
 
 /// Timing information for the last set of agent responses
@@ -537,8 +529,6 @@ impl ConversationUsageView {
             appearance,
         );
 
-        self.append_pricing_breakdown_section(&mut labels, &mut values, appearance);
-
         // Space between sections
         labels.push(
             Container::new(Empty::new().finish())
@@ -806,58 +796,6 @@ impl ConversationUsageView {
                 .with_color(value_color)
                 .finish(),
             );
-        }
-    }
-
-    /// Pushes a "PRICING BREAKDOWN" section with a row per inference
-    /// token category (input, cache read, cache write, output) plus web
-    /// search cost, gated by `FeatureFlag::PricingTransparency`. Absent
-    /// entirely when the flag is off or the breakdown is unavailable (e.g.
-    /// the settings usage-history surface, which sources this view from a
-    /// GraphQL query that doesn't yet expose a per-category cost breakdown
-    /// — documented gap).
-    fn append_pricing_breakdown_section(
-        &self,
-        labels: &mut Vec<Box<dyn Element>>,
-        values: &mut Vec<Box<dyn Element>>,
-        appearance: &Appearance,
-    ) {
-        if !FeatureFlag::PricingTransparency.is_enabled() {
-            return;
-        }
-        let Some(charged_usage) = self.usage_info.charged_usage else {
-            return;
-        };
-
-        labels.push(
-            Container::new(Empty::new().finish())
-                .with_margin_top(12.)
-                .finish(),
-        );
-        values.push(
-            Container::new(Empty::new().finish())
-                .with_margin_top(12.)
-                .finish(),
-        );
-        labels.push(render_section_header(
-            "PRICING BREAKDOWN".to_string(),
-            appearance,
-        ));
-        values.push(render_section_header("".to_string(), appearance));
-
-        let rows: [(&str, f32); 5] = [
-            ("Input", charged_usage.input_cost_in_cents),
-            ("Cache read", charged_usage.input_cache_read_cost_in_cents),
-            ("Cache write", charged_usage.input_cache_write_cost_in_cents),
-            ("Output", charged_usage.output_cost_in_cents),
-            ("Web search", charged_usage.web_search_cost_in_cents),
-        ];
-        for (label, cost_in_cents) in rows {
-            labels.push(render_label_text(label, appearance));
-            values.push(render_value_text(
-                format!("${:.2}", cost_in_cents / 100.0),
-                appearance,
-            ));
         }
     }
 

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -25,7 +25,7 @@ use crate::ai::blocklist::usage::render_context_window_usage_icon;
 use crate::ai::blocklist::usage::rollup::{
     AgentAvatar, OrchestrationCreditRollup, PerAgentCreditEntry, compute_orchestration_rollup,
 };
-use crate::ai::blocklist::view_util::format_credits;
+use crate::ai::blocklist::view_util::{format_credits, format_credits_with_cost};
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
@@ -56,6 +56,22 @@ pub struct ConversationUsageInfo {
     pub lines_added: i32,
     pub lines_removed: i32,
     pub commands_executed: i32,
+    /// Total token count across the whole conversation so far, gated by
+    /// `FeatureFlag::PricingTransparency` (checked inside
+    /// `format_credits_with_cost`). `None` when the source doesn't provide
+    /// it (flag off, or a source that doesn't carry it yet — e.g. the
+    /// settings usage-history surface; documented gap, see `gql_convert.rs`).
+    pub total_tokens: Option<u32>,
+    /// Total real dollar cost across the whole conversation so far, in US
+    /// cents. `None` under the same conditions as `total_tokens`.
+    pub total_cost_in_cents: Option<f32>,
+    /// Total token count over the last block (see
+    /// `credits_spent_for_last_block`). `None` under the same conditions as
+    /// `total_tokens`.
+    pub tokens_for_last_block: Option<u32>,
+    /// Total real dollar cost over the last block, in US cents. `None`
+    /// under the same conditions as `total_tokens`.
+    pub cost_in_cents_for_last_block: Option<f32>,
 }
 
 /// Timing information for the last set of agent responses
@@ -331,6 +347,17 @@ impl ConversationUsageView {
             .map(|r| r.total_credits)
             .unwrap_or(self.usage_info.credits_spent + self.usage_info.platform_credits_spent);
 
+        // Rollup-vs-own-totals split mirrors `total_credits_value` above,
+        // for the token/cost figures shown alongside it.
+        let total_tokens_value = rollup
+            .as_ref()
+            .map(|r| r.total_tokens)
+            .unwrap_or(self.usage_info.total_tokens);
+        let total_cost_in_cents_value = rollup
+            .as_ref()
+            .map(|r| r.total_cost_in_cents)
+            .unwrap_or(self.usage_info.total_cost_in_cents);
+
         if self.display_mode == DisplayMode::Footer
             && self.usage_info.credits_spent_for_last_block.is_some()
         {
@@ -340,13 +367,19 @@ impl ConversationUsageView {
                 appearance,
             ));
             values.push(render_value_text(
-                format_credits(last_block_credits),
+                format_credits_with_cost(
+                    last_block_credits,
+                    self.usage_info.tokens_for_last_block,
+                    self.usage_info.cost_in_cents_for_last_block,
+                ),
                 appearance,
             ));
 
             labels.push(render_label_text("Credits spent (total)", appearance));
             values.push(self.render_total_credits_value_row(
                 total_credits_value,
+                total_tokens_value,
+                total_cost_in_cents_value,
                 rollup.as_ref(),
                 appearance,
             ));
@@ -354,6 +387,8 @@ impl ConversationUsageView {
             labels.push(render_label_text("Credits spent", appearance));
             values.push(self.render_total_credits_value_row(
                 total_credits_value,
+                total_tokens_value,
+                total_cost_in_cents_value,
                 rollup.as_ref(),
                 appearance,
             ));
@@ -366,21 +401,6 @@ impl ConversationUsageView {
         // label/value layout as the rest of the usage summary; the
         // existing flex spacing handles indentation.
         self.append_per_agent_rows(&mut labels, &mut values, rollup.as_ref(), appearance);
-
-        // Total token count, gated by `FeatureFlag::PricingTransparency`. Computed
-        // locally from the per-model breakdown so it's available regardless of
-        // whether the underlying source is the live streaming protocol or a
-        // GraphQL usage-history entry.
-        let total_tokens: u32 = self
-            .usage_info
-            .models
-            .iter()
-            .map(|model| model.warp_tokens + model.byok_tokens + model.custom_endpoint_tokens)
-            .sum();
-        if FeatureFlag::PricingTransparency.is_enabled() && total_tokens > 0 {
-            labels.push(render_label_text("Tokens used", appearance));
-            values.push(render_value_text(total_tokens.to_string(), appearance));
-        }
 
         labels.push(render_label_text("Tool calls", appearance));
         values.push(render_value_text(
@@ -715,10 +735,14 @@ impl ConversationUsageView {
     fn render_total_credits_value_row(
         &self,
         total_credits: f32,
+        total_tokens: Option<u32>,
+        total_cost_in_cents: Option<f32>,
         rollup: Option<&OrchestrationCreditRollup>,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
-        let value_text = render_value_text(format_credits(total_credits), appearance);
+        let credits_text =
+            format_credits_with_cost(total_credits, total_tokens, total_cost_in_cents);
+        let value_text = render_value_text(credits_text, appearance);
         if rollup.is_none() {
             return value_text;
         }

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -44,6 +44,10 @@ fn placeholder_usage_info() -> ConversationUsageInfo {
         lines_added: 0,
         lines_removed: 0,
         commands_executed: 0,
+        total_tokens: None,
+        total_cost_in_cents: None,
+        tokens_for_last_block: None,
+        cost_in_cents_for_last_block: None,
     }
 }
 

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -44,6 +44,7 @@ fn placeholder_usage_info() -> ConversationUsageInfo {
         lines_added: 0,
         lines_removed: 0,
         commands_executed: 0,
+        charged_usage: None,
     }
 }
 

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -44,7 +44,6 @@ fn placeholder_usage_info() -> ConversationUsageInfo {
         lines_added: 0,
         lines_removed: 0,
         commands_executed: 0,
-        charged_usage: None,
     }
 }
 

--- a/app/src/ai/blocklist/usage/rollup.rs
+++ b/app/src/ai/blocklist/usage/rollup.rs
@@ -43,11 +43,28 @@ pub struct OrchestrationCreditRollup {
     /// Sum of `credits_spent` across the orchestrator and every
     /// locally-loaded descendant.
     pub total_credits: f32,
+    /// Sum of `usage_totals().cost_in_cents` across the orchestrator and
+    /// every locally-loaded descendant, mirroring `total_credits`. `None`
+    /// when any contributing conversation lacks a known dollar-cost
+    /// baseline — a partial sum would misrepresent the true total, so the
+    /// rollup omits the dollar figure entirely rather than showing an
+    /// incomplete one.
+    pub total_cost_in_cents: Option<f32>,
     /// One entry per agent that has spent > 0 credits, sorted by
     /// `credits_spent` descending. Ties are broken by spawn order (earlier
     /// spawn first; orchestrator always sorts before its descendants in a
     /// tie).
     pub per_agent: Vec<PerAgentCreditEntry>,
+}
+
+/// Folds one more conversation's optional dollar cost into a running total,
+/// propagating `None` permanently once any contributor lacks a known
+/// baseline (see `OrchestrationCreditRollup::total_cost_in_cents`).
+fn accumulate_cost(total: &mut Option<f32>, cost: Option<f32>) {
+    *total = match (*total, cost) {
+        (Some(t), Some(c)) => Some(t + c),
+        _ => None,
+    };
 }
 
 /// Computes the orchestration credit rollup for `parent_id`.
@@ -72,11 +89,16 @@ pub fn compute_orchestration_rollup(
     }
 
     let mut total_credits: f32 = 0.0;
+    let mut total_cost_in_cents: Option<f32> = Some(0.0);
     let mut entries: Vec<(usize, PerAgentCreditEntry)> = Vec::new();
 
     if let Some(orchestrator) = history.conversation(&parent_id) {
         let credits = orchestrator.credits_spent();
         total_credits += credits;
+        accumulate_cost(
+            &mut total_cost_in_cents,
+            orchestrator.usage_totals().cost_in_cents,
+        );
         if credits > 0.0 {
             entries.push((
                 0,
@@ -97,6 +119,10 @@ pub fn compute_orchestration_rollup(
         };
         let credits = descendant.credits_spent();
         total_credits += credits;
+        accumulate_cost(
+            &mut total_cost_in_cents,
+            descendant.usage_totals().cost_in_cents,
+        );
         if credits > 0.0 {
             entries.push((
                 spawn_idx + 1,
@@ -125,6 +151,7 @@ pub fn compute_orchestration_rollup(
 
     Some(OrchestrationCreditRollup {
         total_credits,
+        total_cost_in_cents,
         per_agent: entries.into_iter().map(|(_, entry)| entry).collect(),
     })
 }

--- a/app/src/ai/blocklist/usage/rollup.rs
+++ b/app/src/ai/blocklist/usage/rollup.rs
@@ -50,6 +50,10 @@ pub struct OrchestrationCreditRollup {
     /// rollup omits the dollar figure entirely rather than showing an
     /// incomplete one.
     pub total_cost_in_cents: Option<f32>,
+    /// Sum of `usage_totals().charged_usage`'s total token count across the
+    /// orchestrator and every locally-loaded descendant. `None` under the
+    /// same conditions as `total_cost_in_cents`.
+    pub total_tokens: Option<u32>,
     /// One entry per agent that has spent > 0 credits, sorted by
     /// `credits_spent` descending. Ties are broken by spawn order (earlier
     /// spawn first; orchestrator always sorts before its descendants in a
@@ -62,6 +66,16 @@ pub struct OrchestrationCreditRollup {
 /// baseline (see `OrchestrationCreditRollup::total_cost_in_cents`).
 fn accumulate_cost(total: &mut Option<f32>, cost: Option<f32>) {
     *total = match (*total, cost) {
+        (Some(t), Some(c)) => Some(t + c),
+        _ => None,
+    };
+}
+
+/// Folds one more conversation's optional token count into a running total,
+/// propagating `None` permanently once any contributor lacks a known count
+/// (see `OrchestrationCreditRollup::total_tokens`).
+fn accumulate_tokens(total: &mut Option<u32>, tokens: Option<u32>) {
+    *total = match (*total, tokens) {
         (Some(t), Some(c)) => Some(t + c),
         _ => None,
     };
@@ -90,14 +104,22 @@ pub fn compute_orchestration_rollup(
 
     let mut total_credits: f32 = 0.0;
     let mut total_cost_in_cents: Option<f32> = Some(0.0);
+    let mut total_tokens: Option<u32> = Some(0);
     let mut entries: Vec<(usize, PerAgentCreditEntry)> = Vec::new();
 
     if let Some(orchestrator) = history.conversation(&parent_id) {
         let credits = orchestrator.credits_spent();
         total_credits += credits;
+        let orchestrator_usage_totals = orchestrator.usage_totals();
         accumulate_cost(
             &mut total_cost_in_cents,
-            orchestrator.usage_totals().cost_in_cents,
+            orchestrator_usage_totals.cost_in_cents,
+        );
+        accumulate_tokens(
+            &mut total_tokens,
+            orchestrator_usage_totals
+                .charged_usage
+                .map(|usage| usage.total_tokens()),
         );
         if credits > 0.0 {
             entries.push((
@@ -119,9 +141,16 @@ pub fn compute_orchestration_rollup(
         };
         let credits = descendant.credits_spent();
         total_credits += credits;
+        let descendant_usage_totals = descendant.usage_totals();
         accumulate_cost(
             &mut total_cost_in_cents,
-            descendant.usage_totals().cost_in_cents,
+            descendant_usage_totals.cost_in_cents,
+        );
+        accumulate_tokens(
+            &mut total_tokens,
+            descendant_usage_totals
+                .charged_usage
+                .map(|usage| usage.total_tokens()),
         );
         if credits > 0.0 {
             entries.push((
@@ -152,6 +181,7 @@ pub fn compute_orchestration_rollup(
     Some(OrchestrationCreditRollup {
         total_credits,
         total_cost_in_cents,
+        total_tokens,
         per_agent: entries.into_iter().map(|(_, entry)| entry).collect(),
     })
 }

--- a/app/src/ai/blocklist/usage/rollup.rs
+++ b/app/src/ai/blocklist/usage/rollup.rs
@@ -44,15 +44,18 @@ pub struct OrchestrationCreditRollup {
     /// locally-loaded descendant.
     pub total_credits: f32,
     /// Sum of `usage_totals().cost_in_cents` across the orchestrator and
-    /// every locally-loaded descendant, mirroring `total_credits`. `None`
-    /// when any contributing conversation lacks a known dollar-cost
-    /// baseline — a partial sum would misrepresent the true total, so the
-    /// rollup omits the dollar figure entirely rather than showing an
-    /// incomplete one.
+    /// every locally-loaded descendant that has spent > 0 credits,
+    /// mirroring `total_credits`. `None` when any such contributing
+    /// conversation lacks a known dollar-cost baseline — a partial sum
+    /// would misrepresent the true total, so the rollup omits the dollar
+    /// figure entirely rather than showing an incomplete one. A
+    /// zero-credit contributor (e.g. a freshly spawned child that hasn't
+    /// reported usage yet) is skipped rather than treated as an unknown
+    /// baseline, since it hasn't contributed anything to sum.
     pub total_cost_in_cents: Option<f32>,
     /// Sum of `usage_totals().charged_usage`'s total token count across the
-    /// orchestrator and every locally-loaded descendant. `None` under the
-    /// same conditions as `total_cost_in_cents`.
+    /// orchestrator and every locally-loaded descendant that has spent > 0
+    /// credits. `None` under the same conditions as `total_cost_in_cents`.
     pub total_tokens: Option<u32>,
     /// One entry per agent that has spent > 0 credits, sorted by
     /// `credits_spent` descending. Ties are broken by spawn order (earlier
@@ -110,18 +113,21 @@ pub fn compute_orchestration_rollup(
     if let Some(orchestrator) = history.conversation(&parent_id) {
         let credits = orchestrator.credits_spent();
         total_credits += credits;
-        let orchestrator_usage_totals = orchestrator.usage_totals();
-        accumulate_cost(
-            &mut total_cost_in_cents,
-            orchestrator_usage_totals.cost_in_cents,
-        );
-        accumulate_tokens(
-            &mut total_tokens,
-            orchestrator_usage_totals
-                .charged_usage
-                .map(|usage| usage.total_tokens()),
-        );
+        // Skip cost/token accumulation for a zero-credit contributor: it
+        // hasn't reported any usage yet, so its `None` charge metadata
+        // must not poison the running total for contributors that have.
         if credits > 0.0 {
+            let orchestrator_usage_totals = orchestrator.usage_totals();
+            accumulate_cost(
+                &mut total_cost_in_cents,
+                orchestrator_usage_totals.cost_in_cents,
+            );
+            accumulate_tokens(
+                &mut total_tokens,
+                orchestrator_usage_totals
+                    .charged_usage
+                    .map(|usage| usage.total_tokens()),
+            );
             entries.push((
                 0,
                 PerAgentCreditEntry {
@@ -141,18 +147,19 @@ pub fn compute_orchestration_rollup(
         };
         let credits = descendant.credits_spent();
         total_credits += credits;
-        let descendant_usage_totals = descendant.usage_totals();
-        accumulate_cost(
-            &mut total_cost_in_cents,
-            descendant_usage_totals.cost_in_cents,
-        );
-        accumulate_tokens(
-            &mut total_tokens,
-            descendant_usage_totals
-                .charged_usage
-                .map(|usage| usage.total_tokens()),
-        );
+        // See the matching comment in the orchestrator branch above.
         if credits > 0.0 {
+            let descendant_usage_totals = descendant.usage_totals();
+            accumulate_cost(
+                &mut total_cost_in_cents,
+                descendant_usage_totals.cost_in_cents,
+            );
+            accumulate_tokens(
+                &mut total_tokens,
+                descendant_usage_totals
+                    .charged_usage
+                    .map(|usage| usage.total_tokens()),
+            );
             entries.push((
                 spawn_idx + 1,
                 PerAgentCreditEntry {

--- a/app/src/ai/blocklist/usage/rollup_tests.rs
+++ b/app/src/ai/blocklist/usage/rollup_tests.rs
@@ -19,6 +19,20 @@ fn set_credits(
     });
 }
 
+fn set_cost_in_cents(
+    app: &mut App,
+    history: &warpui::ModelHandle<BlocklistAIHistoryModel>,
+    id: AIConversationId,
+    cost_in_cents: Option<f32>,
+) {
+    history.update(app, |history, _| {
+        history
+            .conversation_mut(&id)
+            .expect("conversation must be loaded")
+            .set_cost_in_cents_for_test(cost_in_cents);
+    });
+}
+
 fn spawn_child(
     app: &mut App,
     history: &warpui::ModelHandle<BlocklistAIHistoryModel>,
@@ -94,6 +108,69 @@ fn sums_orchestrator_and_loaded_descendants() {
             assert_eq!(rollup.per_agent[1].credits_spent, 3.0);
             assert_eq!(rollup.per_agent[1].avatar, AgentAvatar::Orchestrator);
             assert_eq!(rollup.per_agent[1].display_name, "Orchestrator");
+        });
+    });
+}
+
+#[test]
+fn sums_cost_in_cents_when_all_contributors_have_a_baseline() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = spawn_child(
+            &mut app,
+            &history,
+            "DesignBot",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        set_credits(&mut app, &history, orchestrator_id, 3.0);
+        set_credits(&mut app, &history, child_id, 30.0);
+        set_cost_in_cents(&mut app, &history, orchestrator_id, Some(6.0));
+        set_cost_in_cents(&mut app, &history, child_id, Some(60.0));
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_cost_in_cents, Some(66.0));
+        });
+    });
+}
+
+#[test]
+fn omits_cost_in_cents_when_any_contributor_lacks_a_baseline() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = spawn_child(
+            &mut app,
+            &history,
+            "DesignBot",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        set_credits(&mut app, &history, orchestrator_id, 3.0);
+        set_credits(&mut app, &history, child_id, 30.0);
+        set_cost_in_cents(&mut app, &history, orchestrator_id, Some(6.0));
+        // Child has no known cost baseline (e.g. a legacy conversation).
+        set_cost_in_cents(&mut app, &history, child_id, None);
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_cost_in_cents, None);
         });
     });
 }

--- a/app/src/ai/blocklist/usage/rollup_tests.rs
+++ b/app/src/ai/blocklist/usage/rollup_tests.rs
@@ -3,6 +3,7 @@ use warpui::{App, EntityId};
 use super::*;
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::persistence::model::ChargedUsageTotals;
 use crate::test_util::settings::initialize_history_persistence_for_tests;
 
 fn set_credits(
@@ -30,6 +31,23 @@ fn set_cost_in_cents(
             .conversation_mut(&id)
             .expect("conversation must be loaded")
             .set_cost_in_cents_for_test(cost_in_cents);
+    });
+}
+
+fn set_charged_usage_tokens(
+    app: &mut App,
+    history: &warpui::ModelHandle<BlocklistAIHistoryModel>,
+    id: AIConversationId,
+    total_tokens: Option<u32>,
+) {
+    history.update(app, |history, _| {
+        history
+            .conversation_mut(&id)
+            .expect("conversation must be loaded")
+            .set_charged_usage_for_test(total_tokens.map(|input_tokens| ChargedUsageTotals {
+                input_tokens,
+                ..Default::default()
+            }));
     });
 }
 
@@ -171,6 +189,69 @@ fn omits_cost_in_cents_when_any_contributor_lacks_a_baseline() {
             let rollup = compute_orchestration_rollup(orchestrator_id, history)
                 .expect("rollup should be Some");
             assert_eq!(rollup.total_cost_in_cents, None);
+        });
+    });
+}
+
+#[test]
+fn sums_tokens_when_all_contributors_have_a_count() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = spawn_child(
+            &mut app,
+            &history,
+            "DesignBot",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        set_credits(&mut app, &history, orchestrator_id, 3.0);
+        set_credits(&mut app, &history, child_id, 30.0);
+        set_charged_usage_tokens(&mut app, &history, orchestrator_id, Some(100));
+        set_charged_usage_tokens(&mut app, &history, child_id, Some(900));
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_tokens, Some(1000));
+        });
+    });
+}
+
+#[test]
+fn omits_tokens_when_any_contributor_lacks_a_count() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = spawn_child(
+            &mut app,
+            &history,
+            "DesignBot",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        set_credits(&mut app, &history, orchestrator_id, 3.0);
+        set_credits(&mut app, &history, child_id, 30.0);
+        set_charged_usage_tokens(&mut app, &history, orchestrator_id, Some(100));
+        // Child has no known token count (e.g. flag off, or a legacy conversation).
+        set_charged_usage_tokens(&mut app, &history, child_id, None);
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_tokens, None);
         });
     });
 }

--- a/app/src/ai/blocklist/usage/rollup_tests.rs
+++ b/app/src/ai/blocklist/usage/rollup_tests.rs
@@ -257,6 +257,57 @@ fn omits_tokens_when_any_contributor_lacks_a_count() {
 }
 
 #[test]
+fn zero_credit_descendant_does_not_poison_cost_or_token_totals() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = spawn_child(
+            &mut app,
+            &history,
+            "DesignBot",
+            orchestrator_id,
+            terminal_view_id,
+        );
+        // Freshly spawned, has not reported any usage: zero credits, and no
+        // known cost/token baseline (the defaults).
+        let _idle_id = spawn_child(
+            &mut app,
+            &history,
+            "IdleChild",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        set_credits(&mut app, &history, orchestrator_id, 3.0);
+        set_credits(&mut app, &history, child_id, 30.0);
+        set_cost_in_cents(&mut app, &history, orchestrator_id, Some(6.0));
+        set_cost_in_cents(&mut app, &history, child_id, Some(60.0));
+        set_charged_usage_tokens(&mut app, &history, orchestrator_id, Some(100));
+        set_charged_usage_tokens(&mut app, &history, child_id, Some(900));
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(
+                rollup.total_cost_in_cents,
+                Some(66.0),
+                "the idle child's unset cost baseline must not force the total to None"
+            );
+            assert_eq!(
+                rollup.total_tokens,
+                Some(1000),
+                "the idle child's unset token count must not force the total to None"
+            );
+        });
+    });
+}
+
+#[test]
 fn excludes_zero_credit_descendants_from_breakdown() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -375,3 +375,7 @@ where
         })
         .finish()
 }
+
+#[cfg(test)]
+#[path = "view_util_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
+use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::Appearance;
 use warpui::elements::{
     ChildAnchor, ConstrainedBox, Container, CrossAxisAlignment, Flex, Hoverable, MainAxisAlignment,
@@ -294,6 +295,25 @@ pub fn format_credits(credits: f32) -> String {
     } else {
         format!("{credits:.1} credits")
     }
+}
+
+/// Formats a credit count together with its real dollar cost, e.g.
+/// `"20 credits ($0.36)"`, gated by `FeatureFlag::PricingTransparency`.
+///
+/// When the flag is disabled, returns exactly [`format_credits`] with no
+/// dollar suffix, so flag-off output stays byte-identical to today's. When
+/// the flag is enabled but `cost_in_cents` is `None` (no cost baseline is
+/// available for this figure — never coerced to zero), the dollar figure is
+/// gracefully omitted rather than showing "$0.00".
+pub fn format_credits_with_cost(credits: f32, cost_in_cents: Option<f32>) -> String {
+    let credits_text = format_credits(credits);
+    if !FeatureFlag::PricingTransparency.is_enabled() {
+        return credits_text;
+    }
+    let Some(cost_in_cents) = cost_in_cents else {
+        return credits_text;
+    };
+    format!("{credits_text} (${:.2})", cost_in_cents / 100.0)
 }
 
 /// Renders a secondary button with an MCP/skill provider icon and a text label.

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
+use thousands::Separable;
 use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::Appearance;
 use warpui::elements::{
@@ -297,14 +298,18 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
-/// Builds the `"12345 tokens, $0.36"`-style parenthetical shared by
+/// Builds the `"12,345 tokens, $0.36"`-style parenthetical shared by
 /// [`format_credits_with_cost`] and the conversation details panel's
 /// compact "Credits used" line, gated by `FeatureFlag::PricingTransparency`.
 ///
 /// `tokens` and `cost_in_cents` are independent: either, both, or neither
 /// may be `None` (no baseline is available for that figure — never coerced
-/// to zero), and only the figures that are present are included. Returns
-/// `None` when the flag is disabled, or when both figures are `None`.
+/// to zero), and only the figures that are present are included. A `tokens`
+/// value of `0` is treated the same as `None` (omitted) since a "0 tokens"
+/// figure next to a non-zero credit/cost figure would be confusing rather
+/// than informative (e.g. a purely platform-cost request like a paid web
+/// search). Returns `None` when the flag is disabled, or when both figures
+/// are `None`/omitted.
 ///
 /// This intentionally supersedes the previous standalone "PRICING
 /// BREAKDOWN" section (per-category input/cache/output/platform/web-search
@@ -319,7 +324,9 @@ pub fn format_usage_parenthetical(
     if !FeatureFlag::PricingTransparency.is_enabled() {
         return None;
     }
-    let token_part = tokens.map(|tokens| format!("{tokens} tokens"));
+    let token_part = tokens
+        .filter(|&tokens| tokens > 0)
+        .map(|tokens| format!("{} tokens", tokens.separate_with_commas()));
     let cost_part = cost_in_cents.map(|cost_in_cents| format!("${:.2}", cost_in_cents / 100.0));
     match (token_part, cost_part) {
         (Some(token_part), Some(cost_part)) => Some(format!("{token_part}, {cost_part}")),
@@ -330,7 +337,7 @@ pub fn format_usage_parenthetical(
 }
 
 /// Formats a credit count together with its total token count and real
-/// dollar cost, e.g. `"20 credits (12345 tokens, $0.36)"`. See
+/// dollar cost, e.g. `"20 credits (12,345 tokens, $0.36)"`. See
 /// [`format_usage_parenthetical`] for how the parenthetical is built and
 /// when it's omitted (including always, when `FeatureFlag::PricingTransparency`
 /// is disabled).

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -297,23 +297,53 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
-/// Formats a credit count together with its real dollar cost, e.g.
-/// `"20 credits ($0.36)"`, gated by `FeatureFlag::PricingTransparency`.
+/// Builds the `"12345 tokens, $0.36"`-style parenthetical shared by
+/// [`format_credits_with_cost`] and the conversation details panel's
+/// compact "Credits used" line, gated by `FeatureFlag::PricingTransparency`.
 ///
-/// When the flag is disabled, returns exactly [`format_credits`] with no
-/// dollar suffix, so flag-off output stays byte-identical to today's. When
-/// the flag is enabled but `cost_in_cents` is `None` (no cost baseline is
-/// available for this figure — never coerced to zero), the dollar figure is
-/// gracefully omitted rather than showing "$0.00".
-pub fn format_credits_with_cost(credits: f32, cost_in_cents: Option<f32>) -> String {
-    let credits_text = format_credits(credits);
+/// `tokens` and `cost_in_cents` are independent: either, both, or neither
+/// may be `None` (no baseline is available for that figure — never coerced
+/// to zero), and only the figures that are present are included. Returns
+/// `None` when the flag is disabled, or when both figures are `None`.
+///
+/// This intentionally supersedes the previous standalone "PRICING
+/// BREAKDOWN" section (per-category input/cache/output/platform/web-search
+/// rows): for now a single inline token+dollar figure next to credits is
+/// enough. The deeper `ChargedUsageTotals` breakdown that section rendered
+/// is still computed and available for a future expandable/dropdown
+/// treatment.
+pub fn format_usage_parenthetical(
+    tokens: Option<u32>,
+    cost_in_cents: Option<f32>,
+) -> Option<String> {
     if !FeatureFlag::PricingTransparency.is_enabled() {
-        return credits_text;
+        return None;
     }
-    let Some(cost_in_cents) = cost_in_cents else {
+    let token_part = tokens.map(|tokens| format!("{tokens} tokens"));
+    let cost_part = cost_in_cents.map(|cost_in_cents| format!("${:.2}", cost_in_cents / 100.0));
+    match (token_part, cost_part) {
+        (Some(token_part), Some(cost_part)) => Some(format!("{token_part}, {cost_part}")),
+        (Some(token_part), None) => Some(token_part),
+        (None, Some(cost_part)) => Some(cost_part),
+        (None, None) => None,
+    }
+}
+
+/// Formats a credit count together with its total token count and real
+/// dollar cost, e.g. `"20 credits (12345 tokens, $0.36)"`. See
+/// [`format_usage_parenthetical`] for how the parenthetical is built and
+/// when it's omitted (including always, when `FeatureFlag::PricingTransparency`
+/// is disabled).
+pub fn format_credits_with_cost(
+    credits: f32,
+    tokens: Option<u32>,
+    cost_in_cents: Option<f32>,
+) -> String {
+    let credits_text = format_credits(credits);
+    let Some(parenthetical) = format_usage_parenthetical(tokens, cost_in_cents) else {
         return credits_text;
     };
-    format!("{credits_text} (${:.2})", cost_in_cents / 100.0)
+    format!("{credits_text} ({parenthetical})")
 }
 
 /// Renders a secondary button with an MCP/skill provider icon and a text label.

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -1,0 +1,30 @@
+use warp_core::features::FeatureFlag;
+
+use super::*;
+
+#[test]
+fn format_credits_with_cost_omits_dollar_suffix_when_flag_disabled() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(false);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(36.0)),
+        format_credits(20.0)
+    );
+}
+
+#[test]
+fn format_credits_with_cost_appends_dollar_suffix_when_flag_enabled() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(36.0)),
+        "20 credits ($0.36)"
+    );
+}
+
+#[test]
+fn format_credits_with_cost_omits_dollar_suffix_when_cost_is_unknown() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(format_credits_with_cost(20.0, None), format_credits(20.0));
+}

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -3,28 +3,51 @@ use warp_core::features::FeatureFlag;
 use super::*;
 
 #[test]
-fn format_credits_with_cost_omits_dollar_suffix_when_flag_disabled() {
+fn format_credits_with_cost_omits_parenthetical_when_flag_disabled() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(false);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(36.0)),
+        format_credits_with_cost(20.0, Some(12345), Some(36.0)),
         format_credits(20.0)
     );
 }
 
 #[test]
-fn format_credits_with_cost_appends_dollar_suffix_when_flag_enabled() {
+fn format_credits_with_cost_appends_tokens_and_dollar_suffix_when_flag_enabled() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(36.0)),
+        format_credits_with_cost(20.0, Some(12345), Some(36.0)),
+        "20 credits (12345 tokens, $0.36)"
+    );
+}
+
+#[test]
+fn format_credits_with_cost_omits_dollar_figure_when_cost_is_unknown() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(12345), None),
+        "20 credits (12345 tokens)"
+    );
+}
+
+#[test]
+fn format_credits_with_cost_omits_token_figure_when_tokens_is_unknown() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, None, Some(36.0)),
         "20 credits ($0.36)"
     );
 }
 
 #[test]
-fn format_credits_with_cost_omits_dollar_suffix_when_cost_is_unknown() {
+fn format_credits_with_cost_omits_parenthetical_when_both_are_unknown() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
-    assert_eq!(format_credits_with_cost(20.0, None), format_credits(20.0));
+    assert_eq!(
+        format_credits_with_cost(20.0, None, None),
+        format_credits(20.0)
+    );
 }

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -18,7 +18,17 @@ fn format_credits_with_cost_appends_tokens_and_dollar_suffix_when_flag_enabled()
 
     assert_eq!(
         format_credits_with_cost(20.0, Some(12345), Some(36.0)),
-        "20 credits (12345 tokens, $0.36)"
+        "20 credits (12,345 tokens, $0.36)"
+    );
+}
+
+#[test]
+fn format_credits_with_cost_formats_large_token_counts_with_thousands_separators() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(26.9, Some(719_124), Some(48.0)),
+        "26.9 credits (719,124 tokens, $0.48)"
     );
 }
 
@@ -28,7 +38,7 @@ fn format_credits_with_cost_omits_dollar_figure_when_cost_is_unknown() {
 
     assert_eq!(
         format_credits_with_cost(20.0, Some(12345), None),
-        "20 credits (12345 tokens)"
+        "20 credits (12,345 tokens)"
     );
 }
 
@@ -43,11 +53,31 @@ fn format_credits_with_cost_omits_token_figure_when_tokens_is_unknown() {
 }
 
 #[test]
+fn format_credits_with_cost_omits_token_figure_when_tokens_is_zero() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(0), Some(36.0)),
+        "20 credits ($0.36)"
+    );
+}
+
+#[test]
 fn format_credits_with_cost_omits_parenthetical_when_both_are_unknown() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
         format_credits_with_cost(20.0, None, None),
+        format_credits(20.0)
+    );
+}
+
+#[test]
+fn format_credits_with_cost_omits_parenthetical_when_tokens_are_zero_and_cost_is_unknown() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(0), None),
         format_credits(20.0)
     );
 }

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -12,6 +12,7 @@ use pathfinder_geometry::vector::vec2f;
 use warp_cli::agent::Harness;
 use warp_cli::skill::SkillSpec;
 use warp_core::channel::ChannelState;
+use warp_core::features::FeatureFlag;
 use warp_core::ui::color::coloru_with_opacity;
 use warp_graphql::queries::get_runners::Runner;
 use warpui::clipboard::ClipboardContent;
@@ -57,6 +58,7 @@ use crate::appearance::Appearance;
 use crate::auth::UserUid;
 use crate::cloud_object::CloudObjectLookup as _;
 use crate::notebooks::NotebookId;
+use crate::persistence::model::ChargedUsageTotals;
 use crate::send_telemetry_from_ctx;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ServerApiProvider;
@@ -241,6 +243,15 @@ pub struct ConversationDetailsData {
     created_at: Option<DateTime<Local>>,
     /// Total credits spent on the conversation/task.
     credits: Option<f32>,
+    /// Total token count used, when the source provides it.
+    total_tokens: Option<u32>,
+    /// Cumulative per-category charged-usage breakdown (input/output/
+    /// cache-read/cache-write cost + token counts), gated by
+    /// `FeatureFlag::PricingTransparency`. `None` when the source doesn't
+    /// yet provide it — e.g. cloud task/REST-backed sources, which don't
+    /// carry the wire protocol's per-category charges (documented gap,
+    /// tracked for the REST vertical).
+    charged_usage: Option<ChargedUsageTotals>,
     /// Total duration of the conversation.
     run_time: Option<Duration>,
     /// Artifacts created during the conversation (plans, PRs, branches).
@@ -347,6 +358,13 @@ impl ConversationDetailsData {
             .map(|m| Harness::from(m.harness))
             .or(Some(Harness::Oz));
 
+        let usage_totals = conversation.usage_totals();
+        let total_tokens: u32 = conversation
+            .token_usage()
+            .iter()
+            .map(|model| model.warp_tokens + model.byok_tokens + model.custom_endpoint_tokens)
+            .sum();
+
         ConversationDetailsData {
             mode: PanelMode::Conversation {
                 directory,
@@ -361,6 +379,8 @@ impl ConversationDetailsData {
             executor: None,
             created_at,
             credits: Some(conversation.credits_spent()),
+            total_tokens: (total_tokens > 0).then_some(total_tokens),
+            charged_usage: usage_totals.charged_usage,
             run_time,
             artifacts: conversation.artifacts().to_vec(),
             open_action: None,
@@ -426,6 +446,11 @@ impl ConversationDetailsData {
             created_at: Some(task.created_at.with_timezone(&Local)),
             artifacts: task.artifacts.clone(),
             credits,
+            // GAP: cloud tasks are sourced from the REST `AmbientAgentTask`,
+            // which doesn't yet carry a per-category charges breakdown
+            // (tracked for the REST vertical).
+            total_tokens: None,
+            charged_usage: None,
             run_time: task.run_time(),
             open_action,
             creator: task
@@ -506,6 +531,9 @@ impl ConversationDetailsData {
                 executor,
                 created_at,
                 credits,
+                // GAP: see the `from_task` gap note above.
+                total_tokens: None,
+                charged_usage: None,
                 run_time: task.and_then(AmbientAgentTask::run_time),
                 artifacts: entry.display.artifacts.clone(),
                 open_action,
@@ -533,6 +561,11 @@ impl ConversationDetailsData {
             executor: None,
             created_at,
             credits: entry.display.request_usage,
+            // GAP: this branch has no linked `AmbientAgentTask` and the
+            // entry's denormalized total is a bare credits figure with no
+            // token/breakdown counterpart.
+            total_tokens: None,
+            charged_usage: None,
             run_time: None,
             artifacts: entry.display.artifacts.clone(),
             open_action,
@@ -565,6 +598,8 @@ impl ConversationDetailsData {
             executor: None,
             created_at: None,
             credits: None,
+            total_tokens: None,
+            charged_usage: None,
             run_time: None,
             artifacts: vec![],
             open_action: None,
@@ -607,6 +642,11 @@ impl ConversationDetailsData {
             executor: None,
             created_at: Some(created_at),
             credits: credits_used,
+            // GAP: this legacy management-view constructor only accepts a
+            // bare credits total; no token/breakdown source is threaded
+            // through it.
+            total_tokens: None,
+            charged_usage: None,
             run_time: None,
             open_action,
             artifacts,
@@ -2276,6 +2316,43 @@ impl View for ConversationDetailsPanel {
                     .with_margin_bottom(FIELD_SPACING)
                     .finish(),
             );
+        }
+
+        if FeatureFlag::PricingTransparency.is_enabled() {
+            if let Some(total_tokens) = self.data.total_tokens {
+                content.add_child(
+                    Container::new(self.render_simple_field(
+                        "Tokens used",
+                        &total_tokens.to_string(),
+                        appearance,
+                    ))
+                    .with_margin_bottom(FIELD_SPACING)
+                    .finish(),
+                );
+            }
+
+            if let Some(charged_usage) = self.data.charged_usage {
+                let rows: [(&str, f32); 4] = [
+                    ("Input cost", charged_usage.input_cost_in_cents),
+                    (
+                        "Cache read cost",
+                        charged_usage.input_cache_read_cost_in_cents,
+                    ),
+                    (
+                        "Cache write cost",
+                        charged_usage.input_cache_write_cost_in_cents,
+                    ),
+                    ("Output cost", charged_usage.output_cost_in_cents),
+                ];
+                for (label, cost_in_cents) in rows {
+                    let formatted = format!("${:.2}", cost_in_cents / 100.0);
+                    content.add_child(
+                        Container::new(self.render_simple_field(label, &formatted, appearance))
+                            .with_margin_bottom(FIELD_SPACING)
+                            .finish(),
+                    );
+                }
+            }
         }
 
         if let Some(duration) = self.data.run_time {

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -12,7 +12,6 @@ use pathfinder_geometry::vector::vec2f;
 use warp_cli::agent::Harness;
 use warp_cli::skill::SkillSpec;
 use warp_core::channel::ChannelState;
-use warp_core::features::FeatureFlag;
 use warp_core::ui::color::coloru_with_opacity;
 use warp_graphql::queries::get_runners::Runner;
 use warpui::clipboard::ClipboardContent;
@@ -50,6 +49,7 @@ use crate::ai::ambient_agents::task::TaskPrincipalInfo;
 use crate::ai::ambient_agents::{AmbientAgentTaskId, cancel_task_with_toast};
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::ai::blocklist::view_util::format_usage_parenthetical;
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment};
 use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
@@ -2310,50 +2310,27 @@ impl View for ConversationDetailsPanel {
         }
 
         if let Some(credits) = self.data.credits {
-            let formatted = format!("{credits:.1}");
+            // A single compact "X (N tokens, $Y)" line rather than separate
+            // rows for credits/tokens/per-category cost: for now this
+            // inline figure is enough (see `format_usage_parenthetical` doc
+            // comment for why the deeper per-category breakdown was dropped
+            // from display, though it's still computed and available on
+            // `self.data.charged_usage` for a future expandable treatment).
+            let cost_in_cents = self
+                .data
+                .charged_usage
+                .map(|charged_usage| charged_usage.total_cost_in_cents());
+            let mut formatted = format!("{credits:.1}");
+            if let Some(parenthetical) =
+                format_usage_parenthetical(self.data.total_tokens, cost_in_cents)
+            {
+                formatted = format!("{formatted} ({parenthetical})");
+            }
             content.add_child(
                 Container::new(self.render_simple_field("Credits used", &formatted, appearance))
                     .with_margin_bottom(FIELD_SPACING)
                     .finish(),
             );
-        }
-
-        if FeatureFlag::PricingTransparency.is_enabled() {
-            if let Some(total_tokens) = self.data.total_tokens {
-                content.add_child(
-                    Container::new(self.render_simple_field(
-                        "Tokens used",
-                        &total_tokens.to_string(),
-                        appearance,
-                    ))
-                    .with_margin_bottom(FIELD_SPACING)
-                    .finish(),
-                );
-            }
-
-            if let Some(charged_usage) = self.data.charged_usage {
-                let rows: [(&str, f32); 5] = [
-                    ("Input cost", charged_usage.input_cost_in_cents),
-                    (
-                        "Cache read cost",
-                        charged_usage.input_cache_read_cost_in_cents,
-                    ),
-                    (
-                        "Cache write cost",
-                        charged_usage.input_cache_write_cost_in_cents,
-                    ),
-                    ("Output cost", charged_usage.output_cost_in_cents),
-                    ("Web search cost", charged_usage.web_search_cost_in_cents),
-                ];
-                for (label, cost_in_cents) in rows {
-                    let formatted = format!("${:.2}", cost_in_cents / 100.0);
-                    content.add_child(
-                        Container::new(self.render_simple_field(label, &formatted, appearance))
-                            .with_margin_bottom(FIELD_SPACING)
-                            .finish(),
-                    );
-                }
-            }
         }
 
         if let Some(duration) = self.data.run_time {

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -2332,7 +2332,7 @@ impl View for ConversationDetailsPanel {
             }
 
             if let Some(charged_usage) = self.data.charged_usage {
-                let rows: [(&str, f32); 4] = [
+                let rows: [(&str, f32); 5] = [
                     ("Input cost", charged_usage.input_cost_in_cents),
                     (
                         "Cache read cost",
@@ -2343,6 +2343,7 @@ impl View for ConversationDetailsPanel {
                         charged_usage.input_cache_write_cost_in_cents,
                     ),
                     ("Output cost", charged_usage.output_cost_in_cents),
+                    ("Web search cost", charged_usage.web_search_cost_in_cents),
                 ];
                 for (label, cost_in_cents) in rows {
                     let formatted = format!("${:.2}", cost_in_cents / 100.0);

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -187,6 +187,8 @@ fn create_test_server_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -371,6 +371,8 @@ fn test_server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6958,6 +6958,13 @@ impl TerminalView {
             conversation.total_agent_response_time_since_last_user_query_ms();
         let wall_to_wall_response_time_ms =
             conversation.wall_to_wall_response_time_since_last_query();
+        // Same rollup-vs-own-totals split as the footer's compact usage
+        // button (`render_usage_button`): `cost_in_cents` is the
+        // server-authoritative provider cost baseline, while the token
+        // count comes from the charged-usage breakdown, which is the only
+        // place it's tracked.
+        let usage_totals = conversation.usage_totals();
+        let charged_usage_for_last_block = conversation.charged_usage_for_last_block();
 
         let conversation_usage_info = ConversationUsageInfo {
             credits_spent: conversation.inference_credits_spent(),
@@ -6971,6 +6978,11 @@ impl TerminalView {
             lines_added: tool_usage.apply_file_diff_stats.lines_added,
             lines_removed: tool_usage.apply_file_diff_stats.lines_removed,
             commands_executed: tool_usage.run_command_stats.commands_executed,
+            total_tokens: usage_totals.charged_usage.map(|usage| usage.total_tokens()),
+            total_cost_in_cents: usage_totals.cost_in_cents,
+            tokens_for_last_block: charged_usage_for_last_block.map(|usage| usage.total_tokens()),
+            cost_in_cents_for_last_block: charged_usage_for_last_block
+                .map(|usage| usage.total_cost_in_cents()),
         };
 
         let timing_info = TimingInfo {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6971,6 +6971,7 @@ impl TerminalView {
             lines_added: tool_usage.apply_file_diff_stats.lines_added,
             lines_removed: tool_usage.apply_file_diff_stats.lines_removed,
             commands_executed: tool_usage.run_command_stats.commands_executed,
+            charged_usage: conversation.usage_totals().charged_usage,
         };
 
         let timing_info = TimingInfo {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6971,7 +6971,6 @@ impl TerminalView {
             lines_added: tool_usage.apply_file_diff_stats.lines_added,
             lines_removed: tool_usage.apply_file_diff_stats.lines_removed,
             commands_executed: tool_usage.run_command_stats.commands_executed,
-            charged_usage: conversation.usage_totals().charged_usage,
         };
 
         let timing_info = TimingInfo {

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -305,6 +305,8 @@ fn server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -757,6 +757,8 @@ fn server_conversation_metadata(
             platform_credits_spent: 0.0,
             total_provider_cost_in_cents: None,
             credits_spent_for_last_block: None,
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -174,6 +174,7 @@ pub use crate::code_review::github_repo_model::GitHubRepoModel;
 pub use crate::completer::SessionContext;
 pub use crate::global_resource_handles::GlobalResourceHandlesProvider;
 pub use crate::persistence::PersistenceWriter;
+pub use crate::persistence::model::ChargedUsageTotals;
 pub use crate::prefix::longest_common_prefix;
 pub use crate::search::slash_command_menu::static_commands::commands::{
     self as slash_commands, COMMAND_REGISTRY,

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -366,6 +366,13 @@ impl From<&gql_usage::ConversationUsage> for ConversationUsageInfo {
             lines_added: tool.apply_file_diff_stats.lines_added,
             lines_removed: tool.apply_file_diff_stats.lines_removed,
             commands_executed: tool.run_command_stats.commands_executed,
+            // GAP: the settings usage-history surface sources this view from
+            // a GraphQL query that does not yet expose a token count or
+            // per-category cost breakdown (Milestone 3 / vertical B).
+            total_tokens: None,
+            total_cost_in_cents: None,
+            tokens_for_last_block: None,
+            cost_in_cents_for_last_block: None,
         }
     }
 }

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -366,6 +366,10 @@ impl From<&gql_usage::ConversationUsage> for ConversationUsageInfo {
             lines_added: tool.apply_file_diff_stats.lines_added,
             lines_removed: tool.apply_file_diff_stats.lines_removed,
             commands_executed: tool.run_command_stats.commands_executed,
+            // GAP: the settings usage-history surface sources this view from
+            // a GraphQL query that does not yet expose a per-category cost
+            // breakdown (Milestone 3 / vertical B).
+            charged_usage: None,
         }
     }
 }

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -366,10 +366,6 @@ impl From<&gql_usage::ConversationUsage> for ConversationUsageInfo {
             lines_added: tool.apply_file_diff_stats.lines_added,
             lines_removed: tool.apply_file_diff_stats.lines_removed,
             commands_executed: tool.run_command_stats.commands_executed,
-            // GAP: the settings usage-history surface sources this view from
-            // a GraphQL query that does not yet expose a per-category cost
-            // breakdown (Milestone 3 / vertical B).
-            charged_usage: None,
         }
     }
 }

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -217,6 +217,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             platform_credits_spent: gql.platform_credits_spent as f32,
             total_provider_cost_in_cents: gql.total_provider_cost_in_cents.map(|cost| cost as f32),
             credits_spent_for_last_block: None,
+            // Not yet fetched by this GraphQL query (persisted-history
+            // vertical, milestone 3) -- left `None` rather than fabricated.
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -198,6 +198,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             platform_credits_spent: gql.platform_credits_spent as f32,
             total_provider_cost_in_cents: gql.total_provider_cost_in_cents.map(|cost| cost as f32),
             credits_spent_for_last_block: None,
+            // Not yet fetched by this GraphQL query (persisted-history
+            // vertical, milestone 3) -- left `None` rather than fabricated.
+            charged_usage_for_last_block: None,
+            total_charged_usage: None,
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1623,16 +1623,27 @@ pub struct ChargedUsageTotals {
     pub output_tokens: u32,
     pub input_cache_read_tokens: u32,
     pub input_cache_write_tokens: u32,
+    /// Number of web searches performed, summed across every usage category
+    /// and model. `#[serde(default)]` so blobs persisted before this field
+    /// existed still deserialize.
+    #[serde(default)]
+    pub web_search_count: u32,
+    /// Cumulative cost of web searches performed, in US cents. Included in
+    /// [`Self::total_cost_in_cents`] since it's part of the real, actually-
+    /// charged dollar total (see `warp-proto-apis` PR #363).
+    #[serde(default)]
+    pub web_search_cost_in_cents: f32,
 }
 
 impl ChargedUsageTotals {
-    /// Total inference + platform cost, in US cents.
+    /// Total inference + platform + web-search cost, in US cents.
     pub fn total_cost_in_cents(&self) -> f32 {
         self.input_cost_in_cents
             + self.output_cost_in_cents
             + self.input_cache_read_cost_in_cents
             + self.input_cache_write_cost_in_cents
             + self.platform_cost_in_cents
+            + self.web_search_cost_in_cents
     }
 
     /// Total tokens across every category (input + output + cache-read + cache-write).
@@ -1656,6 +1667,8 @@ impl ChargedUsageTotals {
             self.input_cache_read_cost_in_cents += token_cost.input_cache_read_cost_in_cents;
             self.input_cache_write_cost_in_cents += token_cost.input_cache_write_cost_in_cents;
         }
+        self.web_search_count += usage.web_search_count;
+        self.web_search_cost_in_cents += usage.web_search_cost_in_cents;
     }
 }
 
@@ -1670,6 +1683,8 @@ impl std::ops::AddAssign for ChargedUsageTotals {
         self.output_tokens += rhs.output_tokens;
         self.input_cache_read_tokens += rhs.input_cache_read_tokens;
         self.input_cache_write_tokens += rhs.input_cache_write_tokens;
+        self.web_search_count += rhs.web_search_count;
+        self.web_search_cost_in_cents += rhs.web_search_cost_in_cents;
     }
 }
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1605,6 +1605,97 @@ impl From<&ContextWindowSegment> for stream_finished::ContextWindowSegment {
     }
 }
 
+/// A flat breakdown of charged usage — input/output/cache-read/cache-write
+/// inference cost (in US cents) plus platform cost, and the matching token
+/// counts — summed across every usage category and model. Mirrors the Go
+/// `SumChargedUsage` helper (`warp-server` `logic/ai/multi_agent/usage`);
+/// computed client-side from the wire's category/model-keyed
+/// `RequestCharges` map so downstream displays don't need to walk the map
+/// themselves.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq)]
+pub struct ChargedUsageTotals {
+    pub input_cost_in_cents: f32,
+    pub output_cost_in_cents: f32,
+    pub input_cache_read_cost_in_cents: f32,
+    pub input_cache_write_cost_in_cents: f32,
+    pub platform_cost_in_cents: f32,
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub input_cache_read_tokens: u32,
+    pub input_cache_write_tokens: u32,
+}
+
+impl ChargedUsageTotals {
+    /// Total inference + platform cost, in US cents.
+    pub fn total_cost_in_cents(&self) -> f32 {
+        self.input_cost_in_cents
+            + self.output_cost_in_cents
+            + self.input_cache_read_cost_in_cents
+            + self.input_cache_write_cost_in_cents
+            + self.platform_cost_in_cents
+    }
+
+    /// Total tokens across every category (input + output + cache-read + cache-write).
+    pub fn total_tokens(&self) -> u32 {
+        self.input_tokens
+            + self.output_tokens
+            + self.input_cache_read_tokens
+            + self.input_cache_write_tokens
+    }
+
+    fn add_inference_usage(&mut self, usage: &stream_finished::InferenceUsage) {
+        if let Some(token_count) = usage.token_count.as_ref() {
+            self.input_tokens += token_count.input;
+            self.output_tokens += token_count.output;
+            self.input_cache_read_tokens += token_count.input_cache_read;
+            self.input_cache_write_tokens += token_count.input_cache_write;
+        }
+        if let Some(token_cost) = usage.token_cost.as_ref() {
+            self.input_cost_in_cents += token_cost.input_cost_in_cents;
+            self.output_cost_in_cents += token_cost.output_cost_in_cents;
+            self.input_cache_read_cost_in_cents += token_cost.input_cache_read_cost_in_cents;
+            self.input_cache_write_cost_in_cents += token_cost.input_cache_write_cost_in_cents;
+        }
+    }
+}
+
+impl std::ops::AddAssign for ChargedUsageTotals {
+    fn add_assign(&mut self, rhs: Self) {
+        self.input_cost_in_cents += rhs.input_cost_in_cents;
+        self.output_cost_in_cents += rhs.output_cost_in_cents;
+        self.input_cache_read_cost_in_cents += rhs.input_cache_read_cost_in_cents;
+        self.input_cache_write_cost_in_cents += rhs.input_cache_write_cost_in_cents;
+        self.platform_cost_in_cents += rhs.platform_cost_in_cents;
+        self.input_tokens += rhs.input_tokens;
+        self.output_tokens += rhs.output_tokens;
+        self.input_cache_read_tokens += rhs.input_cache_read_tokens;
+        self.input_cache_write_tokens += rhs.input_cache_write_tokens;
+    }
+}
+
+impl From<&stream_finished::RequestCharges> for ChargedUsageTotals {
+    /// Sums a category-keyed `RequestCharges` map (per-turn or cumulative)
+    /// into a single flat breakdown, mirroring the Go `SumChargedUsage`
+    /// helper. Categories and models are summed together; per-category/
+    /// per-model detail is discarded, matching the single
+    /// pricing-breakdown-section display convention (`warp` PR #15015).
+    fn from(charges: &stream_finished::RequestCharges) -> Self {
+        let mut totals = Self::default();
+        for usage in charges.usage_by_category.values() {
+            for inference_usage in usage
+                .direct_api_inference_usage
+                .values()
+                .chain(usage.byok_inference_usage.values())
+                .chain(usage.custom_endpoint_inference_usage.values())
+            {
+                totals.add_inference_usage(inference_usage);
+            }
+            totals.platform_cost_in_cents += usage.platform_usage_in_cents;
+        }
+        totals
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ConversationUsageMetadata {
     pub was_summarized: bool,
@@ -1619,6 +1710,19 @@ pub struct ConversationUsageMetadata {
     pub total_provider_cost_in_cents: Option<f32>,
     #[serde(default)]
     pub credits_spent_for_last_block: Option<f32>,
+    /// Per-category charged-usage breakdown for the most recent block (all
+    /// agent outputs since the last user input), summed via
+    /// [`ChargedUsageTotals::from`] from `StreamFinished.request_charges`.
+    /// `None` when the server didn't provide charges (flag off) or before
+    /// any block has completed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub charged_usage_for_last_block: Option<ChargedUsageTotals>,
+    /// Cumulative per-category charged-usage breakdown summed across the
+    /// whole conversation so far, from
+    /// `ConversationUsageMetadata.total_charges`. `None` when the server
+    /// didn't provide it (flag off, or a legacy conversation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_charged_usage: Option<ChargedUsageTotals>,
     #[serde(default)]
     pub token_usage: Vec<ModelTokenUsage>,
     #[serde(default)]

--- a/crates/persistence/src/model_tests.rs
+++ b/crates/persistence/src/model_tests.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use warp_multi_agent_api as api;
 
 use super::{
-    AgentConversation, AgentConversationData, AgentConversationSummary, ConversationUsageMetadata,
-    ModelTokenUsage,
+    AgentConversation, AgentConversationData, AgentConversationSummary, ChargedUsageTotals,
+    ConversationUsageMetadata, ModelTokenUsage,
 };
 
 fn parentless_task(id: &str, message_count: usize) -> api::Task {
@@ -133,6 +133,100 @@ fn conversation_usage_metadata_preserves_known_zero_provider_cost() {
             .unwrap()
             .contains("\"total_provider_cost_in_cents\":0.0")
     );
+}
+
+fn inference_usage_with_web_search(
+    input: u32,
+    output: u32,
+    input_cost_in_cents: f32,
+    output_cost_in_cents: f32,
+    web_search_count: u32,
+    web_search_cost_in_cents: f32,
+) -> api::response_event::stream_finished::InferenceUsage {
+    api::response_event::stream_finished::InferenceUsage {
+        token_count: Some(api::response_event::stream_finished::TokenCount {
+            input,
+            output,
+            input_cache_read: 0,
+            input_cache_write: 0,
+        }),
+        token_cost: Some(api::response_event::stream_finished::TokenCost {
+            input_cost_in_cents,
+            output_cost_in_cents,
+            input_cache_read_cost_in_cents: 0.0,
+            input_cache_write_cost_in_cents: 0.0,
+        }),
+        web_search_count,
+        web_search_cost_in_cents,
+    }
+}
+
+#[test]
+fn charged_usage_totals_sums_web_search_fields_across_categories_and_models() {
+    let mut usage_by_category = HashMap::new();
+    usage_by_category.insert(
+        "primary_agent".to_string(),
+        api::response_event::stream_finished::ChargedUsage {
+            direct_api_inference_usage: HashMap::from([(
+                "claude-4.5".to_string(),
+                inference_usage_with_web_search(1000, 200, 3.0, 6.0, 2, 5.0),
+            )]),
+            byok_inference_usage: HashMap::new(),
+            custom_endpoint_inference_usage: HashMap::new(),
+            platform_usage_in_cents: 1.0,
+        },
+    );
+    usage_by_category.insert(
+        "compaction".to_string(),
+        api::response_event::stream_finished::ChargedUsage {
+            direct_api_inference_usage: HashMap::from([(
+                "claude-4.5".to_string(),
+                inference_usage_with_web_search(500, 100, 1.5, 3.0, 1, 2.5),
+            )]),
+            byok_inference_usage: HashMap::new(),
+            custom_endpoint_inference_usage: HashMap::new(),
+            platform_usage_in_cents: 0.0,
+        },
+    );
+    let charges = api::response_event::stream_finished::RequestCharges { usage_by_category };
+
+    let totals = ChargedUsageTotals::from(&charges);
+
+    assert_eq!(totals.web_search_count, 3);
+    assert!((totals.web_search_cost_in_cents - 7.5).abs() < 1e-6);
+    // Total cost must include web search cost alongside the token + platform costs.
+    assert!((totals.total_cost_in_cents() - (3.0 + 6.0 + 1.5 + 3.0 + 1.0 + 7.5)).abs() < 1e-6);
+}
+
+#[test]
+fn charged_usage_totals_add_assign_sums_web_search_fields() {
+    let mut a = ChargedUsageTotals {
+        web_search_count: 2,
+        web_search_cost_in_cents: 4.0,
+        ..Default::default()
+    };
+    let b = ChargedUsageTotals {
+        web_search_count: 3,
+        web_search_cost_in_cents: 6.0,
+        ..Default::default()
+    };
+
+    a += b;
+
+    assert_eq!(a.web_search_count, 5);
+    assert!((a.web_search_cost_in_cents - 10.0).abs() < 1e-6);
+}
+
+#[test]
+fn charged_usage_totals_deserializes_legacy_payload_without_web_search_fields() {
+    let totals: ChargedUsageTotals = serde_json::from_str(
+        r#"{"input_cost_in_cents":1.0,"output_cost_in_cents":2.0,"input_cache_read_cost_in_cents":0.0,"input_cache_write_cost_in_cents":0.0,"platform_cost_in_cents":0.0,"input_tokens":10,"output_tokens":5,"input_cache_read_tokens":0,"input_cache_write_tokens":0}"#,
+    )
+    .unwrap();
+
+    assert_eq!(totals.web_search_count, 0);
+    assert_eq!(totals.web_search_cost_in_cents, 0.0);
+    assert!((totals.total_cost_in_cents() - 3.0).abs() < 1e-6);
 }
 
 fn user_query_message(task_id: &str, query: &str, pwd: Option<&str>) -> api::Message {

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -2490,6 +2490,7 @@ fn response_summary_visibility_is_independent_from_the_footer_usage_mode() {
             credits_spent: 2.5,
             cost_in_cents: Some(3.2),
             has_usage: true,
+            charged_usage: None,
         };
 
         assert_eq!(
@@ -4856,6 +4857,7 @@ fn footer_renders_agent_sections_left_aligned() {
                     credits_spent: 2.5,
                     cost_in_cents: Some(0.0),
                     has_usage: true,
+                    charged_usage: None,
                 },
                 ctx,
                 |_, _| {},
@@ -4949,6 +4951,7 @@ fn footer_usage_entry_shows_unknown_cost_even_with_zero_credits() {
                     credits_spent: 0.0,
                     cost_in_cents: None,
                     has_usage: true,
+                    charged_usage: None,
                 },
                 ctx,
                 |_, _| {},

--- a/crates/warp_tui/src/usage_tests.rs
+++ b/crates/warp_tui/src/usage_tests.rs
@@ -13,6 +13,7 @@ fn totals(credits_spent: f32, cost_in_cents: f32) -> ConversationUsageTotals {
         credits_spent,
         cost_in_cents: Some(cost_in_cents),
         has_usage: true,
+        charged_usage: None,
     }
 }
 
@@ -57,6 +58,7 @@ fn cost_mode_explicitly_marks_unknown_historical_cost() {
                 credits_spent: 0.0,
                 cost_in_cents: None,
                 has_usage: true,
+                charged_usage: None,
             },
         ),
         "Cost unavailable"


### PR DESCRIPTION
## Description
Wires the real per-category (input/output/cache-read/cache-write) dollar breakdown into the GUI's live usage surfaces, sourced from the wire protocol's `StreamFinished.request_charges` / `ConversationUsageMetadata.total_charges` (per Foundation task 1.1/m2t0's proto bump).


### What changed

1. AI block usage pill/button (app/src/ai/blocklist/block/view_impl/output.rs, render_usage_button) — the per-block credit-usage text shown under each agent response, now reads e.g. "24.3 credits (671,642 tokens, $0.44)" via format_credits_with_cost. Also accounts for orchestration rollups (multi-agent totals) via headline_tokens/headline_cost_in_cents.
2. Conversation usage summary card (app/src/ai/blocklist/usage/conversation_usage_view.rs, ConversationUsageView) — used both in the footer (DisplayMode::Footer) and the settings usage-history page (DisplayMode::Settings). The "Credits spent (total)" row now appends the same inline suffix; the old separate "Tokens used" row and "PRICING BREAKDOWN" section were removed.
3. Orchestration credit rollup (app/src/ai/blocklist/usage/rollup.rs) — total_tokens/total_cost_in_cents are now threaded through so multi-agent orchestrator headlines reflect summed usage across descendants.
4. Conversation details side panel (app/src/ai/conversation_details_panel.rs) — the "Credits used" field now shows the same compact parenthetical (used for both local conversations and cloud/Oz task views).

<img width="1248" height="724" alt="Screenshot 2026-08-20 at 4 23 43 PM" src="https://github.com/user-attachments/assets/98abee3b-0932-41ea-9e29-84e9db1f222f" />



## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Warp <agent@warp.dev>
