### PR TITLE
Fix markdown_parser: unclosed <u> markers no longer delete surrounding text

### DIFF
--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1842,6 +1842,14 @@ impl Delimiter {
             return false;
         }
 
+        // `<u>` is only ever closed by an explicit `</u>`, which is handled separately by
+        // `parse_underline` (it never goes through `can_open_for`). Pairing two `<u>` openers
+        // through the emphasis algorithm is always wrong and would silently delete the text
+        // between/around them; an unclosed `<u>` should round-trip to literal text instead.
+        if self.kind == DelimiterKind::UnderlineStart {
+            return false;
+        }
+
         // For strikethrough, the delimiter counts must match.
         if self.kind == DelimiterKind::Strikethrough {
             return self.count == other.count;

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -1982,6 +1982,29 @@ fn test_parse_empty_underline() {
 }
 
 #[test]
+fn test_parse_unclosed_underline_round_trips_to_literal_text() {
+    // Regression test: an unclosed `<u>` followed by another `<u>` used to be matched as an
+    // opener/closer pair by the emphasis algorithm, silently deleting both markers and the text
+    // between/around them. `<u>` is only ever closed by an explicit `</u>` (handled by
+    // `parse_underline`), so two bare `<u>` markers should round-trip to literal text, exactly
+    // like an unclosed `*`.
+    assert_eq!(
+        parse_all("<u><u>", parse_inline),
+        vec![FormattedTextFragment::plain_text("<u><u>")]
+    );
+
+    assert_eq!(
+        parse_all("<u>a<u>", parse_inline),
+        vec![FormattedTextFragment::plain_text("<u>a<u>")]
+    );
+
+    assert_eq!(
+        parse_all("a <u>word<u> b", parse_inline),
+        vec![FormattedTextFragment::plain_text("a <u>word<u> b")]
+    );
+}
+
+#[test]
 fn test_unordered_list_indentation_level_relative() {
     // Test that both 2-space and 4-space relative indentation produce the same structure
     let source_2space = "- top level\n  - sublevel\n    - subsublevel";


### PR DESCRIPTION
## Description

`parse_markdown` was silently **deleting text** when a `<u>` underline marker was left unclosed and another `<u>` appeared later in the same line.

`<u>` is tokenized as an `UnderlineStart` delimiter and pushed onto the shared delimiter stack. `process_emphasis` treats two `<u>` markers as a matchable opener/closer pair (since `can_open_for` only checked `kind` equality), consuming both markers and removing the text nodes between them.

Underline is only ever supposed to be closed by an explicit `</u>`, which is handled separately by `parse_underline` (it never goes through `can_open_for`). Pairing two `<u>` openers through the emphasis path is therefore always wrong.

### Fix
`can_open_for` now explicitly rejects `DelimiterKind::UnderlineStart` openers, so an unclosed `<u>` round-trips to literal text — the same behavior as an unclosed `*` or `~~`.

| Input | Before | After |
|---|---|---|
| `<u><u>` | empty line — all text gone | `<u><u>` |
| `<u>a<u>` | `a` (both `<u>` deleted) | `<u>a<u>` |
| `a <u>word<u> b` | `a word b` (both `<u>` deleted) | `a <u>word<u> b` |

## Linked Issue
Fixes #12863

- [x] The linked issue is labeled `ready-to-implement`.
- [x] No UI changes — this is a pure parser logic fix in `crates/markdown_parser`.

## Testing

- [x] Added `test_parse_unclosed_underline_round_trips_to_literal_text`, covering the three repro cases from the issue (`<u><u>`, `<u>a<u>`, `a <u>word<u> b`).
- [x] Ran `cargo test -p markdown_parser`: all 155 tests pass (154 pre-existing + 1 new).
- [x] Ran `cargo fmt -p markdown_parser --check`: clean.
- [x] Ran `cargo clippy -p markdown_parser --all-targets --all-features -- -D warnings`: no warnings.

This is a crate-scoped, platform-independent parser fix with no UI surface, so it was verified via the automated test suite above rather than manual app testing (`./script/run` builds the full desktop app, which isn't feasible in this environment).

### Screenshots / Videos
N/A — parser-only change, no UI.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed a bug where an unclosed `<u>` underline tag followed by another `<u>` tag would silently delete the surrounding text in rendered Markdown (agent output, markdown viewer, etc.).
-->
