### PR TITLE
Emit mcp_attach_result client events for managed/integration MCP attaches

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -55,7 +55,9 @@ use crate::ai::agent_sdk::environment_snapshot::{
     EnvironmentSnapshot, EnvironmentSnapshotReporter,
 };
 use crate::ai::agent_sdk::retry::{is_transient_graphql_or_http_error, with_bounded_retry_using};
-use crate::ai::agent_sdk::setup_observability::{SetupClientEventReporter, SetupStep};
+use crate::ai::agent_sdk::setup_observability::{
+    McpAttachKind, SetupClientEventReporter, SetupStep,
+};
 use crate::ai::ambient_agents::task::HarnessModelConfig;
 use crate::ai::ambient_agents::{
     AmbientAgentTaskId, AmbientConversationStatus, conversation_output_status_from_conversation,
@@ -902,6 +904,33 @@ register_error!(AgentDriverError);
 struct ResolvedMcpSpecs {
     local_uuids: Vec<Uuid>,
     ephemeral_installations: Vec<TemplatableMCPServerInstallation>,
+    /// Managed/integration servers that resolved into installations, tracked
+    /// so their startup outcomes can be reported as `mcp_attach_result`
+    /// client events.
+    attach_targets: Vec<McpAttachTarget>,
+    /// Managed/integration servers that failed resolution without failing
+    /// the run (well-known integration skips), reported as failed attaches.
+    attach_failures: Vec<McpAttachFailure>,
+}
+
+/// A managed/integration MCP server installation to be spawned during setup,
+/// tracked for `mcp_attach_result` reporting.
+#[derive(Debug)]
+struct McpAttachTarget {
+    installation_uuid: Uuid,
+    mcp_key: String,
+    mcp_ref: String,
+    kind: McpAttachKind,
+}
+
+/// A managed/integration MCP server that failed before an installation could
+/// be spawned.
+#[derive(Debug)]
+struct McpAttachFailure {
+    mcp_key: String,
+    mcp_ref: String,
+    kind: McpAttachKind,
+    error: String,
 }
 
 impl From<warpui::ModelDropped> for AgentDriverError {
@@ -1748,6 +1777,14 @@ impl AgentDriver {
                             message: err.to_string(),
                         }
                     })?;
+                    resolved
+                        .attach_targets
+                        .extend(installations.iter().map(|installation| McpAttachTarget {
+                            installation_uuid: installation.uuid(),
+                            mcp_key: installation.templatable_mcp_server().name.clone(),
+                            mcp_ref: uuid.to_string(),
+                            kind: McpAttachKind::Managed,
+                        }));
                     resolved.ephemeral_installations.extend(installations);
                 }
                 MCPSpec::WellKnown(id) => {
@@ -1778,6 +1815,12 @@ impl AgentDriver {
                         Ok(client_config) => client_config,
                         Err(err) => {
                             log::warn!("Skipping well-known MCP server '{id}': {err:#}");
+                            resolved.attach_failures.push(McpAttachFailure {
+                                mcp_key: id.clone(),
+                                mcp_ref: id.clone(),
+                                kind: McpAttachKind::Integration,
+                                error: format!("{err:#}"),
+                            });
                             continue;
                         }
                     };
@@ -1787,10 +1830,24 @@ impl AgentDriver {
                         id,
                     ) {
                         Ok(installations) => {
+                            resolved.attach_targets.extend(installations.iter().map(
+                                |installation| McpAttachTarget {
+                                    installation_uuid: installation.uuid(),
+                                    mcp_key: installation.templatable_mcp_server().name.clone(),
+                                    mcp_ref: id.clone(),
+                                    kind: McpAttachKind::Integration,
+                                },
+                            ));
                             resolved.ephemeral_installations.extend(installations);
                         }
                         Err(err) => {
                             log::warn!("Skipping well-known MCP server '{id}': {err}");
+                            resolved.attach_failures.push(McpAttachFailure {
+                                mcp_key: id.clone(),
+                                mcp_ref: id.clone(),
+                                kind: McpAttachKind::Integration,
+                                error: err.to_string(),
+                            });
                         }
                     }
                 }
@@ -2106,6 +2163,76 @@ impl AgentDriver {
                 Ok(())
             }
             Err(other) => Err(other),
+        }
+    }
+
+    /// Report one `mcp_attach_result` client event per managed/integration
+    /// MCP server attached during setup. A server is `ok` only when it
+    /// reached `Running` (connected) and its startup `tools/list` query did
+    /// not fail. Best-effort: never affects the run outcome.
+    async fn report_mcp_attach_results(
+        startup_result: &Result<(), AgentDriverError>,
+        attach_targets: Vec<McpAttachTarget>,
+        attach_failures: Vec<McpAttachFailure>,
+        setup_events: &SetupClientEventReporter,
+        foreground: &ModelSpawner<Self>,
+    ) {
+        // A managed resolution failure aborts setup before attach targets
+        // are collected, so report the failed server from the error itself.
+        if let Err(AgentDriverError::ManagedMcpResolutionFailed { uid, message }) = startup_result {
+            setup_events.post_mcp_attach_result_best_effort(
+                uid.to_string(),
+                uid.to_string(),
+                McpAttachKind::Managed,
+                Some(message.clone()),
+            );
+        }
+
+        for failure in attach_failures {
+            setup_events.post_mcp_attach_result_best_effort(
+                failure.mcp_key,
+                failure.mcp_ref,
+                failure.kind,
+                Some(failure.error),
+            );
+        }
+
+        if attach_targets.is_empty() {
+            return;
+        }
+        let Ok(outcomes) = foreground
+            .spawn(move |_, ctx| {
+                let manager = TemplatableMCPServerManager::as_ref(ctx);
+                attach_targets
+                    .into_iter()
+                    .map(|target| {
+                        let error = match manager.get_server_state(target.installation_uuid) {
+                            Some(MCPServerState::Running) => manager
+                                .get_server_tools_list_error(target.installation_uuid)
+                                .map(|err| format!("tools/list failed: {err}")),
+                            Some(MCPServerState::FailedToStart) => Some(
+                                manager
+                                    .get_server_error_message(target.installation_uuid)
+                                    .map(|message| format!("failed to start: {message}"))
+                                    .unwrap_or_else(|| "failed to start".to_string()),
+                            ),
+                            _ => Some("did not reach running state during setup".to_string()),
+                        };
+                        (target, error)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .await
+        else {
+            return;
+        };
+        for (target, error) in outcomes {
+            setup_events.post_mcp_attach_result_best_effort(
+                target.mcp_key,
+                target.mcp_ref,
+                target.kind,
+                error,
+            );
         }
     }
 
@@ -2841,6 +2968,8 @@ impl AgentDriver {
                 .spawn(|_, ctx| ServerApiProvider::as_ref(ctx).get_managed_mcp_client())
                 .await?;
 
+            let mut mcp_attach_targets: Vec<McpAttachTarget> = Vec::new();
+            let mut mcp_attach_failures: Vec<McpAttachFailure> = Vec::new();
             let mcp_startup_result = setup_events
                 .record_result(SetupStep::McpServerStartup, async {
                     let resolved_mcp_specs =
@@ -2848,6 +2977,8 @@ impl AgentDriver {
                             .await?;
                     let existing_uuids = resolved_mcp_specs.local_uuids;
                     let mut ephemeral_installations = resolved_mcp_specs.ephemeral_installations;
+                    mcp_attach_targets = resolved_mcp_specs.attach_targets;
+                    mcp_attach_failures = resolved_mcp_specs.attach_failures;
 
                     // Attach the built-in Factory MCP server. Interactive
                     // clients attach built-ins via
@@ -2937,6 +3068,14 @@ impl AgentDriver {
                     }
                 })
                 .await;
+            Self::report_mcp_attach_results(
+                &mcp_startup_result,
+                mcp_attach_targets,
+                mcp_attach_failures,
+                &setup_events,
+                &foreground,
+            )
+            .await;
             Self::handle_mcp_startup_result(mcp_startup_result, &foreground).await?;
             let profile = task.profile.clone();
             setup_events

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -904,17 +904,15 @@ register_error!(AgentDriverError);
 struct ResolvedMcpSpecs {
     local_uuids: Vec<Uuid>,
     ephemeral_installations: Vec<TemplatableMCPServerInstallation>,
-    /// Managed/integration servers that resolved into installations, tracked
-    /// so their startup outcomes can be reported as `mcp_attach_result`
-    /// client events.
+    /// Managed/integration servers whose startup outcomes get
+    /// `mcp_attach_result` events.
     attach_targets: Vec<McpAttachTarget>,
-    /// Managed/integration servers that failed resolution without failing
-    /// the run (well-known integration skips), reported as failed attaches.
+    /// Resolution failures that did not fail the run (well-known skips).
     attach_failures: Vec<McpAttachFailure>,
 }
 
-/// A managed/integration MCP server installation to be spawned during setup,
-/// tracked for `mcp_attach_result` reporting.
+/// A resolved managed/integration installation pending spawn, tracked for
+/// `mcp_attach_result` reporting.
 #[derive(Debug)]
 struct McpAttachTarget {
     installation_uuid: Uuid,
@@ -923,8 +921,8 @@ struct McpAttachTarget {
     kind: McpAttachKind,
 }
 
-/// A managed/integration MCP server that failed before an installation could
-/// be spawned.
+/// A managed/integration server that failed before its installation could
+/// spawn.
 #[derive(Debug)]
 struct McpAttachFailure {
     mcp_key: String,
@@ -2166,10 +2164,9 @@ impl AgentDriver {
         }
     }
 
-    /// Report one `mcp_attach_result` client event per managed/integration
-    /// MCP server attached during setup. A server is `ok` only when it
-    /// reached `Running` (connected) and its startup `tools/list` query did
-    /// not fail. Best-effort: never affects the run outcome.
+    /// Post one `mcp_attach_result` event per managed/integration MCP
+    /// attach. `ok` requires `Running` plus a clean startup `tools/list`.
+    /// Best-effort: never affects the run outcome.
     async fn report_mcp_attach_results(
         startup_result: &Result<(), AgentDriverError>,
         attach_targets: Vec<McpAttachTarget>,
@@ -2177,8 +2174,8 @@ impl AgentDriver {
         setup_events: &SetupClientEventReporter,
         foreground: &ModelSpawner<Self>,
     ) {
-        // A managed resolution failure aborts setup before attach targets
-        // are collected, so report the failed server from the error itself.
+        // A managed resolution failure aborts setup before targets are
+        // collected; report it from the error.
         if let Err(AgentDriverError::ManagedMcpResolutionFailed { uid, message }) = startup_result {
             setup_events.post_mcp_attach_result_best_effort(
                 uid.to_string(),

--- a/app/src/ai/agent_sdk/setup_observability.rs
+++ b/app/src/ai/agent_sdk/setup_observability.rs
@@ -11,8 +11,7 @@ use crate::server::server_api::ai::{
     AIClient, AgentRunClientEventRequest, AgentRunClientMcpAttachResultPayload,
 };
 
-/// Maximum length for the error string in an `mcp_attach_result` payload;
-/// it is a diagnostic breadcrumb, not a full error report.
+/// Max chars for an `mcp_attach_result` error string.
 const MCP_ATTACH_ERROR_MAX_CHARS: usize = 300;
 
 #[derive(Clone)]
@@ -116,10 +115,9 @@ impl SetupClientEventReporter {
             .detach();
     }
 
-    /// Report the outcome of attaching one managed/integration MCP server
-    /// during run setup as an `mcp_attach_result` client event. `error: None`
-    /// means the attach succeeded. Best-effort: posted in the background and
-    /// never blocks or fails run setup.
+    /// Post an `mcp_attach_result` client event for one managed/integration
+    /// MCP attach. `error: None` means success. Best-effort: posted in the
+    /// background, never blocks or fails setup.
     pub(crate) fn post_mcp_attach_result_best_effort(
         &self,
         mcp_key: String,
@@ -204,8 +202,7 @@ impl SetupClientEventReporter {
     }
 }
 
-/// Collapse a string to a single line and cap it at
-/// [`MCP_ATTACH_ERROR_MAX_CHARS`] characters.
+/// Collapse to one line, capped at [`MCP_ATTACH_ERROR_MAX_CHARS`] chars.
 fn single_line_truncated(input: &str) -> String {
     let line = input
         .lines()
@@ -216,12 +213,12 @@ fn single_line_truncated(input: &str) -> String {
     line.chars().take(MCP_ATTACH_ERROR_MAX_CHARS).collect()
 }
 
-/// Kind of server-owned MCP attachment reported via `mcp_attach_result`.
+/// MCP kind reported in `mcp_attach_result`.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum McpAttachKind {
-    /// A managed MCP server row, referenced by UID.
+    /// Managed MCP row, referenced by UID.
     Managed,
-    /// A well-known integration id (e.g. "linear").
+    /// Well-known integration id (e.g. "linear").
     Integration,
 }
 

--- a/app/src/ai/agent_sdk/setup_observability.rs
+++ b/app/src/ai/agent_sdk/setup_observability.rs
@@ -7,7 +7,13 @@ use tracing::Instrument as _;
 use warpui::r#async::executor::Background;
 
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::server::server_api::ai::{AIClient, AgentRunClientEventRequest};
+use crate::server::server_api::ai::{
+    AIClient, AgentRunClientEventRequest, AgentRunClientMcpAttachResultPayload,
+};
+
+/// Maximum length for the error string in an `mcp_attach_result` payload;
+/// it is a diagnostic breadcrumb, not a full error report.
+const MCP_ATTACH_ERROR_MAX_CHARS: usize = 300;
 
 #[derive(Clone)]
 pub(crate) struct SetupClientEventReporter {
@@ -110,6 +116,42 @@ impl SetupClientEventReporter {
             .detach();
     }
 
+    /// Report the outcome of attaching one managed/integration MCP server
+    /// during run setup as an `mcp_attach_result` client event. `error: None`
+    /// means the attach succeeded. Best-effort: posted in the background and
+    /// never blocks or fails run setup.
+    pub(crate) fn post_mcp_attach_result_best_effort(
+        &self,
+        mcp_key: String,
+        mcp_ref: String,
+        kind: McpAttachKind,
+        error: Option<String>,
+    ) {
+        const EVENT_NAME: &str = "mcp_attach_result";
+        let Some(run_id) = self.run_id else {
+            return;
+        };
+
+        let ai_client = self.ai_client.clone();
+        self.background
+            .spawn(async move {
+                let payload = AgentRunClientMcpAttachResultPayload {
+                    mcp_key,
+                    mcp_ref,
+                    mcp_kind: kind.as_str().to_string(),
+                    ok: error.is_none(),
+                    error: error.as_deref().map(single_line_truncated),
+                };
+                let request = AgentRunClientEventRequest::mcp_attach_result_event(
+                    EVENT_NAME,
+                    Utc::now(),
+                    payload,
+                );
+                Self::post_client_event(run_id, ai_client, EVENT_NAME, request).await;
+            })
+            .detach();
+    }
+
     pub(crate) async fn post_timeline_event(&self, event: OzRunTimelineEvent) {
         let Some(run_id) = self.run_id else {
             return;
@@ -158,6 +200,36 @@ impl SetupClientEventReporter {
             .await
         {
             log::warn!("Failed to post setup client event {event_name} for run {run_id}: {err:#}");
+        }
+    }
+}
+
+/// Collapse a string to a single line and cap it at
+/// [`MCP_ATTACH_ERROR_MAX_CHARS`] characters.
+fn single_line_truncated(input: &str) -> String {
+    let line = input
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    line.chars().take(MCP_ATTACH_ERROR_MAX_CHARS).collect()
+}
+
+/// Kind of server-owned MCP attachment reported via `mcp_attach_result`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum McpAttachKind {
+    /// A managed MCP server row, referenced by UID.
+    Managed,
+    /// A well-known integration id (e.g. "linear").
+    Integration,
+}
+
+impl McpAttachKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Managed => "managed",
+            Self::Integration => "integration",
         }
     }
 }

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -199,9 +199,8 @@ impl TemplatableMCPServerManager {
             .map(|s| s.as_str())
     }
 
-    /// Error from a connected server's startup `tools/list` query, when it
-    /// failed. Tool listing fails soft, so the server still runs with no
-    /// tools.
+    /// Startup `tools/list` error for a connected server. Listing fails
+    /// soft; the server still runs with no tools.
     pub fn get_server_tools_list_error(&self, installation_uuid: Uuid) -> Option<&str> {
         self.active_servers
             .get(&installation_uuid)

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -199,6 +199,15 @@ impl TemplatableMCPServerManager {
             .map(|s| s.as_str())
     }
 
+    /// Error from a connected server's startup `tools/list` query, when it
+    /// failed. Tool listing fails soft, so the server still runs with no
+    /// tools.
+    pub fn get_server_tools_list_error(&self, installation_uuid: Uuid) -> Option<&str> {
+        self.active_servers
+            .get(&installation_uuid)
+            .and_then(|info| info.tools_list_error())
+    }
+
     pub fn resources(&self) -> impl Iterator<Item = &rmcp::model::Resource> {
         self.active_servers
             .values()

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -413,8 +413,8 @@ pub struct AgentRunClientSetupMetricPayload {
     pub is_error: bool,
 }
 
-/// Payload for the `mcp_attach_result` client event, reporting the outcome of
-/// attaching one managed/integration MCP server during run setup.
+/// Payload for the `mcp_attach_result` client event: outcome of one
+/// managed/integration MCP attach during run setup.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AgentRunClientMcpAttachResultPayload {
     /// Config-map name of the server.
@@ -427,6 +427,7 @@ pub struct AgentRunClientMcpAttachResultPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
+
 #[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
 pub struct AgentRunEnvironmentSnapshotRequest {
     pub captured_at: DateTime<Utc>,

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -402,6 +402,7 @@ pub struct AgentRunClientEventRequest {
 #[serde(untagged)]
 pub enum AgentRunClientEventPayload {
     SetupMetric(AgentRunClientSetupMetricPayload),
+    McpAttachResult(AgentRunClientMcpAttachResultPayload),
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -410,6 +411,21 @@ pub struct AgentRunClientSetupMetricPayload {
     pub finish_ts: DateTime<Utc>,
     pub latency_ms: i64,
     pub is_error: bool,
+}
+
+/// Payload for the `mcp_attach_result` client event, reporting the outcome of
+/// attaching one managed/integration MCP server during run setup.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentRunClientMcpAttachResultPayload {
+    /// Config-map name of the server.
+    pub mcp_key: String,
+    /// Managed MCP row UID or integration id (the `warp_id` value).
+    pub mcp_ref: String,
+    /// `"managed"` or `"integration"`.
+    pub mcp_kind: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 #[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
 pub struct AgentRunEnvironmentSnapshotRequest {
@@ -435,6 +451,19 @@ impl AgentRunClientEventRequest {
             event_name: event_name.into(),
             timestamp,
             payload: None,
+        }
+    }
+
+    pub fn mcp_attach_result_event(
+        event_name: impl Into<String>,
+        timestamp: DateTime<Utc>,
+        payload: AgentRunClientMcpAttachResultPayload,
+    ) -> Self {
+        Self {
+            event_uuid: uuid::Uuid::new_v4().to_string(),
+            event_name: event_name.into(),
+            timestamp,
+            payload: Some(AgentRunClientEventPayload::McpAttachResult(payload)),
         }
     }
 

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -16,8 +16,8 @@ pub struct TemplatableMCPServerInfo {
     >,
     resources: Vec<rmcp::model::Resource>,
     tools: Vec<rmcp::model::Tool>,
-    /// Error from the startup `tools/list` query, when it failed. Tool
-    /// listing fails soft, so the server still runs with no tools.
+    /// Startup `tools/list` error. Listing fails soft; the server still
+    /// runs with no tools.
     tools_list_error: Option<String>,
     installation_id: Uuid,
     description: Option<String>,

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -16,6 +16,9 @@ pub struct TemplatableMCPServerInfo {
     >,
     resources: Vec<rmcp::model::Resource>,
     tools: Vec<rmcp::model::Tool>,
+    /// Error from the startup `tools/list` query, when it failed. Tool
+    /// listing fails soft, so the server still runs with no tools.
+    tools_list_error: Option<String>,
     installation_id: Uuid,
     description: Option<String>,
     /// Whether the underlying transport uses authentication.
@@ -37,6 +40,10 @@ impl TemplatableMCPServerInfo {
 
     pub fn tools(&self) -> &Vec<rmcp::model::Tool> {
         &self.tools
+    }
+
+    pub fn tools_list_error(&self) -> Option<&str> {
+        self.tools_list_error.as_deref()
     }
 
     pub fn installation_id(&self) -> Uuid {

--- a/crates/mcp/src/runtime.rs
+++ b/crates/mcp/src/runtime.rs
@@ -321,13 +321,15 @@ pub async fn spawn_server(
 
     let resources =
         query_resources_for(capabilities, &server_name, || service.list_all_resources()).await;
-    let tools = query_tools_for(capabilities, &server_name, || service.list_all_tools()).await;
+    let (tools, tools_list_error) =
+        query_tools_for(capabilities, &server_name, || service.list_all_tools()).await;
 
     Ok(TemplatableMCPServerInfo {
         name: server_name,
         service,
         resources,
         tools,
+        tools_list_error,
         installation_id: uuid,
         description,
         is_authenticated_transport,
@@ -512,24 +514,25 @@ where
 /// error as "no tools" (fail-soft) so a transient `tools/list` failure does
 /// not abort the entire server startup — the user-visible regression #6798
 /// was rooted in the prior asymmetric handling, where a tools-list error on
-/// a server with healthy resources would propagate and fail startup.
+/// a server with healthy resources would propagate and fail startup. The
+/// error is returned alongside the (empty) tool list for diagnostics.
 async fn query_tools_for<F, Fut>(
     capabilities: Option<&rmcp::model::ServerCapabilities>,
     server_name: &str,
     list_tools: F,
-) -> Vec<rmcp::model::Tool>
+) -> (Vec<rmcp::model::Tool>, Option<String>)
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<Vec<rmcp::model::Tool>, rmcp::ServiceError>>,
 {
     if !should_query_tools(capabilities) {
-        return Vec::new();
+        return (Vec::new(), None);
     }
     match list_tools().await {
-        Ok(result) => result,
+        Ok(result) => (result, None),
         Err(err) => {
             log::warn!("Failed to list tools for MCP server '{server_name}': {err}");
-            Vec::new()
+            (Vec::new(), Some(err.to_string()))
         }
     }
 }

--- a/crates/mcp/src/runtime_tests.rs
+++ b/crates/mcp/src/runtime_tests.rs
@@ -71,13 +71,14 @@ async fn query_tools_for_skips_listing_when_capability_not_advertised() {
     let calls_clone = calls.clone();
     let no_caps = caps(false, false);
 
-    let result = query_tools_for(Some(&no_caps), "srv", || async move {
+    let (result, error) = query_tools_for(Some(&no_caps), "srv", || async move {
         calls_clone.fetch_add(1, Ordering::SeqCst);
         Ok(vec![test_tool("never")])
     })
     .await;
 
     assert!(result.is_empty());
+    assert!(error.is_none());
     assert_eq!(calls.load(Ordering::SeqCst), 0);
 }
 
@@ -87,13 +88,14 @@ async fn query_tools_for_skips_listing_when_server_info_is_none() {
     let calls = Arc::new(AtomicUsize::new(0));
     let calls_clone = calls.clone();
 
-    let result = query_tools_for(None, "srv", || async move {
+    let (result, error) = query_tools_for(None, "srv", || async move {
         calls_clone.fetch_add(1, Ordering::SeqCst);
         Ok(vec![test_tool("never")])
     })
     .await;
 
     assert!(result.is_empty());
+    assert!(error.is_none());
     assert_eq!(calls.load(Ordering::SeqCst), 0);
 }
 
@@ -104,9 +106,10 @@ async fn query_tools_for_returns_listed_tools_when_capability_advertised() {
     let expected = vec![test_tool("greet"), test_tool("review")];
     let to_return = expected.clone();
 
-    let result = query_tools_for(Some(&c), "srv", || async move { Ok(to_return) }).await;
+    let (result, error) = query_tools_for(Some(&c), "srv", || async move { Ok(to_return) }).await;
 
     assert_eq!(result, expected);
+    assert!(error.is_none());
 }
 
 /// Returns an empty vector when the server lists no tools.
@@ -116,29 +119,31 @@ async fn query_tools_for_returns_empty_vec_when_server_lists_no_tools() {
     let calls = Arc::new(AtomicUsize::new(0));
     let calls_clone = calls.clone();
 
-    let result = query_tools_for(Some(&c), "srv", || async move {
+    let (result, error) = query_tools_for(Some(&c), "srv", || async move {
         calls_clone.fetch_add(1, Ordering::SeqCst);
         Ok(Vec::new())
     })
     .await;
 
     assert!(result.is_empty());
+    assert!(error.is_none());
     assert_eq!(calls.load(Ordering::SeqCst), 1);
 }
 
 /// **The fail-soft test the bug ticket implicitly demands.** Transport-
 /// closed errors must not abort server startup; the helper must log and
-/// return an empty vec. This is the regression-protector for #6798's
-/// underlying asymmetry — if anyone re-introduces a `return Err(...)` here,
-/// this test fails.
+/// return an empty vec (plus the captured error for diagnostics). This is
+/// the regression-protector for #6798's underlying asymmetry — if anyone
+/// re-introduces a `return Err(...)` here, this test fails.
 #[tokio::test]
 async fn query_tools_for_returns_empty_on_transport_error() {
     let c = caps(true, false);
-    let result = query_tools_for(Some(&c), "srv", || async {
+    let (result, error) = query_tools_for(Some(&c), "srv", || async {
         Err(rmcp::ServiceError::TransportClosed)
     })
     .await;
     assert!(result.is_empty());
+    assert!(error.is_some());
 }
 
 /// MCP-protocol errors (e.g. METHOD_NOT_FOUND from a misbehaving server
@@ -147,7 +152,7 @@ async fn query_tools_for_returns_empty_on_transport_error() {
 #[tokio::test]
 async fn query_tools_for_returns_empty_on_mcp_error() {
     let c = caps(true, false);
-    let result = query_tools_for(Some(&c), "srv", || async {
+    let (result, error) = query_tools_for(Some(&c), "srv", || async {
         Err(rmcp::ServiceError::McpError(ErrorData {
             code: ErrorCode::METHOD_NOT_FOUND,
             message: "tools/list not implemented".into(),
@@ -156,6 +161,7 @@ async fn query_tools_for_returns_empty_on_mcp_error() {
     })
     .await;
     assert!(result.is_empty());
+    assert!(error.is_some());
 }
 
 /// Calls the `tools/list` function exactly once per query.
@@ -182,7 +188,8 @@ async fn query_tools_for_decision_independent_of_other_capabilities() {
         for has_resources in [false, true] {
             let c = caps(has_tools, has_resources);
             let to_return = tools.clone();
-            let result = query_tools_for(Some(&c), "srv", || async move { Ok(to_return) }).await;
+            let (result, _) =
+                query_tools_for(Some(&c), "srv", || async move { Ok(to_return) }).await;
 
             if has_tools {
                 assert_eq!(result, tools);


### PR DESCRIPTION
## Description
Emits one `mcp_attach_result` client event per managed/integration MCP server the client tries to attach during Oz cloud-run setup, so per-run MCP diagnostics land in the server's `ai_run_mcp_events` table. The consumer is warpdotdev/warp-server#16270; until that merges the server rejects the event and the client only logs a warning (`SetupClientEventReporter::post_client_event` already swallows post failures), so this is safe to ship first.

Payload: `{mcp_key, mcp_ref, mcp_kind: "managed"|"integration", ok, error}`. `mcp_key` is the resolved server name, `mcp_ref` the managed row UID or integration id. `ok` is true only when the server reached `Running` (connected) and its startup `tools/list` did not fail. Failures are emitted for the client-config mutation error, connect failure, and tools/list failure. Emission is best-effort and a no-op without a run binding, so local runs and setup outcomes are unaffected.

Where the hooks live:
- `AgentDriver::resolve_mcp_specs_with_local_uuids` records attach targets and resolution failures on `ResolvedMcpSpecs`.
- `AgentDriver::report_mcp_attach_results` (called in `run_internal` right after `SetupStep::McpServerStartup`, before strict-mode handling) reads terminal server states and posts the events.
- `SetupClientEventReporter::post_mcp_attach_result_best_effort` posts through the same client-event path as `worker_container_ready`/setup metrics, truncating errors to one line of ≤300 chars.

One decision worth review: tools/list failures are fail-soft by design (#6798), so the error is now captured in `crates/mcp` (`TemplatableMCPServerInfo::tools_list_error`) instead of changing that behavior; a server that connects but fails tools/list still runs, but reports `ok=false`.

## Linked Issue
No linked issue; requested via Oz orchestration alongside warpdotdev/warp-server#16270.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement` — no linked issue.
- [ ] Screenshots included — not a UI change.

## Testing
`cargo nextest run -p mcp` (23 passed) and `cargo nextest run -p warp -E 'test(mcp)'` (153 passed) cover the changed resolution and tools/list query paths. `cargo fmt` and `cargo clippy -p mcp -p warp --all-targets -- -D warnings` pass. Not exercised end-to-end: that needs a cloud sandbox run against a server with warp-server#16270 deployed; until then the event is expected to be rejected and logged as a warning.

- [ ] I have manually tested my changes locally with `./script/run` — needs an Oz cloud run; not runnable from this environment.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
