### PR TITLE
Add back some go setup commands to release creation workflow.

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -166,6 +166,12 @@ jobs:
         run: rustup target add ${{ matrix.arch }}-apple-darwin
         shell: bash
 
+      # Install go toolchain, which is needed for bundling a pprof binary.
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: stable
+
       - name: Get channel configuration
         id: get-config
         uses: ./.github/actions/get_channel_config/
@@ -282,6 +288,12 @@ jobs:
           ref: ${{ needs.prepare_release.outputs.release_branch }}
           install_release_deps: true
           ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
+
+      # Install go toolchain, which is needed for bundling a pprof binary.
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: stable
 
       - name: Get channel configuration
         id: get-config

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -539,7 +539,7 @@ jobs:
           install_release_deps: true
           ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
 
-      # Install go toolchain, as it may be needed for some build steps.
+      # Install go toolchain, which is needed for bundling a pprof binary.
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -539,12 +539,6 @@ jobs:
           install_release_deps: true
           ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
 
-      # Install go toolchain, which is needed for bundling a pprof binary.
-      - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version: stable
-
       - name: Get channel configuration
         id: get-config
         uses: ./.github/actions/get_channel_config/


### PR DESCRIPTION
## Description

Turns out these were needed for jobs that bundle pprof - we use the go toolchain to build pprof.

I've re-added the ones we needed, and updated all of the comments to make it clear exactly what we need the step for, so it doesn't get accidentally removed in the future.

Example failing GitHub release workflow run: https://github.com/warpdotdev/warp-internal/actions/runs/32627519717/job/97165455295