### PR TITLE
mcp: retain spawn configs so reconnect works for ephemeral/managed/builtin servers

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -506,6 +506,7 @@ cross_repo_context = []
 codebase_index_persistence = ["full_source_code_embedding"]
 well_known_mcp_ids = []
 factory_mcp = []
+mcp_self_heal = []
 default = [
     "agent_mode",
     "osc_hyperlinks",
@@ -705,6 +706,7 @@ default = [
     "file_backed_execution_profiles",
     "well_known_mcp_ids",
     "factory_mcp",
+    "mcp_self_heal",
     "wait_for_events_parent_registration",
     "orchestration_unified_stack",
     "ime_marked_text",

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -16,6 +16,8 @@ use mcp::oauth;
 #[cfg(not(target_family = "wasm"))]
 pub use native::McpIntegration;
 #[cfg(not(target_family = "wasm"))]
+use native::RetainedSpawnConfig;
+#[cfg(not(target_family = "wasm"))]
 use parking_lot::Mutex;
 #[cfg(not(target_family = "wasm"))]
 use simple_logger::SimpleLogger;
@@ -48,6 +50,12 @@ pub struct TemplatableMCPServerManager {
     locally_installed_servers: HashMap<Uuid, TemplatableMCPServerInstallation>,
     server_states: HashMap<Uuid, MCPServerState>,
     active_servers: HashMap<Uuid, TemplatableMCPServerInfo>,
+    /// The installation each server instance was spawned with, keyed by
+    /// installation UUID. Retained so reconnection can respawn servers whose
+    /// configs exist nowhere else (ephemeral, file-based, built-in). Entries
+    /// hold resolved secrets and proxy tokens; never log them.
+    #[cfg(not(target_family = "wasm"))]
+    spawn_configs: HashMap<Uuid, RetainedSpawnConfig>,
 
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
     spawned_servers: HashMap<Uuid, SpawnedServerInfo>,

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -73,6 +73,30 @@ enum SpawnMode {
     Reconnect,
 }
 
+/// How a spawned server's installation was obtained; used to pick the right
+/// source of truth when respawning during reconnect.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SpawnProvenance {
+    /// Installed by the user and persisted in SQLite (`locally_installed_servers`).
+    LocallyInstalled,
+    /// Discovered from an MCP config file (`.mcp.json`, `.claude.json`, ...).
+    FileBased,
+    /// Started ephemerally by a CLI agent run (`oz agent run --mcp`).
+    CliEphemeral,
+    /// Built-in Warp-hosted server (the Factory MCP), authenticated with the
+    /// logged-in user's session credentials.
+    Builtin,
+}
+
+/// The exact installation a server instance was spawned with, retained so a
+/// reconnect can respawn servers whose configs exist nowhere else (ephemeral
+/// installations are consumed by the spawn, and CLI-ephemeral ones carry
+/// resolved secrets that cannot be re-derived).
+pub(crate) struct RetainedSpawnConfig {
+    pub(crate) installation: TemplatableMCPServerInstallation,
+    pub(crate) provenance: SpawnProvenance,
+}
+
 impl SpawnMode {
     fn should_send_telemetry(&self) -> bool {
         matches!(self, SpawnMode::Initial { .. })
@@ -399,6 +423,7 @@ impl TemplatableMCPServerManager {
             cloud_templatable_mcp_servers: Default::default(),
             server_states: Default::default(),
             active_servers: Default::default(),
+            spawn_configs: Default::default(),
             spawned_servers: Default::default(),
             server_credentials: Default::default(),
             file_based_server_credentials: Default::default(),
@@ -744,11 +769,22 @@ impl TemplatableMCPServerManager {
         installation: TemplatableMCPServerInstallation,
         ctx: &mut ModelContext<Self>,
     ) {
+        // External callers (TUI, settings) only spawn file-based installations.
+        self.spawn_ephemeral_server_with_provenance(installation, SpawnProvenance::FileBased, ctx);
+    }
+
+    fn spawn_ephemeral_server_with_provenance(
+        &mut self,
+        installation: TemplatableMCPServerInstallation,
+        provenance: SpawnProvenance,
+        ctx: &mut ModelContext<Self>,
+    ) {
         let installation_uuid = installation.uuid();
         log::debug!("Spawning ephemeral server with installation_uuid {installation_uuid}");
 
         self.spawn_server_impl(
             installation,
+            provenance,
             SpawnMode::Initial {
                 persist_running_state_to_sqlite: false,
             },
@@ -763,7 +799,11 @@ impl TemplatableMCPServerManager {
         ctx: &mut ModelContext<Self>,
     ) {
         self.cli_spawned_server_uuids.insert(installation.uuid());
-        self.spawn_ephemeral_server(installation, ctx);
+        self.spawn_ephemeral_server_with_provenance(
+            installation,
+            SpawnProvenance::CliEphemeral,
+            ctx,
+        );
     }
 
     /// Reconciles built-in Warp-hosted MCP servers (currently the Factory
@@ -829,7 +869,11 @@ impl TemplatableMCPServerManager {
         log::info!("Spawning the built-in Factory MCP server");
         self.builtin_server_uuids.insert(installation_uuid);
         self.builtin_server_token = Some(token.clone());
-        self.spawn_ephemeral_server(builtin::factory_mcp_installation(&token), ctx);
+        self.spawn_ephemeral_server_with_provenance(
+            builtin::factory_mcp_installation(&token),
+            SpawnProvenance::Builtin,
+            ctx,
+        );
     }
 
     /// Spawns a new MCP server from a given installation UUID.
@@ -862,6 +906,7 @@ impl TemplatableMCPServerManager {
 
         self.spawn_server_impl(
             installation,
+            SpawnProvenance::LocallyInstalled,
             SpawnMode::Initial {
                 persist_running_state_to_sqlite: true,
             },
@@ -873,10 +918,22 @@ impl TemplatableMCPServerManager {
     fn spawn_server_impl(
         &mut self,
         installation: TemplatableMCPServerInstallation,
+        provenance: SpawnProvenance,
         mode: SpawnMode,
         ctx: &mut ModelContext<Self>,
     ) {
         let installation_uuid = installation.uuid();
+
+        // Retain the exact installation this instance is spawned with so a
+        // later reconnect can respawn it even when the config exists nowhere
+        // else (see `respawnable_config`).
+        self.spawn_configs.insert(
+            installation_uuid,
+            RetainedSpawnConfig {
+                installation: installation.clone(),
+                provenance,
+            },
+        );
 
         let resolved_json = resolve_json(&installation);
         let template_uuid = installation.template_uuid();
@@ -1244,6 +1301,13 @@ impl TemplatableMCPServerManager {
         if let Some(spawned_info) = self.spawned_servers.remove(&installation_uuid) {
             spawned_info.abort_handle.abort();
         }
+        // A reconnect may be in flight for this server; aborting its spawn
+        // above means the completion callback never runs, so fail the waiters
+        // here or they would hang forever.
+        self.notify_reconnect_waiters(installation_uuid, Err("Server was shut down".to_string()));
+        // An explicitly stopped server must not be resurrected by a later
+        // reconnect; a respawn re-retains its config.
+        self.spawn_configs.remove(&installation_uuid);
         // Close the log stream now rather than when async teardown drops the
         // last logger clone, so an immediate respawn of the same server can
         // re-register its log path.
@@ -1876,8 +1940,14 @@ impl TemplatableMCPServerManager {
         self.pending_reconnections
             .insert(installation_uuid, vec![result_tx]);
 
-        // Remove the old server from active_servers if it exists.
-        self.active_servers.remove(&installation_uuid);
+        // Remove the old server from active_servers if it exists, and cancel
+        // it in the background so its transport (e.g. a stdio child process)
+        // is actually torn down before lingering indefinitely. Unlike
+        // `shutdown_server` this emits no state changes: a respawn is about
+        // to begin.
+        if let Some(server_info) = self.active_servers.remove(&installation_uuid) {
+            ctx.spawn(server_info.shutdown(), |_, _, _| {});
+        }
 
         // Cancel any in-flight spawn.
         if let Some(spawned_info) = self.spawned_servers.remove(&installation_uuid) {
@@ -1890,21 +1960,75 @@ impl TemplatableMCPServerManager {
         }
         self.pending_oauth_csrf
             .retain(|_, v| *v != installation_uuid);
+        self.authorization_urls.remove(&installation_uuid);
 
         // Look up the installation to get server details.
-        let Some(installation) = self
-            .locally_installed_servers
-            .get(&installation_uuid)
-            .cloned()
-        else {
-            self.notify_reconnect_waiters(
-                installation_uuid,
-                Err("Installation not found".to_string()),
-            );
-            return;
+        let (installation, provenance) = match self.respawnable_config(installation_uuid, ctx) {
+            Ok(found) => found,
+            Err(message) => {
+                self.notify_reconnect_waiters(installation_uuid, Err(message));
+                return;
+            }
         };
 
-        self.spawn_server_impl(installation, SpawnMode::Reconnect, ctx);
+        self.spawn_server_impl(installation, provenance, SpawnMode::Reconnect, ctx);
+    }
+
+    /// Resolves the installation (and its provenance) to respawn during a
+    /// reconnect.
+    ///
+    /// With `McpSelfHeal` enabled this consults the configs retained at spawn
+    /// time (`spawn_configs`), so ephemeral servers (file-based, CLI,
+    /// built-in) can reconnect too. Locally installed servers prefer the live
+    /// installation in case the user edited it since the last spawn, and the
+    /// built-in server re-mints its bearer token since the retained one may
+    /// have expired. With the flag disabled only locally installed servers
+    /// can reconnect, matching previous behavior.
+    fn respawnable_config(
+        &mut self,
+        installation_uuid: Uuid,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<(TemplatableMCPServerInstallation, SpawnProvenance), String> {
+        let locally_installed = self
+            .locally_installed_servers
+            .get(&installation_uuid)
+            .cloned();
+
+        let retained = self
+            .spawn_configs
+            .get(&installation_uuid)
+            .filter(|_| FeatureFlag::McpSelfHeal.is_enabled());
+        let Some(retained) = retained else {
+            return locally_installed
+                .map(|installation| (installation, SpawnProvenance::LocallyInstalled))
+                .ok_or_else(|| "Installation not found".to_string());
+        };
+
+        let provenance = retained.provenance;
+        let retained_installation = retained.installation.clone();
+        match provenance {
+            SpawnProvenance::LocallyInstalled => Ok((
+                locally_installed.unwrap_or(retained_installation),
+                SpawnProvenance::LocallyInstalled,
+            )),
+            SpawnProvenance::Builtin => {
+                // The retained bearer may have expired; re-mint from the
+                // current session credentials.
+                let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
+                let Some(token) = auth_state
+                    .credentials()
+                    .and_then(|credentials| builtin::builtin_bearer_token(&credentials))
+                else {
+                    return Err("No usable bearer token for the built-in server".to_string());
+                };
+                self.builtin_server_token = Some(token.clone());
+                Ok((
+                    builtin::factory_mcp_installation(&token),
+                    SpawnProvenance::Builtin,
+                ))
+            }
+            provenance => Ok((retained_installation, provenance)),
+        }
     }
 
     /// Notifies all pending reconnection waiters for the given installation UUID.
@@ -1991,7 +2115,11 @@ impl TemplatableMCPServerManager {
 
         // If not, spawn them.
         for installation in new_installations {
-            self.spawn_ephemeral_server(installation, ctx);
+            self.spawn_ephemeral_server_with_provenance(
+                installation,
+                SpawnProvenance::FileBased,
+                ctx,
+            );
         }
     }
 
@@ -2025,3 +2153,7 @@ impl TemplatableMCPServerManager {
             .contains_key(&installation_hash)
     }
 }
+
+#[cfg(test)]
+#[path = "native_tests.rs"]
+mod native_tests;

--- a/app/src/ai/mcp/templatable_manager/native_tests.rs
+++ b/app/src/ai/mcp/templatable_manager/native_tests.rs
@@ -1,0 +1,234 @@
+//! Tests for spawn-config retention and reconnect installation lookup.
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+use warp_core::features::FeatureFlag;
+use warpui::{App, ModelHandle};
+
+use super::{RetainedSpawnConfig, SpawnProvenance};
+use crate::ai::mcp::{
+    JsonTemplate, TemplatableMCPServer, TemplatableMCPServerInstallation,
+    TemplatableMCPServerManager,
+};
+use crate::auth::AuthStateProvider;
+
+fn setup_app(app: &mut App) -> ModelHandle<TemplatableMCPServerManager> {
+    app.add_singleton_model(|_| {
+        settings::PublicPreferences::new(Box::<
+            warpui_extras::user_preferences::in_memory::InMemoryPreferences,
+        >::default())
+    });
+    app.add_singleton_model(|_| {
+        settings::PrivatePreferences::new(Box::<
+            warpui_extras::user_preferences::in_memory::InMemoryPreferences,
+        >::default())
+    });
+    let global_resources = crate::GlobalResourceHandles::mock(app);
+    app.add_singleton_model(|_| {
+        crate::GlobalResourceHandlesProvider::new(global_resources.clone())
+    });
+    app.add_singleton_model(|_| TemplatableMCPServerManager::default())
+}
+
+fn test_installation(name: &str) -> TemplatableMCPServerInstallation {
+    let server = TemplatableMCPServer {
+        uuid: Uuid::new_v4(),
+        name: name.to_string(),
+        description: None,
+        template: JsonTemplate {
+            json: format!(r#"{{"{name}": {{"command": "echo", "args": []}}}}"#),
+            variables: Vec::new(),
+        },
+        version: 0,
+        gallery_data: None,
+    };
+    TemplatableMCPServerInstallation::new(Uuid::new_v4(), server, HashMap::new())
+}
+
+#[test]
+fn respawnable_config_returns_retained_config_for_ephemeral_servers() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("cli-server");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                },
+            );
+
+            let (found, provenance) = manager
+                .respawnable_config(uuid, ctx)
+                .expect("retained ephemeral config should be respawnable");
+            assert_eq!(found.uuid(), uuid);
+            assert!(matches!(provenance, SpawnProvenance::CliEphemeral));
+        });
+    });
+}
+
+#[test]
+fn respawnable_config_requires_local_install_when_flag_disabled() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(false);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let ephemeral = test_installation("cli-server");
+        let ephemeral_uuid = ephemeral.uuid();
+        let local = test_installation("local-server");
+        let local_uuid = local.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                ephemeral_uuid,
+                RetainedSpawnConfig {
+                    installation: ephemeral.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                },
+            );
+            manager
+                .locally_installed_servers
+                .insert(local_uuid, local.clone());
+
+            // With the flag off, retained ephemeral configs are ignored,
+            // matching pre-self-heal behavior.
+            let err = manager
+                .respawnable_config(ephemeral_uuid, ctx)
+                .expect_err("ephemeral servers should not reconnect with the flag off");
+            assert_eq!(err, "Installation not found");
+
+            let (found, provenance) = manager
+                .respawnable_config(local_uuid, ctx)
+                .expect("locally installed servers should still reconnect");
+            assert_eq!(found.uuid(), local_uuid);
+            assert!(matches!(provenance, SpawnProvenance::LocallyInstalled));
+        });
+    });
+}
+
+#[test]
+fn respawnable_config_prefers_live_locally_installed_config() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let stale = test_installation("stale-server");
+        let uuid = stale.uuid();
+        let edited = TemplatableMCPServerInstallation::new(
+            uuid,
+            TemplatableMCPServer {
+                name: "edited-server".to_string(),
+                ..stale.templatable_mcp_server().clone()
+            },
+            HashMap::new(),
+        );
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: stale.clone(),
+                    provenance: SpawnProvenance::LocallyInstalled,
+                },
+            );
+            manager
+                .locally_installed_servers
+                .insert(uuid, edited.clone());
+
+            let (found, _) = manager
+                .respawnable_config(uuid, ctx)
+                .expect("locally installed config should be respawnable");
+            assert_eq!(found.templatable_mcp_server().name, "edited-server");
+        });
+    });
+}
+
+#[test]
+fn respawnable_config_falls_back_to_locally_installed_without_retained_entry() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let local = test_installation("local-server");
+        let uuid = local.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager
+                .locally_installed_servers
+                .insert(uuid, local.clone());
+
+            let (found, provenance) = manager
+                .respawnable_config(uuid, ctx)
+                .expect("locally installed servers should reconnect without a retained entry");
+            assert_eq!(found.uuid(), uuid);
+            assert!(matches!(provenance, SpawnProvenance::LocallyInstalled));
+
+            let err = manager
+                .respawnable_config(Uuid::new_v4(), ctx)
+                .expect_err("unknown servers cannot reconnect");
+            assert_eq!(err, "Installation not found");
+        });
+    });
+}
+
+#[test]
+fn shutdown_clears_retained_config_and_fails_reconnect_waiters() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("cli-server");
+        let uuid = installation.uuid();
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                },
+            );
+            manager.pending_reconnections.insert(uuid, vec![tx]);
+
+            manager.shutdown_server(uuid, ctx);
+
+            let err = manager
+                .respawnable_config(uuid, ctx)
+                .expect_err("an explicitly stopped server must not be respawnable");
+            assert_eq!(err, "Installation not found");
+        });
+
+        let waiter_result = rx
+            .try_recv()
+            .expect("shutdown should notify pending reconnect waiters");
+        assert_eq!(waiter_result.unwrap_err(), "Server was shut down");
+    });
+}
+
+#[test]
+fn builtin_reconnect_without_credentials_fails() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| AuthStateProvider::new_logged_out_for_test());
+        let manager = setup_app(&mut app);
+        let installation = test_installation("warp-factory");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::Builtin,
+                },
+            );
+
+            let err = manager
+                .respawnable_config(uuid, ctx)
+                .expect_err("builtin reconnect requires a usable bearer token");
+            assert!(err.contains("bearer token"), "unexpected error: {err}");
+        });
+    });
+}

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -287,6 +287,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::APIKeyManagement,
         #[cfg(feature = "mcp_oauth")]
         FeatureFlag::McpOauth,
+        #[cfg(feature = "mcp_self_heal")]
+        FeatureFlag::McpSelfHeal,
         #[cfg(feature = "file_based_mcp")]
         FeatureFlag::FileBasedMcp,
         #[cfg(feature = "diff_set_as_context")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -424,6 +424,10 @@ pub enum FeatureFlag {
     /// Enables OAuth support for MCP.
     McpOauth,
 
+    /// Enables self-healing MCP connections: reconnecting ephemeral/managed/builtin
+    /// servers, broadened tool-call retry, and managed proxy-token re-minting.
+    McpSelfHeal,
+
     /// Enables attaching diff sets (multiple hunks from multiple files) as context in Agent Mode.
     DiffSetAsContext,
 


### PR DESCRIPTION
## Problem

`reconnect_server` only looked up installations in `locally_installed_servers`, so every ephemeral server — managed (backend-proxied), file-based, CLI-run (`oz agent run --mcp`), and the built-in Factory MCP — failed reconnection permanently with `"Installation not found"` the moment its transport closed. The spawn consumes the installation and nothing retained it; CLI-ephemeral installs are the only carrier of resolved secrets, so the config couldn't be re-derived either.

## Changes

- **`spawn_configs` retention**: the manager keeps the exact installation each server instance was spawned with (`RetainedSpawnConfig` + `SpawnProvenance`), inserted on every spawn and removed on shutdown/delete. Entries hold resolved secrets/proxy tokens and are never logged.
- **Universal reconnect lookup** (`respawnable_config`): consults retained configs first; locally installed servers prefer the live installation (the user may have edited it); the built-in server re-mints its bearer from current session credentials. Gated behind the new `McpSelfHeal` feature flag — flag off is exactly today's behavior (covered by tests).
- **Unflagged reconnect hygiene fixes**:
  - the old `RunningService` is now cancelled during reconnect instead of dropped un-awaited (old stdio children could linger and race the respawn);
  - `shutdown_server` fails pending reconnect waiters instead of leaking them forever (their spawn was aborted, so the completion callback never ran);
  - `authorization_urls` is cleared on reconnect (was only cleared on shutdown).

## Tests

`cargo test -p warp --lib ai::mcp` — new in-crate tests cover per-provenance lookup, the live-installation preference, builtin re-mint failure without credentials, waiter drain on shutdown, and flag-off behavior preservation.

Part of the MCP self-healing stack (see stacked PRs above/below in Graphite).