### PR TITLE
Show close button in place of file icon when hovering narrow code tabs

### DIFF
--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -1597,9 +1597,27 @@ impl CodeView {
             .map(|loc| display_name_with_host(loc, app))
             .filter(|n| !n.is_empty())
             .unwrap_or_else(|| "Untitled".to_string());
-        let language_icon =
-            icon_from_file_path(&file_name, appearance, ItemHighlightState::Default);
-        row.add_child(
+
+        // On hover, show the close button in place of the file-type icon rather than only
+        // appending it after the (possibly truncated) file name. This keeps the close affordance
+        // reachable even when the tab is too narrow to show both the icon and a trailing close
+        // button.
+        let icon_slot = if is_hovered {
+            Container::new(
+                ConstrainedBox::new(Self::render_close_button(
+                    appearance,
+                    tab_data.mouse_state_handles.close_handle.clone(),
+                    index,
+                ))
+                .with_width(CLOSE_BUTTON_WIDTH)
+                .with_height(CLOSE_BUTTON_WIDTH)
+                .finish(),
+            )
+            .with_margin_right(TAB_INTERNAL_MARGIN)
+            .finish()
+        } else {
+            let language_icon =
+                icon_from_file_path(&file_name, appearance, ItemHighlightState::Default);
             Container::new(
                 ConstrainedBox::new(language_icon)
                     .with_width(LANGUAGE_ICON_WIDTH)
@@ -1607,8 +1625,9 @@ impl CodeView {
                     .finish(),
             )
             .with_margin_right(TAB_INTERNAL_MARGIN)
-            .finish(),
-        );
+            .finish()
+        };
+        row.add_child(icon_slot);
 
         if has_unsaved_changes {
             row.add_child(
@@ -1642,7 +1661,9 @@ impl CodeView {
             .finish(),
         );
 
-        let show_close = is_active || is_hovered;
+        // While hovering, the close button is already shown in place of the file icon above, so
+        // avoid rendering a second close button in the trailing slot.
+        let show_close = is_active && !is_hovered;
         row.add_child(
             Shrinkable::new(
                 1.,


### PR DESCRIPTION
## Description

Fixes #10592.

When many files are open in the code pane, individual tabs shrink and the close (x) button can end up hidden or unreachable, even though the tab is being hovered. This mirrors Chrome/Safari's tab UX request from the issue: hovering a tab should replace the file-type icon with a close button so the file can always be closed directly from the tab, regardless of how narrow it is.

### Change

In `CodeView::render_tab_internal` (`app/src/code/view.rs`):
- The icon slot (previously always the file-type icon) now renders the close button (reusing the existing `render_close_button`) while the tab is hovered, and falls back to the file-type icon otherwise.
- The trailing close-button slot's visibility condition changed from `is_active || is_hovered` to `is_active && !is_hovered`, so we don't render two close buttons at once while hovering.

This directly addresses the core repro in the issue (icon not replaced by the close button on hover) using the simplest of the incremental behaviors described (item 3 in the issue: reveal the close button in place of the icon on hover), without changing the always-visible-close-button behavior for the active tab.

## Linked Issue

- [x] I have linked the issue(s) this PR resolves, and I have confirmed a maintainer has added the "ready-to-implement" label to them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I don't have access to a macOS/Linux GUI environment capable of running the full Warp app locally in this sandbox (no Metal toolchain license acceptance possible), so I was not able to capture a screen recording per the template. To compensate, I verified correctness through:

- Careful manual tracing of `render_tab_internal` against the existing `render_close_button` call/signature used elsewhere in the same file (identical arguments: `appearance`, `close_handle`, `index`).
- Full workspace compile verification: cross-compiled the `warp` package (`cargo check -p warp --target x86_64-unknown-linux-gnu`) successfully with zero errors, using a Linux cross-toolchain to route around the local Xcode/Metal licensing blocker (this repo's macOS-only Metal shader build is skipped for non-macOS targets).
- `cargo clippy -p warp --target x86_64-unknown-linux-gnu -- -D warnings` - zero warnings/errors.
- `cargo fmt --check -p warp` - clean.

I'm happy to add a video/screenshot if a maintainer can point me to a way to test this locally, or if CI produces build artifacts I can run.

<!--
CHANGELOG-BUG-FIX: Hovering a narrow code editor tab now replaces the file icon with a close button, so files can always be closed even when many tabs are open.
-->
