### PR TITLE
chore(merge): carry the multi-forge client work onto the master tip

### DIFF
--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -477,6 +477,10 @@ fn repository_forge_for_repo(repo: &SourceRepo) -> RepositoryForge {
     match repo.code_forge.unwrap_or_default() {
         CodeForge::GitHub => RepositoryForge::GitHub,
         CodeForge::GitLab => RepositoryForge::GitLab,
+        // MULTIPLE is a container-only marker and never a valid
+        // per-repository value; treat it as the legacy GitHub default
+        // defensively.
+        CodeForge::Multiple => RepositoryForge::GitHub,
     }
 }
 fn head_override_matches_repo(head_override: &RepositoryHeadOverride, repo: &SourceRepo) -> bool {

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -21,6 +21,7 @@ use warpui::{ModelContext, ModelSpawner, SingletonEntity};
 use super::AgentDriverError;
 #[cfg(feature = "local_fs")]
 use super::cache_setup;
+use super::git_credentials;
 use super::terminal::TerminalDriver;
 use crate::ai::agent_sdk::setup_observability::{SetupClientEventReporter, SetupStep};
 use crate::ai::cloud_environments::SourceRepo;
@@ -307,6 +308,13 @@ async fn prepare_environment_impl(
             })
             .await?;
         for repo in source_repos {
+            // Each checkout authors its commits as its own forge's identity.
+            // Done here rather than in the clone script because it must also
+            // apply to a directory that already existed and was reused.
+            git_credentials::configure_repository_git_identity(
+                &working_dir.join(&repo.repo),
+                repo.code_forge.unwrap_or_default().host(),
+            );
             register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
             if !is_sandbox && should_index_codebase {
                 let receiver = index_repo_codebase(

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -10,7 +10,11 @@
 /// - An async refresh loop that periodically fetches a fresh token from the
 ///   server and overwrites the credential files, keeping long-running agents
 ///   authenticated for their entire duration.
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 // Use the project's allowed Command wrapper (not std::process::Command, which is
@@ -64,19 +68,59 @@ fn write_secret_file(path: &std::path::Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-fn git_credentials_file_content(credentials: &[GitCredential]) -> String {
-    let mut content = String::new();
+fn git_credentials_line(cred: &GitCredential) -> String {
+    let userinfo = match &cred.username {
+        Some(username) => format!("{username}:{}", cred.token),
+        None => format!("x-access-token:{}", cred.token),
+    };
+    format!("https://{}@{}", userinfo, cred.host)
+}
+
+/// Extract the host from a `~/.git-credentials` line, i.e. everything after
+/// the last `@`. Returns `None` for a line with no userinfo separator, which
+/// is left alone rather than guessed at.
+fn host_of_credentials_line(line: &str) -> Option<&str> {
+    line.rsplit_once('@').map(|(_, host)| host)
+}
+
+/// Merge fresh credentials into the existing `~/.git-credentials` content,
+/// replacing the line for each refreshed host and preserving every other line.
+///
+/// Merging rather than rebuilding is what makes a partial refresh safe: a host
+/// missing from `credentials` was not refreshed this cycle, not revoked, and
+/// dropping its line would leave `git` unable to authenticate against a forge
+/// whose CLI is still working from its own config.
+fn merge_git_credentials_file_content(existing: &str, credentials: &[GitCredential]) -> String {
+    let refreshed_hosts = credentials
+        .iter()
+        .map(|cred| cred.host.as_str())
+        .collect::<Vec<_>>();
+
+    let mut lines = Vec::new();
+    for line in existing.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let superseded = host_of_credentials_line(trimmed)
+            .is_some_and(|host| refreshed_hosts.contains(&host));
+        if !superseded {
+            lines.push(trimmed.to_string());
+        }
+    }
     for cred in credentials {
-        let userinfo = match &cred.username {
-            Some(username) => format!("{username}:{}", cred.token),
-            None => format!("x-access-token:{}", cred.token),
-        };
-        content.push_str(&format!("https://{}@{}\n", userinfo, cred.host));
+        lines.push(git_credentials_line(cred));
+    }
+
+    let mut content = lines.join("\n");
+    if !content.is_empty() {
+        content.push('\n');
     }
     content
 }
 
-/// Write `~/.git-credentials` with the given credentials.
+/// Write `~/.git-credentials`, replacing the entry for each host in
+/// `credentials` and leaving every other host's entry in place.
 ///
 /// Each credential entry is formatted as:
 /// - `https://{username}:{token}@{host}` when a username is present
@@ -91,7 +135,8 @@ fn write_git_credentials_file(credentials: &[GitCredential]) -> Result<()> {
     let home = home_dir()?;
     let path = home.join(".git-credentials");
     let tmp_path = home.join(".git-credentials.tmp");
-    let content = git_credentials_file_content(credentials);
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let content = merge_git_credentials_file_content(&existing, credentials);
     write_secret_file(&tmp_path, &content)?;
     std::fs::rename(&tmp_path, &path).with_context(|| {
         format!(
@@ -199,35 +244,69 @@ fn write_glab_config(credentials: &[GitCredential], home: &std::path::Path) -> R
 }
 
 /// Formats non-sensitive metadata for verifying local credential injection.
-pub(crate) fn credential_diagnostics(credentials: &[GitCredential]) -> String {
-    credentials
+///
+/// `failed_hosts` are named alongside the fresh ones so a partial cycle is
+/// legible in the log: the surprising state is not "this host is missing" but
+/// "this host is running on a credential older than the others".
+pub(crate) fn credential_diagnostics(credentials: &[GitCredential], failed_hosts: &[String]) -> String {
+    let mut entries = credentials
         .iter()
         .map(|credential| {
             format!(
-                "{}(token_present={}, username_present={})",
+                "{}(refreshed, token_present={}, username_present={})",
                 credential.host,
                 !credential.token.is_empty(),
                 credential.username.is_some()
             )
         })
-        .collect::<Vec<_>>()
-        .join(", ")
+        .collect::<Vec<_>>();
+    entries.extend(
+        failed_hosts
+            .iter()
+            .map(|host| format!("{host}(stale, refresh failed; existing credential kept)")),
+    );
+    entries.join(", ")
 }
 
+/// Write every credential store from `credentials`.
+///
+/// The three writes are independent: one store failing must not skip the
+/// others, since each authenticates a different tool and a partial write is
+/// strictly better than none. The first error is returned once all three have
+/// been attempted.
 pub(crate) fn write_git_credentials(credentials: &[GitCredential]) -> Result<()> {
+    write_git_credentials_with_failures(credentials, &[])
+}
+
+pub(crate) fn write_git_credentials_with_failures(
+    credentials: &[GitCredential],
+    failed_hosts: &[String],
+) -> Result<()> {
     if credentials.is_empty() {
         return Ok(());
     }
-    write_git_credentials_file(credentials)?;
     let home = home_dir()?;
-    write_gh_hosts_yml(credentials, &home)?;
-    write_glab_config(credentials, &home)?;
+    let outcomes = [
+        write_git_credentials_file(credentials),
+        write_gh_hosts_yml(credentials, &home),
+        write_glab_config(credentials, &home),
+    ];
+    let mut first_error = None;
+    for outcome in outcomes {
+        if let Err(e) = outcome {
+            log::warn!("Failed to write a git credential store: {e:#}");
+            first_error.get_or_insert(e);
+        }
+    }
     log::info!(
         "Wrote {} git credential(s) to the local credential store: {}",
         credentials.len(),
-        credential_diagnostics(credentials)
+        credential_diagnostics(credentials, failed_hosts)
     );
-    Ok(())
+    match first_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 pub(crate) fn configure_git_credentials(credentials: &[GitCredential]) -> Result<()> {
@@ -236,6 +315,11 @@ pub(crate) fn configure_git_credentials(credentials: &[GitCredential]) -> Result
     }
     setup_git_config(credentials);
     configure_git_identity(credentials);
+    // Recorded here rather than at each clone, because the refresh loop
+    // deliberately does not redo identity work: identity is set once at
+    // startup and a later credential rotation does not change who the commits
+    // are authored as.
+    record_host_identities(credentials);
     write_git_credentials(credentials)
 }
 
@@ -303,52 +387,159 @@ pub(crate) fn setup_git_config(credentials: &[GitCredential]) {
     }
 }
 
-/// Configure the git user identity from the server-returned credential.
+/// Configure the global git user identity from the server-returned credential.
 ///
 /// Uses the first credential's `username`/`email` fields, falling back to the
 /// Warp defaults when either is absent (e.g. service-account principals).
+///
+/// This is the fallback for work outside any checkout, and for a repository
+/// whose forge issued no credential. A repository whose forge did gets its own
+/// identity written locally instead; see [`configure_repository_git_identity`].
 pub(crate) fn configure_git_identity(credentials: &[GitCredential]) {
-    let (name, email) = credentials
-        .first()
-        .map(|c| {
-            (
-                c.username.as_deref().unwrap_or(DEFAULT_GIT_NAME),
-                c.email.as_deref().unwrap_or(DEFAULT_GIT_EMAIL),
-            )
-        })
-        .unwrap_or((DEFAULT_GIT_NAME, DEFAULT_GIT_EMAIL));
+    let (name, email) = identity_of(credentials.first());
+    run_git_config("user.name", &name);
+    run_git_config("user.email", &email);
+}
 
-    run_git_config("user.name", name);
-    run_git_config("user.email", email);
+/// One forge's git author identity, without its credential.
+#[derive(Clone)]
+struct HostIdentity {
+    host: String,
+    name: String,
+    email: String,
+}
+
+/// The author identity for each forge, captured when credentials are first
+/// configured.
+///
+/// The clone path needs each forge's identity but runs several layers below
+/// credential configuration, and threading the credential list down to it
+/// would carry tokens through code that only needs a name and an email. Only
+/// the non-secret fields are retained.
+static HOST_IDENTITIES: RwLock<Vec<HostIdentity>> = RwLock::new(Vec::new());
+
+fn record_host_identities(credentials: &[GitCredential]) {
+    let identities = credentials
+        .iter()
+        .map(|c| HostIdentity {
+            host: c.host.clone(),
+            name: c.username.as_deref().unwrap_or(DEFAULT_GIT_NAME).to_string(),
+            email: c.email.as_deref().unwrap_or(DEFAULT_GIT_EMAIL).to_string(),
+        })
+        .collect::<Vec<_>>();
+    match HOST_IDENTITIES.write() {
+        Ok(mut stored) => *stored = identities,
+        Err(e) => log::warn!("Failed to record git author identities: {e}"),
+    }
+}
+
+/// Resolve a credential's author identity, falling back to the Warp defaults
+/// for the fields it does not carry (e.g. a service-account principal).
+fn identity_of(credential: Option<&GitCredential>) -> (String, String) {
+    match credential {
+        Some(c) => (
+            c.username.as_deref().unwrap_or(DEFAULT_GIT_NAME).to_string(),
+            c.email.as_deref().unwrap_or(DEFAULT_GIT_EMAIL).to_string(),
+        ),
+        None => (DEFAULT_GIT_NAME.to_string(), DEFAULT_GIT_EMAIL.to_string()),
+    }
+}
+
+/// Select the recorded identity for `host`, falling back to the primary
+/// forge's identity when no credential was issued for it.
+///
+/// Falling back to the primary rather than to the Warp default keeps a
+/// repository whose forge issued no credential behaving exactly as it does
+/// today, rather than quietly downgrading its authorship.
+fn select_host_identity<'a>(
+    identities: &'a [HostIdentity],
+    host: &str,
+) -> Option<&'a HostIdentity> {
+    identities
+        .iter()
+        .find(|identity| identity.host == host)
+        .or_else(|| identities.first())
+}
+
+fn recorded_identity_for_host(host: &str) -> Option<(String, String)> {
+    let stored = HOST_IDENTITIES.read().ok()?;
+    let matched = select_host_identity(&stored, host)?;
+    Some((matched.name.clone(), matched.email.clone()))
+}
+
+/// Write `user.name`/`user.email` into one repository's local git config,
+/// selecting the identity of the forge that hosts it.
+///
+/// The server already sends an identity per credential; only the sandbox
+/// collapsed them. Without this, a checkout spanning two forges would author
+/// every commit as whichever identity happened to be first in the list — the
+/// GitHub bot, since the server orders GitHub before GitLab.
+///
+/// Local config rather than a global `includeIf gitdir:` entry, so the
+/// identity is attached to the repository itself and survives a re-clone, a
+/// move, or a nested checkout.
+pub(crate) fn configure_repository_git_identity(repository_dir: &std::path::Path, host: &str) {
+    let Some((name, email)) = recorded_identity_for_host(host) else {
+        return;
+    };
+    run_repository_git_config(repository_dir, "user.name", &name);
+    run_repository_git_config(repository_dir, "user.email", &email);
+}
+
+/// Run `git -C <dir> config <key> <value>`, logging a warning on failure
+/// rather than propagating: a missing identity degrades authorship, it does
+/// not stop the run.
+fn run_repository_git_config(repository_dir: &std::path::Path, key: &str, value: &str) {
+    let dir = repository_dir.to_string_lossy();
+    match BlockingCommand::new("git")
+        .args(["-C", dir.as_ref(), "config", key, value])
+        .output()
+    {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            log::warn!(
+                "git -C {} config {key} failed: {}",
+                repository_dir.display(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Err(e) => {
+            log::warn!(
+                "Failed to run git -C {} config {key}: {e}",
+                repository_dir.display()
+            );
+        }
+    }
 }
 
 /// Perform one git credentials refresh attempt.
 ///
-/// Returns `Ok(())` on success (including when the server returns no
-/// credentials). Returns `Err` when the workload-token issuance or the server
-/// API call fails — these are transient failures worth retrying.
+/// Returns `Ok(true)` when every applicable forge refreshed, and `Ok(false)`
+/// when some refreshed and others failed — the caller retries on the backoff
+/// in that case, because only the failed hosts are still stale. Returns `Err`
+/// when the workload-token issuance or the whole server call fails.
 #[tracing::instrument(name = "git_credentials::try_refresh", skip_all, err, fields(
     tags.cloud_agent = true,
     task_id,
 ))]
-async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<()> {
+async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<bool> {
     let workload_token =
         warp_isolation_platform::issue_workload_token(Some(Duration::from_secs(5 * 60)))
             .await
             .context("Failed to issue workload token for git credentials refresh")?
             .token;
 
-    let credentials = ai_client
+    let response = ai_client
         .get_task_git_credentials(task_id.to_string(), workload_token)
         .await
         .context("Failed to fetch git credentials from server")?;
 
-    if credentials.is_empty() {
+    if response.credentials.is_empty() && response.failed_hosts.is_empty() {
         log::debug!("No git credentials returned during refresh; skipping file write");
-        return Ok(());
+        return Ok(true);
     }
 
-    match write_git_credentials(&credentials) {
+    match write_git_credentials_with_failures(&response.credentials, &response.failed_hosts) {
         Err(e) => {
             log::warn!("Failed to write refreshed git credentials: {e:#}");
         }
@@ -356,7 +547,7 @@ async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<()>
             log::info!("Git credentials refreshed successfully");
         }
     }
-    Ok(())
+    Ok(response.failed_hosts.is_empty())
 }
 
 /// Infinite async loop that refreshes git credentials every
@@ -391,7 +582,29 @@ pub(crate) async fn refresh_loop(task_id: String, ai_client: Arc<dyn AIClient>) 
         let mut attempt = 0usize;
         loop {
             match try_refresh(&task_id, &ai_client).await {
-                Ok(()) => break,
+                Ok(true) => break,
+                // Some forges refreshed and others did not. The server
+                // reissues only what is still stale, so retrying costs nothing
+                // for the hosts that already succeeded.
+                Ok(false) if attempt < backoff_delays.len() => {
+                    let delay = backoff_delays[attempt];
+                    log::warn!(
+                        "Git credentials refreshed for some forges but not others (attempt {}); \
+                         retrying the remaining ones in {}s",
+                        attempt + 1,
+                        delay.as_secs()
+                    );
+                    warpui::r#async::Timer::after(delay).await;
+                    attempt += 1;
+                }
+                Ok(false) => {
+                    log::warn!(
+                        "Git credentials still stale for some forges after {} attempts; \
+                         those forges may lose access before the next refresh cycle",
+                        attempt + 1
+                    );
+                    break;
+                }
                 Err(e) if attempt < backoff_delays.len() => {
                     let delay = backoff_delays[attempt];
                     log::warn!(

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -82,22 +82,28 @@ fn write_gh_hosts_yml_skips_gitlab_only_credentials() -> Result<()> {
     Ok(())
 }
 
+fn github_credential() -> GitCredential {
+    GitCredential {
+        token: "github-token".to_string(),
+        username: None,
+        email: None,
+        host: "github.com".to_string(),
+    }
+}
+
+fn gitlab_credential() -> GitCredential {
+    GitCredential {
+        token: "gitlab-token".to_string(),
+        username: Some("oauth2".to_string()),
+        email: None,
+        host: "gitlab.com".to_string(),
+    }
+}
+
 #[test]
-fn git_credentials_file_content_includes_each_provider_host() {
-    let content = git_credentials_file_content(&[
-        GitCredential {
-            token: "github-token".to_string(),
-            username: None,
-            email: None,
-            host: "github.com".to_string(),
-        },
-        GitCredential {
-            token: "gitlab-token".to_string(),
-            username: Some("oauth2".to_string()),
-            email: None,
-            host: "gitlab.com".to_string(),
-        },
-    ]);
+fn merged_credentials_include_each_provider_host() {
+    let content =
+        merge_git_credentials_file_content("", &[github_credential(), gitlab_credential()]);
 
     assert_eq!(
         content,
@@ -107,21 +113,101 @@ fn git_credentials_file_content_includes_each_provider_host() {
 }
 
 #[test]
+fn merged_credentials_replace_only_the_refreshed_host() {
+    let existing = "https://x-access-token:stale-github@github.com\n\
+                    https://oauth2:stale-gitlab@gitlab.com\n";
+
+    let content = merge_git_credentials_file_content(existing, &[github_credential()]);
+
+    // The refreshed host is replaced rather than duplicated...
+    assert!(content.contains("https://x-access-token:github-token@github.com"));
+    assert!(!content.contains("stale-github"));
+    // ...and the host that was not refreshed keeps working. Dropping this line
+    // is the split-brain the merge exists to prevent: `git` would fail to
+    // authenticate against GitLab while `glab` kept working from its own
+    // config.
+    assert!(content.contains("https://oauth2:stale-gitlab@gitlab.com"));
+}
+
+#[test]
+fn merged_credentials_preserve_an_unrelated_host() {
+    let existing = "https://user:token@git.example.com\n";
+
+    let content = merge_git_credentials_file_content(existing, &[github_credential()]);
+
+    assert_eq!(
+        content,
+        "https://user:token@git.example.com\n\
+         https://x-access-token:github-token@github.com\n"
+    );
+}
+
+#[test]
 fn credential_diagnostics_reports_presence_without_values() {
-    let diagnostics = credential_diagnostics(&[GitCredential {
-        token: "secret-token".to_string(),
-        username: Some("oauth2".to_string()),
-        email: Some("user@example.com".to_string()),
-        host: "gitlab.com".to_string(),
-    }]);
+    let diagnostics = credential_diagnostics(
+        &[GitCredential {
+            token: "secret-token".to_string(),
+            username: Some("oauth2".to_string()),
+            email: Some("user@example.com".to_string()),
+            host: "gitlab.com".to_string(),
+        }],
+        &[],
+    );
 
     assert_eq!(
         diagnostics,
-        "gitlab.com(token_present=true, username_present=true)"
+        "gitlab.com(refreshed, token_present=true, username_present=true)"
     );
     assert!(!diagnostics.contains("secret-token"));
     assert!(!diagnostics.contains("oauth2"));
     assert!(!diagnostics.contains("user@example.com"));
+}
+
+#[test]
+fn credential_diagnostics_names_the_stale_host() {
+    let diagnostics = credential_diagnostics(
+        &[github_credential()],
+        &["gitlab.com".to_string()],
+    );
+
+    assert!(diagnostics.contains("github.com(refreshed"));
+    assert!(diagnostics.contains("gitlab.com(stale"));
+}
+
+#[test]
+fn repository_identity_selects_the_matching_host() {
+    let identities = [
+        HostIdentity {
+            host: "github.com".to_string(),
+            name: "warp-agent[bot]".to_string(),
+            email: "bot@users.noreply.github.com".to_string(),
+        },
+        HostIdentity {
+            host: "gitlab.com".to_string(),
+            name: "warp-factory-1".to_string(),
+            email: "1-warp-factory-1@users.noreply.gitlab.com".to_string(),
+        },
+    ];
+
+    let matched = select_host_identity(&identities, "gitlab.com").expect("an identity");
+    assert_eq!(matched.name, "warp-factory-1");
+    assert_eq!(matched.email, "1-warp-factory-1@users.noreply.gitlab.com");
+}
+
+#[test]
+fn repository_identity_falls_back_to_the_primary_forge() {
+    let identities = [HostIdentity {
+        host: "github.com".to_string(),
+        name: "warp-agent[bot]".to_string(),
+        email: "bot@users.noreply.github.com".to_string(),
+    }];
+
+    // A repository on a forge that issued no credential keeps today's
+    // behavior rather than being downgraded to the generic default.
+    let matched = select_host_identity(&identities, "gitlab.com").expect("an identity");
+    assert_eq!(matched.name, "warp-agent[bot]");
+
+    assert!(select_host_identity(&[], "github.com").is_none());
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -854,9 +854,19 @@ impl AgentDriverRunner {
         ))
         .await?
         .token;
-        ai_client
+        // A forge that failed at startup is reported by the refresh loop
+        // instead; bootstrap only needs whatever credentials it can get, and
+        // the server already fails the call outright when none are available.
+        let response = ai_client
             .get_task_git_credentials(task_id_str, workload_token)
-            .await
+            .await?;
+        for host in &response.failed_hosts {
+            log::warn!(
+                "No {host} credential could be issued at startup; \
+                 operations against that forge will fail until a refresh succeeds"
+            );
+        }
+        Ok(response.credentials)
     }
 
     async fn bootstrap_git_credentials_for_task(

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -708,6 +708,19 @@ pub struct GitCredential {
     pub host: String,
 }
 
+/// One credential-retrieval cycle's outcome.
+///
+/// A host is in exactly one of three states, and telling them apart is the
+/// whole point of carrying `failed_hosts` beside the credentials: a host with
+/// a fresh credential, a host that failed and whose existing credential must
+/// be left alone until the retry succeeds, and a host in neither list, which
+/// the run needs no credential for.
+#[derive(Clone, Default)]
+pub struct TaskGitCredentialsResponse {
+    pub credentials: Vec<GitCredential>,
+    pub failed_hosts: Vec<String>,
+}
+
 /// Filter parameters for listing ambient agent tasks.
 #[derive(Clone, Debug, Default)]
 pub struct TaskListFilter {
@@ -1425,7 +1438,7 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         task_id: String,
         workload_token: String,
-    ) -> anyhow::Result<Vec<GitCredential>, anyhow::Error>;
+    ) -> anyhow::Result<TaskGitCredentialsResponse, anyhow::Error>;
 
     async fn get_task_attachments(
         &self,
@@ -2646,11 +2659,15 @@ impl AIClient for ServerApi {
         &self,
         task_id: String,
         workload_token: String,
-    ) -> anyhow::Result<Vec<GitCredential>, anyhow::Error> {
+    ) -> anyhow::Result<TaskGitCredentialsResponse, anyhow::Error> {
         let variables = TaskGitCredentialsVariables {
             input: TaskGitCredentialsInput {
                 task_id: cynic::Id::new(task_id),
                 workload_token,
+                // The driver merges each fresh credential over its existing
+                // stores instead of rebuilding them, so one forge's bad minute
+                // no longer has to cost the other its refresh.
+                accepts_partial_refresh: Some(true),
             },
             request_context: get_request_context(),
         };
@@ -2669,7 +2686,10 @@ impl AIClient for ServerApi {
                         host: c.host,
                     })
                     .collect();
-                Ok(credentials)
+                Ok(TaskGitCredentialsResponse {
+                    credentials,
+                    failed_hosts: output.failed_hosts,
+                })
             }
             TaskGitCredentialsResult::UserFacingError(error) => {
                 Err(anyhow!(get_user_facing_error_message(error)))

--- a/crates/cloud_object_models/src/cloud_environment.rs
+++ b/crates/cloud_object_models/src/cloud_environment.rs
@@ -16,6 +16,12 @@ pub enum CodeForge {
     GitHub,
     #[serde(rename = "GITLAB")]
     GitLab,
+    /// Container-only marker for an environment whose repositories span more
+    /// than one forge. It is never a valid per-repository value and never
+    /// fills an omitted repository forge; the server only stores it alongside
+    /// repositories that each declare their own concrete forge.
+    #[serde(rename = "MULTIPLE")]
+    Multiple,
 }
 
 impl CodeForge {
@@ -23,6 +29,9 @@ impl CodeForge {
         match self {
             CodeForge::GitHub => "github.com",
             CodeForge::GitLab => "gitlab.com",
+            // MULTIPLE names no host; per-repository forges are concrete by
+            // invariant, so this is a defensive legacy-GitHub fallback.
+            CodeForge::Multiple => "github.com",
         }
     }
 }
@@ -32,6 +41,7 @@ impl fmt::Display for CodeForge {
         match self {
             CodeForge::GitHub => write!(f, "GitHub"),
             CodeForge::GitLab => write!(f, "GitLab"),
+            CodeForge::Multiple => write!(f, "Multiple forges"),
         }
     }
 }
@@ -239,10 +249,15 @@ impl AmbientAgentEnvironment {
         }
     }
 
-    /// Returns the environment's source-control provider, defaulting to GitHub
-    /// for legacy environments.
+    /// Returns the concrete forge used to fill repositories that omit their
+    /// own, defaulting to GitHub for legacy environments. A MULTIPLE container
+    /// also resolves to GitHub here, which is safe because MULTIPLE is only
+    /// ever stored alongside fully-explicit repositories.
     pub fn effective_code_forge(&self) -> CodeForge {
-        self.code_forge.unwrap_or_default()
+        match self.code_forge {
+            Some(CodeForge::Multiple) | None => CodeForge::GitHub,
+            Some(forge) => forge,
+        }
     }
 
     /// Display string for this environment's base image, empty when the

--- a/crates/cloud_object_models/src/cloud_environment_tests.rs
+++ b/crates/cloud_object_models/src/cloud_environment_tests.rs
@@ -141,6 +141,39 @@ fn deserialize_gitlab_environment_uses_authoritative_source_repos() {
 }
 
 #[test]
+fn deserialize_mixed_forge_environment_with_multiple_container() {
+    // A mixed environment stores code_forge MULTIPLE with every repository
+    // declaring its own concrete forge; MULTIPLE itself never fills one.
+    let json = serde_json::json!({
+        "name": "mixed-env",
+        "code_forge": "MULTIPLE",
+        "github_repos": [{"owner": "warpdotdev", "repo": "warp"}],
+        "source_repos": [
+            {"code_forge": "GITHUB", "owner": "warpdotdev", "repo": "warp"},
+            {"code_forge": "GITLAB", "owner": "platform/backend", "repo": "api"}
+        ],
+        "docker_image": "ubuntu:latest"
+    });
+
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+
+    assert_eq!(env.code_forge, Some(CodeForge::Multiple));
+    // The fill accessor stays concrete: MULTIPLE resolves to GitHub there.
+    assert_eq!(env.effective_code_forge(), CodeForge::GitHub);
+    let repos = env.effective_repos();
+    assert_eq!(repos[0].code_forge, Some(CodeForge::GitHub));
+    assert_eq!(repos[1].code_forge, Some(CodeForge::GitLab));
+    assert_eq!(
+        repos[0].https_clone_url(),
+        "https://github.com/warpdotdev/warp.git"
+    );
+    assert_eq!(
+        repos[1].https_clone_url(),
+        "https://gitlab.com/platform/backend/api.git"
+    );
+}
+
+#[test]
 fn present_empty_source_repos_override_legacy_mirror() {
     let json = serde_json::json!({
         "name": "empty-env",

--- a/crates/graphql/src/api/queries/task_git_credentials.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials.rs
@@ -28,6 +28,10 @@ pub struct TaskGitCredentialsVariables {
 pub struct TaskGitCredentialsInput {
     pub task_id: cynic::Id,
     pub workload_token: String,
+    /// Opts into a response where one forge's credential is fresh and
+    /// another's failed. The driver merges rather than rebuilding its
+    /// credential stores, so it can accept a partial list.
+    pub accepts_partial_refresh: Option<bool>,
 }
 
 #[derive(cynic::InlineFragments, Debug)]
@@ -41,6 +45,9 @@ pub enum TaskGitCredentialsResult {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct TaskGitCredentialsOutput {
     pub credentials: Vec<TaskGitCredential>,
+    /// Hosts whose credential could not be issued this cycle. Distinct from a
+    /// host that is merely absent from `credentials`, which needs none.
+    pub failed_hosts: Vec<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -3712,6 +3712,17 @@ type TaskGitCredential {
 
 """Input for the taskGitCredentials query."""
 input TaskGitCredentialsInput {
+  """
+  Whether the caller can handle a response in which one forge's credential is
+  fresh and another's failed. A caller that opts in must merge the fresh
+  credentials over its existing stores rather than rebuilding them from the
+  response, since a host absent from `credentials` may simply not have been
+  refreshed this cycle. Absent or false preserves the all-or-nothing
+  behavior, so a caller that rebuilds its stores wholesale never sees a
+  partial list.
+  """
+  acceptsPartialRefresh: Boolean
+
   """The ID of the task."""
   taskId: ID!
 
@@ -3720,7 +3731,20 @@ input TaskGitCredentialsInput {
 }
 
 type TaskGitCredentialsOutput implements Response {
+  """The credentials that were freshly issued this cycle, one per host."""
   credentials: [TaskGitCredential!]!
+
+  """
+  Hosts whose credential could not be issued this cycle because of a
+  transient failure. A host listed here is distinct from one that is simply
+  absent from `credentials`: absent means the run has no repository on that
+  forge and needs no credential there, while listed here means the caller
+  should keep whatever it already has for that host and retry.
+  
+  Only populated when the request set `acceptsPartialRefresh`; otherwise a
+  failure on any forge fails the whole request.
+  """
+  failedHosts: [String!]!
   responseContext: ResponseContext!
 }
 


### PR DESCRIPTION
## Summary
This PR merges `factory/remote-2942-multi-forge-harness` (the MULTIPLE container code forge support) onto the `master` tip.

Master already ships the `NONE` member and the `serde(other)` `Unknown` catch-all. The merged enum orders the members `NONE`, `MULTIPLE`, `Unknown`. `MULTIPLE` keeps the defensive legacy-GitHub host fallback. A per-repository `MULTIPLE` maps to the GitHub repository forge. `NONE` and `Unknown` stay non-clonable.

This PR supersedes #15383. The Bitbucket clone support is parked on the branch `factory/forge-registry-harness-01-bitbucket` and is not part of this review.

## Validation
- `cargo nextest run -p cloud_object_models`: 34 passed.
- `cargo check -p warp`: clean.

## Artifacts
- Conversation: https://staging.warp.dev/conversation/fe921040-8660-48b7-87f5-3043cf0b41fa
- Plan: [Forge provider registry: GitHub, GitLab, Bitbucket end to end](https://staging.warp.dev/drive/notebook/2uZd5d0LoXgFRCfe5P17vK)

Co-Authored-By: Warp <agent@warp.dev>