### PR TITLE
Report structured repository revision snapshots

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2841,6 +2841,10 @@ impl AgentDriver {
                         .await?;
                 }
             }
+        } else {
+            setup_events
+                .repository_revision_reporter()
+                .report_empty();
         }
 
         // Skill loading is Oz-only; third-party harnesses have their own skill systems.

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -558,11 +558,7 @@ impl RepositoryRevisionCapture {
         let revisions_dir = self.result_dir.parent().map(Path::to_path_buf);
         let _ = std::fs::remove_dir_all(&self.result_dir);
         if let Some(revisions_dir) = revisions_dir {
-            let warp_dir = revisions_dir.parent().map(Path::to_path_buf);
             let _ = std::fs::remove_dir(&revisions_dir);
-            if let Some(warp_dir) = warp_dir {
-                let _ = std::fs::remove_dir(warp_dir);
-            }
         }
         RepositoryRevisionSnapshotRequest {
             snapshot_uuid: self.snapshot_uuid,

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use ai::index::full_source_code_embedding::manager::{
     CodebaseIndexManager, CodebaseIndexManagerEvent,
 };
+use chrono::Utc;
 use cloud_object_models::CodeForge;
 use futures::channel::oneshot;
 use futures::future::join_all;
@@ -24,6 +25,7 @@ use super::cache_setup;
 use super::terminal::TerminalDriver;
 use crate::ai::agent_sdk::setup_observability::{SetupClientEventReporter, SetupStep};
 use crate::ai::cloud_environments::SourceRepo;
+use crate::server::server_api::ai::{RepositoryRevisionRequest, RepositoryRevisionSnapshotRequest};
 use crate::terminal::model::session::command_executor::shell_escape_single_quotes;
 use crate::terminal::shell::ShellType;
 
@@ -282,6 +284,7 @@ async fn prepare_environment_impl(
     setup_events: SetupClientEventReporter,
 ) -> Result<(), PrepareEnvironmentError> {
     let working_dir_string = working_dir.to_string_lossy().to_string();
+    let revision_reporter = setup_events.repository_revision_reporter();
 
     // Position the session in `working_dir` before running any probes / clones.
     // Routed through the silent executor so we don't add a user-visible `cd`
@@ -296,16 +299,20 @@ async fn prepare_environment_impl(
     let mut codebase_context_receivers = Vec::new();
 
     if !source_repos.is_empty() {
+        let clone_requests = repository_clone_requests(source_repos, repository_head_overrides);
+        let revision_capture = RepositoryRevisionCapture::new(working_dir);
         setup_events
             .record_result(SetupStep::EnvironmentRepoClone, async {
                 clone_checkout_requests(
-                    &repository_clone_requests(source_repos, repository_head_overrides),
+                    &clone_requests,
                     working_dir,
+                    Some(&revision_capture),
                     spawner,
                 )
                 .await
             })
             .await?;
+        revision_reporter.report(revision_capture.into_snapshot(&clone_requests));
         for repo in source_repos {
             register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
             if !is_sandbox && should_index_codebase {
@@ -329,6 +336,8 @@ async fn prepare_environment_impl(
                 codebase_context_receivers,
             );
         }
+    } else {
+        revision_reporter.report_empty();
     }
 
     #[cfg(feature = "local_fs")]
@@ -492,6 +501,99 @@ struct RepositoryCloneRequest {
     checkout: Option<RepositoryHeadRef>,
 }
 
+struct RepositoryRevisionCapture {
+    snapshot_uuid: String,
+    result_dir: PathBuf,
+}
+
+impl RepositoryRevisionCapture {
+    fn new(working_dir: &Path) -> Self {
+        let snapshot_uuid = uuid::Uuid::new_v4().to_string();
+        let result_dir = working_dir
+            .join(".warp")
+            .join("repository-revisions")
+            .join(&snapshot_uuid);
+        Self {
+            snapshot_uuid,
+            result_dir,
+        }
+    }
+
+    fn result_file(&self, index: usize) -> PathBuf {
+        self.result_dir.join(format!("{index}.head"))
+    }
+
+    fn into_snapshot(
+        self,
+        requests: &[RepositoryCloneRequest],
+    ) -> RepositoryRevisionSnapshotRequest {
+        let mut repositories = Vec::with_capacity(requests.len());
+        for (index, request) in requests.iter().enumerate() {
+            let Ok(head_sha) = std::fs::read_to_string(self.result_file(index)) else {
+                continue;
+            };
+            let head_sha = head_sha.trim();
+            if !is_valid_git_object_id(head_sha) {
+                continue;
+            }
+            repositories.push(RepositoryRevisionRequest {
+                code_forge: request.repo.code_forge.unwrap_or_default(),
+                owner: request.repo.owner.clone(),
+                repo: request.repo.repo.clone(),
+                checkout_path: request.repo.repo.clone(),
+                checkout_ref: request
+                    .checkout
+                    .as_ref()
+                    .map(RepositoryHeadRef::value)
+                    .map(str::to_string),
+                head_sha: head_sha.to_string(),
+            });
+        }
+        let unresolved_repository_count = requests.len().saturating_sub(repositories.len());
+        if unresolved_repository_count > 0 {
+            log::warn!(
+                "Could not resolve HEAD for {unresolved_repository_count} structured repositories; reporting the remaining revisions"
+            );
+        }
+        let revisions_dir = self.result_dir.parent().map(Path::to_path_buf);
+        let _ = std::fs::remove_dir_all(&self.result_dir);
+        if let Some(revisions_dir) = revisions_dir {
+            let warp_dir = revisions_dir.parent().map(Path::to_path_buf);
+            let _ = std::fs::remove_dir(&revisions_dir);
+            if let Some(warp_dir) = warp_dir {
+                let _ = std::fs::remove_dir(warp_dir);
+            }
+        }
+        RepositoryRevisionSnapshotRequest {
+            snapshot_uuid: self.snapshot_uuid,
+            captured_at: Utc::now(),
+            unresolved_repository_count,
+            repositories,
+        }
+    }
+}
+
+fn is_valid_git_object_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn build_capture_head_command(repo_dir: &Path, result_file: &Path) -> String {
+    let escaped_repo_dir = shell_escape_single_quotes(&repo_dir.to_string_lossy(), ShellType::Bash);
+    let escaped_result_file =
+        shell_escape_single_quotes(&result_file.to_string_lossy(), ShellType::Bash);
+    format!(
+        "revision_file='{escaped_result_file}'; \
+         revision_tmp=\"$revision_file.tmp.$$\"; \
+         mkdir -p \"$(dirname \"$revision_file\")\" && \
+         git -C '{escaped_repo_dir}' rev-parse HEAD >\"$revision_tmp\" && \
+         mv \"$revision_tmp\" \"$revision_file\" || \
+         {{ rm -f \"$revision_tmp\"; true; }}"
+    )
+}
+
 fn repository_clone_requests(
     repos: &[SourceRepo],
     overrides: &[RepositoryHeadOverride],
@@ -558,7 +660,11 @@ async fn remove_repository_origins_from_repos(
     }
 }
 
-fn build_parallel_clone_command(repos: &[RepositoryCloneRequest], shell_type: ShellType) -> String {
+fn build_parallel_clone_command(
+    repos: &[RepositoryCloneRequest],
+    revision_capture: Option<&RepositoryRevisionCapture>,
+    shell_type: ShellType,
+) -> String {
     let mut script = String::from(
         r#"set +e
 failed=0
@@ -574,6 +680,15 @@ clone_repo() {
   target="$3"
   checkout_ref="$4"
   is_commit_sha="$5"
+  revision_file="$6"
+  capture_head() {
+    [ -n "$revision_file" ] || return 0
+    revision_tmp="$revision_file.tmp.$$"
+    mkdir -p "$(dirname "$revision_file")" &&
+      git -C "$target" rev-parse HEAD >"$revision_tmp" &&
+      mv "$revision_tmp" "$revision_file" ||
+      { rm -f "$revision_tmp"; true; }
+  }
   if [ "$is_commit_sha" = "1" ]; then
     if [ -e "$target" ]; then
       printf '%s\n' "Checking out $checkout_ref in existing repository $repo_name..."
@@ -582,8 +697,10 @@ clone_repo() {
       git init --quiet "$target" || return 1
       git -C "$target" remote add origin "$repo_url" || return 1
     fi
-    git -C "$target" fetch --filter=tree:0 origin "$checkout_ref" && git -C "$target" checkout --detach FETCH_HEAD
-    return
+    git -C "$target" fetch --filter=tree:0 origin "$checkout_ref" &&
+      git -C "$target" checkout --detach FETCH_HEAD || return 1
+    capture_head
+    return 0
   fi
   if [ -d "$target" ]; then
     printf '%s\n' "Repository directory $target already exists, skipping clone..."
@@ -596,8 +713,10 @@ clone_repo() {
     printf '%s\n' "Checking out $checkout_ref in $repo_name..."
     # Fetch leaves the object in FETCH_HEAD; check that out detached so we
     # never prefer a stale local branch with the same name.
-    git -C "$target" fetch --filter=tree:0 origin "$checkout_ref" && git -C "$target" checkout --detach FETCH_HEAD
+    git -C "$target" fetch --filter=tree:0 origin "$checkout_ref" &&
+      git -C "$target" checkout --detach FETCH_HEAD || return 1
   fi
+  capture_head
 }
 "#,
     );
@@ -619,10 +738,15 @@ clone_repo() {
             Some(RepositoryHeadRef::CommitSha(_)) => "1",
             Some(RepositoryHeadRef::Branch(_)) | None => "0",
         };
+        let revision_file = revision_capture
+            .map(|capture| capture.result_file(index))
+            .unwrap_or_default();
+        let escaped_revision_file =
+            shell_escape_single_quotes(&revision_file.to_string_lossy(), ShellType::Bash);
         let log_var = format!("log_file_{index}");
         script.push_str(&format!(
             "{log_var}=\"$tmp_dir/repo-{index}.log\"\n\
-             clone_repo '{escaped_repo_name}' '{escaped_repo_url}' '{escaped_target}' '{escaped_checkout_ref}' '{is_commit_sha}' >\"${log_var}\" 2>&1 &\n"
+             clone_repo '{escaped_repo_name}' '{escaped_repo_url}' '{escaped_target}' '{escaped_checkout_ref}' '{is_commit_sha}' '{escaped_revision_file}' >\"${log_var}\" 2>&1 &\n"
         ));
         script.push_str("pids=\"$pids $!\"\n");
         log_outputs.push_str(&format!(
@@ -661,17 +785,32 @@ pub(super) async fn clone_repos(
     working_dir: &Path,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<(), PrepareEnvironmentError> {
-    clone_checkout_requests(&repository_clone_requests(repos, &[]), working_dir, spawner).await
+    clone_checkout_requests(
+        &repository_clone_requests(repos, &[]),
+        working_dir,
+        None,
+        spawner,
+    )
+    .await
 }
 
 async fn clone_checkout_requests(
     repos: &[RepositoryCloneRequest],
     working_dir: &Path,
+    revision_capture: Option<&RepositoryRevisionCapture>,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<(), PrepareEnvironmentError> {
     match repos {
         [] => Ok(()),
-        [request] => clone_repo(request, working_dir, spawner).await,
+        [request] => {
+            clone_repo(
+                request,
+                working_dir,
+                revision_capture.map(|capture| capture.result_file(0)),
+                spawner,
+            )
+            .await
+        }
         repos => {
             let shell_type = spawner
                 .spawn(|driver, ctx| {
@@ -691,7 +830,7 @@ async fn clone_checkout_requests(
                 full: ("Cloning repositories via terminal: {}", repo_names.join(", "))
             );
 
-            let command = build_parallel_clone_command(repos, shell_type);
+            let command = build_parallel_clone_command(repos, revision_capture, shell_type);
             let exit_code = execute_command(command, spawner).await?;
             if exit_code != 0.into() {
                 return Err(PrepareEnvironmentError::CloneRepo {
@@ -714,6 +853,7 @@ async fn clone_checkout_requests(
 async fn clone_repo(
     request: &RepositoryCloneRequest,
     working_dir: &Path,
+    revision_file: Option<PathBuf>,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<(), PrepareEnvironmentError> {
     let repo = &request.repo;
@@ -740,7 +880,12 @@ async fn clone_repo(
     // paths, and this goes through the silent executor so `test -d` is
     // not added to the user-visible blocklist. Pass the absolute path
     // explicitly so the probe doesn't rely on the session's CWD.
-    let dir_exists = terminal_directory_exists(&repo_dir.to_string_lossy(), spawner).await?;
+    let dir_exists = terminal_directory_exists(
+        &repo_dir.to_string_lossy(),
+        revision_file.as_deref(),
+        spawner,
+    )
+    .await?;
 
     if let Some(commit_sha) = commit_sha {
         if !dir_exists {
@@ -773,7 +918,13 @@ async fn clone_repo(
         );
 
         // We do a partial clone here to speed up environment setup time.
-        let command = format!("git clone --filter=tree:0 '{escaped_url}'");
+        let command = match revision_file.as_deref() {
+            Some(result_file) => format!(
+                "git clone --filter=tree:0 '{escaped_url}' && {}",
+                build_capture_head_command(&repo_dir, result_file)
+            ),
+            None => format!("git clone --filter=tree:0 '{escaped_url}'"),
+        };
         let exit_code = execute_command(command, spawner).await?;
         if exit_code != 0.into() {
             return Err(PrepareEnvironmentError::CloneRepo {
@@ -791,7 +942,11 @@ async fn clone_repo(
     // still be on an old default-branch tip, and a fresh partial clone only
     // fetched the default branch — fetch the ref, then detach to FETCH_HEAD.
     // When checkout_ref is unset, leave an existing directory untouched.
-    if let Some(command) = checkout_command_for(request, working_dir, shell_type) {
+    if let Some(mut command) = checkout_command_for(request, working_dir, shell_type) {
+        if let Some(result_file) = revision_file.as_deref() {
+            command.push_str(" && ");
+            command.push_str(&build_capture_head_command(&repo_dir, result_file));
+        }
         let checkout_ref = request
             .checkout
             .as_ref()
@@ -1130,9 +1285,11 @@ async fn cd_in_terminal_silent(
 /// `Test-Path -PathType Container <path>` for PowerShell).
 async fn terminal_directory_exists(
     path: &str,
+    revision_file: Option<&Path>,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<bool, PrepareEnvironmentError> {
     let path = path.to_owned();
+    let revision_file = revision_file.map(Path::to_path_buf);
     let output = spawner
         .spawn(move |driver, ctx| {
             // Fall back to Bash if the session's shell type isn't known yet
@@ -1142,7 +1299,13 @@ async fn terminal_directory_exists(
                 .active_session_shell_type(ctx)
                 .unwrap_or(ShellType::Bash);
             let escaped = shell_escape_single_quotes(&path, shell_type);
-            let command = format!("test -d '{escaped}'");
+            let command = match revision_file {
+                Some(result_file) => format!(
+                    "test -d '{escaped}' && {}",
+                    build_capture_head_command(Path::new(&path), &result_file)
+                ),
+                None => format!("test -d '{escaped}'"),
+            };
             driver.execute_silent_command(command, ctx)
         })
         .await

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -8,9 +8,10 @@ use warp_cli::agent::{RepositoryForge, RepositoryHeadOverride, RepositoryHeadRef
 use warp_core::command::ExitCode;
 
 use super::{
-    PrepareEnvironmentError, RepositoryCloneRequest, build_parallel_clone_command,
+    PrepareEnvironmentError, RepositoryCloneRequest, RepositoryRevisionCapture,
+    build_capture_head_command, build_parallel_clone_command,
     build_remove_repository_origins_command, checkout_command_for, checkout_result,
-    merge_repos_deduped, repository_clone_requests, single_repo_name,
+    is_valid_git_object_id, merge_repos_deduped, repository_clone_requests, single_repo_name,
     validate_repository_head_overrides,
 };
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, SourceRepo};
@@ -72,6 +73,67 @@ fn single_repo_name_returns_repo_when_exactly_one_repo() {
 
 fn repo(forge: CodeForge, owner: &str, name: &str) -> SourceRepo {
     SourceRepo::new(forge, owner.to_string(), name.to_string())
+}
+
+#[test]
+fn git_object_id_validation_accepts_sha1_and_sha256_only() {
+    assert!(is_valid_git_object_id(
+        "0123456789abcdef0123456789abcdef01234567"
+    ));
+    assert!(is_valid_git_object_id(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    ));
+    assert!(!is_valid_git_object_id(
+        "0123456789ABCDEF0123456789ABCDEF01234567"
+    ));
+    assert!(!is_valid_git_object_id("0123456789abcdef"));
+    assert!(!is_valid_git_object_id(
+        "g123456789abcdef0123456789abcdef01234567"
+    ));
+}
+
+#[test]
+fn revision_snapshot_omits_missing_or_invalid_results_and_cleans_up() {
+    let temp = TempDir::new().unwrap();
+    let capture = RepositoryRevisionCapture::new(temp.path());
+    fs::create_dir_all(&capture.result_dir).unwrap();
+    fs::write(
+        capture.result_file(0),
+        "0123456789abcdef0123456789abcdef01234567\n",
+    )
+    .unwrap();
+    fs::write(capture.result_file(1), "not-a-sha\n").unwrap();
+    let result_dir = capture.result_dir.clone();
+    let requests = vec![
+        clone_request(repo(CodeForge::GitHub, "warpdotdev", "warp"), None),
+        clone_request(
+            repo(CodeForge::GitLab, "platform/backend", "api"),
+            Some(RepositoryHeadRef::Branch("develop".to_string())),
+        ),
+        clone_request(repo(CodeForge::GitHub, "warpdotdev", "docs"), None),
+    ];
+
+    let snapshot = capture.into_snapshot(&requests);
+
+    assert_eq!(snapshot.repositories.len(), 1);
+    assert_eq!(snapshot.unresolved_repository_count, 2);
+    assert_eq!(snapshot.repositories[0].checkout_path, "warp");
+    assert_eq!(
+        snapshot.repositories[0].head_sha,
+        "0123456789abcdef0123456789abcdef01234567"
+    );
+    assert!(!result_dir.exists());
+    assert!(!temp.path().join(".warp").exists());
+}
+
+#[test]
+fn revision_capture_failure_does_not_change_command_success() {
+    let temp = TempDir::new().unwrap();
+    let result_file = temp.path().join("result").join("0.head");
+    let command = build_capture_head_command(temp.path(), &result_file);
+
+    assert!(run_command(&command).success());
+    assert!(!result_file.exists());
 }
 
 #[test]
@@ -176,6 +238,7 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
             .into_iter()
             .map(|repo| clone_request(repo, None))
             .collect::<Vec<_>>(),
+        None,
         ShellType::Bash,
     );
 
@@ -227,6 +290,7 @@ fn parallel_clone_command_threads_checkout_ref_and_pins_after_clone() {
                 clone_request(repo, checkout)
             })
             .collect::<Vec<_>>(),
+        None,
         ShellType::Bash,
     );
 
@@ -234,9 +298,10 @@ fn parallel_clone_command_threads_checkout_ref_and_pins_after_clone() {
     assert!(command.contains("'abc123'"));
     assert!(command.contains("'feature'"));
     assert!(command.contains("if [ -n \"$checkout_ref\" ]; then"));
-    assert!(command.contains(
-        "git -C \"$target\" fetch --filter=tree:0 origin \"$checkout_ref\" && git -C \"$target\" checkout --detach FETCH_HEAD"
-    ));
+    assert!(
+        command.contains("git -C \"$target\" fetch --filter=tree:0 origin \"$checkout_ref\" &&")
+    );
+    assert!(command.contains("git -C \"$target\" checkout --detach FETCH_HEAD || return 1"));
     assert!(command.contains("git clone --filter=tree:0 \"$repo_url\" \"$target\""));
 }
 
@@ -263,6 +328,7 @@ fn parallel_clone_command_fetches_commit_shas_without_cloning_later_history() {
                 Some(RepositoryHeadRef::Branch("develop".to_string())),
             ),
         ],
+        None,
         ShellType::Bash,
     );
 
@@ -440,15 +506,17 @@ fn applied_head_overrides_are_threaded_through_the_existing_clone_command() {
     )];
     let command = build_parallel_clone_command(
         &repository_clone_requests(&repos, &overrides),
+        None,
         ShellType::Bash,
     );
 
     assert!(command.contains("'develop'"));
     assert!(!command.contains("'abc123'"));
     assert!(command.contains("'old-pin'"));
-    assert!(command.contains(
-        "git -C \"$target\" fetch --filter=tree:0 origin \"$checkout_ref\" && git -C \"$target\" checkout --detach FETCH_HEAD"
-    ));
+    assert!(
+        command.contains("git -C \"$target\" fetch --filter=tree:0 origin \"$checkout_ref\" &&")
+    );
+    assert!(command.contains("git -C \"$target\" checkout --detach FETCH_HEAD || return 1"));
     assert!(!command.contains("checkout_commit"));
     assert!(!command.contains("checkout_branch"));
     assert_eq!(command.matches("'1'").count(), 0);
@@ -469,6 +537,7 @@ fn applied_commit_override_uses_sha_only_fetch() {
     )];
     let command = build_parallel_clone_command(
         &repository_clone_requests(&repos, &overrides),
+        None,
         ShellType::Bash,
     );
 
@@ -682,7 +751,7 @@ fn run_parallel_clone_repo_helper(
             None,
         ),
     ];
-    let script = unwrap_sh_c_script(&build_parallel_clone_command(&repos, ShellType::Bash));
+    let script = unwrap_sh_c_script(&build_parallel_clone_command(&repos, None, ShellType::Bash));
 
     // Keep only the clone_repo function definition; drop background clones /
     // waits / logs. Locate by name so we don't grab cleanup_clone_logs instead.
@@ -690,13 +759,13 @@ fn run_parallel_clone_repo_helper(
         .find("clone_repo() {")
         .expect("clone_repo function definition");
     let helper_end = script[helper_start..]
-        .find("\n}")
+        .find("\n}\nlog_file_0")
         .expect("clone_repo function terminator")
         + helper_start
         + 2;
     let helper = &script[helper_start..helper_end];
     let invoke = format!(
-        "set -e\n{helper}\nclone_repo 'warpdotdev/{repo}' '{origin}' '{target}' '{checkout_ref}' '{is_commit_sha}'\n",
+        "set -e\n{helper}\nclone_repo 'warpdotdev/{repo}' '{origin}' '{target}' '{checkout_ref}' '{is_commit_sha}' ''\n",
         repo = fixture.repo_name,
         origin = fixture.origin_url,
         target = target.display(),

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -93,8 +93,9 @@ fn git_object_id_validation_accepts_sha1_and_sha256_only() {
 }
 
 #[test]
-fn revision_snapshot_omits_missing_or_invalid_results_and_cleans_up() {
+fn revision_snapshot_cleans_results_without_removing_workspace_warp_directory() {
     let temp = TempDir::new().unwrap();
+    fs::create_dir(temp.path().join(".warp")).unwrap();
     let capture = RepositoryRevisionCapture::new(temp.path());
     fs::create_dir_all(&capture.result_dir).unwrap();
     fs::write(
@@ -123,7 +124,14 @@ fn revision_snapshot_omits_missing_or_invalid_results_and_cleans_up() {
         "0123456789abcdef0123456789abcdef01234567"
     );
     assert!(!result_dir.exists());
-    assert!(!temp.path().join(".warp").exists());
+    assert!(temp.path().join(".warp").exists());
+    assert!(
+        !temp
+            .path()
+            .join(".warp")
+            .join("repository-revisions")
+            .exists()
+    );
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -101,6 +101,7 @@ mod oauth_flow;
 pub mod output;
 mod profiles;
 mod provider;
+mod repository_revisions;
 pub(crate) mod retry;
 mod runner;
 mod schedule;

--- a/app/src/ai/agent_sdk/repository_revisions.rs
+++ b/app/src/ai/agent_sdk/repository_revisions.rs
@@ -1,0 +1,91 @@
+use chrono::Utc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use warpui::r#async::FutureExt as _;
+use warpui::r#async::executor::Background;
+
+use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::server::retry_strategies::with_bounded_retry;
+use crate::server::server_api::ai::{AIClient, RepositoryRevisionSnapshotRequest};
+
+const REPOSITORY_REVISION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(3);
+
+async fn post_snapshot_with_retry(
+    run_id: AmbientAgentTaskId,
+    ai_client: Arc<dyn AIClient>,
+    request: RepositoryRevisionSnapshotRequest,
+) -> anyhow::Result<()> {
+    with_bounded_retry("post repository revision snapshot", || {
+        let ai_client = ai_client.clone();
+        let request = request.clone();
+        async move {
+            ai_client
+                .post_repository_revision_snapshot(&run_id, request)
+                .with_timeout(REPOSITORY_REVISION_ATTEMPT_TIMEOUT)
+                .await
+                .map_err(|_| anyhow::anyhow!("repository revision snapshot request timed out"))?
+        }
+    })
+    .await
+}
+
+#[derive(Clone)]
+pub(crate) struct RepositoryRevisionReporter {
+    run_id: Option<AmbientAgentTaskId>,
+    ai_client: Arc<dyn AIClient>,
+    background: Arc<Background>,
+}
+
+impl RepositoryRevisionReporter {
+    pub(crate) fn new(
+        run_id: AmbientAgentTaskId,
+        ai_client: Arc<dyn AIClient>,
+        background: Arc<Background>,
+    ) -> Self {
+        Self {
+            run_id: Some(run_id),
+            ai_client,
+            background,
+        }
+    }
+
+    pub(crate) fn noop(ai_client: Arc<dyn AIClient>, background: Arc<Background>) -> Self {
+        Self {
+            run_id: None,
+            ai_client,
+            background,
+        }
+    }
+
+    /// Detaches serialization, network delivery, timeouts, and retries from environment startup.
+    pub(crate) fn report(&self, request: RepositoryRevisionSnapshotRequest) {
+        let Some(run_id) = self.run_id else {
+            return;
+        };
+        let ai_client = self.ai_client.clone();
+        self.background
+            .spawn(async move {
+                let result = post_snapshot_with_retry(run_id, ai_client, request).await;
+                if let Err(error) = result {
+                    log::warn!(
+                        "Failed to post repository revision snapshot; continuing run startup: {error:#}"
+                    );
+                }
+            })
+            .detach();
+    }
+
+    pub(crate) fn report_empty(&self) {
+        self.report(RepositoryRevisionSnapshotRequest {
+            snapshot_uuid: uuid::Uuid::new_v4().to_string(),
+            captured_at: Utc::now(),
+            unresolved_repository_count: 0,
+            repositories: Vec::new(),
+        });
+    }
+}
+
+#[cfg(test)]
+#[path = "repository_revisions_tests.rs"]
+mod tests;

--- a/app/src/ai/agent_sdk/repository_revisions_tests.rs
+++ b/app/src/ai/agent_sdk/repository_revisions_tests.rs
@@ -1,0 +1,106 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use chrono::Utc;
+use cloud_object_models::CodeForge;
+use serde_json::json;
+
+use super::*;
+use crate::server::server_api::ai::{MockAIClient, RepositoryRevisionRequest};
+use crate::server::server_api::presigned_upload::HttpStatusError;
+
+fn task_id() -> AmbientAgentTaskId {
+    "550e8400-e29b-41d4-a716-446655440000".parse().unwrap()
+}
+
+fn request() -> RepositoryRevisionSnapshotRequest {
+    RepositoryRevisionSnapshotRequest {
+        snapshot_uuid: "ea954dd4-4d72-492d-bddd-f3336fc33575".to_string(),
+        captured_at: Utc::now(),
+        unresolved_repository_count: 0,
+        repositories: Vec::new(),
+    }
+}
+
+#[test]
+fn request_serializes_shared_wire_contract() {
+    let request = RepositoryRevisionSnapshotRequest {
+        snapshot_uuid: "ea954dd4-4d72-492d-bddd-f3336fc33575".to_string(),
+        captured_at: "2026-08-19T23:00:00Z".parse().unwrap(),
+        unresolved_repository_count: 1,
+        repositories: vec![RepositoryRevisionRequest {
+            code_forge: CodeForge::GitHub,
+            owner: "warpdotdev".to_string(),
+            repo: "warp".to_string(),
+            checkout_path: "warp".to_string(),
+            checkout_ref: Some("main".to_string()),
+            head_sha: "0123456789abcdef0123456789abcdef01234567".to_string(),
+        }],
+    };
+
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        json!({
+            "snapshot_uuid": "ea954dd4-4d72-492d-bddd-f3336fc33575",
+            "captured_at": "2026-08-19T23:00:00Z",
+            "unresolved_repository_count": 1,
+            "repositories": [{
+                "code_forge": "GITHUB",
+                "owner": "warpdotdev",
+                "repo": "warp",
+                "checkout_path": "warp",
+                "checkout_ref": "main",
+                "head_sha": "0123456789abcdef0123456789abcdef01234567"
+            }]
+        })
+    );
+}
+
+#[tokio::test]
+async fn transient_failure_retries_with_identical_snapshot() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_mock = attempts.clone();
+    let mut client = MockAIClient::new();
+    client
+        .expect_post_repository_revision_snapshot()
+        .times(2)
+        .withf(|run_id, request| {
+            run_id.to_string() == "550e8400-e29b-41d4-a716-446655440000"
+                && request.snapshot_uuid == "ea954dd4-4d72-492d-bddd-f3336fc33575"
+        })
+        .returning(move |_, _| {
+            if attempts_for_mock.fetch_add(1, Ordering::SeqCst) == 0 {
+                Err(HttpStatusError {
+                    status: 503,
+                    body: "unavailable".to_string(),
+                }
+                .into())
+            } else {
+                Ok(())
+            }
+        });
+
+    post_snapshot_with_retry(task_id(), Arc::new(client), request())
+        .await
+        .unwrap();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn permanent_failure_does_not_retry() {
+    let mut client = MockAIClient::new();
+    client
+        .expect_post_repository_revision_snapshot()
+        .times(1)
+        .returning(|_, _| {
+            Err(HttpStatusError {
+                status: 404,
+                body: "not found".to_string(),
+            }
+            .into())
+        });
+
+    let result = post_snapshot_with_retry(task_id(), Arc::new(client), request()).await;
+
+    assert!(result.is_err());
+}

--- a/app/src/ai/agent_sdk/setup_observability.rs
+++ b/app/src/ai/agent_sdk/setup_observability.rs
@@ -6,6 +6,7 @@ use futures::FutureExt as _;
 use tracing::Instrument as _;
 use warpui::r#async::executor::Background;
 
+use crate::ai::agent_sdk::repository_revisions::RepositoryRevisionReporter;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::server::server_api::ai::{AIClient, AgentRunClientEventRequest};
 
@@ -36,6 +37,19 @@ impl SetupClientEventReporter {
             run_id: None,
             ai_client,
             background,
+        }
+    }
+
+    pub(crate) fn repository_revision_reporter(&self) -> RepositoryRevisionReporter {
+        match self.run_id {
+            Some(run_id) => RepositoryRevisionReporter::new(
+                run_id,
+                self.ai_client.clone(),
+                self.background.clone(),
+            ),
+            None => {
+                RepositoryRevisionReporter::noop(self.ai_client.clone(), self.background.clone())
+            }
         }
     }
 

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -446,6 +446,25 @@ impl AgentRunClientEventRequest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RepositoryRevisionSnapshotRequest {
+    pub snapshot_uuid: String,
+    pub captured_at: DateTime<Utc>,
+    pub unresolved_repository_count: usize,
+    pub repositories: Vec<RepositoryRevisionRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RepositoryRevisionRequest {
+    pub code_forge: cloud_object_models::CodeForge,
+    pub owner: String,
+    pub repo: String,
+    pub checkout_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkout_ref: Option<String>,
+    pub head_sha: String,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ReadAgentMessageResponse {
     pub message_id: String,
@@ -1497,6 +1516,11 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         run_id: &AmbientAgentTaskId,
         request: AgentRunClientEventRequest,
+    ) -> anyhow::Result<(), anyhow::Error>;
+    async fn post_repository_revision_snapshot(
+        &self,
+        run_id: &AmbientAgentTaskId,
+        request: RepositoryRevisionSnapshotRequest,
     ) -> anyhow::Result<(), anyhow::Error>;
 
     async fn mark_message_delivered(&self, message_id: &str) -> anyhow::Result<(), anyhow::Error>;
@@ -2942,6 +2966,20 @@ impl AIClient for ServerApi {
         self.post_public_api_response_for_task(
             run_id,
             &format!("agent/runs/{run_id}/client-events"),
+            &request,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn post_repository_revision_snapshot(
+        &self,
+        run_id: &AmbientAgentTaskId,
+        request: RepositoryRevisionSnapshotRequest,
+    ) -> anyhow::Result<(), anyhow::Error> {
+        self.post_public_api_response_for_task(
+            run_id,
+            &format!("agent/runs/{run_id}/repository-revisions"),
             &request,
         )
         .await?;


### PR DESCRIPTION
## Summary
- capture the resolved HEAD for each structured environment repository inside the existing clone/reuse command
- assemble one immutable execution snapshot with bounded unresolved-repository diagnostics
- deliver the typed payload on a detached background task with 3-second per-attempt timeouts and bounded transient retries
- emit an explicit empty snapshot for executions with no structured repositories

## Non-blocking design
Each repository writes to a unique `.warp/repository-revisions/<snapshot_uuid>/<index>.head` path through a temporary file plus atomic rename. Capture commands end in a best-effort fallback, so revision lookup or file-write failures cannot alter clone success. Snapshot parsing omits missing/invalid SHA-1 or SHA-256 IDs and cleans up result directories best effort. HTTP serialization, timeout handling, and retries happen only after `Background::spawn(...).detach()`; no network future is awaited by environment preparation.

## Wire payload
`POST /api/v1/agent/runs/{run_id}/repository-revisions`

Top level: `snapshot_uuid`, `captured_at`, `unresolved_repository_count`, `repositories`.

Repository: `code_forge`, `owner`, `repo`, `checkout_path`, optional `checkout_ref`, `head_sha`.

## Validation
Passed:
- `cargo fmt --all --manifest-path /workspace/warp/Cargo.toml -- --check`
- `git -C /workspace/warp --no-pager diff --check`
- `cargo metadata --manifest-path /workspace/warp/Cargo.toml --no-deps --format-version 1`
- real-Git shell verification of atomic HEAD capture and non-fatal capture failure

Sandbox memory limitation (all reached the monolithic `warp` crate, emitted no Rust diagnostic, and were killed by SIGKILL):
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib git_object_id_validation_accepts_sha1_and_sha256_only --no-run`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib --no-default-features`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_DEV_INCREMENTAL=false cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`

<!-- warp:pr-description-artifacts start -->
_Plans_:
- _[Emit repository revision snapshots for Warp agent runs](https://staging.warp.dev/drive/notebook/WNbgAMWYk8Fd2fTkB5EjVB)_
<!-- warp:pr-description-artifacts end -->

Co-Authored-By: Warp <agent@warp.dev>

