### PR TITLE
fix: Clear Windows title-bar drag state after maximize

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -3,6 +3,10 @@ mod key_events;
 #[cfg(test)]
 mod drag_drop_tests;
 
+#[cfg(test)]
+#[path = "titlebar_tests.rs"]
+mod titlebar_tests;
+
 use std::collections::HashMap;
 use std::mem::ManuallyDrop;
 
@@ -222,6 +226,12 @@ impl WindowState {
         self.last_mouse_button_pressed = Some(new_state);
         click_count
     }
+
+    /// Native window operations can suppress the matching mouse-release event. The last press is
+    /// retained separately so multi-click detection continues to work.
+    fn native_window_operation_completed(&mut self) {
+        self.current_mouse_button_pressed = None;
+    }
 }
 
 /// An extension trait to add helpful methods to [`winit::dpi::LogicalPosition`].
@@ -268,6 +278,26 @@ fn from_winit_modifiers_state(state: keyboard::ModifiersState) -> ModifiersState
         // TODO(advait): Implement the function key for winit.
         // Note there is no function_key() function to use here.
         func: false,
+    }
+}
+
+fn convert_cursor_moved(
+    position: PhysicalPosition<f64>,
+    window_state: &mut WindowState,
+    scale_factor: f32,
+) -> ConvertedEvent {
+    window_state.last_cursor_position = position.to_logical(scale_factor as f64);
+    match window_state.current_mouse_button_pressed {
+        Some(MouseButton::Left) => ConvertedEvent::Event(crate::event::Event::LeftMouseDragged {
+            position: window_state.last_cursor_position.to_vec2f(),
+            modifiers: from_winit_modifiers_state(window_state.modifiers),
+        }),
+        _ => ConvertedEvent::Event(crate::event::Event::MouseMoved {
+            position: window_state.last_cursor_position.to_vec2f(),
+            cmd: window_state.modifiers.super_key(),
+            shift: window_state.modifiers.shift_key(),
+            is_synthetic: false,
+        }),
     }
 }
 
@@ -1165,21 +1195,7 @@ impl EventLoop {
                 ))
             }
             WindowEvent::CursorMoved { position, .. } => {
-                window_state.last_cursor_position = position.to_logical(scale_factor as f64);
-                match window_state.current_mouse_button_pressed {
-                    Some(MouseButton::Left) => Some(ConvertedEvent::Event(
-                        crate::event::Event::LeftMouseDragged {
-                            position: window_state.last_cursor_position.to_vec2f(),
-                            modifiers: from_winit_modifiers_state(window_state.modifiers),
-                        },
-                    )),
-                    _ => Some(ConvertedEvent::Event(crate::event::Event::MouseMoved {
-                        position: window_state.last_cursor_position.to_vec2f(),
-                        cmd: window_state.modifiers.super_key(),
-                        shift: window_state.modifiers.shift_key(),
-                        is_synthetic: false,
-                    })),
-                }
+                Some(convert_cursor_moved(position, window_state, scale_factor))
             }
             WindowEvent::MouseInput { state, button, .. } => match state {
                 ElementState::Pressed => {
@@ -1627,11 +1643,7 @@ impl EventLoop {
             && winit_window.try_drag_resize()
             && window_state.last_touch_purpose.is_none()
         {
-            // If we initiated a drag via the method
-            // [`winit::window::Window::drag_resize_window`], we will not
-            // receive a MouseInput event when the button is release, so we
-            // pre-emptively set this back to None.
-            window_state.current_mouse_button_pressed = None;
+            window_state.native_window_operation_completed();
             return;
         }
         let dispatch_result = self
@@ -1654,12 +1666,13 @@ impl EventLoop {
                 // Double-clicking the titlebar does maximize/restore.
                 if click_count >= 2 {
                     window.toggle_maximized();
+                    window_state.native_window_operation_completed();
                 } else if window_state.last_touch_purpose.is_none() {
                     // Single-click drag moves the window. Skip for touch events as
                     // drag_window doesn't work properly with touch input on Windows.
                     // We won't receive MouseInput::Released after drag_window.
                     match winit_window.drag_window() {
-                        Ok(_) => window_state.current_mouse_button_pressed = None,
+                        Ok(()) => window_state.native_window_operation_completed(),
                         Err(err) => {
                             report_error!(anyhow::Error::new(err).context("error dragging window"))
                         }

--- a/crates/warpui/src/windowing/winit/event_loop/titlebar_tests.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/titlebar_tests.rs
@@ -1,0 +1,47 @@
+use winit::dpi::PhysicalPosition;
+use winit::event::MouseButton;
+
+use super::*;
+
+#[test]
+fn native_window_operation_clears_pressed_button() {
+    let mut window_state = WindowState::new(crate::WindowId::new());
+    window_state.determine_click_count_and_update_button_state(MouseButton::Left);
+
+    window_state.native_window_operation_completed();
+
+    assert_eq!(window_state.current_mouse_button_pressed, None);
+}
+
+#[test]
+fn cursor_move_after_native_window_operation_is_not_a_drag() {
+    let mut window_state = WindowState::new(crate::WindowId::new());
+    window_state.determine_click_count_and_update_button_state(MouseButton::Left);
+
+    let event = convert_cursor_moved(PhysicalPosition::new(10.0, 20.0), &mut window_state, 1.0);
+    assert!(matches!(
+        event,
+        ConvertedEvent::Event(crate::event::Event::LeftMouseDragged { .. })
+    ));
+
+    window_state.native_window_operation_completed();
+
+    let event = convert_cursor_moved(PhysicalPosition::new(20.0, 30.0), &mut window_state, 1.0);
+
+    assert!(matches!(
+        event,
+        ConvertedEvent::Event(crate::event::Event::MouseMoved { .. })
+    ));
+}
+
+#[test]
+fn native_window_operation_preserves_double_click_state() {
+    let mut window_state = WindowState::new(crate::WindowId::new());
+    window_state.determine_click_count_and_update_button_state(MouseButton::Left);
+    window_state.native_window_operation_completed();
+    window_state.determine_click_count_and_update_button_state(MouseButton::Left);
+    window_state.native_window_operation_completed();
+
+    let last_press = window_state.last_mouse_button_pressed.as_ref().unwrap();
+    assert_eq!(last_press.click_count, 2);
+}


### PR DESCRIPTION
## Description

Double-clicking the title bar on Windows left the window stuck in a dragging state: once the window maximized, moving the mouse kept moving the window.

`toggle_maximized()` is a native window operation, and like `drag_window()` and `try_drag_resize()` it does not deliver a matching `MouseInput::Released`. Those two call sites already cleared `current_mouse_button_pressed` by hand, but the double-click maximize path did not, so the field stayed `Some(MouseButton::Left)` and every subsequent `CursorMoved` was converted into `LeftMouseDragged`.

This adds `WindowState::native_window_operation_completed()` and calls it from all three sites. It clears `current_mouse_button_pressed` but deliberately leaves `last_mouse_button_pressed` alone, so double/triple-click detection keeps working.

`convert_cursor_moved()` is extracted from the `WindowEvent::CursorMoved` arm so the press-state to event conversion can be asserted directly.

## Why this matters

The window becomes unusable until the next click: `crates/warpui/src/windowing/winit/event_loop/mod.rs` converts every `CursorMoved` to `LeftMouseDragged` while `current_mouse_button_pressed` is `Some`, so the window follows the cursor with no button held. The two adjacent native-operation call sites in the same function already worked around this by assigning `current_mouse_button_pressed = None` inline, which shows the invariant was known; the maximize branch added later just missed it. Replacing the three inline assignments with one named method keeps the next native-operation call site from repeating the omission.

## Linked Issue

Closes #8518

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

The box above is deliberately unchecked, and the reason affects how this should be reviewed.

`crates/warpui`'s `winit` module is `cfg(winit)`, which `build.rs` defines as `not(macos)`. On macOS that module is not compiled at all, so this code could not be built here, the new tests could not be run, and the original bug could not be reproduced. `cargo check -p warpui --tests` passes locally but never exercises this file; the pre-existing `drag_drop_tests` in the same module are also absent from the test list, which is how the skipped module was confirmed rather than assumed.

What was verified:

- `cargo fmt -- --check` passes.
- Every symbol the new tests use exists with a matching signature: `WindowState::new(crate::WindowId)`, `determine_click_count_and_update_button_state(&mut self, MouseButton) -> u32`, `last_mouse_button_pressed: Option<MouseButtonPressState>` with `click_count: u32`, and `PhysicalPosition` is already imported at the top of `mod.rs`.
- The new test module mirrors how the sibling `drag_drop_tests` is declared and how it constructs `WindowState`.

The three added tests cover the field being cleared, a cursor move after a native window operation converting to `MouseMoved` rather than `LeftMouseDragged`, and click-count survival across two maximize toggles. They should compile and run in CI on Windows and Linux. If CI disagrees with any of the above, I will fix it promptly.

### Screenshots / Videos

None. The repro is Windows-only and this was developed on macOS, so no recording could be captured.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

AI was used for assistance.

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed a bug on Windows where double-clicking the title bar to maximize left the window stuck following the cursor.
