### PR TITLE
Report repository HEADs at execution time

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -22,7 +22,7 @@ use repo_metadata::local_model::IndexedRepoState;
 use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
 use session_sharing_protocol::sharer::SessionRetentionReason;
 use uuid::Uuid;
-use warp_cli::agent::{Harness, OutputFormat};
+use warp_cli::agent::{Harness, OutputFormat, RepositoryBaseline};
 use warp_cli::mcp::MCPSpec;
 use warp_cli::share::ShareRequest;
 use warp_cli::skill::SkillSpec;
@@ -297,6 +297,8 @@ pub struct AgentDriverOptions {
     pub cloud_providers: Vec<Box<dyn cloud_provider::CloudProvider>>,
     /// Resolved environment configuration, if any.
     pub environment: Option<AmbientAgentEnvironment>,
+    /// Server-owned immutable repository baselines for this run.
+    pub repository_baselines: Vec<RepositoryBaseline>,
     /// Selected execution harness for this run.
     pub selected_harness: Harness,
     /// Model config for the selected harness. Only used for non-Oz harnesses.
@@ -364,6 +366,7 @@ pub struct AgentDriver {
 
     /// Resolved environment configuration.
     environment: Option<AmbientAgentEnvironment>,
+    repository_baselines: Vec<RepositoryBaseline>,
 
     // End-of-run snapshot upload controls.
     snapshot_disabled: bool,
@@ -635,6 +638,7 @@ impl AgentDriver {
             resume,
             cloud_providers,
             environment,
+            repository_baselines,
             selected_harness,
             third_party_harness_model_config,
             snapshot_disabled,
@@ -761,6 +765,7 @@ impl AgentDriver {
             resume_payload,
             cloud_providers,
             environment,
+            repository_baselines,
             snapshot_disabled: snapshot_disabled_value,
             snapshot_upload_timeout: snapshot_upload_timeout
                 .unwrap_or(snapshot::DEFAULT_SNAPSHOT_UPLOAD_TIMEOUT),
@@ -805,6 +810,7 @@ impl AgentDriver {
             resume_payload: None,
             cloud_providers: Vec::new(),
             environment: None,
+            repository_baselines: Vec::new(),
             snapshot_disabled: false,
             snapshot_upload_timeout: snapshot::DEFAULT_SNAPSHOT_UPLOAD_TIMEOUT,
             snapshot_script_timeout: snapshot::DEFAULT_DECLARATIONS_SCRIPT_TIMEOUT,
@@ -2156,7 +2162,9 @@ impl AgentDriver {
             .await?;
         let mut environment_skill_repos = Vec::new();
 
-        let environment_opt = foreground.spawn(|me, _| me.environment.clone()).await?;
+        let (environment_opt, repository_baselines) = foreground
+            .spawn(|me, _| (me.environment.clone(), me.repository_baselines.clone()))
+            .await?;
 
         if let Some(environment) = environment_opt {
             log::info!("Loading environment...");
@@ -2197,6 +2205,7 @@ impl AgentDriver {
                             working_dir,
                             false, /* is_sandbox */
                             harness,
+                            environment::RepositoryBaselineContext::new(repository_baselines),
                             setup_events_for_environment,
                             ctx,
                         )
@@ -3638,10 +3647,20 @@ impl AgentDriver {
             return;
         }
 
-        let Ok((working_dir, client)) = spawner
+        let Ok((working_dir, client, repository_baselines)) = spawner
             .spawn(|me, ctx| {
                 let client = ServerApiProvider::as_ref(ctx).get_harness_support_client();
-                (me.working_dir.clone(), client)
+                let repository_baselines = me
+                    .repository_baselines
+                    .iter()
+                    .map(|baseline| {
+                        (
+                            me.working_dir.join(&baseline.repo_name),
+                            baseline.commit_sha.clone(),
+                        )
+                    })
+                    .collect::<HashMap<_, _>>();
+                (me.working_dir.clone(), client, repository_baselines)
             })
             .await
         else {
@@ -3666,9 +3685,10 @@ impl AgentDriver {
         // Cap the upload so a pathological slow upload cannot wedge cleanup.
         // On timeout we surface via report_error! so Sentry captures the incident and on-call
         // alerting can fire, then let cloud-provider teardown continue.
-        if let Err(TimeoutError) = snapshot::upload_snapshot_from_declarations(client, &task_id)
-            .with_timeout(upload_timeout)
-            .await
+        if let Err(TimeoutError) =
+            snapshot::upload_snapshot_from_declarations(client, &task_id, &repository_baselines)
+                .with_timeout(upload_timeout)
+                .await
         {
             report_error!(
                 "Snapshot upload timed out; continuing with cleanup",

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -299,6 +299,8 @@ pub struct AgentDriverOptions {
     pub environment: Option<AmbientAgentEnvironment>,
     /// Server-owned immutable repository baselines for this run.
     pub repository_baselines: Vec<RepositoryBaseline>,
+    /// Whether this server-dispatched run reports its verified repository baselines.
+    pub report_repository_baselines: bool,
     /// Selected execution harness for this run.
     pub selected_harness: Harness,
     /// Model config for the selected harness. Only used for non-Oz harnesses.
@@ -367,6 +369,7 @@ pub struct AgentDriver {
     /// Resolved environment configuration.
     environment: Option<AmbientAgentEnvironment>,
     repository_baselines: Vec<RepositoryBaseline>,
+    report_repository_baselines: bool,
 
     // End-of-run snapshot upload controls.
     snapshot_disabled: bool,
@@ -639,6 +642,7 @@ impl AgentDriver {
             cloud_providers,
             environment,
             repository_baselines,
+            report_repository_baselines,
             selected_harness,
             third_party_harness_model_config,
             snapshot_disabled,
@@ -766,6 +770,7 @@ impl AgentDriver {
             cloud_providers,
             environment,
             repository_baselines,
+            report_repository_baselines,
             snapshot_disabled: snapshot_disabled_value,
             snapshot_upload_timeout: snapshot_upload_timeout
                 .unwrap_or(snapshot::DEFAULT_SNAPSHOT_UPLOAD_TIMEOUT),
@@ -811,6 +816,7 @@ impl AgentDriver {
             cloud_providers: Vec::new(),
             environment: None,
             repository_baselines: Vec::new(),
+            report_repository_baselines: false,
             snapshot_disabled: false,
             snapshot_upload_timeout: snapshot::DEFAULT_SNAPSHOT_UPLOAD_TIMEOUT,
             snapshot_script_timeout: snapshot::DEFAULT_DECLARATIONS_SCRIPT_TIMEOUT,
@@ -2162,8 +2168,16 @@ impl AgentDriver {
             .await?;
         let mut environment_skill_repos = Vec::new();
 
-        let (environment_opt, repository_baselines) = foreground
-            .spawn(|me, _| (me.environment.clone(), me.repository_baselines.clone()))
+        let (environment_opt, repository_baselines, baseline_reporter) = foreground
+            .spawn(|me, ctx| {
+                let baseline_reporter = (me.report_repository_baselines && me.task_id.is_some())
+                    .then(|| ServerApiProvider::as_ref(ctx).get_harness_support_client());
+                (
+                    me.environment.clone(),
+                    me.repository_baselines.clone(),
+                    baseline_reporter,
+                )
+            })
             .await?;
 
         if let Some(environment) = environment_opt {
@@ -2205,7 +2219,10 @@ impl AgentDriver {
                             working_dir,
                             false, /* is_sandbox */
                             harness,
-                            environment::RepositoryBaselineContext::new(repository_baselines),
+                            environment::RepositoryBaselineContext::new(
+                                repository_baselines,
+                                baseline_reporter,
+                            ),
                             setup_events_for_environment,
                             ctx,
                         )

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -7,11 +7,12 @@ use std::time::Duration;
 use ai::index::full_source_code_embedding::manager::{
     CodebaseIndexManager, CodebaseIndexManagerEvent,
 };
+use cloud_object_models::CodeForge;
 use futures::channel::oneshot;
 use futures::future::join_all;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
-use warp_cli::agent::Harness;
-use warp_completer::completer::CommandExitStatus;
+use warp_cli::agent::{Harness, RepositoryBaseline, RepositoryBaselineForge};
+use warp_completer::completer::{CommandExitStatus, CommandOutput};
 use warp_core::command::ExitCode;
 use warp_core::{safe_info, safe_warn};
 use warpui::r#async::FutureExt;
@@ -32,6 +33,12 @@ pub enum PrepareEnvironmentError {
     InvalidRuntimeState,
     #[error("Failed to clone {repo_name}")]
     CloneRepo { repo_name: String },
+    #[error("Invalid repository baselines: {reason}")]
+    InvalidRepositoryBaselines { reason: String },
+    #[error("Failed to prepare repositories: {repo_names}")]
+    PrepareRepositories { repo_names: String },
+    #[error("Failed to remove remotes from pinned repositories")]
+    RemovePinnedRemotes,
     #[error("Failed to run setup command: {command}")]
     SetupCommand { command: String },
     #[error("Failed to change directory into {repo_name}")]
@@ -40,8 +47,77 @@ pub enum PrepareEnvironmentError {
     TerminalDriver { source: AgentDriverError },
 }
 
+/// Server-owned repository pinning context for environment preparation.
+#[derive(Default)]
+pub(crate) struct RepositoryBaselineContext {
+    baselines: Vec<RepositoryBaseline>,
+}
+
+impl RepositoryBaselineContext {
+    pub fn new(baselines: Vec<RepositoryBaseline>) -> Self {
+        Self { baselines }
+    }
+}
+
+pub(crate) fn validate_repository_baselines(
+    environment: Option<&AmbientAgentEnvironment>,
+    baselines: &[RepositoryBaseline],
+) -> Result<(), PrepareEnvironmentError> {
+    if baselines.is_empty() {
+        return Ok(());
+    }
+    let source_repos = environment
+        .ok_or_else(|| PrepareEnvironmentError::InvalidRepositoryBaselines {
+            reason: "repository baselines require an environment".to_string(),
+        })?
+        .effective_repos();
+    let mut identities = HashSet::new();
+    for baseline in baselines {
+        if !identities.insert(baseline.identity()) {
+            return Err(PrepareEnvironmentError::InvalidRepositoryBaselines {
+                reason: format!(
+                    "duplicate repository identity {:?}/{}/{}",
+                    baseline.code_forge, baseline.repo_owner, baseline.repo_name
+                ),
+            });
+        }
+        if !source_repos
+            .iter()
+            .any(|repo| baseline_matches_repo(baseline, repo))
+        {
+            return Err(PrepareEnvironmentError::InvalidRepositoryBaselines {
+                reason: format!(
+                    "repository {:?}/{}/{} is not declared by the environment",
+                    baseline.code_forge, baseline.repo_owner, baseline.repo_name
+                ),
+            });
+        }
+    }
+    if baselines.len() != source_repos.len() {
+        let missing_repositories = source_repos
+            .iter()
+            .filter(|repo| baseline_for_repo(baselines, repo).is_none())
+            .map(|repo| {
+                format!(
+                    "{:?}/{}/{}",
+                    baseline_forge_for_repo(repo),
+                    repo.owner,
+                    repo.repo
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(PrepareEnvironmentError::InvalidRepositoryBaselines {
+            reason: format!(
+                "pinned tasks require one baseline for every environment repository; missing: {missing_repositories}"
+            ),
+        });
+    }
+    Ok(())
+}
+
 /// Prepare a cloud agent environment within a terminal session. This will:
-/// 1. Clone all repositories, skipping any that are already cloned.
+/// 1. Materialize all repositories, enforcing any server-provided commit pins.
 /// 2. Begin codebase indexing for all repositories (Oz harness only).
 /// 3. Run any setup commands.
 /// 4. If there is only one repository, navigate into it.
@@ -57,11 +133,16 @@ pub fn prepare_environment(
     working_dir: PathBuf,
     is_sandbox: bool,
     harness: Harness,
+    repository_baseline_context: RepositoryBaselineContext,
     setup_events: SetupClientEventReporter,
     ctx: &mut ModelContext<TerminalDriver>,
 ) -> impl Future<Output = Result<(), PrepareEnvironmentError>> {
     let spawner = ctx.spawner();
     async move {
+        let RepositoryBaselineContext {
+            baselines: repository_baselines,
+        } = repository_baseline_context;
+        validate_repository_baselines(Some(&environment), &repository_baselines)?;
         let source_repos = environment.effective_repos();
         let setup_commands = environment.setup_commands;
 
@@ -80,6 +161,7 @@ pub fn prepare_environment(
             working_dir.as_path(),
             is_sandbox,
             &source_repos,
+            &repository_baselines,
             setup_commands,
             should_index_codebase,
             Arc::clone(&repo_channels),
@@ -105,6 +187,7 @@ async fn prepare_environment_impl(
     working_dir: &Path,
     is_sandbox: bool,
     source_repos: &[SourceRepo],
+    repository_baselines: &[RepositoryBaseline],
     setup_commands: Vec<String>,
     should_index_codebase: bool,
     repo_channels: Arc<Mutex<HashMap<PathBuf, oneshot::Sender<()>>>>,
@@ -127,25 +210,24 @@ async fn prepare_environment_impl(
     if !source_repos.is_empty() {
         setup_events
             .record_result(SetupStep::EnvironmentRepoClone, async {
-                clone_repos(source_repos, working_dir, spawner).await?;
-                for repo in source_repos {
-                    register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
-                    if !is_sandbox && should_index_codebase {
-                        let receiver = index_repo_codebase(
-                            &repo.repo,
-                            working_dir,
-                            Arc::clone(&repo_channels),
-                            spawner,
-                        )
-                        .await?;
-                        if let Some(receiver) = receiver {
-                            codebase_context_receivers.push(receiver);
-                        }
-                    }
-                }
-                Ok::<(), PrepareEnvironmentError>(())
+                prepare_repositories(source_repos, repository_baselines, working_dir, spawner).await
             })
             .await?;
+        for repo in source_repos {
+            register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
+            if !is_sandbox && should_index_codebase {
+                let receiver = index_repo_codebase(
+                    &repo.repo,
+                    working_dir,
+                    Arc::clone(&repo_channels),
+                    spawner,
+                )
+                .await?;
+                if let Some(receiver) = receiver {
+                    codebase_context_receivers.push(receiver);
+                }
+            }
+        }
 
         if should_index_codebase {
             record_codebase_indexing(
@@ -157,7 +239,7 @@ async fn prepare_environment_impl(
     }
 
     let has_setup_commands = !setup_commands.is_empty();
-    if has_setup_commands {
+    let setup_result = if has_setup_commands {
         setup_events
             .record_result(SetupStep::EnvironmentSetupCommands, async {
                 // Set CI=true so setup commands run in a CI-like environment. This should help us run
@@ -197,14 +279,22 @@ async fn prepare_environment_impl(
                 execute_command("unset CI".to_string(), spawner).await?;
                 Ok::<(), PrepareEnvironmentError>(())
             })
-            .await?;
+            .await
     } else if should_index_codebase && source_repos.is_empty() {
         let _ = spawner
             .spawn(|_, ctx| {
                 ctx.unsubscribe_from_model(&CodebaseIndexManager::handle(ctx));
             })
             .await;
-    }
+        Ok(())
+    } else {
+        Ok(())
+    };
+
+    let remove_remotes_result =
+        remove_pinned_remotes(repository_baselines, working_dir, spawner).await;
+    setup_result?;
+    remove_remotes_result?;
 
     if should_index_codebase && source_repos.is_empty() {
         log::info!("No repositories to index for codebase context");
@@ -259,6 +349,217 @@ fn record_codebase_indexing(
             })
             .await;
     });
+}
+
+fn baseline_forge_for_repo(repo: &SourceRepo) -> RepositoryBaselineForge {
+    match repo.code_forge.unwrap_or_default() {
+        CodeForge::GitHub => RepositoryBaselineForge::GitHub,
+        CodeForge::GitLab => RepositoryBaselineForge::GitLab,
+    }
+}
+
+fn baseline_matches_repo(baseline: &RepositoryBaseline, repo: &SourceRepo) -> bool {
+    baseline.code_forge == baseline_forge_for_repo(repo)
+        && baseline.repo_owner == repo.owner
+        && baseline.repo_name == repo.repo
+}
+
+fn baseline_for_repo<'a>(
+    baselines: &'a [RepositoryBaseline],
+    repo: &SourceRepo,
+) -> Option<&'a RepositoryBaseline> {
+    baselines
+        .iter()
+        .find(|baseline| baseline_matches_repo(baseline, repo))
+}
+
+async fn active_shell_type(spawner: &ModelSpawner<TerminalDriver>) -> ShellType {
+    spawner
+        .spawn(|driver, ctx| {
+            driver
+                .active_session_shell_type(ctx)
+                .unwrap_or(ShellType::Bash)
+        })
+        .await
+        .unwrap_or(ShellType::Bash)
+}
+
+fn build_parallel_prepare_command(
+    repos: &[SourceRepo],
+    baselines: &[RepositoryBaseline],
+    shell_type: ShellType,
+) -> String {
+    let mut script = String::from(
+        r#"set +e
+failed=0
+pids=""
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/warp-repo-logs.XXXXXX")"
+cleanup_repo_logs() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup_repo_logs EXIT
+clone_repo() {
+  repo_name="$1"
+  repo_url="$2"
+  target="$3"
+  if [ -d "$target" ]; then
+    printf '%s\n' "Repository directory $target already exists, skipping clone..."
+    return 0
+  fi
+  printf '%s\n' "Cloning repository $repo_name..."
+  git clone --filter=tree:0 "$repo_url" "$target"
+}
+checkout_pinned_repo() {
+  repo_name="$1"
+  repo_url="$2"
+  target="$3"
+  commit_sha="$4"
+  if [ -e "$target" ]; then
+    printf '%s\n' "Verifying existing pinned repository $repo_name..."
+  else
+    printf '%s\n' "Initializing pinned repository $repo_name..."
+    git init --quiet "$target" || return 1
+    git -C "$target" remote add origin "$repo_url" || return 1
+    git -C "$target" fetch --depth=1 origin "$commit_sha" || return 1
+    git -C "$target" checkout --detach "$commit_sha" || return 1
+  fi
+  if ! git -C "$target" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf '%s\n' "Pinned repository path $target is not a Git repository" >&2
+    return 1
+  fi
+  actual_sha="$(git -C "$target" rev-parse HEAD)" || return 1
+  if [ "$actual_sha" != "$commit_sha" ]; then
+    printf '%s\n' "Pinned repository $repo_name is at $actual_sha, expected $commit_sha" >&2
+    return 1
+  fi
+  if git -C "$target" symbolic-ref --quiet HEAD >/dev/null 2>&1; then
+    printf '%s\n' "Pinned repository $repo_name must use a detached HEAD" >&2
+    return 1
+  fi
+  shallow="$(git -C "$target" rev-parse --is-shallow-repository)" || return 1
+  if [ "$shallow" != "true" ]; then
+    printf '%s\n' "Pinned repository $repo_name is not shallow" >&2
+    return 1
+  fi
+  reachable_commits="$(git -C "$target" rev-list --count HEAD --all)" || return 1
+  if [ "$reachable_commits" != "1" ]; then
+    printf '%s\n' "Pinned repository $repo_name exposes $reachable_commits commits, expected exactly 1" >&2
+    return 1
+  fi
+}
+"#,
+    );
+
+    let mut log_outputs = String::new();
+    for (index, repo) in repos.iter().enumerate() {
+        let repo_name = format!("{}/{}", repo.owner, repo.repo);
+        let escaped_repo_name = shell_escape_single_quotes(&repo_name, ShellType::Bash);
+        let escaped_repo_url = shell_escape_single_quotes(&repo.https_clone_url(), ShellType::Bash);
+        let escaped_target = shell_escape_single_quotes(&repo.repo, ShellType::Bash);
+        let log_var = format!("log_file_{index}");
+        script.push_str(&format!("{log_var}=\"$tmp_dir/repo-{index}.log\"\n"));
+        if let Some(baseline) = baseline_for_repo(baselines, repo) {
+            let escaped_commit_sha =
+                shell_escape_single_quotes(&baseline.commit_sha, ShellType::Bash);
+            script.push_str(&format!(
+                "checkout_pinned_repo '{escaped_repo_name}' '{escaped_repo_url}' '{escaped_target}' '{escaped_commit_sha}' >\"${log_var}\" 2>&1 &\n"
+            ));
+        } else {
+            script.push_str(&format!(
+                "clone_repo '{escaped_repo_name}' '{escaped_repo_url}' '{escaped_target}' >\"${log_var}\" 2>&1 &\n"
+            ));
+        }
+        script.push_str("pids=\"$pids $!\"\n");
+        log_outputs.push_str(&format!(
+            "printf '%s\\n' '===== {escaped_repo_name} ====='\n\
+             if [ -s \"${log_var}\" ]; then\n\
+             \tcat \"${log_var}\"\n\
+             else\n\
+             \tprintf '%s\\n' '(no output)'\n\
+             fi\n"
+        ));
+    }
+
+    script.push_str(
+        r#"for pid in $pids; do
+  if ! wait "$pid"; then
+    failed=1
+  fi
+done
+"#,
+    );
+    script.push_str(&log_outputs);
+    script.push_str(
+        r#"
+exit "$failed"
+"#,
+    );
+
+    let escaped_script = shell_escape_single_quotes(&script, shell_type);
+    format!("sh -c '{escaped_script}'")
+}
+
+async fn prepare_repositories(
+    repos: &[SourceRepo],
+    baselines: &[RepositoryBaseline],
+    working_dir: &Path,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<(), PrepareEnvironmentError> {
+    if baselines.is_empty() {
+        clone_repos(repos, working_dir, spawner).await?;
+    } else {
+        let shell_type = active_shell_type(spawner).await;
+        let command = build_parallel_prepare_command(repos, baselines, shell_type);
+        let exit_code = execute_command(command, spawner).await?;
+        if exit_code != 0.into() {
+            return Err(PrepareEnvironmentError::PrepareRepositories {
+                repo_names: repos
+                    .iter()
+                    .map(|repo| format!("{}/{}", repo.owner, repo.repo))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn build_remove_pinned_remotes_command(
+    baselines: &[RepositoryBaseline],
+    working_dir: &Path,
+    shell_type: ShellType,
+) -> String {
+    let mut script = String::new();
+    for baseline in baselines {
+        let repo_path = working_dir.join(&baseline.repo_name);
+        let escaped_path =
+            shell_escape_single_quotes(&repo_path.to_string_lossy(), ShellType::Bash);
+        script.push_str(&format!(
+            "if git -C '{escaped_path}' remote get-url origin >/dev/null 2>&1; then\n\
+             \tgit -C '{escaped_path}' remote remove origin || exit 1\n\
+             fi\n"
+        ));
+    }
+    let escaped_script = shell_escape_single_quotes(&script, shell_type);
+    format!("sh -c '{escaped_script}'")
+}
+
+async fn remove_pinned_remotes(
+    baselines: &[RepositoryBaseline],
+    working_dir: &Path,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<(), PrepareEnvironmentError> {
+    if baselines.is_empty() {
+        return Ok(());
+    }
+    let shell_type = active_shell_type(spawner).await;
+    let command = build_remove_pinned_remotes_command(baselines, working_dir, shell_type);
+    let output = execute_silent_command(command, spawner).await?;
+    if output.success() {
+        Ok(())
+    } else {
+        Err(PrepareEnvironmentError::RemovePinnedRemotes)
+    }
 }
 
 fn build_parallel_clone_command(repos: &[SourceRepo], shell_type: ShellType) -> String {
@@ -610,6 +911,21 @@ async fn execute_command(
             AgentDriverError::InvalidRuntimeState => PrepareEnvironmentError::InvalidRuntimeState,
             source => PrepareEnvironmentError::TerminalDriver { source },
         })?
+        .await
+        .map_err(|error| match error {
+            AgentDriverError::InvalidRuntimeState => PrepareEnvironmentError::InvalidRuntimeState,
+            source => PrepareEnvironmentError::TerminalDriver { source },
+        })
+}
+
+async fn execute_silent_command(
+    command: String,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<CommandOutput, PrepareEnvironmentError> {
+    spawner
+        .spawn(move |driver, ctx| driver.execute_silent_command(command, ctx))
+        .await
+        .map_err(|_| PrepareEnvironmentError::InvalidRuntimeState)?
         .await
         .map_err(|error| match error {
             AgentDriverError::InvalidRuntimeState => PrepareEnvironmentError::InvalidRuntimeState,

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -22,6 +22,7 @@ use super::terminal::TerminalDriver;
 use super::AgentDriverError;
 use crate::ai::agent_sdk::setup_observability::{SetupClientEventReporter, SetupStep};
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, SourceRepo};
+use crate::server::server_api::harness_support::HarnessSupportClient;
 use crate::terminal::model::session::command_executor::shell_escape_single_quotes;
 use crate::terminal::shell::ShellType;
 
@@ -37,6 +38,10 @@ pub enum PrepareEnvironmentError {
     InvalidRepositoryBaselines { reason: String },
     #[error("Failed to prepare repositories: {repo_names}")]
     PrepareRepositories { repo_names: String },
+    #[error("Failed to verify repository {repo_name}")]
+    VerifyRepository { repo_name: String },
+    #[error("Failed to report repository baselines: {source}")]
+    ReportRepositoryBaselines { source: anyhow::Error },
     #[error("Failed to remove remotes from pinned repositories")]
     RemovePinnedRemotes,
     #[error("Failed to run setup command: {command}")]
@@ -47,15 +52,22 @@ pub enum PrepareEnvironmentError {
     TerminalDriver { source: AgentDriverError },
 }
 
-/// Server-owned repository pinning context for environment preparation.
+/// Server-owned repository pinning and reporting context for environment preparation.
 #[derive(Default)]
 pub(crate) struct RepositoryBaselineContext {
     baselines: Vec<RepositoryBaseline>,
+    reporter: Option<Arc<dyn HarnessSupportClient>>,
 }
 
 impl RepositoryBaselineContext {
-    pub fn new(baselines: Vec<RepositoryBaseline>) -> Self {
-        Self { baselines }
+    pub fn new(
+        baselines: Vec<RepositoryBaseline>,
+        reporter: Option<Arc<dyn HarnessSupportClient>>,
+    ) -> Self {
+        Self {
+            baselines,
+            reporter,
+        }
     }
 }
 
@@ -141,6 +153,7 @@ pub fn prepare_environment(
     async move {
         let RepositoryBaselineContext {
             baselines: repository_baselines,
+            reporter: baseline_reporter,
         } = repository_baseline_context;
         validate_repository_baselines(Some(&environment), &repository_baselines)?;
         let source_repos = environment.effective_repos();
@@ -162,6 +175,7 @@ pub fn prepare_environment(
             is_sandbox,
             &source_repos,
             &repository_baselines,
+            baseline_reporter,
             setup_commands,
             should_index_codebase,
             Arc::clone(&repo_channels),
@@ -188,6 +202,7 @@ async fn prepare_environment_impl(
     is_sandbox: bool,
     source_repos: &[SourceRepo],
     repository_baselines: &[RepositoryBaseline],
+    baseline_reporter: Option<Arc<dyn HarnessSupportClient>>,
     setup_commands: Vec<String>,
     should_index_codebase: bool,
     repo_channels: Arc<Mutex<HashMap<PathBuf, oneshot::Sender<()>>>>,
@@ -207,12 +222,28 @@ async fn prepare_environment_impl(
     }
     let mut codebase_context_receivers = Vec::new();
 
-    if !source_repos.is_empty() {
+    let verified_baselines = if source_repos.is_empty() {
+        Vec::new()
+    } else {
         setup_events
             .record_result(SetupStep::EnvironmentRepoClone, async {
                 prepare_repositories(source_repos, repository_baselines, working_dir, spawner).await
             })
-            .await?;
+            .await?
+    };
+
+    if let Some(reporter) = baseline_reporter {
+        reporter
+            .report_repository_baselines(&verified_baselines)
+            .await
+            .map_err(|source| PrepareEnvironmentError::ReportRepositoryBaselines { source })?;
+    } else if !repository_baselines.is_empty() {
+        return Err(PrepareEnvironmentError::InvalidRepositoryBaselines {
+            reason: "pinned repositories require an authenticated task reporter".to_string(),
+        });
+    }
+
+    if !source_repos.is_empty() {
         for repo in source_repos {
             register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
             if !is_sandbox && should_index_codebase {
@@ -504,7 +535,7 @@ async fn prepare_repositories(
     baselines: &[RepositoryBaseline],
     working_dir: &Path,
     spawner: &ModelSpawner<TerminalDriver>,
-) -> Result<(), PrepareEnvironmentError> {
+) -> Result<Vec<RepositoryBaseline>, PrepareEnvironmentError> {
     if baselines.is_empty() {
         clone_repos(repos, working_dir, spawner).await?;
     } else {
@@ -521,7 +552,75 @@ async fn prepare_repositories(
             });
         }
     }
-    Ok(())
+
+    collect_verified_baselines(repos, baselines, working_dir, spawner).await
+}
+
+async fn collect_verified_baselines(
+    repos: &[SourceRepo],
+    baselines: &[RepositoryBaseline],
+    working_dir: &Path,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<Vec<RepositoryBaseline>, PrepareEnvironmentError> {
+    let shell_type = active_shell_type(spawner).await;
+    let mut verified = Vec::with_capacity(repos.len());
+    for repo in repos {
+        let repo_path = working_dir.join(&repo.repo);
+        let escaped_path =
+            shell_escape_single_quotes(&repo_path.to_string_lossy(), ShellType::Bash);
+        let script = format!(
+            "sha=$(git -C '{escaped_path}' rev-parse HEAD) || exit 1\n\
+             printf '%s\\n' \"$sha\"\n\
+             git -C '{escaped_path}' symbolic-ref --quiet --short HEAD || true"
+        );
+        let escaped_script = shell_escape_single_quotes(&script, shell_type);
+        let command = format!("sh -c '{escaped_script}'");
+        let output = execute_silent_command(command, spawner).await?;
+        if !output.success() {
+            return Err(PrepareEnvironmentError::VerifyRepository {
+                repo_name: format!("{}/{}", repo.owner, repo.repo),
+            });
+        }
+        let stdout = String::from_utf8(output.stdout).map_err(|_| {
+            PrepareEnvironmentError::VerifyRepository {
+                repo_name: format!("{}/{}", repo.owner, repo.repo),
+            }
+        })?;
+        let mut lines = stdout.lines();
+        let commit_sha = lines.next().unwrap_or_default().trim().to_string();
+        if commit_sha.len() != 40
+            || !commit_sha
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(PrepareEnvironmentError::VerifyRepository {
+                repo_name: format!("{}/{}", repo.owner, repo.repo),
+            });
+        }
+        let baseline = baseline_for_repo(baselines, repo);
+        if baseline.is_some_and(|baseline| baseline.commit_sha != commit_sha) {
+            return Err(PrepareEnvironmentError::VerifyRepository {
+                repo_name: format!("{}/{}", repo.owner, repo.repo),
+            });
+        }
+        let branch = baseline
+            .and_then(|baseline| baseline.branch.clone())
+            .or_else(|| {
+                lines
+                    .next()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(str::to_string)
+            });
+        verified.push(RepositoryBaseline {
+            code_forge: baseline_forge_for_repo(repo),
+            repo_owner: repo.owner.clone(),
+            repo_name: repo.repo.clone(),
+            commit_sha,
+            branch,
+        });
+    }
+    Ok(verified)
 }
 
 fn build_remove_pinned_remotes_command(

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -1,8 +1,53 @@
-use cloud_object_models::CodeForge;
+use std::fs;
+use std::path::Path;
 
-use super::{build_parallel_clone_command, single_repo_name};
-use crate::ai::cloud_environments::SourceRepo;
+use cloud_object_models::CodeForge;
+use command::blocking::Command as BlockingCommand;
+use tempfile::TempDir;
+use warp_cli::agent::{RepositoryBaseline, RepositoryBaselineForge};
+
+use super::{
+    build_parallel_clone_command, build_parallel_prepare_command,
+    build_remove_pinned_remotes_command, single_repo_name, validate_repository_baselines,
+};
+use crate::ai::cloud_environments::{AmbientAgentEnvironment, SourceRepo};
 use crate::terminal::shell::ShellType;
+
+fn baseline(
+    code_forge: RepositoryBaselineForge,
+    owner: &str,
+    repo: &str,
+    sha: &str,
+) -> RepositoryBaseline {
+    RepositoryBaseline {
+        code_forge,
+        repo_owner: owner.to_string(),
+        repo_name: repo.to_string(),
+        commit_sha: sha.to_string(),
+        branch: Some("main".to_string()),
+    }
+}
+
+fn environment_with_repos(repos: Vec<SourceRepo>) -> AmbientAgentEnvironment {
+    let mut environment =
+        AmbientAgentEnvironment::new(String::new(), None, vec![], String::new(), vec![]);
+    environment.source_repos = Some(repos);
+    environment
+}
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    let output = BlockingCommand::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
 
 #[test]
 fn single_repo_name_returns_repo_when_exactly_one_repo() {
@@ -73,4 +118,356 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
     assert!(command.contains("===== platform/backend/api ====="));
     assert!(command.contains("cat \"$log_file_1\""));
     assert!(command.contains("exit \"$failed\""));
+}
+
+#[test]
+fn repository_baseline_validation_rejects_duplicates_and_mismatches() {
+    let environment = environment_with_repos(vec![SourceRepo::new(
+        CodeForge::GitHub,
+        "warpdotdev".to_string(),
+        "warp".to_string(),
+    )]);
+    let github = baseline(
+        RepositoryBaselineForge::GitHub,
+        "warpdotdev",
+        "warp",
+        "0123456789abcdef0123456789abcdef01234567",
+    );
+
+    let duplicate_error =
+        validate_repository_baselines(Some(&environment), &[github.clone(), github.clone()])
+            .expect_err("duplicate repository identity must fail");
+    assert!(duplicate_error.to_string().contains("duplicate"));
+
+    let forge_mismatch = baseline(
+        RepositoryBaselineForge::GitLab,
+        "warpdotdev",
+        "warp",
+        "0123456789abcdef0123456789abcdef01234567",
+    );
+    let mismatch_error = validate_repository_baselines(Some(&environment), &[forge_mismatch])
+        .expect_err("forge mismatch must fail");
+    assert!(mismatch_error.to_string().contains("not declared"));
+}
+
+#[test]
+fn repository_baseline_validation_rejects_partial_multi_repo_pin_sets() {
+    let environment = environment_with_repos(vec![
+        SourceRepo::new(
+            CodeForge::GitHub,
+            "warpdotdev".to_string(),
+            "warp".to_string(),
+        ),
+        SourceRepo::new(
+            CodeForge::GitLab,
+            "platform/backend".to_string(),
+            "api".to_string(),
+        ),
+    ]);
+    let partial_baselines = vec![baseline(
+        RepositoryBaselineForge::GitHub,
+        "warpdotdev",
+        "warp",
+        "0123456789abcdef0123456789abcdef01234567",
+    )];
+
+    let error = validate_repository_baselines(Some(&environment), &partial_baselines)
+        .expect_err("partial baseline set must fail");
+
+    assert!(error.to_string().contains("one baseline for every"));
+    assert!(error.to_string().contains("platform/backend/api"));
+}
+
+#[test]
+fn pinned_prepare_command_uses_exact_shallow_detached_checkouts_in_parallel() {
+    let repos = vec![
+        SourceRepo::new(
+            CodeForge::GitHub,
+            "warpdotdev".to_string(),
+            "warp".to_string(),
+        ),
+        SourceRepo::new(
+            CodeForge::GitLab,
+            "platform/backend".to_string(),
+            "api".to_string(),
+        ),
+    ];
+    let baselines = vec![
+        baseline(
+            RepositoryBaselineForge::GitHub,
+            "warpdotdev",
+            "warp",
+            "0123456789abcdef0123456789abcdef01234567",
+        ),
+        baseline(
+            RepositoryBaselineForge::GitLab,
+            "platform/backend",
+            "api",
+            "89abcdef0123456789abcdef0123456789abcdef",
+        ),
+    ];
+
+    let command = build_parallel_prepare_command(&repos, &baselines, ShellType::Bash);
+
+    assert!(command.contains("https://github.com/warpdotdev/warp.git"));
+    assert!(command.contains("https://gitlab.com/platform/backend/api.git"));
+    assert_eq!(command.matches("checkout_pinned_repo '").count(), 2);
+    assert_eq!(command.matches("2>&1 &").count(), 2);
+    assert!(command.contains("fetch --depth=1 origin \"$commit_sha\""));
+    assert!(command.contains("checkout --detach \"$commit_sha\""));
+    assert!(command.contains("rev-parse --is-inside-work-tree"));
+    assert!(command.contains("[ \"$actual_sha\" != \"$commit_sha\" ]"));
+    assert!(command.contains("symbolic-ref --quiet HEAD"));
+    assert!(command.contains("rev-parse --is-shallow-repository"));
+    assert!(command.contains("rev-list --count HEAD --all"));
+    assert!(command.contains("[ \"$reachable_commits\" != \"1\" ]"));
+    assert!(command.contains("return 1"));
+    assert!(!command.contains("fetch origin HEAD"));
+    assert!(!command.contains("checkout main"));
+}
+
+#[test]
+fn pinned_prepare_command_verifies_existing_directories_instead_of_skipping() {
+    let repos = vec![SourceRepo::new(
+        CodeForge::GitHub,
+        "warpdotdev".to_string(),
+        "warp".to_string(),
+    )];
+    let baselines = vec![baseline(
+        RepositoryBaselineForge::GitHub,
+        "warpdotdev",
+        "warp",
+        "0123456789abcdef0123456789abcdef01234567",
+    )];
+
+    let command = build_parallel_prepare_command(&repos, &baselines, ShellType::Bash);
+
+    assert!(command.contains("if [ -e \"$target\" ]"));
+    assert!(command.contains("Verifying existing pinned repository"));
+    assert!(command.contains("Pinned repository path $target is not a Git repository"));
+    assert!(command.contains("expected $commit_sha"));
+    assert!(command.contains("must use a detached HEAD"));
+    assert!(command.contains("is not shallow"));
+    assert!(command.contains("expected exactly 1"));
+}
+
+#[test]
+fn pinned_prepare_command_fails_for_existing_repository_at_wrong_head() {
+    let workspace = TempDir::new().unwrap();
+    let repo_dir = workspace.path().join("warp");
+    fs::create_dir(&repo_dir).unwrap();
+    for args in [
+        vec!["init", "-q"],
+        vec!["config", "user.email", "test@example.com"],
+        vec!["config", "user.name", "Test"],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+    fs::write(repo_dir.join("README.md"), "existing checkout\n").unwrap();
+    for args in [
+        vec!["add", "README.md"],
+        vec!["commit", "-q", "-m", "existing"],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+
+    let repos = vec![SourceRepo::new(
+        CodeForge::GitHub,
+        "warpdotdev".to_string(),
+        "warp".to_string(),
+    )];
+    let baselines = vec![baseline(
+        RepositoryBaselineForge::GitHub,
+        "warpdotdev",
+        "warp",
+        "0000000000000000000000000000000000000000",
+    )];
+    let command = build_parallel_prepare_command(&repos, &baselines, ShellType::Bash);
+
+    let output = BlockingCommand::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("expected"),
+        "unexpected command output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn pinned_prepare_command_rejects_full_repo_at_matching_detached_head() {
+    let workspace = TempDir::new().unwrap();
+    let repo_dir = workspace.path().join("warp");
+    fs::create_dir(&repo_dir).unwrap();
+    for args in [
+        vec!["init", "-q"],
+        vec!["config", "user.email", "test@example.com"],
+        vec!["config", "user.name", "Test"],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+    fs::write(repo_dir.join("README.md"), "full checkout\n").unwrap();
+    for args in [vec!["add", "README.md"], vec!["commit", "-q", "-m", "full"]] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+    let pinned_sha = git_stdout(&repo_dir, &["rev-parse", "HEAD"]);
+    let checkout = BlockingCommand::new("git")
+        .current_dir(&repo_dir)
+        .args(["checkout", "--detach", &pinned_sha])
+        .output()
+        .unwrap();
+    assert!(checkout.status.success());
+
+    let repos = vec![SourceRepo::new(
+        CodeForge::GitHub,
+        "warpdotdev".to_string(),
+        "warp".to_string(),
+    )];
+    let baselines = vec![baseline(
+        RepositoryBaselineForge::GitHub,
+        "warpdotdev",
+        "warp",
+        &pinned_sha,
+    )];
+    let command = build_parallel_prepare_command(&repos, &baselines, ShellType::Bash);
+
+    let output = BlockingCommand::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("is not shallow"),
+        "unexpected command output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn pinned_prepare_command_rejects_shallow_repo_with_history_ref() {
+    let workspace = TempDir::new().unwrap();
+    let repo_dir = workspace.path().join("warp");
+    fs::create_dir(&repo_dir).unwrap();
+    for args in [
+        vec!["init", "-q"],
+        vec!["config", "user.email", "test@example.com"],
+        vec!["config", "user.name", "Test"],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+    fs::write(repo_dir.join("README.md"), "first\n").unwrap();
+    for args in [
+        vec!["add", "README.md"],
+        vec!["commit", "-q", "-m", "first"],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+    let first_sha = git_stdout(&repo_dir, &["rev-parse", "HEAD"]);
+    fs::write(repo_dir.join("README.md"), "second\n").unwrap();
+    for args in [
+        vec!["add", "README.md"],
+        vec!["commit", "-q", "-m", "second"],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+    let pinned_sha = git_stdout(&repo_dir, &["rev-parse", "HEAD"]);
+    for args in [
+        vec!["checkout", "--detach", &pinned_sha],
+        vec!["branch", "exposed-history", &first_sha],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(&repo_dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+    }
+    fs::write(repo_dir.join(".git/shallow"), format!("{pinned_sha}\n")).unwrap();
+
+    let repos = vec![SourceRepo::new(
+        CodeForge::GitHub,
+        "warpdotdev".to_string(),
+        "warp".to_string(),
+    )];
+    let baselines = vec![baseline(
+        RepositoryBaselineForge::GitHub,
+        "warpdotdev",
+        "warp",
+        &pinned_sha,
+    )];
+    let command = build_parallel_prepare_command(&repos, &baselines, ShellType::Bash);
+
+    let output = BlockingCommand::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(workspace.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("exposes 2 commits"),
+        "unexpected command output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn pinned_remote_removal_targets_only_supplied_repositories() {
+    let baselines = vec![baseline(
+        RepositoryBaselineForge::GitHub,
+        "warpdotdev",
+        "warp",
+        "0123456789abcdef0123456789abcdef01234567",
+    )];
+
+    let command =
+        build_remove_pinned_remotes_command(&baselines, Path::new("/workspace"), ShellType::Bash);
+
+    assert!(command.contains("/workspace/warp"));
+    assert!(command.contains("remote get-url origin"));
+    assert!(command.contains("remote remove origin"));
 }

--- a/app/src/ai/agent_sdk/driver/snapshot.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot.rs
@@ -661,6 +661,8 @@ struct RepoManifestEntry {
     branch: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     head_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_sha: Option<String>,
     patch_file: Option<String>,
     status: &'static str,
     uploaded: Option<bool>,
@@ -704,17 +706,32 @@ async fn upload_with_retry(
 pub(super) async fn upload_snapshot_from_declarations(
     client: Arc<dyn HarnessSupportClient>,
     task_id: &AmbientAgentTaskId,
+    repository_baselines: &HashMap<PathBuf, String>,
 ) {
     let declarations_path = resolve_declarations_path(Some(task_id));
-    let _ = upload_snapshot_from_declarations_file(&declarations_path, client).await;
+    let _ = upload_snapshot_from_declarations_file_with_baselines(
+        &declarations_path,
+        client,
+        repository_baselines,
+    )
+    .await;
 }
 
 /// Internal entry that reads from an explicit path and returns the structured outcome so tests
 /// can inspect per-entry statuses. Production callers go through
 /// [`upload_snapshot_from_declarations`] which discards the outcome.
+#[cfg(test)]
 async fn upload_snapshot_from_declarations_file(
     path: &Path,
     client: Arc<dyn HarnessSupportClient>,
+) -> Option<SnapshotOutcome> {
+    upload_snapshot_from_declarations_file_with_baselines(path, client, &HashMap::new()).await
+}
+
+async fn upload_snapshot_from_declarations_file_with_baselines(
+    path: &Path,
+    client: Arc<dyn HarnessSupportClient>,
+    repository_baselines: &HashMap<PathBuf, String>,
 ) -> Option<SnapshotOutcome> {
     log::info!("Snapshot upload starting from {}", path.display());
     let declarations = read_and_parse_declarations(path)?;
@@ -729,7 +746,7 @@ async fn upload_snapshot_from_declarations_file(
         "Snapshot declarations: {} entries ({repo_count} repo, {file_count} file)",
         declarations.len(),
     );
-    let outcome = run_pipeline(declarations, client).await?;
+    let outcome = run_pipeline(declarations, client, repository_baselines).await?;
     log_snapshot_outcome(&outcome);
     Some(outcome)
 }
@@ -876,6 +893,7 @@ pub(crate) async fn upload_snapshot_for_handoff(
 async fn run_pipeline(
     declarations: Vec<DeclarationEntry>,
     client: Arc<dyn HarnessSupportClient>,
+    repository_baselines: &HashMap<PathBuf, String>,
 ) -> Option<SnapshotOutcome> {
     let GatheredSnapshot {
         manifest_filename,
@@ -883,7 +901,7 @@ async fn run_pipeline(
         repos,
         files,
         pre_upload_entries,
-    } = gather_snapshot_entries(declarations).await;
+    } = gather_snapshot_entries_with_baselines(declarations, repository_baselines).await;
 
     upload_gathered_snapshot(
         client,
@@ -905,6 +923,13 @@ struct GatheredSnapshot {
 }
 
 async fn gather_snapshot_entries(declarations: Vec<DeclarationEntry>) -> GatheredSnapshot {
+    gather_snapshot_entries_with_baselines(declarations, &HashMap::new()).await
+}
+
+async fn gather_snapshot_entries_with_baselines(
+    declarations: Vec<DeclarationEntry>,
+    repository_baselines: &HashMap<PathBuf, String>,
+) -> GatheredSnapshot {
     let mut used_filenames = HashSet::new();
     let manifest_filename = unique_filename("snapshot_state.json", &mut used_filenames);
 
@@ -920,8 +945,10 @@ async fn gather_snapshot_entries(declarations: Vec<DeclarationEntry>) -> Gathere
         match entry.kind {
             EntryKind::Repo => {
                 repo_index += 1;
+                let baseline_sha = repository_baselines.get(Path::new(&entry.path));
                 gather_repo(
                     &entry.path,
+                    baseline_sha.map(String::as_str),
                     repo_index,
                     &mut used_filenames,
                     &mut upload_files,
@@ -1104,6 +1131,7 @@ async fn upload_prepared_snapshot_files(
 /// Gather a repo entry: run `build_repo_patch` and append an upload blob + manifest stub.
 async fn gather_repo(
     repo_path: &str,
+    baseline_sha: Option<&str>,
     repo_index: usize,
     used_filenames: &mut HashSet<String>,
     upload_files: &mut Vec<SnapshotUploadFile>,
@@ -1112,13 +1140,14 @@ async fn gather_repo(
 ) {
     let repo = Path::new(repo_path);
     let metadata = repo_metadata(repo).await;
-    match build_repo_patch(repo).await {
+    match build_repo_patch_from_baseline(repo, baseline_sha).await {
         Ok(patch) if patch.is_empty() => {
             repos.push(RepoManifestEntry {
                 path: repo_path.to_string(),
                 repo_name: metadata.repo_name,
                 branch: metadata.branch,
                 head_sha: metadata.head_sha,
+                baseline_sha: baseline_sha.map(str::to_string),
                 patch_file: None,
                 status: "clean",
                 uploaded: None,
@@ -1142,6 +1171,7 @@ async fn gather_repo(
                 repo_name: metadata.repo_name,
                 branch: metadata.branch,
                 head_sha: metadata.head_sha,
+                baseline_sha: baseline_sha.map(str::to_string),
                 patch_file: Some(filename),
                 status: "dirty",
                 uploaded: None,
@@ -1156,6 +1186,7 @@ async fn gather_repo(
                 repo_name: metadata.repo_name,
                 branch: metadata.branch,
                 head_sha: metadata.head_sha,
+                baseline_sha: baseline_sha.map(str::to_string),
                 patch_file: None,
                 status: "gather_failed",
                 uploaded: None,
@@ -1455,8 +1486,21 @@ async fn repo_metadata(repo_dir: &Path) -> RepoMetadata {
     }
 }
 
+#[cfg(test)]
 async fn build_repo_patch(repo_dir: &Path) -> Result<Vec<u8>> {
-    let mut patch = git_output_bytes(repo_dir, ["diff", "--binary", "HEAD"], &[0]).await?;
+    build_repo_patch_from_baseline(repo_dir, None).await
+}
+
+async fn build_repo_patch_from_baseline(
+    repo_dir: &Path,
+    baseline_sha: Option<&str>,
+) -> Result<Vec<u8>> {
+    let mut patch = git_output_bytes(
+        repo_dir,
+        ["diff", "--binary", baseline_sha.unwrap_or("HEAD")],
+        &[0],
+    )
+    .await?;
     let untracked_listing = git_output_bytes(
         repo_dir,
         ["ls-files", "--others", "--exclude-standard", "-z"],

--- a/app/src/ai/agent_sdk/driver/snapshot_tests.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot_tests.rs
@@ -208,6 +208,12 @@ impl HarnessSupportClient for TestClient {
     async fn finish_task(&self, _success: bool, _summary: &str) -> Result<()> {
         unimplemented!("not used by upload_snapshot_from_declarations_file")
     }
+    async fn report_repository_baselines(
+        &self,
+        _repositories: &[warp_cli::agent::RepositoryBaseline],
+    ) -> Result<()> {
+        unimplemented!("not used by upload_snapshot_from_declarations_file")
+    }
 
     async fn report_clean_shutdown(&self) -> Result<()> {
         unimplemented!("not used by upload_snapshot_from_declarations_file")

--- a/app/src/ai/agent_sdk/driver/snapshot_tests.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot_tests.rs
@@ -44,6 +44,99 @@ struct TestClient {
     drop_trailing_targets: usize,
 }
 
+#[test]
+fn pinned_repo_patch_includes_committed_and_uncommitted_changes() {
+    let tempdir = snaptest_tempdir();
+    init_git_repo(tempdir.path(), false);
+    let baseline_sha = git_stdout(tempdir.path(), &["rev-parse", "HEAD"]);
+
+    fs::write(
+        tempdir.path().join("committed.txt"),
+        "subject-commit-content\n",
+    )
+    .unwrap();
+    for args in [
+        vec!["add", "committed.txt"],
+        vec!["commit", "-q", "-m", "subject commit"],
+    ] {
+        let output = BlockingCommand::new("git")
+            .current_dir(tempdir.path())
+            .args(args)
+            .output()
+            .expect("failed to spawn git");
+        assert!(
+            output.status.success(),
+            "git command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    fs::write(tempdir.path().join("README.md"), "working-tree-content\n").unwrap();
+    fs::write(tempdir.path().join("untracked.txt"), "untracked work\n").unwrap();
+
+    let runtime = Runtime::new().unwrap();
+    let legacy_patch = runtime.block_on(build_repo_patch(tempdir.path())).unwrap();
+    let pinned_patch = runtime
+        .block_on(build_repo_patch_from_baseline(
+            tempdir.path(),
+            Some(&baseline_sha),
+        ))
+        .unwrap();
+    let legacy_patch = String::from_utf8_lossy(&legacy_patch);
+    let pinned_patch = String::from_utf8_lossy(&pinned_patch);
+
+    assert!(!legacy_patch.contains("subject-commit-content"));
+    assert!(legacy_patch.contains("working-tree-content"));
+    assert!(legacy_patch.contains("untracked work"));
+    assert!(pinned_patch.contains("subject-commit-content"));
+    assert!(pinned_patch.contains("working-tree-content"));
+    assert!(pinned_patch.contains("untracked work"));
+}
+
+#[test]
+fn pinned_snapshot_manifest_records_baseline_sha() {
+    let repo = snaptest_tempdir();
+    init_git_repo(repo.path(), false);
+    let baseline_sha = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+    fs::write(repo.path().join("README.md"), "subject work\n").unwrap();
+    let declarations_dir = snaptest_tempdir();
+    let declarations_path = write_declarations(declarations_dir.path(), &[repo.path()], &[]);
+    let repository_baselines = HashMap::from([(repo.path().to_path_buf(), baseline_sha.clone())]);
+
+    let mut server = Server::new();
+    let patch_mock = server
+        .mock("PUT", upload_path(r".+\.patch"))
+        .with_status(200)
+        .expect(1)
+        .create();
+    let manifest_mock = server
+        .mock("PUT", upload_path("snapshot_state\\.json"))
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "repos": [{
+                "path": repo.path().to_string_lossy(),
+                "baseline_sha": baseline_sha,
+                "status": "uploaded",
+                "uploaded": true,
+            }],
+        })))
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let client = TestClient::new(server.url());
+    let outcome = Runtime::new()
+        .unwrap()
+        .block_on(upload_snapshot_from_declarations_file_with_baselines(
+            &declarations_path,
+            client,
+            &repository_baselines,
+        ))
+        .expect("pipeline returned None");
+
+    assert!(outcome.manifest_uploaded);
+    patch_mock.assert();
+    manifest_mock.assert();
+}
+
 impl TestClient {
     fn new(server_base_url: String) -> Arc<Self> {
         Arc::new(Self {

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1037,6 +1037,7 @@ impl AgentDriverRunner {
                     resume: None,
                     cloud_providers: Vec::new(),
                     environment: None,
+                    repository_baselines: args.repository_baselines.clone(),
                     selected_harness: args.harness,
                     third_party_harness_model_config,
                     snapshot_disabled: args.snapshot.no_snapshot.then_some(true),
@@ -1105,6 +1106,10 @@ impl AgentDriverRunner {
                 Self::resolve_environment(foreground, environment_id, &mut driver_options),
             )
             .await?;
+        driver::environment::validate_repository_baselines(
+            driver_options.environment.as_ref(),
+            &driver_options.repository_baselines,
+        )?;
 
         Ok((driver_options, task, task_conversation_id))
     }

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1038,6 +1038,7 @@ impl AgentDriverRunner {
                     cloud_providers: Vec::new(),
                     environment: None,
                     repository_baselines: args.repository_baselines.clone(),
+                    report_repository_baselines: args.task_id.is_some(),
                     selected_harness: args.harness,
                     third_party_harness_model_config,
                     snapshot_disabled: args.snapshot.no_snapshot.then_some(true),

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 #[cfg(test)]
 use mockall::automock;
+use warp_cli::agent::RepositoryBaseline;
 
 #[cfg(feature = "local_fs")]
 pub use super::presigned_upload::FileUploadBody;
@@ -145,6 +146,10 @@ struct FinishTaskRequest {
     success: bool,
     summary: String,
 }
+#[derive(serde::Serialize)]
+struct ReportRepositoryBaselinesRequest<'a> {
+    repositories: &'a [RepositoryBaseline],
+}
 
 #[derive(Debug, Clone, serde::Serialize)]
 struct ShutdownError {
@@ -204,6 +209,8 @@ pub trait HarnessSupportClient: 'static + Send + Sync {
     /// Report task completion or failure. The server derives PR links/branches from
     /// artifacts already reported via `report_artifact`.
     async fn finish_task(&self, success: bool, summary: &str) -> Result<()>;
+    /// Report verified initial repository state before environment setup begins.
+    async fn report_repository_baselines(&self, repositories: &[RepositoryBaseline]) -> Result<()>;
 
     /// Report a clean shutdown of the agent process.
     async fn report_clean_shutdown(&self) -> Result<()>;
@@ -379,6 +386,13 @@ impl HarnessSupportClient for ServerApi {
             &GetUploadTargetRequest {
                 conversation_id: conversation_id.to_string(),
             },
+        )
+        .await
+    }
+    async fn report_repository_baselines(&self, repositories: &[RepositoryBaseline]) -> Result<()> {
+        self.post_public_api_unit(
+            "harness-support/repository-baselines",
+            &ReportRepositoryBaselinesRequest { repositories },
         )
         .await
     }

--- a/app/src/terminal/view/docker_sandbox/mod.rs
+++ b/app/src/terminal/view/docker_sandbox/mod.rs
@@ -22,7 +22,9 @@ use warpui::{SingletonEntity, View, ViewHandle};
 use super::TerminalView;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_sdk::driver::{
-    environment::prepare_environment, terminal::TerminalDriver, WARP_DRIVE_SYNC_TIMEOUT,
+    environment::{prepare_environment, RepositoryBaselineContext},
+    terminal::TerminalDriver,
+    WARP_DRIVE_SYNC_TIMEOUT,
 };
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_sdk::setup_observability::SetupClientEventReporter;
@@ -296,6 +298,7 @@ impl TerminalView {
                             DOCKER_SANDBOX_HOME_DIR.into(),
                             true, /* is_sandbox */
                             Harness::Oz,
+                            RepositoryBaselineContext::default(),
                             setup_events,
                             ctx,
                         )

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use clap::builder::PossibleValue;
 use clap::{Args, Subcommand, ValueEnum};
@@ -37,6 +38,68 @@ impl fmt::Display for OutputFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = self.to_possible_value().expect("no values are skipped");
         f.write_str(value.get_name())
+    }
+}
+
+/// Source-control provider for a repository baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RepositoryBaselineForge {
+    #[serde(rename = "GITHUB")]
+    GitHub,
+    #[serde(rename = "GITLAB")]
+    GitLab,
+}
+
+/// Immutable repository state supplied by the server for an agent run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryBaseline {
+    pub code_forge: RepositoryBaselineForge,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub commit_sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+}
+
+impl RepositoryBaseline {
+    pub fn identity(&self) -> (RepositoryBaselineForge, &str, &str) {
+        (
+            self.code_forge,
+            self.repo_owner.as_str(),
+            self.repo_name.as_str(),
+        )
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.repo_owner.is_empty() {
+            return Err("repo_owner must not be empty".to_string());
+        }
+        if self.repo_name.is_empty() {
+            return Err("repo_name must not be empty".to_string());
+        }
+        if self.commit_sha.len() != 40
+            || !self
+                .commit_sha
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(
+                "commit_sha must be an exact 40-character lowercase hexadecimal SHA".to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for RepositoryBaseline {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let baseline = serde_json::from_str::<Self>(value)
+            .map_err(|error| format!("invalid repository baseline JSON: {error}"))?;
+        baseline.validate()?;
+        Ok(baseline)
     }
 }
 
@@ -470,6 +533,16 @@ pub struct RunAgentArgs {
 
     #[arg(long = "configure-git-credentials-with-github", hide = true, requires_all = ["task_id"])]
     pub configure_git_credentials_with_github: bool,
+
+    /// Immutable repository baseline supplied by the server for this task.
+    #[arg(
+        long = "repository-baseline-json",
+        value_name = "JSON",
+        action = clap::ArgAction::Append,
+        requires = "task_id",
+        hide = true
+    )]
+    pub repository_baselines: Vec<RepositoryBaseline>,
 }
 
 impl RunAgentArgs {

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use clap::Parser;
 
 use super::*;
-use crate::agent::{AgentCommand, Harness, OutputFormat};
+use crate::agent::{AgentCommand, Harness, OutputFormat, RepositoryBaselineForge};
 use crate::artifact::ArtifactCommand;
 use crate::environment::{EnvironmentCommand, ImageCommand};
 use crate::harness_support::{HarnessSupportCommand, TaskStatus};
@@ -261,6 +261,94 @@ fn agent_run_rejects_bedrock_role_region_without_role() {
         err.to_string().contains("--bedrock-inference-role"),
         "expected error to reference --bedrock-inference-role, got: {err}"
     );
+}
+
+#[test]
+fn agent_run_parses_repeated_repository_baseline_json() {
+    let args = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run",
+        "--task-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--repository-baseline-json",
+        r#"{"code_forge":"GITHUB","repo_owner":"warpdotdev","repo_name":"warp","commit_sha":"0123456789abcdef0123456789abcdef01234567","branch":"main"}"#,
+        "--repository-baseline-json",
+        r#"{"code_forge":"GITLAB","repo_owner":"platform/backend","repo_name":"api","commit_sha":"89abcdef0123456789abcdef0123456789abcdef"}"#,
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp agent run` command");
+    };
+    let CliCommand::Agent(AgentCommand::Run(run_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp agent run` command");
+    };
+
+    assert_eq!(run_args.repository_baselines.len(), 2);
+    assert_eq!(
+        run_args.repository_baselines[0].code_forge,
+        RepositoryBaselineForge::GitHub
+    );
+    assert_eq!(
+        run_args.repository_baselines[0].branch.as_deref(),
+        Some("main")
+    );
+    assert_eq!(
+        run_args.repository_baselines[1].code_forge,
+        RepositoryBaselineForge::GitLab
+    );
+    assert_eq!(
+        run_args.repository_baselines[1].repo_owner,
+        "platform/backend"
+    );
+}
+
+#[test]
+fn agent_run_rejects_non_lowercase_exact_repository_sha() {
+    for invalid_sha in [
+        "0123456789abcdef0123456789abcdef0123456",
+        "0123456789abcdef0123456789abcdef012345678",
+        "0123456789abcdef0123456789abcdef0123456A",
+    ] {
+        let baseline = format!(
+            r#"{{"code_forge":"GITHUB","repo_owner":"warpdotdev","repo_name":"warp","commit_sha":"{invalid_sha}"}}"#
+        );
+        let err = Args::try_parse_from([
+            "warp",
+            "agent",
+            "run",
+            "--task-id",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--repository-baseline-json",
+            baseline.as_str(),
+        ])
+        .expect_err("invalid commit SHA must fail parsing");
+        assert!(
+            err.to_string()
+                .contains("exact 40-character lowercase hexadecimal SHA"),
+            "unexpected parse error: {err}"
+        );
+    }
+}
+
+#[test]
+fn agent_run_rejects_invalid_repository_baseline_shape() {
+    for invalid_baseline in [
+        r#"{"code_forge":"github","repo_owner":"warpdotdev","repo_name":"warp","commit_sha":"0123456789abcdef0123456789abcdef01234567"}"#,
+        r#"{"code_forge":"GITHUB","repo_owner":"warpdotdev","repo_name":"warp","commit_sha":"0123456789abcdef0123456789abcdef01234567","unexpected":true}"#,
+    ] {
+        Args::try_parse_from([
+            "warp",
+            "agent",
+            "run",
+            "--task-id",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--repository-baseline-json",
+            invalid_baseline,
+        ])
+        .expect_err("invalid baseline JSON must fail parsing");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Description
Stack 2 of 2 on #13718.

Reports the materialized HEAD SHA and branch for each environment repository before setup commands run. The client sends the verified repository state through the harness-support API so the server can record the exact execution baseline for pinned and unpinned task-backed runs.

## Linked Issue
N/A

## Testing
- `./script/format`
- `cargo nextest run -p warp -E 'test(repository_baseline)'` (2 passed)
- Presubmit clippy commands from `script/presubmit`

- [ ] I have manually tested my changes locally with `./script/run` (not applicable to this headless agent setup path)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Conversation: https://staging.warp.dev/conversation/68b43c0f-5ef2-4aa8-b911-115291bdb7a2

Co-Authored-By: Warp <agent@warp.dev>