### PR TITLE
Fix built-in Factory MCP reconnect race

### DIFF
--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -51,6 +51,8 @@ pub struct TemplatableMCPServerManager {
 
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
     spawned_servers: HashMap<Uuid, SpawnedServerInfo>,
+    #[cfg(not(target_family = "wasm"))]
+    reconnectable_ephemeral_installations: HashMap<Uuid, TemplatableMCPServerInstallation>,
     /// Cached credentials for each server.
     ///
     /// We persist these to secure storage, and if they are present when the server is started,
@@ -187,6 +189,47 @@ impl TemplatableMCPServerManager {
     #[cfg(not(target_family = "wasm"))]
     pub fn is_server_active_or_pending(&self, uuid: Uuid) -> bool {
         self.is_server_active(uuid) || self.spawned_servers.contains_key(&uuid)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn reconnectable_installation(
+        &self,
+        installation_uuid: Uuid,
+    ) -> Option<&TemplatableMCPServerInstallation> {
+        self.locally_installed_servers
+            .get(&installation_uuid)
+            .or_else(|| {
+                self.reconnectable_ephemeral_installations
+                    .get(&installation_uuid)
+            })
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn register_reconnect_waiter(
+        &mut self,
+        installation_uuid: Uuid,
+        result_tx: ReconnectResultSender,
+    ) -> bool {
+        let should_start_reconnect = !self.pending_reconnections.contains_key(&installation_uuid)
+            && !self.spawned_servers.contains_key(&installation_uuid);
+        self.pending_reconnections
+            .entry(installation_uuid)
+            .or_default()
+            .push(result_tx);
+        should_start_reconnect
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn notify_reconnect_waiters(
+        &mut self,
+        installation_uuid: Uuid,
+        result: Result<rmcp::Peer<rmcp::RoleClient>, String>,
+    ) {
+        if let Some(waiters) = self.pending_reconnections.remove(&installation_uuid) {
+            for tx in waiters {
+                let _ = tx.send(result.clone());
+            }
+        }
     }
 
     pub fn get_server_state(&self, installation_uuid: Uuid) -> Option<MCPServerState> {
@@ -381,3 +424,7 @@ impl Entity for TemplatableMCPServerManager {
 }
 
 impl SingletonEntity for TemplatableMCPServerManager {}
+
+#[cfg(test)]
+#[path = "templatable_manager_tests.rs"]
+mod tests;

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -68,8 +68,6 @@ enum SpawnMode {
         persist_running_state_to_sqlite: bool,
     },
     /// Reconnection after transport closed - preserves logs, no telemetry.
-    ///
-    /// Waiters are notified via `pending_reconnections` when the connection completes.
     Reconnect,
 }
 
@@ -85,10 +83,6 @@ impl SpawnMode {
                 persist_running_state_to_sqlite: true
             }
         )
-    }
-
-    fn is_reconnect(&self) -> bool {
-        matches!(self, SpawnMode::Reconnect)
     }
 }
 
@@ -400,6 +394,7 @@ impl TemplatableMCPServerManager {
             server_states: Default::default(),
             active_servers: Default::default(),
             spawned_servers: Default::default(),
+            reconnectable_ephemeral_installations: Default::default(),
             server_credentials: Default::default(),
             file_based_server_credentials: Default::default(),
             locally_installed_servers,
@@ -746,6 +741,8 @@ impl TemplatableMCPServerManager {
     ) {
         let installation_uuid = installation.uuid();
         log::debug!("Spawning ephemeral server with installation_uuid {installation_uuid}");
+        self.reconnectable_ephemeral_installations
+            .insert(installation_uuid, installation.clone());
 
         self.spawn_server_impl(
             installation,
@@ -895,12 +892,10 @@ impl TemplatableMCPServerManager {
                         extra: { "template_uuid" => %template_uuid }
                     );
                     self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
-                    if mode.is_reconnect() {
-                        self.notify_reconnect_waiters(
-                            installation_uuid,
-                            Err("Template contains no servers".to_string()),
-                        );
-                    }
+                    self.notify_reconnect_waiters(
+                        installation_uuid,
+                        Err("Template contains no servers".to_string()),
+                    );
                     return;
                 }
             },
@@ -911,9 +906,7 @@ impl TemplatableMCPServerManager {
                     extra: { "template_uuid" => %template_uuid }
                 );
                 self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
-                if mode.is_reconnect() {
-                    self.notify_reconnect_waiters(installation_uuid, Err(detail));
-                }
+                self.notify_reconnect_waiters(installation_uuid, Err(detail));
                 return;
             }
         };
@@ -945,12 +938,10 @@ impl TemplatableMCPServerManager {
                     });
                 }
 
-                if mode.is_reconnect() {
-                    self.notify_reconnect_waiters(
-                        installation_uuid,
-                        Err("PATH not available".to_string()),
-                    );
-                }
+                self.notify_reconnect_waiters(
+                    installation_uuid,
+                    Err("PATH not available".to_string()),
+                );
                 return;
             }
 
@@ -1000,12 +991,10 @@ impl TemplatableMCPServerManager {
                     full: ("Failed to register MCP log file for {template_uuid}: {e}")
                 );
                 self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
-                if mode.is_reconnect() {
-                    self.notify_reconnect_waiters(
-                        installation_uuid,
-                        Err("Failed to register MCP log file".to_string()),
-                    );
-                }
+                self.notify_reconnect_waiters(
+                    installation_uuid,
+                    Err("Failed to register MCP log file".to_string()),
+                );
                 return;
             }
         };
@@ -1134,7 +1123,6 @@ impl TemplatableMCPServerManager {
         // Extract values from mode before moving it into the closure.
         let should_persist = mode.should_persist_running_state_to_sqlite();
         let should_send_telemetry = mode.should_send_telemetry();
-        let is_reconnect = mode.is_reconnect();
 
         self.change_server_state(installation_uuid, MCPServerState::Starting, ctx);
         let task = ctx.spawn(
@@ -1165,10 +1153,7 @@ impl TemplatableMCPServerManager {
                             Self::persist_is_mcp_running(installation_uuid, true, ctx);
                         }
                         me.change_server_state(installation_uuid, MCPServerState::Running, ctx);
-
-                        if is_reconnect {
-                            me.notify_reconnect_waiters(installation_uuid, Ok(peer));
-                        }
+                        me.notify_reconnect_waiters(installation_uuid, Ok(peer));
                         None
                     }
                     Err(e) => {
@@ -1192,9 +1177,7 @@ impl TemplatableMCPServerManager {
 
                         me.delete_credentials_from_secure_storage(installation_uuid, ctx);
 
-                        if is_reconnect {
-                            me.notify_reconnect_waiters(installation_uuid, Err(error_message));
-                        }
+                        me.notify_reconnect_waiters(installation_uuid, Err(error_message));
 
                         Some(e.into())
                     }
@@ -1244,6 +1227,9 @@ impl TemplatableMCPServerManager {
         if let Some(spawned_info) = self.spawned_servers.remove(&installation_uuid) {
             spawned_info.abort_handle.abort();
         }
+        self.reconnectable_ephemeral_installations
+            .remove(&installation_uuid);
+        self.notify_reconnect_waiters(installation_uuid, Err("Server shut down".to_string()));
         // Close the log stream now rather than when async teardown drops the
         // last logger clone, so an immediate respawn of the same server can
         // re-register its log path.
@@ -1863,40 +1849,25 @@ impl TemplatableMCPServerManager {
     ) {
         log::debug!("Reconnecting MCP server with installation uuid {installation_uuid}");
 
-        // If a reconnection is already in progress, add this caller to the waiting list.
-        if let Some(waiters) = self.pending_reconnections.get_mut(&installation_uuid) {
+        if let Some(peer) = self.get_peer_if_connected(installation_uuid) {
+            let _ = result_tx.send(Ok(peer));
+            return;
+        }
+        if !self.register_reconnect_waiter(installation_uuid, result_tx) {
             log::debug!(
-                "Reconnection already in progress for {installation_uuid}, adding to waiters"
+                "Connection already in progress for {installation_uuid}, adding to waiters"
             );
-            waiters.push(result_tx);
             return;
         }
 
-        // Start tracking this reconnection with this caller as the first waiter.
-        self.pending_reconnections
-            .insert(installation_uuid, vec![result_tx]);
-
-        // Remove the old server from active_servers if it exists.
         self.active_servers.remove(&installation_uuid);
-
-        // Cancel any in-flight spawn.
-        if let Some(spawned_info) = self.spawned_servers.remove(&installation_uuid) {
-            spawned_info.abort_handle.abort();
-        }
-        // Release the old instance's log path so the respawn below can
-        // re-register it.
         if let Some(logger) = self.server_loggers.remove(&installation_uuid) {
             logger.close();
         }
         self.pending_oauth_csrf
             .retain(|_, v| *v != installation_uuid);
 
-        // Look up the installation to get server details.
-        let Some(installation) = self
-            .locally_installed_servers
-            .get(&installation_uuid)
-            .cloned()
-        else {
+        let Some(installation) = self.reconnectable_installation(installation_uuid).cloned() else {
             self.notify_reconnect_waiters(
                 installation_uuid,
                 Err("Installation not found".to_string()),
@@ -1905,23 +1876,6 @@ impl TemplatableMCPServerManager {
         };
 
         self.spawn_server_impl(installation, SpawnMode::Reconnect, ctx);
-    }
-
-    /// Notifies all pending reconnection waiters for the given installation UUID.
-    ///
-    /// This removes the waiters from `pending_reconnections` and sends the result to each.
-    fn notify_reconnect_waiters(
-        &mut self,
-        installation_uuid: Uuid,
-        result: Result<rmcp::Peer<rmcp::RoleClient>, String>,
-    ) {
-        if let Some(waiters) = self.pending_reconnections.remove(&installation_uuid) {
-            for tx in waiters {
-                // Clone the result for each waiter. For Ok, we clone the peer.
-                // For Err, we clone the error message.
-                let _ = tx.send(result.clone());
-            }
-        }
     }
 
     /// Returns a reconnecting peer for a server that has the given tool.

--- a/app/src/ai/mcp/templatable_manager_tests.rs
+++ b/app/src/ai/mcp/templatable_manager_tests.rs
@@ -1,0 +1,140 @@
+use futures_util::stream::AbortHandle;
+use uuid::Uuid;
+use warpui::App;
+
+use super::{SpawnedServerInfo, TemplatableMCPServerManager};
+use crate::ai::mcp::builtin;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::{GlobalResourceHandles, GlobalResourceHandlesProvider};
+
+#[test]
+fn reconnectable_installation_falls_back_to_ephemeral_state() {
+    let mut manager = TemplatableMCPServerManager::default();
+    let installation = builtin::factory_mcp_installation("ephemeral-token");
+    let installation_uuid = installation.uuid();
+
+    manager
+        .reconnectable_ephemeral_installations
+        .insert(installation_uuid, installation);
+
+    let resolved = manager
+        .reconnectable_installation(installation_uuid)
+        .expect("ephemeral installation should be reconnectable");
+    assert!(resolved.template_json().contains("ephemeral-token"));
+}
+
+#[test]
+fn reconnectable_installation_prefers_persisted_state() {
+    let mut manager = TemplatableMCPServerManager::default();
+    let installation_uuid = builtin::FACTORY_MCP_INSTALLATION_UUID;
+    manager.reconnectable_ephemeral_installations.insert(
+        installation_uuid,
+        builtin::factory_mcp_installation("ephemeral-token"),
+    );
+    manager.locally_installed_servers.insert(
+        installation_uuid,
+        builtin::factory_mcp_installation("persisted-token"),
+    );
+    let resolved = manager
+        .reconnectable_installation(installation_uuid)
+        .expect("persisted installation should be reconnectable");
+    assert!(resolved.template_json().contains("persisted-token"));
+}
+
+#[test]
+fn reconnect_waiter_joins_pending_spawn() {
+    let mut manager = TemplatableMCPServerManager::default();
+    let installation_uuid = Uuid::new_v4();
+    let (abort_handle, _) = AbortHandle::new_pair();
+    let (oauth_result_tx, _) = async_channel::unbounded();
+    manager.spawned_servers.insert(
+        installation_uuid,
+        SpawnedServerInfo {
+            abort_handle,
+            oauth_result_tx,
+        },
+    );
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+    assert!(!manager.register_reconnect_waiter(installation_uuid, result_tx));
+    assert!(manager.spawned_servers.contains_key(&installation_uuid));
+
+    manager.notify_reconnect_waiters(installation_uuid, Err("spawn failed".to_string()));
+    let error = result_rx
+        .blocking_recv()
+        .expect("waiter should be notified")
+        .expect_err("spawn should fail");
+    assert_eq!(error, "spawn failed");
+}
+
+#[test]
+fn reconnect_completion_notifies_all_waiters() {
+    let mut manager = TemplatableMCPServerManager::default();
+    let installation_uuid = Uuid::new_v4();
+    let (first_tx, first_rx) = tokio::sync::oneshot::channel();
+    let (second_tx, second_rx) = tokio::sync::oneshot::channel();
+
+    assert!(manager.register_reconnect_waiter(installation_uuid, first_tx));
+    assert!(!manager.register_reconnect_waiter(installation_uuid, second_tx));
+
+    manager.notify_reconnect_waiters(installation_uuid, Err("connection failed".to_string()));
+
+    let first_error = first_rx
+        .blocking_recv()
+        .expect("first waiter should be notified")
+        .expect_err("connection should fail");
+    let second_error = second_rx
+        .blocking_recv()
+        .expect("second waiter should be notified")
+        .expect_err("connection should fail");
+    assert_eq!(first_error, "connection failed");
+    assert_eq!(second_error, "connection failed");
+    assert!(
+        !manager
+            .pending_reconnections
+            .contains_key(&installation_uuid)
+    );
+}
+
+#[test]
+fn shutdown_ends_ephemeral_reconnect_lifecycle() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let global_resources = GlobalResourceHandles::mock(&mut app);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resources));
+
+        let installation = builtin::factory_mcp_installation("ephemeral-token");
+        let installation_uuid = installation.uuid();
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let manager = app.add_model(|_| {
+            let mut manager = TemplatableMCPServerManager::default();
+            manager
+                .reconnectable_ephemeral_installations
+                .insert(installation_uuid, installation);
+            manager.register_reconnect_waiter(installation_uuid, result_tx);
+            manager
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.shutdown_server(installation_uuid, ctx);
+        });
+
+        manager.read(&app, |manager, _| {
+            assert!(
+                !manager
+                    .reconnectable_ephemeral_installations
+                    .contains_key(&installation_uuid)
+            );
+            assert!(
+                !manager
+                    .pending_reconnections
+                    .contains_key(&installation_uuid)
+            );
+        });
+        let error = result_rx
+            .await
+            .expect("waiter should be notified")
+            .expect_err("shutdown should end the reconnect");
+        assert_eq!(error, "Server shut down");
+    });
+}


### PR DESCRIPTION
## Description

Fix the built-in Factory MCP reconnect race during credential rotation.

When a tool call requested reconnection while the replacement ephemeral server was still starting, the manager aborted that spawn and then searched only persisted installations. Built-in, CLI, and file-based ephemeral installations are not persisted, so the reconnect failed with `Installation not found`.

This change retains ephemeral installation definitions in runtime-only state, makes reconnect requests join an existing spawn, completes all waiters from every spawn outcome, and clears retained state during shutdown.

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format`
- `cargo clippy -p warp --lib --tests -- -D warnings`
- `cargo nextest run -p warp -E 'test(templatable_manager::tests)'` — 5 passed
- Full presubmit not run
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the built-in Factory MCP failing to reconnect during credential refresh.

Co-Authored-By: Warp [agent@warp.dev](mailto:agent@warp.dev)