### PR TITLE
mcp: broaden reconnect retry, add per-server backoff, keep tools visible during reconnect

### DIFF
--- a/app/src/ai/mcp/reconnecting_peer.rs
+++ b/app/src/ai/mcp/reconnecting_peer.rs
@@ -2,7 +2,9 @@
 
 use std::future::Future;
 
+use mcp::error_classification::{McpErrorClass, classify_service_error, is_safe_to_resend};
 use uuid::Uuid;
+use warp_core::features::FeatureFlag;
 use warpui::ModelSpawner;
 
 use super::TemplatableMCPServerManager;
@@ -89,14 +91,16 @@ impl ReconnectingPeer {
         Ok(peer)
     }
 
-    /// Executes a request with automatic retry on `TransportClosed` errors.
+    /// Executes a request with automatic retry on recoverable transport errors.
     ///
-    /// If the initial request fails with `TransportClosed`, the reconnecting peer will
-    /// detect the closed transport and attempt to reconnect before the retry.
+    /// If the initial request fails in a way a reconnect can fix (closed
+    /// transport, or — with `McpSelfHeal` — a recoverable send failure), the
+    /// reconnecting peer triggers reconnection before the retry.
     ///
     /// Note: We intentionally retry only once to avoid infinite reconnection loops if the
     /// server is persistently failing. If the retry also fails, the error propagates to the
-    /// caller.
+    /// caller. The manager additionally applies a per-server backoff to repeated
+    /// reconnect failures.
     async fn with_reconnect_retry<T, R, F, Fut>(
         &self,
         params: T,
@@ -109,7 +113,7 @@ impl ReconnectingPeer {
     {
         let peer = self.get_connected_peer().await?;
         match f(peer, params.clone()).await {
-            Err(rmcp::ServiceError::TransportClosed) => {
+            Err(error) if should_retry_after_reconnect(&error) => {
                 let peer = self.get_connected_peer().await?;
                 f(peer, params).await
             }
@@ -134,4 +138,96 @@ impl ReconnectingPeer {
         self.with_reconnect_retry(params, |peer, p| async move { peer.read_resource(p).await })
             .await
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use mcp::error_classification::ProxyAuthReason;
+    use rmcp::transport::DynamicTransportError;
+    use rmcp::transport::streamable_http_client::{AuthRequiredError, StreamableHttpError};
+
+    use super::*;
+
+    fn send_error(error: StreamableHttpError<reqwest::Error>) -> rmcp::ServiceError {
+        rmcp::ServiceError::TransportSend(DynamicTransportError::from_parts(
+            "test-transport",
+            std::any::TypeId::of::<()>(),
+            Box::new(error),
+        ))
+    }
+
+    fn expired_proxy_token_error() -> rmcp::ServiceError {
+        send_error(StreamableHttpError::AuthRequired(AuthRequiredError::new(
+            r#"Bearer error="invalid_token", error_description="proxy_token_expired""#.to_string(),
+        )))
+    }
+
+    #[test]
+    fn transport_closed_always_retries() {
+        let _flag = FeatureFlag::McpSelfHeal.override_enabled(false);
+        assert!(should_retry_after_reconnect(
+            &rmcp::ServiceError::TransportClosed
+        ));
+    }
+
+    #[test]
+    fn recoverable_send_failures_retry_only_with_the_flag() {
+        {
+            let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+            assert!(should_retry_after_reconnect(&expired_proxy_token_error()));
+            // Sanity-check the classification the decision builds on.
+            assert!(matches!(
+                classify_service_error(&expired_proxy_token_error()),
+                McpErrorClass::AuthExpiredRecoverable(ProxyAuthReason::ProxyTokenExpired)
+            ));
+        }
+        let _flag = FeatureFlag::McpSelfHeal.override_enabled(false);
+        assert!(!should_retry_after_reconnect(&expired_proxy_token_error()));
+    }
+
+    #[test]
+    fn possibly_executed_or_user_fixable_failures_never_retry() {
+        let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+        // A 5xx after the server accepted the request may have run the tool.
+        assert!(!should_retry_after_reconnect(&send_error(
+            StreamableHttpError::UnexpectedServerResponse(
+                "HTTP 500 Internal Server Error: boom".to_string().into()
+            )
+        )));
+        // A downstream auth rejection needs the user, not a retry.
+        assert!(!should_retry_after_reconnect(&send_error(
+            StreamableHttpError::UnexpectedServerResponse(
+                "HTTP 401 Unauthorized: nope".to_string().into()
+            )
+        )));
+        // Timeouts mean the request was delivered; don't double-execute.
+        assert!(!should_retry_after_reconnect(
+            &rmcp::ServiceError::Timeout {
+                timeout: std::time::Duration::from_secs(1)
+            }
+        ));
+    }
+}
+
+/// Whether a failed request should be retried after reconnecting.
+///
+/// `TransportClosed` always retries (pre-existing behavior). With
+/// `McpSelfHeal` enabled, send-stage failures also retry when the request
+/// provably never executed (no double-running non-idempotent tools) and the
+/// failure is one a reconnect can fix — a transient transport error or an
+/// expired Warp proxy session that reconnection re-mints.
+fn should_retry_after_reconnect(error: &rmcp::ServiceError) -> bool {
+    if matches!(error, rmcp::ServiceError::TransportClosed) {
+        return true;
+    }
+    if !FeatureFlag::McpSelfHeal.is_enabled() {
+        return false;
+    }
+    if !is_safe_to_resend(error) {
+        return false;
+    }
+    matches!(
+        classify_service_error(error),
+        McpErrorClass::Transient | McpErrorClass::AuthExpiredRecoverable(_)
+    )
 }

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -56,6 +56,17 @@ pub struct TemplatableMCPServerManager {
     /// hold resolved secrets and proxy tokens; never log them.
     #[cfg(not(target_family = "wasm"))]
     spawn_configs: HashMap<Uuid, RetainedSpawnConfig>,
+    /// Facts about every server that connected successfully this session,
+    /// keyed by installation UUID. Survives reconnect windows (when the live
+    /// entry leaves `active_servers`) so tools stay routable and visible
+    /// while a server is being respawned.
+    #[cfg(not(target_family = "wasm"))]
+    known_servers: HashMap<Uuid, KnownServerFacts>,
+    /// Backoff state for servers whose reconnects keep failing, keyed by
+    /// installation UUID. Prevents a persistently failing server from being
+    /// respawned in a tight loop.
+    #[cfg(not(target_family = "wasm"))]
+    reconnect_backoff: HashMap<Uuid, ReconnectBackoff>,
 
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
     spawned_servers: HashMap<Uuid, SpawnedServerInfo>,
@@ -126,6 +137,22 @@ struct SpawnedServerInfo {
     abort_handle: AbortHandle,
     #[cfg(not(target_family = "wasm"))]
     oauth_result_tx: async_channel::Sender<oauth::CallbackResult>,
+}
+
+/// Cached facts about a server that connected successfully this session.
+#[cfg(not(target_family = "wasm"))]
+struct KnownServerFacts {
+    name: String,
+    tools: Vec<rmcp::model::Tool>,
+    resources: Vec<rmcp::model::Resource>,
+}
+
+/// Backoff state for a server whose reconnects keep failing.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Default)]
+struct ReconnectBackoff {
+    consecutive_failures: u32,
+    blocked_until: Option<instant::Instant>,
 }
 
 /// The current status of the Figma MCP server.
@@ -207,16 +234,50 @@ impl TemplatableMCPServerManager {
             .map(|s| s.as_str())
     }
 
+    /// Whether the given server is between connections (e.g. reconnecting)
+    /// but still eligible to run, so its cached facts should keep its tools
+    /// routable and visible.
+    #[cfg(not(target_family = "wasm"))]
+    fn is_reconnecting_known_server(&self, uuid: &Uuid) -> bool {
+        warp_core::features::FeatureFlag::McpSelfHeal.is_enabled()
+            && !self.active_servers.contains_key(uuid)
+            && self.spawn_configs.contains_key(uuid)
+    }
+
+    /// Known servers that are currently between connections but still
+    /// eligible to run (see [`Self::is_reconnecting_known_server`]).
+    #[cfg(not(target_family = "wasm"))]
+    fn reconnecting_known_servers(&self) -> impl Iterator<Item = (Uuid, &KnownServerFacts)> {
+        self.known_servers
+            .iter()
+            .filter(|(uuid, _)| self.is_reconnecting_known_server(uuid))
+            .map(|(uuid, facts)| (*uuid, facts))
+    }
+
     pub fn resources(&self) -> impl Iterator<Item = &rmcp::model::Resource> {
-        self.active_servers
+        let active = self
+            .active_servers
             .values()
-            .flat_map(|server| server.resources().iter())
+            .flat_map(|server| server.resources().iter());
+        #[cfg(not(target_family = "wasm"))]
+        let active = active.chain(
+            self.reconnecting_known_servers()
+                .flat_map(|(_, facts)| facts.resources.iter()),
+        );
+        active
     }
 
     pub fn tools(&self) -> impl Iterator<Item = &rmcp::model::Tool> {
-        self.active_servers
+        let active = self
+            .active_servers
             .values()
-            .flat_map(|server| server.tools().iter())
+            .flat_map(|server| server.tools().iter());
+        #[cfg(not(target_family = "wasm"))]
+        let active = active.chain(
+            self.reconnecting_known_servers()
+                .flat_map(|(_, facts)| facts.tools.iter()),
+        );
+        active
     }
 
     /// Returns a reconnecting peer for a server that has the given resource.
@@ -231,24 +292,49 @@ impl TemplatableMCPServerManager {
         self.active_servers
             .iter()
             .find(|(_, server)| server.has_resource(resource))
-            .map(|(installation_uuid, _)| {
-                super::reconnecting_peer::ReconnectingPeer::new(*installation_uuid, spawner.clone())
+            .map(|(installation_uuid, _)| *installation_uuid)
+            .or_else(|| {
+                // A reconnecting server's resources stay routable; the peer
+                // triggers the reconnect on use.
+                self.reconnecting_known_servers()
+                    .find(|(_, facts)| {
+                        facts
+                            .resources
+                            .iter()
+                            .any(|other_resource| other_resource.uri == resource.uri)
+                    })
+                    .map(|(installation_uuid, _)| installation_uuid)
+            })
+            .map(|installation_uuid| {
+                super::reconnecting_peer::ReconnectingPeer::new(installation_uuid, spawner.clone())
             })
     }
 
     pub fn tools_for_server(&self, uuid: Uuid) -> Vec<rmcp::model::Tool> {
-        self.active_servers
-            .get(&uuid)
-            .map(|server| server.tools().clone())
-            .unwrap_or_default()
+        if let Some(server) = self.active_servers.get(&uuid) {
+            return server.tools().clone();
+        }
+        #[cfg(not(target_family = "wasm"))]
+        if self.is_reconnecting_known_server(&uuid)
+            && let Some(facts) = self.known_servers.get(&uuid)
+        {
+            return facts.tools.clone();
+        }
+        Vec::new()
     }
 
     #[cfg(feature = "tui")]
     pub fn resources_for_server(&self, uuid: Uuid) -> Vec<rmcp::model::Resource> {
-        self.active_servers
-            .get(&uuid)
-            .map(|server| server.resources().clone())
-            .unwrap_or_default()
+        if let Some(server) = self.active_servers.get(&uuid) {
+            return server.resources().clone();
+        }
+        #[cfg(not(target_family = "wasm"))]
+        if self.is_reconnecting_known_server(&uuid)
+            && let Some(facts) = self.known_servers.get(&uuid)
+        {
+            return facts.resources.clone();
+        }
+        Vec::new()
     }
     #[cfg(all(not(target_family = "wasm"), feature = "tui"))]
     pub fn authorization_url(&self, uuid: Uuid) -> Option<&str> {
@@ -292,7 +378,16 @@ impl TemplatableMCPServerManager {
                 Box::new(self.active_servers.values())
             };
 
-        candidates.find_map(|server| server.tool_input_schema(tool_name))
+        let schema = candidates.find_map(|server| server.tool_input_schema(tool_name));
+        #[cfg(not(target_family = "wasm"))]
+        let schema = schema.or_else(|| {
+            self.reconnecting_known_servers()
+                .filter(|(uuid, _)| installation_id.is_none_or(|id| id == *uuid))
+                .flat_map(|(_, facts)| facts.tools.iter())
+                .find(|tool| tool.name == tool_name)
+                .map(|tool| tool.input_schema.clone())
+        });
+        schema
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -301,6 +396,15 @@ impl TemplatableMCPServerManager {
             .iter()
             .find(|(_, server)| server.has_tool(&tool))
             .map(|(uuid, _)| uuid)
+            .or_else(|| {
+                self.known_servers
+                    .iter()
+                    .find(|(uuid, facts)| {
+                        self.is_reconnecting_known_server(uuid)
+                            && facts.tools.iter().any(|t| t.name == tool.as_str())
+                    })
+                    .map(|(uuid, _)| uuid)
+            })
     }
 
     /// Returns the installation UUID of the server that provides a resource matching the given
@@ -311,6 +415,21 @@ impl TemplatableMCPServerManager {
             .iter()
             .find(|(_, server)| server.has_resource_name_or_uri(name, uri))
             .map(|(uuid, _)| uuid)
+            .or_else(|| {
+                self.known_servers
+                    .iter()
+                    .find(|(uuid, facts)| {
+                        self.is_reconnecting_known_server(uuid)
+                            && facts.resources.iter().any(|resource| {
+                                if let Some(uri) = uri {
+                                    resource.uri == uri
+                                } else {
+                                    resource.name == name
+                                }
+                            })
+                    })
+                    .map(|(uuid, _)| uuid)
+            })
     }
 
     /// Returns installed templatable servers that are currently active.

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -24,8 +24,8 @@ use warpui::windowing::WindowManager;
 use warpui::{AppContext, ModelContext, SingletonEntity};
 
 use super::{
-    MCPServerState, SpawnedServerInfo, TemplatableMCPServerInfo, TemplatableMCPServerManager,
-    TemplatableMCPServerManagerEvent,
+    KnownServerFacts, MCPServerState, SpawnedServerInfo, TemplatableMCPServerInfo,
+    TemplatableMCPServerManager, TemplatableMCPServerManagerEvent,
 };
 use crate::ai::mcp::file_based_manager::FileBasedMCPManagerEvent;
 use crate::ai::mcp::parsing::resolve_json;
@@ -424,6 +424,8 @@ impl TemplatableMCPServerManager {
             server_states: Default::default(),
             active_servers: Default::default(),
             spawn_configs: Default::default(),
+            known_servers: Default::default(),
+            reconnect_backoff: Default::default(),
             spawned_servers: Default::default(),
             server_credentials: Default::default(),
             file_based_server_credentials: Default::default(),
@@ -1212,6 +1214,17 @@ impl TemplatableMCPServerManager {
                 let error = match server_info {
                     Ok(info) => {
                         let peer = info.peer();
+                        // Cache the server's facts so its tools stay routable
+                        // and visible during later reconnect windows.
+                        me.known_servers.insert(
+                            installation_uuid,
+                            KnownServerFacts {
+                                name: info.name().to_string(),
+                                tools: info.tools().clone(),
+                                resources: info.resources().clone(),
+                            },
+                        );
+                        me.reconnect_backoff.remove(&installation_uuid);
                         me.active_servers.insert(installation_uuid, info);
 
                         // Clear any previous error message on successful connection.
@@ -1256,6 +1269,7 @@ impl TemplatableMCPServerManager {
                         }
 
                         if is_reconnect {
+                            me.record_reconnect_failure(installation_uuid);
                             me.notify_reconnect_waiters(installation_uuid, Err(error_message));
                         }
 
@@ -1314,6 +1328,8 @@ impl TemplatableMCPServerManager {
         // An explicitly stopped server must not be resurrected by a later
         // reconnect; a respawn re-retains its config.
         self.spawn_configs.remove(&installation_uuid);
+        self.known_servers.remove(&installation_uuid);
+        self.reconnect_backoff.remove(&installation_uuid);
         // Close the log stream now rather than when async teardown drops the
         // last logger clone, so an immediate respawn of the same server can
         // re-register its log path.
@@ -1942,6 +1958,25 @@ impl TemplatableMCPServerManager {
             return;
         }
 
+        // Circuit breaker: don't respawn a server that keeps failing to
+        // reconnect in a tight loop.
+        if FeatureFlag::McpSelfHeal.is_enabled()
+            && let Some(backoff) = self.reconnect_backoff.get(&installation_uuid)
+            && let Some(blocked_until) = backoff.blocked_until
+            && instant::Instant::now() < blocked_until
+        {
+            let server_name = self
+                .known_servers
+                .get(&installation_uuid)
+                .map(|facts| facts.name.as_str())
+                .unwrap_or("MCP server");
+            let _ = result_tx.send(Err(format!(
+                "'{server_name}' keeps failing to reconnect; backing off before the next \
+                 attempt. Check the server's logs for the underlying failure."
+            )));
+            return;
+        }
+
         // Start tracking this reconnection with this caller as the first waiter.
         self.pending_reconnections
             .insert(installation_uuid, vec![result_tx]);
@@ -2037,6 +2072,26 @@ impl TemplatableMCPServerManager {
         }
     }
 
+    /// Records a failed reconnect attempt and blocks further attempts for a
+    /// jittered, exponentially growing interval (500ms doubling to a ~32s
+    /// cap, mirroring `retry_strategies`). Cleared on the next successful
+    /// connection.
+    fn record_reconnect_failure(&mut self, installation_uuid: Uuid) {
+        const INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_millis(500);
+        const BACKOFF_JITTER: f32 = 0.3;
+        const BACKOFF_MAX_EXPONENT: u32 = 6;
+
+        let backoff = self.reconnect_backoff.entry(installation_uuid).or_default();
+        backoff.consecutive_failures = backoff.consecutive_failures.saturating_add(1);
+        let exponent = backoff
+            .consecutive_failures
+            .saturating_sub(1)
+            .min(BACKOFF_MAX_EXPONENT);
+        let delay =
+            warpui::duration_with_jitter(INITIAL_BACKOFF * 2u32.pow(exponent), BACKOFF_JITTER);
+        backoff.blocked_until = Some(instant::Instant::now() + delay);
+    }
+
     /// Notifies all pending reconnection waiters for the given installation UUID.
     ///
     /// This removes the waiters from `pending_reconnections` and sends the result to each.
@@ -2065,9 +2120,21 @@ impl TemplatableMCPServerManager {
         self.active_servers
             .iter()
             .find(|(_, server)| server.has_tool(&tool_name))
-            .map(|(installation_uuid, _)| {
+            .map(|(installation_uuid, _)| *installation_uuid)
+            .or_else(|| {
+                // A reconnecting server's tools stay routable; the peer
+                // triggers the reconnect on use.
+                self.known_servers
+                    .iter()
+                    .find(|(uuid, facts)| {
+                        self.is_reconnecting_known_server(uuid)
+                            && facts.tools.iter().any(|tool| tool.name == *tool_name)
+                    })
+                    .map(|(installation_uuid, _)| *installation_uuid)
+            })
+            .map(|installation_uuid| {
                 crate::ai::mcp::reconnecting_peer::ReconnectingPeer::new(
-                    *installation_uuid,
+                    installation_uuid,
                     spawner.clone(),
                 )
             })
@@ -2082,15 +2149,24 @@ impl TemplatableMCPServerManager {
         tool_name: String,
     ) -> Option<crate::ai::mcp::reconnecting_peer::ReconnectingPeer> {
         let spawner = self.spawner.as_ref()?;
-        let server = self.active_servers.get(&installation_id)?;
-        if server.has_tool(&tool_name) {
-            Some(crate::ai::mcp::reconnecting_peer::ReconnectingPeer::new(
+        let has_tool = match self.active_servers.get(&installation_id) {
+            Some(server) => server.has_tool(&tool_name),
+            None => {
+                // A reconnecting server's tools stay routable; the peer
+                // triggers the reconnect on use.
+                self.is_reconnecting_known_server(&installation_id)
+                    && self
+                        .known_servers
+                        .get(&installation_id)
+                        .is_some_and(|facts| facts.tools.iter().any(|tool| tool.name == *tool_name))
+            }
+        };
+        has_tool.then(|| {
+            crate::ai::mcp::reconnecting_peer::ReconnectingPeer::new(
                 installation_id,
                 spawner.clone(),
-            ))
-        } else {
-            None
-        }
+            )
+        })
     }
 
     fn spawn_file_based_servers(

--- a/app/src/ai/mcp/templatable_manager/native_tests.rs
+++ b/app/src/ai/mcp/templatable_manager/native_tests.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use warp_core::features::FeatureFlag;
 use warpui::{App, ModelHandle};
 
+use super::super::KnownServerFacts;
 use super::{RetainedSpawnConfig, SpawnProvenance};
 use crate::ai::mcp::{
     JsonTemplate, TemplatableMCPServer, TemplatableMCPServerInstallation,
@@ -204,6 +205,117 @@ fn shutdown_clears_retained_config_and_fails_reconnect_waiters() {
             .try_recv()
             .expect("shutdown should notify pending reconnect waiters");
         assert_eq!(waiter_result.unwrap_err(), "Server was shut down");
+    });
+}
+
+fn known_facts(name: &str, tool_names: &[&str]) -> KnownServerFacts {
+    KnownServerFacts {
+        name: name.to_string(),
+        tools: tool_names
+            .iter()
+            .map(|tool| {
+                rmcp::model::Tool::new(
+                    tool.to_string(),
+                    "test tool",
+                    rmcp::model::JsonObject::new(),
+                )
+            })
+            .collect(),
+        resources: Vec::new(),
+    }
+}
+
+#[test]
+fn known_server_facts_keep_tools_visible_during_reconnect_windows() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("cli-server");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, _ctx| {
+            manager
+                .known_servers
+                .insert(uuid, known_facts("cli-server", &["do_thing"]));
+
+            // Not eligible without a retained spawn config (e.g. deleted).
+            assert!(manager.tools_for_server(uuid).is_empty());
+
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                },
+            );
+
+            let tools = manager.tools_for_server(uuid);
+            assert_eq!(tools.len(), 1);
+            assert_eq!(tools[0].name, "do_thing");
+            assert_eq!(manager.tools().count(), 1);
+            assert_eq!(
+                manager.server_from_tool("do_thing".to_string()),
+                Some(&uuid)
+            );
+        });
+    });
+}
+
+#[test]
+fn known_server_facts_are_inert_with_the_flag_disabled() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(false);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("cli-server");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, _ctx| {
+            manager
+                .known_servers
+                .insert(uuid, known_facts("cli-server", &["do_thing"]));
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                },
+            );
+
+            assert!(manager.tools_for_server(uuid).is_empty());
+            assert_eq!(manager.tools().count(), 0);
+            assert_eq!(manager.server_from_tool("do_thing".to_string()), None);
+        });
+    });
+}
+
+#[test]
+fn repeated_reconnect_failures_trip_the_circuit_breaker() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("flaky-server");
+        let uuid = installation.uuid();
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager
+                .known_servers
+                .insert(uuid, known_facts("flaky-server", &[]));
+            manager.record_reconnect_failure(uuid);
+            manager.record_reconnect_failure(uuid);
+
+            let backoff = manager.reconnect_backoff.get(&uuid).expect("backoff entry");
+            assert_eq!(backoff.consecutive_failures, 2);
+            assert!(backoff.blocked_until.expect("blocked") > std::time::Instant::now());
+
+            manager.reconnect_server(uuid, tx, ctx);
+            // Blocked: no reconnection was started.
+            assert!(!manager.pending_reconnections.contains_key(&uuid));
+        });
+
+        let result = rx.try_recv().expect("breaker answers immediately");
+        let err = result.expect_err("breaker refuses the reconnect");
+        assert!(err.contains("flaky-server"), "unexpected error: {err}");
     });
 }
 

--- a/crates/mcp/src/error_classification.rs
+++ b/crates/mcp/src/error_classification.rs
@@ -213,6 +213,89 @@ fn classify_reqwest_error(error: &reqwest::Error) -> McpErrorClass {
     McpErrorClass::Transient
 }
 
+/// Whether a failed operation provably never delivered the request to the
+/// server, making an automatic resend safe even for non-idempotent tools.
+///
+/// Failures where the server may have started executing the request (e.g. a
+/// 5xx after accepting it, or a response timeout) return false.
+pub fn is_safe_to_resend(error: &rmcp::ServiceError) -> bool {
+    match error {
+        // A closed transport fails the send before anything leaves.
+        rmcp::ServiceError::TransportClosed => true,
+        rmcp::ServiceError::TransportSend(dynamic_error) => {
+            let error = &dynamic_error.error;
+            if let Some(error) = error.downcast_ref::<StreamableHttpError<reqwest::Error>>() {
+                return streamable_send_is_undelivered(error);
+            }
+            if let Some(error) = error.downcast_ref::<SseTransportError<reqwest::Error>>() {
+                return sse_send_is_undelivered(error, reqwest_send_is_undelivered);
+            }
+            if let Some(error) =
+                error.downcast_ref::<SseTransportError<SseTransportError<reqwest::Error>>>()
+            {
+                return sse_send_is_undelivered(error, |inner| {
+                    sse_send_is_undelivered(inner, reqwest_send_is_undelivered)
+                });
+            }
+            // Unknown transports (e.g. the stdio child process): a failed
+            // send means the pipe broke before delivery.
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Statuses a server returns without executing the request body.
+fn status_rejected_before_execution(status: u16) -> bool {
+    matches!(status, 401 | 403 | 407 | 408 | 429)
+}
+
+fn streamable_send_is_undelivered(error: &StreamableHttpError<reqwest::Error>) -> bool {
+    match error {
+        StreamableHttpError::AuthRequired(_) | StreamableHttpError::InsufficientScope(_) => true,
+        StreamableHttpError::UnexpectedServerResponse(message) => message
+            .strip_prefix("HTTP ")
+            .and_then(|rest| rest.get(..3))
+            .and_then(|status| status.parse::<u16>().ok())
+            .is_some_and(status_rejected_before_execution),
+        StreamableHttpError::Client(client_error) => reqwest_send_is_undelivered(client_error),
+        StreamableHttpError::Sse(_)
+        | StreamableHttpError::Io(_)
+        | StreamableHttpError::UnexpectedEndOfStream
+        | StreamableHttpError::TransportChannelClosed
+        | StreamableHttpError::SessionExpired => true,
+        _ => false,
+    }
+}
+
+fn sse_send_is_undelivered<E: std::error::Error + Send + Sync + 'static>(
+    error: &SseTransportError<E>,
+    client_is_undelivered: impl FnOnce(&E) -> bool,
+) -> bool {
+    match error {
+        SseTransportError::HttpStatus { status, .. } => {
+            status_rejected_before_execution(status.as_u16())
+        }
+        SseTransportError::Client(client_error) => client_is_undelivered(client_error),
+        // Token sourcing failed before any request was sent.
+        SseTransportError::Auth(_) => true,
+        SseTransportError::Sse(_)
+        | SseTransportError::Io(_)
+        | SseTransportError::UnexpectedEndOfStream => true,
+        SseTransportError::UnexpectedContentType(_)
+        | SseTransportError::InvalidUri(_)
+        | SseTransportError::InvalidUriParts(_) => false,
+    }
+}
+
+fn reqwest_send_is_undelivered(error: &reqwest::Error) -> bool {
+    match error.status() {
+        Some(status) => status_rejected_before_execution(status.as_u16()),
+        // No status: the request never reached the server.
+        None => true,
+    }
+}
+
 #[cfg(test)]
 #[path = "error_classification_tests.rs"]
 mod tests;

--- a/crates/mcp/src/error_classification_tests.rs
+++ b/crates/mcp/src/error_classification_tests.rs
@@ -174,6 +174,45 @@ fn unknown_transport_errors_are_transient() {
 }
 
 #[test]
+fn resend_safety_tracks_whether_the_request_could_have_executed() {
+    // Send-stage failures where nothing was delivered are safe to resend.
+    assert!(is_safe_to_resend(&rmcp::ServiceError::TransportClosed));
+    assert!(is_safe_to_resend(&transport_send_error(Box::new(
+        std::io::Error::other("broken pipe")
+    ))));
+    // Rejections that happen before execution (auth, rate limits) are safe.
+    assert!(is_safe_to_resend(&transport_send_error(Box::new(
+        StreamableHttpError::<reqwest::Error>::UnexpectedServerResponse(
+            "HTTP 401 Unauthorized: expired".to_string().into(),
+        )
+    ))));
+    assert!(is_safe_to_resend(&transport_send_error(Box::new(
+        SseTransportError::<reqwest::Error>::HttpStatus {
+            status: http::StatusCode::TOO_MANY_REQUESTS,
+            body: String::new(),
+            www_authenticate: None,
+        }
+    ))));
+    // A 5xx after the server accepted the request may have executed the tool.
+    assert!(!is_safe_to_resend(&transport_send_error(Box::new(
+        StreamableHttpError::<reqwest::Error>::UnexpectedServerResponse(
+            "HTTP 500 Internal Server Error: boom".to_string().into(),
+        )
+    ))));
+    assert!(!is_safe_to_resend(&transport_send_error(Box::new(
+        SseTransportError::<reqwest::Error>::HttpStatus {
+            status: http::StatusCode::BAD_GATEWAY,
+            body: String::new(),
+            www_authenticate: None,
+        }
+    ))));
+    // A timed-out response means the request was delivered.
+    assert!(!is_safe_to_resend(&rmcp::ServiceError::Timeout {
+        timeout: std::time::Duration::from_secs(1)
+    }));
+}
+
+#[test]
 fn credentials_are_deleted_only_on_unrecoverable_auth_rejections() {
     assert!(should_delete_credentials(&McpSpawnError::AuthRequired {
         www_authenticate: None,


### PR DESCRIPTION
## Problem

- `ReconnectingPeer` retried a failed tool call only on `ServiceError::TransportClosed`. A failed streamable-HTTP POST surfaces as `TransportSend` (the worker keeps running), so the common failure mode was never retried.
- Nothing bounded how often a persistently failing server could be respawned.
- During a reconnect window the server left `active_servers`, so its tools vanished: tool calls failed with `"MCP server for tool not found"` and the UI tool list flickered empty.

## Changes

- **Broadened retry** (flag-gated by `McpSelfHeal`): a failed call retries once after reconnect when the error classifies as `Transient` or `AuthExpiredRecoverable` **and** `is_safe_to_resend` proves the request never executed. Resend safety is deliberately conservative: pre-execution rejections (401/403/408/429), connection failures, and broken pipes retry; 5xx-after-accept and response timeouts never do, so non-idempotent tools can't double-run.
- **Per-server circuit breaker**: repeated reconnect failures back off with the shared jittered-exponential schedule (500ms → ~32s cap); while blocked, reconnect requests fail fast with an actionable message naming the server. Cleared on the next successful connection.
- **`known_servers` index**: tools/resources of every successfully connected server stay cached, so during reconnect windows (server retained in `spawn_configs` but not active) the peer factories, `tools()`/`resources()` views, `tool_input_schema`, and `server_from_tool/resource` keep working — the reconnect is triggered on use.

## Tests

Retry-decision tests (retry on re-mintable expiry, never on 5xx/timeout/user-fixable auth, flag-off = old behavior), breaker bookkeeping and fail-fast, known-server visibility lifecycle and flag-off inertness, plus new `is_safe_to_resend` coverage in `cargo test -p mcp`.