### PR TITLE
Recover the renderer after Windows RDP device loss

### DIFF
--- a/crates/warpui/src/rendering/wgpu/renderer.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer.rs
@@ -4,6 +4,8 @@ mod image;
 mod rect;
 mod util;
 
+use std::sync::atomic::Ordering;
+
 use frame::Frame;
 use pathfinder_geometry::vector::Vector2F;
 use util::with_error_scope;
@@ -78,6 +80,12 @@ impl Renderer {
         // zero-sized window.
         if window_size.is_zero() {
             return Ok(());
+        }
+
+        // Surface acquisition can degrade to persistent validation errors after the device-lost
+        // callback fires, which bypasses the event loop's renderer-recovery branch.
+        if resources.device_lost.load(Ordering::SeqCst) {
+            return Err(Error::DeviceLost);
         }
 
         let mut ctx = WGPUContext {


### PR DESCRIPTION
## Description

Warp can lose its GPU device when a Windows RDP session disconnects. The device-lost callback
notices this, but later surface acquisitions can still come back as `Validation` errors. We treat
those as temporary, so the event loop never reaches its existing device-loss recovery path. Warp
keeps retrying and the window stays frozen even though the process is still running.

In my repro the window stays visible instead of disappearing like in the linked issue, but the end
result is similar: tabs and keyboard input stop responding after reconnecting.

The renderer already has a recovery path for `DeviceLost`. This change checks the existing
device-lost flag before starting the next frame and returns that error, which sends the window
through the normal renderer recreation path.

I kept this narrow on purpose. Timeouts, occluded windows, and one-off validation errors still keep
their current behavior.

## Linked Issue

Fixes #7822

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Before/after recordings are included below.

## Testing

Automated checks:

- `git diff --check`
- `./script/format --check`
- `./script/check_no_inline_test_modules`
- `cargo test -p warpui rendering::wgpu::resources::tests`
- `cargo clippy -p warpui --lib -- -D warnings`

Manual test on a Windows 11 host with no physical display, connected through Microsoft Windows App
(formerly Microsoft Remote Desktop):

- Current stable `v0.2026.08.19.08.15.stable_01`: disconnected without signing out and then
  reconnected. Warp was still running, but tab switching and keyboard input no longer worked. The
  log showed `Device is lost`, followed by repeated surface `Validation error` entries and no
  renderer recreation.
- This branch, built as a Windows `warp-oss.exe`: repeated the same disconnect and reconnect flow.
  Warp stayed responsive after reconnecting, and new commands rendered normally.

The stable build repeatedly logged this sequence after the device-lost callback:

```text
The current device is lost. Reason: Unknown. Message: Device is lost
Encountered error while getting the next swap chain texture: Validation error
Failed to render frame: Failed to acquire surface texture: Validation error
```

I did not add a unit test for this. The failure needs a real wgpu device, window surface, and an OS
device-loss event. Pulling the atomic check into a standalone helper would only test the helper and
would not cover the callback-to-renderer-recreation path. The before/after RDP test exercises that
path end to end.

- [x] I have manually tested my changes locally with a patched Windows build.

### Screenshots / Videos

Current stable repro:

https://github.com/user-attachments/assets/f762cfc2-e23f-420c-a110-551418e60f5a

This branch recovering after reconnect:

https://github.com/user-attachments/assets/07d9abcd-33d6-4a64-8e9e-265f722a28c2

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: [Windows] Fixed Warp becoming unresponsive after disconnecting and reconnecting a Remote Desktop session.