### PR TITLE
Create scaffolding that allows CLI to accept name OR ID to refer to environment, runner, and agent objects

### DIFF
--- a/app/src/ai/agent_sdk/agent_management.rs
+++ b/app/src/ai/agent_sdk/agent_management.rs
@@ -117,10 +117,10 @@ impl AgentManagementRunner {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let future = async move {
             if matches!(output_format, OutputFormat::Json) || args.json_output.force_json_output() {
-                let response = ai_client.get_agent_raw(&args.uid).await?;
+                let response = ai_client.get_agent_raw(&args.identifier).await?;
                 super::output::print_raw_json(response, &args.json_output)?;
             } else {
-                let agent = ai_client.get_agent(&args.uid).await?;
+                let agent = ai_client.get_agent(&args.identifier).await?;
                 print_single_agent(&agent, output_format)?;
             }
             Ok(())
@@ -160,7 +160,7 @@ impl AgentManagementRunner {
     ) -> anyhow::Result<()> {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let future = async move {
-            let uid = args.uid.clone();
+            let uid = args.identifier.clone();
             let json_output = args.json_output.clone();
             let needs_current_agent = !args.add_secrets.is_empty()
                 || !args.remove_secrets.is_empty()
@@ -197,8 +197,8 @@ impl AgentManagementRunner {
     ) -> anyhow::Result<()> {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let future = async move {
-            ai_client.delete_agent(&args.uid).await?;
-            print_delete_result(&args.uid, output_format)?;
+            ai_client.delete_agent(&args.identifier).await?;
+            print_delete_result(&args.identifier, output_format)?;
             Ok(())
         };
         self.spawn_command(future, ctx);

--- a/app/src/ai/agent_sdk/agent_management.rs
+++ b/app/src/ai/agent_sdk/agent_management.rs
@@ -12,13 +12,14 @@ use warp_cli::agent::{
     OutputFormat,
 };
 use warp_cli::json_filter::JsonOutput;
+use warp_server_client::HttpStatusError;
 use warpui::platform::TerminationMode;
 use warpui::{AppContext, ModelContext, SingletonEntity};
 
 use super::output::TableFormat;
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::ai::{
-    AgentResponse, CreateAgentRequest, SecretRef, UpdateAgentRequest,
+    AIClient, AgentResponse, CreateAgentRequest, SecretRef, UpdateAgentRequest,
 };
 
 /// Singleton model that runs async work for named-agent CLI commands.
@@ -116,11 +117,11 @@ impl AgentManagementRunner {
     ) -> anyhow::Result<()> {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let future = async move {
+            let agent = resolve_agent_identifier(ai_client.as_ref(), &args.identifier).await?;
             if matches!(output_format, OutputFormat::Json) || args.json_output.force_json_output() {
-                let response = ai_client.get_agent_raw(&args.identifier).await?;
+                let response = ai_client.get_agent_raw(&agent.uid).await?;
                 super::output::print_raw_json(response, &args.json_output)?;
             } else {
-                let agent = ai_client.get_agent(&args.identifier).await?;
                 print_single_agent(&agent, output_format)?;
             }
             Ok(())
@@ -160,27 +161,20 @@ impl AgentManagementRunner {
     ) -> anyhow::Result<()> {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let future = async move {
-            let uid = args.identifier.clone();
             let json_output = args.json_output.clone();
-            let needs_current_agent = !args.add_secrets.is_empty()
-                || !args.remove_secrets.is_empty()
-                || !args.add_skills.is_empty()
-                || !args.remove_skills.is_empty();
-            let current_agent = if needs_current_agent {
-                Some(ai_client.get_agent(&uid).await?)
-            } else {
-                None
-            };
-            let request = build_update_request(args, current_agent.as_ref());
+            let current_agent =
+                resolve_agent_identifier(ai_client.as_ref(), &args.identifier).await?;
+            let request = build_update_request(args, Some(&current_agent));
             if request_is_empty(&request) {
                 return Err(anyhow!("No updates requested"));
             }
-
             if matches!(output_format, OutputFormat::Json) || json_output.force_json_output() {
-                let response = ai_client.update_agent_raw(&uid, request).await?;
+                let response = ai_client
+                    .update_agent_raw(&current_agent.uid, request)
+                    .await?;
                 super::output::print_raw_json(response, &json_output)?;
             } else {
-                let agent = ai_client.update_agent(&uid, request).await?;
+                let agent = ai_client.update_agent(&current_agent.uid, request).await?;
                 print_single_agent(&agent, output_format)?;
             }
             Ok(())
@@ -197,12 +191,39 @@ impl AgentManagementRunner {
     ) -> anyhow::Result<()> {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let future = async move {
-            ai_client.delete_agent(&args.identifier).await?;
-            print_delete_result(&args.identifier, output_format)?;
+            let agent = resolve_agent_identifier(ai_client.as_ref(), &args.identifier).await?;
+            ai_client.delete_agent(&agent.uid).await?;
+            print_delete_result(&agent.uid, output_format)?;
             Ok(())
         };
         self.spawn_command(future, ctx);
         Ok(())
+    }
+}
+
+fn is_not_found(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<HttpStatusError>()
+            .is_some_and(|error| error.status == 404)
+    })
+}
+
+fn is_agent_uid(identifier: &str) -> bool {
+    uuid::Uuid::try_parse(identifier).is_ok_and(|uid| uid.get_version_num() == 7)
+}
+
+pub(super) async fn resolve_agent_identifier(
+    ai_client: &dyn AIClient,
+    identifier: &str,
+) -> anyhow::Result<AgentResponse> {
+    if !is_agent_uid(identifier) {
+        return ai_client.get_agent_by_name(identifier).await;
+    }
+    match ai_client.get_agent(identifier).await {
+        Ok(agent) => Ok(agent),
+        Err(error) if is_not_found(&error) => ai_client.get_agent_by_name(identifier).await,
+        Err(error) => Err(error),
     }
 }
 

--- a/app/src/ai/agent_sdk/agent_management_tests.rs
+++ b/app/src/ai/agent_sdk/agent_management_tests.rs
@@ -218,9 +218,9 @@ fn create_args(name: &str) -> AgentCreateArgs {
     }
 }
 
-fn update_args(uid: &str) -> AgentUpdateArgs {
+fn update_args(identifier: &str) -> AgentUpdateArgs {
     AgentUpdateArgs {
-        uid: uid.to_string(),
+        identifier: identifier.to_string(),
         name: None,
         description: None,
         remove_description: false,

--- a/app/src/ai/agent_sdk/agent_management_tests.rs
+++ b/app/src/ai/agent_sdk/agent_management_tests.rs
@@ -1,6 +1,12 @@
 use chrono::{TimeZone as _, Utc};
+use mockall::predicate::eq;
+use warp_server_client::HttpStatusError;
 
 use super::*;
+use crate::server::server_api::ai::MockAIClient;
+
+const AGENT_UID: &str = "019f8766-c6a5-70af-9624-7c215dd46ccb";
+const OTHER_AGENT_UID: &str = "019f8766-c6a5-70af-9624-7c215dd46ccc";
 
 fn agent(uid: &str, name: &str, created_at_seconds: i64) -> AgentResponse {
     agent_with_available(uid, name, created_at_seconds, true)
@@ -27,6 +33,92 @@ fn agent_with_available(
         base_model: None,
         environment_id: None,
     }
+}
+
+fn http_error(status: u16) -> anyhow::Error {
+    anyhow::Error::new(HttpStatusError {
+        status,
+        body: format!("status {status}"),
+    })
+}
+
+#[test]
+fn agent_uid_requires_uuid_v7() {
+    assert!(is_agent_uid(AGENT_UID));
+    assert!(!is_agent_uid("550e8400-e29b-41d4-a716-446655440000"));
+    assert!(!is_agent_uid("agent-name"));
+}
+
+#[tokio::test]
+async fn resolve_agent_identifier_prefers_direct_uid_lookup() {
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_get_agent()
+        .with(eq(AGENT_UID))
+        .times(1)
+        .returning(|_| Ok(agent(AGENT_UID, "agent-name", 1)));
+    ai_client.expect_get_agent_by_name().times(0);
+
+    let resolved = resolve_agent_identifier(&ai_client, AGENT_UID)
+        .await
+        .unwrap();
+
+    assert_eq!(resolved.uid, AGENT_UID);
+}
+
+#[tokio::test]
+async fn resolve_agent_identifier_uses_name_lookup_for_non_uid() {
+    let mut ai_client = MockAIClient::new();
+    ai_client.expect_get_agent().times(0);
+    ai_client
+        .expect_get_agent_by_name()
+        .with(eq("agent-name"))
+        .times(1)
+        .returning(|_| Ok(agent(AGENT_UID, "agent-name", 1)));
+
+    let resolved = resolve_agent_identifier(&ai_client, "agent-name")
+        .await
+        .unwrap();
+
+    assert_eq!(resolved.uid, AGENT_UID);
+}
+
+#[tokio::test]
+async fn resolve_agent_identifier_falls_back_for_uuid_shaped_name() {
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_get_agent()
+        .with(eq(AGENT_UID))
+        .times(1)
+        .returning(|_| Err(http_error(404)));
+    ai_client
+        .expect_get_agent_by_name()
+        .with(eq(AGENT_UID))
+        .times(1)
+        .returning(|_| Ok(agent(OTHER_AGENT_UID, AGENT_UID, 1)));
+
+    let resolved = resolve_agent_identifier(&ai_client, AGENT_UID)
+        .await
+        .unwrap();
+
+    assert_eq!(resolved.uid, OTHER_AGENT_UID);
+}
+
+#[tokio::test]
+async fn resolve_agent_identifier_does_not_fall_back_on_other_errors() {
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_get_agent()
+        .with(eq(AGENT_UID))
+        .times(1)
+        .returning(|_| Err(http_error(403)));
+    ai_client.expect_get_agent_by_name().times(0);
+
+    let error = resolve_agent_identifier(&ai_client, AGENT_UID)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("403"));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -46,6 +46,7 @@ use crate::server::server_api::ai::{
     ListAgentMessagesRequest, ReadAgentMessageResponse, RunSortBy, RunSortOrder,
     SendAgentMessageRequest, SendAgentMessageResponse, SpawnAgentRequest, TaskListFilter,
 };
+use crate::server::server_api::factory::get_runner_with_fallback;
 use crate::terminal::shared_session;
 use crate::util::time_format::format_approx_duration_from_now_utc;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -554,8 +555,7 @@ impl AmbientAgentRunner {
                         uid: Some(cynic::Id::new(&runner_identifier)),
                         name: Some(runner_identifier),
                     };
-                    let resolved_uid = factory_client
-                        .get_runner(selector)
+                    let resolved_uid = get_runner_with_fallback(factory_client.as_ref(), selector)
                         .await?
                         .uid
                         .inner()

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -21,7 +21,9 @@ use warpui::r#async::{Spawnable, Timer};
 use warpui::platform::TerminationMode;
 use warpui::{AppContext, ModelContext, SingletonEntity};
 
+use super::agent_management::resolve_agent_identifier;
 use super::common::{EnvironmentChoice, ResolveConfigurationError, parse_ambient_task_id};
+use super::runner::resolve_runner;
 use crate::ServerApiProvider;
 use crate::ai::agent::{UserQueryMode, extract_user_query_mode};
 use crate::ai::agent_sdk::driver::attachments::{
@@ -406,6 +408,7 @@ impl AmbientAgentRunner {
             };
 
             let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+            let factory_client = ServerApiProvider::as_ref(ctx).get_factory_client();
 
             // Compute the upgrade link in case we hit capacity.
             let upgrade_link = AuthStateProvider::as_ref(ctx)
@@ -537,6 +540,27 @@ impl AmbientAgentRunner {
             let oz_root_url = ChannelState::oz_root_url();
             let ai_client_clone = ai_client.clone();
             let spawn_future = async move {
+                let mut request = request;
+                if let Some(agent_identifier) = request.agent_identity_uid.clone() {
+                    let agent =
+                        resolve_agent_identifier(ai_client_clone.as_ref(), &agent_identifier)
+                            .await?;
+                    request.agent_identity_uid = Some(agent.uid);
+                }
+                if let Some(runner_identifier) =
+                    request.config.as_ref().and_then(|config| config.runner_id.clone())
+                {
+                    let runners = factory_client.get_runners(None).await?;
+                    let resolved_uid =
+                        resolve_runner(&runners, Some(runner_identifier.as_str()), None)?
+                            .uid
+                            .inner()
+                            .to_string();
+                    if let Some(config) = request.config.as_mut() {
+                        config.runner_id = Some(resolved_uid);
+                    }
+                }
+
                 let mut stream = Box::pin(spawn_task(request, ai_client_clone, Some(TASK_STATUS_POLLING_DURATION)));
                 let mut session_join_info = None;
                 let mut spawned_task_id = None;

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -46,7 +46,6 @@ use crate::server::server_api::ai::{
     ListAgentMessagesRequest, ReadAgentMessageResponse, RunSortBy, RunSortOrder,
     SendAgentMessageRequest, SendAgentMessageResponse, SpawnAgentRequest, TaskListFilter,
 };
-use crate::server::server_api::factory::get_runner_with_fallback;
 use crate::terminal::shared_session;
 use crate::util::time_format::format_approx_duration_from_now_utc;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -555,7 +554,8 @@ impl AmbientAgentRunner {
                         uid: Some(cynic::Id::new(&runner_identifier)),
                         name: Some(runner_identifier),
                     };
-                    let resolved_uid = get_runner_with_fallback(factory_client.as_ref(), selector)
+                    let resolved_uid = factory_client
+                        .get_runner(selector)
                         .await?
                         .uid
                         .inner()

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -17,13 +17,13 @@ use warp_cli::task::{
 use warp_cli::{GlobalOptions, SortOrderArg};
 use warp_core::channel::ChannelState;
 use warp_core::features::FeatureFlag;
+use warp_graphql::queries::get_runner::RunnerSelector;
 use warpui::r#async::{Spawnable, Timer};
 use warpui::platform::TerminationMode;
 use warpui::{AppContext, ModelContext, SingletonEntity};
 
 use super::agent_management::resolve_agent_identifier;
 use super::common::{EnvironmentChoice, ResolveConfigurationError, parse_ambient_task_id};
-use super::runner::resolve_runner;
 use crate::ServerApiProvider;
 use crate::ai::agent::{UserQueryMode, extract_user_query_mode};
 use crate::ai::agent_sdk::driver::attachments::{
@@ -550,12 +550,16 @@ impl AmbientAgentRunner {
                 if let Some(runner_identifier) =
                     request.config.as_ref().and_then(|config| config.runner_id.clone())
                 {
-                    let runners = factory_client.get_runners(None).await?;
-                    let resolved_uid =
-                        resolve_runner(&runners, Some(runner_identifier.as_str()), None)?
-                            .uid
-                            .inner()
-                            .to_string();
+                    let selector = RunnerSelector {
+                        uid: Some(cynic::Id::new(&runner_identifier)),
+                        name: Some(runner_identifier),
+                    };
+                    let resolved_uid = factory_client
+                        .get_runner(selector)
+                        .await?
+                        .uid
+                        .inner()
+                        .to_string();
                     if let Some(config) = request.config.as_mut() {
                         config.runner_id = Some(resolved_uid);
                     }

--- a/app/src/ai/agent_sdk/common.rs
+++ b/app/src/ai/agent_sdk/common.rs
@@ -340,15 +340,22 @@ pub(super) fn resolve_environment(
     resolve_environment_by_name(&CloudAmbientAgentEnvironment::get_all(ctx), identifier)
 }
 
+/// Folds a name for comparison: trims whitespace and lowercases.
+fn comparison_key(name: &str) -> String {
+    name.trim().to_lowercase()
+}
+
 /// Find an unambiguous name match among synced environments.
 fn resolve_environment_by_name(
     environments: &[CloudAmbientAgentEnvironment],
     name: &str,
 ) -> Result<CloudAmbientAgentEnvironment, ResolveConfigurationError> {
+    let key = comparison_key(name);
     let matches: Vec<&CloudAmbientAgentEnvironment> = environments
         .iter()
         .filter(|env| {
-            matches!(env.sync_id(), SyncId::ServerId(_)) && env.model().string_model.name == name
+            matches!(env.sync_id(), SyncId::ServerId(_))
+                && comparison_key(&env.model().string_model.name) == key
         })
         .collect();
     match matches.as_slice() {

--- a/app/src/ai/agent_sdk/common.rs
+++ b/app/src/ai/agent_sdk/common.rs
@@ -214,8 +214,6 @@ pub enum ResolveConfigurationError {
     /// The user canceled the operation, and we should exit.
     #[error("Operation canceled")]
     Canceled,
-    #[error("{id} is not a valid {kind} identifier")]
-    InvalidId { id: String, kind: &'static str },
     #[error("{kind} {id} not found")]
     ObjectNotFound { id: String, kind: &'static str },
     #[error(transparent)]
@@ -313,25 +311,52 @@ Without an environment, the agent will not be able to access private repositorie
     }
 
     fn get_by_id(id: String, ctx: &AppContext) -> Result<Self, ResolveConfigurationError> {
-        let sync_id = SyncId::ServerId(ServerId::try_from(id.as_str()).map_err(|_| {
-            ResolveConfigurationError::InvalidId {
-                id: id.clone(),
-                kind: "environment",
-            }
-        })?);
-
-        let environment =
-            CloudAmbientAgentEnvironment::get_by_id(&sync_id, ctx).ok_or_else(|| {
-                ResolveConfigurationError::ObjectNotFound {
-                    id: id.clone(),
-                    kind: "environment",
-                }
-            })?;
+        let environment = resolve_environment(&id, ctx)?;
+        let resolved_id = match environment.sync_id() {
+            SyncId::ServerId(server_id) => server_id.to_string(),
+            SyncId::ClientId(_) => id,
+        };
 
         Ok(EnvironmentChoice::Environment {
-            id,
+            id: resolved_id,
             name: environment.model().string_model.name.clone(),
         })
+    }
+}
+
+/// Resolve a synced [`CloudAmbientAgentEnvironment`] by ID or name
+pub(super) fn resolve_environment(
+    identifier: &str,
+    ctx: &AppContext,
+) -> Result<CloudAmbientAgentEnvironment, ResolveConfigurationError> {
+    if let Ok(server_id) = ServerId::try_from(identifier) {
+        let sync_id = SyncId::ServerId(server_id);
+        if let Some(environment) = CloudAmbientAgentEnvironment::get_by_id(&sync_id, ctx) {
+            return Ok(environment.clone());
+        }
+    }
+
+    resolve_environment_by_name(&CloudAmbientAgentEnvironment::get_all(ctx), identifier)
+}
+
+/// Find an unambiguous name match among a list of environments.
+fn resolve_environment_by_name(
+    environments: &[CloudAmbientAgentEnvironment],
+    name: &str,
+) -> Result<CloudAmbientAgentEnvironment, ResolveConfigurationError> {
+    let matches: Vec<&CloudAmbientAgentEnvironment> = environments
+        .iter()
+        .filter(|env| env.model().string_model.name == name)
+        .collect();
+    match matches.as_slice() {
+        [] => Err(ResolveConfigurationError::ObjectNotFound {
+            id: name.to_string(),
+            kind: "environment",
+        }),
+        [environment] => Ok((*environment).clone()),
+        _ => Err(ResolveConfigurationError::Other(anyhow::anyhow!(
+            "Multiple environments match '{name}'; specify the environment by ID"
+        ))),
     }
 }
 

--- a/app/src/ai/agent_sdk/common.rs
+++ b/app/src/ai/agent_sdk/common.rs
@@ -312,13 +312,14 @@ Without an environment, the agent will not be able to access private repositorie
 
     fn get_by_id(id: String, ctx: &AppContext) -> Result<Self, ResolveConfigurationError> {
         let environment = resolve_environment(&id, ctx)?;
-        let resolved_id = match environment.sync_id() {
-            SyncId::ServerId(server_id) => server_id.to_string(),
-            SyncId::ClientId(_) => id,
+        let SyncId::ServerId(server_id) = environment.sync_id() else {
+            return Err(ResolveConfigurationError::Other(anyhow::anyhow!(
+                "Resolved environment '{id}' has no server ID"
+            )));
         };
 
         Ok(EnvironmentChoice::Environment {
-            id: resolved_id,
+            id: server_id.to_string(),
             name: environment.model().string_model.name.clone(),
         })
     }
@@ -339,14 +340,16 @@ pub(super) fn resolve_environment(
     resolve_environment_by_name(&CloudAmbientAgentEnvironment::get_all(ctx), identifier)
 }
 
-/// Find an unambiguous name match among a list of environments.
+/// Find an unambiguous name match among synced environments.
 fn resolve_environment_by_name(
     environments: &[CloudAmbientAgentEnvironment],
     name: &str,
 ) -> Result<CloudAmbientAgentEnvironment, ResolveConfigurationError> {
     let matches: Vec<&CloudAmbientAgentEnvironment> = environments
         .iter()
-        .filter(|env| env.model().string_model.name == name)
+        .filter(|env| {
+            matches!(env.sync_id(), SyncId::ServerId(_)) && env.model().string_model.name == name
+        })
         .collect();
     match matches.as_slice() {
         [] => Err(ResolveConfigurationError::ObjectNotFound {

--- a/app/src/ai/agent_sdk/common_tests.rs
+++ b/app/src/ai/agent_sdk/common_tests.rs
@@ -20,11 +20,12 @@ use crate::auth::auth_manager::AuthManager;
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::{
-    CloudObjectMetadata, CloudObjectPermissions, CloudObjectStatuses, CloudObjectSyncStatus, Owner,
+    CloudObject, CloudObjectMetadata, CloudObjectPermissions, CloudObjectStatuses,
+    CloudObjectSyncStatus, Owner,
 };
 use crate::network::NetworkStatus;
 use crate::server::cloud_objects::update_manager::UpdateManager;
-use crate::server::ids::{ServerId, SyncId};
+use crate::server::ids::{ClientId, ServerId, SyncId};
 use crate::server::server_api::ServerApiProvider;
 use crate::server::sync_queue::SyncQueue;
 use crate::test_util::settings::initialize_settings_for_tests;
@@ -39,6 +40,14 @@ fn test_server_id(seed: u32) -> ServerId {
 }
 
 fn make_environment(seed: u32, name: &str) -> CloudAmbientAgentEnvironment {
+    make_environment_with_id(SyncId::ServerId(test_server_id(seed)), name)
+}
+
+fn make_unsynced_environment(name: &str) -> CloudAmbientAgentEnvironment {
+    make_environment_with_id(SyncId::ClientId(ClientId::new()), name)
+}
+
+fn make_environment_with_id(id: SyncId, name: &str) -> CloudAmbientAgentEnvironment {
     let metadata = CloudObjectMetadata {
         revision: None,
         metadata_last_updated_ts: None,
@@ -72,12 +81,7 @@ fn make_environment(seed: u32, name: &str) -> CloudAmbientAgentEnvironment {
         "docker-image".to_string(),
         Vec::new(),
     ));
-    CloudAmbientAgentEnvironment::new(
-        SyncId::ServerId(test_server_id(seed)),
-        model,
-        metadata,
-        permissions,
-    )
+    CloudAmbientAgentEnvironment::new(id, model, metadata, permissions)
 }
 
 #[test]
@@ -103,6 +107,23 @@ fn resolve_environment_by_name_errors_when_ambiguous() {
     let err = resolve_environment_by_name(&environments, "dup").unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("Multiple environments match"), "got: {msg}");
+}
+
+#[test]
+fn resolve_environment_by_name_ignores_unsynced_environments() {
+    let environments = vec![make_unsynced_environment("foo")];
+    let err = resolve_environment_by_name(&environments, "foo").unwrap_err();
+    assert!(matches!(
+        err,
+        ResolveConfigurationError::ObjectNotFound { .. }
+    ));
+}
+
+#[test]
+fn resolve_environment_by_name_matches_synced_env_when_unsynced_duplicate_exists() {
+    let environments = vec![make_unsynced_environment("foo"), make_environment(1, "foo")];
+    let resolved = resolve_environment_by_name(&environments, "foo").unwrap();
+    assert_eq!(resolved.sync_id(), SyncId::ServerId(test_server_id(1)));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/common_tests.rs
+++ b/app/src/ai/agent_sdk/common_tests.rs
@@ -127,6 +127,13 @@ fn resolve_environment_by_name_matches_synced_env_when_unsynced_duplicate_exists
 }
 
 #[test]
+fn resolve_environment_by_name_folds_case_and_surrounding_whitespace() {
+    let environments = vec![make_environment(1, "Prod")];
+    let resolved = resolve_environment_by_name(&environments, "  prod  ").unwrap();
+    assert_eq!(resolved.model().string_model.name, "Prod");
+}
+
+#[test]
 fn parse_ambient_task_id_accepts_valid_ids() {
     let task_id =
         parse_ambient_task_id("550e8400-e29b-41d4-a716-446655440000", "Invalid run ID").unwrap();

--- a/app/src/ai/agent_sdk/common_tests.rs
+++ b/app/src/ai/agent_sdk/common_tests.rs
@@ -3,25 +3,107 @@ use std::collections::HashMap;
 use warpui::App;
 
 use super::{
-    classify_agent_mode_base_model_id, parse_ambient_task_id, validate_agent_mode_base_model_id,
+    ResolveConfigurationError, classify_agent_mode_base_model_id, parse_ambient_task_id,
+    resolve_environment_by_name, validate_agent_mode_base_model_id,
 };
 use crate::LaunchMode;
+use crate::ai::cloud_environments::{
+    AmbientAgentEnvironment, CloudAmbientAgentEnvironment, CloudAmbientAgentEnvironmentModel,
+};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::llms::{
     AvailableLLMs, LLMContextWindow, LLMId, LLMInfo, LLMPreferences, LLMProvider, LLMUsageMetadata,
     ModelsByFeature,
 };
 use crate::ai::mcp::TemplatableMCPServerManager;
-use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
+use crate::auth::{AuthStateProvider, UserUid};
 use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::{
+    CloudObjectMetadata, CloudObjectPermissions, CloudObjectStatuses, CloudObjectSyncStatus, Owner,
+};
 use crate::network::NetworkStatus;
 use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ServerApiProvider;
 use crate::server::sync_queue::SyncQueue;
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::workspaces::team_tester::TeamTesterStatus;
 use crate::workspaces::user_workspaces::UserWorkspaces;
+
+/// Builds a deterministic, valid-length [`ServerId`] for tests (`ServerId` requires
+/// exactly 22 characters).
+fn test_server_id(seed: u32) -> ServerId {
+    ServerId::try_from(format!("test-server-id-{seed:07}").as_str())
+        .expect("seeded string is exactly 22 characters")
+}
+
+fn make_environment(seed: u32, name: &str) -> CloudAmbientAgentEnvironment {
+    let metadata = CloudObjectMetadata {
+        revision: None,
+        metadata_last_updated_ts: None,
+        current_editor_uid: None,
+        pending_changes_statuses: CloudObjectStatuses {
+            content_sync_status: CloudObjectSyncStatus::NoLocalChanges,
+            has_pending_permissions_change: false,
+            has_pending_metadata_change: false,
+            pending_untrash: false,
+            pending_delete: false,
+        },
+        trashed_ts: None,
+        folder_id: None,
+        is_welcome_object: false,
+        last_editor_uid: None,
+        creator_uid: None,
+        last_task_run_ts: None,
+    };
+    let permissions = CloudObjectPermissions {
+        owner: Owner::User {
+            user_uid: UserUid::new("test-user"),
+        },
+        permissions_last_updated_ts: None,
+        anyone_with_link: None,
+        guests: Vec::new(),
+    };
+    let model = CloudAmbientAgentEnvironmentModel::new(AmbientAgentEnvironment::new(
+        name.to_string(),
+        None,
+        Vec::new(),
+        "docker-image".to_string(),
+        Vec::new(),
+    ));
+    CloudAmbientAgentEnvironment::new(
+        SyncId::ServerId(test_server_id(seed)),
+        model,
+        metadata,
+        permissions,
+    )
+}
+
+#[test]
+fn resolve_environment_by_name_matches_unambiguous_name() {
+    let environments = vec![make_environment(1, "alpha"), make_environment(2, "beta")];
+    let resolved = resolve_environment_by_name(&environments, "beta").unwrap();
+    assert_eq!(resolved.model().string_model.name, "beta");
+}
+
+#[test]
+fn resolve_environment_by_name_errors_when_not_found() {
+    let environments = vec![make_environment(1, "alpha")];
+    let err = resolve_environment_by_name(&environments, "missing").unwrap_err();
+    assert!(matches!(
+        err,
+        ResolveConfigurationError::ObjectNotFound { .. }
+    ));
+}
+
+#[test]
+fn resolve_environment_by_name_errors_when_ambiguous() {
+    let environments = vec![make_environment(1, "dup"), make_environment(2, "dup")];
+    let err = resolve_environment_by_name(&environments, "dup").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("Multiple environments match"), "got: {msg}");
+}
 
 #[test]
 fn parse_ambient_task_id_accepts_valid_ids() {

--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -766,8 +766,8 @@ impl EnvironmentCommandRunner {
                     OperationSuccessType::Failure => {
                         super::report_fatal_error(
                             anyhow::anyhow!(
-                                "Failed to create environment: the request to Warp did not \
-                                 complete. Check your network connection and try again."
+                                "Failed to create environment: the request could not be \
+                                 completed. Please try again."
                             ),
                             ctx,
                         );
@@ -775,9 +775,7 @@ impl EnvironmentCommandRunner {
                     OperationSuccessType::Rejection => {
                         super::report_fatal_error(
                             anyhow::anyhow!(
-                                "Failed to create environment: the server rejected the request. \
-                                 It may have already been created; list your environments \
-                                 before retrying."
+                                "Failed to create environment: the server rejected the request."
                             ),
                             ctx,
                         );
@@ -785,8 +783,7 @@ impl EnvironmentCommandRunner {
                     OperationSuccessType::FeatureNotAvailable => {
                         super::report_fatal_error(
                             anyhow::anyhow!(
-                                "Failed to create environment: cloud environments are not \
-                                 available for your account."
+                                "Failed to create environment: cloud environments are unavailable."
                             ),
                             ctx,
                         );

--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -763,9 +763,31 @@ impl EnvironmentCommandRunner {
                     OperationSuccessType::Denied(message) => {
                         super::report_fatal_error(anyhow::anyhow!("{message}"), ctx);
                     }
-                    _ => {
+                    OperationSuccessType::Failure => {
                         super::report_fatal_error(
-                            anyhow::anyhow!("Failed to create environment"),
+                            anyhow::anyhow!(
+                                "Failed to create environment: the request to Warp did not \
+                                 complete. Check your network connection and try again."
+                            ),
+                            ctx,
+                        );
+                    }
+                    OperationSuccessType::Rejection => {
+                        super::report_fatal_error(
+                            anyhow::anyhow!(
+                                "Failed to create environment: the server rejected the request. \
+                                 It may have already been created; list your environments \
+                                 before retrying."
+                            ),
+                            ctx,
+                        );
+                    }
+                    OperationSuccessType::FeatureNotAvailable => {
+                        super::report_fatal_error(
+                            anyhow::anyhow!(
+                                "Failed to create environment: cloud environments are not \
+                                 available for your account."
+                            ),
                             ctx,
                         );
                     }

--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -749,12 +749,24 @@ impl EnvironmentCommandRunner {
         ctx.subscribe_to_model(&UpdateManager::handle(ctx), move |_, _, event, ctx| {
             if let UpdateManagerEvent::ObjectOperationComplete { result } = event
                 && matches!(result.operation, ObjectOperation::Create { .. })
-                && matches!(result.success_type, OperationSuccessType::Success)
                 && result.client_id == Some(client_id)
             {
-                let server_id = result.server_id.unwrap();
-                println!("Environment created successfully with ID: {server_id}");
-                ctx.terminate_app(warpui::platform::TerminationMode::ForceTerminate, None);
+                match &result.success_type {
+                    OperationSuccessType::Success => {
+                        let server_id = result.server_id.unwrap();
+                        println!("Environment created successfully with ID: {server_id}");
+                        ctx.terminate_app(warpui::platform::TerminationMode::ForceTerminate, None);
+                    }
+                    OperationSuccessType::Denied(message) => {
+                        super::report_fatal_error(anyhow::anyhow!("{message}"), ctx);
+                    }
+                    _ => {
+                        super::report_fatal_error(
+                            anyhow::anyhow!("Failed to create environment"),
+                            ctx,
+                        );
+                    }
+                }
             }
         });
     }

--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -90,12 +90,12 @@ pub fn run(
             });
             Ok(())
         }
-        EnvironmentCommand::Delete { id, force } => {
-            runner.update(ctx, |runner, ctx| runner.delete(id, force, ctx));
+        EnvironmentCommand::Delete { identifier, force } => {
+            runner.update(ctx, |runner, ctx| runner.delete(identifier, force, ctx));
             Ok(())
         }
         EnvironmentCommand::Update {
-            id,
+            identifier,
             name,
             description,
             remove_description,
@@ -111,7 +111,7 @@ pub fn run(
 
             runner.update(ctx, |runner, ctx| {
                 runner.update_environment(
-                    id,
+                    identifier,
                     name,
                     description,
                     remove_description,
@@ -126,8 +126,8 @@ pub fn run(
             });
             Ok(())
         }
-        EnvironmentCommand::Get { id } => {
-            runner.update(ctx, |runner, ctx| runner.get(id, ctx));
+        EnvironmentCommand::Get { identifier } => {
+            runner.update(ctx, |runner, ctx| runner.get(identifier, ctx));
             Ok(())
         }
         EnvironmentCommand::Image(image_cmd) => match image_cmd {

--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -269,28 +269,17 @@ impl EnvironmentCommandRunner {
                 return;
             }
 
-            // Get the ServerId and check if the environment exists
-            let server_id = match ServerId::try_from(id.as_str()) {
-                Ok(sid) => sid,
-                Err(_) => {
+            match super::common::resolve_environment(&id, ctx) {
+                Ok(environment) => {
+                    Self::print_environment_details(&environment.model().string_model);
+                    ctx.terminate_app(warpui::platform::TerminationMode::ForceTerminate, None);
+                }
+                Err(err) => {
                     ctx.terminate_app(
                         warpui::platform::TerminationMode::ForceTerminate,
-                        Some(Err(anyhow::anyhow!("Environment {} not found", id))),
+                        Some(Err(anyhow::anyhow!(err))),
                     );
-                    return;
                 }
-            };
-            let sync_id = SyncId::ServerId(server_id);
-            let environment = CloudAmbientAgentEnvironment::get_by_id(&sync_id, ctx);
-
-            if let Some(environment) = environment {
-                Self::print_environment_details(&environment.model().string_model);
-                ctx.terminate_app(warpui::platform::TerminationMode::ForceTerminate, None);
-            } else {
-                ctx.terminate_app(
-                    warpui::platform::TerminationMode::ForceTerminate,
-                    Some(Err(anyhow::anyhow!("Environment {} not found", id))),
-                );
             }
         });
     }
@@ -862,21 +851,17 @@ impl EnvironmentCommandRunner {
                 return;
             }
 
-            // Get the ServerId and check if the environment exists
-            let server_id = match ServerId::try_from(id.as_str()) {
-                Ok(sid) => sid,
-                Err(_) => {
-                    let error = anyhow::anyhow!("Environment {} not found", id);
+            let environment = match super::common::resolve_environment(&id, ctx) {
+                Ok(environment) => environment,
+                Err(err) => {
                     ctx.terminate_app(
                         warpui::platform::TerminationMode::ForceTerminate,
-                        Some(Err(error)),
+                        Some(Err(anyhow::anyhow!(err))),
                     );
                     return;
                 }
             };
-            let sync_id = SyncId::ServerId(server_id);
-            let environment = CloudAmbientAgentEnvironment::get_by_id(&sync_id, ctx);
-            let Some(environment) = environment else {
+            let SyncId::ServerId(server_id) = environment.sync_id() else {
                 let error = anyhow::anyhow!("Environment {} not found", id);
                 ctx.terminate_app(
                     warpui::platform::TerminationMode::ForceTerminate,
@@ -911,12 +896,12 @@ impl EnvironmentCommandRunner {
                 Self::auth_repos_then_execute(add_repos, 1, "update", execute_update, ctx);
             };
 
-            // Check if any integrations are using this environment
+            // Check if any integrations are using this environment.
             if force {
                 auth_repos_before_update(ctx);
             } else {
                 Self::confirm_if_integrations_using_environment(
-                    id,
+                    server_id.to_string(),
                     "update",
                     auth_repos_before_update,
                     ctx,
@@ -1037,21 +1022,17 @@ impl EnvironmentCommandRunner {
                 return;
             }
 
-            // Get the ServerId and check if the environment exists
-            let server_id = match ServerId::try_from(id.as_str()) {
-                Ok(sid) => sid,
-                Err(_) => {
-                    let error = anyhow::anyhow!("Environment {} not found", id);
+            let environment = match super::common::resolve_environment(&id, ctx) {
+                Ok(environment) => environment,
+                Err(err) => {
                     ctx.terminate_app(
                         warpui::platform::TerminationMode::ForceTerminate,
-                        Some(Err(error)),
+                        Some(Err(anyhow::anyhow!(err))),
                     );
                     return;
                 }
             };
-            let sync_id = SyncId::ServerId(server_id);
-            let environment = CloudAmbientAgentEnvironment::get_by_id(&sync_id, ctx);
-            let Some(environment) = environment else {
+            let SyncId::ServerId(server_id) = environment.sync_id() else {
                 let error = anyhow::anyhow!("Environment {} not found", id);
                 ctx.terminate_app(
                     warpui::platform::TerminationMode::ForceTerminate,
@@ -1061,12 +1042,12 @@ impl EnvironmentCommandRunner {
             };
             let type_and_id = environment.cloud_object_type_and_id();
 
-            // Check if any integrations are using this environment
+            // Check if any integrations are using this environment.
             if force {
                 Self::execute_delete(type_and_id, ctx);
             } else {
                 Self::confirm_if_integrations_using_environment(
-                    id,
+                    server_id.to_string(),
                     "delete",
                     move |ctx| {
                         Self::execute_delete(type_and_id, ctx);

--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -710,7 +710,7 @@ impl EnvironmentCommandRunner {
         });
     }
 
-    // Helper function to create environment after successful auth check
+    // Helper function to create environment after successful auth check.
     fn create_environment_after_auth_check(
         name: String,
         description: Option<String>,
@@ -737,11 +737,14 @@ impl EnvironmentCommandRunner {
             }
         };
 
-        // Create on the server
         UpdateManager::handle(ctx).update(ctx, |update_manager, ctx| {
-            update_manager.create_ambient_agent_environment(environment, client_id, owner, ctx);
+            update_manager.create_ambient_agent_environment_online_with_events(
+                environment,
+                client_id,
+                owner,
+                ctx,
+            );
         });
-
         // Await creation on the server, then return.
         // We should subscribe to the UpdateManager here because we want to wait
         // for our environment to be assigned a ServerId. Environments are not

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -60,17 +60,14 @@ use crate::ai::ambient_agents::task::HarnessConfig;
 use crate::ai::attachment_utils::attachments_download_dir;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::aws_credentials::refresh_aws_credentials;
-use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::llms::LLMId;
 use crate::ai::skills::{
     ResolveSkillError, ResolvedSkill, clone_repo_for_skill, resolve_skill_spec,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
-use crate::cloud_object::CloudObjectLookup as _;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::send_telemetry_sync_from_app_ctx;
-use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::ai::{AIClient, AgentConfigSnapshot, GitCredential};
 use crate::terminal::view::ConversationRestorationInNewPaneType;
@@ -1453,24 +1450,14 @@ impl AgentDriverRunner {
 
         let environment = foreground
             .spawn(move |_, ctx| -> Result<_, AgentDriverError> {
-                let server_id = ServerId::try_from(environment_id.as_str()).map_err(|_| {
-                    report_error!(
-                        "Invalid environment ID",
-                        extra: { "environment_id" => %environment_id }
-                    );
-                    AgentDriver::log_valid_environments(ctx);
-                    AgentDriverError::EnvironmentNotFound(environment_id.clone())
-                })?;
-                let sync_id = SyncId::ServerId(server_id);
-
-                CloudAmbientAgentEnvironment::get_by_id(&sync_id, ctx)
-                    .ok_or_else(|| {
+                common::resolve_environment(&environment_id, ctx)
+                    .map_err(|_| {
                         report_error!(
-                            "Environment not found with ID",
+                            "Environment not found",
                             extra: { "environment_id" => %environment_id }
                         );
                         AgentDriver::log_valid_environments(ctx);
-                        AgentDriverError::EnvironmentNotFound(environment_id)
+                        AgentDriverError::EnvironmentNotFound(environment_id.clone())
                     })
                     .map(|env| env.model().string_model.clone())
             })

--- a/app/src/ai/agent_sdk/runner.rs
+++ b/app/src/ai/agent_sdk/runner.rs
@@ -186,10 +186,15 @@ impl RunnerCommandRunner {
         }
 
         let factory = ServerApiProvider::as_ref(ctx).get_factory_client();
-        let uid = args.identifier;
+        let identifier = args.identifier;
 
         ctx.spawn(
             async move {
+                let runners = factory.get_runners(None).await?;
+                let uid = resolve_runner(&runners, Some(identifier.as_str()), None)?
+                    .uid
+                    .inner()
+                    .to_string();
                 let deleted_uid = factory.delete_runner(uid).await?;
                 println!("Runner deleted successfully: {deleted_uid}");
                 Ok(())
@@ -222,20 +227,28 @@ fn confirm_delete(uid: &str, is_terminal: bool) -> Result<bool> {
         .unwrap_or_default())
 }
 
-/// Resolve a runner by UID or (unambiguous) name from a fetched list.
-fn resolve_runner<'a>(
+/// Resolve a runner by UID or name from a fetched list.
+pub(super) fn resolve_runner<'a>(
     runners: &'a [Runner],
-    id: Option<&str>,
+    identifier: Option<&str>,
     name: Option<&str>,
 ) -> Result<&'a Runner> {
-    if let Some(id) = id {
-        return runners
+    if let Some(identifier) = identifier {
+        if let Some(runner) = runners
             .iter()
-            .find(|runner| runner.uid.inner() == id)
-            .ok_or_else(|| anyhow!("Runner '{id}' not found"));
+            .find(|runner| runner.uid.inner() == identifier)
+        {
+            return Ok(runner);
+        }
+        return resolve_runner_by_name(runners, identifier);
     }
 
-    let name = name.ok_or_else(|| anyhow!("A runner UID or --name is required"))?;
+    let name = name.ok_or_else(|| anyhow!("A runner UID or name is required"))?;
+    resolve_runner_by_name(runners, name)
+}
+
+/// Resolve a runner by an unambiguous name match.
+fn resolve_runner_by_name<'a>(runners: &'a [Runner], name: &str) -> Result<&'a Runner> {
     let matches: Vec<&Runner> = runners
         .iter()
         .filter(|runner| runner.config.name == name)

--- a/app/src/ai/agent_sdk/runner.rs
+++ b/app/src/ai/agent_sdk/runner.rs
@@ -13,6 +13,7 @@ use warp_graphql::mutations::upsert_runner::{
 };
 use warp_graphql::object::SpaceType;
 use warp_graphql::object_permissions::Owner as GqlOwner;
+use warp_graphql::queries::get_runner::RunnerSelector;
 use warp_graphql::queries::get_runners::{
     Runner, RunnerArch, RunnerConfig, RunnerMacOsVersion, RunnerOs, RunnerSortBy,
 };
@@ -141,13 +142,11 @@ impl RunnerCommandRunner {
 
         ctx.spawn(
             async move {
-                // Fetch existing runners so we can resolve the target and preserve
-                // any fields that aren't being changed (the server upsert takes a
-                // full runner config).
-                let runners = factory.get_runners(None).await?;
-
-                let existing =
-                    resolve_runner(&runners, args.identifier.as_deref(), args.name.as_deref())?;
+                // Resolve the target runner server-side, preserving any fields
+                // that aren't being changed (the server upsert takes a full
+                // runner config).
+                let selector = update_selector(&args);
+                let existing = factory.get_runner(selector).await?;
                 let uid = existing.uid.inner().to_string();
 
                 let runner = build_update_input(&args, &existing.config)?;
@@ -190,11 +189,11 @@ impl RunnerCommandRunner {
 
         ctx.spawn(
             async move {
-                let runners = factory.get_runners(None).await?;
-                let uid = resolve_runner(&runners, Some(identifier.as_str()), None)?
-                    .uid
-                    .inner()
-                    .to_string();
+                let selector = RunnerSelector {
+                    uid: Some(cynic::Id::new(&identifier)),
+                    name: Some(identifier),
+                };
+                let uid = factory.get_runner(selector).await?.uid.inner().to_string();
                 let deleted_uid = factory.delete_runner(uid).await?;
                 println!("Runner deleted successfully: {deleted_uid}");
                 Ok(())
@@ -227,38 +226,22 @@ fn confirm_delete(uid: &str, is_terminal: bool) -> Result<bool> {
         .unwrap_or_default())
 }
 
-/// Resolve a runner by UID or name from a fetched list.
-pub(super) fn resolve_runner<'a>(
-    runners: &'a [Runner],
-    identifier: Option<&str>,
-    name: Option<&str>,
-) -> Result<&'a Runner> {
-    if let Some(identifier) = identifier {
-        if let Some(runner) = runners
-            .iter()
-            .find(|runner| runner.uid.inner() == identifier)
-        {
-            return Ok(runner);
-        }
-        return resolve_runner_by_name(runners, identifier);
-    }
-
-    let name = name.ok_or_else(|| anyhow!("A runner UID or name is required"))?;
-    resolve_runner_by_name(runners, name)
-}
-
-/// Resolve a runner by an unambiguous name match.
-fn resolve_runner_by_name<'a>(runners: &'a [Runner], name: &str) -> Result<&'a Runner> {
-    let matches: Vec<&Runner> = runners
-        .iter()
-        .filter(|runner| runner.config.name == name)
-        .collect();
-    match matches.as_slice() {
-        [] => Err(anyhow!("Runner '{name}' not found")),
-        [runner] => Ok(runner),
-        _ => Err(anyhow!(
-            "Multiple runners match '{name}'; specify the runner by UID"
-        )),
+/// Build the [`RunnerSelector`] for an `update` call from the CLI args:
+/// the positional identifier (if given) feeds both `uid` and `name`
+/// The server tries uid first and
+/// falls back to name. When no identifier is given, `--name` is required and
+/// becomes the sole (name-only) selector, matching `resolve_updated_name`'s
+/// treatment of that case as a lookup key rather than a rename.
+fn update_selector(args: &UpdateRunnerArgs) -> RunnerSelector {
+    match &args.identifier {
+        Some(identifier) => RunnerSelector {
+            uid: Some(cynic::Id::new(identifier)),
+            name: Some(identifier.clone()),
+        },
+        None => RunnerSelector {
+            uid: None,
+            name: args.name.clone(),
+        },
     }
 }
 

--- a/app/src/ai/agent_sdk/runner.rs
+++ b/app/src/ai/agent_sdk/runner.rs
@@ -23,6 +23,7 @@ use warpui::{AppContext, ModelContext, SingletonEntity};
 use super::output::{self, TableFormat};
 use crate::ai::runner_display::{arch_display, macos_version_display, os_display};
 use crate::server::server_api::ServerApiProvider;
+use crate::server::server_api::factory::get_runner_with_fallback;
 use crate::util::time_format::format_approx_duration_from_now_utc;
 
 /// Handle runner-related CLI commands.
@@ -146,7 +147,7 @@ impl RunnerCommandRunner {
                 // that aren't being changed (the server upsert takes a full
                 // runner config).
                 let selector = update_selector(&args);
-                let existing = factory.get_runner(selector).await?;
+                let existing = get_runner_with_fallback(factory.as_ref(), selector).await?;
                 let uid = existing.uid.inner().to_string();
 
                 let runner = build_update_input(&args, &existing.config)?;
@@ -193,7 +194,11 @@ impl RunnerCommandRunner {
                     uid: Some(cynic::Id::new(&identifier)),
                     name: Some(identifier),
                 };
-                let uid = factory.get_runner(selector).await?.uid.inner().to_string();
+                let uid = get_runner_with_fallback(factory.as_ref(), selector)
+                    .await?
+                    .uid
+                    .inner()
+                    .to_string();
                 let deleted_uid = factory.delete_runner(uid).await?;
                 println!("Runner deleted successfully: {deleted_uid}");
                 Ok(())

--- a/app/src/ai/agent_sdk/runner.rs
+++ b/app/src/ai/agent_sdk/runner.rs
@@ -146,7 +146,8 @@ impl RunnerCommandRunner {
                 // full runner config).
                 let runners = factory.get_runners(None).await?;
 
-                let existing = resolve_runner(&runners, args.id.as_deref(), args.name.as_deref())?;
+                let existing =
+                    resolve_runner(&runners, args.identifier.as_deref(), args.name.as_deref())?;
                 let uid = existing.uid.inner().to_string();
 
                 let runner = build_update_input(&args, &existing.config)?;
@@ -168,7 +169,7 @@ impl RunnerCommandRunner {
         use std::io::IsTerminal as _;
 
         if !args.force {
-            match confirm_delete(&args.id, std::io::stdin().is_terminal()) {
+            match confirm_delete(&args.identifier, std::io::stdin().is_terminal()) {
                 Ok(true) => {}
                 Ok(false) => {
                     // Interactive decline: not an error, exit cleanly.
@@ -185,7 +186,7 @@ impl RunnerCommandRunner {
         }
 
         let factory = ServerApiProvider::as_ref(ctx).get_factory_client();
-        let uid = args.id;
+        let uid = args.identifier;
 
         ctx.spawn(
             async move {
@@ -350,7 +351,11 @@ fn build_update_input(args: &UpdateRunnerArgs, existing: &RunnerConfig) -> Resul
         .or_else(|| existing.description.clone());
 
     Ok(RunnerInput {
-        name: resolve_updated_name(args.id.is_some(), args.name.as_deref(), &existing.name),
+        name: resolve_updated_name(
+            args.identifier.is_some(),
+            args.name.as_deref(),
+            &existing.name,
+        ),
         description,
         setup_commands,
         instance_shape,

--- a/app/src/ai/agent_sdk/runner.rs
+++ b/app/src/ai/agent_sdk/runner.rs
@@ -23,7 +23,6 @@ use warpui::{AppContext, ModelContext, SingletonEntity};
 use super::output::{self, TableFormat};
 use crate::ai::runner_display::{arch_display, macos_version_display, os_display};
 use crate::server::server_api::ServerApiProvider;
-use crate::server::server_api::factory::get_runner_with_fallback;
 use crate::util::time_format::format_approx_duration_from_now_utc;
 
 /// Handle runner-related CLI commands.
@@ -147,7 +146,7 @@ impl RunnerCommandRunner {
                 // that aren't being changed (the server upsert takes a full
                 // runner config).
                 let selector = update_selector(&args);
-                let existing = get_runner_with_fallback(factory.as_ref(), selector).await?;
+                let existing = factory.get_runner(selector).await?;
                 let uid = existing.uid.inner().to_string();
 
                 let runner = build_update_input(&args, &existing.config)?;
@@ -194,11 +193,7 @@ impl RunnerCommandRunner {
                     uid: Some(cynic::Id::new(&identifier)),
                     name: Some(identifier),
                 };
-                let uid = get_runner_with_fallback(factory.as_ref(), selector)
-                    .await?
-                    .uid
-                    .inner()
-                    .to_string();
+                let uid = factory.get_runner(selector).await?.uid.inner().to_string();
                 let deleted_uid = factory.delete_runner(uid).await?;
                 println!("Runner deleted successfully: {deleted_uid}");
                 Ok(())

--- a/app/src/ai/agent_sdk/runner_tests.rs
+++ b/app/src/ai/agent_sdk/runner_tests.rs
@@ -1,31 +1,22 @@
-use warp_graphql::object::Space;
-use warp_graphql::scalars::Time;
+use warp_cli::runner::UpdateRunnerArgs;
 
 use super::{
-    Runner, RunnerArch, RunnerArchArg, RunnerConfig, RunnerOs, RunnerOsArg, SpaceType,
-    confirm_delete, merge_instance_shape, resolve_arch, resolve_runner, resolve_updated_name,
+    RunnerArch, RunnerArchArg, RunnerOsArg, confirm_delete, merge_instance_shape, resolve_arch,
+    resolve_updated_name, update_selector,
 };
 
-fn make_runner(uid: &str, name: &str) -> Runner {
-    Runner {
-        uid: cynic::Id::new(uid),
-        config: RunnerConfig {
-            name: name.to_string(),
-            description: None,
-            setup_commands: None,
-            instance_shape: None,
-            os: RunnerOs::Linux,
-            arch: RunnerArch::X8664,
-            mac: None,
-            linux: None,
-        },
-        last_updated: Time::new(chrono::Utc::now()),
-        scope: Space {
-            uid: cynic::Id::new("space-uid"),
-            type_: SpaceType::User,
-        },
-        creator: None,
-        last_editor: None,
+fn update_args(identifier: Option<&str>, name: Option<&str>) -> UpdateRunnerArgs {
+    UpdateRunnerArgs {
+        identifier: identifier.map(str::to_string),
+        name: name.map(str::to_string),
+        description: None,
+        setup_command: Vec::new(),
+        os: None,
+        arch: None,
+        docker_image: None,
+        macos_version: None,
+        vcpus: None,
+        memory_gb: None,
     }
 }
 
@@ -106,53 +97,35 @@ fn resolve_updated_name_renames_only_with_uid() {
 }
 
 #[test]
-fn resolve_runner_matches_exact_uid() {
-    let runners = vec![make_runner("uid-1", "alpha"), make_runner("uid-2", "beta")];
-    let resolved = resolve_runner(&runners, Some("uid-2"), None).unwrap();
-    assert_eq!(resolved.uid.inner(), "uid-2");
-}
-
-#[test]
-fn resolve_runner_falls_back_to_name_when_identifier_is_not_a_uid() {
-    let runners = vec![make_runner("uid-1", "alpha"), make_runner("uid-2", "beta")];
-    let resolved = resolve_runner(&runners, Some("beta"), None).unwrap();
-    assert_eq!(resolved.uid.inner(), "uid-2");
-}
-
-#[test]
-fn resolve_runner_prefers_uid_match_over_name_param() {
-    let runners = vec![make_runner("uid-1", "alpha"), make_runner("uid-2", "beta")];
-    let resolved = resolve_runner(&runners, Some("uid-1"), Some("new-name")).unwrap();
-    assert_eq!(resolved.uid.inner(), "uid-1");
-}
-
-#[test]
-fn resolve_runner_uses_name_arg_when_identifier_is_absent() {
-    let runners = vec![make_runner("uid-1", "alpha")];
-    let resolved = resolve_runner(&runners, None, Some("alpha")).unwrap();
-    assert_eq!(resolved.uid.inner(), "uid-1");
-}
-
-#[test]
-fn resolve_runner_errors_when_name_is_ambiguous() {
-    let runners = vec![make_runner("uid-1", "dup"), make_runner("uid-2", "dup")];
-    let err = resolve_runner(&runners, Some("dup"), None).unwrap_err();
-    assert!(
-        err.to_string().contains("Multiple runners match"),
-        "got: {err}"
+fn update_selector_uses_identifier_for_both_uid_and_name() {
+    // identifier is ambiguous (uid or name), so it feeds both fields; the
+    // server tries uid first and falls back to name.
+    let args = update_args(Some("uid-or-name"), None);
+    let selector = update_selector(&args);
+    assert_eq!(
+        selector.uid.map(|id| id.inner().to_string()),
+        Some("uid-or-name".to_string())
     );
+    assert_eq!(selector.name.as_deref(), Some("uid-or-name"));
 }
 
 #[test]
-fn resolve_runner_errors_when_not_found() {
-    let runners = vec![make_runner("uid-1", "alpha")];
-    let err = resolve_runner(&runners, Some("missing"), None).unwrap_err();
-    assert!(err.to_string().contains("not found"), "got: {err}");
+fn update_selector_ignores_rename_value_when_identifier_is_given() {
+    // --name alongside a positional identifier is a rename instruction, not a
+    // lookup key, so it must not leak into the selector's name field.
+    let args = update_args(Some("uid-1"), Some("renamed"));
+    let selector = update_selector(&args);
+    assert_eq!(
+        selector.uid.map(|id| id.inner().to_string()),
+        Some("uid-1".to_string())
+    );
+    assert_eq!(selector.name.as_deref(), Some("uid-1"));
 }
 
 #[test]
-fn resolve_runner_errors_when_neither_identifier_nor_name_given() {
-    let runners = vec![make_runner("uid-1", "alpha")];
-    let err = resolve_runner(&runners, None, None).unwrap_err();
-    assert!(err.to_string().contains("required"), "got: {err}");
+fn update_selector_uses_name_flag_as_sole_selector_when_identifier_is_absent() {
+    let args = update_args(None, Some("by-name"));
+    let selector = update_selector(&args);
+    assert_eq!(selector.uid, None);
+    assert_eq!(selector.name.as_deref(), Some("by-name"));
 }

--- a/app/src/ai/agent_sdk/runner_tests.rs
+++ b/app/src/ai/agent_sdk/runner_tests.rs
@@ -1,7 +1,33 @@
+use warp_graphql::object::Space;
+use warp_graphql::scalars::Time;
+
 use super::{
-    RunnerArch, RunnerArchArg, RunnerOsArg, confirm_delete, merge_instance_shape, resolve_arch,
-    resolve_updated_name,
+    Runner, RunnerArch, RunnerArchArg, RunnerConfig, RunnerOs, RunnerOsArg, SpaceType,
+    confirm_delete, merge_instance_shape, resolve_arch, resolve_runner, resolve_updated_name,
 };
+
+fn make_runner(uid: &str, name: &str) -> Runner {
+    Runner {
+        uid: cynic::Id::new(uid),
+        config: RunnerConfig {
+            name: name.to_string(),
+            description: None,
+            setup_commands: None,
+            instance_shape: None,
+            os: RunnerOs::Linux,
+            arch: RunnerArch::X8664,
+            mac: None,
+            linux: None,
+        },
+        last_updated: Time::new(chrono::Utc::now()),
+        scope: Space {
+            uid: cynic::Id::new("space-uid"),
+            type_: SpaceType::User,
+        },
+        creator: None,
+        last_editor: None,
+    }
+}
 
 #[test]
 fn confirm_delete_refuses_non_interactive_without_force() {
@@ -77,4 +103,56 @@ fn resolve_updated_name_renames_only_with_uid() {
     assert_eq!(resolve_updated_name(true, None, "old"), "old");
     // No UID: --name is the selector, so the name is unchanged.
     assert_eq!(resolve_updated_name(false, Some("old"), "old"), "old");
+}
+
+#[test]
+fn resolve_runner_matches_exact_uid() {
+    let runners = vec![make_runner("uid-1", "alpha"), make_runner("uid-2", "beta")];
+    let resolved = resolve_runner(&runners, Some("uid-2"), None).unwrap();
+    assert_eq!(resolved.uid.inner(), "uid-2");
+}
+
+#[test]
+fn resolve_runner_falls_back_to_name_when_identifier_is_not_a_uid() {
+    let runners = vec![make_runner("uid-1", "alpha"), make_runner("uid-2", "beta")];
+    let resolved = resolve_runner(&runners, Some("beta"), None).unwrap();
+    assert_eq!(resolved.uid.inner(), "uid-2");
+}
+
+#[test]
+fn resolve_runner_prefers_uid_match_over_name_param() {
+    let runners = vec![make_runner("uid-1", "alpha"), make_runner("uid-2", "beta")];
+    let resolved = resolve_runner(&runners, Some("uid-1"), Some("new-name")).unwrap();
+    assert_eq!(resolved.uid.inner(), "uid-1");
+}
+
+#[test]
+fn resolve_runner_uses_name_arg_when_identifier_is_absent() {
+    let runners = vec![make_runner("uid-1", "alpha")];
+    let resolved = resolve_runner(&runners, None, Some("alpha")).unwrap();
+    assert_eq!(resolved.uid.inner(), "uid-1");
+}
+
+#[test]
+fn resolve_runner_errors_when_name_is_ambiguous() {
+    let runners = vec![make_runner("uid-1", "dup"), make_runner("uid-2", "dup")];
+    let err = resolve_runner(&runners, Some("dup"), None).unwrap_err();
+    assert!(
+        err.to_string().contains("Multiple runners match"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn resolve_runner_errors_when_not_found() {
+    let runners = vec![make_runner("uid-1", "alpha")];
+    let err = resolve_runner(&runners, Some("missing"), None).unwrap_err();
+    assert!(err.to_string().contains("not found"), "got: {err}");
+}
+
+#[test]
+fn resolve_runner_errors_when_neither_identifier_nor_name_given() {
+    let runners = vec![make_runner("uid-1", "alpha")];
+    let err = resolve_runner(&runners, None, None).unwrap_err();
+    assert!(err.to_string().contains("required"), "got: {err}");
 }

--- a/app/src/server/cloud_objects/update_manager.rs
+++ b/app/src/server/cloud_objects/update_manager.rs
@@ -3246,6 +3246,41 @@ impl UpdateManager {
     }
 
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    pub fn create_ambient_agent_environment_online_with_events(
+        &mut self,
+        ambient_agent_environment: AmbientAgentEnvironment,
+        client_id: ClientId,
+        owner: Owner,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let create_future = self.create_ambient_agent_environment_online(
+            ambient_agent_environment,
+            client_id,
+            owner,
+            ctx,
+        );
+
+        ctx.spawn(create_future, move |_, result, ctx| {
+            let (success_type, server_id) = match result {
+                Ok(server_id) => (OperationSuccessType::Success, Some(server_id)),
+                Err(err) => (OperationSuccessType::Denied(err.to_string()), None),
+            };
+
+            ctx.emit(UpdateManagerEvent::ObjectOperationComplete {
+                result: ObjectOperationResult {
+                    success_type,
+                    operation: ObjectOperation::Create {
+                        initiated_by: InitiatedBy::User,
+                    },
+                    client_id: Some(client_id),
+                    server_id,
+                    num_objects: None,
+                },
+            });
+        });
+    }
+
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub fn create_scheduled_ambient_agent_online(
         &mut self,
         scheduled_ambient_agent: ScheduledAmbientAgent,
@@ -3791,8 +3826,8 @@ impl UpdateManager {
                 Ok(CreateCloudObjectResult::UserFacingError(error)) => {
                     let _ = tx.send(Err(anyhow::anyhow!(error)));
                 }
-                Ok(CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict) => {
-                    let _ = tx.send(Err(anyhow::anyhow!("Unique key conflict")));
+                Ok(CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict(message)) => {
+                    let _ = tx.send(Err(anyhow::anyhow!(message)));
                 }
                 Err(err) => {
                     let _ = tx.send(Err(err));

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -44,6 +44,7 @@ use warp_core::context_flag::ContextFlag;
 use warp_core::telemetry::TelemetryEvent;
 use warp_errors::{AnyhowErrorExt, ErrorExt, register_error, report_error};
 use warp_managed_secrets::client::ManagedSecretsClient;
+use warp_server_client::HttpStatusError;
 use warp_server_client::auth::{AuthClientImpl, AuthEvent, EXPERIMENT_ID_HEADER};
 use warp_server_client::base_client::{
     AmbientHeaderPolicy, AuthenticatedGraphqlConfig, BaseClient, GraphqlRoutingConfig,
@@ -711,9 +712,14 @@ impl ServerApi {
         }
 
         // Try to deserialize error response as { "error": "message" }
+        let status_error = HttpStatusError {
+            status: status.as_u16(),
+            body: response_text.clone(),
+        };
         match serde_json::from_str::<ClientError>(&response_text) {
-            Ok(error_response) => error_response.into(),
-            Err(_) => anyhow!("API request failed with status {status}"),
+            Ok(error_response) => anyhow::Error::new(status_error).context(error_response),
+            Err(_) => anyhow::Error::new(status_error)
+                .context(format!("API request failed with status {status}")),
         }
     }
 

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -1023,6 +1023,12 @@ struct ListAgentsResponse {
 fn build_agent_url(uid: &str) -> String {
     format!("agent/identities/{}", urlencoding::encode(uid))
 }
+fn build_agent_by_name_url(name: &str) -> String {
+    format!(
+        "agent/identities/by-name?name={}",
+        urlencoding::encode(name)
+    )
+}
 
 #[derive(Clone, serde::Deserialize, Debug, PartialEq, Eq)]
 pub struct ConnectedSelfHostedWorker {
@@ -1343,6 +1349,8 @@ pub trait AIClient: 'static + Send + Sync {
     async fn get_agent(&self, uid: &str) -> anyhow::Result<AgentResponse, anyhow::Error>;
 
     async fn get_agent_raw(&self, uid: &str) -> anyhow::Result<serde_json::Value, anyhow::Error>;
+
+    async fn get_agent_by_name(&self, name: &str) -> anyhow::Result<AgentResponse, anyhow::Error>;
 
     async fn create_agent(
         &self,
@@ -2596,6 +2604,10 @@ impl AIClient for ServerApi {
 
     async fn get_agent_raw(&self, uid: &str) -> anyhow::Result<serde_json::Value, anyhow::Error> {
         self.get_public_api(&build_agent_url(uid)).await
+    }
+
+    async fn get_agent_by_name(&self, name: &str) -> anyhow::Result<AgentResponse, anyhow::Error> {
+        self.get_public_api(&build_agent_by_name_url(name)).await
     }
 
     async fn create_agent(

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -11,8 +11,8 @@ use super::{
     ConnectedSelfHostedWorker, ExecutionLocation, ForkConversationResponse,
     ListConnectedSelfHostedWorkersResponse, ListRunsResponse, PrepareAttachmentUploadsResponse,
     ReadAgentMessageResponse, RunFollowupRequest, RunSortBy, RunSortOrder, SpawnAgentRequest,
-    TaskListFilter, UploadFieldValue, UserQueryMode, build_fork_conversation_url,
-    build_list_agent_runs_url, build_run_followup_url,
+    TaskListFilter, UploadFieldValue, UserQueryMode, build_agent_by_name_url,
+    build_fork_conversation_url, build_list_agent_runs_url, build_run_followup_url,
 };
 use crate::notebooks::NotebookId;
 use crate::server::server_api::presigned_upload::upload_to_target;
@@ -38,6 +38,14 @@ fn ambient_agent_headers_for_task_overrides_existing_cloud_agent_header() {
             CLOUD_AGENT_ID_HEADER.to_string(),
             task_scoped_id.to_string()
         )]
+    );
+}
+
+#[test]
+fn agent_by_name_url_encodes_query_parameter() {
+    assert_eq!(
+        build_agent_by_name_url("deploy / test & review"),
+        "agent/identities/by-name?name=deploy%20%2F%20test%20%26%20review"
     );
 }
 

--- a/app/src/server/server_api/factory.rs
+++ b/app/src/server/server_api/factory.rs
@@ -53,6 +53,38 @@ pub trait FactoryClient: 'static + Send + Sync {
     async fn delete_runner(&self, uid: String) -> Result<String>;
 }
 
+/// True when a GraphQL error indicates the server doesn't recognize the
+/// `getRunner` query.
+fn is_missing_get_runner_query_error(err: &anyhow::Error) -> bool {
+    let message = err.to_string();
+    message.contains("getRunner") && message.contains("Cannot query field")
+}
+
+/// Resolves a runner via [`FactoryClient::get_runner`], with a fallback to a
+/// uid match against [`FactoryClient::get_runners`].
+pub async fn get_runner_with_fallback(
+    factory: &dyn FactoryClient,
+    selector: RunnerSelector,
+) -> Result<Runner> {
+    let uid = selector.uid.clone();
+    match factory.get_runner(selector).await {
+        Ok(runner) => Ok(runner),
+        Err(err) if is_missing_get_runner_query_error(&err) => {
+            let Some(uid) = uid else {
+                return Err(err);
+            };
+            let uid = uid.inner().to_string();
+            factory
+                .get_runners(None)
+                .await?
+                .into_iter()
+                .find(|runner| runner.uid.inner() == uid)
+                .ok_or_else(|| anyhow!("runner {uid} not found"))
+        }
+        Err(err) => Err(err),
+    }
+}
+
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl FactoryClient for ServerApi {
@@ -117,5 +149,25 @@ impl FactoryClient for ServerApi {
             }
             DeleteRunnerResult::Unknown => Err(anyhow!("failed to delete runner")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_missing_get_runner_query_error;
+
+    #[test]
+    fn detects_the_missing_get_runner_query_error() {
+        let err = anyhow::anyhow!(
+            "missing response data for get_runner: Cannot query field \"getRunner\" on type \"RootQuery\"."
+        );
+        assert!(is_missing_get_runner_query_error(&err));
+    }
+
+    #[test]
+    fn does_not_treat_other_errors_as_a_missing_query() {
+        assert!(!is_missing_get_runner_query_error(&anyhow::anyhow!(
+            "permission denied"
+        )));
     }
 }

--- a/app/src/server/server_api/factory.rs
+++ b/app/src/server/server_api/factory.rs
@@ -9,6 +9,9 @@ use warp_graphql::mutations::delete_runner::{
 use warp_graphql::mutations::upsert_runner::{
     UpsertRunner, UpsertRunnerInput, UpsertRunnerResult, UpsertRunnerVariables,
 };
+use warp_graphql::queries::get_runner::{
+    GetRunner, GetRunnerResult, GetRunnerVariables, RunnerSelector,
+};
 use warp_graphql::queries::get_runners::{
     GetRunners, GetRunnersResult, GetRunnersVariables, Runner, RunnerSortBy,
 };
@@ -34,6 +37,12 @@ pub trait FactoryClient: 'static + Send + Sync {
     /// Fetch all runners visible to the caller, optionally sorted.
     async fn get_runners(&self, sort_by: Option<RunnerSortBy>) -> Result<Vec<Runner>>;
 
+    /// Resolve a single runner by UID or name, without fetching every
+    /// accessible runner. `selector.uid` takes precedence; `selector.name` is
+    /// used as a fallback if no runner matches the uid.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    async fn get_runner(&self, selector: RunnerSelector) -> Result<Runner>;
+
     /// Create or update a runner. `input.uid` is `None` for a create and
     /// `Some(_)` for an update; this single method backs both CLI commands.
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
@@ -57,6 +66,19 @@ impl FactoryClient for ServerApi {
             GetRunnersResult::GetRunnersOutput(output) => Ok(output.runners),
             GetRunnersResult::UserFacingError(e) => Err(anyhow!(get_user_facing_error_message(e))),
             GetRunnersResult::Unknown => Err(anyhow!("failed to list runners")),
+        }
+    }
+
+    async fn get_runner(&self, selector: RunnerSelector) -> Result<Runner> {
+        let operation = GetRunner::build(GetRunnerVariables {
+            request_context: get_request_context(),
+            selector,
+        });
+        let response = self.send_graphql_request(operation, None).await?;
+        match response.get_runner {
+            GetRunnerResult::GetRunnerOutput(output) => Ok(output.runner),
+            GetRunnerResult::UserFacingError(e) => Err(anyhow!(get_user_facing_error_message(e))),
+            GetRunnerResult::Unknown => Err(anyhow!("failed to resolve runner")),
         }
     }
 

--- a/app/src/server/server_api/factory.rs
+++ b/app/src/server/server_api/factory.rs
@@ -55,6 +55,7 @@ pub trait FactoryClient: 'static + Send + Sync {
 
 /// True when a GraphQL error indicates the server doesn't recognize the
 /// `getRunner` query.
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 fn is_missing_get_runner_query_error(err: &anyhow::Error) -> bool {
     let message = err.to_string();
     message.contains("getRunner") && message.contains("Cannot query field")
@@ -62,6 +63,7 @@ fn is_missing_get_runner_query_error(err: &anyhow::Error) -> bool {
 
 /// Resolves a runner via [`FactoryClient::get_runner`], with a fallback to a
 /// uid match against [`FactoryClient::get_runners`].
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 pub async fn get_runner_with_fallback(
     factory: &dyn FactoryClient,
     selector: RunnerSelector,
@@ -149,25 +151,5 @@ impl FactoryClient for ServerApi {
             }
             DeleteRunnerResult::Unknown => Err(anyhow!("failed to delete runner")),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::is_missing_get_runner_query_error;
-
-    #[test]
-    fn detects_the_missing_get_runner_query_error() {
-        let err = anyhow::anyhow!(
-            "missing response data for get_runner: Cannot query field \"getRunner\" on type \"RootQuery\"."
-        );
-        assert!(is_missing_get_runner_query_error(&err));
-    }
-
-    #[test]
-    fn does_not_treat_other_errors_as_a_missing_query() {
-        assert!(!is_missing_get_runner_query_error(&anyhow::anyhow!(
-            "permission denied"
-        )));
     }
 }

--- a/app/src/server/server_api/factory.rs
+++ b/app/src/server/server_api/factory.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use cynic::{MutationBuilder, QueryBuilder};
 #[cfg(test)]
@@ -53,40 +53,6 @@ pub trait FactoryClient: 'static + Send + Sync {
     async fn delete_runner(&self, uid: String) -> Result<String>;
 }
 
-/// True when a GraphQL error indicates the server doesn't recognize the
-/// `getRunner` query.
-#[cfg_attr(target_family = "wasm", allow(dead_code))]
-fn is_missing_get_runner_query_error(err: &anyhow::Error) -> bool {
-    let message = err.to_string();
-    message.contains("getRunner") && message.contains("Cannot query field")
-}
-
-/// Resolves a runner via [`FactoryClient::get_runner`], with a fallback to a
-/// uid match against [`FactoryClient::get_runners`].
-#[cfg_attr(target_family = "wasm", allow(dead_code))]
-pub async fn get_runner_with_fallback(
-    factory: &dyn FactoryClient,
-    selector: RunnerSelector,
-) -> Result<Runner> {
-    let uid = selector.uid.clone();
-    match factory.get_runner(selector).await {
-        Ok(runner) => Ok(runner),
-        Err(err) if is_missing_get_runner_query_error(&err) => {
-            let Some(uid) = uid else {
-                return Err(err);
-            };
-            let uid = uid.inner().to_string();
-            factory
-                .get_runners(None)
-                .await?
-                .into_iter()
-                .find(|runner| runner.uid.inner() == uid)
-                .ok_or_else(|| anyhow!("runner {uid} not found"))
-        }
-        Err(err) => Err(err),
-    }
-}
-
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl FactoryClient for ServerApi {
@@ -108,11 +74,16 @@ impl FactoryClient for ServerApi {
             request_context: get_request_context(),
             selector,
         });
-        let response = self.send_graphql_request(operation, None).await?;
+        let response = self
+            .send_graphql_request(operation, None)
+            .await
+            .context("could not retrieve runner")?;
         match response.get_runner {
             GetRunnerResult::GetRunnerOutput(output) => Ok(output.runner),
             GetRunnerResult::UserFacingError(e) => Err(anyhow!(get_user_facing_error_message(e))),
-            GetRunnerResult::Unknown => Err(anyhow!("failed to resolve runner")),
+            GetRunnerResult::Unknown => Err(anyhow!(
+                "could not retrieve runner: unexpected response from the server"
+            )),
         }
     }
 

--- a/app/src/server/server_api/object.rs
+++ b/app/src/server/server_api/object.rs
@@ -384,8 +384,8 @@ impl ObjectClient for ServerApi {
                 })
             }
             CreateGenericStringObjectResult::UserFacingError(e) => Ok(match e.error {
-                UserFacingErrorInterface::GenericStringObjectUniqueKeyConflict(_) => {
-                    CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict
+                UserFacingErrorInterface::GenericStringObjectUniqueKeyConflict(error) => {
+                    CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict(error.message)
                 }
                 _ => CreateCloudObjectResult::UserFacingError(get_user_facing_error_message(e)),
             }),

--- a/app/src/server/sync_queue.rs
+++ b/app/src/server/sync_queue.rs
@@ -1373,7 +1373,7 @@ impl SyncQueue {
                                 ctx,
                             );
                         }
-                        CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict => {
+                        CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict(_) => {
                             log::warn!(
                                 "Failed to create {object_type:?} because of conflicting unique key"
                             );

--- a/app/src/server/sync_queue_tests.rs
+++ b/app/src/server/sync_queue_tests.rs
@@ -208,7 +208,11 @@ fn test_generic_string_object_unique_key_failure() {
             .expect_create_generic_string_object()
             .times(1)
             .return_once(move |_, _, _| {
-                Ok(CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict)
+                Ok(
+                    CreateCloudObjectResult::GenericStringObjectUniqueKeyConflict(
+                        "object already exists".to_string(),
+                    ),
+                )
             });
         cloud_objects_client_mock
             .expect_create_workflow()

--- a/crates/cloud_objects/src/cloud_object/creation.rs
+++ b/crates/cloud_objects/src/cloud_object/creation.rs
@@ -49,7 +49,7 @@ pub enum CreateCloudObjectResult {
     UserFacingError(String),
     /// The object creation was rejected because the generic string object had
     /// already been created by another client.
-    GenericStringObjectUniqueKeyConflict,
+    GenericStringObjectUniqueKeyConflict(String),
 }
 
 /// Result of attempting to bulk create a cloud object.

--- a/crates/graphql/src/api/queries/get_runner.rs
+++ b/crates/graphql/src/api/queries/get_runner.rs
@@ -1,0 +1,43 @@
+use crate::error::UserFacingError;
+use crate::queries::get_runners::Runner;
+use crate::request_context::RequestContext;
+use crate::response_context::ResponseContext;
+use crate::schema;
+
+#[derive(cynic::InputObject, Debug)]
+pub struct RunnerSelector {
+    pub uid: Option<cynic::Id>,
+    pub name: Option<String>,
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct GetRunnerVariables {
+    pub request_context: RequestContext,
+    pub selector: RunnerSelector,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct GetRunnerOutput {
+    pub runner: Runner,
+    pub response_context: ResponseContext,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum GetRunnerResult {
+    GetRunnerOutput(GetRunnerOutput),
+    UserFacingError(UserFacingError),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "RootQuery", variables = "GetRunnerVariables")]
+pub struct GetRunner {
+    #[arguments(requestContext: $request_context, selector: $selector)]
+    pub get_runner: GetRunnerResult,
+}
+
+crate::client::define_operation! {
+    get_runner(GetRunnerVariables) -> GetRunner;
+}

--- a/crates/graphql/src/api/queries/get_runner.rs
+++ b/crates/graphql/src/api/queries/get_runner.rs
@@ -4,7 +4,7 @@ use crate::request_context::RequestContext;
 use crate::response_context::ResponseContext;
 use crate::schema;
 
-#[derive(cynic::InputObject, Debug)]
+#[derive(cynic::InputObject, Debug, Clone)]
 pub struct RunnerSelector {
     pub uid: Option<cynic::Id>,
     pub name: Option<String>,

--- a/crates/graphql/src/api/queries/mod.rs
+++ b/crates/graphql/src/api/queries/mod.rs
@@ -16,6 +16,7 @@ pub mod get_oauth_connect_tx_status;
 pub mod get_referral_info;
 pub mod get_relevant_fragments;
 pub mod get_request_limit_info;
+pub mod get_runner;
 pub mod get_runners;
 pub mod get_scheduled_agent_history;
 pub mod get_simple_integrations;

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -384,8 +384,8 @@ pub struct RunAgentArgs {
     /// Maximum time to wait for requested MCP servers to start (e.g. `30s`, `1m`).
     #[arg(long = "mcp-startup-timeout", value_name = "DURATION")]
     pub mcp_startup_timeout: Option<humantime::Duration>,
-    /// Cloud environment to use, identified by ID.
-    #[arg(long = "environment", short = 'e', value_name = "ID")]
+    /// Cloud environment to use, identified by ID or name.
+    #[arg(long = "environment", short = 'e', value_name = "ID|NAME")]
     pub environment: Option<String>,
 
     /// Keep the agent's session open after the conversation completes.
@@ -574,8 +574,8 @@ pub struct RunCloudArgs {
     pub environment: EnvironmentCreateArgs,
 
     /// Runner to use for this agent's compute (docker image, instance size,
-    /// setup commands), identified by ID. Overrides the environment's default runner.
-    #[arg(long = "runner", value_name = "ID")]
+    /// setup commands), identified by ID or name. Overrides the environment's default runner.
+    #[arg(long = "runner", value_name = "ID|NAME")]
     pub runner: Option<String>,
 
     /// Open the agent's session in Warp once it's available.
@@ -589,12 +589,12 @@ pub struct RunCloudArgs {
     #[command(flatten)]
     pub scope: ObjectScope,
 
-    /// UID of the agent to execute this run as.
+    /// UID or name of the agent to execute this run as.
     ///
     /// This will apply the agent's configuration, such
     /// as its skills and base model, and attribute
     /// credit usage back to the agent.
-    #[arg(long = "agent", value_name = "UID")]
+    #[arg(long = "agent", value_name = "UID|NAME")]
     pub agent_uid: Option<String>,
 
     /// Where this job should be hosted. Setting "warp" runs it on Warp's infrastructure. Any other

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -697,8 +697,9 @@ pub struct AgentListArgs {
 /// Arguments for getting a named agent.
 #[derive(Debug, Clone, Args)]
 pub struct AgentGetArgs {
-    /// UID of the agent to get.
-    pub uid: String,
+    /// UID or name of the agent to get.
+    #[arg(value_name = "UID|NAME")]
+    pub identifier: String,
 
     /// JSON formatting configuration.
     #[command(flatten)]
@@ -744,8 +745,9 @@ pub struct AgentCreateArgs {
 /// Arguments for updating a named agent.
 #[derive(Debug, Clone, Args)]
 pub struct AgentUpdateArgs {
-    /// UID of the agent to update.
-    pub uid: String,
+    /// UID or name of the agent to update.
+    #[arg(value_name = "UID|NAME")]
+    pub identifier: String,
 
     /// New name for the agent.
     #[arg(long = "name", short = 'n')]
@@ -846,8 +848,9 @@ pub struct AgentUpdateArgs {
 /// Arguments for deleting a named agent.
 #[derive(Debug, Clone, Args)]
 pub struct AgentDeleteArgs {
-    /// UID of the agent to delete.
-    pub uid: String,
+    /// UID or name of the agent to delete.
+    #[arg(value_name = "UID|NAME")]
+    pub identifier: String,
 }
 
 /// Arguments for listing available agent skills.

--- a/crates/warp_cli/src/environment.rs
+++ b/crates/warp_cli/src/environment.rs
@@ -52,22 +52,25 @@ pub enum EnvironmentCommand {
     },
     /// Delete a cloud environment.
     Delete {
-        /// ID of the environment to delete
-        id: String,
+        /// ID or name of the environment to delete
+        #[arg(value_name = "ID|NAME")]
+        identifier: String,
         /// Force delete without checking for integration usage
         #[arg(long, default_value_t = false)]
         force: bool,
     },
     /// Get details of a cloud environment.
     Get {
-        /// ID of the environment to get
-        id: String,
+        /// ID or name of the environment to get
+        #[arg(value_name = "ID|NAME")]
+        identifier: String,
     },
     /// Update an existing cloud environment.
     Update {
-        /// ID of the environment to update
-        id: String,
-        /// Name of the environment (optional, updates if present)
+        /// ID or name of the environment to update
+        #[arg(value_name = "ID|NAME")]
+        identifier: String,
+        /// New name for the environment (optional, renames if present)
         #[arg(long = "name", short = 'n')]
         name: Option<String>,
         /// Description of the environment (max 240 characters)

--- a/crates/warp_cli/src/environment.rs
+++ b/crates/warp_cli/src/environment.rs
@@ -122,7 +122,7 @@ impl EnvironmentCommand {
 #[group(required = false, multiple = false)]
 pub struct EnvironmentCreateArgs {
     /// Cloud environment to run the agent in.
-    #[arg(long = "environment", value_name = "ENVIRONMENT_ID", short = 'e')]
+    #[arg(long = "environment", value_name = "ID|NAME", short = 'e')]
     pub environment: Option<String>,
 
     /// Do not run the agent in an environment (not recommended).
@@ -135,7 +135,7 @@ pub struct EnvironmentCreateArgs {
 #[group(required = false, multiple = false)]
 pub struct EnvironmentUpdateArgs {
     /// Cloud environment to run the agent in.
-    #[arg(long = "environment", value_name = "ENVIRONMENT_ID", short = 'e')]
+    #[arg(long = "environment", value_name = "ID|NAME", short = 'e')]
     pub environment: Option<String>,
 
     /// Do not run the agent in an environment (not recommended).

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -2076,7 +2076,7 @@ fn environment_update_accepts_description() {
         panic!("Expected `warp environment update` command");
     };
     let CliCommand::Environment(EnvironmentCommand::Update {
-        id,
+        identifier,
         description,
         remove_description,
         ..
@@ -2085,7 +2085,7 @@ fn environment_update_accepts_description() {
         panic!("Expected `warp environment update` command");
     };
 
-    assert_eq!(id, "env-id");
+    assert_eq!(identifier, "env-id");
     assert_eq!(description.as_deref(), Some("Updated description"));
     assert!(!remove_description);
 }
@@ -2105,7 +2105,7 @@ fn environment_update_accepts_remove_description() {
         panic!("Expected `warp environment update` command");
     };
     let CliCommand::Environment(EnvironmentCommand::Update {
-        id,
+        identifier,
         description,
         remove_description,
         ..
@@ -2114,7 +2114,7 @@ fn environment_update_accepts_remove_description() {
         panic!("Expected `warp environment update` command");
     };
 
-    assert_eq!(id, "env-id");
+    assert_eq!(identifier, "env-id");
     assert!(description.is_none());
     assert!(remove_description);
 }

--- a/crates/warp_cli/src/runner.rs
+++ b/crates/warp_cli/src/runner.rs
@@ -139,17 +139,20 @@ pub struct CreateRunnerArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-// At least one of UID or --name is required. They are NOT mutually exclusive:
-// when a UID is given, --name sets the runner's new name (rename); when no UID
-// is given, --name is required and identifies the runner to update.
-#[command(group(ArgGroup::new("runner_identifier").required(true).multiple(true).args(["id", "name"])))]
+// At least one of the positional identifier or --name is required. They are NOT
+// mutually exclusive: when an identifier is given, --name sets the runner's new
+// name (rename); when no identifier is given, --name is required and identifies
+// the runner to update.
+#[command(group(ArgGroup::new("runner_identifier").required(true).multiple(true).args(["identifier", "name"])))]
 pub struct UpdateRunnerArgs {
-    /// UID of the runner to update.
-    #[arg(value_name = "UID")]
-    pub id: Option<String>,
+    /// UID or name of the runner to update.
+    #[arg(value_name = "UID|NAME")]
+    pub identifier: Option<String>,
 
-    /// New name for the runner when a UID is given (renames it). When no UID is
-    /// given, this is required and used to locate the runner to update.
+    /// New name for the runner when a positional identifier is also given (renames it).
+    /// If the positional identifier is omitted, this flag is required and is used
+    /// instead to locate the runner by its current name (the name itself is left
+    /// unchanged in that case).
     #[arg(long = "name", short = 'n')]
     pub name: Option<String>,
 
@@ -188,9 +191,9 @@ pub struct UpdateRunnerArgs {
 
 #[derive(Debug, Clone, Args)]
 pub struct DeleteRunnerArgs {
-    /// UID of the runner to delete.
-    #[arg(value_name = "UID")]
-    pub id: String,
+    /// UID or name of the runner to delete.
+    #[arg(value_name = "UID|NAME")]
+    pub identifier: String,
 
     /// Delete without asking for confirmation.
     #[arg(long, default_value_t = false)]

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -3054,6 +3054,22 @@ type GetRunnersOutput implements Response {
 
 union GetRunnersResult = GetRunnersOutput | UserFacingError
 
+"""
+Selects a single runner by UID or by name. Trying lookup as uid takes
+precedence and name is used as a fallback if no runner matches the uid.
+"""
+input RunnerSelector {
+  uid: ID
+  name: String
+}
+
+type GetRunnerOutput implements Response {
+  runner: Runner!
+  responseContext: ResponseContext!
+}
+
+union GetRunnerResult = GetRunnerOutput | UserFacingError
+
 input RunnerInstanceShapeInput {
   vcpus: Int!
   memoryGb: Int!
@@ -3224,6 +3240,11 @@ type RootQuery {
   getIntegrationsUsingEnvironment(input: GetIntegrationsUsingEnvironmentInput!, requestContext: RequestContext!): GetIntegrationsUsingEnvironmentResult!
   getOAuthConnectTxStatus(input: GetOAuthConnectTxStatusInput!, requestContext: RequestContext!): GetOAuthConnectTxStatusResult!
   getRelevantFragments(input: GetRelevantFragmentsInput!, requestContext: RequestContext!): GetRelevantFragmentsResult!
+
+  """
+  Resolve a single runner accessible to the principal by UID or name.
+  """
+  getRunner(requestContext: RequestContext!, selector: RunnerSelector!): GetRunnerResult!
 
   """
   Get runners accessible to the principal.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR updates the environment, runner, and agent CLI subcommands to accept either an ID or a name for their positional identifier, instead of requiring the raw ID. 

First, the uid/id CLI args were renamed to identifier, with value_name placeholders and doc comments updated to communicate that either form is accepted.

Regarding name resolution logic, each object type now resolves its identifier argument through the same general pattern: try it as an ID first, and if that does not resolve, fall back to matching it against the object's name.
•  Environments: identifier is parsed as a server ID and looked up directly; if that fails, it's matched by name against the full list of environments through a local scan on the on the CloudAmbientAgentEnvironment objects
•  Runners: identifier is matched against runner UIDs first, then against runner names (for lookup), and resolved to the underlying UID before the runner is acted on.
•  Agents: identifier is inspected for ID shape to decide whether to call the by-ID or by-name lookup endpoint, with a fallback to lookup with the by-name backend endpoint if the by-ID call 404s.

Across all three, name-based lookups return an explicit error when no object matches or when more than one object shares the same name.

Server-side enforcement of name uniqueness and creation of the by-name endpoint on the server (and associated resolution logic) is out of scope for this PR.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).
- [ ] 

https://linear.app/warpdotdev/issue/REMOTE-2008/enforce-name-uniqueness-and-allow-using-name-instead-of-id

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

•  cargo test -p warp_cli: 223/223 passed
•  cargo test -p warp --lib agent_management: 44/44 passed
•  cargo fmt --check (both crates): clean
•  cargo clippy -D warnings (both crates): clean, zero warnings
•  cargo check (both crates): compiled with no errors


Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`


<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
