### PR TITLE
mcp: detect dead transports, add Reconnecting state, background reconnect

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2040,6 +2040,7 @@ impl AgentDriver {
                 MCPServerState::NotRunning
                 | MCPServerState::Starting
                 | MCPServerState::Authenticating
+                | MCPServerState::Reconnecting
                 | MCPServerState::ShuttingDown => return,
             }
             if pending_servers.is_empty() {

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -69,6 +69,12 @@ pub struct TemplatableMCPServerManager {
     /// respawned in a tight loop.
     #[cfg(not(target_family = "wasm"))]
     reconnect_backoff: HashMap<Uuid, ReconnectBackoff>,
+    /// Monotonic spawn generation per installation UUID. Spawn completion
+    /// callbacks and transport monitors capture their generation and no-op
+    /// when superseded, so a stale instance can never clobber the state of
+    /// a newer one.
+    #[cfg(not(target_family = "wasm"))]
+    spawn_generation: HashMap<Uuid, u64>,
 
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
     spawned_servers: HashMap<Uuid, SpawnedServerInfo>,

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -454,6 +454,7 @@ impl TemplatableMCPServerManager {
             spawn_configs: Default::default(),
             known_servers: Default::default(),
             reconnect_backoff: Default::default(),
+            spawn_generation: Default::default(),
             spawned_servers: Default::default(),
             server_credentials: Default::default(),
             file_based_server_credentials: Default::default(),
@@ -994,6 +995,11 @@ impl TemplatableMCPServerManager {
                 refresher,
             },
         );
+        let generation = {
+            let entry = self.spawn_generation.entry(installation_uuid).or_insert(0);
+            *entry += 1;
+            *entry
+        };
 
         let resolved_json = resolve_json(&installation);
         let template_uuid = installation.template_uuid();
@@ -1265,6 +1271,12 @@ impl TemplatableMCPServerManager {
             )
             .compat(),
             move |me, server_info: Result<_, mcp::runtime::McpSpawnError>, ctx| {
+                if me.spawn_generation.get(&installation_uuid).copied() != Some(generation) {
+                    log::debug!(
+                        "Ignoring stale spawn completion for {installation_uuid} (superseded)"
+                    );
+                    return;
+                }
                 me.spawned_servers.remove(&installation_uuid);
                 me.pending_oauth_csrf.retain(|_, v| *v != installation_uuid);
                 me.authorization_urls.remove(&installation_uuid);
@@ -1283,6 +1295,24 @@ impl TemplatableMCPServerManager {
                             },
                         );
                         me.reconnect_backoff.remove(&installation_uuid);
+
+                        // Watch for the transport dying so a dead server does
+                        // not keep showing Running with stale tools until the
+                        // next tool call happens to notice.
+                        let mut transport_closed = info.transport_closed();
+                        ctx.spawn(
+                            async move {
+                                while !*transport_closed.borrow() {
+                                    if transport_closed.changed().await.is_err() {
+                                        break;
+                                    }
+                                }
+                            },
+                            move |me, _, ctx| {
+                                me.handle_transport_closed(installation_uuid, generation, ctx);
+                            },
+                        );
+
                         me.active_servers.insert(installation_uuid, info);
 
                         // Clear any previous error message on successful connection.
@@ -1324,6 +1354,13 @@ impl TemplatableMCPServerManager {
                         // user out of the server.
                         if should_delete_credentials(&e) {
                             me.delete_credentials_from_secure_storage(installation_uuid, ctx);
+                        }
+
+                        // The built-in server's token is recorded optimistically
+                        // before the spawn resolves; forget it on failure so the
+                        // next auth event retries even with an unchanged token.
+                        if me.builtin_server_uuids.contains(&installation_uuid) {
+                            me.builtin_server_token = None;
                         }
 
                         if is_reconnect {
@@ -2065,6 +2102,11 @@ impl TemplatableMCPServerManager {
         let (installation, provenance) = match self.respawnable_config(installation_uuid, ctx) {
             Ok(found) => found,
             Err(message) => {
+                // Surface the failure instead of leaving a stale state (the
+                // background monitor may have just set `Reconnecting`).
+                self.server_error_messages
+                    .insert(installation_uuid, message.clone());
+                self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
                 self.notify_reconnect_waiters(installation_uuid, Err(message));
                 return;
             }
@@ -2220,6 +2262,81 @@ impl TemplatableMCPServerManager {
         self.authorization_urls.remove(&installation_uuid);
 
         self.spawn_server_impl(installation, provenance, SpawnMode::Reconnect, ctx);
+    }
+
+    /// Reacts to a spawned server's transport dying: flips the server into
+    /// `Reconnecting` and starts a background reconnect, unless the instance
+    /// was superseded, explicitly stopped, already reconnecting, backing
+    /// off after repeated failures, or would require interactive login.
+    fn handle_transport_closed(
+        &mut self,
+        installation_uuid: Uuid,
+        generation: u64,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.spawn_generation.get(&installation_uuid).copied() != Some(generation) {
+            return;
+        }
+        if !FeatureFlag::McpSelfHeal.is_enabled() {
+            // Pre-self-heal behavior: dead transports are only discovered
+            // lazily by the next tool call.
+            return;
+        }
+        if !self.spawn_configs.contains_key(&installation_uuid) {
+            // Explicitly stopped or deleted; the close was expected.
+            return;
+        }
+        if self.pending_reconnections.contains_key(&installation_uuid) {
+            return;
+        }
+        if let Some(backoff) = self.reconnect_backoff.get(&installation_uuid)
+            && let Some(blocked_until) = backoff.blocked_until
+            && instant::Instant::now() < blocked_until
+        {
+            // Repeated failures: give up on background retries and surface
+            // the failure; a later tool call can still retry lazily.
+            self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
+            return;
+        }
+        // Don't background-reconnect a server that would pop an interactive
+        // login (OAuth transport with no cached credentials and no managed
+        // refresher); surface the failure instead.
+        let needs_interactive_auth = self
+            .active_servers
+            .get(&installation_uuid)
+            .is_some_and(TemplatableMCPServerInfo::is_authenticated_transport)
+            && !self.has_cached_oauth_credentials(installation_uuid, ctx)
+            && self
+                .spawn_configs
+                .get(&installation_uuid)
+                .is_none_or(|config| config.refresher.is_none());
+        if needs_interactive_auth {
+            self.server_error_messages.insert(
+                installation_uuid,
+                "Connection lost; the server requires re-authentication".to_string(),
+            );
+            self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
+            return;
+        }
+
+        log::info!("MCP server {installation_uuid} transport closed; reconnecting");
+        self.change_server_state(installation_uuid, MCPServerState::Reconnecting, ctx);
+        let (result_tx, _result_rx) = tokio::sync::oneshot::channel();
+        self.reconnect_server(installation_uuid, result_tx, ctx);
+    }
+
+    /// Whether OAuth credentials for this server are cached (so a respawn
+    /// can authenticate without interactive login).
+    fn has_cached_oauth_credentials(
+        &self,
+        installation_uuid: Uuid,
+        app: &warpui::AppContext,
+    ) -> bool {
+        if let Some(hash) = FileBasedMCPManager::as_ref(app).get_hash_by_uuid(installation_uuid) {
+            return self.file_based_server_credentials.contains_key(&hash);
+        }
+        self.get_template_uuid(installation_uuid)
+            .is_some_and(|uuid| self.server_credentials.contains_key(&uuid))
     }
 
     /// Records a failed reconnect attempt and blocks further attempts for a

--- a/app/src/ai/mcp/templatable_manager/native_tests.rs
+++ b/app/src/ai/mcp/templatable_manager/native_tests.rs
@@ -351,3 +351,131 @@ fn builtin_reconnect_without_credentials_fails() {
         });
     });
 }
+
+#[test]
+fn transport_closed_reconnects_and_surfaces_lookup_failures() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| AuthStateProvider::new_logged_out_for_test());
+        let manager = setup_app(&mut app);
+        let installation = test_installation("warp-factory");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::Builtin,
+                    refresher: None,
+                },
+            );
+            manager.spawn_generation.insert(uuid, 1);
+
+            // The builtin lookup fails without credentials, so the reconnect
+            // started by the monitor surfaces as FailedToStart rather than
+            // leaving the server stuck in Reconnecting.
+            manager.handle_transport_closed(uuid, 1, ctx);
+
+            assert!(matches!(
+                manager.get_server_state(uuid),
+                Some(crate::ai::mcp::MCPServerState::FailedToStart)
+            ));
+            assert!(
+                manager
+                    .get_server_error_message(uuid)
+                    .is_some_and(|message| message.contains("bearer token"))
+            );
+        });
+    });
+}
+
+#[test]
+fn transport_closed_ignores_stale_generations_and_stopped_servers() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("cli-server");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
+                },
+            );
+            manager.spawn_generation.insert(uuid, 2);
+
+            // A monitor from a superseded instance must not touch state.
+            manager.handle_transport_closed(uuid, 1, ctx);
+            assert!(manager.get_server_state(uuid).is_none());
+
+            // An explicitly stopped server (no retained config) is left alone.
+            manager.spawn_configs.remove(&uuid);
+            manager.handle_transport_closed(uuid, 2, ctx);
+            assert!(manager.get_server_state(uuid).is_none());
+        });
+    });
+}
+
+#[test]
+fn transport_closed_respects_the_circuit_breaker() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(true);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("flaky-server");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
+                },
+            );
+            manager.spawn_generation.insert(uuid, 1);
+            manager.record_reconnect_failure(uuid);
+            manager.record_reconnect_failure(uuid);
+            manager.record_reconnect_failure(uuid);
+
+            manager.handle_transport_closed(uuid, 1, ctx);
+
+            // Backing off: no background spawn storm, failure surfaced.
+            assert!(!manager.pending_reconnections.contains_key(&uuid));
+            assert!(matches!(
+                manager.get_server_state(uuid),
+                Some(crate::ai::mcp::MCPServerState::FailedToStart)
+            ));
+        });
+    });
+}
+
+#[test]
+fn transport_closed_is_inert_with_the_flag_disabled() {
+    let _flag = FeatureFlag::McpSelfHeal.override_enabled(false);
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let installation = test_installation("cli-server");
+        let uuid = installation.uuid();
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.spawn_configs.insert(
+                uuid,
+                RetainedSpawnConfig {
+                    installation: installation.clone(),
+                    provenance: SpawnProvenance::CliEphemeral,
+                    refresher: None,
+                },
+            );
+            manager.spawn_generation.insert(uuid, 1);
+
+            manager.handle_transport_closed(uuid, 1, ctx);
+            assert!(manager.get_server_state(uuid).is_none());
+        });
+    });
+}

--- a/app/src/settings_view/mcp_servers/server_card.rs
+++ b/app/src/settings_view/mcp_servers/server_card.rs
@@ -162,6 +162,9 @@ impl From<MCPServerState> for ServerCardStatus {
         match state {
             MCPServerState::NotRunning => ServerCardStatus::Installed,
             MCPServerState::Starting => ServerCardStatus::StartingServer,
+            // Presented like a fresh start; the reconnect either lands back
+            // in Running or surfaces as Error.
+            MCPServerState::Reconnecting => ServerCardStatus::StartingServer,
             MCPServerState::Authenticating => ServerCardStatus::Authenticating,
             MCPServerState::Running => ServerCardStatus::Running,
             MCPServerState::ShuttingDown => ServerCardStatus::ShuttingDown,

--- a/app/src/tui/mcp.rs
+++ b/app/src/tui/mcp.rs
@@ -722,7 +722,9 @@ fn transport_type(transport: TransportType) -> TuiMcpTransport {
 fn runtime_status(uuid: Uuid, runtime_manager: &TemplatableMCPServerManager) -> TuiMcpServerStatus {
     match runtime_manager.get_server_state(uuid) {
         None | Some(MCPServerState::NotRunning) => TuiMcpServerStatus::Offline,
-        Some(MCPServerState::Starting) => TuiMcpServerStatus::Starting,
+        Some(MCPServerState::Starting | MCPServerState::Reconnecting) => {
+            TuiMcpServerStatus::Starting
+        }
         Some(MCPServerState::Authenticating) => TuiMcpServerStatus::Authenticating,
         Some(MCPServerState::Running) => TuiMcpServerStatus::Running,
         Some(MCPServerState::ShuttingDown) => TuiMcpServerStatus::Stopping,

--- a/crates/cloud_object_models/src/mcp.rs
+++ b/crates/cloud_object_models/src/mcp.rs
@@ -53,6 +53,9 @@ pub enum MCPServerState {
     Authenticating,
     Running,
     ShuttingDown,
+    /// The transport died and the server is being respawned in the
+    /// background; cached tools stay routable in the meantime.
+    Reconnecting,
     FailedToStart,
 }
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -41,3 +41,4 @@ windows = { workspace = true, features = ["Win32_System_Threading"] }
 
 [dev-dependencies]
 axum.workspace = true
+simple_logger = { workspace = true, features = ["test-util"] }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -26,6 +26,10 @@ pub struct TemplatableMCPServerInfo {
     /// to provide a "log out" button.
     #[allow(dead_code)]
     is_authenticated_transport: bool,
+    /// Flips to `true` when the transport observes end-of-input or is
+    /// closed — a push-based death signal, since rmcp's cancellation token
+    /// does not fire when a server dies naturally.
+    transport_closed: tokio::sync::watch::Receiver<bool>,
 }
 
 impl TemplatableMCPServerInfo {
@@ -54,6 +58,12 @@ impl TemplatableMCPServerInfo {
 
     pub fn peer(&self) -> rmcp::Peer<rmcp::RoleClient> {
         self.service.clone()
+    }
+
+    /// A watch receiver that flips to `true` once the underlying transport
+    /// has closed (end-of-input, explicit close, or teardown).
+    pub fn transport_closed(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.transport_closed.clone()
     }
 
     pub fn peer_if_connected(&self) -> Option<rmcp::Peer<rmcp::RoleClient>> {

--- a/crates/mcp/src/runtime.rs
+++ b/crates/mcp/src/runtime.rs
@@ -165,6 +165,10 @@ pub async fn spawn_server(
 ) -> Result<TemplatableMCPServerInfo, McpSpawnError> {
     logger.log("[note] Attention! There may be sensitive information (such as API keys) in these logs. Make sure to redact any secrets before sharing with others.".to_string());
 
+    // Every transport is wrapped in `TransportLoggingWrapper`, which flips
+    // this to true when the connection dies; see
+    // `TemplatableMCPServerInfo::transport_closed`.
+    let (closed_tx, transport_closed) = tokio::sync::watch::channel(false);
     let mut is_authenticated_transport = false;
     let service = match transport_type {
         TransportType::CLIServer(cli_server) => {
@@ -266,6 +270,7 @@ pub async fn spawn_server(
             let transport = TransportLoggingWrapper {
                 transport,
                 logger: logger.clone(),
+                closed_tx: closed_tx.clone(),
             };
 
             // Create the MCP client and connect to the server.
@@ -294,6 +299,7 @@ pub async fn spawn_server(
                     let transport = TransportLoggingWrapper {
                         transport,
                         logger: logger.clone(),
+                        closed_tx: closed_tx.clone(),
                     };
                     Ok(make_client_info().into_dyn().serve(transport).await?)
                 }
@@ -315,6 +321,7 @@ pub async fn spawn_server(
                     let transport = TransportLoggingWrapper {
                         transport,
                         logger: logger.clone(),
+                        closed_tx: closed_tx.clone(),
                     };
                     Ok(make_client_info().into_dyn().serve(transport).await?)
                 }
@@ -335,6 +342,7 @@ pub async fn spawn_server(
                     let transport = TransportLoggingWrapper {
                         transport,
                         logger: logger.clone(),
+                        closed_tx: closed_tx.clone(),
                     };
                     Ok(make_client_info().into_dyn().serve(transport).await?)
                 }
@@ -358,6 +366,7 @@ pub async fn spawn_server(
                     let transport = TransportLoggingWrapper {
                         transport,
                         logger: logger.clone(),
+                        closed_tx: closed_tx.clone(),
                     };
                     Ok(make_client_info().into_dyn().serve(transport).await?)
                 }
@@ -388,6 +397,7 @@ pub async fn spawn_server(
         installation_id: uuid,
         description,
         is_authenticated_transport,
+        transport_closed,
     })
 }
 
@@ -634,10 +644,14 @@ where
     }
 }
 
-/// A wrapper around a [`rmcp::transport::Transport`] that logs all requests and responses.
+/// A wrapper around a [`rmcp::transport::Transport`] that logs all requests
+/// and responses, and signals transport death through a watch channel.
 struct TransportLoggingWrapper<T> {
     transport: T,
     logger: SimpleLogger,
+    /// Flipped to `true` when `receive` observes end-of-input or the
+    /// transport is closed.
+    closed_tx: tokio::sync::watch::Sender<bool>,
 }
 
 impl<T: rmcp::transport::Transport<R>, R: rmcp::service::ServiceRole> rmcp::transport::Transport<R>
@@ -669,16 +683,23 @@ impl<T: rmcp::transport::Transport<R>, R: rmcp::service::ServiceRole> rmcp::tran
         let logger = self.logger.clone();
         async move {
             let result = self.transport.receive().await;
-            if let Some(item) = &result
-                && let Ok(json) = serde_json::to_string(item)
-            {
-                logger.log(format!("[info] MCP: Received response: {json}"));
+            match &result {
+                Some(item) => {
+                    if let Ok(json) = serde_json::to_string(item) {
+                        logger.log(format!("[info] MCP: Received response: {json}"));
+                    }
+                }
+                None => {
+                    // End of input: the server hung up or the child died.
+                    let _ = self.closed_tx.send(true);
+                }
             }
             result
         }
     }
 
     fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        let _ = self.closed_tx.send(true);
         self.transport.close()
     }
 }

--- a/crates/mcp/src/runtime_tests.rs
+++ b/crates/mcp/src/runtime_tests.rs
@@ -370,3 +370,65 @@ mod determine_transport_tests {
         }
     }
 }
+
+mod transport_closed_signal_tests {
+    use rmcp::RoleClient;
+
+    /// A transport whose input ends immediately.
+    #[derive(Clone)]
+    struct EndedTransport;
+
+    impl rmcp::transport::Transport<RoleClient> for EndedTransport {
+        type Error = std::io::Error;
+
+        fn send(
+            &mut self,
+            _item: rmcp::service::TxJsonRpcMessage<RoleClient>,
+        ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+            std::future::ready(Ok(()))
+        }
+
+        fn receive(
+            &mut self,
+        ) -> impl std::future::Future<Output = Option<rmcp::service::RxJsonRpcMessage<RoleClient>>> + Send
+        {
+            std::future::ready(None)
+        }
+
+        fn close(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+            std::future::ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn end_of_input_fires_the_closed_signal() {
+        use rmcp::transport::Transport as _;
+
+        let (closed_tx, closed_rx) = tokio::sync::watch::channel(false);
+        let mut wrapper = super::super::TransportLoggingWrapper {
+            transport: EndedTransport,
+            logger: simple_logger::SimpleLogger::new_discarding_for_test(),
+            closed_tx,
+        };
+
+        assert!(!*closed_rx.borrow());
+        let received: Option<rmcp::service::RxJsonRpcMessage<RoleClient>> = wrapper.receive().await;
+        assert!(received.is_none());
+        assert!(*closed_rx.borrow(), "end of input must flip the signal");
+    }
+
+    #[tokio::test]
+    async fn explicit_close_fires_the_closed_signal() {
+        use rmcp::transport::Transport as _;
+
+        let (closed_tx, closed_rx) = tokio::sync::watch::channel(false);
+        let mut wrapper = super::super::TransportLoggingWrapper {
+            transport: EndedTransport,
+            logger: simple_logger::SimpleLogger::new_discarding_for_test(),
+            closed_tx,
+        };
+
+        let _: Result<(), std::io::Error> = wrapper.close().await;
+        assert!(*closed_rx.borrow(), "close must flip the signal");
+    }
+}

--- a/crates/simple_logger/Cargo.toml
+++ b/crates/simple_logger/Cargo.toml
@@ -20,3 +20,6 @@ warpui_core.workspace = true
 [dev-dependencies]
 instant = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[features]
+test-util = []

--- a/crates/simple_logger/src/lib.rs
+++ b/crates/simple_logger/src/lib.rs
@@ -68,7 +68,8 @@ impl RotationConfig {
 /// clones are still alive briefly in background tasks or callback state.
 pub(crate) struct LogFileWriter {
     log_tx: Sender<String>,
-    _logging_task: BackgroundTask,
+    /// `None` only for the discarding test logger, which has no writer task.
+    _logging_task: Option<BackgroundTask>,
 }
 
 impl LogFileWriter {
@@ -202,12 +203,25 @@ impl SimpleLogger {
         Self {
             writer: Arc::new(LogFileWriter {
                 log_tx,
-                _logging_task: logging_task,
+                _logging_task: Some(logging_task),
             }),
         }
     }
 
     /// Log a message to the file.
+    /// A logger that discards all lines; for tests that need a
+    /// `SimpleLogger` without touching the filesystem or an executor.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn new_discarding_for_test() -> Self {
+        let (log_tx, _log_rx) = async_channel::unbounded::<String>();
+        Self {
+            writer: Arc::new(LogFileWriter {
+                log_tx,
+                _logging_task: None,
+            }),
+        }
+    }
+
     pub fn log(&self, message: String) {
         let _ = self.writer.log_tx.try_send(message);
     }


### PR DESCRIPTION
## Problem

Nothing observed an MCP server dying: rmcp's cancellation token does not fire on natural death, and `RunningService::waiting()` consumes self. Detection was pull-only (`Peer::is_transport_closed` at the next tool call), so a dead server kept showing **Running** and advertising stale tools indefinitely. Separately, the built-in Factory MCP recorded its bearer optimistically before the spawn resolved, so a failed builtin spawn was never retried until the token *value* changed.

## Changes

- **Push-based death signal**: `TransportLoggingWrapper` (which wraps every transport — stdio, streamable HTTP, SSE) flips a `tokio::sync::watch` channel when `receive()` observes end-of-input or the transport is closed; exposed as `TemplatableMCPServerInfo::transport_closed()`.
- **Background monitor**: on spawn success the manager watches that signal; on death it flips the server to the new `MCPServerState::Reconnecting` and starts a background reconnect. Guards: superseded instances no-op (new per-uuid **spawn generation counter**, also applied to spawn completion callbacks to prevent stale-state clobbers), explicitly stopped servers are left alone, the circuit breaker surfaces `FailedToStart` instead of storming, and servers that would require interactive OAuth (authenticated transport, no cached credentials, no managed refresher) surface a re-auth error rather than popping a login flow. Background healing is deliberately single-attempt per death — tool calls remain the retry driver.
- **`MCPServerState::Reconnecting`**: compile-time-only addition (the enum has no serde anywhere); presented as *Starting* in the settings card and TUI; non-terminal for the driver's startup wait. Reconnect lookup failures now surface as `FailedToStart` with the error message instead of leaving stale state.
- **Builtin fix**: a failed spawn clears `builtin_server_token`, so the next auth event retries even with an unchanged token.
- `SimpleLogger::new_discarding_for_test` (behind a new `test-util` feature) so transport tests don't need a filesystem/executor.

Flag-gated by `McpSelfHeal` (flag off restores lazy pull-only detection).

## Tests

Transport-signal tests (end-of-input and explicit close flip the watch), monitor guards (stale generation, stopped server, breaker → FailedToStart, flag-off inert), and the reconnect-lookup-failure surfacing path. Full suites: `cargo test -p mcp` (42), `-p warp --lib ai::mcp` (86), driver (388); clippy clean; TUI feature build checked.