### PR TITLE
Left-gutter inline per-turn cost indicator + historical per-exchange cost persistence

### DIFF
--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -34,6 +34,7 @@ fn test_server_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -32,6 +32,7 @@ fn test_server_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -67,7 +67,8 @@ use crate::notebooks::NotebookId;
 use crate::persistence::ModelEvent;
 use crate::persistence::model::{
     AgentConversationData, ChargedUsageTotals, ContextWindowSegment, ConversationUsageMetadata,
-    ModelTokenUsage, PersistedAutoexecuteMode, ToolUsageMetadata,
+    ExchangeCostSnapshot, ExchangeModelTokenUsage, ModelTokenUsage, PersistedAutoexecuteMode,
+    ToolUsageMetadata,
 };
 use crate::server::ids::ServerId;
 use crate::terminal::general_settings::GeneralSettings;
@@ -209,6 +210,22 @@ impl ConversationUsageTotals {
             .map(|usage| usage.total_cost_in_cents())
             .or(self.cost_in_cents)
     }
+}
+
+/// The aggregated cost of a completed turn (a user query and every
+/// exchange that followed it up to, and including, its final response),
+/// computed on demand for the left-gutter inline cost indicator (Surface 5).
+/// See [`AIConversation::turn_cost_for_exchange`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TurnCost {
+    /// Total credits charged across every request in this turn.
+    pub credits: f32,
+    /// Total provider dollar cost across every request in this turn, in US
+    /// cents. `None` when no constituent request reported token usage.
+    pub cost_in_cents: Option<f32>,
+    /// Per-model token/cost breakdown, summed across every request in this
+    /// turn and merged by `model_id`.
+    pub token_usage: Vec<ExchangeModelTokenUsage>,
 }
 
 /// Whether persisted or server usage metadata carries evidence that the
@@ -835,6 +852,20 @@ impl AIConversation {
             .charged_usage_for_last_block = charged_usage;
     }
 
+    /// Test-only helper that stamps a cost snapshot for the request
+    /// identified by `server_output_id`, bypassing the full response-stream
+    /// plumbing (`added_exchanges_by_response` / `update_cost_and_usage_for_request`).
+    #[cfg(test)]
+    pub(crate) fn set_exchange_cost_for_test(
+        &mut self,
+        server_output_id: impl Into<String>,
+        snapshot: ExchangeCostSnapshot,
+    ) {
+        self.conversation_usage_metadata
+            .exchange_costs
+            .insert(server_output_id.into(), snapshot);
+    }
+
     /// Test-only helper that simulates the root-task upgrade performed by the
     /// `Action::CreateTask` branch of `apply_client_action` when the server
     /// confirms the root for a newly started conversation. Replaces the
@@ -878,6 +909,94 @@ impl AIConversation {
     pub fn charged_usage_for_last_block(&self) -> Option<ChargedUsageTotals> {
         self.conversation_usage_metadata
             .charged_usage_for_last_block
+    }
+
+    /// Returns the cost snapshot recorded for the single request that
+    /// produced `exchange_id`'s output, if any request stamped one. See
+    /// [`ConversationUsageMetadata::exchange_costs`].
+    pub fn exchange_cost(&self, exchange_id: AIAgentExchangeId) -> Option<&ExchangeCostSnapshot> {
+        let exchange = self.exchange_with_id(exchange_id)?;
+        let server_output_id = exchange.output_status.server_output_id()?;
+        self.conversation_usage_metadata
+            .exchange_costs
+            .get(&server_output_id.to_string())
+    }
+
+    /// Returns `true` if `exchange_id` names the last response of a
+    /// now-completed turn in the root task — the surface condition for the
+    /// left-gutter inline cost indicator (Surface 5). A turn spans an
+    /// exchange with a user query through every subsequent exchange up to
+    /// (but not including) the next user query, mirroring the "block"
+    /// concept `credits_spent_for_last_block` already uses.
+    ///
+    /// An exchange qualifies when: its own output has finished streaming,
+    /// and either the next root-task exchange starts a new turn (has a user
+    /// query), or there is no next exchange and the conversation itself is
+    /// no longer in progress (so a still-streaming final turn is excluded).
+    pub fn is_last_response_of_completed_turn(&self, exchange_id: AIAgentExchangeId) -> bool {
+        let exchanges: Vec<&AIAgentExchange> = self.root_task_exchanges().collect();
+        let Some(index) = exchanges
+            .iter()
+            .position(|exchange| exchange.id == exchange_id)
+        else {
+            return false;
+        };
+        if !exchanges[index].output_status.is_finished() {
+            return false;
+        }
+        match exchanges.get(index + 1) {
+            Some(next) => next.has_user_query(),
+            None => !self.status.is_in_progress(),
+        }
+    }
+
+    /// Aggregates the cost of every request in the completed turn ending at
+    /// `exchange_id` (i.e. every root-task exchange since the most recent
+    /// user query, up to and including this one). Returns `None` when no
+    /// exchange in the turn has a recorded cost snapshot — e.g. a
+    /// conversation persisted before this surface's `exchange_costs`
+    /// persistence existed.
+    pub fn turn_cost_for_exchange(&self, exchange_id: AIAgentExchangeId) -> Option<TurnCost> {
+        let exchanges: Vec<&AIAgentExchange> = self.root_task_exchanges().collect();
+        let index = exchanges
+            .iter()
+            .position(|exchange| exchange.id == exchange_id)?;
+        let turn_start = exchanges[..=index]
+            .iter()
+            .rposition(|exchange| exchange.has_user_query())
+            .unwrap_or(0);
+
+        let mut aggregate: Option<TurnCost> = None;
+        for exchange in &exchanges[turn_start..=index] {
+            let Some(snapshot) = exchange.output_status.server_output_id().and_then(|id| {
+                self.conversation_usage_metadata
+                    .exchange_costs
+                    .get(&id.to_string())
+            }) else {
+                continue;
+            };
+            let turn_cost = aggregate.get_or_insert_with(TurnCost::default);
+            turn_cost.credits += snapshot.credits;
+            if let Some(cost_in_cents) = snapshot.cost_in_cents {
+                *turn_cost.cost_in_cents.get_or_insert(0.0) += cost_in_cents;
+            }
+            for usage in &snapshot.token_usage {
+                if let Some(entry) = turn_cost
+                    .token_usage
+                    .iter_mut()
+                    .find(|entry| entry.model_id == usage.model_id)
+                {
+                    entry.total_input += usage.total_input;
+                    entry.output += usage.output;
+                    entry.input_cache_read += usage.input_cache_read;
+                    entry.input_cache_write += usage.input_cache_write;
+                    entry.cost_in_cents += usage.cost_in_cents;
+                } else {
+                    turn_cost.token_usage.push(usage.clone());
+                }
+            }
+        }
+        aggregate
     }
 
     /// Time to first token for the last completed set of agent responses
@@ -1116,6 +1235,29 @@ impl AIConversation {
                     .iter()
                     .map(|new_exchange| new_exchange.exchange_id)
             })
+    }
+
+    /// Returns the stable `server_output_id` (the request ID assigned by the
+    /// server) of the *last* exchange added by `stream_id`, if known.
+    ///
+    /// A response stream can add more than one exchange (e.g. a subtask
+    /// returning to its parent), but the last one is the exchange that
+    /// renders this request's final response — the one
+    /// [`Self::update_cost_and_usage_for_request`] stamps with this
+    /// request's cost snapshot. Unlike `AIAgentExchangeId` (client-generated,
+    /// reassigned on every restore), `server_output_id` is stable across
+    /// restores, which is why [`ConversationUsageMetadata::exchange_costs`]
+    /// is keyed by it instead.
+    fn server_output_id_for_response(&self, stream_id: &ResponseStreamId) -> Option<String> {
+        let AddedExchange {
+            task_id,
+            exchange_id,
+        } = self.added_exchanges_by_response.get(stream_id)?.last();
+        let exchange = self.task_store.get(task_id)?.exchange(*exchange_id)?;
+        exchange
+            .output_status
+            .server_output_id()
+            .map(|id| id.to_string())
     }
 
     pub fn server_conversation_token(&self) -> Option<&ServerConversationToken> {
@@ -2254,6 +2396,7 @@ impl AIConversation {
 
     pub fn update_cost_and_usage_for_request(
         &mut self,
+        stream_id: &ResponseStreamId,
         request_cost: Option<RequestCost>,
         request_charges: Option<stream_finished::RequestCharges>,
         token_usage: Vec<TokenUsage>,
@@ -2263,6 +2406,32 @@ impl AIConversation {
     ) -> Result<(), UpdateConversationError> {
         self.has_usage_metadata |=
             request_cost.is_some() || usage_metadata.is_some() || !token_usage.is_empty();
+
+        // Snapshot this request's own (incremental) cost before folding it
+        // into the conversation-wide running totals below, so it can be
+        // stamped against the exchange this request completed (see
+        // `exchange_costs`). This is what lets the left-gutter inline cost
+        // indicator (Surface 5) show a historical message's own cost, not
+        // just the most recently completed one.
+        let request_token_usage: Vec<ExchangeModelTokenUsage> = token_usage
+            .iter()
+            .map(|usage| ExchangeModelTokenUsage {
+                model_id: usage.model_id.clone(),
+                total_input: usage.total_input,
+                output: usage.output,
+                input_cache_read: usage.input_cache_read,
+                input_cache_write: usage.input_cache_write,
+                cost_in_cents: usage.cost_in_cents,
+            })
+            .collect();
+        let request_cost_in_cents = (!request_token_usage.is_empty()).then(|| {
+            request_token_usage
+                .iter()
+                .map(|usage| usage.cost_in_cents)
+                .sum()
+        });
+        let request_credits = request_cost.map(|cost| cost.value() as f32);
+
         for usage in token_usage.into_iter() {
             if let Some(total_provider_cost_in_cents) = self.total_provider_cost_in_cents.as_mut() {
                 *total_provider_cost_in_cents += usage.cost_in_cents;
@@ -2321,6 +2490,23 @@ impl AIConversation {
                 .charged_usage_for_last_block
                 .get_or_insert_with(ChargedUsageTotals::default);
             *charged_usage_for_last_block += totals;
+        }
+
+        // Stamp a per-request cost snapshot on the exchange this request
+        // completed, keyed by its stable `server_output_id`, so this
+        // specific message can later report its own cost even after other
+        // turns have completed (see `exchange_costs`).
+        if (request_credits.is_some() || request_cost_in_cents.is_some())
+            && let Some(server_output_id) = self.server_output_id_for_response(stream_id)
+        {
+            self.conversation_usage_metadata.exchange_costs.insert(
+                server_output_id,
+                ExchangeCostSnapshot {
+                    credits: request_credits.unwrap_or(0.0),
+                    cost_in_cents: request_cost_in_cents,
+                    token_usage: request_token_usage,
+                },
+            );
         }
 
         if let Some(usage_metadata) = usage_metadata {

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2394,6 +2394,7 @@ impl AIConversation {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_cost_and_usage_for_request(
         &mut self,
         stream_id: &ResponseStreamId,

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -66,8 +66,8 @@ use crate::code_review::CodeReviewTelemetryEvent;
 use crate::notebooks::NotebookId;
 use crate::persistence::ModelEvent;
 use crate::persistence::model::{
-    AgentConversationData, ContextWindowSegment, ConversationUsageMetadata, ModelTokenUsage,
-    PersistedAutoexecuteMode, ToolUsageMetadata,
+    AgentConversationData, ContextWindowSegment, ConversationUsageMetadata, ExchangeCostSnapshot,
+    ExchangeModelTokenUsage, ModelTokenUsage, PersistedAutoexecuteMode, ToolUsageMetadata,
 };
 use crate::server::ids::ServerId;
 use crate::terminal::general_settings::GeneralSettings;
@@ -193,6 +193,22 @@ pub struct ConversationUsageTotals {
     /// while a restored legacy conversation with real usage but an unknown
     /// historical cost still shows it.
     pub has_usage: bool,
+}
+
+/// The aggregated cost of a completed turn (a user query and every
+/// exchange that followed it up to, and including, its final response),
+/// computed on demand for the left-gutter inline cost indicator (Surface 5).
+/// See [`AIConversation::turn_cost_for_exchange`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TurnCost {
+    /// Total credits charged across every request in this turn.
+    pub credits: f32,
+    /// Total provider dollar cost across every request in this turn, in US
+    /// cents. `None` when no constituent request reported token usage.
+    pub cost_in_cents: Option<f32>,
+    /// Per-model token/cost breakdown, summed across every request in this
+    /// turn and merged by `model_id`.
+    pub token_usage: Vec<ExchangeModelTokenUsage>,
 }
 
 /// Whether persisted or server usage metadata carries evidence that the
@@ -790,6 +806,20 @@ impl AIConversation {
         self.conversation_usage_metadata.platform_credits_spent = 0.0;
     }
 
+    /// Test-only helper that stamps a cost snapshot for the request
+    /// identified by `server_output_id`, bypassing the full response-stream
+    /// plumbing (`added_exchanges_by_response` / `update_cost_and_usage_for_request`).
+    #[cfg(test)]
+    pub(crate) fn set_exchange_cost_for_test(
+        &mut self,
+        server_output_id: impl Into<String>,
+        snapshot: ExchangeCostSnapshot,
+    ) {
+        self.conversation_usage_metadata
+            .exchange_costs
+            .insert(server_output_id.into(), snapshot);
+    }
+
     /// Test-only helper that simulates the root-task upgrade performed by the
     /// `Action::CreateTask` branch of `apply_client_action` when the server
     /// confirms the root for a newly started conversation. Replaces the
@@ -821,6 +851,94 @@ impl AIConversation {
         self.conversation_usage_metadata
             .credits_spent_for_last_block
             .map(|credits| (credits * 10.0).round() / 10.0)
+    }
+
+    /// Returns the cost snapshot recorded for the single request that
+    /// produced `exchange_id`'s output, if any request stamped one. See
+    /// [`ConversationUsageMetadata::exchange_costs`].
+    pub fn exchange_cost(&self, exchange_id: AIAgentExchangeId) -> Option<&ExchangeCostSnapshot> {
+        let exchange = self.exchange_with_id(exchange_id)?;
+        let server_output_id = exchange.output_status.server_output_id()?;
+        self.conversation_usage_metadata
+            .exchange_costs
+            .get(&server_output_id.to_string())
+    }
+
+    /// Returns `true` if `exchange_id` names the last response of a
+    /// now-completed turn in the root task — the surface condition for the
+    /// left-gutter inline cost indicator (Surface 5). A turn spans an
+    /// exchange with a user query through every subsequent exchange up to
+    /// (but not including) the next user query, mirroring the "block"
+    /// concept `credits_spent_for_last_block` already uses.
+    ///
+    /// An exchange qualifies when: its own output has finished streaming,
+    /// and either the next root-task exchange starts a new turn (has a user
+    /// query), or there is no next exchange and the conversation itself is
+    /// no longer in progress (so a still-streaming final turn is excluded).
+    pub fn is_last_response_of_completed_turn(&self, exchange_id: AIAgentExchangeId) -> bool {
+        let exchanges: Vec<&AIAgentExchange> = self.root_task_exchanges().collect();
+        let Some(index) = exchanges
+            .iter()
+            .position(|exchange| exchange.id == exchange_id)
+        else {
+            return false;
+        };
+        if !exchanges[index].output_status.is_finished() {
+            return false;
+        }
+        match exchanges.get(index + 1) {
+            Some(next) => next.has_user_query(),
+            None => !self.status.is_in_progress(),
+        }
+    }
+
+    /// Aggregates the cost of every request in the completed turn ending at
+    /// `exchange_id` (i.e. every root-task exchange since the most recent
+    /// user query, up to and including this one). Returns `None` when no
+    /// exchange in the turn has a recorded cost snapshot — e.g. a
+    /// conversation persisted before this surface's `exchange_costs`
+    /// persistence existed.
+    pub fn turn_cost_for_exchange(&self, exchange_id: AIAgentExchangeId) -> Option<TurnCost> {
+        let exchanges: Vec<&AIAgentExchange> = self.root_task_exchanges().collect();
+        let index = exchanges
+            .iter()
+            .position(|exchange| exchange.id == exchange_id)?;
+        let turn_start = exchanges[..=index]
+            .iter()
+            .rposition(|exchange| exchange.has_user_query())
+            .unwrap_or(0);
+
+        let mut aggregate: Option<TurnCost> = None;
+        for exchange in &exchanges[turn_start..=index] {
+            let Some(snapshot) = exchange.output_status.server_output_id().and_then(|id| {
+                self.conversation_usage_metadata
+                    .exchange_costs
+                    .get(&id.to_string())
+            }) else {
+                continue;
+            };
+            let turn_cost = aggregate.get_or_insert_with(TurnCost::default);
+            turn_cost.credits += snapshot.credits;
+            if let Some(cost_in_cents) = snapshot.cost_in_cents {
+                *turn_cost.cost_in_cents.get_or_insert(0.0) += cost_in_cents;
+            }
+            for usage in &snapshot.token_usage {
+                if let Some(entry) = turn_cost
+                    .token_usage
+                    .iter_mut()
+                    .find(|entry| entry.model_id == usage.model_id)
+                {
+                    entry.total_input += usage.total_input;
+                    entry.output += usage.output;
+                    entry.input_cache_read += usage.input_cache_read;
+                    entry.input_cache_write += usage.input_cache_write;
+                    entry.cost_in_cents += usage.cost_in_cents;
+                } else {
+                    turn_cost.token_usage.push(usage.clone());
+                }
+            }
+        }
+        aggregate
     }
 
     /// Time to first token for the last completed set of agent responses
@@ -1059,6 +1177,29 @@ impl AIConversation {
                     .iter()
                     .map(|new_exchange| new_exchange.exchange_id)
             })
+    }
+
+    /// Returns the stable `server_output_id` (the request ID assigned by the
+    /// server) of the *last* exchange added by `stream_id`, if known.
+    ///
+    /// A response stream can add more than one exchange (e.g. a subtask
+    /// returning to its parent), but the last one is the exchange that
+    /// renders this request's final response — the one
+    /// [`Self::update_cost_and_usage_for_request`] stamps with this
+    /// request's cost snapshot. Unlike `AIAgentExchangeId` (client-generated,
+    /// reassigned on every restore), `server_output_id` is stable across
+    /// restores, which is why [`ConversationUsageMetadata::exchange_costs`]
+    /// is keyed by it instead.
+    fn server_output_id_for_response(&self, stream_id: &ResponseStreamId) -> Option<String> {
+        let AddedExchange {
+            task_id,
+            exchange_id,
+        } = self.added_exchanges_by_response.get(stream_id)?.last();
+        let exchange = self.task_store.get(task_id)?.exchange(*exchange_id)?;
+        exchange
+            .output_status
+            .server_output_id()
+            .map(|id| id.to_string())
     }
 
     pub fn server_conversation_token(&self) -> Option<&ServerConversationToken> {
@@ -2197,6 +2338,7 @@ impl AIConversation {
 
     pub fn update_cost_and_usage_for_request(
         &mut self,
+        stream_id: &ResponseStreamId,
         request_cost: Option<RequestCost>,
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<stream_finished::ConversationUsageMetadata>,
@@ -2205,6 +2347,32 @@ impl AIConversation {
     ) -> Result<(), UpdateConversationError> {
         self.has_usage_metadata |=
             request_cost.is_some() || usage_metadata.is_some() || !token_usage.is_empty();
+
+        // Snapshot this request's own (incremental) cost before folding it
+        // into the conversation-wide running totals below, so it can be
+        // stamped against the exchange this request completed (see
+        // `exchange_costs`). This is what lets the left-gutter inline cost
+        // indicator (Surface 5) show a historical message's own cost, not
+        // just the most recently completed one.
+        let request_token_usage: Vec<ExchangeModelTokenUsage> = token_usage
+            .iter()
+            .map(|usage| ExchangeModelTokenUsage {
+                model_id: usage.model_id.clone(),
+                total_input: usage.total_input,
+                output: usage.output,
+                input_cache_read: usage.input_cache_read,
+                input_cache_write: usage.input_cache_write,
+                cost_in_cents: usage.cost_in_cents,
+            })
+            .collect();
+        let request_cost_in_cents = (!request_token_usage.is_empty()).then(|| {
+            request_token_usage
+                .iter()
+                .map(|usage| usage.cost_in_cents)
+                .sum()
+        });
+        let request_credits = request_cost.map(|cost| cost.value() as f32);
+
         for usage in token_usage.into_iter() {
             if let Some(total_provider_cost_in_cents) = self.total_provider_cost_in_cents.as_mut() {
                 *total_provider_cost_in_cents += usage.cost_in_cents;
@@ -2243,6 +2411,23 @@ impl AIConversation {
             // Accumulate response credit usage.
             *credits_spent_for_last_block += request_cost.value() as f32;
             self.total_request_cost += request_cost;
+        }
+
+        // Stamp a per-request cost snapshot on the exchange this request
+        // completed, keyed by its stable `server_output_id`, so this
+        // specific message can later report its own cost even after other
+        // turns have completed (see `exchange_costs`).
+        if (request_credits.is_some() || request_cost_in_cents.is_some())
+            && let Some(server_output_id) = self.server_output_id_for_response(stream_id)
+        {
+            self.conversation_usage_metadata.exchange_costs.insert(
+                server_output_id,
+                ExchangeCostSnapshot {
+                    credits: request_credits.unwrap_or(0.0),
+                    cost_in_cents: request_cost_in_cents,
+                    token_usage: request_token_usage,
+                },
+            );
         }
 
         if let Some(usage_metadata) = usage_metadata {

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -11,12 +11,14 @@ use super::{
     artifact_from_fork_proto, footer_model_token_usage,
 };
 use crate::ai::artifacts::Artifact;
+use crate::ai::blocklist::ResponseStreamId;
 use crate::ai::llms::LLMPreferences;
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
 use crate::network::NetworkStatus;
 use crate::persistence::model::{
-    AgentConversationData, ChargedUsageTotals, ConversationUsageMetadata,
+    AgentConversationData, ChargedUsageTotals, ConversationUsageMetadata, ExchangeCostSnapshot,
+    ExchangeModelTokenUsage,
 };
 use crate::server::server_api::ServerApiProvider;
 use crate::test_util::settings::initialize_settings_for_tests;
@@ -667,6 +669,7 @@ fn restored_usage_totals_preserve_server_provider_cost_and_add_follow_up() {
             app.read(|ctx| {
                 conversation
                     .update_cost_and_usage_for_request(
+                        &ResponseStreamId::new_for_test(),
                         None,
                         None,
                         vec![stream_token_usage("model-a", 10, 2, 1.2)],
@@ -741,6 +744,7 @@ fn restored_legacy_conversation_keeps_provider_cost_unavailable_after_follow_up(
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     None,
                     vec![stream_token_usage("legacy-model", 10, 2, 1.5)],
@@ -783,6 +787,7 @@ fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     None,
                     vec![],
@@ -819,6 +824,7 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     None,
                     vec![],
@@ -902,6 +908,7 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     None,
                     vec![stream_token_usage("model-a", 100, 20, 1.5)],
@@ -915,6 +922,7 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
             // summing, while provider cost accumulates per request.
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     None,
                     vec![stream_token_usage("model-a", 50, 10, 1.2)],
@@ -1505,6 +1513,167 @@ fn fetched_memories_preserves_order_across_and_within_messages() {
         .map(|memory| memory.memory_id)
         .collect();
     assert_eq!(ids, vec!["m1", "m2", "m3"]);
+}
+
+/// Builds a conversation with a single turn spanning three exchanges: the
+/// user query + narration (`req-1`), a tool-call-only exchange with no user
+/// query (`req-2`), and the tool result + final response (`req-3`). Mirrors
+/// the spec's example of a turn that spans a tool round trip before its
+/// final response.
+fn restored_conversation_with_multi_exchange_turn() -> AIConversation {
+    restored_conversation_with_messages(vec![
+        user_query_message("user-1", "req-1", "what repo is this"),
+        agent_output_message("agent-1", "req-1"),
+        tool_call_message(
+            "tool-call-1",
+            "req-2",
+            "call-1",
+            use_computer_tool_call("inspect repo"),
+        ),
+        tool_call_result_message(
+            "tool-result-1",
+            "req-3",
+            "call-1",
+            api::message::tool_call_result::Result::Cancel(()),
+        ),
+        agent_output_message("agent-2", "req-3"),
+    ])
+}
+
+/// A turn with only one exchange (no user query) is excluded from the
+/// completed-turn API, since only exchanges with a resolvable server output
+/// id from a restored conversation are considered.
+#[test]
+fn is_last_response_of_completed_turn_marks_each_turns_final_exchange() {
+    let conversation = restored_conversation_with_queries(&["one", "two"]);
+    let exchanges = conversation.all_exchanges();
+    assert_eq!(exchanges.len(), 2, "one exchange per turn in this fixture");
+
+    for exchange in &exchanges {
+        assert!(
+            conversation.is_last_response_of_completed_turn(exchange.id),
+            "each turn's sole exchange should qualify as its final response"
+        );
+    }
+}
+
+/// Within a turn spanning multiple exchanges (a tool round trip before the
+/// final response), only the last exchange qualifies as the turn's final
+/// response — matching the spec's "last response of each completed turn"
+/// trigger rule.
+#[test]
+fn is_last_response_of_completed_turn_excludes_intermediate_exchanges_within_a_turn() {
+    let conversation = restored_conversation_with_multi_exchange_turn();
+    let exchanges = conversation.all_exchanges();
+    assert_eq!(
+        exchanges.len(),
+        3,
+        "expected user-query, tool-call, and final-response exchanges"
+    );
+
+    assert!(!conversation.is_last_response_of_completed_turn(exchanges[0].id));
+    assert!(!conversation.is_last_response_of_completed_turn(exchanges[1].id));
+    assert!(conversation.is_last_response_of_completed_turn(exchanges[2].id));
+}
+
+/// `exchange_cost` resolves a stamped snapshot via the exchange's stable
+/// `server_output_id`, and returns `None` when no request stamped one (e.g.
+/// a legacy conversation restored before this surface's persistence existed).
+#[test]
+fn exchange_cost_looks_up_snapshot_by_server_output_id() {
+    let mut conversation = restored_conversation_with_queries(&["one", "two"]);
+    let exchanges: Vec<_> = conversation.all_exchanges().iter().map(|e| e.id).collect();
+
+    conversation.set_exchange_cost_for_test(
+        "request-0",
+        ExchangeCostSnapshot {
+            credits: 1.5,
+            cost_in_cents: Some(2.3),
+            token_usage: vec![],
+        },
+    );
+
+    let snapshot = conversation
+        .exchange_cost(exchanges[0])
+        .expect("stamped snapshot should be found by server_output_id");
+    assert_eq!(snapshot.credits, 1.5);
+    assert_eq!(snapshot.cost_in_cents, Some(2.3));
+
+    assert!(
+        conversation.exchange_cost(exchanges[1]).is_none(),
+        "an exchange with no stamped request must have no cost"
+    );
+}
+
+/// `turn_cost_for_exchange` sums every constituent exchange's snapshot
+/// within the completed turn (credits, dollar cost, and per-model token
+/// usage merged by model id) — this is what lets the left-gutter indicator
+/// show a turn's total cost even when it spanned a tool round trip.
+#[test]
+fn turn_cost_for_exchange_aggregates_across_multi_exchange_turn() {
+    let mut conversation = restored_conversation_with_multi_exchange_turn();
+    let exchanges: Vec<_> = conversation.all_exchanges().iter().map(|e| e.id).collect();
+
+    conversation.set_exchange_cost_for_test(
+        "req-1",
+        ExchangeCostSnapshot {
+            credits: 1.0,
+            cost_in_cents: Some(1.0),
+            token_usage: vec![ExchangeModelTokenUsage {
+                model_id: "model-a".to_string(),
+                total_input: 10,
+                output: 5,
+                input_cache_read: 0,
+                input_cache_write: 0,
+                cost_in_cents: 1.0,
+            }],
+        },
+    );
+    conversation.set_exchange_cost_for_test(
+        "req-2",
+        ExchangeCostSnapshot {
+            credits: 0.5,
+            cost_in_cents: None,
+            token_usage: vec![],
+        },
+    );
+    conversation.set_exchange_cost_for_test(
+        "req-3",
+        ExchangeCostSnapshot {
+            credits: 2.0,
+            cost_in_cents: Some(1.3),
+            token_usage: vec![ExchangeModelTokenUsage {
+                model_id: "model-a".to_string(),
+                total_input: 20,
+                output: 8,
+                input_cache_read: 0,
+                input_cache_write: 0,
+                cost_in_cents: 1.3,
+            }],
+        },
+    );
+
+    let turn_cost = conversation
+        .turn_cost_for_exchange(exchanges[2])
+        .expect("turn with stamped snapshots should aggregate");
+
+    assert!((turn_cost.credits - 3.5).abs() < 1e-6);
+    assert!((turn_cost.cost_in_cents.expect("cost known") - 2.3).abs() < 1e-6);
+    assert_eq!(turn_cost.token_usage.len(), 1, "same model_id should merge");
+    let model_usage = &turn_cost.token_usage[0];
+    assert_eq!(model_usage.model_id, "model-a");
+    assert_eq!(model_usage.total_input, 30);
+    assert_eq!(model_usage.output, 13);
+}
+
+/// A conversation with no stamped cost snapshots (e.g. persisted before this
+/// surface's `exchange_costs` field existed) must not fabricate a zero total.
+#[test]
+fn turn_cost_for_exchange_returns_none_when_no_snapshot_recorded() {
+    let conversation = restored_conversation_with_queries(&["one"]);
+    let exchange_id = conversation.all_exchanges()[0].id;
+
+    assert!(conversation.turn_cost_for_exchange(exchange_id).is_none());
 }
 
 #[test]

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -1016,7 +1016,15 @@ fn update_cost_and_usage_resets_stale_charged_usage_for_last_block_on_new_user_t
 
         app.read(|ctx| {
             conversation
-                .update_cost_and_usage_for_request(None, None, vec![], None, true, ctx)
+                .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
+                    None,
+                    None,
+                    vec![],
+                    None,
+                    true,
+                    ctx,
+                )
                 .expect("usage should update");
         });
 

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -11,11 +11,14 @@ use super::{
     artifact_from_fork_proto, footer_model_token_usage,
 };
 use crate::ai::artifacts::Artifact;
+use crate::ai::blocklist::ResponseStreamId;
 use crate::ai::llms::LLMPreferences;
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
 use crate::network::NetworkStatus;
-use crate::persistence::model::{AgentConversationData, ConversationUsageMetadata};
+use crate::persistence::model::{
+    AgentConversationData, ConversationUsageMetadata, ExchangeCostSnapshot, ExchangeModelTokenUsage,
+};
 use crate::server::server_api::ServerApiProvider;
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -664,6 +667,7 @@ fn restored_usage_totals_preserve_server_provider_cost_and_add_follow_up() {
             app.read(|ctx| {
                 conversation
                     .update_cost_and_usage_for_request(
+                        &ResponseStreamId::new_for_test(),
                         None,
                         vec![stream_token_usage("model-a", 10, 2, 1.2)],
                         Some(credits_usage_metadata(1.0, 0.0)),
@@ -737,6 +741,7 @@ fn restored_legacy_conversation_keeps_provider_cost_unavailable_after_follow_up(
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     vec![stream_token_usage("legacy-model", 10, 2, 1.5)],
                     Some(credits_usage_metadata(1.0, 0.0)),
@@ -778,6 +783,7 @@ fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     vec![],
                     Some(custom_endpoint_usage_metadata("config-key", 6)),
@@ -813,6 +819,7 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     vec![],
                     Some(custom_endpoint_usage_metadata("missing-config-key", 9)),
@@ -893,6 +900,7 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
         app.read(|ctx| {
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     vec![stream_token_usage("model-a", 100, 20, 1.5)],
                     Some(credits_usage_metadata(2.0, 0.5)),
@@ -905,6 +913,7 @@ fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
             // summing, while provider cost accumulates per request.
             conversation
                 .update_cost_and_usage_for_request(
+                    &ResponseStreamId::new_for_test(),
                     None,
                     vec![stream_token_usage("model-a", 50, 10, 1.2)],
                     Some(credits_usage_metadata(3.0, 0.5)),
@@ -1409,6 +1418,167 @@ fn fetched_memories_preserves_order_across_and_within_messages() {
         .map(|memory| memory.memory_id)
         .collect();
     assert_eq!(ids, vec!["m1", "m2", "m3"]);
+}
+
+/// Builds a conversation with a single turn spanning three exchanges: the
+/// user query + narration (`req-1`), a tool-call-only exchange with no user
+/// query (`req-2`), and the tool result + final response (`req-3`). Mirrors
+/// the spec's example of a turn that spans a tool round trip before its
+/// final response.
+fn restored_conversation_with_multi_exchange_turn() -> AIConversation {
+    restored_conversation_with_messages(vec![
+        user_query_message("user-1", "req-1", "what repo is this"),
+        agent_output_message("agent-1", "req-1"),
+        tool_call_message(
+            "tool-call-1",
+            "req-2",
+            "call-1",
+            use_computer_tool_call("inspect repo"),
+        ),
+        tool_call_result_message(
+            "tool-result-1",
+            "req-3",
+            "call-1",
+            api::message::tool_call_result::Result::Cancel(()),
+        ),
+        agent_output_message("agent-2", "req-3"),
+    ])
+}
+
+/// A turn with only one exchange (no user query) is excluded from the
+/// completed-turn API, since only exchanges with a resolvable server output
+/// id from a restored conversation are considered.
+#[test]
+fn is_last_response_of_completed_turn_marks_each_turns_final_exchange() {
+    let conversation = restored_conversation_with_queries(&["one", "two"]);
+    let exchanges = conversation.all_exchanges();
+    assert_eq!(exchanges.len(), 2, "one exchange per turn in this fixture");
+
+    for exchange in &exchanges {
+        assert!(
+            conversation.is_last_response_of_completed_turn(exchange.id),
+            "each turn's sole exchange should qualify as its final response"
+        );
+    }
+}
+
+/// Within a turn spanning multiple exchanges (a tool round trip before the
+/// final response), only the last exchange qualifies as the turn's final
+/// response — matching the spec's "last response of each completed turn"
+/// trigger rule.
+#[test]
+fn is_last_response_of_completed_turn_excludes_intermediate_exchanges_within_a_turn() {
+    let conversation = restored_conversation_with_multi_exchange_turn();
+    let exchanges = conversation.all_exchanges();
+    assert_eq!(
+        exchanges.len(),
+        3,
+        "expected user-query, tool-call, and final-response exchanges"
+    );
+
+    assert!(!conversation.is_last_response_of_completed_turn(exchanges[0].id));
+    assert!(!conversation.is_last_response_of_completed_turn(exchanges[1].id));
+    assert!(conversation.is_last_response_of_completed_turn(exchanges[2].id));
+}
+
+/// `exchange_cost` resolves a stamped snapshot via the exchange's stable
+/// `server_output_id`, and returns `None` when no request stamped one (e.g.
+/// a legacy conversation restored before this surface's persistence existed).
+#[test]
+fn exchange_cost_looks_up_snapshot_by_server_output_id() {
+    let mut conversation = restored_conversation_with_queries(&["one", "two"]);
+    let exchanges: Vec<_> = conversation.all_exchanges().iter().map(|e| e.id).collect();
+
+    conversation.set_exchange_cost_for_test(
+        "request-0",
+        ExchangeCostSnapshot {
+            credits: 1.5,
+            cost_in_cents: Some(2.3),
+            token_usage: vec![],
+        },
+    );
+
+    let snapshot = conversation
+        .exchange_cost(exchanges[0])
+        .expect("stamped snapshot should be found by server_output_id");
+    assert_eq!(snapshot.credits, 1.5);
+    assert_eq!(snapshot.cost_in_cents, Some(2.3));
+
+    assert!(
+        conversation.exchange_cost(exchanges[1]).is_none(),
+        "an exchange with no stamped request must have no cost"
+    );
+}
+
+/// `turn_cost_for_exchange` sums every constituent exchange's snapshot
+/// within the completed turn (credits, dollar cost, and per-model token
+/// usage merged by model id) — this is what lets the left-gutter indicator
+/// show a turn's total cost even when it spanned a tool round trip.
+#[test]
+fn turn_cost_for_exchange_aggregates_across_multi_exchange_turn() {
+    let mut conversation = restored_conversation_with_multi_exchange_turn();
+    let exchanges: Vec<_> = conversation.all_exchanges().iter().map(|e| e.id).collect();
+
+    conversation.set_exchange_cost_for_test(
+        "req-1",
+        ExchangeCostSnapshot {
+            credits: 1.0,
+            cost_in_cents: Some(1.0),
+            token_usage: vec![ExchangeModelTokenUsage {
+                model_id: "model-a".to_string(),
+                total_input: 10,
+                output: 5,
+                input_cache_read: 0,
+                input_cache_write: 0,
+                cost_in_cents: 1.0,
+            }],
+        },
+    );
+    conversation.set_exchange_cost_for_test(
+        "req-2",
+        ExchangeCostSnapshot {
+            credits: 0.5,
+            cost_in_cents: None,
+            token_usage: vec![],
+        },
+    );
+    conversation.set_exchange_cost_for_test(
+        "req-3",
+        ExchangeCostSnapshot {
+            credits: 2.0,
+            cost_in_cents: Some(1.3),
+            token_usage: vec![ExchangeModelTokenUsage {
+                model_id: "model-a".to_string(),
+                total_input: 20,
+                output: 8,
+                input_cache_read: 0,
+                input_cache_write: 0,
+                cost_in_cents: 1.3,
+            }],
+        },
+    );
+
+    let turn_cost = conversation
+        .turn_cost_for_exchange(exchanges[2])
+        .expect("turn with stamped snapshots should aggregate");
+
+    assert!((turn_cost.credits - 3.5).abs() < 1e-6);
+    assert!((turn_cost.cost_in_cents.expect("cost known") - 2.3).abs() < 1e-6);
+    assert_eq!(turn_cost.token_usage.len(), 1, "same model_id should merge");
+    let model_usage = &turn_cost.token_usage[0];
+    assert_eq!(model_usage.model_id, "model-a");
+    assert_eq!(model_usage.total_input, 30);
+    assert_eq!(model_usage.output, 13);
+}
+
+/// A conversation with no stamped cost snapshots (e.g. persisted before this
+/// surface's `exchange_costs` field existed) must not fabricate a zero total.
+#[test]
+fn turn_cost_for_exchange_returns_none_when_no_snapshot_recorded() {
+    let conversation = restored_conversation_with_queries(&["one"]);
+    let exchange_id = conversation.all_exchanges()[0].id;
+
+    assert!(conversation.turn_cost_for_exchange(exchange_id).is_none());
 }
 
 #[test]

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -933,6 +933,7 @@ fn create_server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: mock_server_metadata(),
         creator: None,

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -931,6 +931,7 @@ fn create_server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: mock_server_metadata(),
         creator: None,

--- a/app/src/ai/agent_sdk/artifact_upload_tests.rs
+++ b/app/src/ai/agent_sdk/artifact_upload_tests.rs
@@ -46,6 +46,7 @@ fn create_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: create_mock_server_metadata(),
         creator: None,

--- a/app/src/ai/agent_sdk/artifact_upload_tests.rs
+++ b/app/src/ai/agent_sdk/artifact_upload_tests.rs
@@ -44,6 +44,7 @@ fn create_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: create_mock_server_metadata(),
         creator: None,

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -453,6 +453,10 @@ pub(super) struct AIBlockStateHandles {
     /// Mouse state handle for the usage button
     usage_button_handle: MouseStateHandle,
 
+    /// Mouse state handle for the left-gutter inline turn-cost indicator
+    /// shown on the last response of a completed turn (Surface 5).
+    cost_indicator_handle: MouseStateHandle,
+
     /// Mouse state handles per citation.
     /// A given citation should only appear once per block.
     footer_citation_chip_handles: HashMap<AIAgentCitation, MouseStateHandle>,

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -452,6 +452,10 @@ pub(super) struct AIBlockStateHandles {
     /// Mouse state handle for the usage button
     usage_button_handle: MouseStateHandle,
 
+    /// Mouse state handle for the left-gutter inline turn-cost indicator
+    /// shown on the last response of a completed turn (Surface 5).
+    cost_indicator_handle: MouseStateHandle,
+
     /// Mouse state handles per citation.
     /// A given citation should only appear once per block.
     footer_citation_chip_handles: HashMap<AIAgentCitation, MouseStateHandle>,

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -55,7 +55,7 @@ use super::{
 };
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::comment::ReviewComment;
-use crate::ai::agent::conversation::{RecordingSpanInfo, RecordingSpanStatus};
+use crate::ai::agent::conversation::{RecordingSpanInfo, RecordingSpanStatus, TurnCost};
 use crate::ai::agent::icons::{self, gray_stop_icon, yellow_stop_icon};
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
@@ -104,8 +104,8 @@ use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
 use crate::ai::blocklist::view_util::{
-    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits_with_cost, format_usage_parenthetical,
-    should_show_failed_output_usage_notice,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_cost, format_credits, format_credits_with_cost,
+    format_usage_parenthetical, should_show_failed_output_usage_notice,
 };
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
@@ -116,6 +116,7 @@ use crate::ai::skills::{
 use crate::appearance::Appearance;
 use crate::code::diff_viewer::DisplayMode;
 use crate::code::editor_management::CodeSource;
+use crate::settings::{AISettings, TuiUsageDisplayMode};
 use crate::settings_view::SettingsSection;
 use crate::terminal::ShellLaunchData;
 #[cfg(not(target_family = "wasm"))]
@@ -273,6 +274,31 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                     None
                 };
                 let is_complete = matches!(status, AIBlockOutputStatus::Complete { .. });
+
+                // Left-gutter inline cost indicator (Surface 5): shown once,
+                // on the last response of a completed turn. Computed here
+                // (rather than inside the per-message loop below) since it
+                // renders as its own leading row, independent of which
+                // output message happens to render first.
+                let turn_cost_indicator =
+                    if is_complete && request_type.is_active() && status.error().is_none() {
+                        props
+                            .model
+                            .exchange_id(app)
+                            .zip(props.model.conversation(app))
+                            .filter(|(exchange_id, conversation)| {
+                                conversation.is_last_response_of_completed_turn(*exchange_id)
+                            })
+                            .and_then(|(exchange_id, conversation)| {
+                                conversation.turn_cost_for_exchange(exchange_id)
+                            })
+                    } else {
+                        None
+                    };
+                if let Some(turn_cost) = turn_cost_indicator {
+                    output_items.add_child(render_turn_cost_indicator(turn_cost, &props, app));
+                }
+
                 let is_output_for_static_prompt_suggestions =
                     props.model.contains_static_prompt_suggestion_input(app);
 
@@ -1277,6 +1303,99 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
     }
 
     output_items.finish()
+}
+
+/// Renders the inline per-turn cost indicator (Surface 5): a small,
+/// muted, clickable/hoverable label shown on the last response of a
+/// completed turn, reporting that turn's total cost. Hovering or clicking
+/// reveals a per-model token/cost breakdown. Units follow the user's
+/// existing credits⇌cost display preference
+/// (`AISettings::usage_display_mode`, shared with the TUI footer's usage
+/// entry) rather than hardcoding dollars.
+fn render_turn_cost_indicator(
+    turn_cost: TurnCost,
+    props: &Props,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let ui_builder = appearance.ui_builder().clone();
+    let mode = AISettings::as_ref(app).usage_display_mode;
+    let label = turn_cost_label(&turn_cost, mode);
+    let tooltip_text = turn_cost_breakdown_text(&turn_cost, mode);
+
+    let mouse_state = props.state_handles.cost_indicator_handle.clone();
+    Hoverable::new(mouse_state, move |mouse_state| {
+        let theme = appearance.theme();
+        let font_color = if mouse_state.is_hovered() || mouse_state.is_clicked() {
+            blended_colors::text_main(theme, theme.surface_1())
+        } else {
+            blended_colors::text_sub(theme, theme.surface_1())
+        };
+        let text = Text::new_inline(
+            label.clone(),
+            appearance.ui_font_family(),
+            appearance.ui_font_size() - 1.,
+        )
+        .with_color(font_color)
+        .with_selectable(false)
+        .finish();
+
+        if mouse_state.is_hovered() || mouse_state.is_clicked() {
+            let mut stack = Stack::new().with_child(text);
+            let tooltip = ui_builder.tool_tip(tooltip_text.clone()).build().finish();
+            stack.add_positioned_overlay_child(
+                tooltip,
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., 4.),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::BottomLeft,
+                    ChildAnchor::TopLeft,
+                ),
+            );
+            stack.finish()
+        } else {
+            text
+        }
+    })
+    .with_cursor(Cursor::PointingHand)
+    .finish()
+}
+
+/// The turn-cost indicator's own label text, in the unit selected by `mode`.
+fn turn_cost_label(turn_cost: &TurnCost, mode: TuiUsageDisplayMode) -> String {
+    match mode {
+        TuiUsageDisplayMode::Credits => format_credits(turn_cost.credits),
+        TuiUsageDisplayMode::Cost => turn_cost
+            .cost_in_cents
+            .map(format_cost)
+            .unwrap_or_else(|| "Cost unavailable".to_string()),
+    }
+}
+
+/// The hover/click tooltip body: a per-model token/cost breakdown for the
+/// turn, or just the total when no per-model breakdown was recorded (e.g. a
+/// conversation persisted before this surface's cost snapshots existed).
+fn turn_cost_breakdown_text(turn_cost: &TurnCost, mode: TuiUsageDisplayMode) -> String {
+    if turn_cost.token_usage.is_empty() {
+        return turn_cost_label(turn_cost, mode);
+    }
+    turn_cost
+        .token_usage
+        .iter()
+        .map(|usage| {
+            let tokens =
+                usage.total_input + usage.output + usage.input_cache_read + usage.input_cache_write;
+            match mode {
+                TuiUsageDisplayMode::Credits => format!("{}: {tokens} tokens", usage.model_id),
+                TuiUsageDisplayMode::Cost => format!(
+                    "{}: {} ({tokens} tokens)",
+                    usage.model_id,
+                    format_cost(usage.cost_in_cents)
+                ),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn should_render_stopped_output(props: Props, app: &AppContext) -> bool {

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -55,7 +55,7 @@ use super::{
 };
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::comment::ReviewComment;
-use crate::ai::agent::conversation::{RecordingSpanInfo, RecordingSpanStatus};
+use crate::ai::agent::conversation::{RecordingSpanInfo, RecordingSpanStatus, TurnCost};
 use crate::ai::agent::icons::{self, gray_stop_icon, yellow_stop_icon};
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
@@ -104,7 +104,8 @@ use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
 use crate::ai::blocklist::view_util::{
-    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits, should_show_failed_output_usage_notice,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_cost, format_credits,
+    should_show_failed_output_usage_notice,
 };
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
@@ -115,6 +116,7 @@ use crate::ai::skills::{
 use crate::appearance::Appearance;
 use crate::code::diff_viewer::DisplayMode;
 use crate::code::editor_management::CodeSource;
+use crate::settings::{AISettings, TuiUsageDisplayMode};
 use crate::settings_view::SettingsSection;
 use crate::terminal::ShellLaunchData;
 #[cfg(not(target_family = "wasm"))]
@@ -278,6 +280,31 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                     HashMap::new()
                 };
                 let is_complete = matches!(status, AIBlockOutputStatus::Complete { .. });
+
+                // Left-gutter inline cost indicator (Surface 5): shown once,
+                // on the last response of a completed turn. Computed here
+                // (rather than inside the per-message loop below) since it
+                // renders as its own leading row, independent of which
+                // output message happens to render first.
+                let turn_cost_indicator =
+                    if is_complete && request_type.is_active() && status.error().is_none() {
+                        props
+                            .model
+                            .exchange_id(app)
+                            .zip(props.model.conversation(app))
+                            .filter(|(exchange_id, conversation)| {
+                                conversation.is_last_response_of_completed_turn(*exchange_id)
+                            })
+                            .and_then(|(exchange_id, conversation)| {
+                                conversation.turn_cost_for_exchange(exchange_id)
+                            })
+                    } else {
+                        None
+                    };
+                if let Some(turn_cost) = turn_cost_indicator {
+                    output_items.add_child(render_turn_cost_indicator(turn_cost, &props, app));
+                }
+
                 let is_output_for_static_prompt_suggestions =
                     props.model.contains_static_prompt_suggestion_input(app);
 
@@ -1280,6 +1307,99 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
     }
 
     output_items.finish()
+}
+
+/// Renders the inline per-turn cost indicator (Surface 5): a small,
+/// muted, clickable/hoverable label shown on the last response of a
+/// completed turn, reporting that turn's total cost. Hovering or clicking
+/// reveals a per-model token/cost breakdown. Units follow the user's
+/// existing credits⇌cost display preference
+/// (`AISettings::usage_display_mode`, shared with the TUI footer's usage
+/// entry) rather than hardcoding dollars.
+fn render_turn_cost_indicator(
+    turn_cost: TurnCost,
+    props: &Props,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let ui_builder = appearance.ui_builder().clone();
+    let mode = AISettings::as_ref(app).usage_display_mode;
+    let label = turn_cost_label(&turn_cost, mode);
+    let tooltip_text = turn_cost_breakdown_text(&turn_cost, mode);
+
+    let mouse_state = props.state_handles.cost_indicator_handle.clone();
+    Hoverable::new(mouse_state, move |mouse_state| {
+        let theme = appearance.theme();
+        let font_color = if mouse_state.is_hovered() || mouse_state.is_clicked() {
+            blended_colors::text_main(theme, theme.surface_1())
+        } else {
+            blended_colors::text_sub(theme, theme.surface_1())
+        };
+        let text = Text::new_inline(
+            label.clone(),
+            appearance.ui_font_family(),
+            appearance.ui_font_size() - 1.,
+        )
+        .with_color(font_color)
+        .with_selectable(false)
+        .finish();
+
+        if mouse_state.is_hovered() || mouse_state.is_clicked() {
+            let mut stack = Stack::new().with_child(text);
+            let tooltip = ui_builder.tool_tip(tooltip_text.clone()).build().finish();
+            stack.add_positioned_overlay_child(
+                tooltip,
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., 4.),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::BottomLeft,
+                    ChildAnchor::TopLeft,
+                ),
+            );
+            stack.finish()
+        } else {
+            text
+        }
+    })
+    .with_cursor(Cursor::PointingHand)
+    .finish()
+}
+
+/// The turn-cost indicator's own label text, in the unit selected by `mode`.
+fn turn_cost_label(turn_cost: &TurnCost, mode: TuiUsageDisplayMode) -> String {
+    match mode {
+        TuiUsageDisplayMode::Credits => format_credits(turn_cost.credits),
+        TuiUsageDisplayMode::Cost => turn_cost
+            .cost_in_cents
+            .map(format_cost)
+            .unwrap_or_else(|| "Cost unavailable".to_string()),
+    }
+}
+
+/// The hover/click tooltip body: a per-model token/cost breakdown for the
+/// turn, or just the total when no per-model breakdown was recorded (e.g. a
+/// conversation persisted before this surface's cost snapshots existed).
+fn turn_cost_breakdown_text(turn_cost: &TurnCost, mode: TuiUsageDisplayMode) -> String {
+    if turn_cost.token_usage.is_empty() {
+        return turn_cost_label(turn_cost, mode);
+    }
+    turn_cost
+        .token_usage
+        .iter()
+        .map(|usage| {
+            let tokens =
+                usage.total_input + usage.output + usage.input_cache_read + usage.input_cache_write;
+            match mode {
+                TuiUsageDisplayMode::Credits => format!("{}: {tokens} tokens", usage.model_id),
+                TuiUsageDisplayMode::Cost => format!(
+                    "{}: {} ({tokens} tokens)",
+                    usage.model_id,
+                    format_cost(usage.cost_in_cents)
+                ),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn should_render_stopped_output(props: Props, app: &AppContext) -> bool {

--- a/app/src/ai/blocklist/block/view_impl/output_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/output_tests.rs
@@ -15,14 +15,16 @@ use watcher::HomeDirectoryWatcher;
 use super::{
     RecordingCardText, format_upload_artifact_text, parsed_skill_for_common_locations,
     read_skill_display_text, should_decorate_recorded_use_computer, start_recording_card_text,
-    stop_recording_card_text,
+    stop_recording_card_text, turn_cost_breakdown_text, turn_cost_label,
 };
+use crate::ai::agent::conversation::TurnCost;
 use crate::ai::agent::{
     RecordingStarted, RecordingStopped, StartRecordingResult, StopRecordingResult,
     UploadArtifactResult,
 };
 use crate::ai::skills::SkillManager;
-use crate::settings::AISettings;
+use crate::persistence::model::ExchangeModelTokenUsage;
+use crate::settings::{AISettings, TuiUsageDisplayMode};
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
 
 #[test]
@@ -184,6 +186,116 @@ fn use_computer_decoration_skips_screenshot_only_rows() {
 
     request.actions = vec![TargetedAction::screen(Action::Wait(Duration::from_secs(1)))];
     assert!(should_decorate_recorded_use_computer(&request));
+}
+
+#[test]
+fn turn_cost_label_credits_mode_formats_via_format_credits() {
+    let turn_cost = TurnCost {
+        credits: 2.5,
+        cost_in_cents: Some(3.0),
+        token_usage: vec![],
+    };
+
+    assert_eq!(
+        turn_cost_label(&turn_cost, TuiUsageDisplayMode::Credits),
+        "2.5 credits"
+    );
+}
+
+#[test]
+fn turn_cost_label_cost_mode_formats_known_cost_via_format_cost() {
+    let turn_cost = TurnCost {
+        credits: 2.5,
+        cost_in_cents: Some(3.0),
+        token_usage: vec![],
+    };
+
+    assert_eq!(
+        turn_cost_label(&turn_cost, TuiUsageDisplayMode::Cost),
+        "$0.03"
+    );
+}
+
+#[test]
+fn turn_cost_label_cost_mode_reports_unavailable_when_cost_unknown() {
+    // A conversation restored before this surface's cost-in-cents persistence
+    // existed must not fabricate a $0.00 total.
+    let turn_cost = TurnCost {
+        credits: 2.5,
+        cost_in_cents: None,
+        token_usage: vec![],
+    };
+
+    assert_eq!(
+        turn_cost_label(&turn_cost, TuiUsageDisplayMode::Cost),
+        "Cost unavailable"
+    );
+}
+
+#[test]
+fn turn_cost_breakdown_text_falls_back_to_label_when_no_token_usage_recorded() {
+    let turn_cost = TurnCost {
+        credits: 1.0,
+        cost_in_cents: Some(1.0),
+        token_usage: vec![],
+    };
+
+    assert_eq!(
+        turn_cost_breakdown_text(&turn_cost, TuiUsageDisplayMode::Credits),
+        turn_cost_label(&turn_cost, TuiUsageDisplayMode::Credits)
+    );
+}
+
+#[test]
+fn turn_cost_breakdown_text_lists_per_model_token_counts_in_credits_mode() {
+    let turn_cost = TurnCost {
+        credits: 3.5,
+        cost_in_cents: Some(2.3),
+        token_usage: vec![
+            ExchangeModelTokenUsage {
+                model_id: "model-a".to_string(),
+                total_input: 10,
+                output: 5,
+                input_cache_read: 2,
+                input_cache_write: 1,
+                cost_in_cents: 1.0,
+            },
+            ExchangeModelTokenUsage {
+                model_id: "model-b".to_string(),
+                total_input: 20,
+                output: 8,
+                input_cache_read: 0,
+                input_cache_write: 0,
+                cost_in_cents: 1.3,
+            },
+        ],
+    };
+
+    assert_eq!(
+        turn_cost_breakdown_text(&turn_cost, TuiUsageDisplayMode::Credits),
+        "model-a: 18 tokens\nmodel-b: 28 tokens"
+    );
+}
+
+#[test]
+fn turn_cost_breakdown_text_lists_per_model_cost_and_tokens_in_cost_mode() {
+    let turn_cost = TurnCost {
+        credits: 3.5,
+        cost_in_cents: Some(2.3),
+        token_usage: vec![ExchangeModelTokenUsage {
+            model_id: "model-a".to_string(),
+            total_input: 10,
+            output: 5,
+            input_cache_read: 0,
+            input_cache_write: 0,
+            cost_in_cents: 1.0,
+        }],
+    };
+
+    assert_eq!(
+        turn_cost_breakdown_text(&turn_cost, TuiUsageDisplayMode::Cost),
+        "model-a: $0.01 (15 tokens)"
+    );
 }
 
 fn make_skill(name: &str) -> ParsedSkill {

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -3286,6 +3286,7 @@ impl BlocklistAIController {
             });
             history_model.update_conversation_cost_and_usage_for_request(
                 conversation_id,
+                stream_id,
                 request_cost,
                 finished_event.request_charges.take(),
                 finished_event.token_usage,

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -3250,6 +3250,7 @@ impl BlocklistAIController {
             // persisting the conversation.
             history_model.update_conversation_cost_and_usage_for_request(
                 conversation_id,
+                stream_id,
                 finished_event.request_cost.map(|cost| {
                     // Total credits charged for this request = inference (`exact`) + platform.
                     RequestCost::new(f64::from(cost.exact) + f64::from(cost.platform_credits))

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1990,6 +1990,7 @@ impl BlocklistAIHistoryModel {
     pub fn update_conversation_cost_and_usage_for_request(
         &mut self,
         conversation_id: AIConversationId,
+        stream_id: &ResponseStreamId,
         request_cost: Option<RequestCost>,
         request_charges: Option<RequestCharges>,
         token_usage: Vec<TokenUsage>,
@@ -2008,6 +2009,7 @@ impl BlocklistAIHistoryModel {
             || !token_usage.is_empty();
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             if let Err(e) = conversation.update_cost_and_usage_for_request(
+                stream_id,
                 request_cost,
                 request_charges,
                 token_usage,

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1986,9 +1986,11 @@ impl BlocklistAIHistoryModel {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_conversation_cost_and_usage_for_request(
         &mut self,
         conversation_id: AIConversationId,
+        stream_id: &ResponseStreamId,
         request_cost: Option<RequestCost>,
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<ConversationUsageMetadata>,
@@ -2004,6 +2006,7 @@ impl BlocklistAIHistoryModel {
             request_cost.is_some() || usage_metadata.is_some() || !token_usage.is_empty();
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             if let Err(e) = conversation.update_cost_and_usage_for_request(
+                stream_id,
                 request_cost,
                 token_usage,
                 usage_metadata,

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1343,6 +1343,7 @@ fn create_server_metadata(
         token_usage: vec![],
         tool_usage_metadata: Default::default(),
         context_window_segments: Vec::new(),
+        exchange_costs: Default::default(),
     };
 
     ServerAIConversationMetadata {

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1341,6 +1341,7 @@ fn create_server_metadata(
         token_usage: vec![],
         tool_usage_metadata: Default::default(),
         context_window_segments: Vec::new(),
+        exchange_costs: Default::default(),
     };
 
     ServerAIConversationMetadata {

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -377,6 +377,7 @@ fn make_server_metadata_with_harness(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -375,6 +375,7 @@ fn make_server_metadata_with_harness(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -298,6 +298,14 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
+/// Formats an accumulated cost in US cents as dollars (`3.2` cents ->
+/// `$0.03`), matching the TUI's equivalent helper
+/// (`crates/warp_tui/src/usage.rs::format_cost`) so the same underlying
+/// number reads identically in both front-ends.
+pub fn format_cost(cost_in_cents: f32) -> String {
+    format!("${:.2}", cost_in_cents / 100.0)
+}
+
 /// Builds the `"12,345 tokens, $0.36"`-style parenthetical shared by
 /// [`format_credits_with_cost`] and the conversation details panel's
 /// compact "Credits used" line, gated by `FeatureFlag::PricingTransparency`.
@@ -327,7 +335,7 @@ pub fn format_usage_parenthetical(
     let token_part = tokens
         .filter(|&tokens| tokens > 0)
         .map(|tokens| format!("{} tokens", tokens.separate_with_commas()));
-    let cost_part = cost_in_cents.map(|cost_in_cents| format!("${:.2}", cost_in_cents / 100.0));
+    let cost_part = cost_in_cents.map(format_cost);
     match (token_part, cost_part) {
         (Some(token_part), Some(cost_part)) => Some(format!("{token_part}, {cost_part}")),
         (Some(token_part), None) => Some(token_part),

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -296,6 +296,14 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
+/// Formats an accumulated cost in US cents as dollars (`3.2` cents ->
+/// `$0.03`), matching the TUI's equivalent helper
+/// (`crates/warp_tui/src/usage.rs::format_cost`) so the same underlying
+/// number reads identically in both front-ends.
+pub fn format_cost(cost_in_cents: f32) -> String {
+    format!("${:.2}", cost_in_cents / 100.0)
+}
+
 /// Renders a secondary button with an MCP/skill provider icon and a text label.
 pub(crate) fn render_provider_icon_button<F>(
     button_label: &str,

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -192,6 +192,7 @@ fn create_test_server_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -190,6 +190,7 @@ fn create_test_server_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -376,6 +376,7 @@ fn test_server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: mock_server_metadata(),
         creator: None,

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -370,6 +370,7 @@ fn test_server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: mock_server_metadata(),
         creator: None,

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -310,6 +310,7 @@ fn server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: server_metadata(creator_uid),
         creator: None,

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -308,6 +308,7 @@ fn server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: server_metadata(creator_uid),
         creator: None,

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -762,6 +762,7 @@ fn server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -760,6 +760,7 @@ fn server_conversation_metadata(
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
             context_window_segments: Vec::new(),
+            exchange_costs: Default::default(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -224,6 +224,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),
+            // The server does not (yet) report per-exchange cost snapshots
+            // via this GraphQL query; only the local client-side stamping in
+            // `AIConversation::update_cost_and_usage_for_request` populates this.
+            exchange_costs: Default::default(),
         }
     }
 }

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -220,6 +220,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),
+            // The server does not (yet) report per-exchange cost snapshots
+            // via this GraphQL query; only the local client-side stamping in
+            // `AIConversation::update_cost_and_usage_for_request` populates this.
+            exchange_costs: Default::default(),
         }
     }
 }

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -205,6 +205,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),
+            // The server does not (yet) report per-exchange cost snapshots
+            // via this GraphQL query; only the local client-side stamping in
+            // `AIConversation::update_cost_and_usage_for_request` populates this.
+            exchange_costs: Default::default(),
         }
     }
 }

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -201,6 +201,10 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
             context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),
+            // The server does not (yet) report per-exchange cost snapshots
+            // via this GraphQL query; only the local client-side stamping in
+            // `AIConversation::update_cost_and_usage_for_request` populates this.
+            exchange_costs: Default::default(),
         }
     }
 }

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1744,12 +1744,63 @@ pub struct ConversationUsageMetadata {
     pub tool_usage_metadata: ToolUsageMetadata,
     #[serde(default)]
     pub context_window_segments: Vec<ContextWindowSegment>,
+    /// Per-request cost snapshots, keyed by that request's stable
+    /// `server_output_id` (not the client-generated `AIAgentExchangeId`,
+    /// which is reassigned on every restore).
+    ///
+    /// This is new persistence introduced for the left-gutter inline cost
+    /// indicator (Surface 5 of the pricing-transparency effort): previously
+    /// only the *last* block's cost was tracked
+    /// (`credits_spent_for_last_block`), so a historical message earlier in
+    /// the conversation had no way to report its own cost. Populated once
+    /// per completed request in `AIConversation::update_cost_and_usage_for_request`
+    /// and consulted by `AIConversation::exchange_cost` /
+    /// `AIConversation::turn_cost_for_exchange` at render time.
+    #[serde(default)]
+    pub exchange_costs: HashMap<String, ExchangeCostSnapshot>,
 }
 
 impl ConversationUsageMetadata {
     pub fn total_tool_calls(&self) -> i32 {
         self.tool_usage_metadata.total_tool_calls()
     }
+}
+
+/// Per-model token/cost breakdown for a single request. Used by
+/// [`ExchangeCostSnapshot`] to power the left-gutter cost indicator's
+/// hover/click token/model breakdown (Surface 5).
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct ExchangeModelTokenUsage {
+    pub model_id: String,
+    #[serde(default)]
+    pub total_input: u32,
+    #[serde(default)]
+    pub output: u32,
+    #[serde(default)]
+    pub input_cache_read: u32,
+    #[serde(default)]
+    pub input_cache_write: u32,
+    #[serde(default)]
+    pub cost_in_cents: f32,
+}
+
+/// A snapshot of the cost incurred by a single completed request (i.e. one
+/// response stream, corresponding to one exchange). See
+/// [`ConversationUsageMetadata::exchange_costs`] for how this is keyed and
+/// why it exists.
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct ExchangeCostSnapshot {
+    /// Credits charged for this specific request (inference + platform) —
+    /// not the cumulative per-turn or per-conversation total.
+    pub credits: f32,
+    /// Provider dollar cost for this specific request, in US cents. `None`
+    /// when no token usage was reported for this request (e.g. the server
+    /// didn't send per-model usage), which must not be rendered as `$0.00`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_in_cents: Option<f32>,
+    /// Per-model token/cost breakdown for this specific request.
+    #[serde(default)]
+    pub token_usage: Vec<ExchangeModelTokenUsage>,
 }
 
 #[derive(Debug, Insertable)]

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1625,12 +1625,63 @@ pub struct ConversationUsageMetadata {
     pub tool_usage_metadata: ToolUsageMetadata,
     #[serde(default)]
     pub context_window_segments: Vec<ContextWindowSegment>,
+    /// Per-request cost snapshots, keyed by that request's stable
+    /// `server_output_id` (not the client-generated `AIAgentExchangeId`,
+    /// which is reassigned on every restore).
+    ///
+    /// This is new persistence introduced for the left-gutter inline cost
+    /// indicator (Surface 5 of the pricing-transparency effort): previously
+    /// only the *last* block's cost was tracked
+    /// (`credits_spent_for_last_block`), so a historical message earlier in
+    /// the conversation had no way to report its own cost. Populated once
+    /// per completed request in `AIConversation::update_cost_and_usage_for_request`
+    /// and consulted by `AIConversation::exchange_cost` /
+    /// `AIConversation::turn_cost_for_exchange` at render time.
+    #[serde(default)]
+    pub exchange_costs: HashMap<String, ExchangeCostSnapshot>,
 }
 
 impl ConversationUsageMetadata {
     pub fn total_tool_calls(&self) -> i32 {
         self.tool_usage_metadata.total_tool_calls()
     }
+}
+
+/// Per-model token/cost breakdown for a single request. Used by
+/// [`ExchangeCostSnapshot`] to power the left-gutter cost indicator's
+/// hover/click token/model breakdown (Surface 5).
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct ExchangeModelTokenUsage {
+    pub model_id: String,
+    #[serde(default)]
+    pub total_input: u32,
+    #[serde(default)]
+    pub output: u32,
+    #[serde(default)]
+    pub input_cache_read: u32,
+    #[serde(default)]
+    pub input_cache_write: u32,
+    #[serde(default)]
+    pub cost_in_cents: f32,
+}
+
+/// A snapshot of the cost incurred by a single completed request (i.e. one
+/// response stream, corresponding to one exchange). See
+/// [`ConversationUsageMetadata::exchange_costs`] for how this is keyed and
+/// why it exists.
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct ExchangeCostSnapshot {
+    /// Credits charged for this specific request (inference + platform) —
+    /// not the cumulative per-turn or per-conversation total.
+    pub credits: f32,
+    /// Provider dollar cost for this specific request, in US cents. `None`
+    /// when no token usage was reported for this request (e.g. the server
+    /// didn't send per-model usage), which must not be rendered as `$0.00`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_in_cents: Option<f32>,
+    /// Per-model token/cost breakdown for this specific request.
+    #[serde(default)]
+    pub token_usage: Vec<ExchangeModelTokenUsage>,
 }
 
 #[derive(Debug, Insertable)]


### PR DESCRIPTION
## Description
Implements Surface 5 of the pricing-transparency effort: a clickable/hoverable inline per-message cost indicator shown in the transcript on the last response of each completed turn, plus new persistence for historical (not just most-recent) per-exchange costs so a message earlier in the conversation can report its own cost.

**What changed:**
- **Persistence** (`crates/persistence/src/model.rs`): added `ExchangeCostSnapshot` / `ExchangeModelTokenUsage`, and a new `exchange_costs: HashMap<String, ExchangeCostSnapshot>` field on `ConversationUsageMetadata`, keyed by the request's stable `server_output_id` (not the client-generated `AIAgentExchangeId`, which is reassigned on every restore).
- **`AIConversation`** (`app/src/ai/agent/conversation.rs`):
  - `update_cost_and_usage_for_request` now stamps a per-request cost snapshot into `exchange_costs` whenever a request reports cost/token usage.
  - `exchange_cost(exchange_id)` looks up a single exchange's stamped snapshot.
  - `is_last_response_of_completed_turn(exchange_id)` determines whether an exchange is the final response of a now-completed turn (the trigger condition for showing the indicator).
  - `turn_cost_for_exchange(exchange_id)` aggregates cost/token usage across every exchange in a completed turn (handles tool-call round trips spanning multiple requests).
- **GUI rendering** (`app/src/ai/blocklist/block/view_impl/output.rs`): renders the indicator as a leading row on the last response of a completed turn. It's a small muted `Hoverable` label (pointing-hand cursor) that shows a per-model token/cost breakdown tooltip on hover/click, formatted via the user's existing `AISettings::usage_display_mode` (credits vs. provider dollar cost) rather than hardcoding dollars.
- GraphQL conversions (`crates/graphql/src/api/ai.rs`, `.../get_conversation_usage.rs`) default the new `exchange_costs` field since the server doesn't (yet) report per-exchange snapshots via those queries; only local client-side stamping populates it today.

**Added in this session (continuing the WIP):**
- Re-verified the prior agent's work compiles/lints/tests clean after the disk-space interruption.
- Added unit test coverage that was missing for the GUI-side formatting helpers: `turn_cost_label` (credits mode, cost mode with known cost, cost mode falling back to "Cost unavailable" when unknown) and `turn_cost_breakdown_text` (fallback to the plain label when no per-model breakdown was recorded, and per-model listings in both display modes).

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->

## Linked Issue
- [ ] N/A — continuation of an existing WIP branch (`pt-surfaces/left-gutter`) per internal pricing-transparency Surface 5 spec (not tracked by a GitHub issue).

## Testing
- `cargo check -p warp --lib` — pass
- `cargo clippy -p warp --lib -- -D warnings` and `cargo clippy -p warp --lib --tests -- -D warnings` — pass, no warnings
- `./script/format --check` — pass
- New/targeted unit tests, all passing:
  - `ai::agent::conversation::tests::{is_last_response_of_completed_turn_marks_each_turns_final_exchange, is_last_response_of_completed_turn_excludes_intermediate_exchanges_within_a_turn, exchange_cost_looks_up_snapshot_by_server_output_id, turn_cost_for_exchange_aggregates_across_multi_exchange_turn, turn_cost_for_exchange_returns_none_when_no_snapshot_recorded}`
  - `ai::blocklist::block::view_impl::output::tests::{turn_cost_label_credits_mode_formats_via_format_credits, turn_cost_label_cost_mode_formats_known_cost_via_format_cost, turn_cost_label_cost_mode_reports_unavailable_when_cost_unknown, turn_cost_breakdown_text_falls_back_to_label_when_no_token_usage_recorded, turn_cost_breakdown_text_lists_per_model_token_counts_in_credits_mode, turn_cost_breakdown_text_lists_per_model_cost_and_tokens_in_cost_mode}` (added this session)
- Full `ai::agent::conversation` test module (66 tests) — all pass
- `./script/presubmit` — format, inline-test-module check, workspace-wide clippy (`warp`, `warp_completer`), clang-format, and wgslfmt all pass. The full `cargo nextest run --workspace` (11,096 tests) passes except for 42 pre-existing failures, all unrelated to this change and specific to this sandboxed cloud environment: X11-dependent GUI integration tests (clipboard, window recording, font layout), SSH/remote-server integration tests requiring real network targets, and a few `warp_server_client`/`server_api` tests that fail because the sandbox's `nsc` workload-identity tool denies access (verified directly — e.g. `ambient_agent_headers_for_task_overrides_existing_cloud_agent_header` fails with `Failed to get ambient agent workload token: Command nsc exited with non-zero status`, an environment limitation, not a code issue). `cargo test --doc` passes.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included. This sandbox has no live Warp backend/network access, so there was no way to drive an actual completed AI turn (with real per-exchange cost data) end-to-end to capture the indicator on screen. Standing up a full local `warp-server` + Postgres + mocked-LLM stack to produce one was judged too resource-intensive/risky for this environment (the build cache is a tightly-shared, size-limited disk that already hit "no space left on device" twice during this session's `cargo test`/presubmit runs — see Known gaps below). Verification instead relied on the unit tests above (including new coverage for the label/tooltip formatting logic) plus manual code review of the render path against the resolved UX decisions (single indicator per completed turn, hover/click reveal, respects the credits⇄cost display preference).

## Known gaps / follow-ups
- **No visual/computer-use verification** of the rendered indicator (see above) — recommend a follow-up manual/computer-use check against a real backend before shipping broadly.
- **Branch predates a large swath of `master`** (based on `eb56df1`, ~450+ commits behind `391dd76`). A trial merge surfaced conflicts in `conversation.rs`, `conversation_tests.rs`, `output.rs`, `controller.rs`, and `view_util.rs`; resolving + re-validating those was deferred to avoid another resource-exhaustion cycle in this sandbox. This PR will need a rebase/merge (with careful re-check of the cost-indicator gating logic in `output.rs`/`controller.rs`, since both saw independent changes on `master`) before it can land.
- Per-exchange cost snapshots are only ever populated by local client-side stamping (`update_cost_and_usage_for_request`); the server doesn't report them via `GetConversationUsage`/`ai.rs` GraphQL conversions yet, so conversations restored purely from those paths won't have historical per-message costs (documented inline).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
