### PR TITLE
Improve scroll performance for blocklists with many AIBlocks.

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -18,6 +18,7 @@ pub(crate) mod recording_controller;
 #[cfg(not(target_family = "wasm"))]
 pub(crate) mod recording_finalize;
 pub(crate) mod recording_telemetry;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -53,7 +54,9 @@ use self::execute::{
 #[cfg(not(target_family = "wasm"))]
 use self::recording_finalize::{FinalizeReason, finalize_recording_for_conversation};
 use super::BlocklistAIHistoryModel;
-use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::conversation::{
+    AIConversation, AIConversationId, ConversationStatus, RecordingSpanInfo,
+};
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
     AIAgentActionType, AIAgentActionTypeDiscriminants, AIAgentExchange, AIAgentInput,
@@ -239,6 +242,8 @@ pub struct BlocklistAIActionModel {
 
     /// Past actions and their corresponding statuses from previous AI exchanges.
     past_action_results: HashMap<AIAgentActionId, Arc<AIAgentActionResult>>,
+    recording_spans_by_conversation:
+        RefCell<HashMap<AIConversationId, Arc<HashMap<AIAgentActionId, RecordingSpanInfo>>>>,
 
     /// The ID of the terminal view this controller is associated with.
     terminal_view_id: EntityId,
@@ -307,6 +312,7 @@ impl BlocklistAIActionModel {
             finished_action_results: Default::default(),
             executor,
             past_action_results: HashMap::new(),
+            recording_spans_by_conversation: Default::default(),
             running_actions: Default::default(),
             action_order: Default::default(),
             terminal_view_id,
@@ -463,6 +469,7 @@ impl BlocklistAIActionModel {
     /// Clears action results restored from a previous conversation transcript.
     pub fn clear_restored_action_results(&mut self) {
         self.past_action_results.clear();
+        self.recording_spans_by_conversation.get_mut().clear();
     }
 
     fn try_to_execute_available_actions(
@@ -656,8 +663,36 @@ impl BlocklistAIActionModel {
             .or_else(|| self.past_action_results.get(id))
     }
 
+    pub fn recording_spans_for_conversation(
+        &self,
+        conversation: &AIConversation,
+    ) -> Arc<HashMap<AIAgentActionId, RecordingSpanInfo>> {
+        let conversation_id = conversation.id();
+        if let Some(spans) = self
+            .recording_spans_by_conversation
+            .borrow()
+            .get(&conversation_id)
+            .cloned()
+        {
+            return spans;
+        }
+
+        let spans = Arc::new(conversation.recording_spans_by_action_id(Some(self)));
+        self.recording_spans_by_conversation
+            .borrow_mut()
+            .insert(conversation_id, spans.clone());
+        spans
+    }
+
+    pub fn invalidate_recording_spans(&self, conversation_id: AIConversationId) {
+        self.recording_spans_by_conversation
+            .borrow_mut()
+            .remove(&conversation_id);
+    }
+
     /// Bulk restore action results from a list of exchanges (used when loading conversations from tasks)
     pub fn restore_action_results_from_exchanges(&mut self, exchanges: Vec<&AIAgentExchange>) {
+        self.recording_spans_by_conversation.get_mut().clear();
         for exchange in exchanges.iter() {
             for input in &exchange.input {
                 if let AIAgentInput::ActionResult { result, .. } = input {
@@ -1262,6 +1297,9 @@ impl BlocklistAIActionModel {
     pub(super) fn clear_finished_action_results(&mut self, conversation_id: AIConversationId) {
         self.action_order.remove(&conversation_id);
         self.finished_action_results.remove(&conversation_id);
+        self.recording_spans_by_conversation
+            .get_mut()
+            .remove(&conversation_id);
     }
 
     /// The control flow for initiating cancellations across suggested plans, requested commands,
@@ -1346,6 +1384,9 @@ impl BlocklistAIActionModel {
             .entry(conversation_id)
             .or_default()
             .push(action_result);
+        self.recording_spans_by_conversation
+            .get_mut()
+            .remove(&conversation_id);
 
         ctx.emit(BlocklistAIActionEvent::FinishedAction {
             action_id,

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -2001,7 +2001,7 @@ impl AIBlock {
             }
         }
 
-        self.has_recording_related_actions = output.actions().any(|action| {
+        let has_recording_related_actions = output.actions().any(|action| {
             matches!(
                 &action.action,
                 AIAgentActionType::StartRecording { .. }
@@ -2009,6 +2009,13 @@ impl AIBlock {
                     | AIAgentActionType::UseComputer(_)
             )
         });
+        if self.has_recording_related_actions || has_recording_related_actions {
+            let conversation_id = self.client_ids.conversation_id;
+            self.action_model.update(ctx, |action_model, _ctx| {
+                action_model.invalidate_recording_spans(conversation_id);
+            });
+        }
+        self.has_recording_related_actions = has_recording_related_actions;
 
         if FeatureFlag::WebSearchUI.is_enabled() {
             // Handle WebSearch messages

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -5264,13 +5264,24 @@ impl AIBlock {
     }
 
     pub fn dismiss_ai_tooltips(&mut self, ctx: &mut ViewContext<Self>) {
-        self.detected_links_state.link_location_open_tooltip = None;
-        ctx.emit(AIBlockEvent::DismissLinkTooltip);
-        self.secret_redaction_state.dismiss_tooltip();
-        ctx.emit(AIBlockEvent::DismissSecretTooltip);
+        let dismissed_link_tooltip = self
+            .detected_links_state
+            .link_location_open_tooltip
+            .take()
+            .is_some();
+        if dismissed_link_tooltip {
+            ctx.emit(AIBlockEvent::DismissLinkTooltip);
+        }
+
+        let dismissed_secret_tooltip = self.secret_redaction_state.dismiss_tooltip();
+        if dismissed_secret_tooltip {
+            ctx.emit(AIBlockEvent::DismissSecretTooltip);
+        }
+
+        let mut dismissed_search_tooltip = false;
         for search_view in self.search_codebase_view.values() {
             search_view.update(ctx, |view, ctx| {
-                view.clear_link_tooltip(ctx);
+                dismissed_search_tooltip |= view.clear_link_tooltip(ctx);
             });
         }
 
@@ -5282,8 +5293,9 @@ impl AIBlock {
         {
             button_handles.reset_hover_state_on_focus_change();
         }
-
-        ctx.notify();
+        if dismissed_link_tooltip || dismissed_secret_tooltip || dismissed_search_tooltip {
+            ctx.notify();
+        }
     }
 
     fn open_link(

--- a/app/src/ai/blocklist/block/secret_redaction.rs
+++ b/app/src/ai/blocklist/block/secret_redaction.rs
@@ -232,8 +232,8 @@ impl SecretRedactionState {
         self.get_secret_mut(location, secret_range)
     }
 
-    pub fn dismiss_tooltip(&mut self) {
-        self.secret_location_open_tooltip = None;
+    pub fn dismiss_tooltip(&mut self) -> bool {
+        self.secret_location_open_tooltip.take().is_some()
     }
 
     pub fn set_obfuscated(

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -261,21 +261,15 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
         | AIBlockOutputStatus::Failed { .. } => {
             if let Some(output) = status.output_to_render() {
                 let output = output.get();
-                // TODO(vkodithala): Blocks with recording-related actions still
-                // recompute this conversation-wide map on every render. Cache
-                // spans on BlocklistAIActionModel keyed by conversation and
-                // refresh on action/result mutations instead.
                 let recording_spans_by_action_id = if props.has_recording_related_actions {
-                    props
-                        .model
-                        .conversation(app)
-                        .map(|conversation| {
-                            conversation
-                                .recording_spans_by_action_id(Some(props.action_model.as_ref(app)))
-                        })
-                        .unwrap_or_default()
+                    props.model.conversation(app).map(|conversation| {
+                        props
+                            .action_model
+                            .as_ref(app)
+                            .recording_spans_for_conversation(conversation)
+                    })
                 } else {
-                    HashMap::new()
+                    None
                 };
                 let is_complete = matches!(status, AIBlockOutputStatus::Complete { .. });
                 let is_output_for_static_prompt_suggestions =
@@ -781,7 +775,9 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                                 props,
                                 id,
                                 request,
-                                recording_spans_by_action_id.get(id),
+                                recording_spans_by_action_id
+                                    .as_ref()
+                                    .and_then(|spans| spans.get(id)),
                                 app,
                             ));
                         }

--- a/app/src/ai/blocklist/inline_action/search_codebase.rs
+++ b/app/src/ai/blocklist/inline_action/search_codebase.rs
@@ -327,9 +327,16 @@ impl SearchCodebaseView {
         super::search_results_common::render_status_header(text, icon, app)
     }
 
-    pub fn clear_link_tooltip(&mut self, ctx: &mut ViewContext<Self>) {
-        self.detected_links_state.link_location_open_tooltip = None;
-        ctx.notify();
+    pub fn clear_link_tooltip(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        let did_clear = self
+            .detected_links_state
+            .link_location_open_tooltip
+            .take()
+            .is_some();
+        if did_clear {
+            ctx.notify();
+        }
+        did_clear
     }
 
     pub fn clear_selection(&mut self, _ctx: &mut ViewContext<Self>) {


### PR DESCRIPTION
## Description

Scrolling an AIBlock-heavy transcript caused large amounts of unrelated render work. A symbolicated Samply profile showed that `TaskStore::lookup_exchange` accounted for about 24% of renderer samples during the affected scroll. The lookup was repeated because two costs multiplied:

- Tooltip dismissal updated every AI block on each scroll, even when that block had no open tooltip.
- Each recording-related AI block rebuilt the conversation-wide recording span map during every render. That calculation traversed all exchanges twice.

This PR removes both multipliers:

- AI blocks and search result views now notify only when tooltip state changes. Scrolling still dismisses an open tooltip, but no-op dismissals do not dirty unrelated AI blocks.
- `BlocklistAIActionModel` now caches recording spans by conversation. Recording output changes, completed action results, restored results, and rewind cleanup invalidate the cache. Recording-related blocks share the cached map instead of rebuilding it independently.

## Linked Issue

No linked issue. This change follows a profile-driven investigation of Warp-on-Web scrolling performance.

## Testing

- [x] I manually tested my changes locally with `./script/run`.
  - Compared an AIBlock-heavy transcript before and after the change.
  - Confirmed that scrolling performance was substantially improved in the native build.
- [x] `cargo check -p warp`
- [x] `./script/format --check`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [ ] Warp-on-Web manual verification. `./script/wasm/run` was stopped before verification completed.

No integration test was added. This change targets redundant invalidation and derived-state recomputation during rendering, and the affected scrolling behavior was verified manually with a representative transcript.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/6c08df13-9e77-44a3-9fd7-d7dd25de7270

CHANGELOG-BUG-FIX: Improved scrolling performance in transcripts with many Agent Mode blocks.

Co-Authored-By: Warp <agent@warp.dev>
