### PR TITLE
Rewrite the README in pirate speak

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,54 +25,54 @@
 </p>
 
 > [!NOTE]
-> OpenAI is the founding sponsor of the new, open-source Warp repository, and the new agentic management workflows are powered by GPT models.
+> OpenAI be the founding sponsor o' this here new, open-source Warp treasure chest, and the new agentic management workflows be powered by GPT models. Aye!
 
 <h1></h1>
 
 ## About
 
-[Warp](https://www.warp.dev) is an agentic development environment, born out of the terminal. Use Warp's built-in coding agent, or bring your own CLI agent (Claude Code, Codex, Gemini CLI, and others).
+[Warp](https://www.warp.dev) be an agentic development environment, born o' the terminal like a kraken from the deep. Use Warp's built-in coding agent, or bring yer own CLI agent (Claude Code, Codex, Gemini CLI, and other scurvy companions).
 
 ## Installation
 
-You can [download Warp](https://www.warp.dev/download) and [read our docs](https://docs.warp.dev/) for platform-specific instructions.
+Ye can [download Warp](https://www.warp.dev/download) and [read our docs](https://docs.warp.dev/) for platform-specific instructions, ye landlubber.
 
 ## Warp Contributions Overview Dashboard
 
-Explore [build.warp.dev](https://build.warp.dev) to:
-- Watch thousands of Oz agents triage issues, write specs, implement changes, and review PRs
-- View top contributors and in-flight features
-- Track your own issues with GitHub sign-in
+Set sail for [build.warp.dev](https://build.warp.dev) to:
+- Watch thousands o' Oz agents triage issues, write specs, implement changes, and review PRs — a proper crew at work
+- Spy the top contributors and in-flight features
+- Track yer own issues with GitHub sign-in
 - Click into active agent sessions in a web-compiled Warp terminal
 
 ## Oz for OSS
 
-Maintaining a popular open-source project? [Apply for Oz credits](https://tally.so/r/LZWxqG) to explore [Oz for OSS](https://github.com/warpdotdev/oz-for-oss).
+Keepin' a popular open-source project afloat? [Apply for Oz credits](https://tally.so/r/LZWxqG) to explore [Oz for OSS](https://github.com/warpdotdev/oz-for-oss).
 
-Oz for OSS is our partner program for bringing the same agentic open-source management workflows used in this repository to select partner repositories. We work directly with maintainers to implement workflows for issue triage, PR review, community management, and contributor coordination in a way that fits each project.
+Oz for OSS be our partner program for bringin' the same agentic open-source management workflows used in this here repository to select partner ships. We work directly with maintainers to implement workflows for issue triage, PR review, community management, and contributor coordination in a way that fits each voyage.
 
 ## Licensing
 
-Warp's UI framework (the `warpui_core` and `warpui` crates) are licensed under the [MIT license](LICENSE-MIT).
+Warp's UI framework (the `warpui_core` and `warpui` crates) be licensed under the [MIT license](LICENSE-MIT).
 
-The rest of the code in this repository is licensed under the [AGPL v3](LICENSE-AGPL).
+The rest o' the code in this treasure chest be licensed under the [AGPL v3](LICENSE-AGPL).
 
 ## Open Source & Contributing
 
-Warp's client codebase is open source and lives in this repository. We welcome community contributions and have designed a lightweight workflow to help new contributors get started. For the full contribution flow, read our [CONTRIBUTING.md](CONTRIBUTING.md) guide.
+Warp's client codebase be open source and lives in this here repository. We welcome community contributions and have designed a lightweight workflow to help new hands get started. For the full contribution flow, read our [CONTRIBUTING.md](CONTRIBUTING.md) guide, ye scurvy dog.
 
 > [!TIP]
-> **Chat with contributors and the Warp team** in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) Slack channel — a good place for ad-hoc questions, design discussion, and pairing with maintainers. New here? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then jump into `#oss-contributors`.
+> **Chat with contributors and the Warp crew** in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) Slack channel — a fine tavern for ad-hoc questions, design discussion, and pairing with maintainers. New aboard? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then jump into `#oss-contributors`.
 
 ### Issue to PR
 
-Before filing, [search existing issues](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) for your bug or feature request. If nothing exists, [file an issue](https://github.com/warpdotdev/warp/issues/new/choose) using our templates. Security vulnerabilities should be reported privately as described in [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues).
+Before filin', [search existing issues](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) for yer bug or feature request. If nothin' exists, [file an issue](https://github.com/warpdotdev/warp/issues/new/choose) usin' our templates. Security vulnerabilities should be reported privately as described in [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues) — no shoutin' secrets across the deck.
 
-Once filed, a Warp maintainer reviews the issue and may apply a readiness label: [`ready-to-spec`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-spec) signals the design is open for contributors to spec out, and [`ready-to-implement`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-implement) signals the design is settled and code PRs are welcome. Anyone can pick up a labeled issue — mention **@oss-maintainers** on an issue if you'd like it considered for a readiness label.
+Once filed, a Warp maintainer reviews the issue and may apply a readiness label: [`ready-to-spec`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-spec) signals the design be open for contributors to spec out, and [`ready-to-implement`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-implement) signals the design be settled and code PRs be welcome. Anyone can pick up a labeled issue — mention **@oss-maintainers** on an issue if ye'd like it considered for a readiness label.
 
 ### Building the Repo Locally
 
-To build and run Warp from source:
+To build and run Warp from source, weigh anchor:
 
 ```bash
 ./script/bootstrap   # platform-specific setup
@@ -80,26 +80,26 @@ To build and run Warp from source:
 ./script/presubmit   # fmt, clippy, and tests
 ```
 
-See [AGENTS.md](AGENTS.md) for the full engineering guide, including coding style, testing, and platform-specific notes.
+See [AGENTS.md](AGENTS.md) for the full engineering guide, includin' coding style, testing, and platform-specific notes.
 
 ## Joining the Team
 
-Interested in joining the team? See our [open roles](https://www.warp.dev/careers).
+Fancy joinin' the crew? See our [open roles](https://www.warp.dev/careers).
 
 ## Support and Questions
 
-1. See our [docs](https://docs.warp.dev/) for a comprehensive guide to Warp's features.
-2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp team — contributors hang out in [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB).
+1. See our [docs](https://docs.warp.dev/) for a comprehensive guide to Warp's features, ye curious sailor.
+2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp crew — contributors hang out in [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB).
 3. Try our [Preview build](https://www.warp.dev/download-preview) to test the latest experimental features.
-4. Mention **@oss-maintainers** on any issue to escalate to the team — for example, if you encounter problems with the automated agents.
+4. Mention **@oss-maintainers** on any issue to escalate to the crew — for example, if ye encounter problems with the automated agents.
 
 ## Code of Conduct
 
-We ask everyone to be respectful and empathetic. Warp follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report violations, email warp-coc at warp.dev.
+We ask everyone to be respectful and empathetic. No keelhaulin' o' crewmates. Warp follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report violations, email warp-coc at warp.dev.
 
 ## Open Source Dependencies
 
-We'd like to call out a few of the [open source dependencies](https://docs.warp.dev/help/licenses) that have helped Warp to get off the ground:
+We'd like to call out a few o' the [open source dependencies](https://docs.warp.dev/help/licenses) that have helped Warp get off the ground and sail the seven seas:
 
 - [Tokio](https://github.com/tokio-rs/tokio)
 - [NuShell](https://github.com/nushell/nushell)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Arrr! This PR rewrites the root `README.md` so it sounds like a pirate, while keepin' all links, badges, commands, and file names intact.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

No app behavior changed. Verified by reading the rendered markdown: structure, URLs, and bootstrap/run/presubmit commands are unchanged.

### Screenshots / Videos
N/A — markdown-only copy change.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b8176f2-d040-495b-b027-cfe74c7e64aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b8176f2-d040-495b-b027-cfe74c7e64aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

