### PR TITLE
Force code editor for global search matches so line jump always works

### DIFF
--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -53,9 +53,7 @@ use crate::util::bindings::keybinding_name_to_display_string;
 use crate::util::file::external_editor::EditorSettings;
 use crate::util::openable_file_type::FileTarget;
 #[cfg(feature = "local_fs")]
-use crate::util::openable_file_type::{
-    EditorLayout, is_markdown_file, resolve_file_target_with_editor_choice,
-};
+use crate::util::openable_file_type::{EditorLayout, resolve_file_target_with_editor_choice};
 use crate::workspace::WorkspaceAction;
 use crate::workspace::view::conversation_list::view::{
     ConversationListView, Event as ConversationListViewEvent,
@@ -903,25 +901,32 @@ impl LeftPanelView {
 
                 let settings = EditorSettings::as_ref(ctx);
                 let target = match location {
-                    LocalOrRemotePath::Local(path) => resolve_file_target_with_editor_choice(
-                        path,
-                        *settings.open_code_panels_file_editor,
-                        *settings.prefer_markdown_viewer,
-                        *settings.open_file_layout,
-                        None,
-                    ),
+                    LocalOrRemotePath::Local(path) => {
+                        let resolved = resolve_file_target_with_editor_choice(
+                            path,
+                            *settings.open_code_panels_file_editor,
+                            *settings.prefer_markdown_viewer,
+                            *settings.open_file_layout,
+                            None,
+                        );
+                        // The Markdown Viewer doesn't support jumping to a specific line, so a
+                        // match would silently open at the top of the file. Force the raw code
+                        // editor for matches so the requested line is always honored, regardless
+                        // of the user's Markdown Viewer preference.
+                        if let FileTarget::MarkdownViewer(layout) = resolved {
+                            FileTarget::CodeEditor(layout)
+                        } else {
+                            resolved
+                        }
+                    }
                     // Local-fs-based target resolution can't inspect remote
                     // files; mirror the file tree's remote handling (code
                     // editor, or markdown viewer by extension + preference).
-                    LocalOrRemotePath::Remote(remote) => {
-                        let is_markdown =
-                            is_markdown_file(std::path::Path::new(remote.path.as_str()));
-                        if is_markdown && *settings.prefer_markdown_viewer {
-                            FileTarget::MarkdownViewer(EditorLayout::SplitPane)
-                        } else {
-                            FileTarget::CodeEditor(EditorLayout::SplitPane)
-                        }
-                    }
+                    //
+                    // Unlike the file tree, matches always carry a specific line, and the
+                    // Markdown Viewer doesn't support jumping to it, so always use the code
+                    // editor here rather than respecting `prefer_markdown_viewer`.
+                    LocalOrRemotePath::Remote(_) => FileTarget::CodeEditor(EditorLayout::SplitPane),
                 };
 
                 send_telemetry_from_ctx!(

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -919,13 +919,14 @@ impl LeftPanelView {
                             resolved
                         }
                     }
-                    // Local-fs-based target resolution can't inspect remote
-                    // files; mirror the file tree's remote handling (code
-                    // editor, or markdown viewer by extension + preference).
+                    // Local-fs-based target resolution can't inspect remote files, so the
+                    // target is chosen directly here rather than via
+                    // `resolve_file_target_with_editor_choice`.
                     //
-                    // Unlike the file tree, matches always carry a specific line, and the
-                    // Markdown Viewer doesn't support jumping to it, so always use the code
-                    // editor here rather than respecting `prefer_markdown_viewer`.
+                    // Search matches always carry a specific line and the Markdown Viewer
+                    // can't jump to one, so this deliberately always opens the code editor
+                    // and ignores `prefer_markdown_viewer` -- unlike the file tree, which
+                    // has no line to honor and so may open the Markdown Viewer.
                     LocalOrRemotePath::Remote(_) => FileTarget::CodeEditor(EditorLayout::SplitPane),
                 };
 


### PR DESCRIPTION
## Description

Fixes #9657.

Clicking a global search result opens the matching file, but when the file is markdown and the user has the "prefer Markdown Viewer" setting enabled, the match opened at the top of the file instead of jumping to the matched line.

### Root cause

Tracing `GlobalSearchViewEvent::OpenMatch` -> `LeftPanelEvent::OpenFileWithTarget` -> `open_file_with_target`:
- For `FileTarget::CodeEditor`, `line_col` is correctly threaded through `open_or_focus_existing` -> `jump_to_line_col_in_tab` -> `ScrollPosition::LineAndColumn`, and it works.
- For `FileTarget::MarkdownViewer`, the file is opened via `open_file_notebook` -> `FilePane::new`, neither of which accepts a `line_col` parameter at all. It's structurally impossible for the Markdown Viewer to jump to a line today.

So any search match in a markdown file, when the Markdown Viewer preference is on, silently loses the requested line and opens at the top.

### Fix

In `LeftPanelView::handle_global_search_event` (`app/src/workspace/view/left_panel.rs`), force `FileTarget::CodeEditor` for search-match opens, for both local and remote paths, overriding the Markdown Viewer preference specifically for this flow. A search match always carries a specific line to jump to, and only the code editor supports that today, so this is the minimal, targeted fix (the underlying Markdown Viewer limitation is a separate, larger gap that would need a `line_col` parameter threaded through `open_file_notebook`/`FilePane`, out of scope for this issue).

## Linked Issue

- [x] I have linked the issue(s) this PR resolves, and I have confirmed a maintainer has added the "ready-to-implement" label to them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I don't have access to a macOS/Linux GUI environment capable of running the full Warp app locally in this sandbox (no Metal toolchain license acceptance possible), so I was not able to capture a screen recording per the template. To compensate, I verified correctness through:

- Deep manual tracing of the full call chain (`OpenMatch` -> `OpenFileWithTarget` -> `open_file_with_target` -> `open_code`/`open_file_notebook`) confirming `line_col` is dropped only in the Markdown Viewer path, and that `FileTarget::CodeEditor`/`FileTarget::MarkdownViewer` variant signatures (`EditorLayout`) match my usage exactly.
- Full workspace compile verification: cross-compiled the `warp` package (`cargo check -p warp --target x86_64-unknown-linux-gnu`) successfully with zero errors, using a Linux cross-toolchain to route around the local Xcode/Metal licensing blocker (this repo's macOS-only Metal shader build is skipped for non-macOS targets).
- `cargo clippy -p warp --target x86_64-unknown-linux-gnu -- -D warnings` - zero warnings/errors.
- `cargo fmt --check -p warp` - clean.

I'm happy to add a video/screenshot if a maintainer can point me to a way to test this locally, or if CI produces build artifacts I can run.

<!--
CHANGELOG-BUG-FIX: Clicking a global search match now always jumps to the matched line, even for markdown files when the Markdown Viewer is preferred.
-->
