### PR TITLE
Fix last-tab shortcut hint precedence

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -76,6 +76,20 @@ pub(crate) const TAB_ACTIVATE_BINDING_NAMES: [&str; 8] = [
     "workspace:activate_seventh_tab",
     "workspace:activate_eighth_tab",
 ];
+pub(crate) const TAB_ACTIVATE_LAST_BINDING_NAME: &str = "workspace:activate_last_tab";
+
+pub(crate) fn tab_activate_binding_name(
+    tab_index: usize,
+    tab_count: usize,
+) -> Option<&'static str> {
+    if tab_index >= tab_count {
+        return None;
+    }
+    if let Some(binding_name) = TAB_ACTIVATE_BINDING_NAMES.get(tab_index).copied() {
+        return Some(binding_name);
+    }
+    (tab_index == tab_count - 1).then_some(TAB_ACTIVATE_LAST_BINDING_NAME)
+}
 
 /// Modifier kinds relevant to revealing tab shortcut hints. The Super kind is
 /// the Cmd key on macOS and the Windows/Super key elsewhere; a `Keystroke`'s
@@ -202,6 +216,8 @@ pub(crate) fn reveals_tab_shortcut_hints(ctx: &AppContext) -> bool {
     }
     let binding_kinds: HashSet<_> = TAB_ACTIVATE_BINDING_NAMES
         .iter()
+        .copied()
+        .chain(std::iter::once(TAB_ACTIVATE_LAST_BINDING_NAME))
         .filter_map(|name| keybinding_name_to_keystroke(name, ctx))
         .flat_map(|keystroke| keystroke_modifier_kinds(&keystroke))
         .collect();
@@ -1169,12 +1185,12 @@ impl<'a> TabComponent<'a> {
             .as_ref(ctx)
             .is_terminal_pane_being_shared(ctx);
         let should_show_indicators = *TabSettings::as_ref(ctx).show_indicators.value();
-        let shortcut_hint_label =
-            if reveals_tab_shortcut_hints(ctx) && tab_index < TAB_ACTIVATE_BINDING_NAMES.len() {
-                keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[tab_index], ctx)
-            } else {
-                None
-            };
+        let shortcut_hint_label = if reveals_tab_shortcut_hints(ctx) {
+            tab_activate_binding_name(tab_index, tab_bar.tab_count)
+                .and_then(|binding_name| keybinding_name_to_display_string(binding_name, ctx))
+        } else {
+            None
+        };
         let are_inputs_synced = SyncedInputState::as_ref(ctx)
             .should_sync_this_pane_group(tab.pane_group.id(), tab.pane_group.window_id(ctx));
 

--- a/app/src/tab_tests.rs
+++ b/app/src/tab_tests.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use warpui::platform::keyboard::KeyCode;
 
 use super::{
-    SelectedTabColor, ShortcutModifierKind, TabShortcutModifierState, next_tab_color,
-    tab_group_menu_entry_flags,
+    SelectedTabColor, ShortcutModifierKind, TAB_ACTIVATE_BINDING_NAMES,
+    TAB_ACTIVATE_LAST_BINDING_NAME, TabShortcutModifierState, next_tab_color,
+    tab_activate_binding_name, tab_group_menu_entry_flags,
 };
 use crate::themes::theme::AnsiColorIdentifier;
 use crate::ui_components::color_dot::TAB_COLOR_OPTIONS;
@@ -69,6 +70,37 @@ fn tab_shortcut_modifier_state_only_reveals_keys_that_remain_held() {
     assert!(state.held_keys.remove(&KeyCode::SuperLeft));
     assert!(!state.reveal_key_if_held(KeyCode::SuperLeft));
     assert!(state.held_kinds().is_empty());
+}
+
+#[test]
+fn tab_activate_binding_name_prefers_numbered_binding_for_final_tab() {
+    assert_eq!(
+        tab_activate_binding_name(2, 3),
+        Some(TAB_ACTIVATE_BINDING_NAMES[2])
+    );
+    assert_eq!(
+        tab_activate_binding_name(7, 8),
+        Some(TAB_ACTIVATE_BINDING_NAMES[7])
+    );
+}
+
+#[test]
+fn tab_activate_binding_name_uses_last_tab_binding_beyond_numbered_tabs() {
+    assert_eq!(
+        tab_activate_binding_name(8, 9),
+        Some(TAB_ACTIVATE_LAST_BINDING_NAME)
+    );
+    assert_eq!(
+        tab_activate_binding_name(9, 10),
+        Some(TAB_ACTIVATE_LAST_BINDING_NAME)
+    );
+}
+
+#[test]
+fn tab_activate_binding_name_omits_unbound_and_out_of_bounds_tabs() {
+    assert_eq!(tab_activate_binding_name(8, 10), None);
+    assert_eq!(tab_activate_binding_name(10, 10), None);
+    assert_eq!(tab_activate_binding_name(0, 0), None);
 }
 
 // GH-13073 follow-up: a tab that shares a group with siblings SHOULD still be

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -56,8 +56,8 @@ use crate::pane_group::{
 };
 use crate::safe_triangle::SafeTriangle;
 use crate::tab::{
-    SelectedTabColor, TAB_ACTIVATE_BINDING_NAMES, TAB_INDICATOR_SYNCED_COLOR, TabData,
-    reveals_tab_shortcut_hints, tab_position_id,
+    SelectedTabColor, TAB_INDICATOR_SYNCED_COLOR, TabData, reveals_tab_shortcut_hints,
+    tab_activate_binding_name, tab_position_id,
 };
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::session_settings::SessionSettings;
@@ -411,7 +411,7 @@ fn render_pane_row_element(
         pane_rename_editor: _,
         is_pinned,
         container_is_hovered,
-        shortcut_hint_tab_index: _,
+        shortcut_hint_binding_name: _,
     } = props;
     let is_selected = is_active_tab && is_focused;
     let show_pin = FeatureFlag::PinnedTabs.is_enabled() && is_pinned && !container_is_hovered;
@@ -857,7 +857,7 @@ struct PaneProps<'a> {
     /// True when the tab container containing this pane is hovered.
     /// The pin icon is hidden when a tab is hovered.
     container_is_hovered: bool,
-    shortcut_hint_tab_index: Option<usize>,
+    shortcut_hint_binding_name: Option<&'static str>,
 }
 
 struct PaneRowState {
@@ -1240,7 +1240,7 @@ impl VerticalTabsPanelState {
                                 None,
                                 tab.pinned,
                                 false,
-                                Some(*tab_index),
+                                None,
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -1848,7 +1848,7 @@ fn render_groups(
                                     None,
                                     tab.pinned,
                                     false,
-                                    Some(tab_index),
+                                    None,
                                     app,
                                 )
                                 .is_some_and(|props| {
@@ -1880,7 +1880,7 @@ fn render_groups(
                                 None,
                                 tab.pinned,
                                 false,
-                                Some(tab_index),
+                                None,
                                 app,
                             )
                             .is_some_and(|props| pane_matches_query(&props, &query_lower, app))
@@ -2240,7 +2240,7 @@ fn render_tab_group_internal(
                     None,
                     tab.pinned,
                     group_state.is_hovered(),
-                    Some(tab_index),
+                    tab_activate_binding_name(tab_index, workspace.tabs.len()),
                     app,
                 ) else {
                     return Empty::new().finish();
@@ -2300,7 +2300,7 @@ fn render_tab_group_internal(
                     is_pane_being_renamed.then_some(workspace.pane_rename_editor.clone()),
                     tab.pinned,
                     group_state.is_hovered(),
-                    Some(tab_index),
+                    tab_activate_binding_name(tab_index, workspace.tabs.len()),
                     app,
                 ) else {
                     continue;
@@ -3437,22 +3437,13 @@ fn render_synced_inputs_indicator() -> Box<dyn Element> {
     .finish()
 }
 
-/// Whether a row is eligible to surface the switch-to-tab shortcut hint: the
-/// reveal modifier is held and the tab falls within the first 8 (the only tabs
-/// with a `cmdorctrl-N` binding). Whether a label is actually shown also
-/// depends on the binding being assigned — see [`shortcut_hint_label`].
-fn shows_shortcut_hint(modifier_held: bool, tab_index: usize) -> bool {
-    modifier_held && tab_index < TAB_ACTIVATE_BINDING_NAMES.len()
-}
-
 /// Resolves the switch-to-tab shortcut label for a row while the reveal
 /// modifier is held. Returns `None` when no hint should be shown.
 fn shortcut_hint_label(props: &PaneProps<'_>, app: &AppContext) -> Option<String> {
-    let tab_index = props.shortcut_hint_tab_index?;
-    if !shows_shortcut_hint(reveals_tab_shortcut_hints(app), tab_index) {
+    if !reveals_tab_shortcut_hints(app) {
         return None;
     }
-    keybinding_name_to_display_string(TAB_ACTIVATE_BINDING_NAMES[tab_index], app)
+    keybinding_name_to_display_string(props.shortcut_hint_binding_name?, app)
 }
 
 /// Inline label showing the switch-to-tab keyboard shortcut, mirroring the
@@ -3915,7 +3906,7 @@ impl<'a> PaneProps<'a> {
         pane_rename_editor: Option<ViewHandle<EditorView>>,
         is_pinned: bool,
         container_is_hovered: bool,
-        shortcut_hint_tab_index: Option<usize>,
+        shortcut_hint_binding_name: Option<&'static str>,
         app: &AppContext,
     ) -> Option<Self> {
         let pane = pane_group.pane_by_id(pane_id)?;
@@ -3970,7 +3961,7 @@ impl<'a> PaneProps<'a> {
             pane_rename_editor,
             is_pinned,
             container_is_hovered,
-            shortcut_hint_tab_index,
+            shortcut_hint_binding_name,
         })
     }
 

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -16,7 +16,7 @@ use super::{
     pane_ids_for_display_granularity, pane_search_text_fragments, preferred_agent_tab_titles,
     push_normalized_unique_summary_label, search_fragments_contain_query,
     select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
-    should_show_tab_group_header, shows_shortcut_hint, shows_synced_inputs_indicator,
+    should_show_tab_group_header, shows_synced_inputs_indicator,
     sort_summary_primary_labels_status_first, summary_overflow_count,
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
     terminal_pull_request_badge_label, terminal_search_text_fragments,
@@ -28,7 +28,7 @@ use crate::context_chips::display_chip::GitLineChanges;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
-use crate::tab::{ShortcutModifierKind, TAB_ACTIVATE_BINDING_NAMES, reveals_shortcut_hints};
+use crate::tab::{ShortcutModifierKind, reveals_shortcut_hints};
 use crate::terminal::CLIAgent;
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 
@@ -1167,42 +1167,6 @@ fn synced_inputs_indicator_respects_tab_indicators_setting() {
 #[test]
 fn synced_inputs_indicator_hidden_on_non_terminal_rows() {
     assert!(!shows_synced_inputs_indicator(false, true, true));
-}
-
-#[test]
-fn shortcut_hint_shown_when_modifier_held_within_first_eight_tabs() {
-    assert!(shows_shortcut_hint(true, 0));
-    assert!(shows_shortcut_hint(
-        true,
-        TAB_ACTIVATE_BINDING_NAMES.len() - 1
-    ));
-}
-
-#[test]
-fn shortcut_hint_hidden_when_modifier_not_held() {
-    assert!(!shows_shortcut_hint(false, 0));
-}
-
-#[test]
-fn shortcut_hint_hidden_beyond_eighth_tab() {
-    assert!(!shows_shortcut_hint(true, TAB_ACTIVATE_BINDING_NAMES.len()));
-    assert!(!shows_shortcut_hint(
-        true,
-        TAB_ACTIVATE_BINDING_NAMES.len() + 1
-    ));
-}
-
-#[test]
-fn tab_activate_binding_names_cover_first_eight_tabs_in_order() {
-    assert_eq!(TAB_ACTIVATE_BINDING_NAMES.len(), 8);
-    assert_eq!(
-        TAB_ACTIVATE_BINDING_NAMES[0],
-        "workspace:activate_first_tab"
-    );
-    assert_eq!(
-        TAB_ACTIVATE_BINDING_NAMES[TAB_ACTIVATE_BINDING_NAMES.len() - 1],
-        "workspace:activate_eighth_tab"
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Follow-up to #15221 that includes the `workspace:activate_last_tab` binding when rendering tab shortcut hints.


https://github.com/user-attachments/assets/712e99a3-0847-4e00-8dcb-2a2b958ec557



Numbered bindings take precedence for tabs 1–8, including when one of those tabs is last. For windows with nine or more tabs, the final tab falls back to the configurable last-tab binding (`Cmd/Ctrl+9`). Horizontal and vertical tab labels share the same binding resolver.

## Linked Issue

Follow-up to #15221.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format`
- `cargo clippy -p warp --lib --tests -- -D warnings`
- `cargo nextest run -p warp tab_activate_binding_name` (3 passed)
- `git diff --check`
- Full workspace Clippy was attempted but is currently blocked by unrelated existing `collapsible_if` and `let_and_return` errors in `crates/warp_completer/src/completer/engine/argument/v2.rs`.
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/1a8dd30e-3e8b-44be-9285-47aaca8b1841

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>