### PR TITLE
Add word wrap toggle for the code editor and diff/Code Review view

### DIFF
--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -12,6 +12,7 @@ use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::Fill;
 use warp_core::ui::theme::color::internal_colors;
+use warp_editor::content::buffer::{Buffer, ToBufferPoint};
 use warp_editor::editor::EditorView;
 use warp_editor::render::element::lens_element::RichTextElementLens;
 use warp_editor::render::element::{RenderableBlock, RichTextElement, VerticalExpansionBehavior};
@@ -379,6 +380,10 @@ struct CommentBox {
 
 pub struct EditorWrapper<V: EditorView> {
     editor: InnerEditor<V>,
+    /// The underlying text buffer. Used to resolve wrap-independent, logical (source) line
+    /// numbers for the gutter and diff-hunk matching, since [`RenderState`]'s own `LineCount`
+    /// counts wrapped visual rows rather than raw buffer lines when word wrap is enabled.
+    buffer: ModelHandle<Buffer>,
     element_size: Option<Vector2F>,
     element_origin: Option<Point>,
     /// Whether the editor should expand vertically to fill the available space.
@@ -499,6 +504,7 @@ impl<V: EditorView> EditorWrapper<V> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         editor: InnerEditor<V>,
+        buffer: ModelHandle<Buffer>,
         vertical_expansion_behavior: VerticalExpansionBehavior,
         line_number_config: Option<LineNumberConfig>,
         diff_status: DiffStatus,
@@ -518,6 +524,7 @@ impl<V: EditorView> EditorWrapper<V> {
     ) -> Self {
         Self {
             editor,
+            buffer,
             vertical_expansion_behavior,
             element_size: None,
             element_origin: None,
@@ -585,6 +592,27 @@ impl<V: EditorView> EditorWrapper<V> {
         line_number_config.active_cursor_is_visible
     }
 
+    /// Returns the 0-indexed logical (source) line number containing `offset`, counted from
+    /// actual newlines in the buffer's raw text.
+    ///
+    /// This is deliberately independent of [`RenderState`]'s own `LineCount`, which counts
+    /// wrapped *visual* rows: when word wrap is enabled, a single source line can span multiple
+    /// visual rows, which would otherwise inflate line numbers for every line that follows it.
+    /// Diff hunks (from [`DiffStatus`]) are keyed by real source line numbers too, so using this
+    /// instead of the render model's line index keeps gutter numbers and diff-hunk matching
+    /// correct regardless of wrapping.
+    fn logical_line_number(
+        &self,
+        offset: string_offset::CharOffset,
+        app: &AppContext,
+    ) -> LineCount {
+        let buffer = self.buffer.as_ref(app);
+        // Buffer `Point`s report rows using the editor's one-based convention, while `LineCount`
+        // (as used by render blocks, e.g. `RenderState::start_line_index`) is zero-based.
+        let row = offset.to_buffer_point(buffer).row.saturating_sub(1);
+        LineCount::from(row as usize)
+    }
+
     /// Returning **no** gutter means the gutter shouldn't be rendered at all.
     /// Returning an **empty** gutter means the gutter should be rendered with no contents.
     fn gutter_elements(&self, app: &AppContext) -> Option<Vec<GutterElement>> {
@@ -605,9 +633,7 @@ impl<V: EditorView> EditorWrapper<V> {
         let mut removed_hunk_line_number: Option<LineCount> = None;
         let mut removed_hunk_line_index: usize = 0;
         for (block_idx, block) in blocks.iter().enumerate() {
-            let Some(line_count) = model.start_line_index(&**block) else {
-                continue;
-            };
+            let line_count = self.logical_line_number(block.viewport_item().block_offset, app);
 
             // For lens element, we need to use use the content offset - scroll top instead of the render model's viewport
             // offset since we are only rendering a section of the editor.
@@ -728,11 +754,12 @@ impl<V: EditorView> EditorWrapper<V> {
             }
 
             if block.is_hidden_section() {
-                let line_range = self
-                    .model()
-                    .as_ref(app)
-                    .line_range(&**block)
-                    .unwrap_or_default();
+                // Hidden blocks are never soft-wrapped (they render no text), so their length in
+                // lines is unaffected by word wrap. Only the range's start needs to come from the
+                // logical (wrap-independent) line number computed above.
+                let render_line_range = model.line_range(&**block).unwrap_or_default();
+                let line_range =
+                    line_count..(line_count + (render_line_range.end - render_line_range.start));
 
                 let range_hovered = hovered_range
                     .as_ref()

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -74,6 +74,7 @@ use crate::code::editor::line_iterator::LineIterator;
 use crate::code_review::comments::{CommentId, CommentOrigin, LineDiffContent};
 use crate::editor::InteractionState;
 use crate::notebooks::editor::model::word_unit;
+use crate::settings::CodeSettings;
 use crate::themes::theme::AnsiColorIdentifier;
 use crate::util::link_detection::get_word_range_at_offset;
 
@@ -336,6 +337,8 @@ impl CodeEditorModel {
             buffer.set_session_platform(session_platform);
         });
 
+        let width_setting = Self::width_setting_for_word_wrap(*CodeSettings::as_ref(ctx).word_wrap);
+
         Self::from_content(
             content,
             true,        // show_current_line_highlights
@@ -345,10 +348,20 @@ impl CodeEditorModel {
             |hidden_lines, ctx| {
                 ctx.add_model(|ctx| {
                     RenderState::new(text_styles, lazy_layout, Some(hidden_lines.clone()), ctx)
-                        .with_width_setting(WidthSetting::InfiniteWidth)
+                        .with_width_setting(width_setting)
                 })
             },
         )
+    }
+
+    /// Maps the user-facing word-wrap toggle to the underlying [`WidthSetting`]: when word wrap
+    /// is off, content lays out at its full intrinsic width and relies on horizontal scrolling.
+    fn width_setting_for_word_wrap(word_wrap: bool) -> WidthSetting {
+        if word_wrap {
+            WidthSetting::FitViewport
+        } else {
+            WidthSetting::InfiniteWidth
+        }
     }
 
     /// Constructs a `CodeEditorModel` in TUI char-cell mode.
@@ -1809,6 +1822,18 @@ impl CodeEditorModel {
         self.set_color_map(ctx);
         self.update_cursor_line_highlights(ctx);
         ctx.notify();
+    }
+
+    /// Handle a change to the user's word-wrap setting, relaying out the buffer if needed.
+    pub fn handle_word_wrap_setting_change(&self, word_wrap: bool, ctx: &mut ModelContext<Self>) {
+        let width_setting = Self::width_setting_for_word_wrap(word_wrap);
+        let changed = self.render_state.update(ctx, |render_state, _| {
+            render_state.set_width_setting(width_setting)
+        });
+
+        if changed {
+            self.rebuild_layout_and_refresh_diff(ctx);
+        }
     }
 
     /// Begin selecting at `offset`.

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -77,7 +77,7 @@ use crate::code_review::comments::{CommentId, CommentOrigin};
 use crate::editor::InteractionState;
 use crate::features::FeatureFlag;
 use crate::notebooks::editor::rich_text_styles;
-use crate::settings::{AppEditorSettings, CodeEditorLineNumberMode, FontSettings};
+use crate::settings::{AppEditorSettings, CodeEditorLineNumberMode, CodeSettings, FontSettings};
 use crate::view_components::find::FindDirection;
 
 mod actions;
@@ -311,6 +311,10 @@ impl CodeEditorView {
         let app_editor_settings_handle = AppEditorSettings::handle(ctx);
         ctx.subscribe_to_model(&app_editor_settings_handle, |_, _, _, ctx| {
             ctx.notify();
+        });
+        let code_settings_handle = CodeSettings::handle(ctx);
+        ctx.subscribe_to_model(&code_settings_handle, |me, _, _, ctx| {
+            me.handle_word_wrap_setting_change(ctx);
         });
 
         let model = ctx.add_model(|ctx| {
@@ -612,6 +616,7 @@ impl CodeEditorView {
 
         EditorWrapper::new(
             InnerEditor::Lens(lens),
+            self.model.as_ref(ctx).buffer().clone(),
             self.display_options.vertical_expansion_behavior,
             line_number_config,
             diff_status,
@@ -1383,6 +1388,15 @@ impl CodeEditorView {
         );
         self.model.update(ctx, move |model, ctx| {
             model.handle_appearance_or_font_change(new_styles, ctx);
+        });
+    }
+
+    /// Handles [`CodeSettings`] changes by propagating the current word-wrap value to the
+    /// render model. The model is responsible for no-op'ing when the value hasn't changed.
+    fn handle_word_wrap_setting_change(&mut self, ctx: &mut ViewContext<Self>) {
+        let word_wrap = *CodeSettings::as_ref(ctx).word_wrap;
+        self.model.update(ctx, move |model, ctx| {
+            model.handle_word_wrap_setting_change(word_wrap, ctx);
         });
     }
 
@@ -2207,6 +2221,7 @@ impl View for CodeEditorView {
 
         let focused = self.is_focused(app);
         let blink_cursors = AppEditorSettings::as_ref(app).cursor_blink_enabled();
+        let word_wrap_enabled = *CodeSettings::as_ref(app).word_wrap;
 
         let display_options = DisplayOptions {
             debug_bounds: false,
@@ -2250,6 +2265,7 @@ impl View for CodeEditorView {
 
         let mut code_editor = EditorWrapper::new(
             InnerEditor::FullEditor(editor_rich_content),
+            self.model.as_ref(app).buffer().clone(),
             self.display_options.vertical_expansion_behavior,
             line_number_config,
             diff_status,
@@ -2333,13 +2349,21 @@ impl View for CodeEditorView {
             child: NewScrollableElement::finish_scrollable(code_editor),
         };
 
+        // When word wrap is on, content never overflows horizontally, so hide the horizontal
+        // scrollbar regardless of the configured appearance.
+        let horizontal_scrollbar_appearance = if word_wrap_enabled {
+            ScrollableAppearance::new(warpui::elements::ScrollbarWidth::None, false)
+        } else {
+            self.display_options.horizontal_scrollbar_appearance
+        };
+
         let scrollable = NewScrollable::horizontal_and_vertical(
             config,
             theme.disabled_text_color(theme.background()).into(),
             theme.main_text_color(theme.background()).into(),
             Fill::None,
         )
-        .with_horizontal_scrollbar(self.display_options.horizontal_scrollbar_appearance)
+        .with_horizontal_scrollbar(horizontal_scrollbar_appearance)
         .with_vertical_scrollbar(self.display_options.vertical_scrollbar_appearance)
         .with_propagate_mousewheel_if_not_handled(true)
         .finish();

--- a/app/src/settings/code.rs
+++ b/app/src/settings/code.rs
@@ -100,4 +100,16 @@ define_settings_group!(CodeSettings, settings: [
         toml_path: "code.editor.auto_save",
         description: "Whether the Warp text editor automatically saves changes as you type and when the editor loses focus.",
     },
+    // Controls whether long lines in the code editor and diff / Code Review view are
+    // soft-wrapped to fit the viewport, instead of requiring horizontal scrolling.
+    word_wrap: WordWrap {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        surface: settings::SettingSurfaces::GUI,
+        private: false,
+        toml_path: "code.editor.word_wrap",
+        description: "Whether long lines in the code editor and diff view wrap to fit the viewport instead of scrolling horizontally.",
+    },
 ]);

--- a/app/src/settings_view/code_editor_review_page.rs
+++ b/app/src/settings_view/code_editor_review_page.rs
@@ -72,6 +72,7 @@ impl EditorAndCodeReviewPageView {
             Box::new(ShowHiddenFilesToggleWidget::default()),
             Box::new(FormatOnSaveToggleWidget::default()),
             Box::new(AutoSaveToggleWidget::default()),
+            Box::new(WordWrapToggleWidget::default()),
         ]);
 
         PageType::new_uncategorized(widgets, Some(PAGE_TITLE))
@@ -104,6 +105,7 @@ pub enum EditorAndCodeReviewPageAction {
     ToggleShowHiddenFiles,
     ToggleFormatOnSave,
     ToggleAutoSave,
+    ToggleWordWrap,
 }
 
 impl TypedActionView for EditorAndCodeReviewPageView {
@@ -154,6 +156,12 @@ impl TypedActionView for EditorAndCodeReviewPageView {
             EditorAndCodeReviewPageAction::ToggleAutoSave => {
                 CodeSettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings.auto_save.toggle_and_save_value(ctx));
+                });
+                ctx.notify();
+            }
+            EditorAndCodeReviewPageAction::ToggleWordWrap => {
+                CodeSettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings.word_wrap.toggle_and_save_value(ctx));
                 });
                 ctx.notify();
             }
@@ -269,6 +277,14 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
                 )),
                 context,
                 flags::SHOW_HIDDEN_FILES,
+            ),
+            ToggleSettingActionPair::new(
+                "word wrap in the code editor and diff view",
+                builder(SettingsAction::EditorAndCodeReview(
+                    EditorAndCodeReviewPageAction::ToggleWordWrap,
+                )),
+                context,
+                flags::WORD_WRAP_FLAG,
             ),
         ],
         app,
@@ -631,6 +647,49 @@ impl SettingsWidget for AutoSaveToggleWidget {
                 .finish(),
             Some(
                 "Automatically saves changes in the Warp text editor as you type and when the editor loses focus."
+                    .into(),
+            ),
+        )
+    }
+}
+
+#[derive(Default)]
+struct WordWrapToggleWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for WordWrapToggleWidget {
+    type View = EditorAndCodeReviewPageView;
+
+    fn search_terms(&self) -> &str {
+        "word wrap soft wrap long lines code editor diff review markdown source view scroll"
+    }
+
+    fn render(
+        &self,
+        _view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let code_settings = CodeSettings::as_ref(app);
+
+        render_body_item::<EditorAndCodeReviewPageAction>(
+            "Word wrap".into(),
+            None,
+            LocalOnlyIconState::Hidden,
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .switch(self.switch_state.clone())
+                .check(*code_settings.word_wrap)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(EditorAndCodeReviewPageAction::ToggleWordWrap);
+                })
+                .finish(),
+            Some(
+                "Wrap long lines in the code editor and diff view instead of scrolling horizontally."
                     .into(),
             ),
         )

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -667,6 +667,7 @@ pub mod flags {
     pub const SHOW_PROJECT_EXPLORER: &str = "ShowProjectExplorer";
     pub const SHOW_GLOBAL_SEARCH: &str = "ShowGlobalSearch";
     pub const SHOW_HIDDEN_FILES: &str = "ShowHiddenFiles";
+    pub const WORD_WRAP_FLAG: &str = "Word_Wrap_Enabled";
 }
 
 pub fn init_actions_from_parent_view<T: Action + Clone>(

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -175,7 +175,7 @@ const DASHED_UNDERLINE_GAP_LENGTH: f32 = 4.;
 
 /// In the future, we should also support MinimumWidth(f32) setting so the content will
 /// be laid out with a minimum width that could be larger than the viewport.
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WidthSetting {
     #[default]
     FitViewport,
@@ -2920,6 +2920,20 @@ impl RenderState {
             return action;
         }
         StyleUpdateAction::None
+    }
+
+    /// Update the width setting controlling whether text wraps to fit the viewport or lays out
+    /// at its full intrinsic width. Because the render model does not directly reference the
+    /// content model, the caller is responsible for re-laying out existing content (e.g. via
+    /// [`Self::layout_edit_delta`] over the full buffer range) when this returns `true`.
+    ///
+    /// Returns whether the setting changed, and therefore whether a relayout is needed.
+    pub fn set_width_setting(&mut self, new_setting: WidthSetting) -> bool {
+        if new_setting == self.width_setting {
+            return false;
+        }
+        self.width_setting = new_setting;
+        true
     }
 
     /// Handle to obtain saved position IDs within the rendered text.

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -29,6 +29,7 @@ use crate::content::text::{
 use crate::render::model::test_utils::{TEST_STYLES, laid_out_paragraph, mock_paragraph};
 use crate::render::model::{
     ColumnUnit, Height, LayoutSummary, LineCount, RenderedSelection, SoftWrapPoint, TEXT_SPACING,
+    WidthSetting,
 };
 
 #[test]
@@ -72,6 +73,24 @@ fn test_height() {
             item_count: 4,
         }
     );
+}
+
+#[test]
+fn test_set_width_setting() {
+    let mut render_state =
+        RenderState::new_for_test(TEST_STYLES.clone(), 40.0.into_pixels(), 60.0.into_pixels());
+
+    // The default width setting is `FitViewport`; setting the same value is a no-op.
+    assert!(!render_state.set_width_setting(WidthSetting::FitViewport));
+
+    // Changing to `InfiniteWidth` reports a change.
+    assert!(render_state.set_width_setting(WidthSetting::InfiniteWidth));
+
+    // Setting the same value again does not report a change.
+    assert!(!render_state.set_width_setting(WidthSetting::InfiniteWidth));
+
+    // Switching back reports a change again.
+    assert!(render_state.set_width_setting(WidthSetting::FitViewport));
 }
 
 #[test]


### PR DESCRIPTION
Closes: https://github.com/warpdotdev/warp/issues/15399, https://github.com/warpdotdev/warp/issues/9040, https://github.com/warpdotdev/warp/issues/9017

## Description
Adds a "Word wrap" toggle (off by default) for the code editor and the Code Review diff pane, addressing #9017.

`CodeEditorModel::new` hardcoded `WidthSetting::InfiniteWidth`, which is why long lines never soft-wrapped in either the file editor or the Code Review diff view. This PR:
- Adds a `word_wrap` entry to `CodeSettings`, exposed via **Settings > Editor and Code Review** and the Command Palette.
- Wires it into `CodeEditorModel`/`RenderState`, toggling live via the same relayout-on-settings-change mechanism already used for font/appearance changes, and hides the horizontal scrollbar when wrap is on.
- Fixes a correctness issue that enabling wrap alone would have introduced: `RenderState`'s `LineCount` conflates wrapped *visual* row count with *logical* source-line number (a distinction invisible only because wrapping was previously always off). Left as-is, this would have silently broken diff-hunk highlighting and gutter line numbers once wrapping caused any line to span multiple visual rows. `EditorWrapper` now derives gutter/diff line numbers from the buffer's own newline-based `Point` (via `ToBufferPoint`) instead, independent of wrapping.

## Linked Issue
- [x] The linked issue (#9017) is labeled `ready-to-spec`.
- [ ] Screenshots/video not included — see Testing note below.

## Testing
- `cargo check -p warp_editor` passes, confirming the render-model (`WidthSetting`/`set_width_setting`) changes compile.
- Added `render::model::test_set_width_setting` (in `crates/editor`) covering the no-op/changed transitions of the new toggle.
- `cargo fmt -p warp -p warp_editor` run and diffed to confirm only whitespace/wrapping changes.
- **Not done:** `cargo check -p warp` / running the full app locally. This environment only had Xcode Command Line Tools installed, not full Xcode, so `warpui`'s Metal shader build step could not run and the app crate could not be compiled or launched via `./script/run`. Installing full Xcode was explicitly declined for this session. The app-crate changes (`model.rs`, `view.rs`, `element.rs`, `settings_view/*`) were instead verified via careful manual review against existing call-site patterns in the codebase; this review caught and fixed one real bug (a missing `CodeSettings` import).

- [ ] I have manually tested my changes locally with `./script/run`

**Before merging, this PR needs, on a machine with full Xcode:**
- `cargo check -p warp` and `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- Manual QA: toggling word wrap in Settings, verifying wrapped lines in both the file editor and Code Review diff pane, and confirming gutter line numbers, diff-hunk highlighting, cursor placement/selection, and hidden-section expansion all remain correct on wrapped content.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---
Generated by [Warp](https://app.warp.dev/conversation/42418160-8e26-4ebe-91e3-ee53ae1d8d11) from [this plan](https://app.warp.dev/drive/notebook/X1wYYqb29VA47O6Ga9heFR).

Co-Authored-By: Warp <agent@warp.dev>
