### PR TITLE
Add semantic agent session streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12615,7 +12615,7 @@ dependencies = [
 [[package]]
 name = "session-sharing-protocol"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/session-sharing-protocol.git?rev=b30fdd06379a3d073b398eabd106abed5b443aae#b30fdd06379a3d073b398eabd106abed5b443aae"
+source = "git+https://github.com/warpdotdev/session-sharing-protocol.git?rev=70ce23ea754cf0a419d53183447bbae7037cd589#70ce23ea754cf0a419d53183447bbae7037cd589"
 dependencies = [
  "byte-unit",
  "serde",
@@ -15391,6 +15391,7 @@ dependencies = [
  "warp_channel_config",
  "warp_cli",
  "warp_completer",
+ "warp_conversation_mutation_api",
  "warp_core",
  "warp_editor",
  "warp_errors",
@@ -15404,6 +15405,7 @@ dependencies = [
  "warp_multi_agent_client",
  "warp_ripgrep",
  "warp_search_core",
+ "warp_semantic_session",
  "warp_server_auth",
  "warp_server_client",
  "warp_terminal",
@@ -15557,6 +15559,18 @@ dependencies = [
  "warp_js",
  "warp_util",
  "warpui_core",
+]
+
+[[package]]
+name = "warp_conversation_mutation_api"
+version = "0.0.0"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=cf6ad8536099ce0c5d7044beaf09d5d52cca8160#cf6ad8536099ce0c5d7044beaf09d5d52cca8160"
+dependencies = [
+ "prost",
+ "prost-reflect",
+ "prost-reflect-build",
+ "prost-types",
+ "regex",
 ]
 
 [[package]]
@@ -15904,6 +15918,30 @@ dependencies = [
  "warp_core",
  "warp_errors",
  "warpui_core",
+]
+
+[[package]]
+name = "warp_semantic_session"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "prost-types",
+ "session-sharing-protocol",
+ "thiserror 2.0.17",
+ "uuid",
+ "warp_conversation_mutation_api",
+ "warp_multi_agent_api",
+]
+
+[[package]]
+name = "warp_semantic_session_wasm"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "serde_json",
+ "warp_conversation_mutation_api",
+ "warp_semantic_session",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,8 @@ warp_managed_secrets = { path = "crates/managed_secrets" }
 warp_multi_agent_client = { path = "crates/warp_multi_agent_client" }
 warp_ripgrep = { path = "crates/warp_ripgrep" }
 warp_search_core = { path = "crates/warp_search_core" }
+warp_semantic_session = { path = "crates/warp_semantic_session" }
+warp_semantic_session_wasm = { path = "crates/warp_semantic_session_wasm" }
 warp_server_auth = { path = "crates/warp_server_auth" }
 warp_server_client = { path = "crates/warp_server_client" }
 warp_terminal = { path = "crates/warp_terminal" }
@@ -279,7 +281,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 serde_urlencoded = "0.7"
 serde_with = "^3.21"
 serde_yaml = "0.8"
-session-sharing-protocol = { git = "https://github.com/warpdotdev/session-sharing-protocol.git", rev = "b30fdd06379a3d073b398eabd106abed5b443aae" }
+session-sharing-protocol = { git = "https://github.com/warpdotdev/session-sharing-protocol.git", rev = "70ce23ea754cf0a419d53183447bbae7037cd589" }
 similar = { version = "2.7", features = ["inline"] }
 simplelog = "0.12.2"
 smallvec = "1.6.1"
@@ -348,6 +350,7 @@ vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
 warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "f0028fa6d05db1ba63726eaf6f8d33ab17abe37b" }
+warp_conversation_mutation_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "cf6ad8536099ce0c5d7044beaf09d5d52cca8160" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [
@@ -580,7 +583,3 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
 # warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
-
-[patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
-# Uncomment for local development of session-sharing-protocol
-# session-sharing-protocol = { path = "../session-sharing-protocol" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -229,12 +229,14 @@ warp-workflows.workspace = true
 warp_assets.workspace = true
 warp_channel_config.workspace = true
 warp_completer.workspace = true
+warp_conversation_mutation_api.workspace = true
 warp_core.workspace = true
 warp_errors = { workspace = true, features = ["reqwest-errors"] }
 warp_editor.workspace = true
 warp_graphql.workspace = true
 warp_js = { workspace = true, optional = true }
 warp_search_core.workspace = true
+warp_semantic_session.workspace = true
 warp_server_auth.workspace = true
 warp_server_client.workspace = true
 warp_util.workspace = true

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1463,9 +1463,24 @@ impl AgentConversationsModel {
                 .map(AmbientAgentTask::active_live_session_state)
             {
                 Some(AmbientAgentLiveSessionState::Attachable { session_id }) => {
+                    let requested_content = match self
+                        .tasks
+                        .get(&task_id)
+                        .expect("live-session state came from this task")
+                        .requested_session_content()
+                    {
+                        Ok(content) => content,
+                        Err(err) => {
+                            log::error!(
+                                "Refusing to open ambient session with invalid Factory semantic capability: {err:#}"
+                            );
+                            return None;
+                        }
+                    };
                     return Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                         session_id,
                         task_id,
+                        requested_content,
                     });
                 }
                 Some(AmbientAgentLiveSessionState::ActiveUnattachable) => {

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -27,7 +27,9 @@ use crate::ai::agent::conversation::{
     AIAgentHarness, AIConversation, AIConversationId, ConversationStatus,
     ServerAIConversationMetadata,
 };
-use crate::ai::ambient_agents::task::{HarnessConfig, TaskPrincipalInfo, TaskStatusMessage};
+use crate::ai::ambient_agents::task::{
+    FactorySemanticSession, HarnessConfig, TaskPrincipalInfo, TaskStatusMessage,
+};
 use crate::ai::ambient_agents::{
     AgentConfigSnapshot, AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState,
     ExecutionLocation,
@@ -78,8 +80,127 @@ fn create_test_task(
         artifacts: vec![],
         is_sandbox_running: false,
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
+}
+fn factory_semantic_capability(
+    task: &AmbientAgentTask,
+    session_id: &str,
+) -> FactorySemanticSession {
+    FactorySemanticSession {
+        content_mode: "semantic_conversation_only".to_string(),
+        schema_version: 1,
+        conversation_id: "factory-conversation".to_string(),
+        execution_id: "factory-execution".to_string(),
+        run_id: task.task_id.to_string(),
+        request_id: Some("factory-request".to_string()),
+        session_id: Some(session_id.to_string()),
+        accepted_message_context: None,
+    }
+}
+
+#[test]
+fn test_resolve_open_action_preserves_factory_semantic_identity() {
+    App::test((), |mut app| async move {
+        add_entry_projection_test_models(&mut app);
+
+        let session_id = make_uuid(8209);
+        let mut task = create_test_task(&make_uuid(8210), "user-a", Utc::now());
+        task.state = AmbientAgentTaskState::InProgress;
+        task.session_id = Some(session_id.clone());
+        task.session_link = Some("https://example.com/session".to_string());
+        task.is_sandbox_running = true;
+        task.factory_semantic_session =
+            Some(factory_semantic_capability(&task, session_id.as_str()));
+        let task_id = task.task_id;
+
+        app.add_singleton_model(|_| {
+            let mut model = create_test_model();
+            model.tasks.insert(task_id, task);
+            model
+        });
+
+        app.update(|ctx| {
+            let action = AgentConversationsModel::resolve_open_action(
+                AgentConversationNavigationSubject::Entry(AgentConversationEntryId::AmbientRun(
+                    task_id,
+                )),
+                None,
+                ctx,
+            );
+
+            let Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
+                session_id: resolved_session_id,
+                task_id: resolved_task_id,
+                requested_content,
+            }) = action
+            else {
+                panic!("capable live Factory task should open its semantic session");
+            };
+            assert_eq!(resolved_session_id.to_string(), session_id);
+            assert_eq!(resolved_task_id, task_id);
+            let warp_semantic_session::RequestedSessionContent::SemanticConversation {
+                schema_version,
+                execution_identity,
+                initial_accepted_message_context,
+            } = requested_content
+            else {
+                panic!("Factory capability should select semantic content");
+            };
+            assert_eq!(schema_version, 1);
+            assert_eq!(execution_identity.conversation_id, "factory-conversation");
+            assert_eq!(execution_identity.execution_id, "factory-execution");
+            let expected_run_id = task_id.to_string();
+            assert_eq!(
+                execution_identity.run_id.as_deref(),
+                Some(expected_run_id.as_str())
+            );
+            assert_eq!(
+                execution_identity.request_id.as_deref(),
+                Some("factory-request")
+            );
+            assert!(initial_accepted_message_context.is_none());
+        });
+    });
+}
+
+#[test]
+fn test_resolve_open_action_rejects_invalid_factory_semantic_capability() {
+    App::test((), |mut app| async move {
+        add_entry_projection_test_models(&mut app);
+
+        let session_id = make_uuid(8211);
+        let mut task = create_test_task(&make_uuid(8212), "user-a", Utc::now());
+        task.state = AmbientAgentTaskState::InProgress;
+        task.session_id = Some(session_id.clone());
+        task.session_link = Some("https://example.com/session".to_string());
+        task.is_sandbox_running = true;
+        let mut capability = factory_semantic_capability(&task, session_id.as_str());
+        capability.schema_version = 2;
+        task.factory_semantic_session = Some(capability);
+        let task_id = task.task_id;
+
+        app.add_singleton_model(|_| {
+            let mut model = create_test_model();
+            model.tasks.insert(task_id, task);
+            model
+        });
+
+        app.update(|ctx| {
+            let action = AgentConversationsModel::resolve_open_action(
+                AgentConversationNavigationSubject::Entry(AgentConversationEntryId::AmbientRun(
+                    task_id,
+                )),
+                None,
+                ctx,
+            );
+            assert!(
+                action.is_none(),
+                "an explicit unsupported Factory capability must not downgrade to terminal"
+            );
+        });
+    });
 }
 
 type CapturedConversationUpdate = Mutex<Option<ConversationUpdateKind>>;
@@ -1444,7 +1565,6 @@ fn test_resolve_open_action_prefers_active_ambient_terminal() {
         });
     });
 }
-
 #[test]
 fn test_resolve_open_action_opens_active_ambient_session() {
     App::test((), |mut app| async move {
@@ -1479,6 +1599,8 @@ fn test_resolve_open_action_opens_active_ambient_session() {
                 Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                     session_id: resolved_session_id,
                     task_id: resolved_task_id,
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 }) if resolved_session_id.to_string() == session_id && resolved_task_id == task_id
             ));
         });
@@ -1518,6 +1640,8 @@ fn test_resolve_open_action_opens_active_ambient_session_from_link() {
                 Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                     session_id: resolved_session_id,
                     task_id: resolved_task_id,
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 }) if resolved_session_id.to_string() == session_id && resolved_task_id == task_id
             ));
         });
@@ -1557,6 +1681,8 @@ fn test_resolve_open_action_opens_retained_failed_ambient_session_from_link() {
                 Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                     session_id: resolved_session_id,
                     task_id: resolved_task_id,
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 }) if resolved_session_id.to_string() == session_id && resolved_task_id == task_id
             ));
 
@@ -2098,6 +2224,8 @@ fn test_resolve_open_action_reopens_ambient_session_after_terminal_unregister() 
                 Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                     session_id: resolved_session_id,
                     task_id: resolved_task_id,
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 }) if resolved_session_id.to_string() == session_id && resolved_task_id == task_id
             ));
         });
@@ -2120,6 +2248,8 @@ fn test_resolve_open_action_reopens_ambient_session_after_terminal_unregister() 
                 Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                     session_id: resolved_session_id,
                     task_id: resolved_task_id,
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 }) if resolved_session_id.to_string() == session_id && resolved_task_id == task_id
             ));
         });

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -515,6 +515,9 @@ pub struct AgentDriverOptions {
     pub parent_run_id: Option<String>,
     /// Whether the agent run should share its session.
     pub should_share: bool,
+    /// Exact shared-session content requested by authoritative run metadata.
+    /// Ordinary and locally-created runs use the full-terminal default.
+    pub requested_session_content: warp_semantic_session::RequestedSessionContent,
     /// How long to keep the session alive after the agent run completes, if at all.
     pub idle_on_complete: Option<Duration>,
     /// How long to keep the session alive after the agent run ends in a terminal error, if at
@@ -936,6 +939,7 @@ impl AgentDriver {
             task_id,
             parent_run_id,
             should_share,
+            requested_session_content,
             idle_on_complete,
             idle_on_fail,
             secrets,
@@ -1022,6 +1026,7 @@ impl AgentDriver {
                 working_dir: working_dir.clone(),
                 env_vars: HashMap::clone(&resolved_env_vars),
                 should_share,
+                requested_session_content,
                 task_id,
                 conversation_restoration,
             },

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -14,6 +14,7 @@ use warp_cli::share::{ShareAccessLevel, ShareRequest, ShareSubject};
 use warp_completer::completer::CommandOutput;
 use warp_core::command::ExitCode;
 use warp_core::features::FeatureFlag;
+use warp_semantic_session::RequestedSessionContent;
 use warp_terminal::model::grid::Dimensions;
 use warp_util::path::ShellFamily;
 use warpui::r#async::FutureExt;
@@ -110,6 +111,7 @@ pub(crate) struct TerminalDriverOptions {
     pub working_dir: PathBuf,
     pub env_vars: HashMap<OsString, OsString>,
     pub should_share: bool,
+    pub requested_session_content: RequestedSessionContent,
     pub task_id: Option<AmbientAgentTaskId>,
     pub conversation_restoration: Option<ConversationRestorationInNewPaneType>,
 }
@@ -192,7 +194,10 @@ fn create_terminal_view(
 ) -> Result<ViewHandle<TerminalView>, AgentDriverError> {
     let is_shared_session_creator = if options.should_share {
         IsSharedSessionCreator::Yes {
-            source: SharedSessionSource::ambient_agent(options.task_id.map(|t| t.to_string())),
+            source: SharedSessionSource::ambient_agent_with_content(
+                options.task_id.map(|t| t.to_string()),
+                options.requested_session_content,
+            ),
         }
     } else {
         IsSharedSessionCreator::No

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1053,6 +1053,8 @@ impl AgentDriverRunner {
                     task_id,
                     parent_run_id: None,
                     should_share,
+                    requested_session_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                     idle_on_complete: args.idle_on_complete.map(|d| d.into()),
                     idle_on_fail: args.idle_on_fail.map(|d| d.into()),
                     secrets: Default::default(),
@@ -1323,8 +1325,12 @@ impl AgentDriverRunner {
             task_harness,
             task_harness_model_config,
             additional_source_repos,
+            requested_session_content,
         ) = match task_metadata_result {
             Ok(Some(task_metadata)) => {
+                let requested_session_content = task_metadata
+                    .requested_session_content()
+                    .map_err(AgentDriverError::TaskMetadataFetchFailed)?;
                 // The task's harness is stored on the snapshot; if absent, it's the default Oz.
                 let agent_config_snapshot = task_metadata.agent_config_snapshot;
                 let task_harness_config = agent_config_snapshot
@@ -1343,9 +1349,17 @@ impl AgentDriverRunner {
                     Some(task_harness),
                     task_harness_model_config,
                     additional_source_repos,
+                    requested_session_content,
                 )
             }
-            Ok(None) => (None, None, None, None, Vec::new()),
+            Ok(None) => (
+                None,
+                None,
+                None,
+                None,
+                Vec::new(),
+                warp_semantic_session::RequestedSessionContent::FullTerminal,
+            ),
             Err(err) => return Err(AgentDriverError::TaskMetadataFetchFailed(err)),
         };
 
@@ -1364,6 +1378,7 @@ impl AgentDriverRunner {
         driver_options.task_id = parsed_task_id;
         driver_options.parent_run_id = parent_run_id;
         driver_options.additional_source_repos = additional_source_repos;
+        driver_options.requested_session_content = requested_session_content;
         driver_options.secrets = secrets;
         // CLI flags continue to take precedence so users can still override per-invocation.
         if driver_options.third_party_harness_model_config.is_none() {

--- a/app/src/ai/ambient_agents/spawn.rs
+++ b/app/src/ai/ambient_agents/spawn.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use futures::{FutureExt, Stream, StreamExt, select};
 use session_sharing_protocol::common::SessionId;
+use warp_semantic_session::RequestedSessionContent;
 
 use super::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
 use crate::server::retry_strategies::with_bounded_retry;
@@ -38,15 +39,24 @@ const MAX_STALE_POLLS_BEFORE_FAILURE: usize = 10;
 pub struct SessionJoinInfo {
     pub session_id: Option<SessionId>,
     pub session_link: String,
+    pub requested_content: RequestedSessionContent,
 }
 
 impl SessionJoinInfo {
     pub fn from_task(task: &AmbientAgentTask) -> Option<Self> {
+        Self::try_from_task(task).ok().flatten()
+    }
+
+    pub fn try_from_task(task: &AmbientAgentTask) -> anyhow::Result<Option<Self>> {
         let run_execution = task.active_run_execution();
         // The cloud-mode pane joins on `session_id`; a standalone `session_link` isn't
         // actionable without it.
-        let session_id_str = run_execution.session_id?;
-        let session_id = SessionId::from_str(session_id_str).ok()?;
+        let Some(session_id_str) = run_execution.session_id else {
+            return Ok(None);
+        };
+        let Ok(session_id) = SessionId::from_str(session_id_str) else {
+            return Ok(None);
+        };
 
         // Prefer the server-provided `session_link`; fall back to constructing one from
         // `session_id`. `active_run_execution()` already filters out empty links.
@@ -54,10 +64,12 @@ impl SessionJoinInfo {
             .session_link
             .map(String::from)
             .unwrap_or_else(|| shared_session::join_link(&session_id));
-        Some(Self {
+        let requested_content = task.requested_session_content()?;
+        Ok(Some(Self {
             session_id: Some(session_id),
             session_link,
-        })
+            requested_content,
+        }))
     }
 }
 
@@ -300,8 +312,17 @@ fn poll_run_until_joinable_session(
                                 return;
                             }
 
-                            if task.state == AmbientAgentTaskState::InProgress
-                                && let Some(session_join_info) = SessionJoinInfo::from_task(&task) {
+                            if task.state == AmbientAgentTaskState::InProgress {
+                                let session_join_info = match SessionJoinInfo::try_from_task(&task) {
+                                    Ok(session_join_info) => session_join_info,
+                                    Err(err) => {
+                                        yield Err(err.context(
+                                            "Invalid server-authored Factory semantic session capability"
+                                        ));
+                                        return;
+                                    }
+                                };
+                                if let Some(session_join_info) = session_join_info {
                                     let has_new_session = match &mode {
                                         RunPollMode::InitialRun
                                         | RunPollMode::Followup {
@@ -321,6 +342,7 @@ fn poll_run_until_joinable_session(
                                         return;
                                     }
                                 }
+                            }
                         }
                         Err(err) => {
                             yield Err(err);

--- a/app/src/ai/ambient_agents/spawn_tests.rs
+++ b/app/src/ai/ambient_agents/spawn_tests.rs
@@ -9,6 +9,7 @@ use super::{
     spawn_task, submit_run_followup,
 };
 use crate::ai::agent::UserQueryMode;
+use crate::ai::ambient_agents::task::FactorySemanticSession;
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
 use crate::server::server_api::ai::{MockAIClient, SpawnAgentResponse, TaskStatusMessage};
 use crate::terminal::shared_session;
@@ -41,8 +42,109 @@ fn task_with(
         artifacts: vec![],
         is_sandbox_running: true,
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
+}
+fn semantic_capability(task: &AmbientAgentTask, session_id: SessionId) -> FactorySemanticSession {
+    FactorySemanticSession {
+        content_mode: "semantic_conversation_only".to_string(),
+        schema_version: 1,
+        conversation_id: "factory-conversation".to_string(),
+        execution_id: "factory-execution".to_string(),
+        run_id: task.task_id.to_string(),
+        request_id: Some("factory-request".to_string()),
+        session_id: Some(session_id.to_string()),
+        accepted_message_context: None,
+    }
+}
+
+#[test]
+fn session_join_info_preserves_factory_semantic_identity() {
+    let session_id = SessionId::new();
+    let mut task = task_with(
+        AmbientAgentTaskState::InProgress,
+        Some(session_id.to_string()),
+        Some("https://example.com/session/semantic".to_string()),
+    );
+    task.factory_semantic_session = Some(semantic_capability(&task, session_id));
+
+    let join_info = SessionJoinInfo::try_from_task(&task)
+        .expect("valid capability")
+        .expect("joinable session");
+    assert_eq!(join_info.session_id, Some(session_id));
+    let warp_semantic_session::RequestedSessionContent::SemanticConversation {
+        schema_version,
+        execution_identity,
+        initial_accepted_message_context,
+    } = join_info.requested_content
+    else {
+        panic!("Factory capability should select semantic content");
+    };
+    assert_eq!(schema_version, 1);
+    assert_eq!(execution_identity.conversation_id, "factory-conversation");
+    assert_eq!(execution_identity.execution_id, "factory-execution");
+    let expected_run_id = task.task_id.to_string();
+    assert_eq!(
+        execution_identity.run_id.as_deref(),
+        Some(expected_run_id.as_str())
+    );
+    assert_eq!(
+        execution_identity.request_id.as_deref(),
+        Some("factory-request")
+    );
+    assert!(initial_accepted_message_context.is_none());
+}
+
+#[tokio::test]
+async fn monitor_spawned_task_fails_closed_for_invalid_factory_capability() {
+    use futures::StreamExt;
+
+    let session_id = SessionId::new();
+    let mut task = task_with(
+        AmbientAgentTaskState::InProgress,
+        Some(session_id.to_string()),
+        Some("https://example.com/session/semantic".to_string()),
+    );
+    let mut capability = semantic_capability(&task, session_id);
+    capability.schema_version = 2;
+    task.factory_semantic_session = Some(capability);
+
+    let mut mock = MockAIClient::new();
+    mock.expect_spawn_agent().times(0);
+    mock.expect_get_ambient_agent_task()
+        .times(1)
+        .return_once(move |_| Ok(task));
+    let mut stream = Box::pin(monitor_spawned_task(
+        run_id(),
+        "already-created-run".to_owned(),
+        false,
+        Arc::new(mock),
+        None,
+    ));
+
+    assert!(matches!(
+        stream.next().await.expect("spawned event").expect("ok"),
+        AmbientAgentEvent::TaskSpawned { .. }
+    ));
+    assert!(matches!(
+        stream.next().await.expect("state event").expect("ok"),
+        AmbientAgentEvent::StateChanged {
+            state: AmbientAgentTaskState::InProgress,
+            ..
+        }
+    ));
+    let error = stream
+        .next()
+        .await
+        .expect("capability error")
+        .expect_err("invalid capability must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("Invalid server-authored Factory semantic session capability")
+    );
+    assert!(stream.next().await.is_none());
 }
 
 #[tokio::test]

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -6,10 +6,13 @@ pub use cloud_object_models::HarnessModelConfig;
 pub use cloud_object_models::{AgentConfigSnapshot, HarnessAuthSecretsConfig, HarnessConfig};
 use iso8601_duration::Duration as Iso8601Duration;
 use serde::{Deserialize, Serialize};
-use session_sharing_protocol::common::SessionId;
+use session_sharing_protocol::common::{
+    ExecutionIdentity, SEMANTIC_CONVERSATION_SCHEMA_VERSION_V1, SessionId,
+};
 use url::Url;
 use warp_core::ui::theme::WarpTheme;
 use warp_errors::report_error;
+use warp_semantic_session::{RequestedSessionContent, decode_accepted_message_context};
 use warpui::color::ColorU;
 use warpui::{SingletonEntity, View, ViewContext};
 
@@ -201,6 +204,101 @@ where
     })
 }
 
+const FACTORY_SEMANTIC_CONTENT_MODE: &str = "semantic_conversation_only";
+
+/// Server-authored capability for a Factory run whose shared session carries
+/// semantic conversation mutations instead of terminal state.
+///
+/// This object must only be populated from the active server-side Factory
+/// execution binding. Client-authored task metadata and agent configuration
+/// are not capability signals.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct FactorySemanticSession {
+    pub content_mode: String,
+    pub schema_version: u32,
+    pub conversation_id: String,
+    pub execution_id: String,
+    pub run_id: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub accepted_message_context: Option<Vec<u8>>,
+}
+
+impl FactorySemanticSession {
+    fn validate_identifier(field: &'static str, value: &str) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !value.is_empty() && value.trim() == value,
+            "invalid Factory semantic session {field}"
+        );
+        Ok(())
+    }
+
+    fn requested_content(
+        &self,
+        task_id: AmbientAgentTaskId,
+        active_session_id: Option<&str>,
+    ) -> anyhow::Result<RequestedSessionContent> {
+        anyhow::ensure!(
+            self.content_mode == FACTORY_SEMANTIC_CONTENT_MODE,
+            "unsupported Factory semantic session content mode {:?}",
+            self.content_mode
+        );
+        anyhow::ensure!(
+            self.schema_version == SEMANTIC_CONVERSATION_SCHEMA_VERSION_V1,
+            "unsupported Factory semantic session schema version {}",
+            self.schema_version
+        );
+        Self::validate_identifier("conversation_id", &self.conversation_id)?;
+        Self::validate_identifier("execution_id", &self.execution_id)?;
+        Self::validate_identifier("run_id", &self.run_id)?;
+        anyhow::ensure!(
+            self.run_id == task_id.to_string(),
+            "Factory semantic session run_id does not match task_id"
+        );
+        if let Some(request_id) = self.request_id.as_deref() {
+            Self::validate_identifier("request_id", request_id)?;
+        }
+        if let Some(session_id) = self.session_id.as_deref() {
+            Self::validate_identifier("session_id", session_id)?;
+            let parsed_capability_session_id = session_id
+                .parse::<SessionId>()
+                .map_err(|_| anyhow::anyhow!("invalid Factory semantic session session_id"))?;
+            if let Some(active_session_id) = active_session_id {
+                let parsed_active_session_id = active_session_id
+                    .parse::<SessionId>()
+                    .map_err(|_| anyhow::anyhow!("invalid active shared-session session_id"))?;
+                anyhow::ensure!(
+                    parsed_capability_session_id == parsed_active_session_id,
+                    "Factory semantic session session_id does not match active session"
+                );
+            }
+        }
+
+        let execution_identity = ExecutionIdentity {
+            conversation_id: self.conversation_id.clone(),
+            execution_id: self.execution_id.clone(),
+            run_id: Some(self.run_id.clone()),
+            request_id: self.request_id.clone(),
+        };
+        match self.accepted_message_context.as_deref() {
+            Some(bytes) => {
+                let context = decode_accepted_message_context(
+                    bytes,
+                    &execution_identity,
+                    self.schema_version,
+                )?;
+                Ok(RequestedSessionContent::semantic_v1_with_initial_context(
+                    execution_identity,
+                    context,
+                )?)
+            }
+            None => Ok(RequestedSessionContent::semantic_v1(execution_identity)),
+        }
+    }
+}
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct AmbientAgentTask {
     pub task_id: AmbientAgentTaskId,
@@ -240,6 +338,11 @@ pub struct AmbientAgentTask {
     /// server supports it; `None` on older servers.
     #[serde(default)]
     pub last_event_sequence: Option<i64>,
+    /// Explicit semantic-session capability derived from the active
+    /// server-side Factory execution binding. Absence preserves the legacy
+    /// full-terminal session.
+    #[serde(default)]
+    pub factory_semantic_session: Option<FactorySemanticSession>,
 
     /// The server-recorded `run_id`s of direct children of this run. Used
     /// by orchestration event-delivery restore to discover children whose
@@ -328,6 +431,19 @@ impl AmbientAgentTask {
 
     pub fn conversation_id(&self) -> Option<&str> {
         self.conversation_id.as_deref()
+    }
+    /// Resolves the exact content contract requested by this run.
+    ///
+    /// An absent capability is the backwards-compatible full-terminal path.
+    /// Once the server emits the capability, malformed or unsupported values
+    /// are errors and must never downgrade to terminal sharing.
+    pub fn requested_session_content(&self) -> anyhow::Result<RequestedSessionContent> {
+        match self.factory_semantic_session.as_ref() {
+            Some(capability) => {
+                capability.requested_content(self.task_id, self.active_run_execution().session_id)
+            }
+            None => Ok(RequestedSessionContent::FullTerminal),
+        }
     }
 
     /// Returns true when this task's source must not accept user-triggered cloud follow-ups.

--- a/app/src/ai/ambient_agents/task_tests.rs
+++ b/app/src/ai/ambient_agents/task_tests.rs
@@ -1,9 +1,15 @@
 use chrono::{Duration, Utc};
+use prost::Message as _;
 use serde_json::{Value, json};
+use warp_conversation_mutation_api::{
+    AcceptedMessageContext, Attribution, Author, Origin, SchemaVersion, author, origin,
+};
+use warp_semantic_session::RequestedSessionContent;
 
 use super::{
     AgentConfigSnapshot, AgentSource, AmbientAgentLiveSessionState, AmbientAgentTask,
-    AmbientAgentTaskState, ExecutionLocation, TaskStatusErrorCode, TaskStatusMessage,
+    AmbientAgentTaskState, ExecutionLocation, FactorySemanticSession, TaskStatusErrorCode,
+    TaskStatusMessage,
 };
 
 fn make_task(snapshot_name: Option<&str>, title: &str) -> AmbientAgentTask {
@@ -35,8 +41,120 @@ fn make_task(snapshot_name: Option<&str>, title: &str) -> AmbientAgentTask {
         agent_config_snapshot,
         artifacts: vec![],
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
+}
+
+fn accepted_message_context() -> AcceptedMessageContext {
+    AcceptedMessageContext {
+        schema_version: SchemaVersion::V1 as i32,
+        conversation_id: "conversation-1".to_string(),
+        execution_id: "execution-1".to_string(),
+        message_id: "initial-message".to_string(),
+        attribution: Some(Attribution {
+            author: Some(Author {
+                id: "factory-user".to_string(),
+                kind: author::Kind::User as i32,
+                display_name: "Factory User".to_string(),
+            }),
+            origin: Some(Origin {
+                kind: origin::Kind::Factory as i32,
+                source_id: "factory".to_string(),
+                subtype: "linear".to_string(),
+            }),
+            source_delivery: None,
+        }),
+        media: Vec::new(),
+    }
+}
+
+fn valid_factory_semantic_session(task: &AmbientAgentTask) -> FactorySemanticSession {
+    FactorySemanticSession {
+        content_mode: "semantic_conversation_only".to_string(),
+        schema_version: 1,
+        conversation_id: "conversation-1".to_string(),
+        execution_id: "execution-1".to_string(),
+        run_id: task.task_id.to_string(),
+        request_id: Some("request-1".to_string()),
+        session_id: task.session_id.clone(),
+        accepted_message_context: None,
+    }
+}
+
+#[test]
+fn missing_factory_capability_preserves_full_terminal_mode() {
+    let task = make_task(None, "ordinary ambient run");
+    assert_eq!(
+        task.requested_session_content().unwrap(),
+        RequestedSessionContent::FullTerminal
+    );
+}
+
+#[test]
+fn valid_factory_capability_selects_semantic_v1_with_exact_identity() {
+    let mut task = make_task(None, "Factory run");
+    task.factory_semantic_session = Some(valid_factory_semantic_session(&task));
+
+    let RequestedSessionContent::SemanticConversation {
+        schema_version,
+        execution_identity,
+        initial_accepted_message_context,
+    } = task.requested_session_content().unwrap()
+    else {
+        panic!("Factory capability should select semantic conversation mode");
+    };
+    assert_eq!(schema_version, 1);
+    assert_eq!(execution_identity.conversation_id, "conversation-1");
+    assert_eq!(execution_identity.execution_id, "execution-1");
+    let expected_run_id = task.task_id.to_string();
+    assert_eq!(
+        execution_identity.run_id.as_deref(),
+        Some(expected_run_id.as_str())
+    );
+    assert_eq!(execution_identity.request_id.as_deref(), Some("request-1"));
+    assert!(initial_accepted_message_context.is_none());
+}
+
+#[test]
+fn factory_capability_preserves_validated_initial_accepted_message_context() {
+    let mut task = make_task(None, "Factory run");
+    let context = accepted_message_context();
+    let mut capability = valid_factory_semantic_session(&task);
+    capability.accepted_message_context = Some(context.encode_to_vec());
+    task.factory_semantic_session = Some(capability);
+
+    let requested_content = task.requested_session_content().unwrap();
+    assert_eq!(
+        requested_content.initial_accepted_message_context(),
+        Some(&context)
+    );
+
+    let mut invalid = accepted_message_context();
+    invalid.execution_id = "different-execution".to_string();
+    let mut capability = valid_factory_semantic_session(&task);
+    capability.accepted_message_context = Some(invalid.encode_to_vec());
+    task.factory_semantic_session = Some(capability);
+    assert!(task.requested_session_content().is_err());
+}
+
+#[test]
+fn explicit_invalid_factory_capability_never_downgrades_to_terminal() {
+    let mut task = make_task(None, "Factory run");
+    let mut capability = valid_factory_semantic_session(&task);
+    capability.schema_version = 2;
+    task.factory_semantic_session = Some(capability);
+    assert!(task.requested_session_content().is_err());
+
+    let mut capability = valid_factory_semantic_session(&task);
+    capability.run_id = "different-run".to_string();
+    task.factory_semantic_session = Some(capability);
+    assert!(task.requested_session_content().is_err());
+
+    let mut capability = valid_factory_semantic_session(&task);
+    capability.execution_id = " ".to_string();
+    task.factory_semantic_session = Some(capability);
+    assert!(task.requested_session_content().is_err());
 }
 
 fn task_json_with_run_time(run_time_key: &str, run_time: Value) -> Value {

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use session_sharing_protocol::common::{AgentAttachment, ParticipantId, ServerConversationToken};
+use warp_conversation_mutation_api::AcceptedMessageContext;
 use warp_core::features::FeatureFlag;
 use warp_errors::report_error;
 use warp_multi_agent_api::client_action::Action;
@@ -664,6 +665,7 @@ impl BlocklistAIController {
         server_conversation_token: Option<ServerConversationToken>,
         attachments: Vec<AgentAttachment>,
         participant_id: ParticipantId,
+        accepted_message_context: Option<AcceptedMessageContext>,
         ctx: &mut ModelContext<Self>,
     ) {
         // Map server token to sharer's local conversation ID
@@ -726,6 +728,7 @@ impl BlocklistAIController {
                 conversation_id,
                 participant_id,
                 HashMap::new(),
+                accepted_message_context,
                 ctx,
             );
             return;
@@ -741,6 +744,7 @@ impl BlocklistAIController {
                 conversation_id,
                 participant_id,
                 HashMap::new(),
+                accepted_message_context,
                 ctx,
             );
             return;
@@ -752,6 +756,7 @@ impl BlocklistAIController {
                 conversation_id,
                 participant_id,
                 HashMap::new(),
+                accepted_message_context,
                 ctx,
             );
             return;
@@ -824,6 +829,7 @@ impl BlocklistAIController {
                     conversation_id,
                     participant_id,
                     file_attachments,
+                    accepted_message_context,
                     ctx,
                 );
             },
@@ -838,8 +844,14 @@ impl BlocklistAIController {
         conversation_id: Option<AIConversationId>,
         participant_id: ParticipantId,
         file_attachments: HashMap<String, AIAgentAttachment>,
+        accepted_message_context: Option<AcceptedMessageContext>,
         ctx: &mut ModelContext<Self>,
     ) {
+        if let Some(context) = accepted_message_context {
+            self.terminal_model
+                .lock()
+                .send_accepted_message_context_for_shared_session(context);
+        }
         if let Some(conversation_id) = conversation_id {
             if FeatureFlag::AgentView.is_enabled() {
                 // Enter agent view for this conversation so the sharer's UI state is correct

--- a/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
+++ b/app/src/ai/blocklist/orchestration_child_tracker_tests.rs
@@ -88,6 +88,7 @@ fn seed_row(task_id: AmbientAgentTaskId) -> Box<AmbientAgentTask> {
         artifacts: vec![],
         is_sandbox_running: false,
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     })
 }

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -338,6 +338,7 @@ fn make_ambient_task_with_event_seq(
         artifacts: vec![],
         is_sandbox_running: false,
         last_event_sequence,
+        factory_semantic_session: None,
         children: vec![],
     }
 }

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -48,6 +48,7 @@ fn create_test_task(task_id: &str) -> AmbientAgentTask {
         artifacts: vec![],
         is_sandbox_running: false,
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
 }

--- a/app/src/pane_group/ambient_pane_restoration.rs
+++ b/app/src/pane_group/ambient_pane_restoration.rs
@@ -1,6 +1,7 @@
 use session_sharing_protocol::common::SessionId;
 use uuid::Uuid;
 use warp_errors::report_error;
+use warp_semantic_session::RequestedSessionContent;
 use warpui::{SingletonEntity, ViewContext, ViewHandle};
 
 use crate::ai::agent::api::ServerConversationToken;
@@ -16,7 +17,10 @@ use crate::workspace::WorkspaceAction;
 /// The restoration path for an ambient agent pane.
 pub(in crate::pane_group) enum AmbientRestoreKind {
     /// Active shared session
-    SharedSession { session_id: SessionId },
+    SharedSession {
+        session_id: SessionId,
+        requested_content: RequestedSessionContent,
+    },
     /// Conversation data isn't loaded yet — show a loading pane and
     /// defer the real restoration to the pending-restoration subscription
     /// (which waits for the data to be loaded async).
@@ -98,14 +102,16 @@ impl PaneGroup {
             ) {
                 Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                     session_id,
+                    requested_content,
                     task_id: _,
                 }) => {
-                    let (view, terminal_manager) = Self::create_shared_session_viewer(
+                    let (view, terminal_manager) = Self::create_shared_session_viewer_with_content(
                         session_id,
                         resources.clone(),
                         view_size,
                         true, // enable_orchestration_polling
                         true, // is_ambient_agent
+                        requested_content,
                         ctx,
                     );
                     let new_pane = TerminalPane::new(

--- a/app/src/pane_group/child_agent/hydration.rs
+++ b/app/src/pane_group/child_agent/hydration.rs
@@ -166,7 +166,10 @@ impl PaneGroup {
         ctx: &mut ViewContext<Self>,
     ) {
         match decide_child_pane_materialization(&task) {
-            ChildPaneMaterialization::AttachLive { session_id } => {
+            ChildPaneMaterialization::AttachLive {
+                session_id,
+                requested_content,
+            } => {
                 let child_id = child_conversation.id();
                 if self.failed_viewer_child_sessions.get(&child_id) == Some(&session_id) {
                     // The session already failed to join; wait for a later
@@ -188,7 +191,12 @@ impl PaneGroup {
                 if let Some(task_id) = child_conversation.task_id() {
                     self.pending_child_hydrations.remove(&task_id);
                 }
-                self.attach_ambient_orchestration_child_session(child_id, session_id, ctx);
+                self.attach_ambient_orchestration_child_session(
+                    child_id,
+                    session_id,
+                    requested_content,
+                    ctx,
+                );
             }
             ChildPaneMaterialization::LoadTranscript { server_token } => {
                 let child_id = child_conversation.id();
@@ -229,6 +237,11 @@ impl PaneGroup {
                 self.pending_child_hydrations.insert(task_id, child_id);
                 self.ensure_pending_ambient_restoration_subscription(ctx);
             }
+            ChildPaneMaterialization::InvalidSemanticCapability => {
+                log::error!(
+                    "Refusing to materialize orchestration child with invalid semantic capability"
+                );
+            }
         }
     }
 
@@ -241,6 +254,7 @@ impl PaneGroup {
         &mut self,
         child_id: AIConversationId,
         session_id: SessionId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
         ctx: &mut ViewContext<Self>,
     ) {
         let Some(child_conversation) = BlocklistAIHistoryModel::as_ref(ctx)
@@ -280,7 +294,12 @@ impl PaneGroup {
         };
         let view_size = Self::estimated_view_bounds(ctx).size();
         let (new_terminal_view, terminal_manager) = Self::create_ambient_orchestration_child_pane(
-            session_id, child_id, resources, view_size, ctx,
+            session_id,
+            child_id,
+            requested_content,
+            resources,
+            view_size,
+            ctx,
         );
         let pane_data = TerminalPane::new(
             Uuid::new_v4().as_bytes().to_vec(),
@@ -694,14 +713,22 @@ impl PaneGroup {
             };
 
             match decide_child_pane_materialization(&task) {
-                ChildPaneMaterialization::AttachLive { session_id }
+                ChildPaneMaterialization::AttachLive { session_id, .. }
                     if self.failed_viewer_child_sessions.get(&child_id) == Some(&session_id) =>
                 {
                     self.pending_child_hydrations.insert(task_id, child_id);
                 }
-                ChildPaneMaterialization::AttachLive { session_id } => {
+                ChildPaneMaterialization::AttachLive {
+                    session_id,
+                    requested_content,
+                } => {
                     self.failed_viewer_child_sessions.remove(&child_id);
-                    self.attach_ambient_orchestration_child_session(child_id, session_id, ctx);
+                    self.attach_ambient_orchestration_child_session(
+                        child_id,
+                        session_id,
+                        requested_content,
+                        ctx,
+                    );
                 }
                 ChildPaneMaterialization::LoadTranscript { server_token } => {
                     self.failed_viewer_child_sessions.remove(&child_id);
@@ -709,6 +736,11 @@ impl PaneGroup {
                 }
                 ChildPaneMaterialization::Pending => {
                     self.pending_child_hydrations.insert(task_id, child_id);
+                }
+                ChildPaneMaterialization::InvalidSemanticCapability => {
+                    log::error!(
+                        "Refusing to materialize orchestration child with invalid semantic capability"
+                    );
                 }
             }
         }

--- a/app/src/pane_group/child_agent/materialization.rs
+++ b/app/src/pane_group/child_agent/materialization.rs
@@ -1,4 +1,5 @@
 use session_sharing_protocol::common::SessionId;
+use warp_semantic_session::RequestedSessionContent;
 
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::ambient_agents::{AmbientAgentLiveSessionState, AmbientAgentTask};
@@ -8,7 +9,13 @@ use crate::ai::ambient_agents::{AmbientAgentLiveSessionState, AmbientAgentTask};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ChildPaneMaterialization {
     /// Attachable live session — join it in place using `session_id`.
-    AttachLive { session_id: SessionId },
+    AttachLive {
+        session_id: SessionId,
+        requested_content: RequestedSessionContent,
+    },
+    /// The server explicitly requested semantic mode, but its capability was
+    /// malformed or unsupported. Never downgrade this child to terminal mode.
+    InvalidSemanticCapability,
     /// No live session but a server conversation token is available; load
     /// the cloud transcript for it.
     LoadTranscript {
@@ -29,7 +36,18 @@ pub(crate) fn decide_child_pane_materialization(
     if let AmbientAgentLiveSessionState::Attachable { session_id } =
         task.active_live_session_state()
     {
-        return ChildPaneMaterialization::AttachLive { session_id };
+        return match task.requested_session_content() {
+            Ok(requested_content) => ChildPaneMaterialization::AttachLive {
+                session_id,
+                requested_content,
+            },
+            Err(err) => {
+                log::error!(
+                    "Refusing child viewer with invalid Factory semantic capability: {err:#}"
+                );
+                ChildPaneMaterialization::InvalidSemanticCapability
+            }
+        };
     }
 
     // Only terminal runs load a transcript. Empty/whitespace tokens would

--- a/app/src/pane_group/child_agent/materialization_tests.rs
+++ b/app/src/pane_group/child_agent/materialization_tests.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 
 use super::{ChildPaneMaterialization, decide_child_pane_materialization};
 use crate::ai::agent::api::ServerConversationToken;
+use crate::ai::ambient_agents::task::FactorySemanticSession;
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
 
 /// Builds a minimal [`AmbientAgentTask`] for materialization tests.
@@ -42,8 +43,70 @@ fn task(
         agent_config_snapshot: None,
         artifacts: vec![],
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
+}
+
+#[test]
+fn attachable_factory_task_preserves_semantic_content() {
+    let session_id = "22222222-2222-2222-2222-222222222222";
+    let mut task = task(
+        AmbientAgentTaskState::InProgress,
+        true,
+        Some(session_id),
+        Some("server-token-irrelevant-for-attach"),
+    );
+    task.factory_semantic_session = Some(FactorySemanticSession {
+        content_mode: "semantic_conversation_only".to_string(),
+        schema_version: 1,
+        conversation_id: "factory-conversation".to_string(),
+        execution_id: "factory-execution".to_string(),
+        run_id: task.task_id.to_string(),
+        request_id: Some("factory-request".to_string()),
+        session_id: Some(session_id.to_string()),
+        accepted_message_context: None,
+    });
+
+    let ChildPaneMaterialization::AttachLive {
+        session_id: attached_session_id,
+        requested_content,
+    } = decide_child_pane_materialization(&task)
+    else {
+        panic!("valid Factory capability should attach the semantic child");
+    };
+    assert_eq!(attached_session_id, session_id.parse().unwrap());
+    assert_eq!(
+        requested_content.execution_identity().unwrap().execution_id,
+        "factory-execution"
+    );
+    assert!(requested_content.is_semantic());
+}
+
+#[test]
+fn attachable_factory_task_rejects_invalid_semantic_capability() {
+    let session_id = "22222222-2222-2222-2222-222222222222";
+    let mut task = task(
+        AmbientAgentTaskState::InProgress,
+        true,
+        Some(session_id),
+        None,
+    );
+    task.factory_semantic_session = Some(FactorySemanticSession {
+        content_mode: "semantic_conversation_only".to_string(),
+        schema_version: 2,
+        conversation_id: "factory-conversation".to_string(),
+        execution_id: "factory-execution".to_string(),
+        run_id: task.task_id.to_string(),
+        request_id: Some("factory-request".to_string()),
+        session_id: Some(session_id.to_string()),
+        accepted_message_context: None,
+    });
+
+    assert_eq!(
+        decide_child_pane_materialization(&task),
+        ChildPaneMaterialization::InvalidSemanticCapability
+    );
 }
 
 #[test]
@@ -79,6 +142,7 @@ fn attachable_task_attaches_live_with_session_id() {
         decide_child_pane_materialization(&task),
         ChildPaneMaterialization::AttachLive {
             session_id: "22222222-2222-2222-2222-222222222222".parse().unwrap(),
+            requested_content: warp_semantic_session::RequestedSessionContent::FullTerminal,
         },
     );
 }

--- a/app/src/pane_group/child_agent/restoration.rs
+++ b/app/src/pane_group/child_agent/restoration.rs
@@ -613,6 +613,7 @@ impl PaneGroup {
         &mut self,
         child_conversation_id: AIConversationId,
         child_session_id: SessionId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
         ctx: &mut ViewContext<Self>,
     ) {
         // Race recovery: a pill click before materialization had a
@@ -654,12 +655,13 @@ impl PaneGroup {
         // Per-child viewer: parent's model already discovers descendants, and
         // hidden child viewers aren't snapshotted, so `is_cloud_mode` stays
         // `false` (no `ambient_agent_view_model` needed for snapshot round-trip).
-        let (new_terminal_view, terminal_manager) = Self::create_shared_session_viewer(
+        let (new_terminal_view, terminal_manager) = Self::create_shared_session_viewer_with_content(
             child_session_id,
             resources,
             view_size,
             false, // enable_orchestration_polling
             false, // is_ambient_agent
+            requested_content,
             ctx,
         );
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -1933,8 +1933,12 @@ impl PaneGroup {
                         ) {
                             Some(WorkspaceAction::OpenOrAttachAmbientAgentConversation {
                                 session_id,
+                                requested_content,
                                 ..
-                            }) => AmbientRestoreKind::SharedSession { session_id },
+                            }) => AmbientRestoreKind::SharedSession {
+                                session_id,
+                                requested_content,
+                            },
                             // Transcript viewer and other non-session actions depend on conversation metadata from
                             // BlocklistAIHistoryModel, which is loaded asynchronously.
                             // Defer to the pending-restoration handler so it can retry once that metadata arrives.
@@ -1954,11 +1958,17 @@ impl PaneGroup {
 
                 let mut pending_task: Option<AmbientAgentTaskId> = None;
                 let (terminal_view, terminal_manager) = match restore_kind {
-                    AmbientRestoreKind::SharedSession { session_id } => {
-                        Self::create_shared_session_viewer(
-                            session_id, resources, view_size,
+                    AmbientRestoreKind::SharedSession {
+                        session_id,
+                        requested_content,
+                    } => {
+                        Self::create_shared_session_viewer_with_content(
+                            session_id,
+                            resources,
+                            view_size,
                             true, // enable_orchestration_polling
                             true, // is_ambient_agent
+                            requested_content,
                             ctx,
                         )
                     }
@@ -3591,13 +3601,36 @@ impl PaneGroup {
         is_ambient_agent: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
+        Self::new_for_shared_session_viewer_with_content(
+            session_id,
+            tips_completed,
+            user_default_shell_unsupported_banner_model_handle,
+            server_api,
+            model_event_sender,
+            is_ambient_agent,
+            warp_semantic_session::RequestedSessionContent::FullTerminal,
+            ctx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_for_shared_session_viewer_with_content(
+        session_id: SessionId,
+        tips_completed: ModelHandle<TipsCompleted>,
+        user_default_shell_unsupported_banner_model_handle: ModelHandle<BannerState>,
+        server_api: Arc<ServerApi>,
+        model_event_sender: Option<SyncSender<ModelEvent>>,
+        is_ambient_agent: bool,
+        requested_content: warp_semantic_session::RequestedSessionContent,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
         let model_event_sender_clone = model_event_sender.clone();
         let initial_layout = move |resources,
                                    pane_contents: &mut HashMap<PaneId, Box<dyn AnyPaneContent>>,
                                    pane_history: &mut Vec<PaneId>,
                                    view_bounds: RectF,
                                    ctx: &mut ViewContext<Self>| {
-            let (view, terminal_manager) = PaneGroup::create_shared_session_viewer(
+            let (view, terminal_manager) = PaneGroup::create_shared_session_viewer_with_content(
                 session_id,
                 resources,
                 view_bounds.size(),
@@ -3607,6 +3640,7 @@ impl PaneGroup {
                 // link may still turn out to be ambient, in which case the model is
                 // created lazily at `SessionJoined`.
                 is_ambient_agent,
+                requested_content,
                 ctx,
             );
 
@@ -6231,7 +6265,7 @@ impl PaneGroup {
     /// generic shared-session joins: if such a session turns out to be ambient,
     /// the model is created lazily at `SessionJoined` via
     /// `TerminalView::begin_viewing_ambient_session`.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, dead_code)]
     fn create_shared_session_viewer(
         session_id: SessionId,
         resources: TerminalViewResources,
@@ -6243,14 +6277,39 @@ impl PaneGroup {
         ViewHandle<TerminalView>,
         ModelHandle<Box<dyn TerminalManager>>,
     ) {
+        Self::create_shared_session_viewer_with_content(
+            session_id,
+            resources,
+            initial_size,
+            enable_orchestration_polling,
+            is_ambient_agent,
+            warp_semantic_session::RequestedSessionContent::FullTerminal,
+            ctx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_shared_session_viewer_with_content(
+        session_id: SessionId,
+        resources: TerminalViewResources,
+        initial_size: Vector2F,
+        enable_orchestration_polling: bool,
+        is_ambient_agent: bool,
+        requested_content: warp_semantic_session::RequestedSessionContent,
+        ctx: &mut ViewContext<Self>,
+    ) -> (
+        ViewHandle<TerminalView>,
+        ModelHandle<Box<dyn TerminalManager>>,
+    ) {
         let window_id = ctx.window_id();
-        let terminal_init = shared_session::viewer::TerminalManager::new(
+        let terminal_init = shared_session::viewer::TerminalManager::new_with_content(
             session_id,
             resources,
             initial_size,
             window_id,
             enable_orchestration_polling,
             is_ambient_agent,
+            requested_content,
             ctx,
         );
         let viewer_manager = terminal_init.manager;
@@ -6321,6 +6380,7 @@ impl PaneGroup {
     fn create_ambient_orchestration_child_pane(
         session_id: SessionId,
         conversation_id: AIConversationId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
         resources: TerminalViewResources,
         initial_size: Vector2F,
         ctx: &mut ViewContext<Self>,
@@ -6332,6 +6392,7 @@ impl PaneGroup {
             shared_session::viewer::TerminalManager::new_for_ambient_orchestration_child(
                 session_id,
                 conversation_id,
+                requested_content,
                 resources,
                 initial_size,
                 ctx.window_id(),
@@ -7162,6 +7223,7 @@ impl PaneGroup {
         &mut self,
         pane_id: PaneId,
         session_id: SessionId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
         ctx: &mut ViewContext<Self>,
     ) -> bool {
         let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) else {
@@ -7197,7 +7259,7 @@ impl PaneGroup {
             .cloned()
         {
             ambient_agent_view_model.update(ctx, |model, ctx| {
-                model.attach_execution_session(session_id, ctx);
+                model.attach_execution_session(session_id, requested_content.clone(), ctx);
             });
             terminal_view.update(ctx, |view, ctx| {
                 view.prepare_for_live_session_reattach(ctx);
@@ -7228,7 +7290,8 @@ impl PaneGroup {
                 );
                 return;
             };
-            attached = manager.attach_execution_session(session_id, ctx);
+            attached =
+                manager.attach_execution_session_with_content(session_id, requested_content, ctx);
         });
 
         if attached {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -319,6 +319,7 @@ fn ambient_agent_task_for_current_user(task_id: AmbientAgentTaskId) -> AmbientAg
         agent_config_snapshot: None,
         artifacts: vec![],
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
 }
@@ -2040,7 +2041,12 @@ fn attach_execution_session_refuses_read_only_transcript_viewer_pane() {
             );
 
             assert!(
-                !panes.attach_execution_session_to_ambient_pane(pane_id, SessionId::new(), ctx),
+                !panes.attach_execution_session_to_ambient_pane(
+                    pane_id,
+                    SessionId::new(),
+                    warp_semantic_session::RequestedSessionContent::FullTerminal,
+                    ctx,
+                ),
                 "a read-only transcript viewer must not report a successful live-session attach",
             );
         });
@@ -2077,7 +2083,12 @@ fn attach_execution_session_keeps_read_only_state_when_the_attach_fails() {
             );
 
             assert!(
-                !panes.attach_execution_session_to_ambient_pane(pane_id, SessionId::new(), ctx),
+                !panes.attach_execution_session_to_ambient_pane(
+                    pane_id,
+                    SessionId::new(),
+                    warp_semantic_session::RequestedSessionContent::FullTerminal,
+                    ctx,
+                ),
                 "precondition: this attach cannot succeed",
             );
             assert!(
@@ -2151,6 +2162,51 @@ fn create_shared_session_viewer_without_cloud_mode_does_not_populate_ambient_age
                 terminal_view.as_ref(ctx).ambient_agent_view_model().is_none(),
                 "non-cloud-mode shared-session viewer must not construct an ambient_agent_view_model; existing callers depend on this",
             );
+        });
+    });
+}
+
+#[test]
+fn create_shared_session_viewer_with_content_forwards_semantic_identity_to_network() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+
+        pane_group.update(&mut app, |panes, ctx| {
+            let resources = TerminalViewResources {
+                tips_completed: panes.tips_completed.clone(),
+                server_api: panes.server_api.clone(),
+                model_event_sender: panes.model_event_sender.clone(),
+            };
+            let requested_content = warp_semantic_session::RequestedSessionContent::semantic_v1(
+                session_sharing_protocol::common::ExecutionIdentity {
+                    conversation_id: "factory-conversation".to_string(),
+                    execution_id: "factory-execution".to_string(),
+                    run_id: Some("factory-run".to_string()),
+                    request_id: Some("factory-request".to_string()),
+                },
+            );
+            let (_terminal_view, terminal_manager) =
+                PaneGroup::create_shared_session_viewer_with_content(
+                    SessionId::new(),
+                    resources,
+                    Vector2F::new(800., 600.),
+                    false,
+                    true,
+                    requested_content.clone(),
+                    ctx,
+                );
+
+            terminal_manager.read(ctx, |terminal_manager, ctx| {
+                let viewer_manager = terminal_manager
+                    .as_any()
+                    .downcast_ref::<shared_session::viewer::TerminalManager>()
+                    .expect("content-aware constructor should return a viewer manager");
+                assert_eq!(
+                    viewer_manager.requested_content_for_test(ctx),
+                    Some(requested_content.clone())
+                );
+            });
         });
     });
 }

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1445,6 +1445,7 @@ fn handle_terminal_view_event(
             Event::EnsureSharedSessionViewerChildPane {
                 conversation_id,
                 session_id,
+                requested_content,
             } => {
                 // Emitted by `OrchestrationViewerModel` when a child of the
                 // orchestrator currently being viewed first surfaces a
@@ -1454,7 +1455,12 @@ fn handle_terminal_view_event(
                 // cloud-mode shell. Only reached while
                 // `OrchestrationUnifiedStack` is disabled; the unified stack
                 // emits `EnsureUnifiedViewerChildPane` instead.
-                group.ensure_shared_session_viewer_child_pane(*conversation_id, *session_id, ctx);
+                group.ensure_shared_session_viewer_child_pane(
+                    *conversation_id,
+                    *session_id,
+                    requested_content.clone(),
+                    ctx,
+                );
             }
             Event::OpenChildAgentInNewTab { conversation_id } => {
                 // Pane group can't add tabs; forward to the workspace.

--- a/app/src/pane_group/pane/terminal_pane_tests.rs
+++ b/app/src/pane_group/pane/terminal_pane_tests.rs
@@ -52,6 +52,7 @@ fn inherit_share_cascades_user_source_for_manually_shared_local_orchestrator() {
                 SharedSessionSource {
                     source_type: SessionSourceType::User,
                     source_task_id: Some(task_id),
+                    ..
                 },
         } => {
             assert_eq!(
@@ -80,6 +81,7 @@ fn inherit_share_cascades_ambient_source_for_cloud_orchestrator() {
                             task_id: Some(task_id),
                         },
                     source_task_id,
+                    ..
                 },
         } => {
             assert_eq!(task_id, expected_child_str);

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -687,6 +687,7 @@ impl TerminalManager<TerminalView> {
         scrollback_type: SharedSessionScrollbackType,
         lifetime: Lifetime,
         source: SharedSessionSource,
+        content: warp_semantic_session::RequestedSessionContent,
         model: Arc<FairMutex<TerminalModel>>,
         window_id: WindowId,
         sharer_remote_update_guard: RemoteUpdateGuard,
@@ -748,6 +749,7 @@ impl TerminalManager<TerminalView> {
         });
 
         let (events_tx, events_rx) = async_channel::unbounded();
+        let (semantic_agent_events_tx, semantic_agent_events_rx) = async_channel::unbounded();
 
         let scrollback_first_block_index = scrollback_type.first_block_index(&model.lock());
         let max_session_size = max_session_size(window_id, ctx);
@@ -757,6 +759,7 @@ impl TerminalManager<TerminalView> {
         cfg_if::cfg_if! {
             if #[cfg(any(test, feature = "integration_tests"))] {
                 let _ = lifetime;
+                let _ = semantic_agent_events_rx;
                 let network = ctx.add_model(|ctx| Network::new_for_test(
                     model.clone(),
                     events_rx,
@@ -856,6 +859,8 @@ impl TerminalManager<TerminalView> {
                         universal_developer_input_context,
                         lifetime,
                         source.clone(),
+                        content.clone(),
+                        semantic_agent_events_rx,
                         max_session_size,
                         ctx,
                     )
@@ -865,14 +870,21 @@ impl TerminalManager<TerminalView> {
 
         // Secret redaction relies on a lookback, so it can't work with
         // real-time session sharing.
-        model
-            .lock()
-            .disable_secret_obfuscation_for_shared_sesson_creator(scrollback_first_block_index);
+        if !content.is_semantic() {
+            model
+                .lock()
+                .disable_secret_obfuscation_for_shared_sesson_creator(scrollback_first_block_index);
+        }
 
         // Set the event sender on the model for ordered terminal events.
         model
             .lock()
             .set_ordered_terminal_events_for_shared_session_tx(events_tx);
+        if content.is_semantic() {
+            model
+                .lock()
+                .set_semantic_agent_events_for_shared_session_tx(semantic_agent_events_tx);
+        }
 
         let shared_session_model_clone = shared_session_model.clone();
         ctx.subscribe_to_model(&network, move |network, event, ctx| match event {
@@ -927,26 +939,28 @@ impl TerminalManager<TerminalView> {
 
                 // Flush the initial input operations that the sharer performed
                 // in the latest buffer before the share was started.
-                let is_ambient = model.lock().is_shared_ambient_agent_session();
-                let init_input_ops: Vec<CrdtOperation> = terminal_view
-                    .as_ref(ctx)
-                    .input()
-                    .as_ref(ctx)
-                    .latest_buffer_operations()
-                    .filter(|op| !should_skip_sharer_op(is_ambient, op))
-                    .cloned()
-                    .collect();
-                if !init_input_ops.is_empty() {
-                    network.update(ctx, |network, _ctx| {
-                        network.send_input_update(
-                            model.lock().block_list().active_block_id(),
-                            init_input_ops.iter(),
-                        );
-                    });
+                if !content.is_semantic() {
+                    let is_ambient = model.lock().is_shared_ambient_agent_session();
+                    let init_input_ops: Vec<CrdtOperation> = terminal_view
+                        .as_ref(ctx)
+                        .input()
+                        .as_ref(ctx)
+                        .latest_buffer_operations()
+                        .filter(|op| !should_skip_sharer_op(is_ambient, op))
+                        .cloned()
+                        .collect();
+                    if !init_input_ops.is_empty() {
+                        network.update(ctx, |network, _ctx| {
+                            network.send_input_update(
+                                model.lock().block_list().active_block_id(),
+                                init_input_ops.iter(),
+                            );
+                        });
+                    }
                 }
 
                 // Stream historical agent conversations so viewers have conversation and task context.
-                if FeatureFlag::AgentSharedSessions.is_enabled() {
+                if FeatureFlag::AgentSharedSessions.is_enabled() && !content.is_semantic() {
                     Self::stream_historical_agent_conversations(&terminal_view, &model, ctx);
                 }
 
@@ -1003,6 +1017,22 @@ impl TerminalManager<TerminalView> {
                 terminal_view.update(ctx, |view, ctx| {
                     let reason_string = session_terminated_reason_string(reason, max_session_size);
                     view.show_persistent_toast(reason_string, ToastFlavor::Error, ctx);
+                });
+            }
+            NetworkEvent::SemanticResyncRequired { reason } => {
+                log::warn!("Semantic shared session requires resync: {reason:?}");
+                Self::shared_session_terminated(
+                    &terminal_view,
+                    shared_session_model_clone.clone(),
+                    model.clone(),
+                    ctx,
+                );
+                terminal_view.update(ctx, |view, ctx| {
+                    view.show_persistent_toast(
+                        "The semantic session fell out of sync. Please share it again.".to_string(),
+                        ToastFlavor::Error,
+                        ctx,
+                    );
                 });
             }
             NetworkEvent::Reconnecting => {
@@ -1299,6 +1329,7 @@ impl TerminalManager<TerminalView> {
                 id,
                 participant_id,
                 request,
+                accepted_message_context,
             } => {
                 if !FeatureFlag::AgentSharedSessions.is_enabled() {
                     return;
@@ -1369,6 +1400,16 @@ impl TerminalManager<TerminalView> {
                     .session(terminal_view_id)
                     .is_some();
                 if has_active_cli_agent {
+                    if accepted_message_context.is_some() {
+                        network.update(ctx, |network, _ctx| {
+                            network.send_agent_prompt_rejection(
+                                id.clone(),
+                                participant_id.clone(),
+                                AgentPromptFailureReason::InvalidConversation,
+                            );
+                        });
+                        return;
+                    }
                     // Reuse the rich input submit pipeline so agent-specific
                     // strategies are applied. Bypasses the rich-input-UI side effects 
   					// (telemetry, draft clear, editor buffer clear, pending-image consumption).
@@ -1392,6 +1433,7 @@ impl TerminalManager<TerminalView> {
                             request.server_conversation_token,
                             request.attachments.clone(),
                             participant_id.clone(),
+                            accepted_message_context.as_deref().cloned(),
                             ctx,
                         );
                     });
@@ -1692,6 +1734,7 @@ impl TerminalManager<TerminalView> {
             TerminalViewEvent::StartSharingCurrentSession {
                 scrollback_type,
                 source,
+                content,
             } if FeatureFlag::CreatingSharedSessions.is_enabled() => {
                 Self::start_sharing_session(
                     view.clone(),
@@ -1700,6 +1743,7 @@ impl TerminalManager<TerminalView> {
                     *scrollback_type,
                     session_lifetime,
                     source.clone(),
+                    content.clone(),
                     model.clone(),
                     window_id,
                     sharer_remote_update_guard.clone(),

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -78,7 +78,6 @@ use crate::terminal::model::index::VisibleRow;
 use crate::terminal::model::iterm_image::{ITermImage, ITermImageMetadata};
 use crate::terminal::model::secrets::ObfuscateSecrets;
 use crate::terminal::model::session::SessionInfo;
-use crate::terminal::shared_session::ai_agent::encode_agent_response_event;
 use crate::terminal::shared_session::{SharedSessionSource, SharedSessionStatus};
 use crate::terminal::shell::{ShellName, ShellType};
 use crate::terminal::ssh::util::{InteractiveSshCommand, SshLoginState};
@@ -500,6 +499,9 @@ pub struct TerminalModel {
     /// TODO: consider combining this with `shared_session_status` because
     /// the state can technically diverge.
     ordered_terminal_events_for_shared_session_tx: Option<Sender<OrderedTerminalEventType>>,
+
+    semantic_agent_events_for_shared_session_tx:
+        Option<Sender<crate::terminal::shared_session::SemanticAgentEvent>>,
 
     /// A sender for write to pty events for a shared session viewer.
     ///
@@ -1091,6 +1093,7 @@ impl TerminalModel {
             is_dummy_cloud_mode_session,
             conversation_transcript_viewer_status: None,
             ordered_terminal_events_for_shared_session_tx: None,
+            semantic_agent_events_for_shared_session_tx: None,
             write_to_pty_events_for_shared_session_tx: None,
             is_receiving_agent_conversation_replay: false,
             notify_on_end_of_ssh_login: None,
@@ -1246,6 +1249,28 @@ impl TerminalModel {
 
     pub fn clear_ordered_terminal_events_for_shared_session_tx(&mut self) {
         self.ordered_terminal_events_for_shared_session_tx = None;
+        self.semantic_agent_events_for_shared_session_tx = None;
+    }
+
+    pub fn set_semantic_agent_events_for_shared_session_tx(
+        &mut self,
+        tx: Sender<crate::terminal::shared_session::SemanticAgentEvent>,
+    ) {
+        self.semantic_agent_events_for_shared_session_tx = Some(tx);
+    }
+
+    pub fn send_accepted_message_context_for_shared_session(
+        &mut self,
+        context: warp_conversation_mutation_api::AcceptedMessageContext,
+    ) {
+        let Some(tx) = &self.semantic_agent_events_for_shared_session_tx else {
+            return;
+        };
+        if let Err(error) = tx.try_send(
+            crate::terminal::shared_session::SemanticAgentEvent::AcceptedMessageContext(context),
+        ) {
+            log::warn!("Failed to send accepted semantic message context: {error}");
+        }
     }
 
     fn ai_metadata_to_protocol(metadata: &AgentInteractionMetadata) -> AICommandMetadata {
@@ -1301,8 +1326,19 @@ impl TerminalModel {
         }
 
         if self.shared_session_status().is_sharer() {
+            if let Some(tx) = &self.semantic_agent_events_for_shared_session_tx {
+                if let Err(e) = tx.try_send(
+                    crate::terminal::shared_session::SemanticAgentEvent::Response(response.clone()),
+                ) {
+                    log::warn!("Failed to send typed semantic agent response event: {e}");
+                }
+                return;
+            }
             if let Some(tx) = &self.ordered_terminal_events_for_shared_session_tx {
-                let encoded = encode_agent_response_event(response);
+                let encoded =
+                    crate::terminal::shared_session::ai_agent::encode_agent_response_event(
+                        response,
+                    );
                 if let Err(e) = tx.try_send(OrderedTerminalEventType::AgentResponseEvent {
                     response_initiator,
                     response_event: encoded,

--- a/app/src/terminal/shared_session/mod.rs
+++ b/app/src/terminal/shared_session/mod.rs
@@ -3,6 +3,7 @@ use instant::Duration;
 use serde::{Deserialize, Serialize};
 use session_sharing_protocol::common::{Role, Scrollback, ScrollbackBlock, SessionId};
 use session_sharing_protocol::sharer::SessionSourceType;
+use warp_semantic_session::RequestedSessionContent;
 use warpui::keymap::ContextPredicate;
 use warpui::{AppContext, WindowId, id};
 
@@ -29,6 +30,12 @@ pub(super) mod shared_handlers;
 pub mod sharer;
 pub mod viewer;
 
+#[derive(Clone)]
+pub enum SemanticAgentEvent {
+    AcceptedMessageContext(warp_conversation_mutation_api::AcceptedMessageContext),
+    Response(warp_multi_agent_api::ResponseEvent),
+}
+
 #[cfg(test)]
 pub use tests::MAX_BYTES_SHAREABLE;
 
@@ -47,6 +54,7 @@ const SELECTION_THROTTLE_PERIOD: Duration = Duration::from_millis(20);
 pub struct SharedSessionSource {
     pub source_type: SessionSourceType,
     pub source_task_id: Option<String>,
+    requested_content: RequestedSessionContent,
 }
 
 impl SharedSessionSource {
@@ -54,15 +62,35 @@ impl SharedSessionSource {
         Self {
             source_type: SessionSourceType::User,
             source_task_id,
+            requested_content: RequestedSessionContent::FullTerminal,
+        }
+    }
+
+    pub(crate) fn from_network(
+        source_type: SessionSourceType,
+        source_task_id: Option<String>,
+    ) -> Self {
+        Self {
+            source_type,
+            source_task_id,
+            requested_content: RequestedSessionContent::FullTerminal,
         }
     }
 
     pub fn ambient_agent(task_id: Option<String>) -> Self {
+        Self::ambient_agent_with_content(task_id, RequestedSessionContent::FullTerminal)
+    }
+
+    pub fn ambient_agent_with_content(
+        task_id: Option<String>,
+        requested_content: RequestedSessionContent,
+    ) -> Self {
         Self {
             source_type: SessionSourceType::AmbientAgent {
                 task_id: task_id.clone(),
             },
             source_task_id: task_id,
+            requested_content,
         }
     }
 
@@ -72,6 +100,10 @@ impl SharedSessionSource {
             SessionSourceType::AmbientAgent { task_id } => task_id.as_deref(),
             SessionSourceType::User => None,
         })
+    }
+
+    pub fn requested_content(&self) -> &RequestedSessionContent {
+        &self.requested_content
     }
 }
 

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -17,15 +17,17 @@ use futures_util::stream::AbortHandle;
 use futures_util::{SinkExt, StreamExt};
 use instant::Instant;
 use parking_lot::FairMutex;
+use prost::Message as _;
 use session_sharing_protocol::common::{
     ActivePrompt, ActivePromptUpdate, AgentPromptFailureReason, AgentPromptRequest,
-    AgentPromptRequestId, CommandExecutionFailureReason, CommandExecutionRequestId, ControlAction,
-    ControlActionFailureReason, ControlActionRequestId, FeatureSupport, InputOperationId,
-    InputOperationSeqNo, InputUpdate, OrderedTerminalEvent, OrderedTerminalEventType,
-    ParticipantId, ParticipantList, ParticipantPresenceUpdate, Role, RoleRequestId,
-    RoleRequestResponse, Scrollback, Selection, SelectionUpdate, SessionId,
-    UniversalDeveloperInputContext, UniversalDeveloperInputContextUpdate, UserID, WindowSize,
-    WriteToPtyFailureReason, WriteToPtyRequestId,
+    AgentPromptRequestId, BlockId as SharedBlockId, CommandExecutionFailureReason,
+    CommandExecutionRequestId, ControlAction, ControlActionFailureReason, ControlActionRequestId,
+    FeatureSupport, InputOperationId, InputOperationSeqNo, InputReplicaId, InputUpdate,
+    OrderedTerminalEvent, OrderedTerminalEventType, ParticipantId, ParticipantList,
+    ParticipantPresenceUpdate, Role, RoleRequestId, RoleRequestResponse, Scrollback, Selection,
+    SelectionUpdate, SemanticResyncReason, SessionId, UniversalDeveloperInputContext,
+    UniversalDeveloperInputContextUpdate, UserID, WindowSize, WriteToPtyFailureReason,
+    WriteToPtyRequestId,
 };
 #[cfg(not(any(test, feature = "integration_tests")))]
 use session_sharing_protocol::common::{SelectedAgentModel, TelemetryContext};
@@ -38,9 +40,12 @@ use session_sharing_protocol::sharer::{
     SessionTerminatedReason, TeamAccessLevelUpdateResponse, UpdatePendingUserRoleResponse,
     UpstreamMessage,
 };
+use warp_conversation_mutation_api::{ConversationMutation, InterruptionReason};
 use warp_core::features::FeatureFlag;
 use warp_errors::report_error;
+use warp_semantic_session::{RequestedSessionContent, SemanticMutationProducer};
 use warp_server_client::iap::IapManager;
+use warp_terminal::model::secrets::{SECRETS_REGEX, find_secrets_in_text_with_levels_using_regex};
 use warpui::r#async::Timer;
 use warpui::{Entity, ModelContext, RequestState, RetryOption, SingletonEntity};
 use websocket::{Message, Sink, Stream, WebSocket, WebsocketMessage as _};
@@ -55,7 +60,8 @@ use crate::terminal::model::block::BlockId;
 #[cfg(not(any(test, feature = "integration_tests")))]
 use crate::terminal::shared_session::SharedSessionScrollbackType;
 use crate::terminal::shared_session::{
-    EventNumber, SELECTION_THROTTLE_PERIOD, SharedSessionSource, connect_endpoint,
+    EventNumber, SELECTION_THROTTLE_PERIOD, SemanticAgentEvent, SharedSessionSource,
+    connect_endpoint,
 };
 use crate::throttle::throttle;
 
@@ -72,6 +78,8 @@ const PTY_READS_BATCH_THRESHOLD: Duration = Duration::from_millis(250);
 const CREATE_SESSION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg_attr(any(test, feature = "integration_tests"), allow(dead_code))]
 const AMBIENT_CREATE_SESSION_MAX_ATTEMPTS: usize = 3;
+const MAX_UNACKED_EVENTS: usize = 4_096;
+const MAX_UNACKED_EVENT_BYTES: u64 = 16 * 1024 * 1024;
 /// Exponential backoff when retrying reconnection. This configuration has us retry for ~128 seconds before giving up,
 /// where the last interval between retries is 26s.
 /// We should be somewhat generous with the amount of retries allowed when a sharer wants to recover their session,
@@ -169,6 +177,36 @@ struct StartupConfig {
     selected_model_id: String,
 }
 
+struct InitialTerminalState {
+    active_prompt: ActivePrompt,
+    window_size: WindowSize,
+    selection: Selection,
+    init_block_id: SharedBlockId,
+    input_replica_id: InputReplicaId,
+    universal_developer_input_context: Option<UniversalDeveloperInputContext>,
+}
+
+fn semantic_initial_terminal_state() -> InitialTerminalState {
+    InitialTerminalState {
+        active_prompt: ActivePrompt::default(),
+        window_size: WindowSize::default(),
+        selection: Selection::default(),
+        init_block_id: SharedBlockId::default(),
+        input_replica_id: InputReplicaId::default(),
+        universal_developer_input_context: None,
+    }
+}
+
+fn redact_semantic_content(text: &str) -> String {
+    let secrets_regex = SECRETS_REGEX.lock().clone();
+    let ranges = find_secrets_in_text_with_levels_using_regex(text, &secrets_regex);
+    let mut redacted = text.to_owned();
+    for (range, _) in ranges.into_iter().rev() {
+        redacted.replace_range(range.byte_range, "[REDACTED]");
+    }
+    redacted
+}
+
 #[derive(Debug)]
 struct StartupRetryState {
     current_attempt: usize,
@@ -194,6 +232,7 @@ impl StartupRetryState {
 enum StartupFailure {
     Transport,
     InitializeSend,
+    Negotiation,
     WebsocketClosedBeforeStarted,
     WebsocketError,
     Timeout,
@@ -208,6 +247,7 @@ impl StartupFailure {
             | Self::WebsocketClosedBeforeStarted
             | Self::WebsocketError
             | Self::Timeout => true,
+            Self::Negotiation => false,
             Self::ServerRejected(reason) => matches!(
                 reason,
                 FailedToInitializeSessionReason::InternalServerError { .. }
@@ -226,7 +266,7 @@ impl StartupFailure {
             Self::Timeout => FailedToInitializeSessionReason::InternalServerError {
                 details: "Timed out creating shared session".to_string(),
             },
-            Self::Transport | Self::InitializeSend | Self::WebsocketError => {
+            Self::Transport | Self::InitializeSend | Self::Negotiation | Self::WebsocketError => {
                 FailedToInitializeSessionReason::internal_server_error_without_details()
             }
         }
@@ -236,6 +276,7 @@ impl StartupFailure {
         match self {
             Self::Transport => "transport_error",
             Self::InitializeSend => "initialize_send_error",
+            Self::Negotiation => "negotiation_error",
             Self::WebsocketClosedBeforeStarted => "websocket_closed_before_started",
             Self::WebsocketError => "websocket_error",
             Self::Timeout => "timeout",
@@ -294,10 +335,16 @@ pub struct Network {
     sharer_id: Option<ParticipantId>,
     startup_config: Option<StartupConfig>,
     source: SharedSessionSource,
+    content: RequestedSessionContent,
+    semantic_producer: Option<SemanticMutationProducer>,
+    pending_semantic_mutations: Vec<ConversationMutation>,
+    pending_semantic_mutation_bytes: usize,
+    semantic_last_sequence: Option<u64>,
 
     /// HashMap from event_no to the event. We keep these in memory to support reconnections
     /// until the server acks that they have been processed and are safe to remove.
     unacked_terminal_events: HashMap<usize, OrderedTerminalEvent>,
+    unacked_terminal_event_bytes: u64,
 
     /// The parameters for the next input operation to send.
     next_buffer_seq_no: (BlockId, InputOperationSeqNo),
@@ -347,7 +394,13 @@ impl Network {
             sharer_id: None,
             startup_config: None,
             source: SharedSessionSource::default(),
+            content: RequestedSessionContent::FullTerminal,
+            semantic_producer: None,
+            pending_semantic_mutations: Vec::new(),
+            pending_semantic_mutation_bytes: 0,
+            semantic_last_sequence: None,
             unacked_terminal_events: HashMap::new(),
+            unacked_terminal_event_bytes: 0,
             next_buffer_seq_no: (init_block_id, InputOperationSeqNo::zero()),
             pending_input_updates: Vec::new(),
         };
@@ -387,11 +440,20 @@ impl Network {
         universal_developer_input_context: UniversalDeveloperInputContext,
         lifetime: Lifetime,
         source: SharedSessionSource,
+        content: RequestedSessionContent,
+        semantic_agent_events_rx: Receiver<SemanticAgentEvent>,
         max_session_size: Byte,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
-        let scrollback = scrollback_type.to_scrollback(&model.lock());
+        let scrollback = if content.is_semantic() {
+            Scrollback {
+                blocks: Vec::new(),
+                is_alt_screen_active: false,
+            }
+        } else {
+            scrollback_type.to_scrollback(&model.lock())
+        };
         let num_bytes_scrollback = scrollback.num_bytes();
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
@@ -419,6 +481,16 @@ impl Network {
             selected_model_id,
         };
 
+        let semantic_producer = content.execution_identity().cloned().map(|identity| {
+            let mut producer =
+                SemanticMutationProducer::new_with_redactor(identity, redact_semantic_content);
+            if let Some(context) = content.initial_accepted_message_context() {
+                producer
+                    .register_accepted_message_context(context.clone())
+                    .expect("requested semantic content has validated initial context");
+            }
+            producer
+        });
         let mut network = Network {
             event_no: EventNumber::new(),
             selection_event_no: EventNumber::new(),
@@ -442,7 +514,13 @@ impl Network {
             sharer_id: None,
             startup_config: Some(startup_config),
             source,
+            content,
+            semantic_producer,
+            pending_semantic_mutations: Vec::new(),
+            pending_semantic_mutation_bytes: 0,
+            semantic_last_sequence: None,
             unacked_terminal_events: HashMap::new(),
+            unacked_terminal_event_bytes: 0,
             next_buffer_seq_no: (init_block_id.clone(), InputOperationSeqNo::zero()),
             pending_input_updates: Vec::new(),
         };
@@ -459,6 +537,7 @@ impl Network {
             });
         } else {
             network.start_ordered_terminal_events_listener(ordered_events_rx, ctx);
+            network.start_semantic_agent_events_listener(semantic_agent_events_rx, ctx);
             network.start_create_session_attempt(ctx);
         }
         ctx.spawn_stream_local(
@@ -527,6 +606,9 @@ impl Network {
     }
 
     fn send_active_prompt_update(&mut self, active_prompt: ActivePrompt) {
+        if self.content.is_semantic() {
+            return;
+        }
         let message = UpstreamMessage::UpdateActivePrompt(ActivePromptUpdate {
             active_prompt: active_prompt.clone(),
             last_event_no: self.event_no.into(),
@@ -546,6 +628,9 @@ impl Network {
 
     /// Send the presence selection to the server, with a throttle period.
     fn send_presence_selection(&mut self, selection: Selection) {
+        if self.content.is_semantic() {
+            return;
+        }
         self.cached_latest_state.selection = selection.clone();
         if let Err(e) = self.selection_throttled_tx.try_send(selection) {
             sharer_warn!(
@@ -617,6 +702,9 @@ impl Network {
         block_id: &BlockId,
         operations: impl Iterator<Item = &'a CrdtOperation>,
     ) {
+        if self.content.is_semantic() {
+            return;
+        }
         let Some(sharer_id) = self.sharer_id.clone() else {
             return;
         };
@@ -733,6 +821,9 @@ impl Network {
         &mut self,
         update: UniversalDeveloperInputContextUpdate,
     ) {
+        if self.content.is_semantic() {
+            return;
+        }
         // Skip update if nothing would change
         if let Some(ref cached) = self.cached_latest_state.universal_developer_input_context
             && !update.changes_cached_context(cached)
@@ -835,25 +926,42 @@ impl Network {
                     network.clear_startup_transport_handle(attempt);
                     // We don't use the `send_message_to_server` API here
                     // because we don't want to buffer this message.
-                    let universal_developer_input_context = network
-                        .cached_latest_state
-                        .universal_developer_input_context
-                        .clone()
-                        .unwrap_or_else(|| config.universal_developer_input_context.clone());
+                    let initial_terminal_state = if network.content.is_semantic() {
+                        semantic_initial_terminal_state()
+                    } else {
+                        let universal_developer_input_context = network
+                            .cached_latest_state
+                            .universal_developer_input_context
+                            .clone()
+                            .unwrap_or_else(|| config.universal_developer_input_context.clone());
+                        InitialTerminalState {
+                            active_prompt: network.cached_latest_state.prompt.clone(),
+                            window_size: config.window_size,
+                            selection: network.cached_latest_state.selection.clone(),
+                            init_block_id: config.init_block_id.clone().into(),
+                            input_replica_id: config.input_replica_id.clone().to_string().into(),
+                            universal_developer_input_context: Some(
+                                UniversalDeveloperInputContext {
+                                    selected_model: Some(SelectedAgentModel::new(
+                                        config.selected_model_id.clone(),
+                                    )),
+                                    ..universal_developer_input_context
+                                },
+                            ),
+                        }
+                    };
 
                     let message = UpstreamMessage::Initialize(InitPayload {
                         scrollback: config.scrollback,
-                        active_prompt: network.cached_latest_state.prompt.clone(),
-                        window_size: config.window_size,
+                        active_prompt: initial_terminal_state.active_prompt,
+                        window_size: initial_terminal_state.window_size,
                         user_id,
-                        selection: network.cached_latest_state.selection.clone(),
-                        init_block_id: config.init_block_id.into(),
-                        input_replica_id: config.input_replica_id.into(),
+                        selection: initial_terminal_state.selection,
+                        init_block_id: initial_terminal_state.init_block_id,
+                        input_replica_id: initial_terminal_state.input_replica_id,
                         telemetry_context: Some(TelemetryContext(telemetry_context().as_value())),
-                        universal_developer_input_context: Some(UniversalDeveloperInputContext {
-                            selected_model: Some(SelectedAgentModel::new(config.selected_model_id)),
-                            ..universal_developer_input_context
-                        }),
+                        universal_developer_input_context: initial_terminal_state
+                            .universal_developer_input_context,
                         lifetime: config.lifetime,
                         source_type: network.source.source_type.clone(),
                         source_task_id: network.source.source_task_id.clone(),
@@ -861,7 +969,11 @@ impl Network {
                             supports_agent_view: FeatureFlag::AgentView.is_enabled(),
                             supports_full_role: true,
                             supports_full_role_for_real: true,
+                            supports_semantic_conversation: true,
                         },
+                        content_mode: network.content.content_mode(),
+                        semantic_schema_version: network.content.schema_version(),
+                        execution_identity: network.content.execution_identity().cloned(),
                     });
                     if let Err(e) = network.ws_proxy_tx.try_send(message) {
                         sharer_error!(network, "Sharer failed to send initialization message: {e}");
@@ -1130,7 +1242,12 @@ impl Network {
                                 supports_agent_view: FeatureFlag::AgentView.is_enabled(),
                                 supports_full_role: true,
                                 supports_full_role_for_real: true,
+                                supports_semantic_conversation: true,
                             },
+                            content_mode: network.content.content_mode(),
+                            semantic_schema_version: network.content.schema_version(),
+                            execution_identity: network.content.execution_identity().cloned(),
+                            semantic_cursor: network.semantic_cursor(),
                         });
                         if let Err(e) = network.ws_proxy_tx.try_send(message) {
                             sharer_error!(network, "Sharer failed to send reconnect message: {e}");
@@ -1284,6 +1401,61 @@ impl Network {
         );
     }
 
+    fn start_semantic_agent_events_listener(
+        &self,
+        events_rx: Receiver<SemanticAgentEvent>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.spawn_stream_local(
+            events_rx,
+            |network, event, _ctx| {
+                if !network.content.is_semantic() {
+                    return;
+                }
+                let producer = network
+                    .semantic_producer
+                    .as_mut()
+                    .expect("semantic content has a producer");
+                let result = match event {
+                    SemanticAgentEvent::AcceptedMessageContext(context) => producer
+                        .register_accepted_message_context(context)
+                        .map(|_| Vec::new()),
+                    SemanticAgentEvent::Response(response) => producer.normalize(&response),
+                };
+                match result {
+                    Ok(mutations) => {
+                        for mutation in mutations {
+                            if !network.send_semantic_mutation(mutation) {
+                                sharer_warn!(
+                                    network,
+                                    "Stopping semantic session after pending mutation limit"
+                                );
+                                network.end_session(SessionEndedReason::ExceededSizeLimit);
+                                break;
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        sharer_warn!(
+                            network,
+                            "Stopping semantic session after unsupported response event: {error}"
+                        );
+                        if network.session_id.is_some() {
+                            let interruption = network
+                                .semantic_producer
+                                .as_mut()
+                                .expect("semantic content has a producer")
+                                .interruption(InterruptionReason::ProtocolError, false);
+                            let _ = network.send_semantic_mutation(interruption);
+                        }
+                        network.end_session(SessionEndedReason::EndedBySharer);
+                    }
+                }
+            },
+            |_, _| {},
+        );
+    }
+
     fn process_websocket_message(&mut self, message: Message, ctx: &mut ModelContext<Self>) {
         // Ignore non-text frames (e.g. ping frames sent by the server).
         let Some(text) = message.text() else {
@@ -1296,13 +1468,30 @@ impl Network {
             );
             return;
         };
+        if self.content.is_semantic()
+            && !matches!(
+                &downstream_message,
+                DownstreamMessage::SessionInitialized { .. }
+                    | DownstreamMessage::FailedToInitializeSession { .. }
+                    | DownstreamMessage::SessionReconnected { .. }
+                    | DownstreamMessage::FailedToReconnect { .. }
+                    | DownstreamMessage::SessionTerminated { .. }
+                    | DownstreamMessage::SemanticResyncRequired { .. }
+                    | DownstreamMessage::EventsProcessedAck { .. }
+                    | DownstreamMessage::AgentPromptRequested { .. }
+                    | DownstreamMessage::Pong { .. }
+            )
+        {
+            return;
+        }
         match downstream_message {
             DownstreamMessage::SessionInitialized {
                 session_id,
+                session_secret: _,
                 reconnect_token,
                 sharer_id,
                 sharer_firebase_uid,
-                ..
+                negotiated_content,
             } => {
                 let Stage::BeforeStarted { startup_retry } = &self.stage else {
                     sharer_warn!(
@@ -1313,6 +1502,16 @@ impl Network {
                 };
                 let attempt = startup_retry.current_attempt;
                 let max_attempts = startup_retry.max_attempts;
+                if let Err(error) = self.content.validate_echo(negotiated_content.as_ref()) {
+                    self.handle_startup_failure_with_cause(
+                        StartupFailure::Negotiation,
+                        Some(Arc::new(anyhow::anyhow!(
+                            "session content negotiation failed: {error:?}"
+                        ))),
+                        ctx,
+                    );
+                    return;
+                }
                 self.session_id = Some(session_id);
                 self.reconnect_token = Some(reconnect_token);
                 self.sharer_id = Some(sharer_id.clone());
@@ -1329,6 +1528,7 @@ impl Network {
 
                 // Flush all events starting from the very first event 0, since events were buffered before the session was initialized.
                 self.flush_terminal_events_to_server(0);
+                self.flush_pending_semantic_mutations();
                 // Non terminal events where we only care about the latest value were dropped before we were connected.
                 self.send_latest_state_to_server();
 
@@ -1345,12 +1545,22 @@ impl Network {
             DownstreamMessage::SessionReconnected {
                 last_received_event_no,
                 participant_list,
+                negotiated_content,
             } => {
                 if !matches!(self.stage, Stage::Reconnecting { .. }) {
                     sharer_warn!(
                         self,
                         "Received unexpected SessionReconnected message when we weren't reconnecting"
                     );
+                    return;
+                }
+                if let Err(error) = self.content.validate_echo(negotiated_content.as_ref()) {
+                    sharer_warn!(
+                        self,
+                        "Session content reconnect negotiation failed: {error:?}"
+                    );
+                    self.close_without_reconnection();
+                    ctx.emit(NetworkEvent::FailedToReconnect);
                     return;
                 }
                 sharer_info!(
@@ -1389,13 +1599,25 @@ impl Network {
                 self.close_without_reconnection();
                 ctx.emit(NetworkEvent::SessionTerminated { reason });
             }
+            DownstreamMessage::SemanticResyncRequired { reason } => {
+                self.close_without_reconnection();
+                ctx.emit(NetworkEvent::SemanticResyncRequired { reason });
+            }
             DownstreamMessage::EventsProcessedAck {
                 latest_processed_event_no,
             } => {
-                let mut event_no = latest_processed_event_no;
-                // Remove all stored events before latest_processed_event_no to free up memory.
-                while self.unacked_terminal_events.remove(&event_no).is_some() && event_no > 0 {
-                    event_no -= 1;
+                let acknowledged: Vec<_> = self
+                    .unacked_terminal_events
+                    .keys()
+                    .copied()
+                    .filter(|event_no| *event_no <= latest_processed_event_no)
+                    .collect();
+                for event_no in acknowledged {
+                    if let Some(event) = self.unacked_terminal_events.remove(&event_no) {
+                        self.unacked_terminal_event_bytes = self
+                            .unacked_terminal_event_bytes
+                            .saturating_sub(event.num_bytes().as_u64());
+                    }
                 }
             }
             DownstreamMessage::ParticipantListUpdated(participant_list) => {
@@ -1482,10 +1704,60 @@ impl Network {
                 participant_id,
                 request,
             } => {
+                let accepted_message_context = if self.content.is_semantic() {
+                    if !matches!(self.stage, Stage::StartedSuccessfully { .. }) {
+                        self.send_agent_prompt_rejection(
+                            id,
+                            participant_id,
+                            AgentPromptFailureReason::InvalidConversation,
+                        );
+                        return;
+                    }
+                    let Some(bytes) = request.accepted_message_context.as_deref() else {
+                        self.send_agent_prompt_rejection(
+                            id,
+                            participant_id,
+                            AgentPromptFailureReason::InvalidConversation,
+                        );
+                        return;
+                    };
+                    let Some(execution_identity) = self.content.execution_identity() else {
+                        self.send_agent_prompt_rejection(
+                            id,
+                            participant_id,
+                            AgentPromptFailureReason::InvalidConversation,
+                        );
+                        return;
+                    };
+                    let Some(schema_version) = self.content.schema_version() else {
+                        self.send_agent_prompt_rejection(
+                            id,
+                            participant_id,
+                            AgentPromptFailureReason::InvalidConversation,
+                        );
+                        return;
+                    };
+                    let Ok(context) = warp_semantic_session::decode_accepted_message_context(
+                        bytes,
+                        execution_identity,
+                        schema_version,
+                    ) else {
+                        self.send_agent_prompt_rejection(
+                            id,
+                            participant_id,
+                            AgentPromptFailureReason::InvalidConversation,
+                        );
+                        return;
+                    };
+                    Some(context)
+                } else {
+                    None
+                };
                 ctx.emit(NetworkEvent::AgentPromptRequested {
                     id,
                     participant_id,
                     request,
+                    accepted_message_context: accepted_message_context.map(Box::new),
                 });
             }
             DownstreamMessage::LinkAccessLevelUpdateResponse(response) => {
@@ -1536,6 +1808,9 @@ impl Network {
         ctx.spawn_stream_local(
             events_rx,
             move |network, event_type, ctx| {
+                if network.content.is_semantic() {
+                    return;
+                }
                 let should_send = {
                     let model = network.model.lock();
                     !model.is_receiving_in_band_command_output()
@@ -1597,6 +1872,17 @@ impl Network {
     /// Flushes the accumulated PTY reads into a single [`OrderedTerminalEventType::PtyBytesRead`]
     /// which is then sent to the server.
     fn send_pty_bytes_read_message(&mut self) {
+        if self.content.is_semantic() {
+            if let PtyBytesBatchStatus::Batching { abort_handle, .. } = std::mem::replace(
+                &mut self.pty_bytes_batch_status,
+                PtyBytesBatchStatus::NotBatching {
+                    last_sent_at: Instant::now(),
+                },
+            ) {
+                abort_handle.abort();
+            }
+            return;
+        }
         // We need to check this since we might have flushed the PTY bytes read before the timer expired
         // (for example, when a non-pty bytes read eevnt is received while we're batching).
         // Since Rust can't infer that we'll replace the batch status with a new one if we're currently batching,
@@ -1631,9 +1917,31 @@ impl Network {
     }
 
     fn send_ordered_terminal_event_message(&mut self, event_type: OrderedTerminalEventType) {
+        if self.content.is_semantic()
+            && !matches!(
+                &event_type,
+                OrderedTerminalEventType::SemanticConversationMutation { .. }
+            )
+        {
+            return;
+        }
         // If this send is going to exceed the max number of shareable bytes,
         // let's just end the session.
         let num_bytes = event_type.num_bytes();
+        if self.content.is_semantic()
+            && (self.unacked_terminal_events.len() >= MAX_UNACKED_EVENTS
+                || self
+                    .unacked_terminal_event_bytes
+                    .saturating_add(num_bytes.as_u64())
+                    > MAX_UNACKED_EVENT_BYTES)
+        {
+            sharer_warn!(
+                self,
+                "Stopping shared session because unacknowledged event limits were exceeded"
+            );
+            self.end_session(SessionEndedReason::ExceededSizeLimit);
+            return;
+        }
         self.num_bytes_shared = self.num_bytes_shared.add(num_bytes).unwrap_or(Byte::MAX);
         if self.num_bytes_shared > self.max_session_size {
             sharer_info!(self, "Stopping shared session because max bytes exceeded.");
@@ -1655,7 +1963,27 @@ impl Network {
     /// TODO(roland): non OrderedTerminalEvents (like warp prompt) can be dropped if we're not connected. For non OrderedTerminalEvents,
     /// we only need the latest value and can drop old values. We can send the latest value of needed events as part of reconnection.
     fn send_message_to_server(&mut self, message: UpstreamMessage) {
+        if self.content.is_semantic()
+            && !matches!(
+                &message,
+                UpstreamMessage::Initialize(_)
+                    | UpstreamMessage::Reconnect(_)
+                    | UpstreamMessage::Ping { .. }
+                    | UpstreamMessage::EndSession { .. }
+                    | UpstreamMessage::ExtendSessionRetention { .. }
+                    | UpstreamMessage::RejectAgentPromptRequest { .. }
+                    | UpstreamMessage::OrderedTerminalEvent(OrderedTerminalEvent {
+                        event_type: OrderedTerminalEventType::SemanticConversationMutation { .. },
+                        ..
+                    })
+            )
+        {
+            return;
+        }
         if let UpstreamMessage::OrderedTerminalEvent(event) = &message {
+            self.unacked_terminal_event_bytes = self
+                .unacked_terminal_event_bytes
+                .saturating_add(event.num_bytes().as_u64());
             self.unacked_terminal_events
                 .insert(event.event_no, event.clone());
         }
@@ -1682,6 +2010,10 @@ impl Network {
     /// This is more a best-effort attempt because these events are not critical - that's why they are not ordered terminal events.
     /// With ordered terminal events we require an ack from the server before the client can remove them from the buffer, but we don't do that for these events.
     fn flush_pending_input_updates_to_server(&mut self) {
+        if self.content.is_semantic() {
+            self.pending_input_updates.clear();
+            return;
+        }
         // Take the updates out of self to avoid a borrow conflict with sharer_warn!, which
         // borrows all of self while drain() holds a mutable borrow on pending_input_updates.
         let updates = std::mem::take(&mut self.pending_input_updates);
@@ -1722,6 +2054,9 @@ impl Network {
     /// Send everything in `self.cached_latest_state` to the server.
     /// This is needed when we (re)connect to the server, since all values were dropped before we were connected.
     fn send_latest_state_to_server(&mut self) {
+        if self.content.is_semantic() {
+            return;
+        }
         self.send_active_prompt_update(self.cached_latest_state.prompt.clone());
 
         // Only send a selection update if we've sent selection updates before or the selection update is non-trivial.
@@ -1747,6 +2082,54 @@ impl Network {
     pub fn is_connected(&self) -> bool {
         matches!(self.stage, Stage::StartedSuccessfully { .. })
     }
+
+    fn send_semantic_mutation(&mut self, mutation: ConversationMutation) -> bool {
+        let Some(identity) = mutation.identity.as_ref() else {
+            return false;
+        };
+        self.semantic_last_sequence = Some(identity.sequence);
+        let Some(session_id) = self.session_id else {
+            let encoded_len = mutation.encoded_len();
+            if self.pending_semantic_mutations.len() >= MAX_UNACKED_EVENTS
+                || self
+                    .pending_semantic_mutation_bytes
+                    .saturating_add(encoded_len)
+                    > MAX_UNACKED_EVENT_BYTES as usize
+            {
+                return false;
+            }
+            self.pending_semantic_mutation_bytes = self
+                .pending_semantic_mutation_bytes
+                .saturating_add(encoded_len);
+            self.pending_semantic_mutations.push(mutation);
+            return true;
+        };
+        let Some(cursor) = self.content.cursor(session_id, identity.sequence) else {
+            return false;
+        };
+        self.send_ordered_terminal_event_message(
+            OrderedTerminalEventType::SemanticConversationMutation {
+                cursor,
+                mutation: mutation.encode_to_vec(),
+            },
+        );
+        true
+    }
+
+    fn flush_pending_semantic_mutations(&mut self) {
+        self.pending_semantic_mutation_bytes = 0;
+        for mutation in std::mem::take(&mut self.pending_semantic_mutations) {
+            if !self.send_semantic_mutation(mutation) {
+                self.end_session(SessionEndedReason::ExceededSizeLimit);
+                break;
+            }
+        }
+    }
+
+    fn semantic_cursor(&self) -> Option<session_sharing_protocol::common::SemanticCursor> {
+        self.content
+            .cursor(self.session_id?, self.semantic_last_sequence?)
+    }
 }
 
 const NO_QUOTA_REMAINING_MESSAGE: &str =
@@ -1755,6 +2138,7 @@ fn session_terminated_reason_diagnostic_label(reason: &SessionTerminatedReason) 
     match reason {
         SessionTerminatedReason::NoUserQuotaRemaining {} => "no_user_quota_remaining",
         SessionTerminatedReason::ExceededSizeLimit => "exceeded_size_limit",
+        SessionTerminatedReason::StorageUnavailable => "storage_unavailable",
         SessionTerminatedReason::InternalServerError { .. } => "internal_server_error",
     }
 }
@@ -1772,6 +2156,10 @@ pub fn session_terminated_reason_string(
         SessionTerminatedReason::ExceededSizeLimit => {
             let max_bytes = max_session_size.get_appropriate_unit(UnitType::Decimal);
             format!("Session limit ({max_bytes}) exceeded. Please reshare to continue.")
+        }
+        SessionTerminatedReason::StorageUnavailable => {
+            "The semantic session ended because durable storage is unavailable. Please retry."
+                .to_string()
         }
         SessionTerminatedReason::InternalServerError { .. } => {
             "Session ended due to an internal error. Please try sharing again.".to_string()
@@ -1825,6 +2213,9 @@ pub enum NetworkEvent {
     SessionTerminated {
         reason: SessionTerminatedReason,
     },
+    SemanticResyncRequired {
+        reason: SemanticResyncReason,
+    },
     Reconnecting,
     ParticipantListUpdated(Box<ParticipantList>),
     ParticipantPresenceUpdated(ParticipantPresenceUpdate),
@@ -1861,6 +2252,8 @@ pub enum NetworkEvent {
         id: AgentPromptRequestId,
         participant_id: ParticipantId,
         request: AgentPromptRequest,
+        accepted_message_context:
+            Option<Box<warp_conversation_mutation_api::AcceptedMessageContext>>,
     },
     LinkAccessLevelUpdateResponse {
         response: LinkAccessLevelUpdateResponse,

--- a/app/src/terminal/shared_session/sharer/network_tests.rs
+++ b/app/src/terminal/shared_session/sharer/network_tests.rs
@@ -6,13 +6,21 @@ use byte_unit::Byte;
 use futures_util::stream::AbortHandle;
 use instant::Instant;
 use parking_lot::FairMutex;
+use prost::Message as _;
 use session_sharing_protocol::common::{
-    ActivePrompt, OrderedTerminalEvent, OrderedTerminalEventType, ParticipantId, Selection,
-    SessionId,
+    ActivePrompt, AgentPromptFailureReason, AgentPromptRequest, AgentPromptRequestId,
+    ExecutionIdentity, NegotiatedSessionContent, OrderedTerminalEvent, OrderedTerminalEventType,
+    ParticipantId, Selection, SemanticCursor, SessionContentMode, SessionId,
 };
 use session_sharing_protocol::sharer::{
     DownstreamMessage, FailedToInitializeSessionReason, QuotaType, ReconnectToken, UpstreamMessage,
 };
+use warp_conversation_mutation_api::{
+    AcceptedMessageContext, Attribution, Author, ConversationMutation, Origin, SchemaVersion,
+    author, origin,
+};
+use warp_multi_agent_api::{ResponseEvent, response_event};
+use warp_semantic_session::{RequestedSessionContent, SemanticMutationProducer};
 use warp_server_client::iap::IapManager;
 use warpui::r#async::FutureExt as _;
 use warpui::{App, ModelHandle};
@@ -20,7 +28,9 @@ use websocket::{Message, WebsocketMessage as _};
 
 use super::{
     AMBIENT_CREATE_SESSION_MAX_ATTEMPTS, Network, PTY_READS_BATCH_THRESHOLD, PtyBytesBatchStatus,
-    Stage, StartupFailure, StartupRetryState, startup_max_attempts,
+    Stage, StartupFailure, StartupRetryState, semantic_initial_terminal_state,
+    session_terminated_reason_diagnostic_label, session_terminated_reason_string,
+    startup_max_attempts,
 };
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
@@ -29,6 +39,57 @@ use crate::server::telemetry::context_provider::AppTelemetryContextProvider;
 use crate::terminal::TerminalModel;
 use crate::terminal::shared_session::{MAX_BYTES_SHAREABLE, SharedSessionSource};
 use crate::test_util::assert_eventually;
+
+fn execution() -> ExecutionIdentity {
+    ExecutionIdentity {
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        run_id: Some("run".to_owned()),
+        request_id: Some("request".to_owned()),
+    }
+}
+
+fn semantic_cursor(session_id: SessionId, mutation_sequence: u64) -> SemanticCursor {
+    SemanticCursor {
+        session_id,
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        content_mode: SessionContentMode::SemanticConversationOnly,
+        schema_version: 1,
+        mutation_sequence,
+    }
+}
+
+fn semantic_echo(execution_identity: ExecutionIdentity) -> NegotiatedSessionContent {
+    NegotiatedSessionContent {
+        content_mode: SessionContentMode::SemanticConversationOnly,
+        semantic_schema_version: 1,
+        execution_identity,
+    }
+}
+
+fn accepted_message_context() -> AcceptedMessageContext {
+    AcceptedMessageContext {
+        schema_version: SchemaVersion::V1 as i32,
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        message_id: "accepted-message".to_owned(),
+        attribution: Some(Attribution {
+            author: Some(Author {
+                id: "factory-user".to_owned(),
+                kind: author::Kind::User as i32,
+                display_name: "Factory User".to_owned(),
+            }),
+            origin: Some(Origin {
+                kind: origin::Kind::Factory as i32,
+                source_id: "factory".to_owned(),
+                subtype: "slack".to_owned(),
+            }),
+            source_delivery: None,
+        }),
+        media: Vec::new(),
+    }
+}
 
 fn is_upstream_message_pty_bytes_read(
     message: UpstreamMessage,
@@ -57,6 +118,7 @@ fn test_startup_max_attempts_only_retries_ambient_agent_sources() {
 fn test_startup_failure_retryability() {
     assert!(StartupFailure::Transport.is_retryable());
     assert!(StartupFailure::InitializeSend.is_retryable());
+    assert!(!StartupFailure::Negotiation.is_retryable());
     assert!(StartupFailure::WebsocketClosedBeforeStarted.is_retryable());
     assert!(StartupFailure::WebsocketError.is_retryable());
     assert!(StartupFailure::Timeout.is_retryable());
@@ -81,6 +143,18 @@ fn test_startup_failure_retryability() {
         !StartupFailure::ServerRejected(FailedToInitializeSessionReason::UserNotFound)
             .is_retryable()
     );
+}
+#[test]
+fn test_semantic_initial_terminal_state_is_sanitized() {
+    let state = semantic_initial_terminal_state();
+
+    assert!(matches!(state.active_prompt, ActivePrompt::PS1));
+    assert_eq!(state.window_size.num_rows, 0);
+    assert_eq!(state.window_size.num_cols, 0);
+    assert!(matches!(state.selection, Selection::None));
+    assert!(state.init_block_id.to_string().is_empty());
+    assert!(state.input_replica_id.to_string().is_empty());
+    assert!(state.universal_developer_input_context.is_none());
 }
 
 #[test]
@@ -191,6 +265,382 @@ fn create_network(
     }
 
     (network, ordered_events_tx)
+}
+
+fn configure_semantic_network(network: &ModelHandle<Network>, app: &mut App) -> SessionId {
+    let session_id = SessionId::new();
+    network.update(app, |network, _| {
+        let execution_identity = execution();
+        network.content = RequestedSessionContent::semantic_v1(execution_identity.clone());
+        network.semantic_producer = Some(SemanticMutationProducer::new(execution_identity));
+        network.session_id = Some(session_id);
+        network.stage = Stage::StartedSuccessfully {
+            startup_attempt: None,
+        };
+    });
+    session_id
+}
+
+#[test]
+fn test_semantic_negotiation_fails_closed_without_exact_echo() {
+    App::test((), |mut app| async move {
+        let missing_echo = create_network(&mut app, false).0;
+        missing_echo.update(&mut app, |network, ctx| {
+            let execution_identity = execution();
+            network.content = RequestedSessionContent::semantic_v1(execution_identity.clone());
+            network.semantic_producer = Some(SemanticMutationProducer::new(execution_identity));
+            let Stage::BeforeStarted { startup_retry } = &mut network.stage else {
+                panic!("test network should be starting");
+            };
+            startup_retry.current_attempt = 1;
+            let message = DownstreamMessage::SessionInitialized {
+                session_id: SessionId::new(),
+                session_secret: Default::default(),
+                reconnect_token: ReconnectToken::new(),
+                sharer_id: ParticipantId::new(),
+                sharer_firebase_uid: "mock_firebase_uid".to_owned(),
+                negotiated_content: None,
+            };
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        missing_echo.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::Finished));
+            assert!(network.session_id.is_none());
+        });
+
+        let matching_echo = create_network(&mut app, false).0;
+        matching_echo.update(&mut app, |network, ctx| {
+            let execution_identity = execution();
+            network.content = RequestedSessionContent::semantic_v1(execution_identity.clone());
+            network.semantic_producer =
+                Some(SemanticMutationProducer::new(execution_identity.clone()));
+            let message = DownstreamMessage::SessionInitialized {
+                session_id: SessionId::new(),
+                session_secret: Default::default(),
+                reconnect_token: ReconnectToken::new(),
+                sharer_id: ParticipantId::new(),
+                sharer_firebase_uid: "mock_firebase_uid".to_owned(),
+                negotiated_content: Some(semantic_echo(execution_identity)),
+            };
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        matching_echo.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::StartedSuccessfully { .. }));
+            assert!(network.session_id.is_some());
+        });
+    });
+}
+
+#[test]
+fn test_semantic_prompt_requires_valid_context_after_negotiation() {
+    App::test((), |mut app| async move {
+        let missing = create_network(&mut app, true).0;
+        configure_semantic_network(&missing, &mut app);
+        let missing_responses = missing.read(&app, |network, _| network.ws_proxy_rx.clone());
+        missing.update(&mut app, |network, ctx| {
+            let request_id = AgentPromptRequestId::default();
+            let message = DownstreamMessage::AgentPromptRequested {
+                id: request_id.clone(),
+                participant_id: ParticipantId::new(),
+                request: AgentPromptRequest {
+                    id: request_id,
+                    server_conversation_token: None,
+                    prompt: "missing context".to_owned(),
+                    attachments: Vec::new(),
+                    accepted_message_context: None,
+                },
+            };
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        assert!(matches!(
+            missing_responses.try_recv().unwrap(),
+            UpstreamMessage::RejectAgentPromptRequest {
+                reason: AgentPromptFailureReason::InvalidConversation,
+                ..
+            }
+        ));
+
+        let invalid = create_network(&mut app, true).0;
+        configure_semantic_network(&invalid, &mut app);
+        let invalid_responses = invalid.read(&app, |network, _| network.ws_proxy_rx.clone());
+        invalid.update(&mut app, |network, ctx| {
+            let request_id = AgentPromptRequestId::default();
+            let mut context = accepted_message_context();
+            context.execution_id = "different".to_owned();
+            let message = DownstreamMessage::AgentPromptRequested {
+                id: request_id.clone(),
+                participant_id: ParticipantId::new(),
+                request: AgentPromptRequest {
+                    id: request_id,
+                    server_conversation_token: None,
+                    prompt: "invalid context".to_owned(),
+                    attachments: Vec::new(),
+                    accepted_message_context: Some(context.encode_to_vec()),
+                },
+            };
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        assert!(matches!(
+            invalid_responses.try_recv().unwrap(),
+            UpstreamMessage::RejectAgentPromptRequest {
+                reason: AgentPromptFailureReason::InvalidConversation,
+                ..
+            }
+        ));
+
+        let valid = create_network(&mut app, true).0;
+        configure_semantic_network(&valid, &mut app);
+        let captured = Arc::new(parking_lot::Mutex::new(None));
+        let captured_clone = captured.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&valid, move |_, event, _| {
+                if let super::NetworkEvent::AgentPromptRequested {
+                    accepted_message_context,
+                    ..
+                } = event
+                {
+                    *captured_clone.lock() = accepted_message_context.as_deref().cloned();
+                }
+            });
+        });
+        valid.update(&mut app, |network, ctx| {
+            let request_id = AgentPromptRequestId::default();
+            let message = DownstreamMessage::AgentPromptRequested {
+                id: request_id.clone(),
+                participant_id: ParticipantId::new(),
+                request: AgentPromptRequest {
+                    id: request_id,
+                    server_conversation_token: None,
+                    prompt: "valid context".to_owned(),
+                    attachments: Vec::new(),
+                    accepted_message_context: Some(accepted_message_context().encode_to_vec()),
+                },
+            };
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        assert_eq!(*captured.lock(), Some(accepted_message_context()));
+    });
+}
+
+#[test]
+fn test_actual_producer_mutation_transport_and_retransmission_are_identical() {
+    App::test((), |mut app| async move {
+        let network = create_network(&mut app, true).0;
+        configure_semantic_network(&network, &mut app);
+        let ws_proxy_rx = network.read(&app, |network, _| network.ws_proxy_rx.clone());
+        let mut producer = SemanticMutationProducer::new(execution());
+        let mutation = producer
+            .normalize(&ResponseEvent {
+                r#type: Some(response_event::Type::Init(response_event::StreamInit {
+                    conversation_id: "conversation".to_owned(),
+                    request_id: "request".to_owned(),
+                    run_id: "run".to_owned(),
+                })),
+            })
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        network.update(&mut app, |network, _| {
+            assert!(network.send_semantic_mutation(mutation.clone()));
+        });
+        let first = ws_proxy_rx.recv().await.unwrap();
+        let first_json = first.to_json().unwrap();
+        let UpstreamMessage::OrderedTerminalEvent(first_event) = first else {
+            panic!("producer mutation should use ordered semantic transport");
+        };
+        let OrderedTerminalEventType::SemanticConversationMutation {
+            mutation: encoded, ..
+        } = first_event.event_type
+        else {
+            panic!("producer mutation should remain semantic");
+        };
+        assert_eq!(
+            ConversationMutation::decode(encoded.as_slice()).unwrap(),
+            mutation
+        );
+
+        network.update(&mut app, |network, _| {
+            network.flush_terminal_events_to_server(0);
+        });
+        let retransmitted = ws_proxy_rx.recv().await.unwrap();
+        assert_eq!(retransmitted.to_json().unwrap(), first_json);
+    });
+}
+
+#[test]
+fn test_storage_unavailable_has_exhaustive_diagnostic_and_user_message() {
+    let reason = session_sharing_protocol::sharer::SessionTerminatedReason::StorageUnavailable;
+    assert_eq!(
+        session_terminated_reason_diagnostic_label(&reason),
+        "storage_unavailable"
+    );
+    assert!(session_terminated_reason_string(&reason, Byte::from_u64(1)).contains("storage"));
+}
+
+#[test]
+fn test_semantic_filtering_happens_before_batching_and_event_numbering() {
+    App::test((), |mut app| async move {
+        let network = create_network(&mut app, true).0;
+        let session_id = configure_semantic_network(&network, &mut app);
+        let ws_proxy_rx = network.read(&app, |network, _| network.ws_proxy_rx.clone());
+
+        network.update(&mut app, |network, _| {
+            network.send_ordered_terminal_event_message(
+                OrderedTerminalEventType::CommandExecutionStarted {
+                    participant_id: ParticipantId::new(),
+                    ai_metadata: None,
+                },
+            );
+            network.pty_bytes_batch_status = PtyBytesBatchStatus::Batching {
+                accumulated: b"terminal output".to_vec(),
+                abort_handle: AbortHandle::new_pair().0,
+            };
+            network.send_pty_bytes_read_message();
+        });
+
+        network.read(&app, |network, _| {
+            assert_eq!(usize::from(network.event_no), 0);
+            assert!(network.unacked_terminal_events.is_empty());
+            assert!(matches!(
+                network.pty_bytes_batch_status,
+                PtyBytesBatchStatus::NotBatching { .. }
+            ));
+        });
+        assert!(ws_proxy_rx.is_empty());
+
+        network.update(&mut app, |network, _| {
+            network.send_ordered_terminal_event_message(
+                OrderedTerminalEventType::SemanticConversationMutation {
+                    cursor: semantic_cursor(session_id, 1),
+                    mutation: vec![1, 2, 3],
+                },
+            );
+        });
+
+        let message = ws_proxy_rx.recv().await.unwrap();
+        assert!(matches!(
+            message,
+            UpstreamMessage::OrderedTerminalEvent(OrderedTerminalEvent {
+                event_no: 0,
+                event_type: OrderedTerminalEventType::SemanticConversationMutation { .. },
+            })
+        ));
+        network.read(&app, |network, _| {
+            assert_eq!(usize::from(network.event_no), 1);
+            assert_eq!(network.unacked_terminal_events.len(), 1);
+            assert_eq!(network.unacked_terminal_event_bytes, 3);
+        });
+
+        network.update(&mut app, |network, ctx| {
+            let ack = DownstreamMessage::EventsProcessedAck {
+                latest_processed_event_no: 0,
+            };
+            network.process_websocket_message(Message::new(ack.to_json().unwrap()), ctx);
+        });
+        network.read(&app, |network, _| {
+            assert!(network.unacked_terminal_events.is_empty());
+            assert_eq!(network.unacked_terminal_event_bytes, 0);
+        });
+    });
+}
+
+#[test]
+fn test_semantic_final_sender_rejects_direct_terminal_event() {
+    App::test((), |mut app| async move {
+        let network = create_network(&mut app, true).0;
+        configure_semantic_network(&network, &mut app);
+        let ws_proxy_rx = network.read(&app, |network, _| network.ws_proxy_rx.clone());
+
+        network.update(&mut app, |network, _| {
+            network.send_message_to_server(UpstreamMessage::OrderedTerminalEvent(
+                OrderedTerminalEvent {
+                    event_no: 0,
+                    event_type: OrderedTerminalEventType::PtyBytesRead {
+                        bytes: b"terminal output".to_vec(),
+                    },
+                },
+            ));
+        });
+
+        network.read(&app, |network, _| {
+            assert!(network.unacked_terminal_events.is_empty());
+            assert_eq!(network.unacked_terminal_event_bytes, 0);
+        });
+        assert!(ws_proxy_rx.is_empty());
+    });
+}
+
+#[test]
+fn test_unacked_count_and_byte_limits_stop_before_allocating_an_event_number() {
+    App::test((), |mut app| async move {
+        let byte_limited = create_network(&mut app, true).0;
+        let session_id = configure_semantic_network(&byte_limited, &mut app);
+        byte_limited.update(&mut app, |network, _| {
+            network.unacked_terminal_event_bytes = super::MAX_UNACKED_EVENT_BYTES;
+            network.send_ordered_terminal_event_message(
+                OrderedTerminalEventType::SemanticConversationMutation {
+                    cursor: semantic_cursor(session_id, 1),
+                    mutation: vec![1],
+                },
+            );
+        });
+        byte_limited.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::Finished));
+            assert_eq!(usize::from(network.event_no), 0);
+        });
+
+        let count_limited = create_network(&mut app, true).0;
+        let session_id = configure_semantic_network(&count_limited, &mut app);
+        count_limited.update(&mut app, |network, _| {
+            network
+                .unacked_terminal_events
+                .extend((0..super::MAX_UNACKED_EVENTS).map(|event_no| {
+                    (
+                        event_no,
+                        OrderedTerminalEvent {
+                            event_no,
+                            event_type: OrderedTerminalEventType::CommandExecutionStarted {
+                                participant_id: ParticipantId::new(),
+                                ai_metadata: None,
+                            },
+                        },
+                    )
+                }));
+            network.send_ordered_terminal_event_message(
+                OrderedTerminalEventType::SemanticConversationMutation {
+                    cursor: semantic_cursor(session_id, 1),
+                    mutation: vec![1],
+                },
+            );
+        });
+        count_limited.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::Finished));
+            assert_eq!(usize::from(network.event_no), 0);
+            assert_eq!(
+                network.unacked_terminal_events.len(),
+                super::MAX_UNACKED_EVENTS
+            );
+        });
+    });
+}
+
+#[test]
+fn test_semantic_unacked_limits_do_not_stop_full_terminal_sessions() {
+    App::test((), |mut app| async move {
+        let network = create_network(&mut app, true).0;
+        network.update(&mut app, |network, _| {
+            network.unacked_terminal_event_bytes = super::MAX_UNACKED_EVENT_BYTES;
+            network.send_ordered_terminal_event_message(OrderedTerminalEventType::PtyBytesRead {
+                bytes: vec![1],
+            });
+        });
+
+        network.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::StartedSuccessfully { .. }));
+            assert_eq!(usize::from(network.event_no), 1);
+        });
+    });
 }
 
 #[test]
@@ -660,6 +1110,7 @@ fn test_messages_are_buffered_before_session_initialized() {
                 reconnect_token: ReconnectToken::new(),
                 sharer_id: ParticipantId::new(),
                 sharer_firebase_uid: "mock_firebase_uid".to_string(),
+                negotiated_content: None,
             };
             let serialized = downstream_message.to_json().unwrap();
             network.process_websocket_message(Message::new(serialized), ctx);
@@ -714,6 +1165,7 @@ fn test_messages_are_buffered_while_reconnecting() {
                 reconnect_token: ReconnectToken::new(),
                 sharer_id: ParticipantId::new(),
                 sharer_firebase_uid: "mock_firebase_uid".to_string(),
+                negotiated_content: None,
             };
             let serialized = downstream_message.to_json().unwrap();
             network.process_websocket_message(Message::new(serialized), ctx);
@@ -765,6 +1217,7 @@ fn test_messages_are_buffered_while_reconnecting() {
             let downstream_message = DownstreamMessage::SessionReconnected {
                 last_received_event_no: None,
                 participant_list: Default::default(),
+                negotiated_content: None,
             };
             let serialized = downstream_message.to_json().unwrap();
             network.process_websocket_message(Message::new(serialized), ctx);
@@ -798,6 +1251,7 @@ fn test_events_are_saved_on_send_and_removed_on_ack() {
                 reconnect_token: ReconnectToken::new(),
                 sharer_id: ParticipantId::new(),
                 sharer_firebase_uid: "mock_firebase_uid".to_string(),
+                negotiated_content: None,
             };
             let serialized = downstream_message.to_json().unwrap();
             network.process_websocket_message(Message::new(serialized), ctx);

--- a/app/src/terminal/shared_session/viewer/event_loop.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop.rs
@@ -415,6 +415,11 @@ impl EventLoop {
                         });
                     }
                 }
+                OrderedTerminalEventType::SemanticConversationMutation { .. } => {
+                    warp_errors::report_error!(
+                        "Semantic mutation reached the legacy terminal event loop"
+                    );
+                }
             }
 
             if Some(self.next_event_no) == self.catching_up_to_event_no

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -16,19 +16,21 @@ use session_sharing_protocol::common::{
     ActivePrompt, ActivePromptUpdate, AddGuestsResponse, AgentAttachment, AgentPromptFailureReason,
     AgentPromptRequest, AgentPromptRequestId, CommandExecutionFailureReason, ControlAction,
     ControlActionFailureReason, FeatureSupport, InputOperationId, InputOperationSeqNo, InputUpdate,
-    LinkAccessLevelUpdateResponse, ParticipantId, ParticipantList, ParticipantPresenceUpdate,
-    RemoveGuestResponse, Role, RoleRequestId, RoleRequestResponse, Selection, SelectionUpdate,
-    ServerConversationToken, SessionId, TeamAccessLevelUpdateResponse, TeamAclData,
-    TelemetryContext, UniversalDeveloperInputContext, UniversalDeveloperInputContextUpdate,
-    UpdatePendingUserRoleResponse, UserID, WindowSize, WriteToPtyFailureReason,
-    WriteToPtyRequestId, WriteToPtySeqNo,
+    LinkAccessLevelUpdateResponse, OrderedTerminalEventType, ParticipantId, ParticipantList,
+    ParticipantPresenceUpdate, RemoveGuestResponse, Role, RoleRequestId, RoleRequestResponse,
+    Selection, SelectionUpdate, SemanticResyncReason, ServerConversationToken, SessionId,
+    TeamAccessLevelUpdateResponse, TeamAclData, TelemetryContext, UniversalDeveloperInputContext,
+    UniversalDeveloperInputContextUpdate, UpdatePendingUserRoleResponse, UserID, WindowSize,
+    WriteToPtyFailureReason, WriteToPtyRequestId, WriteToPtySeqNo,
 };
 use session_sharing_protocol::viewer::{
     DownstreamMessage, InitPayload, RoleUpdatedReason, SessionEndedReason, UpstreamMessage,
     ViewerRemovedReason,
 };
+use warp_conversation_mutation_api::ConversationMutation;
 use warp_core::features::FeatureFlag;
 use warp_errors::report_error;
+use warp_semantic_session::{ConsumeOutcome, RequestedSessionContent, SemanticConsumer};
 use warp_server_client::iap::IapManager;
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{
@@ -105,10 +107,31 @@ struct CachedLatestState {
     universal_developer_input_context: Option<UniversalDeveloperInputContext>,
 }
 
+fn semantic_join_has_terminal_state(
+    scrollback: &session_sharing_protocol::common::Scrollback,
+    active_prompt: &ActivePrompt,
+    window_size: WindowSize,
+    init_block_id: &session_sharing_protocol::common::BlockId,
+    input_replica_id: &session_sharing_protocol::common::InputReplicaId,
+    universal_developer_input_context: &Option<UniversalDeveloperInputContext>,
+) -> bool {
+    !scrollback.blocks.is_empty()
+        || scrollback.is_alt_screen_active
+        || !matches!(active_prompt, ActivePrompt::PS1)
+        || window_size.num_rows != 0
+        || window_size.num_cols != 0
+        || !init_block_id.to_string().is_empty()
+        || !input_replica_id.to_string().is_empty()
+        || universal_developer_input_context.is_some()
+}
+
 /// The network interface to allow communication to and from the
 /// cloud-backed shared session.
 pub struct Network {
     session_id: SessionId,
+    content: RequestedSessionContent,
+    semantic_consumer: Option<SemanticConsumer>,
+    semantic_last_event_no: Option<usize>,
     /// [`None`] until the viewer receives the successful join ack.
     event_loop: Option<ModelHandle<EventLoop>>,
 
@@ -150,6 +173,10 @@ pub struct Network {
 }
 
 impl Network {
+    #[cfg(test)]
+    pub(super) fn requested_content_for_test(&self) -> &RequestedSessionContent {
+        &self.content
+    }
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         session_id: SessionId,
@@ -159,6 +186,7 @@ impl Network {
         write_to_pty_events_rx: Receiver<Vec<u8>>,
         initial_load_mode: SharedSessionInitialLoadMode,
         remote_update_guard: RemoteUpdateGuard,
+        content: RequestedSessionContent,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
@@ -166,6 +194,17 @@ impl Network {
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let model = Network {
             session_id,
+            semantic_consumer: content.execution_identity().cloned().map(|identity| {
+                SemanticConsumer::new(
+                    session_id,
+                    identity,
+                    content
+                        .schema_version()
+                        .expect("semantic content has a schema"),
+                )
+            }),
+            content,
+            semantic_last_event_no: None,
             event_loop: None,
             ws_proxy_tx,
             #[cfg(test)]
@@ -229,6 +268,9 @@ impl Network {
 
         let model = Network {
             session_id,
+            content: RequestedSessionContent::FullTerminal,
+            semantic_consumer: None,
+            semantic_last_event_no: None,
             event_loop: None,
             ws_proxy_tx,
             ws_proxy_rx,
@@ -254,13 +296,14 @@ impl Network {
         };
 
         ctx.emit(NetworkEvent::JoinedSuccessfully {
+            is_semantic: false,
             active_prompt,
             viewer_id,
             viewer_firebase_uid,
             participant_list: Default::default(),
             input_replica_id: ReplicaId::random(),
             universal_developer_input_context: None,
-            source: SharedSessionSource::default(),
+            source: Box::new(SharedSessionSource::default()),
         });
 
         model.start_write_to_pty_events_listener(write_to_pty_events_rx, ctx);
@@ -407,7 +450,12 @@ impl Network {
                             supports_agent_view: FeatureFlag::AgentView.is_enabled(),
                             supports_full_role: true,
                             supports_full_role_for_real: true,
+                            supports_semantic_conversation: true,
                         },
+                        content_mode: network.content.content_mode(),
+                        semantic_schema_version: network.content.schema_version(),
+                        execution_identity: network.content.execution_identity().cloned(),
+                        semantic_cursor: None,
                     });
                     if let Err(e) = network.ws_proxy_tx.try_send(initialize_message) {
                         report_error!(anyhow::Error::new(e)
@@ -449,10 +497,11 @@ impl Network {
         // timer. Stage is guaranteed not Reconnecting here, so close() will
         // not abort any in-progress reconnect handle.
         self.close();
-        let Some(event_loop) = self.event_loop.clone() else {
+        let event_loop = self.event_loop.clone();
+        if !self.content.is_semantic() && event_loop.is_none() {
             report_error!("Cannot reconnect to server as viewer when event loop does not exist");
             return;
-        };
+        }
         let session_id = self.session_id;
         let auth_client = ServerApiProvider::as_ref(ctx).get_auth_client();
         let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
@@ -478,19 +527,47 @@ impl Network {
             move |network, conn, ctx| match conn {
                 RequestState::RequestSucceeded(((sink, stream), user_id)) => {
                     log::info!("Successfully reconnected to server as viewer");
-                    let last_received_event_no = event_loop.as_ref(ctx).last_received_event_no();
-                    let latest_block_id = network.terminal_model.lock().block_list().active_block_id().clone();
+                    let last_received_event_no = if network.content.is_semantic() {
+                        network.semantic_last_event_no
+                    } else {
+                        event_loop
+                            .as_ref()
+                            .expect("full-terminal viewers have an event loop")
+                            .as_ref(ctx)
+                            .last_received_event_no()
+                    };
+                    let latest_block_id = if network.content.is_semantic() {
+                        None
+                    } else {
+                        Some(
+                            network
+                                .terminal_model
+                                .lock()
+                                .block_list()
+                                .active_block_id()
+                                .clone()
+                                .into(),
+                        )
+                    };
                     let initialize_message = UpstreamMessage::Initialize(InitPayload {
                         viewer_id: network.id.clone(),
                         user_id,
                         last_received_event_no,
-                        latest_block_id: Some(latest_block_id.into()),
+                        latest_block_id,
                         telemetry_context: Some(TelemetryContext(telemetry_context().as_value())),
                         feature_support: FeatureSupport {
                             supports_agent_view: FeatureFlag::AgentView.is_enabled(),
                             supports_full_role: true,
                             supports_full_role_for_real: true,
+                            supports_semantic_conversation: true,
                         },
+                        content_mode: network.content.content_mode(),
+                        semantic_schema_version: network.content.schema_version(),
+                        execution_identity: network.content.execution_identity().cloned(),
+                        semantic_cursor: network
+                            .semantic_consumer
+                            .as_ref()
+                            .and_then(SemanticConsumer::cursor),
                     });
                     let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
                     network.ws_proxy_tx = ws_proxy_tx;
@@ -550,6 +627,21 @@ impl Network {
             log::warn!("Got unexpected message from shared session viewer websocket");
             return;
         };
+        if self.content.is_semantic()
+            && !matches!(
+                &msg,
+                DownstreamMessage::JoinedSuccessfully { .. }
+                    | DownstreamMessage::RejoinedSuccessfully { .. }
+                    | DownstreamMessage::SemanticResyncRequired { .. }
+                    | DownstreamMessage::FailedToJoin { .. }
+                    | DownstreamMessage::SessionEnded { .. }
+                    | DownstreamMessage::ViewerRemoved { .. }
+                    | DownstreamMessage::OrderedTerminalEvent(_)
+                    | DownstreamMessage::Pong { .. }
+            )
+        {
+            return;
+        }
         match msg {
             DownstreamMessage::JoinedSuccessfully {
                 scrollback,
@@ -559,22 +651,47 @@ impl Network {
                 participant_list,
                 viewer_id,
                 viewer_firebase_uid,
+                init_block_id,
                 input_replica_id,
                 universal_developer_input_context,
                 // We use the more detailed source type here,
                 // ignoring the legacy source_type field (which was kept around for backwards compatibility).
                 detailed_source_type: source_type,
                 source_task_id,
+                negotiated_content,
                 ..
             } => {
-                let source = SharedSessionSource {
-                    source_type,
-                    source_task_id,
-                };
+                let source = SharedSessionSource::from_network(source_type, source_task_id);
                 if matches!(self.stage, Stage::JoinedSuccessfully) {
                     log::warn!(
                         "Received unexpected JoinedSuccessfully message when we've already joined"
                     );
+                    return;
+                }
+                if let Err(error) = self.content.validate_echo(negotiated_content.as_ref()) {
+                    log::warn!("Session content negotiation failed: {error:?}");
+                    self.close_without_reconnection();
+                    ctx.emit(NetworkEvent::FailedToJoin {
+                        reason: FailedToJoinReason::Unknown,
+                    });
+                    return;
+                }
+                let is_semantic = self.content.is_semantic();
+                if is_semantic
+                    && semantic_join_has_terminal_state(
+                        &scrollback,
+                        &active_prompt,
+                        window_size,
+                        &init_block_id,
+                        &input_replica_id,
+                        &universal_developer_input_context,
+                    )
+                {
+                    log::warn!("Semantic shared session returned terminal state");
+                    self.close_without_reconnection();
+                    ctx.emit(NetworkEvent::FailedToJoin {
+                        reason: FailedToJoinReason::Unknown,
+                    });
                     return;
                 }
                 self.id = Some(viewer_id.clone());
@@ -582,39 +699,52 @@ impl Network {
 
                 // Initialize the cache with the server's initial context so that subsequent
                 // local changes are correctly compared against what the server knows.
-                self.cached_latest_state.universal_developer_input_context =
-                    universal_developer_input_context.clone();
+                if !is_semantic {
+                    self.cached_latest_state.universal_developer_input_context =
+                        universal_developer_input_context.clone();
+                }
 
-                // Create the event loop now that we've joined and are ready to receive events from the server.
-                let event_loop = ctx.add_model(|ctx| {
-                    EventLoop::new(
-                        self.terminal_model.clone(),
-                        self.terminal_view.clone(),
-                        self.channel_event_proxy.clone(),
-                        window_size,
-                        *scrollback,
-                        latest_event_no,
-                        self.initial_load_mode,
-                        self.remote_update_guard.clone(),
-                        ctx,
-                    )
-                });
-                self.event_loop = Some(event_loop);
+                if !is_semantic {
+                    let event_loop = ctx.add_model(|ctx| {
+                        EventLoop::new(
+                            self.terminal_model.clone(),
+                            self.terminal_view.clone(),
+                            self.channel_event_proxy.clone(),
+                            window_size,
+                            *scrollback,
+                            latest_event_no,
+                            self.initial_load_mode,
+                            self.remote_update_guard.clone(),
+                            ctx,
+                        )
+                    });
+                    self.event_loop = Some(event_loop);
+                }
                 ctx.emit(NetworkEvent::JoinedSuccessfully {
+                    is_semantic,
                     active_prompt,
                     viewer_id,
                     viewer_firebase_uid: UserUid::new(viewer_firebase_uid.as_str()),
                     participant_list: Box::new(*participant_list),
                     input_replica_id: input_replica_id.into(),
                     universal_developer_input_context,
-                    source,
+                    source: Box::new(source),
                 });
             }
-            DownstreamMessage::RejoinedSuccessfully { participant_list } => {
+            DownstreamMessage::RejoinedSuccessfully {
+                participant_list,
+                negotiated_content,
+            } => {
                 if matches!(self.stage, Stage::JoinedSuccessfully) {
                     log::warn!(
                         "Received unexpected RejoinedSuccessfully message when we've already joined"
                     );
+                    return;
+                }
+                if let Err(error) = self.content.validate_echo(negotiated_content.as_ref()) {
+                    log::warn!("Session content reconnect negotiation failed: {error:?}");
+                    self.close_without_reconnection();
+                    ctx.emit(NetworkEvent::FailedToReconnect);
                     return;
                 }
                 log::info!("Successfully reconnected to shared session as viewer.");
@@ -628,6 +758,20 @@ impl Network {
                 )));
             }
             DownstreamMessage::OrderedTerminalEvent(event) => {
+                if self.content.is_semantic() {
+                    if !matches!(self.stage, Stage::JoinedSuccessfully) {
+                        log::warn!(
+                            "Received semantic mutation before session content negotiation completed"
+                        );
+                        self.close_without_reconnection();
+                        ctx.emit(NetworkEvent::SemanticResyncRequired {
+                            reason: SemanticResyncReason::SessionStateUnavailable,
+                        });
+                        return;
+                    }
+                    self.process_semantic_event(event, ctx);
+                    return;
+                }
                 if let Some(event_loop) = &self.event_loop {
                     event_loop.update(ctx, |event_loop, ctx| {
                         event_loop.process_ordered_terminal_event(event, ctx);
@@ -645,6 +789,10 @@ impl Network {
             DownstreamMessage::ViewerRemoved { reason } => {
                 self.close_without_reconnection();
                 ctx.emit(NetworkEvent::ViewerRemoved { reason })
+            }
+            DownstreamMessage::SemanticResyncRequired { reason } => {
+                self.close_without_reconnection();
+                ctx.emit(NetworkEvent::SemanticResyncRequired { reason });
             }
             DownstreamMessage::ActivePromptUpdated(active_prompt_update) => {
                 ctx.emit(NetworkEvent::SharerActivePromptUpdated(
@@ -770,6 +918,70 @@ impl Network {
         }
     }
 
+    fn process_semantic_event(
+        &mut self,
+        event: session_sharing_protocol::common::OrderedTerminalEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let event_no = event.event_no;
+        let expected_mutation_sequence = u64::try_from(event_no)
+            .ok()
+            .and_then(|event_no| event_no.checked_add(1));
+        let mutation_sequence = match &event.event_type {
+            OrderedTerminalEventType::SemanticConversationMutation { cursor, .. } => {
+                Some(cursor.mutation_sequence)
+            }
+            _ => None,
+        };
+        if mutation_sequence != expected_mutation_sequence {
+            self.close_without_reconnection();
+            ctx.emit(NetworkEvent::SemanticResyncRequired {
+                reason: SemanticResyncReason::SessionStateUnavailable,
+            });
+            return;
+        }
+        let expected_event_no = self
+            .semantic_last_event_no
+            .map_or(0, |last_event_no| last_event_no + 1);
+        if event_no > expected_event_no {
+            self.close_without_reconnection();
+            ctx.emit(NetworkEvent::SemanticResyncRequired {
+                reason: SemanticResyncReason::SessionStateUnavailable,
+            });
+            return;
+        }
+        let is_replay = event_no < expected_event_no;
+        let outcome = self
+            .semantic_consumer
+            .as_mut()
+            .expect("semantic content has a consumer")
+            .consume(event);
+        match outcome {
+            Ok(ConsumeOutcome::Applied(mutation)) if !is_replay => {
+                self.semantic_last_event_no = Some(event_no);
+                ctx.emit(NetworkEvent::SemanticMutationApplied(mutation));
+            }
+            Ok(ConsumeOutcome::Duplicate) if is_replay => {}
+            Ok(ConsumeOutcome::Applied(_) | ConsumeOutcome::Duplicate) => {
+                self.close_without_reconnection();
+                ctx.emit(NetworkEvent::SemanticResyncRequired {
+                    reason: SemanticResyncReason::SessionStateUnavailable,
+                });
+            }
+            Ok(ConsumeOutcome::ResyncRequired(reason)) => {
+                self.close_without_reconnection();
+                ctx.emit(NetworkEvent::SemanticResyncRequired { reason });
+            }
+            Err(error) => {
+                log::warn!("Failed to consume semantic mutation: {error}");
+                self.close_without_reconnection();
+                ctx.emit(NetworkEvent::SemanticResyncRequired {
+                    reason: SemanticResyncReason::SessionStateUnavailable,
+                });
+            }
+        }
+    }
+
     /// Start a process to listen for and batch pty write events.
     fn start_write_to_pty_events_listener(
         &self,
@@ -779,6 +991,9 @@ impl Network {
         ctx.spawn_stream_local(
             events_rx,
             move |network, bytes, ctx| {
+                if network.content.is_semantic() {
+                    return;
+                }
                 match &mut network.pty_bytes_batch_status {
                     PtyBytesBatchStatus::NotBatching { last_sent_at } => {
                         // Start batching
@@ -830,6 +1045,14 @@ impl Network {
         let Stage::JoinedSuccessfully = self.stage else {
             return;
         };
+        if self.content.is_semantic()
+            && !matches!(
+                &message,
+                UpstreamMessage::Ping { .. } | UpstreamMessage::Reauthenticated { .. }
+            )
+        {
+            return;
+        }
         if let Err(e) = self.ws_proxy_tx.try_send(message) {
             log::warn!("Failed to send message over ws_proxy channel in viewer network: {e}");
         }
@@ -846,6 +1069,9 @@ impl Network {
 
     /// Send the presence selection to the server, with a throttle period.
     pub fn send_presence_selection(&mut self, selection: Selection) {
+        if self.content.is_semantic() {
+            return;
+        }
         self.cached_latest_state.selection = selection.clone();
         if let Err(e) = self.selection_throttled_tx.try_send(selection) {
             log::warn!(
@@ -859,6 +1085,9 @@ impl Network {
         block_id: &BlockId,
         operations: impl Iterator<Item = &'a CrdtOperation>,
     ) {
+        if self.content.is_semantic() {
+            return;
+        }
         let Some(viewer_id) = self.id.clone() else {
             return;
         };
@@ -907,6 +1136,16 @@ impl Network {
     }
 
     pub fn send_write_to_pty(&mut self) {
+        if self.content.is_semantic() {
+            if let PtyBytesBatchStatus::Batching { abort_handle, .. } = &self.pty_bytes_batch_status
+            {
+                abort_handle.abort();
+                self.pty_bytes_batch_status = PtyBytesBatchStatus::NotBatching {
+                    last_sent_at: Instant::now(),
+                };
+            }
+            return;
+        }
         let Some(viewer_id) = self.id.clone() else {
             return;
         };
@@ -953,6 +1192,7 @@ impl Network {
             server_conversation_token,
             prompt,
             attachments,
+            accepted_message_context: None,
         };
         self.send_message_to_server(UpstreamMessage::SendAgentPrompt(request));
     }
@@ -1006,6 +1246,10 @@ impl Network {
 
     /// Sends all input updates buffered during disconnection to the server, then clears the buffer.
     fn flush_pending_input_updates_to_server(&mut self) {
+        if self.content.is_semantic() {
+            self.pending_input_updates.clear();
+            return;
+        }
         for update in self.pending_input_updates.drain(..) {
             if let Err(e) = self
                 .ws_proxy_tx
@@ -1022,6 +1266,9 @@ impl Network {
     /// Send everything in `self.cached_latest_state` to the server.
     /// This is needed when we reconnect to the server, since all values were dropped before we were connected.
     fn send_latest_state_to_server(&mut self) {
+        if self.content.is_semantic() {
+            return;
+        }
         self.send_presence_selection(self.cached_latest_state.selection.clone())
     }
 
@@ -1043,6 +1290,9 @@ impl Network {
         &mut self,
         update: UniversalDeveloperInputContextUpdate,
     ) {
+        if self.content.is_semantic() {
+            return;
+        }
         // Skip update if nothing would change
         if let Some(ref cached) = self.cached_latest_state.universal_developer_input_context
             && !update.changes_cached_context(cached)
@@ -1183,13 +1433,14 @@ pub fn control_action_failure_reason_string(reason: &ControlActionFailureReason)
 
 pub enum NetworkEvent {
     JoinedSuccessfully {
+        is_semantic: bool,
         active_prompt: ActivePrompt,
         viewer_id: ParticipantId,
         viewer_firebase_uid: UserUid,
         participant_list: Box<ParticipantList>,
         input_replica_id: ReplicaId,
         universal_developer_input_context: Option<UniversalDeveloperInputContext>,
-        source: SharedSessionSource,
+        source: Box<SharedSessionSource>,
     },
     FailedToJoin {
         reason: FailedToJoinReason,
@@ -1197,6 +1448,10 @@ pub enum NetworkEvent {
     FailedToReconnect,
     SessionEnded {
         reason: SessionEndedReason,
+    },
+    SemanticMutationApplied(Box<ConversationMutation>),
+    SemanticResyncRequired {
+        reason: SemanticResyncReason,
     },
     SharerActivePromptUpdated(ActivePromptUpdate),
     UniversalDeveloperInputContextUpdated(UniversalDeveloperInputContextUpdate),

--- a/app/src/terminal/shared_session/viewer/network_tests.rs
+++ b/app/src/terminal/shared_session/viewer/network_tests.rs
@@ -5,15 +5,76 @@ use async_channel::Sender;
 use async_io::Timer;
 use instant::Instant;
 use parking_lot::FairMutex;
-use session_sharing_protocol::viewer::UpstreamMessage;
+use prost::Message as _;
+use session_sharing_protocol::common::{
+    ActivePrompt, BlockId, ExecutionIdentity, InputReplicaId, OrderedTerminalEvent,
+    OrderedTerminalEventType, Scrollback, Selection, SemanticCursor, SessionContentMode, SessionId,
+    WindowSize,
+};
+use session_sharing_protocol::viewer::{DownstreamMessage, UpstreamMessage};
+use warp_conversation_mutation_api::{
+    ContentEncoding, ContentMutation, ConversationMutation, MutationIdentity, SchemaVersion,
+    content_mutation, conversation_mutation,
+};
+use warp_semantic_session::{RequestedSessionContent, SemanticConsumer};
 use warpui::{App, ModelHandle};
+use websocket::{Message, WebsocketMessage as _};
 
-use super::{Network, PtyBytesBatchStatus, Stage};
+use super::{Network, PtyBytesBatchStatus, Stage, semantic_join_has_terminal_state};
 use crate::terminal::TerminalModel;
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
 use crate::test_util::add_window_with_terminal;
 use crate::test_util::terminal::initialize_app_for_terminal_view;
+
+fn execution() -> ExecutionIdentity {
+    ExecutionIdentity {
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        run_id: Some("run".to_owned()),
+        request_id: Some("request".to_owned()),
+    }
+}
+
+fn semantic_cursor(session_id: SessionId, mutation_sequence: u64) -> SemanticCursor {
+    SemanticCursor {
+        session_id,
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        content_mode: SessionContentMode::SemanticConversationOnly,
+        schema_version: 1,
+        mutation_sequence,
+    }
+}
+
+fn mutation(sequence: u64) -> ConversationMutation {
+    ConversationMutation {
+        schema_version: SchemaVersion::V1 as i32,
+        identity: Some(MutationIdentity {
+            conversation_id: "conversation".to_owned(),
+            execution_id: "execution".to_owned(),
+            mutation_id: format!("mutation-{sequence}"),
+            sequence,
+            run_id: "run".to_owned(),
+            request_id: "request".to_owned(),
+        }),
+        attribution: None,
+        occurred_at: Some(prost_types::Timestamp {
+            seconds: 1_700_000_000,
+            nanos: 0,
+        }),
+        mutation: Some(conversation_mutation::Mutation::Content(ContentMutation {
+            entry_id: "entry".to_owned(),
+            content_id: "content".to_owned(),
+            content_index: 0,
+            change: Some(content_mutation::Change::Delta(content_mutation::Delta {
+                delta_index: sequence - 1,
+                encoding: ContentEncoding::Utf8Text as i32,
+                data: b"text".to_vec(),
+            })),
+        })),
+    }
+}
 
 fn create_network(app: &mut App) -> (ModelHandle<Network>, Sender<Vec<u8>>) {
     initialize_app_for_terminal_view(app);
@@ -38,6 +99,183 @@ fn create_network(app: &mut App) -> (ModelHandle<Network>, Sender<Vec<u8>>) {
     });
 
     (network, write_to_pty_events_tx)
+}
+
+fn configure_semantic_network(network: &ModelHandle<Network>, app: &mut App) -> SessionId {
+    network.update(app, |network, _| {
+        network.content = RequestedSessionContent::semantic_v1(execution());
+        network.semantic_consumer = Some(SemanticConsumer::new(network.session_id, execution(), 1));
+    });
+    network.read(app, |network, _| network.session_id)
+}
+
+#[test]
+fn test_semantic_join_rejects_any_terminal_state() {
+    let scrollback = Scrollback {
+        blocks: Vec::new(),
+        is_alt_screen_active: false,
+    };
+    assert!(!semantic_join_has_terminal_state(
+        &scrollback,
+        &ActivePrompt::default(),
+        WindowSize::default(),
+        &BlockId::default(),
+        &InputReplicaId::default(),
+        &None,
+    ));
+    assert!(semantic_join_has_terminal_state(
+        &scrollback,
+        &ActivePrompt::default(),
+        WindowSize {
+            num_rows: 24,
+            num_cols: 80,
+        },
+        &BlockId::default(),
+        &InputReplicaId::default(),
+        &None,
+    ));
+}
+
+#[test]
+fn test_semantic_viewer_suppresses_terminal_upstream_state_before_numbering() {
+    App::test((), |mut app| async move {
+        let (network, _) = create_network(&mut app);
+        configure_semantic_network(&network, &mut app);
+        let ws_proxy_rx = network.read(&app, |network, _| network.ws_proxy_rx.clone());
+
+        network.update(&mut app, |network, ctx| {
+            let abort_handle = ctx.spawn_abortable(
+                Timer::after(Duration::from_secs(1)),
+                move |_, _, _| {},
+                |_, _| {},
+            );
+            network.pty_bytes_batch_status = PtyBytesBatchStatus::Batching {
+                accumulated: b"terminal input".to_vec(),
+                abort_handle,
+            };
+            network.send_write_to_pty();
+            network.send_presence_selection(Selection::None);
+        });
+
+        network.read(&app, |network, _| {
+            assert_eq!(network.write_to_pty_event_no.as_usize(), 0);
+            assert_eq!(usize::from(network.selection_event_no), 0);
+            assert!(matches!(
+                network.pty_bytes_batch_status,
+                PtyBytesBatchStatus::NotBatching { .. }
+            ));
+        });
+        assert!(ws_proxy_rx.is_empty());
+    });
+}
+
+#[test]
+fn test_semantic_viewer_rejects_events_before_negotiation() {
+    App::test((), |mut app| async move {
+        let (network, _) = create_network(&mut app);
+        let session_id = configure_semantic_network(&network, &mut app);
+        network.update(&mut app, |network, ctx| {
+            network.stage = Stage::BeforeJoined;
+            let message = DownstreamMessage::OrderedTerminalEvent(OrderedTerminalEvent {
+                event_no: 0,
+                event_type: OrderedTerminalEventType::SemanticConversationMutation {
+                    cursor: semantic_cursor(session_id, 1),
+                    mutation: mutation(1).encode_to_vec(),
+                },
+            });
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+
+        network.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::Finished));
+            assert!(network.semantic_last_event_no.is_none());
+            assert!(
+                network
+                    .semantic_consumer
+                    .as_ref()
+                    .and_then(SemanticConsumer::cursor)
+                    .is_none()
+            );
+        });
+    });
+}
+
+#[test]
+fn test_semantic_viewer_routes_typed_mutations_and_fails_closed_on_event_gaps() {
+    App::test((), |mut app| async move {
+        let (network, _) = create_network(&mut app);
+        let session_id = configure_semantic_network(&network, &mut app);
+        let first_mutation = mutation(1);
+        let semantic_event = OrderedTerminalEvent {
+            event_no: 0,
+            event_type: OrderedTerminalEventType::SemanticConversationMutation {
+                cursor: semantic_cursor(session_id, 1),
+                mutation: first_mutation.encode_to_vec(),
+            },
+        };
+
+        network.update(&mut app, |network, ctx| {
+            let message = DownstreamMessage::OrderedTerminalEvent(semantic_event.clone());
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        network.read(&app, |network, _| {
+            assert_eq!(network.semantic_last_event_no, Some(0));
+            assert_eq!(
+                network
+                    .semantic_consumer
+                    .as_ref()
+                    .and_then(SemanticConsumer::cursor)
+                    .unwrap()
+                    .mutation_sequence,
+                1
+            );
+            assert!(matches!(network.stage, Stage::JoinedSuccessfully));
+        });
+        network.update(&mut app, |network, ctx| {
+            let message = DownstreamMessage::OrderedTerminalEvent(semantic_event);
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        network.read(&app, |network, _| {
+            assert_eq!(network.semantic_last_event_no, Some(0));
+            assert!(matches!(network.stage, Stage::JoinedSuccessfully));
+        });
+
+        network.update(&mut app, |network, ctx| {
+            let message = DownstreamMessage::OrderedTerminalEvent(OrderedTerminalEvent {
+                event_no: 1,
+                event_type: OrderedTerminalEventType::SemanticConversationMutation {
+                    cursor: semantic_cursor(session_id, 3),
+                    mutation: mutation(3).encode_to_vec(),
+                },
+            });
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        network.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::Finished));
+        });
+    });
+}
+
+#[test]
+fn test_semantic_viewer_rejects_event_number_overflow() {
+    App::test((), |mut app| async move {
+        let (network, _) = create_network(&mut app);
+        let session_id = configure_semantic_network(&network, &mut app);
+        network.update(&mut app, |network, ctx| {
+            let message = DownstreamMessage::OrderedTerminalEvent(OrderedTerminalEvent {
+                event_no: usize::MAX,
+                event_type: OrderedTerminalEventType::SemanticConversationMutation {
+                    cursor: semantic_cursor(session_id, u64::MAX),
+                    mutation: mutation(u64::MAX).encode_to_vec(),
+                },
+            });
+            network.process_websocket_message(Message::new(message.to_json().unwrap()), ctx);
+        });
+        network.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::Finished));
+            assert!(network.semantic_last_event_no.is_none());
+        });
+    });
 }
 
 #[test]

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -653,9 +653,19 @@ impl OrchestrationViewerModel {
                 .as_deref()
                 .and_then(|session_id| session_id.parse::<SessionId>().ok())
             {
+                let requested_content = match task.requested_session_content() {
+                    Ok(content) => content,
+                    Err(err) => {
+                        log::error!(
+                            "Refusing legacy child viewer with invalid Factory semantic capability: {err:#}"
+                        );
+                        return;
+                    }
+                };
                 ctx.emit(TerminalViewEvent::EnsureSharedSessionViewerChildPane {
                     conversation_id,
                     session_id,
+                    requested_content,
                 });
             }
         });

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -757,6 +757,7 @@ fn task(id: &str, state: AmbientAgentTaskState, title: &str) -> AmbientAgentTask
         agent_config_snapshot: None,
         artifacts: vec![],
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
 }

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -6,14 +6,15 @@ use parking_lot::FairMutex;
 use pathfinder_geometry::vector::Vector2F;
 use session_sharing_protocol::common::{
     ActivePrompt, AddGuestsResponse, CLIAgentSessionState, CommandExecutionFailureReason,
-    LinkAccessLevelUpdateResponse, LongRunningCommandAgentInteraction, RemoveGuestResponse,
-    SelectedAgentModel, SessionId, TeamAccessLevelUpdateResponse,
+    ExecutionIdentity, LinkAccessLevelUpdateResponse, LongRunningCommandAgentInteraction,
+    RemoveGuestResponse, SelectedAgentModel, SessionId, TeamAccessLevelUpdateResponse,
     UniversalDeveloperInputContextUpdate, UpdatePendingUserRoleResponse,
 };
 use session_sharing_protocol::sharer::SessionSourceType;
 use session_sharing_protocol::viewer::SessionEndedReason;
 use settings::Setting as _;
 use warp_errors::report_error;
+use warp_semantic_session::{RequestedSessionContent, SemanticTranscript};
 use warpui::{
     AppContext, ModelContext, ModelHandle, SingletonEntity, ViewContext, ViewHandle,
     WeakViewHandle, WindowId,
@@ -97,6 +98,7 @@ pub struct TerminalManager {
     network_state: NetworkState,
     network_resources: NetworkResources,
     current_network: Arc<FairMutex<Option<ModelHandle<Network>>>>,
+    semantic_transcript: Arc<FairMutex<SemanticTranscript>>,
     viewer_remote_update_guard: RemoteUpdateGuard,
     outbound_handlers_registered: bool,
     /// Owns child discovery + status polling for an orchestrated ambient
@@ -122,6 +124,17 @@ pub struct TerminalManagerInit {
 }
 
 impl TerminalManager {
+    #[cfg(test)]
+    pub(crate) fn requested_content_for_test(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<RequestedSessionContent> {
+        Self::current_network(&self.current_network).map(|network| {
+            network.read(ctx, |network, _| {
+                network.requested_content_for_test().clone()
+            })
+        })
+    }
     fn send_selected_conversation_update_for_viewer_to_current_network(
         guard: &RemoteUpdateGuard,
         model: &Arc<FairMutex<TerminalModel>>,
@@ -153,6 +166,7 @@ impl TerminalManager {
     pub fn new_for_ambient_orchestration_child(
         session_id: SessionId,
         conversation_id: AIConversationId,
+        requested_content: RequestedSessionContent,
         resources: TerminalViewResources,
         initial_size: Vector2F,
         window_id: WindowId,
@@ -173,11 +187,39 @@ impl TerminalManager {
         terminal_manager.connect_session(
             session_id,
             SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+            requested_content,
             ctx,
         );
         TerminalManagerInit {
             manager: terminal_manager,
             view: terminal_view,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn connect_to_semantic_session(
+        &mut self,
+        session_id: SessionId,
+        execution_identity: ExecutionIdentity,
+        ctx: &mut AppContext,
+    ) -> bool {
+        match self.network_state {
+            NetworkState::Idle => {
+                self.connect_session(
+                    session_id,
+                    SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                    RequestedSessionContent::semantic_v1(execution_identity),
+                    ctx,
+                );
+                true
+            }
+            NetworkState::Connecting => {
+                log::warn!(
+                    "connect_to_semantic_session called while already connecting to shared session"
+                );
+                false
+            }
+            NetworkState::Active(_) => false,
         }
     }
 
@@ -361,6 +403,7 @@ impl TerminalManager {
                 channel_event_proxy,
             },
             current_network: Arc::new(FairMutex::new(None)),
+            semantic_transcript: Arc::new(FairMutex::new(SemanticTranscript::default())),
             viewer_remote_update_guard: RemoteUpdateGuard::new(),
             outbound_handlers_registered: false,
             orchestration_viewer_model: Arc::new(FairMutex::new(None)),
@@ -383,7 +426,7 @@ impl TerminalManager {
     /// that only discover the session is ambient at `JoinedSuccessfully` (e.g. a
     /// raw `shared_session` link) pass `false` and get the model created lazily
     /// then via `TerminalView::begin_viewing_ambient_session`.
-    #[allow(clippy::new_ret_no_self)]
+    #[allow(clippy::new_ret_no_self, dead_code)]
     pub fn new(
         session_id: SessionId,
         resources: TerminalViewResources,
@@ -391,6 +434,29 @@ impl TerminalManager {
         window_id: WindowId,
         enable_orchestration_polling: bool,
         is_ambient_agent: bool,
+        ctx: &mut AppContext,
+    ) -> TerminalManagerInit {
+        Self::new_with_content(
+            session_id,
+            resources,
+            initial_size,
+            window_id,
+            enable_orchestration_polling,
+            is_ambient_agent,
+            RequestedSessionContent::FullTerminal,
+            ctx,
+        )
+    }
+
+    #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
+    pub fn new_with_content(
+        session_id: SessionId,
+        resources: TerminalViewResources,
+        initial_size: Vector2F,
+        window_id: WindowId,
+        enable_orchestration_polling: bool,
+        is_ambient_agent: bool,
+        requested_content: RequestedSessionContent,
         ctx: &mut AppContext,
     ) -> TerminalManagerInit {
         let TerminalManagerInit {
@@ -409,6 +475,7 @@ impl TerminalManager {
         terminal_manager.connect_session(
             session_id,
             SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+            requested_content,
             ctx,
         );
 
@@ -448,10 +515,26 @@ impl TerminalManager {
     /// Local-to-cloud handoff panes set this to `true` so the pre-populated
     /// forked conversation is not replaced by the cloud session's replay
     /// scrollback.
+    #[allow(dead_code)]
     pub fn connect_to_session(
         &mut self,
         session_id: SessionId,
         append_followup_scrollback: bool,
+        ctx: &mut AppContext,
+    ) -> bool {
+        self.connect_to_session_with_content(
+            session_id,
+            append_followup_scrollback,
+            RequestedSessionContent::FullTerminal,
+            ctx,
+        )
+    }
+
+    pub fn connect_to_session_with_content(
+        &mut self,
+        session_id: SessionId,
+        append_followup_scrollback: bool,
+        requested_content: RequestedSessionContent,
         ctx: &mut AppContext,
     ) -> bool {
         let load_mode = if append_followup_scrollback {
@@ -461,7 +544,7 @@ impl TerminalManager {
         };
         match self.network_state {
             NetworkState::Idle => {
-                self.connect_session(session_id, load_mode, ctx);
+                self.connect_session(session_id, load_mode, requested_content, ctx);
                 true
             }
             NetworkState::Connecting => {
@@ -472,9 +555,23 @@ impl TerminalManager {
         }
     }
 
+    #[allow(dead_code)]
     pub fn attach_execution_session(
         &mut self,
         session_id: SessionId,
+        ctx: &mut AppContext,
+    ) -> bool {
+        self.attach_execution_session_with_content(
+            session_id,
+            RequestedSessionContent::FullTerminal,
+            ctx,
+        )
+    }
+
+    pub fn attach_execution_session_with_content(
+        &mut self,
+        session_id: SessionId,
+        requested_content: RequestedSessionContent,
         ctx: &mut AppContext,
     ) -> bool {
         match std::mem::replace(&mut self.network_state, NetworkState::Connecting) {
@@ -502,6 +599,7 @@ impl TerminalManager {
         self.connect_session(
             session_id,
             SharedSessionInitialLoadMode::AppendFollowupScrollback,
+            requested_content,
             ctx,
         );
         self.start_cloud_mode_setup_command_tracking();
@@ -523,6 +621,7 @@ impl TerminalManager {
         &mut self,
         session_id: SessionId,
         initial_load_mode: SharedSessionInitialLoadMode,
+        content: RequestedSessionContent,
         ctx: &mut AppContext,
     ) {
         match std::mem::replace(&mut self.network_state, NetworkState::Connecting) {
@@ -557,6 +656,7 @@ impl TerminalManager {
                 write_to_pty_events_rx,
                 initial_load_mode,
                 self.viewer_remote_update_guard.clone(),
+                content,
                 ctx,
             )
         });
@@ -567,6 +667,7 @@ impl TerminalManager {
             &self.view,
             self.model.clone(),
             self.current_network.clone(),
+            self.semantic_transcript.clone(),
             self.network_resources.prompt_type.clone(),
             self.viewer_remote_update_guard.clone(),
             self.orchestration_viewer_model.clone(),
@@ -811,6 +912,7 @@ impl TerminalManager {
         view: &ViewHandle<TerminalView>,
         model: Arc<FairMutex<TerminalModel>>,
         current_network: Arc<FairMutex<Option<ModelHandle<Network>>>>,
+        semantic_transcript: Arc<FairMutex<SemanticTranscript>>,
         prompt_type: ModelHandle<PromptType>,
         viewer_remote_update_guard: RemoteUpdateGuard,
         orchestration_viewer_model: Arc<FairMutex<Option<ModelHandle<OrchestrationViewerModel>>>>,
@@ -824,6 +926,7 @@ impl TerminalManager {
 
         ctx.subscribe_to_model(network, move |network, event, ctx| match event {
             NetworkEvent::JoinedSuccessfully {
+                is_semantic,
                 active_prompt,
                 viewer_id,
                 viewer_firebase_uid,
@@ -832,42 +935,56 @@ impl TerminalManager {
                 universal_developer_input_context,
                 source,
             } => {
-                model.lock().set_shared_session_source(source.clone());
+                model
+                    .lock()
+                    .set_shared_session_source(source.as_ref().clone());
 
-                Self::handle_active_prompt_update(
-                    model.clone(),
-                    prompt_type.clone(),
-                    weak_view_handle.clone(),
-                    active_prompt,
-                    ctx,
-                );
-
-                // Apply the universal developer input context if present.
-                let active_remote_update = viewer_remote_update_guard.start_remote_update();
-                if let Some(universal_developer_input_context) = universal_developer_input_context {
-                    if let Some(ref model) = universal_developer_input_context.selected_model {
-                        Self::handle_selected_agent_model_update(&weak_view_handle, model, &active_remote_update, ctx);
-                    }
-                    if let Some(ref input_mode) = universal_developer_input_context.input_mode {
-                        Self::handle_input_mode_update(&weak_view_handle, input_mode, &active_remote_update, ctx);
-                    }
-                    apply_cli_agent_state_update(
-                        &weak_view_handle,
-                        &universal_developer_input_context.cli_agent_session,
-                        &active_remote_update,
+                if !*is_semantic {
+                    Self::handle_active_prompt_update(
+                        model.clone(),
+                        prompt_type.clone(),
+                        weak_view_handle.clone(),
+                        active_prompt,
                         ctx,
                     );
-                    if let Some(ref selected_conversation) = universal_developer_input_context.selected_conversation {
-                        Self::handle_selected_conversation_update(
+
+                    let active_remote_update = viewer_remote_update_guard.start_remote_update();
+                    if let Some(universal_developer_input_context) =
+                        universal_developer_input_context
+                    {
+                        if let Some(ref model) = universal_developer_input_context.selected_model {
+                            Self::handle_selected_agent_model_update(
+                                &weak_view_handle,
+                                model,
+                                &active_remote_update,
+                                ctx,
+                            );
+                        }
+                        if let Some(ref input_mode) = universal_developer_input_context.input_mode {
+                            Self::handle_input_mode_update(
+                                &weak_view_handle,
+                                input_mode,
+                                &active_remote_update,
+                                ctx,
+                            );
+                        }
+                        apply_cli_agent_state_update(
                             &weak_view_handle,
-                            selected_conversation,
+                            &universal_developer_input_context.cli_agent_session,
                             &active_remote_update,
                             ctx,
                         );
+                        if let Some(ref selected_conversation) =
+                            universal_developer_input_context.selected_conversation
+                        {
+                            Self::handle_selected_conversation_update(
+                                &weak_view_handle,
+                                selected_conversation,
+                                &active_remote_update,
+                                ctx,
+                            );
+                        }
                     }
-                    // TODO(roland): we do not apply universal_developer_input_context.long_running_command_agent_interaction here
-                    // because the block it should apply to won't exist yet, until the `OrderedTerminalEvents` that come after are processed.
-                    // We should try to apply it after catching up to the latest state.
                 }
                 let Some(view) = weak_view_handle.upgrade(ctx) else {
                     return;
@@ -930,15 +1047,26 @@ impl TerminalManager {
                         }
                     }
 
-                    terminal_view.on_session_share_joined(
-                        viewer_id.clone(),
-                        *viewer_firebase_uid,
-                        input_replica_id.clone(),
-                        participant_list.clone(),
-                        session_id,
-                        source.source_type.clone(),
-                        ctx,
-                    );
+                    if *is_semantic {
+                        terminal_view.on_semantic_session_share_joined(
+                            viewer_id.clone(),
+                            *viewer_firebase_uid,
+                            participant_list.clone(),
+                            session_id,
+                            source.source_type.clone(),
+                            ctx,
+                        );
+                    } else {
+                        terminal_view.on_session_share_joined(
+                            viewer_id.clone(),
+                            *viewer_firebase_uid,
+                            input_replica_id.clone(),
+                            participant_list.clone(),
+                            session_id,
+                            source.source_type.clone(),
+                            ctx,
+                        );
+                    }
                 });
 
                 #[cfg(target_family = "wasm")]
@@ -984,6 +1112,47 @@ impl TerminalManager {
                             );
                         }
                     }
+                });
+            }
+            NetworkEvent::SemanticMutationApplied(mutation) => {
+                if let Err(error) = semantic_transcript.lock().apply(mutation) {
+                    log::warn!("Failed to project semantic mutation: {error}");
+                    network.update(ctx, |network, _| network.close_without_reconnection());
+                    if let Some(view) = weak_view_handle.upgrade(ctx) {
+                        view.update(ctx, |terminal_view, ctx| {
+                            terminal_view.show_persistent_toast(
+                                "The semantic session could not be projected. Please reconnect."
+                                    .to_owned(),
+                                ToastFlavor::Error,
+                                ctx,
+                            );
+                        });
+                    }
+                }
+            }
+            NetworkEvent::SemanticResyncRequired { reason } => {
+                log::warn!("Semantic shared session requires resync: {reason:?}");
+                let Some(view) = weak_view_handle.upgrade(ctx) else {
+                    return;
+                };
+                let is_ambient_agent = model.lock().is_shared_ambient_agent_session();
+                if !Self::handle_viewer_session_end(
+                    &view,
+                    model.clone(),
+                    &current_network,
+                    &network,
+                    &orchestration_viewer_model,
+                    is_ambient_agent,
+                    ctx,
+                ) {
+                    return;
+                }
+                view.update(ctx, |terminal_view, ctx| {
+                    terminal_view.show_persistent_toast(
+                        "The semantic session fell out of sync. Please reconnect.".to_string(),
+                        ToastFlavor::Error,
+                        ctx,
+                    );
                 });
             }
             NetworkEvent::ViewerRemoved { reason } => {

--- a/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
@@ -94,6 +94,7 @@ fn build_manager_with_registered_ovm(app: &mut App) -> (TerminalManager, Ambient
             channel_event_proxy,
         },
         current_network: Arc::new(FairMutex::new(None)),
+        semantic_transcript: Arc::new(FairMutex::new(SemanticTranscript::default())),
         viewer_remote_update_guard: RemoteUpdateGuard::new(),
         outbound_handlers_registered: false,
         orchestration_viewer_model: Arc::new(FairMutex::new(Some(ovm_handle))),

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1784,6 +1784,7 @@ pub enum Event {
     StartSharingCurrentSession {
         scrollback_type: SharedSessionScrollbackType,
         source: SharedSessionSource,
+        content: warp_semantic_session::RequestedSessionContent,
     },
     EstablishedSharedSession {
         session_id: session_sharing_protocol::common::SessionId,
@@ -2023,6 +2024,7 @@ pub enum Event {
     EnsureSharedSessionViewerChildPane {
         conversation_id: AIConversationId,
         session_id: session_sharing_protocol::common::SessionId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
     },
     /// Unified-stack counterpart to [`Self::EnsureSharedSessionViewerChildPane`].
     /// Carries the fetched task snapshot so pane construction uses the same

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -113,22 +113,37 @@ pub fn wire_ambient_agent_session_events(
                 return;
             };
             match event {
-                AmbientAgentViewModelEvent::SessionReady { session_id } => {
+                AmbientAgentViewModelEvent::SessionReady {
+                    session_id,
+                    requested_content,
+                } => {
                     // Local-to-cloud handoff panes pre-populate the forked
                     // conversation on chip click. Use append-mode scrollback
                     // + replay suppression so the cloud agent's replay doesn't
                     // duplicate the blocks we already have.
                     let append_followup_scrollback =
                         view_model.as_ref(ctx).is_local_to_cloud_handoff();
-                    if manager.connect_to_session(*session_id, append_followup_scrollback, ctx) {
+                    if manager.connect_to_session_with_content(
+                        *session_id,
+                        append_followup_scrollback,
+                        requested_content.clone(),
+                        ctx,
+                    ) {
                         manager.start_cloud_mode_setup_command_tracking();
                     }
                 }
-                AmbientAgentViewModelEvent::ExecutionSessionReady { session_id } => {
+                AmbientAgentViewModelEvent::ExecutionSessionReady {
+                    session_id,
+                    requested_content,
+                } => {
                     // Returns false when the viewer is mid-connect, in which case the pane stays
                     // on its current session. Recoverable, but silent otherwise: the attach is
                     // driven by an event, so the caller that requested it has already returned.
-                    if !manager.attach_execution_session(*session_id, ctx) {
+                    if !manager.attach_execution_session_with_content(
+                        *session_id,
+                        requested_content.clone(),
+                        ctx,
+                    ) {
                         log::warn!(
                             "Ambient viewer could not re-attach to execution session {session_id}"
                         );

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -902,6 +902,7 @@ impl AmbientAgentViewModel {
     pub fn attach_execution_session(
         &mut self,
         session_id: SessionId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
         ctx: &mut ModelContext<Self>,
     ) {
         self.stop_progress_timer();
@@ -909,7 +910,10 @@ impl AmbientAgentViewModel {
         self.last_ended_execution_session_id = None;
         self.pending_followup_prompt = None;
         self.status = Status::AgentRunning;
-        ctx.emit(AmbientAgentViewModelEvent::ExecutionSessionReady { session_id });
+        ctx.emit(AmbientAgentViewModelEvent::ExecutionSessionReady {
+            session_id,
+            requested_content,
+        });
     }
 
     pub fn submit_cloud_followup(&mut self, prompt: String, ctx: &mut ModelContext<Self>) {
@@ -1261,12 +1265,14 @@ impl AmbientAgentViewModel {
                 if let Some(session_id) = session_join_info.session_id {
                     self.stop_progress_timer();
                     let event_session_id = session_id;
+                    let requested_content = session_join_info.requested_content;
                     let event = match &self.status {
                         Status::WaitingForSession {
                             kind: SessionStartupKind::InitialRun,
                             ..
                         } => AmbientAgentViewModelEvent::SessionReady {
                             session_id: event_session_id,
+                            requested_content,
                         },
                         Status::WaitingForSession {
                             kind: SessionStartupKind::Followup,
@@ -1275,6 +1281,7 @@ impl AmbientAgentViewModel {
                         | Status::AgentRunning => {
                             AmbientAgentViewModelEvent::ExecutionSessionReady {
                                 session_id: event_session_id,
+                                requested_content,
                             }
                         }
                         Status::Setup
@@ -1549,10 +1556,12 @@ pub enum AmbientAgentViewModelEvent {
     /// The ambient agent has started sharing its session.
     SessionReady {
         session_id: SessionId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
     },
     /// An execution has started sharing a session for an already-canonical ambient pane.
     ExecutionSessionReady {
         session_id: SessionId,
+        requested_content: warp_semantic_session::RequestedSessionContent,
     },
     /// An environment was selected.
     EnvironmentSelected,

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -218,6 +218,7 @@ fn ambient_agent_task(
         agent_config_snapshot: None,
         artifacts: vec![],
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
 }

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -43,6 +43,7 @@ fn task_with_run_time_and_credits() -> AmbientAgentTask {
         artifacts: vec![],
         is_sandbox_running: false,
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
 }

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -75,6 +75,25 @@ impl TerminalView {
         self.shared_session.as_ref().map(|s| s.kind())
     }
 
+    pub fn attempt_to_share_semantic_session(
+        &mut self,
+        execution_identity: session_sharing_protocol::common::ExecutionIdentity,
+        source: SharedSessionSource,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.model
+            .lock()
+            .set_shared_session_status(SharedSessionStatus::SharePending);
+        self.notify_shared_session_link_changed(ctx);
+        ctx.emit(Event::StartSharingCurrentSession {
+            scrollback_type: SharedSessionScrollbackType::None,
+            source,
+            content: warp_semantic_session::RequestedSessionContent::semantic_v1(
+                execution_identity,
+            ),
+        });
+    }
+
     pub fn sharer_session_kind_mut(&mut self) -> Option<&mut Kind> {
         self.shared_session.as_mut().map(|s| s.kind_mut())
     }
@@ -622,10 +641,12 @@ impl TerminalView {
             .set_shared_session_status(SharedSessionStatus::SharePending);
         self.notify_shared_session_link_changed(ctx);
         log::info!("Emitting request to start sharing current session");
+        let content = source.requested_content().clone();
 
         ctx.emit(Event::StartSharingCurrentSession {
             scrollback_type,
             source,
+            content,
         });
         if let Some(action_source) = action_source {
             send_telemetry_from_ctx!(
@@ -751,6 +772,48 @@ impl TerminalView {
         source_type: SessionSourceType,
         ctx: &mut ViewContext<Self>,
     ) {
+        self.on_session_share_joined_internal(
+            viewer_id,
+            firebase_uid,
+            Some(input_replica_id),
+            participant_list,
+            session_id,
+            source_type,
+            ctx,
+        );
+    }
+
+    pub fn on_semantic_session_share_joined(
+        &mut self,
+        viewer_id: ParticipantId,
+        firebase_uid: UserUid,
+        participant_list: Box<ParticipantList>,
+        session_id: SessionId,
+        source_type: SessionSourceType,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.on_session_share_joined_internal(
+            viewer_id,
+            firebase_uid,
+            None,
+            participant_list,
+            session_id,
+            source_type,
+            ctx,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn on_session_share_joined_internal(
+        &mut self,
+        viewer_id: ParticipantId,
+        firebase_uid: UserUid,
+        input_replica_id: Option<ReplicaId>,
+        participant_list: Box<ParticipantList>,
+        session_id: SessionId,
+        source_type: SessionSourceType,
+        ctx: &mut ViewContext<Self>,
+    ) {
         let started_at = Local::now();
         let self_handle = ctx.handle();
         let adapter = Adapter::new_for_viewer(
@@ -773,33 +836,33 @@ impl TerminalView {
             ctx,
         );
 
-        self.input.update(ctx, |input, ctx| {
-            input.on_session_share_joined(input_replica_id, presence_manager, ctx);
-        });
-
-        // Mark this terminal as a viewer for chips and AI context menu once on join
-        let is_ambient = self.is_ambient_agent_session(ctx);
-        self.input().update(ctx, |input, ctx| {
-            input
-                .prompt_render_helper
-                .prompt_view()
-                .update(ctx, |prompt_display, ctx| {
-                    prompt_display.update_shared_session_viewer_status(true, ctx);
-                });
-
-            input.editor().update(ctx, |editor, ctx| {
-                if let Some(ai_context_menu) = editor.ai_context_menu() {
-                    ai_context_menu.update(ctx, |menu, ctx| {
-                        menu.set_is_shared_session_viewer(true, ctx);
-                        menu.set_is_in_ambient_agent(is_ambient, ctx);
-                    });
-                }
+        if let Some(input_replica_id) = input_replica_id {
+            self.input.update(ctx, |input, ctx| {
+                input.on_session_share_joined(input_replica_id, presence_manager, ctx);
             });
-        });
 
-        // If viewer joined as an executor, make sure the view state is updated.
-        if let Some(role) = role {
-            self.on_self_role_updated(role, ctx);
+            let is_ambient = self.is_ambient_agent_session(ctx);
+            self.input().update(ctx, |input, ctx| {
+                input
+                    .prompt_render_helper
+                    .prompt_view()
+                    .update(ctx, |prompt_display, ctx| {
+                        prompt_display.update_shared_session_viewer_status(true, ctx);
+                    });
+
+                input.editor().update(ctx, |editor, ctx| {
+                    if let Some(ai_context_menu) = editor.ai_context_menu() {
+                        ai_context_menu.update(ctx, |menu, ctx| {
+                            menu.set_is_shared_session_viewer(true, ctx);
+                            menu.set_is_in_ambient_agent(is_ambient, ctx);
+                        });
+                    }
+                });
+            });
+
+            if let Some(role) = role {
+                self.on_self_role_updated(role, ctx);
+            }
         }
 
         self.pane_configuration.update(ctx, |pane_config, ctx| {

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -42,6 +42,63 @@ use crate::terminal::view::{AIQueryRouting, TerminalAction, resolve_ai_query_rou
 use crate::test_util::add_window_with_terminal;
 use crate::test_util::terminal::initialize_app_for_terminal_view;
 use crate::{FeatureFlag, assert_lines_approx_eq};
+#[test]
+fn attempt_to_share_session_uses_trusted_source_content_only() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let emitted_content = Rc::new(RefCell::new(Vec::new()));
+        let emitted_content_for_subscription = emitted_content.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let crate::terminal::view::Event::StartSharingCurrentSession {
+                    content, ..
+                } = event
+                {
+                    emitted_content_for_subscription
+                        .borrow_mut()
+                        .push(content.clone());
+                }
+            });
+        });
+
+        let semantic_content = warp_semantic_session::RequestedSessionContent::semantic_v1(
+            session_sharing_protocol::common::ExecutionIdentity {
+                conversation_id: "factory-conversation".to_string(),
+                execution_id: "factory-execution".to_string(),
+                run_id: Some("factory-run".to_string()),
+                request_id: Some("factory-request".to_string()),
+            },
+        );
+        terminal.update(&mut app, |view, ctx| {
+            view.attempt_to_share_session(
+                SharedSessionScrollbackType::All,
+                None,
+                SharedSessionSource::ambient_agent_with_content(
+                    Some("factory-run".to_string()),
+                    semantic_content.clone(),
+                ),
+                true,
+                ctx,
+            );
+            view.attempt_to_share_session(
+                SharedSessionScrollbackType::All,
+                None,
+                SharedSessionSource::user(None),
+                true,
+                ctx,
+            );
+        });
+
+        assert_eq!(
+            emitted_content.borrow().as_slice(),
+            &[
+                semantic_content,
+                warp_semantic_session::RequestedSessionContent::FullTerminal,
+            ]
+        );
+    });
+}
 
 #[test]
 fn test_prompt_context_menu_items_shared_session_viewer_no_edit_prompt() {
@@ -707,6 +764,7 @@ fn create_cloud_mode_task_for_user(creator_uid: &str) -> AmbientAgentTask {
         agent_config_snapshot: None,
         artifacts: vec![],
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
 }
@@ -1056,6 +1114,8 @@ fn test_cloud_cloud_handoff_session_join_keeps_closed_details_panel_hidden() {
             view.handle_ambient_agent_event(
                 &crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent::ExecutionSessionReady {
                     session_id: SessionId::new(),
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 },
                 ctx,
             );
@@ -1120,6 +1180,8 @@ fn test_cloud_cloud_handoff_session_join_respects_details_panel_closed_after_fol
             view.handle_ambient_agent_event(
                 &crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent::ExecutionSessionReady {
                     session_id: SessionId::new(),
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 },
                 ctx,
             );
@@ -2361,6 +2423,8 @@ fn test_non_owned_tombstone_is_removed_for_followup_and_reinserted_after_complet
             view.handle_ambient_agent_event(
                 &crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent::ExecutionSessionReady {
                     session_id: SessionId::new(),
+                    requested_content:
+                        warp_semantic_session::RequestedSessionContent::FullTerminal,
                 },
                 ctx,
             );

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -135,6 +135,7 @@ fn owned_resumable_oz_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
         agent_config_snapshot: None,
         artifacts: vec![],
         last_event_sequence: None,
+        factory_semantic_session: None,
         children: vec![],
     }
 }

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use session_sharing_protocol::common::SessionId;
 use ui_components::lightbox;
+use warp_semantic_session::RequestedSessionContent;
 use warp_util::path::LineAndColumnArg;
 use warpui::accessibility::AccessibilityVerbosity;
 use warpui::geometry::rect::RectF;
@@ -815,6 +816,7 @@ pub enum WorkspaceAction {
     OpenOrAttachAmbientAgentConversation {
         session_id: SessionId,
         task_id: AmbientAgentTaskId,
+        requested_content: RequestedSessionContent,
     },
     /// Load cloud conversation data into a transcript viewer.
     /// Used when CloudConversations is enabled and the sandbox is not running.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -4356,8 +4356,23 @@ impl Workspace {
         is_ambient_agent: bool,
         ctx: &mut ViewContext<Self>,
     ) {
+        self.add_tab_for_joining_shared_session_with_content(
+            session_id,
+            is_ambient_agent,
+            warp_semantic_session::RequestedSessionContent::FullTerminal,
+            ctx,
+        );
+    }
+
+    fn add_tab_for_joining_shared_session_with_content(
+        &mut self,
+        session_id: SharedSessionId,
+        is_ambient_agent: bool,
+        requested_content: warp_semantic_session::RequestedSessionContent,
+        ctx: &mut ViewContext<Self>,
+    ) {
         let new_pane_group = ctx.add_typed_action_view(|ctx| {
-            PaneGroup::new_for_shared_session_viewer(
+            PaneGroup::new_for_shared_session_viewer_with_content(
                 session_id,
                 self.tips_completed.clone(),
                 self.user_default_shell_unsupported_banner_model_handle
@@ -4365,6 +4380,7 @@ impl Workspace {
                 self.server_api.clone(),
                 self.model_event_sender.clone(),
                 is_ambient_agent,
+                requested_content,
                 ctx,
             )
         });
@@ -25486,6 +25502,7 @@ impl TypedActionView for Workspace {
             OpenOrAttachAmbientAgentConversation {
                 session_id,
                 task_id,
+                requested_content,
             } => {
                 // An existing pane for this run is only reusable if it can host the live session.
                 // A read-only pane (e.g. a conversation transcript viewer opened earlier for the
@@ -25503,6 +25520,7 @@ impl TypedActionView for Workspace {
                         pane_group.attach_execution_session_to_ambient_pane(
                             locator.pane_id,
                             *session_id,
+                            requested_content.clone(),
                             ctx,
                         )
                     });
@@ -25514,7 +25532,12 @@ impl TypedActionView for Workspace {
                 match attached_locator {
                     Some(locator) => self.focus_pane(locator, ctx),
                     // Attaching to a known ambient run: build the pane in ambient mode.
-                    None => self.add_tab_for_joining_shared_session(*session_id, true, ctx),
+                    None => self.add_tab_for_joining_shared_session_with_content(
+                        *session_id,
+                        true,
+                        requested_content.clone(),
+                        ctx,
+                    ),
                 }
             }
             OpenConversationTranscriptViewer {

--- a/crates/warp_semantic_session/Cargo.toml
+++ b/crates/warp_semantic_session/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "warp_semantic_session"
+version = "0.1.0"
+edition = "2024"
+authors.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+prost.workspace = true
+prost-types.workspace = true
+session-sharing-protocol.workspace = true
+thiserror.workspace = true
+warp_conversation_mutation_api.workspace = true
+warp_multi_agent_api.workspace = true
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+uuid.workspace = true

--- a/crates/warp_semantic_session/src/consumer.rs
+++ b/crates/warp_semantic_session/src/consumer.rs
@@ -1,0 +1,281 @@
+use std::collections::{BTreeMap, HashMap};
+
+use prost::Message;
+use session_sharing_protocol::common::{
+    ExecutionIdentity, OrderedTerminalEvent, OrderedTerminalEventType, SemanticCursor,
+    SemanticResyncReason, SessionContentMode, SessionId,
+};
+use warp_conversation_mutation_api::{
+    ConversationMutation, SchemaVersion, content_mutation, conversation_mutation,
+};
+
+use crate::validation::{ConversationMutationValidationError, validate_mutation_timestamps};
+
+const MAX_SEEN_MUTATIONS: usize = 4_096;
+const MAX_SEEN_MUTATION_BYTES: usize = 16 * 1024 * 1024;
+const MAX_TRACKED_CONTENTS: usize = 4_096;
+
+#[derive(Debug, PartialEq)]
+pub enum ConsumeOutcome {
+    Applied(Box<ConversationMutation>),
+    Duplicate,
+    ResyncRequired(SemanticResyncReason),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SemanticConsumerError {
+    #[error("semantic consumer received a terminal event")]
+    UnexpectedTerminalEvent,
+    #[error("failed to decode conversation mutation: {0}")]
+    Decode(#[from] prost::DecodeError),
+    #[error("conversation mutation is missing identity")]
+    MissingIdentity,
+    #[error("conversation mutation is missing a payload")]
+    MissingMutation,
+    #[error("conversation mutation is missing a mutation ID")]
+    MissingMutationId,
+    #[error("conversation mutation has invalid canonical timestamps: {0}")]
+    InvalidTimestamp(#[from] ConversationMutationValidationError),
+}
+
+struct SeenMutation {
+    mutation_id: String,
+    bytes: Vec<u8>,
+}
+
+pub struct SemanticConsumer {
+    session_id: SessionId,
+    execution_identity: ExecutionIdentity,
+    schema_version: u32,
+    next_sequence: u64,
+    seen_mutations: BTreeMap<u64, SeenMutation>,
+    seen_mutation_ids: HashMap<String, u64>,
+    seen_mutation_bytes: usize,
+    content_positions: HashMap<String, (String, u32)>,
+    next_content_indexes: HashMap<String, u32>,
+    next_delta_indexes: HashMap<String, u64>,
+}
+
+impl SemanticConsumer {
+    pub fn new(
+        session_id: SessionId,
+        execution_identity: ExecutionIdentity,
+        schema_version: u32,
+    ) -> Self {
+        Self {
+            session_id,
+            execution_identity,
+            schema_version,
+            next_sequence: 1,
+            seen_mutations: BTreeMap::new(),
+            seen_mutation_ids: HashMap::new(),
+            seen_mutation_bytes: 0,
+            content_positions: HashMap::new(),
+            next_content_indexes: HashMap::new(),
+            next_delta_indexes: HashMap::new(),
+        }
+    }
+
+    pub fn cursor(&self) -> Option<SemanticCursor> {
+        (self.next_sequence > 1).then(|| SemanticCursor {
+            session_id: self.session_id,
+            conversation_id: self.execution_identity.conversation_id.clone(),
+            execution_id: self.execution_identity.execution_id.clone(),
+            content_mode: SessionContentMode::SemanticConversationOnly,
+            schema_version: self.schema_version,
+            mutation_sequence: self.next_sequence - 1,
+        })
+    }
+
+    pub fn consume(
+        &mut self,
+        event: OrderedTerminalEvent,
+    ) -> Result<ConsumeOutcome, SemanticConsumerError> {
+        let OrderedTerminalEventType::SemanticConversationMutation { cursor, mutation } =
+            event.event_type
+        else {
+            return Err(SemanticConsumerError::UnexpectedTerminalEvent);
+        };
+        self.consume_mutation(cursor, &mutation)
+    }
+
+    pub fn consume_mutation(
+        &mut self,
+        cursor: SemanticCursor,
+        bytes: &[u8],
+    ) -> Result<ConsumeOutcome, SemanticConsumerError> {
+        if cursor.session_id != self.session_id {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::CursorSessionMismatch,
+            ));
+        }
+        if cursor.conversation_id != self.execution_identity.conversation_id {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::ExecutionChanged,
+            ));
+        }
+        if cursor.execution_id != self.execution_identity.execution_id {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::CursorExecutionMismatch,
+            ));
+        }
+        if cursor.content_mode != SessionContentMode::SemanticConversationOnly {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::SessionStateUnavailable,
+            ));
+        }
+        if cursor.schema_version != self.schema_version {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::SchemaMismatch {
+                    expected: self.schema_version,
+                    received: cursor.schema_version,
+                },
+            ));
+        }
+
+        let mutation = ConversationMutation::decode(bytes)?;
+        let identity = mutation
+            .identity
+            .as_ref()
+            .ok_or(SemanticConsumerError::MissingIdentity)?;
+        if mutation.mutation.is_none() {
+            return Err(SemanticConsumerError::MissingMutation);
+        }
+        if identity.mutation_id.is_empty() {
+            return Err(SemanticConsumerError::MissingMutationId);
+        }
+        validate_mutation_timestamps(&mutation)?;
+        if mutation.schema_version != SchemaVersion::V1 as i32
+            || mutation.schema_version as u32 != self.schema_version
+        {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::SchemaMismatch {
+                    expected: self.schema_version,
+                    received: mutation.schema_version.max(0) as u32,
+                },
+            ));
+        }
+        if identity.conversation_id != self.execution_identity.conversation_id
+            || identity.execution_id != self.execution_identity.execution_id
+        {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::ExecutionChanged,
+            ));
+        }
+        if identity.sequence != cursor.mutation_sequence {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::ReplayGap {
+                    expected_sequence: cursor.mutation_sequence,
+                    next_available_sequence: identity.sequence,
+                },
+            ));
+        }
+
+        if identity.sequence < self.next_sequence {
+            let Some(seen) = self.seen_mutations.get(&identity.sequence) else {
+                return Ok(ConsumeOutcome::ResyncRequired(
+                    SemanticResyncReason::CursorExpired,
+                ));
+            };
+            return Ok(
+                if seen.mutation_id == identity.mutation_id && seen.bytes == bytes {
+                    ConsumeOutcome::Duplicate
+                } else {
+                    ConsumeOutcome::ResyncRequired(SemanticResyncReason::ConflictingDuplicate {
+                        mutation_sequence: identity.sequence,
+                    })
+                },
+            );
+        }
+        if identity.sequence > self.next_sequence {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::ReplayGap {
+                    expected_sequence: self.next_sequence,
+                    next_available_sequence: identity.sequence,
+                },
+            ));
+        }
+
+        if self.seen_mutation_ids.contains_key(&identity.mutation_id) {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::ConflictingDuplicate {
+                    mutation_sequence: identity.sequence,
+                },
+            ));
+        }
+        if !self.validate_content_indexes(&mutation) {
+            return Ok(ConsumeOutcome::ResyncRequired(
+                SemanticResyncReason::SessionStateUnavailable,
+            ));
+        }
+        self.seen_mutation_bytes = self.seen_mutation_bytes.saturating_add(bytes.len());
+        self.seen_mutation_ids
+            .insert(identity.mutation_id.clone(), identity.sequence);
+        self.seen_mutations.insert(
+            identity.sequence,
+            SeenMutation {
+                mutation_id: identity.mutation_id.clone(),
+                bytes: bytes.to_vec(),
+            },
+        );
+        while self.seen_mutations.len() > MAX_SEEN_MUTATIONS
+            || self.seen_mutation_bytes > MAX_SEEN_MUTATION_BYTES
+        {
+            let Some((sequence, seen)) = self.seen_mutations.pop_first() else {
+                break;
+            };
+            self.seen_mutation_bytes = self.seen_mutation_bytes.saturating_sub(seen.bytes.len());
+            if self.seen_mutation_ids.get(&seen.mutation_id) == Some(&sequence) {
+                self.seen_mutation_ids.remove(&seen.mutation_id);
+            }
+        }
+        self.next_sequence += 1;
+        Ok(ConsumeOutcome::Applied(Box::new(mutation)))
+    }
+
+    pub fn resync_required(reason: SemanticResyncReason) -> ConsumeOutcome {
+        ConsumeOutcome::ResyncRequired(reason)
+    }
+
+    fn validate_content_indexes(&mut self, mutation: &ConversationMutation) -> bool {
+        let Some(conversation_mutation::Mutation::Content(content)) = mutation.mutation.as_ref()
+        else {
+            return true;
+        };
+        let position = (content.entry_id.clone(), content.content_index);
+        if let Some(existing) = self.content_positions.get(&content.content_id) {
+            if existing != &position {
+                return false;
+            }
+        } else {
+            if self.content_positions.len() >= MAX_TRACKED_CONTENTS {
+                return false;
+            }
+            let next_index = self
+                .next_content_indexes
+                .entry(content.entry_id.clone())
+                .or_default();
+            if content.content_index != *next_index {
+                return false;
+            }
+            *next_index += 1;
+            self.content_positions
+                .insert(content.content_id.clone(), position);
+        }
+        if let Some(content_mutation::Change::Delta(delta)) = content.change.as_ref() {
+            let next_delta = self
+                .next_delta_indexes
+                .entry(content.content_id.clone())
+                .or_default();
+            if delta.delta_index != *next_delta {
+                return false;
+            }
+            *next_delta += 1;
+        }
+        true
+    }
+
+    pub fn retained_mutation_count(&self) -> usize {
+        self.seen_mutations.len()
+    }
+}

--- a/crates/warp_semantic_session/src/lib.rs
+++ b/crates/warp_semantic_session/src/lib.rs
@@ -1,0 +1,125 @@
+mod consumer;
+mod producer;
+mod reducer;
+mod validation;
+
+pub use consumer::{ConsumeOutcome, SemanticConsumer, SemanticConsumerError};
+pub use producer::{SemanticMutationProducer, SemanticProducerError};
+pub use reducer::{
+    SemanticAction, SemanticContent, SemanticEntry, SemanticMedia, SemanticReducerError,
+    SemanticTranscript, semantic_payload_key,
+};
+use session_sharing_protocol::common::{
+    ExecutionIdentity, NegotiatedSessionContent, SemanticCursor, SemanticNegotiationError,
+    SessionContentMode, SessionId, validate_negotiated_content,
+};
+pub use validation::{
+    AcceptedMessageContextError, ConversationMutationValidationError,
+    decode_accepted_message_context, validate_accepted_message_context,
+};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum RequestedSessionContent {
+    #[default]
+    FullTerminal,
+    SemanticConversation {
+        schema_version: u32,
+        execution_identity: ExecutionIdentity,
+        initial_accepted_message_context:
+            Option<Box<warp_conversation_mutation_api::AcceptedMessageContext>>,
+    },
+}
+impl Eq for RequestedSessionContent {}
+
+impl RequestedSessionContent {
+    pub fn semantic_v1(execution_identity: ExecutionIdentity) -> Self {
+        Self::SemanticConversation {
+            schema_version:
+                session_sharing_protocol::common::SEMANTIC_CONVERSATION_SCHEMA_VERSION_V1,
+            execution_identity,
+            initial_accepted_message_context: None,
+        }
+    }
+    pub fn semantic_v1_with_initial_context(
+        execution_identity: ExecutionIdentity,
+        context: warp_conversation_mutation_api::AcceptedMessageContext,
+    ) -> Result<Self, AcceptedMessageContextError> {
+        validate_accepted_message_context(
+            &context,
+            &execution_identity,
+            session_sharing_protocol::common::SEMANTIC_CONVERSATION_SCHEMA_VERSION_V1,
+        )?;
+        Ok(Self::SemanticConversation {
+            schema_version:
+                session_sharing_protocol::common::SEMANTIC_CONVERSATION_SCHEMA_VERSION_V1,
+            execution_identity,
+            initial_accepted_message_context: Some(Box::new(context)),
+        })
+    }
+
+    pub fn content_mode(&self) -> SessionContentMode {
+        match self {
+            Self::FullTerminal => SessionContentMode::FullTerminal,
+            Self::SemanticConversation { .. } => SessionContentMode::SemanticConversationOnly,
+        }
+    }
+
+    pub fn schema_version(&self) -> Option<u32> {
+        match self {
+            Self::FullTerminal => None,
+            Self::SemanticConversation { schema_version, .. } => Some(*schema_version),
+        }
+    }
+
+    pub fn execution_identity(&self) -> Option<&ExecutionIdentity> {
+        match self {
+            Self::FullTerminal => None,
+            Self::SemanticConversation {
+                execution_identity, ..
+            } => Some(execution_identity),
+        }
+    }
+    pub fn initial_accepted_message_context(
+        &self,
+    ) -> Option<&warp_conversation_mutation_api::AcceptedMessageContext> {
+        match self {
+            Self::FullTerminal => None,
+            Self::SemanticConversation {
+                initial_accepted_message_context,
+                ..
+            } => initial_accepted_message_context.as_deref(),
+        }
+    }
+
+    pub fn is_semantic(&self) -> bool {
+        matches!(self, Self::SemanticConversation { .. })
+    }
+
+    pub fn validate_echo(
+        &self,
+        echoed: Option<&NegotiatedSessionContent>,
+    ) -> Result<(), SemanticNegotiationError> {
+        validate_negotiated_content(
+            self.content_mode(),
+            self.schema_version(),
+            self.execution_identity(),
+            echoed,
+        )
+    }
+
+    pub fn cursor(&self, session_id: SessionId, mutation_sequence: u64) -> Option<SemanticCursor> {
+        let execution_identity = self.execution_identity()?;
+        Some(SemanticCursor {
+            session_id,
+            conversation_id: execution_identity.conversation_id.clone(),
+            execution_id: execution_identity.execution_id.clone(),
+            content_mode: self.content_mode(),
+            schema_version: self.schema_version()?,
+            mutation_sequence,
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/warp_semantic_session/src/lib_tests.rs
+++ b/crates/warp_semantic_session/src/lib_tests.rs
@@ -1,0 +1,716 @@
+use prost::Message;
+use session_sharing_protocol::common::{
+    ExecutionIdentity, OrderedTerminalEvent, OrderedTerminalEventType, SemanticCursor,
+    SemanticNegotiationError, SessionId,
+};
+use warp_conversation_mutation_api::{
+    AcceptedMessageContext, Attribution, Author, ContentEncoding, ContentMutation,
+    ConversationMutation, MediaReference, MutationIdentity, Origin, SchemaVersion,
+    SourceDeliveryReference, action_mutation, author, content_mutation, conversation_mutation,
+    entry_mutation, media_reference, origin,
+};
+use warp_multi_agent_api::{
+    ClientAction, Message as AgentMessage, ResponseEvent, Task, client_action, message,
+    response_event,
+};
+
+use super::*;
+
+fn execution() -> ExecutionIdentity {
+    ExecutionIdentity {
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        run_id: Some("run".to_owned()),
+        request_id: Some("request".to_owned()),
+    }
+}
+
+fn timestamp() -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: 1_700_000_000,
+        nanos: 123_456_789,
+    }
+}
+
+fn accepted_context(message_id: &str) -> AcceptedMessageContext {
+    AcceptedMessageContext {
+        schema_version: SchemaVersion::V1 as i32,
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        message_id: message_id.to_owned(),
+        attribution: Some(Attribution {
+            author: Some(Author {
+                id: "factory-user".to_owned(),
+                kind: author::Kind::User as i32,
+                display_name: "Factory User".to_owned(),
+            }),
+            origin: Some(Origin {
+                kind: origin::Kind::Factory as i32,
+                source_id: "factory".to_owned(),
+                subtype: "slack".to_owned(),
+            }),
+            source_delivery: Some(SourceDeliveryReference {
+                delivery_id: "delivery".to_owned(),
+                channel_id: "channel".to_owned(),
+                thread_id: "thread".to_owned(),
+                message_id: "source-message".to_owned(),
+            }),
+        }),
+        media: vec![MediaReference {
+            media_id: "media".to_owned(),
+            kind: media_reference::Kind::File as i32,
+            mime_type: "text/plain".to_owned(),
+            size_bytes: 12,
+            sha256: vec![7; 32],
+            display_name: "input.txt".to_owned(),
+            reference: "artifact".to_owned(),
+        }],
+    }
+}
+
+#[test]
+fn producer_binds_accepted_context_once_to_user_entry() {
+    let context = accepted_context("canonical-user-message");
+    let mut producer = SemanticMutationProducer::new_with_redactor(execution(), ToOwned::to_owned);
+    producer
+        .register_accepted_message_context(context.clone())
+        .unwrap();
+    assert_eq!(
+        producer.register_accepted_message_context(context.clone()),
+        Err(SemanticProducerError::DuplicateAcceptedMessageContext)
+    );
+
+    let response = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::AddMessagesToTask(
+            client_action::AddMessagesToTask {
+                task_id: "task".to_owned(),
+                messages: vec![AgentMessage {
+                    id: "server-user-message".to_owned(),
+                    task_id: "task".to_owned(),
+                    request_id: "request".to_owned(),
+                    timestamp: Some(timestamp()),
+                    message: Some(message::Message::UserQuery(message::UserQuery {
+                        query: "hello".to_owned(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                }],
+            },
+        )),
+    }]);
+    let mutations = producer.normalize(&response).unwrap();
+    assert_eq!(mutations.len(), 3);
+    assert!(mutations.iter().all(|mutation| {
+        mutation.attribution == context.attribution
+            && mutation
+                .occurred_at
+                .as_ref()
+                .is_some_and(super::validation::timestamp_is_valid)
+    }));
+    let Some(conversation_mutation::Mutation::Entry(entry)) = mutations[0].mutation.as_ref() else {
+        panic!("first user mutation should create an entry");
+    };
+    assert_eq!(entry.entry_id, context.message_id);
+    let Some(entry_mutation::Change::Created(created)) = entry.change.as_ref() else {
+        panic!("first user mutation should create an entry");
+    };
+    assert_eq!(created.media, context.media);
+
+    assert_eq!(
+        producer.normalize(&response),
+        Err(SemanticProducerError::MissingAcceptedMessageContext)
+    );
+}
+
+#[test]
+fn producer_rejects_stale_and_wrong_execution_context() {
+    let mut producer = SemanticMutationProducer::new(execution());
+    let mut wrong_execution = accepted_context("wrong-execution");
+    wrong_execution.execution_id = "other".to_owned();
+    assert!(matches!(
+        producer.register_accepted_message_context(wrong_execution),
+        Err(SemanticProducerError::InvalidAcceptedMessageContext(
+            AcceptedMessageContextError::ExecutionMismatch
+        ))
+    ));
+
+    producer
+        .register_accepted_message_context(accepted_context("stale"))
+        .unwrap();
+    let finished = ResponseEvent {
+        r#type: Some(response_event::Type::Finished(
+            response_event::StreamFinished::default(),
+        )),
+    };
+    assert_eq!(
+        producer.normalize(&finished),
+        Err(SemanticProducerError::StaleAcceptedMessageContext)
+    );
+}
+
+#[test]
+fn accepted_context_validation_rejects_invalid_nested_attribution_and_media() {
+    let mut invalid_author = accepted_context("invalid-author");
+    invalid_author
+        .attribution
+        .as_mut()
+        .unwrap()
+        .author
+        .as_mut()
+        .unwrap()
+        .kind = author::Kind::Unspecified as i32;
+    assert_eq!(
+        validate_accepted_message_context(&invalid_author, &execution(), 1),
+        Err(AcceptedMessageContextError::InvalidField(
+            "attribution.author.kind"
+        ))
+    );
+
+    let mut invalid_digest = accepted_context("invalid-digest");
+    invalid_digest.media[0].sha256 = vec![1; 31];
+    assert_eq!(
+        validate_accepted_message_context(&invalid_digest, &execution(), 1),
+        Err(AcceptedMessageContextError::InvalidField("media.sha256"))
+    );
+
+    let mut duplicate_media = accepted_context("duplicate-media");
+    duplicate_media.media.push(duplicate_media.media[0].clone());
+    assert_eq!(
+        validate_accepted_message_context(&duplicate_media, &execution(), 1),
+        Err(AcceptedMessageContextError::DuplicateMedia)
+    );
+}
+
+#[test]
+fn producer_emits_valid_nested_timestamps_and_unique_repeated_state_ids() {
+    let mut producer = SemanticMutationProducer::new(execution());
+    let init = ResponseEvent {
+        r#type: Some(response_event::Type::Init(response_event::StreamInit {
+            conversation_id: "conversation".to_owned(),
+            request_id: "request".to_owned(),
+            run_id: "run".to_owned(),
+        })),
+    };
+    let started = producer.normalize(&init).unwrap().pop().unwrap();
+    super::validation::validate_mutation_timestamps(&started).unwrap();
+
+    let first_finished = ResponseEvent {
+        r#type: Some(response_event::Type::Finished(
+            response_event::StreamFinished::default(),
+        )),
+    };
+    let first = producer.normalize(&first_finished).unwrap().pop().unwrap();
+    let second = producer.normalize(&first_finished).unwrap().pop().unwrap();
+    super::validation::validate_mutation_timestamps(&first).unwrap();
+    super::validation::validate_mutation_timestamps(&second).unwrap();
+    assert_ne!(
+        first.identity.as_ref().unwrap().mutation_id,
+        second.identity.as_ref().unwrap().mutation_id
+    );
+
+    let interruption = producer.interruption(
+        warp_conversation_mutation_api::InterruptionReason::Disconnected,
+        true,
+    );
+    super::validation::validate_mutation_timestamps(&interruption).unwrap();
+    let Some(conversation_mutation::Mutation::Interruption(interruption_payload)) =
+        interruption.mutation.as_ref()
+    else {
+        panic!("expected interruption mutation");
+    };
+    assert_eq!(
+        interruption_payload.interrupted_at,
+        interruption.occurred_at
+    );
+}
+
+#[test]
+fn encoded_context_and_producer_mutation_conform_through_transport() {
+    let context = accepted_context("transport-user");
+    let encoded_context = context.encode_to_vec();
+    let decoded_context =
+        decode_accepted_message_context(&encoded_context, &execution(), 1).unwrap();
+    assert_eq!(decoded_context, context);
+
+    let session_id = SessionId::new();
+    let mut producer = SemanticMutationProducer::new(execution());
+    let init = ResponseEvent {
+        r#type: Some(response_event::Type::Init(response_event::StreamInit {
+            conversation_id: "conversation".to_owned(),
+            request_id: "request".to_owned(),
+            run_id: "run".to_owned(),
+        })),
+    };
+    let mutation = producer.normalize(&init).unwrap().pop().unwrap();
+    let encoded_mutation = mutation.encode_to_vec();
+    let message = session_sharing_protocol::sharer::UpstreamMessage::OrderedTerminalEvent(
+        OrderedTerminalEvent {
+            event_no: 0,
+            event_type: OrderedTerminalEventType::SemanticConversationMutation {
+                cursor: cursor(session_id, 1),
+                mutation: encoded_mutation.clone(),
+            },
+        },
+    );
+    let json = message.to_json().unwrap();
+    let decoded = session_sharing_protocol::sharer::UpstreamMessage::from_json(&json).unwrap();
+    let session_sharing_protocol::sharer::UpstreamMessage::OrderedTerminalEvent(event) = decoded
+    else {
+        panic!("semantic mutation should remain an ordered event");
+    };
+    let mut consumer = SemanticConsumer::new(session_id, execution(), 1);
+    let ConsumeOutcome::Applied(applied) = consumer.consume(event).unwrap() else {
+        panic!("transported semantic mutation should apply");
+    };
+    assert_eq!(applied.encode_to_vec(), encoded_mutation);
+}
+
+#[test]
+fn producer_redacts_visible_content_before_encoding() {
+    let mut producer = SemanticMutationProducer::new_with_redactor(execution(), |text| {
+        text.replace("sk-live-secret", "[REDACTED]")
+    });
+    let response = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::CreateTask(
+            client_action::CreateTask {
+                task: Some(Task {
+                    id: "task".to_owned(),
+                    messages: vec![AgentMessage {
+                        id: "assistant".to_owned(),
+                        task_id: "task".to_owned(),
+                        request_id: "request".to_owned(),
+                        message: Some(message::Message::AgentOutput(message::AgentOutput {
+                            text: "prefix sk-live-secret suffix".to_owned(),
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+            },
+        )),
+    }]);
+
+    let mutations = producer.normalize(&response).unwrap();
+    assert!(mutations.iter().all(|mutation| {
+        !mutation
+            .encode_to_vec()
+            .windows("sk-live-secret".len())
+            .any(|window| window == b"sk-live-secret")
+    }));
+    let attribution = mutations[0].attribution.as_ref().unwrap();
+    assert_eq!(attribution.author.as_ref().unwrap().id, "task");
+    assert_eq!(attribution.origin.as_ref().unwrap().source_id, "run");
+}
+
+#[test]
+fn producer_applies_append_masks_and_derives_stable_mutation_ids() {
+    let mut producer = SemanticMutationProducer::new_with_redactor(execution(), ToOwned::to_owned);
+    let add = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::AddMessagesToTask(
+            client_action::AddMessagesToTask {
+                task_id: "task".to_owned(),
+                messages: vec![AgentMessage {
+                    id: "assistant".to_owned(),
+                    task_id: "task".to_owned(),
+                    request_id: "request".to_owned(),
+                    message: Some(message::Message::AgentOutput(message::AgentOutput {
+                        text: "hello".to_owned(),
+                    })),
+                    ..Default::default()
+                }],
+            },
+        )),
+    }]);
+    let initial = producer.normalize(&add).unwrap();
+    assert_eq!(
+        initial[0].identity.as_ref().unwrap().mutation_id,
+        "execution:00000000000000000001:entry:assistant:created"
+    );
+
+    let append = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::AppendToMessageContent(
+            client_action::AppendToMessageContent {
+                task_id: "task".to_owned(),
+                message: Some(AgentMessage {
+                    id: "assistant".to_owned(),
+                    message: Some(message::Message::AgentOutput(message::AgentOutput {
+                        text: " world".to_owned(),
+                    })),
+                    ..Default::default()
+                }),
+                mask: Some(prost_types::FieldMask {
+                    paths: vec!["agent_output.text".to_owned()],
+                }),
+            },
+        )),
+    }]);
+    let mutations = producer.normalize(&append).unwrap();
+    let identity = mutations[0].identity.as_ref().unwrap();
+    assert!(
+        identity
+            .mutation_id
+            .contains("content:assistant:content:0:delta:1:")
+    );
+}
+
+#[test]
+fn producer_projects_tool_results_without_phantom_result_entries() {
+    let mut producer = SemanticMutationProducer::new_with_redactor(execution(), ToOwned::to_owned);
+    let call = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::AddMessagesToTask(
+            client_action::AddMessagesToTask {
+                task_id: "task".to_owned(),
+                messages: vec![AgentMessage {
+                    id: "tool-entry".to_owned(),
+                    task_id: "task".to_owned(),
+                    message: Some(message::Message::ToolCall(message::ToolCall {
+                        tool_call_id: "tool-call".to_owned(),
+                        tool: Some(message::tool_call::Tool::RunShellCommand(
+                            message::tool_call::RunShellCommand::default(),
+                        )),
+                    })),
+                    ..Default::default()
+                }],
+            },
+        )),
+    }]);
+    producer.normalize(&call).unwrap();
+    let result = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::AddMessagesToTask(
+            client_action::AddMessagesToTask {
+                task_id: "task".to_owned(),
+                messages: vec![AgentMessage {
+                    id: "result-entry".to_owned(),
+                    message: Some(message::Message::ToolCallResult(message::ToolCallResult {
+                        tool_call_id: "tool-call".to_owned(),
+                        result: Some(message::tool_call_result::Result::Cancel(())),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                }],
+            },
+        )),
+    }]);
+
+    let mutations = producer.normalize(&result).unwrap();
+    assert_eq!(mutations.len(), 2);
+    assert!(
+        mutations
+            .iter()
+            .all(|mutation| match mutation.mutation.as_ref() {
+                Some(conversation_mutation::Mutation::Entry(entry)) =>
+                    entry.entry_id == "tool-entry",
+                Some(conversation_mutation::Mutation::Action(action)) => {
+                    action.entry_id == "tool-entry"
+                }
+                _ => false,
+            })
+    );
+}
+
+fn cursor(session_id: SessionId, mutation_sequence: u64) -> SemanticCursor {
+    SemanticCursor {
+        session_id,
+        conversation_id: "conversation".to_owned(),
+        execution_id: "execution".to_owned(),
+        content_mode:
+            session_sharing_protocol::common::SessionContentMode::SemanticConversationOnly,
+        schema_version: 1,
+        mutation_sequence,
+    }
+}
+
+fn mutation(sequence: u64, mutation_id: &str) -> ConversationMutation {
+    ConversationMutation {
+        schema_version: SchemaVersion::V1 as i32,
+        identity: Some(MutationIdentity {
+            conversation_id: "conversation".to_owned(),
+            execution_id: "execution".to_owned(),
+            mutation_id: mutation_id.to_owned(),
+            sequence,
+            run_id: "run".to_owned(),
+            request_id: "request".to_owned(),
+        }),
+        attribution: None,
+        occurred_at: Some(timestamp()),
+        mutation: Some(conversation_mutation::Mutation::Content(ContentMutation {
+            entry_id: "entry".to_owned(),
+            content_id: "content".to_owned(),
+            content_index: 0,
+            change: Some(content_mutation::Change::Delta(content_mutation::Delta {
+                delta_index: sequence - 1,
+                encoding: ContentEncoding::Utf8Text as i32,
+                data: b"text".to_vec(),
+            })),
+        })),
+    }
+}
+
+#[test]
+fn semantic_negotiation_fails_closed_without_echo() {
+    let requested = RequestedSessionContent::semantic_v1(execution());
+    assert_eq!(
+        requested.validate_echo(None),
+        Err(SemanticNegotiationError::MissingServerEcho)
+    );
+}
+
+#[test]
+fn consumer_applies_contiguous_events_and_dedupes_exact_replay() {
+    let session_id = SessionId::new();
+    let mut consumer = SemanticConsumer::new(session_id, execution(), 1);
+    let first = mutation(1, "mutation-1");
+    let event = OrderedTerminalEvent {
+        event_no: 0,
+        event_type: OrderedTerminalEventType::SemanticConversationMutation {
+            cursor: cursor(session_id, 1),
+            mutation: first.encode_to_vec(),
+        },
+    };
+    assert!(matches!(
+        consumer.consume(event.clone()).unwrap(),
+        ConsumeOutcome::Applied(_)
+    ));
+    assert_eq!(consumer.consume(event).unwrap(), ConsumeOutcome::Duplicate);
+    assert_eq!(consumer.cursor().unwrap().mutation_sequence, 1);
+    for sequence in 2..=4 {
+        let event = OrderedTerminalEvent {
+            event_no: (sequence - 1) as usize,
+            event_type: OrderedTerminalEventType::SemanticConversationMutation {
+                cursor: cursor(session_id, sequence),
+                mutation: mutation(sequence, &format!("mutation-{sequence}")).encode_to_vec(),
+            },
+        };
+        assert!(matches!(
+            consumer.consume(event).unwrap(),
+            ConsumeOutcome::Applied(_)
+        ));
+        assert_eq!(consumer.cursor().unwrap().mutation_sequence, sequence);
+    }
+}
+
+#[test]
+fn consumer_requests_resync_for_gap_and_conflicting_duplicate() {
+    let session_id = SessionId::new();
+    let mut consumer = SemanticConsumer::new(session_id, execution(), 1);
+    let gap = mutation(2, "mutation-2");
+    let gap_outcome = consumer
+        .consume_mutation(cursor(session_id, 2), &gap.encode_to_vec())
+        .unwrap();
+    assert!(matches!(
+        gap_outcome,
+        ConsumeOutcome::ResyncRequired(
+            session_sharing_protocol::common::SemanticResyncReason::ReplayGap {
+                expected_sequence: 1,
+                next_available_sequence: 2
+            }
+        )
+    ));
+
+    let first = mutation(1, "mutation-1");
+    consumer
+        .consume_mutation(cursor(session_id, 1), &first.encode_to_vec())
+        .unwrap();
+    let conflicting = mutation(1, "different-id");
+    assert!(matches!(
+        consumer
+            .consume_mutation(cursor(session_id, 1), &conflicting.encode_to_vec(),)
+            .unwrap(),
+        ConsumeOutcome::ResyncRequired(
+            session_sharing_protocol::common::SemanticResyncReason::ConflictingDuplicate {
+                mutation_sequence: 1
+            }
+        )
+    ));
+
+    let mut conflicting_payload = first;
+    let Some(conversation_mutation::Mutation::Content(content)) =
+        conflicting_payload.mutation.as_mut()
+    else {
+        panic!("test mutation should contain content");
+    };
+    let Some(content_mutation::Change::Delta(delta)) = content.change.as_mut() else {
+        panic!("test mutation should contain a delta");
+    };
+    delta.data = b"different".to_vec();
+    assert!(matches!(
+        consumer
+            .consume_mutation(cursor(session_id, 1), &conflicting_payload.encode_to_vec(),)
+            .unwrap(),
+        ConsumeOutcome::ResyncRequired(
+            session_sharing_protocol::common::SemanticResyncReason::ConflictingDuplicate {
+                mutation_sequence: 1
+            }
+        )
+    ));
+}
+
+fn client_actions(actions: Vec<ClientAction>) -> ResponseEvent {
+    ResponseEvent {
+        r#type: Some(response_event::Type::ClientActions(
+            response_event::ClientActions { actions },
+        )),
+    }
+}
+
+#[test]
+fn producer_redacts_tool_input() {
+    let mut producer = SemanticMutationProducer::new(execution());
+    let response = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::AddMessagesToTask(
+            client_action::AddMessagesToTask {
+                task_id: "task".to_owned(),
+                messages: vec![AgentMessage {
+                    id: "tool-entry".to_owned(),
+                    message: Some(message::Message::ToolCall(message::ToolCall {
+                        tool_call_id: "tool-call".to_owned(),
+                        tool: Some(message::tool_call::Tool::RunShellCommand(
+                            message::tool_call::RunShellCommand {
+                                command: "printf super-secret".to_owned(),
+                                ..Default::default()
+                            },
+                        )),
+                    })),
+                    ..Default::default()
+                }],
+            },
+        )),
+    }]);
+
+    let mutations = producer.normalize(&response).unwrap();
+    let action = mutations
+        .iter()
+        .find_map(|mutation| match mutation.mutation.as_ref() {
+            Some(conversation_mutation::Mutation::Action(action)) => Some(action),
+            _ => None,
+        })
+        .expect("tool call produces an action mutation");
+    let Some(action_mutation::Change::Started(started)) = action.change.as_ref() else {
+        panic!("tool action should be started");
+    };
+    assert_eq!(started.input_json, b"{}");
+    assert!(mutations.iter().all(|mutation| {
+        !mutation
+            .encode_to_vec()
+            .windows(12)
+            .any(|w| w == b"super-secret")
+    }));
+}
+
+#[test]
+fn transcript_reducer_applies_entries_and_rejects_delta_gaps() {
+    let mut transcript = SemanticTranscript::default();
+    let created = ConversationMutation {
+        mutation: Some(conversation_mutation::Mutation::Entry(
+            warp_conversation_mutation_api::EntryMutation {
+                entry_id: "assistant".to_owned(),
+                change: Some(entry_mutation::Change::Created(entry_mutation::Created {
+                    kind: warp_conversation_mutation_api::EntryKind::AssistantMessage as i32,
+                    ..Default::default()
+                })),
+            },
+        )),
+        ..Default::default()
+    };
+    transcript.apply(&created).unwrap();
+    let mut content = mutation(1, "content");
+    let Some(conversation_mutation::Mutation::Content(content_mutation)) =
+        content.mutation.as_mut()
+    else {
+        panic!("test mutation should contain content");
+    };
+    content_mutation.entry_id = "assistant".to_owned();
+    transcript.apply(&content).unwrap();
+    assert_eq!(transcript.entries["assistant"].contents[&0].data, b"text");
+
+    let mut gap = content;
+    let Some(conversation_mutation::Mutation::Content(content_mutation)) = gap.mutation.as_mut()
+    else {
+        panic!("test mutation should contain content");
+    };
+    let Some(content_mutation::Change::Delta(delta)) = content_mutation.change.as_mut() else {
+        panic!("test mutation should contain delta");
+    };
+    delta.delta_index = 2;
+    assert_eq!(
+        transcript.apply(&gap),
+        Err(SemanticReducerError::DeltaIndexMismatch)
+    );
+}
+
+#[test]
+fn producer_rejects_unsupported_message_without_raw_fallback() {
+    let mut producer = SemanticMutationProducer::new(execution());
+    let response = client_actions(vec![ClientAction {
+        action: Some(client_action::Action::AddMessagesToTask(
+            client_action::AddMessagesToTask {
+                task_id: "task".to_owned(),
+                messages: vec![AgentMessage {
+                    id: "system".to_owned(),
+                    message: Some(message::Message::SystemQuery(
+                        message::SystemQuery::default(),
+                    )),
+                    ..Default::default()
+                }],
+            },
+        )),
+    }]);
+
+    assert_eq!(
+        producer.normalize(&response),
+        Err(SemanticProducerError::UnsupportedMessage("system_query"))
+    );
+}
+
+#[test]
+fn producer_rejects_stream_identity_mismatch() {
+    let mut producer = SemanticMutationProducer::new(execution());
+    let response = ResponseEvent {
+        r#type: Some(response_event::Type::Init(response_event::StreamInit {
+            conversation_id: "different".to_owned(),
+            request_id: "request".to_owned(),
+            run_id: "run".to_owned(),
+        })),
+    };
+    assert_eq!(
+        producer.normalize(&response),
+        Err(SemanticProducerError::StreamIdentityMismatch)
+    );
+}
+
+#[test]
+fn consumer_requests_resync_for_session_and_execution_mismatch() {
+    let session_id = SessionId::new();
+    let mut consumer = SemanticConsumer::new(session_id, execution(), 1);
+    let first = mutation(1, "mutation-1").encode_to_vec();
+
+    assert!(matches!(
+        consumer
+            .consume_mutation(
+                SemanticCursor {
+                    session_id: SessionId::new(),
+                    ..cursor(session_id, 1)
+                },
+                &first,
+            )
+            .unwrap(),
+        ConsumeOutcome::ResyncRequired(
+            session_sharing_protocol::common::SemanticResyncReason::CursorSessionMismatch
+        )
+    ));
+    assert!(matches!(
+        consumer
+            .consume_mutation(
+                SemanticCursor {
+                    session_id,
+                    execution_id: "different".to_owned(),
+                    ..cursor(session_id, 1)
+                },
+                &first,
+            )
+            .unwrap(),
+        ConsumeOutcome::ResyncRequired(
+            session_sharing_protocol::common::SemanticResyncReason::CursorExecutionMismatch
+        )
+    ));
+}

--- a/crates/warp_semantic_session/src/producer.rs
+++ b/crates/warp_semantic_session/src/producer.rs
@@ -1,0 +1,953 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use warp_conversation_mutation_api::{
+    AcceptedMessageContext, ActionKind, ActionMutation, ActionState, Attribution, Author,
+    ContentEncoding, ContentMutation, ConversationMutation, EntryKind, EntryMutation, EntryState,
+    ExecutionMutation, ExecutionState, InterruptionMutation, InterruptionReason, InterruptionScope,
+    MutationIdentity, Origin, SchemaVersion, action_mutation, content_mutation,
+    conversation_mutation, entry_mutation, execution_mutation,
+};
+use warp_multi_agent_api::{Message, ResponseEvent, client_action, message, response_event};
+
+use crate::validation::{AcceptedMessageContextError, timestamp_is_valid};
+
+const MAX_TRACKED_MESSAGES: usize = 4_096;
+const MAX_PENDING_MESSAGE_CONTEXTS: usize = 64;
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum SemanticProducerError {
+    #[error("response event did not contain a type")]
+    MissingResponseType,
+    #[error("stream identity did not match requested semantic execution")]
+    StreamIdentityMismatch,
+    #[error("client action is not supported by semantic sessions: {0}")]
+    UnsupportedClientAction(&'static str),
+    #[error("message is not supported by semantic sessions: {0}")]
+    UnsupportedMessage(&'static str),
+    #[error("message did not contain a type")]
+    MissingMessageType,
+    #[error("tool result did not match a previously observed tool call")]
+    UnknownToolResult,
+    #[error("message update referenced an unknown message")]
+    UnknownMessage,
+    #[error("message update used an unsupported field mask path: {0}")]
+    UnsupportedFieldMask(String),
+    #[error("semantic producer exceeded its tracked-message limit")]
+    StateLimit,
+    #[error("semantic user message did not have an accepted message context")]
+    MissingAcceptedMessageContext,
+    #[error("accepted message context was already registered")]
+    DuplicateAcceptedMessageContext,
+    #[error("semantic execution finished with an unconsumed accepted message context")]
+    StaleAcceptedMessageContext,
+    #[error("semantic producer exceeded its pending accepted-message-context limit")]
+    AcceptedMessageContextLimit,
+    #[error("invalid accepted message context: {0}")]
+    InvalidAcceptedMessageContext(#[from] AcceptedMessageContextError),
+}
+fn canonical_timestamp(preferred: Option<&prost_types::Timestamp>) -> prost_types::Timestamp {
+    if let Some(preferred) = preferred.filter(|timestamp| timestamp_is_valid(timestamp)) {
+        return *preferred;
+    }
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    prost_types::Timestamp {
+        seconds: i64::try_from(duration.as_secs().min(253_402_300_799)).unwrap_or_default(),
+        nanos: duration.subsec_nanos() as i32,
+    }
+}
+
+impl PendingMutation {
+    fn entry_id(&self) -> Option<&str> {
+        match self {
+            Self::Entry(value) => Some(&value.entry_id),
+            Self::Content(value) => Some(&value.entry_id),
+            Self::Action(value) => Some(&value.entry_id),
+            Self::Execution(_) | Self::Interruption(_) => None,
+        }
+    }
+
+    fn stable_source_key(&self) -> String {
+        match self {
+            Self::Execution(value) => match value.change.as_ref() {
+                Some(execution_mutation::Change::Started(_)) => "execution:started".to_owned(),
+                Some(execution_mutation::Change::StateChanged(change)) => {
+                    format!("execution:state:{}", change.state)
+                }
+                Some(execution_mutation::Change::Finished(change)) => {
+                    format!("execution:finished:{}", change.state)
+                }
+                None => "execution:missing".to_owned(),
+            },
+            Self::Entry(value) => match value.change.as_ref() {
+                Some(entry_mutation::Change::Created(_)) => {
+                    format!("entry:{}:created", value.entry_id)
+                }
+                Some(entry_mutation::Change::Finalized(change)) => {
+                    format!("entry:{}:finalized:{}", value.entry_id, change.state)
+                }
+                None => format!("entry:{}:missing", value.entry_id),
+            },
+            Self::Content(value) => match value.change.as_ref() {
+                Some(content_mutation::Change::Delta(change)) => format!(
+                    "content:{}:delta:{}:{:016x}",
+                    value.content_id,
+                    change.delta_index,
+                    stable_hash(&change.data)
+                ),
+                Some(content_mutation::Change::Final(change)) => format!(
+                    "content:{}:final:{:016x}",
+                    value.content_id,
+                    stable_hash(&change.data)
+                ),
+                None => format!("content:{}:missing", value.content_id),
+            },
+            Self::Action(value) => match value.change.as_ref() {
+                Some(action_mutation::Change::Started(_)) => {
+                    format!("action:{}:started", value.action_id)
+                }
+                Some(action_mutation::Change::StateChanged(change)) => {
+                    format!("action:{}:state:{}", value.action_id, change.state)
+                }
+                Some(action_mutation::Change::Result(result)) => {
+                    format!("action:{}:result:{}", value.action_id, result.state)
+                }
+                None => format!("action:{}:missing", value.action_id),
+            },
+            Self::Interruption(value) => {
+                format!(
+                    "interruption:{}:{}:{}",
+                    value.scope, value.target_id, value.reason
+                )
+            }
+        }
+    }
+}
+
+fn apply_message_field(
+    target: &mut Message,
+    source: &Message,
+    path: &str,
+    append: bool,
+) -> Result<(), SemanticProducerError> {
+    let path = path.strip_prefix("message.").unwrap_or(path);
+    match (path, target.message.as_mut(), source.message.as_ref()) {
+        (
+            "user_query.query",
+            Some(message::Message::UserQuery(target)),
+            Some(message::Message::UserQuery(source)),
+        ) => update_string(&mut target.query, &source.query, append),
+        (
+            "agent_output.text",
+            Some(message::Message::AgentOutput(target)),
+            Some(message::Message::AgentOutput(source)),
+        ) => update_string(&mut target.text, &source.text, append),
+        (
+            "agent_reasoning.reasoning",
+            Some(message::Message::AgentReasoning(target)),
+            Some(message::Message::AgentReasoning(source)),
+        ) => update_string(&mut target.reasoning, &source.reasoning, append),
+        ("timestamp", _, _) if !append => target.timestamp = source.timestamp,
+        _ => {
+            return Err(SemanticProducerError::UnsupportedFieldMask(path.to_owned()));
+        }
+    }
+    Ok(())
+}
+
+fn update_string(target: &mut String, source: &str, append: bool) {
+    if append {
+        target.push_str(source);
+    } else {
+        target.clear();
+        target.push_str(source);
+    }
+}
+
+fn attribution_for_message(message: &Message, kind: EntryKind, run_id: &str) -> Attribution {
+    let is_user = kind == EntryKind::UserMessage;
+    let author_id = if is_user {
+        message.request_id.as_str()
+    } else {
+        message.task_id.as_str()
+    };
+    Attribution {
+        author: Some(Author {
+            id: if author_id.is_empty() {
+                run_id.to_owned()
+            } else {
+                author_id.to_owned()
+            },
+            kind: if is_user {
+                warp_conversation_mutation_api::author::Kind::User as i32
+            } else {
+                warp_conversation_mutation_api::author::Kind::Agent as i32
+            },
+            display_name: String::new(),
+        }),
+        origin: Some(Origin {
+            kind: warp_conversation_mutation_api::origin::Kind::Warp as i32,
+            source_id: run_id.to_owned(),
+            subtype: "multi_agent".to_owned(),
+        }),
+        source_delivery: None,
+    }
+}
+
+fn system_attribution(run_id: &str) -> Attribution {
+    Attribution {
+        author: Some(Author {
+            id: run_id.to_owned(),
+            kind: warp_conversation_mutation_api::author::Kind::System as i32,
+            display_name: String::new(),
+        }),
+        origin: Some(Origin {
+            kind: warp_conversation_mutation_api::origin::Kind::Warp as i32,
+            source_id: run_id.to_owned(),
+            subtype: "multi_agent".to_owned(),
+        }),
+        source_delivery: None,
+    }
+}
+
+fn stable_hash(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
+pub struct SemanticMutationProducer {
+    execution_identity: session_sharing_protocol::common::ExecutionIdentity,
+    next_sequence: u64,
+    request_id: String,
+    run_id: String,
+    open_entries: HashSet<String>,
+    action_entries: HashMap<String, String>,
+    messages: HashMap<String, Message>,
+    entry_ids: HashMap<String, String>,
+    entry_attributions: HashMap<String, Attribution>,
+    content_delta_indexes: HashMap<String, u64>,
+    pending_message_contexts: VecDeque<AcceptedMessageContext>,
+    accepted_message_ids: HashSet<String>,
+    accepted_message_id_order: VecDeque<String>,
+    redact: Arc<dyn Fn(&str) -> String + Send + Sync>,
+}
+
+impl SemanticMutationProducer {
+    pub fn new(execution_identity: session_sharing_protocol::common::ExecutionIdentity) -> Self {
+        Self::new_with_redactor(execution_identity, |_| "[REDACTED]".to_owned())
+    }
+
+    pub fn new_with_redactor(
+        execution_identity: session_sharing_protocol::common::ExecutionIdentity,
+        redact: impl Fn(&str) -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            request_id: execution_identity.request_id.clone().unwrap_or_default(),
+            run_id: execution_identity.run_id.clone().unwrap_or_default(),
+            execution_identity,
+            next_sequence: 1,
+            open_entries: HashSet::new(),
+            action_entries: HashMap::new(),
+            messages: HashMap::new(),
+            entry_ids: HashMap::new(),
+            entry_attributions: HashMap::new(),
+            content_delta_indexes: HashMap::new(),
+            pending_message_contexts: VecDeque::new(),
+            accepted_message_ids: HashSet::new(),
+            accepted_message_id_order: VecDeque::new(),
+            redact: Arc::new(redact),
+        }
+    }
+
+    pub fn register_accepted_message_context(
+        &mut self,
+        context: AcceptedMessageContext,
+    ) -> Result<(), SemanticProducerError> {
+        crate::validate_accepted_message_context(
+            &context,
+            &self.execution_identity,
+            SchemaVersion::V1 as u32,
+        )?;
+        if self.accepted_message_ids.contains(&context.message_id) {
+            return Err(SemanticProducerError::DuplicateAcceptedMessageContext);
+        }
+        if self.pending_message_contexts.len() >= MAX_PENDING_MESSAGE_CONTEXTS {
+            return Err(SemanticProducerError::AcceptedMessageContextLimit);
+        }
+        if self.accepted_message_id_order.len() >= MAX_TRACKED_MESSAGES
+            && let Some(expired) = self.accepted_message_id_order.pop_front()
+        {
+            self.accepted_message_ids.remove(&expired);
+        }
+        self.accepted_message_ids.insert(context.message_id.clone());
+        self.accepted_message_id_order
+            .push_back(context.message_id.clone());
+        self.pending_message_contexts.push_back(context);
+        Ok(())
+    }
+
+    pub fn normalize(
+        &mut self,
+        response: &ResponseEvent,
+    ) -> Result<Vec<ConversationMutation>, SemanticProducerError> {
+        let pending = match response
+            .r#type
+            .as_ref()
+            .ok_or(SemanticProducerError::MissingResponseType)?
+        {
+            response_event::Type::Init(init) => {
+                if init.conversation_id != self.execution_identity.conversation_id
+                    || self
+                        .execution_identity
+                        .request_id
+                        .as_ref()
+                        .is_some_and(|request_id| request_id != &init.request_id)
+                    || self
+                        .execution_identity
+                        .run_id
+                        .as_ref()
+                        .is_some_and(|run_id| run_id != &init.run_id)
+                {
+                    return Err(SemanticProducerError::StreamIdentityMismatch);
+                }
+                self.request_id.clone_from(&init.request_id);
+                self.run_id.clone_from(&init.run_id);
+                vec![PendingMutation::Execution(ExecutionMutation {
+                    change: Some(execution_mutation::Change::Started(
+                        execution_mutation::Started { started_at: None },
+                    )),
+                })]
+            }
+            response_event::Type::ClientActions(actions) => {
+                self.normalize_client_actions(&actions.actions)?
+            }
+            response_event::Type::Finished(finished) => self.normalize_finished(finished)?,
+        };
+        Ok(pending
+            .into_iter()
+            .map(|mutation| self.finish_mutation(mutation))
+            .collect())
+    }
+
+    pub fn interruption(
+        &mut self,
+        reason: InterruptionReason,
+        recoverable: bool,
+    ) -> ConversationMutation {
+        self.finish_mutation(PendingMutation::Interruption(InterruptionMutation {
+            scope: InterruptionScope::Execution as i32,
+            target_id: self.execution_identity.execution_id.clone(),
+            reason: reason as i32,
+            recoverable,
+            detail: String::new(),
+            interrupted_at: None,
+        }))
+    }
+
+    fn normalize_client_actions(
+        &mut self,
+        actions: &[warp_multi_agent_api::ClientAction],
+    ) -> Result<Vec<PendingMutation>, SemanticProducerError> {
+        let mut mutations = Vec::new();
+        for action in actions {
+            match action
+                .action
+                .as_ref()
+                .ok_or(SemanticProducerError::UnsupportedClientAction(
+                    "missing_action",
+                ))? {
+                client_action::Action::CreateTask(create) => {
+                    let task = create.task.as_ref().ok_or(
+                        SemanticProducerError::UnsupportedClientAction("create_task_without_task"),
+                    )?;
+                    for message in &task.messages {
+                        mutations.extend(self.normalize_added_message(message)?);
+                    }
+                }
+                client_action::Action::UpdateTaskSummary(_)
+                | client_action::Action::UpdateTaskDescription(_)
+                | client_action::Action::BeginTransaction(_)
+                | client_action::Action::CommitTransaction(_)
+                | client_action::Action::UpdateTaskServerData(_) => {}
+                client_action::Action::AddMessagesToTask(add) => {
+                    for message in &add.messages {
+                        mutations.extend(self.normalize_added_message(message)?);
+                    }
+                }
+                client_action::Action::UpdateTaskMessage(update) => {
+                    mutations.extend(self.normalize_updated_message(update)?);
+                }
+                client_action::Action::AppendToMessageContent(append) => {
+                    mutations.push(self.normalize_appended_content(append)?);
+                }
+                client_action::Action::RollbackTransaction(_) => {
+                    return Err(SemanticProducerError::UnsupportedClientAction(
+                        "rollback_transaction",
+                    ));
+                }
+                client_action::Action::ShowSuggestions(_) => {
+                    return Err(SemanticProducerError::UnsupportedClientAction(
+                        "show_suggestions",
+                    ));
+                }
+                client_action::Action::StartNewConversation(_) => {
+                    return Err(SemanticProducerError::UnsupportedClientAction(
+                        "start_new_conversation",
+                    ));
+                }
+                client_action::Action::MoveMessagesToNewTask(_) => {
+                    return Err(SemanticProducerError::UnsupportedClientAction(
+                        "move_messages_to_new_task",
+                    ));
+                }
+            }
+        }
+        Ok(mutations)
+    }
+    fn normalize_updated_message(
+        &mut self,
+        update: &client_action::UpdateTaskMessage,
+    ) -> Result<Vec<PendingMutation>, SemanticProducerError> {
+        let update_message = update
+            .message
+            .as_ref()
+            .ok_or(SemanticProducerError::MissingMessageType)?;
+        let mut message = self
+            .messages
+            .get(&update_message.id)
+            .cloned()
+            .ok_or(SemanticProducerError::UnknownMessage)?;
+        let paths = update
+            .mask
+            .as_ref()
+            .map(|mask| mask.paths.as_slice())
+            .unwrap_or_default();
+        if paths.is_empty() {
+            message = update_message.clone();
+        } else {
+            for path in paths {
+                apply_message_field(&mut message, update_message, path, false)?;
+            }
+        }
+        let mutations = self.normalize_final_message(&message)?;
+        self.messages.insert(message.id.clone(), message);
+        Ok(mutations)
+    }
+
+    fn normalize_appended_content(
+        &mut self,
+        append: &client_action::AppendToMessageContent,
+    ) -> Result<PendingMutation, SemanticProducerError> {
+        let fragment = append
+            .message
+            .as_ref()
+            .ok_or(SemanticProducerError::MissingMessageType)?;
+        let paths = append
+            .mask
+            .as_ref()
+            .map(|mask| mask.paths.as_slice())
+            .unwrap_or_default();
+        if paths.len() != 1 {
+            return Err(SemanticProducerError::UnsupportedFieldMask(paths.join(",")));
+        }
+        let mut message = self
+            .messages
+            .get(&fragment.id)
+            .cloned()
+            .ok_or(SemanticProducerError::UnknownMessage)?;
+        apply_message_field(&mut message, fragment, &paths[0], true)?;
+        self.messages.insert(message.id.clone(), message);
+        self.normalize_content_delta(fragment)
+    }
+
+    fn normalize_added_message(
+        &mut self,
+        message: &Message,
+    ) -> Result<Vec<PendingMutation>, SemanticProducerError> {
+        let message_type = message
+            .message
+            .as_ref()
+            .ok_or(SemanticProducerError::MissingMessageType)?;
+        if let message::Message::ToolCallResult(result) = message_type {
+            let entry_id = self
+                .action_entries
+                .get(&result.tool_call_id)
+                .cloned()
+                .ok_or(SemanticProducerError::UnknownToolResult)?;
+            return Ok(vec![
+                PendingMutation::Action(ActionMutation {
+                    entry_id: entry_id.clone(),
+                    action_id: result.tool_call_id.clone(),
+                    change: Some(action_mutation::Change::Result(action_mutation::Result {
+                        state: tool_result_state(result) as i32,
+                        output_json: b"{}".to_vec(),
+                        media: Vec::new(),
+                        error_message: String::new(),
+                        finished_at: message.timestamp,
+                    })),
+                }),
+                finalize_entry(entry_id, message.timestamp),
+            ]);
+        }
+        if !self.messages.contains_key(&message.id) && self.messages.len() >= MAX_TRACKED_MESSAGES {
+            return Err(SemanticProducerError::StateLimit);
+        }
+        let (kind, keep_open) = match message_type {
+            message::Message::UserQuery(_) => (EntryKind::UserMessage, false),
+            message::Message::AgentOutput(_) => (EntryKind::AssistantMessage, true),
+            message::Message::AgentReasoning(_) => (EntryKind::Reasoning, true),
+            message::Message::ToolCall(tool_call) => {
+                self.action_entries
+                    .insert(tool_call.tool_call_id.clone(), message.id.clone());
+                (EntryKind::Action, true)
+            }
+            message::Message::ToolCallResult(_) => unreachable!("handled above"),
+            message::Message::SystemQuery(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("system_query"));
+            }
+            message::Message::ServerEvent(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("server_event"));
+            }
+            message::Message::UpdateTodos(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("update_todos"));
+            }
+            message::Message::Summarization(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("summarization"));
+            }
+            message::Message::CodeReview(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("code_review"));
+            }
+            message::Message::UpdateReviewComments(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage(
+                    "update_review_comments",
+                ));
+            }
+            message::Message::WebSearch(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("web_search"));
+            }
+            message::Message::WebFetch(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("web_fetch"));
+            }
+            message::Message::DebugOutput(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("debug_output"));
+            }
+            message::Message::ArtifactEvent(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("artifact_event"));
+            }
+            message::Message::InvokeSkill(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("invoke_skill"));
+            }
+            message::Message::MessagesReceivedFromAgents(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage(
+                    "messages_received_from_agents",
+                ));
+            }
+            message::Message::ModelUsed(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage("model_used"));
+            }
+            message::Message::EventsFromAgents(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage(
+                    "events_from_agents",
+                ));
+            }
+            message::Message::PassiveSuggestionResult(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage(
+                    "passive_suggestion_result",
+                ));
+            }
+            message::Message::OrchestrationConfigSnapshot(_) => {
+                return Err(SemanticProducerError::UnsupportedMessage(
+                    "orchestration_config_snapshot",
+                ));
+            }
+        };
+        let accepted_context = if kind == EntryKind::UserMessage {
+            Some(
+                self.pending_message_contexts
+                    .pop_front()
+                    .ok_or(SemanticProducerError::MissingAcceptedMessageContext)?,
+            )
+        } else {
+            None
+        };
+        let entry_id = accepted_context
+            .as_ref()
+            .map(|context| context.message_id.clone())
+            .unwrap_or_else(|| message.id.clone());
+        let attribution = accepted_context
+            .as_ref()
+            .and_then(|context| context.attribution.clone())
+            .unwrap_or_else(|| attribution_for_message(message, kind, &self.run_id));
+        let media = accepted_context
+            .as_ref()
+            .map(|context| context.media.clone())
+            .unwrap_or_default();
+
+        self.messages.insert(message.id.clone(), message.clone());
+        self.entry_ids.insert(message.id.clone(), entry_id.clone());
+        self.entry_attributions
+            .insert(entry_id.clone(), attribution);
+        let mut mutations = vec![PendingMutation::Entry(EntryMutation {
+            entry_id: entry_id.clone(),
+            change: Some(entry_mutation::Change::Created(entry_mutation::Created {
+                kind: kind as i32,
+                parent_entry_id: String::new(),
+                created_at: message.timestamp,
+                media,
+            })),
+        })];
+        match message_type {
+            message::Message::UserQuery(_)
+            | message::Message::AgentOutput(_)
+            | message::Message::AgentReasoning(_) => {
+                mutations.push(self.normalize_content(message, &entry_id, keep_open)?);
+            }
+            message::Message::ToolCall(tool_call) => {
+                mutations.push(PendingMutation::Action(ActionMutation {
+                    entry_id: entry_id.clone(),
+                    action_id: tool_call.tool_call_id.clone(),
+                    change: Some(action_mutation::Change::Started(action_mutation::Started {
+                        kind: action_kind(tool_call) as i32,
+                        name: action_name(tool_call)?.to_owned(),
+                        input_json: b"{}".to_vec(),
+                        started_at: message.timestamp,
+                    })),
+                }));
+            }
+            _ => unreachable!("unsupported messages returned above"),
+        }
+        if keep_open {
+            self.open_entries.insert(entry_id.clone());
+        } else {
+            mutations.push(finalize_entry(entry_id, message.timestamp));
+        }
+        Ok(mutations)
+    }
+
+    fn normalize_final_message(
+        &mut self,
+        message: &Message,
+    ) -> Result<Vec<PendingMutation>, SemanticProducerError> {
+        let entry_id = self
+            .entry_ids
+            .get(&message.id)
+            .cloned()
+            .ok_or(SemanticProducerError::UnknownMessage)?;
+        let mut mutations = vec![self.normalize_content(message, &entry_id, false)?];
+        if self.open_entries.remove(&entry_id) {
+            mutations.push(finalize_entry(entry_id, message.timestamp));
+        }
+        Ok(mutations)
+    }
+
+    fn normalize_content_delta(
+        &mut self,
+        message: &Message,
+    ) -> Result<PendingMutation, SemanticProducerError> {
+        let entry_id = self
+            .entry_ids
+            .get(&message.id)
+            .cloned()
+            .ok_or(SemanticProducerError::UnknownMessage)?;
+        self.normalize_content(message, &entry_id, true)
+    }
+
+    fn normalize_content(
+        &mut self,
+        message: &Message,
+        entry_id: &str,
+        delta: bool,
+    ) -> Result<PendingMutation, SemanticProducerError> {
+        let (data, encoding) = display_content(message)?;
+        let data = (self.redact)(&data);
+        let content_id = format!("{entry_id}:content:0");
+        let change = if delta {
+            let delta_index = self
+                .content_delta_indexes
+                .entry(content_id.clone())
+                .or_default();
+            let current = *delta_index;
+            *delta_index += 1;
+            content_mutation::Change::Delta(content_mutation::Delta {
+                delta_index: current,
+                encoding: encoding as i32,
+                data: data.into_bytes(),
+            })
+        } else {
+            content_mutation::Change::Final(content_mutation::Final {
+                encoding: encoding as i32,
+                data: data.into_bytes(),
+                media: Vec::new(),
+            })
+        };
+        Ok(PendingMutation::Content(ContentMutation {
+            entry_id: entry_id.to_owned(),
+            content_id,
+            content_index: 0,
+            change: Some(change),
+        }))
+    }
+
+    fn normalize_finished(
+        &mut self,
+        finished: &response_event::StreamFinished,
+    ) -> Result<Vec<PendingMutation>, SemanticProducerError> {
+        if !self.pending_message_contexts.is_empty() {
+            return Err(SemanticProducerError::StaleAcceptedMessageContext);
+        }
+        let mut entries: Vec<_> = self.open_entries.drain().collect();
+        entries.sort();
+        let mut mutations: Vec<_> = entries
+            .into_iter()
+            .map(|entry_id| finalize_entry(entry_id, None))
+            .collect();
+        let state = match finished.reason {
+            Some(response_event::stream_finished::Reason::Done(_)) | None => {
+                ExecutionState::Succeeded
+            }
+            Some(_) => ExecutionState::Failed,
+        };
+        mutations.push(PendingMutation::Execution(ExecutionMutation {
+            change: Some(execution_mutation::Change::Finished(
+                execution_mutation::Finished {
+                    state: state as i32,
+                    finished_at: None,
+                    detail: String::new(),
+                },
+            )),
+        }));
+        Ok(mutations)
+    }
+
+    fn finish_mutation(&mut self, mut mutation: PendingMutation) -> ConversationMutation {
+        let sequence = self.next_sequence;
+        self.next_sequence += 1;
+        let mutation_id = format!(
+            "{}:{sequence:020}:{}",
+            self.execution_identity.execution_id,
+            mutation.stable_source_key()
+        );
+        let attribution = mutation
+            .entry_id()
+            .and_then(|entry_id| self.entry_attributions.get(entry_id))
+            .cloned()
+            .unwrap_or_else(|| system_attribution(&self.run_id));
+        let occurred_at = canonical_timestamp(mutation.source_timestamp());
+        mutation.set_canonical_timestamp(occurred_at);
+        ConversationMutation {
+            schema_version: SchemaVersion::V1 as i32,
+            identity: Some(MutationIdentity {
+                conversation_id: self.execution_identity.conversation_id.clone(),
+                execution_id: self.execution_identity.execution_id.clone(),
+                mutation_id,
+                sequence,
+                run_id: self.run_id.clone(),
+                request_id: self.request_id.clone(),
+            }),
+            attribution: Some(attribution),
+            occurred_at: Some(occurred_at),
+            mutation: Some(mutation.into()),
+        }
+    }
+}
+
+enum PendingMutation {
+    Execution(ExecutionMutation),
+    Entry(EntryMutation),
+    Content(ContentMutation),
+    Action(ActionMutation),
+    Interruption(InterruptionMutation),
+}
+impl PendingMutation {
+    fn source_timestamp(&self) -> Option<&prost_types::Timestamp> {
+        match self {
+            Self::Execution(execution) => match execution.change.as_ref() {
+                Some(execution_mutation::Change::Started(started)) => started.started_at.as_ref(),
+                Some(execution_mutation::Change::Finished(finished)) => {
+                    finished.finished_at.as_ref()
+                }
+                Some(execution_mutation::Change::StateChanged(_)) | None => None,
+            },
+            Self::Entry(entry) => match entry.change.as_ref() {
+                Some(entry_mutation::Change::Created(created)) => created.created_at.as_ref(),
+                Some(entry_mutation::Change::Finalized(finalized)) => {
+                    finalized.finalized_at.as_ref()
+                }
+                None => None,
+            },
+            Self::Action(action) => match action.change.as_ref() {
+                Some(action_mutation::Change::Started(started)) => started.started_at.as_ref(),
+                Some(action_mutation::Change::Result(result)) => result.finished_at.as_ref(),
+                Some(action_mutation::Change::StateChanged(_)) | None => None,
+            },
+            Self::Interruption(interruption) => interruption.interrupted_at.as_ref(),
+            Self::Content(_) => None,
+        }
+    }
+
+    fn set_canonical_timestamp(&mut self, timestamp: prost_types::Timestamp) {
+        match self {
+            Self::Execution(execution) => match execution.change.as_mut() {
+                Some(execution_mutation::Change::Started(started)) => {
+                    started.started_at = Some(timestamp);
+                }
+                Some(execution_mutation::Change::Finished(finished)) => {
+                    finished.finished_at = Some(timestamp);
+                }
+                Some(execution_mutation::Change::StateChanged(_)) | None => {}
+            },
+            Self::Entry(entry) => match entry.change.as_mut() {
+                Some(entry_mutation::Change::Created(created)) => {
+                    created.created_at = Some(timestamp);
+                }
+                Some(entry_mutation::Change::Finalized(finalized)) => {
+                    finalized.finalized_at = Some(timestamp);
+                }
+                None => {}
+            },
+            Self::Action(action) => match action.change.as_mut() {
+                Some(action_mutation::Change::Started(started)) => {
+                    started.started_at = Some(timestamp);
+                }
+                Some(action_mutation::Change::Result(result)) => {
+                    result.finished_at = Some(timestamp);
+                }
+                Some(action_mutation::Change::StateChanged(_)) | None => {}
+            },
+            Self::Interruption(interruption) => {
+                interruption.interrupted_at = Some(timestamp);
+            }
+            Self::Content(_) => {}
+        }
+    }
+}
+
+impl From<PendingMutation> for conversation_mutation::Mutation {
+    fn from(value: PendingMutation) -> Self {
+        match value {
+            PendingMutation::Execution(value) => Self::Execution(value),
+            PendingMutation::Entry(value) => Self::Entry(value),
+            PendingMutation::Content(value) => Self::Content(value),
+            PendingMutation::Action(value) => Self::Action(value),
+            PendingMutation::Interruption(value) => Self::Interruption(value),
+        }
+    }
+}
+
+fn finalize_entry(
+    entry_id: String,
+    finalized_at: Option<prost_types::Timestamp>,
+) -> PendingMutation {
+    PendingMutation::Entry(EntryMutation {
+        entry_id,
+        change: Some(entry_mutation::Change::Finalized(
+            entry_mutation::Finalized {
+                state: EntryState::Final as i32,
+                finalized_at,
+            },
+        )),
+    })
+}
+
+fn display_content(message: &Message) -> Result<(String, ContentEncoding), SemanticProducerError> {
+    match message
+        .message
+        .as_ref()
+        .ok_or(SemanticProducerError::MissingMessageType)?
+    {
+        message::Message::UserQuery(query) => Ok((query.query.clone(), ContentEncoding::Utf8Text)),
+        message::Message::AgentOutput(output) => {
+            Ok((output.text.clone(), ContentEncoding::Utf8Markdown))
+        }
+        message::Message::AgentReasoning(reasoning) => {
+            Ok((reasoning.reasoning.clone(), ContentEncoding::Utf8Markdown))
+        }
+        _ => Err(SemanticProducerError::UnsupportedMessage(
+            "non_display_content",
+        )),
+    }
+}
+
+fn action_kind(tool_call: &message::ToolCall) -> ActionKind {
+    match tool_call.tool {
+        Some(message::tool_call::Tool::RunShellCommand(_))
+        | Some(message::tool_call::Tool::WriteToLongRunningShellCommand(_))
+        | Some(message::tool_call::Tool::ReadShellCommandOutput(_))
+        | Some(message::tool_call::Tool::TransferShellCommandControlToUser(_)) => {
+            ActionKind::Command
+        }
+        Some(message::tool_call::Tool::UseComputer(_))
+        | Some(message::tool_call::Tool::RequestComputerUse(_))
+        | Some(message::tool_call::Tool::StartRecording(_))
+        | Some(message::tool_call::Tool::StopRecording(_)) => ActionKind::ComputerUse,
+        Some(message::tool_call::Tool::Subagent(_))
+        | Some(message::tool_call::Tool::RunAgents(_))
+        | Some(message::tool_call::Tool::SendMessageToAgent(_))
+        | Some(message::tool_call::Tool::WaitForEvents(_)) => ActionKind::Subagent,
+        Some(message::tool_call::Tool::ReadMcpResource(_))
+        | Some(message::tool_call::Tool::CallMcpTool(_)) => ActionKind::Integration,
+        Some(_) | None => ActionKind::Tool,
+    }
+}
+
+#[allow(deprecated)]
+fn action_name(tool_call: &message::ToolCall) -> Result<&'static str, SemanticProducerError> {
+    let name = match tool_call
+        .tool
+        .as_ref()
+        .ok_or(SemanticProducerError::UnsupportedMessage("missing_tool"))?
+    {
+        message::tool_call::Tool::RunShellCommand(_) => "run_shell_command",
+        message::tool_call::Tool::SearchCodebase(_) => "search_codebase",
+        message::tool_call::Tool::Server(_) => "server",
+        message::tool_call::Tool::ReadFiles(_) => "read_files",
+        message::tool_call::Tool::ApplyFileDiffs(_) => "apply_file_diffs",
+        message::tool_call::Tool::SuggestPlan(_) => "suggest_plan",
+        message::tool_call::Tool::SuggestCreatePlan(_) => "suggest_create_plan",
+        message::tool_call::Tool::Grep(_) => "grep",
+        message::tool_call::Tool::FileGlob(_) => "file_glob",
+        message::tool_call::Tool::ReadMcpResource(_) => "read_mcp_resource",
+        message::tool_call::Tool::CallMcpTool(_) => "call_mcp_tool",
+        message::tool_call::Tool::WriteToLongRunningShellCommand(_) => {
+            "write_to_long_running_shell_command"
+        }
+        message::tool_call::Tool::SuggestNewConversation(_) => "suggest_new_conversation",
+        message::tool_call::Tool::FileGlobV2(_) => "file_glob_v2",
+        message::tool_call::Tool::SuggestPrompt(_) => "suggest_prompt",
+        message::tool_call::Tool::OpenCodeReview(_) => "open_code_review",
+        message::tool_call::Tool::InitProject(_) => "init_project",
+        message::tool_call::Tool::Subagent(_) => "subagent",
+        message::tool_call::Tool::ReadDocuments(_) => "read_documents",
+        message::tool_call::Tool::EditDocuments(_) => "edit_documents",
+        message::tool_call::Tool::CreateDocuments(_) => "create_documents",
+        message::tool_call::Tool::ReadShellCommandOutput(_) => "read_shell_command_output",
+        message::tool_call::Tool::UseComputer(_) => "use_computer",
+        message::tool_call::Tool::InsertReviewComments(_) => "insert_review_comments",
+        message::tool_call::Tool::ReadSkill(_) => "read_skill",
+        message::tool_call::Tool::RequestComputerUse(_) => "request_computer_use",
+        message::tool_call::Tool::FetchConversation(_) => "fetch_conversation",
+        message::tool_call::Tool::SendMessageToAgent(_) => "send_message_to_agent",
+        message::tool_call::Tool::TransferShellCommandControlToUser(_) => {
+            "transfer_shell_command_control_to_user"
+        }
+        message::tool_call::Tool::AskUserQuestion(_) => "ask_user_question",
+        message::tool_call::Tool::UploadFileArtifact(_) => "upload_file_artifact",
+        message::tool_call::Tool::RunAgents(_) => "run_agents",
+        message::tool_call::Tool::WaitForEvents(_) => "wait_for_events",
+        message::tool_call::Tool::StartRecording(_) => "start_recording",
+        message::tool_call::Tool::StopRecording(_) => "stop_recording",
+    };
+    Ok(name)
+}
+
+fn tool_result_state(result: &message::ToolCallResult) -> ActionState {
+    match result.result {
+        Some(message::tool_call_result::Result::Cancel(_)) => ActionState::Cancelled,
+        Some(_) => ActionState::Succeeded,
+        None => ActionState::Failed,
+    }
+}

--- a/crates/warp_semantic_session/src/reducer.rs
+++ b/crates/warp_semantic_session/src/reducer.rs
@@ -1,0 +1,423 @@
+use std::collections::BTreeMap;
+
+use prost::Message;
+use warp_conversation_mutation_api::{
+    ActionState, ConversationMutation, EntryKind, EntryState, ExecutionState, MediaReference,
+    action_mutation, content_mutation, conversation_mutation, entry_mutation, execution_mutation,
+};
+
+const MAX_TRANSCRIPT_ENTRIES: usize = 4_096;
+const MAX_TRANSCRIPT_ACTIONS: usize = 16_384;
+const MAX_TRANSCRIPT_MEDIA_REFERENCES: usize = 16_384;
+const MAX_TRANSCRIPT_RETAINED_BYTES: usize = 16 * 1024 * 1024;
+const MAX_TRANSCRIPT_PROCESSED_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SemanticMedia {
+    pub media_id: String,
+    pub kind: i32,
+    pub mime_type: String,
+    pub size_bytes: u64,
+    pub display_name: String,
+    pub reference: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SemanticContent {
+    pub content_id: String,
+    pub encoding: i32,
+    pub data: Vec<u8>,
+    pub media: Vec<SemanticMedia>,
+    next_delta_index: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SemanticAction {
+    pub kind: i32,
+    pub name: String,
+    pub state: i32,
+    pub input_json: Vec<u8>,
+    pub output_json: Vec<u8>,
+    pub media: Vec<SemanticMedia>,
+    pub detail: String,
+    pub error_message: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SemanticEntry {
+    pub kind: i32,
+    pub state: i32,
+    pub parent_entry_id: String,
+    pub media: Vec<SemanticMedia>,
+    pub contents: BTreeMap<u32, SemanticContent>,
+    pub actions: BTreeMap<String, SemanticAction>,
+    pub action_order: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum SemanticReducerError {
+    #[error("mutation is missing a payload")]
+    MissingMutation,
+    #[error("mutation referenced an unknown entry")]
+    UnknownEntry,
+    #[error("content delta index mismatch")]
+    DeltaIndexMismatch,
+    #[error("content index conflicts with an existing content block")]
+    ContentIndexConflict,
+    #[error("content identity conflicts with an existing content block")]
+    ContentIdentityConflict,
+    #[error("semantic transcript exceeded its retention limit")]
+    RetentionLimit,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SemanticTranscript {
+    pub execution_state: i32,
+    pub entries: BTreeMap<String, SemanticEntry>,
+    pub entry_order: Vec<String>,
+    retained_bytes: usize,
+    processed_bytes: usize,
+    action_count: usize,
+    media_reference_count: usize,
+}
+
+impl SemanticTranscript {
+    pub fn apply(&mut self, mutation: &ConversationMutation) -> Result<(), SemanticReducerError> {
+        let processed_bytes = self
+            .processed_bytes
+            .checked_add(mutation.encoded_len())
+            .filter(|bytes| *bytes <= MAX_TRANSCRIPT_PROCESSED_BYTES)
+            .ok_or(SemanticReducerError::RetentionLimit)?;
+        match mutation
+            .mutation
+            .as_ref()
+            .ok_or(SemanticReducerError::MissingMutation)?
+        {
+            conversation_mutation::Mutation::Execution(execution) => {
+                self.execution_state = match execution.change.as_ref() {
+                    Some(execution_mutation::Change::Started(_)) => ExecutionState::Running as i32,
+                    Some(execution_mutation::Change::StateChanged(state)) => state.state,
+                    Some(execution_mutation::Change::Finished(finished)) => finished.state,
+                    None => self.execution_state,
+                };
+            }
+            conversation_mutation::Mutation::Entry(entry) => match entry.change.as_ref() {
+                Some(entry_mutation::Change::Created(created)) => {
+                    let existing_media = self
+                        .entries
+                        .get(&entry.entry_id)
+                        .map_or(0, |entry| entry.media.len());
+                    self.ensure_replacement_media(existing_media, created.media.len())?;
+                    if !self.entries.contains_key(&entry.entry_id) {
+                        if self.entries.len() >= MAX_TRANSCRIPT_ENTRIES {
+                            return Err(SemanticReducerError::RetentionLimit);
+                        }
+                        self.entry_order.push(entry.entry_id.clone());
+                    }
+                    self.media_reference_count =
+                        self.media_reference_count.saturating_sub(existing_media)
+                            + created.media.len();
+                    self.entries
+                        .entry(entry.entry_id.clone())
+                        .and_modify(|projected| {
+                            projected.kind = created.kind;
+                            projected
+                                .parent_entry_id
+                                .clone_from(&created.parent_entry_id);
+                            projected.media = semantic_media(&created.media);
+                        })
+                        .or_insert_with(|| SemanticEntry {
+                            kind: created.kind,
+                            state: EntryState::Streaming as i32,
+                            parent_entry_id: created.parent_entry_id.clone(),
+                            media: semantic_media(&created.media),
+                            ..Default::default()
+                        });
+                }
+                Some(entry_mutation::Change::Finalized(finalized)) => {
+                    self.entries
+                        .get_mut(&entry.entry_id)
+                        .ok_or(SemanticReducerError::UnknownEntry)?
+                        .state = finalized.state;
+                }
+                None => {}
+            },
+            conversation_mutation::Mutation::Content(content) => {
+                let entry = self
+                    .entries
+                    .get(&content.entry_id)
+                    .ok_or(SemanticReducerError::UnknownEntry)?;
+                if !entry.contents.contains_key(&content.content_index)
+                    && entry.contents.len() != content.content_index as usize
+                {
+                    return Err(SemanticReducerError::ContentIndexConflict);
+                }
+                let existing = entry.contents.get(&content.content_index);
+                if existing.is_some_and(|projected| {
+                    !projected.content_id.is_empty() && projected.content_id != content.content_id
+                }) {
+                    return Err(SemanticReducerError::ContentIdentityConflict);
+                }
+                let existing_data_len = existing.map_or(0, |content| content.data.len());
+                let existing_media = existing.map_or(0, |content| content.media.len());
+
+                match content.change.as_ref() {
+                    Some(content_mutation::Change::Delta(delta)) => {
+                        if existing.map_or(0, |content| content.next_delta_index)
+                            != delta.delta_index
+                        {
+                            return Err(SemanticReducerError::DeltaIndexMismatch);
+                        }
+                        let next_bytes = self.checked_retained_bytes(0, delta.data.len())?;
+                        let projected = self
+                            .entries
+                            .get_mut(&content.entry_id)
+                            .expect("entry was checked")
+                            .contents
+                            .entry(content.content_index)
+                            .or_default();
+                        projected.content_id.clone_from(&content.content_id);
+                        projected.encoding = delta.encoding;
+                        projected.data.extend_from_slice(&delta.data);
+                        projected.next_delta_index += 1;
+                        self.retained_bytes = next_bytes;
+                    }
+                    Some(content_mutation::Change::Final(final_content)) => {
+                        self.ensure_replacement_media(existing_media, final_content.media.len())?;
+                        let next_bytes = self
+                            .checked_retained_bytes(existing_data_len, final_content.data.len())?;
+                        let projected = self
+                            .entries
+                            .get_mut(&content.entry_id)
+                            .expect("entry was checked")
+                            .contents
+                            .entry(content.content_index)
+                            .or_default();
+                        projected.content_id.clone_from(&content.content_id);
+                        projected.encoding = final_content.encoding;
+                        projected.data.clone_from(&final_content.data);
+                        projected.media = semantic_media(&final_content.media);
+                        self.retained_bytes = next_bytes;
+                        self.media_reference_count =
+                            self.media_reference_count.saturating_sub(existing_media)
+                                + final_content.media.len();
+                    }
+                    None => {}
+                }
+            }
+            conversation_mutation::Mutation::Action(action) => {
+                let entry = self
+                    .entries
+                    .get(&action.entry_id)
+                    .ok_or(SemanticReducerError::UnknownEntry)?;
+                let existing = entry.actions.get(&action.action_id);
+                let is_new = existing.is_none();
+                if is_new && self.action_count >= MAX_TRANSCRIPT_ACTIONS {
+                    return Err(SemanticReducerError::RetentionLimit);
+                }
+
+                match action.change.as_ref() {
+                    Some(action_mutation::Change::Started(started)) => {
+                        let existing_len = existing.map_or(0, |action| action.input_json.len());
+                        let next_bytes =
+                            self.checked_retained_bytes(existing_len, started.input_json.len())?;
+                        let entry = self
+                            .entries
+                            .get_mut(&action.entry_id)
+                            .expect("entry was checked");
+                        if is_new {
+                            entry.action_order.push(action.action_id.clone());
+                            self.action_count += 1;
+                        }
+                        let projected = entry.actions.entry(action.action_id.clone()).or_default();
+                        projected.kind = started.kind;
+                        projected.name.clone_from(&started.name);
+                        projected.state = ActionState::Running as i32;
+                        projected.input_json.clone_from(&started.input_json);
+                        self.retained_bytes = next_bytes;
+                    }
+                    Some(action_mutation::Change::StateChanged(state)) => {
+                        let existing_len = existing.map_or(0, |action| action.detail.len());
+                        let next_bytes =
+                            self.checked_retained_bytes(existing_len, state.detail.len())?;
+                        let entry = self
+                            .entries
+                            .get_mut(&action.entry_id)
+                            .expect("entry was checked");
+                        if is_new {
+                            entry.action_order.push(action.action_id.clone());
+                            self.action_count += 1;
+                        }
+                        let projected = entry.actions.entry(action.action_id.clone()).or_default();
+                        projected.state = state.state;
+                        projected.detail.clone_from(&state.detail);
+                        self.retained_bytes = next_bytes;
+                    }
+                    Some(action_mutation::Change::Result(result)) => {
+                        let existing_len = existing.map_or(0, |action| {
+                            action.output_json.len() + action.error_message.len()
+                        });
+                        let existing_media = existing.map_or(0, |action| action.media.len());
+                        self.ensure_replacement_media(existing_media, result.media.len())?;
+                        let next_bytes = self.checked_retained_bytes(
+                            existing_len,
+                            result.output_json.len() + result.error_message.len(),
+                        )?;
+                        let entry = self
+                            .entries
+                            .get_mut(&action.entry_id)
+                            .expect("entry was checked");
+                        if is_new {
+                            entry.action_order.push(action.action_id.clone());
+                            self.action_count += 1;
+                        }
+                        let projected = entry.actions.entry(action.action_id.clone()).or_default();
+                        projected.state = result.state;
+                        projected.output_json.clone_from(&result.output_json);
+                        projected.media = semantic_media(&result.media);
+                        projected.error_message.clone_from(&result.error_message);
+                        self.retained_bytes = next_bytes;
+                        self.media_reference_count =
+                            self.media_reference_count.saturating_sub(existing_media)
+                                + result.media.len();
+                    }
+                    None => {}
+                }
+            }
+            conversation_mutation::Mutation::Interruption(interruption) => {
+                if interruption.scope
+                    == warp_conversation_mutation_api::InterruptionScope::Execution as i32
+                {
+                    self.execution_state = ExecutionState::Interrupted as i32;
+                }
+            }
+            conversation_mutation::Mutation::Delivery(_)
+            | conversation_mutation::Mutation::Control(_) => {}
+        }
+        self.processed_bytes = processed_bytes;
+        Ok(())
+    }
+
+    fn checked_retained_bytes(
+        &self,
+        replaced: usize,
+        replacement: usize,
+    ) -> Result<usize, SemanticReducerError> {
+        let next = self
+            .retained_bytes
+            .saturating_sub(replaced)
+            .checked_add(replacement)
+            .ok_or(SemanticReducerError::RetentionLimit)?;
+        if next > MAX_TRANSCRIPT_RETAINED_BYTES {
+            return Err(SemanticReducerError::RetentionLimit);
+        }
+        Ok(next)
+    }
+
+    fn ensure_replacement_media(
+        &self,
+        replaced: usize,
+        replacement: usize,
+    ) -> Result<(), SemanticReducerError> {
+        if self
+            .media_reference_count
+            .saturating_sub(replaced)
+            .saturating_add(replacement)
+            > MAX_TRANSCRIPT_MEDIA_REFERENCES
+        {
+            return Err(SemanticReducerError::RetentionLimit);
+        }
+        Ok(())
+    }
+}
+
+impl SemanticEntry {
+    pub fn kind(&self) -> Option<EntryKind> {
+        EntryKind::try_from(self.kind).ok()
+    }
+}
+
+pub fn semantic_payload_key(
+    mutation: &ConversationMutation,
+) -> Result<String, SemanticReducerError> {
+    let payload = match mutation
+        .mutation
+        .as_ref()
+        .ok_or(SemanticReducerError::MissingMutation)?
+    {
+        conversation_mutation::Mutation::Execution(execution) => match execution.change.as_ref() {
+            Some(execution_mutation::Change::Started(_)) => "execution:started".to_owned(),
+            Some(execution_mutation::Change::StateChanged(state)) => {
+                format!("execution:state:{}", state.state)
+            }
+            Some(execution_mutation::Change::Finished(finished)) => {
+                format!("execution:finished:{}", finished.state)
+            }
+            None => "execution:empty".to_owned(),
+        },
+        conversation_mutation::Mutation::Entry(entry) => match entry.change.as_ref() {
+            Some(entry_mutation::Change::Created(_)) => {
+                format!("entry:{}:created", entry.entry_id)
+            }
+            Some(entry_mutation::Change::Finalized(finalized)) => {
+                format!("entry:{}:finalized:{}", entry.entry_id, finalized.state)
+            }
+            None => format!("entry:{}:empty", entry.entry_id),
+        },
+        conversation_mutation::Mutation::Content(content) => match content.change.as_ref() {
+            Some(content_mutation::Change::Delta(delta)) => format!(
+                "content:{}:{}:{}:delta:{}",
+                content.entry_id, content.content_id, content.content_index, delta.delta_index
+            ),
+            Some(content_mutation::Change::Final(_)) => format!(
+                "content:{}:{}:{}:final",
+                content.entry_id, content.content_id, content.content_index
+            ),
+            None => format!(
+                "content:{}:{}:{}:empty",
+                content.entry_id, content.content_id, content.content_index
+            ),
+        },
+        conversation_mutation::Mutation::Action(action) => match action.change.as_ref() {
+            Some(action_mutation::Change::Started(_)) => {
+                format!("action:{}:{}:started", action.entry_id, action.action_id)
+            }
+            Some(action_mutation::Change::StateChanged(state)) => format!(
+                "action:{}:{}:state:{}",
+                action.entry_id, action.action_id, state.state
+            ),
+            Some(action_mutation::Change::Result(result)) => format!(
+                "action:{}:{}:result:{}",
+                action.entry_id, action.action_id, result.state
+            ),
+            None => format!("action:{}:{}:empty", action.entry_id, action.action_id),
+        },
+        conversation_mutation::Mutation::Delivery(delivery) => format!(
+            "delivery:{}:{}:{}",
+            delivery.delivery_id, delivery.entry_id, delivery.state
+        ),
+        conversation_mutation::Mutation::Interruption(interruption) => format!(
+            "interruption:{}:{}:{}",
+            interruption.scope, interruption.target_id, interruption.reason
+        ),
+        conversation_mutation::Mutation::Control(control) => format!(
+            "control:{}:{}:{}:{}",
+            control.control_id, control.kind, control.state, control.target_id
+        ),
+    };
+    Ok(payload)
+}
+
+fn semantic_media(media: &[MediaReference]) -> Vec<SemanticMedia> {
+    media
+        .iter()
+        .map(|reference| SemanticMedia {
+            media_id: reference.media_id.clone(),
+            kind: reference.kind,
+            mime_type: reference.mime_type.clone(),
+            size_bytes: reference.size_bytes,
+            display_name: reference.display_name.clone(),
+            reference: reference.reference.clone(),
+        })
+        .collect()
+}

--- a/crates/warp_semantic_session/src/validation.rs
+++ b/crates/warp_semantic_session/src/validation.rs
@@ -1,0 +1,275 @@
+use std::collections::HashSet;
+
+use prost::Message;
+use session_sharing_protocol::common::ExecutionIdentity;
+use warp_conversation_mutation_api::{
+    AcceptedMessageContext, Attribution, ConversationMutation, MediaReference, SchemaVersion,
+    action_mutation, author, conversation_mutation, entry_mutation, execution_mutation,
+    media_reference, origin,
+};
+
+const MAX_ACCEPTED_MESSAGE_CONTEXT_BYTES: usize = 64 * 1024;
+const MAX_MEDIA_REFERENCES: usize = 64;
+const MAX_IDENTIFIER_BYTES: usize = 1_024;
+const MAX_LABEL_BYTES: usize = 4_096;
+
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum AcceptedMessageContextError {
+    #[error("accepted message context is missing")]
+    Missing,
+    #[error("accepted message context exceeds its encoded size limit")]
+    EncodedSizeLimit,
+    #[error("failed to decode accepted message context: {0}")]
+    Decode(String),
+    #[error("accepted message context schema does not match the semantic session")]
+    SchemaMismatch,
+    #[error("accepted message context conversation does not match the semantic session")]
+    ConversationMismatch,
+    #[error("accepted message context execution does not match the semantic session")]
+    ExecutionMismatch,
+    #[error("accepted message context has an invalid {0}")]
+    InvalidField(&'static str),
+    #[error("accepted message context has too many media references")]
+    MediaLimit,
+    #[error("accepted message context contains a duplicate media ID")]
+    DuplicateMedia,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum ConversationMutationValidationError {
+    #[error("conversation mutation is missing occurred_at")]
+    MissingOccurredAt,
+    #[error("conversation mutation has an invalid {0} timestamp")]
+    InvalidTimestamp(&'static str),
+    #[error("conversation mutation is missing its {0} timestamp")]
+    MissingTimestamp(&'static str),
+    #[error("conversation interruption timestamp does not equal occurred_at")]
+    InterruptionTimestampMismatch,
+}
+
+pub fn decode_accepted_message_context(
+    bytes: &[u8],
+    execution_identity: &ExecutionIdentity,
+    schema_version: u32,
+) -> Result<AcceptedMessageContext, AcceptedMessageContextError> {
+    if bytes.is_empty() {
+        return Err(AcceptedMessageContextError::Missing);
+    }
+    if bytes.len() > MAX_ACCEPTED_MESSAGE_CONTEXT_BYTES {
+        return Err(AcceptedMessageContextError::EncodedSizeLimit);
+    }
+    let context = AcceptedMessageContext::decode(bytes)
+        .map_err(|error| AcceptedMessageContextError::Decode(error.to_string()))?;
+    validate_accepted_message_context(&context, execution_identity, schema_version)?;
+    Ok(context)
+}
+
+pub fn validate_accepted_message_context(
+    context: &AcceptedMessageContext,
+    execution_identity: &ExecutionIdentity,
+    schema_version: u32,
+) -> Result<(), AcceptedMessageContextError> {
+    if context.schema_version != SchemaVersion::V1 as i32
+        || context.schema_version.max(0) as u32 != schema_version
+    {
+        return Err(AcceptedMessageContextError::SchemaMismatch);
+    }
+    if context.conversation_id != execution_identity.conversation_id {
+        return Err(AcceptedMessageContextError::ConversationMismatch);
+    }
+    if context.execution_id != execution_identity.execution_id {
+        return Err(AcceptedMessageContextError::ExecutionMismatch);
+    }
+    validate_identifier("message_id", &context.message_id)?;
+    validate_attribution(
+        context
+            .attribution
+            .as_ref()
+            .ok_or(AcceptedMessageContextError::InvalidField("attribution"))?,
+    )?;
+    if context.media.len() > MAX_MEDIA_REFERENCES {
+        return Err(AcceptedMessageContextError::MediaLimit);
+    }
+    let mut media_ids = HashSet::with_capacity(context.media.len());
+    for media in &context.media {
+        validate_media_reference(media)?;
+        if !media_ids.insert(media.media_id.as_str()) {
+            return Err(AcceptedMessageContextError::DuplicateMedia);
+        }
+    }
+    Ok(())
+}
+
+fn validate_attribution(attribution: &Attribution) -> Result<(), AcceptedMessageContextError> {
+    let author = attribution
+        .author
+        .as_ref()
+        .ok_or(AcceptedMessageContextError::InvalidField(
+            "attribution.author",
+        ))?;
+    validate_identifier("attribution.author.id", &author.id)?;
+    if author::Kind::try_from(author.kind)
+        .ok()
+        .is_none_or(|kind| kind == author::Kind::Unspecified)
+    {
+        return Err(AcceptedMessageContextError::InvalidField(
+            "attribution.author.kind",
+        ));
+    }
+    validate_label("attribution.author.display_name", &author.display_name)?;
+
+    let origin = attribution
+        .origin
+        .as_ref()
+        .ok_or(AcceptedMessageContextError::InvalidField(
+            "attribution.origin",
+        ))?;
+    if origin::Kind::try_from(origin.kind)
+        .ok()
+        .is_none_or(|kind| kind == origin::Kind::Unspecified)
+    {
+        return Err(AcceptedMessageContextError::InvalidField(
+            "attribution.origin.kind",
+        ));
+    }
+    validate_identifier("attribution.origin.source_id", &origin.source_id)?;
+    validate_label("attribution.origin.subtype", &origin.subtype)?;
+
+    if let Some(delivery) = attribution.source_delivery.as_ref() {
+        validate_identifier(
+            "attribution.source_delivery.delivery_id",
+            &delivery.delivery_id,
+        )?;
+        validate_label(
+            "attribution.source_delivery.channel_id",
+            &delivery.channel_id,
+        )?;
+        validate_label("attribution.source_delivery.thread_id", &delivery.thread_id)?;
+        validate_identifier(
+            "attribution.source_delivery.message_id",
+            &delivery.message_id,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_media_reference(media: &MediaReference) -> Result<(), AcceptedMessageContextError> {
+    validate_identifier("media.media_id", &media.media_id)?;
+    if media_reference::Kind::try_from(media.kind)
+        .ok()
+        .is_none_or(|kind| kind == media_reference::Kind::Unspecified)
+    {
+        return Err(AcceptedMessageContextError::InvalidField("media.kind"));
+    }
+    validate_label("media.mime_type", &media.mime_type)?;
+    if !media.sha256.is_empty() && media.sha256.len() != 32 {
+        return Err(AcceptedMessageContextError::InvalidField("media.sha256"));
+    }
+    validate_label("media.display_name", &media.display_name)?;
+    validate_identifier("media.reference", &media.reference)
+}
+
+fn validate_identifier(
+    field: &'static str,
+    value: &str,
+) -> Result<(), AcceptedMessageContextError> {
+    if value.is_empty()
+        || value.trim() != value
+        || value.len() > MAX_IDENTIFIER_BYTES
+        || value.contains('\0')
+    {
+        return Err(AcceptedMessageContextError::InvalidField(field));
+    }
+    Ok(())
+}
+
+fn validate_label(field: &'static str, value: &str) -> Result<(), AcceptedMessageContextError> {
+    if value.len() > MAX_LABEL_BYTES || value.contains('\0') {
+        return Err(AcceptedMessageContextError::InvalidField(field));
+    }
+    Ok(())
+}
+
+pub(crate) fn timestamp_is_valid(timestamp: &prost_types::Timestamp) -> bool {
+    (-62_135_596_800..=253_402_300_799).contains(&timestamp.seconds)
+        && (0..1_000_000_000).contains(&timestamp.nanos)
+}
+
+pub(crate) fn validate_mutation_timestamps(
+    mutation: &ConversationMutation,
+) -> Result<(), ConversationMutationValidationError> {
+    let occurred_at = mutation
+        .occurred_at
+        .as_ref()
+        .ok_or(ConversationMutationValidationError::MissingOccurredAt)?;
+    if !timestamp_is_valid(occurred_at) {
+        return Err(ConversationMutationValidationError::InvalidTimestamp(
+            "occurred_at",
+        ));
+    }
+
+    let nested = match mutation.mutation.as_ref() {
+        Some(conversation_mutation::Mutation::Execution(execution)) => {
+            match execution.change.as_ref() {
+                Some(execution_mutation::Change::Started(started)) => {
+                    Some(("execution.started_at", started.started_at.as_ref()))
+                }
+                Some(execution_mutation::Change::Finished(finished)) => {
+                    Some(("execution.finished_at", finished.finished_at.as_ref()))
+                }
+                Some(execution_mutation::Change::StateChanged(_)) | None => None,
+            }
+        }
+        Some(conversation_mutation::Mutation::Entry(entry)) => match entry.change.as_ref() {
+            Some(entry_mutation::Change::Created(created)) => {
+                Some(("entry.created_at", created.created_at.as_ref()))
+            }
+            Some(entry_mutation::Change::Finalized(finalized)) => {
+                Some(("entry.finalized_at", finalized.finalized_at.as_ref()))
+            }
+            None => None,
+        },
+        Some(conversation_mutation::Mutation::Action(action)) => match action.change.as_ref() {
+            Some(action_mutation::Change::Started(started)) => {
+                Some(("action.started_at", started.started_at.as_ref()))
+            }
+            Some(action_mutation::Change::Result(result)) => {
+                Some(("action.finished_at", result.finished_at.as_ref()))
+            }
+            Some(action_mutation::Change::StateChanged(_)) | None => None,
+        },
+        Some(conversation_mutation::Mutation::Delivery(delivery)) => {
+            Some(("delivery.changed_at", delivery.changed_at.as_ref()))
+        }
+        Some(conversation_mutation::Mutation::Interruption(interruption)) => {
+            let interrupted_at = require_valid_timestamp(
+                "interruption.interrupted_at",
+                interruption.interrupted_at.as_ref(),
+            )?;
+            if interrupted_at != occurred_at {
+                return Err(ConversationMutationValidationError::InterruptionTimestampMismatch);
+            }
+            None
+        }
+        Some(conversation_mutation::Mutation::Control(control)) => {
+            Some(("control.changed_at", control.changed_at.as_ref()))
+        }
+        Some(conversation_mutation::Mutation::Content(_)) | None => None,
+    };
+    if let Some((field, timestamp)) = nested {
+        require_valid_timestamp(field, timestamp)?;
+    }
+    Ok(())
+}
+
+fn require_valid_timestamp<'a>(
+    field: &'static str,
+    timestamp: Option<&'a prost_types::Timestamp>,
+) -> Result<&'a prost_types::Timestamp, ConversationMutationValidationError> {
+    let timestamp =
+        timestamp.ok_or(ConversationMutationValidationError::MissingTimestamp(field))?;
+    if !timestamp_is_valid(timestamp) {
+        return Err(ConversationMutationValidationError::InvalidTimestamp(field));
+    }
+    Ok(timestamp)
+}

--- a/crates/warp_semantic_session_wasm/Cargo.toml
+++ b/crates/warp_semantic_session_wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "warp_semantic_session_wasm"
+version = "0.1.0"
+edition = "2024"
+authors.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+prost.workspace = true
+serde_json.workspace = true
+wasm-bindgen.workspace = true
+warp_conversation_mutation_api.workspace = true
+warp_semantic_session.workspace = true

--- a/crates/warp_semantic_session_wasm/src/lib.rs
+++ b/crates/warp_semantic_session_wasm/src/lib.rs
@@ -1,0 +1,228 @@
+use prost::Message;
+use serde_json::{Value, json};
+use warp_conversation_mutation_api::ConversationMutation;
+use warp_semantic_session::{SemanticMedia, SemanticTranscript, semantic_payload_key};
+use wasm_bindgen::prelude::*;
+const MAX_CANONICAL_MUTATION_BYTES: usize = 256 * 1024;
+
+#[wasm_bindgen]
+#[derive(Default)]
+pub struct SemanticTranscriptClient {
+    transcript: SemanticTranscript,
+}
+
+#[wasm_bindgen]
+impl SemanticTranscriptClient {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn apply_protobuf_mutation(&mut self, bytes: &[u8]) -> Result<(), JsError> {
+        let mutation = decode_mutation(bytes)?;
+        self.transcript
+            .apply(&mutation)
+            .map_err(|error| JsError::new(&error.to_string()))
+    }
+
+    pub fn reset(&mut self) {
+        self.transcript = SemanticTranscript::default();
+    }
+
+    pub fn mutation_key(&self, bytes: &[u8]) -> Result<String, JsError> {
+        let mutation = decode_mutation(bytes)?;
+        semantic_payload_key(&mutation).map_err(|error| JsError::new(&error.to_string()))
+    }
+
+    pub fn execution_state(&self) -> i32 {
+        self.transcript.execution_state
+    }
+
+    pub fn entry_count(&self) -> usize {
+        self.transcript.entries.len()
+    }
+
+    pub fn entry_text(&self, entry_id: &str) -> Option<String> {
+        let entry = self.transcript.entries.get(entry_id)?;
+        let mut bytes = Vec::new();
+        for content in entry.contents.values() {
+            bytes.extend_from_slice(&content.data);
+        }
+        String::from_utf8(bytes).ok()
+    }
+
+    pub fn renderable_state_json(&self) -> Result<String, JsError> {
+        let entries = self
+            .transcript
+            .entry_order
+            .iter()
+            .filter_map(|entry_id| {
+                let entry = self.transcript.entries.get(entry_id)?;
+                let contents = entry
+                    .contents
+                    .iter()
+                    .map(|(content_index, content)| {
+                        json!({
+                            "content_id": content.content_id,
+                            "content_index": content_index,
+                            "encoding": content.encoding,
+                            "text": String::from_utf8(content.data.clone()).ok(),
+                            "media": media_json(&content.media),
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let actions = entry
+                    .action_order
+                    .iter()
+                    .filter_map(|action_id| {
+                        let action = entry.actions.get(action_id)?;
+                        Some(json!({
+                            "action_id": action_id,
+                            "kind": action.kind,
+                            "name": action.name,
+                            "state": action.state,
+                            "input": parse_json(&action.input_json),
+                            "output": parse_json(&action.output_json),
+                            "media": media_json(&action.media),
+                            "detail": action.detail,
+                            "error_message": action.error_message,
+                        }))
+                    })
+                    .collect::<Vec<_>>();
+                Some(json!({
+                    "entry_id": entry_id,
+                    "kind": entry.kind,
+                    "state": entry.state,
+                    "parent_entry_id": entry.parent_entry_id,
+                    "media": media_json(&entry.media),
+                    "contents": contents,
+                    "actions": actions,
+                }))
+            })
+            .collect::<Vec<_>>();
+        serde_json::to_string(&json!({
+            "execution_state": self.transcript.execution_state,
+            "entries": entries,
+        }))
+        .map_err(|error| JsError::new(&format!("failed to encode transcript projection: {error}")))
+    }
+}
+
+fn decode_mutation(bytes: &[u8]) -> Result<ConversationMutation, JsError> {
+    if bytes.is_empty() || bytes.len() > MAX_CANONICAL_MUTATION_BYTES {
+        return Err(JsError::new(
+            "canonical conversation mutation size is invalid",
+        ));
+    }
+    ConversationMutation::decode(bytes)
+        .map_err(|error| JsError::new(&format!("invalid conversation mutation: {error}")))
+}
+
+fn parse_json(bytes: &[u8]) -> Value {
+    if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(bytes).into_owned()))
+    }
+}
+
+fn media_json(media: &[SemanticMedia]) -> Vec<Value> {
+    media
+        .iter()
+        .map(|reference| {
+            json!({
+                "media_id": reference.media_id,
+                "kind": reference.kind,
+                "mime_type": reference.mime_type,
+                "size_bytes": reference.size_bytes,
+                "display_name": reference.display_name,
+                "reference": reference.reference,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use prost::Message as _;
+    use serde_json::Value;
+    use warp_conversation_mutation_api::{
+        ContentEncoding, ContentMutation, ConversationMutation, EntryKind, EntryMutation,
+        MutationIdentity, content_mutation, conversation_mutation, entry_mutation,
+    };
+
+    use super::*;
+
+    #[test]
+    fn decodes_protobuf_mutations_through_the_wasm_boundary() {
+        let mutation = ConversationMutation {
+            mutation: Some(conversation_mutation::Mutation::Entry(EntryMutation {
+                entry_id: "entry".to_owned(),
+                change: Some(entry_mutation::Change::Created(entry_mutation::Created {
+                    kind: EntryKind::AssistantMessage as i32,
+                    ..Default::default()
+                })),
+            })),
+            ..Default::default()
+        };
+        let mut client = SemanticTranscriptClient::new();
+        client
+            .apply_protobuf_mutation(&mutation.encode_to_vec())
+            .unwrap();
+        assert_eq!(client.entry_count(), 1);
+    }
+
+    #[test]
+    fn exposes_ordered_renderable_entries_and_stable_delta_keys() {
+        let mut client = SemanticTranscriptClient::new();
+        let entry = ConversationMutation {
+            identity: Some(MutationIdentity {
+                mutation_id: "entry-created".to_owned(),
+                ..Default::default()
+            }),
+            mutation: Some(conversation_mutation::Mutation::Entry(EntryMutation {
+                entry_id: "entry".to_owned(),
+                change: Some(entry_mutation::Change::Created(entry_mutation::Created {
+                    kind: EntryKind::AssistantMessage as i32,
+                    ..Default::default()
+                })),
+            })),
+            ..Default::default()
+        };
+        client
+            .apply_protobuf_mutation(&entry.encode_to_vec())
+            .unwrap();
+
+        let delta = ConversationMutation {
+            identity: Some(MutationIdentity {
+                mutation_id: "content-delta".to_owned(),
+                ..Default::default()
+            }),
+            mutation: Some(conversation_mutation::Mutation::Content(ContentMutation {
+                entry_id: "entry".to_owned(),
+                content_id: "content".to_owned(),
+                content_index: 0,
+                change: Some(content_mutation::Change::Delta(content_mutation::Delta {
+                    delta_index: 0,
+                    encoding: ContentEncoding::Utf8Markdown as i32,
+                    data: b"hello".to_vec(),
+                })),
+            })),
+            ..Default::default()
+        };
+        let bytes = delta.encode_to_vec();
+        assert_eq!(
+            client.mutation_key(&bytes).unwrap(),
+            "content:entry:content:0:delta:0"
+        );
+        client.apply_protobuf_mutation(&bytes).unwrap();
+
+        let state: Value = serde_json::from_str(&client.renderable_state_json().unwrap()).unwrap();
+        assert_eq!(state["entries"][0]["entry_id"], "entry");
+        assert_eq!(state["entries"][0]["contents"][0]["text"], "hello");
+
+        client.reset();
+        assert_eq!(client.entry_count(), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add a negotiated `SemanticConversationOnly` shared-session mode with exact conversation, execution, session, and schema identity
- produce canonical protobuf mutations only after fail-closed negotiation, filtering terminal/PTTY state before event allocation and retransmission
- add bounded Rust producer, consumer, and transcript reducer crates plus a browser-ready WASM boundary
- propagate semantic session identity through Factory task and orchestration restoration paths without changing full terminal sharing

## Dependencies
- https://github.com/warpdotdev/warp-proto-apis/pull/368
- https://github.com/warpdotdev/session-sharing-protocol/pull/77
- https://github.com/warpdotdev/session-sharing-server/pull/493

## Validation
- `./script/format`
- strict default-feature Clippy across all targets/tests for `warp`, `warp_semantic_session`, and `warp_semantic_session_wasm`
- `cargo check -p warp_semantic_session -p warp_semantic_session_wasm --target wasm32-unknown-unknown`
- 18/18 semantic reducer and WASM tests
- full Warp library run: 6,238 passed, 6 ignored; 12 environment/parallel-sensitive failures, with all six failures in modified terminal/workspace areas passing individually

Full-workspace Rust 1.92 Clippy is currently blocked by five pre-existing lints in unchanged `warp_completer` code; `--all-features` is additionally blocked by existing `agent_mode_evals` test cfg drift.

## Plan
[Native Factory Semantic Session Streaming](https://staging.warp.dev/drive/notebook/BOjlgsw2BUunaAz7Hxzt0I)
