### PR TITLE
Prevent zsh correction prompts from blocking agent commands

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -976,14 +976,9 @@ fn decorate_requested_command_for_shell(
         // can block agent-driven commands. Prefixing the full command line with `nocorrect`
         // suppresses correction for this execution while preserving the user's shell state.
         //
-        // `nocorrect` cannot directly precede a parenthesized subshell, so for the pager-wrapped
-        // form we first run a no-op `:` command to flip the parser's nocorrect state and then run
-        // the real pipeline unchanged.
-        if disables_pager {
-            format!("nocorrect :; {command}")
-        } else {
-            format!("nocorrect {command}")
-        }
+        // Run a no-op `:` command after `nocorrect` so the parser's nocorrect state is set
+        // before arbitrary command syntax (simple commands, lists, subshells, loops, etc.).
+        format!("nocorrect :; {command}")
     } else {
         command
     }

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -188,23 +188,6 @@ impl ShellCommandExecutor {
         }
     }
 
-    /// Decorate the command so that we can turn off pager.
-    fn turn_off_pager_for_command(&self, command: &String, ctx: &mut ModelContext<Self>) -> String {
-        match self.active_session.as_ref(ctx).shell_type(ctx) {
-            // If it's a posix shell, we can use parentheses as the grouping character. Add command to
-            // avoid cases with aliases.
-            Some(ShellType::Zsh) | Some(ShellType::Bash) => format!("({command}) | command cat"),
-            // Fish doesn't have grouping characters. We need to use begin; and end; to ensure the command
-            // gets evaluated first.
-            Some(ShellType::Fish) => format!("begin; {command} ;end | command cat"),
-            // For powershell, we use Out-Host to send paged output to the
-            // console. Add a backslash to avoid executing an alias.
-            Some(ShellType::PowerShell) => format!("({command}) | \\Out-Host"),
-            // If we can't determine a shell type, run command as it is.
-            None => command.clone(),
-        }
-    }
-
     pub(super) fn execute(
         &mut self,
         input: ExecuteActionInput,
@@ -250,15 +233,13 @@ impl ShellCommandExecutor {
                         RequestCommandOutputResult::CancelledBeforeExecution,
                     ));
                 }
-                // If the command might use pager and can't be interacted with,
-                // we pipe its output to cat so we can prevent activating the altscreen.
-                // The parentheses here ensures the command always gets evaluated first.
-                let decorated_command =
-                    if uses_pager.is_some_and(|uses_pager| uses_pager) && *wait_until_completion {
-                        self.turn_off_pager_for_command(command, ctx)
-                    } else {
-                        command.clone()
-                    };
+                let shell_type = self.active_session.as_ref(ctx).shell_type(ctx);
+                let decorated_command = decorate_requested_command_for_shell(
+                    shell_type,
+                    command,
+                    uses_pager.is_some_and(|uses_pager| uses_pager),
+                    *wait_until_completion,
+                );
                 // Let the recording controller decide whether this command's
                 // on-screen work should be kept in an active computer-use
                 // recording, opening an action group before it starts if so.
@@ -975,6 +956,54 @@ enum ActionResult {
     },
     Cancelled,
     BlockNotFound,
+}
+
+fn decorate_requested_command_for_shell(
+    shell_type: Option<ShellType>,
+    command: &str,
+    uses_pager: bool,
+    wait_until_completion: bool,
+) -> String {
+    let disables_pager = uses_pager && wait_until_completion;
+    let command = if disables_pager {
+        turn_off_pager_for_command(shell_type, command)
+    } else {
+        command.to_owned()
+    };
+
+    if matches!(shell_type, Some(ShellType::Zsh)) {
+        // Zsh spelling correction prompts (for example, `correct 'zef' to 'zed' [nyae]?`)
+        // can block agent-driven commands. Prefixing the full command line with `nocorrect`
+        // suppresses correction for this execution while preserving the user's shell state.
+        //
+        // `nocorrect` cannot directly precede a parenthesized subshell, so for the pager-wrapped
+        // form we first run a no-op `:` command to flip the parser's nocorrect state and then run
+        // the real pipeline unchanged.
+        if disables_pager {
+            format!("nocorrect :; {command}")
+        } else {
+            format!("nocorrect {command}")
+        }
+    } else {
+        command
+    }
+}
+
+/// Decorate the command so that we can turn off pager.
+fn turn_off_pager_for_command(shell_type: Option<ShellType>, command: &str) -> String {
+    match shell_type {
+        // If it's a posix shell, we can use parentheses as the grouping character. Add command to
+        // avoid cases with aliases.
+        Some(ShellType::Zsh) | Some(ShellType::Bash) => format!("({command}) | command cat"),
+        // Fish doesn't have grouping characters. We need to use begin; and end; to ensure the command
+        // gets evaluated first.
+        Some(ShellType::Fish) => format!("begin; {command} ;end | command cat"),
+        // For powershell, we use Out-Host to send paged output to the
+        // console. Add a backslash to avoid executing an alias.
+        Some(ShellType::PowerShell) => format!("({command}) | \\Out-Host"),
+        // If we can't determine a shell type, run command as it is.
+        None => command.to_owned(),
+    }
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -5,13 +5,14 @@ use futures::channel::oneshot;
 use parking_lot::FairMutex;
 use warpui::{App, EntityId};
 
-use super::{BlockSelector, ShellCommandExecutor};
+use super::{decorate_requested_command_for_shell, BlockSelector, ShellCommandExecutor};
 use crate::terminal::event::{BlockMetadataReceivedEvent, BlockWorkingDirectoryUpdatedEvent};
 use crate::terminal::model::block::{BlockId, BlockMetadata};
 use crate::terminal::model::session::Sessions;
 use crate::terminal::model::session::active_session::ActiveSession;
 use crate::terminal::model::terminal_model::{BlockIndex, TerminalModel};
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
+use crate::terminal::shell::ShellType;
 
 /// Locks in the contract that `ShellCommandExecutor`'s requested-command finish
 /// detector reacts only to `BlockMetadataReceived` (precmd) and not to
@@ -88,4 +89,46 @@ fn block_working_directory_updated_does_not_drain_finish_senders() {
             "BlockMetadataReceived should drain the finish senders"
         );
     });
+}
+
+#[test]
+fn decorate_requested_command_for_shell_prefixes_zsh_commands_with_nocorrect() {
+    assert_eq!(
+        decorate_requested_command_for_shell(Some(ShellType::Zsh), "zef file.md", false, true),
+        "nocorrect zef file.md"
+    );
+}
+
+#[test]
+fn decorate_requested_command_for_shell_prefixes_pager_wrapped_zsh_commands_with_nocorrect() {
+    assert_eq!(
+        decorate_requested_command_for_shell(
+            Some(ShellType::Zsh),
+            "git --no-pager diff",
+            true,
+            true,
+        ),
+        "nocorrect :; (git --no-pager diff) | command cat"
+    );
+}
+
+#[test]
+fn decorate_requested_command_for_shell_leaves_bash_commands_unchanged_without_pager() {
+    assert_eq!(
+        decorate_requested_command_for_shell(Some(ShellType::Bash), "zef file.md", false, true),
+        "zef file.md"
+    );
+}
+
+#[test]
+fn decorate_requested_command_for_shell_only_wraps_bash_pager_commands() {
+    assert_eq!(
+        decorate_requested_command_for_shell(
+            Some(ShellType::Bash),
+            "git --no-pager diff",
+            true,
+            true,
+        ),
+        "(git --no-pager diff) | command cat"
+    );
 }

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -95,7 +95,7 @@ fn block_working_directory_updated_does_not_drain_finish_senders() {
 fn decorate_requested_command_for_shell_prefixes_zsh_commands_with_nocorrect() {
     assert_eq!(
         decorate_requested_command_for_shell(Some(ShellType::Zsh), "zef file.md", false, true),
-        "nocorrect zef file.md"
+        "nocorrect :; zef file.md"
     );
 }
 


### PR DESCRIPTION
Use zsh-specific command decoration for agent-requested commands while preserving pager handling and existing execution guards.

## Description
Fixes an Agent Mode regression in interactive zsh sessions with correction enabled.

When the agent runs a mistyped command (for example zef README.md), zsh can prompt:

```
zsh: correct 'zef' to 'zed' [nyae]?
```

That prompt blocks autonomous agent execution. This PR suppresses zsh correction only for agent-requested commands by decorating those commands with nocorrect, while preserving existing command execution behavior and pager handling.

## Linked Issue
Closes https://github.com/warpdotdev/warp/issues/13613

## Testing
Manually tested with `./script/run`.
Reproduced baseline behavior in stable build:
```
zsh: correct 'zef' to 'zed' [nyae]?
```
appears and can block flow

Verified fixed behavior in local build:
◦  agent-requested mistyped command does not block on correction prompt
◦  command fails normally (e.g. command not found)
Verified manual user-typed commands still keep normal zsh correction behavior

Also auto-tests are updated.

### Screenshots / Videos
How it works currently in production build:
<img width="998" height="400" alt="production_build" src="https://github.com/user-attachments/assets/2c0736c9-1c06-4f42-a035-50c57b6ddb0f" />

And how it works after fix in this PR:
<img width="1015" height="475" alt="local_build_with_fix" src="https://github.com/user-attachments/assets/c892dd3e-68d6-488c-a656-2453db8dcc99" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--

## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
