### PR TITLE
[multi-team PR 1B] Team model catalogs and selector window lifetime

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -21,7 +21,9 @@ use crate::network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind};
 use crate::server::ids::ServerId;
 use crate::server::server_api::ServerApiProvider;
 use crate::user_config::{WarpConfig, WarpConfigUpdateEvent};
-use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
+use crate::workspaces::user_workspaces::{
+    TeamContext, TeamScopeKey, UserWorkspaces, UserWorkspacesEvent,
+};
 
 /// Checks if a user's' API key is being used for the given provider.
 /// Returns `true` if BYO API key is enabled and a key exists for the provider.
@@ -741,12 +743,31 @@ struct AvailableLLMsUpdate {
     popup_visibility_state: Arc<FairMutex<UpdatePopupVisibilityState>>,
 }
 
+/// A model catalog plus its own refresh bookkeeping.
+///
+/// Kept per-team (in [`LLMPreferences::models_by_team`]) rather than as a single instance so
+/// that fetching or marking one team's catalog stale can never leak into another
+/// concurrently open team's state.
+#[derive(Default)]
+struct TeamModelState {
+    models_by_feature: ModelsByFeature,
+    /// Whether the most recent authed fetch failed.
+    agent_mode_models_unavailable: bool,
+}
+
 /// Singleton model holding user/workspace LLM preferences, including the set of LLMs available for
 /// use as well as the user's preferred LLM for Agent Mode.
 pub struct LLMPreferences {
-    models_by_feature: ModelsByFeature,
-    /// Whether the most recent authed agent-mode model-list fetch failed.
-    agent_mode_models_unavailable: bool,
+    /// The catalog read by every accessor that has not adopted an explicit team scope, and
+    /// populated by the account-wide, unscoped model-choice fetch. Deliberately a separate
+    /// field rather than `models_by_team`'s `None` entry: that entry means an operation
+    /// resolved it has no team, which is a different thing that happens to coincide with
+    /// this catalog today. Conflating them would let a genuinely-resolved no-team read
+    /// silently inherit whichever team's data last flowed through this legacy, ambient path.
+    legacy_models: TeamModelState,
+    /// Catalogs resolved for an explicit team-operation scope, keyed opaquely (see
+    /// [`TeamScopeKey`]); the no-team key is distinct from `legacy_models` above.
+    models_by_team: HashMap<TeamScopeKey, TeamModelState>,
     last_update: Option<AvailableLLMsUpdate>,
     // Stores model overrides for a given terminal view. User selections are
     // normalized against the GUI profile default, while explicit child-run
@@ -766,7 +787,10 @@ pub struct LLMPreferences {
 
 impl LLMPreferences {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
-        let models_by_feature = get_cached_models(ctx).unwrap_or_default();
+        let legacy_models = TeamModelState {
+            models_by_feature: get_cached_models(ctx).unwrap_or_default(),
+            agent_mode_models_unavailable: false,
+        };
 
         ctx.subscribe_to_model(&NetworkStatus::handle(ctx), |me, _, event, ctx| {
             if let NetworkStatusEvent::NetworkStatusChanged {
@@ -774,6 +798,7 @@ impl LLMPreferences {
             } = event
             {
                 me.refresh_authed_models(ctx);
+                me.refresh_scoped_teams(ctx);
             }
         });
 
@@ -784,6 +809,7 @@ impl LLMPreferences {
         ctx.subscribe_to_model(&AuthManager::handle(ctx), |me, _, event, ctx| {
             if let AuthManagerEvent::AuthComplete = event {
                 me.refresh_authed_models(ctx);
+                me.refresh_scoped_teams(ctx);
             }
         });
 
@@ -791,6 +817,7 @@ impl LLMPreferences {
             if let UserWorkspacesEvent::TeamsChanged = event {
                 me.sanitize_disabled_custom_model_preferences(ctx);
                 me.refresh_authed_models(ctx);
+                me.prune_and_refresh_scoped_teams(ctx);
             }
         });
 
@@ -822,8 +849,8 @@ impl LLMPreferences {
         let custom_llms = build_custom_llm_infos(ApiKeyManager::as_ref(ctx).keys());
 
         let mut me = Self {
-            models_by_feature,
-            agent_mode_models_unavailable: false,
+            legacy_models,
+            models_by_team: HashMap::new(),
             last_update: None,
             base_llm_for_terminal_view,
             custom_llms,
@@ -845,11 +872,65 @@ impl LLMPreferences {
 
         me
     }
+
+    /// The model catalog read by every accessor below that has not yet adopted an explicit
+    /// team scope. See the field doc on `legacy_models` for why it is not `models_by_team`'s
+    /// `None` entry.
+    fn models_by_feature(&self) -> &ModelsByFeature {
+        &self.legacy_models.models_by_feature
+    }
+
+    /// Mutable counterpart to [`Self::models_by_feature`]. Only used by
+    /// [`Self::add_agent_mode_model_for_test`] today.
+    #[cfg(any(test, feature = "test-util"))]
+    fn models_by_feature_mut(&mut self) -> &mut ModelsByFeature {
+        &mut self.legacy_models.models_by_feature
+    }
+
+    /// Entry of `models_by_team` for `key`, or a shared empty default when nothing has been
+    /// fetched for that scope yet. Never allocates an entry, so reading a scope no caller
+    /// has resolved does not spuriously grow `models_by_team` or imply a fetch is in flight.
+    fn team_state(&self, key: TeamScopeKey) -> &TeamModelState {
+        static DEFAULT: OnceLock<TeamModelState> = OnceLock::new();
+        self.models_by_team
+            .get(&key)
+            .unwrap_or_else(|| DEFAULT.get_or_init(TeamModelState::default))
+    }
+
+    /// The model catalog for a captured team-operation scope, or the resolved no-team scope
+    /// when `context` is `None`. Returns a shared empty default when nothing has been
+    /// fetched for that scope yet.
+    #[allow(dead_code)]
+    pub(crate) fn models_by_feature_for_context(
+        &self,
+        context: Option<&TeamContext>,
+    ) -> &ModelsByFeature {
+        &self
+            .team_state(UserWorkspaces::cache_key_for_context(context))
+            .models_by_feature
+    }
+
+    /// Whether the most recent authed fetch for `context`'s scope failed. See
+    /// [`Self::models_by_feature_for_context`].
+    #[allow(dead_code)]
+    pub(crate) fn agent_mode_models_unavailable_for_context(
+        &self,
+        context: Option<&TeamContext>,
+    ) -> bool {
+        self.team_state(UserWorkspaces::cache_key_for_context(context))
+            .agent_mode_models_unavailable
+    }
+
+    /// Builds an `LLMPreferences` for unit tests that only need to set `legacy_models` and
+    /// `custom_llms` directly, without the singleton machinery `new()` requires.
     #[cfg(test)]
     fn for_test(models_by_feature: ModelsByFeature, custom_llms: Vec<LLMInfo>) -> Self {
         Self {
-            models_by_feature,
-            agent_mode_models_unavailable: false,
+            legacy_models: TeamModelState {
+                models_by_feature,
+                agent_mode_models_unavailable: false,
+            },
+            models_by_team: HashMap::new(),
             last_update: None,
             base_llm_for_terminal_view: HashMap::new(),
             custom_llms,
@@ -876,7 +957,7 @@ impl LLMPreferences {
             let raw_override = self.base_llm_for_terminal_view.get(&terminal_view_id);
             if let Some(llm_id) = raw_override
                 && let Some(llm_info) =
-                    self.model_info_for_id(&self.models_by_feature.agent_mode, llm_id, app)
+                    self.model_info_for_id(&self.models_by_feature().agent_mode, llm_id, app)
             {
                 return llm_info;
             }
@@ -898,8 +979,8 @@ impl LLMPreferences {
             .data()
             .base_model
             .clone()
-            .and_then(|id| self.model_info_for_id(&self.models_by_feature.agent_mode, &id, app))
-            .unwrap_or_else(|| self.fallback_llm_info(&self.models_by_feature.agent_mode, app))
+            .and_then(|id| self.model_info_for_id(&self.models_by_feature().agent_mode, &id, app))
+            .unwrap_or_else(|| self.fallback_llm_info(&self.models_by_feature().agent_mode, app))
     }
 
     /// Disable-aware fallback for when the user has no explicit (usable)
@@ -955,8 +1036,8 @@ impl LLMPreferences {
             .data()
             .coding_model
             .clone()
-            .and_then(|id| self.model_info_for_id(&self.models_by_feature.coding, &id, app))
-            .unwrap_or_else(|| self.fallback_llm_info(&self.models_by_feature.coding, app))
+            .and_then(|id| self.model_info_for_id(&self.models_by_feature().coding, &id, app))
+            .unwrap_or_else(|| self.fallback_llm_info(&self.models_by_feature().coding, app))
     }
 
     /// Resolves `id` against a server-provided model list, but hides cloud/team
@@ -984,7 +1065,7 @@ impl LLMPreferences {
     ) -> impl Iterator<Item = &LLMInfo> + use<'_> {
         // Don't show admin-disabled models in the dropdown
         let routers_enabled = FeatureFlag::CustomModelRouters.is_enabled();
-        self.models_by_feature
+        self.models_by_feature()
             .agent_mode
             .choices
             .iter()
@@ -1000,7 +1081,7 @@ impl LLMPreferences {
 
     #[cfg(any(test, feature = "test-util"))]
     pub fn add_agent_mode_model_for_test(&mut self, llm: LLMInfo) {
-        self.models_by_feature.agent_mode.choices.push(llm);
+        self.models_by_feature_mut().agent_mode.choices.push(llm);
     }
 
     /// Returns the set of LLMs available for coding.
@@ -1010,7 +1091,7 @@ impl LLMPreferences {
     ) -> impl Iterator<Item = &LLMInfo> + use<'_> {
         // Don't show admin-disabled models in the dropdown
         let routers_enabled = FeatureFlag::CustomModelRouters.is_enabled();
-        self.models_by_feature
+        self.models_by_feature()
             .coding
             .choices
             .iter()
@@ -1065,10 +1146,11 @@ impl LLMPreferences {
 
     /// Helper to get the AvailableLLMs for cli_agent, falling back to agent_mode.
     fn get_cli_agent_available(&self) -> &AvailableLLMs {
-        self.models_by_feature
+        let models_by_feature = self.models_by_feature();
+        models_by_feature
             .cli_agent
             .as_ref()
-            .unwrap_or(&self.models_by_feature.agent_mode)
+            .unwrap_or(&models_by_feature.agent_mode)
     }
 
     /// Returns the set of LLMs available for computer use agent.
@@ -1108,7 +1190,7 @@ impl LLMPreferences {
     /// Falls back to a computer-use-specific default if None.
     fn get_computer_use_available(&self) -> &AvailableLLMs {
         static DEFAULT: OnceLock<AvailableLLMs> = OnceLock::new();
-        self.models_by_feature
+        self.models_by_feature()
             .computer_use
             .as_ref()
             .unwrap_or_else(|| DEFAULT.get_or_init(default_computer_use_llms))
@@ -1118,7 +1200,7 @@ impl LLMPreferences {
     /// Falls back to the user's custom-endpoint LLMs when the id isn't a server-known model
     /// id (e.g. when it's a `config_key` UUID).
     pub fn get_llm_info(&self, id: &LLMId) -> Option<&LLMInfo> {
-        self.models_by_feature
+        self.models_by_feature()
             .info_for_id(id)
             .or_else(|| self.custom_llm_info_for_id(id))
             .or_else(|| self.custom_router_llm_info_for_id(id))
@@ -1445,28 +1527,28 @@ impl LLMPreferences {
     /// Returns the effective default base model as a fallback
     /// (disable-aware, see [`Self::fallback_llm_info`]).
     pub fn get_default_base_model(&self, app: &AppContext) -> &LLMInfo {
-        self.fallback_llm_info(&self.models_by_feature.agent_mode, app)
+        self.fallback_llm_info(&self.models_by_feature().agent_mode, app)
     }
 
     /// Returns the effective default coding model as a fallback
     /// (disable-aware, see [`Self::fallback_llm_info`]).
     pub fn get_default_coding_model(&self, app: &AppContext) -> &LLMInfo {
-        self.fallback_llm_info(&self.models_by_feature.coding, app)
+        self.fallback_llm_info(&self.models_by_feature().coding, app)
     }
 
     /// Returns the preferred Codex model, if set by the server.
     pub fn get_preferred_codex_model(&self) -> Option<&LLMInfo> {
-        self.models_by_feature
-            .agent_mode
+        let agent_mode = &self.models_by_feature().agent_mode;
+        agent_mode
             .preferred_codex_model_id
             .as_ref()
-            .and_then(|id| self.models_by_feature.agent_mode.info_for_id(id))
+            .and_then(|id| agent_mode.info_for_id(id))
     }
 
     /// Returns `true` when the most recent authed agent-mode model-list fetch
     /// failed, so the server-provided model list is currently unavailable.
     pub fn agent_mode_models_unavailable(&self) -> bool {
-        self.agent_mode_models_unavailable
+        self.legacy_models.agent_mode_models_unavailable
     }
 
     /// Sets whether the authed agent-mode model list is currently unavailable.
@@ -1474,12 +1556,15 @@ impl LLMPreferences {
     /// [`Self::on_server_update`] on any successful model-list update, and
     /// from tests.
     pub(crate) fn set_agent_mode_models_unavailable(&mut self, unavailable: bool) {
-        self.agent_mode_models_unavailable = unavailable;
+        self.legacy_models.agent_mode_models_unavailable = unavailable;
     }
 
     #[cfg(feature = "integration_tests")]
     pub fn is_available_agent_mode_llm(&self, id: &LLMId) -> bool {
-        self.models_by_feature.agent_mode.info_for_id(id).is_some()
+        self.models_by_feature()
+            .agent_mode
+            .info_for_id(id)
+            .is_some()
     }
 
     /// Creates a pane-level override for the Agent Mode LLM.
@@ -1622,7 +1707,7 @@ impl LLMPreferences {
         terminal_view_id: Option<EntityId>,
         ctx: &mut ModelContext<Self>,
     ) {
-        let new_value = if preferred_llm_id == &self.models_by_feature.coding.default_id {
+        let new_value = if preferred_llm_id == &self.models_by_feature().coding.default_id {
             None
         } else {
             Some(preferred_llm_id.clone())
@@ -1700,7 +1785,7 @@ impl LLMPreferences {
             async move { ai_api_client.get_feature_model_choices().await },
             |me, result, ctx| match result {
                 Ok(update) => {
-                    if update != me.models_by_feature {
+                    if update != *me.models_by_feature() {
                         me.on_server_update(update, ctx);
                     }
                     // Clear the flag; on_server_update also clears it but may be skipped when the list is unchanged.
@@ -1716,6 +1801,70 @@ impl LLMPreferences {
         );
     }
 
+    /// Fetches the latest model catalog for `key`'s scope and stores it under that scope's
+    /// own entry in `models_by_team`, leaving every other entry untouched. The completion is
+    /// dropped if `key`'s team is no longer a current team membership by the time the
+    /// response arrives, so a slow response cannot resurrect an entry that
+    /// [`Self::prune_and_refresh_scoped_teams`] just removed.
+    ///
+    /// The transport call below does not yet accept a team scope, so every scope's fetch
+    /// currently retrieves the same account-wide response; this establishes the per-scope
+    /// cache/invalidation shape ahead of that.
+    fn refresh_models_for_team(&self, key: TeamScopeKey, ctx: &mut ModelContext<Self>) {
+        if !AuthStateProvider::as_ref(ctx).get().is_logged_in() {
+            return;
+        }
+
+        let ai_api_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        ctx.spawn(
+            async move { ai_api_client.get_feature_model_choices().await },
+            move |me, result, ctx| {
+                if !UserWorkspaces::as_ref(ctx).is_team_scope_key_current(key) {
+                    return;
+                }
+                match result {
+                    Ok(update) => me.on_server_update_for_team(key, update),
+                    Err(e) => {
+                        report_error!(e.context("Failed to fetch LLMs from server"));
+                        me.models_by_team
+                            .entry(key)
+                            .or_default()
+                            .agent_mode_models_unavailable = true;
+                    }
+                }
+            },
+        );
+    }
+
+    /// The context-bearing counterpart to [`Self::refresh_models_for_team`], for a caller
+    /// holding a captured team-operation scope rather than an opaque key.
+    #[allow(dead_code)]
+    pub(crate) fn refresh_models_for_context(
+        &self,
+        context: Option<&TeamContext>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.refresh_models_for_team(UserWorkspaces::cache_key_for_context(context), ctx);
+    }
+
+    /// Re-fetches every team scope already cached in `models_by_team`, without pruning.
+    fn refresh_scoped_teams(&self, ctx: &mut ModelContext<Self>) {
+        let keys: Vec<TeamScopeKey> = self.models_by_team.keys().copied().collect();
+        for key in keys {
+            self.refresh_models_for_team(key, ctx);
+        }
+    }
+
+    /// Drops `models_by_team` entries for a team no longer present in any workspace, then
+    /// refreshes every entry that remains. Keeps a stale team's catalog from surviving
+    /// indefinitely and from being refetched forever after the user leaves it.
+    fn prune_and_refresh_scoped_teams(&mut self, ctx: &mut ModelContext<Self>) {
+        let user_workspaces = UserWorkspaces::as_ref(ctx);
+        self.models_by_team
+            .retain(|key, _| user_workspaces.is_team_scope_key_current(*key));
+        self.refresh_scoped_teams(ctx);
+    }
+
     /// No auth required (i.e. to populate the pre-login onboarding picker).
     fn refresh_public_models(&self, ctx: &mut ModelContext<Self>) {
         let ai_api_client = ServerApiProvider::as_ref(ctx).get_ai_client();
@@ -1723,7 +1872,7 @@ impl LLMPreferences {
             async move { ai_api_client.get_free_available_models(None).await },
             |me, result, ctx| match result {
                 Ok(update) => {
-                    if update != me.models_by_feature {
+                    if update != *me.models_by_feature() {
                         me.on_server_update(update, ctx);
                     }
                 }
@@ -1752,15 +1901,28 @@ impl LLMPreferences {
         }
     }
 
+    /// Test-only counterpart to [`Self::update_feature_model_choices`] for a captured
+    /// team-operation scope. See [`Self::on_server_update_for_team`].
+    #[cfg(test)]
+    pub(crate) fn update_feature_model_choices_for_context(
+        &mut self,
+        context: Option<&TeamContext>,
+        choices_result: Result<ModelsByFeature, anyhow::Error>,
+    ) {
+        if let Ok(choices) = choices_result {
+            self.on_server_update_for_team(UserWorkspaces::cache_key_for_context(context), choices);
+        }
+    }
+
     fn on_server_update(&mut self, update: ModelsByFeature, ctx: &mut ModelContext<Self>) {
         // Clear the unavailable flag on every successful model-list update.
         self.set_agent_mode_models_unavailable(false);
 
         let has_existing_persisted_config = get_cached_models(ctx).is_some();
 
-        let old = std::mem::replace(&mut self.models_by_feature, update);
+        let old = std::mem::replace(&mut self.legacy_models.models_by_feature, update);
 
-        match serde_json::to_string(&self.models_by_feature)
+        match serde_json::to_string(self.models_by_feature())
             .context("Failed to serialize LLMs for cache")
         {
             Ok(serialized_update) => {
@@ -1788,7 +1950,7 @@ impl LLMPreferences {
         }
 
         let new_choices =
-            get_new_agent_mode_choices(&old.agent_mode, &self.models_by_feature.agent_mode);
+            get_new_agent_mode_choices(&old.agent_mode, &self.models_by_feature().agent_mode);
         if !new_choices.is_empty() {
             self.last_update = Some(AvailableLLMsUpdate {
                 new_choices,
@@ -1806,6 +1968,17 @@ impl LLMPreferences {
         ctx.emit(LLMPreferencesEvent::UpdatedAvailableLLMs);
     }
 
+    /// Applies a model-list update for a real team scope. Unlike [`Self::on_server_update`]
+    /// (the legacy, account-wide path), this does not persist to the on-disk cache,
+    /// reconcile execution-profile preferences, rebuild custom routers, or track "new
+    /// choices" popup state: those side effects all belong to the single legacy catalog
+    /// surfaced by `models_by_feature()`, which a per-team entry has no bearing on.
+    fn on_server_update_for_team(&mut self, key: TeamScopeKey, update: ModelsByFeature) {
+        let state = self.models_by_team.entry(key).or_default();
+        state.agent_mode_models_unavailable = false;
+        state.models_by_feature = update;
+    }
+
     /// Clear any model selections where the model is no longer supported
     /// or effectively disabled, and clear orphaned context window limits
     /// for non-configurable or unusable models.
@@ -1820,6 +1993,7 @@ impl LLMPreferences {
     /// are not erroneously reset and synced back to cloud, which would destroy the
     /// user's settings on their primary device.
     fn reconcile_disabled_model_preferences(&self, ctx: &mut ModelContext<Self>) {
+        let models_by_feature = self.models_by_feature();
         let profiles_model = AIExecutionProfilesModel::handle(ctx);
         profiles_model.update(ctx, |profiles, ctx| {
             for profile_id in profiles.get_all_profile_ids() {
@@ -1828,7 +2002,7 @@ impl LLMPreferences {
                     let preferred_base_model = profile_data.base_model.clone();
                     let effective_base_model_id = preferred_base_model
                         .as_ref()
-                        .unwrap_or(&self.models_by_feature.agent_mode.default_id);
+                        .unwrap_or(&models_by_feature.agent_mode.default_id);
 
                     // Only reconcile a preferred model when this device recognizes its ID.
                     // If neither the server catalog nor local custom endpoints know it, the ID
@@ -1836,8 +2010,7 @@ impl LLMPreferences {
                     // it here would sync the removal back to cloud and erase the user's setting
                     // on every other device.
                     let preferred_base_model_is_recognized = preferred_base_model.is_none()
-                        || self
-                            .models_by_feature
+                        || models_by_feature
                             .agent_mode
                             .info_for_id(effective_base_model_id)
                             .is_some()
@@ -1845,8 +2018,7 @@ impl LLMPreferences {
                             .custom_llm_info_for_id(effective_base_model_id)
                             .is_some();
 
-                    let effective_base_model_usable = self
-                        .models_by_feature
+                    let effective_base_model_usable = models_by_feature
                         .agent_mode
                         .usable_info_for_id(effective_base_model_id, ctx)
                         .or_else(|| {
@@ -1871,15 +2043,13 @@ impl LLMPreferences {
                     }
                     if let Some(preferred_llm_id) = &profile.data().coding_model {
                         // Same guard: only clear recognized IDs.
-                        let is_recognized = self
-                            .models_by_feature
+                        let is_recognized = models_by_feature
                             .coding
                             .info_for_id(preferred_llm_id)
                             .is_some()
                             || self.custom_llm_info_for_id(preferred_llm_id).is_some();
                         if is_recognized
-                            && self
-                                .models_by_feature
+                            && models_by_feature
                                 .coding
                                 .usable_info_for_id(preferred_llm_id, ctx)
                                 .or_else(|| {

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -1279,7 +1279,7 @@ fn explicit_child_model_pin_preserves_gui_behavior_and_only_emits_for_effective_
     });
 }
 
-// -- Team-scoped credential-source UI --
+// -- Per-team model catalog lifecycle (PR 3A: `models_by_team`) --
 
 #[derive(Default)]
 struct TeamScopeTestView;
@@ -1370,6 +1370,83 @@ fn initialize_team_scope_test_app(app: &mut App, workspace: Workspace) {
     });
 }
 
+#[test]
+fn team_scoped_catalogs_stay_independent_for_two_windows_on_different_teams() {
+    let team_a = team_for_llms_test(111, "team-a");
+    let team_b = team_for_llms_test(222, "team-b");
+    let workspace = workspace_for_llms_test(vec![team_a.clone(), team_b.clone()]);
+
+    App::test((), |mut app| async move {
+        initialize_team_scope_test_app(&mut app, workspace);
+        let llm_preferences = app.add_singleton_model(LLMPreferences::new);
+
+        let (window_a, view_a) = create_team_scope_test_window(&mut app);
+        let (window_b, view_b) = create_team_scope_test_window(&mut app);
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.set_team_for_window(window_a, team_a.uid, ctx);
+            user_workspaces.set_team_for_window(window_b, team_b.uid, ctx);
+        });
+
+        // Each window mints its own context through the same production path a real
+        // call site would use (`UserWorkspaces::team_context_for_view`).
+        let context_a = view_a
+            .update(&mut app, |_, ctx| {
+                UserWorkspaces::as_ref(ctx).team_context_for_view(ctx)
+            })
+            .expect("window A has a team");
+        let context_b = view_b
+            .update(&mut app, |_, ctx| {
+                UserWorkspaces::as_ref(ctx).team_context_for_view(ctx)
+            })
+            .expect("window B has a team");
+
+        let models_a = ModelsByFeature {
+            agent_mode: available(
+                "auto",
+                vec![server_llm("auto", None), server_llm("team-a-model", None)],
+            ),
+            ..ModelsByFeature::default()
+        };
+        let models_b = ModelsByFeature {
+            agent_mode: available(
+                "auto",
+                vec![server_llm("auto", None), server_llm("team-b-model", None)],
+            ),
+            ..ModelsByFeature::default()
+        };
+
+        llm_preferences.update(&mut app, |preferences, _| {
+            preferences
+                .update_feature_model_choices_for_context(Some(&context_a), Ok(models_a.clone()));
+            preferences
+                .update_feature_model_choices_for_context(Some(&context_b), Ok(models_b.clone()));
+        });
+
+        llm_preferences.read(&app, |preferences, _| {
+            assert_eq!(
+                preferences.models_by_feature_for_context(Some(&context_a)),
+                &models_a,
+                "window A's context should read window A's catalog"
+            );
+            assert_eq!(
+                preferences.models_by_feature_for_context(Some(&context_b)),
+                &models_b,
+                "window B's context should read window B's catalog, independent of window A's"
+            );
+            assert_eq!(
+                preferences.models_by_feature_for_context(None),
+                &ModelsByFeature::default(),
+                "a resolved no-team scope must stay independent of either team's catalog"
+            );
+            assert_eq!(
+                preferences.models_by_feature(),
+                &ModelsByFeature::default(),
+                "the legacy bucket must not observe either team's update"
+            );
+        });
+    });
+}
+
 // -- Credential-source UI is team-scoped (not blocked on #15359: team_byo policy and
 // team-provided keys are already genuinely team-differentiated on the wire today; only the
 // model catalog itself is not) --
@@ -1435,6 +1512,55 @@ fn credential_source_for_model_differs_by_window_team_policy() {
             assert!(
                 !should_show_key_icon_for_model(&anthropic_llm, team_uid_b, ctx),
                 "window B should not show the key icon"
+            );
+        });
+    });
+}
+
+#[test]
+fn teams_changed_prunes_a_removed_teams_scoped_catalog() {
+    let team = team_for_llms_test(111, "team-a");
+    let workspace = workspace_for_llms_test(vec![team.clone()]);
+
+    App::test((), |mut app| async move {
+        initialize_team_scope_test_app(&mut app, workspace);
+        let llm_preferences = app.add_singleton_model(LLMPreferences::new);
+
+        let (window, view) = create_team_scope_test_window(&mut app);
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.set_team_for_window(window, team.uid, ctx);
+        });
+        let context = view
+            .update(&mut app, |_, ctx| {
+                UserWorkspaces::as_ref(ctx).team_context_for_view(ctx)
+            })
+            .expect("window has a team");
+
+        // Seed a cached entry as if a caller had already fetched this team's catalog.
+        llm_preferences.update(&mut app, |preferences, _| {
+            preferences.update_feature_model_choices_for_context(
+                Some(&context),
+                Ok(ModelsByFeature::default()),
+            );
+        });
+        llm_preferences.read(&app, |preferences, _| {
+            assert_eq!(
+                preferences.models_by_feature_for_context(Some(&context)),
+                &ModelsByFeature::default(),
+                "the entry should be seeded before the team is removed"
+            );
+            assert_eq!(preferences.models_by_team.len(), 1);
+        });
+
+        // The user leaves the team: no workspace has it anymore.
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.update_workspaces(vec![], ctx);
+        });
+
+        llm_preferences.read(&app, |preferences, _| {
+            assert!(
+                preferences.models_by_team.is_empty(),
+                "a team removed from every workspace should be pruned from models_by_team"
             );
         });
     });

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -250,6 +250,16 @@ impl ModelSelectorDataSource {
         ctx.notify();
     }
 
+    /// Updates the window this data source resolves its team from. `InlineModelSelectorView`
+    /// (the sole owner) is a rendered child of `Input`, itself a child of `TerminalView`, so
+    /// cross-window tab drag can transfer it to another window; without this, `run_query` would
+    /// keep resolving `team_uid_for_window` against the source window indefinitely. Called from
+    /// `InlineModelSelectorView::on_window_transferred`, since models don't receive that
+    /// notification directly.
+    pub(crate) fn set_window_id(&mut self, window_id: WindowId) {
+        self.window_id = window_id;
+    }
+
     /// Returns whether a model should appear in the inline picker.
     /// Custom-endpoint models are suppressed in Oz cloud agent panes because
     /// they cannot route through Warp's cloud inference infrastructure.
@@ -351,6 +361,10 @@ impl SyncDataSource for ModelSelectorDataSource {
 impl Entity for ModelSelectorDataSource {
     type Event = ();
 }
+
+#[cfg(test)]
+#[path = "data_source_tests.rs"]
+mod tests;
 
 #[derive(Clone)]
 struct ModelSearchItem {

--- a/app/src/terminal/input/models/data_source_tests.rs
+++ b/app/src/terminal/input/models/data_source_tests.rs
@@ -1,0 +1,221 @@
+use std::sync::Arc;
+
+use warpui::platform::WindowStyle;
+use warpui::{App, Element, Entity, TypedActionView, View, ViewHandle, WindowId};
+
+use super::*;
+use crate::LaunchMode;
+use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::mcp::TemplatableMCPServerManager;
+use crate::auth::AuthStateProvider;
+use crate::auth::auth_manager::AuthManager;
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::network::NetworkStatus;
+use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::server_api::ServerApiProvider;
+use crate::server::server_api::team::MockTeamClient;
+use crate::server::server_api::workspace::MockWorkspaceClient;
+use crate::server::sync_queue::SyncQueue;
+use crate::settings::PrivacySettings;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::workspaces::team::Team;
+use crate::workspaces::team_tester::TeamTesterStatus;
+use crate::workspaces::workspace::{
+    ByoFirstPartyKey, ManagedByokByoePolicy, TeamByoSettings, Workspace,
+};
+
+fn team_for_test(uid: i64, name: &str) -> Team {
+    Team {
+        uid: uid.into(),
+        name: name.to_string(),
+        color: None,
+        invite_link: None,
+        members: vec![],
+        pending_email_invites: vec![],
+        invite_link_domain_restrictions: vec![],
+        billing_metadata: Default::default(),
+        stripe_customer_id: None,
+        settings: Default::default(),
+        is_eligible_for_discovery: false,
+        has_billing_history: false,
+        visibility: crate::workspaces::team::TeamVisibility::Open,
+    }
+}
+
+/// Two teams with opposing `team_byo` policy, mirroring the already-verified fixture in
+/// `credential_source_for_model_differs_by_window_team_policy` (`ai/llms_tests.rs`): team A has
+/// a team-provided Anthropic key; team B has no `team_byo` at all, so once the workspace's
+/// managed-BYOK/BYOE plan entitlement is on, it has neither a team-provided key nor member keys.
+fn workspace_with_two_teams_of_opposing_byo_policy() -> (Team, Team, Workspace) {
+    let mut team_a = team_for_test(111, "team-a");
+    team_a.settings.team_byo = Some(TeamByoSettings {
+        first_party_enabled: true,
+        endpoints_enabled: false,
+        allow_user_keys: false,
+        allow_user_endpoints: false,
+        first_party_keys: vec![ByoFirstPartyKey {
+            provider: LLMProvider::Anthropic,
+            credential_uid: "cred-a".to_string(),
+        }],
+        endpoints: vec![],
+    });
+    let team_b = team_for_test(222, "team-b");
+
+    let mut workspace = Workspace {
+        uid: "workspace_uid123456789".to_string().into(),
+        name: "test".to_string(),
+        stripe_customer_id: None,
+        teams: vec![team_a.clone(), team_b.clone()],
+        billing_metadata: Default::default(),
+        bonus_grants_purchased_this_month: Default::default(),
+        billing_cycle_usage: None,
+        has_billing_history: false,
+        settings: Default::default(),
+        invite_link_domain_restrictions: vec![],
+        pending_email_invites: vec![],
+        is_eligible_for_discovery: false,
+        members: vec![],
+        total_requests_used_since_last_refresh: 0,
+    };
+    workspace.billing_metadata.tier.managed_byok_byoe_policy =
+        Some(ManagedByokByoePolicy { enabled: true });
+    (team_a, team_b, workspace)
+}
+
+fn anthropic_llm() -> LLMInfo {
+    LLMInfo {
+        display_name: "Claude".to_string(),
+        base_model_name: "Claude".to_string(),
+        id: "claude-opus".into(),
+        reasoning_level: None,
+        usage_metadata: crate::ai::llms::LLMUsageMetadata {
+            request_multiplier: 1,
+            credit_multiplier: None,
+        },
+        description: None,
+        disable_reason: None,
+        vision_supported: false,
+        spec: None,
+        provider: LLMProvider::Anthropic,
+        host_configs: Default::default(),
+        discount_percentage: None,
+        context_window: Default::default(),
+    }
+}
+
+#[derive(Default)]
+struct WindowTestView;
+
+impl Entity for WindowTestView {
+    type Event = ();
+}
+
+impl View for WindowTestView {
+    fn ui_name() -> &'static str {
+        "WindowTestView"
+    }
+
+    fn render(&self, _: &AppContext) -> Box<dyn Element> {
+        warpui::elements::Empty::new().finish()
+    }
+}
+
+impl TypedActionView for WindowTestView {
+    type Action = ();
+}
+
+fn create_test_window(app: &mut App) -> WindowId {
+    let (window_id, _view): (WindowId, ViewHandle<WindowTestView>) =
+        app.add_window(WindowStyle::NotStealFocus, |_| WindowTestView);
+    window_id
+}
+
+/// Regression for a `ModelSelectorDataSource` left resolving the *source* window's team
+/// after its owning `InlineModelSelectorView` is transferred to another window (cross-window
+/// tab drag): `set_window_id` (called from `InlineModelSelectorView::on_window_transferred`)
+/// must actually change which team's `team_byo` policy the credential-source computation
+/// downstream of `window_id` (`ModelSearchItem::new`, via `byo_key_source_for_model`) uses.
+#[test]
+fn set_window_id_changes_the_team_used_for_credential_source_resolution() {
+    let (team_a, team_b, workspace) = workspace_with_two_teams_of_opposing_byo_policy();
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(PrivacySettings::mock);
+        app.add_singleton_model(|ctx| {
+            UserWorkspaces::mock(
+                Arc::new(MockTeamClient::new()),
+                Arc::new(MockWorkspaceClient::new()),
+                vec![workspace],
+                ctx,
+            )
+        });
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+        app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        app.add_singleton_model(LLMPreferences::new);
+
+        let window_a = create_test_window(&mut app);
+        let window_b = create_test_window(&mut app);
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.set_team_for_window(window_a, team_a.uid, ctx);
+            user_workspaces.set_team_for_window(window_b, team_b.uid, ctx);
+        });
+
+        let data_source =
+            app.add_model(|_| ModelSelectorDataSource::new(EntityId::new(), window_a, None));
+
+        let llm = anthropic_llm();
+        let choice = || ModelPickerChoice {
+            llm: llm.clone(),
+            disable_reason: None,
+            name_match_result: None,
+            score: OrderedFloat(0.),
+        };
+        let active_llm_id = llm.id.clone();
+
+        app.read(|ctx| {
+            // Before any transfer: resolves team A's team-provided-key policy.
+            let team_uid_before =
+                UserWorkspaces::as_ref(ctx).team_uid_for_window(data_source.as_ref(ctx).window_id);
+            assert_eq!(team_uid_before, Some(team_a.uid));
+            let item_a =
+                ModelSearchItem::new(choice(), &active_llm_id, window_a, team_uid_before, ctx);
+            assert_eq!(
+                item_a.byo_key_source,
+                Some(ByoKeySource::TeamProvided),
+                "team A's first-party key should surface as the credential source"
+            );
+        });
+
+        // Simulate what `InlineModelSelectorView::on_window_transferred` does after a
+        // cross-window tab drag lands this data source's owning view in window B.
+        data_source.update(&mut app, |ds, _| ds.set_window_id(window_b));
+
+        app.read(|ctx| {
+            let team_uid_after =
+                UserWorkspaces::as_ref(ctx).team_uid_for_window(data_source.as_ref(ctx).window_id);
+            assert_eq!(
+                team_uid_after,
+                Some(team_b.uid),
+                "set_window_id must update which window's team is resolved"
+            );
+            let item_b =
+                ModelSearchItem::new(choice(), &active_llm_id, window_b, team_uid_after, ctx);
+            assert_eq!(
+                item_b.byo_key_source, None,
+                "after the transfer, credential-source resolution must use team B's \
+                 restrictive policy, not team A's stale one"
+            );
+        });
+    });
+}

--- a/app/src/terminal/input/models/view.rs
+++ b/app/src/terminal/input/models/view.rs
@@ -534,6 +534,18 @@ impl View for InlineModelSelectorView {
         "InlineModelSelectorView"
     }
 
+    fn on_window_transferred(
+        &mut self,
+        _source_window_id: warpui::WindowId,
+        target_window_id: warpui::WindowId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.model_selector_data_source
+            .update(ctx, |data_source, _| {
+                data_source.set_window_id(target_window_id);
+            });
+    }
+
     fn render(&self, _app: &warpui::AppContext) -> Box<dyn Element> {
         ChildView::new(&self.menu_view).finish()
     }

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -2237,6 +2237,15 @@ impl View for ProfileModelSelector {
         "ProfileModelSelector"
     }
 
+    fn on_window_transferred(
+        &mut self,
+        _source_window_id: WindowId,
+        target_window_id: WindowId,
+        _ctx: &mut ViewContext<Self>,
+    ) {
+        self.window_id = target_window_id;
+    }
+
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -28670,6 +28670,16 @@ impl View for TerminalView {
             final_element
         }
     }
+
+    fn on_window_transferred(
+        &mut self,
+        _source_window_id: WindowId,
+        target_window_id: WindowId,
+        _: &mut ViewContext<Self>,
+    ) {
+        self.window_id = target_window_id;
+    }
+
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
         if focus_ctx.is_self_focused() {
             self.maybe_report_focus_in(ctx);

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -173,6 +173,15 @@ pub(crate) struct TeamContext {
     team_uid: ServerId,
 }
 
+/// An opaque key identifying the team scope a [`TeamContext`] was captured for, or a
+/// resolved no-team operation. Lets an external per-team cache (e.g. a per-team model or
+/// usage-state map) key its entries by team without itself extracting or comparing raw
+/// UIDs; the only operations available on it are equality and hashing. Minted only by
+/// [`UserWorkspaces::cache_key_for_context`], and checked for continued team membership
+/// only by [`UserWorkspaces::is_team_scope_key_current`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct TeamScopeKey(Option<ServerId>);
+
 /// The team a view renders as, borrowed for the duration of a single render.
 ///
 /// Current-team UI must reflect the window's team as of this frame, so this is resolved
@@ -409,6 +418,21 @@ impl UserWorkspaces {
     /// current workspace, e.g. after the user leaves it.
     pub(crate) fn team_for_context(&self, context: &TeamContext) -> Option<&Team> {
         self.team_from_uid(context.team_uid)
+    }
+
+    /// Mints the opaque cache key for `context`'s scope, or for a resolved no-team
+    /// operation when `context` is `None`. See [`TeamScopeKey`].
+    pub(crate) fn cache_key_for_context(context: Option<&TeamContext>) -> TeamScopeKey {
+        TeamScopeKey(context.map(|context| context.team_uid))
+    }
+
+    /// Whether `key`'s scope is still current: a resolved no-team scope always is; a real
+    /// team scope is current only while that team is still a member of some workspace.
+    /// Used to drop a cache entry (or an in-flight fetch's result) for a team the user has
+    /// left, without the caller ever needing the raw UID `key` was minted from.
+    pub(crate) fn is_team_scope_key_current(&self, key: TeamScopeKey) -> bool {
+        key.0
+            .is_none_or(|uid| self.team_uids_across_all_workspaces().contains(&uid))
     }
 
     /// Returns the windows whose team assignment changed.

--- a/app/src/workspaces/user_workspaces_tests.rs
+++ b/app/src/workspaces/user_workspaces_tests.rs
@@ -1548,6 +1548,66 @@ fn test_agent_settings_byo_reads_default_without_a_team() {
 }
 
 #[test]
+fn test_team_scope_key_distinguishes_teams_and_tracks_membership() {
+    let (team_a, team_b) = two_teams();
+    let mut workspace = workspace_for_test(&team_a);
+    workspace.teams.push(team_b.clone());
+
+    App::test((), |mut app| async move {
+        initialize_window_team_test_app(&mut app, vec![workspace.clone()]);
+
+        let (window_a, view_a) = create_test_window(&mut app);
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            user_workspaces.set_team_for_window(window_a, team_a.uid, ctx);
+        });
+
+        let context_a = view_a
+            .update(&mut app, |_, ctx| {
+                UserWorkspaces::as_ref(ctx).team_context_for_view(ctx)
+            })
+            .expect("a window assigned to team A should mint a context");
+        let key_a = UserWorkspaces::cache_key_for_context(Some(&context_a));
+        let key_none = UserWorkspaces::cache_key_for_context(None);
+
+        assert!(
+            key_a != key_none,
+            "a team scope key must differ from the no-team key"
+        );
+        assert!(
+            key_a == UserWorkspaces::cache_key_for_context(Some(&context_a)),
+            "minting a key twice for the same context should be equal, so it can key a map"
+        );
+
+        app.read(|ctx| {
+            let user_workspaces = UserWorkspaces::as_ref(ctx);
+            assert!(
+                user_workspaces.is_team_scope_key_current(key_a),
+                "a team the user still belongs to should be a current scope"
+            );
+            assert!(
+                user_workspaces.is_team_scope_key_current(key_none),
+                "the no-team scope is always current"
+            );
+        });
+
+        UserWorkspaces::handle(&app).update(&mut app, |user_workspaces, ctx| {
+            let mut updated_workspace = workspace.clone();
+            updated_workspace
+                .teams
+                .retain(|team| team.uid != team_a.uid);
+            user_workspaces.update_workspaces(vec![updated_workspace], ctx);
+        });
+
+        app.read(|ctx| {
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_team_scope_key_current(key_a),
+                "a team the user has left should no longer be a current scope"
+            );
+        });
+    })
+}
+
+#[test]
 fn test_spaces_for_window_orders_selected_team_shared_and_personal() {
     let _flag = FeatureFlag::SharedWithMe.override_enabled(true);
     let first_team = team_for_test();


### PR DESCRIPTION
## Description
This stacked draft removes two concerns from #15350 so its base PR stays focused on team-scoped key, endpoint, router, Bedrock, and Gemini Enterprise request policy.

- Store model catalogs and refresh state by opaque `TeamScopeKey`.
- Keep scoped catalog updates and invalidation independent across teams.
- Prune catalog state when team membership changes.
- Refresh cached window identity after cross-window terminal and model-selector transfers.

Base PR: #15350

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
Not rerun after the split. This draft preserves the code and tests that were previously part of #15350 so the larger model-catalog architecture can be reviewed separately.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
