### PR TITLE
Add billing@warp.dev contact to restricted billing copy

### DIFF
--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -37,7 +37,7 @@ const COMPARE_PLANS_TEXT: &str = "Compare plans";
 const CONTACT_SUPPORT_TEXT: &str = "Contact support";
 const CONTACT_BILLING_TEXT: &str = "billing@warp.dev";
 const CONTACT_BILLING_MAILTO: &str = "mailto:billing@warp.dev";
-const NON_ADMIN_CONTACT_ADMIN_TEXT: &str = ", contact a team admin";
+const NON_ADMIN_CONTACT_ADMIN_TEXT: &str = " Contact a team admin for help.";
 const NON_ADMIN_ASK_ADMIN_TO_ENABLE_OVERAGES_TEXT: &str = ", ask a team admin to enable overages";
 const NON_ADMIN_ASK_ADMIN_TO_INCREASE_OVERAGES_TEXT: &str =
     ", ask a team admin to increase overages";
@@ -265,13 +265,8 @@ impl PromptAlertView {
             }
             PromptAlertState::DelinquentDueToPaymentIssue => {
                 text_fragments.push(FormattedTextFragment::plain_text(
-                    "Restricted due to payment issue. Contact ",
+                    "Restricted due to payment issue.",
                 ));
-                text_fragments.push(FormattedTextFragment::hyperlink(
-                    CONTACT_BILLING_TEXT,
-                    CONTACT_BILLING_MAILTO.to_owned(),
-                ));
-                text_fragments.push(FormattedTextFragment::plain_text(" for assistance."));
             }
             PromptAlertState::OveragesToggleableButNotEnabled
             | PromptAlertState::MonthlyOveragesSpendLimitReached
@@ -312,12 +307,23 @@ impl PromptAlertView {
                     .map(|team| team.has_billing_history)
                     .unwrap_or_default();
                 if has_admin_permissions && has_billing_history {
-                    text_fragments.push(FormattedTextFragment::plain_text("  "));
+                    text_fragments.push(FormattedTextFragment::plain_text(
+                        " Update your payment information or contact ",
+                    ));
+                    text_fragments.push(FormattedTextFragment::hyperlink(
+                        CONTACT_BILLING_TEXT,
+                        CONTACT_BILLING_MAILTO.to_owned(),
+                    ));
+                    text_fragments.push(FormattedTextFragment::plain_text(" for help.  "));
                     text_fragments.push(FormattedTextFragment::hyperlink_action(
                         DELINQUENT_DUE_TO_PAYMENT_ISSUE_ACTION_TEXT,
                         PromptAlertAction::ManageBillingClicked {
                             team_uid: current_team.map(|team| team.uid).unwrap_or_default(),
                         },
+                    ));
+                } else if has_admin_permissions {
+                    text_fragments.push(FormattedTextFragment::plain_text(
+                        " Contact your Account Executive for help.",
                     ));
                 } else {
                     text_fragments.push(FormattedTextFragment::plain_text(

--- a/app/src/ai/blocklist/prompt/prompt_alert.rs
+++ b/app/src/ai/blocklist/prompt/prompt_alert.rs
@@ -26,7 +26,6 @@ const ANONYMOUS_USER_REQUEST_LIMIT_SOFT_GATE_PERCENTAGE: f32 = 0.5;
 const NO_CONNECTION_PRIMARY_TEXT: &str = "No internet connection";
 const ANONYMOUS_USER_REQUEST_LIMIT_SOFT_GATE_PRIMARY_TEXT: &str = "";
 const ANONYMOUS_USER_REQUEST_LIMIT_HARD_GATE_PRIMARY_TEXT: &str = "At Limit -";
-const DELINQUENT_DUE_TO_PAYMENT_ISSUE_PRIMARY_TEXT: &str = "Restricted due to payment issue";
 const OUT_OF_REQUESTS_PRIMARY_TEXT: &str = "Out of credits";
 
 const ANONYMOUS_USER_REQUEST_LIMIT_ACTION_TEXT: &str = "Sign up for more AI credits";
@@ -36,6 +35,8 @@ const MONTHLY_OVERAGES_SPEND_LIMIT_REACHED_ACTION_TEXT: &str = "Increase monthly
 const UPGRADE_TEXT: &str = "Upgrade";
 const COMPARE_PLANS_TEXT: &str = "Compare plans";
 const CONTACT_SUPPORT_TEXT: &str = "Contact support";
+const CONTACT_BILLING_TEXT: &str = "billing@warp.dev";
+const CONTACT_BILLING_MAILTO: &str = "mailto:billing@warp.dev";
 const NON_ADMIN_CONTACT_ADMIN_TEXT: &str = ", contact a team admin";
 const NON_ADMIN_ASK_ADMIN_TO_ENABLE_OVERAGES_TEXT: &str = ", ask a team admin to enable overages";
 const NON_ADMIN_ASK_ADMIN_TO_INCREASE_OVERAGES_TEXT: &str =
@@ -264,8 +265,13 @@ impl PromptAlertView {
             }
             PromptAlertState::DelinquentDueToPaymentIssue => {
                 text_fragments.push(FormattedTextFragment::plain_text(
-                    DELINQUENT_DUE_TO_PAYMENT_ISSUE_PRIMARY_TEXT,
+                    "Restricted due to payment issue. Contact ",
                 ));
+                text_fragments.push(FormattedTextFragment::hyperlink(
+                    CONTACT_BILLING_TEXT,
+                    CONTACT_BILLING_MAILTO.to_owned(),
+                ));
+                text_fragments.push(FormattedTextFragment::plain_text(" for assistance."));
             }
             PromptAlertState::OveragesToggleableButNotEnabled
             | PromptAlertState::MonthlyOveragesSpendLimitReached

--- a/app/src/billing/shared_objects_creation_denied_body.rs
+++ b/app/src/billing/shared_objects_creation_denied_body.rs
@@ -17,9 +17,9 @@ const BUTTON_PADDING: f32 = 12.;
 const BUTTON_FONT_SIZE: f32 = 14.;
 const BUTTON_BORDER_RADIUS: f32 = 4.;
 
-const DEFAULT_DELINQUENT_ADMIN_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease update your payment information to restore access. Contact billing@warp.dev for assistance.";
-const DEFAULT_DELINQUENT_ADMIN_ENTERPRISE_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease contact billing@warp.dev for assistance.";
-const DEFAULT_DELINQUENT_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease contact a team admin to restore access. Contact billing@warp.dev for assistance.";
+const DEFAULT_DELINQUENT_ADMIN_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nUpdate your payment information or contact billing@warp.dev for help.";
+const DEFAULT_DELINQUENT_ADMIN_ENTERPRISE_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nContact your Account Executive for help.";
+const DEFAULT_DELINQUENT_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nContact a team admin for help.";
 const DEFAULT_ADMIN_PROSUMER_MODAL_SUBHEADER: &str = "Warp's Pro plan comes with a limited number of shared drive objects.\n\nFor access to unlimited shared drive objects, upgrade to the Turbo plan.";
 const DEFAULT_PROSUMER_MODAL_SUBHEADER: &str = "Warp's Pro plan comes with a limited number of shared drive objects.\n\nFor access to unlimited shared drive objects, contact a team admin to upgrade to the Turbo plan.";
 const DEFAULT_ADMIN_MODAL_SUBHEADER: &str = "Warp's free plan comes with a limited number of shared drive objects.\n\nFor access to unlimited shared drive objects, upgrade to a paid plan.";
@@ -101,16 +101,16 @@ impl View for SharedObjectsCreationDeniedBody {
                     (true, true, _) => {
                         if is_stripe_paid_plan {
                             format!(
-                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease update your payment information to restore access. Contact billing@warp.dev for assistance."
+                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nUpdate your payment information or contact billing@warp.dev for help."
                             )
                         } else {
                             format!(
-                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease contact billing@warp.dev for assistance."
+                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nContact your Account Executive for help."
                             )
                         }
                     }
                     (true, false, _) => format!(
-                        "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease contact a team admin to restore access. Contact billing@warp.dev for assistance."
+                        "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nContact a team admin for help."
                     ),
                     (false, true, CustomerType::Prosumer) => {
                         format!(

--- a/app/src/billing/shared_objects_creation_denied_body.rs
+++ b/app/src/billing/shared_objects_creation_denied_body.rs
@@ -17,9 +17,9 @@ const BUTTON_PADDING: f32 = 12.;
 const BUTTON_FONT_SIZE: f32 = 14.;
 const BUTTON_BORDER_RADIUS: f32 = 4.;
 
-const DEFAULT_DELINQUENT_ADMIN_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease update your payment information to restore access.";
-const DEFAULT_DELINQUENT_ADMIN_ENTERPRISE_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease contact support@warp.dev to restore access.";
-const DEFAULT_DELINQUENT_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease contact a team admin to restore access.";
+const DEFAULT_DELINQUENT_ADMIN_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease update your payment information to restore access. Contact billing@warp.dev for assistance.";
+const DEFAULT_DELINQUENT_ADMIN_ENTERPRISE_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease contact billing@warp.dev for assistance.";
+const DEFAULT_DELINQUENT_MODAL_SUBHEADER: &str = "Shared drive objects have been restricted due to a subscription payment issue.\n\nPlease contact a team admin to restore access. Contact billing@warp.dev for assistance.";
 const DEFAULT_ADMIN_PROSUMER_MODAL_SUBHEADER: &str = "Warp's Pro plan comes with a limited number of shared drive objects.\n\nFor access to unlimited shared drive objects, upgrade to the Turbo plan.";
 const DEFAULT_PROSUMER_MODAL_SUBHEADER: &str = "Warp's Pro plan comes with a limited number of shared drive objects.\n\nFor access to unlimited shared drive objects, contact a team admin to upgrade to the Turbo plan.";
 const DEFAULT_ADMIN_MODAL_SUBHEADER: &str = "Warp's free plan comes with a limited number of shared drive objects.\n\nFor access to unlimited shared drive objects, upgrade to a paid plan.";
@@ -101,16 +101,16 @@ impl View for SharedObjectsCreationDeniedBody {
                     (true, true, _) => {
                         if is_stripe_paid_plan {
                             format!(
-                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease update your payment information to restore access."
+                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease update your payment information to restore access. Contact billing@warp.dev for assistance."
                             )
                         } else {
                             format!(
-                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease contact support@warp.dev to restore access."
+                                "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease contact billing@warp.dev for assistance."
                             )
                         }
                     }
                     (true, false, _) => format!(
-                        "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease contact a team admin to restore access."
+                        "Shared {object_type}s have been restricted due to a subscription payment issue.\n\nPlease contact a team admin to restore access. Contact billing@warp.dev for assistance."
                     ),
                     (false, true, CustomerType::Prosumer) => {
                         format!(

--- a/app/src/drive/index.rs
+++ b/app/src/drive/index.rs
@@ -194,13 +194,13 @@ const SHARED_OBJECT_LIMIT_HIT_BANNER_LINE: &str =
 const PAYMENT_ISSUE_BANNER_LINE_1: &str =
     "Shared objects have been restricted due to a subscription payment issue.";
 
-const PAYMENT_ISSUE_BANNER_LINE_2_ADMIN: &str = "Please update your payment information to restore access. Contact billing@warp.dev for assistance.";
+const PAYMENT_ISSUE_BANNER_LINE_2_ADMIN: &str =
+    "Update your payment information or contact billing@warp.dev for help.";
 
 const PAYMENT_ISSUE_BANNER_LINE_2_ADMIN_ENTERPRISE: &str =
-    "Please contact billing@warp.dev for assistance.";
+    "Contact your Account Executive for help.";
 
-const PAYMENT_ISSUE_BANNER_LINE_2_NONADMIN: &str =
-    "Please contact a team admin to restore access. Contact billing@warp.dev for assistance.";
+const PAYMENT_ISSUE_BANNER_LINE_2_NONADMIN: &str = "Contact a team admin for help.";
 
 /// Struct to hold different state-related information on per-space basis.
 /// Currently, we only have 1 space (1 Team), but as we're working on personal space, and add

--- a/app/src/drive/index.rs
+++ b/app/src/drive/index.rs
@@ -194,13 +194,13 @@ const SHARED_OBJECT_LIMIT_HIT_BANNER_LINE: &str =
 const PAYMENT_ISSUE_BANNER_LINE_1: &str =
     "Shared objects have been restricted due to a subscription payment issue.";
 
-const PAYMENT_ISSUE_BANNER_LINE_2_ADMIN: &str =
-    "Please update your payment information to restore access.";
+const PAYMENT_ISSUE_BANNER_LINE_2_ADMIN: &str = "Please update your payment information to restore access. Contact billing@warp.dev for assistance.";
 
 const PAYMENT_ISSUE_BANNER_LINE_2_ADMIN_ENTERPRISE: &str =
-    "Please contact support@warp.dev to restore access.";
+    "Please contact billing@warp.dev for assistance.";
 
-const PAYMENT_ISSUE_BANNER_LINE_2_NONADMIN: &str = "Please contact a team admin to restore access.";
+const PAYMENT_ISSUE_BANNER_LINE_2_NONADMIN: &str =
+    "Please contact a team admin to restore access. Contact billing@warp.dev for assistance.";
 
 /// Struct to hold different state-related information on per-space basis.
 /// Currently, we only have 1 space (1 Team), but as we're working on personal space, and add

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -79,8 +79,7 @@ const SORT_MENU_ITEM_REQUEST_USAGE_ASCENDING_LABEL: &str = "Usage ascending";
 const SORT_MENU_ITEM_REQUEST_USAGE_DESCENDING_LABEL: &str = "Usage descending";
 
 const AUTO_RELOAD_EXCEED_LIMIT_WARNING_STRING: &str = "Auto reload is disabled, as the next reload would exceed your monthly spend limit. Increase your limit to use auto reload.";
-const AUTO_RELOAD_DELINQUENT_WARNING_STRING: &str =
-    "Restricted due to billing issue. Update your payment method to purchase add-on credits.";
+const AUTO_RELOAD_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Update your payment method to purchase add-on credits. Contact billing@warp.dev for assistance.";
 const RESTRICTED_BILLING_USAGE_WARNING_STRING: &str = "Auto reload is disabled due to recent failed reload. Please update your payment method and try again.";
 
 const OVERVIEW_TAB_TEXT: &str = "Overview";
@@ -2369,7 +2368,7 @@ impl BillingAndUsagePageView {
         }
 
         let request_count_label = if workspace_is_delinquent_due_to_payment_issue {
-            "Restricted due to billing issue".to_string()
+            "Restricted due to billing issue. Contact billing@warp.dev for assistance.".to_string()
         } else {
             match divisor {
                 Some(Divisor::Unlimited) => {

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -79,7 +79,7 @@ const SORT_MENU_ITEM_REQUEST_USAGE_ASCENDING_LABEL: &str = "Usage ascending";
 const SORT_MENU_ITEM_REQUEST_USAGE_DESCENDING_LABEL: &str = "Usage descending";
 
 const AUTO_RELOAD_EXCEED_LIMIT_WARNING_STRING: &str = "Auto reload is disabled, as the next reload would exceed your monthly spend limit. Increase your limit to use auto reload.";
-const AUTO_RELOAD_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Update your payment method to purchase add-on credits. Contact billing@warp.dev for assistance.";
+const AUTO_RELOAD_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Update your payment information or contact billing@warp.dev for help.";
 const RESTRICTED_BILLING_USAGE_WARNING_STRING: &str = "Auto reload is disabled due to recent failed reload. Please update your payment method and try again.";
 
 const OVERVIEW_TAB_TEXT: &str = "Overview";
@@ -2368,7 +2368,7 @@ impl BillingAndUsagePageView {
         }
 
         let request_count_label = if workspace_is_delinquent_due_to_payment_issue {
-            "Restricted due to billing issue. Contact billing@warp.dev for assistance.".to_string()
+            "Restricted due to billing issue".to_string()
         } else {
             match divisor {
                 Some(Divisor::Unlimited) => {

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -66,10 +66,8 @@ const ADDITIONAL_ADDON_CREDITS_DESCRIPTION_FOR_TEAM: &str =
     "Purchased add-on credits are added to your personal balance.";
 const MANAGED_AUTO_RELOAD_HEADER: &str = "Auto-reload is enabled";
 
-const ADDON_CREDITS_DELINQUENT_WARNING_STRING: &str =
-    "Restricted due to billing issue. Update your payment method to purchase add-on credits.";
-const ADDON_CREDITS_NON_ADMIN_DELINQUENT_WARNING_STRING: &str =
-    "Restricted due to billing issue. Contact your team admin to update their payment method.";
+const ADDON_CREDITS_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Update your payment method to purchase add-on credits. Contact billing@warp.dev for assistance.";
+const ADDON_CREDITS_NON_ADMIN_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Contact your team admin to update their payment method. Contact billing@warp.dev for assistance.";
 const RESTRICTED_BILLING_USAGE_WARNING_STRING: &str = "Auto reload is disabled due to recent failed reload. Please update your payment method and try again.";
 const RESTRICTED_BILLING_USAGE_NON_ADMIN_WARNING_STRING: &str = "Auto reload is disabled due to recent failed reload. Contact your team admin to update their payment method.";
 

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -66,8 +66,9 @@ const ADDITIONAL_ADDON_CREDITS_DESCRIPTION_FOR_TEAM: &str =
     "Purchased add-on credits are added to your personal balance.";
 const MANAGED_AUTO_RELOAD_HEADER: &str = "Auto-reload is enabled";
 
-const ADDON_CREDITS_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Update your payment method to purchase add-on credits. Contact billing@warp.dev for assistance.";
-const ADDON_CREDITS_NON_ADMIN_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Contact your team admin to update their payment method. Contact billing@warp.dev for assistance.";
+const ADDON_CREDITS_DELINQUENT_WARNING_STRING: &str = "Restricted due to billing issue. Update your payment information or contact billing@warp.dev for help.";
+const ADDON_CREDITS_NON_ADMIN_DELINQUENT_WARNING_STRING: &str =
+    "Restricted due to billing issue. Contact a team admin for help.";
 const RESTRICTED_BILLING_USAGE_WARNING_STRING: &str = "Auto reload is disabled due to recent failed reload. Please update your payment method and try again.";
 const RESTRICTED_BILLING_USAGE_NON_ADMIN_WARNING_STRING: &str = "Auto reload is disabled due to recent failed reload. Contact your team admin to update their payment method.";
 

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -2068,7 +2068,7 @@ impl TeamsWidget {
         );
         let cta_sentence = if !has_admin_permissions {
             if is_delinquency {
-                "Contact a team admin to restore access. Contact billing@warp.dev for assistance."
+                "Contact a team admin for help."
             } else {
                 "Contact a team admin to grow the team."
             }
@@ -2076,12 +2076,12 @@ impl TeamsWidget {
             match cta {
                 GrowTeamWarningCta::Upgrade => "Upgrade to grow your team.",
                 GrowTeamWarningCta::UpdateBilling => {
-                    "Update your payment information to restore access. Contact billing@warp.dev for assistance."
+                    "Update your payment information or contact billing@warp.dev for help."
                 }
-                GrowTeamWarningCta::ContactSupport => "Contact billing@warp.dev for assistance.",
+                GrowTeamWarningCta::ContactSupport => "Contact your Account Executive for help.",
                 GrowTeamWarningCta::None => {
                     if is_delinquency {
-                        "Contact billing@warp.dev for assistance."
+                        "Contact your Account Executive for help."
                     } else {
                         "Contact sales to grow your team."
                     }

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -2068,7 +2068,7 @@ impl TeamsWidget {
         );
         let cta_sentence = if !has_admin_permissions {
             if is_delinquency {
-                "Contact a team admin to restore access."
+                "Contact a team admin to restore access. Contact billing@warp.dev for assistance."
             } else {
                 "Contact a team admin to grow the team."
             }
@@ -2076,12 +2076,12 @@ impl TeamsWidget {
             match cta {
                 GrowTeamWarningCta::Upgrade => "Upgrade to grow your team.",
                 GrowTeamWarningCta::UpdateBilling => {
-                    "Update your payment information to restore access."
+                    "Update your payment information to restore access. Contact billing@warp.dev for assistance."
                 }
-                GrowTeamWarningCta::ContactSupport => "Contact support to restore access.",
+                GrowTeamWarningCta::ContactSupport => "Contact billing@warp.dev for assistance.",
                 GrowTeamWarningCta::None => {
                     if is_delinquency {
-                        "Contact support to restore access."
+                        "Contact billing@warp.dev for assistance."
                     } else {
                         "Contact sales to grow your team."
                     }

--- a/app/src/terminal/view/inline_banner/prompt_suggestions.rs
+++ b/app/src/terminal/view/inline_banner/prompt_suggestions.rs
@@ -43,7 +43,8 @@ use crate::workspaces::user_workspaces::UserWorkspaces;
 const INLINE_BANNER_SPACING: f32 = 8.;
 const INLINE_BANNER_BUTTON_PADDING: f32 = 8.;
 
-const DELINQUENT_DUE_TO_PAYMENT_ISSUE_TOOLTIP_MESSAGE: &str = "Restricted due to payment issue";
+const DELINQUENT_DUE_TO_PAYMENT_ISSUE_TOOLTIP_MESSAGE: &str =
+    "Restricted due to payment issue. Contact billing@warp.dev for assistance.";
 const OUT_OF_REQUESTS_TOOLTIP_MESSAGE: &str = "Out of credits";
 
 /// Types of zero-state prompt suggestions.

--- a/app/src/terminal/view/inline_banner/prompt_suggestions.rs
+++ b/app/src/terminal/view/inline_banner/prompt_suggestions.rs
@@ -43,8 +43,7 @@ use crate::workspaces::user_workspaces::UserWorkspaces;
 const INLINE_BANNER_SPACING: f32 = 8.;
 const INLINE_BANNER_BUTTON_PADDING: f32 = 8.;
 
-const DELINQUENT_DUE_TO_PAYMENT_ISSUE_TOOLTIP_MESSAGE: &str =
-    "Restricted due to payment issue. Contact billing@warp.dev for assistance.";
+const DELINQUENT_DUE_TO_PAYMENT_ISSUE_TOOLTIP_MESSAGE: &str = "Restricted due to payment issue.";
 const OUT_OF_REQUESTS_TOOLTIP_MESSAGE: &str = "Out of credits";
 
 /// Types of zero-state prompt suggestions.


### PR DESCRIPTION
## Description
- Consolidates payment/billing restriction CTAs by audience:
  - **Member:** Contact a team admin for help.
  - **Admin (self-serve/Stripe):** Update your payment information or contact billing@warp.dev for help.
  - **Admin (enterprise / no portal):** Contact your Account Executive for help.
- Fixes awkward `., contact a team admin` concatenation on the AI prompt alert
- Surfaces `mailto:billing@warp.dev` only on admin self-serve paths where relevant
- Applies across Drive banner, shared-object denial modal, Teams invite warning, Billing & Usage warnings, and prompt-suggestion tooltip

## How to test
1. Delinquent **member**: prompt alert, Drive banner, shared-object modal, Teams invite warning → team admin only
2. Delinquent **Stripe admin**: same surfaces → payment update + billing@warp.dev (mailto on prompt alert)
3. Delinquent **enterprise admin**: Account Executive CTA (no billing@ email)

## Linear

## Changelog
CHANGELOG-IMPROVEMENT: Restricted billing/payment messages use clearer audience-specific help CTAs.

Co-Authored-By: Warp <agent@warp.dev>