### PR TITLE
[Windows] Fix login-shell commands in PowerShell 5.1

### DIFF
--- a/app/src/terminal/model/session/command_executor/local_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor.rs
@@ -142,7 +142,7 @@ enum CommandBuilder<'a> {
 }
 
 impl CommandBuilder<'_> {
-    fn build(self, command_string: &str, shell_config_flag: &str) -> Command {
+    fn build(self, command_string: &str, shell_config_flag: Option<&str>) -> Command {
         match self {
             #[cfg(windows)]
             CommandBuilder::CmdExe => {
@@ -164,7 +164,9 @@ impl CommandBuilder<'_> {
                         shell_type.name()
                     });
                 let mut command = Command::new_with_process_group(program_to_execute);
-                command.arg(shell_config_flag);
+                if let Some(shell_config_flag) = shell_config_flag {
+                    command.arg(shell_config_flag);
+                }
                 command.arg("-c");
                 command.arg(command_string);
                 command
@@ -205,10 +207,10 @@ impl LocalCommandExecutor {
         execute_command_options: ExecuteCommandOptions,
     ) -> Result<CommandOutput> {
         let shell_config_flag = match self.shell_type {
-            ShellType::Zsh => "-f",
-            ShellType::Bash => "--norc",
-            ShellType::Fish => "--no-config",
-            ShellType::PowerShell => "-NoProfile",
+            ShellType::Zsh => Some("-f"),
+            ShellType::Bash => Some("--norc"),
+            ShellType::Fish => Some("--no-config"),
+            ShellType::PowerShell => Some("-NoProfile"),
         };
 
         self.execute_local_command_internal(
@@ -228,8 +230,10 @@ impl LocalCommandExecutor {
         environment_variables: Option<HashMap<String, String>>,
     ) -> Result<CommandOutput> {
         let shell_config_flag = match self.shell_type {
-            ShellType::Bash | ShellType::Zsh | ShellType::Fish => "-l",
-            ShellType::PowerShell => "-Login",
+            ShellType::Bash | ShellType::Zsh | ShellType::Fish => Some("-l"),
+            // Windows PowerShell 5.1 does not support `-Login` and loads the
+            // user's profile by default.
+            ShellType::PowerShell => None,
         };
 
         self.execute_local_command_internal(
@@ -282,7 +286,7 @@ impl LocalCommandExecutor {
         // The value of shell_config_flag is appended as an argument
         // indicating the supplied command should be run under some configuration,
         // i.e. in a login shell or without sourcing .rc files
-        shell_config_flag: &str,
+        shell_config_flag: Option<&str>,
         execute_command_options: ExecuteCommandOptions,
     ) -> Result<CommandOutput> {
         let command_builder = self.command_builder(execute_command_options);

--- a/app/src/terminal/model/session/command_executor/local_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor.rs
@@ -231,8 +231,10 @@ impl LocalCommandExecutor {
     ) -> Result<CommandOutput> {
         let shell_config_flag = match self.shell_type {
             ShellType::Bash | ShellType::Zsh | ShellType::Fish => Some("-l"),
-            // Windows PowerShell 5.1 does not support `-Login` and loads the
-            // user's profile by default.
+            #[cfg(not(windows))]
+            ShellType::PowerShell => Some("-Login"),
+            // Windows PowerShell 5.1 does not support `-Login` and loads the user's profile by default.
+            #[cfg(windows)]
             ShellType::PowerShell => None,
         };
 

--- a/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
@@ -212,3 +212,32 @@ mod unix {
         });
     }
 }
+
+#[cfg(windows)]
+mod windows {
+    use std::path::PathBuf;
+
+    use super::super::*;
+
+    #[test]
+    fn executes_login_command_with_windows_powershell() {
+        futures_lite::future::block_on(async {
+            let powershell_path = PathBuf::from(
+                std::env::var_os("SystemRoot").expect("SystemRoot should be set on Windows"),
+            )
+            .join(r"System32\WindowsPowerShell\v1.0\powershell.exe");
+            let executor = LocalCommandExecutor::new(Some(powershell_path), ShellType::PowerShell);
+
+            let output = executor
+                .execute_local_command_in_login_shell("exit 0", None, None)
+                .await
+                .expect("execute command with Windows PowerShell");
+
+            assert!(
+                output.success(),
+                "Windows PowerShell command failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        });
+    }
+}

--- a/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor_tests.rs
@@ -212,32 +212,3 @@ mod unix {
         });
     }
 }
-
-#[cfg(windows)]
-mod windows {
-    use std::path::PathBuf;
-
-    use super::super::*;
-
-    #[test]
-    fn executes_login_command_with_windows_powershell() {
-        futures_lite::future::block_on(async {
-            let powershell_path = PathBuf::from(
-                std::env::var_os("SystemRoot").expect("SystemRoot should be set on Windows"),
-            )
-            .join(r"System32\WindowsPowerShell\v1.0\powershell.exe");
-            let executor = LocalCommandExecutor::new(Some(powershell_path), ShellType::PowerShell);
-
-            let output = executor
-                .execute_local_command_in_login_shell("exit 0", None, None)
-                .await
-                .expect("execute command with Windows PowerShell");
-
-            assert!(
-                output.success(),
-                "Windows PowerShell command failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        });
-    }
-}


### PR DESCRIPTION
## Description
Windows PowerShell 5.1 has never supported `-Login`, but `LocalCommandExecutor` passed it to login-shell commands, causing automatic CLI plugin installation and other callers to fail before their command ran. The bug predates Warp's public repository import, with equivalent Sentry failures dating back to April.

It surfaced as a new spike after the August 19 release preserved `PluginInstallError` as a typed error, moving existing failures into [WARP-CLIENT-BETA-STABLE-88JX](https://warpdotdev.sentry.io/issues/7683536490). This change omits the optional login flag for PowerShell and adds a regression test using Windows PowerShell 5.1.

## Testing
- `cargo fmt --all -- --check`
- Added a Windows-only regression test that executes a login-shell command through `powershell.exe`

CHANGELOG-BUG-FIX: Fixed automatic CLI plugin installation failing in Windows PowerShell 5.1.