### PR TITLE
Support stored screenshot references in computer-use tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15860,7 +15860,6 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=2bd5df2e3a73ada980d1e9c613ce369232e8c41d#2bd5df2e3a73ada980d1e9c613ce369232e8c41d"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15860,6 +15860,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=7b638a3bce15b6159116c25caa1dda62cf004b0e#7b638a3bce15b6159116c25caa1dda62cf004b0e"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -582,7 +582,7 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
-# warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
+warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
 
 [patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
 # Uncomment for local development of session-sharing-protocol

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "2bd5df2e3a73ada980d1e9c613ce369232e8c41d" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "7b638a3bce15b6159116c25caa1dda62cf004b0e" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [
@@ -582,7 +582,7 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
-warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
+# warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
 
 [patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
 # Uncomment for local development of session-sharing-protocol

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1037,6 +1037,7 @@ osc_hyperlinks = []
 ctrl_c_cancels_third_party_harness = []
 shell_widget_handoff = []
 history_search_ranking_v2 = []
+stored_screenshots = []
 
 [package.metadata.bundle.bin.warp-oss]
 category = "public.app-category.developer-tools"

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -10,8 +10,8 @@ use std::time::{Duration, SystemTime};
 
 use ai::agent::action_result::{
     AskUserQuestionAnswerItem, AskUserQuestionResult, FetchConversationResult, ReadSkillResult,
-    RecordingStarted, RecordingStopped, RequestComputerUseResult, SendMessageToAgentResult,
-    StartRecordingResult, StopRecordingResult, UseComputerResult,
+    RecordingStarted, RecordingStopped, RequestComputerUseResult, ScreenshotSource,
+    SendMessageToAgentResult, StartRecordingResult, StopRecordingResult, UseComputerResult,
 };
 use ai::skills::{ParsedSkill, SkillPathOrigin};
 use chrono::{DateTime, Local, TimeZone};
@@ -1370,32 +1370,34 @@ pub(crate) fn convert_tool_call_result_to_input(
             let use_computer_result =
                 match &result.result {
                     Some(api::use_computer_result::Result::Success(success)) => {
-                        // A screenshot whose bytes were offloaded to object storage arrives
-                        // with the `StoredRef` source variant; it converts to no inline
-                        // image while the ref is carried alongside for on-demand fetching.
-                        let stored_screenshot_ref =
-                            success.screenshot.as_ref().and_then(|s| match &s.source {
-                                Some(api::raw_image::Source::StoredRef(stored_ref)) => {
-                                    Some(stored_ref.clone())
-                                }
-                                Some(api::raw_image::Source::Data(_)) | None => None,
-                            });
-                        let screenshot = success.screenshot.as_ref().and_then(|s| {
-                            let data = match &s.source {
-                                Some(api::raw_image::Source::Data(data)) => data.clone(),
-                                Some(api::raw_image::Source::StoredRef(_)) => return None,
-                                None => Vec::new(),
-                            };
+                        let screenshot = success.screenshot.as_ref().map(|s| {
                             // The original dimensions are not preserved through the API, so
                             // we use the current dimensions for both.
-                            Some(computer_use::Screenshot {
-                                width: s.width as usize,
-                                height: s.height as usize,
-                                original_width: s.width as usize,
-                                original_height: s.height as usize,
-                                data,
-                                mime_type: s.mime_type.clone().into(),
-                            })
+                            let inline = |data| {
+                                ScreenshotSource::Inline(computer_use::Screenshot {
+                                    width: s.width as usize,
+                                    height: s.height as usize,
+                                    original_width: s.width as usize,
+                                    original_height: s.height as usize,
+                                    data,
+                                    mime_type: s.mime_type.clone().into(),
+                                })
+                            };
+                            match &s.source {
+                                Some(api::raw_image::Source::Data(data)) => inline(data.clone()),
+                                // A screenshot whose bytes were offloaded to object storage
+                                // arrives with the `StoredRef` source variant; the ref is
+                                // carried for on-demand fetching.
+                                Some(api::raw_image::Source::StoredRef(stored_ref)) => {
+                                    ScreenshotSource::Stored {
+                                        stored_ref: stored_ref.clone(),
+                                        mime_type: s.mime_type.clone(),
+                                        width: s.width,
+                                        height: s.height,
+                                    }
+                                }
+                                None => inline(Vec::new()),
+                            }
                         });
                         let cursor_position = success
                             .cursor_position
@@ -1417,13 +1419,10 @@ pub(crate) fn convert_tool_call_result_to_input(
                             }
                         });
                         UseComputerResult::Success {
-                            result: computer_use::ActionResult {
-                                screenshot,
-                                cursor_position,
-                                windows,
-                                captured_window,
-                            },
-                            stored_screenshot_ref,
+                            screenshot,
+                            cursor_position,
+                            windows,
+                            captured_window,
                         }
                     }
                     Some(api::use_computer_result::Result::Error(error)) => {

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1370,17 +1370,32 @@ pub(crate) fn convert_tool_call_result_to_input(
             let use_computer_result =
                 match &result.result {
                     Some(api::use_computer_result::Result::Success(success)) => {
-                        let screenshot = success.screenshot.as_ref().map(|s| {
-                            // The original dimensions are not preserved through the API, so we use
-                            // the current dimensions for both.
-                            computer_use::Screenshot {
+                        // A screenshot whose bytes were offloaded to object storage arrives
+                        // with the `StoredRef` source variant; it converts to no inline
+                        // image while the ref is carried alongside for on-demand fetching.
+                        let stored_screenshot_ref =
+                            success.screenshot.as_ref().and_then(|s| match &s.source {
+                                Some(api::raw_image::Source::StoredRef(stored_ref)) => {
+                                    Some(stored_ref.clone())
+                                }
+                                Some(api::raw_image::Source::Data(_)) | None => None,
+                            });
+                        let screenshot = success.screenshot.as_ref().and_then(|s| {
+                            let data = match &s.source {
+                                Some(api::raw_image::Source::Data(data)) => data.clone(),
+                                Some(api::raw_image::Source::StoredRef(_)) => return None,
+                                None => Vec::new(),
+                            };
+                            // The original dimensions are not preserved through the API, so
+                            // we use the current dimensions for both.
+                            Some(computer_use::Screenshot {
                                 width: s.width as usize,
                                 height: s.height as usize,
                                 original_width: s.width as usize,
                                 original_height: s.height as usize,
-                                data: s.data.clone(),
+                                data,
                                 mime_type: s.mime_type.clone().into(),
-                            }
+                            })
                         });
                         let cursor_position = success
                             .cursor_position
@@ -1401,12 +1416,15 @@ pub(crate) fn convert_tool_call_result_to_input(
                                 height_px: c.height_px,
                             }
                         });
-                        UseComputerResult::Success(computer_use::ActionResult {
-                            screenshot,
-                            cursor_position,
-                            windows,
-                            captured_window,
-                        })
+                        UseComputerResult::Success {
+                            result: computer_use::ActionResult {
+                                screenshot,
+                                cursor_position,
+                                windows,
+                                captured_window,
+                            },
+                            stored_screenshot_ref,
+                        }
                     }
                     Some(api::use_computer_result::Result::Error(error)) => {
                         UseComputerResult::Error(error.message.clone())
@@ -1441,7 +1459,12 @@ pub(crate) fn convert_tool_call_result_to_input(
                                 height: initial_screenshot.height as usize,
                                 original_width: screen_dimensions.width_px as usize,
                                 original_height: screen_dimensions.height_px as usize,
-                                data: initial_screenshot.data.clone(),
+                                // Initial screenshots are never offloaded, so any non-inline
+                                // source defensively converts to an empty image.
+                                data: match &initial_screenshot.source {
+                                    Some(api::raw_image::Source::Data(data)) => data.clone(),
+                                    Some(api::raw_image::Source::StoredRef(_)) | None => Vec::new(),
+                                },
                                 mime_type: initial_screenshot.mime_type.clone().into(),
                             },
                             platform,

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -108,6 +108,7 @@ pub async fn generate_multi_agent_output(
                 && FeatureFlag::CloudAgentRunners.is_enabled(),
             supports_background_computer_use: FeatureFlag::BackgroundComputerUse.is_enabled()
                 && computer_use::background_supported(),
+            supports_stored_screenshots: FeatureFlag::StoredScreenshots.is_enabled(),
             custom_model_providers: params.custom_model_providers,
             custom_model_routers: params.custom_model_routers,
         }),

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -3313,15 +3313,19 @@ impl AIConversation {
                 }
 
                 let task_id = TaskId::new(task_id);
-                let exchange_id = self
+                // Updates may target messages from exchanges added by earlier response
+                // streams (e.g. the server swapping computer-use screenshot bytes for a
+                // stored ref), so the current stream is not required to have added an
+                // exchange for this task. `Task::upsert_message` resolves the exchange
+                // that owns the message and only needs this one for new messages.
+                let current_stream_exchange_id = self
                     .added_exchanges_by_response
                     .get(response_stream_id)
                     .ok_or(UpdateConversationError::NoPendingRequest)?
                     .iter()
                     .find_map(|new_exchange| {
                         (new_exchange.task_id == task_id).then_some(new_exchange.exchange_id)
-                    })
-                    .ok_or(UpdateConversationError::ExchangeNotFound)?;
+                    });
 
                 let current_todo_list = self.todo_lists.last().cloned();
                 let current_comment_state = self.code_review.as_ref().cloned();
@@ -3331,12 +3335,12 @@ impl AIConversation {
                 // sent on this client). Once we reconstruct these inputs, we will insert them
                 // to mimic the normal conversation flow. (If this is not a shared session, the
                 // exchange inputs will already be populated).
-                let todos_op = self
+                let (exchange_id, todos_op) = self
                     .task_store
                     .modify_task(&task_id, |task| {
                         task.upsert_message(
                             message,
-                            exchange_id,
+                            current_stream_exchange_id,
                             TaskMessageContext {
                                 current_todo_list: current_todo_list.as_ref(),
                                 active_code_review: current_comment_state.as_ref(),
@@ -3345,7 +3349,7 @@ impl AIConversation {
                             mask,
                             is_viewing_shared_session,
                         )
-                        .map(|msg| msg.todos_op().cloned())
+                        .map(|(exchange_id, msg)| (exchange_id, msg.todos_op().cloned()))
                     })
                     .ok_or(UpdateConversationError::TaskNotFound)??;
                 // Update todo list if needed

--- a/app/src/ai/agent/task.rs
+++ b/app/src/ai/agent/task.rs
@@ -647,14 +647,21 @@ impl Task {
         Ok(())
     }
 
+    /// Upserts `message` into the task, returning the exchange whose rendered output was
+    /// updated along with the resulting task message.
+    ///
+    /// An update for an existing message is applied to the exchange that added that message,
+    /// which may predate the current response stream (e.g. the server swapping an earlier
+    /// screenshot's inline bytes for a stored ref). Only a genuinely new message requires
+    /// `current_stream_exchange_id`, the exchange the current stream added for this task.
     pub(super) fn upsert_message(
         &mut self,
         message: api::Message,
-        exchange_id: AIAgentExchangeId,
+        current_stream_exchange_id: Option<AIAgentExchangeId>,
         message_context: TaskMessageContext<'_>,
         mask: FieldMask,
         should_convert_input_messages: bool,
-    ) -> Result<&api::Message, UpdateTaskError> {
+    ) -> Result<(AIAgentExchangeId, &api::Message), UpdateTaskError> {
         let Some((idx, existing_message)) = self
             .try_get_source()?
             .messages
@@ -662,6 +669,8 @@ impl Task {
             .enumerate()
             .find(|(_, m)| message.id == m.id)
         else {
+            let exchange_id =
+                current_stream_exchange_id.ok_or(UpdateTaskError::ExchangeNotFound)?;
             self.add_messages(
                 vec![message.clone()],
                 exchange_id,
@@ -672,6 +681,7 @@ impl Task {
                 .try_get_source()?
                 .messages
                 .last()
+                .map(|message| (exchange_id, message))
                 .ok_or(UpdateTaskError::MessageNotFound);
         };
         let updated_message =
@@ -680,6 +690,14 @@ impl Task {
                 .map_err(UpdateTaskError::from)?;
 
         let id = self.id.clone();
+        let message_id = MessageId::new(message.id.clone());
+        let exchange_id = self
+            .exchanges
+            .iter()
+            .find(|exchange| exchange.added_message_ids.contains(&message_id))
+            .map(|exchange| exchange.id)
+            .or(current_stream_exchange_id)
+            .ok_or(UpdateTaskError::ExchangeNotFound)?;
         let exchange_to_update = self
             .exchange_mut(exchange_id)
             .ok_or(UpdateTaskError::ExchangeNotFound)?;
@@ -726,7 +744,7 @@ impl Task {
 
         let source = self.try_get_source_mut()?;
         source.messages[idx] = updated_message;
-        Ok(&source.messages[idx])
+        Ok((exchange_id, &source.messages[idx]))
     }
 
     pub(super) fn append_to_message_content(
@@ -968,10 +986,10 @@ impl AIAgentExchange {
         task_message: &api::Message,
         conversion_params: super::api::ConversionParams<'_>,
     ) -> Result<(), UpdateTaskError> {
-        if let AIAgentOutputStatus::Streaming {
-            output: Some(output),
-        } = &self.output_status
-        {
+        // Applies to finished outputs as well as streaming ones: updates can target
+        // messages owned by exchanges whose output already completed (e.g. a stored-ref
+        // swap for a screenshot from an earlier exchange).
+        if let Some(output) = self.output_status.output() {
             let mut output = output.get_mut();
             let message_idx = output
                 .messages

--- a/app/src/ai/agent/task_tests.rs
+++ b/app/src/ai/agent/task_tests.rs
@@ -1,6 +1,16 @@
+use std::sync::Arc;
+
+use ai::skills::SkillPathOrigin;
+use prost_types::FieldMask;
 use warp_multi_agent_api as api;
 
-use super::{ExtractMessagesError, Task};
+use super::{ExtractMessagesError, Task, TaskMessageContext, UpdateTaskError};
+use crate::ai::agent::{
+    AIAgentActionResult, AIAgentActionResultType, AIAgentExchange, AIAgentExchangeId, AIAgentInput,
+    AIAgentOutput, AIAgentOutputStatus, FinishedAIAgentOutput, MessageId, Shared, TaskId,
+    UseComputerResult,
+};
+use crate::ai::llms::LLMId;
 use crate::test_util::ai_agent_tasks::{
     create_api_subtask, create_api_task, create_message, create_subagent_tool_call_message,
 };
@@ -445,6 +455,314 @@ fn test_new_moved_messages_subtask_preserves_messages() {
     // All messages should be preserved.
     let message_ids: Vec<_> = subtask.messages().map(|m| m.id.as_str()).collect();
     assert_eq!(message_ids, vec!["s1", "s2", "s3"]);
+}
+
+// =============================================================================
+// Tests for Task::upsert_message()
+// =============================================================================
+
+fn create_exchange(
+    owned_message_ids: &[&str],
+    output_status: AIAgentOutputStatus,
+    start_time: chrono::DateTime<chrono::Local>,
+) -> AIAgentExchange {
+    let model_id = LLMId::from("auto");
+    AIAgentExchange {
+        id: AIAgentExchangeId::new(),
+        input: vec![],
+        output_status,
+        added_message_ids: owned_message_ids
+            .iter()
+            .map(|id| MessageId::new(id.to_string()))
+            .collect(),
+        start_time,
+        finish_time: None,
+        time_to_first_token_ms: None,
+        working_directory: None,
+        model_id: model_id.clone(),
+        request_cost: None,
+        coding_model_id: model_id.clone(),
+        cli_agent_model_id: model_id.clone(),
+        computer_use_model_id: model_id,
+        response_initiator: None,
+    }
+}
+
+fn streaming_output_status() -> AIAgentOutputStatus {
+    AIAgentOutputStatus::Streaming {
+        output: Some(Shared::new(AIAgentOutput::default())),
+    }
+}
+
+fn finished_output_status() -> AIAgentOutputStatus {
+    AIAgentOutputStatus::Finished {
+        finished_output: FinishedAIAgentOutput::Success {
+            output: Shared::new(AIAgentOutput::default()),
+        },
+    }
+}
+
+fn message_context() -> TaskMessageContext<'static> {
+    TaskMessageContext {
+        current_todo_list: None,
+        active_code_review: None,
+        skill_path_origin: &SkillPathOrigin::Unavailable,
+    }
+}
+
+fn agent_output_message(id: &str, task_id: &str, text: &str) -> api::Message {
+    api::Message {
+        message: Some(api::message::Message::AgentOutput(
+            api::message::AgentOutput {
+                text: text.to_string(),
+            },
+        )),
+        ..create_message(id, task_id)
+    }
+}
+
+fn use_computer_result_message(
+    id: &str,
+    task_id: &str,
+    tool_call_id: &str,
+    screenshot: api::RawImage,
+) -> api::Message {
+    api::Message {
+        message: Some(api::message::Message::ToolCallResult(
+            api::message::ToolCallResult {
+                tool_call_id: tool_call_id.to_string(),
+                context: None,
+                result: Some(api::message::tool_call_result::Result::UseComputer(
+                    api::UseComputerResult {
+                        result: Some(api::use_computer_result::Result::Success(
+                            api::use_computer_result::Success {
+                                screenshot: Some(screenshot),
+                                cursor_position: None,
+                                windows: vec![],
+                                captured_window: None,
+                            },
+                        )),
+                    },
+                )),
+            },
+        )),
+        ..create_message(id, task_id)
+    }
+}
+
+fn inline_raw_image() -> api::RawImage {
+    api::RawImage {
+        source: Some(api::raw_image::Source::Data(vec![1, 2, 3])),
+        mime_type: "image/png".to_string(),
+        width: 2,
+        height: 2,
+    }
+}
+
+fn stored_ref_raw_image() -> api::RawImage {
+    api::RawImage {
+        source: Some(api::raw_image::Source::StoredRef(
+            api::StoredScreenshotRef {
+                screenshot_uid: "shot-1".to_string(),
+                conversation_id: "conv-1".to_string(),
+                size_bytes: 3,
+            },
+        )),
+        mime_type: "image/png".to_string(),
+        width: 2,
+        height: 2,
+    }
+}
+
+#[test]
+fn test_upsert_message_same_stream_updates_current_exchange() {
+    let task_id = "task1";
+    let api_task = create_api_task(
+        task_id,
+        vec![agent_output_message("m1", task_id, "original text")],
+    );
+    let exchange = create_exchange(&["m1"], streaming_output_status(), chrono::Local::now());
+    let exchange_id = exchange.id;
+    let mut task = Task::new_restored_root(api_task, std::iter::once(exchange));
+
+    let (updated_exchange_id, updated_message) = task
+        .upsert_message(
+            agent_output_message("m1", task_id, "updated text"),
+            Some(exchange_id),
+            message_context(),
+            FieldMask {
+                paths: vec!["agent_output".to_string()],
+            },
+            false,
+        )
+        .expect("same-stream upsert should succeed");
+
+    assert_eq!(updated_exchange_id, exchange_id);
+    assert!(matches!(
+        &updated_message.message,
+        Some(api::message::Message::AgentOutput(output)) if output.text == "updated text"
+    ));
+
+    // The rendered output of the current stream's exchange picked up the update.
+    let exchange = task.exchange(exchange_id).expect("exchange exists");
+    let output = exchange.output_status.output().expect("output exists");
+    let messages = &output.get().messages;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].id, MessageId::new("m1".to_string()));
+}
+
+#[test]
+fn test_upsert_message_cross_exchange_swaps_screenshot_bytes_for_stored_ref() {
+    let task_id = "task1";
+    let api_task = create_api_task(
+        task_id,
+        vec![use_computer_result_message(
+            "m-shot",
+            task_id,
+            "tool-1",
+            inline_raw_image(),
+        )],
+    );
+
+    // The earlier exchange owns the screenshot message and already finished, and holds the
+    // corresponding action-result input as reconstructed by shared-session viewers.
+    let mut earlier_exchange = create_exchange(
+        &["m-shot"],
+        finished_output_status(),
+        chrono::Local::now() - chrono::Duration::minutes(1),
+    );
+    earlier_exchange.input.push(AIAgentInput::ActionResult {
+        result: AIAgentActionResult {
+            id: "tool-1".to_string().into(),
+            task_id: TaskId::new(task_id.to_string()),
+            result: AIAgentActionResultType::UseComputer(UseComputerResult::success(
+                computer_use::ActionResult::legacy(
+                    Some(computer_use::Screenshot {
+                        width: 2,
+                        height: 2,
+                        original_width: 2,
+                        original_height: 2,
+                        data: vec![1, 2, 3],
+                        mime_type: "image/png".into(),
+                    }),
+                    None,
+                ),
+            )),
+        },
+        context: Arc::from(Vec::new()),
+    });
+    let earlier_exchange_id = earlier_exchange.id;
+    let current_exchange = create_exchange(&[], streaming_output_status(), chrono::Local::now());
+    let current_exchange_id = current_exchange.id;
+    let mut task =
+        Task::new_restored_root(api_task, [earlier_exchange, current_exchange].into_iter());
+
+    let (updated_exchange_id, updated_message) = task
+        .upsert_message(
+            use_computer_result_message("m-shot", task_id, "tool-1", stored_ref_raw_image()),
+            Some(current_exchange_id),
+            message_context(),
+            FieldMask {
+                paths: vec!["tool_call_result".to_string()],
+            },
+            true,
+        )
+        .expect("cross-exchange upsert should succeed");
+
+    // The update lands on the exchange that owns the message, not the current stream's.
+    assert_eq!(updated_exchange_id, earlier_exchange_id);
+
+    // The task source (echoed back to the server) retains the stored ref in place of the
+    // inline bytes.
+    let Some(api::message::Message::ToolCallResult(result)) = &updated_message.message else {
+        panic!("expected a tool call result message");
+    };
+    let Some(api::message::tool_call_result::Result::UseComputer(use_computer)) = &result.result
+    else {
+        panic!("expected a use computer result");
+    };
+    let Some(api::use_computer_result::Result::Success(success)) = &use_computer.result else {
+        panic!("expected a success result");
+    };
+    let screenshot = success.screenshot.as_ref().expect("screenshot present");
+    let Some(api::raw_image::Source::StoredRef(stored_ref)) = &screenshot.source else {
+        panic!("expected a stored ref screenshot source");
+    };
+    assert_eq!(stored_ref.screenshot_uid, "shot-1");
+
+    // The owning exchange's action-result input was swapped to the ref-only form.
+    let earlier_exchange = task
+        .exchange(earlier_exchange_id)
+        .expect("earlier exchange exists");
+    let AIAgentInput::ActionResult { result, .. } = &earlier_exchange.input[0] else {
+        panic!("expected an action result input");
+    };
+    let AIAgentActionResultType::UseComputer(UseComputerResult::Success {
+        result: action_result,
+        stored_screenshot_ref,
+    }) = &result.result
+    else {
+        panic!("expected a use computer success result");
+    };
+    assert!(action_result.screenshot.is_none());
+    assert_eq!(
+        stored_screenshot_ref
+            .as_ref()
+            .map(|stored_ref| stored_ref.screenshot_uid.as_str()),
+        Some("shot-1")
+    );
+}
+
+#[test]
+fn test_upsert_message_succeeds_without_current_stream_exchange() {
+    let task_id = "task1";
+    let api_task = create_api_task(
+        task_id,
+        vec![agent_output_message("m1", task_id, "original text")],
+    );
+    let exchange = create_exchange(&["m1"], finished_output_status(), chrono::Local::now());
+    let exchange_id = exchange.id;
+    let mut task = Task::new_restored_root(api_task, std::iter::once(exchange));
+
+    // No exchange was added for this task in the current stream; the update still applies
+    // to the (finished) exchange that owns the message.
+    let (updated_exchange_id, _) = task
+        .upsert_message(
+            agent_output_message("m1", task_id, "updated text"),
+            None,
+            message_context(),
+            FieldMask {
+                paths: vec!["agent_output".to_string()],
+            },
+            false,
+        )
+        .expect("upsert without a current-stream exchange should succeed");
+
+    assert_eq!(updated_exchange_id, exchange_id);
+
+    // The finished exchange's rendered output picked up the update.
+    let exchange = task.exchange(exchange_id).expect("exchange exists");
+    let output = exchange.output_status.output().expect("output exists");
+    assert_eq!(output.get().messages.len(), 1);
+}
+
+#[test]
+fn test_upsert_message_new_message_requires_current_stream_exchange() {
+    let task_id = "task1";
+    let api_task = create_api_task(task_id, vec![]);
+    let mut task = create_server_task(api_task);
+
+    let result = task.upsert_message(
+        agent_output_message("new-message", task_id, "text"),
+        None,
+        message_context(),
+        FieldMask {
+            paths: vec!["agent_output".to_string()],
+        },
+        false,
+    );
+
+    assert!(matches!(result, Err(UpdateTaskError::ExchangeNotFound)));
 }
 
 // =============================================================================

--- a/app/src/ai/agent/task_tests.rs
+++ b/app/src/ai/agent/task_tests.rs
@@ -7,8 +7,8 @@ use warp_multi_agent_api as api;
 use super::{ExtractMessagesError, Task, TaskMessageContext, UpdateTaskError};
 use crate::ai::agent::{
     AIAgentActionResult, AIAgentActionResultType, AIAgentExchange, AIAgentExchangeId, AIAgentInput,
-    AIAgentOutput, AIAgentOutputStatus, FinishedAIAgentOutput, MessageId, Shared, TaskId,
-    UseComputerResult,
+    AIAgentOutput, AIAgentOutputStatus, FinishedAIAgentOutput, MessageId, ScreenshotSource, Shared,
+    TaskId, UseComputerResult,
 };
 use crate::ai::llms::LLMId;
 use crate::test_util::ai_agent_tasks::{
@@ -697,20 +697,15 @@ fn test_upsert_message_cross_exchange_swaps_screenshot_bytes_for_stored_ref() {
     let AIAgentInput::ActionResult { result, .. } = &earlier_exchange.input[0] else {
         panic!("expected an action result input");
     };
-    let AIAgentActionResultType::UseComputer(UseComputerResult::Success {
-        result: action_result,
-        stored_screenshot_ref,
-    }) = &result.result
+    let AIAgentActionResultType::UseComputer(UseComputerResult::Success { screenshot, .. }) =
+        &result.result
     else {
         panic!("expected a use computer success result");
     };
-    assert!(action_result.screenshot.is_none());
-    assert_eq!(
-        stored_screenshot_ref
-            .as_ref()
-            .map(|stored_ref| stored_ref.screenshot_uid.as_str()),
-        Some("shot-1")
-    );
+    let Some(ScreenshotSource::Stored { stored_ref, .. }) = screenshot else {
+        panic!("expected a stored-ref screenshot source");
+    };
+    assert_eq!(stored_ref.screenshot_uid, "shot-1");
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -279,7 +279,7 @@ pub mod text {
                 AIAgentActionResultType::TransferShellCommandControlToUser { .. } => Ok(()),
                 AIAgentActionResultType::UseComputer(result) => match result {
                     // TODO(AGENT-2281): implement
-                    UseComputerResult::Success(_result) => Ok(()),
+                    UseComputerResult::Success { .. } => Ok(()),
                     UseComputerResult::Error(error) => writeln!(w, "Use computer error: {error}"),
                     UseComputerResult::Cancelled => writeln!(w, "{CANCELLED_MESSAGE}"),
                 },

--- a/app/src/ai/blocklist/action_model/execute/use_computer.rs
+++ b/app/src/ai/blocklist/action_model/execute/use_computer.rs
@@ -105,7 +105,7 @@ impl UseComputerExecutor {
                     )
                     .await
                 {
-                    Ok(result) => UseComputerResult::Success(result),
+                    Ok(result) => UseComputerResult::success(result),
                     Err(error) => UseComputerResult::Error(error),
                 };
                 // Capture the finish offset immediately after the complete
@@ -125,7 +125,7 @@ impl UseComputerExecutor {
             move |(result, finish_offset, pointer_events), ctx| {
                 if meaningful {
                     RecordingController::handle(ctx).update(ctx, |controller, _| match result {
-                        UseComputerResult::Success(_) => {
+                        UseComputerResult::Success { .. } => {
                             if let Some(finish_offset) = finish_offset {
                                 controller.commit_action_group(
                                     conversation_id,

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -51,6 +51,7 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::content::edit::resolve_asset_source_relative_to_directory;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_errors::{report_error, report_if_error};
+use warp_multi_agent_api::StoredScreenshotRef;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::path::ShellFamily;
 use warpui::assets::asset_cache::AssetCache;
@@ -6457,6 +6458,35 @@ fn open_code_action_event(
     }
 }
 
+/// The raw-asset cache ID under which a UseComputer action's screenshot bytes are stored.
+fn screenshot_asset_id(action_id: &AIAgentActionId) -> String {
+    format!("screenshot-{action_id}")
+}
+
+/// Opens the lightbox over the given UseComputer actions' screenshots, which must already be
+/// present in the `AssetCache` under their [`screenshot_asset_id`]s.
+fn open_screenshot_lightbox(
+    action_ids: &[AIAgentActionId],
+    initial_index: usize,
+    ctx: &mut ViewContext<AIBlock>,
+) {
+    let images = action_ids
+        .iter()
+        .map(|action_id| ui_components::lightbox::LightboxImage {
+            source: ui_components::lightbox::LightboxImageSource::Resolved {
+                asset_source: warpui::assets::asset_cache::AssetSource::Raw {
+                    id: screenshot_asset_id(action_id),
+                },
+            },
+            description: None,
+        })
+        .collect();
+    ctx.dispatch_typed_action(&WorkspaceAction::OpenLightbox {
+        images,
+        initial_index,
+    });
+}
+
 impl TypedActionView for AIBlock {
     type Action = AIBlockAction;
 
@@ -7098,12 +7128,15 @@ impl TypedActionView for AIBlock {
                         .flat_map(|c| c.use_computer_action_ids())
                         .collect();
 
-                // Build lightbox images for each action that has a screenshot result.
+                // For each action with a screenshot result, either insert the inline
+                // bytes into the AssetCache immediately or record the stored ref that
+                // must first be fetched from object storage (restored/shared
+                // conversations whose screenshot bytes were offloaded by the server).
                 // We Arc::clone the result each iteration to release the immutable
                 // borrow on ctx, allowing the mutable AssetCache update in the same
                 // loop body. Arc::clone is just a refcount bump (no data copied).
-                let mut screenshot_action_ids: Vec<&AIAgentActionId> = Vec::new();
-                let mut images: Vec<ui_components::lightbox::LightboxImage> = Vec::new();
+                let mut screenshot_actions: Vec<(AIAgentActionId, Option<StoredScreenshotRef>)> =
+                    Vec::new();
                 for action_id in &use_computer_action_ids {
                     let Some(result) = self
                         .action_model
@@ -7114,46 +7147,111 @@ impl TypedActionView for AIBlock {
                         continue;
                     };
                     let AIAgentActionResultType::UseComputer(
-                        crate::ai::agent::UseComputerResult::Success(computer_use::ActionResult {
-                            screenshot: Some(screenshot),
-                            ..
-                        }),
+                        crate::ai::agent::UseComputerResult::Success {
+                            result: action_result,
+                            stored_screenshot_ref,
+                        },
                     ) = &result.result
                     else {
                         continue;
                     };
-                    let asset_id = format!("screenshot-{action_id}");
-                    AssetCache::handle(ctx).update(ctx, |asset_cache, ctx| {
-                        asset_cache.insert_raw_asset_bytes::<ImageType>(
-                            asset_id.clone(),
-                            &screenshot.data,
-                            ctx,
-                        );
-                    });
-                    images.push(ui_components::lightbox::LightboxImage {
-                        source: ui_components::lightbox::LightboxImageSource::Resolved {
-                            asset_source: warpui::assets::asset_cache::AssetSource::Raw {
-                                id: asset_id,
-                            },
-                        },
-                        description: None,
-                    });
-                    screenshot_action_ids.push(action_id);
+                    match (&action_result.screenshot, stored_screenshot_ref) {
+                        (Some(screenshot), _) => {
+                            let asset_id = screenshot_asset_id(action_id);
+                            AssetCache::handle(ctx).update(ctx, |asset_cache, ctx| {
+                                asset_cache.insert_raw_asset_bytes::<ImageType>(
+                                    asset_id,
+                                    &screenshot.data,
+                                    ctx,
+                                );
+                            });
+                            screenshot_actions.push((action_id.clone(), None));
+                        }
+                        (None, Some(stored_ref)) => {
+                            screenshot_actions.push((action_id.clone(), Some(stored_ref.clone())));
+                        }
+                        (None, None) => {}
+                    }
                 }
 
-                if images.is_empty() {
+                if screenshot_actions.is_empty() {
                     return;
                 }
 
-                let initial_index = screenshot_action_ids
+                let initial_index = screenshot_actions
                     .iter()
-                    .position(|id| *id == action_id)
+                    .position(|(id, _)| id == action_id)
                     .unwrap_or(0);
+                let refs_to_fetch: Vec<(AIAgentActionId, StoredScreenshotRef)> = screenshot_actions
+                    .iter()
+                    .filter_map(|(id, stored_ref)| {
+                        stored_ref
+                            .as_ref()
+                            .map(|stored_ref| (id.clone(), stored_ref.clone()))
+                    })
+                    .collect();
+                let ordered_action_ids: Vec<AIAgentActionId> =
+                    screenshot_actions.into_iter().map(|(id, _)| id).collect();
 
-                ctx.dispatch_typed_action(&WorkspaceAction::OpenLightbox {
-                    images,
-                    initial_index,
-                });
+                if refs_to_fetch.is_empty() {
+                    open_screenshot_lightbox(&ordered_action_ids, initial_index, ctx);
+                    return;
+                }
+
+                // Resolve each stored ref to a signed URL and download the image
+                // bytes before opening the lightbox.
+                let server_api_provider = ServerApiProvider::handle(ctx);
+                let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
+                let http_client = server_api_provider.as_ref(ctx).get_http_client();
+                ctx.spawn(
+                    async move {
+                        let mut fetched = Vec::with_capacity(refs_to_fetch.len());
+                        for (action_id, stored_ref) in refs_to_fetch {
+                            let download = ai_client
+                                .get_screenshot_download(
+                                    &stored_ref.conversation_id,
+                                    &stored_ref.screenshot_uid,
+                                )
+                                .await?;
+                            let response = http_client.get(&download.download_url).send().await?;
+                            if !response.status().is_success() {
+                                return Err(anyhow::anyhow!(
+                                    "Failed to download screenshot {}: HTTP {}",
+                                    stored_ref.screenshot_uid,
+                                    response.status()
+                                ));
+                            }
+                            let bytes = response.bytes().await?;
+                            fetched.push((action_id, bytes));
+                        }
+                        anyhow::Ok(fetched)
+                    },
+                    move |_, result, ctx| match result {
+                        Ok(fetched) => {
+                            for (action_id, bytes) in fetched {
+                                let asset_id = screenshot_asset_id(&action_id);
+                                AssetCache::handle(ctx).update(ctx, |asset_cache, ctx| {
+                                    asset_cache
+                                        .insert_raw_asset_bytes::<ImageType>(asset_id, &bytes, ctx);
+                                });
+                            }
+                            open_screenshot_lightbox(&ordered_action_ids, initial_index, ctx);
+                        }
+                        Err(error) => {
+                            log::warn!("Failed to load stored screenshots for lightbox: {error:#}");
+                            let window_id = ctx.window_id();
+                            ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                                toast_stack.add_ephemeral_toast(
+                                    DismissibleToast::error(
+                                        "Failed to load screenshot.".to_string(),
+                                    ),
+                                    window_id,
+                                    ctx,
+                                );
+                            });
+                        }
+                    },
+                );
             }
             AIBlockAction::OpenSubmittedAttachmentLightbox { image_index } => {
                 let decoded_images = self

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -51,10 +51,9 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::content::edit::resolve_asset_source_relative_to_directory;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_errors::{report_error, report_if_error};
-use warp_multi_agent_api::StoredScreenshotRef;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::path::ShellFamily;
-use warpui::assets::asset_cache::AssetCache;
+use warpui::assets::asset_cache::{AssetCache, AssetSource};
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
@@ -155,6 +154,7 @@ use crate::ai::get_relevant_files::controller::{
 #[cfg(feature = "local_fs")]
 use crate::ai::skills::SkillOpenOrigin;
 use crate::ai::skills::{SkillManager, SkillTelemetryEvent};
+use crate::ai::stored_screenshots::stored_screenshot_asset_source;
 use crate::ai::{AIRequestUsageModel, AIRequestUsageModelEvent};
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::cloud_object::model::generic_string_model::GenericStringObjectId;
@@ -6463,21 +6463,16 @@ fn screenshot_asset_id(action_id: &AIAgentActionId) -> String {
     format!("screenshot-{action_id}")
 }
 
-/// Opens the lightbox over the given UseComputer actions' screenshots, which must already be
-/// present in the `AssetCache` under their [`screenshot_asset_id`]s.
+/// Opens the lightbox over the given screenshot asset sources.
 fn open_screenshot_lightbox(
-    action_ids: &[AIAgentActionId],
+    sources: Vec<AssetSource>,
     initial_index: usize,
     ctx: &mut ViewContext<AIBlock>,
 ) {
-    let images = action_ids
-        .iter()
-        .map(|action_id| ui_components::lightbox::LightboxImage {
-            source: ui_components::lightbox::LightboxImageSource::Resolved {
-                asset_source: warpui::assets::asset_cache::AssetSource::Raw {
-                    id: screenshot_asset_id(action_id),
-                },
-            },
+    let images = sources
+        .into_iter()
+        .map(|asset_source| ui_components::lightbox::LightboxImage {
+            source: ui_components::lightbox::LightboxImageSource::Resolved { asset_source },
             description: None,
         })
         .collect();
@@ -7128,15 +7123,14 @@ impl TypedActionView for AIBlock {
                         .flat_map(|c| c.use_computer_action_ids())
                         .collect();
 
-                // For each action with a screenshot result, either insert the inline
-                // bytes into the AssetCache immediately or record the stored ref that
-                // must first be fetched from object storage (restored/shared
-                // conversations whose screenshot bytes were offloaded by the server).
+                let server_api_provider = ServerApiProvider::handle(ctx);
+                let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
+                let http_client = server_api_provider.as_ref(ctx).get_http_client();
+
                 // We Arc::clone the result each iteration to release the immutable
                 // borrow on ctx, allowing the mutable AssetCache update in the same
                 // loop body. Arc::clone is just a refcount bump (no data copied).
-                let mut screenshot_actions: Vec<(AIAgentActionId, Option<StoredScreenshotRef>)> =
-                    Vec::new();
+                let mut screenshot_sources: Vec<(AIAgentActionId, AssetSource)> = Vec::new();
                 for action_id in &use_computer_action_ids {
                     let Some(result) = self
                         .action_model
@@ -7157,98 +7151,41 @@ impl TypedActionView for AIBlock {
                             let asset_id = screenshot_asset_id(action_id);
                             AssetCache::handle(ctx).update(ctx, |asset_cache, ctx| {
                                 asset_cache.insert_raw_asset_bytes::<ImageType>(
-                                    asset_id,
+                                    asset_id.clone(),
                                     &screenshot.data,
                                     ctx,
                                 );
                             });
-                            screenshot_actions.push((action_id.clone(), None));
+                            screenshot_sources
+                                .push((action_id.clone(), AssetSource::Raw { id: asset_id }));
                         }
                         Some(ScreenshotSource::Stored { stored_ref, .. }) => {
-                            screenshot_actions.push((action_id.clone(), Some(stored_ref.clone())));
+                            screenshot_sources.push((
+                                action_id.clone(),
+                                stored_screenshot_asset_source(
+                                    stored_ref.clone(),
+                                    ai_client.clone(),
+                                    http_client.clone(),
+                                ),
+                            ));
                         }
                         None => {}
                     }
                 }
 
-                if screenshot_actions.is_empty() {
+                if screenshot_sources.is_empty() {
                     return;
                 }
 
-                let initial_index = screenshot_actions
+                let initial_index = screenshot_sources
                     .iter()
                     .position(|(id, _)| id == action_id)
                     .unwrap_or(0);
-                let refs_to_fetch: Vec<(AIAgentActionId, StoredScreenshotRef)> = screenshot_actions
-                    .iter()
-                    .filter_map(|(id, stored_ref)| {
-                        stored_ref
-                            .as_ref()
-                            .map(|stored_ref| (id.clone(), stored_ref.clone()))
-                    })
+                let sources = screenshot_sources
+                    .into_iter()
+                    .map(|(_, source)| source)
                     .collect();
-                let ordered_action_ids: Vec<AIAgentActionId> =
-                    screenshot_actions.into_iter().map(|(id, _)| id).collect();
-
-                if refs_to_fetch.is_empty() {
-                    open_screenshot_lightbox(&ordered_action_ids, initial_index, ctx);
-                    return;
-                }
-
-                // Resolve each stored ref to a signed URL and download the image
-                // bytes before opening the lightbox.
-                let server_api_provider = ServerApiProvider::handle(ctx);
-                let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
-                let http_client = server_api_provider.as_ref(ctx).get_http_client();
-                ctx.spawn(
-                    async move {
-                        let mut fetched = Vec::with_capacity(refs_to_fetch.len());
-                        for (action_id, stored_ref) in refs_to_fetch {
-                            let download = ai_client
-                                .get_screenshot_download(
-                                    &stored_ref.conversation_id,
-                                    &stored_ref.screenshot_uid,
-                                )
-                                .await?;
-                            let response = http_client.get(&download.download_url).send().await?;
-                            if !response.status().is_success() {
-                                return Err(anyhow::anyhow!(
-                                    "Failed to download screenshot {}: HTTP {}",
-                                    stored_ref.screenshot_uid,
-                                    response.status()
-                                ));
-                            }
-                            let bytes = response.bytes().await?;
-                            fetched.push((action_id, bytes));
-                        }
-                        anyhow::Ok(fetched)
-                    },
-                    move |_, result, ctx| match result {
-                        Ok(fetched) => {
-                            for (action_id, bytes) in fetched {
-                                let asset_id = screenshot_asset_id(&action_id);
-                                AssetCache::handle(ctx).update(ctx, |asset_cache, ctx| {
-                                    asset_cache
-                                        .insert_raw_asset_bytes::<ImageType>(asset_id, &bytes, ctx);
-                                });
-                            }
-                            open_screenshot_lightbox(&ordered_action_ids, initial_index, ctx);
-                        }
-                        Err(error) => {
-                            log::warn!("Failed to load stored screenshots for lightbox: {error:#}");
-                            let window_id = ctx.window_id();
-                            ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                                toast_stack.add_ephemeral_toast(
-                                    DismissibleToast::error(
-                                        "Failed to load screenshot.".to_string(),
-                                    ),
-                                    window_id,
-                                    ctx,
-                                );
-                            });
-                        }
-                    },
-                );
+                open_screenshot_lightbox(sources, initial_index, ctx);
             }
             AIBlockAction::OpenSubmittedAttachmentLightbox { image_index } => {
                 let decoded_images = self

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -7123,9 +7123,7 @@ impl TypedActionView for AIBlock {
                         .flat_map(|c| c.use_computer_action_ids())
                         .collect();
 
-                let server_api_provider = ServerApiProvider::handle(ctx);
-                let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
-                let http_client = server_api_provider.as_ref(ctx).get_http_client();
+                let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
 
                 // We Arc::clone the result each iteration to release the immutable
                 // borrow on ctx, allowing the mutable AssetCache update in the same
@@ -7165,7 +7163,6 @@ impl TypedActionView for AIBlock {
                                 stored_screenshot_asset_source(
                                     stored_ref.clone(),
                                     ai_client.clone(),
-                                    http_client.clone(),
                                 ),
                             ));
                         }

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -99,9 +99,9 @@ use crate::ai::agent::{
     AIAgentOutputMessageType, AIAgentTextSection, AIIdentifiers, CancellationReason,
     CreateDocumentsRequest, CreateDocumentsResult, DocumentToCreate, EditDocumentsResult,
     MessageId, PassiveSuggestionTrigger, ProgrammingLanguage, RenderableAIError,
-    RequestCommandOutputResult, RequestFileEditsResult, SearchCodebaseResult, ServerOutputId,
-    SubagentCall, SubagentType, SuggestPromptRequest, SuggestPromptResult, SuggestedLoggingId,
-    SummarizationType, TodoOperation,
+    RequestCommandOutputResult, RequestFileEditsResult, ScreenshotSource, SearchCodebaseResult,
+    ServerOutputId, SubagentCall, SubagentType, SuggestPromptRequest, SuggestPromptResult,
+    SuggestedLoggingId, SummarizationType, TodoOperation,
 };
 use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentConversationsModelEvent};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -7147,16 +7147,13 @@ impl TypedActionView for AIBlock {
                         continue;
                     };
                     let AIAgentActionResultType::UseComputer(
-                        crate::ai::agent::UseComputerResult::Success {
-                            result: action_result,
-                            stored_screenshot_ref,
-                        },
+                        crate::ai::agent::UseComputerResult::Success { screenshot, .. },
                     ) = &result.result
                     else {
                         continue;
                     };
-                    match (&action_result.screenshot, stored_screenshot_ref) {
-                        (Some(screenshot), _) => {
+                    match screenshot {
+                        Some(ScreenshotSource::Inline(screenshot)) => {
                             let asset_id = screenshot_asset_id(action_id);
                             AssetCache::handle(ctx).update(ctx, |asset_cache, ctx| {
                                 asset_cache.insert_raw_asset_bytes::<ImageType>(
@@ -7167,10 +7164,10 @@ impl TypedActionView for AIBlock {
                             });
                             screenshot_actions.push((action_id.clone(), None));
                         }
-                        (None, Some(stored_ref)) => {
+                        Some(ScreenshotSource::Stored { stored_ref, .. }) => {
                             screenshot_actions.push((action_id.clone(), Some(stored_ref.clone())));
                         }
-                        (None, None) => {}
+                        None => {}
                     }
                 }
 

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3200,7 +3200,8 @@ fn render_use_computer(
             renderable_action.with_footer(render_recording_footer(recording_span.status, app));
     }
 
-    // Add a "View screenshot" button if the action result contains a screenshot.
+    // Add a "View screenshot" button if the action result contains a screenshot,
+    // either inline or offloaded to object storage.
     let has_screenshot = props
         .action_model
         .as_ref(app)
@@ -3209,8 +3210,11 @@ fn render_use_computer(
             matches!(
                 &result.result,
                 AIAgentActionResultType::UseComputer(
-                    crate::ai::agent::UseComputerResult::Success(action_result)
-                ) if action_result.screenshot.is_some()
+                    crate::ai::agent::UseComputerResult::Success {
+                        result: action_result,
+                        stored_screenshot_ref,
+                    }
+                ) if action_result.screenshot.is_some() || stored_screenshot_ref.is_some()
             )
         });
 

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3211,10 +3211,10 @@ fn render_use_computer(
                 &result.result,
                 AIAgentActionResultType::UseComputer(
                     crate::ai::agent::UseComputerResult::Success {
-                        result: action_result,
-                        stored_screenshot_ref,
+                        screenshot: Some(_),
+                        ..
                     }
-                ) if action_result.screenshot.is_some() || stored_screenshot_ref.is_some()
+                )
             )
         });
 

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -55,6 +55,7 @@ pub mod request_usage_model;
 pub(crate) mod restored_conversations;
 pub(crate) mod runner_display;
 pub(crate) mod skills;
+pub(crate) mod stored_screenshots;
 #[cfg(not(target_family = "wasm"))]
 pub(crate) mod tui_api_keys;
 pub(crate) mod voice;

--- a/app/src/ai/stored_screenshots.rs
+++ b/app/src/ai/stored_screenshots.rs
@@ -14,45 +14,24 @@ use crate::server::server_api::ai::AIClient;
 struct StoredScreenshotAsset;
 impl AsyncAssetType for StoredScreenshotAsset {}
 
-/// Builds an async asset source that resolves the stored ref to a signed URL and downloads the
-/// screenshot bytes on demand. Keyed by the screenshot UID (not the signed URL, which changes on
-/// every resolution) so repeat loads reuse the cached bytes.
+/// Builds an async asset source that downloads the screenshot bytes on demand. Keyed by the
+/// screenshot UID so repeat loads reuse the cached bytes.
 pub fn stored_screenshot_asset_source(
     stored_ref: StoredScreenshotRef,
     ai_client: Arc<dyn AIClient>,
-    http_client: Arc<http_client::Client>,
 ) -> AssetSource {
     AssetSource::Async {
         id: AsyncAssetId::new::<StoredScreenshotAsset>(stored_ref.screenshot_uid.clone()),
         fetch: Arc::new(move || {
             let ai_client = ai_client.clone();
-            let http_client = http_client.clone();
             let stored_ref = stored_ref.clone();
             Box::pin(async move {
-                let download = ai_client
-                    .get_screenshot_download(
+                ai_client
+                    .download_stored_screenshot(
                         &stored_ref.conversation_id,
                         &stored_ref.screenshot_uid,
                     )
-                    .await?;
-                // Strip the signed URL from transport errors so it cannot leak
-                // into logs or Sentry breadcrumbs.
-                let response = http_client
-                    .get(&download.download_url)
-                    .send()
                     .await
-                    .map_err(|error| anyhow::Error::new(error.without_url()))?;
-                if !response.status().is_success() {
-                    anyhow::bail!(
-                        "Failed to download screenshot {}: HTTP {}",
-                        stored_ref.screenshot_uid,
-                        response.status()
-                    );
-                }
-                response
-                    .bytes()
-                    .await
-                    .map_err(|error| anyhow::Error::new(error.without_url()))
             })
         }),
     }

--- a/app/src/ai/stored_screenshots.rs
+++ b/app/src/ai/stored_screenshots.rs
@@ -1,0 +1,59 @@
+//! Loading of computer-use screenshots whose bytes live in Warp-managed object
+//! storage rather than inline on the client (e.g. restored/shared conversations
+//! whose screenshot bytes were offloaded by the server).
+
+use std::sync::Arc;
+
+use warp_multi_agent_api::StoredScreenshotRef;
+use warpui::assets::asset_cache::{AssetSource, AsyncAssetId, AsyncAssetType};
+
+use crate::server::server_api::ai::AIClient;
+
+/// Namespace for computer-use screenshot bytes fetched on demand from
+/// Warp-managed object storage.
+struct StoredScreenshotAsset;
+impl AsyncAssetType for StoredScreenshotAsset {}
+
+/// Builds an async asset source that resolves the stored ref to a signed URL and downloads the
+/// screenshot bytes on demand. Keyed by the screenshot UID (not the signed URL, which changes on
+/// every resolution) so repeat loads reuse the cached bytes.
+pub fn stored_screenshot_asset_source(
+    stored_ref: StoredScreenshotRef,
+    ai_client: Arc<dyn AIClient>,
+    http_client: Arc<http_client::Client>,
+) -> AssetSource {
+    AssetSource::Async {
+        id: AsyncAssetId::new::<StoredScreenshotAsset>(stored_ref.screenshot_uid.clone()),
+        fetch: Arc::new(move || {
+            let ai_client = ai_client.clone();
+            let http_client = http_client.clone();
+            let stored_ref = stored_ref.clone();
+            Box::pin(async move {
+                let download = ai_client
+                    .get_screenshot_download(
+                        &stored_ref.conversation_id,
+                        &stored_ref.screenshot_uid,
+                    )
+                    .await?;
+                // Strip the signed URL from transport errors so it cannot leak
+                // into logs or Sentry breadcrumbs.
+                let response = http_client
+                    .get(&download.download_url)
+                    .send()
+                    .await
+                    .map_err(|error| anyhow::Error::new(error.without_url()))?;
+                if !response.status().is_success() {
+                    anyhow::bail!(
+                        "Failed to download screenshot {}: HTTP {}",
+                        stored_ref.screenshot_uid,
+                        response.status()
+                    );
+                }
+                response
+                    .bytes()
+                    .await
+                    .map_err(|error| anyhow::Error::new(error.without_url()))
+            })
+        }),
+    }
+}

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -529,6 +529,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::ShellWidgetHandoff,
         #[cfg(feature = "history_search_ranking_v2")]
         FeatureFlag::HistorySearchRankingV2,
+        #[cfg(feature = "stored_screenshots")]
+        FeatureFlag::StoredScreenshots,
     ]);
 
     flags

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -10,7 +10,6 @@ use ai::index::full_source_code_embedding::{
 use anyhow::anyhow;
 use async_trait::async_trait;
 use base64::Engine;
-#[cfg(not(target_family = "wasm"))]
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use cloud_object_models::CodeForge;
@@ -593,14 +592,6 @@ pub struct ScreenshotArtifactResponseData {
     pub expires_at: DateTime<Utc>,
     pub content_type: String,
     pub description: Option<String>,
-}
-
-/// Response from the stored computer-use screenshot download endpoint.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct ScreenshotDownloadResponse {
-    /// Short-lived signed URL from which the screenshot bytes can be fetched.
-    pub download_url: String,
-    pub expires_at: DateTime<Utc>,
 }
 
 /// File-specific data from the artifact endpoint.
@@ -1529,13 +1520,13 @@ pub trait AIClient: 'static + Send + Sync {
         artifact_uid: &str,
     ) -> anyhow::Result<ArtifactDownloadResponse, anyhow::Error>;
 
-    /// Fetches a signed download URL for a computer-use screenshot stored in
-    /// Warp-managed object storage. Requires view access to the conversation.
-    async fn get_screenshot_download(
+    /// Downloads the bytes of a computer-use screenshot stored in Warp-managed
+    /// object storage. Requires view access to the conversation.
+    async fn download_stored_screenshot(
         &self,
         conversation_id: &str,
         screenshot_uid: &str,
-    ) -> anyhow::Result<ScreenshotDownloadResponse, anyhow::Error>;
+    ) -> anyhow::Result<Bytes, anyhow::Error>;
 
     async fn prepare_attachments_for_upload(
         &self,
@@ -3018,19 +3009,25 @@ impl AIClient for ServerApi {
         Ok(response)
     }
 
-    async fn get_screenshot_download(
+    async fn download_stored_screenshot(
         &self,
         conversation_id: &str,
         screenshot_uid: &str,
-    ) -> anyhow::Result<ScreenshotDownloadResponse, anyhow::Error> {
-        let response: ScreenshotDownloadResponse = self
-            .get_public_api(&format!(
-                "agent/conversations/{}/screenshots/{}",
+    ) -> anyhow::Result<Bytes, anyhow::Error> {
+        // The endpoint redirects to a short-lived signed URL, which the HTTP
+        // client follows transparently. Strip that URL from body-read errors so
+        // it cannot leak into logs or Sentry breadcrumbs.
+        let response = self
+            .get_public_api_response(&format!(
+                "agent/conversations/{}/screenshots/{}/download",
                 urlencoding::encode(conversation_id),
                 urlencoding::encode(screenshot_uid)
             ))
             .await?;
-        Ok(response)
+        response
+            .bytes()
+            .await
+            .map_err(|error| anyhow::Error::new(error.without_url()))
     }
 
     async fn prepare_attachments_for_upload(

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -595,6 +595,14 @@ pub struct ScreenshotArtifactResponseData {
     pub description: Option<String>,
 }
 
+/// Response from the stored computer-use screenshot download endpoint.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct ScreenshotDownloadResponse {
+    /// Short-lived signed URL from which the screenshot bytes can be fetched.
+    pub download_url: String,
+    pub expires_at: DateTime<Utc>,
+}
+
 /// File-specific data from the artifact endpoint.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct FileArtifactResponseData {
@@ -1520,6 +1528,14 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         artifact_uid: &str,
     ) -> anyhow::Result<ArtifactDownloadResponse, anyhow::Error>;
+
+    /// Fetches a signed download URL for a computer-use screenshot stored in
+    /// Warp-managed object storage. Requires view access to the conversation.
+    async fn get_screenshot_download(
+        &self,
+        conversation_id: &str,
+        screenshot_uid: &str,
+    ) -> anyhow::Result<ScreenshotDownloadResponse, anyhow::Error>;
 
     async fn prepare_attachments_for_upload(
         &self,
@@ -2998,6 +3014,21 @@ impl AIClient for ServerApi {
     ) -> anyhow::Result<ArtifactDownloadResponse, anyhow::Error> {
         let response: ArtifactDownloadResponse = self
             .get_public_api(&format!("agent/artifacts/{artifact_uid}"))
+            .await?;
+        Ok(response)
+    }
+
+    async fn get_screenshot_download(
+        &self,
+        conversation_id: &str,
+        screenshot_uid: &str,
+    ) -> anyhow::Result<ScreenshotDownloadResponse, anyhow::Error> {
+        let response: ScreenshotDownloadResponse = self
+            .get_public_api(&format!(
+                "agent/conversations/{}/screenshots/{}",
+                urlencoding::encode(conversation_id),
+                urlencoding::encode(screenshot_uid)
+            ))
             .await?;
         Ok(response)
     }

--- a/app/src/workspace/lightbox_view.rs
+++ b/app/src/workspace/lightbox_view.rs
@@ -142,25 +142,32 @@ impl View for LightboxView {
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
 
-        // Determine the native pixel size of the current image by querying the
-        // asset cache. This will be `Some` once the image bytes have been fully
-        // loaded and decoded.
-        let current_image_native_size =
-            self.params
-                .images
-                .get(self.current_index)
-                .and_then(|img| match &img.source {
-                    lightbox::LightboxImageSource::Resolved { asset_source } => {
-                        let asset_cache = AssetCache::as_ref(app);
-                        match asset_cache.load_asset::<ImageType>(asset_source.clone()) {
-                            AssetState::Loaded { data } => data
-                                .image_size()
-                                .map(|size| Vector2F::new(size.x() as f32, size.y() as f32)),
-                            _ => None,
+        // Determine the load state of the current image by querying the asset
+        // cache. The image renders once its bytes have been fully loaded and
+        // decoded; a failed fetch or decode surfaces as an error state.
+        let current_image_state = self
+            .params
+            .images
+            .get(self.current_index)
+            .map(|img| match &img.source {
+                lightbox::LightboxImageSource::Resolved { asset_source } => {
+                    let asset_cache = AssetCache::as_ref(app);
+                    match asset_cache.load_asset::<ImageType>(asset_source.clone()) {
+                        AssetState::Loaded { data } => data
+                            .image_size()
+                            .map(|size| lightbox::CurrentImageState::Loaded {
+                                native_size: Vector2F::new(size.x() as f32, size.y() as f32),
+                            })
+                            .unwrap_or(lightbox::CurrentImageState::Failed),
+                        AssetState::FailedToLoad(_) => lightbox::CurrentImageState::Failed,
+                        AssetState::Loading { .. } | AssetState::Evicted => {
+                            lightbox::CurrentImageState::Loading
                         }
                     }
-                    lightbox::LightboxImageSource::Loading => None,
-                });
+                }
+                lightbox::LightboxImageSource::Loading => lightbox::CurrentImageState::Loading,
+            })
+            .unwrap_or(lightbox::CurrentImageState::Loading);
 
         self.lightbox.render(
             appearance,
@@ -170,7 +177,7 @@ impl View for LightboxView {
                 on_dismiss: Arc::new(|ctx, _| {
                     ctx.dispatch_typed_action(LightboxViewAction::Dismiss);
                 }),
-                current_image_native_size,
+                current_image_state,
                 options: lightbox::Options {
                     dismiss_keystroke: Keystroke::parse("escape").ok(),
                     on_navigate: Some(Arc::new(|direction, ctx, _| match direction {

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -1088,7 +1088,7 @@ impl TryFrom<RequestComputerUseResult> for api::request::input::tool_call_result
                                     height_px: screenshot.original_height as i32,
                                 }),
                                 initial_screenshot: Some(api::RawImage {
-                                    data: screenshot.data,
+                                    source: Some(api::raw_image::Source::Data(screenshot.data)),
                                     mime_type: screenshot.mime_type.to_string(),
                                     width: screenshot.width as i32,
                                     height: screenshot.height as i32,
@@ -1127,7 +1127,7 @@ impl TryFrom<UseComputerResult> for api::request::input::tool_call_result::Resul
 
     fn try_from(result: UseComputerResult) -> Result<Self, Self::Error> {
         match result {
-            UseComputerResult::Success(result) => {
+            UseComputerResult::Success { result, .. } => {
                 // Copy out the captured-window metadata (if any) before the owned fields of
                 // `result` are moved into the message below.
                 let captured = result.captured_window;
@@ -1135,8 +1135,11 @@ impl TryFrom<UseComputerResult> for api::request::input::tool_call_result::Resul
                     api::UseComputerResult {
                         result: Some(api::use_computer_result::Result::Success(
                             api::use_computer_result::Success {
+                                // Results sent as request inputs always come from a local
+                                // capture, so the screenshot bytes are inline and no stored
+                                // ref exists yet; the server performs the offload.
                                 screenshot: result.screenshot.map(|s| api::RawImage {
-                                    data: s.data,
+                                    source: Some(api::raw_image::Source::Data(s.data)),
                                     mime_type: s.mime_type.to_string(),
                                     width: s.width as i32,
                                     height: s.height as i32,

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -1127,43 +1127,31 @@ impl TryFrom<UseComputerResult> for api::request::input::tool_call_result::Resul
 
     fn try_from(result: UseComputerResult) -> Result<Self, Self::Error> {
         match result {
-            UseComputerResult::Success { result, .. } => {
-                // Copy out the captured-window metadata (if any) before the owned fields of
-                // `result` are moved into the message below.
-                let captured = result.captured_window;
-                Ok(api::request::input::tool_call_result::Result::UseComputer(
-                    api::UseComputerResult {
-                        result: Some(api::use_computer_result::Result::Success(
-                            api::use_computer_result::Success {
-                                // Results sent as request inputs always come from a local
-                                // capture, so the screenshot bytes are inline and no stored
-                                // ref exists yet; the server performs the offload.
-                                screenshot: result.screenshot.map(|s| api::RawImage {
-                                    source: Some(api::raw_image::Source::Data(s.data)),
-                                    mime_type: s.mime_type.to_string(),
-                                    width: s.width as i32,
-                                    height: s.height as i32,
-                                }),
-                                cursor_position: result.cursor_position.map(vec_to_coordinates),
-                                windows: result
-                                    .windows
-                                    .into_iter()
-                                    .map(convert_window_info)
-                                    .collect(),
-                                // The window id is an opaque string on the wire; on macOS it is a
-                                // CGWindowID, so format the u32 back to a string at the boundary.
-                                captured_window: captured.map(|c| {
-                                    api::use_computer_result::success::CapturedWindow {
-                                        window_id: c.window_id.to_string(),
-                                        width_px: c.width_px,
-                                        height_px: c.height_px,
-                                    }
-                                }),
-                            },
-                        )),
-                    },
-                ))
-            }
+            UseComputerResult::Success {
+                screenshot,
+                cursor_position,
+                windows,
+                captured_window,
+            } => Ok(api::request::input::tool_call_result::Result::UseComputer(
+                api::UseComputerResult {
+                    result: Some(api::use_computer_result::Result::Success(
+                        api::use_computer_result::Success {
+                            screenshot: screenshot.map(convert_screenshot_source),
+                            cursor_position: cursor_position.map(vec_to_coordinates),
+                            windows: windows.into_iter().map(convert_window_info).collect(),
+                            // The window id is an opaque string on the wire; on macOS it is a
+                            // CGWindowID, so format the u32 back to a string at the boundary.
+                            captured_window: captured_window.map(|c| {
+                                api::use_computer_result::success::CapturedWindow {
+                                    window_id: c.window_id.to_string(),
+                                    width_px: c.width_px,
+                                    height_px: c.height_px,
+                                }
+                            }),
+                        },
+                    )),
+                },
+            )),
             UseComputerResult::Error(error) => {
                 Ok(api::request::input::tool_call_result::Result::UseComputer(
                     api::UseComputerResult {
@@ -1175,6 +1163,30 @@ impl TryFrom<UseComputerResult> for api::request::input::tool_call_result::Resul
             }
             UseComputerResult::Cancelled => Err(ConvertToAPITypeError::Ignore),
         }
+    }
+}
+
+/// Converts a screenshot source to the wire `RawImage`, preserving whether the
+/// bytes are inline or a stored object-storage ref.
+fn convert_screenshot_source(source: ScreenshotSource) -> api::RawImage {
+    match source {
+        ScreenshotSource::Inline(screenshot) => api::RawImage {
+            source: Some(api::raw_image::Source::Data(screenshot.data)),
+            mime_type: screenshot.mime_type.to_string(),
+            width: screenshot.width as i32,
+            height: screenshot.height as i32,
+        },
+        ScreenshotSource::Stored {
+            stored_ref,
+            mime_type,
+            width,
+            height,
+        } => api::RawImage {
+            source: Some(api::raw_image::Source::StoredRef(stored_ref)),
+            mime_type,
+            width,
+            height,
+        },
     }
 }
 

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -1207,23 +1207,49 @@ impl Display for ReadSkillResult {
 }
 #[derive(Debug, Clone, PartialEq)]
 pub enum UseComputerResult {
-    /// Computer use succeeded, with one result per requested action.
+    /// Computer use succeeded. Mirrors the wire `Success` message.
     Success {
-        result: computer_use::ActionResult,
-        /// Present when the screenshot bytes live in Warp-managed object
-        /// storage instead of inline in `result`.
-        stored_screenshot_ref: Option<StoredScreenshotRef>,
+        screenshot: Option<ScreenshotSource>,
+        cursor_position: Option<computer_use::Vector2I>,
+        /// The on-screen windows, refreshed after the actions ran, so the caller always has a
+        /// fresh list to target next. Empty on platforms without window enumeration.
+        windows: Vec<computer_use::WindowInfo>,
+        /// Metadata about the captured window, populated only when a window target was
+        /// screenshotted, so window-local coordinates map onto the screenshot image.
+        captured_window: Option<computer_use::CapturedWindow>,
     },
     Error(String),
     Cancelled,
 }
 
+/// Where a computer-use screenshot's bytes live, mirroring the wire's
+/// `RawImage.source` oneof.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScreenshotSource {
+    /// The bytes are inline on the client.
+    Inline(computer_use::Screenshot),
+    /// The bytes live in Warp-managed object storage and must be fetched via a
+    /// signed URL.
+    Stored {
+        stored_ref: StoredScreenshotRef,
+        /// MIME type of the stored image (e.g. "image/png").
+        mime_type: String,
+        /// The width of the stored image, in pixels.
+        width: i32,
+        /// The height of the stored image, in pixels.
+        height: i32,
+    },
+}
+
 impl UseComputerResult {
-    /// Builds a success result whose screenshot bytes (if any) are inline.
+    /// Builds a success result from a locally captured action result, whose
+    /// screenshot bytes (if any) are inline.
     pub fn success(result: computer_use::ActionResult) -> Self {
         Self::Success {
-            result,
-            stored_screenshot_ref: None,
+            screenshot: result.screenshot.map(ScreenshotSource::Inline),
+            cursor_position: result.cursor_position,
+            windows: result.windows,
+            captured_window: result.captured_window,
         }
     }
 }

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Local};
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use warp_core::command::ExitCode;
+use warp_multi_agent_api::StoredScreenshotRef;
 use warp_multi_agent_api::apply_file_diffs_result::success::UpdatedFileContent;
 use warp_terminal::model::BlockId;
 
@@ -879,7 +880,7 @@ impl AIAgentActionResultType {
                 ReadShellCommandOutputResult::CommandFinished { .. }
                 | ReadShellCommandOutputResult::LongRunningCommandSnapshot { .. },
             )
-            | Self::UseComputer(UseComputerResult::Success(_))
+            | Self::UseComputer(UseComputerResult::Success { .. })
             | Self::InsertReviewComments(InsertReviewCommentsResult::Success { .. })
             | Self::RequestComputerUse(RequestComputerUseResult::Approved { .. })
             | Self::StartRecording(StartRecordingResult::Success(_))
@@ -1207,15 +1208,30 @@ impl Display for ReadSkillResult {
 #[derive(Debug, Clone, PartialEq)]
 pub enum UseComputerResult {
     /// Computer use succeeded, with one result per requested action.
-    Success(computer_use::ActionResult),
+    Success {
+        result: computer_use::ActionResult,
+        /// Present when the screenshot bytes live in Warp-managed object
+        /// storage instead of inline in `result`.
+        stored_screenshot_ref: Option<StoredScreenshotRef>,
+    },
     Error(String),
     Cancelled,
+}
+
+impl UseComputerResult {
+    /// Builds a success result whose screenshot bytes (if any) are inline.
+    pub fn success(result: computer_use::ActionResult) -> Self {
+        Self::Success {
+            result,
+            stored_screenshot_ref: None,
+        }
+    }
 }
 
 impl Display for UseComputerResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UseComputerResult::Success(_) => write!(f, "Use computer completed"),
+            UseComputerResult::Success { .. } => write!(f, "Use computer completed"),
             UseComputerResult::Error(error) => write!(f, "Use computer error: {error}"),
             UseComputerResult::Cancelled => write!(f, "Use computer cancelled"),
         }

--- a/crates/ui_components/examples/library.rs
+++ b/crates/ui_components/examples/library.rs
@@ -550,10 +550,11 @@ impl RootView {
     }
 
     fn render_lightbox(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
-        let current_image_native_size = self
+        let current_image_state = self
             .lightbox_images
             .get(self.lightbox_current_index)
-            .and_then(|img| native_size_for_image(img, app));
+            .map(|img| image_state_for_image(img, app))
+            .unwrap_or(lightbox::CurrentImageState::Loading);
 
         self.lightbox.render(
             appearance,
@@ -563,7 +564,7 @@ impl RootView {
                 on_dismiss: Arc::new(|ctx, _app| {
                     ctx.dispatch_typed_action(Action::CloseLightbox);
                 }),
-                current_image_native_size,
+                current_image_state,
                 options: lightbox::Options {
                     dismiss_keystroke: Some(warpui_core::keymap::Keystroke {
                         key: "escape".to_string(),
@@ -583,10 +584,11 @@ impl RootView {
     }
 
     fn render_async_lightbox(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
-        let current_image_native_size = self
+        let current_image_state = self
             .async_lightbox_images
             .get(self.async_lightbox_current_index)
-            .and_then(|img| native_size_for_image(img, app));
+            .map(|img| image_state_for_image(img, app))
+            .unwrap_or(lightbox::CurrentImageState::Loading);
 
         self.async_lightbox.render(
             appearance,
@@ -596,7 +598,7 @@ impl RootView {
                 on_dismiss: Arc::new(|ctx, _app| {
                     ctx.dispatch_typed_action(Action::CloseLightbox);
                 }),
-                current_image_native_size,
+                current_image_state,
                 options: lightbox::Options {
                     dismiss_keystroke: Some(warpui_core::keymap::Keystroke {
                         key: "escape".to_string(),
@@ -724,20 +726,25 @@ struct ButtonRow {
     icon: button::Button,
 }
 
-/// Queries the `AssetCache` for the native pixel dimensions of a lightbox image.
-/// Returns `Some` when the image bytes have been fully loaded and decoded.
-fn native_size_for_image(image: &LightboxImage, app: &AppContext) -> Option<Vector2F> {
+/// Queries the `AssetCache` for the load state of a lightbox image's bytes.
+fn image_state_for_image(image: &LightboxImage, app: &AppContext) -> lightbox::CurrentImageState {
     match &image.source {
         LightboxImageSource::Resolved { asset_source } => {
             let asset_cache = AssetCache::as_ref(app);
             match asset_cache.load_asset::<ImageType>(asset_source.clone()) {
                 AssetState::Loaded { data } => data
                     .image_size()
-                    .map(|size| Vector2F::new(size.x() as f32, size.y() as f32)),
-                _ => None,
+                    .map(|size| lightbox::CurrentImageState::Loaded {
+                        native_size: Vector2F::new(size.x() as f32, size.y() as f32),
+                    })
+                    .unwrap_or(lightbox::CurrentImageState::Failed),
+                AssetState::FailedToLoad(_) => lightbox::CurrentImageState::Failed,
+                AssetState::Loading { .. } | AssetState::Evicted => {
+                    lightbox::CurrentImageState::Loading
+                }
             }
         }
-        LightboxImageSource::Loading => None,
+        LightboxImageSource::Loading => lightbox::CurrentImageState::Loading,
     }
 }
 

--- a/crates/ui_components/src/lightbox.rs
+++ b/crates/ui_components/src/lightbox.rs
@@ -35,6 +35,20 @@ pub enum LightboxImageSource {
     Resolved { asset_source: AssetSource },
 }
 
+/// The load state of the currently displayed image's bytes.
+#[derive(Clone, Copy, Debug)]
+pub enum CurrentImageState {
+    /// The image bytes are still being fetched or decoded.
+    Loading,
+    /// The image is fully loaded and decoded.
+    Loaded {
+        /// The native pixel dimensions of the image.
+        native_size: Vector2F,
+    },
+    /// The image bytes failed to load or decode.
+    Failed,
+}
+
 /// A single image entry in the lightbox.
 #[derive(Clone, Debug)]
 pub struct LightboxImage {
@@ -76,11 +90,10 @@ pub struct Params<'a> {
     /// Handler to invoke when the lightbox is dismissed.
     pub on_dismiss: DismissHandler,
 
-    /// The native pixel dimensions of the currently displayed image, if known.
-    /// When `Some`, the image is fully loaded and the lightbox renders it with a
-    /// `ConstrainedBox` plus description. When `None`, the lightbox shows a loading
-    /// indicator instead.
-    pub current_image_native_size: Option<Vector2F>,
+    /// The load state of the currently displayed image. When `Loaded`, the
+    /// lightbox renders the image with a `ConstrainedBox` plus description;
+    /// otherwise it shows a loading indicator or an error message.
+    pub current_image_state: CurrentImageState,
 
     /// Optional configuration for the lightbox.
     pub options: Options,
@@ -144,54 +157,64 @@ impl Component for Lightbox {
             },
         );
 
-        // Build the central content based on the image source and whether the
-        // native size is known (i.e. the image data has been loaded).
-        let central_content: Box<dyn Element> =
-            match (current_source, params.current_image_native_size) {
-                // Image source resolved AND native size known → render the image.
-                (Some(LightboxImageSource::Resolved { asset_source }), Some(native_size)) => {
-                    let image = ConstrainedBox::new(
-                        Image::new(asset_source.clone(), CacheOption::Original)
-                            .contain()
-                            .layout_using_paint_bounds()
-                            .before_load(Align::new(loading_element(appearance)).finish())
-                            .finish(),
-                    )
-                    .with_max_width(native_size.x())
-                    .with_max_height(native_size.y())
-                    .finish();
-
-                    EventHandler::new(image)
-                        .on_left_mouse_down(|_, _, _| DispatchEventResult::StopPropagation)
-                        .finish()
-                }
-                // No images provided at all.
-                _ if image_count == 0 => {
-                    Text::new("No images", appearance.ui_font_family(), text_size)
-                        .with_color(ColorU::white())
-                        .finish()
-                }
-                // Still loading (either metadata or image bytes).
-                _ => loading_element(appearance),
-            };
-
-        // Show the description only when the image is fully loaded (native size known).
-        let content_with_description = if let (Some(description), Some(_)) =
-            (current_description, params.current_image_native_size)
-        {
-            let description_text = Text::new(description, appearance.ui_font_family(), text_size)
-                .with_color(ColorU::white())
+        // Build the central content based on the image source and the load
+        // state of the current image's bytes.
+        let central_content: Box<dyn Element> = match (current_source, params.current_image_state) {
+            // Image source resolved AND bytes loaded → render the image.
+            (
+                Some(LightboxImageSource::Resolved { asset_source }),
+                CurrentImageState::Loaded { native_size },
+            ) => {
+                let image = ConstrainedBox::new(
+                    Image::new(asset_source.clone(), CacheOption::Original)
+                        .contain()
+                        .layout_using_paint_bounds()
+                        .before_load(Align::new(loading_element(appearance)).finish())
+                        .finish(),
+                )
+                .with_max_width(native_size.x())
+                .with_max_height(native_size.y())
                 .finish();
 
-            Flex::column()
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_spacing(DESCRIPTION_SPACING)
-                .with_child(Shrinkable::new(1.0, central_content).finish())
-                .with_child(description_text)
-                .finish()
-        } else {
-            central_content
+                EventHandler::new(image)
+                    .on_left_mouse_down(|_, _, _| DispatchEventResult::StopPropagation)
+                    .finish()
+            }
+            // No images provided at all.
+            _ if image_count == 0 => Text::new("No images", appearance.ui_font_family(), text_size)
+                .with_color(ColorU::white())
+                .finish(),
+            // The image bytes failed to load or decode.
+            (_, CurrentImageState::Failed) => Text::new(
+                "Failed to load image",
+                appearance.ui_font_family(),
+                text_size,
+            )
+            .with_color(ColorU::white())
+            .finish(),
+            // Still loading (either metadata or image bytes).
+            _ => loading_element(appearance),
         };
+
+        // Show the description only when the image is fully loaded.
+        let content_with_description =
+            if let (Some(description), CurrentImageState::Loaded { .. }) =
+                (current_description, params.current_image_state)
+            {
+                let description_text =
+                    Text::new(description, appearance.ui_font_family(), text_size)
+                        .with_color(ColorU::white())
+                        .finish();
+
+                Flex::column()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(DESCRIPTION_SPACING)
+                    .with_child(Shrinkable::new(1.0, central_content).finish())
+                    .with_child(description_text)
+                    .finish()
+            } else {
+                central_content
+            };
 
         let centered_content = Align::new(content_with_description).finish();
 

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -990,6 +990,11 @@ pub enum FeatureFlag {
     /// fuzzy-match score against the whole query as a single pattern. Disabling this is a full
     /// return to the pre-APP-5650 history search behavior, not an approximation of it.
     HistorySearchRankingV2,
+
+    /// Advertises client support for server-issued task-message updates that
+    /// replace inline computer-use screenshot bytes with references to
+    /// Warp-managed object storage.
+    StoredScreenshots,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -1067,6 +1072,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::CtrlCCancelsThirdPartyHarness,
     FeatureFlag::WarpingModelName,
     FeatureFlag::LrcActivitySignal,
+    FeatureFlag::StoredScreenshots,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Client half of computer-use screenshot offload (server: warpdotdev/warp-server#16148). The server now swaps inline screenshot bytes in task messages for small `StoredScreenshotRef`s via `UpdateTaskMessage` — and those updates target messages from **earlier** turns.

That's the new part. A task lives in two forms: the proto `source` (echoed back to the server) and per-turn `exchanges` (rendered UI). `UpdateTaskMessage` handling assumed the target message was created by the current stream: it errored if the stream had no exchange for the task, and rendered the update into the current turn either way. Both are wrong for history edits.

The fix routes by ownership: `upsert_message` updates the exchange that actually contains the message (current-stream exchange only for genuinely new ones), and finished exchanges now render updates. Same-stream behavior is unchanged, pinned by a regression test.

Also: refs survive conversion/restore round-trips, and the lightbox fetches ref-only screenshots via signed URL. `Cargo.toml` temporarily patches the proto crate to a local checkout until warpdotdev/warp-proto-apis#367 publishes.

## Linked Issue
- [ ] No linked issue — tracked via the Warp conversation below.
- [ ] No UI change; no screenshots.

## Testing
4 new `task_tests.rs` tests (same-stream regression, cross-exchange swap, no-current-exchange, new-message error); scoped nextest/check/clippy/format all clean. Presubmit + master-merge owed before leaving draft.

- [ ] Not manually tested yet — needs the server flag (staging or local server); planned before marking ready.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

---
[Warp conversation](https://staging.warp.dev/conversation/94d4736c-ab24-4a6c-8279-416ad3dc61e3) · [Plan](https://staging.warp.dev/drive/notebook/wD0rnN6nnopfiXz580bLet)
