### PR TITLE
Enable well_known_mcp_ids and factory_mcp feature flags in production

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -509,6 +509,8 @@ crash_reporting = [
 creating_shared_sessions = []
 cross_repo_context = []
 codebase_index_persistence = ["full_source_code_embedding"]
+well_known_mcp_ids = []
+factory_mcp = []
 default = [
     "agent_mode",
     "osc_hyperlinks",
@@ -707,6 +709,8 @@ default = [
     "cloud_runners",
     "cloud_agent_runners",
     "file_backed_execution_profiles",
+    "well_known_mcp_ids",
+    "factory_mcp",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -309,6 +309,10 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::SummarizationConversationCommand,
         #[cfg(feature = "mcp_grouped_server_context")]
         FeatureFlag::MCPGroupedServerContext,
+        #[cfg(feature = "well_known_mcp_ids")]
+        FeatureFlag::WellKnownMcpIds,
+        #[cfg(feature = "factory_mcp")]
+        FeatureFlag::FactoryMcp,
         #[cfg(feature = "web_search_ui")]
         FeatureFlag::WebSearchUI,
         #[cfg(feature = "web_fetch_ui")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -1040,8 +1040,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::OrchestrationUnifiedStack,
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::BoxDrawingGlyphs,
-    FeatureFlag::WellKnownMcpIds,
-    FeatureFlag::FactoryMcp,
     FeatureFlag::PricingTransparency,
     FeatureFlag::PeriodicHandoffCheckpoints,
 ];


### PR DESCRIPTION
This PR promotes the `well_known_mcp_ids` and `factory_mcp` feature flags to the default build. By moving these out of the dogfood-only list and into the standard feature set, we are enabling these MCP-related capabilities for all users.

*   Added `well_known_mcp_ids` and `factory_mcp` to the default feature list in `Cargo.toml`.
*   Updated `features.rs` to ensure these flags are correctly registered in the enabled features set.
*   Removed these flags from the `DOGFOOD_FLAGS` list in `warp_features` to reflect their promotion to general availability.