### PR TITLE
Add keyboard shortcut to toggle Markdown rendered/raw view

### DIFF
--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -45,7 +45,10 @@ use crate::code::{EditorTabBarDropTargetData, ImmediateSaveError, SaveOutcome, S
 use crate::editor::InteractionState;
 use crate::input::Vector2F;
 use crate::menu::{MenuItem, MenuItemFields};
-use crate::notebooks::file::{MarkdownDisplayMode, renders_in_warp_notebook_viewer};
+use crate::notebooks::file::{
+    MARKDOWN_TOGGLE_BINDING_DESCRIPTION, MARKDOWN_TOGGLE_BINDING_NAME, MarkdownDisplayMode,
+    renders_in_warp_notebook_viewer,
+};
 use crate::pane_group::focus_state::PaneFocusHandle;
 use crate::pane_group::pane::view::header::components::{
     CenteredHeaderEdgeWidth, render_pane_header_buttons, render_pane_header_title_text,
@@ -132,8 +135,8 @@ pub fn init(app: &mut AppContext) {
         // target sets `local_fs`.
         #[cfg(feature = "local_fs")]
         EditableBinding::new(
-            "code_view:render_markdown",
-            "Show rendered Markdown",
+            MARKDOWN_TOGGLE_BINDING_NAME,
+            MARKDOWN_TOGGLE_BINDING_DESCRIPTION,
             CodeViewAction::RenderMarkdown,
         )
         .with_context_predicate(id!(MARKDOWN_TOGGLEABLE_CONTEXT))

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -85,6 +85,10 @@ const TAB_HORIZONTAL_MARGIN: f32 = 8.;
 const TAB_PADDING: f32 = 2.;
 
 // Keybinding constants - exported so AI document view can reuse
+/// Keymap context identifier present only while the active tab holds a file that Warp can render
+/// in the notebook viewer, so the toggle binding is inert on ordinary code tabs.
+pub const MARKDOWN_TOGGLEABLE_CONTEXT: &str = "CodeView_MarkdownToggleable";
+
 pub const SAVE_FILE_BINDING_NAME: &str = "code_view:save";
 pub const SAVE_FILE_BINDING_DESCRIPTION: &str = "Save file";
 
@@ -122,6 +126,13 @@ pub fn init(app: &mut AppContext) {
         )
         .with_context_predicate(id!("CodeEditorView"))
         .with_key_binding("cmdorctrl-r u"),
+        EditableBinding::new(
+            "code_view:render_markdown",
+            "Show rendered Markdown",
+            CodeViewAction::RenderMarkdown,
+        )
+        .with_context_predicate(id!(MARKDOWN_TOGGLEABLE_CONTEXT))
+        .with_key_binding("cmdorctrl-e"),
     ]);
 }
 
@@ -624,6 +635,18 @@ impl CodeView {
 
     fn clear_drag_position(&mut self) {
         self.drag_position = None;
+    }
+
+    /// Whether the active tab holds a file Warp can render in the notebook viewer.
+    ///
+    /// Detection reads the standardized path component rather than an OS path, so it stays correct
+    /// for files opened over a remote session.
+    fn active_tab_renders_in_notebook_viewer(&self) -> bool {
+        self.tab_at(self.active_tab_index)
+            .and_then(|tab| tab.location.as_ref())
+            .is_some_and(|location| {
+                renders_in_warp_notebook_viewer(location.path_component().as_str())
+            })
     }
 
     pub fn tab_at(&self, index: usize) -> Option<&TabData> {
@@ -2240,6 +2263,14 @@ impl Entity for CodeView {
 impl View for CodeView {
     fn ui_name() -> &'static str {
         "CodeView"
+    }
+
+    fn keymap_context(&self, _app: &AppContext) -> warpui::keymap::Context {
+        let mut context = Self::default_keymap_context();
+        if self.active_tab_renders_in_notebook_viewer() {
+            context.set.insert(MARKDOWN_TOGGLEABLE_CONTEXT);
+        }
+        context
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -126,6 +126,11 @@ pub fn init(app: &mut AppContext) {
         )
         .with_context_predicate(id!("CodeEditorView"))
         .with_key_binding("cmdorctrl-r u"),
+        // Guarded to match the action it dispatches, like the rest of this file's
+        // filesystem-backed actions. The guard is always true in practice: this module is
+        // path-swapped to `wasm.rs` for wasm targets (see `code/mod.rs`), and every non-wasm
+        // target sets `local_fs`.
+        #[cfg(feature = "local_fs")]
         EditableBinding::new(
             "code_view:render_markdown",
             "Show rendered Markdown",

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -213,6 +213,10 @@ impl FileState {
     }
 }
 
+/// Keymap context identifier present only while this pane can toggle between rendered and raw
+/// Markdown, so the toggle binding is inert on panes that have no such mode.
+pub const MARKDOWN_TOGGLEABLE_CONTEXT: &str = "FileNotebookView_MarkdownToggleable";
+
 pub fn init(app: &mut AppContext) {
     use warpui::keymap::macros::*;
 
@@ -230,6 +234,13 @@ pub fn init(app: &mut AppContext) {
             FileNotebookAction::ReloadFile,
         )
         .with_context_predicate(id!("FileNotebookView")),
+        EditableBinding::new(
+            "notebookview:show_raw_markdown",
+            "Show raw Markdown",
+            FileNotebookAction::ToggleMarkdownDisplayMode(MarkdownDisplayMode::Raw),
+        )
+        .with_context_predicate(id!(MARKDOWN_TOGGLEABLE_CONTEXT))
+        .with_key_binding("cmdorctrl-e"),
     ])
 }
 
@@ -1012,6 +1023,14 @@ impl Entity for FileNotebookView {
 impl View for FileNotebookView {
     fn ui_name() -> &'static str {
         "FileNotebookView"
+    }
+
+    fn keymap_context(&self, _app: &AppContext) -> warpui::keymap::Context {
+        let mut context = Self::default_keymap_context();
+        if self.shows_markdown_toggle() {
+            context.set.insert(MARKDOWN_TOGGLEABLE_CONTEXT);
+        }
+        context
     }
 
     fn accessibility_contents(&self, _ctx: &AppContext) -> Option<AccessibilityContent> {

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -217,6 +217,16 @@ impl FileState {
 /// Markdown, so the toggle binding is inert on panes that have no such mode.
 pub const MARKDOWN_TOGGLEABLE_CONTEXT: &str = "FileNotebookView_MarkdownToggleable";
 
+/// Name and description shared by both halves of the Markdown rendered/raw toggle.
+///
+/// The two halves dispatch different actions from different views, so they have to be registered
+/// separately. They share a name because custom triggers are stored and applied by name, so a
+/// rebind in Settings has to reach both directions; they share a description because the settings
+/// page collapses duplicates on the name/description pair and would otherwise list two rows
+/// fighting over the same shortcut.
+pub const MARKDOWN_TOGGLE_BINDING_NAME: &str = "markdown:toggle_display_mode";
+pub const MARKDOWN_TOGGLE_BINDING_DESCRIPTION: &str = "Toggle rendered Markdown";
+
 pub fn init(app: &mut AppContext) {
     use warpui::keymap::macros::*;
 
@@ -235,8 +245,8 @@ pub fn init(app: &mut AppContext) {
         )
         .with_context_predicate(id!("FileNotebookView")),
         EditableBinding::new(
-            "notebookview:show_raw_markdown",
-            "Show raw Markdown",
+            MARKDOWN_TOGGLE_BINDING_NAME,
+            MARKDOWN_TOGGLE_BINDING_DESCRIPTION,
             FileNotebookAction::ToggleMarkdownDisplayMode(MarkdownDisplayMode::Raw),
         )
         .with_context_predicate(id!(MARKDOWN_TOGGLEABLE_CONTEXT))

--- a/app/src/notebooks/file/mod_tests.rs
+++ b/app/src/notebooks/file/mod_tests.rs
@@ -476,3 +476,53 @@ fn test_file_notebook_mermaid_context_menu_does_not_show_copy_image() {
         });
     });
 }
+
+/// The toggle binding is scoped by keymap context rather than filtered inside the handler, so the
+/// context identifier must be absent on panes that have no rendered/raw mode to switch between.
+#[test]
+fn test_markdown_toggle_keymap_context() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let (_, handle) = app.add_window(WindowStyle::NotStealFocus, FileNotebookView::new);
+        let session = Arc::new(Session::test());
+
+        app.read(|ctx| {
+            assert!(
+                !handle
+                    .as_ref(ctx)
+                    .keymap_context(ctx)
+                    .set
+                    .contains(super::MARKDOWN_TOGGLEABLE_CONTEXT),
+                "an empty pane has no rendered/raw mode to toggle"
+            );
+        });
+
+        handle.update(&mut app, |file_notebook, ctx| {
+            file_notebook.open_local("../README.md", Some(session.clone()), ctx);
+        });
+        app.read(|ctx| {
+            assert!(
+                handle
+                    .as_ref(ctx)
+                    .keymap_context(ctx)
+                    .set
+                    .contains(super::MARKDOWN_TOGGLEABLE_CONTEXT),
+                "a Markdown pane should expose the toggle context"
+            );
+        });
+
+        handle.update(&mut app, |file_notebook, ctx| {
+            file_notebook.open_local("../Cargo.toml", Some(session), ctx);
+        });
+        app.read(|ctx| {
+            assert!(
+                !handle
+                    .as_ref(ctx)
+                    .keymap_context(ctx)
+                    .set
+                    .contains(super::MARKDOWN_TOGGLEABLE_CONTEXT),
+                "a non-Markdown pane should not expose the toggle context"
+            );
+        });
+    });
+}

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -160,3 +160,48 @@ fn test_terminal_page_scroll_bindings_are_editable() {
         });
     });
 }
+
+/// Both halves of the Markdown rendered/raw toggle are registered separately, from different views
+/// with different actions. They share a binding name so that a rebind in Settings reaches both
+/// directions rather than leaving one stuck on the old shortcut.
+#[test]
+fn test_markdown_toggle_rebind_applies_to_both_directions() {
+    App::test((), |mut app| async move {
+        app.update(crate::code::view::init);
+        app.update(crate::notebooks::file::init);
+
+        app.update(|ctx| {
+            use crate::notebooks::file::MARKDOWN_TOGGLE_BINDING_NAME;
+
+            let triggers = |ctx: &warpui::AppContext| {
+                ctx.editable_bindings()
+                    .filter(|binding| binding.name == MARKDOWN_TOGGLE_BINDING_NAME)
+                    .map(|binding| trigger_to_keystroke(binding.trigger))
+                    .collect::<Vec<_>>()
+            };
+
+            assert_eq!(
+                vec![
+                    Keystroke::parse("cmdorctrl-e").ok(),
+                    Keystroke::parse("cmdorctrl-e").ok(),
+                ],
+                triggers(ctx),
+                "both directions should be registered under the shared name"
+            );
+
+            ctx.set_custom_trigger(
+                MARKDOWN_TOGGLE_BINDING_NAME.to_owned(),
+                Trigger::Keystrokes(vec![Keystroke::parse("cmd-shift-M").unwrap()]),
+            );
+
+            assert_eq!(
+                vec![
+                    Keystroke::parse("cmd-shift-M").ok(),
+                    Keystroke::parse("cmd-shift-M").ok(),
+                ],
+                triggers(ctx),
+                "rebinding the shared name should move both directions"
+            );
+        });
+    });
+}

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -1068,6 +1068,85 @@ fn test_open_file_with_target_event_preserves_requested_line() {
     });
 }
 
+/// The Markdown toggle binding is scoped by keymap context rather than filtered inside the action
+/// handler, so a raw code pane must advertise the context only while its active tab holds a file
+/// the notebook viewer can render.
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_code_pane_markdown_toggle_keymap_context_tracks_active_tab() {
+    use warpui::View;
+
+    use crate::code::buffer_location::LocalOrRemotePath;
+    use crate::code::editor_management::CodeManager;
+    use crate::code::global_buffer_model::GlobalBufferModel;
+    use crate::code::view::MARKDOWN_TOGGLEABLE_CONTEXT;
+    use crate::terminal::local_shell::LocalShellState;
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.add_singleton_model(|_| CodeManager::default());
+        app.add_singleton_model(|_| LocalShellState::NotLoaded);
+        app.add_singleton_model(GlobalBufferModel::new);
+        let workspace = mock_workspace(&mut app);
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+
+        let markdown_path = temp_dir.path().join("README.md");
+        std::fs::write(&markdown_path, "# Test\n").expect("failed to write markdown file");
+        let code_path = temp_dir.path().join("main.rs");
+        std::fs::write(&code_path, "fn main() {}\n").expect("failed to write code file");
+
+        workspace.update(&mut app, |workspace, ctx| {
+            let pane_group = workspace.active_tab_pane_group().clone();
+            workspace.handle_file_tree_event(
+                pane_group,
+                &crate::pane_group::Event::OpenFileWithTarget {
+                    path: markdown_path.clone(),
+                    target: FileTarget::CodeEditor(EditorLayout::SplitPane),
+                    line_col: None,
+                },
+                ctx,
+            );
+        });
+
+        let code_view = app.read(|ctx| {
+            let pane_group = workspace.as_ref(ctx).active_tab_pane_group().as_ref(ctx);
+            let code_panes = pane_group.code_panes(ctx).collect_vec();
+            assert_eq!(code_panes.len(), 1);
+            code_panes[0].1.clone()
+        });
+
+        app.read(|ctx| {
+            assert!(
+                code_view
+                    .as_ref(ctx)
+                    .keymap_context(ctx)
+                    .set
+                    .contains(MARKDOWN_TOGGLEABLE_CONTEXT),
+                "a raw Markdown tab should expose the toggle context"
+            );
+        });
+
+        code_view.update(&mut app, |code_view, ctx| {
+            code_view.open_or_focus_existing(
+                Some(LocalOrRemotePath::Local(code_path.clone())),
+                None,
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            assert!(
+                !code_view
+                    .as_ref(ctx)
+                    .keymap_context(ctx)
+                    .set
+                    .contains(MARKDOWN_TOGGLEABLE_CONTEXT),
+                "a non-Markdown tab should not expose the toggle context"
+            );
+        });
+    });
+}
+
 /// Regression test for the raw-code toggle: the notebook-viewer target used to
 /// drop the `CodeSource` outright, so the raw view always started at line 1.
 #[cfg(feature = "local_fs")]


### PR DESCRIPTION
## Description

Adds an editable `cmd/ctrl+E` binding to switch Markdown panes between the rendered viewer and raw source, in both directions (`FileNotebookView` → raw, `CodeView` → rendered).

Following the review feedback on #12826, the binding is scoped with a **keymap context** rather than by post-filtering inside the action handler. Each view overrides `keymap_context` and advertises an identifier only while that pane actually has a rendered/raw mode:

- `FileNotebookView_MarkdownToggleable`, inserted when `shows_markdown_toggle()` holds.
- `CodeView_MarkdownToggleable`, inserted when the active tab renders in the notebook viewer.


`cmd/ctrl+E` matches Obsidian's shortcut and did not collide with an existing binding. It is registered as an `EditableBinding`, so it is rebindable from the keybindings settings.

## Linked Issue

Fixes #11786

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

[

https://github.com/user-attachments/assets/f7a555ab-d6f2-4c3f-a849-5b413ef9ebff

](url)

- Added `test_markdown_toggle_keymap_context`, asserting the context identifier is absent on an empty pane, present after opening a Markdown file, and absent again after opening a non-Markdown file. This is the property the handler-filtering approach could not express.
- Ran the `notebooks::file::` and `code::view::` suites (10 tests, all passing).
- Ran `./script/format` and `cargo check` with no warnings.
- Built and launched the OSS bundle via `./script/run`.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Pending manual visual validation; publishing as a draft until a recording of the toggle (and of the binding correctly doing nothing in a non-Markdown pane) is captured.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a keyboard shortcut to toggle Markdown files between the rendered viewer and raw source.
