### PR TITLE
Make ephemeral MCP installation IDs deterministic across sandbox rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12685,6 +12685,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14895,6 +14901,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,7 +339,7 @@ unicode-general-category = "1.1.0"
 unicode-linebreak = "0.1.5"
 unicode-segmentation = "1.11.0"
 unicode-width = "0.1.12"
-uuid = { version = "1.1.2", features = ["v4", "serde", "js"] }
+uuid = { version = "1.1.2", features = ["v4", "v5", "serde", "js"] }
 vec1 = { version = "1.8.0", features = ["serde"] }
 version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -193,6 +193,43 @@ const LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV: &str =
     "OZ_PARENT_LISTENER_MANAGED_EXTERNALLY";
 const LEGACY_OZ_PARENT_STATE_ROOT_ENV: &str = "OZ_PARENT_STATE_ROOT";
 
+/// Fixed, arbitrary namespace for [`ephemeral_mcp_installation_id`]. Never reused
+/// for anything else; only its stability across builds matters.
+const EPHEMERAL_MCP_INSTALLATION_NAMESPACE: Uuid = Uuid::from_bytes([
+    0xf9, 0x79, 0x1a, 0x88, 0xff, 0xb7, 0x41, 0x88, 0xa6, 0x39, 0xa7, 0x2d, 0xf2, 0x94, 0x22, 0x3f,
+]);
+
+/// Derives the installation id for an ephemeral MCP server resolved from a managed
+/// MCP client config (a well-known integration sentinel or a non-local managed MCP
+/// UUID).
+///
+/// When `task_id` is set (ambient/cloud runs), the id is deterministic: hashing the
+/// run id together with the requested spec token and the resolved server's own name
+/// means a run that resumes in a rebuilt sandbox re-resolves the *same* server to the
+/// *same* id, instead of a fresh random one every time. That stability matters
+/// because the id is echoed into the model's tool-call arguments and can persist in
+/// conversation history across a rebuild; a random id would silently go stale and
+/// the model's next reference to it would fail with "MCP server not found".
+///
+/// When `task_id` is `None` (local interactive sessions, which never rebuild a
+/// sandbox), a random id is used instead: a deterministic id keyed only on the spec
+/// token would collide across concurrent conversations resolving the same well-known
+/// id in the same process, since `TemplatableMCPServerManager` tracks installations
+/// in a single process-wide map keyed by this id.
+fn ephemeral_mcp_installation_id(
+    task_id: Option<AmbientAgentTaskId>,
+    spec_token: &str,
+    server_name: &str,
+) -> Uuid {
+    match task_id {
+        Some(task_id) => Uuid::new_v5(
+            &EPHEMERAL_MCP_INSTALLATION_NAMESPACE,
+            format!("{task_id}:{spec_token}:{server_name}").as_bytes(),
+        ),
+        None => Uuid::new_v4(),
+    }
+}
+
 /// IdleTimeoutSender is wrapper around a sender that signals when a run is done after
 /// an idle timeout. Used for both Oz runs and third-party harnesses.
 ///
@@ -1378,24 +1415,31 @@ impl AgentDriver {
         managed_mcp_client: Arc<dyn ManagedMcpClient>,
         foreground: &ModelSpawner<Self>,
     ) -> Result<ResolvedMcpSpecs, AgentDriverError> {
-        let local_installed_uuids = foreground
-            .spawn(|_, ctx| {
-                TemplatableMCPServerManager::as_ref(ctx)
+        let (local_installed_uuids, task_id) = foreground
+            .spawn(|me, ctx| {
+                let local_installed_uuids = TemplatableMCPServerManager::as_ref(ctx)
                     .get_installed_templatable_servers()
                     .keys()
                     .copied()
-                    .collect::<HashSet<_>>()
+                    .collect::<HashSet<_>>();
+                (local_installed_uuids, me.task_id)
             })
             .await?;
 
-        Self::resolve_mcp_specs_with_local_uuids(specs, &local_installed_uuids, managed_mcp_client)
-            .await
+        Self::resolve_mcp_specs_with_local_uuids(
+            specs,
+            &local_installed_uuids,
+            managed_mcp_client,
+            task_id,
+        )
+        .await
     }
 
     async fn resolve_mcp_specs_with_local_uuids(
         specs: &[MCPSpec],
         local_installed_uuids: &HashSet<Uuid>,
         managed_mcp_client: Arc<dyn ManagedMcpClient>,
+        task_id: Option<AmbientAgentTaskId>,
     ) -> Result<ResolvedMcpSpecs, AgentDriverError> {
         let mut resolved = ResolvedMcpSpecs::default();
 
@@ -1414,6 +1458,8 @@ impl AgentDriver {
                         })?;
                     let installations = Self::installations_from_managed_client_config_json(
                         &client_config.mcp_config_json,
+                        task_id,
+                        &uuid.to_string(),
                     )
                     .map_err(|err| {
                         AgentDriverError::ManagedMcpResolutionFailed {
@@ -1449,6 +1495,8 @@ impl AgentDriver {
                     };
                     match Self::installations_from_managed_client_config_json(
                         &client_config.mcp_config_json,
+                        task_id,
+                        id,
                     ) {
                         Ok(installations) => {
                             resolved.ephemeral_installations.extend(installations);
@@ -1522,6 +1570,8 @@ impl AgentDriver {
 
     fn installations_from_managed_client_config_json(
         json_str: &str,
+        task_id: Option<AmbientAgentTaskId>,
+        spec_token: &str,
     ) -> Result<Vec<TemplatableMCPServerInstallation>, AgentDriverError> {
         let normalized_json = normalize_mcp_json(json_str)
             .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
@@ -1565,8 +1615,13 @@ impl AgentDriver {
                         });
                 }
 
+                let installation_id = ephemeral_mcp_installation_id(
+                    task_id,
+                    spec_token,
+                    &templatable_mcp_server.name,
+                );
                 Ok(TemplatableMCPServerInstallation::new(
-                    uuid::Uuid::new_v4(),
+                    installation_id,
                     templatable_mcp_server,
                     variable_values,
                 ))

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -193,29 +193,23 @@ const LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV: &str =
     "OZ_PARENT_LISTENER_MANAGED_EXTERNALLY";
 const LEGACY_OZ_PARENT_STATE_ROOT_ENV: &str = "OZ_PARENT_STATE_ROOT";
 
-/// Fixed, arbitrary namespace for [`ephemeral_mcp_installation_id`]. Never reused
-/// for anything else; only its stability across builds matters.
+/// Fixed namespace for [`ephemeral_mcp_installation_id`]. Arbitrary; never reused.
 const EPHEMERAL_MCP_INSTALLATION_NAMESPACE: Uuid = Uuid::from_bytes([
     0xf9, 0x79, 0x1a, 0x88, 0xff, 0xb7, 0x41, 0x88, 0xa6, 0x39, 0xa7, 0x2d, 0xf2, 0x94, 0x22, 0x3f,
 ]);
 
-/// Derives the installation id for an ephemeral MCP server resolved from a managed
-/// MCP client config (a well-known integration sentinel or a non-local managed MCP
-/// UUID).
+/// Installation id for an ephemeral MCP server (well-known sentinel or non-local
+/// managed MCP UUID) resolved from a managed MCP client config.
 ///
-/// When `task_id` is set (ambient/cloud runs), the id is deterministic: hashing the
-/// run id together with the requested spec token and the resolved server's own name
-/// means a run that resumes in a rebuilt sandbox re-resolves the *same* server to the
-/// *same* id, instead of a fresh random one every time. That stability matters
-/// because the id is echoed into the model's tool-call arguments and can persist in
-/// conversation history across a rebuild; a random id would silently go stale and
-/// the model's next reference to it would fail with "MCP server not found".
+/// With `task_id` (ambient/cloud runs), the id is deterministic: hashing run id +
+/// spec token + server name means a rebuilt sandbox re-resolves the same server to
+/// the same id. Ids can persist in the model's conversation history across a
+/// rebuild; a random id would go stale and fail as "MCP server not found".
 ///
-/// When `task_id` is `None` (local interactive sessions, which never rebuild a
-/// sandbox), a random id is used instead: a deterministic id keyed only on the spec
-/// token would collide across concurrent conversations resolving the same well-known
-/// id in the same process, since `TemplatableMCPServerManager` tracks installations
-/// in a single process-wide map keyed by this id.
+/// Without `task_id` (local sessions; no rebuilds), ids stay random: hashing only
+/// the spec token would collide across concurrent conversations in the same
+/// process, since `TemplatableMCPServerManager` keys installations by this id
+/// process-wide.
 fn ephemeral_mcp_installation_id(
     task_id: Option<AmbientAgentTaskId>,
     spec_token: &str,

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -463,7 +463,7 @@ fn managed_command_config_missing_secret_leaves_placeholder() {
     }
 }
 
-// ── Ephemeral MCP installation id stability across sandbox rebuilds ────────
+// ── Ephemeral MCP installation ids: stable across rebuilds ─────────────────
 
 #[test]
 fn ephemeral_installation_id_is_stable_across_resolutions_for_same_run() {
@@ -471,8 +471,7 @@ fn ephemeral_installation_id_is_stable_across_resolutions_for_same_run() {
     let config_json =
         r#"{"mcpServers":{"slack":{"url":"https://app.warp.dev/mcp/integration-proxy/slack"}}}"#;
 
-    // Simulates the same run re-resolving the same well-known server on a rebuilt
-    // sandbox: two independent calls, same task_id and spec token.
+    // Same run re-resolving the same server after a rebuild.
     let first = AgentDriver::installations_from_managed_client_config_json(
         config_json,
         Some(task_id),
@@ -491,8 +490,7 @@ fn ephemeral_installation_id_is_stable_across_resolutions_for_same_run() {
     assert_eq!(
         first[0].uuid(),
         second[0].uuid(),
-        "the same run resolving the same well-known server must get the same id \
-         every time, or a stale id from before a sandbox rebuild goes unresolvable"
+        "same run + same server must yield the same id across rebuilds"
     );
 }
 
@@ -519,8 +517,7 @@ fn ephemeral_installation_id_differs_across_runs() {
     assert_ne!(
         a[0].uuid(),
         b[0].uuid(),
-        "different runs resolving the same well-known server must not collide, since \
-         TemplatableMCPServerManager tracks installations in a single process-wide map"
+        "different runs must not collide onto the same id"
     );
 }
 
@@ -548,7 +545,7 @@ fn ephemeral_installation_id_differs_across_servers_in_same_run() {
     assert_ne!(
         slack[0].uuid(),
         linear[0].uuid(),
-        "two different servers within the same run must not collide onto one id"
+        "different servers in one run must not collide onto the same id"
     );
 }
 
@@ -567,8 +564,7 @@ fn ephemeral_installation_id_is_random_without_task_id() {
     assert_ne!(
         first[0].uuid(),
         second[0].uuid(),
-        "local interactive sessions (no task_id) never rebuild a sandbox, so ids stay \
-         random to avoid colliding across concurrent conversations in the same process"
+        "no task_id means no rebuild to survive, so ids stay random"
     );
 }
 

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -179,6 +179,7 @@ fn managed_resolver_local_uuid_does_not_call_managed_client() {
         &[MCPSpec::Uuid(uuid)],
         &local_installed_uuids,
         Arc::new(mock),
+        None,
     ))
     .unwrap();
 
@@ -203,6 +204,7 @@ fn managed_resolver_non_local_uuid_calls_managed_client() {
         &[MCPSpec::Uuid(uuid)],
         &HashSet::new(),
         Arc::new(mock),
+        None,
     ))
     .unwrap();
 
@@ -226,6 +228,7 @@ fn well_known_spec_resolves_via_managed_client() {
         &[MCPSpec::WellKnown("linear".to_string())],
         &HashSet::new(),
         Arc::new(mock),
+        None,
     ))
     .unwrap();
 
@@ -247,6 +250,7 @@ fn well_known_resolution_failure_skips_server() {
         &[MCPSpec::WellKnown("linear".to_string())],
         &HashSet::new(),
         Arc::new(mock),
+        None,
     ))
     .unwrap();
 
@@ -279,6 +283,7 @@ fn well_known_resolution_failure_does_not_drop_other_specs() {
         ],
         &HashSet::new(),
         Arc::new(mock),
+        None,
     ))
     .unwrap();
 
@@ -296,6 +301,7 @@ fn well_known_spec_is_skipped_when_flag_disabled() {
         &[MCPSpec::WellKnown("linear".to_string())],
         &HashSet::new(),
         Arc::new(mock),
+        None,
     ))
     .unwrap();
 
@@ -307,6 +313,8 @@ fn well_known_spec_is_skipped_when_flag_disabled() {
 fn managed_command_config_env_placeholder_uses_local_secret() {
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"API_TOKEN":"{{API_TOKEN}}"}}}}"#,
+        None,
+        "github",
     )
     .unwrap();
     let rendered = render_installations(
@@ -326,6 +334,8 @@ fn managed_command_config_env_placeholder_uses_local_secret() {
 fn managed_command_config_arg_placeholder_uses_local_secret() {
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"]}}}"#,
+        None,
+        "github",
     )
     .unwrap();
     let rendered = render_installations(
@@ -345,6 +355,8 @@ fn managed_command_config_arg_placeholder_uses_local_secret() {
 fn managed_command_config_preserves_literal_env_when_synthesizing_arg_placeholder() {
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"],"env":{"LOG_LEVEL":"info"}}}}"#,
+        None,
+        "github",
     )
     .unwrap();
     let rendered = render_installations(
@@ -365,6 +377,8 @@ fn managed_command_config_preserves_literal_env_when_synthesizing_arg_placeholde
 fn managed_url_config_preserves_proxy_url_and_header() {
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"url":"https://proxy.example/mcp","headers":{"Authorization":"Bearer proxy-token"}}}}"#,
+        None,
+        "github",
     )
     .unwrap();
     let rendered = render_installations(installations, HashMap::new());
@@ -387,6 +401,8 @@ fn managed_url_config_preserves_header_despite_colliding_local_secret() {
     // happens to share the header's key name (`apply_secrets` implicit key-name match).
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"url":"https://proxy.example/mcp","headers":{"Authorization":"Bearer proxy-token"}}}}"#,
+        None,
+        "github",
     )
     .unwrap();
     let rendered = render_installations(
@@ -412,6 +428,8 @@ fn managed_command_config_preserves_literal_env_despite_colliding_local_secret()
     // shares the env key name.
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"LOG_LEVEL":"info"}}}}"#,
+        None,
+        "github",
     )
     .unwrap();
     let rendered = render_installations(
@@ -431,6 +449,8 @@ fn managed_command_config_preserves_literal_env_despite_colliding_local_secret()
 fn managed_command_config_missing_secret_leaves_placeholder() {
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"]}}}"#,
+        None,
+        "github",
     )
     .unwrap();
     let rendered = render_installations(installations, HashMap::new());
@@ -441,6 +461,115 @@ fn managed_command_config_missing_secret_leaves_placeholder() {
         }
         other => panic!("expected CLI server, got {other:?}"),
     }
+}
+
+// ── Ephemeral MCP installation id stability across sandbox rebuilds ────────
+
+#[test]
+fn ephemeral_installation_id_is_stable_across_resolutions_for_same_run() {
+    let task_id: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-446655440010".parse().unwrap();
+    let config_json =
+        r#"{"mcpServers":{"slack":{"url":"https://app.warp.dev/mcp/integration-proxy/slack"}}}"#;
+
+    // Simulates the same run re-resolving the same well-known server on a rebuilt
+    // sandbox: two independent calls, same task_id and spec token.
+    let first = AgentDriver::installations_from_managed_client_config_json(
+        config_json,
+        Some(task_id),
+        "slack",
+    )
+    .unwrap();
+    let second = AgentDriver::installations_from_managed_client_config_json(
+        config_json,
+        Some(task_id),
+        "slack",
+    )
+    .unwrap();
+
+    assert_eq!(first.len(), 1);
+    assert_eq!(second.len(), 1);
+    assert_eq!(
+        first[0].uuid(),
+        second[0].uuid(),
+        "the same run resolving the same well-known server must get the same id \
+         every time, or a stale id from before a sandbox rebuild goes unresolvable"
+    );
+}
+
+#[test]
+fn ephemeral_installation_id_differs_across_runs() {
+    let task_id_a: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-446655440011".parse().unwrap();
+    let task_id_b: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-446655440012".parse().unwrap();
+    let config_json =
+        r#"{"mcpServers":{"slack":{"url":"https://app.warp.dev/mcp/integration-proxy/slack"}}}"#;
+
+    let a = AgentDriver::installations_from_managed_client_config_json(
+        config_json,
+        Some(task_id_a),
+        "slack",
+    )
+    .unwrap();
+    let b = AgentDriver::installations_from_managed_client_config_json(
+        config_json,
+        Some(task_id_b),
+        "slack",
+    )
+    .unwrap();
+
+    assert_ne!(
+        a[0].uuid(),
+        b[0].uuid(),
+        "different runs resolving the same well-known server must not collide, since \
+         TemplatableMCPServerManager tracks installations in a single process-wide map"
+    );
+}
+
+#[test]
+fn ephemeral_installation_id_differs_across_servers_in_same_run() {
+    let task_id: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-446655440013".parse().unwrap();
+    let slack_config =
+        r#"{"mcpServers":{"slack":{"url":"https://app.warp.dev/mcp/integration-proxy/slack"}}}"#;
+    let linear_config =
+        r#"{"mcpServers":{"linear":{"url":"https://app.warp.dev/mcp/integration-proxy/linear"}}}"#;
+
+    let slack = AgentDriver::installations_from_managed_client_config_json(
+        slack_config,
+        Some(task_id),
+        "slack",
+    )
+    .unwrap();
+    let linear = AgentDriver::installations_from_managed_client_config_json(
+        linear_config,
+        Some(task_id),
+        "linear",
+    )
+    .unwrap();
+
+    assert_ne!(
+        slack[0].uuid(),
+        linear[0].uuid(),
+        "two different servers within the same run must not collide onto one id"
+    );
+}
+
+#[test]
+fn ephemeral_installation_id_is_random_without_task_id() {
+    let config_json =
+        r#"{"mcpServers":{"slack":{"url":"https://app.warp.dev/mcp/integration-proxy/slack"}}}"#;
+
+    let first =
+        AgentDriver::installations_from_managed_client_config_json(config_json, None, "slack")
+            .unwrap();
+    let second =
+        AgentDriver::installations_from_managed_client_config_json(config_json, None, "slack")
+            .unwrap();
+
+    assert_ne!(
+        first[0].uuid(),
+        second[0].uuid(),
+        "local interactive sessions (no task_id) never rebuild a sandbox, so ids stay \
+         random to avoid colliding across concurrent conversations in the same process"
+    );
 }
 
 // ── Built-in Factory MCP injection tests ────────────────────────────────────
@@ -508,6 +637,7 @@ fn managed_resolution_failure_includes_uid_and_message() {
         &[MCPSpec::Uuid(uuid)],
         &HashSet::new(),
         Arc::new(mock),
+        None,
     ))
     .unwrap_err();
 

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -165,7 +165,7 @@ if (-not $gitBinDir) {
 Add-DirectoryToPathIfPresent $gitBinDir
 
 # Some Rust build scripts depend on Unix patch.exe, which ships with Git for Windows.
-$gitUsrBinDir = Join-Path (Split-Path -Parent $gitBinDir) 'usr\bin'
+$gitUsrBinDir = Join-Path (Split-Path -Path $gitBinDir -Parent) 'usr\bin'
 Add-DirectoryToPathIfPresent $gitUsrBinDir
 
 function Resolve-CommonSkillsScript {

--- a/script/windows/prepare_bundled_resources.ps1
+++ b/script/windows/prepare_bundled_resources.ps1
@@ -25,7 +25,7 @@ Param(
 
 $ErrorActionPreference = 'Stop'
 
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptDir = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
 $RepoRoot = (Get-Item "$ScriptDir\..\.." | Select-Object -ExpandProperty FullName)
 $ResourcesSource = Join-Path $RepoRoot 'resources'
 


### PR DESCRIPTION
This PR ensures that ephemeral MCP installation IDs remain stable across sandbox rebuilds. Previously, these IDs were generated randomly, which caused issues when a sandbox was rebuilt during a task; the model would hold a reference to a stale ID, leading to "MCP server not found" errors.

Key changes include:
*   Introduced `ephemeral_mcp_installation_id` to generate deterministic UUIDs (v5) when a `task_id` is present, using the task ID, spec token, and server name as inputs.
*   Maintained random UUID generation (v4) for local interactive sessions to prevent ID collisions within the same process.
*   Updated `AgentDriver` to propagate the `task_id` during MCP spec resolution, ensuring the deterministic ID logic is applied consistently.
*   Added comprehensive unit tests to verify ID stability for cloud runs and randomness for local sessions.