### PR TITLE
Change owner of vertical tabs to @peicodes

### DIFF
--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -106,8 +106,8 @@
 /app/src/ai/agent/ @zachbai
 
 # Vertical tabs
-/app/src/workspace/view/vertical_tabs.rs @johnturcoo
-/app/src/workspace/view/vertical_tabs/ @johnturcoo
+/app/src/workspace/view/vertical_tabs.rs @peicodes
+/app/src/workspace/view/vertical_tabs/ @peicodes
 
 # Image attachment, voice input, and passive suggestions
 /app/src/ai/attachment_utils.rs @Advait-M


### PR DESCRIPTION
## Description
Updates the "Vertical tabs" entries in `.github/STAKEHOLDERS` to point at `@peicodes` instead of `@johnturcoo`:

- `/app/src/workspace/view/vertical_tabs.rs`
- `/app/src/workspace/view/vertical_tabs/`

`.github/STAKEHOLDERS` maps source paths to subject-matter experts for issue and PR triage (it borrows CODEOWNERS syntax but is not a CODEOWNERS file, so it does not gate reviews). This change re-routes vertical tabs triage.

Note: the file header lists `warpdotdev/feedback-triage-bot` → `ownership-areas.md` as the source of truth, so this may also need to be mirrored there to take effect.

## Linked Issue
N/A — ownership metadata change.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Metadata-only change: no Rust code is touched, so there is no behavior to test and `cargo fmt` / `cargo clippy` are not applicable.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Warp <agent@warp.dev>
