### PR TITLE
Compile time: replace serde Content buffering with JSON-value deserializers

### DIFF
--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -2189,7 +2189,13 @@ pub struct MCPServer {
 }
 
 /// Contains context that may be attached to a user query.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Serialization derives the externally tagged form for the named variants,
+/// with `Block` serialized untagged as a bare [`BlockContext`] object.
+/// Deserialization is hand-written below and must accept exactly those
+/// forms; it avoids the generic buffering machinery that serde generates for
+/// enums that mix tagged and untagged variants.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum AIAgentContext {
     Directory {
         pwd: Option<String>,
@@ -2246,19 +2252,14 @@ pub enum AIAgentContext {
     /// Information about the GitHub pull request associated with the current branch.
     PullRequest {
         /// The pull request number.
-        #[serde(default, deserialize_with = "deserialize_pull_request_number")]
         number: i32,
         /// The pull request state (for example, `OPEN`, `MERGED`, or `CLOSED`).
-        #[serde(default)]
         state: String,
         /// Whether the pull request is marked as draft.
-        #[serde(default)]
         draft: bool,
         /// The pull request's base branch.
-        #[serde(default)]
         base_branch: String,
         /// The full URL of the pull request (e.g. "https://github.com/owner/repo/pull/123").
-        #[serde(default)]
         url: String,
     },
 
@@ -2270,6 +2271,131 @@ pub enum AIAgentContext {
 
     #[serde(untagged)]
     Block(Box<BlockContext>),
+}
+
+/// The tagged variants of [`AIAgentContext`], used by its hand-written
+/// `Deserialize` implementation. The variant and field shapes must stay
+/// identical to [`AIAgentContext`] so the serialized forms match.
+#[derive(Deserialize)]
+enum AIAgentContextTagged {
+    Directory {
+        pwd: Option<String>,
+        home_dir: Option<String>,
+        are_file_symbols_indexed: bool,
+    },
+    SelectedText(String),
+    ExecutionEnvironment(WarpAiExecutionContext),
+    CurrentTime {
+        current_time: DateTime<Local>,
+    },
+    Image(ImageContext),
+    Codebase {
+        path: String,
+        name: String,
+    },
+    ProjectRules {
+        root_path: String,
+        active_rules: Vec<FileContext>,
+        additional_rule_paths: Vec<String>,
+    },
+    File(FileContext),
+    Git {
+        head: String,
+        branch: Option<String>,
+    },
+    Repository {
+        name: String,
+        owner: Option<String>,
+        host: Option<String>,
+    },
+    PullRequest {
+        #[serde(default, deserialize_with = "deserialize_pull_request_number")]
+        number: i32,
+        #[serde(default)]
+        state: String,
+        #[serde(default)]
+        draft: bool,
+        #[serde(default)]
+        base_branch: String,
+        #[serde(default)]
+        url: String,
+    },
+    Skills {
+        skills: Vec<SkillDescriptor>,
+    },
+}
+
+impl From<AIAgentContextTagged> for AIAgentContext {
+    fn from(tagged: AIAgentContextTagged) -> Self {
+        match tagged {
+            AIAgentContextTagged::Directory {
+                pwd,
+                home_dir,
+                are_file_symbols_indexed,
+            } => AIAgentContext::Directory {
+                pwd,
+                home_dir,
+                are_file_symbols_indexed,
+            },
+            AIAgentContextTagged::SelectedText(text) => AIAgentContext::SelectedText(text),
+            AIAgentContextTagged::ExecutionEnvironment(context) => {
+                AIAgentContext::ExecutionEnvironment(context)
+            }
+            AIAgentContextTagged::CurrentTime { current_time } => {
+                AIAgentContext::CurrentTime { current_time }
+            }
+            AIAgentContextTagged::Image(image) => AIAgentContext::Image(image),
+            AIAgentContextTagged::Codebase { path, name } => {
+                AIAgentContext::Codebase { path, name }
+            }
+            AIAgentContextTagged::ProjectRules {
+                root_path,
+                active_rules,
+                additional_rule_paths,
+            } => AIAgentContext::ProjectRules {
+                root_path,
+                active_rules,
+                additional_rule_paths,
+            },
+            AIAgentContextTagged::File(file) => AIAgentContext::File(file),
+            AIAgentContextTagged::Git { head, branch } => AIAgentContext::Git { head, branch },
+            AIAgentContextTagged::Repository { name, owner, host } => {
+                AIAgentContext::Repository { name, owner, host }
+            }
+            AIAgentContextTagged::PullRequest {
+                number,
+                state,
+                draft,
+                base_branch,
+                url,
+            } => AIAgentContext::PullRequest {
+                number,
+                state,
+                draft,
+                base_branch,
+                url,
+            },
+            AIAgentContextTagged::Skills { skills } => AIAgentContext::Skills { skills },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AIAgentContext {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Buffer the input into one JSON value, then try the tagged variants
+        // and fall back to the untagged Block variant. This matches the
+        // behavior of serde's derive for mixed tagged and untagged enums.
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match AIAgentContextTagged::deserialize(&value) {
+            Ok(tagged) => Ok(tagged.into()),
+            Err(tagged_error) => BlockContext::deserialize(&value)
+                .map(|block| AIAgentContext::Block(Box::new(block)))
+                .map_err(|_| serde::de::Error::custom(tagged_error)),
+        }
+    }
 }
 
 fn deserialize_pull_request_number<'de, D>(deserializer: D) -> Result<i32, D::Error>
@@ -2339,7 +2465,12 @@ pub enum DocumentContentAttachmentSource {
     PlanEdited,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Serialization derives the externally tagged form for the named variants,
+/// with `Block` serialized untagged as a bare [`BlockContext`] object.
+/// Deserialization is hand-written below and must accept exactly those
+/// forms; it avoids the generic buffering machinery that serde generates for
+/// enums that mix tagged and untagged variants.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum AIAgentAttachment {
     PlainText(String),
     DocumentContent {
@@ -2382,6 +2513,118 @@ pub enum AIAgentAttachment {
     },
     #[serde(untagged)]
     Block(BlockContext),
+}
+
+/// The tagged variants of [`AIAgentAttachment`], used by its hand-written
+/// `Deserialize` implementation. The variant and field shapes must stay
+/// identical to [`AIAgentAttachment`] so the serialized forms match.
+#[derive(Deserialize)]
+enum AIAgentAttachmentTagged {
+    PlainText(String),
+    DocumentContent {
+        document_id: String,
+        content: String,
+        source: DocumentContentAttachmentSource,
+        line_range: Option<Range<LineCount>>,
+    },
+    DriveObject {
+        uid: String,
+        payload: Option<DriveObjectPayload>,
+    },
+    DiffHunk {
+        file_path: String,
+        line_range: Range<LineCount>,
+        diff_content: String,
+        lines_added: u32,
+        lines_removed: u32,
+        current: Option<CurrentHead>,
+        base: DiffBase,
+    },
+    DiffSet {
+        file_diffs: HashMap<String, Vec<DiffSetHunk>>,
+        current: Option<CurrentHead>,
+        base: DiffBase,
+    },
+    FilePathReference {
+        file_id: String,
+        file_name: String,
+        file_path: String,
+    },
+}
+
+impl From<AIAgentAttachmentTagged> for AIAgentAttachment {
+    fn from(tagged: AIAgentAttachmentTagged) -> Self {
+        match tagged {
+            AIAgentAttachmentTagged::PlainText(text) => AIAgentAttachment::PlainText(text),
+            AIAgentAttachmentTagged::DocumentContent {
+                document_id,
+                content,
+                source,
+                line_range,
+            } => AIAgentAttachment::DocumentContent {
+                document_id,
+                content,
+                source,
+                line_range,
+            },
+            AIAgentAttachmentTagged::DriveObject { uid, payload } => {
+                AIAgentAttachment::DriveObject { uid, payload }
+            }
+            AIAgentAttachmentTagged::DiffHunk {
+                file_path,
+                line_range,
+                diff_content,
+                lines_added,
+                lines_removed,
+                current,
+                base,
+            } => AIAgentAttachment::DiffHunk {
+                file_path,
+                line_range,
+                diff_content,
+                lines_added,
+                lines_removed,
+                current,
+                base,
+            },
+            AIAgentAttachmentTagged::DiffSet {
+                file_diffs,
+                current,
+                base,
+            } => AIAgentAttachment::DiffSet {
+                file_diffs,
+                current,
+                base,
+            },
+            AIAgentAttachmentTagged::FilePathReference {
+                file_id,
+                file_name,
+                file_path,
+            } => AIAgentAttachment::FilePathReference {
+                file_id,
+                file_name,
+                file_path,
+            },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AIAgentAttachment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Buffer the input into one JSON value, then try the tagged variants
+        // and fall back to the untagged Block variant. This matches the
+        // behavior of serde's derive for mixed tagged and untagged enums.
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match AIAgentAttachmentTagged::deserialize(&value) {
+            Ok(tagged) => Ok(tagged.into()),
+            Err(tagged_error) => BlockContext::deserialize(&value)
+                .map(AIAgentAttachment::Block)
+                .map_err(|_| serde::de::Error::custom(tagged_error)),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/app/src/ai/agent/mod_tests.rs
+++ b/app/src/ai/agent/mod_tests.rs
@@ -17,6 +17,7 @@ use crate::ai::agent::{
     TransientNetworkErrorKind,
 };
 use crate::ai::block_context::BlockContext;
+use crate::ai_assistant::execution_context::{WarpAiExecutionContext, WarpAiOsContext};
 use crate::server::server_api::AIApiError;
 use crate::terminal::shell::ShellType;
 
@@ -384,6 +385,14 @@ fn ai_agent_context_round_trips_tagged_variants() {
             are_file_symbols_indexed: true,
         },
         AIAgentContext::SelectedText("selected text".to_string()),
+        AIAgentContext::ExecutionEnvironment(WarpAiExecutionContext {
+            os: WarpAiOsContext {
+                category: Some("MacOS".to_string()),
+                distribution: None,
+            },
+            shell_name: "zsh".to_string(),
+            shell_version: Some("5.9".to_string()),
+        }),
         AIAgentContext::CurrentTime {
             current_time: Utc
                 .with_ymd_and_hms(2024, 1, 15, 10, 30, 0)

--- a/app/src/ai/agent/mod_tests.rs
+++ b/app/src/ai/agent/mod_tests.rs
@@ -1,16 +1,22 @@
+use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use chrono::{Local, TimeZone, Utc};
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
+use warp_editor::render::model::LineCount;
 use warp_multi_agent_api::{FileContent, FileContentLineRange};
 
 use crate::ai::agent::{
-    AIAgentContext, AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, AIAgentText,
-    AIAgentTextSection, AgentOutputImage, AgentOutputImageLayout, AgentOutputMermaidDiagram,
-    AnyFileContent, FileContext, FormattedTextWrapper, MessageId, ProgrammingLanguage,
-    RenderableAIError, TransientNetworkErrorKind,
+    AIAgentAttachment, AIAgentContext, AIAgentOutput, AIAgentOutputMessage,
+    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AgentOutputImage,
+    AgentOutputImageLayout, AgentOutputMermaidDiagram, AnyFileContent, CurrentHead, DiffBase,
+    DiffSetHunk, DocumentContentAttachmentSource, DriveObjectPayload, FileContext,
+    FormattedTextWrapper, ImageContext, MessageId, ProgrammingLanguage, RenderableAIError,
+    TransientNetworkErrorKind,
 };
+use crate::ai::block_context::BlockContext;
 use crate::server::server_api::AIApiError;
 use crate::terminal::shell::ShellType;
 
@@ -347,6 +353,177 @@ fn format_for_copy_preserves_visual_markdown_sections() {
         output.format_for_copy(None),
         "Intro\n![Diagram](./diagram.png)\n```mermaid\ngraph TD\nA --> B\n```"
     );
+}
+
+fn sample_block_context() -> BlockContext {
+    BlockContext {
+        id: "block-1".to_string().into(),
+        index: 0.into(),
+        command: "ls".to_string(),
+        output: "file.txt".to_string(),
+        exit_code: 0.into(),
+        is_auto_attached: false,
+        started_ts: None,
+        finished_ts: None,
+        pwd: Some("/tmp".to_string()),
+        shell: None,
+        username: None,
+        hostname: None,
+        git_branch: None,
+        os: None,
+        session_id: None,
+    }
+}
+
+#[test]
+fn ai_agent_context_round_trips_tagged_variants() {
+    let contexts = vec![
+        AIAgentContext::Directory {
+            pwd: Some("/tmp/project".to_string()),
+            home_dir: Some("/Users/me".to_string()),
+            are_file_symbols_indexed: true,
+        },
+        AIAgentContext::SelectedText("selected text".to_string()),
+        AIAgentContext::CurrentTime {
+            current_time: Utc
+                .with_ymd_and_hms(2024, 1, 15, 10, 30, 0)
+                .unwrap()
+                .with_timezone(&Local),
+        },
+        AIAgentContext::Image(ImageContext {
+            data: "aGVsbG8=".to_string(),
+            mime_type: "image/png".to_string(),
+            file_name: "shot.png".to_string(),
+            is_figma: false,
+        }),
+        AIAgentContext::Codebase {
+            path: "/tmp/project".to_string(),
+            name: "project".to_string(),
+        },
+        AIAgentContext::ProjectRules {
+            root_path: "/tmp/project".to_string(),
+            active_rules: vec![FileContext::new(
+                "WARP.md".to_string(),
+                AnyFileContent::StringContent("Be nice.".to_string()),
+                None,
+                None,
+            )],
+            additional_rule_paths: vec!["sub/WARP.md".to_string()],
+        },
+        AIAgentContext::File(FileContext::new(
+            "a.txt".to_string(),
+            AnyFileContent::StringContent("hey\nyou".to_string()),
+            None,
+            None,
+        )),
+        AIAgentContext::Git {
+            head: "abc1234".to_string(),
+            branch: Some("main".to_string()),
+        },
+        AIAgentContext::Repository {
+            name: "warp".to_string(),
+            owner: Some("warpdotdev".to_string()),
+            host: Some("github.com".to_string()),
+        },
+        AIAgentContext::PullRequest {
+            number: 42,
+            state: "OPEN".to_string(),
+            draft: true,
+            base_branch: "main".to_string(),
+            url: "https://github.com/warpdotdev/warp/pull/42".to_string(),
+        },
+        AIAgentContext::Skills { skills: vec![] },
+    ];
+    for context in contexts {
+        let json = serde_json::to_value(&context).unwrap();
+        let deserialized: AIAgentContext = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, context);
+    }
+}
+
+#[test]
+fn ai_agent_context_round_trips_untagged_block_variant() {
+    let context = AIAgentContext::Block(Box::new(sample_block_context()));
+    let json = serde_json::to_value(&context).unwrap();
+    // The Block variant must serialize untagged, as a bare object.
+    assert!(
+        json.get("block_id").is_some(),
+        "expected untagged block object, got {json}"
+    );
+    let deserialized: AIAgentContext = serde_json::from_value(json).unwrap();
+    assert_eq!(deserialized, context);
+}
+
+#[test]
+fn ai_agent_context_rejects_unknown_variants() {
+    let result = serde_json::from_str::<AIAgentContext>(r#"{"NotARealVariant":{}}"#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn ai_agent_attachment_round_trips_tagged_variants() {
+    let attachments = vec![
+        AIAgentAttachment::PlainText("hello".to_string()),
+        AIAgentAttachment::DocumentContent {
+            document_id: "doc-1".to_string(),
+            content: "# Plan".to_string(),
+            source: DocumentContentAttachmentSource::UserAttached,
+            line_range: Some(LineCount::range(1..5)),
+        },
+        AIAgentAttachment::DriveObject {
+            uid: "drive-1".to_string(),
+            payload: Some(DriveObjectPayload::Workflow {
+                name: "deploy".to_string(),
+                description: "Deploy the app".to_string(),
+                command: "make deploy".to_string(),
+            }),
+        },
+        AIAgentAttachment::DiffHunk {
+            file_path: "src/main.rs".to_string(),
+            line_range: LineCount::range(1..3),
+            diff_content: "+fn main() {}".to_string(),
+            lines_added: 1,
+            lines_removed: 0,
+            current: Some(CurrentHead::BranchName("feature".to_string())),
+            base: DiffBase::BranchName("main".to_string()),
+        },
+        AIAgentAttachment::DiffSet {
+            file_diffs: HashMap::from([(
+                "src/main.rs".to_string(),
+                vec![DiffSetHunk {
+                    line_range: LineCount::range(1..3),
+                    diff_content: "+use std::fmt;".to_string(),
+                    lines_added: 1,
+                    lines_removed: 0,
+                }],
+            )]),
+            current: None,
+            base: DiffBase::UncommittedChanges,
+        },
+        AIAgentAttachment::FilePathReference {
+            file_id: "file-1".to_string(),
+            file_name: "report.txt".to_string(),
+            file_path: "/tmp/report.txt".to_string(),
+        },
+    ];
+    for attachment in attachments {
+        let json = serde_json::to_value(&attachment).unwrap();
+        let deserialized: AIAgentAttachment = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, attachment);
+    }
+}
+
+#[test]
+fn ai_agent_attachment_round_trips_untagged_block_variant() {
+    let attachment = AIAgentAttachment::Block(sample_block_context());
+    let json = serde_json::to_value(&attachment).unwrap();
+    // The Block variant must serialize untagged, as a bare object.
+    assert!(
+        json.get("block_id").is_some(),
+        "expected untagged block object, got {json}"
+    );
+    let deserialized: AIAgentAttachment = serde_json::from_value(json).unwrap();
+    assert_eq!(deserialized, attachment);
 }
 
 #[path = "suggestions_tests.rs"]

--- a/app/src/ai/artifacts/mod.rs
+++ b/app/src/ai/artifacts/mod.rs
@@ -71,39 +71,66 @@ pub enum Artifact {
     },
 }
 
+/// The tag names of [`Artifact`], used for unknown-variant errors.
+const ARTIFACT_TYPES: &[&str] = &[
+    "PLAN",
+    "PULL_REQUEST",
+    "EXTERNAL_REFERENCE",
+    "SCREENSHOT",
+    "FILE",
+];
+
+/// The adjacently tagged envelope shape of a serialized [`Artifact`]. The
+/// `data` payload is parsed once the tag is known.
 #[derive(serde::Deserialize)]
-#[serde(tag = "artifact_type", content = "data")]
-enum ArtifactHelper {
-    #[serde(rename = "PLAN")]
-    Plan {
-        document_uid: String,
-        notebook_uid: Option<NotebookId>,
-        title: Option<String>,
-    },
-    #[serde(rename = "PULL_REQUEST")]
-    PullRequest { url: String, branch: String },
-    #[serde(rename = "EXTERNAL_REFERENCE")]
-    ExternalReference {
-        reference_type: String,
-        url: String,
-        title: Option<String>,
-        metadata: Option<serde_json::Value>,
-    },
-    #[serde(rename = "SCREENSHOT")]
-    Screenshot {
-        artifact_uid: String,
-        mime_type: String,
-        description: Option<String>,
-    },
-    #[serde(rename = "FILE")]
-    File {
-        artifact_uid: String,
-        filepath: String,
-        filename: String,
-        mime_type: String,
-        description: Option<String>,
-        size_bytes: Option<i32>,
-    },
+struct ArtifactEnvelope {
+    artifact_type: String,
+    data: serde_json::Value,
+}
+
+#[derive(serde::Deserialize)]
+struct PlanData {
+    document_uid: String,
+    notebook_uid: Option<NotebookId>,
+    title: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct PullRequestData {
+    url: String,
+    branch: String,
+}
+
+#[derive(serde::Deserialize)]
+struct ExternalReferenceData {
+    reference_type: String,
+    url: String,
+    title: Option<String>,
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(serde::Deserialize)]
+struct ScreenshotData {
+    artifact_uid: String,
+    mime_type: String,
+    description: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct FileData {
+    artifact_uid: String,
+    filepath: String,
+    filename: String,
+    mime_type: String,
+    description: Option<String>,
+    size_bytes: Option<i32>,
+}
+
+/// Parses a buffered JSON value into an artifact payload type.
+fn parse_artifact_data<T: serde::de::DeserializeOwned, E: serde::de::Error>(
+    data: serde_json::Value,
+) -> Result<T, E> {
+    serde_json::from_value(data).map_err(E::custom)
 }
 
 impl<'de> serde::Deserialize<'de> for Artifact {
@@ -111,18 +138,23 @@ impl<'de> serde::Deserialize<'de> for Artifact {
     where
         D: serde::Deserializer<'de>,
     {
-        let helper = ArtifactHelper::deserialize(deserializer)?;
-        Ok(match helper {
-            ArtifactHelper::Plan {
-                document_uid,
-                notebook_uid,
-                title,
-            } => Artifact::Plan {
-                document_uid,
-                notebook_uid,
-                title,
-            },
-            ArtifactHelper::PullRequest { url, branch } => {
+        let envelope = ArtifactEnvelope::deserialize(deserializer)?;
+        Ok(match envelope.artifact_type.as_str() {
+            "PLAN" => {
+                let PlanData {
+                    document_uid,
+                    notebook_uid,
+                    title,
+                } = parse_artifact_data::<_, D::Error>(envelope.data)?;
+                Artifact::Plan {
+                    document_uid,
+                    notebook_uid,
+                    title,
+                }
+            }
+            "PULL_REQUEST" => {
+                let PullRequestData { url, branch } =
+                    parse_artifact_data::<_, D::Error>(envelope.data)?;
                 let (repo, number) = parse_github_pr_url(&url).unzip();
                 Artifact::PullRequest {
                     url,
@@ -131,41 +163,53 @@ impl<'de> serde::Deserialize<'de> for Artifact {
                     number,
                 }
             }
-            ArtifactHelper::ExternalReference {
-                reference_type,
-                url,
-                title,
-                metadata,
-            } => Artifact::ExternalReference {
-                reference_type,
-                url,
-                title,
-                metadata,
-            },
-            ArtifactHelper::Screenshot {
-                artifact_uid,
-                mime_type,
-                description,
-            } => Artifact::Screenshot {
-                artifact_uid,
-                mime_type,
-                description,
-            },
-            ArtifactHelper::File {
-                artifact_uid,
-                filepath,
-                filename,
-                mime_type,
-                description,
-                size_bytes,
-            } => Artifact::File {
-                artifact_uid,
-                filepath,
-                filename,
-                mime_type,
-                description,
-                size_bytes,
-            },
+            "EXTERNAL_REFERENCE" => {
+                let ExternalReferenceData {
+                    reference_type,
+                    url,
+                    title,
+                    metadata,
+                } = parse_artifact_data::<_, D::Error>(envelope.data)?;
+                Artifact::ExternalReference {
+                    reference_type,
+                    url,
+                    title,
+                    metadata,
+                }
+            }
+            "SCREENSHOT" => {
+                let ScreenshotData {
+                    artifact_uid,
+                    mime_type,
+                    description,
+                } = parse_artifact_data::<_, D::Error>(envelope.data)?;
+                Artifact::Screenshot {
+                    artifact_uid,
+                    mime_type,
+                    description,
+                }
+            }
+            "FILE" => {
+                let FileData {
+                    artifact_uid,
+                    filepath,
+                    filename,
+                    mime_type,
+                    description,
+                    size_bytes,
+                } = parse_artifact_data::<_, D::Error>(envelope.data)?;
+                Artifact::File {
+                    artifact_uid,
+                    filepath,
+                    filename,
+                    mime_type,
+                    description,
+                    size_bytes,
+                }
+            }
+            unknown => {
+                return Err(serde::de::Error::unknown_variant(unknown, ARTIFACT_TYPES));
+            }
         })
     }
 }

--- a/app/src/ai/artifacts/mod_tests.rs
+++ b/app/src/ai/artifacts/mod_tests.rs
@@ -163,6 +163,98 @@ fn download_success_message_includes_filename_and_directory() {
 }
 
 #[test]
+fn artifact_round_trips_all_variants() {
+    let artifacts = vec![
+        Artifact::Plan {
+            document_uid: "doc-1".to_string(),
+            notebook_uid: Some(NotebookId::from("0123456789abcdefABCDEF".to_string())),
+            title: Some("My plan".to_string()),
+        },
+        Artifact::Plan {
+            document_uid: "doc-2".to_string(),
+            notebook_uid: None,
+            title: None,
+        },
+        Artifact::PullRequest {
+            url: "https://github.com/warpdotdev/warp/pull/123".to_string(),
+            branch: "feature-branch".to_string(),
+            repo: Some("warp".to_string()),
+            number: Some(123),
+        },
+        Artifact::ExternalReference {
+            reference_type: "linear_issue".to_string(),
+            url: "https://linear.app/team/issue/ABC-1".to_string(),
+            title: Some("An issue".to_string()),
+            metadata: Some(serde_json::json!({"key": "value"})),
+        },
+        Artifact::ExternalReference {
+            reference_type: "linear_issue".to_string(),
+            url: "https://linear.app/team/issue/ABC-2".to_string(),
+            title: None,
+            metadata: None,
+        },
+        Artifact::Screenshot {
+            artifact_uid: "shot-1".to_string(),
+            mime_type: "image/png".to_string(),
+            description: Some("A screenshot".to_string()),
+        },
+        Artifact::File {
+            artifact_uid: "file-1".to_string(),
+            filepath: "outputs/report.txt".to_string(),
+            filename: "report.txt".to_string(),
+            mime_type: "text/plain".to_string(),
+            description: Some("Daily summary".to_string()),
+            size_bytes: Some(42),
+        },
+    ];
+    for artifact in artifacts {
+        let json = serde_json::to_value(&artifact).unwrap();
+        let deserialized: Artifact = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, artifact);
+    }
+}
+
+#[test]
+fn artifact_pull_request_derives_repo_and_number_on_deserialize() {
+    let artifact: Artifact = serde_json::from_str(
+        r#"{"artifact_type":"PULL_REQUEST","data":{"url":"https://github.com/warpdotdev/warp/pull/456","branch":"main"}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        artifact,
+        Artifact::PullRequest {
+            url: "https://github.com/warpdotdev/warp/pull/456".to_string(),
+            branch: "main".to_string(),
+            repo: Some("warp".to_string()),
+            number: Some(456),
+        }
+    );
+}
+
+#[test]
+fn artifact_pull_request_without_github_url_has_no_repo_or_number() {
+    let artifact: Artifact = serde_json::from_str(
+        r#"{"artifact_type":"PULL_REQUEST","data":{"url":"https://example.com/pr/1","branch":"main"}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        artifact,
+        Artifact::PullRequest {
+            url: "https://example.com/pr/1".to_string(),
+            branch: "main".to_string(),
+            repo: None,
+            number: None,
+        }
+    );
+}
+
+#[test]
+fn artifact_rejects_unknown_artifact_type() {
+    let result = serde_json::from_str::<Artifact>(r#"{"artifact_type":"UNKNOWN","data":{}}"#);
+    assert!(result.is_err());
+}
+
+#[test]
 fn converts_graphql_file_artifact() {
     let artifact = Artifact::try_from(warp_graphql::ai::AIConversationArtifact::FileArtifact(
         warp_graphql::ai::FileArtifact {

--- a/app/src/terminal/model/ansi/dcs_hooks.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use ordered_float::OrderedFloat;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use warp_core::command::ExitCode;
 
@@ -33,7 +34,12 @@ pub(super) const UNENCODED_KV_MARKER: char = 'k';
 pub type HookSessionId = Option<u64>;
 
 /// Enum representing all possible JSON payloads for Warp's DCS's.
-#[derive(Serialize, Debug, Deserialize)]
+///
+/// Serialization derives the internally tagged form
+/// (`{"hook": "...", "value": {...}}`). Deserialization is hand-written
+/// below and must accept exactly that form; it avoids the generic buffering
+/// machinery that serde generates for internally tagged enums.
+#[derive(Serialize, Debug)]
 #[allow(clippy::upper_case_acronyms)]
 #[serde(tag = "hook")]
 pub(super) enum DProtoHook {
@@ -78,6 +84,94 @@ pub(super) enum DProtoHook {
     ExitShell {
         value: ExitShellValue,
     },
+}
+
+/// The variant names of [`DProtoHook`], used for unknown-variant errors.
+const DPROTO_HOOK_VARIANTS: &[&str] = &[
+    "CommandFinished",
+    "Precmd",
+    "Preexec",
+    "Bootstrapped",
+    "PreInteractiveSSHSession",
+    "SSH",
+    "InitShell",
+    "InputBuffer",
+    "Clear",
+    "InitSubshell",
+    "SourcedRcFileForWarp",
+    "FinishUpdate",
+    "ExitShell",
+];
+
+/// The envelope shape of a serialized hook: the `hook` tag plus the `value`
+/// payload, which is parsed once the tag is known.
+#[derive(Deserialize)]
+struct RawDProtoHook {
+    hook: String,
+    value: serde_json::Value,
+}
+
+/// Parses a buffered JSON value into a hook payload type.
+fn parse_hook_value<T: DeserializeOwned, E: serde::de::Error>(
+    value: serde_json::Value,
+) -> Result<T, E> {
+    serde_json::from_value(value).map_err(E::custom)
+}
+
+impl<'de> Deserialize<'de> for DProtoHook {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawDProtoHook::deserialize(deserializer)?;
+        Ok(match raw.hook.as_str() {
+            "CommandFinished" => DProtoHook::CommandFinished {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "Precmd" => DProtoHook::Precmd {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "Preexec" => DProtoHook::Preexec {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "Bootstrapped" => DProtoHook::Bootstrapped {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "PreInteractiveSSHSession" => DProtoHook::PreInteractiveSSHSession {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "SSH" => DProtoHook::SSH {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "InitShell" => DProtoHook::InitShell {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "InputBuffer" => DProtoHook::InputBuffer {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "Clear" => DProtoHook::Clear {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "InitSubshell" => DProtoHook::InitSubshell {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "SourcedRcFileForWarp" => DProtoHook::SourcedRcFileForWarp {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "FinishUpdate" => DProtoHook::FinishUpdate {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            "ExitShell" => DProtoHook::ExitShell {
+                value: parse_hook_value::<_, D::Error>(raw.value)?,
+            },
+            unknown => {
+                return Err(serde::de::Error::unknown_variant(
+                    unknown,
+                    DPROTO_HOOK_VARIANTS,
+                ));
+            }
+        })
+    }
 }
 
 impl DProtoHook {
@@ -596,104 +690,210 @@ pub struct PreexecValue {
 
 /// Received from the pty after the shell has finished executing Warp's
 /// bootstrap script.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+///
+/// Deserialization is hand-written through [`RawBootstrappedValue`] below,
+/// which applies the per-field string conversions in one place instead of
+/// through per-field `deserialize_with` wrappers.
+#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
 pub struct BootstrappedValue {
-    #[serde(default)]
     pub session_id: HookSessionId,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub histfile: Option<String>,
 
-    #[serde(deserialize_with = "trim_null_byte_deserializer", default)]
     pub shell: String,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub home_dir: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub path: Option<String>,
 
     /// `CDPATH` from the shell, colon-separated.
-    #[serde(deserialize_with = "empty_string_is_none", default)]
     pub cdpath: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none", default)]
     pub editor: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub aliases: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub abbreviations: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub function_names: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub env_var_names: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub builtins: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub keywords: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none")]
     pub shell_version: Option<String>,
 
     /// A list of options enabled for the shell by the end of bootstrap.  Will
     /// be None if the shell doesn't support listing options via builtin.
-    #[serde(deserialize_with = "parse_shell_options_list_deserializer", default)]
     pub shell_options: Option<HashSet<String>>,
 
     /// The time at which we started sourcing the user rcfiles, measured in
     /// seconds since epoch.
-    #[serde(deserialize_with = "parse_float_from_string_deserializer", default)]
     pub rcfiles_start_time: Option<OrderedFloat<f64>>,
 
     /// The time at which we finished sourcing the user rcfiles, measured in
     /// seconds since epoch.
-    #[serde(deserialize_with = "parse_float_from_string_deserializer", default)]
     pub rcfiles_end_time: Option<OrderedFloat<f64>>,
 
     /// Tags for known shell configurations/plugins, especially ones that are
     /// incompatible with Warp.
-    #[serde(deserialize_with = "parse_shell_options_list_deserializer", default)]
     pub shell_plugins: Option<HashSet<String>>,
 
     /// Whether the shell's native vi mode implementation is on.
-    #[serde(deserialize_with = "empty_string_is_none", default)]
     pub vi_mode_enabled: Option<String>,
 
     /// The operating system category (e.g. MacOS, Linux, Windows).
-    #[serde(deserialize_with = "empty_string_is_none", default)]
     pub os_category: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none", default)]
     pub linux_distribution: Option<String>,
 
-    #[serde(deserialize_with = "empty_string_is_none", default)]
     pub wsl_name: Option<String>,
 
     /// The full path to the running shell binary (e.g. "/usr/bin/zsh").
-    #[serde(deserialize_with = "empty_string_is_none", default)]
     pub shell_path: Option<String>,
 }
 
-/// Custom serde deserializer that parses a float from a string.
-fn parse_float_from_string_deserializer<'de, D>(
-    deserializer: D,
-) -> Result<Option<OrderedFloat<f64>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    if s.is_empty() {
-        return Ok(None);
+/// An optional string field of [`RawBootstrappedValue`]. It distinguishes a
+/// missing field from a present string, so the conversions below can mirror
+/// the `#[serde(default)]` behavior of the former derived deserializer.
+#[derive(Debug, Default)]
+enum RawBootstrappedField {
+    #[default]
+    Missing,
+    Present(String),
+}
+
+impl<'de> Deserialize<'de> for RawBootstrappedField {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self::Present)
     }
-    Ok(Some(
-        s.parse::<f64>().map_err(serde::de::Error::custom)?.into(),
-    ))
+}
+
+impl RawBootstrappedField {
+    /// Mirrors the `empty_string_is_none` field deserializer, with a missing
+    /// field mapping to `None`.
+    fn empty_string_to_none(self) -> Option<String> {
+        match self {
+            Self::Missing => None,
+            Self::Present(s) => empty_string_to_none(s),
+        }
+    }
+
+    /// Mirrors the `trim_null_byte_deserializer` field deserializer, with a
+    /// missing field mapping to an empty string.
+    fn trimmed(self) -> String {
+        match self {
+            Self::Missing => String::new(),
+            Self::Present(s) => trim_null_byte(s),
+        }
+    }
+
+    /// Mirrors the former `parse_shell_options_list_deserializer` field
+    /// deserializer, with a missing field mapping to `None`.
+    fn shell_options(self) -> Option<HashSet<String>> {
+        match self {
+            Self::Missing => None,
+            Self::Present(s) => Some(parse_shell_options_list(s)),
+        }
+    }
+
+    /// Mirrors the former `parse_float_from_string_deserializer` field
+    /// deserializer, with a missing field mapping to `None`. A non-empty
+    /// string that does not parse as a float is an error, exactly as in the
+    /// former field deserializer.
+    fn float_from_string<E: serde::de::Error>(self) -> Result<Option<OrderedFloat<f64>>, E> {
+        match self {
+            Self::Missing => Ok(None),
+            Self::Present(s) => {
+                if s.is_empty() {
+                    return Ok(None);
+                }
+                Ok(Some(s.parse::<f64>().map_err(E::custom)?.into()))
+            }
+        }
+    }
+}
+
+/// The raw wire shape of [`BootstrappedValue`]. Fields without a
+/// `#[serde(default)]` attribute are required, exactly as in the former
+/// derived deserializer.
+#[derive(Deserialize)]
+struct RawBootstrappedValue {
+    #[serde(default)]
+    session_id: HookSessionId,
+    histfile: String,
+    #[serde(default)]
+    shell: RawBootstrappedField,
+    home_dir: String,
+    path: String,
+    #[serde(default)]
+    cdpath: RawBootstrappedField,
+    #[serde(default)]
+    editor: RawBootstrappedField,
+    aliases: String,
+    abbreviations: String,
+    function_names: String,
+    env_var_names: String,
+    builtins: String,
+    keywords: String,
+    shell_version: String,
+    #[serde(default)]
+    shell_options: RawBootstrappedField,
+    #[serde(default)]
+    rcfiles_start_time: RawBootstrappedField,
+    #[serde(default)]
+    rcfiles_end_time: RawBootstrappedField,
+    #[serde(default)]
+    shell_plugins: RawBootstrappedField,
+    #[serde(default)]
+    vi_mode_enabled: RawBootstrappedField,
+    #[serde(default)]
+    os_category: RawBootstrappedField,
+    #[serde(default)]
+    linux_distribution: RawBootstrappedField,
+    #[serde(default)]
+    wsl_name: RawBootstrappedField,
+    #[serde(default)]
+    shell_path: RawBootstrappedField,
+}
+
+impl<'de> Deserialize<'de> for BootstrappedValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawBootstrappedValue::deserialize(deserializer)?;
+        Ok(Self {
+            session_id: raw.session_id,
+            histfile: empty_string_to_none(raw.histfile),
+            shell: raw.shell.trimmed(),
+            home_dir: empty_string_to_none(raw.home_dir),
+            path: empty_string_to_none(raw.path),
+            cdpath: raw.cdpath.empty_string_to_none(),
+            editor: raw.editor.empty_string_to_none(),
+            aliases: empty_string_to_none(raw.aliases),
+            abbreviations: empty_string_to_none(raw.abbreviations),
+            function_names: empty_string_to_none(raw.function_names),
+            env_var_names: empty_string_to_none(raw.env_var_names),
+            builtins: empty_string_to_none(raw.builtins),
+            keywords: empty_string_to_none(raw.keywords),
+            shell_version: empty_string_to_none(raw.shell_version),
+            shell_options: raw.shell_options.shell_options(),
+            rcfiles_start_time: raw.rcfiles_start_time.float_from_string()?,
+            rcfiles_end_time: raw.rcfiles_end_time.float_from_string()?,
+            shell_plugins: raw.shell_plugins.shell_options(),
+            vi_mode_enabled: raw.vi_mode_enabled.empty_string_to_none(),
+            os_category: raw.os_category.empty_string_to_none(),
+            linux_distribution: raw.linux_distribution.empty_string_to_none(),
+            wsl_name: raw.wsl_name.empty_string_to_none(),
+            shell_path: raw.shell_path.empty_string_to_none(),
+        })
+    }
 }
 
 fn parse_float_from_string(s: String) -> Option<OrderedFloat<f64>> {
@@ -832,24 +1032,17 @@ fn empty_string_is_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Er
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    let trimmed = trim_null_byte(s);
-    if trimmed.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(trimmed))
-    }
+    Ok(empty_string_to_none(String::deserialize(deserializer)?))
 }
 
-fn parse_shell_options_list_deserializer<'de, D>(
-    deserializer: D,
-) -> Result<Option<HashSet<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    let options: HashSet<String> = parse_shell_options_list(s);
-    Ok(Some(options))
+/// Trims the string and maps an empty result to `None`.
+fn empty_string_to_none(s: String) -> Option<String> {
+    let trimmed = trim_null_byte(s);
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
 
 fn parse_shell_options_list(s: String) -> HashSet<String> {
@@ -901,3 +1094,7 @@ impl PendingHook {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "dcs_hooks_tests.rs"]
+mod tests;

--- a/app/src/terminal/model/ansi/dcs_hooks_tests.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks_tests.rs
@@ -137,6 +137,68 @@ fn missing_value_field_is_an_error() {
 }
 
 #[test]
+fn every_hook_tag_dispatches_to_the_matching_variant() {
+    let cases = [
+        (
+            "CommandFinished",
+            serde_json::json!({"exit_code": 0, "next_block_id": "block-1"}),
+        ),
+        ("Precmd", serde_json::json!({})),
+        ("Preexec", serde_json::json!({"command": "echo hi"})),
+        (
+            "Bootstrapped",
+            serde_json::json!({
+                "histfile": "",
+                "home_dir": "",
+                "path": "",
+                "aliases": "",
+                "abbreviations": "",
+                "function_names": "",
+                "env_var_names": "",
+                "builtins": "",
+                "keywords": "",
+                "shell_version": "",
+            }),
+        ),
+        ("PreInteractiveSSHSession", serde_json::json!({})),
+        (
+            "SSH",
+            serde_json::json!({"socket_path": "/tmp/warp.sock", "remote_shell": "bash"}),
+        ),
+        (
+            "InitShell",
+            serde_json::json!({"session_id": 1, "shell": "zsh"}),
+        ),
+        ("InputBuffer", serde_json::json!({"buffer": "echo hi"})),
+        ("Clear", serde_json::json!({})),
+        (
+            "InitSubshell",
+            serde_json::json!({"shell": "zsh", "uname": "Darwin"}),
+        ),
+        (
+            "SourcedRcFileForWarp",
+            serde_json::json!({"shell": "zsh", "uname": "Darwin"}),
+        ),
+        ("FinishUpdate", serde_json::json!({"update_id": "update-1"})),
+        ("ExitShell", serde_json::json!({"session_id": 1})),
+    ];
+    let covered_variants = cases.each_ref().map(|(name, _)| *name);
+    assert_eq!(covered_variants.as_slice(), DPROTO_HOOK_VARIANTS);
+
+    for (expected_name, value) in cases {
+        let hook: DProtoHook = serde_json::from_value(serde_json::json!({
+            "hook": expected_name,
+            "value": value,
+        }))
+        .unwrap();
+        assert_eq!(hook.name(), expected_name);
+
+        let serialized = serde_json::to_value(hook).unwrap();
+        assert_eq!(serialized["hook"], expected_name);
+    }
+}
+
+#[test]
 fn precmd_hook_with_completion_metadata_classifies() {
     let json = r#"{
         "hook": "Precmd",

--- a/app/src/terminal/model/ansi/dcs_hooks_tests.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks_tests.rs
@@ -1,0 +1,236 @@
+use std::collections::HashSet;
+
+use super::*;
+
+#[test]
+fn bootstrapped_hook_parses_full_payload() {
+    let json = r#"{
+        "hook": "Bootstrapped",
+        "value": {
+            "session_id": 42,
+            "histfile": "/Users/me/.zsh_history",
+            "shell": "zsh\u0000",
+            "home_dir": "/Users/me",
+            "path": "/usr/bin:/bin",
+            "cdpath": "",
+            "editor": "vim",
+            "aliases": "",
+            "abbreviations": "",
+            "function_names": "foo bar",
+            "env_var_names": "PATH HOME",
+            "builtins": "cd echo",
+            "keywords": "if then",
+            "shell_version": "5.9",
+            "shell_options": "autocd extendedglob",
+            "rcfiles_start_time": "100.5",
+            "rcfiles_end_time": "101.25",
+            "shell_plugins": "ohmyzsh",
+            "vi_mode_enabled": "",
+            "os_category": "MacOS",
+            "linux_distribution": "",
+            "wsl_name": "",
+            "shell_path": "/bin/zsh"
+        }
+    }"#;
+    let DProtoHook::Bootstrapped { value } = serde_json::from_str::<DProtoHook>(json).unwrap()
+    else {
+        panic!("expected a Bootstrapped hook");
+    };
+    let expected = BootstrappedValue {
+        session_id: Some(42),
+        histfile: Some("/Users/me/.zsh_history".to_string()),
+        shell: "zsh".to_string(),
+        home_dir: Some("/Users/me".to_string()),
+        path: Some("/usr/bin:/bin".to_string()),
+        cdpath: None,
+        editor: Some("vim".to_string()),
+        aliases: None,
+        abbreviations: None,
+        function_names: Some("foo bar".to_string()),
+        env_var_names: Some("PATH HOME".to_string()),
+        builtins: Some("cd echo".to_string()),
+        keywords: Some("if then".to_string()),
+        shell_version: Some("5.9".to_string()),
+        shell_options: Some(HashSet::from([
+            "autocd".to_string(),
+            "extendedglob".to_string(),
+        ])),
+        rcfiles_start_time: Some(100.5.into()),
+        rcfiles_end_time: Some(101.25.into()),
+        shell_plugins: Some(HashSet::from(["ohmyzsh".to_string()])),
+        vi_mode_enabled: None,
+        os_category: Some("MacOS".to_string()),
+        linux_distribution: None,
+        wsl_name: None,
+        shell_path: Some("/bin/zsh".to_string()),
+    };
+    assert_eq!(*value, expected);
+}
+
+#[test]
+fn bootstrapped_hook_defaults_optional_fields() {
+    let json = r#"{
+        "hook": "Bootstrapped",
+        "value": {
+            "histfile": "",
+            "home_dir": "/Users/me",
+            "path": "",
+            "aliases": "",
+            "abbreviations": "",
+            "function_names": "",
+            "env_var_names": "",
+            "builtins": "",
+            "keywords": "",
+            "shell_version": ""
+        }
+    }"#;
+    let DProtoHook::Bootstrapped { value } = serde_json::from_str::<DProtoHook>(json).unwrap()
+    else {
+        panic!("expected a Bootstrapped hook");
+    };
+    let expected = BootstrappedValue {
+        home_dir: Some("/Users/me".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(*value, expected);
+}
+
+#[test]
+fn bootstrapped_hook_requires_required_fields() {
+    // The histfile field has no default, so its absence is an error.
+    let json = r#"{"hook": "Bootstrapped", "value": {"home_dir": "/Users/me"}}"#;
+    assert!(serde_json::from_str::<DProtoHook>(json).is_err());
+}
+
+#[test]
+fn bootstrapped_hook_rejects_malformed_rcfiles_time() {
+    let json = r#"{
+        "hook": "Bootstrapped",
+        "value": {
+            "histfile": "",
+            "home_dir": "",
+            "path": "",
+            "aliases": "",
+            "abbreviations": "",
+            "function_names": "",
+            "env_var_names": "",
+            "builtins": "",
+            "keywords": "",
+            "shell_version": "",
+            "rcfiles_start_time": "not-a-float"
+        }
+    }"#;
+    assert!(serde_json::from_str::<DProtoHook>(json).is_err());
+}
+
+#[test]
+fn unknown_hook_name_is_an_error() {
+    let json = r#"{"hook": "NotARealHook", "value": {}}"#;
+    let error = serde_json::from_str::<DProtoHook>(json).unwrap_err();
+    assert!(error.to_string().contains("unknown variant"));
+}
+
+#[test]
+fn missing_value_field_is_an_error() {
+    let json = r#"{"hook": "Clear"}"#;
+    assert!(serde_json::from_str::<DProtoHook>(json).is_err());
+}
+
+#[test]
+fn precmd_hook_with_completion_metadata_classifies() {
+    let json = r#"{
+        "hook": "Precmd",
+        "value": {
+            "pwd": "/Users/me",
+            "ps1": "",
+            "exit_code": 0,
+            "next_block_id": "block-1",
+            "session_id": 7
+        }
+    }"#;
+    let DProtoHook::Precmd { value } = serde_json::from_str::<DProtoHook>(json).unwrap() else {
+        panic!("expected a Precmd hook");
+    };
+    let PrecmdHookValue::WithCompletionMetadata(value) = value else {
+        panic!("expected completion metadata");
+    };
+    assert_eq!(value.prompt_metadata.pwd.as_deref(), Some("/Users/me"));
+    assert_eq!(value.prompt_metadata.session_id, Some(7));
+}
+
+#[test]
+fn precmd_hook_without_completion_metadata_is_prompt_only() {
+    let json = r#"{"hook": "Precmd", "value": {"pwd": "/Users/me", "session_id": 7}}"#;
+    let DProtoHook::Precmd { value } = serde_json::from_str::<DProtoHook>(json).unwrap() else {
+        panic!("expected a Precmd hook");
+    };
+    assert!(matches!(value, PrecmdHookValue::PromptOnly(_)));
+}
+
+#[test]
+fn sourced_rc_file_hook_parses_frozen_snippet_format() {
+    // This literal payload shape ships inside user RC files, so it must keep
+    // parsing forever.
+    let json = r#"{"hook": "SourcedRcFileForWarp", "value": {"shell": "zsh", "uname": "Darwin"}}"#;
+    let DProtoHook::SourcedRcFileForWarp { value } =
+        serde_json::from_str::<DProtoHook>(json).unwrap()
+    else {
+        panic!("expected a SourcedRcFileForWarp hook");
+    };
+    assert_eq!(value.shell, "zsh");
+    assert_eq!(value.uname.as_deref(), Some("Darwin"));
+}
+
+#[test]
+fn sourced_rc_file_hook_ignores_legacy_tmux_field() {
+    let json = r#"{"hook": "SourcedRcFileForWarp", "value": {"shell": "zsh", "uname": "Darwin", "tmux": false}}"#;
+    assert!(serde_json::from_str::<DProtoHook>(json).is_ok());
+}
+
+#[test]
+fn ssh_hook_round_trips_through_serialization() {
+    let hook = DProtoHook::SSH {
+        value: SSHValue {
+            socket_path: "/tmp/warp.sock".into(),
+            remote_shell: "bash".to_string(),
+            session_id: Some(3),
+            remote_session_id: Some(4),
+            external_control_master: true,
+        },
+    };
+    let json = serde_json::to_string(&hook).unwrap();
+    let DProtoHook::SSH { value } = serde_json::from_str::<DProtoHook>(&json).unwrap() else {
+        panic!("expected an SSH hook");
+    };
+    assert_eq!(value.socket_path, PathBuf::from("/tmp/warp.sock"));
+    assert_eq!(value.remote_shell, "bash");
+    assert_eq!(value.session_id, Some(3));
+    assert_eq!(value.remote_session_id, Some(4));
+    assert!(value.external_control_master);
+}
+
+#[test]
+fn init_shell_hook_round_trips_through_serialization() {
+    // Note that `wsl_name` must be `Some` here: the field's deserializer
+    // requires a string, and `None` serializes to `null`. Real hook payloads
+    // always send a string, with the empty string standing in for `None`.
+    let hook = DProtoHook::InitShell {
+        value: InitShellValue {
+            session_id: 9.into(),
+            shell: "zsh".to_string(),
+            is_subshell: false,
+            user: "me".to_string(),
+            hostname: "host".to_string(),
+            wsl_name: Some("Ubuntu".to_string()),
+        },
+    };
+    let json = serde_json::to_string(&hook).unwrap();
+    let DProtoHook::InitShell { value } = serde_json::from_str::<DProtoHook>(&json).unwrap() else {
+        panic!("expected an InitShell hook");
+    };
+    assert_eq!(value.session_id, 9.into());
+    assert_eq!(value.shell, "zsh");
+    assert_eq!(value.user, "me");
+    assert_eq!(value.hostname, "host");
+    assert_eq!(value.wsl_name.as_deref(), Some("Ubuntu"));
+}


### PR DESCRIPTION
## Description

This is PR 3 of a stack that reduces the compile time of the `warp` crate. It is stacked on #15454.

### Why

For enums that are internally tagged, adjacently tagged, or that mix tagged and untagged variants, serde's derive cannot deserialize in one pass. It generates buffering machinery (`Content`, `ContentRefDeserializer`, `ContentDeserializer`) that copies the input into a generic tree and replays it for each candidate variant. Fields with `deserialize_with` also each get a private `__DeserializeWith` wrapper struct. This machinery is generic over the input lifetime and the error type, so it monomorphizes widely and it pulls large dependent trees (for example `BlockContext` and its field types) into the instantiations.

The affected types are only deserialized from JSON (`serde_json::from_str` / `from_slice` / `from_value`). I verified each call site before this change. Because the input format is known, a hand-written `Deserialize` can buffer into `serde_json::Value` once and then parse the payload directly, with no generic replay machinery.

### What changed

Serialization derives are unchanged everywhere. Only deserialization is hand-written, and it accepts the exact same wire format as before:

- `DProtoHook` (`app/src/terminal/model/ansi/dcs_hooks.rs`): a small raw struct captures the `hook` tag and the `value` payload, and a 13-arm match parses the payload. The `SourcedRcFileForWarp` shape is frozen because the payload literal ships inside user RC files; a test pins it.
- `BootstrappedValue` (same file): a raw twin struct replaces the per-field `deserialize_with` wrappers (`empty_string_is_none`, float parsing, shell-option splitting). The conversions now run in one non-generic place. A `RawBootstrappedField` helper keeps the old missing-versus-present semantics for optional fields.
- `Artifact` (`app/src/ai/artifacts/mod.rs`): an `ArtifactEnvelope` struct replaces the `ArtifactHelper` mirror enum for the adjacently tagged (`artifact_type` / `data`) format. The `PULL_REQUEST` arm still derives `repo` and `number` from the URL.
- `AIAgentContext` and `AIAgentAttachment` (`app/src/ai/agent/mod.rs`): these mix externally tagged variants with an untagged `Block(BlockContext)` variant, which is the most expensive derive pattern. A private derived twin enum handles the tagged variants, and the impl falls back to `BlockContext` when the tagged parse fails — the same fallthrough order the derive used. This also removes `BlockContext`'s large deserializer tree from the `ContentRefDeserializer` instantiations.

### Alternatives considered

- Re-tagging the enums (for example, making `Block` a tagged variant) would remove the machinery with less code, but it changes the wire format. These payloads live in persisted conversations, RC-file snippets, and server messages, so the format must not change.
- Keeping the derives was the status quo; the buffering machinery accounted for ~167K IR lines at the base of this branch.
- `CodeSource` was on the candidate list but is a plain externally tagged enum. Its derive does not generate the buffering machinery, so it was left alone.
- `PrecmdValue`/`PromptMetadata` use `#[serde(flatten)]`, which generates similar buffering. That is left as follow-up work because the flatten structure is more intricate.

### Measured effect (vs. PR 2, Apple M5 Pro, rustc 1.92.0, dev profile)

- `cargo llvm-lines -p warp --lib`: 17,022,929 → 16,966,243 lines (−0.33%); 573,201 → 571,576 copies.
- Serde buffering machinery (`Content*` / `__DeserializeWith` symbols): 167,090 → 89,078 IR lines (−47%). The remainder comes from other crates' types that still use these patterns.
- Per type (IR lines): `DProtoHook` 24,664 → 6,773; `BootstrappedValue` 13,299 → 7,158; `Artifact` symbols 39,443 → 18,148 (`ArtifactHelper` 23,101 → 0); `AIAgentContext` 21,473 → 18,172; `AIAgentAttachment` 15,841 → 13,418.
- Macro expansion (`-Zmacro-stats`): 32,172,116 → 31,907,058 bytes (−0.8%).
- Clean `warp` lib rebuild (deps cached, `CARGO_INCREMENTAL=0`, two runs): 71.4 s / 71.1 s → 69.2 s / 69.1 s.
- Incremental touch rebuild (two runs): 15.4 s / 14.8 s → 14.7 s / 14.2 s.

The wall-clock gain is small (~2 s clean); the main value is removing the widest remaining serde instantiations in the crate and establishing the pattern for the flatten-based types.

## Linked Issue

No linked issue. This PR comes from a compile-time investigation; see the conversation link below.

## Testing

- New round-trip and frozen-format unit tests: `app/src/terminal/model/ansi/dcs_hooks_tests.rs` (new file), plus new tests in `app/src/ai/artifacts/mod_tests.rs` and `app/src/ai/agent/mod_tests.rs`. They serialize each variant with the unchanged derived `Serialize` and assert the hand-written `Deserialize` returns an equal value, and they pin raw JSON literals for the frozen formats (RC-file hook, artifact envelope, pull-request number coercion).
- `cargo nextest run -p warp -E 'test(/ai::|conversation/)'`: 2372 passed.
- `./script/format` and all three presubmit clippy passes are clean.
- Not manually run with `./script/run`; behavior is covered by the deserialization tests above, and the wire formats are unchanged.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/024e797d-1d35-4c62-8394-abf93f7ddb0e

Co-Authored-By: Warp <agent@warp.dev>

CHANGELOG-NONE
