### PR TITLE
Fix line editor status dropping precmd before session registration | Ubuntu 24 LTS

### DIFF
--- a/app/src/terminal/line_editor_status.rs
+++ b/app/src/terminal/line_editor_status.rs
@@ -69,16 +69,21 @@ impl LineEditorStatus {
     }
 
     fn handle_model_event(&mut self, event: &ModelEvent, ctx: &mut ModelContext<Self>) {
-        let Some(active_session_id) = self.model_event_dispatcher.as_ref(ctx).active_session_id()
-        else {
-            return;
+        // The shell's first precmd can arrive before its session is registered -- the
+        // Bootstrapped hook lands after it. Returning early here deadlocked the terminal:
+        // bash only emits another precmd once a command finishes, but no command can be
+        // written to the pty while the line editor is inactive, so nothing ever ran. Treat
+        // an unknown session as non-zsh, which is the correct reading of precmd for every
+        // shell except zsh.
+        let active_session_id = self.model_event_dispatcher.as_ref(ctx).active_session_id();
+        let is_active_session_zsh = match active_session_id {
+            Some(active_session_id) => self
+                .sessions
+                .as_ref(ctx)
+                .get(active_session_id)
+                .is_some_and(|session| session.shell().shell_type() == ShellType::Zsh),
+            None => false,
         };
-
-        let Some(active_session) = self.sessions.as_ref(ctx).get(active_session_id) else {
-            return;
-        };
-
-        let is_active_session_zsh = active_session.shell().shell_type() == ShellType::Zsh;
         match event {
             ModelEvent::Handler(AnsiHandlerEvent::Precmd) => {
                 if is_active_session_zsh {


### PR DESCRIPTION
## Description

`LineEditorStatus::handle_model_event` returned early whenever a model event arrived before the active session was registered. On some shells the first `precmd` hook can arrive before `Bootstrapped` registers the session, so that `precmd` was silently dropped.

Since bash only emits another `precmd` after a command finishes, and no command can be written to the pty while the line editor is considered inactive, this created a permanent deadlock: Enter dispatched normally but every command was queued and never executed, with no error shown.

Treat a session that isn't registered yet as non-zsh (the correct reading of `precmd` for every shell except zsh) instead of discarding the event.

## Linked Issue

Closes #15653

- Likely also the root cause of #8862 — that thread's later comment ("this is now happening all the time, more or less every time I split to a new window or open a new tab") matches this race exactly: every new session re-runs the bootstrap handshake, so every new tab/window is another chance for `Precmd` to beat `Bootstrapped`. The original folder-specific/`.git`-folder report in that issue may just be incidental timing rather than the actual trigger.
- Possibly related to #14234 (SSH sessions requiring multiple Enter presses) — flagging for triage, not claiming to fix it, since that may be a distinct race in the SSH bootstrap path.

- [ ] The linked issue is labeled `ready-to-implement`. (#15653 is newly filed; awaiting maintainer triage — the fix and reproduction are already verified below.)

## Testing

Reproduced on Ubuntu 24.04 (X11, bash): built from source, confirmed via app logs that `Precmd hook` is received before `Bootstrapped hook` on every session start, and that the input box accepted text and dispatched `EditorAction::Enter` normally but no command ever ran (`can_write_to_pty` stayed false forever, so writes were parked in `pending_writes`).

After the fix, ran multiple commands (`echo`, `whoami`, `pwd`) in a freshly built binary and confirmed each executed and printed output, across repeated new-session launches.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fix a race on session startup where a shell's first precmd hook could arrive before its session was registered, silently dropping the event and permanently blocking command execution.
-->
