### PR TITLE
feat(agent): add Bitbucket code forge support for cloud clones

### DIFF
--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -18,11 +18,10 @@ use warp_core::{safe_info, safe_warn};
 use warpui::r#async::FutureExt;
 use warpui::{ModelContext, ModelSpawner, SingletonEntity};
 
-use super::AgentDriverError;
 #[cfg(feature = "local_fs")]
 use super::cache_setup;
-use super::git_credentials;
 use super::terminal::TerminalDriver;
+use super::{AgentDriverError, git_credentials};
 use crate::ai::agent_sdk::setup_observability::{SetupClientEventReporter, SetupStep};
 use crate::ai::cloud_environments::SourceRepo;
 use crate::terminal::model::session::command_executor::shell_escape_single_quotes;
@@ -485,6 +484,7 @@ fn repository_forge_for_repo(repo: &SourceRepo) -> Option<RepositoryForge> {
     match repo.code_forge.unwrap_or_default() {
         CodeForge::GitHub => Some(RepositoryForge::GitHub),
         CodeForge::GitLab => Some(RepositoryForge::GitLab),
+        CodeForge::Bitbucket => Some(RepositoryForge::Bitbucket),
         // MULTIPLE is a container-only marker and never a valid
         // per-repository value; treat it as the legacy GitHub default
         // defensively.

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -10,7 +10,7 @@ use warp_core::command::ExitCode;
 use super::{
     PrepareEnvironmentError, RepositoryCloneRequest, build_parallel_clone_command,
     build_remove_repository_origins_command, checkout_command_for, checkout_result,
-    merge_repos_deduped, repository_clone_requests, single_repo_name,
+    merge_repos_deduped, repository_clone_requests, repository_forge_for_repo, single_repo_name,
     validate_repository_head_overrides,
 };
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, SourceRepo};
@@ -72,6 +72,25 @@ fn single_repo_name_returns_repo_when_exactly_one_repo() {
 
 fn repo(forge: CodeForge, owner: &str, name: &str) -> SourceRepo {
     SourceRepo::new(forge, owner.to_string(), name.to_string())
+}
+
+#[test]
+fn repository_forge_mapping_covers_every_code_forge() {
+    let forge_for = |forge| repository_forge_for_repo(&repo(forge, "owner", "name"));
+    assert_eq!(forge_for(CodeForge::GitHub), Some(RepositoryForge::GitHub));
+    assert_eq!(forge_for(CodeForge::GitLab), Some(RepositoryForge::GitLab));
+    assert_eq!(
+        forge_for(CodeForge::Bitbucket),
+        Some(RepositoryForge::Bitbucket)
+    );
+    // MULTIPLE is container-only; a repository carrying it falls back to the
+    // legacy GitHub default rather than failing the clone.
+    assert_eq!(
+        forge_for(CodeForge::Multiple),
+        Some(RepositoryForge::GitHub)
+    );
+    assert_eq!(forge_for(CodeForge::None), None);
+    assert_eq!(forge_for(CodeForge::Unknown), None);
 }
 
 #[test]
@@ -169,6 +188,11 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
             "platform/backend".to_string(),
             "api".to_string(),
         ),
+        SourceRepo::new(
+            CodeForge::Bitbucket,
+            "warp-workspace".to_string(),
+            "tooling".to_string(),
+        ),
     ];
 
     let command = build_parallel_clone_command(
@@ -184,21 +208,27 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
     assert!(command.contains("https://github.com/warpdotdev/warp.git"));
     assert!(command.contains("platform/backend/api"));
     assert!(command.contains("https://gitlab.com/platform/backend/api.git"));
-    assert_eq!(command.matches("clone_repo").count(), 3);
-    assert_eq!(command.matches("2>&1 &").count(), 2);
+    assert!(command.contains("warp-workspace/tooling"));
+    assert!(command.contains("https://bitbucket.org/warp-workspace/tooling.git"));
+    assert_eq!(command.matches("clone_repo").count(), 4);
+    assert_eq!(command.matches("2>&1 &").count(), 3);
     assert!(command.contains("mktemp -d"));
     assert!(command.contains("warp-clone-logs"));
     assert!(command.contains("trap cleanup_clone_logs EXIT"));
     assert!(command.contains("repo-0.log"));
     assert!(command.contains("repo-1.log"));
+    assert!(command.contains("repo-2.log"));
     assert!(command.contains(">\"$log_file_0\" 2>&1 &"));
     assert!(command.contains(">\"$log_file_1\" 2>&1 &"));
+    assert!(command.contains(">\"$log_file_2\" 2>&1 &"));
     assert!(command.contains("pids=\"$pids $!\""));
     assert!(command.contains("wait \"$pid\""));
     assert!(command.contains("===== warpdotdev/warp ====="));
     assert!(command.contains("cat \"$log_file_0\""));
     assert!(command.contains("===== platform/backend/api ====="));
     assert!(command.contains("cat \"$log_file_1\""));
+    assert!(command.contains("===== warp-workspace/tooling ====="));
+    assert!(command.contains("cat \"$log_file_2\""));
     assert!(command.contains("exit \"$failed\""));
 }
 
@@ -355,6 +385,27 @@ fn head_overrides_replace_checkout_ref_only_for_matching_repos() {
     assert_eq!(
         prepared[1].checkout,
         Some(RepositoryHeadRef::Branch("old-pin".to_string()))
+    );
+}
+
+#[test]
+fn head_overrides_match_bitbucket_repositories() {
+    let repos = vec![repo(CodeForge::Bitbucket, "warp-workspace", "api")];
+    let overrides = vec![commit_head_override(
+        RepositoryForge::Bitbucket,
+        "warp-workspace",
+        "api",
+        "0123456789abcdef0123456789abcdef01234567",
+    )];
+
+    validate_repository_head_overrides(&repos, &overrides)
+        .expect("a bitbucket override must match its bitbucket repository");
+    let prepared = repository_clone_requests(&repos, &overrides).unwrap();
+    assert_eq!(
+        prepared[0].checkout,
+        Some(RepositoryHeadRef::CommitSha(
+            "0123456789abcdef0123456789abcdef01234567".to_string(),
+        ))
     );
 }
 

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -102,8 +102,8 @@ fn merge_git_credentials_file_content(existing: &str, credentials: &[GitCredenti
         if trimmed.is_empty() {
             continue;
         }
-        let superseded = host_of_credentials_line(trimmed)
-            .is_some_and(|host| refreshed_hosts.contains(&host));
+        let superseded =
+            host_of_credentials_line(trimmed).is_some_and(|host| refreshed_hosts.contains(&host));
         if !superseded {
             lines.push(trimmed.to_string());
         }
@@ -248,7 +248,10 @@ fn write_glab_config(credentials: &[GitCredential], home: &std::path::Path) -> R
 /// `failed_hosts` are named alongside the fresh ones so a partial cycle is
 /// legible in the log: the surprising state is not "this host is missing" but
 /// "this host is running on a credential older than the others".
-pub(crate) fn credential_diagnostics(credentials: &[GitCredential], failed_hosts: &[String]) -> String {
+pub(crate) fn credential_diagnostics(
+    credentials: &[GitCredential],
+    failed_hosts: &[String],
+) -> String {
     let mut entries = credentials
         .iter()
         .map(|credential| {
@@ -423,7 +426,11 @@ fn record_host_identities(credentials: &[GitCredential]) {
         .iter()
         .map(|c| HostIdentity {
             host: c.host.clone(),
-            name: c.username.as_deref().unwrap_or(DEFAULT_GIT_NAME).to_string(),
+            name: c
+                .username
+                .as_deref()
+                .unwrap_or(DEFAULT_GIT_NAME)
+                .to_string(),
             email: c.email.as_deref().unwrap_or(DEFAULT_GIT_EMAIL).to_string(),
         })
         .collect::<Vec<_>>();
@@ -438,7 +445,10 @@ fn record_host_identities(credentials: &[GitCredential]) {
 fn identity_of(credential: Option<&GitCredential>) -> (String, String) {
     match credential {
         Some(c) => (
-            c.username.as_deref().unwrap_or(DEFAULT_GIT_NAME).to_string(),
+            c.username
+                .as_deref()
+                .unwrap_or(DEFAULT_GIT_NAME)
+                .to_string(),
             c.email.as_deref().unwrap_or(DEFAULT_GIT_EMAIL).to_string(),
         ),
         None => (DEFAULT_GIT_NAME.to_string(), DEFAULT_GIT_EMAIL.to_string()),

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -100,16 +100,48 @@ fn gitlab_credential() -> GitCredential {
     }
 }
 
+fn bitbucket_credential() -> GitCredential {
+    GitCredential {
+        token: "bitbucket-token".to_string(),
+        username: Some("x-token-auth".to_string()),
+        email: None,
+        host: "bitbucket.org".to_string(),
+    }
+}
+
 #[test]
 fn merged_credentials_include_each_provider_host() {
-    let content =
-        merge_git_credentials_file_content("", &[github_credential(), gitlab_credential()]);
+    let content = merge_git_credentials_file_content(
+        "",
+        &[
+            github_credential(),
+            gitlab_credential(),
+            bitbucket_credential(),
+        ],
+    );
 
     assert_eq!(
         content,
         "https://x-access-token:github-token@github.com\n\
-         https://oauth2:gitlab-token@gitlab.com\n"
+         https://oauth2:gitlab-token@gitlab.com\n\
+         https://x-token-auth:bitbucket-token@bitbucket.org\n"
     );
+}
+
+#[test]
+fn cli_config_writes_exclude_bitbucket_credentials() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    // A bitbucket.org credential authenticates git itself through
+    // ~/.git-credentials; it must not leak into the GitHub or GitLab CLI
+    // configs, and on its own it must not create either config.
+    write_gh_hosts_yml(&[bitbucket_credential()], temp_dir.path())?;
+    write_glab_config(&[bitbucket_credential()], temp_dir.path())?;
+
+    assert!(!temp_dir.path().join(".config").join("gh").exists());
+    assert!(!temp_dir.path().join(".config").join("glab-cli").exists());
+
+    Ok(())
 }
 
 #[test]
@@ -165,10 +197,7 @@ fn credential_diagnostics_reports_presence_without_values() {
 
 #[test]
 fn credential_diagnostics_names_the_stale_host() {
-    let diagnostics = credential_diagnostics(
-        &[github_credential()],
-        &["gitlab.com".to_string()],
-    );
+    let diagnostics = credential_diagnostics(&[github_credential()], &["gitlab.com".to_string()]);
 
     assert!(diagnostics.contains("github.com(refreshed"));
     assert!(diagnostics.contains("gitlab.com(stale"));
@@ -187,11 +216,20 @@ fn repository_identity_selects_the_matching_host() {
             name: "warp-factory-1".to_string(),
             email: "1-warp-factory-1@users.noreply.gitlab.com".to_string(),
         },
+        HostIdentity {
+            host: "bitbucket.org".to_string(),
+            name: "warp-workspace-bot".to_string(),
+            email: "bot@warp-workspace.example.com".to_string(),
+        },
     ];
 
     let matched = select_host_identity(&identities, "gitlab.com").expect("an identity");
     assert_eq!(matched.name, "warp-factory-1");
     assert_eq!(matched.email, "1-warp-factory-1@users.noreply.gitlab.com");
+
+    let matched = select_host_identity(&identities, "bitbucket.org").expect("an identity");
+    assert_eq!(matched.name, "warp-workspace-bot");
+    assert_eq!(matched.email, "bot@warp-workspace.example.com");
 }
 
 #[test]

--- a/crates/cloud_object_models/src/cloud_environment.rs
+++ b/crates/cloud_object_models/src/cloud_environment.rs
@@ -16,6 +16,8 @@ pub enum CodeForge {
     GitHub,
     #[serde(rename = "GITLAB")]
     GitLab,
+    #[serde(rename = "BITBUCKET")]
+    Bitbucket,
     /// Explicit "no code forge" container value: a repo-less environment
     /// that clones nothing and relies entirely on `setup_commands`.
     #[serde(rename = "NONE")]
@@ -41,6 +43,7 @@ impl CodeForge {
         match self {
             CodeForge::GitHub => "github.com",
             CodeForge::GitLab => "gitlab.com",
+            CodeForge::Bitbucket => "bitbucket.org",
             CodeForge::None | CodeForge::Unknown => "",
             // MULTIPLE names no host; per-repository forges are concrete by
             // invariant, so this is a defensive legacy-GitHub fallback.
@@ -54,6 +57,7 @@ impl fmt::Display for CodeForge {
         match self {
             CodeForge::GitHub => write!(f, "GitHub"),
             CodeForge::GitLab => write!(f, "GitLab"),
+            CodeForge::Bitbucket => write!(f, "Bitbucket"),
             CodeForge::None => write!(f, "None"),
             CodeForge::Multiple => write!(f, "Multiple forges"),
             CodeForge::Unknown => write!(f, "Unknown"),

--- a/crates/cloud_object_models/src/cloud_environment_tests.rs
+++ b/crates/cloud_object_models/src/cloud_environment_tests.rs
@@ -132,7 +132,7 @@ fn deserialize_environment_with_unrecognized_forge_still_succeeds() {
     // deserialization of the whole environment.
     let json = serde_json::json!({
         "name": "future-forge-env",
-        "code_forge": "BITBUCKET",
+        "code_forge": "SOURCEHUT",
         "github_repos": [],
         "setup_commands": ["echo hello"]
     });
@@ -140,6 +140,20 @@ fn deserialize_environment_with_unrecognized_forge_still_succeeds() {
     let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
 
     assert_eq!(env.effective_code_forge(), CodeForge::Unknown);
+}
+
+#[test]
+fn bitbucket_forge_round_trips_serde_host_and_display() {
+    // BITBUCKET is a recognized value on this client build: it must
+    // deserialize to the concrete variant, not the Unknown catch-all.
+    let forge: CodeForge = serde_json::from_value(serde_json::json!("BITBUCKET")).unwrap();
+    assert_eq!(forge, CodeForge::Bitbucket);
+    assert_eq!(
+        serde_json::to_value(CodeForge::Bitbucket).unwrap(),
+        serde_json::json!("BITBUCKET")
+    );
+    assert_eq!(CodeForge::Bitbucket.host(), "bitbucket.org");
+    assert_eq!(CodeForge::Bitbucket.to_string(), "Bitbucket");
 }
 
 #[test]
@@ -182,6 +196,37 @@ fn deserialize_gitlab_environment_uses_authoritative_source_repos() {
 }
 
 #[test]
+fn deserialize_bitbucket_environment_uses_authoritative_source_repos() {
+    let json = serde_json::json!({
+        "name": "bitbucket-env",
+        "code_forge": "BITBUCKET",
+        "github_repos": [{"owner": "legacy-mirror", "repo": "ignored"}],
+        "source_repos": [{
+            "owner": "warp-workspace",
+            "repo": "api"
+        }],
+        "docker_image": "ubuntu:latest"
+    });
+
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+
+    assert_eq!(env.effective_code_forge(), CodeForge::Bitbucket);
+    assert_eq!(env.source_repos.as_ref().unwrap()[0].code_forge, None);
+    assert_eq!(
+        env.effective_repos(),
+        vec![SourceRepo::new(
+            CodeForge::Bitbucket,
+            "warp-workspace".into(),
+            "api".into()
+        )]
+    );
+    assert_eq!(
+        env.effective_repos()[0].https_clone_url(),
+        "https://bitbucket.org/warp-workspace/api.git"
+    );
+}
+
+#[test]
 fn deserialize_mixed_forge_environment_with_multiple_container() {
     // A mixed environment stores code_forge MULTIPLE with every repository
     // declaring its own concrete forge; MULTIPLE itself never fills one.
@@ -191,7 +236,8 @@ fn deserialize_mixed_forge_environment_with_multiple_container() {
         "github_repos": [{"owner": "warpdotdev", "repo": "warp"}],
         "source_repos": [
             {"code_forge": "GITHUB", "owner": "warpdotdev", "repo": "warp"},
-            {"code_forge": "GITLAB", "owner": "platform/backend", "repo": "api"}
+            {"code_forge": "GITLAB", "owner": "platform/backend", "repo": "api"},
+            {"code_forge": "BITBUCKET", "owner": "warp-workspace", "repo": "tooling"}
         ],
         "docker_image": "ubuntu:latest"
     });
@@ -204,6 +250,7 @@ fn deserialize_mixed_forge_environment_with_multiple_container() {
     let repos = env.effective_repos();
     assert_eq!(repos[0].code_forge, Some(CodeForge::GitHub));
     assert_eq!(repos[1].code_forge, Some(CodeForge::GitLab));
+    assert_eq!(repos[2].code_forge, Some(CodeForge::Bitbucket));
     assert_eq!(
         repos[0].https_clone_url(),
         "https://github.com/warpdotdev/warp.git"
@@ -211,6 +258,10 @@ fn deserialize_mixed_forge_environment_with_multiple_container() {
     assert_eq!(
         repos[1].https_clone_url(),
         "https://gitlab.com/platform/backend/api.git"
+    );
+    assert_eq!(
+        repos[2].https_clone_url(),
+        "https://bitbucket.org/warp-workspace/tooling.git"
     );
 }
 

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -48,6 +48,8 @@ pub enum RepositoryForge {
     GitHub,
     #[serde(rename = "GITLAB")]
     GitLab,
+    #[serde(rename = "BITBUCKET")]
+    Bitbucket,
 }
 /// Server-supplied repository HEAD used to prepare an agent run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -347,6 +347,8 @@ fn agent_run_parses_repeated_repository_head_override_json() {
         r#"{"code_forge":"GITHUB","repo_owner":"warpdotdev","repo_name":"warp","head":{"type":"COMMIT_SHA","value":"0123456789abcdef0123456789abcdef01234567"}}"#,
         "--repository-head-override-json",
         r#"{"code_forge":"GITLAB","repo_owner":"platform/backend","repo_name":"api","head":{"type":"BRANCH","value":"develop"}}"#,
+        "--repository-head-override-json",
+        r#"{"code_forge":"BITBUCKET","repo_owner":"warp-workspace","repo_name":"tooling","head":{"type":"BRANCH","value":"main"}}"#,
     ])
     .unwrap();
 
@@ -357,7 +359,7 @@ fn agent_run_parses_repeated_repository_head_override_json() {
         panic!("Expected `warp agent run` command");
     };
 
-    assert_eq!(run_args.repository_head_overrides.len(), 2);
+    assert_eq!(run_args.repository_head_overrides.len(), 3);
     assert_eq!(
         run_args.repository_head_overrides[0].code_forge,
         RepositoryForge::GitHub
@@ -377,6 +379,18 @@ fn agent_run_parses_repeated_repository_head_override_json() {
     assert_eq!(
         run_args.repository_head_overrides[1].head,
         RepositoryHeadRef::Branch("develop".to_string())
+    );
+    assert_eq!(
+        run_args.repository_head_overrides[2].code_forge,
+        RepositoryForge::Bitbucket
+    );
+    assert_eq!(
+        run_args.repository_head_overrides[2].repo_owner,
+        "warp-workspace"
+    );
+    assert_eq!(
+        run_args.repository_head_overrides[2].head,
+        RepositoryHeadRef::Branch("main".to_string())
     );
 }
 


### PR DESCRIPTION
## Summary
The client can now clone Bitbucket repositories in cloud environments.

- `CodeForge::Bitbucket` (`serde` rename `BITBUCKET`), host `bitbucket.org`, display name `Bitbucket`. `Unknown` stays last with `serde(other)`.
- `RepositoryForge::Bitbucket` flows through `repository_forge_for_repo`, head-override parsing, and clone URL construction (`https://bitbucket.org/{owner}/{repo}.git`).
- The credential path needed no logic change: the store, the `insteadOf` rewrites, and per-repo identity selection key on the host string from `taskGitCredentials`, so `bitbucket.org` uses the same generic path as `gitlab.com`. Tests prove a `bitbucket.org` credential merges into `~/.git-credentials` and does not leak into the `gh`/`glab` CLI configs.

Stacked on #15508.

## Validation
- `cargo nextest run -p cloud_object_models -p warp_cli`: 270 passed.
- `cargo nextest run -p warp -E 'test(/ai::agent_sdk::driver::(environment|git_credentials)::tests/)'`: 49 passed.
- `./script/format --check` and the full presubmit clippy set: clean.

## Artifacts
- Conversation: https://staging.warp.dev/conversation/fe921040-8660-48b7-87f5-3043cf0b41fa
- Plan: [Forge provider registry: GitHub, GitLab, Bitbucket end to end](https://staging.warp.dev/drive/notebook/2uZd5d0LoXgFRCfe5P17vK)

Co-Authored-By: Warp <agent@warp.dev>