### PR TITLE
mcp: classify auth failures (HTTP + SSE) and guard OAuth credential deletion

### DIFF
--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -8,7 +8,7 @@ use mcp::oauth::{
     PersistedCredentialsMap, TEMPLATABLE_MCP_CREDENTIALS_KEY, load_credentials_from_secure_storage,
     write_to_secure_storage,
 };
-use mcp::runtime::{error_to_user_message, spawn_server};
+use mcp::runtime::{should_delete_credentials, spawn_error_to_user_message, spawn_server};
 use parking_lot::Mutex;
 use simple_logger::manager::LogManager;
 use url::Url;
@@ -1204,7 +1204,7 @@ impl TemplatableMCPServerManager {
                 auth_context,
             )
             .compat(),
-            move |me, server_info: Result<_, rmcp::RmcpError>, ctx| {
+            move |me, server_info: Result<_, mcp::runtime::McpSpawnError>, ctx| {
                 me.spawned_servers.remove(&installation_uuid);
                 me.pending_oauth_csrf.retain(|_, v| *v != installation_uuid);
                 me.authorization_urls.remove(&installation_uuid);
@@ -1237,7 +1237,7 @@ impl TemplatableMCPServerManager {
                         log::warn!("Failed to spawn MCP server: {e:#}");
 
                         // Store user-friendly error message.
-                        let error_message = error_to_user_message(&e);
+                        let error_message = spawn_error_to_user_message(&e);
                         me.server_error_messages
                             .insert(installation_uuid, error_message.clone());
 
@@ -1247,7 +1247,13 @@ impl TemplatableMCPServerManager {
                             ctx,
                         );
 
-                        me.delete_credentials_from_secure_storage(installation_uuid, ctx);
+                        // Only a definitive auth rejection justifies dropping
+                        // cached OAuth credentials; transient failures
+                        // (network, DNS, command-not-found) must not log the
+                        // user out of the server.
+                        if should_delete_credentials(&e) {
+                            me.delete_credentials_from_secure_storage(installation_uuid, ctx);
+                        }
 
                         if is_reconnect {
                             me.notify_reconnect_waiters(installation_uuid, Err(error_message));

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -324,6 +324,18 @@ pub enum MCPServerTelemetryError {
 }
 
 #[cfg(not(target_family = "wasm"))]
+impl From<mcp::runtime::McpSpawnError> for MCPServerTelemetryError {
+    fn from(err: mcp::runtime::McpSpawnError) -> Self {
+        match err {
+            mcp::runtime::McpSpawnError::AuthRequired { message, .. } => {
+                Self::Initialization(message)
+            }
+            mcp::runtime::McpSpawnError::Other(err) => err.into(),
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
 impl From<rmcp::RmcpError> for MCPServerTelemetryError {
     fn from(err: rmcp::RmcpError) -> Self {
         match err {

--- a/crates/mcp/src/error_classification.rs
+++ b/crates/mcp/src/error_classification.rs
@@ -1,0 +1,218 @@
+//! Classification of MCP transport and service errors.
+//!
+//! Reconnect and re-auth logic needs to know *why* an operation failed:
+//! an expired Warp proxy session heals by re-minting a token, a closed
+//! transport heals by reconnecting, and a rejected downstream OAuth grant
+//! only heals when the user re-authenticates. The transports bury that
+//! signal in nested error types; this module digs it out in one place.
+
+use rmcp::transport::streamable_http_client::StreamableHttpError;
+
+use crate::sse_transport::SseTransportError;
+
+/// Why the Warp managed-MCP proxy rejected a proxy session token.
+///
+/// These correspond to the machine-readable reasons the proxy puts in its
+/// `WWW-Authenticate` challenge (`error_description`) and JSON error bodies
+/// (`code`). Both mean a freshly minted proxy session token will fix the
+/// connection without user interaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProxyAuthReason {
+    /// The proxy session token is past its expiry.
+    ProxyTokenExpired,
+    /// The token was minted against a previous OAuth grant that has since
+    /// been re-authorized.
+    ProxyTokenStale,
+}
+
+/// How a failed MCP operation should be handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpErrorClass {
+    /// An expired or stale Warp proxy session: re-mint the proxy token and
+    /// reconnect without involving the user.
+    AuthExpiredRecoverable(ProxyAuthReason),
+    /// The server (or the downstream service behind the Warp proxy) rejected
+    /// authentication in a way only the user can fix by re-authenticating.
+    AuthRequiresUser,
+    /// A likely-transient failure (closed transport, network error, 5xx);
+    /// reconnecting or retrying may succeed.
+    Transient,
+    /// Retrying will not help (protocol or application-level errors).
+    Fatal,
+}
+
+/// Parses the re-mint reason out of a `WWW-Authenticate` challenge.
+///
+/// The Warp proxy denies its own token problems with challenges like
+/// `Bearer error="invalid_token", error_description="proxy_token_expired"`.
+/// Challenges relayed from other servers never carry these descriptions.
+pub fn parse_www_authenticate_reason(header: &str) -> Option<ProxyAuthReason> {
+    if !header.contains(r#"error="invalid_token""#) {
+        return None;
+    }
+    parse_proxy_reason(header)
+}
+
+/// Finds a proxy re-mint reason anywhere in a body or message string.
+///
+/// The proxy's JSON error bodies carry `"code":"proxy_token_expired"` /
+/// `"code":"proxy_token_stale"`; rmcp surfaces those bodies only inside
+/// formatted message strings, so this matches on the code substrings.
+fn parse_proxy_reason(text: &str) -> Option<ProxyAuthReason> {
+    if text.contains("proxy_token_expired") {
+        Some(ProxyAuthReason::ProxyTokenExpired)
+    } else if text.contains("proxy_token_stale") {
+        Some(ProxyAuthReason::ProxyTokenStale)
+    } else {
+        None
+    }
+}
+
+/// Classifies an [`rmcp::ServiceError`] from a failed MCP operation
+/// (e.g. `call_tool`) into the action its caller should take.
+pub fn classify_service_error(error: &rmcp::ServiceError) -> McpErrorClass {
+    match error {
+        rmcp::ServiceError::TransportClosed => McpErrorClass::Transient,
+        rmcp::ServiceError::Timeout { .. } => McpErrorClass::Transient,
+        rmcp::ServiceError::TransportSend(dynamic_error) => {
+            classify_boxed_transport_error(dynamic_error.error.as_ref())
+        }
+        // McpError (application-level), UnexpectedResponse, Cancelled, and
+        // any future variants: the connection itself worked.
+        _ => McpErrorClass::Fatal,
+    }
+}
+
+/// Classifies the boxed error inside a `TransportSend` failure by trying the
+/// concrete error types of every transport Warp spawns.
+fn classify_boxed_transport_error(
+    error: &(dyn std::error::Error + Send + Sync + 'static),
+) -> McpErrorClass {
+    if let Some(http_error) = error.downcast_ref::<StreamableHttpError<reqwest::Error>>() {
+        return classify_streamable_http_error(http_error);
+    }
+    if let Some(sse_error) = error.downcast_ref::<SseTransportError<reqwest::Error>>() {
+        return classify_sse_error(sse_error, classify_reqwest_error);
+    }
+    // The OAuth SSE path nests the plain transport error inside `Client`
+    // (see `sse_transport::auth_impl`).
+    if let Some(sse_error) =
+        error.downcast_ref::<SseTransportError<SseTransportError<reqwest::Error>>>()
+    {
+        return classify_sse_error(sse_error, |inner| {
+            classify_sse_error(inner, classify_reqwest_error)
+        });
+    }
+    // Unknown transports (e.g. the stdio child process): a failed send
+    // usually means the connection is gone, which a reconnect can fix.
+    McpErrorClass::Transient
+}
+
+fn classify_streamable_http_error(error: &StreamableHttpError<reqwest::Error>) -> McpErrorClass {
+    match error {
+        StreamableHttpError::AuthRequired(auth_required) => {
+            match parse_www_authenticate_reason(&auth_required.www_authenticate_header) {
+                Some(reason) => McpErrorClass::AuthExpiredRecoverable(reason),
+                None => McpErrorClass::AuthRequiresUser,
+            }
+        }
+        // rmcp formats non-success responses as "HTTP {status}: {body}",
+        // which is the only place a 401 body survives on this transport.
+        StreamableHttpError::UnexpectedServerResponse(message) => {
+            classify_http_message(message, None)
+        }
+        StreamableHttpError::Client(client_error) => classify_reqwest_error(client_error),
+        StreamableHttpError::Auth(_) | StreamableHttpError::InsufficientScope(_) => {
+            McpErrorClass::AuthRequiresUser
+        }
+        StreamableHttpError::Sse(_)
+        | StreamableHttpError::Io(_)
+        | StreamableHttpError::UnexpectedEndOfStream
+        | StreamableHttpError::TransportChannelClosed
+        | StreamableHttpError::SessionExpired => McpErrorClass::Transient,
+        // Deserialize, UnexpectedContentType, protocol-support errors, and
+        // any future variants.
+        _ => McpErrorClass::Fatal,
+    }
+}
+
+fn classify_sse_error<E: std::error::Error + Send + Sync + 'static>(
+    error: &SseTransportError<E>,
+    classify_client: impl FnOnce(&E) -> McpErrorClass,
+) -> McpErrorClass {
+    match error {
+        SseTransportError::HttpStatus {
+            status,
+            body,
+            www_authenticate,
+        } => classify_http_status(*status, body, www_authenticate.as_deref()),
+        SseTransportError::Client(client_error) => classify_client(client_error),
+        SseTransportError::Auth(_) => McpErrorClass::AuthRequiresUser,
+        SseTransportError::Sse(_)
+        | SseTransportError::Io(_)
+        | SseTransportError::UnexpectedEndOfStream => McpErrorClass::Transient,
+        SseTransportError::UnexpectedContentType(_)
+        | SseTransportError::InvalidUri(_)
+        | SseTransportError::InvalidUriParts(_) => McpErrorClass::Fatal,
+    }
+}
+
+/// Classifies an HTTP error response with a known status code.
+pub fn classify_http_status(
+    status: http::StatusCode,
+    body: &str,
+    www_authenticate: Option<&str>,
+) -> McpErrorClass {
+    if let Some(reason) = www_authenticate.and_then(parse_www_authenticate_reason) {
+        return McpErrorClass::AuthExpiredRecoverable(reason);
+    }
+    if let Some(reason) = parse_proxy_reason(body) {
+        return McpErrorClass::AuthExpiredRecoverable(reason);
+    }
+    // The proxy's code for "the downstream OAuth grant is unusable": only
+    // the user re-authenticating fixes that.
+    if body.contains("downstream_auth_failed") {
+        return McpErrorClass::AuthRequiresUser;
+    }
+    match status.as_u16() {
+        401 | 403 => McpErrorClass::AuthRequiresUser,
+        408 | 429 | 500..=599 => McpErrorClass::Transient,
+        _ => McpErrorClass::Fatal,
+    }
+}
+
+/// Classifies rmcp's "HTTP {status}: {body}" message strings.
+fn classify_http_message(message: &str, www_authenticate: Option<&str>) -> McpErrorClass {
+    if let Some(reason) = www_authenticate.and_then(parse_www_authenticate_reason) {
+        return McpErrorClass::AuthExpiredRecoverable(reason);
+    }
+    if let Some(reason) = parse_proxy_reason(message) {
+        return McpErrorClass::AuthExpiredRecoverable(reason);
+    }
+    if message.contains("downstream_auth_failed") {
+        return McpErrorClass::AuthRequiresUser;
+    }
+    if message.starts_with("HTTP 401") || message.starts_with("HTTP 403") {
+        return McpErrorClass::AuthRequiresUser;
+    }
+    if message.starts_with("HTTP 408")
+        || message.starts_with("HTTP 429")
+        || message.starts_with("HTTP 5")
+    {
+        return McpErrorClass::Transient;
+    }
+    McpErrorClass::Fatal
+}
+
+fn classify_reqwest_error(error: &reqwest::Error) -> McpErrorClass {
+    if let Some(status) = error.status() {
+        return classify_http_status(status, "", None);
+    }
+    // Connect, timeout, and request-level failures without a status are all
+    // network conditions a retry can outlast.
+    McpErrorClass::Transient
+}
+
+#[cfg(test)]
+#[path = "error_classification_tests.rs"]
+mod tests;

--- a/crates/mcp/src/error_classification_tests.rs
+++ b/crates/mcp/src/error_classification_tests.rs
@@ -1,0 +1,195 @@
+//! Tests for MCP error classification.
+
+use std::any::TypeId;
+
+use rmcp::transport::DynamicTransportError;
+use rmcp::transport::streamable_http_client::{AuthRequiredError, StreamableHttpError};
+
+use super::*;
+use crate::runtime::{McpSpawnError, should_delete_credentials};
+
+const EXPIRED_CHALLENGE: &str =
+    r#"Bearer error="invalid_token", error_description="proxy_token_expired""#;
+const STALE_CHALLENGE: &str =
+    r#"Bearer error="invalid_token", error_description="proxy_token_stale""#;
+
+fn transport_send_error(error: Box<dyn std::error::Error + Send + Sync>) -> rmcp::ServiceError {
+    rmcp::ServiceError::TransportSend(DynamicTransportError::from_parts(
+        "test-transport",
+        TypeId::of::<()>(),
+        error,
+    ))
+}
+
+#[test]
+fn parses_proxy_challenges() {
+    assert_eq!(
+        parse_www_authenticate_reason(EXPIRED_CHALLENGE),
+        Some(ProxyAuthReason::ProxyTokenExpired)
+    );
+    assert_eq!(
+        parse_www_authenticate_reason(STALE_CHALLENGE),
+        Some(ProxyAuthReason::ProxyTokenStale)
+    );
+    // Foreign challenges (no proxy reason) and non-token errors don't match.
+    assert_eq!(
+        parse_www_authenticate_reason(r#"Bearer realm="downstream""#),
+        None
+    );
+    assert_eq!(
+        parse_www_authenticate_reason(
+            r#"Bearer error="insufficient_scope", error_description="proxy_token_expired""#
+        ),
+        None
+    );
+}
+
+#[test]
+fn closed_and_timed_out_transports_are_transient() {
+    assert_eq!(
+        classify_service_error(&rmcp::ServiceError::TransportClosed),
+        McpErrorClass::Transient
+    );
+    assert_eq!(
+        classify_service_error(&rmcp::ServiceError::Timeout {
+            timeout: std::time::Duration::from_secs(1)
+        }),
+        McpErrorClass::Transient
+    );
+}
+
+#[test]
+fn mcp_application_errors_are_fatal() {
+    let error = rmcp::ServiceError::McpError(rmcp::model::ErrorData {
+        code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+        message: "boom".into(),
+        data: None,
+    });
+    assert_eq!(classify_service_error(&error), McpErrorClass::Fatal);
+}
+
+#[test]
+fn streamable_http_auth_required_uses_the_challenge() {
+    let expired = transport_send_error(Box::new(
+        StreamableHttpError::<reqwest::Error>::AuthRequired(AuthRequiredError::new(
+            EXPIRED_CHALLENGE.to_string(),
+        )),
+    ));
+    assert_eq!(
+        classify_service_error(&expired),
+        McpErrorClass::AuthExpiredRecoverable(ProxyAuthReason::ProxyTokenExpired)
+    );
+
+    let foreign = transport_send_error(Box::new(
+        StreamableHttpError::<reqwest::Error>::AuthRequired(AuthRequiredError::new(
+            r#"Bearer realm="downstream""#.to_string(),
+        )),
+    ));
+    assert_eq!(
+        classify_service_error(&foreign),
+        McpErrorClass::AuthRequiresUser
+    );
+}
+
+#[test]
+fn streamable_http_server_responses_classify_by_status_and_body() {
+    let classify = |message: &str| {
+        classify_service_error(&transport_send_error(Box::new(StreamableHttpError::<
+            reqwest::Error,
+        >::UnexpectedServerResponse(
+            message.to_string().into(),
+        ))))
+    };
+
+    // A proxy code in the body wins regardless of challenge stripping.
+    assert_eq!(
+        classify(r#"HTTP 401 Unauthorized: {"error":"expired","code":"proxy_token_expired"}"#),
+        McpErrorClass::AuthExpiredRecoverable(ProxyAuthReason::ProxyTokenExpired)
+    );
+    // A bare 401 through the proxy means the downstream rejected auth.
+    assert_eq!(
+        classify("HTTP 401 Unauthorized: nope"),
+        McpErrorClass::AuthRequiresUser
+    );
+    // The proxy's dead-grant denial code is a user-fixable auth problem.
+    assert_eq!(
+        classify(r#"HTTP 502 Bad Gateway: {"error":"...","code":"downstream_auth_failed"}"#),
+        McpErrorClass::AuthRequiresUser
+    );
+    assert_eq!(
+        classify("HTTP 503 Service Unavailable: try later"),
+        McpErrorClass::Transient
+    );
+    assert_eq!(classify("HTTP 400 Bad Request: nope"), McpErrorClass::Fatal);
+}
+
+#[test]
+fn nested_oauth_sse_errors_are_unwrapped() {
+    // The OAuth SSE path wraps the plain transport error inside `Client`.
+    let nested: SseTransportError<SseTransportError<reqwest::Error>> =
+        SseTransportError::Client(SseTransportError::HttpStatus {
+            status: http::StatusCode::UNAUTHORIZED,
+            body: String::new(),
+            www_authenticate: Some(STALE_CHALLENGE.to_string()),
+        });
+    assert_eq!(
+        classify_service_error(&transport_send_error(Box::new(nested))),
+        McpErrorClass::AuthExpiredRecoverable(ProxyAuthReason::ProxyTokenStale)
+    );
+}
+
+#[test]
+fn sse_http_statuses_classify_like_http_responses() {
+    let classify = |error: SseTransportError<reqwest::Error>| {
+        classify_service_error(&transport_send_error(Box::new(error)))
+    };
+
+    assert_eq!(
+        classify(SseTransportError::HttpStatus {
+            status: http::StatusCode::FORBIDDEN,
+            body: String::new(),
+            www_authenticate: None,
+        }),
+        McpErrorClass::AuthRequiresUser
+    );
+    assert_eq!(
+        classify(SseTransportError::HttpStatus {
+            status: http::StatusCode::BAD_GATEWAY,
+            body: r#"{"error":"...","code":"downstream_auth_failed"}"#.to_string(),
+            www_authenticate: None,
+        }),
+        McpErrorClass::AuthRequiresUser
+    );
+    assert_eq!(
+        classify(SseTransportError::UnexpectedEndOfStream),
+        McpErrorClass::Transient
+    );
+}
+
+#[test]
+fn unknown_transport_errors_are_transient() {
+    // E.g. a stdio child whose pipe broke.
+    let error = transport_send_error(Box::new(std::io::Error::other("broken pipe")));
+    assert_eq!(classify_service_error(&error), McpErrorClass::Transient);
+}
+
+#[test]
+fn credentials_are_deleted_only_on_unrecoverable_auth_rejections() {
+    assert!(should_delete_credentials(&McpSpawnError::AuthRequired {
+        www_authenticate: None,
+        reason: None,
+        message: "rejected".to_string(),
+    }));
+    // Re-mintable proxy expiry heals without re-auth; keep credentials.
+    assert!(!should_delete_credentials(&McpSpawnError::AuthRequired {
+        www_authenticate: Some(EXPIRED_CHALLENGE.to_string()),
+        reason: Some(ProxyAuthReason::ProxyTokenExpired),
+        message: "expired".to_string(),
+    }));
+    // Transient failures must never log the user out.
+    assert!(!should_delete_credentials(&McpSpawnError::Other(
+        rmcp::RmcpError::transport_creation::<
+            rmcp::transport::StreamableHttpClientTransport<reqwest::Client>,
+        >("dns failure".to_string()),
+    )));
+}

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,4 +1,6 @@
 #[cfg(not(target_family = "wasm"))]
+pub mod error_classification;
+#[cfg(not(target_family = "wasm"))]
 pub mod oauth;
 #[cfg(not(target_family = "wasm"))]
 pub mod runtime;

--- a/crates/mcp/src/runtime.rs
+++ b/crates/mcp/src/runtime.rs
@@ -19,9 +19,55 @@ use uuid::Uuid;
 use warp_errors::report_error;
 
 use super::TemplatableMCPServerInfo;
+use crate::error_classification::ProxyAuthReason;
 
 type ReqwestHttpTransport = rmcp::transport::StreamableHttpClientTransport<reqwest::Client>;
 type ReqwestSseTransport = crate::sse_transport::SseClientTransport<reqwest::Client>;
+
+/// Error from [`spawn_server`], distinguishing authentication failures from
+/// other spawn failures so callers can react without string matching.
+#[derive(Debug, thiserror::Error)]
+#[allow(clippy::large_enum_variant)] // `Other` carries rmcp's (large) error type.
+pub enum McpSpawnError {
+    /// The server rejected the connection as unauthenticated, and interactive
+    /// authentication was unavailable or failed.
+    #[error("{message}")]
+    AuthRequired {
+        /// The `WWW-Authenticate` challenge, when the server provided one.
+        www_authenticate: Option<String>,
+        /// The Warp proxy re-mint reason parsed from the challenge, if any.
+        /// `Some` means a freshly minted proxy session token will fix this
+        /// without user interaction.
+        reason: Option<ProxyAuthReason>,
+        /// User-facing description of the failure.
+        message: String,
+    },
+    #[error(transparent)]
+    Other(#[from] rmcp::RmcpError),
+}
+
+impl From<rmcp::service::ClientInitializeError> for McpSpawnError {
+    fn from(error: rmcp::service::ClientInitializeError) -> Self {
+        Self::Other(error.into())
+    }
+}
+
+/// Whether a spawn failure justifies deleting cached OAuth credentials.
+///
+/// Only a definitive authentication rejection that re-minting cannot fix
+/// qualifies. Transient failures (network, DNS, command-not-found) and
+/// re-mintable proxy-token expiry must never log the user out of a server.
+pub fn should_delete_credentials(error: &McpSpawnError) -> bool {
+    matches!(error, McpSpawnError::AuthRequired { reason: None, .. })
+}
+
+/// Convert a spawn error to a user-friendly error message.
+pub fn spawn_error_to_user_message(error: &McpSpawnError) -> String {
+    match error {
+        McpSpawnError::AuthRequired { message, .. } => message.clone(),
+        McpSpawnError::Other(error) => error_to_user_message(error),
+    }
+}
 
 /// Convert an rmcp error to a user-friendly error message.
 pub fn error_to_user_message(error: &rmcp::RmcpError) -> String {
@@ -70,6 +116,19 @@ pub fn error_to_user_message(error: &rmcp::RmcpError) -> String {
     }
 }
 
+/// Bounded reconnect policy for legacy SSE streams.
+///
+/// The upstream default retries forever every second, hammering a dead or
+/// auth-rejecting endpoint indefinitely. Exhaustion ends the stream, which
+/// surfaces as a closed transport that higher layers can recover from
+/// deliberately.
+fn sse_retry_policy() -> std::sync::Arc<dyn crate::sse_transport::SseRetryPolicy> {
+    std::sync::Arc::new(crate::sse_transport::ExponentialBackoff {
+        max_times: Some(6),
+        base_duration: std::time::Duration::from_millis(1000),
+    })
+}
+
 /// Builds a `HeaderMap` from a `HashMap<String, String>` of user-provided headers.
 ///
 /// Invalid header names or values are skipped.
@@ -103,7 +162,7 @@ pub async fn spawn_server(
     transport_type: TransportType,
     logger: SimpleLogger,
     auth_context: Option<crate::oauth::AuthContext>,
-) -> Result<TemplatableMCPServerInfo, rmcp::RmcpError> {
+) -> Result<TemplatableMCPServerInfo, McpSpawnError> {
     logger.log("[note] Attention! There may be sensitive information (such as API keys) in these logs. Make sure to redact any secrets before sharing with others.".to_string());
 
     let mut is_authenticated_transport = false;
@@ -210,7 +269,7 @@ pub async fn spawn_server(
             };
 
             // Create the MCP client and connect to the server.
-            Ok::<_, rmcp::RmcpError>(make_client_info().into_dyn().serve(transport).await?)
+            Ok::<_, McpSpawnError>(make_client_info().into_dyn().serve(transport).await?)
         }
         TransportType::ServerSentEvents(sse_server) => {
             let headers: HashMap<String, String> = sse_server
@@ -267,6 +326,7 @@ pub async fn spawn_server(
                         client,
                         crate::sse_transport::SseClientConfig {
                             sse_endpoint: sse_server.url.into(),
+                            retry_policy: sse_retry_policy(),
                             ..Default::default()
                         },
                     )
@@ -280,24 +340,21 @@ pub async fn spawn_server(
                 }
                 Ok(Transport::Sse(None)) => {
                     logger.log("[info] MCP: Using (legacy) SSE transport (due to preflight failing with a 404)".to_string());
-                    let transport = if headers.is_empty() {
-                        crate::sse_transport::SseClientTransport::start(sse_server.url.clone())
-                            .await
-                            .map_err(|e| {
-                                rmcp::RmcpError::transport_creation::<ReqwestSseTransport>(e)
-                            })?
+                    let client = if headers.is_empty() {
+                        reqwest::Client::default()
                     } else {
-                        let client = build_client_with_headers(&headers)?;
-                        crate::sse_transport::SseClientTransport::start_with_client(
-                            client,
-                            crate::sse_transport::SseClientConfig {
-                                sse_endpoint: sse_server.url.clone().into(),
-                                ..Default::default()
-                            },
-                        )
-                        .await
-                        .map_err(rmcp::RmcpError::transport_creation::<ReqwestSseTransport>)?
+                        build_client_with_headers(&headers)?
                     };
+                    let transport = crate::sse_transport::SseClientTransport::start_with_client(
+                        client,
+                        crate::sse_transport::SseClientConfig {
+                            sse_endpoint: sse_server.url.clone().into(),
+                            retry_policy: sse_retry_policy(),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .map_err(rmcp::RmcpError::transport_creation::<ReqwestSseTransport>)?;
                     let transport = TransportLoggingWrapper {
                         transport,
                         logger: logger.clone(),
@@ -353,22 +410,26 @@ async fn determine_transport(
     url: &str,
     headers: &HashMap<String, String>,
     auth_context: Option<crate::oauth::AuthContext>,
-) -> Result<Transport, rmcp::RmcpError> {
+) -> Result<Transport, McpSpawnError> {
     use reqwest::StatusCode;
 
-    fn unexpected_error(status: reqwest::StatusCode) -> rmcp::RmcpError {
+    fn unexpected_error(status: reqwest::StatusCode) -> McpSpawnError {
         rmcp::RmcpError::transport_creation::<ReqwestHttpTransport>(format!(
             "Unexpected status code: {status}"
         ))
+        .into()
     }
     match send_initialize_request(url, headers, None).await? {
         StatusCode::OK => Ok(Transport::Http(None)),
         StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED => Ok(Transport::Sse(None)),
         StatusCode::UNAUTHORIZED => {
             let Some(mut auth_context) = auth_context else {
-                return Err(rmcp::RmcpError::transport_creation::<ReqwestHttpTransport>(
-                    "Server requires authentication, which is not yet supported.".to_string(),
-                ));
+                return Err(McpSpawnError::AuthRequired {
+                    www_authenticate: None,
+                    reason: None,
+                    message: "Server requires authentication, which is not yet supported."
+                        .to_string(),
+                });
             };
 
             // Grab the post-authentication callback so we can invoke it once we know for sure that we successfully
@@ -381,7 +442,11 @@ async fn determine_transport(
             let (client, did_require_login) =
                 crate::oauth::make_authenticated_client(url, http_client, auth_context)
                     .await
-                    .map_err(rmcp::RmcpError::transport_creation::<ReqwestHttpTransport>)?;
+                    .map_err(|error| McpSpawnError::AuthRequired {
+                        www_authenticate: None,
+                        reason: None,
+                        message: format!("{error:#}"),
+                    })?;
 
             // Define a helper function to invoke when we've successfully authenticated.
             let emit_authenticated_notification = async move || {

--- a/crates/mcp/src/sse_transport/client_side_sse.rs
+++ b/crates/mcp/src/sse_transport/client_side_sse.rs
@@ -101,6 +101,13 @@ pub(crate) trait SseStreamReconnect {
     fn handle_control_event(&mut self, _event: &Sse) -> Result<(), Self::Error> {
         Ok(())
     }
+    /// Whether a failed reconnect attempt should terminate the stream instead
+    /// of consuming further retries (e.g. an auth rejection that later
+    /// attempts cannot fix). Warp-specific addition (not in the upstream rmcp
+    /// copy). Defaults to never.
+    fn is_fatal_error(&self, _error: &Self::Error) -> bool {
+        false
+    }
     fn handle_stream_error(
         &mut self,
         error: &(dyn std::error::Error + 'static),
@@ -240,6 +247,11 @@ where
                 match retry_result {
                     Ok(new_stream) => SseAutoReconnectStreamState::Connected { stream: new_stream },
                     Err(e) => {
+                        if this.connector.is_fatal_error(&e) {
+                            tracing::error!("sse stream error: {e}, not retrying");
+                            this.state.set(SseAutoReconnectStreamState::Terminated);
+                            return Poll::Ready(Some(Err(e)));
+                        }
                         tracing::debug!("retry sse stream error: {e}");
                         *retry_times += 1;
                         if let Some(interval) = this.retry_policy.retry(*retry_times) {

--- a/crates/mcp/src/sse_transport/client_side_sse_tests.rs
+++ b/crates/mcp/src/sse_transport/client_side_sse_tests.rs
@@ -1,0 +1,92 @@
+//! Tests for the auto-reconnect stream's retry bounding and fatal-error
+//! short-circuit.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use futures::StreamExt as _;
+
+use super::client_side_sse::{
+    BoxedSseResponse, FixedInterval, SseAutoReconnectStream, SseStreamReconnect,
+};
+use super::sse_client::SseTransportError;
+
+/// A connector whose reconnect attempts always fail with the given error.
+struct FailingConnector {
+    error: fn() -> SseTransportError<reqwest::Error>,
+    attempts: Arc<AtomicUsize>,
+}
+
+impl SseStreamReconnect for FailingConnector {
+    type Error = SseTransportError<reqwest::Error>;
+    type Future = futures::future::Ready<Result<BoxedSseResponse, Self::Error>>;
+
+    fn retry_connection(&mut self, _last_event_id: Option<&str>) -> Self::Future {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        futures::future::ready(Err((self.error)()))
+    }
+
+    fn is_fatal_error(&self, error: &Self::Error) -> bool {
+        matches!(error, SseTransportError::HttpStatus { .. })
+    }
+}
+
+/// An initial stream that immediately fails, driving the reconnect path.
+fn failing_stream() -> BoxedSseResponse {
+    futures::stream::once(async { Err(sse_stream::Error::InvalidLine) }).boxed()
+}
+
+#[tokio::test]
+async fn fatal_reconnect_errors_terminate_immediately() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut stream = Box::pin(SseAutoReconnectStream::new(
+        failing_stream(),
+        FailingConnector {
+            error: || SseTransportError::HttpStatus {
+                status: http::StatusCode::UNAUTHORIZED,
+                body: String::new(),
+                www_authenticate: None,
+            },
+            attempts: attempts.clone(),
+        },
+        Arc::new(FixedInterval {
+            max_times: Some(100),
+            duration: Duration::from_millis(1),
+        }),
+    ));
+
+    let item = stream.next().await.expect("stream yields the fatal error");
+    assert!(matches!(
+        item,
+        Err(SseTransportError::HttpStatus { status, .. })
+            if status == http::StatusCode::UNAUTHORIZED
+    ));
+    // One attempt, not one hundred: auth rejections must not hammer the server.
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert!(stream.next().await.is_none(), "stream is terminated");
+}
+
+#[tokio::test]
+async fn non_fatal_reconnect_errors_stop_after_the_retry_budget() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut stream = Box::pin(SseAutoReconnectStream::new(
+        failing_stream(),
+        FailingConnector {
+            error: || SseTransportError::UnexpectedEndOfStream,
+            attempts: attempts.clone(),
+        },
+        Arc::new(FixedInterval {
+            max_times: Some(3),
+            duration: Duration::from_millis(1),
+        }),
+    ));
+
+    let item = stream.next().await.expect("stream yields the final error");
+    assert!(matches!(
+        item,
+        Err(SseTransportError::UnexpectedEndOfStream)
+    ));
+    assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    assert!(stream.next().await.is_none(), "stream is terminated");
+}

--- a/crates/mcp/src/sse_transport/mod.rs
+++ b/crates/mcp/src/sse_transport/mod.rs
@@ -8,3 +8,10 @@ mod sse_client;
 
 pub use client_side_sse::{ExponentialBackoff, FixedInterval, NeverRetry, SseRetryPolicy};
 pub use sse_client::{SseClient, SseClientConfig, SseClientTransport, SseTransportError};
+
+#[cfg(test)]
+#[path = "client_side_sse_tests.rs"]
+mod client_side_sse_tests;
+#[cfg(test)]
+#[path = "reqwest_impl_tests.rs"]
+mod reqwest_impl_tests;

--- a/crates/mcp/src/sse_transport/reqwest_impl.rs
+++ b/crates/mcp/src/sse_transport/reqwest_impl.rs
@@ -15,6 +15,37 @@ use super::sse_client::{SseClient, SseClientConfig, SseClientTransport, SseTrans
 const HEADER_LAST_EVENT_ID: &str = "Last-Event-Id";
 const EVENT_STREAM_MIME_TYPE: &str = "text/event-stream";
 
+/// Error bodies are diagnostics, not payloads; cap what we retain.
+pub(crate) const MAX_ERROR_BODY_BYTES: usize = 4096;
+
+/// Builds an [`SseTransportError::HttpStatus`] from a non-success response,
+/// capturing what `error_for_status` would discard: the `WWW-Authenticate`
+/// challenge and a bounded copy of the body, both needed to classify auth
+/// failures (e.g. the Warp proxy's `proxy_token_expired`).
+async fn http_status_error<E: std::error::Error + Send + Sync + 'static>(
+    response: reqwest::Response,
+) -> SseTransportError<E> {
+    let status = response.status();
+    let www_authenticate = response
+        .headers()
+        .get(reqwest::header::WWW_AUTHENTICATE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let mut body = response.text().await.unwrap_or_default();
+    if body.len() > MAX_ERROR_BODY_BYTES {
+        let mut end = MAX_ERROR_BODY_BYTES;
+        while !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        body.truncate(end);
+    }
+    SseTransportError::HttpStatus {
+        status,
+        body,
+        www_authenticate,
+    }
+}
+
 impl From<reqwest::Error> for SseTransportError<reqwest::Error> {
     fn from(e: reqwest::Error) -> Self {
         SseTransportError::Client(e)
@@ -34,12 +65,11 @@ impl SseClient for reqwest::Client {
         if let Some(auth_header) = auth_token {
             request_builder = request_builder.bearer_auth(auth_header);
         }
-        request_builder
-            .send()
-            .await
-            .and_then(|resp| resp.error_for_status())
-            .map_err(SseTransportError::from)
-            .map(drop)
+        let response = request_builder.send().await?;
+        if !response.status().is_success() {
+            return Err(http_status_error(response).await);
+        }
+        Ok(())
     }
 
     async fn get_stream(
@@ -58,7 +88,9 @@ impl SseClient for reqwest::Client {
             request_builder = request_builder.header(HEADER_LAST_EVENT_ID, last_event_id);
         }
         let response = request_builder.send().await?;
-        let response = response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(http_status_error(response).await);
+        }
         match response.headers().get(reqwest::header::CONTENT_TYPE) {
             Some(ct) => {
                 if !ct.as_bytes().starts_with(EVENT_STREAM_MIME_TYPE.as_bytes()) {

--- a/crates/mcp/src/sse_transport/reqwest_impl_tests.rs
+++ b/crates/mcp/src/sse_transport/reqwest_impl_tests.rs
@@ -1,0 +1,115 @@
+//! Tests for the reqwest `SseClient` impl's HTTP error capture.
+
+use axum::Router;
+use axum::routing::{get, post};
+
+use super::sse_client::{SseClient as _, SseTransportError};
+
+const EXPIRED_CHALLENGE: &str =
+    r#"Bearer error="invalid_token", error_description="proxy_token_expired""#;
+const ERROR_BODY: &str = r#"{"error":"proxy session expired","code":"proxy_token_expired"}"#;
+
+async fn serve(router: Router) -> std::net::SocketAddr {
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+async fn unauthorized() -> impl axum::response::IntoResponse {
+    (
+        axum::http::StatusCode::UNAUTHORIZED,
+        [(axum::http::header::WWW_AUTHENTICATE, EXPIRED_CHALLENGE)],
+        ERROR_BODY,
+    )
+}
+
+fn test_message() -> rmcp::model::ClientJsonRpcMessage {
+    let request = rmcp::model::InitializeRequest::new(rmcp::model::ClientInfo::new(
+        Default::default(),
+        rmcp::model::Implementation::new("test".to_string(), "0.0.0".to_string()),
+    ));
+    rmcp::model::ClientJsonRpcMessage::request(
+        rmcp::model::ClientRequest::InitializeRequest(request),
+        rmcp::model::RequestId::Number(0),
+    )
+}
+
+#[tokio::test]
+async fn post_message_captures_status_body_and_challenge() {
+    let addr = serve(Router::new().route("/mcp", post(unauthorized))).await;
+    let uri: http::Uri = format!("http://{addr}/mcp").parse().expect("uri");
+
+    let error = reqwest::Client::default()
+        .post_message(uri, test_message(), None)
+        .await
+        .expect_err("401 should error");
+
+    match error {
+        SseTransportError::HttpStatus {
+            status,
+            body,
+            www_authenticate,
+        } => {
+            assert_eq!(status, http::StatusCode::UNAUTHORIZED);
+            assert_eq!(body, ERROR_BODY);
+            assert_eq!(www_authenticate.as_deref(), Some(EXPIRED_CHALLENGE));
+        }
+        other => panic!("expected HttpStatus, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn get_stream_captures_status_body_and_challenge() {
+    let addr = serve(Router::new().route("/sse", get(unauthorized))).await;
+    let uri: http::Uri = format!("http://{addr}/sse").parse().expect("uri");
+
+    let error = match reqwest::Client::default().get_stream(uri, None, None).await {
+        Ok(_) => panic!("401 should error"),
+        Err(error) => error,
+    };
+
+    match error {
+        SseTransportError::HttpStatus {
+            status,
+            body,
+            www_authenticate,
+        } => {
+            assert_eq!(status, http::StatusCode::UNAUTHORIZED);
+            assert_eq!(body, ERROR_BODY);
+            assert_eq!(www_authenticate.as_deref(), Some(EXPIRED_CHALLENGE));
+        }
+        other => panic!("expected HttpStatus, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn error_bodies_are_bounded() {
+    let addr = serve(Router::new().route(
+        "/mcp",
+        post(|| async {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "x".repeat(1024 * 1024),
+            )
+        }),
+    ))
+    .await;
+    let uri: http::Uri = format!("http://{addr}/mcp").parse().expect("uri");
+
+    let error = reqwest::Client::default()
+        .post_message(uri, test_message(), None)
+        .await
+        .expect_err("500 should error");
+
+    match error {
+        SseTransportError::HttpStatus { body, .. } => {
+            assert_eq!(body.len(), super::reqwest_impl::MAX_ERROR_BODY_BYTES);
+        }
+        other => panic!("expected HttpStatus, got: {other:?}"),
+    }
+}

--- a/crates/mcp/src/sse_transport/sse_client.rs
+++ b/crates/mcp/src/sse_transport/sse_client.rs
@@ -29,6 +29,16 @@ pub enum SseTransportError<E: std::error::Error + Send + Sync + 'static> {
     Io(#[from] std::io::Error),
     #[error("Client error: {0}")]
     Client(E),
+    /// A non-success HTTP response, with the diagnostics `error_for_status`
+    /// would discard: a bounded copy of the body and the `WWW-Authenticate`
+    /// challenge. Warp-specific addition (not in the upstream rmcp copy) so
+    /// callers can classify auth failures.
+    #[error("HTTP status {status}: {body}")]
+    HttpStatus {
+        status: http::StatusCode,
+        body: String,
+        www_authenticate: Option<String>,
+    },
     #[error("unexpected end of stream")]
     UnexpectedEndOfStream,
     #[error("Unexpected content type: {0:?}")]
@@ -107,6 +117,17 @@ impl<C: SseClient> SseStreamReconnect for SseClientReconnect<C> {
             last_event_id = last_event_id.unwrap_or(""),
             "sse stream error: {error}"
         );
+    }
+
+    fn is_fatal_error(&self, error: &Self::Error) -> bool {
+        // An auth-rejected reconnect attempt (e.g. an expired Warp proxy
+        // token) will keep failing identically; stop hammering the server
+        // and let higher layers own recovery.
+        matches!(
+            error,
+            SseTransportError::HttpStatus { status, .. }
+                if matches!(status.as_u16(), 401 | 403)
+        )
     }
 }
 type ServerMessageStream<C> = Pin<Box<SseAutoReconnectStream<SseClientReconnect<C>>>>;


### PR DESCRIPTION
## Problem

Auth failures were invisible to the code that needs to react to them:

- The warp-server managed-MCP proxy tells clients exactly why a request was denied (`WWW-Authenticate: Bearer error="invalid_token", error_description="proxy_token_expired"|"proxy_token_stale"`), but nothing client-side parsed it.
- The forked legacy SSE transport used `error_for_status()`, discarding HTTP error bodies and challenges entirely, and its auto-reconnect retried **forever at 1s** — an expired-token SSE server got hammered indefinitely.
- Any spawn failure — including a network blip or `command not found` — unconditionally **deleted the server's cached OAuth credentials**, forcing interactive re-auth (source of the throttled report_error noise, see #15498).

## Changes

- New `mcp::error_classification` module:
  - `classify_service_error` → `AuthExpiredRecoverable(reason)` / `AuthRequiresUser` / `Transient` / `Fatal`, digging through rmcp's `StreamableHttpError` and both nestings of the fork's `SseTransportError` (the OAuth path double-wraps).
  - `parse_www_authenticate_reason` recognizes the proxy's re-mintable codes; `downstream_auth_failed` bodies classify as user-fixable.
- SSE fork: new `SseTransportError::HttpStatus { status, body (≤4KiB), www_authenticate }` variant replaces `error_for_status()`; GET-stream errors no longer silently map to a closed stream. Reconnects are bounded (exponential, max 6) and a 401/403 on reconnect terminates immediately instead of retrying.
- `spawn_server` now returns a typed `McpSpawnError` distinguishing `AuthRequired { reason }` from other failures (auth-context-missing and failed-OAuth flows populate it).
- **Credential deletion is now guarded**: only a definitive auth rejection that re-minting cannot fix (`AuthRequired { reason: None }`) deletes cached credentials. Network/DNS/command failures and re-mintable proxy expiry never log the user out.

## Tests

`cargo test -p mcp` — axum-based tests assert the HttpStatus capture (status/body/challenge, bounded body), challenge parsing, classification of every class, nested-error unwrapping, bounded/fatal SSE retry behavior, and the credential-deletion predicate.