### PR TITLE
factory-files: teach the skill and validator about webhook sources

### DIFF
--- a/resources/bundled/skills/factory-files/SKILL.md
+++ b/resources/bundled/skills/factory-files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: factory-files
-description: Create and edit file-based Warp software factory definitions, in a repository tree rooted at a factory.yaml. Use when authoring or changing that factory.yaml, Agent, Automation, Scorer, or Runner files under that root, or its factory and agent skill trees, and when fixing Factory file diagnostics. Do not use for agent-definition Markdown that belongs to another tool, for a tree with no factory.yaml, or to operate a live factory or hand work to one through Factory MCP.
+description: Create and edit file-based Warp software factory definitions, in a repository tree rooted at a factory.yaml. Use when authoring or changing that factory.yaml, Agent, Automation, Scorer, Runner, or Webhook files under that root, or its factory and agent skill trees, and when fixing Factory file diagnostics. Do not use for agent-definition Markdown that belongs to another tool, for a tree with no factory.yaml, or to operate a live factory or hand work to one through Factory MCP.
 ---
 
 # Factory Files
@@ -40,6 +40,7 @@ agents/<name>/skills/**             skills only that agent can use
 automations/<name>/automation.md    optional
 runners/<name>.yaml                 optional
 scorers/<name>/scorer.md            optional; Markdown body is the rubric
+webhooks/<name>.yaml                optional; custom webhook sources
 skills/**                           skills every agent in the factory can use
 ```
 
@@ -70,11 +71,11 @@ curl -s https://app.warp.dev/api/v1/factory-files/schemas/<schemaVersion>
 The registry lists the versions the server supports. The version endpoint
 returns every document describing one version, keyed by file name:
 `factory.schema.json` for `factory.yaml`, `agent.schema.json`,
-`automation.schema.json`, `runner.schema.json` and `scorer.schema.json` for the
-corresponding resources, and `common.schema.json` for the definitions they
-share. Both endpoints are unauthenticated. They are exact for the version they
-describe: an unknown field is an error, and each enumerated value is one the
-server accepts today.
+`automation.schema.json`, `runner.schema.json`, `scorer.schema.json` and
+`webhook.schema.json` for the corresponding resources, and
+`common.schema.json` for the definitions they share. Both endpoints are
+unauthenticated. They are exact for the version they describe: an unknown
+field is an error, and each enumerated value is one the server accepts today.
 
 If the server does not publish the declared version, stop. Do not measure the
 tree against a version it does not claim to be, and never lower
@@ -157,6 +158,17 @@ read them.
   its canonical key, and declaring both is an error. The Linear and Slack ones
   name objects the server looks up at apply time, so they take a plain list of
   names rather than an `in`/`not_in` matcher.
+- A webhook never carries secret material. `secretName` is required in every
+  `authMode` and names an existing managed secret; the server does not generate
+  a secret for a file-declared source, because nothing could then read it back
+  to configure the sender.
+- `signatureScheme` is required when `authMode: signature` and rejected
+  otherwise.
+- `authMode` and `signatureScheme` cannot be changed on an existing source.
+  Changing either means deleting the file and adding a new one under a
+  different name.
+- A webhook subscription's `filter.webhook_ids` takes source UIDs the server
+  assigned, not the file names declared here.
 
 ## Do not add a local copy of the format
 It is tempting to bundle the schema, or to reimplement a few checks here so

--- a/resources/bundled/skills/factory-files/references/examples.md
+++ b/resources/bundled/skills/factory-files/references/examples.md
@@ -194,6 +194,41 @@ Evaluate whether the agent ran the relevant tests before finishing. Return
 return `tests_skipped`.
 ```
 
+## Webhook source
+`webhooks/ci.yaml`, a token-authenticated source:
+
+```yaml
+authMode: token
+secretName: CI_WEBHOOK_TOKEN
+```
+
+`webhooks/github-events.yaml`, verifying GitHub's own signature scheme:
+
+```yaml
+authMode: signature
+signatureScheme: github
+secretName: GITHUB_WEBHOOK_SECRET
+deliveryIdHeader: X-GitHub-Delivery
+enabled: true
+```
+
+`secretName` is required in every `authMode` and names a managed secret that
+already exists; the file never carries the secret itself, and the server does
+not mint one for a file-declared source. The source's name is the file name.
+
+An automation subscribes to a source by the UID the server assigned it, not by
+the file name:
+
+```yaml
+triggers:
+  - provider: webhook
+    event: received
+    filter:
+      webhook_ids: [wh_01J9Z2K3M4N5P6Q7R8S9T0]
+      payload:
+        action: [opened, reopened]
+```
+
 ## Scoped skills
 A skill under `skills/` is available to every agent in the factory. A skill
 under `agents/<name>/skills/` is available only to that agent.

--- a/resources/bundled/skills/factory-files/scripts/validate_factory_files.py
+++ b/resources/bundled/skills/factory-files/scripts/validate_factory_files.py
@@ -131,6 +131,9 @@ def classify(relative: str) -> tuple[str, str]:
         return ("scorer", segments[1]) if _valid_name(segments[1]) else ("invalid", "")
     if len(segments) == 2 and segments[0] == "scorers" and segments[1].endswith(".md"):
         return "invalid", ""
+    if len(segments) == 2 and segments[0] == "webhooks" and segments[1].endswith(".yaml"):
+        name = segments[1][: -len(".yaml")]
+        return ("webhook", name) if _valid_name(name) else ("invalid", "")
     base = segments[-1]
     if segments[0] == "agents" and base == "agent.md":
         return "invalid", ""
@@ -139,6 +142,8 @@ def classify(relative: str) -> tuple[str, str]:
     if segments[0] == "runners" and base.endswith(".yaml"):
         return "invalid", ""
     if segments[0] == "scorers" and base == "scorer.md":
+        return "invalid", ""
+    if segments[0] == "webhooks" and base.endswith(".yaml"):
         return "invalid", ""
     return "unrelated", ""
 
@@ -149,7 +154,7 @@ def _valid_name(name: str) -> bool:
 
 def _resource_files(root: Path) -> list[Path]:
     files = [root / "factory.yaml"]
-    for directory_name in ("agents", "automations", "runners", "scorers"):
+    for directory_name in ("agents", "automations", "runners", "scorers", "webhooks"):
         resource_root = root / directory_name
         if not resource_root.is_dir():
             continue

--- a/script/test_factory_files_skill.py
+++ b/script/test_factory_files_skill.py
@@ -198,10 +198,14 @@ def assert_submits_only_resource_files() -> None:
             "automations/nightly/automation.md": "---\nagent: main\n---\nrun\n",
             "runners/linux.yaml": "platform:\n  linux:\n    dockerImage: ubuntu:24.04\n",
             "scorers/tests/scorer.md": "---\nagents: [main]\n---\nRubric.\n",
+            "webhooks/ci.yaml": "authMode: token\nsecretName: CI_TOKEN\n",
             "skills/helper/SKILL.md": "---\nname: helper\n---\nhelp\n",
             "agents/main/skills/inner/SKILL.md": "---\nname: inner\n---\nhelp\n",
             "README.md": "unrelated",
             "agents/main/notes.txt": "unrelated",
+            # Not a canonical webhook path: the server would not classify a
+            # nested file as a source, so submitting it would be noise.
+            "webhooks/nested/inner.yaml": "authMode: token\n",
         }
     ) as root:
         with fake_server(CLEAN_RESPONSE) as server:
@@ -215,6 +219,7 @@ def assert_submits_only_resource_files() -> None:
             "automations/nightly/automation.md",
             "runners/linux.yaml",
             "scorers/tests/scorer.md",
+            "webhooks/ci.yaml",
         }
         if submitted != expected:
             raise RuntimeError(


### PR DESCRIPTION
## Description

warp-server is adding `webhooks/<name>.yaml` as a file-backed Factory resource kind (warpdotdev/warp-server#15686). The bundled `factory-files` skill did not know about it, and the gap was not only documentation:

**The validator silently skipped webhook files.** `_resource_files` only walked `agents`, `automations`, `runners` and `scorers`, and `classify` had no `webhooks/` arm, so a tree containing a webhook source uploaded everything *except* that file and the server returned a clean verdict for the rest. An author would have been told the tree was checked when the new resource never left the machine — the exact "never imply a check that did not happen" failure the skill is otherwise careful about.

Changes:
- `scripts/validate_factory_files.py`: collect `webhooks/`, classify `webhooks/<name>.yaml` as a resource, and treat other shapes under `webhooks/` as invalid rather than unrelated (mirroring `runners/`).
- `SKILL.md`: add the path to the layout, `webhook.schema.json` to the published schema documents, `Webhook` to the trigger description, and four easy-to-get-wrong rules (secrets are referenced not authored, `signatureScheme` is required iff `authMode: signature`, auth mode and scheme are immutable, and `filter.webhook_ids` takes server-assigned UIDs rather than file names).
- `references/examples.md`: worked token and signature examples plus the subscription filter.

No copy of the format is added — field definitions still come from the server's published schema, per the skill's standing rule.

## Linked Issue

REMOTE-2447. Server side is warpdotdev/warp-server#15686.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (not applicable — no UI surface).

## Testing

- `./script/test_factory_files_skill.py` (the suite presubmit runs): all 12 cases pass, including `source and bundled trees match`.
- Extended `assert_submits_only_resource_files` so it fails if this regresses: the tree now contains `webhooks/ci.yaml`, which must be submitted, and `webhooks/nested/inner.yaml`, which must not. Verified by reverting just the validator and re-running — it fails with `missing=['webhooks/ci.yaml']`. The nested case passes either way (it was already excluded, as `unrelated` rather than `invalid`); it is there to pin the boundary.
- `cargo test -p warp --lib factory_files_bundled_skill` passes — it asserts on the frontmatter description I edited and on the reference files existing.

Not manually run through `./script/run`: this change is a bundled skill document and a Python validator script with no UI or runtime surface, and both are exercised directly by the suites above.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE:
