### PR TITLE
REMOTE-2467: add a Windows CLI release artifact

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2276,6 +2276,263 @@ jobs:
             ${{ steps.bundle_tui.outputs.pdb_file_path }}
           if-no-files-found: error
 
+  build_windows_cli_binaries:
+    name: Build Release Binary (Windows CLI ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    needs: prepare_release
+    if: ${{ inputs.build_windows != false }}
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest-large
+          # Namespace Windows runners are amd64-only for v1 (see REMOTE-2467), so the
+          # arm64 leg is left commented rather than built. Uncomment alongside
+          # release_windows_cli's matrix below if/when an arm64 CLI is needed.
+          # - arch: arm64
+          #   runner: windows-arm-latest-large
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/prepare_environment
+        with:
+          target_os: windows
+          cache_key: cli-${{ matrix.arch }}
+          is_self_hosted: false
+          ref: ${{ needs.prepare_release.outputs.release_branch }}
+          install_release_deps: true
+          ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
+
+      - name: Get channel configuration
+        id: get-config
+        uses: ./.github/actions/get_channel_config/
+        with:
+          config_file: ${{ env.CONFIG_FILE }}
+          channel: ${{ inputs.channel }}
+
+      - name: Build Windows CLI binary
+        id: build_cli
+        run: script/bundle --artifact cli --channel "$CHANNEL" --skip_build_installer --arch ${{ matrix.arch }}
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+
+      # actions/upload-artifact stores paths relative to the least common
+      # ancestor of everything it's given; binary_path and pdb_file_path live
+      # in the same directory, so uploading them directly would collapse the
+      # LCA to that directory and strip the target/<triple>/<profile> prefix
+      # that release_windows_cli's own script/bundle invocation expects to
+      # find them at. Tar with explicit relative paths instead, so the
+      # structure is guaranteed rather than an emergent property of which
+      # paths happen to be listed.
+      - name: Create tar archive with build artifacts
+        run: |
+          BINARY_PATH="$(realpath --relative-to="$(pwd)" "$(cygpath -u "$BINARY_PATH")")"
+          PDB_FILE_PATH="$(realpath --relative-to="$(pwd)" "$(cygpath -u "$PDB_FILE_PATH")")"
+          tar czfv build-artifacts.tar.gz "$BINARY_PATH" "$PDB_FILE_PATH"
+        shell: bash
+        env:
+          BINARY_PATH: ${{ steps.build_cli.outputs.binary_path }}
+          PDB_FILE_PATH: ${{ steps.build_cli.outputs.pdb_file_path }}
+
+      - name: Archive Windows CLI binary build
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: windows-cli-binary-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
+          retention-days: 1
+          # We compress the tar archive, so no need to re-compress.
+          compression-level: 0
+          path: build-artifacts.tar.gz
+
+  # Packages the CLI binary build_windows_cli_binaries built separately (in
+  # parallel), then signs it and tars it up alongside its resources dir. Unlike
+  # release_windows_tui, this never calls ISCC: the CLI ships as a bare binary
+  # plus a resources dir, matching the macOS and Linux `--artifact cli` builds,
+  # not an installer. bundle.ps1 enforces this itself (it exits right after
+  # preparing resources for the `cli` artifact), so no `-skip_build_installer`
+  # is needed on the final script/bundle call below.
+  release_windows_cli:
+    name: Build Release (Windows CLI ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    needs: [prepare_release, build_windows_binaries, build_windows_cli_binaries]
+    if: ${{ inputs.build_windows != false }}
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            release_arch: x86_64
+            runner: windows-latest-large
+          # - arch: arm64
+          #   release_arch: aarch64
+          #   runner: windows-arm-latest-large
+    env:
+      TRUSTED_SIGNING_ENDPOINT: https://eus.codesigning.azure.net/
+      TRUSTED_SIGNING_ACCOUNT: warpdotdev
+      TRUSTED_SIGNING_CERT_PROFILE: warpterminal
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/prepare_environment
+        with:
+          target_os: windows
+          cache_key: cli-${{ matrix.arch }}
+          is_self_hosted: false
+          ref: ${{ needs.prepare_release.outputs.release_branch }}
+          install_release_deps: true
+          ssh_key: ${{ secrets.WARP_CHANNEL_CONFIG_ACCESS_SSH_KEY }}
+
+      - name: Get channel configuration
+        id: get-config
+        uses: ./.github/actions/get_channel_config/
+        with:
+          config_file: ${{ env.CONFIG_FILE }}
+          channel: ${{ inputs.channel }}
+
+      - name: Download Windows CLI binary build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-cli-binary-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
+
+      - name: Extract Windows CLI binary build
+        run: tar xzvf build-artifacts.tar.gz
+        shell: bash
+
+      - name: Download canonical Windows settings schema
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: settings-schema-windows-${{ steps.get-config.outputs.channel }}
+          path: .release-artifacts/settings-schema-windows
+
+      - name: Locate CLI binary build outputs
+        id: binary_paths
+        run: script/bundle --artifact cli --channel "$CHANNEL" --skip_build_binary --skip_build_installer --arch ${{ matrix.arch }}
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+
+      - name: Sign the oz CLI executable with Azure Trusted Signing
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1.2.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ env.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ env.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ env.TRUSTED_SIGNING_CERT_PROFILE }}
+          files: ${{ steps.binary_paths.outputs.binary_path }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          # The action's dependency cache is not keyed by runner architecture, so
+          # concurrent legs of this matrix can clobber each other's cached tools
+          # (Azure/artifact-signing-action#146).
+          cache-dependencies: false
+
+      - name: Bundle Windows CLI resources
+        id: bundle_cli
+        run: script/bundle --artifact cli --channel "$CHANNEL" --skip_build_binary --arch ${{ matrix.arch }}
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+          SETTINGS_SCHEMA_SOURCE: ${{ github.workspace }}/.release-artifacts/settings-schema-windows/settings_schema.json
+
+      # ConPTY (plus its OpenConsole.exe console-host fallback) is required at
+      # runtime by any headless build: `local_tty` - and with it PTY spawning via
+      # conpty_api.rs - is compiled in for every non-wasm target regardless of the
+      # `gui` feature, since running shell commands is core agent functionality,
+      # not a GUI-only concern. The MSVC redistributable DLLs are bundled
+      # alongside it rather than assumed present, since whether the Namespace
+      # Windows base image ships the VC++ runtime is an open question (see the
+      # PR description). dxcompiler.dll/dxil.dll are wgpu/rendering-only and are
+      # deliberately left out of this headless archive.
+      - name: Package Windows CLI binary
+        id: package_cli
+        run: |
+          set -e
+          OZ_EXE="oz-${CHANNEL}.exe"
+          PKG_DIR="$(mktemp -d)"
+          cp "$BINARY_PATH" "$PKG_DIR/$OZ_EXE"
+          cp -r "$BUNDLED_RESOURCES_DIR" "$PKG_DIR/resources"
+          for asset in conpty.dll OpenConsole.exe vcruntime140.dll vcruntime140_1.dll msvcp140.dll; do
+            cp "app/assets/windows/${WIN_ARCH}/$asset" "$PKG_DIR/$asset"
+          done
+          PACKAGE_NAME="oz-${CHANNEL}-windows-${RELEASE_ARCH}.tar.gz"
+          tar czf "$PACKAGE_NAME" -C "$PKG_DIR" "$OZ_EXE" resources conpty.dll OpenConsole.exe vcruntime140.dll vcruntime140_1.dll msvcp140.dll
+          echo "package_path=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          BINARY_PATH: ${{ steps.bundle_cli.outputs.binary_path }}
+          BUNDLED_RESOURCES_DIR: ${{ steps.bundle_cli.outputs.bundled_resources_dir }}
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          RELEASE_ARCH: ${{ matrix.release_arch }}
+          WIN_ARCH: ${{ matrix.arch }}
+
+      - name: Add CLI to GitHub release assets
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ needs.prepare_release.outputs.release_tag }}
+          files: ${{ steps.package_cli.outputs.package_path }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        with:
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
+      - name: Upload CLI to Google Cloud Storage
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
+        with:
+          path: ${{ steps.package_cli.outputs.package_path }}
+          destination: warp-releases/${{ steps.get-config.outputs.channel }}/${{ needs.prepare_release.outputs.release_tag }}/cli/windows/${{ matrix.release_arch }}
+          process_gcloudignore: false
+          headers: |-
+            cache-control: ${{ steps.get-config.outputs.gcs_cache_control_value }}
+
+      - name: Verify CLI package in Google Cloud Storage
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        run: |
+          package_name="$(basename "$PACKAGE_PATH")"
+          curl.exe --fail --silent --show-error --head \
+            "https://releases.warp.dev/${CHANNEL}/${RELEASE_TAG}/cli/windows/${RELEASE_ARCH}/${package_name}"
+        shell: bash
+        env:
+          PACKAGE_PATH: ${{ steps.package_cli.outputs.package_path }}
+          CHANNEL: ${{ steps.get-config.outputs.channel }}
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
+          RELEASE_ARCH: ${{ matrix.release_arch }}
+
+      - name: Upload CLI as workflow artifact
+        if: ${{ needs.prepare_release.outputs.should_publish != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-windows-cli-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
+          path: ${{ steps.package_cli.outputs.package_path }}
+
+      - name: Set up Sentry CLI
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        uses: warpdotdev/setup-sentry-cli@8ae49c71bd731e547de697f75770727f86c95ecd # v2.0.0
+        with:
+          token: ${{ secrets.SENTRY_RELEASE_TOKEN }}
+          organization: warpdotdev
+          project: ${{ steps.get-config.outputs.sentry_project }}
+
+      - name: Upload debugging symbols to Sentry
+        if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
+        run: |
+          script/sentry_upload_dif.sh
+        shell: bash
+        env:
+          DEBUG_FILE_OR_FOLDER_PATH: ${{ steps.bundle_cli.outputs.pdb_file_path }}
+
   build_windows_binaries:
     name: Build Release Binary (Windows ${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -2538,6 +2795,7 @@ jobs:
       - release_web
       - release_windows_tui
       - release_windows
+      - release_windows_cli
     if: always()
     outputs:
       failed: ${{ steps.collect.outputs.failed }}
@@ -2569,6 +2827,7 @@ jobs:
           WEB_RESULT: ${{ needs.release_web.result }}
           WINDOWS_TUI_RESULT: ${{ needs.release_windows_tui.result }}
           WINDOWS_RESULT: ${{ needs.release_windows.result }}
+          WINDOWS_CLI_RESULT: ${{ needs.release_windows_cli.result }}
         run: |
           FAILED=()
 
@@ -2608,6 +2867,7 @@ jobs:
           check "WASM" "$WEB_RESULT" "$WEB_DISABLED"
           check "Windows TUI" "$WINDOWS_TUI_RESULT" "$WINDOWS_DISABLED"
           check "Windows" "$WINDOWS_RESULT" "$WINDOWS_DISABLED"
+          check "Windows CLI" "$WINDOWS_CLI_RESULT" "$WINDOWS_DISABLED"
 
           if (( ${#FAILED[@]} )); then
             printf -v FORMATTED "%s, " "${FAILED[@]}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2346,6 +2346,7 @@ jobs:
           # We compress the tar archive, so no need to re-compress.
           compression-level: 0
           path: build-artifacts.tar.gz
+          if-no-files-found: error
 
   # Packages the CLI binary build_windows_cli_binaries built separately (in
   # parallel), then signs it and tars it up alongside its resources dir. Unlike
@@ -2416,7 +2417,7 @@ jobs:
           CHANNEL: ${{ steps.get-config.outputs.channel }}
           GIT_RELEASE_TAG: ${{ needs.prepare_release.outputs.release_tag }}
 
-      - name: Sign the oz CLI executable with Azure Trusted Signing
+      - name: Sign the oz CLI executable and sidecar DLLs with Azure Trusted Signing
         uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1.2.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -2426,6 +2427,10 @@ jobs:
           trusted-signing-account-name: ${{ env.TRUSTED_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ env.TRUSTED_SIGNING_CERT_PROFILE }}
           files: ${{ steps.binary_paths.outputs.binary_path }}
+          files-folder: ${{ github.workspace }}\app\assets\windows\${{ matrix.arch }}
+          files-folder-filter: dll,exe
+          files-folder-recurse: true
+          files-folder-depth: 2
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
@@ -2436,7 +2441,7 @@ jobs:
 
       - name: Bundle Windows CLI resources
         id: bundle_cli
-        run: script/bundle --artifact cli --channel "$CHANNEL" --skip_build_binary --arch ${{ matrix.arch }}
+        run: script/bundle --artifact cli --channel "$CHANNEL" --skip_build_binary --require_signatures --arch ${{ matrix.arch }}
         shell: bash
         env:
           CHANNEL: ${{ steps.get-config.outputs.channel }}
@@ -2515,7 +2520,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-windows-cli-${{ matrix.arch }}-${{ steps.get-config.outputs.channel }}
-          path: ${{ steps.package_cli.outputs.package_path }}
+          path: |
+            ${{ steps.package_cli.outputs.package_path }}
+            ${{ steps.bundle_cli.outputs.pdb_file_path }}
+          if-no-files-found: error
 
       - name: Set up Sentry CLI
         if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2281,6 +2281,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: prepare_release
     if: ${{ inputs.build_windows != false }}
+    permissions:
+      contents: read
     timeout-minutes: 150
     strategy:
       fail-fast: false
@@ -2360,6 +2362,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [prepare_release, build_windows_binaries, build_windows_cli_binaries]
     if: ${{ inputs.build_windows != false }}
+    permissions:
+      contents: read
     timeout-minutes: 150
     strategy:
       fail-fast: false

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2453,10 +2453,15 @@ jobs:
       # conpty_api.rs - is compiled in for every non-wasm target regardless of the
       # `gui` feature, since running shell commands is core agent functionality,
       # not a GUI-only concern. The MSVC redistributable DLLs are bundled
-      # alongside it rather than assumed present, since whether the Namespace
-      # Windows base image ships the VC++ runtime is an open question (see the
-      # PR description). dxcompiler.dll/dxil.dll are wgpu/rendering-only and are
-      # deliberately left out of this headless archive.
+      # alongside it rather than assumed present, since it's unconfirmed whether
+      # the Namespace Windows base image ships the VC++ runtime. All five files
+      # copied below live under app/assets/windows/${WIN_ARCH}, so they're already
+      # covered by the recursive `files-folder` signing in the "Sign the oz CLI
+      # executable and sidecar DLLs" step above and don't need a separate signing
+      # pass here. dxcompiler.dll/dxil.dll are wgpu/rendering-only and are
+      # deliberately left out of this headless archive, mirroring the TUI
+      # installer (tui-installer.iss), which likewise omits them from its own
+      # standalone (non-`gui`) bundle.
       - name: Package Windows CLI binary
         id: package_cli
         run: |

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -8,7 +8,7 @@ Param (
 
     [Alias('check-only')]
     [Switch]$CHECK_ONLY,
-    [ValidateSet('app', 'tui')]
+    [ValidateSet('app', 'tui', 'cli')]
     [String]$ARTIFACT = 'app',
 
     [ValidateSet('local', 'dev', 'preview', 'stable', 'oss')]
@@ -105,12 +105,13 @@ $WORKSPACE_ROOT_DIR = $PWD.Path
 $CARGO_TARGET_DIR = $WORKSPACE_ROOT_DIR + '\target'
 $WINDOWS_INSTALLER_DIR = $WORKSPACE_ROOT_DIR + '\script\windows'
 $IS_TUI = $ARTIFACT -eq 'tui'
+$IS_CLI = $ARTIFACT -eq 'cli'
 
 if ($DEBUG_BUILD) {
     $CARGO_PROFILE = 'dev'
-} elseif ($IS_TUI -and (("$CHANNEL" -eq 'local') -or ("$CHANNEL" -eq 'dev'))) {
+} elseif (($IS_TUI -or $IS_CLI) -and (("$CHANNEL" -eq 'local') -or ("$CHANNEL" -eq 'dev'))) {
     $CARGO_PROFILE = 'rclida'
-} elseif ($IS_TUI) {
+} elseif ($IS_TUI -or $IS_CLI) {
     $CARGO_PROFILE = 'rcli'
 } elseif (("$CHANNEL" -eq 'local') -or ("$CHANNEL" -eq 'dev')) {
     # For dev bundles, we want to enable debug assertions to
@@ -191,6 +192,15 @@ if ($IS_TUI) {
         'oss' { 'tui-oss' }
     }
     $FEATURES = 'release_bundle,standalone,voice_input'
+    if ("$CHANNEL" -ne 'oss') {
+        $FEATURES = "$FEATURES,crash_reporting"
+    }
+} elseif ($IS_CLI) {
+    # The CLI ships the same channel binary target as the app (no separate bin), so keep
+    # $WARP_BIN from above but skip the app's display-name rename and gui/nld_classifier
+    # features, mirroring the macOS and Linux `--artifact cli` builds.
+    $BINARY_NAME = "$WARP_BIN.exe"
+    $FEATURES = 'release_bundle,standalone'
     if ("$CHANNEL" -ne 'oss') {
         $FEATURES = "$FEATURES,crash_reporting"
     }
@@ -275,8 +285,8 @@ Write-Output "Built for $ARCH with executable at $BINARY_PATH"
 
 # Prepare bundled resources
 if ($env:SKIP_SETTINGS_SCHEMA -ne '1' -and -not $env:SETTINGS_SCHEMA_EXECUTABLE -and -not $env:SETTINGS_SCHEMA_SOURCE) {
-    if ($IS_TUI) {
-        Write-Error 'TUI bundles require SETTINGS_SCHEMA_SOURCE or SETTINGS_SCHEMA_EXECUTABLE.'
+    if ($IS_TUI -or $IS_CLI) {
+        Write-Error 'TUI and CLI bundles require SETTINGS_SCHEMA_SOURCE or SETTINGS_SCHEMA_EXECUTABLE.'
         exit 1
     } elseif ($SKIP_BUILD_BINARY) {
         Write-Error '-skip_build_binary requires SETTINGS_SCHEMA_SOURCE or SETTINGS_SCHEMA_EXECUTABLE.'
@@ -293,6 +303,19 @@ Write-Output 'Preparing bundled resources...'
 if (-Not $?) {
     Write-Error 'Failed to prepare bundled resources'
     exit 1
+}
+if ($IS_CLI) {
+    # The CLI ships as a bare binary plus its resources dir, mirroring the macOS and Linux
+    # `--artifact cli` builds; it has no installer to build, so stop here rather than
+    # falling through to the Inno Setup section below.
+    if ($env:GITHUB_ACTIONS -eq 'true') {
+        Write-Output '::echo::on'
+        "binary_path=$BINARY_PATH" >> "$env:GITHUB_OUTPUT"
+        "pdb_file_path=$PDB_PATH" >> "$env:GITHUB_OUTPUT"
+        "bundled_resources_dir=$BUNDLED_RESOURCES_DIR" >> "$env:GITHUB_OUTPUT"
+        Write-Output '::echo::off'
+    }
+    exit 0
 }
 if ($IS_TUI) {
     $WINDOWS_ASSETS_DIR = "$WORKSPACE_ROOT_DIR\app\assets\windows\$ARCH"

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -197,13 +197,14 @@ if ($IS_TUI) {
     }
 } elseif ($IS_CLI) {
     # The CLI ships the same channel binary target as the app (no separate bin), so keep
-    # $WARP_BIN from above but skip the app's display-name rename and gui/nld_classifier
-    # features, mirroring the macOS and Linux `--artifact cli` builds.
+    # $WARP_BIN and the channel-scoped $FEATURES set above (crash_reporting, preview_channel,
+    # agent_mode_debug, etc.) but swap the app's `gui` feature for `standalone`, mirroring the
+    # macOS and Linux `--artifact cli` builds. Filtering (rather than overwriting) $FEATURES is
+    # required so per-channel additions above -- e.g. preview_channel, required by the `preview`
+    # cargo target -- survive into the CLI build.
     $BINARY_NAME = "$WARP_BIN.exe"
-    $FEATURES = 'release_bundle,standalone'
-    if ("$CHANNEL" -ne 'oss') {
-        $FEATURES = "$FEATURES,crash_reporting"
-    }
+    $FEATURES = (($FEATURES -split ',') | Where-Object { $_ -ne 'gui' }) -join ','
+    $FEATURES = "$FEATURES,standalone"
 } else {
     # All app channels ship the v3 classifier and v2 heuristic.
     $FEATURES = "$FEATURES,nld_classifier_v3,nld_heuristic_v2"
@@ -304,20 +305,12 @@ if (-Not $?) {
     Write-Error 'Failed to prepare bundled resources'
     exit 1
 }
-if ($IS_CLI) {
-    # The CLI ships as a bare binary plus its resources dir, mirroring the macOS and Linux
-    # `--artifact cli` builds; it has no installer to build, so stop here rather than
-    # falling through to the Inno Setup section below.
-    if ($env:GITHUB_ACTIONS -eq 'true') {
-        Write-Output '::echo::on'
-        "binary_path=$BINARY_PATH" >> "$env:GITHUB_OUTPUT"
-        "pdb_file_path=$PDB_PATH" >> "$env:GITHUB_OUTPUT"
-        "bundled_resources_dir=$BUNDLED_RESOURCES_DIR" >> "$env:GITHUB_OUTPUT"
-        Write-Output '::echo::off'
-    }
-    exit 0
-}
-if ($IS_TUI) {
+if ($IS_TUI -or $IS_CLI) {
+    # Both the TUI and CLI ship the ConPTY/OpenConsole payload and MSVC redistributable DLLs
+    # alongside the binary (see the packaging step in create_release.yml for the CLI, and the
+    # Inno Setup script for the TUI). Verify the files exist, and -- when requested -- are
+    # signed, before the CLI branch below hands off to the workflow's own packaging step,
+    # which otherwise has no way to detect a missing or unsigned sidecar file.
     $WINDOWS_ASSETS_DIR = "$WORKSPACE_ROOT_DIR\app\assets\windows\$ARCH"
     $requiredPayloadFiles = @(
         $BINARY_PATH,
@@ -335,6 +328,19 @@ if ($IS_TUI) {
             Assert-ValidSignature -Path $requiredFile
         }
     }
+}
+if ($IS_CLI) {
+    # The CLI ships as a bare binary plus its resources dir, mirroring the macOS and Linux
+    # `--artifact cli` builds; it has no installer to build, so stop here rather than
+    # falling through to the Inno Setup section below.
+    if ($env:GITHUB_ACTIONS -eq 'true') {
+        Write-Output '::echo::on'
+        "binary_path=$BINARY_PATH" >> "$env:GITHUB_OUTPUT"
+        "pdb_file_path=$PDB_PATH" >> "$env:GITHUB_OUTPUT"
+        "bundled_resources_dir=$BUNDLED_RESOURCES_DIR" >> "$env:GITHUB_OUTPUT"
+        Write-Output '::echo::off'
+    }
+    exit 0
 }
 
 Write-Output 'Building Warp installer'


### PR DESCRIPTION
## Description

Windows `oz` CLI doesn't exist as a published artifact yet.
- `releases.warp.dev` has `oz` for macOS and Linux, but nothing for Windows.
- This adds the Windows CLI release job to `create_release.yml`, mirroring the existing jobs.
- Output: `oz-<channel>-windows-x86_64.tar.gz`, published to `cli/windows/x86_64`.
- Contains: `oz.exe` binary, `resources/` directory, five sidecar files (`conpty.dll`, `OpenConsole.exe`, three MSVC runtime DLLs).

Unblocks the Windows agent sidecar work in [warp-agent-docker #215](https://github.com/warpdotdev/warp-agent-docker/pull/215), which needs a real binary to package.

## Review guide

Two things aren't obvious from the diff and are worth a deliberate look.

**Signing scope:**
- App release (`release_windows`) re-signs everything in `app/assets/windows/<arch>` with Warp's certificate.
- Here, only `oz.exe` gets signed. Five sidecar DLLs come straight from the checkout.
- Fine for a headless artifact on a sandboxed VM, but wanted it explicit rather than accidental.

**Schema dependency:**
- `release_windows_cli` depends on `build_windows_binaries`, not just its own binary build.
- Needs the app's x64 leg to run `dump-settings-schema` and produce the settings schema.
- CLI build runs in parallel, but packaging waits for the app.
- CLI release failure inherits any app build failure.
- New job joins `collect_results`, so its failure shows as a failed release overall.

## Decisions

**x64 only.**
- Namespace Windows runners are amd64 for v1.
- Both job matrices have commented arm64 entries; uncomment them together when needed.

**ConPTY goes in the archive.**
- Headless `oz` CLI needs to spawn shells.
- ConPTY is compiled in (`local_tty` is `#[cfg(not(target_family = "wasm"))]`, not gated on `gui`).
- `conpty_api.rs` loads `conpty.dll` at runtime.
- Without it, the CLI can't work.
- Rendering DLLs (`dxcompiler.dll`, `dxil.dll`) are left out.

**Bundle MSVC redistributables.**
- Whether Namespace's Windows base image includes the VC++ runtime is still an open question.
- Three DLLs are cheap. Debugging a missing runtime on a booted Windows instance isn't.

**No installer.**
- `bundle.ps1` exits for `cli` right after preparing resources.
- CLI ships as a binary plus a resources dir, like macOS and Linux.
- Features: `release_bundle,standalone` plus `crash_reporting` (except `oss`).
- No `gui`, no TUI-only `voice_input`.
- Uses the same `rcli`/`rclida` short aliases that macOS uses.

## Linked Issue

[REMOTE-2467](https://linear.app/warpdotdev/issue/REMOTE-2467/package-warp-agent-sidecar-for-windows). This work is in Linear, not GitHub.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. REMOTE-2467 has no labels.
- [ ] Screenshots or video. Not applicable. This is release infrastructure, not a user-facing change.

## Testing

Dispatched `create_release.yml` against this branch: [run 33105229105](https://github.com/warpdotdev/warp-internal/actions/runs/33105229105).
- Channel `dev`, `build_windows: true`, other platforms off.
- Both jobs succeeded end to end: build, Azure Trusted Signing, packaging.
- Publish steps (GitHub release, GCS upload, Sentry) all skipped.
  - `should_publish` only exists as a `workflow_call` input, so dispatch can't publish.
- Downloaded the artifact and confirmed it contains `oz-dev.exe`, `resources/`, and the five sidecars.

**What this doesn't cover:**
- The actual publish to `releases.warp.dev` won't happen until a real channel cut runs with `should_publish: true`.
- Merging this alone doesn't put anything at `cli/windows/x86_64`. The next `dev` cut is the check.
- Nothing here runs `oz.exe`. That gets tested in warp-agent-docker #215.

- [ ] I have manually tested my changes locally with `./script/run`. Not applicable. This is release CI and a bundle script, which `./script/run` doesn't touch. The dispatch above is the equivalent.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE


---
Migrated from warpdotdev/warp-internal#27782.

Co-Authored-By: Warp <agent@warp.dev>
