### PR TITLE
Use logical filename instead of file_id for attachment downloads

### DIFF
--- a/app/src/ai/agent_sdk/driver/attachments.rs
+++ b/app/src/ai/agent_sdk/driver/attachments.rs
@@ -60,7 +60,7 @@ pub(crate) async fn fetch_and_download_attachments(
 }
 
 /// Fetches handoff snapshot attachments for the active execution and downloads
-/// them into `{attachments_dir}/handoff/{attachment_uuid}` so the runtime's
+/// them into `{attachments_dir}/handoff/{filename}` so the runtime's
 /// rehydration prompt references always point at a file that exists on disk.
 ///
 /// Returns `Some(attachments_dir)` when at least one attachment wrote to disk, mirroring
@@ -97,9 +97,13 @@ pub(crate) async fn fetch_and_download_handoff_snapshot_attachments(
         .await
         .context("Failed to create handoff attachments directory")?;
 
+    // Join on the logical `filename`, not `file_id`: `file_id` is the GCS *storage* name,
+    // which for a checkpoint-mode snapshot embeds generation path segments (e.g.
+    // `checkpoint/<gen>/snapshot_state.json`). Joining on that would try to create a file
+    // inside a subdirectory that was never made and fail every download.
     let attempts = attachments.len();
     let download_futures = attachments.into_iter().map(|attachment| {
-        let file_path = handoff_dir.join(&attachment.file_id);
+        let file_path = handoff_dir.join(&attachment.filename);
         download_handoff_entry(attachment, file_path, http_client)
     });
     let results = join_all(download_futures).await;
@@ -208,16 +212,16 @@ async fn download_handoff_entry(
     file_path: PathBuf,
     http_client: &http_client::Client,
 ) -> Result<(), (String, String)> {
-    // Factor `file_id` and `download_url` out before the retry closure so `attachment` is fully
-    // consumed up-front. The closure borrows the two fields it needs as references.
+    // Factor `filename` and `download_url` out before the retry closure so `attachment` is
+    // fully consumed up-front. The closure borrows the two fields it needs as references.
     let TaskAttachment {
-        file_id,
+        filename,
         download_url,
         ..
     } = attachment;
     download_attachment(http_client, &download_url, &file_path)
         .await
-        .map_err(|e| (file_id, format!("{e:#}")))
+        .map_err(|e| (filename, format!("{e:#}")))
 }
 
 /// Shared download primitive: GET `download_url`, write the body to `file_path`, and retry

--- a/app/src/ai/agent_sdk/driver/attachments.rs
+++ b/app/src/ai/agent_sdk/driver/attachments.rs
@@ -97,15 +97,10 @@ pub(crate) async fn fetch_and_download_handoff_snapshot_attachments(
         .await
         .context("Failed to create handoff attachments directory")?;
 
-    // Join on the logical `filename`, not `file_id`: `file_id` is the GCS *storage* name,
-    // which for a checkpoint-mode snapshot embeds generation path segments (e.g.
-    // `checkpoint/<gen>/snapshot_state.json`). Joining on that would try to create a file
-    // inside a subdirectory that was never made and fail every download.
     let attempts = attachments.len();
-    let download_futures = attachments.into_iter().map(|attachment| {
-        let file_path = handoff_dir.join(&attachment.filename);
-        download_handoff_entry(attachment, file_path, http_client)
-    });
+    let download_futures = attachments
+        .into_iter()
+        .map(|attachment| download_handoff_entry(attachment, &handoff_dir, http_client));
     let results = join_all(download_futures).await;
 
     let mut succeeded: usize = 0;
@@ -113,7 +108,7 @@ pub(crate) async fn fetch_and_download_handoff_snapshot_attachments(
     for result in results {
         match result {
             Ok(()) => succeeded += 1,
-            Err((filename, err)) => failures.push((filename, err)),
+            Err((label, err)) => failures.push((label, err)),
         }
     }
 
@@ -122,7 +117,7 @@ pub(crate) async fn fetch_and_download_handoff_snapshot_attachments(
     } else {
         let detail = failures
             .iter()
-            .map(|(filename, err)| format!("{filename}: {err}"))
+            .map(|(label, err)| format!("{label}: {err}"))
             .collect::<Vec<_>>()
             .join("; ");
         log::warn!(
@@ -204,24 +199,43 @@ async fn download_task_attachment(
     Ok(())
 }
 
-/// Download a single handoff attachment into `file_path`, mapping failure to
-/// `(filename, error_message)` so the aggregator in
+/// Download a single handoff attachment into `handoff_dir`, mapping failure to
+/// `("{filename} ({file_id})", error_message)` so the aggregator in
 /// [`fetch_and_download_handoff_snapshot_attachments`] can log and count per-file outcomes.
+/// Both names are carried because two checkpoint generations share one logical name, and that
+/// aggregated WARN log is the only signal a per-file failure produces.
 async fn download_handoff_entry(
     attachment: TaskAttachment,
-    file_path: PathBuf,
+    handoff_dir: &Path,
     http_client: &http_client::Client,
 ) -> Result<(), (String, String)> {
-    // Factor `filename` and `download_url` out before the retry closure so `attachment` is
-    // fully consumed up-front. The closure borrows the two fields it needs as references.
+    // Factor the fields out before the retry closure so `attachment` is fully consumed
+    // up-front. The closure borrows the two fields it needs as references.
     let TaskAttachment {
+        file_id,
         filename,
         download_url,
         ..
     } = attachment;
+    let label = format!("{filename} ({file_id})");
+
+    // Join on the logical `filename`, not `file_id`: `file_id` is the GCS *storage* name, which
+    // for a checkpoint-mode snapshot embeds generation path segments (e.g.
+    // `checkpoint/<gen>/snapshot_state.json`). Joining on that would try to create a file inside
+    // a subdirectory that was never made and fail every download. Reduce to a basename the way
+    // the sibling [`download_task_attachment`] does, so a server-supplied name can never write
+    // outside `handoff_dir`. This assumes logical names are unique within one listing, which
+    // holds because selection returns a single checkpoint generation or the legacy set, never a
+    // mix; two entries sharing a name would stream into the same path concurrently.
+    let safe_filename = Path::new(&filename)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| (label.clone(), format!("Invalid filename '{filename}'")))?;
+    let file_path = handoff_dir.join(safe_filename);
+
     download_attachment(http_client, &download_url, &file_path)
         .await
-        .map_err(|e| (filename, format!("{e:#}")))
+        .map_err(|e| (label, format!("{e:#}")))
 }
 
 /// Shared download primitive: GET `download_url`, write the body to `file_path`, and retry

--- a/app/src/ai/agent_sdk/driver/attachments_tests.rs
+++ b/app/src/ai/agent_sdk/driver/attachments_tests.rs
@@ -127,16 +127,60 @@ async fn e2e_happy_path_downloads_all_and_writes_to_disk() {
     .expect("should not be fatal");
 
     assert_eq!(result.as_deref(), Some(&*attachments_dir.to_string_lossy()));
+    // Written under the logical filename, not the storage-side file_id.
     assert_eq!(
-        fs::read(attachments_dir.join("handoff").join("alpha-uuid")).unwrap(),
+        fs::read(attachments_dir.join("handoff").join("alpha.patch")).unwrap(),
         b"alpha-body"
     );
     assert_eq!(
-        fs::read(attachments_dir.join("handoff").join("beta-uuid")).unwrap(),
+        fs::read(attachments_dir.join("handoff").join("beta.patch")).unwrap(),
         b"beta-body"
     );
     first_mock.assert();
     second_mock.assert();
+}
+
+#[tokio::test]
+async fn e2e_checkpoint_mode_storage_name_does_not_leak_into_the_written_path() {
+    // Regression test: a checkpoint-mode snapshot's file_id is a storage path
+    // (`checkpoint/<generation>/<logical name>`), while filename stays a plain name. The
+    // download must land at `{handoff_dir}/{filename}`, not fail trying to create a
+    // `checkpoint/<generation>/` subdirectory that was never made.
+    let _guard = FeatureFlag::OzHandoff.override_enabled(true);
+    let tempdir = handoff_tempdir();
+    let attachments_dir = tempdir.path().to_path_buf();
+    let http = build_test_http_client();
+    let mut server = Server::new_async().await;
+
+    let file_id = "checkpoint/1787245813225-2/snapshot_state.json";
+    let mock = server
+        .mock("GET", download_path(&regex::escape(file_id)))
+        .with_status(200)
+        .with_body("checkpoint-body")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let attachments = vec![make_attachment(&server.url(), file_id, "snapshot_state.json")];
+    let result = fetch_and_download_handoff_snapshot_attachments(
+        mock_client_returning(attachments),
+        &http,
+        fake_task_id(),
+        attachments_dir.clone(),
+    )
+    .await
+    .expect("should not be fatal");
+
+    assert_eq!(result.as_deref(), Some(&*attachments_dir.to_string_lossy()));
+    assert_eq!(
+        fs::read(attachments_dir.join("handoff").join("snapshot_state.json")).unwrap(),
+        b"checkpoint-body"
+    );
+    assert!(
+        !attachments_dir.join("handoff").join("checkpoint").exists(),
+        "the storage name's generation segment must never be materialized as a directory"
+    );
+    mock.assert_async().await;
 }
 
 #[tokio::test]
@@ -176,7 +220,7 @@ async fn e2e_transient_5xx_retried_then_succeeds() {
 
     assert_eq!(result.as_deref(), Some(&*attachments_dir.to_string_lossy()));
     assert_eq!(
-        fs::read(attachments_dir.join("handoff").join("flaky-uuid")).unwrap(),
+        fs::read(attachments_dir.join("handoff").join("flaky.patch")).unwrap(),
         b"finally-here"
     );
     flaky_fail.assert_async().await;
@@ -212,10 +256,7 @@ async fn e2e_permanent_4xx_fails_fast_without_retries() {
 
     assert!(result.is_none(), "no file landed, dir should be None");
     assert!(
-        !attachments_dir
-            .join("handoff")
-            .join("missing-uuid")
-            .exists(),
+        !attachments_dir.join("handoff").join("gone.patch").exists(),
         "no file should be written on permanent failure"
     );
     missing.assert_async().await;
@@ -249,14 +290,14 @@ async fn e2e_retry_exhaustion_marks_failed() {
     .unwrap();
 
     assert!(result.is_none());
-    assert!(!attachments_dir.join("handoff").join("dead-uuid").exists());
+    assert!(!attachments_dir.join("handoff").join("dead.patch").exists());
     persistent.assert_async().await;
 }
 
 #[tokio::test]
 async fn e2e_partial_success_returns_dir_with_downloaded_subset() {
     // One attachment succeeds, one fails permanently. The dir is returned so the caller can
-    // still see `{handoff_dir}/ok-uuid` downstream; the failed sibling's file is absent.
+    // still see `{handoff_dir}/ok.patch` downstream; the failed sibling's file is absent.
     let _guard = FeatureFlag::OzHandoff.override_enabled(true);
     let tempdir = handoff_tempdir();
     let attachments_dir = tempdir.path().to_path_buf();
@@ -293,10 +334,10 @@ async fn e2e_partial_success_returns_dir_with_downloaded_subset() {
 
     assert_eq!(result.as_deref(), Some(&*attachments_dir.to_string_lossy()));
     assert_eq!(
-        fs::read(attachments_dir.join("handoff").join("ok-uuid")).unwrap(),
+        fs::read(attachments_dir.join("handoff").join("ok.patch")).unwrap(),
         b"present"
     );
-    assert!(!attachments_dir.join("handoff").join("bad-uuid").exists());
+    assert!(!attachments_dir.join("handoff").join("bad.patch").exists());
     ok_mock.assert_async().await;
     bad_mock.assert_async().await;
 }

--- a/app/src/ai/agent_sdk/driver/attachments_tests.rs
+++ b/app/src/ai/agent_sdk/driver/attachments_tests.rs
@@ -90,7 +90,7 @@ fn mock_client_returning(attachments: Vec<TaskAttachment>) -> Arc<MockAIClient> 
 #[tokio::test]
 async fn e2e_happy_path_downloads_all_and_writes_to_disk() {
     // Two attachments, both served 200 with distinct payloads. The pipeline must write each
-    // byte stream to `{attachments_dir}/handoff/{file_id}` and report the dir back.
+    // byte stream to `{attachments_dir}/handoff/{filename}` and report the dir back.
     let _guard = FeatureFlag::OzHandoff.override_enabled(true);
     let tempdir = handoff_tempdir();
     let attachments_dir = tempdir.path().to_path_buf();
@@ -127,7 +127,6 @@ async fn e2e_happy_path_downloads_all_and_writes_to_disk() {
     .expect("should not be fatal");
 
     assert_eq!(result.as_deref(), Some(&*attachments_dir.to_string_lossy()));
-    // Written under the logical filename, not the storage-side file_id.
     assert_eq!(
         fs::read(attachments_dir.join("handoff").join("alpha.patch")).unwrap(),
         b"alpha-body"
@@ -161,7 +160,11 @@ async fn e2e_checkpoint_mode_storage_name_does_not_leak_into_the_written_path() 
         .create_async()
         .await;
 
-    let attachments = vec![make_attachment(&server.url(), file_id, "snapshot_state.json")];
+    let attachments = vec![make_attachment(
+        &server.url(),
+        file_id,
+        "snapshot_state.json",
+    )];
     let result = fetch_and_download_handoff_snapshot_attachments(
         mock_client_returning(attachments),
         &http,
@@ -181,6 +184,81 @@ async fn e2e_checkpoint_mode_storage_name_does_not_leak_into_the_written_path() 
         "the storage name's generation segment must never be materialized as a directory"
     );
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn e2e_traversal_in_filename_cannot_escape_the_handoff_dir() {
+    // `filename` is server-supplied. A name carrying path segments is reduced to its basename
+    // and lands inside the handoff dir, never above it.
+    let _guard = FeatureFlag::OzHandoff.override_enabled(true);
+    let tempdir = handoff_tempdir();
+    let attachments_dir = tempdir.path().to_path_buf();
+    let http = build_test_http_client();
+    let mut server = Server::new_async().await;
+
+    let mock = server
+        .mock("GET", download_path("escape-uuid"))
+        .with_status(200)
+        .with_body("contained")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let attachments = vec![make_attachment(
+        &server.url(),
+        "escape-uuid",
+        "../../escape.json",
+    )];
+    let result = fetch_and_download_handoff_snapshot_attachments(
+        mock_client_returning(attachments),
+        &http,
+        fake_task_id(),
+        attachments_dir.clone(),
+    )
+    .await
+    .expect("should not be fatal");
+
+    assert_eq!(result.as_deref(), Some(&*attachments_dir.to_string_lossy()));
+    assert_eq!(
+        fs::read(attachments_dir.join("handoff").join("escape.json")).unwrap(),
+        b"contained"
+    );
+    assert!(
+        !attachments_dir.join("escape.json").exists(),
+        "a traversal segment must not write outside the handoff dir"
+    );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn e2e_filename_without_a_basename_is_rejected_before_downloading() {
+    // `..` has no basename to reduce to, so the entry fails the guard and is never fetched.
+    let _guard = FeatureFlag::OzHandoff.override_enabled(true);
+    let tempdir = handoff_tempdir();
+    let attachments_dir = tempdir.path().to_path_buf();
+    let http = build_test_http_client();
+    let mut server = Server::new_async().await;
+
+    let never_called = server
+        .mock("GET", download_path("dotdot-uuid"))
+        .with_status(200)
+        .with_body("unreachable")
+        .expect(0)
+        .create_async()
+        .await;
+
+    let attachments = vec![make_attachment(&server.url(), "dotdot-uuid", "..")];
+    let result = fetch_and_download_handoff_snapshot_attachments(
+        mock_client_returning(attachments),
+        &http,
+        fake_task_id(),
+        attachments_dir.clone(),
+    )
+    .await
+    .expect("an invalid name is a per-file failure, not a fatal one");
+
+    assert!(result.is_none());
+    never_called.assert_async().await;
 }
 
 #[tokio::test]

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1244,7 +1244,7 @@ impl AgentDriverRunner {
         };
 
         // Handoff snapshot attachments for follow-up executions are written to
-        // {attachments_dir}/handoff/{uuid} so the server-side rehydration prompt
+        // {attachments_dir}/handoff/{filename} so the server-side rehydration prompt
         // references resolve to real files.
         let handoff_snapshot_ai_client = ai_client.clone();
         let handoff_snapshot_server_api = server_api.clone();


### PR DESCRIPTION
## Description
Handoff snapshot files were written under the storage-side `file_id` but referenced under the logical `filename`, so on a rebuilt sandbox every checkpoint-mode download failed and the agent was pointed at files that had never been written.

`ListHandoffSnapshotAttachmentsHandler` returns two names per snapshot file: `AttachmentId`, the GCS object name, and `Filename`, the logical name. For a checkpoint-mode snapshot the object name is `checkpoint/<generation>/<logical name>`. The client joined the object name onto `{attachments_dir}/handoff/`, so `File::create` tried to write inside a `checkpoint/<generation>/` directory that nothing had created. Every file failed, the function returned `Ok(None)` after a VM-local `log::warn!`, and the server's rehydration prompt went on to reference `{attachments_dir}/handoff/{logicalName}` — a third path nobody wrote. Downloads now join the logical `filename`, which is the path the server already references.

That name comes from the server, so it is reduced to its basename before the join, the way the sibling `download_task_attachment` does. No current server can produce a name that this rejects — checkpoint names pass an allowlist and legacy names are filtered for separators — so the guard is consistency with the sibling rather than a hole being closed. Per-file failures are keyed on `"{filename} ({file_id})"`, because two checkpoint generations share one logical name and that aggregated WARN line is the only signal this failure produces anywhere.

Version skew is safe in both directions. An old client against a current server behaves exactly as it does today. A new client against a pre-checkpoint server is byte-identical, because those servers set `Filename` equal to `AttachmentId`.

This is the second of three defects in REV-2287. warpdotdev/warp-server#15959 fixes the first: the requeue path records follow-up attachments on the execution input but not on the task definition, which is what the client's boot-time download reads. The third — agent-visible paths that are constructed and never verified, which is what makes both of the others silent — is out of scope here.

## Linked Issue
Fixes [REV-2287](https://linear.app/warpdotdev/issue/REV-2287/follow-up-attachments-are-not-delivered-on-a-rebuilt-sandbox).
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. Tracked in Linear, which does not carry those labels.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below. Nothing to show: the change is a filesystem path inside the cloud agent driver, with no UI surface.

## Testing
`attachments_tests.rs` drives the real `fetch_and_download_handoff_snapshot_attachments` pipeline against a `mockito` server and a real `http_client::Client`, stubbing only the listing call. New cases cover the checkpoint-mode storage name not leaking into the written path, a `filename` carrying traversal segments landing inside the handoff dir, and a name with no basename failing before any request goes out. Retry, partial-failure, empty-list and flag-disabled behavior were already covered. Nothing covers the server side of the contract; warp-server#15959 carries its own tests.

Locally I ran only `./script/format --check`, which passes. The tests are unrun locally — this sandbox cannot compile the `warp` crate — so the `Run Linux tests`, `Run MacOS tests` and `Run Windows tests` jobs are the first execution of the new cases, and `Formatting + Clippy` is the first clippy run on this branch.

- [ ] I have manually tested my changes locally with `./script/run`. Reproducing needs a cloud run whose sandbox is rebuilt against a checkpoint-mode snapshot, which `./script/run` cannot stage.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Fixed handoff snapshot files not reaching a rebuilt cloud sandbox, which left the agent referencing files that were never downloaded.
