### PR TITLE
Fix duplicate orchestration pills for local child agents

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1557,6 +1557,18 @@ impl BlocklistAIHistoryModel {
         };
 
         if let Some(key) = agent_key {
+            // The SSE family drain can race this local registration: it may
+            // have already fetched task metadata and materialized an
+            // `is_remote_child` placeholder for this run_id
+            // (`ensure_remote_child_placeholder`) before this local
+            // conversation claimed it. Discard that stale placeholder so
+            // exactly one conversation — and one pill — ever represents this
+            // run_id, regardless of which side wins the race.
+            if let Some(existing) = self.agent_id_to_conversation_id.get(&key).copied()
+                && existing != conversation_id
+            {
+                self.discard_stale_placeholder_for_run_id(existing, conversation_id, &key, ctx);
+            }
             self.agent_id_to_conversation_id
                 .insert(key, conversation_id);
         }
@@ -1570,6 +1582,39 @@ impl BlocklistAIHistoryModel {
             conversation_id,
             terminal_surface_id,
         });
+    }
+
+    /// Discards `stale_conversation_id` when it is a remote-child placeholder
+    /// left behind by a `run_id` that `conversation_id` is now authoritatively
+    /// claiming. Only ever discards a placeholder (`is_remote_child`) — if the
+    /// existing mapping instead points at a real conversation, that would be
+    /// an unrelated bug, so it's logged rather than silently deleted.
+    fn discard_stale_placeholder_for_run_id(
+        &mut self,
+        stale_conversation_id: AIConversationId,
+        conversation_id: AIConversationId,
+        run_id: &str,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let is_placeholder = self
+            .conversations_by_id
+            .get(&stale_conversation_id)
+            .is_some_and(|conversation| conversation.is_remote_child());
+        if !is_placeholder {
+            log::warn!(
+                "assign_run_id_for_conversation: run_id={run_id} already mapped to \
+                 non-placeholder conversation {stale_conversation_id:?}; leaving it in place \
+                 and rebinding the run-id index to {conversation_id:?}."
+            );
+            return;
+        }
+        log::info!(
+            "assign_run_id_for_conversation: discarding stale remote-child placeholder \
+             {stale_conversation_id:?} for run_id={run_id}, superseded by local conversation \
+             {conversation_id:?}."
+        );
+        let terminal_surface_id = self.terminal_surface_id_for_conversation(&stale_conversation_id);
+        self.remove_conversation_from_memory(stale_conversation_id, terminal_surface_id, ctx);
     }
 
     /// Resolves a server-side agent identifier to a local conversation ID.

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -131,6 +131,98 @@ fn ensure_remote_child_conversation_creates_one_named_run_mapping() {
     });
 }
 
+/// Reproduces the race between the SSE family drain (which materializes an
+/// `is_remote_child` placeholder for a `child_agent_started` event before the
+/// local in-process child conversation has claimed its run_id) and the local
+/// child-launch path (which calls `assign_run_id_for_conversation` once its
+/// own conversation is ready). Whichever side loses the race must not leave
+/// an orphaned duplicate behind in `children_by_parent`.
+#[test]
+fn assign_run_id_for_conversation_discards_stale_remote_placeholder_for_same_run_id() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let parent_run_id = "11111111-1111-1111-1111-111111111111";
+        let child_task_id: AmbientAgentTaskId =
+            "22222222-2222-2222-2222-222222222222".parse().unwrap();
+
+        let (parent_id, placeholder_id, local_id) =
+            history_model.update(&mut app, |history, ctx| {
+                let parent_id =
+                    history.start_new_conversation(terminal_view_id, false, true, false, ctx);
+                history.assign_run_id_for_conversation(
+                    parent_id,
+                    parent_run_id.to_string(),
+                    parent_run_id.parse().ok(),
+                    terminal_view_id,
+                    ctx,
+                );
+
+                // SSE side wins the race first: the family drain fetches task
+                // metadata and materializes a remote-child placeholder before the
+                // local launch has finished.
+                let placeholder_id = history.ensure_remote_child_conversation(
+                    terminal_view_id,
+                    parent_id,
+                    child_task_id.to_string(),
+                    child_task_id,
+                    "Researcher".to_string(),
+                    String::new(),
+                    Some(Harness::Codex),
+                    ctx,
+                );
+
+                // Local side finishes afterwards: it already created its own real
+                // hidden-pane conversation and now claims the same run_id.
+                let local_id = history.start_new_child_conversation(
+                    terminal_view_id,
+                    "Researcher".to_string(),
+                    parent_id,
+                    Some(Harness::Codex),
+                    false,
+                    ctx,
+                );
+                history.assign_run_id_for_conversation(
+                    local_id,
+                    child_task_id.to_string(),
+                    Some(child_task_id),
+                    terminal_view_id,
+                    ctx,
+                );
+
+                (parent_id, placeholder_id, local_id)
+            });
+
+        assert_ne!(
+            placeholder_id, local_id,
+            "the placeholder and the local conversation must be distinct records for this race \
+             to be meaningful"
+        );
+        history_model.read(&app, |history, _| {
+            assert_eq!(
+                history.child_conversation_ids_of(&parent_id),
+                &[local_id],
+                "the orphaned remote placeholder must not remain alongside the real local child; \
+                 exactly one pill should represent this run_id",
+            );
+            assert_eq!(
+                history.conversation_id_for_agent_id(&child_task_id.to_string()),
+                Some(local_id),
+            );
+            assert!(
+                history.conversation(&placeholder_id).is_none(),
+                "the stale placeholder conversation should be fully discarded",
+            );
+            let child = history.conversation(&local_id).unwrap();
+            assert!(
+                !child.is_remote_child(),
+                "the surviving conversation is the real local child, not a placeholder",
+            );
+        });
+    });
+}
+
 fn create_user_query_message(
     id: &str,
     task_id: &str,


### PR DESCRIPTION
## Description
Fixes a race that could create two orchestration pills for a single local child agent — one `is_remote_child`-badged, one normal — both backed by the same underlying run.

When a local child agent is launched, `create_agent_task` both returns the new `run_id` to the caller *and* appends `child_agent_started` to the parent's event log, which the parent's ancestor SSE stream also observes independently. If the SSE-driven `ensure_remote_child_placeholder` path wins that race, it materializes a remote-child placeholder conversation before the local child's own conversation claims the run_id. `assign_run_id_for_conversation` previously just overwrote the run_id → conversation index when this happened, leaving the placeholder orphaned in `children_by_parent`.

`assign_run_id_for_conversation` now detects when a run_id is already claimed by a *different* conversation and, if that conversation is a remote-child placeholder, discards it via the existing conversation-removal path before rebinding the index — so exactly one conversation (and pill) ever represents a given run_id, regardless of which side of the race lands first.

## Linked Issue
No linked issue — found and fixed during an interactive debugging session.

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Added a regression test (`assign_run_id_for_conversation_discards_stale_remote_placeholder_for_same_run_id` in history_model_tests.rs) that drives the model through the exact race — a remote-child placeholder created first, then a local child conversation claiming the same run_id — and asserts only one conversation remains under the parent. Confirmed it fails against the old code and passes with the fix.

Ran `./script/presubmit`: formatting, clippy (all three configurations), clang-format, and wgslfmt all pass. Full workspace test suite passes except for pre-existing `shell_integration_tests::test_ssh_into_*` failures, which are unrelated environment/gcloud-auth issues in this sandbox, not caused by this change.

Did not manually exercise this through the running app (`./script/run`), since reproducing the race live requires real network timing skew between the local child-launch path and the SSE family drain; the regression test exercises the same code path deterministically instead.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
