### PR TITLE
[multi-team] Attribute new agent runs to a team

### DIFF
--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -40,8 +40,8 @@ use crate::cloud_object::model::persistence::CloudModel;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ServerApi;
 use crate::server::server_api::ai::{
-    AIClient, AgentMessageHeader, AgentRunEvent, AgentSource, ArtifactType, ExecutionLocation,
-    ListAgentMessagesRequest, ReadAgentMessageResponse, RunSortBy, RunSortOrder,
+    AIClient, AgentMessageHeader, AgentRunEvent, AgentRunScope, AgentSource, ArtifactType,
+    ExecutionLocation, ListAgentMessagesRequest, ReadAgentMessageResponse, RunSortBy, RunSortOrder,
     SendAgentMessageRequest, SendAgentMessageResponse, SpawnAgentRequest, TaskListFilter,
 };
 use crate::terminal::shared_session;
@@ -519,16 +519,31 @@ impl AmbientAgentRunner {
                 }
                 None => (None, UserQueryMode::Normal),
             };
+            // Resolved the same way as other object-owning CLI commands (`--team[=<uid>]`
+            // picks a specific team on a multi-team account; bare `--team` requires a sole
+            // team). `--personal` and the no-flag default both mean "not team-owned", but are
+            // not the same wire value (see `AgentRunScope`): a bare invocation leaves the scope
+            // unspecified so the server applies its own default, while `--personal` explicitly
+            // asks for personal ownership.
+            let scope = if args.scope.is_team() {
+                match super::common::resolve_team_scope(&args.scope, ctx) {
+                    Ok(team_scope) => AgentRunScope::Team(team_scope.uid()),
+                    Err(err) => {
+                        super::report_fatal_error(err, ctx);
+                        return;
+                    }
+                }
+            } else if args.scope.personal {
+                AgentRunScope::Personal
+            } else {
+                AgentRunScope::Unspecified
+            };
             let request = SpawnAgentRequest {
                 prompt,
                 mode,
                 config,
                 title: args.title,
-                team: match (args.scope.is_team(), args.scope.personal) {
-                    (true, _) => Some(true),
-                    (_, true) => Some(false),
-                    _ => None,
-                },
+                scope,
                 agent_identity_uid: args.agent_uid,
                 skill,
                 attachments,

--- a/app/src/ai/agent_sdk/common.rs
+++ b/app/src/ai/agent_sdk/common.rs
@@ -178,7 +178,10 @@ fn resolve_team_uid(scope: &ObjectScope, ctx: &AppContext) -> anyhow::Result<Ser
 
 /// The team a CLI command's policy reads are scoped to, resolved from the same `--team` the
 /// object's owner is resolved from so the two cannot disagree.
-fn resolve_team_scope(scope: &ObjectScope, ctx: &AppContext) -> anyhow::Result<TeamScopeForCli> {
+pub(super) fn resolve_team_scope(
+    scope: &ObjectScope,
+    ctx: &AppContext,
+) -> anyhow::Result<TeamScopeForCli> {
     let team_uid = resolve_team_uid(scope, ctx)?;
     UserWorkspaces::as_ref(ctx)
         .team_scope_for_cli(team_uid)

--- a/app/src/ai/agent_sdk/mcp_config_tests.rs
+++ b/app/src/ai/agent_sdk/mcp_config_tests.rs
@@ -300,7 +300,7 @@ fn validation_rejects_invalid_entries() {
 fn serializes_mcp_servers_as_object_not_string() {
     use crate::ai::agent::UserQueryMode;
     use crate::ai::ambient_agents::AgentConfigSnapshot;
-    use crate::server::server_api::ai::SpawnAgentRequest;
+    use crate::server::server_api::ai::{AgentRunScope, SpawnAgentRequest};
 
     let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
     let mcp_servers = build_mcp_servers_from_specs(&[MCPSpec::Uuid(uuid)])
@@ -315,7 +315,7 @@ fn serializes_mcp_servers_as_object_not_string() {
             ..Default::default()
         }),
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],

--- a/app/src/ai/ambient_agents/spawn_tests.rs
+++ b/app/src/ai/ambient_agents/spawn_tests.rs
@@ -10,7 +10,9 @@ use super::{
 };
 use crate::ai::agent::UserQueryMode;
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
-use crate::server::server_api::ai::{MockAIClient, SpawnAgentResponse, TaskStatusMessage};
+use crate::server::server_api::ai::{
+    AgentRunScope, MockAIClient, SpawnAgentResponse, TaskStatusMessage,
+};
 use crate::terminal::shared_session;
 
 fn task_with(
@@ -735,7 +737,7 @@ async fn poll_retries_transient_429_errors() {
         mode: crate::ai::agent::UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],
@@ -804,7 +806,7 @@ async fn poll_fails_on_permanent_http_error() {
         mode: crate::ai::agent::UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],
@@ -874,7 +876,7 @@ async fn poll_gives_up_after_max_transient_retries() {
         mode: crate::ai::agent::UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],
@@ -938,7 +940,7 @@ async fn poll_stops_on_terminal_failure_like_state() {
         mode: UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],
@@ -1085,7 +1087,7 @@ async fn poll_for_session_join_info_waits_until_link_is_available() {
         mode: UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],

--- a/app/src/ai/blocklist/handoff/pipeline.rs
+++ b/app/src/ai/blocklist/handoff/pipeline.rs
@@ -55,7 +55,8 @@ use crate::ai::orchestration::{
 use crate::cloud_object::CloudObjectLookup as _;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ai::{
-    AIClient, AgentConfigSnapshot, AttachmentInput, InitialSnapshotToken, SpawnAgentRequest,
+    AIClient, AgentConfigSnapshot, AgentRunScope, AttachmentInput, InitialSnapshotToken,
+    SpawnAgentRequest,
 };
 use crate::settings::AISettings;
 
@@ -983,7 +984,9 @@ fn build_spawn_request(
         mode,
         config: Some(config),
         title,
-        team: None,
+        // Preserves the pre-existing omitted-scope wire behavior; handoff has no
+        // window-selected team wired through yet.
+        scope: AgentRunScope::Unspecified,
         skill: None,
         attachments,
         interactive: Some(true),

--- a/app/src/ai/orchestration/remote_child.rs
+++ b/app/src/ai/orchestration/remote_child.rs
@@ -29,7 +29,7 @@ use crate::ai::blocklist::StartAgentRequest;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::skills::resolve_skill_spec;
 use crate::ai::skills::{SkillManager, SkillReference};
-use crate::server::server_api::ai::{AgentConfigSnapshot, SpawnAgentRequest};
+use crate::server::server_api::ai::{AgentConfigSnapshot, AgentRunScope, SpawnAgentRequest};
 use crate::server::server_api::{AIApiError, ClientError, CloudAgentCapacityError};
 use crate::settings::PrivacySettings;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -293,7 +293,9 @@ pub fn prepare_remote_child_launch(
             ..Default::default()
         }),
         title: (!title.is_empty()).then_some(title),
-        team: None,
+        // A remote child inherits scope from `parent_run_id` server-side; preserves the
+        // pre-existing omitted-scope wire behavior rather than forcing personal ownership.
+        scope: AgentRunScope::Unspecified,
         skill: None,
         attachments: Vec::new(),
         interactive: Some(true),

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -48,6 +48,7 @@ use warp_server_client::HttpStatusError;
 use warp_server_client::auth::{AuthClientImpl, AuthEvent, EXPERIMENT_ID_HEADER};
 use warp_server_client::base_client::{
     AmbientHeaderPolicy, AuthenticatedGraphqlConfig, BaseClient, GraphqlRoutingConfig,
+    TEAM_UID_HEADER,
 };
 use warp_server_client::iap::{IapManager, IapState};
 use warp_server_client::network_logging::NetworkLogModel;
@@ -65,6 +66,7 @@ use crate::ai::predict::{generate_ai_input_suggestions, generate_am_query_sugges
 use crate::ai::voice::transcribe::{TranscribeRequest, TranscribeResponse};
 use crate::auth::auth_manager::AuthManager;
 use crate::auth::auth_state::AuthState;
+use crate::server::ids::ServerId;
 use crate::server::telemetry::TelemetryApi;
 use crate::settings::PrivacySettingsSnapshot;
 use crate::{ChannelState, settings_view};
@@ -689,6 +691,21 @@ impl ServerApi {
     where
         B: Serialize,
     {
+        self.post_public_api_response_with_headers(path, body, &[])
+            .await
+    }
+
+    /// Same as [`Self::post_public_api_response`], with additional caller-supplied headers
+    /// (e.g. `X-Warp-Team-Uid`) attached alongside the ambient headers.
+    async fn post_public_api_response_with_headers<B>(
+        &self,
+        path: &str,
+        body: &B,
+        extra_headers: &[(String, String)],
+    ) -> Result<http_client::Response>
+    where
+        B: Serialize,
+    {
         let auth_token = self
             .get_or_refresh_access_token()
             .await
@@ -702,6 +719,9 @@ impl ServerApi {
         }
 
         for (name, value) in self.ambient_agent_headers().await? {
+            request = request.header(name, value);
+        }
+        for (name, value) in extra_headers {
             request = request.header(name, value);
         }
 
@@ -777,12 +797,39 @@ impl ServerApi {
         B: Serialize,
         R: serde::de::DeserializeOwned,
     {
-        let response = self.post_public_api_response(path, body).await?;
+        self.post_public_api_with_headers(path, body, &[]).await
+    }
+
+    /// Same as [`Self::post_public_api`], with additional caller-supplied headers attached.
+    async fn post_public_api_with_headers<B, R>(
+        &self,
+        path: &str,
+        body: &B,
+        extra_headers: &[(String, String)],
+    ) -> Result<R>
+    where
+        B: Serialize,
+        R: serde::de::DeserializeOwned,
+    {
+        let response = self
+            .post_public_api_response_with_headers(path, body, extra_headers)
+            .await?;
         let url = response.url().clone();
         response
             .json::<R>()
             .await
             .with_context(|| format!("Failed to deserialize response from {url}"))
+    }
+
+    /// Builds the `X-Warp-Team-Uid` header pair for a request scoped to `team_uid`, or no
+    /// headers when the operation is not team-scoped. Shared by every bucket-2 transport path
+    /// (REST and GraphQL) that needs to send the same team into a request; see
+    /// `specs/multi-team-api-context/TECH.md`.
+    pub(crate) fn team_uid_header(team_uid: Option<ServerId>) -> Vec<(String, String)> {
+        team_uid
+            .map(|uid| (TEAM_UID_HEADER.to_string(), uid.uid()))
+            .into_iter()
+            .collect()
     }
 
     /// Sends a PUT request to a public API endpoint and returns the raw response on success.

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -154,12 +154,10 @@ use crate::ai_assistant::{AIGeneratedCommand, GenerateCommandsFromNaturalLanguag
 use crate::drive::workflows::ai_assist::{GeneratedCommandMetadata, GeneratedCommandMetadataError};
 use crate::persistence::model::ConversationUsageMetadata;
 use crate::server::graphql::{get_request_context, get_user_facing_error_message};
+use crate::server::ids::ServerId;
 use crate::terminal::model::block::SerializedBlock;
 #[cfg(not(feature = "agent_mode_evals"))]
-use crate::{
-    server::ids::ServerId,
-    workspaces::{gql_convert::PLACEHOLDER_WORKSPACE_UID, workspace::WorkspaceUid},
-};
+use crate::workspaces::{gql_convert::PLACEHOLDER_WORKSPACE_UID, workspace::WorkspaceUid};
 
 const AI_ASSISTANT_REQUEST_TIMEOUT_SECONDS: u64 = 30;
 
@@ -204,6 +202,51 @@ impl TaskStatusUpdate {
     }
 }
 
+/// The execution scope for a new agent run. Replaces the ambiguous `team: Option<bool>`
+/// boolean previously constructed directly at call sites, while preserving all three wire
+/// states it could take on `POST /agent/run`'s `team` field — they are not equivalent, since
+/// the server treats an omitted value as its own default (team ownership for a single-team
+/// account) rather than as personal:
+/// - `Unspecified` omits `team` entirely: the caller expressed no preference (e.g. no
+///   `--team`/`--personal` flag), so the server applies its own default.
+/// - `Personal` sends `team: false`: the caller explicitly asked for personal ownership.
+/// - `Team(uid)` sends `team: true` plus `uid` in the `X-Warp-Team-Uid` header.
+///
+/// See `specs/multi-team-api-context/TECH.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentRunScope {
+    Unspecified,
+    Personal,
+    Team(ServerId),
+}
+
+impl AgentRunScope {
+    fn is_unspecified(&self) -> bool {
+        matches!(self, Self::Unspecified)
+    }
+
+    fn team_uid(self) -> Option<ServerId> {
+        match self {
+            Self::Unspecified | Self::Personal => None,
+            Self::Team(team_uid) => Some(team_uid),
+        }
+    }
+}
+
+impl serde::Serialize for AgentRunScope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            // `skip_serializing_if` omits this variant before the serializer is ever reached.
+            Self::Unspecified => serializer.serialize_bool(false),
+            Self::Personal => serializer.serialize_bool(false),
+            Self::Team(_) => serializer.serialize_bool(true),
+        }
+    }
+}
+
 /// JSON payload sent to the public `POST /agent/run` API.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SpawnAgentRequest {
@@ -217,8 +260,8 @@ pub struct SpawnAgentRequest {
     pub config: Option<AgentConfigSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub team: Option<bool>,
+    #[serde(rename = "team", skip_serializing_if = "AgentRunScope::is_unspecified")]
+    pub scope: AgentRunScope,
     /// Agent identity UID to use as the execution principal for the run.
     #[serde(rename = "agent_identity_uid", skip_serializing_if = "Option::is_none")]
     pub agent_identity_uid: Option<String>,
@@ -2202,7 +2245,10 @@ impl AIClient for ServerApi {
         &self,
         request: SpawnAgentRequest,
     ) -> anyhow::Result<SpawnAgentResponse, anyhow::Error> {
-        let response: SpawnAgentResponse = self.post_public_api("agent/run", &request).await?;
+        let extra_headers = Self::team_uid_header(request.scope.team_uid());
+        let response: SpawnAgentResponse = self
+            .post_public_api_with_headers("agent/run", &request, &extra_headers)
+            .await?;
         Ok(response)
     }
 

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -2,12 +2,13 @@ use chrono::{TimeZone, Utc};
 use futures::executor::block_on;
 use itertools::Itertools;
 use mockito::{Matcher, Server};
-use warp_server_client::base_client::CLOUD_AGENT_ID_HEADER;
+use warp_core::channel::ChannelState;
+use warp_server_client::base_client::{CLOUD_AGENT_ID_HEADER, TEAM_UID_HEADER};
 
 use super::super::ServerApi;
 use super::{
-    AgentMessageHeader, AgentRunEvent, AgentSource, AmbientAgentTaskState, Artifact,
-    ArtifactDownloadResponse, ArtifactType, CONNECTED_SELF_HOSTED_WORKERS_PATH,
+    AIClient, AgentMessageHeader, AgentRunEvent, AgentRunScope, AgentSource, AmbientAgentTaskState,
+    Artifact, ArtifactDownloadResponse, ArtifactType, CONNECTED_SELF_HOSTED_WORKERS_PATH,
     ConnectedSelfHostedWorker, ExecutionLocation, ForkConversationResponse,
     ListConnectedSelfHostedWorkersResponse, ListRunsResponse, PrepareAttachmentUploadsResponse,
     ReadAgentMessageResponse, RunFollowupRequest, RunSortBy, RunSortOrder, SpawnAgentRequest,
@@ -15,7 +16,63 @@ use super::{
     build_list_agent_runs_url, build_run_followup_url,
 };
 use crate::notebooks::NotebookId;
+use crate::server::ids::ServerId;
 use crate::server::server_api::presigned_upload::upload_to_target;
+
+fn spawn_request_with_scope(scope: AgentRunScope) -> SpawnAgentRequest {
+    SpawnAgentRequest {
+        prompt: Some("hello".to_string()),
+        mode: UserQueryMode::Normal,
+        config: None,
+        title: None,
+        scope,
+        agent_identity_uid: None,
+        skill: None,
+        attachments: vec![],
+        interactive: None,
+        parent_run_id: None,
+        runtime_skills: vec![],
+        referenced_attachments: vec![],
+        conversation_id: None,
+        initial_snapshot_token: None,
+        snapshot_disabled: None,
+        orchestration_handoff: None,
+    }
+}
+
+/// Regression coverage for the trap this PR calls out explicitly: nothing else would catch a
+/// dropped or wrong `X-Warp-Team-Uid` header, or the header leaking onto a non-team request,
+/// since the wire body alone (`team: true`) does not carry the UID.
+#[test]
+fn spawn_agent_sends_matching_team_uid_header_and_body_flag_only_when_team_scoped() {
+    let team_uid = ServerId::from(42);
+    let _team_request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/agent/run")
+            .match_header(TEAM_UID_HEADER, team_uid.uid().as_str())
+            .match_body(Matcher::PartialJson(serde_json::json!({ "team": true })))
+            .with_status(200)
+            .with_body(r#"{"task_id":"550e8400-e29b-41d4-a716-446655440000","run_id":"run-1"}"#)
+            .create()
+    };
+    let server_api = ServerApi::new_for_test();
+    block_on(server_api.spawn_agent(spawn_request_with_scope(AgentRunScope::Team(team_uid))))
+        .expect("team-scoped spawn should succeed against the matching mock");
+
+    let _personal_request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/agent/run")
+            .match_header(TEAM_UID_HEADER, Matcher::Missing)
+            .match_body(Matcher::PartialJson(serde_json::json!({ "team": false })))
+            .with_status(200)
+            .with_body(r#"{"task_id":"550e8400-e29b-41d4-a716-446655440001","run_id":"run-2"}"#)
+            .create()
+    };
+    block_on(server_api.spawn_agent(spawn_request_with_scope(AgentRunScope::Personal)))
+        .expect("personal spawn should succeed against the matching mock");
+}
 
 #[test]
 fn ambient_agent_headers_for_task_overrides_existing_cloud_agent_header() {
@@ -48,7 +105,7 @@ fn spawn_agent_request_serializes_agent_uid_as_agent_identity_uid() {
         mode: UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: Some("agent_123".to_string()),
         skill: None,
         attachments: vec![],
@@ -69,6 +126,51 @@ fn spawn_agent_request_serializes_agent_uid_as_agent_identity_uid() {
         Some("agent_123")
     );
     assert!(value.get("agent_uid").is_none());
+}
+
+#[test]
+fn spawn_agent_request_serializes_all_three_scope_wire_states() {
+    fn request(scope: AgentRunScope) -> SpawnAgentRequest {
+        SpawnAgentRequest {
+            prompt: None,
+            mode: UserQueryMode::Normal,
+            config: None,
+            title: None,
+            scope,
+            agent_identity_uid: None,
+            skill: None,
+            attachments: vec![],
+            interactive: None,
+            parent_run_id: None,
+            runtime_skills: vec![],
+            referenced_attachments: vec![],
+            conversation_id: None,
+            initial_snapshot_token: None,
+            snapshot_disabled: None,
+            orchestration_handoff: None,
+        }
+    }
+
+    // `Unspecified` matches the old omitted-`team`-field wire shape (`team: None`); the server
+    // applies its own default for this case rather than treating it as personal.
+    let unspecified_value = serde_json::to_value(request(AgentRunScope::Unspecified)).unwrap();
+    assert!(unspecified_value.get("team").is_none());
+
+    // `Personal` matches the old explicit `team: Some(false)` wire shape. This is NOT the same
+    // as omitting the field: an omitted value resolves to team ownership by default for a
+    // single-team account, so collapsing `Personal` into an omission would silently start
+    // producing team-owned runs for `--personal`.
+    let personal_value = serde_json::to_value(request(AgentRunScope::Personal)).unwrap();
+    assert_eq!(
+        personal_value.get("team").and_then(|v| v.as_bool()),
+        Some(false)
+    );
+
+    // `Team` matches the old `team: Some(true)` wire shape; the raw UID never appears on the
+    // wire itself (it goes into the `X-Warp-Team-Uid` header, built separately by
+    // `ServerApi::team_uid_header`).
+    let team_value = serde_json::to_value(request(AgentRunScope::Team(ServerId::from(1)))).unwrap();
+    assert_eq!(team_value.get("team").and_then(|v| v.as_bool()), Some(true));
 }
 
 #[test]
@@ -126,7 +228,7 @@ fn spawn_agent_request_omits_prompt_when_none() {
         mode: UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -42,7 +42,7 @@ use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ServerApiProvider;
 use crate::server::server_api::ai::{
-    AgentConfigSnapshot, AmbientAgentTaskState, AttachmentInput, SpawnAgentRequest,
+    AgentConfigSnapshot, AgentRunScope, AmbientAgentTaskState, AttachmentInput, SpawnAgentRequest,
 };
 use crate::terminal::CLIAgent;
 use crate::terminal::view::ambient_agent::{SetupCommandGroupId, SetupCommandState};
@@ -1074,7 +1074,9 @@ impl AmbientAgentViewModel {
             mode,
             config,
             title: None,
-            team: None,
+            // Preserves the pre-existing omitted-scope wire behavior; this pane has no
+            // window-selected team wired through yet.
+            scope: AgentRunScope::Unspecified,
             agent_identity_uid: None,
             skill: None,
             attachments,

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -343,7 +343,7 @@ fn retry_request(prompt: impl Into<String>) -> SpawnAgentRequest {
             ..Default::default()
         }),
         title: Some("Retry title".to_string()),
-        team: Some(true),
+        scope: AgentRunScope::Team(ServerId::from(456)),
         agent_identity_uid: Some("agent-123".to_string()),
         skill: None,
         attachments: vec![attachment()],
@@ -430,7 +430,7 @@ fn github_auth_completed_retries_stored_initial_run_request() {
             assert_eq!(request.prompt.as_deref(), Some("retry this"));
             assert_eq!(request.attachments.len(), 1);
             assert_eq!(request.interactive, Some(true));
-            assert_eq!(request.team, Some(true));
+            assert_eq!(request.scope, AgentRunScope::Team(ServerId::from(456)));
             assert_eq!(request.parent_run_id.as_deref(), Some("parent-run-123"));
             assert_eq!(request.title.as_deref(), Some("Retry title"));
             assert_eq!(request.agent_identity_uid.as_deref(), Some("agent-123"));

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -28,7 +28,7 @@ use crate::ai::blocklist::{
 };
 use crate::features::FeatureFlag;
 use crate::search::slash_command_menu::static_commands::commands;
-use crate::server::server_api::ai::SpawnAgentRequest;
+use crate::server::server_api::ai::{AgentRunScope, SpawnAgentRequest};
 use crate::terminal::input::{Event as InputEvent, Input};
 use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent;
@@ -97,7 +97,7 @@ fn cloud_spawn_request(prompt: &str) -> SpawnAgentRequest {
         mode: UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],
@@ -120,7 +120,7 @@ fn promptless_cloud_spawn_request() -> SpawnAgentRequest {
         mode: UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: vec![],

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -33,7 +33,7 @@ use crate::editor::InteractionState;
 use crate::pane_group::{BackingView, PaneConfigurationEvent};
 use crate::server::ids::ServerId;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::server::server_api::ai::SpawnAgentRequest;
+use crate::server::server_api::ai::{AgentRunScope, SpawnAgentRequest};
 use crate::terminal::TerminalView;
 use crate::terminal::model::blocks::{INLINE_BANNER_HEIGHT, ToTotalIndex as _};
 use crate::terminal::model::terminal_model::ConversationTranscriptViewerStatus;
@@ -939,7 +939,7 @@ fn handoff_request_for_test() -> SpawnAgentRequest {
         mode: UserQueryMode::Normal,
         config: None,
         title: None,
-        team: None,
+        scope: AgentRunScope::Personal,
         agent_identity_uid: None,
         skill: None,
         attachments: Vec::new(),

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -53,7 +53,7 @@ use crate::pane_group::focus_state::PaneGroupFocusState;
 use crate::pane_group::pane::PaneStack;
 use crate::pane_group::{BackingView, TerminalPaneId};
 use crate::server::ids::{ClientId, SyncId};
-use crate::server::server_api::ai::SpawnAgentRequest;
+use crate::server::server_api::ai::{AgentRunScope, SpawnAgentRequest};
 use crate::settings::import::model::ImportedConfigModel;
 use crate::settings::{AISettings, AppEditorSettings, RightClickBehavior, WarpPromptSeparator};
 use crate::terminal::alt_screen::should_intercept_mouse;
@@ -3433,7 +3433,7 @@ fn cloud_mode_dispatched_agent_inserts_queued_user_query() {
                             mode: UserQueryMode::Normal,
                             config: None,
                             title: None,
-                            team: None,
+                            scope: AgentRunScope::Personal,
                             agent_identity_uid: None,
                             skill: None,
                             attachments: vec![],

--- a/app/src/workspaces/user_workspaces/team_workspace_settings.rs
+++ b/app/src/workspaces/user_workspaces/team_workspace_settings.rs
@@ -101,6 +101,15 @@ impl TeamScope for TeamScopeForCli {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
+impl TeamScopeForCli {
+    /// The team the command line named. Definite, unlike [`TeamScope::team_uid`], which is
+    /// optional only because a window may have no team selected.
+    pub(crate) fn uid(&self) -> ServerId {
+        self.0
+    }
+}
+
 /// A teamless [`TeamScope`] for tests that pass a scope without standing up a window.
 #[cfg(test)]
 pub(crate) struct TeamlessScopeForTest;

--- a/crates/warp_cli/src/scope.rs
+++ b/crates/warp_cli/src/scope.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-/// Common args for scoping objects to team or personal drives.
+/// Common args for choosing whether a command scoped to a team or as the caller's own account.
 ///
 /// `--team` is optional-valued so it answers both "team or personal?" and "which team?":
 /// absent, bare `--team` (your sole team), or `--team=<UID>` when you are on several.

--- a/crates/warp_server_client/src/base_client.rs
+++ b/crates/warp_server_client/src/base_client.rs
@@ -22,6 +22,13 @@ pub const CLOUD_AGENT_ID_HEADER: &str = "X-Warp-Cloud-Agent-ID";
 /// Header used to communicate the source of an agent run.
 pub const AGENT_SOURCE_HEADER: &str = "X-Oz-Api-Source";
 
+/// Header carrying the request-local team scope for an operation whose team is inferred
+/// from the current window rather than named explicitly in the request body. See
+/// `specs/multi-team-api-context/TECH.md`. The server authenticates membership and rejects
+/// a header that disagrees with the request body or an existing resource; adding this header
+/// is not itself proof of membership.
+pub const TEAM_UID_HEADER: &str = "X-Warp-Team-Uid";
+
 /// IDs in the staging database that were created specifically for evals.
 ///
 /// Keep this list in sync with `script/populate_agent_mode_eval_user.sql` in warp-server.
@@ -185,6 +192,7 @@ impl BaseClient {
             AMBIENT_WORKLOAD_TOKEN_HEADER,
             CLOUD_AGENT_ID_HEADER,
             AGENT_SOURCE_HEADER,
+            TEAM_UID_HEADER,
         ]
         .iter()
         .any(|reserved| name.eq_ignore_ascii_case(reserved))

--- a/crates/warp_server_client/src/public_api.rs
+++ b/crates/warp_server_client/src/public_api.rs
@@ -32,6 +32,16 @@ impl BaseClient {
     /// Unlike [`get_public_api`], this does not attempt JSON deserialization on the
     /// response body, allowing the caller to decode it however they need.
     pub async fn get_public_api_response(&self, path: &str) -> Result<http_client::Response> {
+        self.get_public_api_response_with_headers(path, &[]).await
+    }
+
+    /// Same as [`get_public_api_response`], with additional caller-supplied headers (e.g.
+    /// `X-Warp-Team-Uid`) attached alongside the ambient headers.
+    pub async fn get_public_api_response_with_headers(
+        &self,
+        path: &str,
+        extra_headers: &[(String, String)],
+    ) -> Result<http_client::Response> {
         let auth_token = self
             .get_or_refresh_access_token()
             .await
@@ -45,6 +55,9 @@ impl BaseClient {
             .ambient_headers(AmbientHeaderPolicy::inherit_all())
             .await?
         {
+            request = request.header(name, value);
+        }
+        for (name, value) in extra_headers {
             request = request.header(name, value);
         }
 
@@ -81,7 +94,21 @@ impl BaseClient {
     where
         R: DeserializeOwned,
     {
-        let response = self.get_public_api_response(path).await?;
+        self.get_public_api_with_headers(path, &[]).await
+    }
+
+    /// Same as [`get_public_api`], with additional caller-supplied headers attached.
+    pub async fn get_public_api_with_headers<R>(
+        &self,
+        path: &str,
+        extra_headers: &[(String, String)],
+    ) -> Result<R>
+    where
+        R: DeserializeOwned,
+    {
+        let response = self
+            .get_public_api_response_with_headers(path, extra_headers)
+            .await?;
         let response_url = response.url().clone();
         response
             .json::<R>()


### PR DESCRIPTION
## Description
Adds the transport plumbing to say **which team a new cloud agent run belongs to**, so the server can attribute the run — and its cost — to that team once a user can be on several.

Split out of #15355, which now carries only the multi-agent (`/ai/multi-agent`) half. This half is independent and lands on its own.

**What's here:**
- `X-Warp-Team-Uid` header constant, `*_with_headers` variants of the REST helpers so a caller can attach per-request headers alongside the ambient ones, and a shared `team_uid_header` builder.
- `SpawnAgentRequest.team: Option<bool>` becomes an explicit `AgentRunScope`. The three wire states are **not** interchangeable, so each is preserved:
  - `Unspecified` omits `team` — the server applies its own default, which for a single-team account is *team* ownership.
  - `Personal` sends `team: false`.
  - `Team(uid)` sends `team: true` plus the header.

  Collapsing `Personal` into omission would silently make `--personal` mean team-owned. That was a real bug caught in review on the original PR.
- CLI resolves `--team` / `--personal` through the same membership-checked path other object-owning commands use.

Call sites that cannot name a team send `Unspecified` rather than forcing personal ownership: a remote child inherits its scope from `parent_run_id` server-side, and the handoff and cloud-agent-pane paths have no window-selected team wired through yet.

**Reviewer note:** the "omitted = server default = team for a single-team account" claim is load-bearing for the wire-state design and currently lives only in a client-side comment. There's no generated client for this REST API, so nothing verifies it — worth a server-side confirmation.

## Linked Issue
See `specs/multi-team-api-context/TECH.md`.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
`app/src/server/server_api/ai_tests.rs` covers the wire contract directly — all three `AgentRunScope` states, and that the `X-Warp-Team-Uid` header and the body `team` flag agree and are only sent when team-scoped (asserted against a mock public-API request).

Verified locally: `./script/format`, `cargo clippy -p warp --all-targets --tests -- -D warnings`, and 344 related tests passing.

No UI changes, so no screenshots.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->