### PR TITLE
Add Credits/Dollars usage display unit toggle to Appearance settings

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1222,7 +1222,8 @@ impl AIBlock {
                     ctx.notify();
                 }
                 AISettingsChangedEvent::ThinkingDisplayMode { .. }
-                | AISettingsChangedEvent::OrchestrationMessageDisplayMode { .. } => {
+                | AISettingsChangedEvent::OrchestrationMessageDisplayMode { .. }
+                | AISettingsChangedEvent::UsageDisplayUnit { .. } => {
                     ctx.notify();
                 }
                 _ => {}

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -104,7 +104,7 @@ use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
 use crate::ai::blocklist::view_util::{
-    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits_with_cost, format_usage_parenthetical,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits_with_cost,
     should_show_failed_output_usage_notice,
 };
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
@@ -116,6 +116,7 @@ use crate::ai::skills::{
 use crate::appearance::Appearance;
 use crate::code::diff_viewer::DisplayMode;
 use crate::code::editor_management::CodeSource;
+use crate::settings::AISettings;
 use crate::settings_view::SettingsSection;
 use crate::terminal::ShellLaunchData;
 #[cfg(not(target_family = "wasm"))]
@@ -3722,9 +3723,14 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
         Icon::ChevronRight
     };
 
+    let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
     let total_credits_spent = headline_credits;
-    let mut credit_usage_text =
-        format_credits_with_cost(total_credits_spent, headline_tokens, headline_cost_in_cents);
+    let mut credit_usage_text = format_credits_with_cost(
+        total_credits_spent,
+        headline_tokens,
+        headline_cost_in_cents,
+        usage_display_unit,
+    );
     if let Some(credits_spent_for_last_block) = conversation.credits_spent_for_last_block() {
         // Only show the credits spent for the last block if it is different from the total credits spent
         // and we spent a non-zero amount of credits for the last block.
@@ -3734,26 +3740,17 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
             && total_credits_spent != credits_spent_for_last_block
             && props.model.status(app).error().is_none()
         {
-            // If the first part of the decimal is 0, we just display the whole number.
-            let last_block_credits_text = if credits_spent_for_last_block.fract() < 0.1 {
-                format!("{}", credits_spent_for_last_block.trunc() as i32)
-            } else {
-                format!("{credits_spent_for_last_block:.1}")
-            };
             // The last-block figure has no rollup equivalent: it stays
             // bound to the orchestrator's own last block, same as
             // `credits_spent_for_last_block` above.
             let last_block_charged_usage = conversation.charged_usage_for_last_block();
-            let last_block_detail = format_usage_parenthetical(
+            let last_block_text = format_credits_with_cost(
+                credits_spent_for_last_block,
                 last_block_charged_usage.map(|usage| usage.total_tokens()),
                 last_block_charged_usage.map(|usage| usage.total_cost_in_cents()),
+                usage_display_unit,
             );
-            credit_usage_text = match last_block_detail {
-                Some(detail) => {
-                    format!("{credit_usage_text} (+{last_block_credits_text}, {detail})")
-                }
-                None => format!("{credit_usage_text} (+{last_block_credits_text})"),
-            };
+            credit_usage_text = format!("{credit_usage_text} (+{last_block_text})");
         }
     }
 

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3725,7 +3725,7 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
 
     let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
     let total_credits_spent = headline_credits;
-    let mut credit_usage_text = format_credits_with_cost(
+    let mut usage_text = format_credits_with_cost(
         total_credits_spent,
         headline_tokens,
         headline_cost_in_cents,
@@ -3750,7 +3750,7 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
                 last_block_charged_usage.map(|usage| usage.total_cost_in_cents()),
                 usage_display_unit,
             );
-            credit_usage_text = format!("{credit_usage_text} (+{last_block_text})");
+            usage_text = format!("{usage_text} (+{last_block_text})");
         }
     }
 
@@ -3761,7 +3761,7 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
         .with_child(
             Container::new(
                 Text::new_inline(
-                    credit_usage_text,
+                    usage_text,
                     appearance.ui_font_family(),
                     appearance.monospace_font_size(),
                 )

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -104,8 +104,7 @@ use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
 use crate::ai::blocklist::view_util::{
-    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_credits_with_cost,
-    should_show_failed_output_usage_notice,
+    FAILED_OUTPUT_USAGE_NOTICE_TEXT, format_usage, should_show_failed_output_usage_notice,
 };
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
@@ -3725,7 +3724,7 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
 
     let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
     let total_credits_spent = headline_credits;
-    let mut usage_text = format_credits_with_cost(
+    let mut usage_text = format_usage(
         total_credits_spent,
         headline_tokens,
         headline_cost_in_cents,
@@ -3744,7 +3743,7 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
             // bound to the orchestrator's own last block, same as
             // `credits_spent_for_last_block` above.
             let last_block_charged_usage = conversation.charged_usage_for_last_block();
-            let last_block_text = format_credits_with_cost(
+            let last_block_text = format_usage(
                 credits_spent_for_last_block,
                 last_block_charged_usage.map(|usage| usage.total_tokens()),
                 last_block_charged_usage.map(|usage| usage.total_cost_in_cents()),

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -25,7 +25,7 @@ use crate::ai::blocklist::usage::render_context_window_usage_icon;
 use crate::ai::blocklist::usage::rollup::{
     AgentAvatar, OrchestrationCreditRollup, PerAgentCreditEntry, compute_orchestration_rollup,
 };
-use crate::ai::blocklist::view_util::{format_credits, format_credits_with_cost, usage_label};
+use crate::ai::blocklist::view_util::{UsageLabelKind, format_credits, format_usage, usage_label};
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
@@ -349,16 +349,13 @@ impl ConversationUsageView {
         ));
         values.push(render_section_header("".to_string(), appearance));
 
-        // "Credits spent (total)" value: use the rollup total when available,
-        // otherwise the orchestrator's own self total (today's behavior).
-        // PRODUCT invariants 2a, 11.
+        // Total usage value: the rollup total when available, otherwise the
+        // orchestrator's own self total. PRODUCT invariants 2a, 11.
         let total_credits_value = rollup
             .as_ref()
             .map(|r| r.total_credits)
             .unwrap_or(self.usage_info.credits_spent + self.usage_info.platform_credits_spent);
 
-        // Rollup-vs-own-totals split mirrors `total_credits_value` above,
-        // for the token/cost figures shown alongside it.
         let total_tokens_value = rollup
             .as_ref()
             .map(|r| r.total_tokens)
@@ -373,15 +370,11 @@ impl ConversationUsageView {
         {
             let last_block_credits = self.usage_info.credits_spent_for_last_block.unwrap();
             labels.push(render_label_text(
-                usage_label(
-                    "Credits spent (last response)",
-                    "Usage charged (last response)",
-                    usage_display_unit,
-                ),
+                &usage_label(UsageLabelKind::LastResponse, usage_display_unit),
                 appearance,
             ));
             values.push(render_value_text(
-                format_credits_with_cost(
+                format_usage(
                     last_block_credits,
                     self.usage_info.tokens_for_last_block,
                     self.usage_info.cost_in_cents_for_last_block,
@@ -391,14 +384,10 @@ impl ConversationUsageView {
             ));
 
             labels.push(render_label_text(
-                usage_label(
-                    "Credits spent (total)",
-                    "Usage charged (total)",
-                    usage_display_unit,
-                ),
+                &usage_label(UsageLabelKind::Total, usage_display_unit),
                 appearance,
             ));
-            values.push(self.render_total_credits_value_row(
+            values.push(self.render_total_usage_value_row(
                 total_credits_value,
                 total_tokens_value,
                 total_cost_in_cents_value,
@@ -408,10 +397,10 @@ impl ConversationUsageView {
             ));
         } else {
             labels.push(render_label_text(
-                usage_label("Credits spent", "Usage charged", usage_display_unit),
+                &usage_label(UsageLabelKind::Plain, usage_display_unit),
                 appearance,
             ));
-            values.push(self.render_total_credits_value_row(
+            values.push(self.render_total_usage_value_row(
                 total_credits_value,
                 total_tokens_value,
                 total_cost_in_cents_value,
@@ -421,12 +410,9 @@ impl ConversationUsageView {
             ));
         }
 
-        // Per-agent breakdown rows render immediately beneath the
-        // "Credits spent (total)" row so they read as a drill-down of
-        // that value, not as a separate section appended at the bottom
-        // of the card. The rows are pushed into the same two-column
-        // label/value layout as the rest of the usage summary; the
-        // existing flex spacing handles indentation.
+        // Per-agent breakdown rows render immediately beneath the total
+        // usage row so they read as a drill-down of that value rather than
+        // a separate section.
         self.append_per_agent_rows(&mut labels, &mut values, rollup.as_ref(), appearance);
 
         labels.push(render_label_text("Tool calls", appearance));
@@ -756,10 +742,10 @@ impl ConversationUsageView {
         }
     }
 
-    /// Renders the "Credits spent (total)" value cell. When a rollup
-    /// applies, the cell is a row with the value followed by a
-    /// "View details ▾" / "Hide details ▴" toggle.
-    fn render_total_credits_value_row(
+    /// Renders the total usage value cell. When a rollup applies, the cell
+    /// is a row with the value followed by a "View details" / "Hide
+    /// details" toggle.
+    fn render_total_usage_value_row(
         &self,
         total_credits: f32,
         total_tokens: Option<u32>,
@@ -768,13 +754,13 @@ impl ConversationUsageView {
         rollup: Option<&OrchestrationCreditRollup>,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
-        let credits_text = format_credits_with_cost(
+        let usage_text = format_usage(
             total_credits,
             total_tokens,
             total_cost_in_cents,
             usage_display_unit,
         );
-        let value_text = render_value_text(credits_text, appearance);
+        let value_text = render_value_text(usage_text, appearance);
         if rollup.is_none() {
             return value_text;
         }

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -177,8 +177,6 @@ impl ConversationUsageView {
         parent_conversation_id: AIConversationId,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        // Re-render immediately when the usage display unit changes, since
-        // `render_unified_layout` reads it directly at render time.
         ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
             if matches!(event, AISettingsChangedEvent::UsageDisplayUnit { .. }) {
                 ctx.notify();
@@ -349,8 +347,6 @@ impl ConversationUsageView {
         ));
         values.push(render_section_header("".to_string(), appearance));
 
-        // Total usage value: the rollup total when available, otherwise the
-        // orchestrator's own self total. PRODUCT invariants 2a, 11.
         let total_credits_value = rollup
             .as_ref()
             .map(|r| r.total_credits)
@@ -422,9 +418,6 @@ impl ConversationUsageView {
             ));
         }
 
-        // Per-agent breakdown rows render immediately beneath the total
-        // usage row so they read as a drill-down of that value rather than
-        // a separate section.
         self.append_per_agent_rows(&mut labels, &mut values, rollup.as_ref(), appearance);
 
         labels.push(render_label_text("Tool calls", appearance));
@@ -754,9 +747,6 @@ impl ConversationUsageView {
         }
     }
 
-    /// Renders the total usage value cell. When a rollup applies, the cell
-    /// is a row with the value followed by a "View details" / "Hide
-    /// details" toggle.
     fn render_total_usage_value_row(
         &self,
         total_credits: f32,

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -370,7 +370,11 @@ impl ConversationUsageView {
         {
             let last_block_credits = self.usage_info.credits_spent_for_last_block.unwrap();
             labels.push(render_label_text(
-                &usage_label(UsageLabelKind::LastResponse, usage_display_unit),
+                &usage_label(
+                    UsageLabelKind::LastResponse,
+                    self.usage_info.cost_in_cents_for_last_block,
+                    usage_display_unit,
+                ),
                 appearance,
             ));
             values.push(render_value_text(
@@ -384,7 +388,11 @@ impl ConversationUsageView {
             ));
 
             labels.push(render_label_text(
-                &usage_label(UsageLabelKind::Total, usage_display_unit),
+                &usage_label(
+                    UsageLabelKind::Total,
+                    total_cost_in_cents_value,
+                    usage_display_unit,
+                ),
                 appearance,
             ));
             values.push(self.render_total_usage_value_row(
@@ -397,7 +405,11 @@ impl ConversationUsageView {
             ));
         } else {
             labels.push(render_label_text(
-                &usage_label(UsageLabelKind::Plain, usage_display_unit),
+                &usage_label(
+                    UsageLabelKind::Plain,
+                    total_cost_in_cents_value,
+                    usage_display_unit,
+                ),
                 appearance,
             ));
             values.push(self.render_total_usage_value_row(

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -32,7 +32,7 @@ use crate::persistence::model::{
     ContextWindowSegment, ContextWindowSegmentType, FULL_TERMINAL_USE_CATEGORY, ModelTokenUsage,
     PRIMARY_AGENT_CATEGORY, token_usage_category_display_name,
 };
-use crate::settings::{AISettings, UsageDisplayUnit};
+use crate::settings::{AISettings, AISettingsChangedEvent, UsageDisplayUnit};
 use crate::ui_components::blended_colors;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -177,6 +177,14 @@ impl ConversationUsageView {
         parent_conversation_id: AIConversationId,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
+        // Re-render immediately when the usage display unit changes, since
+        // `render_unified_layout` reads it directly at render time.
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
+            if matches!(event, AISettingsChangedEvent::UsageDisplayUnit { .. }) {
+                ctx.notify();
+            }
+        });
+
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         ctx.subscribe_to_model(&history_model, move |_, history, event, ctx| {
             // Narrow to events that can actually change *this* orchestrator's

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -25,7 +25,7 @@ use crate::ai::blocklist::usage::render_context_window_usage_icon;
 use crate::ai::blocklist::usage::rollup::{
     AgentAvatar, OrchestrationCreditRollup, PerAgentCreditEntry, compute_orchestration_rollup,
 };
-use crate::ai::blocklist::view_util::{format_credits, format_credits_with_cost};
+use crate::ai::blocklist::view_util::{format_credits, format_credits_with_cost, usage_label};
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
@@ -373,7 +373,11 @@ impl ConversationUsageView {
         {
             let last_block_credits = self.usage_info.credits_spent_for_last_block.unwrap();
             labels.push(render_label_text(
-                "Credits spent (last response)",
+                usage_label(
+                    "Credits spent (last response)",
+                    "Usage charged (last response)",
+                    usage_display_unit,
+                ),
                 appearance,
             ));
             values.push(render_value_text(
@@ -386,7 +390,14 @@ impl ConversationUsageView {
                 appearance,
             ));
 
-            labels.push(render_label_text("Credits spent (total)", appearance));
+            labels.push(render_label_text(
+                usage_label(
+                    "Credits spent (total)",
+                    "Usage charged (total)",
+                    usage_display_unit,
+                ),
+                appearance,
+            ));
             values.push(self.render_total_credits_value_row(
                 total_credits_value,
                 total_tokens_value,
@@ -396,7 +407,10 @@ impl ConversationUsageView {
                 appearance,
             ));
         } else {
-            labels.push(render_label_text("Credits spent", appearance));
+            labels.push(render_label_text(
+                usage_label("Credits spent", "Usage charged", usage_display_unit),
+                appearance,
+            ));
             values.push(self.render_total_credits_value_row(
                 total_credits_value,
                 total_tokens_value,

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -32,6 +32,7 @@ use crate::persistence::model::{
     ContextWindowSegment, ContextWindowSegmentType, FULL_TERMINAL_USE_CATEGORY, ModelTokenUsage,
     PRIMARY_AGENT_CATEGORY, token_usage_category_display_name,
 };
+use crate::settings::{AISettings, UsageDisplayUnit};
 use crate::ui_components::blended_colors;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -319,6 +320,7 @@ impl ConversationUsageView {
         let theme = appearance.theme();
         let font_size = appearance.ui_font_size() + 2.;
         let text_color = blended_colors::text_main(theme, theme.surface_2());
+        let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
         let context_window_breakdown_enabled = FeatureFlag::ContextWindowUsageBreakdown
             .is_enabled()
             && !context_window_segment_display_rows(
@@ -371,6 +373,7 @@ impl ConversationUsageView {
                     last_block_credits,
                     self.usage_info.tokens_for_last_block,
                     self.usage_info.cost_in_cents_for_last_block,
+                    usage_display_unit,
                 ),
                 appearance,
             ));
@@ -380,6 +383,7 @@ impl ConversationUsageView {
                 total_credits_value,
                 total_tokens_value,
                 total_cost_in_cents_value,
+                usage_display_unit,
                 rollup.as_ref(),
                 appearance,
             ));
@@ -389,6 +393,7 @@ impl ConversationUsageView {
                 total_credits_value,
                 total_tokens_value,
                 total_cost_in_cents_value,
+                usage_display_unit,
                 rollup.as_ref(),
                 appearance,
             ));
@@ -737,11 +742,16 @@ impl ConversationUsageView {
         total_credits: f32,
         total_tokens: Option<u32>,
         total_cost_in_cents: Option<f32>,
+        usage_display_unit: UsageDisplayUnit,
         rollup: Option<&OrchestrationCreditRollup>,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
-        let credits_text =
-            format_credits_with_cost(total_credits, total_tokens, total_cost_in_cents);
+        let credits_text = format_credits_with_cost(
+            total_credits,
+            total_tokens,
+            total_cost_in_cents,
+            usage_display_unit,
+        );
         let value_text = render_value_text(credits_text, appearance);
         if rollup.is_none() {
             return value_text;

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -52,7 +52,10 @@ fn placeholder_usage_info() -> ConversationUsageInfo {
     }
 }
 
-/// Registers the singletons required by the view.
+/// Registers the singletons that the view touches when constructed and
+/// when `ctx.notify()` runs (theme lookups, settings, etc.). Keep this
+/// minimal: the goal is to satisfy the runtime, not to mirror the full
+/// production app.
 fn initialize_test_app(app: &mut App) {
     initialize_settings_for_tests(app);
     app.add_singleton_model(|_| Appearance::mock());

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -30,6 +30,7 @@ use warpui::platform::WindowStyle;
 
 use super::*;
 use crate::persistence::model::{ModelTokenUsage, PRIMARY_AGENT_CATEGORY};
+use crate::test_util::settings::initialize_settings_for_tests;
 
 fn placeholder_usage_info() -> ConversationUsageInfo {
     ConversationUsageInfo {
@@ -52,9 +53,11 @@ fn placeholder_usage_info() -> ConversationUsageInfo {
 }
 
 /// Registers the singletons that the view touches when constructed and
-/// when `ctx.notify()` runs (theme lookups, etc.). Keep this minimal: the
-/// goal is to satisfy the runtime, not to mirror the full production app.
+/// when `ctx.notify()` runs (theme lookups, settings, etc.). Keep this
+/// minimal: the goal is to satisfy the runtime, not to mirror the full
+/// production app.
 fn initialize_test_app(app: &mut App) {
+    initialize_settings_for_tests(app);
     app.add_singleton_model(|_| Appearance::mock());
 }
 

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -52,10 +52,7 @@ fn placeholder_usage_info() -> ConversationUsageInfo {
     }
 }
 
-/// Registers the singletons that the view touches when constructed and
-/// when `ctx.notify()` runs (theme lookups, settings, etc.). Keep this
-/// minimal: the goal is to satisfy the runtime, not to mirror the full
-/// production app.
+/// Registers the singletons required by the view.
 fn initialize_test_app(app: &mut App) {
     initialize_settings_for_tests(app);
     app.add_singleton_model(|_| Appearance::mock());

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -348,6 +348,24 @@ pub fn format_credits_with_cost(
     format!("{} tokens / {unit_text}", tokens.separate_with_commas())
 }
 
+/// Returns `dollars_label` when `unit` is `Dollars` and
+/// `FeatureFlag::PricingTransparency` is enabled, otherwise returns
+/// `credits_label`. Used to swap usage-row labels (e.g. "Credits spent" ->
+/// "Usage charged") to match the unit shown by [`format_credits_with_cost`]
+/// -- gated the same way so a row's label and its formatted value never
+/// disagree (e.g. a "Usage" label next to a plain credits fallback figure).
+pub fn usage_label(
+    credits_label: &'static str,
+    dollars_label: &'static str,
+    unit: UsageDisplayUnit,
+) -> &'static str {
+    if matches!(unit, UsageDisplayUnit::Dollars) && FeatureFlag::PricingTransparency.is_enabled() {
+        dollars_label
+    } else {
+        credits_label
+    }
+}
+
 /// Renders a secondary button with an MCP/skill provider icon and a text label.
 pub(crate) fn render_provider_icon_button<F>(
     button_label: &str,

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -299,10 +299,8 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
-/// Formats the single-unit figure (credits or dollars) selected by `unit`.
-/// Returns `None` when `unit` is `Dollars` but no cost figure is available
-/// -- there is no meaningful fallback within the dollar figure itself, so
-/// [`format_credits_with_cost`] falls back to a plain credits total instead.
+/// Formats the figure for `unit`. `None` when `unit` is `Dollars` but no
+/// cost figure is available.
 fn format_usage_unit_value(
     credits: f32,
     cost_in_cents: Option<f32>,
@@ -316,21 +314,12 @@ fn format_usage_unit_value(
     }
 }
 
-/// Formats a credit count together with its total token count and real
-/// dollar cost, showing tokens plus exactly one of credits or dollars
-/// (never both) depending on `unit` -- e.g. `"12,345 tokens / 20 credits"`
-/// (Credits) or `"12,345 tokens / $0.36"` (Dollars).
-///
-/// A `tokens` value of `0` is treated the same as `None` (omitted) since a
-/// "0 tokens" figure next to a non-zero credit/cost figure would be
-/// confusing rather than informative (e.g. a purely platform-cost request
-/// like a paid web search).
-///
-/// Falls back to a plain credits-only figure (no tokens) when `unit` is
-/// `Dollars` but no cost figure is available, or when
-/// `FeatureFlag::PricingTransparency` is disabled (today's pre-breakdown
-/// behavior).
-pub fn format_credits_with_cost(
+/// Formats a usage figure as its token count plus exactly one of credits or
+/// dollars, e.g. `"12,345 tokens / 20 credits"` or `"12,345 tokens / $0.36"`.
+/// Zero/unknown token counts are omitted. Falls back to a plain credits
+/// figure when no dollar figure is available or
+/// `FeatureFlag::PricingTransparency` is disabled.
+pub fn format_usage(
     credits: f32,
     tokens: Option<u32>,
     cost_in_cents: Option<f32>,
@@ -348,22 +337,42 @@ pub fn format_credits_with_cost(
     format!("{} tokens / {unit_text}", tokens.separate_with_commas())
 }
 
-/// Returns `dollars_label` when `unit` is `Dollars` and
-/// `FeatureFlag::PricingTransparency` is enabled, otherwise returns
-/// `credits_label`. Used to swap usage-row labels (e.g. "Credits spent" ->
-/// "Usage charged") to match the unit shown by [`format_credits_with_cost`]
-/// -- gated the same way so a row's label and its formatted value never
-/// disagree (e.g. a "Usage" label next to a plain credits fallback figure).
-pub fn usage_label(
-    credits_label: &'static str,
-    dollars_label: &'static str,
-    unit: UsageDisplayUnit,
-) -> &'static str {
-    if matches!(unit, UsageDisplayUnit::Dollars) && FeatureFlag::PricingTransparency.is_enabled() {
-        dollars_label
+/// The usage surface a label is rendered on, which determines its wording.
+#[derive(Clone, Copy)]
+pub enum UsageLabelKind {
+    LastResponse,
+    Total,
+    Plain,
+    DetailsPanel,
+}
+
+/// Returns the label for a usage row, worded to match the unit shown by
+/// [`format_usage`] so a label and its value never disagree.
+pub fn usage_label(kind: UsageLabelKind, unit: UsageDisplayUnit) -> String {
+    // The Dollars setting only takes effect once PricingTransparency is on.
+    let unit = if FeatureFlag::PricingTransparency.is_enabled() {
+        unit
     } else {
-        credits_label
-    }
+        UsageDisplayUnit::Credits
+    };
+    let base = match (kind, unit) {
+        (UsageLabelKind::DetailsPanel, UsageDisplayUnit::Credits) => "Credits used",
+        (UsageLabelKind::DetailsPanel, UsageDisplayUnit::Dollars) => "Usage",
+        (
+            UsageLabelKind::LastResponse | UsageLabelKind::Total | UsageLabelKind::Plain,
+            UsageDisplayUnit::Credits,
+        ) => "Credits spent",
+        (
+            UsageLabelKind::LastResponse | UsageLabelKind::Total | UsageLabelKind::Plain,
+            UsageDisplayUnit::Dollars,
+        ) => "Usage charged",
+    };
+    let suffix = match kind {
+        UsageLabelKind::LastResponse => " (last response)",
+        UsageLabelKind::Total => " (total)",
+        UsageLabelKind::Plain | UsageLabelKind::DetailsPanel => "",
+    };
+    format!("{base}{suffix}")
 }
 
 /// Renders a secondary button with an MCP/skill provider icon and a text label.

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -299,11 +299,6 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
-/// Derives the unit actually displayed for a usage figure, accounting for
-/// `FeatureFlag::PricingTransparency` and for cost-data availability.
-/// `format_usage` and [`usage_label`] both derive from this so a label and
-/// its value never disagree: whenever `Dollars` can't actually be shown
-/// (flag disabled, or no cost figure available), both fall back to `Credits`.
 fn effective_usage_unit(unit: UsageDisplayUnit, cost_in_cents: Option<f32>) -> UsageDisplayUnit {
     if !FeatureFlag::PricingTransparency.is_enabled() {
         return UsageDisplayUnit::Credits;
@@ -315,8 +310,6 @@ fn effective_usage_unit(unit: UsageDisplayUnit, cost_in_cents: Option<f32>) -> U
     }
 }
 
-/// Formats the figure for `unit`. Falls back to a plain credits figure if
-/// `unit` is `Dollars` but no cost figure is available.
 fn format_usage_unit_value(
     credits: f32,
     cost_in_cents: Option<f32>,
@@ -330,11 +323,7 @@ fn format_usage_unit_value(
     }
 }
 
-/// Formats a usage figure as its token count plus exactly one of credits or
-/// dollars, e.g. `"12,345 tokens / 20 credits"` or `"12,345 tokens / $0.36"`.
-/// Zero/unknown token counts are omitted. Falls back to a plain credits
-/// figure (without a token breakdown) when no dollar figure is available or
-/// `FeatureFlag::PricingTransparency` is disabled.
+/// Formats tokens with the selected unit, falling back to credits when dollars are unavailable.
 pub fn format_usage(
     credits: f32,
     tokens: Option<u32>,
@@ -352,7 +341,6 @@ pub fn format_usage(
     format!("{} tokens / {unit_text}", tokens.separate_with_commas())
 }
 
-/// The usage surface a label is rendered on, which determines its wording.
 #[derive(Clone, Copy)]
 pub enum UsageLabelKind {
     LastResponse,
@@ -361,9 +349,7 @@ pub enum UsageLabelKind {
     DetailsPanel,
 }
 
-/// Returns the label for a usage row, worded to match the unit [`format_usage`]
-/// would show for the same `cost_in_cents`, so a label and its value never
-/// disagree.
+/// Matches the label to the unit [`format_usage`] will render.
 pub fn usage_label(
     kind: UsageLabelKind,
     cost_in_cents: Option<f32>,

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -299,25 +299,41 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
-/// Formats the figure for `unit`. `None` when `unit` is `Dollars` but no
-/// cost figure is available.
+/// Derives the unit actually displayed for a usage figure, accounting for
+/// `FeatureFlag::PricingTransparency` and for cost-data availability.
+/// `format_usage` and [`usage_label`] both derive from this so a label and
+/// its value never disagree: whenever `Dollars` can't actually be shown
+/// (flag disabled, or no cost figure available), both fall back to `Credits`.
+fn effective_usage_unit(unit: UsageDisplayUnit, cost_in_cents: Option<f32>) -> UsageDisplayUnit {
+    if !FeatureFlag::PricingTransparency.is_enabled() {
+        return UsageDisplayUnit::Credits;
+    }
+    match unit {
+        UsageDisplayUnit::Credits => UsageDisplayUnit::Credits,
+        UsageDisplayUnit::Dollars if cost_in_cents.is_some() => UsageDisplayUnit::Dollars,
+        UsageDisplayUnit::Dollars => UsageDisplayUnit::Credits,
+    }
+}
+
+/// Formats the figure for `unit`. Falls back to a plain credits figure if
+/// `unit` is `Dollars` but no cost figure is available.
 fn format_usage_unit_value(
     credits: f32,
     cost_in_cents: Option<f32>,
     unit: UsageDisplayUnit,
-) -> Option<String> {
+) -> String {
     match unit {
-        UsageDisplayUnit::Credits => Some(format_credits(credits)),
-        UsageDisplayUnit::Dollars => {
-            cost_in_cents.map(|cost_in_cents| format!("${:.2}", cost_in_cents / 100.0))
-        }
+        UsageDisplayUnit::Credits => format_credits(credits),
+        UsageDisplayUnit::Dollars => cost_in_cents
+            .map(|cost_in_cents| format!("${:.2}", cost_in_cents / 100.0))
+            .unwrap_or_else(|| format_credits(credits)),
     }
 }
 
 /// Formats a usage figure as its token count plus exactly one of credits or
 /// dollars, e.g. `"12,345 tokens / 20 credits"` or `"12,345 tokens / $0.36"`.
 /// Zero/unknown token counts are omitted. Falls back to a plain credits
-/// figure when no dollar figure is available or
+/// figure (without a token breakdown) when no dollar figure is available or
 /// `FeatureFlag::PricingTransparency` is disabled.
 pub fn format_usage(
     credits: f32,
@@ -325,12 +341,11 @@ pub fn format_usage(
     cost_in_cents: Option<f32>,
     unit: UsageDisplayUnit,
 ) -> String {
-    if !FeatureFlag::PricingTransparency.is_enabled() {
+    let resolved_unit = effective_usage_unit(unit, cost_in_cents);
+    if !FeatureFlag::PricingTransparency.is_enabled() || resolved_unit != unit {
         return format_credits(credits);
     }
-    let Some(unit_text) = format_usage_unit_value(credits, cost_in_cents, unit) else {
-        return format_credits(credits);
-    };
+    let unit_text = format_usage_unit_value(credits, cost_in_cents, resolved_unit);
     let Some(tokens) = tokens.filter(|&tokens| tokens > 0) else {
         return unit_text;
     };
@@ -346,15 +361,15 @@ pub enum UsageLabelKind {
     DetailsPanel,
 }
 
-/// Returns the label for a usage row, worded to match the unit shown by
-/// [`format_usage`] so a label and its value never disagree.
-pub fn usage_label(kind: UsageLabelKind, unit: UsageDisplayUnit) -> String {
-    // The Dollars setting only takes effect once PricingTransparency is on.
-    let unit = if FeatureFlag::PricingTransparency.is_enabled() {
-        unit
-    } else {
-        UsageDisplayUnit::Credits
-    };
+/// Returns the label for a usage row, worded to match the unit [`format_usage`]
+/// would show for the same `cost_in_cents`, so a label and its value never
+/// disagree.
+pub fn usage_label(
+    kind: UsageLabelKind,
+    cost_in_cents: Option<f32>,
+    unit: UsageDisplayUnit,
+) -> String {
+    let unit = effective_usage_unit(unit, cost_in_cents);
     let base = match (kind, unit) {
         (UsageLabelKind::DetailsPanel, UsageDisplayUnit::Credits) => "Credits used",
         (UsageLabelKind::DetailsPanel, UsageDisplayUnit::Dollars) => "Usage",

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -19,6 +19,7 @@ use warpui::{AppContext, Element, EntityId, EventContext, SingletonEntity};
 
 use crate::ai::AIRequestUsageModel;
 use crate::ai::agent::RenderableAIError;
+use crate::settings::UsageDisplayUnit;
 use crate::themes::theme::{AnsiColorIdentifier, Fill, WarpTheme};
 use crate::ui_components::icons::Icon;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -298,59 +299,53 @@ pub fn format_credits(credits: f32) -> String {
     }
 }
 
-/// Builds the `"12,345 tokens, $0.36"`-style parenthetical shared by
-/// [`format_credits_with_cost`] and the conversation details panel's
-/// compact "Credits used" line, gated by `FeatureFlag::PricingTransparency`.
-///
-/// `tokens` and `cost_in_cents` are independent: either, both, or neither
-/// may be `None` (no baseline is available for that figure — never coerced
-/// to zero), and only the figures that are present are included. A `tokens`
-/// value of `0` is treated the same as `None` (omitted) since a "0 tokens"
-/// figure next to a non-zero credit/cost figure would be confusing rather
-/// than informative (e.g. a purely platform-cost request like a paid web
-/// search). Returns `None` when the flag is disabled, or when both figures
-/// are `None`/omitted.
-///
-/// This intentionally supersedes the previous standalone "PRICING
-/// BREAKDOWN" section (per-category input/cache/output/platform/web-search
-/// rows): for now a single inline token+dollar figure next to credits is
-/// enough. The deeper `ChargedUsageTotals` breakdown that section rendered
-/// is still computed and available for a future expandable/dropdown
-/// treatment.
-pub fn format_usage_parenthetical(
-    tokens: Option<u32>,
+/// Formats the single-unit figure (credits or dollars) selected by `unit`.
+/// Returns `None` when `unit` is `Dollars` but no cost figure is available
+/// -- there is no meaningful fallback within the dollar figure itself, so
+/// [`format_credits_with_cost`] falls back to a plain credits total instead.
+fn format_usage_unit_value(
+    credits: f32,
     cost_in_cents: Option<f32>,
+    unit: UsageDisplayUnit,
 ) -> Option<String> {
-    if !FeatureFlag::PricingTransparency.is_enabled() {
-        return None;
-    }
-    let token_part = tokens
-        .filter(|&tokens| tokens > 0)
-        .map(|tokens| format!("{} tokens", tokens.separate_with_commas()));
-    let cost_part = cost_in_cents.map(|cost_in_cents| format!("${:.2}", cost_in_cents / 100.0));
-    match (token_part, cost_part) {
-        (Some(token_part), Some(cost_part)) => Some(format!("{token_part}, {cost_part}")),
-        (Some(token_part), None) => Some(token_part),
-        (None, Some(cost_part)) => Some(cost_part),
-        (None, None) => None,
+    match unit {
+        UsageDisplayUnit::Credits => Some(format_credits(credits)),
+        UsageDisplayUnit::Dollars => {
+            cost_in_cents.map(|cost_in_cents| format!("${:.2}", cost_in_cents / 100.0))
+        }
     }
 }
 
 /// Formats a credit count together with its total token count and real
-/// dollar cost, e.g. `"20 credits (12,345 tokens, $0.36)"`. See
-/// [`format_usage_parenthetical`] for how the parenthetical is built and
-/// when it's omitted (including always, when `FeatureFlag::PricingTransparency`
-/// is disabled).
+/// dollar cost, showing tokens plus exactly one of credits or dollars
+/// (never both) depending on `unit` -- e.g. `"12,345 tokens / 20 credits"`
+/// (Credits) or `"12,345 tokens / $0.36"` (Dollars).
+///
+/// A `tokens` value of `0` is treated the same as `None` (omitted) since a
+/// "0 tokens" figure next to a non-zero credit/cost figure would be
+/// confusing rather than informative (e.g. a purely platform-cost request
+/// like a paid web search).
+///
+/// Falls back to a plain credits-only figure (no tokens) when `unit` is
+/// `Dollars` but no cost figure is available, or when
+/// `FeatureFlag::PricingTransparency` is disabled (today's pre-breakdown
+/// behavior).
 pub fn format_credits_with_cost(
     credits: f32,
     tokens: Option<u32>,
     cost_in_cents: Option<f32>,
+    unit: UsageDisplayUnit,
 ) -> String {
-    let credits_text = format_credits(credits);
-    let Some(parenthetical) = format_usage_parenthetical(tokens, cost_in_cents) else {
-        return credits_text;
+    if !FeatureFlag::PricingTransparency.is_enabled() {
+        return format_credits(credits);
+    }
+    let Some(unit_text) = format_usage_unit_value(credits, cost_in_cents, unit) else {
+        return format_credits(credits);
     };
-    format!("{credits_text} ({parenthetical})")
+    let Some(tokens) = tokens.filter(|&tokens| tokens > 0) else {
+        return unit_text;
+    };
+    format!("{} tokens / {unit_text}", tokens.separate_with_commas())
 }
 
 /// Renders a secondary button with an MCP/skill provider icon and a text label.

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -4,115 +4,139 @@ use super::*;
 use crate::settings::UsageDisplayUnit;
 
 #[test]
-fn format_credits_with_cost_returns_credits_only_when_flag_disabled() {
+fn format_usage_returns_credits_only_when_flag_disabled() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(false);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Dollars),
+        format_usage(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Dollars),
         format_credits(20.0)
     );
 }
 
 #[test]
-fn format_credits_with_cost_uses_credits_unit() {
+fn format_usage_uses_credits_unit() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Credits),
+        format_usage(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Credits),
         "12,345 tokens / 20 credits"
     );
 }
 
 #[test]
-fn format_credits_with_cost_uses_dollars_unit() {
+fn format_usage_uses_dollars_unit() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Dollars),
+        format_usage(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Dollars),
         "12,345 tokens / $0.36"
     );
 }
 
 #[test]
-fn format_credits_with_cost_formats_large_token_counts_with_thousands_separators() {
+fn format_usage_formats_large_token_counts_with_thousands_separators() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(26.9, Some(719_124), Some(48.0), UsageDisplayUnit::Dollars),
+        format_usage(26.9, Some(719_124), Some(48.0), UsageDisplayUnit::Dollars),
         "719,124 tokens / $0.48"
     );
 }
 
 #[test]
-fn format_credits_with_cost_falls_back_to_credits_when_dollars_unavailable() {
+fn format_usage_falls_back_to_credits_when_dollars_unavailable() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(12345), None, UsageDisplayUnit::Dollars),
+        format_usage(20.0, Some(12345), None, UsageDisplayUnit::Dollars),
         format_credits(20.0)
     );
 }
 
 #[test]
-fn format_credits_with_cost_omits_tokens_when_tokens_is_unknown() {
+fn format_usage_omits_tokens_when_tokens_is_unknown() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, None, Some(36.0), UsageDisplayUnit::Dollars),
+        format_usage(20.0, None, Some(36.0), UsageDisplayUnit::Dollars),
         "$0.36"
     );
     assert_eq!(
-        format_credits_with_cost(20.0, None, Some(36.0), UsageDisplayUnit::Credits),
+        format_usage(20.0, None, Some(36.0), UsageDisplayUnit::Credits),
         format_credits(20.0)
     );
 }
 
 #[test]
-fn format_credits_with_cost_omits_tokens_when_tokens_is_zero() {
+fn format_usage_omits_tokens_when_tokens_is_zero() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(0), Some(36.0), UsageDisplayUnit::Dollars),
+        format_usage(20.0, Some(0), Some(36.0), UsageDisplayUnit::Dollars),
         "$0.36"
     );
 }
 
 #[test]
-fn format_credits_with_cost_credits_unit_omits_tokens_when_tokens_is_zero() {
+fn format_usage_credits_unit_omits_tokens_when_tokens_is_zero() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(0), None, UsageDisplayUnit::Credits),
+        format_usage(20.0, Some(0), None, UsageDisplayUnit::Credits),
         format_credits(20.0)
     );
 }
 
 #[test]
-fn usage_label_uses_dollars_label_when_unit_is_dollars_and_flag_enabled() {
+fn usage_label_uses_dollars_wording_when_unit_is_dollars_and_flag_enabled() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        usage_label("Credits spent", "Usage charged", UsageDisplayUnit::Dollars),
+        usage_label(UsageLabelKind::Plain, UsageDisplayUnit::Dollars),
         "Usage charged"
     );
-}
-
-#[test]
-fn usage_label_uses_credits_label_when_unit_is_credits() {
-    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
-
     assert_eq!(
-        usage_label("Credits spent", "Usage charged", UsageDisplayUnit::Credits),
-        "Credits spent"
+        usage_label(UsageLabelKind::LastResponse, UsageDisplayUnit::Dollars),
+        "Usage charged (last response)"
+    );
+    assert_eq!(
+        usage_label(UsageLabelKind::Total, UsageDisplayUnit::Dollars),
+        "Usage charged (total)"
+    );
+    assert_eq!(
+        usage_label(UsageLabelKind::DetailsPanel, UsageDisplayUnit::Dollars),
+        "Usage"
     );
 }
 
 #[test]
-fn usage_label_uses_credits_label_when_flag_disabled_even_if_unit_is_dollars() {
+fn usage_label_uses_credits_wording_when_unit_is_credits() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        usage_label(UsageLabelKind::Plain, UsageDisplayUnit::Credits),
+        "Credits spent"
+    );
+    assert_eq!(
+        usage_label(UsageLabelKind::LastResponse, UsageDisplayUnit::Credits),
+        "Credits spent (last response)"
+    );
+    assert_eq!(
+        usage_label(UsageLabelKind::Total, UsageDisplayUnit::Credits),
+        "Credits spent (total)"
+    );
+    assert_eq!(
+        usage_label(UsageLabelKind::DetailsPanel, UsageDisplayUnit::Credits),
+        "Credits used"
+    );
+}
+
+#[test]
+fn usage_label_uses_credits_wording_when_flag_disabled_even_if_unit_is_dollars() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(false);
 
     assert_eq!(
-        usage_label("Credits spent", "Usage charged", UsageDisplayUnit::Dollars),
+        usage_label(UsageLabelKind::Plain, UsageDisplayUnit::Dollars),
         "Credits spent"
     );
 }

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -1,24 +1,35 @@
 use warp_core::features::FeatureFlag;
 
 use super::*;
+use crate::settings::UsageDisplayUnit;
 
 #[test]
-fn format_credits_with_cost_omits_parenthetical_when_flag_disabled() {
+fn format_credits_with_cost_returns_credits_only_when_flag_disabled() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(false);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(12345), Some(36.0)),
+        format_credits_with_cost(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Dollars),
         format_credits(20.0)
     );
 }
 
 #[test]
-fn format_credits_with_cost_appends_tokens_and_dollar_suffix_when_flag_enabled() {
+fn format_credits_with_cost_uses_credits_unit() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(12345), Some(36.0)),
-        "20 credits (12,345 tokens, $0.36)"
+        format_credits_with_cost(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Credits),
+        "12,345 tokens / 20 credits"
+    );
+}
+
+#[test]
+fn format_credits_with_cost_uses_dollars_unit() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(12345), Some(36.0), UsageDisplayUnit::Dollars),
+        "12,345 tokens / $0.36"
     );
 }
 
@@ -27,57 +38,51 @@ fn format_credits_with_cost_formats_large_token_counts_with_thousands_separators
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(26.9, Some(719_124), Some(48.0)),
-        "26.9 credits (719,124 tokens, $0.48)"
+        format_credits_with_cost(26.9, Some(719_124), Some(48.0), UsageDisplayUnit::Dollars),
+        "719,124 tokens / $0.48"
     );
 }
 
 #[test]
-fn format_credits_with_cost_omits_dollar_figure_when_cost_is_unknown() {
+fn format_credits_with_cost_falls_back_to_credits_when_dollars_unavailable() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(12345), None),
-        "20 credits (12,345 tokens)"
-    );
-}
-
-#[test]
-fn format_credits_with_cost_omits_token_figure_when_tokens_is_unknown() {
-    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
-
-    assert_eq!(
-        format_credits_with_cost(20.0, None, Some(36.0)),
-        "20 credits ($0.36)"
-    );
-}
-
-#[test]
-fn format_credits_with_cost_omits_token_figure_when_tokens_is_zero() {
-    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
-
-    assert_eq!(
-        format_credits_with_cost(20.0, Some(0), Some(36.0)),
-        "20 credits ($0.36)"
-    );
-}
-
-#[test]
-fn format_credits_with_cost_omits_parenthetical_when_both_are_unknown() {
-    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
-
-    assert_eq!(
-        format_credits_with_cost(20.0, None, None),
+        format_credits_with_cost(20.0, Some(12345), None, UsageDisplayUnit::Dollars),
         format_credits(20.0)
     );
 }
 
 #[test]
-fn format_credits_with_cost_omits_parenthetical_when_tokens_are_zero_and_cost_is_unknown() {
+fn format_credits_with_cost_omits_tokens_when_tokens_is_unknown() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        format_credits_with_cost(20.0, Some(0), None),
+        format_credits_with_cost(20.0, None, Some(36.0), UsageDisplayUnit::Dollars),
+        "$0.36"
+    );
+    assert_eq!(
+        format_credits_with_cost(20.0, None, Some(36.0), UsageDisplayUnit::Credits),
+        format_credits(20.0)
+    );
+}
+
+#[test]
+fn format_credits_with_cost_omits_tokens_when_tokens_is_zero() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(0), Some(36.0), UsageDisplayUnit::Dollars),
+        "$0.36"
+    );
+}
+
+#[test]
+fn format_credits_with_cost_credits_unit_omits_tokens_when_tokens_is_zero() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        format_credits_with_cost(20.0, Some(0), None, UsageDisplayUnit::Credits),
         format_credits(20.0)
     );
 }

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -92,19 +92,27 @@ fn usage_label_uses_dollars_wording_when_unit_is_dollars_and_flag_enabled() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        usage_label(UsageLabelKind::Plain, UsageDisplayUnit::Dollars),
+        usage_label(UsageLabelKind::Plain, Some(36.0), UsageDisplayUnit::Dollars),
         "Usage charged"
     );
     assert_eq!(
-        usage_label(UsageLabelKind::LastResponse, UsageDisplayUnit::Dollars),
+        usage_label(
+            UsageLabelKind::LastResponse,
+            Some(36.0),
+            UsageDisplayUnit::Dollars
+        ),
         "Usage charged (last response)"
     );
     assert_eq!(
-        usage_label(UsageLabelKind::Total, UsageDisplayUnit::Dollars),
+        usage_label(UsageLabelKind::Total, Some(36.0), UsageDisplayUnit::Dollars),
         "Usage charged (total)"
     );
     assert_eq!(
-        usage_label(UsageLabelKind::DetailsPanel, UsageDisplayUnit::Dollars),
+        usage_label(
+            UsageLabelKind::DetailsPanel,
+            Some(36.0),
+            UsageDisplayUnit::Dollars
+        ),
         "Usage"
     );
 }
@@ -114,19 +122,27 @@ fn usage_label_uses_credits_wording_when_unit_is_credits() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
     assert_eq!(
-        usage_label(UsageLabelKind::Plain, UsageDisplayUnit::Credits),
+        usage_label(UsageLabelKind::Plain, None, UsageDisplayUnit::Credits),
         "Credits spent"
     );
     assert_eq!(
-        usage_label(UsageLabelKind::LastResponse, UsageDisplayUnit::Credits),
+        usage_label(
+            UsageLabelKind::LastResponse,
+            None,
+            UsageDisplayUnit::Credits
+        ),
         "Credits spent (last response)"
     );
     assert_eq!(
-        usage_label(UsageLabelKind::Total, UsageDisplayUnit::Credits),
+        usage_label(UsageLabelKind::Total, None, UsageDisplayUnit::Credits),
         "Credits spent (total)"
     );
     assert_eq!(
-        usage_label(UsageLabelKind::DetailsPanel, UsageDisplayUnit::Credits),
+        usage_label(
+            UsageLabelKind::DetailsPanel,
+            None,
+            UsageDisplayUnit::Credits
+        ),
         "Credits used"
     );
 }
@@ -136,7 +152,20 @@ fn usage_label_uses_credits_wording_when_flag_disabled_even_if_unit_is_dollars()
     let _flag = FeatureFlag::PricingTransparency.override_enabled(false);
 
     assert_eq!(
-        usage_label(UsageLabelKind::Plain, UsageDisplayUnit::Dollars),
+        usage_label(UsageLabelKind::Plain, Some(36.0), UsageDisplayUnit::Dollars),
+        "Credits spent"
+    );
+}
+
+#[test]
+fn usage_label_uses_credits_wording_when_dollars_requested_but_cost_unavailable() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    // Matches format_usage_falls_back_to_credits_when_dollars_unavailable: when
+    // no cost figure is available, the value falls back to plain credits, so
+    // the label must match rather than saying "Usage charged".
+    assert_eq!(
+        usage_label(UsageLabelKind::Plain, None, UsageDisplayUnit::Dollars),
         "Credits spent"
     );
 }

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -86,3 +86,33 @@ fn format_credits_with_cost_credits_unit_omits_tokens_when_tokens_is_zero() {
         format_credits(20.0)
     );
 }
+
+#[test]
+fn usage_label_uses_dollars_label_when_unit_is_dollars_and_flag_enabled() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        usage_label("Credits spent", "Usage charged", UsageDisplayUnit::Dollars),
+        "Usage charged"
+    );
+}
+
+#[test]
+fn usage_label_uses_credits_label_when_unit_is_credits() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
+
+    assert_eq!(
+        usage_label("Credits spent", "Usage charged", UsageDisplayUnit::Credits),
+        "Credits spent"
+    );
+}
+
+#[test]
+fn usage_label_uses_credits_label_when_flag_disabled_even_if_unit_is_dollars() {
+    let _flag = FeatureFlag::PricingTransparency.override_enabled(false);
+
+    assert_eq!(
+        usage_label("Credits spent", "Usage charged", UsageDisplayUnit::Dollars),
+        "Credits spent"
+    );
+}

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -161,9 +161,6 @@ fn usage_label_uses_credits_wording_when_flag_disabled_even_if_unit_is_dollars()
 fn usage_label_uses_credits_wording_when_dollars_requested_but_cost_unavailable() {
     let _flag = FeatureFlag::PricingTransparency.override_enabled(true);
 
-    // Matches format_usage_falls_back_to_credits_when_dollars_unavailable: when
-    // no cost figure is available, the value falls back to plain credits, so
-    // the label must match rather than saying "Usage charged".
     assert_eq!(
         usage_label(UsageLabelKind::Plain, None, UsageDisplayUnit::Dollars),
         "Credits spent"

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -49,7 +49,7 @@ use crate::ai::ambient_agents::task::TaskPrincipalInfo;
 use crate::ai::ambient_agents::{AmbientAgentTaskId, cancel_task_with_toast};
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
-use crate::ai::blocklist::view_util::format_credits_with_cost;
+use crate::ai::blocklist::view_util::{format_credits_with_cost, usage_label};
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment};
 use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
@@ -2328,8 +2328,9 @@ impl View for ConversationDetailsPanel {
                 cost_in_cents,
                 usage_display_unit,
             );
+            let label = usage_label("Credits used", "Usage", usage_display_unit);
             content.add_child(
-                Container::new(self.render_simple_field("Credits used", &formatted, appearance))
+                Container::new(self.render_simple_field(label, &formatted, appearance))
                     .with_margin_bottom(FIELD_SPACING)
                     .finish(),
             );

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -63,9 +63,7 @@ use crate::send_telemetry_from_ctx;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::ai::AmbientAgentTask;
-use crate::settings::ai::AISettings;
-#[cfg(not(target_family = "wasm"))]
-use crate::settings::ai::AISettingsChangedEvent;
+use crate::settings::ai::{AISettings, AISettingsChangedEvent};
 use crate::ui_components::avatar::{Avatar, AvatarContent};
 use crate::ui_components::blended_colors;
 use crate::ui_components::buttons::icon_button;
@@ -770,9 +768,12 @@ impl ConversationDetailsPanel {
                     ctx.dispatch_typed_action(ConversationDetailsPanelAction::OpenInOz);
                 })
         });
-        #[cfg(not(target_family = "wasm"))]
         ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
-            if matches!(event, AISettingsChangedEvent::IsAnyAIEnabled { .. }) {
+            if matches!(
+                event,
+                AISettingsChangedEvent::IsAnyAIEnabled { .. }
+                    | AISettingsChangedEvent::UsageDisplayUnit { .. }
+            ) {
                 ctx.notify();
             }
         });

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -49,7 +49,7 @@ use crate::ai::ambient_agents::task::TaskPrincipalInfo;
 use crate::ai::ambient_agents::{AmbientAgentTaskId, cancel_task_with_toast};
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
-use crate::ai::blocklist::view_util::format_usage_parenthetical;
+use crate::ai::blocklist::view_util::format_credits_with_cost;
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment};
 use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
@@ -63,8 +63,9 @@ use crate::send_telemetry_from_ctx;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::ai::AmbientAgentTask;
+use crate::settings::ai::AISettings;
 #[cfg(not(target_family = "wasm"))]
-use crate::settings::ai::{AISettings, AISettingsChangedEvent};
+use crate::settings::ai::AISettingsChangedEvent;
 use crate::ui_components::avatar::{Avatar, AvatarContent};
 use crate::ui_components::blended_colors;
 use crate::ui_components::buttons::icon_button;
@@ -2310,22 +2311,22 @@ impl View for ConversationDetailsPanel {
         }
 
         if let Some(credits) = self.data.credits {
-            // A single compact "X (N tokens, $Y)" line rather than separate
-            // rows for credits/tokens/per-category cost: for now this
-            // inline figure is enough (see `format_usage_parenthetical` doc
-            // comment for why the deeper per-category breakdown was dropped
-            // from display, though it's still computed and available on
-            // `self.data.charged_usage` for a future expandable treatment).
+            // A single compact "tokens / unit" line rather than separate rows
+            // for credits/tokens/per-category cost: for now this inline figure
+            // is enough (though the deeper per-category breakdown is still
+            // computed and available on `self.data.charged_usage` for a future
+            // expandable treatment).
             let cost_in_cents = self
                 .data
                 .charged_usage
                 .map(|charged_usage| charged_usage.total_cost_in_cents());
-            let mut formatted = format!("{credits:.1}");
-            if let Some(parenthetical) =
-                format_usage_parenthetical(self.data.total_tokens, cost_in_cents)
-            {
-                formatted = format!("{formatted} ({parenthetical})");
-            }
+            let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
+            let formatted = format_credits_with_cost(
+                credits,
+                self.data.total_tokens,
+                cost_in_cents,
+                usage_display_unit,
+            );
             content.add_child(
                 Container::new(self.render_simple_field("Credits used", &formatted, appearance))
                     .with_margin_bottom(FIELD_SPACING)

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -49,7 +49,7 @@ use crate::ai::ambient_agents::task::TaskPrincipalInfo;
 use crate::ai::ambient_agents::{AmbientAgentTaskId, cancel_task_with_toast};
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
-use crate::ai::blocklist::view_util::{format_credits_with_cost, usage_label};
+use crate::ai::blocklist::view_util::{UsageLabelKind, format_usage, usage_label};
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment};
 use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
@@ -2322,15 +2322,15 @@ impl View for ConversationDetailsPanel {
                 .charged_usage
                 .map(|charged_usage| charged_usage.total_cost_in_cents());
             let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
-            let formatted = format_credits_with_cost(
+            let formatted = format_usage(
                 credits,
                 self.data.total_tokens,
                 cost_in_cents,
                 usage_display_unit,
             );
-            let label = usage_label("Credits used", "Usage", usage_display_unit);
+            let label = usage_label(UsageLabelKind::DetailsPanel, usage_display_unit);
             content.add_child(
-                Container::new(self.render_simple_field(label, &formatted, appearance))
+                Container::new(self.render_simple_field(&label, &formatted, appearance))
                     .with_margin_bottom(FIELD_SPACING)
                     .finish(),
             );

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -2312,11 +2312,6 @@ impl View for ConversationDetailsPanel {
         }
 
         if let Some(credits) = self.data.credits {
-            // A single compact "tokens / unit" line rather than separate rows
-            // for credits/tokens/per-category cost: for now this inline figure
-            // is enough (though the deeper per-category breakdown is still
-            // computed and available on `self.data.charged_usage` for a future
-            // expandable treatment).
             let cost_in_cents = self
                 .data
                 .charged_usage

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -2328,7 +2328,11 @@ impl View for ConversationDetailsPanel {
                 cost_in_cents,
                 usage_display_unit,
             );
-            let label = usage_label(UsageLabelKind::DetailsPanel, usage_display_unit);
+            let label = usage_label(
+                UsageLabelKind::DetailsPanel,
+                cost_in_cents,
+                usage_display_unit,
+            );
             content.add_child(
                 Container::new(self.render_simple_field(&label, &formatted, appearance))
                     .with_margin_bottom(FIELD_SPACING)

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -1836,11 +1836,7 @@ pub struct RootView {
     /// settings to apply after a new user login / initial cloud load completes
     pending_post_auth_onboarding_settings: Option<SelectedSettings>,
     pending_account_first_settings_class: Option<FtueAccountClass>,
-    /// Whether the account had not yet completed onboarding (i.e. `AuthState::is_onboarded()`
-    /// was `false`) at the time `pending_account_first_settings_class` was captured, before
-    /// `set_user_onboarded` flips it locally. Threaded through to
-    /// `apply_account_first_onboarding_settings` so an existing, already-onboarded account
-    /// signing in on a new device doesn't have its synced usage-unit choice overwritten.
+    /// Prevents onboarding on a new device from overwriting an existing preference.
     pending_account_first_is_new_account: bool,
     pending_account_first_tutorial_after_settings: bool,
     pending_account_first_sso_login: Option<AccountFirstLoginContext>,
@@ -2462,10 +2458,6 @@ impl RootView {
         if FeatureFlag::HOAOnboardingFlow.is_enabled() {
             mark_hoa_onboarding_completed(ctx);
         }
-        // Captured before `set_user_onboarded` flips this locally: account-first
-        // onboarding can also be reached by an existing, already-onboarded account
-        // signing in (e.g. on a new device), and only genuinely new accounts should
-        // get account-first defaults like the usage-unit display.
         let is_new_account = !AuthStateProvider::as_ref(ctx)
             .get()
             .is_onboarded()

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -1836,6 +1836,12 @@ pub struct RootView {
     /// settings to apply after a new user login / initial cloud load completes
     pending_post_auth_onboarding_settings: Option<SelectedSettings>,
     pending_account_first_settings_class: Option<FtueAccountClass>,
+    /// Whether the account had not yet completed onboarding (i.e. `AuthState::is_onboarded()`
+    /// was `false`) at the time `pending_account_first_settings_class` was captured, before
+    /// `set_user_onboarded` flips it locally. Threaded through to
+    /// `apply_account_first_onboarding_settings` so an existing, already-onboarded account
+    /// signing in on a new device doesn't have its synced usage-unit choice overwritten.
+    pending_account_first_is_new_account: bool,
     pending_account_first_tutorial_after_settings: bool,
     pending_account_first_sso_login: Option<AccountFirstLoginContext>,
     account_first_refresh_in_flight: bool,
@@ -1945,6 +1951,7 @@ impl RootView {
             pending_tutorial: None,
             pending_post_auth_onboarding_settings: None,
             pending_account_first_settings_class: None,
+            pending_account_first_is_new_account: false,
             pending_account_first_tutorial_after_settings: false,
             pending_account_first_sso_login: None,
             account_first_refresh_in_flight: false,
@@ -2455,6 +2462,14 @@ impl RootView {
         if FeatureFlag::HOAOnboardingFlow.is_enabled() {
             mark_hoa_onboarding_completed(ctx);
         }
+        // Captured before `set_user_onboarded` flips this locally: account-first
+        // onboarding can also be reached by an existing, already-onboarded account
+        // signing in (e.g. on a new device), and only genuinely new accounts should
+        // get account-first defaults like the usage-unit display.
+        let is_new_account = !AuthStateProvider::as_ref(ctx)
+            .get()
+            .is_onboarded()
+            .unwrap_or(true);
         if AuthStateProvider::as_ref(ctx).get().is_logged_in() {
             AuthManager::handle(ctx).update(ctx, |model, ctx| model.set_user_onboarded(ctx));
         }
@@ -2469,6 +2484,7 @@ impl RootView {
                 apply_account_first_onboarding_settings(
                     &selected_settings,
                     account_class,
+                    is_new_account,
                     team_context,
                     ctx,
                 );
@@ -2476,6 +2492,7 @@ impl RootView {
             true
         } else {
             self.pending_account_first_settings_class = account_class;
+            self.pending_account_first_is_new_account = is_new_account;
             false
         };
 
@@ -2522,6 +2539,7 @@ impl RootView {
                 self.pending_tutorial = None;
                 self.pending_post_auth_onboarding_settings = None;
                 self.pending_account_first_settings_class = None;
+                self.pending_account_first_is_new_account = false;
                 self.pending_account_first_tutorial_after_settings = false;
                 ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
                 self.focus(ctx);
@@ -3832,11 +3850,13 @@ impl RootView {
             return;
         }
         if let Some(account_class) = self.pending_account_first_settings_class.take() {
+            let is_new_account = self.pending_account_first_is_new_account;
             if let Some(selected_settings) = self.pending_post_auth_onboarding_settings.take() {
                 let team_context = UserWorkspaces::as_ref(ctx).team_context_for_operation(ctx);
                 apply_account_first_onboarding_settings(
                     &selected_settings,
                     Some(account_class),
+                    is_new_account,
                     team_context,
                     ctx,
                 );

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -673,7 +673,7 @@ settings::macros::implement_setting_for_enum!(
     description: "Which unit the usage entry displays in Warp Agent CLI: credits or provider cost.",
 );
 
-/// Which unit the GUI's usage/spend displays show (credits or dollars).
+/// Unit for GUI usage and spend displays.
 #[derive(
     Default,
     Debug,
@@ -691,10 +691,8 @@ settings::macros::implement_setting_for_enum!(
     rename_all = "snake_case"
 )]
 pub enum UsageDisplayUnit {
-    /// Credits spent (default).
     #[default]
     Credits,
-    /// Real dollar cost.
     Dollars,
 }
 
@@ -711,7 +709,6 @@ settings::macros::implement_setting_for_enum!(
 );
 
 impl UsageDisplayUnit {
-    /// Display name for the settings dropdown.
     pub fn display_name(&self) -> &'static str {
         match self {
             UsageDisplayUnit::Credits => "Credits",
@@ -1520,8 +1517,6 @@ define_settings_group!(AISettings, settings: [
     //
     // TUI-only and file-backed so the choice persists across TUI sessions.
     usage_display_mode: TuiUsageDisplayMode,
-    // Which unit the GUI's usage/spend displays show (credits or dollars).
-    // Gated by FeatureFlag::PricingTransparency.
     usage_display_unit: UsageDisplayUnit,
     // Ordered visibility configuration for the TUI's bottom statusline.
     // TUI-only and local so separate devices can use different terminal layouts.

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -672,6 +672,54 @@ settings::macros::implement_setting_for_enum!(
     toml_path: "agents.usage_display_mode",
     description: "Which unit the usage entry displays in Warp Agent CLI: credits or provider cost.",
 );
+
+/// Which unit the GUI's usage/spend displays show (credits or dollars).
+#[derive(
+    Default,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Copy,
+    Clone,
+    EnumIter,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+#[schemars(
+    description = "Which unit the GUI's usage/spend displays show: credits or dollars.",
+    rename_all = "snake_case"
+)]
+pub enum UsageDisplayUnit {
+    /// Credits spent (default).
+    #[default]
+    Credits,
+    /// Real dollar cost.
+    Dollars,
+}
+
+settings::macros::implement_setting_for_enum!(
+    UsageDisplayUnit,
+    AISettings,
+    SupportedPlatforms::ALL,
+    SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+    surface: settings::SettingSurfaces::GUI,
+    private: false,
+    toml_path: "agents.warp_agent.other.usage_display_unit",
+    description: "Which unit the GUI's usage/spend displays show: credits or dollars.",
+    feature_flag: FeatureFlag::PricingTransparency,
+);
+
+impl UsageDisplayUnit {
+    /// Display name for the settings dropdown.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            UsageDisplayUnit::Credits => "Credits",
+            UsageDisplayUnit::Dollars => "Dollars",
+        }
+    }
+}
+
 /// One configurable item in the Warp Agent CLI statusline.
 #[derive(
     Debug,
@@ -1472,6 +1520,9 @@ define_settings_group!(AISettings, settings: [
     //
     // TUI-only and file-backed so the choice persists across TUI sessions.
     usage_display_mode: TuiUsageDisplayMode,
+    // Which unit the GUI's usage/spend displays show (credits or dollars).
+    // Gated by FeatureFlag::PricingTransparency.
+    usage_display_unit: UsageDisplayUnit,
     // Ordered visibility configuration for the TUI's bottom statusline.
     // TUI-only and local so separate devices can use different terminal layouts.
     tui_statusline: TuiStatusline {

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -498,6 +498,37 @@ fn test_toolbar_command_map_matched_agent() {
 }
 
 #[test]
+fn usage_display_unit_defaults_to_credits_and_round_trips() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        AISettings::handle(&app).read(&app, |settings, _ctx| {
+            assert_eq!(settings.usage_display_unit, UsageDisplayUnit::Credits);
+        });
+
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            report_if_error!(
+                settings
+                    .usage_display_unit
+                    .set_value(UsageDisplayUnit::Dollars, ctx)
+            );
+        });
+
+        AISettings::handle(&app).read(&app, |settings, _ctx| {
+            assert_eq!(settings.usage_display_unit, UsageDisplayUnit::Dollars);
+        });
+    });
+}
+
+#[test]
+fn usage_display_unit_toml_path() {
+    assert_eq!(
+        UsageDisplayUnit::toml_path(),
+        Some("agents.warp_agent.other.usage_display_unit")
+    );
+}
+
+#[test]
 fn orchestration_is_enabled_when_ai_is_enabled() {
     App::test((), |mut app| async move {
         initialize_settings_for_tests(&mut app);

--- a/app/src/settings/onboarding.rs
+++ b/app/src/settings/onboarding.rs
@@ -16,6 +16,7 @@ use crate::workspaces::workspace::FtueAccountClass;
 pub(crate) fn apply_account_first_onboarding_settings(
     selected_settings: &SelectedSettings,
     account_class: Option<FtueAccountClass>,
+    is_new_account: bool,
     team_context: TeamContextForOperation,
     app: &mut AppContext,
 ) {
@@ -31,10 +32,13 @@ pub(crate) fn apply_account_first_onboarding_settings(
 
     // Brand-new accounts default the usage-unit display to dollars, rather
     // than the `UsageDisplayUnit` enum's own `Credits` default, which exists
-    // to leave pre-existing users/devices unaffected. `account_class` is
-    // `None` only for `AccountFirstCompletion::AccountSkipped`, which does
-    // not create an account, so this only fires for genuinely new accounts.
-    if account_class.is_some() {
+    // to leave pre-existing users/devices unaffected. Account-first onboarding
+    // can also be reached by an *existing* account signing in (e.g. on a new
+    // device), so this additionally requires `is_new_account` -- captured by
+    // the caller from the account's `is_onboarded` status prior to this
+    // sign-in -- rather than relying on `account_class` alone, which only
+    // reflects the account's current plan tier.
+    if account_class.is_some() && is_new_account {
         AISettings::handle(app).update(app, |settings, ctx| {
             report_if_error!(
                 settings

--- a/app/src/settings/onboarding.rs
+++ b/app/src/settings/onboarding.rs
@@ -30,14 +30,7 @@ pub(crate) fn apply_account_first_onboarding_settings(
         ) => true,
     };
 
-    // Brand-new accounts default the usage-unit display to dollars, rather
-    // than the `UsageDisplayUnit` enum's own `Credits` default, which exists
-    // to leave pre-existing users/devices unaffected. Account-first onboarding
-    // can also be reached by an *existing* account signing in (e.g. on a new
-    // device), so this additionally requires `is_new_account` -- captured by
-    // the caller from the account's `is_onboarded` status prior to this
-    // sign-in -- rather than relying on `account_class` alone, which only
-    // reflects the account's current plan tier.
+    // Preserve an existing account's synced preference on a new device.
     if account_class.is_some() && is_new_account {
         AISettings::handle(app).update(app, |settings, ctx| {
             report_if_error!(

--- a/app/src/settings/onboarding.rs
+++ b/app/src/settings/onboarding.rs
@@ -8,7 +8,7 @@ use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::execution_profiles::{ActionPermission, WriteToPtyPermission};
 use crate::drive::settings::WarpDriveSettings;
 use crate::settings::ai::DefaultSessionMode;
-use crate::settings::{AISettings, CodeSettings};
+use crate::settings::{AISettings, CodeSettings, UsageDisplayUnit};
 use crate::workspace::tab_settings::TabSettings;
 use crate::workspaces::user_workspaces::{TeamContextForOperation, UserWorkspaces};
 use crate::workspaces::workspace::FtueAccountClass;
@@ -28,6 +28,21 @@ pub(crate) fn apply_account_first_onboarding_settings(
             FtueAccountClass::Paid | FtueAccountClass::FreeIcp | FtueAccountClass::FreeStandard,
         ) => true,
     };
+
+    // Brand-new accounts default the usage-unit display to dollars, rather
+    // than the `UsageDisplayUnit` enum's own `Credits` default, which exists
+    // to leave pre-existing users/devices unaffected. `account_class` is
+    // `None` only for `AccountFirstCompletion::AccountSkipped`, which does
+    // not create an account, so this only fires for genuinely new accounts.
+    if account_class.is_some() {
+        AISettings::handle(app).update(app, |settings, ctx| {
+            report_if_error!(
+                settings
+                    .usage_display_unit
+                    .set_value(UsageDisplayUnit::Dollars, ctx)
+            );
+        });
+    }
 
     match selected_settings {
         SelectedSettings::AgentDrivenDevelopment {

--- a/app/src/settings/onboarding_tests.rs
+++ b/app/src/settings/onboarding_tests.rs
@@ -246,12 +246,6 @@ fn account_first_settings_enable_agent_for_authenticated_users_and_apply_ui_choi
     });
 }
 
-/// New accounts default the usage-display unit to dollars, but skipping
-/// account creation (`account_class: None`) must leave the enum's own
-/// `Credits` default untouched so existing users/devices are unaffected.
-/// Likewise, an existing account signing in through account-first onboarding
-/// (e.g. on a new device) must not have its synced choice overwritten, even
-/// though `account_class` is populated in that case too.
 #[test]
 fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() {
     let _account_first = FeatureFlag::AccountFirstOnboarding.override_enabled(true);
@@ -276,7 +270,6 @@ fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() 
             show_agent_notifications: true,
         };
 
-        // Skipping account creation must not touch the default.
         app.update(|ctx| {
             apply_account_first_onboarding_settings(
                 &selected_settings,
@@ -294,9 +287,6 @@ fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() 
             );
         });
 
-        // An existing account signing in (is_new_account: false) must not
-        // have its synced Credits choice overwritten, even with a populated
-        // account_class.
         app.update(|ctx| {
             apply_account_first_onboarding_settings(
                 &selected_settings,
@@ -314,7 +304,6 @@ fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() 
             );
         });
 
-        // A genuinely new account explicitly defaults to Dollars.
         app.update(|ctx| {
             apply_account_first_onboarding_settings(
                 &selected_settings,

--- a/app/src/settings/onboarding_tests.rs
+++ b/app/src/settings/onboarding_tests.rs
@@ -229,6 +229,7 @@ fn account_first_settings_enable_agent_for_authenticated_users_and_apply_ui_choi
                 apply_account_first_onboarding_settings(
                     &selected_settings,
                     account_class,
+                    true,
                     team_context_for_test(),
                     ctx,
                 );
@@ -248,6 +249,9 @@ fn account_first_settings_enable_agent_for_authenticated_users_and_apply_ui_choi
 /// New accounts default the usage-display unit to dollars, but skipping
 /// account creation (`account_class: None`) must leave the enum's own
 /// `Credits` default untouched so existing users/devices are unaffected.
+/// Likewise, an existing account signing in through account-first onboarding
+/// (e.g. on a new device) must not have its synced choice overwritten, even
+/// though `account_class` is populated in that case too.
 #[test]
 fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() {
     let _account_first = FeatureFlag::AccountFirstOnboarding.override_enabled(true);
@@ -277,6 +281,7 @@ fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() 
             apply_account_first_onboarding_settings(
                 &selected_settings,
                 None,
+                true,
                 team_context_for_test(),
                 ctx,
             );
@@ -289,11 +294,32 @@ fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() 
             );
         });
 
+        // An existing account signing in (is_new_account: false) must not
+        // have its synced Credits choice overwritten, even with a populated
+        // account_class.
+        app.update(|ctx| {
+            apply_account_first_onboarding_settings(
+                &selected_settings,
+                Some(FtueAccountClass::FreeStandard),
+                false,
+                team_context_for_test(),
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            assert_eq!(
+                AISettings::as_ref(ctx).usage_display_unit,
+                UsageDisplayUnit::Credits,
+                "an existing account logging in must not have its choice overwritten"
+            );
+        });
+
         // A genuinely new account explicitly defaults to Dollars.
         app.update(|ctx| {
             apply_account_first_onboarding_settings(
                 &selected_settings,
                 Some(FtueAccountClass::FreeStandard),
+                true,
                 team_context_for_test(),
                 ctx,
             );

--- a/app/src/settings/onboarding_tests.rs
+++ b/app/src/settings/onboarding_tests.rs
@@ -20,8 +20,8 @@ use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::sync_queue::SyncQueue;
 use crate::settings::{
-    AISettings, CodeSettings, PrivacySettings, apply_account_first_onboarding_settings,
-    apply_onboarding_settings,
+    AISettings, CodeSettings, PrivacySettings, UsageDisplayUnit,
+    apply_account_first_onboarding_settings, apply_onboarding_settings,
 };
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::workspace::tab_settings::TabSettings;
@@ -242,6 +242,69 @@ fn account_first_settings_enable_agent_for_authenticated_users_and_apply_ui_choi
                 assert!(!*CodeSettings::as_ref(ctx).show_global_search);
             });
         }
+    });
+}
+
+/// New accounts default the usage-display unit to dollars, but skipping
+/// account creation (`account_class: None`) must leave the enum's own
+/// `Credits` default untouched so existing users/devices are unaffected.
+#[test]
+fn apply_account_first_onboarding_settings_sets_dollars_for_new_accounts_only() {
+    let _account_first = FeatureFlag::AccountFirstOnboarding.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+        app.add_singleton_model(PrivacySettings::mock);
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+
+        let selected_settings = SelectedSettings::Terminal {
+            ui_customization: None,
+            cli_agent_toolbar_enabled: true,
+            show_agent_notifications: true,
+        };
+
+        // Skipping account creation must not touch the default.
+        app.update(|ctx| {
+            apply_account_first_onboarding_settings(
+                &selected_settings,
+                None,
+                team_context_for_test(),
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            assert_eq!(
+                AISettings::as_ref(ctx).usage_display_unit,
+                UsageDisplayUnit::Credits,
+                "skipping account creation must leave the Credits default untouched"
+            );
+        });
+
+        // A genuinely new account explicitly defaults to Dollars.
+        app.update(|ctx| {
+            apply_account_first_onboarding_settings(
+                &selected_settings,
+                Some(FtueAccountClass::FreeStandard),
+                team_context_for_test(),
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            assert_eq!(
+                AISettings::as_ref(ctx).usage_display_unit,
+                UsageDisplayUnit::Dollars,
+                "a freshly created account should default to Dollars"
+            );
+        });
     });
 }
 

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -56,12 +56,12 @@ use crate::prompt::editor_modal::OpenSource as PromptEditorOpenSource;
 use crate::server::telemetry::{InputUXChangeOrigin, TelemetryEvent};
 use crate::settings::app_icon::{AppIcon, AppIconSettings, ShowDockIconState};
 use crate::settings::{
-    AIFontName, AISettings, AppEditorSettings, CodeSettings, CursorBlink, CursorBlinkEnabled,
-    CursorDisplayType, DEFAULT_MONOSPACE_FONT_NAME, EnforceMinimumContrast, FocusPaneOnHover,
-    FontSettings, FontSettingsChangedEvent, GPUSettings, InputBoxType, InputModeSettings,
-    InputModeState, InputSettings, InputSettingsChangedEvent, MonospaceFontName, PaneSettings,
-    ShouldDimInactivePanes, ThemeSettings, UseSystemTheme, UseThinStrokes, active_theme_kind,
-    respect_system_theme,
+    AIFontName, AISettings, AISettingsChangedEvent, AppEditorSettings, CodeSettings, CursorBlink,
+    CursorBlinkEnabled, CursorDisplayType, DEFAULT_MONOSPACE_FONT_NAME, EnforceMinimumContrast,
+    FocusPaneOnHover, FontSettings, FontSettingsChangedEvent, GPUSettings, InputBoxType,
+    InputModeSettings, InputModeState, InputSettings, InputSettingsChangedEvent, MonospaceFontName,
+    PaneSettings, ShouldDimInactivePanes, ThemeSettings, UsageDisplayUnit, UseSystemTheme,
+    UseThinStrokes, active_theme_kind, respect_system_theme,
 };
 use crate::terminal::block_list_viewport::InputMode;
 use crate::terminal::blockgrid_element::BlockGridElement;
@@ -525,6 +525,7 @@ pub enum AppearancePageAction {
     RemoveDefaultDirectoryTabColor {
         path: PathBuf,
     },
+    SetUsageDisplayUnit(UsageDisplayUnit),
 }
 
 pub struct AppearanceSettingsPageView {
@@ -546,6 +547,7 @@ pub struct AppearanceSettingsPageView {
     #[allow(dead_code)]
     thin_strokes_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
     enforce_min_contrast_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
+    usage_display_unit_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
     input_mode_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
     input_type_radio_state: RadioButtonStateHandle,
     app_icon_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
@@ -622,6 +624,12 @@ impl TypedActionView for AppearanceSettingsPageView {
             }
             SetWorkspaceDecorationVisibility(value) => {
                 self.set_workspace_decoration_visibility(*value, ctx)
+            }
+            SetUsageDisplayUnit(value) => {
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings.usage_display_unit.set_value(*value, ctx));
+                });
+                ctx.notify();
             }
             ToggleWorkspaceDecorationVisibility => self.toggle_workspace_decoration_visiblity(ctx),
             ToggleJumpToBottomOfBlockButton => self.toggle_jump_to_bottom_of_block_button(ctx),
@@ -1039,6 +1047,19 @@ impl AppearanceSettingsPageView {
             ctx.notify();
         });
 
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |me, _, event, ctx| {
+            if matches!(event, AISettingsChangedEvent::UsageDisplayUnit { .. }) {
+                let current_value = AISettings::as_ref(ctx).usage_display_unit;
+                me.usage_display_unit_dropdown.update(ctx, |dropdown, ctx| {
+                    dropdown.set_selected_by_action(
+                        AppearancePageAction::SetUsageDisplayUnit(current_value),
+                        ctx,
+                    );
+                });
+                ctx.notify();
+            }
+        });
+
         let line_height_editor = Self::editor(
             |me, event, ctx| me.handle_line_editor_event(event, ctx),
             &format!("{line_height_ratio}"),
@@ -1273,6 +1294,37 @@ impl AppearanceSettingsPageView {
             dropdown
         });
 
+        let usage_display_unit_dropdown = ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = Dropdown::new(ctx);
+
+            let values = vec![UsageDisplayUnit::Credits, UsageDisplayUnit::Dollars];
+            let current_value = AISettings::as_ref(ctx).usage_display_unit;
+            let selected_index = values
+                .iter()
+                .position(|val| *val == current_value)
+                .unwrap_or_else(|| {
+                    report_error!(
+                        "Could not find current UsageDisplayUnit value in dropdown option list"
+                    );
+                    0
+                });
+
+            dropdown.add_items(
+                values
+                    .into_iter()
+                    .map(|val| {
+                        DropdownItem::new(
+                            val.display_name(),
+                            AppearancePageAction::SetUsageDisplayUnit(val),
+                        )
+                    })
+                    .collect(),
+                ctx,
+            );
+            dropdown.set_selected_by_index(selected_index, ctx);
+            dropdown
+        });
+
         let context_chips = Self::get_context_chip_renderers(ctx);
 
         let alt_screen_padding_editor = {
@@ -1325,6 +1377,7 @@ impl AppearanceSettingsPageView {
             input_type_radio_state,
             app_icon_dropdown,
             enforce_min_contrast_dropdown,
+            usage_display_unit_dropdown,
             workspace_decorations_dropdown: Self::build_workspace_decoration_visibility_dropdown(
                 ctx,
             ),
@@ -1539,6 +1592,11 @@ impl AppearanceSettingsPageView {
         categories.push(Category::new(
             "Full-screen Apps",
             vec![Box::new(AltScreenPaddingWidget::default())],
+        ));
+
+        categories.push(Category::new(
+            "Usage",
+            vec![Box::new(UsageDisplayUnitWidget::default())],
         ));
 
         PageType::new_categorized(categories, None)
@@ -4601,6 +4659,43 @@ impl SettingsWidget for MinimumContrastWidget {
             ),
             None,
             &view.enforce_min_contrast_dropdown,
+        )
+    }
+}
+
+#[derive(Default)]
+struct UsageDisplayUnitWidget {}
+
+impl SettingsWidget for UsageDisplayUnitWidget {
+    type View = AppearanceSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "usage credits dollars cost spend display unit pricing transparency"
+    }
+
+    fn should_render(&self, _app: &AppContext) -> bool {
+        FeatureFlag::PricingTransparency.is_enabled()
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        render_dropdown_item(
+            appearance,
+            "Usage display unit",
+            Some("Which unit usage and spend amounts are shown in."),
+            None,
+            LocalOnlyIconState::for_setting(
+                UsageDisplayUnit::storage_key(),
+                UsageDisplayUnit::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            None,
+            &view.usage_display_unit_dropdown,
         )
     }
 }

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -4686,7 +4686,7 @@ impl SettingsWidget for UsageDisplayUnitWidget {
         render_dropdown_item(
             appearance,
             "Usage display unit",
-            Some("Which unit usage and spend amounts are shown in."),
+            Some("Select the unit for usage and spend amounts."),
             None,
             LocalOnlyIconState::for_setting(
                 UsageDisplayUnit::storage_key(),

--- a/app/src/settings_view/billing_and_usage/usage_history_entry.rs
+++ b/app/src/settings_view/billing_and_usage/usage_history_entry.rs
@@ -113,10 +113,6 @@ impl UsageHistoryEntry {
         let total_credits =
             entry.usage_metadata.credits_spent + entry.usage_metadata.platform_credits_spent;
         let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
-        // GAP: this GraphQL-backed source doesn't yet thread through a token
-        // count or dollar cost (see `ConversationUsageInfo::from` in
-        // `gql_convert.rs`), so this always falls back to a plain credits
-        // figure today; it will pick up tokens/dollars once that gap closes.
         let credits_spent = Text::new_inline(
             format_credits_with_cost(total_credits as f32, None, None, usage_display_unit),
             appearance.ui_font_family(),

--- a/app/src/settings_view/billing_and_usage/usage_history_entry.rs
+++ b/app/src/settings_view/billing_and_usage/usage_history_entry.rs
@@ -114,7 +114,15 @@ impl UsageHistoryEntry {
             entry.usage_metadata.credits_spent + entry.usage_metadata.platform_credits_spent;
         let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
         let credits_spent = Text::new_inline(
-            format_usage(total_credits as f32, None, None, usage_display_unit),
+            format_usage(
+                total_credits as f32,
+                None,
+                entry
+                    .usage_metadata
+                    .total_provider_cost_in_cents
+                    .map(|cost_in_cents| cost_in_cents as f32),
+                usage_display_unit,
+            ),
             appearance.ui_font_family(),
             14.,
         )

--- a/app/src/settings_view/billing_and_usage/usage_history_entry.rs
+++ b/app/src/settings_view/billing_and_usage/usage_history_entry.rs
@@ -12,7 +12,7 @@ use warpui::{AppContext, Element, SingletonEntity, View};
 use crate::ai::blocklist::usage::conversation_usage_view::{
     ConversationUsageInfo, ConversationUsageView, DisplayMode,
 };
-use crate::ai::blocklist::view_util::format_credits_with_cost;
+use crate::ai::blocklist::view_util::format_usage;
 use crate::settings::AISettings;
 use crate::settings_view::billing_and_usage_page::BillingAndUsagePageAction;
 use crate::ui_components::blended_colors;
@@ -114,7 +114,7 @@ impl UsageHistoryEntry {
             entry.usage_metadata.credits_spent + entry.usage_metadata.platform_credits_spent;
         let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
         let credits_spent = Text::new_inline(
-            format_credits_with_cost(total_credits as f32, None, None, usage_display_unit),
+            format_usage(total_credits as f32, None, None, usage_display_unit),
             appearance.ui_font_family(),
             14.,
         )

--- a/app/src/settings_view/billing_and_usage/usage_history_entry.rs
+++ b/app/src/settings_view/billing_and_usage/usage_history_entry.rs
@@ -7,12 +7,13 @@ use warpui::elements::{
     MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Radius, Shrinkable, Text,
 };
 use warpui::platform::Cursor;
-use warpui::{AppContext, Element, View};
+use warpui::{AppContext, Element, SingletonEntity, View};
 
-use crate::ai::blocklist::format_credits;
 use crate::ai::blocklist::usage::conversation_usage_view::{
     ConversationUsageInfo, ConversationUsageView, DisplayMode,
 };
+use crate::ai::blocklist::view_util::format_credits_with_cost;
+use crate::settings::AISettings;
 use crate::settings_view::billing_and_usage_page::BillingAndUsagePageAction;
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
@@ -44,7 +45,7 @@ impl UsageHistoryEntry {
     pub fn render(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let mut res = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_child(self.render_header(appearance));
+            .with_child(self.render_header(appearance, app));
 
         if let Some(entry) = &self.entry
             && self.is_expanded
@@ -77,7 +78,7 @@ impl UsageHistoryEntry {
             .finish()
     }
 
-    fn render_header(&self, appearance: &Appearance) -> Box<dyn Element> {
+    fn render_header(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let Some(entry) = &self.entry else {
             return self.render_loading_entry(appearance);
         };
@@ -111,8 +112,13 @@ impl UsageHistoryEntry {
 
         let total_credits =
             entry.usage_metadata.credits_spent + entry.usage_metadata.platform_credits_spent;
+        let usage_display_unit = AISettings::as_ref(app).usage_display_unit;
+        // GAP: this GraphQL-backed source doesn't yet thread through a token
+        // count or dollar cost (see `ConversationUsageInfo::from` in
+        // `gql_convert.rs`), so this always falls back to a plain credits
+        // figure today; it will pick up tokens/dollars once that gap closes.
         let credits_spent = Text::new_inline(
-            format_credits(total_credits as f32),
+            format_credits_with_cost(total_credits as f32, None, None, usage_display_unit),
             appearance.ui_font_family(),
             14.,
         )

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -320,7 +320,6 @@ impl BillingAndUsagePageView {
         // On page init, fetch the usage history for the current user.
         usage_history_model.update(ctx, |m, ctx| m.refresh_usage_history_async(ctx));
 
-        // Re-render usage-history rows immediately when the usage display unit changes.
         ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
             if matches!(event, AISettingsChangedEvent::UsageDisplayUnit { .. }) {
                 ctx.notify();

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -49,7 +49,7 @@ use crate::modal::{Modal, ModalEvent, ModalViewState};
 use crate::pricing::{PricingInfoModel, PricingInfoModelEvent};
 use crate::server::ids::ServerId;
 use crate::server::telemetry::TelemetryEvent;
-use crate::settings::ai::AISettings;
+use crate::settings::ai::{AISettings, AISettingsChangedEvent};
 use crate::settings_view::settings_page::TOGGLE_BUTTON_RIGHT_PADDING;
 use crate::ui_components::blended_colors;
 use crate::ui_components::buttons::icon_button;
@@ -319,6 +319,13 @@ impl BillingAndUsagePageView {
         });
         // On page init, fetch the usage history for the current user.
         usage_history_model.update(ctx, |m, ctx| m.refresh_usage_history_async(ctx));
+
+        // Re-render usage-history rows immediately when the usage display unit changes.
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
+            if matches!(event, AISettingsChangedEvent::UsageDisplayUnit { .. }) {
+                ctx.notify();
+            }
+        });
 
         let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
 

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -49,7 +49,7 @@ use crate::modal::{Modal, ModalEvent, ModalViewState};
 use crate::pricing::PricingInfoModel;
 use crate::server::ids::ServerId;
 use crate::server::telemetry::TelemetryEvent;
-use crate::settings::ai::AISettings;
+use crate::settings::ai::{AISettings, AISettingsChangedEvent};
 use crate::ui_components::blended_colors;
 use crate::ui_components::buttons::icon_button;
 use crate::ui_components::icons::Icon;
@@ -318,6 +318,13 @@ impl BillingAndUsagePageV2View {
             ctx.notify();
         });
         usage_history_model.update(ctx, |m, ctx| m.refresh_usage_history_async(ctx));
+
+        // Re-render usage-history rows immediately when the usage display unit changes.
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
+            if matches!(event, AISettingsChangedEvent::UsageDisplayUnit { .. }) {
+                ctx.notify();
+            }
+        });
 
         let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
 

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -319,7 +319,6 @@ impl BillingAndUsagePageV2View {
         });
         usage_history_model.update(ctx, |m, ctx| m.refresh_usage_history_async(ctx));
 
-        // Re-render usage-history rows immediately when the usage display unit changes.
         ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
             if matches!(event, AISettingsChangedEvent::UsageDisplayUnit { .. }) {
                 ctx.notify();


### PR DESCRIPTION
## Description
Adds a persisted GUI Appearance setting, `UsageDisplayUnit` (`Credits` default / `Dollars`), gated by `FeatureFlag::PricingTransparency`, that lets users switch the primary unit for usage/spend displays.

**What**
- New `UsageDisplayUnit` setting in `app/src/settings/ai.rs` (`surface: GUI`, `SyncToCloud::Globally(RespectUserSyncSetting::Yes)`, default `Credits`).
- New dropdown control (`UsageDisplayUnitWidget`) in the Appearance settings page, in a new "Usage" category, gated by the feature flag.
- `format_credits_with_cost` in `app/src/ai/blocklist/view_util.rs` reworked to take a `UsageDisplayUnit` and show tokens plus exactly one of credits or dollars — never both — e.g. `"12,345 tokens / $0.36"` or `"12,345 tokens / 20 credits"`. Falls back to a plain credits figure when dollars are unavailable or the feature flag is off.
- Wired the setting through usage/spend call sites: the AI block's inline usage pill (`ai/blocklist/block/view_impl/output.rs`), the conversation usage footer/settings view (`conversation_usage_view.rs`), the conversation details panel's "Credits used" row, and the settings usage-history header row.
- Brand-new accounts default to `Dollars`; existing users/devices keep the enum's own `Credits` default untouched.

**Note:** This does not update the billing and usage page, as that currently shows both credits and dollars and will be updated in a subsequent PR

## Testing
- `./script/format` — no diffs beyond my changes.
- `cargo clippy -p warp --all-targets --tests -- -D warnings` — clean. (`--all-features` also enables `warp_completer`'s `v2` feature, which fails clippy on unmodified `master` too — confirmed via `git stash` — unrelated to this change.)
- `cargo nextest run -p warp --no-fail-fast` targeted at touched modules (`view_util`, `usage_display_unit`, `conversation_usage_view`, `conversation_details_panel`, `usage_history_entry`, `appearance_page`, `onboarding`) — all passing (159+ tests).
- Added unit tests: formatter behavior (both units, cost-unavailable fallback, flag-off fallback, thousands separators), settings round-trip + toml path, and new-account-vs-skipped-account default behavior.
- [X] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/36664e78ec604a908879f23b1f46ade7

#### New user gets dollars by default

https://oz.staging.warp.dev/artifacts/01a03feb-1da2-72d5-92c7-b207009dd319

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
