### PR TITLE
mcp: re-mint expired managed proxy tokens on demand instead of failing or misrouting to OAuth

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -190,6 +190,11 @@ const TASK_STATUS_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 /// capacity period), while staying well under the ~35s a run had before it was marked
 /// FAILED in that incident.
 const MANAGED_MCP_RESOLVE_MAX_ATTEMPTS: usize = 6;
+/// Attempt budget for re-minting one managed MCP server's client config
+/// mid-run, when its proxy session expired and a reconnect needs a fresh
+/// token. Unlike run-startup resolution this sits on the tool-call latency
+/// path, so the budget is small; a hard failure surfaces as a tool error.
+const MANAGED_MCP_REMINT_MAX_ATTEMPTS: usize = 3;
 /// Timeout for individual harness auth preflight commands.
 const PREFLIGHT_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const WARP_DRIVE_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
@@ -861,6 +866,10 @@ register_error!(AgentDriverError);
 struct ResolvedMcpSpecs {
     local_uuids: Vec<Uuid>,
     ephemeral_installations: Vec<TemplatableMCPServerInstallation>,
+    /// For entries of `ephemeral_installations` resolved via
+    /// `createManagedMcpClientConfig`: the `uid` to re-mint the short-lived
+    /// proxy config with, keyed by installation UUID.
+    managed_uids: HashMap<Uuid, String>,
 }
 
 impl From<warpui::ModelDropped> for AgentDriverError {
@@ -1707,6 +1716,11 @@ impl AgentDriver {
                             message: err.to_string(),
                         }
                     })?;
+                    for installation in &installations {
+                        resolved
+                            .managed_uids
+                            .insert(installation.uuid(), uuid.to_string());
+                    }
                     resolved.ephemeral_installations.extend(installations);
                 }
                 MCPSpec::WellKnown(id) => {
@@ -1746,6 +1760,11 @@ impl AgentDriver {
                         id,
                     ) {
                         Ok(installations) => {
+                            for installation in &installations {
+                                resolved
+                                    .managed_uids
+                                    .insert(installation.uuid(), id.clone());
+                            }
                             resolved.ephemeral_installations.extend(installations);
                         }
                         Err(err) => {
@@ -2183,6 +2202,7 @@ impl AgentDriver {
     fn start_ephemeral_mcp_servers(
         &self,
         mut installations: Vec<TemplatableMCPServerInstallation>,
+        managed_uids: HashMap<Uuid, String>,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = Result<(), AgentDriverError>> + use<> {
         if installations.is_empty() {
@@ -2207,15 +2227,95 @@ impl AgentDriver {
             .collect();
         let wait = self.wait_for_mcp_servers_started(named_servers, ctx);
 
-        // Spawn the ephemeral servers.
+        // Spawn the ephemeral servers. Managed ones get a refresher so a
+        // reconnect can re-mint their short-lived proxy config.
+        let task_id = self.task_id;
+        let secrets = self.secrets.clone();
         let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
         templatable_mcp_manager.update(ctx, move |manager, ctx| {
+            let self_heal = FeatureFlag::McpSelfHeal.is_enabled();
+            let managed_mcp_client =
+                self_heal.then(|| ServerApiProvider::as_ref(ctx).get_managed_mcp_client());
             for installation in installations {
-                manager.spawn_cli_ephemeral_server(installation, ctx);
+                match (
+                    &managed_mcp_client,
+                    managed_uids.get(&installation.uuid()).cloned(),
+                ) {
+                    (Some(managed_mcp_client), Some(managed_uid)) => {
+                        let refresher = Self::managed_installation_refresher(
+                            managed_uid.clone(),
+                            managed_mcp_client.clone(),
+                            task_id,
+                            secrets.clone(),
+                        );
+                        manager.spawn_managed_ephemeral_server(
+                            installation,
+                            crate::ai::mcp::templatable_manager::ManagedProvenance { managed_uid },
+                            refresher,
+                            ctx,
+                        );
+                    }
+                    _ => manager.spawn_cli_ephemeral_server(installation, ctx),
+                }
             }
         });
 
         Either::Left(wait)
+    }
+
+    /// Builds the refresher a managed ephemeral server uses to re-mint its
+    /// proxy config before a respawn. Re-minting is overlap-safe (proxy
+    /// sessions are stateless server-side; the old token stays valid until
+    /// its expiry), and the retry budget is small because this runs on the
+    /// tool-call latency path.
+    fn managed_installation_refresher(
+        managed_uid: String,
+        managed_mcp_client: Arc<dyn ManagedMcpClient>,
+        task_id: Option<AmbientAgentTaskId>,
+        secrets: Arc<HashMap<String, ManagedSecretValue>>,
+    ) -> crate::ai::mcp::templatable_manager::InstallationRefresher {
+        Arc::new(move |stale: TemplatableMCPServerInstallation| {
+            let managed_uid = managed_uid.clone();
+            let managed_mcp_client = managed_mcp_client.clone();
+            let secrets = secrets.clone();
+            Box::pin(async move {
+                let client_config = with_bounded_retry_using(
+                    &format!("re-mint managed MCP config '{managed_uid}'"),
+                    MANAGED_MCP_REMINT_MAX_ATTEMPTS,
+                    is_transient_graphql_or_http_error,
+                    || managed_mcp_client.create_managed_mcp_client_config(managed_uid.clone()),
+                )
+                .await
+                .map_err(|err| format!("{err:#}"))?;
+
+                let server_name = stale.templatable_mcp_server().name.clone();
+                let fresh = Self::installations_from_managed_client_config_json(
+                    &client_config.mcp_config_json,
+                    task_id,
+                    &managed_uid,
+                )
+                .map_err(|err| err.to_string())?
+                .into_iter()
+                .find(|candidate| candidate.templatable_mcp_server().name == server_name)
+                .ok_or_else(|| {
+                    format!("server '{server_name}' missing from re-minted managed MCP config")
+                })?;
+
+                // Preserve the stale instance's identities: the installation
+                // UUID keys all manager state (and is random for local runs,
+                // so re-parsing yields a different one), and the template
+                // UUID keys the log file.
+                let mut fresh_server = fresh.templatable_mcp_server().clone();
+                fresh_server.uuid = stale.template_uuid();
+                let mut rebuilt = TemplatableMCPServerInstallation::new(
+                    stale.uuid(),
+                    fresh_server,
+                    fresh.variable_values().clone(),
+                );
+                rebuilt.apply_secrets(&secrets);
+                Ok(rebuilt)
+            })
+        })
     }
 
     /// Subscribe to [`FileBasedMCPManagerEvent::CloudEnvMcpScanComplete`]
@@ -2807,6 +2907,7 @@ impl AgentDriver {
                             .await?;
                     let existing_uuids = resolved_mcp_specs.local_uuids;
                     let mut ephemeral_installations = resolved_mcp_specs.ephemeral_installations;
+                    let managed_uids = resolved_mcp_specs.managed_uids;
 
                     // Attach the built-in Factory MCP server. Interactive
                     // clients attach built-ins via
@@ -2883,7 +2984,11 @@ impl AgentDriver {
                     if !ephemeral_installations.is_empty() {
                         let result = foreground
                             .spawn(move |me, ctx| {
-                                me.start_ephemeral_mcp_servers(ephemeral_installations, ctx)
+                                me.start_ephemeral_mcp_servers(
+                                    ephemeral_installations,
+                                    managed_uids,
+                                    ctx,
+                                )
                             })
                             .await?
                             .await;

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -241,6 +241,111 @@ fn well_known_spec_resolves_via_managed_client() {
 }
 
 #[test]
+fn managed_resolution_records_managed_uids_for_remint() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
+    let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let uuid_json = r#"{"mcpServers":{"GitHub MCP":{"command":"npx"}}}"#;
+    let linear_json = r#"{"mcpServers":{"linear":{"url":"https://app.warp.dev/mcp/integration-proxy/linear","headers":{"Authorization":"Bearer tok"}}}}"#;
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(2)
+        .returning(move |requested_uid| {
+            Ok(managed_client_config_output(if requested_uid == "linear" {
+                linear_json
+            } else {
+                uuid_json
+            }))
+        });
+
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[
+            MCPSpec::Uuid(uuid),
+            MCPSpec::WellKnown("linear".to_string()),
+        ],
+        &HashSet::new(),
+        Arc::new(mock),
+        None,
+    ))
+    .unwrap();
+
+    assert_eq!(resolved.ephemeral_installations.len(), 2);
+    for installation in &resolved.ephemeral_installations {
+        let expected_uid = if installation.templatable_mcp_server().name == "linear" {
+            "linear".to_string()
+        } else {
+            uuid.to_string()
+        };
+        assert_eq!(
+            resolved.managed_uids.get(&installation.uuid()),
+            Some(&expected_uid)
+        );
+    }
+}
+
+#[test]
+fn managed_refresher_preserves_identity_and_swaps_token() {
+    let old_json = r#"{"mcpServers":{"linear":{"url":"https://app.warp.dev/mcp/proxy/abc","headers":{"Authorization":"Bearer old-token"}}}}"#;
+    let new_json = r#"{"mcpServers":{"linear":{"url":"https://app.warp.dev/mcp/proxy/abc","headers":{"Authorization":"Bearer new-token"}}}}"#;
+    let stale =
+        AgentDriver::installations_from_managed_client_config_json(old_json, None, "linear")
+            .unwrap()
+            .pop()
+            .unwrap();
+
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(1)
+        .returning(move |requested_uid| {
+            assert_eq!(requested_uid, "linear");
+            Ok(managed_client_config_output(new_json))
+        });
+
+    let refresher = AgentDriver::managed_installation_refresher(
+        "linear".to_string(),
+        Arc::new(mock),
+        None,
+        Arc::new(HashMap::new()),
+    );
+    let fresh = block_on(refresher(stale.clone())).unwrap();
+
+    // Identities that key manager state and log files survive the re-mint...
+    assert_eq!(fresh.uuid(), stale.uuid());
+    assert_eq!(fresh.template_uuid(), stale.template_uuid());
+    // ...while the rendered config carries the fresh proxy token.
+    let rendered = render_installations(vec![fresh], HashMap::new());
+    let server = serde_json::to_value(&rendered["linear"]).unwrap();
+    assert_eq!(
+        server["headers"]["Authorization"].as_str().unwrap(),
+        "Bearer new-token"
+    );
+}
+
+#[test]
+fn managed_refresher_errors_when_server_name_disappears() {
+    let old_json = r#"{"mcpServers":{"linear":{"url":"https://app.warp.dev/mcp/proxy/abc","headers":{"Authorization":"Bearer old-token"}}}}"#;
+    let renamed_json = r#"{"mcpServers":{"other":{"url":"https://app.warp.dev/mcp/proxy/abc","headers":{"Authorization":"Bearer new-token"}}}}"#;
+    let stale =
+        AgentDriver::installations_from_managed_client_config_json(old_json, None, "linear")
+            .unwrap()
+            .pop()
+            .unwrap();
+
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(1)
+        .returning(move |_| Ok(managed_client_config_output(renamed_json)));
+
+    let refresher = AgentDriver::managed_installation_refresher(
+        "linear".to_string(),
+        Arc::new(mock),
+        None,
+        Arc::new(HashMap::new()),
+    );
+    let error = block_on(refresher(stale)).unwrap_err();
+    assert!(error.contains("missing from re-minted"), "got: {error}");
+}
+
+#[test]
 fn well_known_resolution_failure_skips_server() {
     let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let mut mock = MockManagedMcpClient::new();

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -18,6 +18,8 @@ pub use native::McpIntegration;
 #[cfg(not(target_family = "wasm"))]
 use native::RetainedSpawnConfig;
 #[cfg(not(target_family = "wasm"))]
+pub(crate) use native::{InstallationRefresher, ManagedProvenance};
+#[cfg(not(target_family = "wasm"))]
 use parking_lot::Mutex;
 #[cfg(not(target_family = "wasm"))]
 use simple_logger::SimpleLogger;

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -75,7 +75,7 @@ enum SpawnMode {
 
 /// How a spawned server's installation was obtained; used to pick the right
 /// source of truth when respawning during reconnect.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum SpawnProvenance {
     /// Installed by the user and persisted in SQLite (`locally_installed_servers`).
     LocallyInstalled,
@@ -83,10 +83,35 @@ pub(crate) enum SpawnProvenance {
     FileBased,
     /// Started ephemerally by a CLI agent run (`oz agent run --mcp`).
     CliEphemeral,
+    /// Resolved from a backend-managed MCP configuration
+    /// (`createManagedMcpClientConfig`), proxied through warp-server.
+    Managed(ManagedProvenance),
     /// Built-in Warp-hosted server (the Factory MCP), authenticated with the
     /// logged-in user's session credentials.
     Builtin,
 }
+
+/// How a backend-managed installation was resolved, so its short-lived proxy
+/// config can be re-minted.
+#[derive(Clone, Debug)]
+pub(crate) struct ManagedProvenance {
+    /// The `uid` passed to `createManagedMcpClientConfig`: a managed MCP
+    /// server UUID or a well-known integration id (e.g. "linear").
+    pub(crate) managed_uid: String,
+}
+
+/// Produces a fresh installation to respawn with, e.g. by re-minting a
+/// managed server's proxy config. Takes the stale installation (for identity
+/// and naming) and returns the replacement, or a user-facing error message.
+pub(crate) type InstallationRefresher = std::sync::Arc<
+    dyn Fn(
+            TemplatableMCPServerInstallation,
+        ) -> futures_util::future::BoxFuture<
+            'static,
+            Result<TemplatableMCPServerInstallation, String>,
+        > + Send
+        + Sync,
+>;
 
 /// The exact installation a server instance was spawned with, retained so a
 /// reconnect can respawn servers whose configs exist nowhere else (ephemeral
@@ -95,6 +120,9 @@ pub(crate) enum SpawnProvenance {
 pub(crate) struct RetainedSpawnConfig {
     pub(crate) installation: TemplatableMCPServerInstallation,
     pub(crate) provenance: SpawnProvenance,
+    /// Refreshes the installation before a respawn (managed servers re-mint
+    /// their proxy token). `None` for servers whose config never goes stale.
+    pub(crate) refresher: Option<InstallationRefresher>,
 }
 
 impl SpawnMode {
@@ -808,6 +836,30 @@ impl TemplatableMCPServerManager {
         );
     }
 
+    /// Spawns an ephemeral, backend-managed MCP server resolved via
+    /// `createManagedMcpClientConfig`. The `refresher` re-mints the server's
+    /// short-lived proxy config; reconnects invoke it before respawning so an
+    /// expired proxy token heals without user interaction.
+    pub(crate) fn spawn_managed_ephemeral_server(
+        &mut self,
+        installation: TemplatableMCPServerInstallation,
+        provenance: ManagedProvenance,
+        refresher: InstallationRefresher,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let installation_uuid = installation.uuid();
+        // Managed ephemerals are CLI-run-scoped, like the plain CLI path.
+        self.cli_spawned_server_uuids.insert(installation_uuid);
+        self.spawn_ephemeral_server_with_provenance(
+            installation,
+            SpawnProvenance::Managed(provenance),
+            ctx,
+        );
+        if let Some(config) = self.spawn_configs.get_mut(&installation_uuid) {
+            config.refresher = Some(refresher);
+        }
+    }
+
     /// Reconciles built-in Warp-hosted MCP servers (currently the Factory
     /// MCP) with the feature-flag and auth state: spawns the server when it
     /// should be running and isn't, and shuts it down when it shouldn't be.
@@ -928,12 +980,18 @@ impl TemplatableMCPServerManager {
 
         // Retain the exact installation this instance is spawned with so a
         // later reconnect can respawn it even when the config exists nowhere
-        // else (see `respawnable_config`).
+        // else (see `respawnable_config`). Preserve any refresher installed
+        // by `spawn_managed_ephemeral_server` across respawns.
+        let refresher = self
+            .spawn_configs
+            .get(&installation_uuid)
+            .and_then(|config| config.refresher.clone());
         self.spawn_configs.insert(
             installation_uuid,
             RetainedSpawnConfig {
                 installation: installation.clone(),
                 provenance,
+                refresher,
             },
         );
 
@@ -2012,6 +2070,45 @@ impl TemplatableMCPServerManager {
             }
         };
 
+        // Managed servers re-mint their short-lived proxy config before
+        // respawning: the retained Authorization header may have expired.
+        if FeatureFlag::McpSelfHeal.is_enabled()
+            && let Some(refresher) = self
+                .spawn_configs
+                .get(&installation_uuid)
+                .and_then(|config| config.refresher.clone())
+        {
+            if let SpawnProvenance::Managed(managed) = &provenance {
+                log::info!(
+                    "Re-minting managed MCP config '{}' before reconnecting {installation_uuid}",
+                    managed.managed_uid
+                );
+            }
+            ctx.spawn(
+                refresher(installation).compat(),
+                move |me, result: Result<TemplatableMCPServerInstallation, String>, ctx| {
+                    match result {
+                        Ok(fresh) => {
+                            me.spawn_server_impl(fresh, provenance, SpawnMode::Reconnect, ctx)
+                        }
+                        Err(message) => {
+                            log::warn!(
+                                "Failed to refresh managed MCP config for {installation_uuid}: {message}"
+                            );
+                            me.change_server_state(
+                                installation_uuid,
+                                MCPServerState::FailedToStart,
+                                ctx,
+                            );
+                            me.record_reconnect_failure(installation_uuid);
+                            me.notify_reconnect_waiters(installation_uuid, Err(message));
+                        }
+                    }
+                },
+            );
+            return;
+        }
+
         self.spawn_server_impl(installation, provenance, SpawnMode::Reconnect, ctx);
     }
 
@@ -2045,7 +2142,7 @@ impl TemplatableMCPServerManager {
                 .ok_or_else(|| "Installation not found".to_string());
         };
 
-        let provenance = retained.provenance;
+        let provenance = retained.provenance.clone();
         let retained_installation = retained.installation.clone();
         match provenance {
             SpawnProvenance::LocallyInstalled => Ok((

--- a/app/src/ai/mcp/templatable_manager/native_tests.rs
+++ b/app/src/ai/mcp/templatable_manager/native_tests.rs
@@ -61,6 +61,7 @@ fn respawnable_config_returns_retained_config_for_ephemeral_servers() {
                 RetainedSpawnConfig {
                     installation: installation.clone(),
                     provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
                 },
             );
 
@@ -89,6 +90,7 @@ fn respawnable_config_requires_local_install_when_flag_disabled() {
                 RetainedSpawnConfig {
                     installation: ephemeral.clone(),
                     provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
                 },
             );
             manager
@@ -133,6 +135,7 @@ fn respawnable_config_prefers_live_locally_installed_config() {
                 RetainedSpawnConfig {
                     installation: stale.clone(),
                     provenance: SpawnProvenance::LocallyInstalled,
+                    refresher: None,
                 },
             );
             manager
@@ -189,6 +192,7 @@ fn shutdown_clears_retained_config_and_fails_reconnect_waiters() {
                 RetainedSpawnConfig {
                     installation: installation.clone(),
                     provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
                 },
             );
             manager.pending_reconnections.insert(uuid, vec![tx]);
@@ -246,6 +250,7 @@ fn known_server_facts_keep_tools_visible_during_reconnect_windows() {
                 RetainedSpawnConfig {
                     installation: installation.clone(),
                     provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
                 },
             );
 
@@ -278,6 +283,7 @@ fn known_server_facts_are_inert_with_the_flag_disabled() {
                 RetainedSpawnConfig {
                     installation: installation.clone(),
                     provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
                 },
             );
 
@@ -334,6 +340,7 @@ fn builtin_reconnect_without_credentials_fails() {
                 RetainedSpawnConfig {
                     installation: installation.clone(),
                     provenance: SpawnProvenance::Builtin,
+                    refresher: None,
                 },
             );
 

--- a/crates/mcp/src/runtime.rs
+++ b/crates/mcp/src/runtime.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use warp_errors::report_error;
 
 use super::TemplatableMCPServerInfo;
-use crate::error_classification::ProxyAuthReason;
+use crate::error_classification::{ProxyAuthReason, parse_www_authenticate_reason};
 
 type ReqwestHttpTransport = rmcp::transport::StreamableHttpClientTransport<reqwest::Client>;
 type ReqwestSseTransport = crate::sse_transport::SseClientTransport<reqwest::Client>;
@@ -419,13 +419,29 @@ async fn determine_transport(
         ))
         .into()
     }
-    match send_initialize_request(url, headers, None).await? {
+    let probe = send_initialize_request(url, headers, None).await?;
+    match probe.status {
         StatusCode::OK => Ok(Transport::Http(None)),
         StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED => Ok(Transport::Sse(None)),
         StatusCode::UNAUTHORIZED => {
+            // An expired/stale Warp proxy session is not an OAuth problem:
+            // routing it into the interactive OAuth flow would show a
+            // misleading "authenticate this server" prompt. Surface it as a
+            // re-mintable auth failure instead.
+            if let Some(reason) = probe
+                .www_authenticate
+                .as_deref()
+                .and_then(parse_www_authenticate_reason)
+            {
+                return Err(McpSpawnError::AuthRequired {
+                    www_authenticate: probe.www_authenticate,
+                    reason: Some(reason),
+                    message: "The Warp proxy session for this MCP server has expired.".to_string(),
+                });
+            }
             let Some(mut auth_context) = auth_context else {
                 return Err(McpSpawnError::AuthRequired {
-                    www_authenticate: None,
+                    www_authenticate: probe.www_authenticate,
                     reason: None,
                     message: "Server requires authentication, which is not yet supported."
                         .to_string(),
@@ -458,7 +474,10 @@ async fn determine_transport(
                 }
             };
 
-            match send_initialize_request(url, headers, Some(&client)).await? {
+            match send_initialize_request(url, headers, Some(&client))
+                .await?
+                .status
+            {
                 StatusCode::OK => {
                     emit_authenticated_notification().await;
                     Ok(Transport::Http(Some(client)))
@@ -474,13 +493,22 @@ async fn determine_transport(
     }
 }
 
-/// Sends an InitializeRequest to the server, and returns the HTTP status code from the response.
+/// The observable outcome of a preflight InitializeRequest.
+struct InitializeProbe {
+    status: reqwest::StatusCode,
+    /// The `WWW-Authenticate` challenge on a 401, used to distinguish a
+    /// re-mintable Warp proxy-session expiry from a real OAuth requirement.
+    www_authenticate: Option<String>,
+}
+
+/// Sends an InitializeRequest to the server, and returns the HTTP status code
+/// (plus auth challenge, if any) from the response.
 #[allow(clippy::result_large_err)]
 async fn send_initialize_request(
     url: &str,
     headers: &HashMap<String, String>,
     auth_client: Option<&rmcp::transport::auth::AuthClient<reqwest::Client>>,
-) -> Result<reqwest::StatusCode, rmcp::RmcpError> {
+) -> Result<InitializeProbe, rmcp::RmcpError> {
     use rmcp::transport::common::http_header::{EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE};
 
     let request = rmcp::model::InitializeRequest::new(make_client_info());
@@ -510,7 +538,14 @@ async fn send_initialize_request(
         .await
         .map_err(rmcp::RmcpError::transport_creation::<ReqwestHttpTransport>)?;
 
-    Ok(response.status())
+    Ok(InitializeProbe {
+        status: response.status(),
+        www_authenticate: response
+            .headers()
+            .get(http::header::WWW_AUTHENTICATE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned),
+    })
 }
 
 /// Creates a [`ClientInfo`] for the MCP client.

--- a/crates/mcp/src/runtime_tests.rs
+++ b/crates/mcp/src/runtime_tests.rs
@@ -279,3 +279,94 @@ async fn query_resources_for_calls_list_function_exactly_once() {
 
     assert_eq!(calls.load(Ordering::SeqCst), 1);
 }
+
+mod determine_transport_tests {
+    use std::collections::HashMap;
+
+    use axum::Router;
+    use axum::routing::post;
+
+    use crate::error_classification::ProxyAuthReason;
+    use crate::runtime::McpSpawnError;
+
+    const EXPIRED_CHALLENGE: &str =
+        r#"Bearer error="invalid_token", error_description="proxy_token_expired""#;
+
+    async fn serve_status(
+        status: axum::http::StatusCode,
+        www_authenticate: Option<&'static str>,
+    ) -> String {
+        let handler = move || async move {
+            let mut response =
+                axum::response::Response::new(axum::body::Body::from(r#"{"error":"denied"}"#));
+            *response.status_mut() = status;
+            if let Some(challenge) = www_authenticate {
+                response.headers_mut().insert(
+                    axum::http::header::WWW_AUTHENTICATE,
+                    axum::http::HeaderValue::from_static(challenge),
+                );
+            }
+            response
+        };
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, Router::new().route("/mcp", post(handler))).await;
+        });
+        format!("http://{addr}/mcp")
+    }
+
+    #[tokio::test]
+    async fn expired_proxy_challenge_short_circuits_oauth() {
+        let url = serve_status(
+            axum::http::StatusCode::UNAUTHORIZED,
+            Some(EXPIRED_CHALLENGE),
+        )
+        .await;
+
+        let error = super::super::determine_transport(
+            "test-server".to_string(),
+            &url,
+            &HashMap::new(),
+            None,
+        )
+        .await
+        .map(|_| ())
+        .expect_err("expired proxy session should error");
+
+        match error {
+            McpSpawnError::AuthRequired {
+                reason,
+                www_authenticate,
+                message,
+            } => {
+                assert_eq!(reason, Some(ProxyAuthReason::ProxyTokenExpired));
+                assert_eq!(www_authenticate.as_deref(), Some(EXPIRED_CHALLENGE));
+                assert!(message.contains("proxy session"), "got: {message}");
+            }
+            other => panic!("expected AuthRequired, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bare_401_without_auth_context_requires_user() {
+        let url = serve_status(axum::http::StatusCode::UNAUTHORIZED, None).await;
+
+        let error = super::super::determine_transport(
+            "test-server".to_string(),
+            &url,
+            &HashMap::new(),
+            None,
+        )
+        .await
+        .map(|_| ())
+        .expect_err("401 without auth context should error");
+
+        match error {
+            McpSpawnError::AuthRequired { reason, .. } => assert_eq!(reason, None),
+            other => panic!("expected AuthRequired, got: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Managed (backend-proxied) MCP servers authenticate with a short-lived proxy session token minted once per run via `createManagedMcpClientConfig`. Six of the mutation's eight response fields were dead code; nothing retained the managed `uid`. When the token expired (external sessions: 3h), every tool call failed for the rest of the run — the explicit v1 deferral in `specs/managed-mcp-cli-resolution/TECH.md`. Worse, an expired token at spawn time routed into the interactive OAuth flow with a misleading "Please authenticate this server in the Warp desktop app" message.

## Changes

- Resolution now records each managed installation's `uid` (`ResolvedMcpSpecs.managed_uids`).
- Managed ephemerals spawn via `spawn_managed_ephemeral_server` carrying an `InstallationRefresher`: a closure that re-mints the client config (bounded retry — it sits on the tool-call latency path), re-parses it, and rebuilds the installation **preserving the installation UUID** (random for local runs, keys all manager state) **and template UUID** (keys the log file), then re-applies secrets.
- `reconnect_server` invokes the refresher before respawning a managed server, so the end-to-end reactive path is: mid-run 401 `proxy_token_expired` → classified recoverable (prev PR) → retry via reconnect → re-mint → respawn with the fresh header → tool call succeeds, nothing surfaced to the user. Overlap-safe: proxy sessions are stateless JWTs server-side; the old token stays valid until its expiry.
- Startup-401 misroute fix: the preflight now captures `WWW-Authenticate`, and a proxy re-mint reason returns a typed `AuthRequired { reason: Some(..) }` instead of entering the OAuth flow (no credential deletion either, per the guard in the classification PR).

Flag-gated by `McpSelfHeal`. Not covered (by design): third-party harnesses receive rendered JSON config and own their MCP connections; and an *initial* spawn hitting `AuthRequired` does not auto-re-mint — resolution happens seconds before spawn, so a token expired at that point indicates clock skew rather than age.

## Tests

`MockManagedMcpClient` tests: refresher preserves identities and swaps only the Authorization value (asserted via rendered config), errors cleanly when the server disappears from the re-minted config, resolution records uids for both UUID and well-known specs; axum test asserts the preflight returns `AuthRequired{Some(ProxyTokenExpired)}` instead of the OAuth path.