### PR TITLE
fix(rendering): recreate renderer when surface errors persist across frames

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -126,6 +126,13 @@ struct ScrollVelocity {
     last_update: Instant,
 }
 
+/// The number of consecutive failed frames after which we stop assuming a
+/// normally-transient render error (e.g. a surface `Validation` error) will
+/// resolve on its own, and rebuild the renderer instead. Without this, a GPU
+/// reset that leaves the surface permanently invalid freezes the window
+/// forever while the render loop retries the same failing call every frame.
+const MAX_CONSECUTIVE_RENDER_FAILURES: u32 = 10;
+
 /// The set of state we need to track per-window across frames.
 struct WindowState {
     /// The UI framework's identifier for the window in question (not to be
@@ -167,6 +174,11 @@ struct WindowState {
     /// UI element only requests the keyboard during LeftMouseDown.
     #[cfg(target_family = "wasm")]
     pending_soft_keyboard_request: bool,
+    /// The number of consecutive frames that have failed to render. Reset to
+    /// zero on a successful frame or when the renderer is recreated. Once this
+    /// reaches [`MAX_CONSECUTIVE_RENDER_FAILURES`], errors that are normally
+    /// skipped as transient escalate to a renderer rebuild.
+    consecutive_render_failures: u32,
 }
 
 impl WindowState {
@@ -186,6 +198,7 @@ impl WindowState {
             momentum_scroll_abort: None,
             #[cfg(target_family = "wasm")]
             pending_soft_keyboard_request: false,
+            consecutive_render_failures: 0,
         }
     }
 
@@ -965,6 +978,7 @@ impl EventLoop {
         window_id: winit::window::WindowId,
         window_target: &ActiveEventLoop,
     ) {
+        let winit_window_id = window_id;
         let Some(window_id) = self
             .state
             .windows
@@ -1019,24 +1033,51 @@ impl EventLoop {
         })();
 
         match render_result {
-            Ok(_) => self.callbacks.for_window(window).frame_drawn(),
+            Ok(_) => {
+                if let Some(state) = self.state.windows.get_mut(&winit_window_id) {
+                    state.consecutive_render_failures = 0;
+                }
+                self.callbacks.for_window(window).frame_drawn()
+            }
             Err(err) => {
                 log::warn!("Failed to render frame: {err:#}");
                 self.callbacks.for_window(window).frame_failed_to_draw();
 
-                match err {
+                let consecutive_render_failures = self
+                    .state
+                    .windows
+                    .get_mut(&winit_window_id)
+                    .map(|state| {
+                        state.consecutive_render_failures += 1;
+                        state.consecutive_render_failures
+                    })
+                    .unwrap_or(0);
+
+                let recreate_renderer = match err {
                     // If we failed to configure the surface, or...
                     renderer::Error::SurfaceConfigureError { .. }
                     // If the device was lost, or...
                     | renderer::Error::SurfaceError(renderer::GetSurfaceTextureError::Lost)
                     | renderer::Error::DeviceLost
                     // If we ran into any other wgpu error -
-                    | renderer::Error::Unknown(_)=> {
-                        log::warn!("Recreating the renderer in an attempt to recover...");
-                        window.drop_renderer(Box::new(window_target.owned_display_handle()));
-                        window.recreate_renderer(self.downrank_non_nvidia_vulkan_adapters);
+                    | renderer::Error::Unknown(_) => true,
+                    // Any other error (e.g. a surface `Validation` error) is
+                    // normally transient, and skipping the frame is enough.
+                    // But after a GPU reset, acquiring the surface texture can
+                    // keep failing with `Validation` indefinitely, leaving the
+                    // window permanently frozen. If the error hasn't resolved
+                    // itself after this many frames, it isn't transient -
+                    // escalate to a renderer rebuild.
+                    _ => consecutive_render_failures >= MAX_CONSECUTIVE_RENDER_FAILURES,
+                };
+
+                if recreate_renderer {
+                    log::warn!("Recreating the renderer in an attempt to recover...");
+                    if let Some(state) = self.state.windows.get_mut(&winit_window_id) {
+                        state.consecutive_render_failures = 0;
                     }
-                    _ => {}
+                    window.drop_renderer(Box::new(window_target.owned_display_handle()));
+                    window.recreate_renderer(self.downrank_non_nvidia_vulkan_adapters);
                 }
             }
         }


### PR DESCRIPTION
## Description

After a GPU engine reset (e.g. the Intel `xe` kernel driver killing a hung GPU job on Linux), `surface.get_current_texture()` can fail with `Validation` on **every** subsequent frame. Today the event loop treats `SurfaceError(Validation)` as transient — it logs, skips the frame, and hopes — and never escalates. The result is a window that is frozen forever while the process, terminal server, and all pty sessions stay alive, with `warp.log` filling with:

```
[WARN] Encountered error while getting the next swap chain texture: Validation error
[WARN] Failed to render frame: Failed to acquire surface texture: Validation error
```

This PR adds a per-window `consecutive_render_failures` counter. On any render error the counter increments (reset on the next successful frame). Errors that already trigger recovery (`SurfaceConfigureError`, `SurfaceError(Lost)`, `DeviceLost`, `Unknown`) behave exactly as before. Errors that were previously ignored — notably `SurfaceError(Validation)` — now escalate to the same existing `drop_renderer` + `recreate_renderer` recovery path once they have persisted for `MAX_CONSECUTIVE_RENDER_FAILURES` (10) consecutive frames. Genuinely transient validation errors (the case the current skip-a-frame behavior was written for) still just skip a frame or two and never reach the threshold.

The counter is reset when the renderer is recreated, so if the first rebuild doesn't take (e.g. the GPU is still resetting), the new renderer gets another full threshold's worth of frames before we try again, rather than rebuilding on every frame.

## Linked Issue

Fixes #15303

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement` — *filed together with this PR; flagging for triage per the "PRs opened without a linked issue" flow in CONTRIBUTING.md*
- [x] Relevant details included below

## Testing

- [x] I have manually tested my changes locally

- **Manually reproduced and verified**: built `warp-oss` from this branch on the affected machine, forced GT0 engine resets via `xe` debugfs until the kernel killed an in-flight warp-oss job (the exact trigger from #15303), and confirmed recovery: exactly 10 consecutive `SurfaceError(Validation)` frames, then `Recreating the renderer...`, then a clean re-init and a fully interactive window — ~1s of visible stall, session preserved. Full logs and method in [this comment](https://github.com/warpdotdev/warp/pull/15304#issuecomment-5339668483). On the unpatched stable build, the identical kernel event froze the window permanently (6+ hours of the same log loop until killed).
- **Transient path preserved**: an organic one-off surface `Timeout` during the same test session skipped a single frame without triggering a rebuild; idle-window resets and media-engine (GT1) resets cause no errors and no rebuilds.
- `cargo check -p warpui` passes on the patched tree (Rust 1.92.0).
- Real-world failure evidence and the full root-cause trace are in #15303.

No new automated tests: the behavior under test is the interaction between the winit event loop and a lost GPU device, which has no existing test harness in `warpui`; the change is confined to the error-handling arm of `redraw_window`.

CHANGELOG-BUG-FIX: Recover the renderer when surface errors persist across frames (e.g. after a GPU reset on Linux) instead of leaving the window frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
