### PR TITLE
Compile time: share settings registration code across settings

### DIFF
--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod macros;
 pub mod manager;
+pub mod registration;
 pub mod schema;
 
 // Re-export commonly used types and traits
@@ -638,6 +639,17 @@ pub trait Setting {
 
     /// Returns true if this setting was explicitly set by the user (i.e., not using the default value).
     fn is_value_explicitly_set(&self) -> bool;
+}
+
+/// A trait that maps a setting to the change event of its settings group.
+///
+/// The setting macros implement this trait for each setting they define. This
+/// lets the shared `Setting` implementations construct the correct group event
+/// variant without expanding per-setting event code at each emit site.
+pub trait SettingChangeEvent: Setting {
+    /// Returns the group event that reports a change to this setting for the
+    /// given reason.
+    fn change_event(reason: ChangeEventReason) -> <Self::Group as Entity>::Event;
 }
 
 /// Shared persistence operations for typed settings backed by secure storage.

--- a/crates/settings/src/macros.rs
+++ b/crates/settings/src/macros.rs
@@ -319,13 +319,12 @@ macro_rules! define_setting {
                 &mut self,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 Self::clear_from_preferences(Self::preferences_for_setting(ctx))?;
                 self.inner = self.validate(Self::default_value());
                 self.is_explicitly_set = false;
-                ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                    change_event_reason: ChangeEventReason::Clear,
-                }}));
+                ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                    $crate::ChangeEventReason::Clear,
+                ));
                 Ok(())
             }
 
@@ -334,15 +333,14 @@ macro_rules! define_setting {
                 new_value: Self::Value,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 let changed_in_storage =
                     Self::write_to_preferences(&new_value, Self::preferences_for_setting(ctx))?;
                 if self.value() != &new_value || changed_in_storage {
                     self.inner = self.validate(new_value);
                     self.is_explicitly_set = true;
-                    ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                        change_event_reason: ChangeEventReason::CloudSync,
-                    }}));
+                    ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                        $crate::ChangeEventReason::CloudSync,
+                    ));
                 }
                 Ok(())
             }
@@ -352,15 +350,14 @@ macro_rules! define_setting {
                 new_value: Self::Value,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 let changed_in_storage =
                     Self::write_to_preferences(&new_value, Self::preferences_for_setting(ctx))?;
                 if self.value() != &new_value || changed_in_storage {
                     self.inner = self.validate(new_value);
                     self.is_explicitly_set = true;
-                    ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                        change_event_reason: ChangeEventReason::LocalChange,
-                    }}));
+                    ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                        $crate::ChangeEventReason::LocalChange,
+                    ));
                 }
                 Ok(())
             }
@@ -371,14 +368,13 @@ macro_rules! define_setting {
                 explicitly_set: bool,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 let validated = self.validate(new_value);
                 if self.value() != &validated || self.is_explicitly_set != explicitly_set {
                     self.inner = validated;
                     self.is_explicitly_set = explicitly_set;
-                    ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                        change_event_reason: ChangeEventReason::LocalChange,
-                    }}));
+                    ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                        $crate::ChangeEventReason::LocalChange,
+                    ));
                 }
                 Ok(())
             }
@@ -410,6 +406,16 @@ macro_rules! define_setting {
                 self.value()
             }
         }
+
+        $crate::macros::concat_idents!(EventName = $group, ChangedEvent {
+            impl $crate::SettingChangeEvent for $name {
+                fn change_event(reason: $crate::ChangeEventReason) -> EventName {
+                    EventName::$name {
+                        change_event_reason: reason,
+                    }
+                }
+            }
+        });
 
         $crate::submit_schema_entry!(
             private: $private,
@@ -596,12 +602,11 @@ macro_rules! implement_setting_for_enum {
                 &mut self,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 Self::clear_from_preferences(Self::preferences_for_setting(ctx))?;
                 *self = self.validate(Self::default_value());
-                ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                    change_event_reason: ChangeEventReason::Clear,
-                }}));
+                ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                    $crate::ChangeEventReason::Clear,
+                ));
                 Ok(())
             }
 
@@ -610,14 +615,13 @@ macro_rules! implement_setting_for_enum {
                 new_value: Self::Value,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 let changed_in_storage =
                     Self::write_to_preferences(&new_value, Self::preferences_for_setting(ctx))?;
                 if self.value() != &new_value || changed_in_storage {
                     *self = self.validate(new_value);
-                    ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                        change_event_reason: ChangeEventReason::CloudSync,
-                    }}));
+                    ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                        $crate::ChangeEventReason::CloudSync,
+                    ));
                 }
                 Ok(())
             }
@@ -627,14 +631,13 @@ macro_rules! implement_setting_for_enum {
                 new_value: Self::Value,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 let changed_in_storage =
                     Self::write_to_preferences(&new_value, Self::preferences_for_setting(ctx))?;
                 if self.value() != &new_value || changed_in_storage {
                     *self = self.validate(new_value);
-                    ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                        change_event_reason: ChangeEventReason::LocalChange,
-                    }}));
+                    ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                        $crate::ChangeEventReason::LocalChange,
+                    ));
                 }
                 Ok(())
             }
@@ -645,13 +648,12 @@ macro_rules! implement_setting_for_enum {
                 _explicitly_set: bool,
                 ctx: &mut $crate::warpui_core::ModelContext<Self::Group>,
             ) -> anyhow::Result<()> {
-                use $crate::ChangeEventReason;
                 let validated = self.validate(new_value);
                 if self.value() != &validated {
                     *self = validated;
-                    ctx.emit($crate::macros::concat_idents!(EventName = $group, ChangedEvent { EventName::$name {
-                        change_event_reason: ChangeEventReason::LocalChange,
-                    }}));
+                    ctx.emit(<Self as $crate::SettingChangeEvent>::change_event(
+                        $crate::ChangeEventReason::LocalChange,
+                    ));
                 }
                 Ok(())
             }
@@ -676,6 +678,16 @@ macro_rules! implement_setting_for_enum {
             }
             )?
         }
+
+        $crate::macros::concat_idents!(EventName = $group, ChangedEvent {
+            impl $crate::SettingChangeEvent for $name {
+                fn change_event(reason: $crate::ChangeEventReason) -> EventName {
+                    EventName::$name {
+                        change_event_reason: reason,
+                    }
+                }
+            }
+        });
 
         $crate::submit_schema_entry!(
             private: $private,
@@ -810,158 +822,50 @@ pub use define_settings_group;
 #[macro_export]
 macro_rules! register_settings_events {
     ( $group:ident, $var:ident, $setting:ident, $handle:expr, $ctx:expr ) => {{
-        $crate::macros::generate_settings_event_fn!($group, $var, $setting);
-
-        concat_idents::concat_idents!(fn_name = register_events_for_, $setting, {
-            fn_name($handle, $ctx);
-        });
+        // The callback bodies must expand here, with the concrete setting
+        // type, so an inherent method on the setting (for example
+        // `current_value_is_syncable`) can shadow the `Setting` trait
+        // default, exactly as in the formerly expanded registration code.
+        $crate::registration::register_setting_events::<$setting, _>(
+            $handle,
+            $crate::registration::SettingCallbacks {
+                apply_set: |settings_group: &mut $group, value, from_cloud_sync, ctx| {
+                    use $crate::Setting as _;
+                    if from_cloud_sync {
+                        settings_group.$var.set_value_from_cloud_sync(value, ctx)
+                    } else {
+                        settings_group.$var.set_value(value, ctx)
+                    }
+                },
+                apply_clear: |settings_group: &mut $group, ctx| {
+                    use $crate::Setting as _;
+                    if settings_group
+                        .$var
+                        .is_setting_syncable_on_current_platform(true)
+                    {
+                        log::debug!(
+                            "Clearing cloud synced setting from local storage: {}",
+                            <$setting as $crate::Setting>::storage_key()
+                        );
+                        settings_group.$var.clear_value(ctx)
+                    } else {
+                        Ok(())
+                    }
+                },
+                apply_load: |settings_group: &mut $group, value, explicitly_set, ctx| {
+                    use $crate::Setting as _;
+                    settings_group.$var.load_value(value, explicitly_set, ctx)
+                },
+                current_value_is_syncable: |settings_group: &$group| {
+                    use $crate::Setting as _;
+                    settings_group.$var.current_value_is_syncable()
+                },
+            },
+            $ctx,
+        );
     }};
 }
 pub use register_settings_events;
-
-/// Generates a function that can be used to register event handlers for a
-/// for letting the SettingsManager know when a setting has been updated.
-/// Used for managing the flow of events for local and cloud settings.
-#[macro_export]
-macro_rules! generate_settings_event_fn {
-    ( $group:ident, $var:ident, $setting:ident ) => {
-        concat_idents::concat_idents!(fn_name = register_events_for_, $setting, {
-            #[allow(dead_code)]
-            #[allow(non_snake_case)]
-            fn fn_name(
-                settings_group: $crate::warpui_core::ModelHandle<$group>,
-                ctx: &mut (
-                         impl $crate::warpui_core::GetSingletonModelHandle
-                         + $crate::warpui_core::AddSingletonModel
-                         + $crate::warpui_core::UpdateModel
-                     ),
-            ) {
-                use anyhow::anyhow;
-                use serde_json;
-                use $crate::Setting as _;
-                use $crate::manager::{SettingsEvent, SettingsManager};
-                use $crate::warpui_core::SingletonEntity;
-                SettingsManager::handle(ctx).update(ctx, |manager, ctx| {
-                    // Propagate per settings change events through the SettingsManager
-                    ctx.subscribe_to_model(&settings_group, |_manager, _, _, ctx| {
-                        ctx.emit(SettingsEvent::LocalPreferencesUpdated {
-                            storage_key: $setting::storage_key().to_string(),
-                            sync_to_cloud: $setting::sync_to_cloud(),
-                        });
-                    });
-                    // Register callbacks for updating individual settings model by storage key
-                    let settings_group_update_clone = settings_group.clone();
-                    let settings_group_reset_clone = settings_group.clone();
-                    let settings_group_load_clone = settings_group.clone();
-                    let settings_group_is_syncable_clone = settings_group.clone();
-                    let serialized_default_value =
-                        serde_json::to_string(&$setting::default_value())
-                            .expect("default should serialize");
-                    let file_serialized_default_value = {
-                        use $crate::_settings_value::SettingsValue as _;
-                        let file_value = $setting::default_value().to_file_value();
-                        serde_json::to_string(&file_value)
-                            .expect("default file value should serialize")
-                    };
-                    manager.register_setting(
-                        $setting::storage_key(),
-                        $setting::sync_to_cloud(),
-                        $setting::supported_platforms(),
-                        serialized_default_value,
-                        file_serialized_default_value,
-                        $setting::hierarchy(),
-                        $setting::toml_key(),
-                        $setting::max_table_depth(),
-                        $setting::is_private(),
-                        move |value, from_cloud_sync, ctx| {
-                            use $crate::_settings_value::SettingsValue as _;
-                            // Try SettingsValue first (handles snake_case enums etc.),
-                            // then fall back to serde for cloud sync values.
-                            let value = serde_json::from_str::<serde_json::Value>(&value)
-                                .ok()
-                                .and_then(|json_val| {
-                                    <$setting as $crate::Setting>::Value::from_file_value(&json_val)
-                                })
-                                .or_else(|| serde_json::from_str(&value).ok());
-                            let Some(value) = value else {
-                                return Err(anyhow!(
-                                    "Failed to parse updated value for setting {}: Not updating",
-                                    $setting::storage_key()
-                                ));
-                            };
-                            settings_group_update_clone.update(ctx, |settings_group, ctx| {
-                                if from_cloud_sync {
-                                    settings_group.$var.set_value_from_cloud_sync(value, ctx)
-                                } else {
-                                    settings_group.$var.set_value(value, ctx)
-                                }
-                            })
-                        },
-                        move |ctx| {
-                            settings_group_reset_clone.update(ctx, |settings_group, ctx| {
-                                if settings_group
-                                    .$var
-                                    .is_setting_syncable_on_current_platform(true)
-                                {
-                                    log::debug!(
-                                        "Clearing cloud synced setting from local storage: {}",
-                                        $setting::storage_key()
-                                    );
-                                    settings_group.$var.clear_value(ctx)
-                                } else {
-                                    Ok(())
-                                }
-                            })
-                        },
-                        move |value, explicitly_set, ctx| {
-                            use $crate::_settings_value::SettingsValue as _;
-                            let value = serde_json::from_str::<serde_json::Value>(&value)
-                                .ok()
-                                .and_then(|json_val| {
-                                    <$setting as $crate::Setting>::Value::from_file_value(&json_val)
-                                })
-                                .or_else(|| serde_json::from_str(&value).ok());
-                            let Some(value) = value else {
-                                return Err(anyhow!(
-                                    "Failed to parse loaded value for setting {}: Not loading",
-                                    $setting::storage_key()
-                                ));
-                            };
-                            settings_group_load_clone.update(ctx, |settings_group, ctx| {
-                                settings_group.$var.load_value(value, explicitly_set, ctx)
-                            })
-                        },
-                        |left, right| {
-                            use $crate::_settings_value::SettingsValue as _;
-                            let parse =
-                                |s: &str| -> anyhow::Result<<$setting as $crate::Setting>::Value> {
-                                    let json_val = serde_json::from_str::<serde_json::Value>(s)?;
-                                    <$setting as $crate::Setting>::Value::from_file_value(&json_val)
-                                        .or_else(|| serde_json::from_str(s).ok())
-                                        .ok_or_else(|| {
-                                            anyhow!(
-                                                "Failed to parse value for {}",
-                                                $setting::storage_key()
-                                            )
-                                        })
-                                };
-                            let left_setting = $setting::new(Some(parse(left)?));
-                            let right_setting = $setting::new(Some(parse(right)?));
-                            Ok(left_setting.value() == right_setting.value())
-                        },
-                        move |ctx| {
-                            settings_group_is_syncable_clone
-                                .as_ref(ctx)
-                                .$var
-                                .current_value_is_syncable()
-                        },
-                    );
-                });
-            }
-        });
-    };
-}
-pub use generate_settings_event_fn;
 
 #[cfg(test)]
 #[path = "macros_tests.rs"]

--- a/crates/settings/src/macros.rs
+++ b/crates/settings/src/macros.rs
@@ -822,10 +822,9 @@ pub use define_settings_group;
 #[macro_export]
 macro_rules! register_settings_events {
     ( $group:ident, $var:ident, $setting:ident, $handle:expr, $ctx:expr ) => {{
-        // The callback bodies must expand here, with the concrete setting
-        // type, so an inherent method on the setting (for example
-        // `current_value_is_syncable`) can shadow the `Setting` trait
-        // default, exactly as in the formerly expanded registration code.
+        // The callback bodies must expand here with the concrete setting type
+        // so an inherent method on the setting (for example
+        // `current_value_is_syncable`) can shadow the `Setting` trait default.
         $crate::registration::register_setting_events::<$setting, _>(
             $handle,
             $crate::registration::SettingCallbacks {

--- a/crates/settings/src/registration.rs
+++ b/crates/settings/src/registration.rs
@@ -1,0 +1,213 @@
+//! Runtime support for wiring settings into the [`SettingsManager`].
+//!
+//! The `register_settings_events!` macro used to expand the full registration
+//! body for every setting. The macro now only builds [`SettingCallbacks`] (a
+//! set of small function pointers with concrete types) and calls
+//! [`register_setting_events`]. The registration body lives here in functions
+//! that are generic over the group model and the value type, so settings that
+//! share those types share one compiled instantiation.
+
+use anyhow::{Result, anyhow};
+use serde::de::DeserializeOwned;
+use settings_value::SettingsValue;
+use warpui_core::{
+    AddSingletonModel, Entity, GetSingletonModelHandle, ModelContext, ModelHandle, SingletonEntity,
+    UpdateModel,
+};
+
+use crate::manager::{SettingsEvent, SettingsManager};
+use crate::{Setting, SupportedPlatforms, SyncToCloud};
+
+/// Parses a serialized setting value. Tries the settings-file representation
+/// first (which handles snake_case enums and other file forms), then falls
+/// back to plain serde for cloud sync values.
+fn parse_value<V: SettingsValue + DeserializeOwned>(serialized: &str) -> Option<V> {
+    serde_json::from_str::<serde_json::Value>(serialized)
+        .ok()
+        .and_then(|json_val| V::from_file_value(&json_val))
+        .or_else(|| serde_json::from_str(serialized).ok())
+}
+
+/// Strict variant of [`parse_value`] for the equality callback. It propagates
+/// JSON syntax errors, so validation can detect malformed stored values.
+fn parse_value_strict<V: SettingsValue + DeserializeOwned>(
+    serialized: &str,
+    storage_key: &'static str,
+) -> Result<V> {
+    let json_val = serde_json::from_str::<serde_json::Value>(serialized)?;
+    V::from_file_value(&json_val)
+        .or_else(|| serde_json::from_str(serialized).ok())
+        .ok_or_else(|| anyhow!("Failed to parse value for {}", storage_key))
+}
+
+/// Compares two serialized values of the given setting for semantic equality.
+fn equals_serialized<S: Setting>(left: &str, right: &str) -> Result<bool> {
+    let left_setting = S::new(Some(parse_value_strict::<S::Value>(
+        left,
+        S::storage_key(),
+    )?));
+    let right_setting = S::new(Some(parse_value_strict::<S::Value>(
+        right,
+        S::storage_key(),
+    )?));
+    Ok(left_setting.value() == right_setting.value())
+}
+
+/// Typed operations on one setting within its group model.
+///
+/// The `register_settings_events!` macro constructs this struct at its
+/// expansion site, with the concrete group and setting types. This keeps the
+/// method resolution of the formerly expanded registration code: an inherent
+/// method on the setting type (for example `current_value_is_syncable`) can
+/// still shadow the [`Setting`] trait default.
+pub struct SettingCallbacks<G: Entity, V> {
+    /// Applies an updated value with `set_value`, or with
+    /// `set_value_from_cloud_sync` when the second argument is true.
+    pub apply_set: fn(&mut G, V, bool, &mut ModelContext<G>) -> Result<()>,
+    /// Clears the setting from local storage when its value is syncable on
+    /// the current platform.
+    pub apply_clear: fn(&mut G, &mut ModelContext<G>) -> Result<()>,
+    /// Loads a value into memory with `load_value`; the second argument is
+    /// whether the value was explicitly set.
+    pub apply_load: fn(&mut G, V, bool, &mut ModelContext<G>) -> Result<()>,
+    /// Reports whether the setting's current value should sync to the cloud.
+    pub current_value_is_syncable: fn(&G) -> bool,
+}
+
+impl<G: Entity, V> Clone for SettingCallbacks<G, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<G: Entity, V> Copy for SettingCallbacks<G, V> {}
+
+/// The per-setting values that [`register_setting_events`] gathers from the
+/// [`Setting`] trait before it hands off to the shared registration body.
+struct SettingMetadata {
+    storage_key: &'static str,
+    sync_to_cloud: SyncToCloud,
+    supported_platforms: SupportedPlatforms,
+    serialized_default_value: String,
+    file_serialized_default_value: String,
+    hierarchy: Option<&'static str>,
+    toml_key: &'static str,
+    max_table_depth: Option<u32>,
+    is_private: bool,
+}
+
+/// Registers listeners for settings events that get piped through the
+/// [`SettingsManager`]. These events allow anyone to listen to settings
+/// changes based on storage key rather than individual settings models.
+///
+/// This function gathers the per-setting metadata and then delegates to a
+/// body that is generic over only the group and value types, which keeps the
+/// per-setting compiled code small.
+pub fn register_setting_events<S, C>(
+    settings_group: ModelHandle<S::Group>,
+    callbacks: SettingCallbacks<S::Group, S::Value>,
+    ctx: &mut C,
+) where
+    S: Setting + 'static,
+    <S::Group as Entity>::Event: 'static,
+    C: GetSingletonModelHandle + AddSingletonModel + UpdateModel,
+{
+    let serialized_default_value =
+        serde_json::to_string(&S::default_value()).expect("default should serialize");
+    let file_serialized_default_value = {
+        let file_value = S::default_value().to_file_value();
+        serde_json::to_string(&file_value).expect("default file value should serialize")
+    };
+    register_setting_events_impl(
+        settings_group,
+        SettingMetadata {
+            storage_key: S::storage_key(),
+            sync_to_cloud: S::sync_to_cloud(),
+            supported_platforms: S::supported_platforms(),
+            serialized_default_value,
+            file_serialized_default_value,
+            hierarchy: S::hierarchy(),
+            toml_key: S::toml_key(),
+            max_table_depth: S::max_table_depth(),
+            is_private: S::is_private(),
+        },
+        callbacks,
+        equals_serialized::<S>,
+        ctx,
+    );
+}
+
+/// The shared registration body. Generic only over the group model, the
+/// value type, and the context, so settings that share those types share one
+/// compiled instantiation.
+fn register_setting_events_impl<G, V, C>(
+    settings_group: ModelHandle<G>,
+    metadata: SettingMetadata,
+    callbacks: SettingCallbacks<G, V>,
+    equals: fn(&str, &str) -> Result<bool>,
+    ctx: &mut C,
+) where
+    G: Entity,
+    G::Event: 'static,
+    V: SettingsValue + DeserializeOwned + 'static,
+    C: GetSingletonModelHandle + AddSingletonModel + UpdateModel,
+{
+    SettingsManager::handle(ctx).update(ctx, |manager, ctx| {
+        let storage_key = metadata.storage_key;
+        let sync_to_cloud = metadata.sync_to_cloud;
+        // Propagate per settings change events through the SettingsManager.
+        ctx.subscribe_to_model(&settings_group, move |_manager, _, _, ctx| {
+            ctx.emit(SettingsEvent::LocalPreferencesUpdated {
+                storage_key: storage_key.to_string(),
+                sync_to_cloud,
+            });
+        });
+        // Register callbacks for updating individual settings model by storage key.
+        let settings_group_update_clone = settings_group.clone();
+        let settings_group_reset_clone = settings_group.clone();
+        let settings_group_load_clone = settings_group.clone();
+        let settings_group_is_syncable_clone = settings_group.clone();
+        manager.register_setting(
+            metadata.storage_key,
+            metadata.sync_to_cloud,
+            metadata.supported_platforms,
+            metadata.serialized_default_value,
+            metadata.file_serialized_default_value,
+            metadata.hierarchy,
+            metadata.toml_key,
+            metadata.max_table_depth,
+            metadata.is_private,
+            move |value, from_cloud_sync, ctx| {
+                let Some(value) = parse_value::<V>(&value) else {
+                    return Err(anyhow!(
+                        "Failed to parse updated value for setting {}: Not updating",
+                        storage_key
+                    ));
+                };
+                settings_group_update_clone.update(ctx, |settings_group, ctx| {
+                    (callbacks.apply_set)(settings_group, value, from_cloud_sync, ctx)
+                })
+            },
+            move |ctx| {
+                settings_group_reset_clone.update(ctx, |settings_group, ctx| {
+                    (callbacks.apply_clear)(settings_group, ctx)
+                })
+            },
+            move |value, explicitly_set, ctx| {
+                let Some(value) = parse_value::<V>(&value) else {
+                    return Err(anyhow!(
+                        "Failed to parse loaded value for setting {}: Not loading",
+                        storage_key
+                    ));
+                };
+                settings_group_load_clone.update(ctx, |settings_group, ctx| {
+                    (callbacks.apply_load)(settings_group, value, explicitly_set, ctx)
+                })
+            },
+            equals,
+            move |ctx| {
+                (callbacks.current_value_is_syncable)(settings_group_is_syncable_clone.as_ref(ctx))
+            },
+        );
+    });
+}

--- a/crates/settings/src/registration.rs
+++ b/crates/settings/src/registration.rs
@@ -1,11 +1,8 @@
 //! Runtime support for wiring settings into the [`SettingsManager`].
 //!
-//! The `register_settings_events!` macro used to expand the full registration
-//! body for every setting. The macro now only builds [`SettingCallbacks`] (a
-//! set of small function pointers with concrete types) and calls
-//! [`register_setting_events`]. The registration body lives here in functions
-//! that are generic over the group model and the value type, so settings that
-//! share those types share one compiled instantiation.
+//! The registration body is generic over the group model and value type so
+//! settings that share those types share one compiled instantiation, while
+//! [`SettingCallbacks`] preserves setting-specific method resolution.
 
 use anyhow::{Result, anyhow};
 use serde::de::DeserializeOwned;
@@ -56,10 +53,10 @@ fn equals_serialized<S: Setting>(left: &str, right: &str) -> Result<bool> {
 /// Typed operations on one setting within its group model.
 ///
 /// The `register_settings_events!` macro constructs this struct at its
-/// expansion site, with the concrete group and setting types. This keeps the
-/// method resolution of the formerly expanded registration code: an inherent
-/// method on the setting type (for example `current_value_is_syncable`) can
-/// still shadow the [`Setting`] trait default.
+/// expansion site, with the concrete group and setting types. This keeps
+/// method resolution local to the concrete setting, so an inherent method
+/// (for example `current_value_is_syncable`) can shadow the [`Setting`] trait
+/// default.
 pub struct SettingCallbacks<G: Entity, V> {
     /// Applies an updated value with `set_value`, or with
     /// `set_value_from_cloud_sync` when the second argument is true.


### PR DESCRIPTION
## Description

This is PR 2 of 3 in a stack that reduces the compile time of the `warp` crate. It is stacked on #15453.

The settings macros are the largest single source of macro-expanded code in the `warp` crate. Before this change, they produced 10.7 MB of the 36.7 MB total macro expansion, and the settings registration path produced about 660K lines of LLVM IR.

This PR makes two changes:

1. **Move the registration body out of the macro.** The `register_settings_events!` macro expanded a full registration function (parse, update, clear, load, equality, and syncable callbacks) for every one of the ~300 registered settings. The body now lives in `settings::registration::register_setting_events_impl`, which is generic over only the settings group type and the value type. Settings that share those two types (for example, the many `bool` settings in one group) now share one compiled instantiation. A thin per-setting wrapper gathers the `Setting` trait metadata (storage key, defaults, platforms, and so on) into a plain struct before it hands off to the shared body.
2. **Emit change events through a trait.** `define_setting!` and `implement_setting_for_enum!` expanded four separate `concat_idents!` blocks per setting to construct the group's `*ChangedEvent` variant at each emit site. Each setting now gets one small `SettingChangeEvent` impl, and the emit sites call `<Self as SettingChangeEvent>::change_event(reason)`. This cuts `concat_idents!` from 606 uses (2.49 MB) to 351 uses (0.13 MB).

### How method resolution is preserved

The old macro expansion called setting methods (for example `set_value` and `current_value_is_syncable`) at the expansion site. This matters: `Theme`, `SystemThemes`, and one test type define *inherent* `current_value_is_syncable` methods that shadow the `Setting` trait default. To keep this behavior, the macro builds a `SettingCallbacks` struct of function pointers at its expansion site. Each callback is a small non-capturing closure with the concrete setting type, so inherent methods still shadow trait defaults exactly as before. The shared generic body only invokes the function pointers.

### Alternatives considered and discarded

- **Per-setting generic function (measured).** A first version kept the whole body generic over the setting type `S`. It removed the macro bytes but only cut 22K IR lines (−0.13%), because the body still monomorphized once per setting. The (group, value) split in this PR cuts the registration path from 660K to 238K IR lines.
- **Trait default method on `Setting`.** Moving the body into a default method has the same per-setting monomorphization problem, and it changes method resolution for the shadowed inherent methods.
- **Full type erasure with `Box<dyn Any>`.** This would compile the body exactly once, but it needs runtime downcasts on every settings update and loses type safety. The (group, value) fn-pointer design gets most of the win with no runtime cost.
- **Group-level registration aggregation.** Registering a whole group in one call could remove more per-setting glue, but it is a larger behavioral change and risks the schema byte-identity guarantee. It can be a follow-up.

### Measured results (Apple M5 Pro, rustc 1.92.0, dev profile, relative to PR 1)

- `cargo llvm-lines -p warp --lib`: 17,279,212 → 17,022,929 lines (−1.5%); copies 580,747 → 573,201. The settings registration path drops from ~660K to ~238K lines (−64%).
- Macro expansion (`-Zmacro-stats`): 36.7 MB → 32.2 MB (−12.4% versus master). The 1.99 MB `generate_settings_event_fn!` output is gone.
- Touch-incremental rebuild of the `warp` lib: unchanged (15.4/14.8 s versus 15.4/14.6 s).
- Clean rebuild of the `warp` lib (deps cached): unchanged within run-to-run noise (71–74 s versus 68 s; master measured ~71 s on the same machine).

The wall-clock effect of this PR alone is within measurement noise. The change still removes a large fixed cost from macro expansion and codegen, and it makes each new setting much cheaper to add.

## Linked Issue
N/A — compile-time work from a profiling session.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo nextest run -p settings`: 71/71 passed.
- `cargo nextest run -p warp -E 'test(cloud_preferences) or test(theme) or test(/settings::/)'`: 168/168 passed.
- `generate_settings_schema` output (221 settings) is byte-identical to the output on the base branch.
- `./script/format` and all presubmit clippy passes are clean.

This is a pure refactor with no user-visible behavior change, so no new tests were added. The schema byte-identity check plus the existing settings test suite cover the behavior that could regress.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Warp conversation](https://staging.warp.dev/conversation/024e797d-1d35-4c62-8394-abf93f7ddb0e)

Co-Authored-By: Warp <agent@warp.dev>

CHANGELOG-NONE
