### PR TITLE
Add the ai_types crate for pure AI model types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ai_types"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9992,6 +10003,7 @@ dependencies = [
 name = "persistence"
 version = "0.0.0"
 dependencies = [
+ "ai_types",
  "chrono",
  "diesel",
  "diesel_migrations",
@@ -15123,6 +15135,7 @@ dependencies = [
  "aha-reqwest-eventsource",
  "aho-corasick",
  "ai",
+ "ai_types",
  "alphanumeric-sort",
  "anyhow",
  "app-installation-detection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ publish = false
 [workspace.dependencies]
 # Local workspace crates. This lets us reference them in other crates without specifying a path.
 ai = { path = "crates/ai" }
+ai_types = { path = "crates/ai_types" }
 app-installation-detection = { path = "crates/app-installation-detection" }
 asset_cache = { path = "crates/asset_cache" }
 asset_macro = { path = "crates/asset_macro" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -56,6 +56,7 @@ test = false
 [dependencies]
 addr = "0.15.6"
 ai.workspace = true
+ai_types.workspace = true
 alphanumeric-sort = "1.5.7"
 anyhow.workspace = true
 arrayvec.workspace = true

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
 
 use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationConfigStatus};
 use ai::document::AIDocumentId;
@@ -7,8 +6,6 @@ use ai::skills::SkillPathOrigin;
 use anyhow::Context as _;
 use chrono::{DateTime, Local, TimeZone};
 use itertools::Itertools as _;
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 use vec1::{Size0Error, Vec1};
 use warp_cli::agent::Harness;
 use warp_core::command::ExitCode;
@@ -4565,35 +4562,7 @@ pub enum UpdateConversationError {
     NoPendingRequest,
 }
 
-/// A globally unique ID for a conversation with an AI agent.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AIConversationId(Uuid);
-
-impl Display for AIConversationId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl AIConversationId {
-    pub fn new() -> Self {
-        Self(Uuid::new_v4())
-    }
-}
-
-impl Default for AIConversationId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl TryFrom<String> for AIConversationId {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Ok(Self(Uuid::try_parse(&value)?))
-    }
-}
+pub use ai_types::AIConversationId;
 
 /// The harness that produced an agent conversation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -18,12 +18,13 @@ use std::ops::{AddAssign, Deref, DerefMut, Range};
 use std::sync::Arc;
 use std::time::Duration;
 
-// Re-export types that were moved to the ai crate.
+// Re-export types that were moved to the ai and ai_types crates.
 pub use ai::agent::action::*;
 pub use ai::agent::action_result::*;
 use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationConfigStatus};
 pub use ai::agent::{AIAgentCitation, FileLocations};
 use ai::skills::ParsedSkill;
+pub use ai_types::{AIAgentActionId, EntrypointType, PassiveSuggestionTriggerType};
 use chrono::{DateTime, Local, TimeDelta};
 use comment::ReviewComment;
 use derivative::Derivative;
@@ -1034,43 +1035,6 @@ pub struct SuggestedAgentModeWorkflow {
     pub name: String,
     pub prompt: String,
     pub logging_id: SuggestedLoggingId,
-}
-
-/// A ID for an AI action generated as part of an [`AIAgentOutput`].
-///
-/// The internal ID itself should be opaque to all callers. This ID may be relayed back to the AI with
-/// the `AIAgentActionResult` from the action.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct AIAgentActionId(String);
-
-impl From<String> for AIAgentActionId {
-    fn from(value: String) -> Self {
-        AIAgentActionId(value)
-    }
-}
-
-impl From<AIAgentActionId> for String {
-    fn from(value: AIAgentActionId) -> Self {
-        value.0
-    }
-}
-
-impl Display for AIAgentActionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl From<crate::persistence::model::AIAgentActionId> for AIAgentActionId {
-    fn from(value: crate::persistence::model::AIAgentActionId) -> Self {
-        Self(value.0)
-    }
-}
-
-impl From<AIAgentActionId> for crate::persistence::model::AIAgentActionId {
-    fn from(value: AIAgentActionId) -> Self {
-        crate::persistence::model::AIAgentActionId(value.0)
-    }
 }
 
 /// An "action" included in an AI output.
@@ -2549,37 +2513,6 @@ pub enum StaticQueryType {
     Deploy,
     SomethingElse,
     EvaluationSuite,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(clippy::enum_variant_names)]
-pub enum EntrypointType {
-    PromptSuggestion {
-        is_static: bool,
-        is_coding: bool,
-    },
-    ZeroStateAgentModePromptSuggestion,
-    InitProjectRules,
-    TriggerPassiveSuggestion {
-        trigger: Option<PassiveSuggestionTriggerType>,
-    },
-    UserInitiated,
-    AgentInitiated,
-    SharedSession,
-    CloneRepository,
-    ResumeConversation,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(clippy::enum_variant_names)]
-pub enum PassiveSuggestionTriggerType {
-    /// Used for unit test generation.
-    FilesChanged,
-    /// Used for unit test generation.
-    CommandRun,
-
-    ShellCommandCompleted,
-    AgentResponseCompleted,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/app/src/ai/agent/task.rs
+++ b/app/src/ai/agent/task.rs
@@ -2,16 +2,14 @@ pub mod helper;
 pub mod transaction;
 
 use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
-use std::ops::Deref;
 
 use ai::skills::SkillPathOrigin;
+pub use ai_types::TaskId;
 use anyhow::Context as _;
 use field_mask::{FieldMaskError, FieldMaskOperation};
 use helper::{MessageExt, SubagentExt, ToolCallExt};
 use itertools::Itertools;
 use prost_types::FieldMask;
-use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use warp_errors::report_error;
 use warp_multi_agent_api::message::Message;
@@ -32,35 +30,6 @@ use super::{
 use crate::AIAgentTodoList;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentVersion};
 use crate::terminal::model::block::BlockId;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct TaskId(String);
-
-impl TaskId {
-    pub fn new(id: String) -> Self {
-        TaskId(id)
-    }
-}
-
-impl From<TaskId> for String {
-    fn from(id: TaskId) -> Self {
-        id.0
-    }
-}
-
-impl Deref for TaskId {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Display for TaskId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
 
 #[derive(Debug, thiserror::Error)]
 pub enum UpdateTaskError {
@@ -269,7 +238,7 @@ impl Task {
         restored_exchanges.sort_by_key(|exchange| exchange.start_time);
 
         Self {
-            id: TaskId(task.id.clone()),
+            id: TaskId::new(task.id.clone()),
             data: TaskImpl::Server(ServerTask {
                 source: task,
                 subagent_params: None,
@@ -326,7 +295,7 @@ impl Task {
         let messages_clone = subtask.messages.clone();
         let new_exchange_id = new_exchange.id;
         let mut me = Self {
-            id: TaskId(subtask.id.clone()),
+            id: TaskId::new(subtask.id.clone()),
             exchanges: vec![new_exchange],
             data: TaskImpl::Server(ServerTask {
                 source: subtask,
@@ -361,7 +330,7 @@ impl Task {
         });
 
         Self {
-            id: TaskId(subtask.id.clone()),
+            id: TaskId::new(subtask.id.clone()),
             exchanges: restored_exchanges,
             data: TaskImpl::Server(ServerTask {
                 source: subtask,
@@ -386,7 +355,7 @@ impl Task {
         });
 
         Self {
-            id: TaskId(subtask.id.clone()),
+            id: TaskId::new(subtask.id.clone()),
             exchanges: vec![],
             data: TaskImpl::Server(ServerTask {
                 source: subtask,
@@ -470,7 +439,7 @@ impl Task {
     pub fn parent_id(&self) -> Option<TaskId> {
         self.source()
             .and_then(|source| source.dependencies.as_ref())
-            .map(|dependencies| TaskId(dependencies.parent_task_id.clone()))
+            .map(|dependencies| TaskId::new(dependencies.parent_task_id.clone()))
     }
 
     pub fn is_root_task(&self) -> bool {

--- a/app/src/ai/agent/telemetry.rs
+++ b/app/src/ai/agent/telemetry.rs
@@ -2,10 +2,7 @@ use serde::Serialize;
 use warpui::{AppContext, SingletonEntity};
 
 use super::conversation::AIConversationId;
-use super::{
-    AIAgentCitation, AIAgentExchangeId, EntrypointType, PassiveSuggestionTriggerType,
-    ServerOutputId,
-};
+use super::{AIAgentCitation, AIAgentExchangeId, ServerOutputId};
 use crate::CloudModel;
 use crate::ai::llms::LLMId;
 use crate::server::telemetry::AgentModeCitation as CitationForTelemetry;
@@ -41,45 +38,6 @@ impl ForTelemetry for AIAgentCitation {
                 memory_store_id: memory_store_id.clone(),
                 memory_id: memory_id.clone(),
             }),
-        }
-    }
-}
-
-impl EntrypointType {
-    pub fn entrypoint(&self) -> String {
-        match self {
-            Self::PromptSuggestion {
-                is_static,
-                is_coding,
-            } => match (is_static, is_coding) {
-                (true, true) => "PROMPT_SUGGESTION.CODING_STATIC".to_string(),
-                (true, false) => "PROMPT_SUGGESTION.STATIC".to_string(),
-                (false, true) => "PROMPT_SUGGESTION.CODING".to_string(),
-                (false, false) => "PROMPT_SUGGESTION.SIMPLE".to_string(),
-            },
-            Self::ZeroStateAgentModePromptSuggestion => {
-                "ZERO_STATE_AGENT_MODE_PROMPT_SUGGESTION".to_string()
-            }
-            Self::InitProjectRules => "INIT_PROJECT_RULES".to_string(),
-            Self::UserInitiated => "USER_INITIATED".to_string(),
-            Self::AgentInitiated => "AGENT_INITIATED".to_string(),
-            Self::TriggerPassiveSuggestion { trigger } => {
-                let trigger_name = match trigger {
-                    Some(PassiveSuggestionTriggerType::FilesChanged) => "FILES_CHANGED",
-                    Some(PassiveSuggestionTriggerType::CommandRun) => "COMMAND_RUN",
-                    Some(PassiveSuggestionTriggerType::ShellCommandCompleted) => {
-                        "SHELL_COMMAND_COMPLETED"
-                    }
-                    Some(PassiveSuggestionTriggerType::AgentResponseCompleted) => {
-                        "AGENT_RESPONSE_COMPLETED"
-                    }
-                    None => "NONE",
-                };
-                format!("TRIGGER_SUGGEST_PROMPT.{trigger_name}")
-            }
-            Self::CloneRepository => "CLONE_REPOSITORY".to_string(),
-            Self::SharedSession => "SHARED_SESSION".to_string(),
-            Self::ResumeConversation => "RESUME_CONVERSATION".to_string(),
         }
     }
 }

--- a/app/src/ai/ambient_agents/mod.rs
+++ b/app/src/ai/ambient_agents/mod.rs
@@ -1,9 +1,3 @@
-use std::fmt::Display;
-use std::str::FromStr;
-
-use serde::{Deserialize, Serialize};
-use uuid::{NonNilUuid, Uuid};
-
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent::{
     AIAgentOutputStatus, CancellationReason, FinishedAIAgentOutput, RenderableAIError,
@@ -26,34 +20,7 @@ pub const OUT_OF_CREDITS_TASK_FAILURE_MESSAGE: &str =
 pub const SERVER_OVERLOADED_TASK_FAILURE_MESSAGE: &str =
     "Warp is temporarily overloaded. Please try again shortly.";
 
-#[derive(Debug, thiserror::Error)]
-#[error("Invalid task ID: {0}")]
-pub struct ParseAmbientAgentTaskIdError(#[from] uuid::Error);
-
-/// A globally unique ID for an ambient agent task.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AmbientAgentTaskId(NonNilUuid);
-
-impl Display for AmbientAgentTaskId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl FromStr for AmbientAgentTaskId {
-    type Err = ParseAmbientAgentTaskIdError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let uuid = Uuid::try_parse(s)?;
-        Ok(Self(NonNilUuid::try_from(uuid)?))
-    }
-}
-
-impl From<AmbientAgentTaskId> for cynic::Id {
-    fn from(id: AmbientAgentTaskId) -> Self {
-        Self::new(id.to_string())
-    }
-}
+pub use ai_types::AmbientAgentTaskId;
 
 /// High-level outcome of an ambient agent conversation.
 #[derive(Clone, Debug)]

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -53,11 +53,9 @@ impl ActiveSkillLookupError {
 
 #[cfg(not(target_family = "wasm"))]
 mod global_skills;
+pub use ai::skills::SkillDescriptor;
 #[cfg(not(target_family = "wasm"))]
 pub use global_skills::{filter_skills_by_spec, resolve_skill_repos};
-
-mod listed_skill;
-pub use listed_skill::SkillDescriptor;
 
 mod skill_utils;
 pub use skill_utils::{

--- a/app/src/ai_assistant/execution_context.rs
+++ b/app/src/ai_assistant/execution_context.rs
@@ -1,43 +1,17 @@
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
+pub use ai_types::{WarpAiExecutionContext, WarpAiOsContext};
 
 use crate::terminal::model::session::Session;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WarpAiOsContext {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub category: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub distribution: Option<String>,
-}
-
-/// The execution context of the active session. This struct
-/// is sent as a JSON blob in our AI prompts.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WarpAiExecutionContext {
-    pub os: WarpAiOsContext,
-    pub shell_name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub shell_version: Option<String>,
-}
-
-impl WarpAiExecutionContext {
-    pub fn new(session: &Arc<Session>) -> Self {
-        WarpAiExecutionContext {
-            os: WarpAiOsContext {
-                category: session.host_info().os_category.clone(),
-                distribution: session.host_info().linux_distribution.clone(),
-            },
-            shell_name: session.shell().shell_type().name().to_owned(),
-            shell_version: session.shell().version().clone(),
-        }
-    }
-}
-impl WarpAiExecutionContext {
-    pub fn to_json_string(&self) -> Option<String> {
-        serde_json::to_string(self).ok()
+/// Build the execution context that describes the given session.
+pub fn execution_context_for_session(session: &Arc<Session>) -> WarpAiExecutionContext {
+    WarpAiExecutionContext {
+        os: WarpAiOsContext {
+            category: session.host_info().os_category.clone(),
+            distribution: session.host_info().linux_distribution.clone(),
+        },
+        shell_name: session.shell().shell_type().name().to_owned(),
+        shell_version: session.shell().version().clone(),
     }
 }

--- a/app/src/ai_assistant/panel.rs
+++ b/app/src/ai_assistant/panel.rs
@@ -25,7 +25,7 @@ use warpui::{
     ViewContext, ViewHandle, WeakViewHandle,
 };
 
-use super::execution_context::WarpAiExecutionContext;
+use super::execution_context::execution_context_for_session;
 use super::requests::{Event as RequestsEvent, RequestStatus, Requests};
 use super::transcript::{Transcript, TranscriptEvent};
 use super::utils::{TranscriptPart, render_prepared_response_button, render_request_limit_info};
@@ -266,7 +266,7 @@ impl AIAssistantPanelView {
             .as_ref(ctx)
             .session(window_id)
             .as_ref()
-            .map(WarpAiExecutionContext::new);
+            .map(execution_context_for_session);
         self.requests_model.update(ctx, |requests, _| {
             requests.update_ai_execution_context(ai_execution_context);
         });

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2151,7 +2151,7 @@ impl AIClient for ServerApi {
     ) -> anyhow::Result<(), anyhow::Error> {
         let variables = UpdateAgentTaskVariables {
             input: UpdateAgentTaskInput {
-                task_id: task_id.into(),
+                task_id: task_id.to_string().into(),
                 task_state,
                 session_id: session_id.map(|id| id.to_string().into()),
                 conversation_id: conversation_id.map(|id| id.into()),

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -207,7 +207,7 @@ use crate::ai::predict::prompt_suggestions::{
     is_accept_prompt_suggestion_bound_to_ctrl_enter,
 };
 use crate::ai::skills::{SkillOpenOrigin, SkillTelemetryEvent};
-use crate::ai_assistant::execution_context::WarpAiExecutionContext;
+use crate::ai_assistant::execution_context::execution_context_for_session;
 use crate::appearance::{Appearance, AppearanceEvent};
 use crate::channel::{Channel, ChannelState};
 use crate::cloud_object::model::actions::ObjectActionType;
@@ -7033,7 +7033,7 @@ impl Input {
         let Some(session) = self.active_session(ctx) else {
             return;
         };
-        let context = WarpAiExecutionContext::new(&session);
+        let context = execution_context_for_session(&session);
         let completer_data = self.completer_data();
         let block_context = Some(BlockContext::from_completed_block(
             &block_completed,
@@ -9755,7 +9755,7 @@ impl Input {
             let Some(session) = self.active_session(ctx) else {
                 return;
             };
-            let context = WarpAiExecutionContext::new(&session);
+            let context = execution_context_for_session(&session);
             if let Some(last_user_block_completed) =
                 completer_data.last_user_block_completed.clone()
             {
@@ -13911,7 +13911,7 @@ impl Input {
         let Some(session) = self.active_session(ctx) else {
             return;
         };
-        let context = WarpAiExecutionContext::new(&session);
+        let context = execution_context_for_session(&session);
 
         let request = PredictAMQueriesRequest {
             context_messages: vec![json_message.to_string()],

--- a/app/src/terminal/model/session/active_session.rs
+++ b/app/src/terminal/model/session/active_session.rs
@@ -8,7 +8,9 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle};
 
 use super::{Session, SessionType, Sessions};
-use crate::ai_assistant::execution_context::WarpAiExecutionContext;
+use crate::ai_assistant::execution_context::{
+    WarpAiExecutionContext, execution_context_for_session,
+};
 use crate::terminal::ShellLaunchData;
 use crate::terminal::model::session::SessionsEvent;
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
@@ -126,7 +128,9 @@ impl ActiveSession {
 
     /// Returns the `WarpAiExecutionContext` for the active session.
     pub fn ai_execution_environment(&self, app: &AppContext) -> Option<WarpAiExecutionContext> {
-        self.session(app).as_ref().map(WarpAiExecutionContext::new)
+        self.session(app)
+            .as_ref()
+            .map(execution_context_for_session)
     }
 }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -223,7 +223,7 @@ use crate::ai::facts::{AIFactManager, AIFactView, AIFactViewEvent};
 use crate::ai::llms::LLMId as HandoffLLMId;
 use crate::ai::llms::LLMPreferences;
 use crate::ai::persisted_workspace::PersistedWorkspace;
-use crate::ai_assistant::execution_context::WarpAiExecutionContext;
+use crate::ai_assistant::execution_context::execution_context_for_session;
 use crate::ai_assistant::panel::{AIAssistantPanelEvent, AIAssistantPanelView};
 use crate::ai_assistant::{AI_ASSISTANT_FEATURE_NAME, AI_ASSISTANT_LOGO_COLOR, AskAIType};
 use crate::app_state::{
@@ -17298,7 +17298,7 @@ impl Workspace {
 
             let ai_execution_context = session_context
                 .as_ref()
-                .map(|session_context| WarpAiExecutionContext::new(&session_context.session));
+                .map(|session_context| execution_context_for_session(&session_context.session));
 
             let menu_positioning = active_input_handle
                 .as_ref()

--- a/crates/ai/src/skills/listed_skill.rs
+++ b/crates/ai/src/skills/listed_skill.rs
@@ -1,6 +1,7 @@
-use ai::skills::{ParsedSkill, SkillProvider, SkillReference, SkillScope};
 use serde::{Deserialize, Serialize};
 use warp_core::ui::icons::Icon;
+
+use super::{ParsedSkill, SkillProvider, SkillReference, SkillScope};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct SkillDescriptor {

--- a/crates/ai/src/skills/mod.rs
+++ b/crates/ai/src/skills/mod.rs
@@ -1,4 +1,5 @@
 mod conversion;
+mod listed_skill;
 mod parse_skill;
 mod parser;
 mod read_skills;
@@ -8,6 +9,7 @@ pub use conversion::{
     SkillConversionError, SkillPathOrigin, skill_reference_from_api_skill_ref,
     skill_reference_from_read_skill_ref,
 };
+pub use listed_skill::SkillDescriptor;
 pub use parse_skill::{
     ParsedSkill, parse_bundled_skill, parse_skill, parse_skill_content_at_location,
 };

--- a/crates/ai_types/Cargo.toml
+++ b/crates/ai_types/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ai_types"
+version = "0.1.0"
+edition = "2024"
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+uuid.workspace = true

--- a/crates/ai_types/src/agent.rs
+++ b/crates/ai_types/src/agent.rs
@@ -1,0 +1,159 @@
+use std::fmt::Display;
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A globally unique ID for a conversation with an AI agent.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AIConversationId(Uuid);
+
+impl Display for AIConversationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AIConversationId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for AIConversationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<String> for AIConversationId {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Ok(Self(Uuid::try_parse(&value)?))
+    }
+}
+
+/// A ID for an AI action generated as part of an `AIAgentOutput`.
+///
+/// The internal ID itself should be opaque to all callers. This ID may be relayed back to the AI with
+/// the `AIAgentActionResult` from the action.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AIAgentActionId(String);
+
+impl From<String> for AIAgentActionId {
+    fn from(value: String) -> Self {
+        AIAgentActionId(value)
+    }
+}
+
+impl From<AIAgentActionId> for String {
+    fn from(value: AIAgentActionId) -> Self {
+        value.0
+    }
+}
+
+impl Display for AIAgentActionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TaskId(String);
+
+impl TaskId {
+    pub fn new(id: String) -> Self {
+        TaskId(id)
+    }
+}
+
+impl From<TaskId> for String {
+    fn from(id: TaskId) -> Self {
+        id.0
+    }
+}
+
+impl Deref for TaskId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for TaskId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::enum_variant_names)]
+pub enum EntrypointType {
+    PromptSuggestion {
+        is_static: bool,
+        is_coding: bool,
+    },
+    ZeroStateAgentModePromptSuggestion,
+    InitProjectRules,
+    TriggerPassiveSuggestion {
+        trigger: Option<PassiveSuggestionTriggerType>,
+    },
+    UserInitiated,
+    AgentInitiated,
+    SharedSession,
+    CloneRepository,
+    ResumeConversation,
+}
+
+impl EntrypointType {
+    pub fn entrypoint(&self) -> String {
+        match self {
+            Self::PromptSuggestion {
+                is_static,
+                is_coding,
+            } => match (is_static, is_coding) {
+                (true, true) => "PROMPT_SUGGESTION.CODING_STATIC".to_string(),
+                (true, false) => "PROMPT_SUGGESTION.STATIC".to_string(),
+                (false, true) => "PROMPT_SUGGESTION.CODING".to_string(),
+                (false, false) => "PROMPT_SUGGESTION.SIMPLE".to_string(),
+            },
+            Self::ZeroStateAgentModePromptSuggestion => {
+                "ZERO_STATE_AGENT_MODE_PROMPT_SUGGESTION".to_string()
+            }
+            Self::InitProjectRules => "INIT_PROJECT_RULES".to_string(),
+            Self::UserInitiated => "USER_INITIATED".to_string(),
+            Self::AgentInitiated => "AGENT_INITIATED".to_string(),
+            Self::TriggerPassiveSuggestion { trigger } => {
+                let trigger_name = match trigger {
+                    Some(PassiveSuggestionTriggerType::FilesChanged) => "FILES_CHANGED",
+                    Some(PassiveSuggestionTriggerType::CommandRun) => "COMMAND_RUN",
+                    Some(PassiveSuggestionTriggerType::ShellCommandCompleted) => {
+                        "SHELL_COMMAND_COMPLETED"
+                    }
+                    Some(PassiveSuggestionTriggerType::AgentResponseCompleted) => {
+                        "AGENT_RESPONSE_COMPLETED"
+                    }
+                    None => "NONE",
+                };
+                format!("TRIGGER_SUGGEST_PROMPT.{trigger_name}")
+            }
+            Self::CloneRepository => "CLONE_REPOSITORY".to_string(),
+            Self::SharedSession => "SHARED_SESSION".to_string(),
+            Self::ResumeConversation => "RESUME_CONVERSATION".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::enum_variant_names)]
+pub enum PassiveSuggestionTriggerType {
+    /// Used for unit test generation.
+    FilesChanged,
+    /// Used for unit test generation.
+    CommandRun,
+
+    ShellCommandCompleted,
+    AgentResponseCompleted,
+}

--- a/crates/ai_types/src/ambient_agent.rs
+++ b/crates/ai_types/src/ambient_agent.rs
@@ -1,0 +1,28 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use uuid::{NonNilUuid, Uuid};
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid task ID: {0}")]
+pub struct ParseAmbientAgentTaskIdError(#[from] uuid::Error);
+
+/// A globally unique ID for an ambient agent task.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AmbientAgentTaskId(NonNilUuid);
+
+impl Display for AmbientAgentTaskId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for AmbientAgentTaskId {
+    type Err = ParseAmbientAgentTaskIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uuid = Uuid::try_parse(s)?;
+        Ok(Self(NonNilUuid::try_from(uuid)?))
+    }
+}

--- a/crates/ai_types/src/execution_context.rs
+++ b/crates/ai_types/src/execution_context.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WarpAiOsContext {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub category: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub distribution: Option<String>,
+}
+
+/// The execution context of the active session. This struct
+/// is sent as a JSON blob in our AI prompts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WarpAiExecutionContext {
+    pub os: WarpAiOsContext,
+    pub shell_name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub shell_version: Option<String>,
+}
+
+impl WarpAiExecutionContext {
+    pub fn to_json_string(&self) -> Option<String> {
+        serde_json::to_string(self).ok()
+    }
+}

--- a/crates/ai_types/src/lib.rs
+++ b/crates/ai_types/src/lib.rs
@@ -1,0 +1,15 @@
+//! Pure, dependency-light AI model types shared across Warp crates.
+//!
+//! This crate sits below `warp_terminal` and `ai` in the dependency graph, so
+//! it must not depend on any workspace crate above `warp_core`. Keep the
+//! contents limited to IDs, small enums, and small serializable structs.
+
+mod agent;
+mod ambient_agent;
+mod execution_context;
+
+pub use agent::{
+    AIAgentActionId, AIConversationId, EntrypointType, PassiveSuggestionTriggerType, TaskId,
+};
+pub use ambient_agent::{AmbientAgentTaskId, ParseAmbientAgentTaskIdError};
+pub use execution_context::{WarpAiExecutionContext, WarpAiOsContext};

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -19,6 +19,7 @@ diesel = { workspace = true, features = [
 # via some mechanism that the feature resolver has access to, we can't
 # make it optional.
 diesel_migrations = "2.2.0"
+ai_types.workspace = true
 serde.workspace = true
 warp_multi_agent_api.workspace = true
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1226,6 +1226,18 @@ pub struct AgentConversationData {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AIAgentActionId(pub String);
 
+impl From<AIAgentActionId> for ai_types::AIAgentActionId {
+    fn from(value: AIAgentActionId) -> Self {
+        Self::from(value.0)
+    }
+}
+
+impl From<ai_types::AIAgentActionId> for AIAgentActionId {
+    fn from(value: ai_types::AIAgentActionId) -> Self {
+        AIAgentActionId(String::from(value))
+    }
+}
+
 pub type TokenUsageCategory = String;
 
 pub const PRIMARY_AGENT_CATEGORY: &str = "primary_agent";


### PR DESCRIPTION
## Description

This PR creates a new `crates/ai_types` crate and moves pure AI model types into it. This is the first structural step of the crate-split plan to shrink the `warp` crate: lower-level crates (for example `warp_terminal`) will be able to name AI identifiers without a dependency on the heavy `ai` crate or on `warp` itself.

`ai_types` has a small dependency budget: `serde`, `serde_json`, `uuid`, `anyhow`, and `thiserror`. Nothing above `warp_core` is permitted.

Types moved into `ai_types`:
- `AIConversationId` (from `app/src/ai/agent/conversation.rs`)
- `AIAgentActionId` (from `app/src/ai/agent/mod.rs`)
- `TaskId` (from `app/src/ai/agent/task.rs`)
- `AmbientAgentTaskId` and `ParseAmbientAgentTaskIdError` (from `app/src/ai/ambient_agents/mod.rs`)
- `EntrypointType` and `PassiveSuggestionTriggerType` (from `app/src/ai/agent/mod.rs`, with the pure `entrypoint()` mapping from `telemetry.rs`)
- `WarpAiExecutionContext` and `WarpAiOsContext` (from `app/src/ai_assistant/execution_context.rs`)

`SkillDescriptor` moves to `crates/ai/src/skills/listed_skill.rs` instead, because it uses `ai::skills` and `warp_core` types.

The `warp` crate re-exports all moved types from their old paths, so almost all call sites do not change. Three mechanical adjustments were necessary:
- The `From` conversions between persistence rows and `AIAgentActionId` move into `crates/persistence` to satisfy the orphan rule.
- `WarpAiExecutionContext::new(&Arc<Session>)` becomes the free function `execution_context_for_session` in `app/src/ai_assistant/execution_context.rs`, because it reads app `Session` state.
- `TaskId` now has a private field, so a few construction sites use `TaskId::new` and one GraphQL call site converts `AmbientAgentTaskId` through `to_string()`.

## Linked Issue

Part of the crate-split compile-time work. No linked issue.

## Testing

- `cargo check -p ai_types -p persistence -p ai -p warp -p warp_tui --all-targets` passes.
- `cargo nextest run -p ai_types -p persistence` passes (26 tests).
- `cargo nextest run -p warp` filtered to `ai::agent`, `ambient_agents`, `execution_context`, and `ai_assistant` passes (873 tests).
- `./script/format` and all three presubmit clippy passes are clean.

This is a pure type move with re-exports; there is no behavior change to test manually.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Warp AI Artifacts

- [Conversation](https://staging.warp.dev/conversation/024e797d-1d35-4c62-8394-abf93f7ddb0e)
- [Plan: Crate-split scoping: shrink the warp crate](https://staging.warp.dev/drive/notebook/FMSFMUMu22aK8Dz4FLOnhb)

<!--
CHANGELOG-NONE
-->
