### PR TITLE
Fix release compilation errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,7 +787,7 @@ jobs:
           if ${{ matrix.os == 'wasm' }}; then
             ./script/wasm/bundle --channel oss --nouniversal --check-only
           else
-            ./script/bundle --channel oss --nouniversal --check-only --features crash_reporting,release_bundle,gui
+            ./script/bundle --channel oss --nouniversal --check-only
           fi
         env:
           # Attach the GitHub auth token so that requests to the GitHub API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,14 +780,15 @@ jobs:
         with:
           target_os: ${{ matrix.os }}
           is_self_hosted: ${{ matrix.is_self_hosted }}
+          ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
 
       - name: Verify compilation with release flags
         shell: bash
         run: |
           if ${{ matrix.os == 'wasm' }}; then
-            ./script/wasm/bundle --channel oss --nouniversal --check-only
+            ./script/wasm/bundle --channel local --nouniversal --check-only
           else
-            ./script/bundle --channel oss --nouniversal --check-only
+            ./script/bundle --channel local --nouniversal --check-only
           fi
         env:
           # Attach the GitHub auth token so that requests to the GitHub API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,15 +780,14 @@ jobs:
         with:
           target_os: ${{ matrix.os }}
           is_self_hosted: ${{ matrix.is_self_hosted }}
-          ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
 
       - name: Verify compilation with release flags
         shell: bash
         run: |
           if ${{ matrix.os == 'wasm' }}; then
-            ./script/wasm/bundle --channel local --nouniversal --check-only
+            ./script/wasm/bundle --channel oss --nouniversal --check-only
           else
-            ./script/bundle --channel local --nouniversal --check-only
+            ./script/bundle --channel oss --nouniversal --check-only --features crash_reporting,release_bundle,gui
           fi
         env:
           # Attach the GitHub auth token so that requests to the GitHub API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16027,6 +16027,7 @@ dependencies = [
  "rangemap",
  "regex",
  "regex-automata",
+ "sentry",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/warp_terminal/Cargo.toml
+++ b/crates/warp_terminal/Cargo.toml
@@ -41,6 +41,7 @@ rand.workspace = true
 rangemap.workspace = true
 regex.workspace = true
 regex-automata = "0.4.6"
+sentry = { workspace = true, optional = true}
 serde.workspace = true
 serde_json.workspace = true
 session-sharing-protocol.workspace = true
@@ -118,7 +119,7 @@ unicode-segmentation = "1.11.0"
 warp_core = { workspace = true, features = ["test-util"] }
 
 [features]
-crash_reporting = ["warp_errors/crash_reporting"]
+crash_reporting = ["dep:sentry", "warp_errors/crash_reporting"]
 integration_tests = ["warp_core/integration_tests", "warpui_core/integration_tests"]
 local_fs = ["warp_core/local_fs"]
 local_tty = []

--- a/crates/warp_terminal/Cargo.toml
+++ b/crates/warp_terminal/Cargo.toml
@@ -41,7 +41,7 @@ rand.workspace = true
 rangemap.workspace = true
 regex.workspace = true
 regex-automata = "0.4.6"
-sentry = { workspace = true, optional = true}
+sentry = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 session-sharing-protocol.workspace = true


### PR DESCRIPTION
## Description

This fixes a compilation error when building releases (see [failed job](https://github.com/warpdotdev/warp-internal/actions/runs/32825958144/job/97734793818#step:8:153)) due to a missing declared `sentry` dependency.

I believe this got through CI because we were testing bundling against the `oss` channel (which doesn't enable crash reporting) as opposed to using one of our first-party channels.  I'll send a separate PR that ensures that we're enabling the right set of features when running this CI check (it's non-trivial and I want to unblock cutting a new dev release).