### PR TITLE
fix(find): keep async find matches ordered after boundary-spanning dirty update (#14231)

### DIFF
--- a/app/src/terminal/find/model/async_find.rs
+++ b/app/src/terminal/find/model/async_find.rs
@@ -413,11 +413,17 @@ impl BlockFindResults {
 
         matches.splice(replace_range, new_matches);
 
-        // Assert that matches are still in ascending order.
-        debug_assert!(
-            matches.windows(2).all(|w| w[0] <= w[1]),
-            "Matches should be in ascending order after update_dirty_matches"
-        );
+        // The splice window above is computed from row overlap only, but
+        // `AbsoluteMatch` ordering compares full (row, col) end points. A new
+        // match that spans past the dirty-range boundary row can therefore
+        // land next to a retained same-row neighbor that sorts before it by
+        // column, breaking ascending order. Restore the invariant when that
+        // seam breaks; the `is_sorted` fast-path keeps the common case cheap,
+        // and per-block match counts are bounded with throttled updates, so
+        // the occasional re-sort is negligible.
+        if !matches.is_sorted() {
+            matches.sort_unstable();
+        }
     }
 }
 

--- a/app/src/terminal/find/model/async_find.rs
+++ b/app/src/terminal/find/model/async_find.rs
@@ -373,42 +373,38 @@ impl BlockFindResults {
             return;
         }
 
-        // If the dirty range is before all existing matches, insert at the start.
-        if matches
+        let replace_range = if matches
             .first()
             .is_some_and(|first_match| *dirty_range.end() < first_match.start_row())
         {
-            matches.splice(0..0, new_matches);
-            return;
-        }
-
-        // If the dirty range is after all existing matches, append at the end.
-        if matches
+            // The dirty range is before all existing matches: insert at the start.
+            0..0
+        } else if matches
             .last()
             .is_some_and(|last_match| last_match.end_row() < *dirty_range.start())
         {
-            matches.extend(new_matches);
-            return;
-        }
-
-        // Find the range of matches that overlap with the dirty range.
-        // A match overlaps if: match.start <= dirty.end AND match.end >= dirty.start
-        let replace_start = matches
-            .iter()
-            .position(|m| m.end_row() >= *dirty_range.start())
-            .unwrap_or(matches.len());
-
-        let replace_end = matches
-            .iter()
-            .rposition(|m| m.start_row() <= *dirty_range.end())
-            .map(|pos| pos + 1)
-            .unwrap_or(replace_start);
-
-        let replace_range = if replace_start <= replace_end {
-            replace_start..replace_end
+            // The dirty range is after all existing matches: append at the end.
+            matches.len()..matches.len()
         } else {
-            // Dirty range lies between two adjacent matches; insert without replacing.
-            replace_start..replace_start
+            // Find the range of matches that overlap with the dirty range.
+            // A match overlaps if: match.start <= dirty.end AND match.end >= dirty.start
+            let replace_start = matches
+                .iter()
+                .position(|m| m.end_row() >= *dirty_range.start())
+                .unwrap_or(matches.len());
+
+            let replace_end = matches
+                .iter()
+                .rposition(|m| m.start_row() <= *dirty_range.end())
+                .map(|pos| pos + 1)
+                .unwrap_or(replace_start);
+
+            if replace_start <= replace_end {
+                replace_start..replace_end
+            } else {
+                // Dirty range lies between two adjacent matches; insert without replacing.
+                replace_start..replace_start
+            }
         };
 
         matches.splice(replace_range, new_matches);
@@ -417,10 +413,11 @@ impl BlockFindResults {
         // `AbsoluteMatch` ordering compares full (row, col) end points. A new
         // match that spans past the dirty-range boundary row can therefore
         // land next to a retained same-row neighbor that sorts before it by
-        // column, breaking ascending order. Restore the invariant when that
-        // seam breaks; the `is_sorted` fast-path keeps the common case cheap,
-        // and per-block match counts are bounded with throttled updates, so
-        // the occasional re-sort is negligible.
+        // column, breaking ascending order — on the prepend fast path just as
+        // much as on the general path. Restore the invariant when that seam
+        // breaks; the `is_sorted` fast-path keeps the common case cheap, and
+        // per-block match counts are bounded with throttled updates, so the
+        // occasional re-sort is negligible.
         if !matches.is_sorted() {
             matches.sort_unstable();
         }

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -660,6 +660,51 @@ fn test_update_dirty_matches_clear_range() {
     assert_eq!(stored[1].start_row(), 25);
 }
 
+#[test]
+fn test_update_dirty_matches_boundary_spanning_match_keeps_order() {
+    let mut results = BlockFindResults::default();
+    let block_index = BlockIndex(0);
+    let grid_type = GridType::Output;
+
+    // Seed with sorted matches: one ending on row 9 and one on row 11 ending
+    // at column 2.
+    results.terminal_matches.insert(
+        (block_index, grid_type),
+        vec![make_match(9), make_match_at(11, 0, 2)],
+    );
+
+    // Rescanning dirty row 10 yields a match that starts on row 10 and spans
+    // onto row 11, ending at column 4 — past the retained row-11 match's end
+    // column. The row-based splice window does not cover the retained row-11
+    // match, so the merged vector is only ordered if the merge accounts for
+    // column-level `Ord`.
+    let spanning_match = AbsoluteMatch {
+        start: AbsolutePoint { row: 10, col: 0 },
+        end: AbsolutePoint { row: 11, col: 4 },
+        is_filtered: false,
+    };
+    results.update_dirty_matches(
+        block_index,
+        grid_type,
+        10..=10,
+        vec![spanning_match.clone()],
+    );
+
+    let stored = results
+        .terminal_matches
+        .get(&(block_index, grid_type))
+        .unwrap();
+    assert_eq!(stored.len(), 3);
+    assert!(
+        stored.windows(2).all(|w| w[0] <= w[1]),
+        "matches must remain in ascending order after a boundary-spanning dirty update: {stored:?}"
+    );
+    assert!(
+        stored.contains(&spanning_match),
+        "the boundary-spanning match must be retained: {stored:?}"
+    );
+}
+
 fn assert_async_focused_order_matches_sync(block_sort_direction: BlockSortDirection) {
     App::test((), |mut app| async move {
         initialize_settings_for_tests(&mut app);

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -705,6 +705,49 @@ fn test_update_dirty_matches_boundary_spanning_match_keeps_order() {
     );
 }
 
+#[test]
+fn test_update_dirty_matches_boundary_spanning_match_keeps_order_on_prepend() {
+    let mut results = BlockFindResults::default();
+    let block_index = BlockIndex(0);
+    let grid_type = GridType::Output;
+
+    // Seed with a single match on row 11 ending at column 2. A dirty range
+    // ending on row 10 sits entirely before it, so the merge takes the
+    // prepend fast path.
+    results
+        .terminal_matches
+        .insert((block_index, grid_type), vec![make_match_at(11, 0, 2)]);
+
+    // The rescan of dirty row 10 yields a match spanning onto row 11 with a
+    // later end column than the retained match, so a plain prepend would
+    // place it out of ascending order.
+    let spanning_match = AbsoluteMatch {
+        start: AbsolutePoint { row: 10, col: 0 },
+        end: AbsolutePoint { row: 11, col: 4 },
+        is_filtered: false,
+    };
+    results.update_dirty_matches(
+        block_index,
+        grid_type,
+        10..=10,
+        vec![spanning_match.clone()],
+    );
+
+    let stored = results
+        .terminal_matches
+        .get(&(block_index, grid_type))
+        .unwrap();
+    assert_eq!(stored.len(), 2);
+    assert!(
+        stored.windows(2).all(|w| w[0] <= w[1]),
+        "matches must remain in ascending order after a boundary-spanning prepend: {stored:?}"
+    );
+    assert!(
+        stored.contains(&spanning_match),
+        "the boundary-spanning match must be retained: {stored:?}"
+    );
+}
+
 fn assert_async_focused_order_matches_sync(block_sort_direction: BlockSortDirection) {
     App::test((), |mut app| async move {
         initialize_settings_for_tests(&mut app);


### PR DESCRIPTION
Fixes #14231

Async terminal find's incremental merge (`BlockFindResults::update_dirty_matches`) can leave a block's match list out of ascending order. In debug / from-source builds this trips the trailing `debug_assert!` and aborts the process (`SIGABRT`); in release builds the assert is stripped, so the mis-ordering silently persists and can corrupt the match count, next/previous traversal, and highlight placement.

Credit to @samithaj for the report, crash signature, and root-cause analysis (and the earlier #14232, which was auto-closed before the issue was marked `ready-to-implement`).

## Reproduction

The splice window is computed from **row** overlap only:

```rust
let replace_start = matches.iter().position(|m| m.end_row()   >= *dirty_range.start())...;
let replace_end   = matches.iter().rposition(|m| m.start_row() <= *dirty_range.end())...;
```

but `AbsoluteMatch::Ord` compares full **(row, col)** end points. So with existing sorted matches ending at `(9,5)` and `(11,2)`, a rescan of dirty row `10` that yields a match spanning `(10,0)–(11,4)` splices it *before* the retained `(11,2)` match — `(11,4) > (11,2)` → not ascending → `debug_assert!` → abort. In practice this surfaces when Find is active on a block whose content is still changing (streaming output), so dirty-range merges run repeatedly.

The new regression test encodes exactly this scenario. Against unfixed `master` it fails on the same assert as the crash report:

```
thread '...test_update_dirty_matches_boundary_spanning_match_keeps_order' panicked at
app/src/terminal/find/model/async_find.rs:417:9:
Matches should be in ascending order after update_dirty_matches
test result: FAILED. 0 passed; 1 failed
```

## Fix

Restore the ascending invariant after the splice instead of asserting it, as suggested in triage:

```rust
matches.splice(replace_range, new_matches);
if !matches.is_sorted() {
    matches.sort_unstable();
}
```

The `is_sorted()` fast-path keeps the common (already-ordered) case free of any copying; the re-sort runs only when a boundary-spanning match actually breaks the seam. Per-block match counts are bounded and dirty updates are throttled, so the occasional `sort_unstable` is negligible.

One honest caveat: when a new match spans past the dirty boundary, the retained neighbor it collides with may partially overlap it (stale data from the previous scan). Sorting preserves a correct, crash-free ordering and the next dirty update of those rows reconciles the contents; deduplicating overlaps at the seam would be a follow-up if it's ever observed to matter in practice.

## Tests

- New: `test_update_dirty_matches_boundary_spanning_match_keeps_order` — fails (assert/abort) without the fix, passes with it.
- All 12 existing `update_dirty_matches` tests (async find + the `filtering.rs` original it was adapted from) still pass.
- Full async-find suite: 23 passed, 0 failed.

## Demo

Before (unfixed code, new test):

```
test terminal::find::model::async_find::tests::test_update_dirty_matches_boundary_spanning_match_keeps_order ... FAILED
panicked at app/src/terminal/find/model/async_find.rs:417:9:
Matches should be in ascending order after update_dirty_matches
```

After (with fix):

```
test terminal::find::model::async_find::tests::test_update_dirty_matches_boundary_spanning_match_keeps_order ... ok
test result: ok. 13 passed; 0 failed   (all update_dirty_matches tests)
test result: ok. 23 passed; 0 failed   (full async_find filter)
```

`./script/format` and `cargo clippy -p warp --lib --tests` are clean.
