### PR TITLE
Terminate TUI when host terminal disconnects

### DIFF
--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -24,7 +24,7 @@ use warp_core::telemetry::TelemetryEvent as _;
 use warp_errors::report_error;
 use warpui::SingletonEntity as _;
 use warpui_core::platform::{TerminationMode, WindowStyle};
-use warpui_core::runtime::{TuiFocusPolicy, spawn_tui_driver};
+use warpui_core::runtime::{TuiDriverStartupError, TuiFocusPolicy, spawn_tui_driver};
 use warpui_core::{AddWindowOptions, AppContext, ModelHandle, ViewHandle};
 
 use crate::clipboard::copy_to_clipboard;
@@ -337,7 +337,17 @@ fn init(
                 ensure_terminal_session(&sessions, &root, ctx);
             }
         }
-        Err(error) => {
+        Err(error) => handle_tui_driver_startup_error(error, ctx),
+    }
+}
+
+fn handle_tui_driver_startup_error(error: TuiDriverStartupError, ctx: &mut AppContext) {
+    match error {
+        TuiDriverStartupError::TerminalDisconnected(error) => {
+            log::error!("failed to start the TUI driver: {error}");
+            ctx.terminate_app(TerminationMode::ForceTerminate, None);
+        }
+        TuiDriverStartupError::Unexpected(error) => {
             let error = anyhow::Error::new(error);
             report_error!(&error);
             ctx.terminate_app(TerminationMode::ForceTerminate, Some(Err(error)));

--- a/crates/warp_tui/src/session_tests.rs
+++ b/crates/warp_tui/src/session_tests.rs
@@ -1,11 +1,16 @@
+use std::io;
+
 use ai::LLMProvider;
 use clap::Parser;
 use warp::tui_export::register_tui_session_view_test_singletons;
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, SingletonEntity};
 use warpui_core::App;
+use warpui_core::runtime::TuiDriverStartupError;
 
-use super::{TuiArgs, ensure_terminal_session, parse_resume_token};
+use super::{
+    TuiArgs, ensure_terminal_session, handle_tui_driver_startup_error, parse_resume_token,
+};
 use crate::root_view::RootTuiView;
 use crate::session_registry::TuiSessions;
 use crate::test_fixtures::{add_test_semantic_selection, add_test_terminal_session};
@@ -109,6 +114,22 @@ fn terminal_bootstrap_is_idempotent_after_background_terminal_exists() {
         });
 
         app.read(|ctx| assert_eq!(TuiSessions::as_ref(ctx).len(), 1));
+    });
+}
+#[test]
+fn terminal_disconnect_during_driver_startup_exits_without_error() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            handle_tui_driver_startup_error(
+                TuiDriverStartupError::TerminalDisconnected(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "terminal disconnected",
+                )),
+                ctx,
+            );
+        });
+
+        assert!(app.termination_result().is_none());
     });
 }
 

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -41,6 +41,7 @@ use crate::r#async::executor::ForegroundTask;
 use crate::r#async::{Timer, block_on};
 use crate::elements::tui::{TuiEvent, TuiEventContext, TuiPoint, TuiRect, TuiSize};
 use crate::event::ModifiersState;
+use crate::platform::TerminationMode;
 use crate::presenter::tui::TuiPresenter;
 use crate::{App, AppContext, TuiView, ViewHandle, WindowId};
 
@@ -79,6 +80,92 @@ pub enum TuiFocusPolicy {
     Unrestricted,
     /// Return focus to the root when the focused view is outside the presented tree.
     PresentedTree,
+}
+#[derive(Debug, thiserror::Error)]
+pub enum TuiDriverStartupError {
+    #[error("host terminal disconnected while starting the TUI driver: {0}")]
+    TerminalDisconnected(#[source] io::Error),
+    #[error("failed to start the TUI driver: {0}")]
+    Unexpected(#[source] io::Error),
+}
+
+impl From<io::Error> for TuiDriverStartupError {
+    fn from(error: io::Error) -> Self {
+        if is_terminal_disconnect(&error) {
+            Self::TerminalDisconnected(error)
+        } else {
+            Self::Unexpected(error)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TuiDriverIoOperation {
+    DrawFrame,
+    ReadEvent,
+}
+
+impl TuiDriverIoOperation {
+    fn error_context(self) -> &'static str {
+        match self {
+            Self::DrawFrame => "failed to draw a TUI frame",
+            Self::ReadEvent => "failed to read a terminal event",
+        }
+    }
+}
+
+enum TuiDriverEvent {
+    Terminal(CrosstermEvent),
+    InputFailed(io::Error),
+}
+
+fn is_terminal_disconnect(error: &io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::BrokenPipe
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::NotConnected
+            | io::ErrorKind::UnexpectedEof
+    ) {
+        return true;
+    }
+
+    #[cfg(unix)]
+    if matches!(error.raw_os_error(), Some(libc::EIO | libc::ENXIO)) {
+        return true;
+    }
+
+    #[cfg(windows)]
+    if error.raw_os_error() == Some(233) {
+        return true;
+    }
+
+    false
+}
+
+fn fail_tui_driver(
+    error: io::Error,
+    operation: TuiDriverIoOperation,
+    failed: &Rc<Cell<bool>>,
+    repaint_timer: &Rc<RefCell<Option<ForegroundTask>>>,
+    ctx: &mut AppContext,
+) {
+    if failed.replace(true) {
+        return;
+    }
+    repaint_timer.borrow_mut().take();
+
+    let error_context = operation.error_context();
+    if is_terminal_disconnect(&error) {
+        log::error!("{error_context}: {error}");
+        ctx.terminate_app(TerminationMode::ForceTerminate, None);
+        return;
+    }
+
+    let error = anyhow::Error::new(error).context(error_context);
+    report_error!(&error);
+    ctx.terminate_app(TerminationMode::ForceTerminate, Some(Err(error)));
 }
 
 /// The rendering half of the TUI: owns the presenter, renderer, and host
@@ -632,7 +719,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     focus_policy: TuiFocusPolicy,
     report_modifier_key_lifecycle: bool,
     freeze_repaints_when_unfocused: bool,
-) -> io::Result<TuiDriverHandle> {
+) -> Result<TuiDriverHandle, TuiDriverStartupError> {
     let guard = TuiTerminalGuard::enter(report_modifier_key_lifecycle)?;
 
     // The presenter + renderer + terminal live behind an `Rc<RefCell<_>>` owned
@@ -650,6 +737,7 @@ pub fn spawn_tui_driver<T: TuiView>(
     let repaint_timer: Rc<RefCell<Option<ForegroundTask>>> = Rc::default();
     let focused = Rc::new(Cell::new(true));
     let freeze_repaints_when_unfocused = Rc::new(Cell::new(freeze_repaints_when_unfocused));
+    let failed = Rc::new(Cell::new(false));
 
     // Redraw whenever the window is invalidated. `update_windows` invokes this at
     // the end of every `flush_effects`, so any `notify()` repaints. (The callback
@@ -660,17 +748,22 @@ pub fn spawn_tui_driver<T: TuiView>(
         let repaint_timer = repaint_timer.clone();
         let focused = focused.clone();
         let freeze_repaints_when_unfocused = freeze_repaints_when_unfocused.clone();
+        let failed = failed.clone();
         ctx.on_window_invalidated(window_id, move |_, ctx| {
             if let Err(error) = draw_and_schedule_repaint(
                 &screen,
                 &repaint_timer,
                 &focused,
                 &freeze_repaints_when_unfocused,
+                &failed,
                 ctx,
             ) {
-                report_error!(
-                    anyhow::Error::new(error).context("failed to draw a TUI frame"),
-                    warp_errors::ReportErrorLogMode::OncePerRun
+                fail_tui_driver(
+                    error,
+                    TuiDriverIoOperation::DrawFrame,
+                    &failed,
+                    &repaint_timer,
+                    ctx,
                 );
             }
         });
@@ -683,16 +776,20 @@ pub fn spawn_tui_driver<T: TuiView>(
     // returning `Err` here drops `guard` (restoring the terminal) and lets the
     // caller surface the error, rather than leaving a live raw-mode session with
     // no usable frame.
-    draw_and_schedule_repaint(
+    if let Err(error) = draw_and_schedule_repaint(
         &screen,
         &repaint_timer,
         &focused,
         &freeze_repaints_when_unfocused,
+        &failed,
         ctx,
-    )?;
+    ) {
+        failed.set(true);
+        return Err(error.into());
+    }
 
     let weak_app = ctx.weak_app();
-    let (sender, receiver) = async_channel::unbounded::<CrosstermEvent>();
+    let (sender, receiver) = async_channel::unbounded::<TuiDriverEvent>();
 
     // Blocking terminal reads run off the main thread and are forwarded to the
     // foreground executor through the channel, so the main thread's event loop is
@@ -705,14 +802,13 @@ pub fn spawn_tui_driver<T: TuiView>(
                     Ok(event) => {
                         // The reader runs on a dedicated thread, so blocking on the
                         // send is fine; an error means the receiver was dropped.
-                        if block_on(sender.send(event)).is_err() {
+                        if block_on(sender.send(TuiDriverEvent::Terminal(event))).is_err() {
                             break;
                         }
                     }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
                     Err(error) => {
-                        report_error!(
-                            anyhow::Error::new(error).context("failed to read a terminal event")
-                        );
+                        let _ = block_on(sender.send(TuiDriverEvent::InputFailed(error)));
                         break;
                     }
                 }
@@ -723,8 +819,9 @@ pub fn spawn_tui_driver<T: TuiView>(
     let dispatch_repaint_timer = repaint_timer.clone();
     let dispatch_focused = focused.clone();
     let dispatch_freeze_repaints_when_unfocused = freeze_repaints_when_unfocused.clone();
+    let dispatch_failed = failed.clone();
     let task = ctx.foreground_executor().spawn(async move {
-        while let Ok(event) = receiver.recv().await {
+        while let Ok(driver_event) = receiver.recv().await {
             let Some(mut app) = weak_app.upgrade() else {
                 break;
             };
@@ -732,6 +829,22 @@ pub fn spawn_tui_driver<T: TuiView>(
             let repaint_timer = dispatch_repaint_timer.clone();
             let focused = dispatch_focused.clone();
             let freeze_repaints_when_unfocused = dispatch_freeze_repaints_when_unfocused.clone();
+            let failed = dispatch_failed.clone();
+            let event = match driver_event {
+                TuiDriverEvent::Terminal(event) => event,
+                TuiDriverEvent::InputFailed(error) => {
+                    app.update(move |ctx| {
+                        fail_tui_driver(
+                            error,
+                            TuiDriverIoOperation::ReadEvent,
+                            &failed,
+                            &repaint_timer,
+                            ctx,
+                        );
+                    });
+                    break;
+                }
+            };
             // Dispatch reuses the shared screen's cached element tree (so embedded
             // child views resolve their elements). Edits queue effects that flush
             // when this `update` returns — firing the invalidation callback to
@@ -784,8 +897,12 @@ fn draw_and_schedule_repaint<T: TuiView, R: TuiTerminal + 'static>(
     timer_slot: &Rc<RefCell<Option<ForegroundTask>>>,
     focused: &Rc<Cell<bool>>,
     freeze_repaints_when_unfocused: &Rc<Cell<bool>>,
+    failed: &Rc<Cell<bool>>,
     ctx: &mut AppContext,
 ) -> io::Result<()> {
+    if failed.get() {
+        return Ok(());
+    }
     let deadline = screen.borrow_mut().draw(ctx)?;
     let timer = deadline
         .filter(|_| should_schedule_repaints(focused.get(), freeze_repaints_when_unfocused.get()))
@@ -793,6 +910,7 @@ fn draw_and_schedule_repaint<T: TuiView, R: TuiTerminal + 'static>(
             let screen = screen.clone();
             let focused = Rc::clone(focused);
             let freeze_repaints_when_unfocused = Rc::clone(freeze_repaints_when_unfocused);
+            let failed = failed.clone();
             // Weak, or the slot (held by the task) and the task (held by the slot)
             // would keep each other alive.
             let weak_slot = Rc::downgrade(timer_slot);
@@ -815,11 +933,15 @@ fn draw_and_schedule_repaint<T: TuiView, R: TuiTerminal + 'static>(
                         &timer_slot,
                         &focused,
                         &freeze_repaints_when_unfocused,
+                        &failed,
                         ctx,
                     ) {
-                        report_error!(
-                            anyhow::Error::new(error).context("failed to draw a TUI frame"),
-                            warp_errors::ReportErrorLogMode::OncePerRun
+                        fail_tui_driver(
+                            error,
+                            TuiDriverIoOperation::DrawFrame,
+                            &failed,
+                            &timer_slot,
+                            ctx,
                         );
                     }
                 });

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -111,6 +111,7 @@ fn invalidation_driver_does_not_schedule_repaints_while_unfocused() {
         let timer = Rc::new(RefCell::new(None));
         let focused = Rc::new(Cell::new(true));
         let freeze_repaints_when_unfocused = Rc::new(Cell::new(true));
+        let failed = Rc::new(Cell::new(false));
 
         app.update(|ctx| {
             draw_and_schedule_repaint(
@@ -118,6 +119,7 @@ fn invalidation_driver_does_not_schedule_repaints_while_unfocused() {
                 &timer,
                 &focused,
                 &freeze_repaints_when_unfocused,
+                &failed,
                 ctx,
             )
         })
@@ -131,6 +133,7 @@ fn invalidation_driver_does_not_schedule_repaints_while_unfocused() {
                 &timer,
                 &focused,
                 &freeze_repaints_when_unfocused,
+                &failed,
                 ctx,
             )
         })
@@ -144,6 +147,7 @@ fn invalidation_driver_does_not_schedule_repaints_while_unfocused() {
                 &timer,
                 &focused,
                 &freeze_repaints_when_unfocused,
+                &failed,
                 ctx,
             )
         })
@@ -385,6 +389,46 @@ impl TuiTerminal for TestTerminal {
         &mut self.output
     }
 }
+struct FailingWriter {
+    attempts: Rc<Cell<usize>>,
+}
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+        self.attempts.set(self.attempts.get() + 1);
+        Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "terminal disconnected",
+        ))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.attempts.set(self.attempts.get() + 1);
+        Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "terminal disconnected",
+        ))
+    }
+}
+
+struct FailingTerminal {
+    size: TuiSize,
+    writer: FailingWriter,
+}
+
+impl TuiTerminal for FailingTerminal {
+    fn size(&self) -> io::Result<TuiSize> {
+        Ok(self.size)
+    }
+
+    fn poll_event(&mut self, _timeout: Duration) -> io::Result<Option<CrosstermEvent>> {
+        Ok(None)
+    }
+
+    fn writer(&mut self) -> &mut dyn Write {
+        &mut self.writer
+    }
+}
 
 fn window_options() -> AddWindowOptions {
     AddWindowOptions {
@@ -393,6 +437,141 @@ fn window_options() -> AddWindowOptions {
     }
 }
 
+#[test]
+fn terminal_disconnects_include_pipe_and_tty_errors() {
+    assert!(is_terminal_disconnect(&io::Error::new(
+        io::ErrorKind::BrokenPipe,
+        "closed pipe"
+    )));
+
+    #[cfg(unix)]
+    {
+        assert!(is_terminal_disconnect(&io::Error::from_raw_os_error(
+            libc::EIO
+        )));
+        assert!(is_terminal_disconnect(&io::Error::from_raw_os_error(
+            libc::ENXIO
+        )));
+    }
+
+    #[cfg(windows)]
+    assert!(is_terminal_disconnect(&io::Error::from_raw_os_error(233)));
+
+    assert!(!is_terminal_disconnect(&io::Error::other(
+        "unexpected failure"
+    )));
+}
+#[test]
+fn startup_errors_classify_terminal_disconnects() {
+    let disconnect = TuiDriverStartupError::from(io::Error::new(
+        io::ErrorKind::BrokenPipe,
+        "terminal disconnected",
+    ));
+    assert!(matches!(
+        disconnect,
+        TuiDriverStartupError::TerminalDisconnected(_)
+    ));
+
+    let unexpected = TuiDriverStartupError::from(io::Error::other("unexpected failure"));
+    assert!(matches!(unexpected, TuiDriverStartupError::Unexpected(_)));
+}
+
+#[test]
+fn disconnected_driver_cancels_repaints_and_stops_drawing() {
+    App::test((), |mut app| async move {
+        let (window_id, root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| TextView));
+        let attempts = Rc::new(Cell::new(0));
+        let screen = Rc::new(RefCell::new(TuiScreen::new(
+            window_id,
+            root,
+            FailingTerminal {
+                size: TuiSize::new(20, 3),
+                writer: FailingWriter {
+                    attempts: attempts.clone(),
+                },
+            },
+        )));
+        let timer = Rc::new(RefCell::new(Some(app.update(|ctx| {
+            ctx.foreground_executor().spawn(async {
+                std::future::pending::<()>().await;
+            })
+        }))));
+        let focused = Rc::new(Cell::new(true));
+        let freeze_repaints_when_unfocused = Rc::new(Cell::new(false));
+        let failed = Rc::new(Cell::new(false));
+
+        let error = app
+            .update(|ctx| {
+                draw_and_schedule_repaint(
+                    &screen,
+                    &timer,
+                    &focused,
+                    &freeze_repaints_when_unfocused,
+                    &failed,
+                    ctx,
+                )
+            })
+            .unwrap_err();
+        app.update(|ctx| {
+            fail_tui_driver(error, TuiDriverIoOperation::DrawFrame, &failed, &timer, ctx);
+        });
+
+        assert!(failed.get());
+        assert!(timer.borrow().is_none());
+        assert_eq!(attempts.get(), 1);
+
+        app.update(|ctx| {
+            draw_and_schedule_repaint(
+                &screen,
+                &timer,
+                &focused,
+                &freeze_repaints_when_unfocused,
+                &failed,
+                ctx,
+            )
+        })
+        .unwrap();
+
+        assert_eq!(attempts.get(), 1);
+        assert!(app.termination_result().is_none());
+    });
+}
+
+#[test]
+fn unexpected_driver_failure_terminates_with_one_error() {
+    App::test((), |mut app| async move {
+        let timer: Rc<RefCell<Option<ForegroundTask>>> = Rc::default();
+        let failed = Rc::new(Cell::new(false));
+
+        app.update(|ctx| {
+            fail_tui_driver(
+                io::Error::other("first failure"),
+                TuiDriverIoOperation::ReadEvent,
+                &failed,
+                &timer,
+                ctx,
+            );
+            fail_tui_driver(
+                io::Error::other("second failure"),
+                TuiDriverIoOperation::DrawFrame,
+                &failed,
+                &timer,
+                ctx,
+            );
+        });
+
+        let error = app
+            .termination_result()
+            .expect("unexpected I/O should set a termination result")
+            .expect_err("unexpected I/O should terminate with an error");
+        assert_eq!(
+            error.to_string(),
+            "failed to read a terminal event",
+            "the first failure should win"
+        );
+    });
+}
 #[test]
 fn run_until_draws_view_text_and_exits_on_quit() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

### What

- Treat host-terminal input and output disconnects as terminal TUI driver failures.
- Stop pending and future redraws after the first driver failure.
- Retry interrupted input reads, log expected disconnects once without reporting them to Sentry, and preserve Sentry reporting for unexpected I/O failures.
- Add regression tests for disconnect classification, repaint cancellation, and unexpected failure propagation.

### Why

The TUI continued running after its host terminal became unavailable. Each subsequent invalidation attempted another frame draw and reported the same non-actionable terminal-disconnect error, producing more than 160,000 events from one affected session.

### How

Input-reader failures now reach the foreground runtime through a typed driver-event channel. A shared failure latch and termination path cancel scheduled repaints, prevent further draws, and cleanly stop the frontend. Expected pipe and TTY disconnect errors terminate without a Sentry event; unexpected I/O errors are still reported once and returned as the termination result.

## Linked Issue

- [Sentry: WARP-CLIENT-BETA-STABLE-86T9](https://warpdotdev.sentry.io/issues/7655080610/)

## Testing

- `./script/format --check`
- `./script/check_no_inline_test_modules`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo nextest run -p warpui_core --features tui -E 'test(terminal_disconnects_include_pipe_and_tty_errors) | test(disconnected_driver_cancels_repaints_and_stops_drawing) | test(unexpected_driver_failure_terminates_with_one_error)'`
- `cargo nextest run -p warpui_core --features tui`
- `CARGO_BUILD_JOBS=2 cargo check -p warp_tui --bin warp-tui-oss`
- `cargo check -p warpui_core --features tui --target x86_64-pc-windows-msvc`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Warp conversation](https://staging.warp.dev/conversation/721e99ae-7b0b-497e-a06f-b457aaf596e7)

CHANGELOG-BUG-FIX: Fixed Warp Agent CLI repeatedly redrawing and reporting errors after its host terminal disconnects.

Co-Authored-By: Warp <agent@warp.dev>
