### PR TITLE
fix(macOS): stop declaring Warp as a Markdown document handler

### DIFF
--- a/script/update_plist
+++ b/script/update_plist
@@ -81,18 +81,6 @@ if [[ -z "$WARP_PLIST_NO_FILE_TYPES" ]]; then
       </array>
     </dict>
     <dict>
-      <key>CFBundleTypeName</key><string>Markdown File</string>
-      <key>CFBundleTypeRole</key><string>Editor</string>
-      <key>LSHandlerRank</key><string>Alternate</string>
-      <key>LSItemContentTypes</key>
-      <array>
-        <string>net.daringfireball.markdown</string>
-        <string>com.unknown.md</string>
-        <string>net.ia.markdown</string>
-        <string>public.markdown</string>
-      </array>
-    </dict>
-    <dict>
       <key>CFBundleTypeName</key><string>Plain Text File</string>
       <key>CFBundleTypeRole</key><string>Editor</string>
       <key>LSHandlerRank</key><string>Alternate</string>
@@ -252,10 +240,14 @@ if [[ -z "$WARP_PLIST_NO_FILE_TYPES" ]]; then
   </array>" "$WARP_PLIST_PATH"
 fi
 
-# Unfortunately, there isn't a single standard UTI (what goes in LSItemContentTypes) for Markdown
-# files. Instead, we list all the common ones - see these for more info:
-# https://github.com/sbarex/QLMarkdown#installation
-# https://blog.smittytone.net/2021/01/19/how-tools-try-to-own-markdown/
+# Markdown is deliberately NOT declared above. There is no single standard UTI for it, so declaring
+# it means claiming all the common ones (net.daringfireball.markdown, net.ia.markdown,
+# public.markdown). Most editors register Markdown only by file extension, and Launch Services
+# prefers a UTI-level handler over an extension-only one - so declaring these makes Warp win the
+# default-app resolution for .md even at LSHandlerRank Alternate, and win it back on every update
+# that re-registers the bundle. See #13268; #13121 demoted the entry to Alternate, which was not
+# enough for exactly that reason. Users who want Warp to open .md can still choose it explicitly via
+# Finder's "Open With".
 
 echo "Updating plist with permissions descriptions"
 plutil -insert NSAppleEventsUsageDescription -string "A program in Warp wants to use AppleScript." "$WARP_PLIST_PATH"


### PR DESCRIPTION
## Description

`script/update_plist` declares a `Markdown File` document type in the generated `Info.plist`, registering Warp as an **Editor** for `net.daringfireball.markdown`, `com.unknown.md`, `net.ia.markdown` and `public.markdown`. This PR removes that declaration.

`.md` resolves to the UTI `net.daringfireball.markdown`. Most editors register Markdown by file **extension** rather than by that UTI, and Launch Services prefers a UTI-level handler over an extension-only one — so Warp wins the default-app resolution for `.md`, and wins it back on every auto-update that re-registers the bundle. The claim is made at the OS level, so turning off the in-app Markdown viewer (`prefer_markdown_viewer = false`) does not prevent it.

`com.unknown.md` is removed with the rest; it is not a real UTI.

#### Why #13121 was not enough

#13121 demoted this entry to `LSHandlerRank = Alternate`. That is the right fix where competing editors register the **same UTI** — `Alternate` then loses to their `Owner`/`Default` rank. It does not help for `.md`, because the competition is not rank-versus-rank at the same level: it is a UTI-level claim (Warp) against extension-only registrations (most editors). Launch Services resolves the UTI-level handler first, so `Alternate` still wins.

@AaronReboot laid this out in #13268 after testing #13121, and @alokedesai accepted it and marked the issue `ready-to-implement` on 2026-07-13.

#### Expected trade-off

After this change Warp no longer advertises itself as a Markdown handler, so it stops competing to be the default for `.md`. It does still appear in Finder's "Open With" list, because the bundle continues to declare `public.plain-text` (which `net.daringfireball.markdown` conforms to) and `public.data`, and Launch Services folds conformance into the handler list — so users who want to open a `.md` file in Warp can still pick it there. Warp's own in-app Markdown viewing is unaffected; that path never went through Launch Services.

#### Scope

One file, declaration-only. No Rust changes, no behavior changes inside the app.

*Prior attempts on this issue: #13266 (closed) and #13796 (closed after review). #13796's reviews found no correctness issues in the diff; it was closed for missing visual evidence, which this PR supplies below.*

## Linked Issue

Fixes #13268

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

This is a packaging-script change, so the meaningful test is what the generated bundle declares and how macOS then ranks it. I built this branch's base and tip as two `WarpOss.app` bundles, registered them one at a time with `lsregister`, and ran the same `LSCopyAllRoleHandlersForContentType("net.daringfireball.markdown")` query against each — recording and stills below.

I also fed both versions of the document-type XML through the same `plutil -insert` the script itself uses, into an empty plist, and diffed the result: 8 document types / 4 Markdown UTIs on `master`, 7 / 0 here. `plutil -lint` passes on both, and `bash -n script/update_plist` passes.

No Rust changed, so there is no in-app behavior to add automated tests for.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Both halves are reproducible by any reviewer on macOS; nothing here depends on my machine's configuration.

**1. The declaration, before and after.** The generated document-type array, applied to an empty plist with the same `plutil -insert` the script uses:

| | document types declared | Markdown UTIs declared |
|---|---|---|
| `master` (`eb56df113`) | 8 | `net.daringfireball.markdown`, `com.unknown.md`, `net.ia.markdown`, `public.markdown` |
| this PR | 7 | none |

**2. What actually changes for `.md` resolution.** `LSCopyAllRoleHandlersForContentType` returns handlers in preference order. Same machine, same bundle id, only the build swapped:

| build | Warp's rank for `net.daringfireball.markdown` |
|---|---|
| `master` (`eb56df113`) | **7 of 19** — ahead of TextEdit, behind VS Code |
| this PR | **19 of 19** — last |

Recorded end to end — the two builds registered one at a time with `lsregister`, the same query run against each:

![before/after: Warp's Launch Services rank for net.daringfireball.markdown goes from 7 of 19 to 19 of 19](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-13268/pr-assets/before-after.gif)

<details>
<summary>The same two moments as stills</summary>

**BEFORE — `master` `eb56df113`**: the bundle declares the four Markdown UTIs, and Warp ranks 7 of 19.

![before](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-13268/pr-assets/before.png)

**AFTER — this PR**: zero Markdown document types left in the bundle, and Warp ranks 19 of 19.

![after](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-13268/pr-assets/after.png)

</details>

Note the last line of both runs — `default: tech.ankey.Markout`, this machine's chosen Markdown editor — it is identical before and after, so the whole comparison was made without altering any file association.

(The recording shows `10b4cb71d`, the tip at recording time. The branch was then rebased onto current `master`; the diff is unchanged, and `script/update_plist` had no upstream commits in between.)

That is the behaviour the issue is about: declaring the UTI puts Warp into the contest for the default; without the declaration it only trails in via `public.plain-text` conformance and stops competing.

The other three UTIs removed here (`public.markdown`, `net.ia.markdown`, `com.unknown.md`) have **no handlers at all** on that machine, before or after — consistent with `com.unknown.md` not being a real UTI, and with removing them being inert.

**3. The asymmetry this fixes, on a real machine.** From `lsregister -dump` on macOS (stock install of both apps):

| bundle | declares `net.daringfireball.markdown`? |
|---|---|
| `/Applications/Warp.app` (`dev.warp.Warp-Stable`) | **yes** |
| `/Applications/Visual Studio Code.app` (`com.microsoft.VSCode`) | no |

The same dump also lists **15 additional registered copies** of Warp under `~/Library/Application Support/dev.warp.Warp-Stable/autoupdate/…`, every one of them carrying the Markdown declaration — which is the mechanism behind the "reclaims the association after updates" half of the report.

(For precision: VS Code still appears in `LSCopyAllRoleHandlersForContentType("net.daringfireball.markdown")`, because Launch Services folds extension registrations into the UTI's handler list. The difference is in what each bundle *declares*, which is what determines how the handler is ranked.)

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Warp no longer registers itself as a handler for Markdown files on macOS, so it no longer takes over the default app for `.md`.
-->
