### PR TITLE
CLIAgentSessionStatus updates should update ConversationStatus

### DIFF
--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -183,6 +183,21 @@ impl LocalAgentTaskSyncModel {
         );
     }
 
+    /// Test-only equivalent of `register_cli_session` that only records the
+    /// `terminal_view_id → task_id` mapping, without enqueuing the
+    /// IN_PROGRESS report that `register_cli_session` sends via the real
+    /// `AIClient`. Use this in tests that only need
+    /// `task_id_for_terminal_view` to resolve (e.g. exercising
+    /// `TerminalView::conversation_id_for_cli_status_updates`).
+    #[cfg(test)]
+    pub(crate) fn register_cli_session_for_test(
+        &mut self,
+        terminal_view_id: EntityId,
+        task_id: AmbientAgentTaskId,
+    ) {
+        self.cli_session_task_ids.insert(terminal_view_id, task_id);
+    }
+
     /// Returns the ambient task this terminal pane's CLI-harness session, if
     /// any, is registered under. Callers use this to identify which local
     /// `AIConversation` (if any) represents the same run as CLI agent

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -183,6 +183,22 @@ impl LocalAgentTaskSyncModel {
         );
     }
 
+    /// Returns the ambient task this terminal pane's CLI-harness session, if
+    /// any, is registered under. Callers use this to identify which local
+    /// `AIConversation` (if any) represents the same run as CLI agent
+    /// lifecycle events observed in this pane — comparing against
+    /// `AIConversation::task_id()` rather than relying on pane-active-
+    /// conversation heuristics alone, since a pane can host conversations
+    /// unrelated to its CLI-harness session (e.g. an earlier native Agent
+    /// Mode conversation). Returns `None` for a purely interactive CLI agent
+    /// session with no ambient task behind it.
+    pub fn task_id_for_terminal_view(
+        &self,
+        terminal_view_id: EntityId,
+    ) -> Option<AmbientAgentTaskId> {
+        self.cli_session_task_ids.get(&terminal_view_id).copied()
+    }
+
     /// Stops reporting CLI agent status changes for a completed driver run.
     /// Task updates accepted before unregistration remain queued until delivery
     /// finishes.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13413,10 +13413,7 @@ impl TerminalView {
     /// CLI-harness conversation needs this bridge just as much as a child
     /// one does (e.g. for orchestration event delivery, which reads
     /// `ConversationStatus` directly).
-    fn conversation_id_for_cli_status_updates(
-        &self,
-        ctx: &AppContext,
-    ) -> Option<AIConversationId> {
+    fn conversation_id_for_cli_status_updates(&self, ctx: &AppContext) -> Option<AIConversationId> {
         let task_id =
             LocalAgentTaskSyncModel::as_ref(ctx).task_id_for_terminal_view(self.view_id)?;
         let matches_task = |conversation: &&AIConversation| conversation.task_id() == Some(task_id);
@@ -13435,10 +13432,7 @@ impl TerminalView {
             .filter(matches_task)
             .map(|conversation| conversation.id());
         let conversation_id = conversation_ids.next()?;
-        conversation_ids
-            .next()
-            .is_none()
-            .then_some(conversation_id)
+        conversation_ids.next().is_none().then_some(conversation_id)
     }
 
     /// If the startup auto-open setting is enabled, auto-opens rich input for a

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -244,6 +244,7 @@ use crate::ai::blocklist::codebase_index_speedbump_banner::{
 use crate::ai::blocklist::diff_storage::DiffStorageHelper;
 use crate::ai::blocklist::diff_types::FileDiff;
 use crate::ai::blocklist::inline_action::code_diff_view::CodeDiffView;
+use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
 use crate::ai::blocklist::model::{
     AIBlockModel, AIBlockModelHelper, AIBlockModelImpl, AIBlockOutputStatus,
 };
@@ -13392,30 +13393,52 @@ impl TerminalView {
         }
     }
 
-    fn child_conversation_id_for_cli_status_updates(
+    /// Resolves the conversation this pane's CLI agent status updates should
+    /// be written to: the conversation whose `task_id` matches the ambient
+    /// task this pane's CLI-harness session is registered under (see
+    /// `LocalAgentTaskSyncModel::register_cli_session`). Prefers the pane's
+    /// active conversation; otherwise falls back to this terminal surface's
+    /// sole live conversation with a matching task_id, if unambiguous.
+    ///
+    /// Returns `None` when this pane has no registered ambient task — e.g. a
+    /// purely interactive CLI agent session with no orchestration/ambient
+    /// run behind it — since there is no `AIConversation` to bridge status
+    /// into in that case. The task_id match also guards against writing
+    /// into an unrelated conversation that happens to be live in the same
+    /// pane (e.g. an earlier native Agent Mode conversation).
+    ///
+    /// Not scoped to child (orchestration) conversations: nothing else in
+    /// the codebase keeps a CLI-harness conversation's `ConversationStatus`
+    /// in sync with the harness's own lifecycle hooks, so a root/standalone
+    /// CLI-harness conversation needs this bridge just as much as a child
+    /// one does (e.g. for orchestration event delivery, which reads
+    /// `ConversationStatus` directly).
+    fn conversation_id_for_cli_status_updates(
         &self,
         ctx: &AppContext,
     ) -> Option<AIConversationId> {
-        if let Some(conversation_id) = BlocklistAIHistoryModel::as_ref(ctx)
+        let task_id =
+            LocalAgentTaskSyncModel::as_ref(ctx).task_id_for_terminal_view(self.view_id)?;
+        let matches_task = |conversation: &&AIConversation| conversation.task_id() == Some(task_id);
+
+        let history_model = BlocklistAIHistoryModel::as_ref(ctx);
+        if let Some(conversation_id) = history_model
             .active_conversation(self.view_id)
-            .and_then(|conversation| {
-                conversation
-                    .is_child_agent_conversation()
-                    .then_some(conversation.id())
-            })
+            .filter(matches_task)
+            .map(|conversation| conversation.id())
         {
             return Some(conversation_id);
         }
 
-        let mut child_conversation_ids = BlocklistAIHistoryModel::as_ref(ctx)
+        let mut conversation_ids = history_model
             .all_live_conversations_for_terminal_surface(self.view_id)
-            .filter(|conversation| conversation.is_child_agent_conversation())
+            .filter(matches_task)
             .map(|conversation| conversation.id());
-        let child_conversation_id = child_conversation_ids.next()?;
-        child_conversation_ids
+        let conversation_id = conversation_ids.next()?;
+        conversation_ids
             .next()
             .is_none()
-            .then_some(child_conversation_id)
+            .then_some(conversation_id)
     }
 
     /// If the startup auto-open setting is enabled, auto-opens rich input for a
@@ -13507,7 +13530,7 @@ impl TerminalView {
             return;
         }
 
-        if let Some(conversation_id) = self.child_conversation_id_for_cli_status_updates(ctx) {
+        if let Some(conversation_id) = self.conversation_id_for_cli_status_updates(ctx) {
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
                 history_model.update_conversation_status(
                     self.view_id,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13413,7 +13413,10 @@ impl TerminalView {
     /// CLI-harness conversation needs this bridge just as much as a child
     /// one does (e.g. for orchestration event delivery, which reads
     /// `ConversationStatus` directly).
-    fn conversation_id_for_cli_status_updates(&self, ctx: &AppContext) -> Option<AIConversationId> {
+    fn conversation_id_for_cli_agent_status_updates(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<AIConversationId> {
         let task_id =
             LocalAgentTaskSyncModel::as_ref(ctx).task_id_for_terminal_view(self.view_id)?;
         let matches_task = |conversation: &&AIConversation| conversation.task_id() == Some(task_id);
@@ -13524,7 +13527,7 @@ impl TerminalView {
             return;
         }
 
-        if let Some(conversation_id) = self.conversation_id_for_cli_status_updates(ctx) {
+        if let Some(conversation_id) = self.conversation_id_for_cli_agent_status_updates(ctx) {
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
                 history_model.update_conversation_status(
                     self.view_id,

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -32,6 +32,7 @@ use crate::ai::blocklist::agent_view::{
     ExitAgentViewError,
 };
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
+use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
 use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, FakeAIBlockModel, InputConfig, InputType,
     ResponseStream, ResponseStreamId,
@@ -8641,6 +8642,8 @@ fn cli_session_status_updates_active_child_conversation() {
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
+        let task_id = AmbientAgentTaskId::from_str("123e4567-e89b-12d3-a456-426614174000")
+            .expect("valid task id");
 
         let child_conversation_id = terminal.update(&mut app, |view, ctx| {
             let parent_conversation_id =
@@ -8649,14 +8652,19 @@ fn cli_session_status_updates_active_child_conversation() {
                 });
             let child_conversation_id =
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-                    history_model.start_new_child_conversation(
+                    let child_conversation_id = history_model.start_new_child_conversation(
                         view.view_id,
                         "Agent 2".to_string(),
                         parent_conversation_id,
                         None,
                         false,
                         ctx,
-                    )
+                    );
+                    history_model
+                        .conversation_mut(&child_conversation_id)
+                        .expect("child conversation should exist")
+                        .set_task_id(task_id);
+                    child_conversation_id
                 });
 
             view.enter_agent_view(
@@ -8665,6 +8673,13 @@ fn cli_session_status_updates_active_child_conversation() {
                 AgentViewEntryOrigin::ChildAgent,
                 ctx,
             );
+
+            // Status updates only route to a conversation whose `task_id` matches
+            // the ambient task this pane's CLI-harness session is registered
+            // under (see `TerminalView::conversation_id_for_cli_status_updates`).
+            LocalAgentTaskSyncModel::handle(ctx).update(ctx, |sync_model, _ctx| {
+                sync_model.register_cli_session_for_test(view.view_id, task_id);
+            });
 
             CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions, ctx| {
                 sessions.set_session(
@@ -8794,6 +8809,8 @@ fn cli_session_status_updates_single_child_conversation_without_agent_view() {
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
+        let task_id = AmbientAgentTaskId::from_str("123e4567-e89b-12d3-a456-426614174000")
+            .expect("valid task id");
 
         let child_conversation_id = terminal.update(&mut app, |view, ctx| {
             let parent_conversation_id =
@@ -8802,15 +8819,27 @@ fn cli_session_status_updates_single_child_conversation_without_agent_view() {
                 });
             let child_conversation_id =
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-                    history_model.start_new_child_conversation(
+                    let child_conversation_id = history_model.start_new_child_conversation(
                         view.view_id,
                         "Agent 2".to_string(),
                         parent_conversation_id,
                         None,
                         false,
                         ctx,
-                    )
+                    );
+                    history_model
+                        .conversation_mut(&child_conversation_id)
+                        .expect("child conversation should exist")
+                        .set_task_id(task_id);
+                    child_conversation_id
                 });
+
+            // Status updates only route to a conversation whose `task_id` matches
+            // the ambient task this pane's CLI-harness session is registered
+            // under (see `TerminalView::conversation_id_for_cli_status_updates`).
+            LocalAgentTaskSyncModel::handle(ctx).update(ctx, |sync_model, _ctx| {
+                sync_model.register_cli_session_for_test(view.view_id, task_id);
+            });
 
             CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions, ctx| {
                 sessions.set_session(


### PR DESCRIPTION
## Description

There used to be some weird logic about the `CLIAgentSessionStatus` (what's updated on 3p harness hooks) only updating the conversation status for child conversations. It should always keep conversation status in sync.

To match which conversation this hook updated the CLIAgentSessionStatus for, we consult the `LocalAgentTaskSyncModel` instead of assuming it's the active conversation of the pane. Only ambient agent 3p harnesses have a Conversation associated with them (not 3p harnesses the user ran themselves)