### PR TITLE
fix(repo_metadata): stop re-walking indexed directories on watcher `Modify` events; serialize walks per repository

### DIFF
--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -258,9 +258,12 @@ pub struct LocalRepoMetadataModel {
     lazy_loaded_paths: HashMap<StandardizedPath, usize>,
     /// Spawned filesystem tree build tasks keyed by owning repo and target directory.
     build_tasks: HashMap<BuildTaskKey, BuildTask>,
-    /// Spawned watcher update tasks keyed by repository root, then spawned future.
+    /// Watcher update pipeline keyed by repository root. At most one
+    /// filesystem-walking task is in flight per repository; events that arrive
+    /// while it runs are coalesced into the queue's `pending` update and
+    /// applied by the next task. See [`Self::enqueue_watcher_update`].
     #[cfg(feature = "local_fs")]
-    watcher_update_tasks: HashMap<StandardizedPath, HashMap<FutureId, SpawnedFutureHandle>>,
+    watcher_update_tasks: HashMap<StandardizedPath, WatcherUpdateQueue>,
     /// File system watcher for monitoring changes.
     #[cfg(feature = "local_fs")]
     watcher: Option<ModelHandle<BulkFilesystemWatcher>>,
@@ -293,6 +296,47 @@ struct RepoUpdate {
     added: Vec<PathBuf>,
     deleted: Vec<PathBuf>,
     moved: HashMap<PathBuf, PathBuf>,
+}
+
+#[cfg(feature = "local_fs")]
+impl RepoUpdate {
+    /// Folds a later update into this one. Paths are deduplicated so a
+    /// directory touched by several coalesced events is walked once, not once
+    /// per event. Ordering between an add and a delete of the same path does
+    /// not matter: [`LocalRepoMetadataModel::compute_file_tree_mutations`]
+    /// emits removals first and re-checks the live filesystem before adding.
+    fn merge(&mut self, other: RepoUpdate) {
+        for path in other.added {
+            if !self.added.contains(&path) {
+                self.added.push(path);
+            }
+        }
+        for path in other.deleted {
+            if !self.deleted.contains(&path) {
+                self.deleted.push(path);
+            }
+        }
+        self.moved.extend(other.moved);
+    }
+}
+
+/// Per-repository watcher update pipeline: one walking task at a time, later
+/// events merged into `pending` until that task completes.
+///
+/// Without this bound, every debounced watcher tick spawned its own subtree
+/// walk regardless of whether the previous one had finished. A directory that
+/// is touched every second (e.g. an agent tool writing under `.claude/`) then
+/// accumulates concurrent walks of the same subtree until every core is busy
+/// and each in-flight walk holds its own copy of the subtree in memory
+/// (warpdotdev/warp#8409). Serializing per repository also guarantees that
+/// mutations are applied in event order.
+#[cfg(feature = "local_fs")]
+#[derive(Default)]
+struct WatcherUpdateQueue {
+    /// The single walking task currently running for this repository.
+    in_flight: Option<(FutureId, SpawnedFutureHandle)>,
+    /// Updates that arrived while `in_flight` was running, merged together.
+    pending: Option<RepoUpdate>,
 }
 #[cfg(feature = "local_fs")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -588,9 +632,28 @@ impl LocalRepoMetadataModel {
         let mut repo_updates: HashMap<StandardizedPath, RepoUpdate> = HashMap::new();
         let symlink_target_paths = self.add_symlink_target_updates(event, &mut repo_updates);
 
-        // Process added or updated files
-        for path in event.added_or_updated_iter() {
+        // Process created files and directories.
+        for path in &event.added {
             if let Some(repo_path) = self.find_repository_for_watcher_entry_path(path) {
+                let repo_update = repo_updates.entry(repo_path).or_default();
+                repo_update.added.push(path.to_path_buf());
+            }
+        }
+
+        // Process modified paths. A modification event on a directory that is
+        // already in the tree carries no information of its own: Windows
+        // (`ReadDirectoryChangesW`) reports the parent directory as modified
+        // whenever a child is created, removed or renamed, and each of those
+        // children arrives as its own event. Treating the directory as newly
+        // added would rebuild its entire subtree on every event, which for a
+        // large, frequently touched directory keeps every core busy
+        // (warpdotdev/warp#8409). Files, and directories not yet in the tree,
+        // still flow through so metadata refreshes and missed creates are kept.
+        for path in &event.modified {
+            if let Some(repo_path) = self.find_repository_for_watcher_entry_path(path) {
+                if self.is_indexed_directory(&repo_path, path) {
+                    continue;
+                }
                 let repo_update = repo_updates.entry(repo_path).or_default();
                 repo_update.added.push(path.to_path_buf());
             }
@@ -622,10 +685,85 @@ impl LocalRepoMetadataModel {
         ctx.emit(RepositoryMetadataEvent::FileTreeUpdated {
             paths: repo_updates.keys().cloned().collect(),
         });
-        // Apply updates to each affected repository asynchronously.
-        // Phase 1 (background thread): compute lightweight mutations via filesystem I/O.
-        // Phase 2 (main thread callback): apply mutations directly to the tree — no clone needed.
+        // Apply updates to each affected repository asynchronously, at most one
+        // walking task per repository at a time (see [`WatcherUpdateQueue`]).
         for (repo_path, repo_scoped_update) in repo_updates {
+            self.enqueue_watcher_update(repo_path, repo_scoped_update, ctx);
+        }
+    }
+
+    /// Returns true when `path` is already present in `repo_path`'s tree as a
+    /// directory (loaded, lazy or ignored placeholder alike).
+    #[cfg(feature = "local_fs")]
+    fn is_indexed_directory(&self, repo_path: &StandardizedPath, path: &Path) -> bool {
+        let Some(IndexedRepoState::Indexed(state)) = self.repositories.get(repo_path) else {
+            return false;
+        };
+        let Ok(path) = StandardizedPath::try_from_local(path) else {
+            return false;
+        };
+        matches!(
+            state.entry.get(&path),
+            Some(FileTreeEntryState::Directory(_))
+        )
+    }
+
+    /// Queues a watcher update for `repo_path`. If a walking task is already
+    /// in flight for the repository the update is merged into the pending
+    /// batch and dispatched when that task completes; otherwise it starts now.
+    #[cfg(feature = "local_fs")]
+    fn enqueue_watcher_update(
+        &mut self,
+        repo_path: StandardizedPath,
+        update: RepoUpdate,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let queue = self
+            .watcher_update_tasks
+            .entry(repo_path.clone())
+            .or_default();
+        if queue.in_flight.is_some() {
+            queue
+                .pending
+                .get_or_insert_with(RepoUpdate::default)
+                .merge(update);
+            return;
+        }
+        self.spawn_watcher_update(repo_path, update, ctx);
+    }
+
+    /// Starts the next pending update for `repo_path`, if any, once the
+    /// in-flight task has finished. Drops the queue entry when idle.
+    #[cfg(feature = "local_fs")]
+    fn dispatch_pending_watcher_update(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(queue) = self.watcher_update_tasks.get_mut(repo_path) else {
+            return;
+        };
+        if queue.in_flight.is_some() {
+            return;
+        }
+        match queue.pending.take() {
+            Some(next) => self.spawn_watcher_update(repo_path.clone(), next, ctx),
+            None => {
+                self.watcher_update_tasks.remove(repo_path);
+            }
+        }
+    }
+
+    /// Phase 1 (background thread): compute lightweight mutations via filesystem I/O.
+    /// Phase 2 (main thread callback): apply mutations directly to the tree — no clone needed.
+    #[cfg(feature = "local_fs")]
+    fn spawn_watcher_update(
+        &mut self,
+        repo_path: StandardizedPath,
+        repo_scoped_update: RepoUpdate,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        {
             if let Some(IndexedRepoState::Indexed(state)) = self.repositories.get(&repo_path) {
                 let repo_path_clone = repo_path.clone();
                 let gitignores_clone = state.gitignores.clone();
@@ -709,6 +847,10 @@ impl LocalRepoMetadataModel {
                         for removed in &removed_roots {
                             model.unwatch_removed_subtree(&repo_path, removed, ctx);
                         }
+
+                        // Events that arrived while this task ran were merged
+                        // into the repository's pending batch; walk them now.
+                        model.dispatch_pending_watcher_update(&repo_path, ctx);
                     },
                 );
                 task_future_id.set(Some(update_handle.future_id()));
@@ -839,38 +981,37 @@ impl LocalRepoMetadataModel {
         handle: SpawnedFutureHandle,
     ) {
         let future_id = handle.future_id();
-        if let Some(existing_task) = self
-            .watcher_update_tasks
-            .entry(repo_path)
-            .or_default()
-            .insert(future_id, handle)
-        {
+        let queue = self.watcher_update_tasks.entry(repo_path).or_default();
+        if let Some((_, existing_task)) = queue.in_flight.replace((future_id, handle)) {
             existing_task.abort();
         }
     }
 
     #[cfg(feature = "local_fs")]
+    /// Marks the in-flight task for `repo_path` as complete. Returns `None`
+    /// when `future_id` is not the current in-flight task (stale completion).
+    /// The queue entry is retained so the completion callback can dispatch
+    /// any pending batch; [`Self::dispatch_pending_watcher_update`] removes it
+    /// when idle.
     fn finish_watcher_update_task(
         &mut self,
         repo_path: &StandardizedPath,
         future_id: Option<FutureId>,
     ) -> Option<SpawnedFutureHandle> {
         let future_id = future_id?;
-        let (handle, remove_repo_entry) = {
-            let tasks = self.watcher_update_tasks.get_mut(repo_path)?;
-            let handle = tasks.remove(&future_id)?;
-            (handle, tasks.is_empty())
-        };
-        if remove_repo_entry {
-            self.watcher_update_tasks.remove(repo_path);
+        let queue = self.watcher_update_tasks.get_mut(repo_path)?;
+        match &queue.in_flight {
+            Some((in_flight_id, _)) if *in_flight_id == future_id => {
+                queue.in_flight.take().map(|(_, handle)| handle)
+            }
+            _ => None,
         }
-        Some(handle)
     }
 
     #[cfg(feature = "local_fs")]
     fn abort_watcher_update_tasks_for_repo(&mut self, repo_path: &StandardizedPath) {
-        if let Some(tasks) = self.watcher_update_tasks.remove(repo_path) {
-            for handle in tasks.into_values() {
+        if let Some(queue) = self.watcher_update_tasks.remove(repo_path) {
+            if let Some((_, handle)) = queue.in_flight {
                 handle.abort();
             }
         }

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -407,14 +407,17 @@ fn remove_repository_aborts_and_drops_watcher_update_tasks() {
         });
 
         model_handle.read(&app, |model, _ctx| {
+            // Only one walk is ever in flight per repository: tracking the
+            // second task replaced (and aborted) the first.
+            let queue = model
+                .watcher_update_tasks
+                .get(&repo_path)
+                .expect("watcher tasks should be tracked");
             assert_eq!(
-                model
-                    .watcher_update_tasks
-                    .get(&repo_path)
-                    .expect("watcher tasks should be tracked")
-                    .len(),
-                2
+                queue.in_flight.as_ref().map(|(id, _)| *id),
+                Some(second_future_id)
             );
+            assert!(queue.pending.is_none());
         });
 
         model_handle.update(&mut app, |model, ctx| {
@@ -472,13 +475,13 @@ fn remove_repository_keeps_nested_repo_watcher_update_tasks() {
 
         let nested_handle = model_handle.update(&mut app, |model, _ctx| {
             assert!(model.repository_state(&parent_repo_path).is_none());
-            let tasks = model
+            let queue = model
                 .watcher_update_tasks
                 .remove(&nested_repo_path)
                 .expect("nested repo watcher task should not be aborted by parent teardown");
-            tasks
-                .into_values()
-                .next()
+            queue
+                .in_flight
+                .map(|(_, handle)| handle)
                 .expect("nested repo watcher task should still be tracked")
         });
 
@@ -488,6 +491,199 @@ fn remove_repository_keeps_nested_repo_watcher_update_tasks() {
                 ctx.await_spawned_future(nested_future_id)
             })
             .await;
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn watcher_updates_coalesce_while_a_walk_is_in_flight() {
+    let repo_path = StandardizedPath::try_new("/watcher_update_coalesced_repo").unwrap();
+    let path_a = PathBuf::from("/watcher_update_coalesced_repo/a");
+    let path_b = PathBuf::from("/watcher_update_coalesced_repo/b");
+    let path_c = PathBuf::from("/watcher_update_coalesced_repo/c");
+
+    App::test((), |mut app| async move {
+        let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+        let in_flight_id = model_handle.update(&mut app, |model, ctx| {
+            model.repositories.insert(
+                repo_path.clone(),
+                IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
+            );
+            let handle = ctx.spawn(
+                async move {
+                    let _ = release_rx.await;
+                },
+                |_, _, _| {},
+            );
+            let future_id = handle.future_id();
+            model.track_watcher_update_task(repo_path.clone(), handle);
+            future_id
+        });
+
+        // Two debounced events arrive while the walk is still running. Neither
+        // may start a second walk; both are merged into one pending batch with
+        // duplicate paths collapsed.
+        model_handle.update(&mut app, |model, ctx| {
+            model.enqueue_watcher_update(
+                repo_path.clone(),
+                RepoUpdate {
+                    added: vec![path_a.clone()],
+                    ..Default::default()
+                },
+                ctx,
+            );
+            model.enqueue_watcher_update(
+                repo_path.clone(),
+                RepoUpdate {
+                    added: vec![path_a.clone(), path_b.clone()],
+                    deleted: vec![path_c.clone()],
+                    ..Default::default()
+                },
+                ctx,
+            );
+            let queue = model
+                .watcher_update_tasks
+                .get(&repo_path)
+                .expect("watcher queue should be tracked");
+            assert_eq!(
+                queue.in_flight.as_ref().map(|(id, _)| *id),
+                Some(in_flight_id),
+                "no second walk may start while one is in flight"
+            );
+            let pending = queue
+                .pending
+                .as_ref()
+                .expect("events during a walk are held as one pending batch");
+            assert_eq!(pending.added, vec![path_a.clone(), path_b.clone()]);
+            assert_eq!(pending.deleted, vec![path_c.clone()]);
+        });
+
+        // The walk finishes: the pending batch becomes exactly one new task.
+        let _ = release_tx.send(());
+        model_handle
+            .update(&mut app, |_, ctx| ctx.await_spawned_future(in_flight_id))
+            .await;
+        let next_id = model_handle.update(&mut app, |model, ctx| {
+            assert!(
+                model
+                    .finish_watcher_update_task(&repo_path, Some(in_flight_id))
+                    .is_some()
+            );
+            model.dispatch_pending_watcher_update(&repo_path, ctx);
+            let queue = model
+                .watcher_update_tasks
+                .get(&repo_path)
+                .expect("pending batch should have been dispatched");
+            assert!(queue.pending.is_none());
+            queue
+                .in_flight
+                .as_ref()
+                .map(|(id, _)| *id)
+                .expect("pending batch should now be the in-flight walk")
+        });
+        assert_ne!(next_id, in_flight_id);
+        model_handle
+            .update(&mut app, |_, ctx| ctx.await_spawned_future(next_id))
+            .await;
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn modified_event_on_indexed_directory_does_not_rebuild_its_subtree() {
+    VirtualFS::test("modified_indexed_directory_no_rebuild", |dirs, mut vfs| {
+        vfs.mkdir("repo/src/nested")
+            .with_files(vec![Stub::FileWithContent(
+                "repo/src/nested/main.rs",
+                "fn main() {}\n",
+            )]);
+
+        let repo_root = dirs.tests().join("repo");
+        let src_dir = repo_root.join("src");
+        let source_file = repo_root.join("src/nested/main.rs");
+
+        App::test((), |mut app| async move {
+            app.add_singleton_model(DirectoryWatcher::new_for_testing);
+            let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
+            let repo_root_for_index =
+                StandardizedPath::from_local_canonicalized(&repo_root).unwrap();
+
+            let (tx, rx) = oneshot::channel();
+            let repo_root_for_event = repo_root_for_index.clone();
+            let indexed = Rc::new(RefCell::new(Some(tx)));
+            let indexed_for_event = indexed.clone();
+            app.update(|ctx| {
+                ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
+                    if matches!(
+                        event,
+                        RepositoryMetadataEvent::RepositoryUpdated { path }
+                            if path == &repo_root_for_event
+                    ) && let Some(tx) = indexed_for_event.borrow_mut().take()
+                    {
+                        let _ = tx.send(());
+                    }
+                });
+            });
+            model_handle.update(&mut app, |model, ctx| {
+                model
+                    .index_directory_path(&repo_root_for_index, ctx)
+                    .unwrap();
+            });
+            rx.with_timeout(Duration::from_secs(5))
+                .await
+                .expect("timed out waiting for repository index")
+                .expect("repository index completion sender dropped");
+            model_handle.read(&app, |model, _ctx| {
+                let Some(IndexedRepoState::Indexed(state)) =
+                    model.repository_state(&repo_root_for_index)
+                else {
+                    panic!("expected indexed repository");
+                };
+                assert!(matches!(
+                    state
+                        .entry
+                        .get(&StandardizedPath::try_from_local(&src_dir).unwrap()),
+                    Some(FileTreeEntryState::Directory(_))
+                ));
+            });
+
+            // Windows reports a directory as modified whenever a child is
+            // created, removed or renamed. That event carries nothing the
+            // children's own events do not, so it must not walk the subtree.
+            model_handle.update(&mut app, |model, ctx| {
+                model.handle_watcher_event(
+                    &BulkFilesystemWatcherEvent {
+                        modified: std::collections::HashSet::from([src_dir.clone()]),
+                        ..Default::default()
+                    },
+                    ctx,
+                );
+                assert!(
+                    !model.watcher_update_tasks.contains_key(&repo_root_for_index),
+                    "a modified event on an already-indexed directory must not spawn a subtree rebuild"
+                );
+            });
+
+            // A modified file still flows through the pipeline.
+            let file_task_id = model_handle.update(&mut app, |model, ctx| {
+                model.handle_watcher_event(
+                    &BulkFilesystemWatcherEvent {
+                        modified: std::collections::HashSet::from([source_file.clone()]),
+                        ..Default::default()
+                    },
+                    ctx,
+                );
+                model
+                    .watcher_update_tasks
+                    .get(&repo_root_for_index)
+                    .and_then(|queue| queue.in_flight.as_ref().map(|(id, _)| *id))
+                    .expect("a modified file should still be refreshed by the watcher pipeline")
+            });
+            model_handle
+                .update(&mut app, |_, ctx| ctx.await_spawned_future(file_task_id))
+                .await;
+        });
     });
 }
 


### PR DESCRIPTION
Fixes #8409 (Warp pins every core for hours while a coding agent runs in a tab).

## What was happening

Sampled a symbolized release build (`--features gui,skip_login`, `debug = 1`) with a
dbghelp stack sampler while a Claude Code session worked in a tab. Warp went from
0.3 % → 88 % of 16 cores and 3 GB RSS within 15 minutes and stayed there. 48 % of all
samples were inside

```
repo_metadata::local_model::LocalRepoMetadataModel::handle_watcher_event
  └─ compute_file_tree_mutations
       └─ Entry::build_tree_with_standing_queries
            └─ evaluate_entry  (is_symlink / metadata / canonicalize / strip_prefix per entry)
```

Two independent defects combine:

1. **A `Modify` event on an already-indexed directory rebuilt its entire subtree.**
   On Windows `ReadDirectoryChangesW` reports the *parent directory* as modified
   whenever a child is created, removed or renamed. `handle_watcher_event` merged
   `event.added` and `event.modified` into one list, `compute_file_tree_mutations`
   saw `path.is_dir()` and called `build_tree_with_standing_queries` on it — a full
   walk of the subtree, once per debounced tick. Any tool that keeps writing files
   under one directory (coding agents write hook/ledger files under `.claude/` every
   few seconds; in the reproducing repo that directory holds ~62 k files) makes Warp
   re-walk that subtree continuously.

2. **Walks were never coalesced.** `track_watcher_update_task` keyed tasks by
   `FutureId`, so every tick spawned another walk regardless of whether the previous
   one had finished. Walks pile up without bound; each in-flight walk holds its own
   subtree in memory. That is the "every core busy + multi-GB RSS" signature in
   #8409. It also allowed mutations from a later event to be applied before an
   earlier one (create-dir walk still running while the delete of the same dir is
   applied → stale entry).

## The change

- `handle_watcher_event` processes `event.added` and `event.modified` separately. A
  modified path that is already present in the repository tree as a **directory** is
  skipped (`is_indexed_directory`) — its children's own events carry the change.
  Files, and directories not yet in the tree, still flow through unchanged.
- `WatcherUpdateQueue { in_flight, pending }` per repository: at most one walking
  task runs at a time; events that arrive meanwhile are merged into `pending`
  (`RepoUpdate::merge`, paths deduplicated) and dispatched from the completion
  callback. `abort_watcher_update_tasks_for_repo` / `finish_watcher_update_task`
  keep their semantics (stale completions are ignored, repo removal drops the queue).

No behaviour change for `added` / `moved` / `deleted`, symlink-target refresh, lazy
roots or standing-query deltas.

## Tests

- `modified_event_on_indexed_directory_does_not_rebuild_its_subtree` — fails on
  `main` (a task is spawned), passes with the fix; also asserts a modified *file*
  still goes through the pipeline.
- `watcher_updates_coalesce_while_a_walk_is_in_flight` — two events during an
  in-flight walk produce one merged pending batch and exactly one follow-up task.
- Updated `remove_repository_aborts_and_drops_watcher_update_tasks` and
  `remove_repository_keeps_nested_repo_watcher_update_tasks` for the new queue shape.
- `cargo test -p repo_metadata --features local_fs`: 126 passed, 0 failed, 2 ignored (pre-existing).

## Verification on the reproducing machine

Windows 11, 16 cores, 7 tabs each hosting a long-running coding agent whose hooks
create/delete files under `<repo>/.claude/` every few seconds; one repo has ~62 k files
under that directory.

| | CPU (of 16 cores) | RSS | threads |
|---|---|---|---|
| before (same session, min 15–35) | 70–90 % sustained | 2.5–3.2 GB | 156–171 |
| after, same workload | 0–1 % | ~700 MB flat | 87 |
| after, synthetic trigger: 171 create/delete cycles in `<repo>/.claude` over 90 s | 0.4–1.1 % | 708 MB flat | 87 |

The regression test `modified_event_on_indexed_directory_does_not_rebuild_its_subtree`
was also run against the pre-patch `local_model.rs` (shape-neutral copy): it fails there
with "a modified event on an already-indexed directory must not spawn a subtree rebuild",
and passes with the patch.
