### PR TITLE
Show switch-to-tab shortcut hints while their modifier is held

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -312,6 +312,7 @@ use crate::settings_view::DisplayCount;
 use crate::settings_view::keybindings::KeybindingChangedNotifier;
 use crate::suggestions::ignored_suggestions_model::IgnoredSuggestionsModel;
 use crate::system::SystemStats;
+use crate::tab::TabShortcutModifierState;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::keys::TerminalKeybindings;
 use crate::terminal::resizable_data::ResizableData;
@@ -2115,6 +2116,7 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(|_| SystemStats::new());
     workspace::auto_handoff::init(ctx);
     ctx.add_singleton_model(|_| KeybindingChangedNotifier::new());
+    ctx.add_singleton_model(|_| TabShortcutModifierState::new());
     ctx.add_singleton_model(|_| search::command_palette::SelectedItems::new());
     ctx.add_singleton_model(search::files::model::FileSearchModel::new);
     ctx.add_singleton_model(|_| VimRegisters::new());

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,6 +10,7 @@ use warp_core::context_flag::ContextFlag;
 use warp_core::ui::builder::UiBuilder;
 use warp_core::ui::theme::AnsiColors;
 use warp_core::ui::theme::color::internal_colors;
+use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::elements::{
     Align, Border, ChildAnchor, Clipped, ConstrainedBox, Container, CornerRadius,
     CrossAxisAlignment, DragAxis, Draggable, DraggableState, DropTarget, Element, Empty, Fill,
@@ -25,7 +25,7 @@ use warpui::platform::keyboard::KeyCode;
 use warpui::text_layout::ClipConfig;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::ui_components::text_input::TextInput;
-use warpui::{AppContext, Entity, SingletonEntity, ViewHandle};
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity, ViewHandle};
 
 use crate::BlocklistAIHistoryModel;
 use crate::ai::agent::conversation::ConversationStatus;
@@ -62,6 +62,7 @@ use crate::workspace::{
 
 pub const TAB_BAR_BORDER_HEIGHT: f32 = 1.0;
 pub(crate) const TAB_INDICATOR_HEIGHT: f32 = 14.0;
+const TAB_SHORTCUT_HINT_REVEAL_DELAY: Duration = Duration::from_millis(750);
 
 /// Binding names for switching to tabs 1–8 (tab index 0–7), used to surface the
 /// effective keystroke (including user overrides) on each tab.
@@ -122,12 +123,11 @@ pub(crate) fn reveals_shortcut_hints(
     held.intersection(binding_kinds).next().is_some()
 }
 
-/// Tracks which physical modifier keys are currently held, so tab surfaces can
-/// temporarily show switch-to-tab shortcut hints while a relevant modifier is
-/// down.
 #[derive(Default)]
 pub struct TabShortcutModifierState {
-    held_keys: RefCell<HashSet<KeyCode>>,
+    held_keys: HashSet<KeyCode>,
+    revealed_keys: HashSet<KeyCode>,
+    reveal_tasks: HashMap<KeyCode, SpawnedFutureHandle>,
 }
 
 impl TabShortcutModifierState {
@@ -135,30 +135,51 @@ impl TabShortcutModifierState {
         Default::default()
     }
 
-    /// Returns whether the held-key set changed.
-    pub fn set_key_held(&self, key_code: KeyCode, pressed: bool) -> bool {
-        let mut held_keys = self.held_keys.borrow_mut();
+    pub fn set_key_held(&mut self, key_code: KeyCode, pressed: bool, ctx: &mut ModelContext<Self>) {
         if pressed {
-            held_keys.insert(key_code)
+            if !self.held_keys.insert(key_code) {
+                return;
+            }
+
+            let task = ctx.spawn_abortable(
+                Timer::after(TAB_SHORTCUT_HINT_REVEAL_DELAY),
+                move |state, _, ctx| {
+                    state.reveal_tasks.remove(&key_code);
+                    if state.reveal_key_if_held(key_code) {
+                        ctx.notify();
+                    }
+                },
+                |_, _| {},
+            );
+            self.reveal_tasks.insert(key_code, task);
         } else {
-            held_keys.remove(&key_code)
+            self.held_keys.remove(&key_code);
+            if let Some(task) = self.reveal_tasks.remove(&key_code) {
+                task.abort();
+            }
+            if self.revealed_keys.remove(&key_code) {
+                ctx.notify();
+            }
         }
     }
 
-    /// Clears all held keys and returns whether the held-key set changed.
-    pub fn clear_held_keys(&self) -> bool {
-        let mut held_keys = self.held_keys.borrow_mut();
-        if held_keys.is_empty() {
-            false
-        } else {
-            held_keys.clear();
-            true
+    fn reveal_key_if_held(&mut self, key_code: KeyCode) -> bool {
+        self.held_keys.contains(&key_code) && self.revealed_keys.insert(key_code)
+    }
+
+    /// Clears all held keys and returns whether shortcut-hint visibility changed.
+    pub fn clear_held_keys(&mut self) -> bool {
+        for (_, task) in self.reveal_tasks.drain() {
+            task.abort();
         }
+        self.held_keys.clear();
+        let changed = !self.revealed_keys.is_empty();
+        self.revealed_keys.clear();
+        changed
     }
 
     fn held_kinds(&self) -> HashSet<ShortcutModifierKind> {
-        self.held_keys
-            .borrow()
+        self.revealed_keys
             .iter()
             .filter_map(|key| shortcut_modifier_kind(*key))
             .collect()

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -145,6 +145,17 @@ impl TabShortcutModifierState {
         }
     }
 
+    /// Clears all held keys and returns whether the held-key set changed.
+    pub fn clear_held_keys(&self) -> bool {
+        let mut held_keys = self.held_keys.borrow_mut();
+        if held_keys.is_empty() {
+            false
+        } else {
+            held_keys.clear();
+            true
+        }
+    }
+
     fn held_kinds(&self) -> HashSet<ShortcutModifierKind> {
         self.held_keys
             .borrow()
@@ -1722,7 +1733,7 @@ impl<'a> TabComponent<'a> {
         )
         .with_color(theme.sub_text_color(theme.background()).into())
         .finish();
-        Some(Container::new(text).with_margin_right(4.).finish())
+        Some(Container::new(text).with_margin_left(4.).finish())
     }
 
     fn render_tab_container(&self, is_hovered: bool) -> Box<dyn Element> {
@@ -1825,9 +1836,6 @@ impl<'a> TabComponent<'a> {
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_main_axis_alignment(MainAxisAlignment::Center)
                 .with_cross_axis_alignment(warpui::elements::CrossAxisAlignment::Center);
-            if let Some(hint) = self.render_shortcut_hint() {
-                flex_row.add_child(hint);
-            }
             if let Some(indicator) = self.render_indicator() {
                 flex_row.add_child(indicator);
             }
@@ -1839,6 +1847,9 @@ impl<'a> TabComponent<'a> {
                 )
                 .finish(),
             );
+            if let Some(hint) = self.render_shortcut_hint() {
+                flex_row.add_child(hint);
+            }
             // Equal padding on both sides so the title stays centered; the pin
             // vanishes before it can reach the title.
             let horizontal_padding = if reserve_pin_space {

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,10 +20,12 @@ use warpui::elements::{
     SizeConstraintSwitch, Stack, Text,
 };
 use warpui::fonts::Weight;
+use warpui::keymap::Keystroke;
+use warpui::platform::keyboard::KeyCode;
 use warpui::text_layout::ClipConfig;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::ui_components::text_input::TextInput;
-use warpui::{AppContext, SingletonEntity, ViewHandle};
+use warpui::{AppContext, Entity, SingletonEntity, ViewHandle};
 
 use crate::BlocklistAIHistoryModel;
 use crate::ai::agent::conversation::ConversationStatus;
@@ -44,6 +47,7 @@ use crate::themes::theme::{AnsiColorIdentifier, Fill as ThemeFill, VerticalGradi
 use crate::ui_components::buttons::icon_button;
 use crate::ui_components::color_dot::{TAB_COLOR_OPTIONS, render_color_dot};
 use crate::ui_components::icons::{ICON_DIMENSIONS, Icon};
+use crate::util::bindings::{keybinding_name_to_display_string, keybinding_name_to_keystroke};
 use crate::util::color::{Opacity, coloru_with_opacity};
 use crate::util::truncation::truncate_from_end;
 use crate::window_settings::WindowSettings;
@@ -58,6 +62,119 @@ use crate::workspace::{
 
 pub const TAB_BAR_BORDER_HEIGHT: f32 = 1.0;
 pub(crate) const TAB_INDICATOR_HEIGHT: f32 = 14.0;
+
+/// Binding names for switching to tabs 1–8 (tab index 0–7), used to surface the
+/// effective keystroke (including user overrides) on each tab.
+pub(crate) const TAB_ACTIVATE_BINDING_NAMES: [&str; 8] = [
+    "workspace:activate_first_tab",
+    "workspace:activate_second_tab",
+    "workspace:activate_third_tab",
+    "workspace:activate_fourth_tab",
+    "workspace:activate_fifth_tab",
+    "workspace:activate_sixth_tab",
+    "workspace:activate_seventh_tab",
+    "workspace:activate_eighth_tab",
+];
+
+/// Modifier kinds relevant to revealing tab shortcut hints. The Super kind is
+/// the Cmd key on macOS and the Windows/Super key elsewhere; a `Keystroke`'s
+/// `cmd` and `meta` flags both correspond to it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ShortcutModifierKind {
+    Super,
+    Control,
+    Alt,
+    Shift,
+}
+
+pub(crate) fn shortcut_modifier_kind(key_code: KeyCode) -> Option<ShortcutModifierKind> {
+    match key_code {
+        KeyCode::SuperLeft | KeyCode::SuperRight => Some(ShortcutModifierKind::Super),
+        KeyCode::ControlLeft | KeyCode::ControlRight => Some(ShortcutModifierKind::Control),
+        KeyCode::AltLeft | KeyCode::AltRight => Some(ShortcutModifierKind::Alt),
+        KeyCode::ShiftLeft | KeyCode::ShiftRight => Some(ShortcutModifierKind::Shift),
+        // KeyCode is non_exhaustive; non-modifier keys reveal nothing.
+        _ => None,
+    }
+}
+
+pub(crate) fn keystroke_modifier_kinds(keystroke: &Keystroke) -> HashSet<ShortcutModifierKind> {
+    let mut kinds = HashSet::new();
+    if keystroke.cmd || keystroke.meta {
+        kinds.insert(ShortcutModifierKind::Super);
+    }
+    if keystroke.ctrl {
+        kinds.insert(ShortcutModifierKind::Control);
+    }
+    if keystroke.alt {
+        kinds.insert(ShortcutModifierKind::Alt);
+    }
+    if keystroke.shift {
+        kinds.insert(ShortcutModifierKind::Shift);
+    }
+    kinds
+}
+
+pub(crate) fn reveals_shortcut_hints(
+    held: &HashSet<ShortcutModifierKind>,
+    binding_kinds: &HashSet<ShortcutModifierKind>,
+) -> bool {
+    held.intersection(binding_kinds).next().is_some()
+}
+
+/// Tracks which physical modifier keys are currently held, so tab surfaces can
+/// temporarily show switch-to-tab shortcut hints while a relevant modifier is
+/// down.
+#[derive(Default)]
+pub struct TabShortcutModifierState {
+    held_keys: RefCell<HashSet<KeyCode>>,
+}
+
+impl TabShortcutModifierState {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns whether the held-key set changed.
+    pub fn set_key_held(&self, key_code: KeyCode, pressed: bool) -> bool {
+        let mut held_keys = self.held_keys.borrow_mut();
+        if pressed {
+            held_keys.insert(key_code)
+        } else {
+            held_keys.remove(&key_code)
+        }
+    }
+
+    fn held_kinds(&self) -> HashSet<ShortcutModifierKind> {
+        self.held_keys
+            .borrow()
+            .iter()
+            .filter_map(|key| shortcut_modifier_kind(*key))
+            .collect()
+    }
+}
+
+impl Entity for TabShortcutModifierState {
+    type Event = ();
+}
+
+impl SingletonEntity for TabShortcutModifierState {}
+
+/// Whether shortcut hints should show right now: some held modifier is one the
+/// current switch-to-tab bindings actually use. Derived from the bindings so a
+/// user who remapped, say, ⌘1 to ⌥1 reveals with ⌥, not ⌘.
+pub(crate) fn reveals_tab_shortcut_hints(ctx: &AppContext) -> bool {
+    let held = TabShortcutModifierState::as_ref(ctx).held_kinds();
+    if held.is_empty() {
+        return false;
+    }
+    let binding_kinds: HashSet<_> = TAB_ACTIVATE_BINDING_NAMES
+        .iter()
+        .filter_map(|name| keybinding_name_to_keystroke(name, ctx))
+        .flat_map(|keystroke| keystroke_modifier_kinds(&keystroke))
+        .collect();
+    reveals_shortcut_hints(&held, &binding_kinds)
+}
 
 /// Label for the tab right-click menu's "Move to group" submenu parent.
 pub const MOVE_TO_GROUP_LABEL: &str = "Move to group";
@@ -932,6 +1049,7 @@ pub struct TabComponent<'a> {
     /// both the in-selection highlight and the right-click menu dispatch
     /// (multi-tab menu vs single-tab menu).
     is_in_multi_tab_selection: bool,
+    shortcut_hint_label: Option<String>,
 }
 
 /// Structure that holds TabComponent styles.
@@ -1019,6 +1137,12 @@ impl<'a> TabComponent<'a> {
             .as_ref(ctx)
             .is_terminal_pane_being_shared(ctx);
         let should_show_indicators = *TabSettings::as_ref(ctx).show_indicators.value();
+        let shortcut_hint_label =
+            if reveals_tab_shortcut_hints(ctx) && tab_index < TAB_ACTIVATE_BINDING_NAMES.len() {
+                keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[tab_index], ctx)
+            } else {
+                None
+            };
         let are_inputs_synced = SyncedInputState::as_ref(ctx)
             .should_sync_this_pane_group(tab.pane_group.id(), tab.pane_group.window_id(ctx));
 
@@ -1094,6 +1218,7 @@ impl<'a> TabComponent<'a> {
             sole_grouped_member: false,
             locator,
             is_in_multi_tab_selection: false,
+            shortcut_hint_label,
         }
     }
 
@@ -1580,6 +1705,26 @@ impl<'a> TabComponent<'a> {
         })
     }
 
+    fn render_shortcut_hint(&self) -> Option<Box<dyn Element>> {
+        if self.for_drag_ghost {
+            return None;
+        }
+        let label = self.shortcut_hint_label.as_ref()?;
+        let theme = self.appearance.theme();
+        let font_size = self.styles.default.font_size.unwrap_or(12.);
+        let text = Text::new_inline(
+            label.clone(),
+            self.styles
+                .default
+                .font_family_id
+                .expect("Font family defined"),
+            font_size,
+        )
+        .with_color(theme.sub_text_color(theme.background()).into())
+        .finish();
+        Some(Container::new(text).with_margin_right(4.).finish())
+    }
+
     fn render_tab_container(&self, is_hovered: bool) -> Box<dyn Element> {
         let is_tab_dragging = self.is_tab_dragging();
         let is_hovered = is_hovered && !self.tab_bar.is_any_tab_dragging;
@@ -1680,6 +1825,9 @@ impl<'a> TabComponent<'a> {
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_main_axis_alignment(MainAxisAlignment::Center)
                 .with_cross_axis_alignment(warpui::elements::CrossAxisAlignment::Center);
+            if let Some(hint) = self.render_shortcut_hint() {
+                flex_row.add_child(hint);
+            }
             if let Some(indicator) = self.render_indicator() {
                 flex_row.add_child(indicator);
             }

--- a/app/src/tab_tests.rs
+++ b/app/src/tab_tests.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
 
-use super::{SelectedTabColor, next_tab_color, tab_group_menu_entry_flags};
+use warpui::platform::keyboard::KeyCode;
+
+use super::{
+    SelectedTabColor, ShortcutModifierKind, TabShortcutModifierState, next_tab_color,
+    tab_group_menu_entry_flags,
+};
 use crate::themes::theme::AnsiColorIdentifier;
 use crate::ui_components::color_dot::TAB_COLOR_OPTIONS;
 use crate::workspace::tab_group::{TabGroup, TabGroupId};
@@ -33,6 +38,23 @@ fn sole_member_of_group_hides_new_group_and_offers_remove() {
         show_remove_from_group,
         "a tab in a group should offer 'Remove from group'"
     );
+}
+
+#[test]
+fn tab_shortcut_modifier_state_clear_reports_whether_state_changed() {
+    let state = TabShortcutModifierState::new();
+
+    assert!(!state.clear_held_keys());
+
+    assert!(state.set_key_held(KeyCode::SuperLeft, true));
+    assert_eq!(
+        state.held_kinds(),
+        [ShortcutModifierKind::Super].into_iter().collect()
+    );
+
+    assert!(state.clear_held_keys());
+    assert!(state.held_kinds().is_empty());
+    assert!(!state.clear_held_keys());
 }
 
 // GH-13073 follow-up: a tab that shares a group with siblings SHOULD still be

--- a/app/src/tab_tests.rs
+++ b/app/src/tab_tests.rs
@@ -42,11 +42,13 @@ fn sole_member_of_group_hides_new_group_and_offers_remove() {
 
 #[test]
 fn tab_shortcut_modifier_state_clear_reports_whether_state_changed() {
-    let state = TabShortcutModifierState::new();
+    let mut state = TabShortcutModifierState::new();
 
     assert!(!state.clear_held_keys());
 
-    assert!(state.set_key_held(KeyCode::SuperLeft, true));
+    assert!(state.held_keys.insert(KeyCode::SuperLeft));
+    assert!(state.held_kinds().is_empty());
+    assert!(state.reveal_key_if_held(KeyCode::SuperLeft));
     assert_eq!(
         state.held_kinds(),
         [ShortcutModifierKind::Super].into_iter().collect()
@@ -55,6 +57,18 @@ fn tab_shortcut_modifier_state_clear_reports_whether_state_changed() {
     assert!(state.clear_held_keys());
     assert!(state.held_kinds().is_empty());
     assert!(!state.clear_held_keys());
+}
+
+#[test]
+fn tab_shortcut_modifier_state_only_reveals_keys_that_remain_held() {
+    let mut state = TabShortcutModifierState::new();
+
+    assert!(!state.reveal_key_if_held(KeyCode::SuperLeft));
+
+    assert!(state.held_keys.insert(KeyCode::SuperLeft));
+    assert!(state.held_keys.remove(&KeyCode::SuperLeft));
+    assert!(!state.reveal_key_if_held(KeyCode::SuperLeft));
+    assert!(state.held_kinds().is_empty());
 }
 
 // GH-13073 follow-up: a tab that shares a group with siblings SHOULD still be

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -9,6 +9,7 @@ use warpui::accessibility::AccessibilityVerbosity;
 use warpui::geometry::rect::RectF;
 use warpui::geometry::vector::Vector2F;
 use warpui::platform::Cursor;
+use warpui::platform::keyboard::KeyCode;
 use warpui::{EntityId, WeakViewHandle, WindowId};
 
 use super::global_actions::{ForkFromExchange, ForkedConversationDestination};
@@ -304,6 +305,10 @@ pub enum WorkspaceAction {
     DecreaseZoom,
     ResetZoom,
     ActivateTabByNumber(usize),
+    SetTabShortcutModifierKey {
+        key_code: KeyCode,
+        pressed: bool,
+    },
     OpenPalette {
         mode: PaletteMode,
         source: PaletteSource,
@@ -933,6 +938,7 @@ impl WorkspaceAction {
             ContinueThirdPartyConversationLocally { .. } => true,
             ActivateTab(_)
             | ActivateTabByNumber(_)
+            | SetTabShortcutModifierKey { .. }
             | ActivatePrevTab
             | ActivateNextTab
             | ActivateLastTab

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18897,6 +18897,15 @@ impl Workspace {
             StateEvent::ValueChanged { current, previous } => {
                 let did_window_change_focus =
                     WindowManager::did_window_change_focus(self.window_id, current, previous);
+                let window_lost_focus = previous.active_window == Some(self.window_id)
+                    && current.active_window != Some(self.window_id);
+                let app_lost_focus = previous.stage == ApplicationStage::Active
+                    && current.stage != ApplicationStage::Active;
+                let shortcut_state_changed = if window_lost_focus || app_lost_focus {
+                    TabShortcutModifierState::as_ref(ctx).clear_held_keys()
+                } else {
+                    false
+                };
                 let cached_window_is_active = current.active_window == Some(self.window_id);
                 let app_became_active = previous.stage != ApplicationStage::Active
                     && current.stage == ApplicationStage::Active;
@@ -18924,8 +18933,10 @@ impl Workspace {
                     );
                 }
 
-                // Re-render if fullscreen state for active window has changed.
-                if current.is_active_window_fullscreen != previous.is_active_window_fullscreen {
+                // Re-render if fullscreen or shortcut-hint visibility changed.
+                if current.is_active_window_fullscreen != previous.is_active_window_fullscreen
+                    || shortcut_state_changed
+                {
                     ctx.notify();
                 } else if did_window_change_focus {
                     // Re-render if this window's focus state has changed.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18938,7 +18938,7 @@ impl Workspace {
                     );
                 }
 
-                // Re-render if fullscreen changed.
+                // Re-render if fullscreen state for active window has changed.
                 if current.is_active_window_fullscreen != previous.is_active_window_fullscreen {
                     ctx.notify();
                 } else if did_window_change_focus {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -98,6 +98,7 @@ use warpui::elements::{
     ParentOffsetBounds, PositionedElementAnchor, PositionedElementOffsetBounds, Radius, Rect,
     SavePosition, Shrinkable, SizeConstraintCondition, SizeConstraintSwitch, Stack, Text,
 };
+use warpui::event::KeyState;
 use warpui::fonts::{Properties, Weight};
 use warpui::geometry::vector::{Vector2F, vec2f};
 use warpui::keymap::Context;
@@ -365,8 +366,8 @@ use crate::tab::{
     COMPACT_TAB_WIDTH_THRESHOLD, ColorPickerTarget, MOVE_TO_GROUP_LABEL, NewSessionMenuItem,
     PaneNameMenuTarget, SelectedTabColor, TAB_BAR_BORDER_HEIGHT, TAB_INDICATOR_HEIGHT,
     TAB_PIN_INDICATOR_ICON_SIZE, TAB_PIN_VANISH_THRESHOLD, TabBarState, TabComponent, TabData,
-    TabTelemetryAction, color_picker_menu_items, next_tab_color, tab_position_id,
-    uses_vertical_tabs,
+    TabShortcutModifierState, TabTelemetryAction, color_picker_menu_items, next_tab_color,
+    tab_position_id, uses_vertical_tabs,
 };
 use crate::tab_configs::action_sidecar::SidecarItemKind;
 use crate::tab_configs::remove_confirmation_dialog::{
@@ -23862,6 +23863,13 @@ impl TypedActionView for Workspace {
         match action {
             ActivateTab(index) => self.activate_tab(*index, ctx),
             ActivateTabByNumber(num) => self.activate_tab(num.saturating_sub(1), ctx),
+            SetTabShortcutModifierKey { key_code, pressed } => {
+                let changed =
+                    TabShortcutModifierState::as_ref(ctx).set_key_held(*key_code, *pressed);
+                if changed {
+                    ctx.notify();
+                }
+            }
             ActivatePrevTab => self.activate_prev_tab(ctx),
             OpenLaunchConfigSaveModal => self.open_launch_config_save_modal(ctx),
             ActivateNextTab => self.activate_next_tab(ctx),
@@ -27865,6 +27873,15 @@ impl View for Workspace {
                     DispatchEventResult::StopPropagation
                 });
         }
+
+        let event_handler =
+            event_handler.on_modifier_state_changed(|ctx, _app, key_code, state| {
+                ctx.dispatch_typed_action(WorkspaceAction::SetTabShortcutModifierKey {
+                    key_code: *key_code,
+                    pressed: matches!(state, KeyState::Pressed),
+                });
+                DispatchEventResult::PropagateToParent
+            });
 
         event_handler.finish()
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -2928,6 +2928,9 @@ impl Workspace {
         ctx.subscribe_to_model(&state_handle, |me, _, event, ctx| {
             me.handle_window_state_change(event, ctx);
         });
+        ctx.observe(&TabShortcutModifierState::handle(ctx), |_, _, ctx| {
+            ctx.notify();
+        });
 
         ctx.observe(&RelaunchModel::handle(ctx), |_, _, ctx| {
             ctx.notify();
@@ -18901,11 +18904,13 @@ impl Workspace {
                     && current.active_window != Some(self.window_id);
                 let app_lost_focus = previous.stage == ApplicationStage::Active
                     && current.stage != ApplicationStage::Active;
-                let shortcut_state_changed = if window_lost_focus || app_lost_focus {
-                    TabShortcutModifierState::as_ref(ctx).clear_held_keys()
-                } else {
-                    false
-                };
+                if window_lost_focus || app_lost_focus {
+                    TabShortcutModifierState::handle(ctx).update(ctx, |state, ctx| {
+                        if state.clear_held_keys() {
+                            ctx.notify();
+                        }
+                    });
+                }
                 let cached_window_is_active = current.active_window == Some(self.window_id);
                 let app_became_active = previous.stage != ApplicationStage::Active
                     && current.stage == ApplicationStage::Active;
@@ -18933,10 +18938,8 @@ impl Workspace {
                     );
                 }
 
-                // Re-render if fullscreen or shortcut-hint visibility changed.
-                if current.is_active_window_fullscreen != previous.is_active_window_fullscreen
-                    || shortcut_state_changed
-                {
+                // Re-render if fullscreen changed.
+                if current.is_active_window_fullscreen != previous.is_active_window_fullscreen {
                     ctx.notify();
                 } else if did_window_change_focus {
                     // Re-render if this window's focus state has changed.
@@ -23875,11 +23878,9 @@ impl TypedActionView for Workspace {
             ActivateTab(index) => self.activate_tab(*index, ctx),
             ActivateTabByNumber(num) => self.activate_tab(num.saturating_sub(1), ctx),
             SetTabShortcutModifierKey { key_code, pressed } => {
-                let changed =
-                    TabShortcutModifierState::as_ref(ctx).set_key_held(*key_code, *pressed);
-                if changed {
-                    ctx.notify();
-                }
+                TabShortcutModifierState::handle(ctx).update(ctx, |state, ctx| {
+                    state.set_key_held(*key_code, *pressed, ctx);
+                });
             }
             ActivatePrevTab => self.activate_prev_tab(ctx),
             OpenLaunchConfigSaveModal => self.open_launch_config_save_modal(ctx),

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -411,7 +411,7 @@ fn render_pane_row_element(
         pane_rename_editor: _,
         is_pinned,
         container_is_hovered,
-        tab_index: _,
+        shortcut_hint_tab_index: _,
     } = props;
     let is_selected = is_active_tab && is_focused;
     let show_pin = FeatureFlag::PinnedTabs.is_enabled() && is_pinned && !container_is_hovered;
@@ -857,7 +857,7 @@ struct PaneProps<'a> {
     /// True when the tab container containing this pane is hovered.
     /// The pin icon is hidden when a tab is hovered.
     container_is_hovered: bool,
-    tab_index: usize,
+    shortcut_hint_tab_index: Option<usize>,
 }
 
 struct PaneRowState {
@@ -1240,7 +1240,7 @@ impl VerticalTabsPanelState {
                                 None,
                                 tab.pinned,
                                 false,
-                                *tab_index,
+                                Some(*tab_index),
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -1848,7 +1848,7 @@ fn render_groups(
                                     None,
                                     tab.pinned,
                                     false,
-                                    tab_index,
+                                    Some(tab_index),
                                     app,
                                 )
                                 .is_some_and(|props| {
@@ -1880,7 +1880,7 @@ fn render_groups(
                                 None,
                                 tab.pinned,
                                 false,
-                                tab_index,
+                                Some(tab_index),
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -2240,7 +2240,7 @@ fn render_tab_group_internal(
                     None,
                     tab.pinned,
                     group_state.is_hovered(),
-                    tab_index,
+                    Some(tab_index),
                     app,
                 ) else {
                     return Empty::new().finish();
@@ -2300,7 +2300,7 @@ fn render_tab_group_internal(
                     is_pane_being_renamed.then_some(workspace.pane_rename_editor.clone()),
                     tab.pinned,
                     group_state.is_hovered(),
-                    tab_index,
+                    Some(tab_index),
                     app,
                 ) else {
                     continue;
@@ -3448,10 +3448,11 @@ fn shows_shortcut_hint(modifier_held: bool, tab_index: usize) -> bool {
 /// Resolves the switch-to-tab shortcut label for a row while the reveal
 /// modifier is held. Returns `None` when no hint should be shown.
 fn shortcut_hint_label(props: &PaneProps<'_>, app: &AppContext) -> Option<String> {
-    if !shows_shortcut_hint(reveals_tab_shortcut_hints(app), props.tab_index) {
+    let tab_index = props.shortcut_hint_tab_index?;
+    if !shows_shortcut_hint(reveals_tab_shortcut_hints(app), tab_index) {
         return None;
     }
-    keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[props.tab_index], app)
+    keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[tab_index], app)
 }
 
 /// Inline label showing the switch-to-tab keyboard shortcut, mirroring the
@@ -3914,7 +3915,7 @@ impl<'a> PaneProps<'a> {
         pane_rename_editor: Option<ViewHandle<EditorView>>,
         is_pinned: bool,
         container_is_hovered: bool,
-        tab_index: usize,
+        shortcut_hint_tab_index: Option<usize>,
         app: &AppContext,
     ) -> Option<Self> {
         let pane = pane_group.pane_by_id(pane_id)?;
@@ -3969,7 +3970,7 @@ impl<'a> PaneProps<'a> {
             pane_rename_editor,
             is_pinned,
             container_is_hovered,
-            tab_index,
+            shortcut_hint_tab_index,
         })
     }
 
@@ -6808,9 +6809,7 @@ fn detail_pane_props<'a>(
         None,
         false,
         false,
-        // The detail sidecar never renders a tab shortcut hint, so the tab
-        // index is unused here; pass the active tab as a harmless stand-in.
-        workspace.active_tab_index,
+        None,
         app,
     )
 }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -55,7 +55,10 @@ use crate::pane_group::{
     CodePane, NotebookPane, PaneGroup, PaneId, TabBarHoverIndex, TerminalPane, WorkflowPane,
 };
 use crate::safe_triangle::SafeTriangle;
-use crate::tab::{SelectedTabColor, TAB_INDICATOR_SYNCED_COLOR, TabData, tab_position_id};
+use crate::tab::{
+    SelectedTabColor, TAB_ACTIVATE_BINDING_NAMES, TAB_INDICATOR_SYNCED_COLOR, TabData,
+    reveals_tab_shortcut_hints, tab_position_id,
+};
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::session_settings::SessionSettings;
 use crate::terminal::view::TerminalViewState;
@@ -408,6 +411,7 @@ fn render_pane_row_element(
         pane_rename_editor: _,
         is_pinned,
         container_is_hovered,
+        tab_index: _,
     } = props;
     let is_selected = is_active_tab && is_focused;
     let show_pin = FeatureFlag::PinnedTabs.is_enabled() && is_pinned && !container_is_hovered;
@@ -853,6 +857,7 @@ struct PaneProps<'a> {
     /// True when the tab container containing this pane is hovered.
     /// The pin icon is hidden when a tab is hovered.
     container_is_hovered: bool,
+    tab_index: usize,
 }
 
 struct PaneRowState {
@@ -1235,6 +1240,7 @@ impl VerticalTabsPanelState {
                                 None,
                                 tab.pinned,
                                 false,
+                                *tab_index,
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -1842,6 +1848,7 @@ fn render_groups(
                                     None,
                                     tab.pinned,
                                     false,
+                                    tab_index,
                                     app,
                                 )
                                 .is_some_and(|props| {
@@ -1873,6 +1880,7 @@ fn render_groups(
                                 None,
                                 tab.pinned,
                                 false,
+                                tab_index,
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -2232,6 +2240,7 @@ fn render_tab_group_internal(
                     None,
                     tab.pinned,
                     group_state.is_hovered(),
+                    tab_index,
                     app,
                 ) else {
                     return Empty::new().finish();
@@ -2291,6 +2300,7 @@ fn render_tab_group_internal(
                     is_pane_being_renamed.then_some(workspace.pane_rename_editor.clone()),
                     tab.pinned,
                     group_state.is_hovered(),
+                    tab_index,
                     app,
                 ) else {
                     continue;
@@ -3427,6 +3437,32 @@ fn render_synced_inputs_indicator() -> Box<dyn Element> {
     .finish()
 }
 
+/// Whether a row is eligible to surface the switch-to-tab shortcut hint: the
+/// reveal modifier is held and the tab falls within the first 8 (the only tabs
+/// with a `cmdorctrl-N` binding). Whether a label is actually shown also
+/// depends on the binding being assigned — see [`shortcut_hint_label`].
+fn shows_shortcut_hint(modifier_held: bool, tab_index: usize) -> bool {
+    modifier_held && tab_index < TAB_ACTIVATE_BINDING_NAMES.len()
+}
+
+/// Resolves the switch-to-tab shortcut label for a row while the reveal
+/// modifier is held. Returns `None` when no hint should be shown.
+fn shortcut_hint_label(props: &PaneProps<'_>, app: &AppContext) -> Option<String> {
+    if !shows_shortcut_hint(reveals_tab_shortcut_hints(app), props.tab_index) {
+        return None;
+    }
+    keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[props.tab_index], app)
+}
+
+/// Inline label showing the switch-to-tab keyboard shortcut, mirroring the
+/// horizontal tab bar's `TabComponent::render_shortcut_hint`.
+fn render_shortcut_hint(label: &str, appearance: &Appearance) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    Text::new_inline(label.to_string(), appearance.ui_font_family(), 12.)
+        .with_color(theme.sub_text_color(theme.background()).into())
+        .finish()
+}
+
 /// Row title line with its trailing indicators — the synchronized-inputs link
 /// icon followed by the unread-activity dot — pinned to the right edge. Returns
 /// `title` untouched when the row has no indicator to show.
@@ -3434,9 +3470,10 @@ fn render_row_title_line(
     title: Box<dyn Element>,
     shows_synced_inputs: bool,
     shows_activity_indicator: bool,
+    shortcut_hint: Option<Box<dyn Element>>,
     theme: &WarpTheme,
 ) -> Box<dyn Element> {
-    if !shows_synced_inputs && !shows_activity_indicator {
+    if !shows_synced_inputs && !shows_activity_indicator && shortcut_hint.is_none() {
         return title;
     }
 
@@ -3449,6 +3486,9 @@ fn render_row_title_line(
     }
     if shows_activity_indicator {
         indicators.add_child(render_title_indicator(theme));
+    }
+    if let Some(hint) = shortcut_hint {
+        indicators.add_child(hint);
     }
 
     Flex::row()
@@ -3521,6 +3561,13 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
         if has_indicator {
             title_row.add_child(
                 Container::new(render_title_indicator(theme))
+                    .with_margin_left(4.)
+                    .finish(),
+            );
+        }
+        if let Some(label) = shortcut_hint_label(&props, app) {
+            title_row.add_child(
+                Container::new(render_shortcut_hint(&label, appearance))
                     .with_margin_left(4.)
                     .finish(),
             );
@@ -3867,6 +3914,7 @@ impl<'a> PaneProps<'a> {
         pane_rename_editor: Option<ViewHandle<EditorView>>,
         is_pinned: bool,
         container_is_hovered: bool,
+        tab_index: usize,
         app: &AppContext,
     ) -> Option<Self> {
         let pane = pane_group.pane_by_id(pane_id)?;
@@ -3921,6 +3969,7 @@ impl<'a> PaneProps<'a> {
             pane_rename_editor,
             is_pinned,
             container_is_hovered,
+            tab_index,
         })
     }
 
@@ -4484,6 +4533,7 @@ fn render_terminal_row_content(
         first_line,
         row_shows_synced_inputs_indicator(props, app),
         has_unread_activity(&props.typed, app),
+        shortcut_hint_label(props, app).map(|label| render_shortcut_hint(&label, appearance)),
         theme,
     );
 
@@ -4774,6 +4824,7 @@ fn render_summary_tab_item(
         title_region.finish(),
         row_shows_synced_inputs_indicator(&props, app),
         summary.has_unread_activity,
+        shortcut_hint_label(&props, app).map(|label| render_shortcut_hint(&label, appearance)),
         theme,
     ));
 
@@ -6757,6 +6808,9 @@ fn detail_pane_props<'a>(
         None,
         false,
         false,
+        // The detail sidecar never renders a tab shortcut hint, so the tab
+        // index is unused here; pass the active tab as a harmless stand-in.
+        workspace.active_tab_index,
         app,
     )
 }
@@ -7360,6 +7414,7 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
         title_element,
         row_shows_synced_inputs_indicator(&props, app),
         has_indicator,
+        shortcut_hint_label(&props, app).map(|label| render_shortcut_hint(&label, appearance)),
         theme,
     );
 

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -1,3 +1,4 @@
+use std::iter::once;
 use std::path::PathBuf;
 
 use pathfinder_geometry::rect::RectF;
@@ -27,9 +28,7 @@ use crate::context_chips::display_chip::GitLineChanges;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
-use crate::tab::{
-    ShortcutModifierKind, TAB_ACTIVATE_BINDING_NAMES, reveals_shortcut_hints,
-};
+use crate::tab::{ShortcutModifierKind, TAB_ACTIVATE_BINDING_NAMES, reveals_shortcut_hints};
 use crate::terminal::CLIAgent;
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 
@@ -1208,10 +1207,10 @@ fn tab_activate_binding_names_cover_first_eight_tabs_in_order() {
 
 #[test]
 fn reveals_shortcut_hints_requires_overlap_with_binding_modifiers() {
-    let super_kind = std::iter::once(ShortcutModifierKind::Super).collect();
+    let super_kind = once(ShortcutModifierKind::Super).collect();
     assert!(reveals_shortcut_hints(&super_kind, &super_kind));
 
-    let alt_kind = std::iter::once(ShortcutModifierKind::Alt).collect();
+    let alt_kind = once(ShortcutModifierKind::Alt).collect();
     assert!(!reveals_shortcut_hints(&alt_kind, &super_kind));
 
     let empty = std::collections::HashSet::new();

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -4,8 +4,6 @@ use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
 use warpui::EntityId;
 use warpui::elements::PositionedElementOffsetBounds;
-use warpui::keymap::Keystroke;
-use warpui::platform::keyboard::KeyCode;
 
 use super::{
     AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons, TerminalAgentText,
@@ -30,8 +28,7 @@ use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
 use crate::tab::{
-    ShortcutModifierKind, TAB_ACTIVATE_BINDING_NAMES, keystroke_modifier_kinds,
-    reveals_shortcut_hints, shortcut_modifier_kind,
+    ShortcutModifierKind, TAB_ACTIVATE_BINDING_NAMES, reveals_shortcut_hints,
 };
 use crate::terminal::CLIAgent;
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
@@ -1206,49 +1203,6 @@ fn tab_activate_binding_names_cover_first_eight_tabs_in_order() {
     assert_eq!(
         TAB_ACTIVATE_BINDING_NAMES[TAB_ACTIVATE_BINDING_NAMES.len() - 1],
         "workspace:activate_eighth_tab"
-    );
-}
-
-#[test]
-fn shortcut_modifier_kind_maps_modifier_keys() {
-    assert_eq!(
-        shortcut_modifier_kind(KeyCode::SuperLeft),
-        Some(ShortcutModifierKind::Super)
-    );
-    assert_eq!(
-        shortcut_modifier_kind(KeyCode::ControlRight),
-        Some(ShortcutModifierKind::Control)
-    );
-    assert_eq!(
-        shortcut_modifier_kind(KeyCode::AltLeft),
-        Some(ShortcutModifierKind::Alt)
-    );
-    assert_eq!(
-        shortcut_modifier_kind(KeyCode::ShiftLeft),
-        Some(ShortcutModifierKind::Shift)
-    );
-    assert_eq!(shortcut_modifier_kind(KeyCode::KeyA), None);
-}
-
-#[test]
-fn keystroke_modifier_kinds_cover_all_flags() {
-    let keystroke = Keystroke {
-        cmd: true,
-        ctrl: true,
-        alt: true,
-        shift: true,
-        meta: false,
-        key: "1".to_string(),
-    };
-    assert_eq!(
-        keystroke_modifier_kinds(&keystroke),
-        [
-            ShortcutModifierKind::Super,
-            ShortcutModifierKind::Control,
-            ShortcutModifierKind::Alt,
-            ShortcutModifierKind::Shift,
-        ]
-        .into()
     );
 }
 

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -4,6 +4,8 @@ use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
 use warpui::EntityId;
 use warpui::elements::PositionedElementOffsetBounds;
+use warpui::keymap::Keystroke;
+use warpui::platform::keyboard::KeyCode;
 
 use super::{
     AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons, TerminalAgentText,
@@ -15,7 +17,7 @@ use super::{
     pane_ids_for_display_granularity, pane_search_text_fragments, preferred_agent_tab_titles,
     push_normalized_unique_summary_label, search_fragments_contain_query,
     select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
-    should_show_tab_group_header, shows_synced_inputs_indicator,
+    should_show_tab_group_header, shows_shortcut_hint, shows_synced_inputs_indicator,
     sort_summary_primary_labels_status_first, summary_overflow_count,
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
     terminal_pull_request_badge_label, terminal_search_text_fragments,
@@ -27,6 +29,10 @@ use crate::context_chips::display_chip::GitLineChanges;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
+use crate::tab::{
+    ShortcutModifierKind, TAB_ACTIVATE_BINDING_NAMES, keystroke_modifier_kinds,
+    reveals_shortcut_hints, shortcut_modifier_kind,
+};
 use crate::terminal::CLIAgent;
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 
@@ -1165,6 +1171,97 @@ fn synced_inputs_indicator_respects_tab_indicators_setting() {
 #[test]
 fn synced_inputs_indicator_hidden_on_non_terminal_rows() {
     assert!(!shows_synced_inputs_indicator(false, true, true));
+}
+
+#[test]
+fn shortcut_hint_shown_when_modifier_held_within_first_eight_tabs() {
+    assert!(shows_shortcut_hint(true, 0));
+    assert!(shows_shortcut_hint(
+        true,
+        TAB_ACTIVATE_BINDING_NAMES.len() - 1
+    ));
+}
+
+#[test]
+fn shortcut_hint_hidden_when_modifier_not_held() {
+    assert!(!shows_shortcut_hint(false, 0));
+}
+
+#[test]
+fn shortcut_hint_hidden_beyond_eighth_tab() {
+    assert!(!shows_shortcut_hint(true, TAB_ACTIVATE_BINDING_NAMES.len()));
+    assert!(!shows_shortcut_hint(
+        true,
+        TAB_ACTIVATE_BINDING_NAMES.len() + 1
+    ));
+}
+
+#[test]
+fn tab_activate_binding_names_cover_first_eight_tabs_in_order() {
+    assert_eq!(TAB_ACTIVATE_BINDING_NAMES.len(), 8);
+    assert_eq!(
+        TAB_ACTIVATE_BINDING_NAMES[0],
+        "workspace:activate_first_tab"
+    );
+    assert_eq!(
+        TAB_ACTIVATE_BINDING_NAMES[TAB_ACTIVATE_BINDING_NAMES.len() - 1],
+        "workspace:activate_eighth_tab"
+    );
+}
+
+#[test]
+fn shortcut_modifier_kind_maps_modifier_keys() {
+    assert_eq!(
+        shortcut_modifier_kind(KeyCode::SuperLeft),
+        Some(ShortcutModifierKind::Super)
+    );
+    assert_eq!(
+        shortcut_modifier_kind(KeyCode::ControlRight),
+        Some(ShortcutModifierKind::Control)
+    );
+    assert_eq!(
+        shortcut_modifier_kind(KeyCode::AltLeft),
+        Some(ShortcutModifierKind::Alt)
+    );
+    assert_eq!(
+        shortcut_modifier_kind(KeyCode::ShiftLeft),
+        Some(ShortcutModifierKind::Shift)
+    );
+    assert_eq!(shortcut_modifier_kind(KeyCode::KeyA), None);
+}
+
+#[test]
+fn keystroke_modifier_kinds_cover_all_flags() {
+    let keystroke = Keystroke {
+        cmd: true,
+        ctrl: true,
+        alt: true,
+        shift: true,
+        meta: false,
+        key: "1".to_string(),
+    };
+    assert_eq!(
+        keystroke_modifier_kinds(&keystroke),
+        [
+            ShortcutModifierKind::Super,
+            ShortcutModifierKind::Control,
+            ShortcutModifierKind::Alt,
+            ShortcutModifierKind::Shift,
+        ]
+        .into()
+    );
+}
+
+#[test]
+fn reveals_shortcut_hints_requires_overlap_with_binding_modifiers() {
+    let super_kind = std::iter::once(ShortcutModifierKind::Super).collect();
+    assert!(reveals_shortcut_hints(&super_kind, &super_kind));
+
+    let alt_kind = std::iter::once(ShortcutModifierKind::Alt).collect();
+    assert!(!reveals_shortcut_hints(&alt_kind, &super_kind));
+
+    let empty = std::collections::HashSet::new();
+    assert!(!reveals_shortcut_hints(&empty, &super_kind));
 }
 
 #[test]

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -103,6 +103,7 @@ pub(crate) fn initialize_app(app: &mut App) {
     app.add_singleton_model(|ctx| AutoupdateState::new(ServerApiProvider::as_ref(ctx).get()));
     app.add_singleton_model(|_| NetworkStatus::new());
     app.add_singleton_model(|_| SystemStats::new());
+    app.add_singleton_model(|_| crate::tab::TabShortcutModifierState::new());
     app.add_singleton_model(SyncQueue::mock);
     app.add_singleton_model(CloudModel::mock);
     app.add_singleton_model(CloudEnvironmentCatalog::new);


### PR DESCRIPTION
Closes #14977

## Description
Warp binds `cmdorctrl-1`..`-8` to switching tabs, but nothing in the UI surfaces those shortcuts. This PR makes each tab temporarily show its switch-to-tab shortcut (⌘1..⌘8 by default) while a relevant modifier is held, then hide it again on release — no new setting. Works in both the horizontal tab bar and the vertical tabs sidebar.

Two properties worth calling out for review:

- **The reveal modifier is derived from the bindings, not hardcoded.** A hold reveals when the held modifier is one the current `workspace:activate_*_tab` keystrokes actually use (the union of their modifier kinds). A user who remapped ⌘1 to ⌥1 reveals with ⌥, not ⌘; typing capitals (Shift, unused by the default bindings) never flashes the hints; if every tab binding is removed, nothing reveals.
- **Labels are binding-aware.** Rendered via the existing `keybinding_name_to_display_string`, so each tab shows its effective keystroke (⌘N on macOS, Ctrl N on Windows/Linux, `⇧⌘2` after a remap) and a tab whose binding was removed shows no hint at all.

Implementation: a `TabShortcutModifierState` singleton tracks currently-held physical modifier keys, driven by `Event::ModifierKeyChanged` (bare modifier presses generate these on both the macOS AppKit path and winit; the command palette's Ctrl-hold already uses this event). `reveals_tab_shortcut_hints` intersects held kinds with the bindings' modifier kinds. The workspace root's existing `EventHandler` (the one handling ctrl+scroll zoom) forwards modifier key events as `WorkspaceAction::SetTabShortcutModifierKey`; the workspace view re-renders when the held set changes.

Known limitation (shared with the command palette's Ctrl-hold behavior): a modifier released while the window is unfocused can leave the state stale until the next modifier press. Happy to add a window-focus reset if reviewers want it.

Design note: #14977 originally described an opt-in setting; after discussing with the team, this hold-to-reveal approach (no settings surface) was preferred.

## Linked Issue
Closes #14977
- [x] N/A — the linked issue is not labeled `ready-to-spec`/`ready-to-implement` yet; happy to hold this PR until triage completes, or rework per feedback.

## Testing
- `./script/format` — clean.
- `cargo clippy -p warp --tests -- -D warnings` — clean.
- `cargo test -p warp --lib workspace::` — 217 passed (includes 7 new tests: `shows_shortcut_hint` gating truth table, `TAB_ACTIVATE_BINDING_NAMES` ordering regression guard, `shortcut_modifier_kind` key mapping, `keystroke_modifier_kinds` flag coverage, `reveals_shortcut_hints` overlap logic).
- Manually verified in a dev build (`./script/run`) with vertical tabs: holding ⌘ reveals ⌘1..⌘8 on the first 8 tabs, release hides them, the 9th tab shows nothing, ⌘N switching still works, and plain typing (Shift) does not trigger hints.
- [x] I have manually tested my changes locally with `./script/run`

https://github.com/user-attachments/assets/1de8a0bb-049d-40f4-8b64-a413278ebd4c


### Screenshots / Videos
<!-- TODO: attach screenshot/recording of holding ⌘ revealing the hints -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Holding a modifier now shows each tab's switch-to-tab keyboard shortcut on the tab itself.