### PR TITLE
Reduce monomorphization in warpui_core update and spawn paths

### DIFF
--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -4598,28 +4598,81 @@ impl AppContext {
     }
 }
 
+impl AppContext {
+    /// Removes the model with the given ID so that an update closure can run against it.
+    ///
+    /// This bookkeeping is not generic, so it is compiled once instead of being duplicated into
+    /// every instantiation of [`UpdateModel::update_model`].
+    fn take_model_for_update(&mut self, model_id: EntityId) -> Box<dyn AnyModel> {
+        let Some(model) = self.models.remove(&model_id) else {
+            panic!("Circular model update");
+        };
+        self.pending_flushes += 1;
+        model
+    }
+
+    /// Restores a model removed by [`Self::take_model_for_update`] and flushes pending effects.
+    fn finish_model_update(&mut self, model_id: EntityId, model: Box<dyn AnyModel>) {
+        self.models.insert(model_id, model);
+        self.flush_effects();
+    }
+
+    /// Removes the view with the given ID so that an update closure can run against it.
+    ///
+    /// This bookkeeping is not generic, so it is compiled once instead of being duplicated into
+    /// every instantiation of [`UpdateView::update_view`].
+    fn take_view_for_update(&mut self, window_id: WindowId, view_id: EntityId) -> StoredView {
+        self.pending_flushes += 1;
+        let Some(window) = self.windows.get_mut(&window_id) else {
+            panic!("Window does not exist");
+        };
+        let Some(view) = window.views.remove(&view_id) else {
+            panic!("Circular view update");
+        };
+        view
+    }
+
+    /// Restores a view removed by [`Self::take_view_for_update`] and flushes pending effects.
+    fn finish_view_update(&mut self, window_id: WindowId, view_id: EntityId, view: StoredView) {
+        if let Some(window) = self.windows.get_mut(&window_id) {
+            window.views.insert(view_id, view);
+        }
+        self.flush_effects();
+    }
+}
+
+/// Downcasts a checked-out model to its concrete type.
+///
+/// This is generic over the entity type only, so the downcast and panic machinery is shared by
+/// all [`UpdateModel::update_model`] call sites for a given model type.
+fn downcast_model_mut<T: Entity>(model: &mut Box<dyn AnyModel>) -> &mut T {
+    model
+        .as_any_mut()
+        .downcast_mut()
+        .expect("Downcast is type safe")
+}
+
+/// Downcasts a checked-out view to its concrete type.
+///
+/// This is generic over the entity type only, so the downcast and panic machinery is shared by
+/// all [`UpdateView::update_view`] call sites for a given view type.
+fn downcast_view_mut<T: Entity>(view: &mut StoredView) -> &mut T {
+    view.as_any_mut()
+        .downcast_mut()
+        .expect("Downcast is type safe")
+}
+
 impl UpdateModel for AppContext {
     fn update_model<T, F, S>(&mut self, handle: &ModelHandle<T>, update: F) -> S
     where
         T: Entity,
         F: FnOnce(&mut T, &mut ModelContext<T>) -> S,
     {
-        if let Some(mut model) = self.models.remove(&handle.id()) {
-            self.pending_flushes += 1;
-            let mut ctx = ModelContext::new(self, handle.id());
-            let result = update(
-                model
-                    .as_any_mut()
-                    .downcast_mut()
-                    .expect("Downcast is type safe"),
-                &mut ctx,
-            );
-            self.models.insert(handle.id(), model);
-            self.flush_effects();
-            result
-        } else {
-            panic!("Circular model update");
-        }
+        let mut model = self.take_model_for_update(handle.id());
+        let mut ctx = ModelContext::new(self, handle.id());
+        let result = update(downcast_model_mut(&mut model), &mut ctx);
+        self.finish_model_update(handle.id(), model);
+        result
     }
 }
 
@@ -4629,29 +4682,11 @@ impl UpdateView for AppContext {
         T: Entity,
         F: FnOnce(&mut T, &mut ViewContext<T>) -> S,
     {
-        self.pending_flushes += 1;
         let window_id = handle.window_id(self);
-        let mut view = if let Some(window) = self.windows.get_mut(&window_id) {
-            if let Some(view) = window.views.remove(&handle.id()) {
-                view
-            } else {
-                panic!("Circular view update");
-            }
-        } else {
-            panic!("Window does not exist");
-        };
-
+        let mut view = self.take_view_for_update(window_id, handle.id());
         let mut ctx = ViewContext::new(self, window_id, handle.id());
-        let result = update(
-            view.as_any_mut()
-                .downcast_mut()
-                .expect("Downcast is type safe"),
-            &mut ctx,
-        );
-        if let Some(window) = self.windows.get_mut(&window_id) {
-            window.views.insert(handle.id(), view);
-        }
-        self.flush_effects();
+        let result = update(downcast_view_mut(&mut view), &mut ctx);
+        self.finish_view_update(window_id, handle.id(), view);
         result
     }
 }

--- a/crates/warpui_core/src/core/model/context.rs
+++ b/crates/warpui_core/src/core/model/context.rs
@@ -10,7 +10,9 @@ use thiserror::Error;
 use warp_errors::report_error;
 
 use crate::accessibility::AccessibilityContent;
-use crate::r#async::{SpawnableOutput, SpawnedFutureHandle, SpawnedLocalStream, Timer, executor};
+use crate::r#async::{
+    BoxFuture, SpawnableOutput, SpawnedFutureHandle, SpawnedLocalStream, Timer, executor,
+};
 use crate::core::{Observation, Subscription, SubscriptionKey, TaskCallback};
 use crate::windowing::WindowManager;
 use crate::{
@@ -23,6 +25,12 @@ use crate::{
 #[derive(Debug, Error, PartialEq, Eq)]
 #[error("Model has been dropped")]
 pub struct ModelDropped;
+
+/// Callback that receives the output of a resolved future spawned from a [`ModelContext`].
+type SpawnResolveCallback<T, O> = Box<dyn FnOnce(&mut T, O, &mut ModelContext<T>)>;
+
+/// Callback that runs when a future spawned from a [`ModelContext`] is aborted.
+type SpawnAbortCallback<T> = Box<dyn FnOnce(&mut T, &mut ModelContext<T>)>;
 
 /// Structure that combines model identifiers and a handle to the application
 /// context/application state.
@@ -398,12 +406,12 @@ impl<'a, T: Entity> ModelContext<'a, T> {
         F: 'static + FnOnce(&mut T, S::Output, &mut ModelContext<T>) -> U,
         U: 'static,
     {
-        self.spawn_abortable::<S, _, _>(
-            future,
-            |view, output, ctx| {
-                callback(view, output, ctx);
-            },
-            |_, _| {},
+        self.spawn_abortable_boxed(
+            Box::pin(future),
+            Box::new(|model, output, ctx| {
+                callback(model, output, ctx);
+            }),
+            Box::new(|_, _| {}),
         )
     }
 
@@ -436,6 +444,22 @@ impl<'a, T: Entity> ModelContext<'a, T> {
         <S as Future>::Output: crate::r#async::SpawnableOutput,
         F: 'static + FnOnce(&mut T, S::Output, &mut ModelContext<T>),
         A: 'static + FnOnce(&mut T, &mut ModelContext<T>),
+    {
+        self.spawn_abortable_boxed(Box::pin(future), Box::new(on_resolve), Box::new(on_abort))
+    }
+
+    /// Type-erased body of [`Self::spawn`] and [`Self::spawn_abortable`].
+    ///
+    /// The public entry points box the future and the callbacks immediately, so this body is
+    /// compiled once per output type instead of once per call site.
+    fn spawn_abortable_boxed<O>(
+        &mut self,
+        future: BoxFuture<'static, O>,
+        on_resolve: SpawnResolveCallback<T, O>,
+        on_abort: SpawnAbortCallback<T>,
+    ) -> SpawnedFutureHandle
+    where
+        O: 'static + SpawnableOutput,
     {
         let (tx, rx) = futures::channel::oneshot::channel();
 

--- a/crates/warpui_core/src/core/view/context.rs
+++ b/crates/warpui_core/src/core/view/context.rs
@@ -15,7 +15,7 @@ use super::handle::{AnyViewHandle, ReadView, UpdateView, ViewAsRef, ViewHandle, 
 use super::{TypedActionView, View};
 use crate::accessibility::AccessibilityContent;
 use crate::r#async::executor::{Background, Foreground};
-use crate::r#async::{SpawnableOutput, SpawnedFutureHandle, SpawnedLocalStream};
+use crate::r#async::{BoxFuture, SpawnableOutput, SpawnedFutureHandle, SpawnedLocalStream};
 use crate::core::{Observation, Subscription, SubscriptionKey, TaskCallback};
 use crate::fonts::Cache as FontCache;
 use crate::modals::{AlertDialogWithCallbacks, ModalButton, ViewModalCallback};
@@ -45,6 +45,12 @@ impl<'a, T: View> ViewContext<'a, T> {
         }
     }
 }
+
+/// Callback that receives the output of a resolved future spawned from a [`ViewContext`].
+type SpawnResolveCallback<T, O> = Box<dyn FnOnce(&mut T, O, &mut ViewContext<T>)>;
+
+/// Callback that runs when a future spawned from a [`ViewContext`] is aborted.
+type SpawnAbortCallback<T> = Box<dyn FnOnce(&mut T, &mut ViewContext<T>)>;
 
 /// Structure that combines view identifiers and a handle to the application
 /// context/application state.
@@ -562,12 +568,12 @@ impl<'a, T: Entity> ViewContext<'a, T> {
         F: 'static + FnOnce(&mut T, <S as Future>::Output, &mut ViewContext<T>) -> U,
         U: 'static,
     {
-        self.spawn_abortable::<S, _, _>(
-            future,
-            |view, output, ctx| {
+        self.spawn_abortable_boxed(
+            Box::pin(future),
+            Box::new(|view, output, ctx| {
                 callback(view, output, ctx);
-            },
-            |_, _| {},
+            }),
+            Box::new(|_, _| {}),
         )
     }
 
@@ -600,6 +606,22 @@ impl<'a, T: Entity> ViewContext<'a, T> {
         <S as Future>::Output: crate::r#async::SpawnableOutput,
         F: 'static + FnOnce(&mut T, <S as Future>::Output, &mut ViewContext<T>),
         A: 'static + FnOnce(&mut T, &mut ViewContext<T>),
+    {
+        self.spawn_abortable_boxed(Box::pin(future), Box::new(on_resolve), Box::new(on_abort))
+    }
+
+    /// Type-erased body of [`Self::spawn`] and [`Self::spawn_abortable`].
+    ///
+    /// The public entry points box the future and the callbacks immediately, so this body is
+    /// compiled once per output type instead of once per call site.
+    fn spawn_abortable_boxed<O>(
+        &mut self,
+        future: BoxFuture<'static, O>,
+        on_resolve: SpawnResolveCallback<T, O>,
+        on_abort: SpawnAbortCallback<T>,
+    ) -> SpawnedFutureHandle
+    where
+        O: 'static + SpawnableOutput,
     {
         let (tx, rx) = futures::channel::oneshot::channel();
 


### PR DESCRIPTION
## Description

Compilation of the `warp` crate is slow. One cause is monomorphization bloat from two very hot generic APIs in `warpui_core`. This PR reduces that bloat with two changes. Runtime behavior does not change.

**1. Outline the entity bookkeeping in `update_model` / `update_view`.**

`AppContext::update_model` and `AppContext::update_view` are generic over the entity type, the closure type, and the return type. The `warp` crate instantiates them at ~6,200 call sites. Each instantiation contained the full map-removal, panic, re-insertion, and flush logic. This PR moves the bookkeeping into four non-generic helpers (`take_model_for_update`, `finish_model_update`, `take_view_for_update`, `finish_view_update`). The downcast-and-panic machinery moves into helpers that are generic over the entity type only. The generic shims that remain are small.

Semantics are preserved: same panic messages, same panic conditions, same flush ordering. One minor difference: in `update_view`, the read-only `handle.window_id(self)` lookup now runs before `pending_flushes` increments. This is only observable if that lookup itself panics.

**2. Box futures and callbacks at the `spawn` / `spawn_abortable` entry points.**

`ViewContext::{spawn, spawn_abortable}` and `ModelContext::{spawn, spawn_abortable}` instantiated the oneshot-channel plus `Abortable` plus `spawn_local` chain once per call site (~700 sites). The bodies now live in `spawn_abortable_boxed`, which takes a `BoxFuture<'static, O>` and boxed callbacks. The chain now compiles once per output type. The public entry points keep their exact signatures; they box the arguments and forward. The future was already boxed two lines into the old chain (`spawn_boxed(Box::pin(...))`), so the cost of this change is only two small callback allocations per spawn call.

**Alternatives considered and discarded**
- Fully type-erase `update_model` / `update_view` by boxing the update closure. Rejected: it adds an allocation to an extremely hot path, and it gives no meaningful compile-time win beyond outlining.
- `#[inline(never)]` on the generic functions. Rejected: it does not reduce the number of instantiations; each call site still gets its own codegen copy.

**Measured impact** (Apple M5 Pro, rustc 1.92.0, dev profile; baselines measured on `master` with the same method)
- `cargo llvm-lines -p warp --lib`: 17,874,810 → 17,279,212 lines (**−595,598, −3.3%**); 581,916 → 580,747 copies.
  - `update_model`: 765,122 → 500,326 lines. `update_view`: 558,281 → 300,261 lines. `spawn_abortable*`: 743,365 → 521,375 lines (11,622 → 7,823 copies). `spawn_local`: 432,495 → 311,179 lines (8,582 → 6,057 copies).
- Non-incremental `warp` lib build (`CARGO_INCREMENTAL=0`, deps cached): ~71 s → ~68 s.
- Touch-incremental `warp` lib rebuild (`touch app/src/lib.rs`): ~19.7 s → ~14.6–15.4 s (**−22%**). The win is larger here because mono-item collection runs during every incremental build, and this change removes many mono items.

This is PR 1 of a 3-PR stack of compile-time improvements. PR 2 (settings macro type erasure) and PR 3 (serde enum deserializers) stack on this branch.

## Linked Issue
None. This work comes from a compile-time profiling investigation.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

This change is a mechanical refactor with identical semantics, validated by:
- `cargo check -p warpui_core`, `cargo check -p warp`, and `cargo check -p warp_tui` pass.
- `./script/format` produces no changes; all three presubmit clippy invocations pass.
- `cargo nextest run -p warpui_core -p warpui`: 353 passed, 0 failed. These suites cover the spawn and update paths.

- [ ] I have manually tested my changes locally with `./script/run`

Manual testing was not performed: there is no user-visible behavior change, and the touched paths run on every frame and every spawned task, so any regression would be caught immediately by the test suites and by normal app usage in CI builds.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/024e797d-1d35-4c62-8394-abf93f7ddb0e)

CHANGELOG-NONE
