### PR TITLE
Spec: allow deleting selected blocks

### DIFF
--- a/specs/GH50/product.md
+++ b/specs/GH50/product.md
@@ -1,0 +1,53 @@
+# Delete selected terminal blocks
+
+GitHub issue: [https://github.com/warpdotdev/warp/issues/50](https://github.com/warpdotdev/warp/issues/50)
+Figma: none provided
+
+## Summary
+
+Users can delete one or more selected terminal blocks from the current pane — via `⌘+Backspace` (macOS) / `Ctrl+Backspace` (Windows/Linux), or **Delete Selected Blocks** in the block context menu and the macOS **Blocks** menu — without clearing the rest of the session. The active (current input) block is never deleted. Deletion is persisted locally so restored sessions do not bring those blocks back.
+
+This is a focused first cut of [#50](https://github.com/warpdotdev/warp/issues/50). Hide/collapse and purging commands from Ctrl+R history are out of scope.
+
+## Problem
+
+Warp groups every command and its output into a block that can be selected, copied, bookmarked, and shared — but not removed. Users who mistype a command, print a secret, or want to clean a demo session have only **Clear Blocks** (`⌘+K` / `Ctrl+Shift+K`), which wipes the entire pane. That is the wrong tool when they meant to delete the selection.
+
+## Goals / Non-goals
+
+**Goals:**
+
+- Delete the selected completed blocks from the pane and from local session restore.
+- Default shortcut is `⌘+Backspace` on macOS and `Ctrl+Backspace` on Windows/Linux, remappable as `terminal:delete_blocks`.
+- Unmodified Backspace always edits the input, even when blocks are selected.
+- With no deletable selection, `⌘+Backspace` / `Ctrl+Backspace` keep their existing editor meaning (delete all left on macOS, delete word left on Windows/Linux).
+- **Clear Blocks** is unchanged.
+
+**Non-goals:**
+
+- Hide or collapse ([#23](https://github.com/warpdotdev/warp/issues/23)).
+- Removing the command from Ctrl+R / shell history.
+- Deleting the active/current input block.
+- Deleting shared-block permalinks on the server.
+
+## Behavior
+
+1. With at least one **non-active** block selected, `⌘+Backspace` (macOS) or `Ctrl+Backspace` (Windows/Linux) deletes those selected blocks (skipping the active block if it is also selected). Unmodified Backspace still edits the input.
+
+2. With no block selection, or with **only** the active block selected, `⌘+Backspace` / `Ctrl+Backspace` keep their existing editor behavior. The active block is never removed; selecting only it is a no-op for delete.
+
+3. The block context menu (overflow, right-click, or keyboard) and the macOS **Blocks** menu show **Delete Selected Blocks**, with the current `terminal:delete_blocks` shortcut label, only when at least one non-active block is selected. Choosing it has the same effect as the keybinding.
+
+4. `terminal:delete_blocks` is an editable Blocks shortcut. Default trigger is `cmdorctrl-backspace`. It appears in Settings → Keyboard shortcuts, the Resource Center Blocks section, and the Command Palette under the description **Delete Selected Blocks**.
+
+5. If the user rebinds `terminal:delete_blocks` away from `⌘+Backspace` / `Ctrl+Backspace`, that chord returns to its editor meaning even when a deletable selection exists. The menu shortcut labels follow the current binding.
+
+6. Remaining blocks keep their relative order. Bookmarks on surviving blocks stay attached after indices remap. Selection is cleared after a successful delete.
+
+7. Deleted blocks disappear from the pane immediately and do not reappear on session restore.
+
+8. Find-in-terminal matches for deleted content disappear. If the find bar is open, search re-runs against the remaining list.
+
+9. IME composition (`IMEOpen`) blocks the keybinding, matching other terminal block bindings.
+
+10. **Clear Blocks** / empty-buffer behavior is unchanged. Delete is selective; Clear still wipes the whole list.

--- a/specs/GH50/tech.md
+++ b/specs/GH50/tech.md
@@ -1,0 +1,97 @@
+# Delete selected terminal blocks — Tech spec
+
+Product spec: `specs/GH50/product.md`
+GitHub issue: [https://github.com/warpdotdev/warp/issues/50](https://github.com/warpdotdev/warp/issues/50)
+
+HEAD researched: `[0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7)`
+
+## Context
+
+See `product.md` for user-visible behavior.
+
+Today a pane can wipe its whole block list (`terminal:clear_blocks` → `TerminalAction::ClearBuffer`) but cannot remove an arbitrary subset. `BlockList` already has a private `remove_block_at_index` that refuses to drop the active block. Persistence only deletes **all** blocks for a pane (`ModelEvent::DeleteBlocks(pane_id)`), which is what pane close uses.
+
+`⌘+K` / `Ctrl+Shift+K` **Clear Blocks** is a `CustomAction` with a macOS **Blocks** menu item. Menu key equivalents are safe for that chord. Unmodified Backspace is not — it is a fixed editor binding used for typing, so it must not become a menu equivalent.
+
+The default delete-blocks chord is `cmdorctrl-backspace`. That overlaps the editor's **Delete all left** (`cmd-backspace` on Mac) and **Delete word left** (`ctrl-backspace` on Windows/Linux). Those are editable editor bindings, so when the input is focused they match before `TerminalView` unless they are suppressed.
+
+Relevant code at HEAD:
+
+- `app/src/terminal/view/init.rs` [(472-480) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/terminal/view/init.rs#L472-L480) — `terminal:clear_blocks` editable binding + `CustomAction::ClearBlocks`
+- `app/src/app_menus.rs` [(549-551) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/app_menus.rs#L549-L551) — Blocks app menu
+- `app/src/editor/view/mod.rs` [(760-820) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/editor/view/mod.rs#L760-L820) — `editor:delete_word_left` / `editor_view:delete_all_left`
+- `app/src/terminal/view.rs` [(16531-16547) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/terminal/view.rs#L16531-L16547) — Clear Blocks context-menu item
+- `app/src/terminal/model/blocks.rs` [(1425) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/terminal/model/blocks.rs#L1425) — `remove_block_at_index`
+- `app/src/persistence/mod.rs` [(242) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/persistence/mod.rs#L242) / `sqlite.rs` [(585) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/persistence/sqlite.rs#L585) / `block_list.rs` [(255) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/persistence/block_list.rs#L255) — pane-wide `DeleteBlocks`
+- `app/src/resource_center/utils.rs` [(8-25) @ 0b737e22a](https://github.com/warpdotdev/warp/blob/0b737e22a2c75cfef4aa76ac2179112a691bc3b7/app/src/resource_center/utils.rs#L8-L25) — Blocks keybinding catalog (must stay aligned with [docs.warp.dev keyboard shortcuts](https://docs.warp.dev/getting-started/keyboard-shortcuts))
+
+
+
+## Proposed changes
+
+
+
+### Binding as `CustomAction` (like Clear Blocks)
+
+Register `terminal:delete_blocks` as an `EditableBinding` with `CustomAction::DeleteBlocks`. Default keystroke is `cmdorctrl-backspace` via `custom_tag_to_keystroke` (same pattern as `CustomAction::ClearBlocks` → `cmdorctrl-shift-k`). Predicate: `Terminal & !IMEOpen & TerminalView_HasDeletableBlockSelection`.
+
+`TerminalView_HasDeletableBlockSelection` is set when the selection contains at least one non-active block. That keeps the macOS menu item **disabled** (so the OS does not steal `⌘+Backspace`) unless delete can actually succeed.
+
+Add **Delete Selected Blocks** to the macOS **Blocks** menu next to **Clear Blocks**.
+
+Unmodified Backspace stays a fixed editor binding. Do not attach it to this action.
+
+### Yield the overlapping editor chord while delete can succeed
+
+When a deletable selection exists **and** `terminal:delete_blocks` is currently bound to `cmdorctrl-backspace`, the input editor's keymap context sets `TERMINAL_BACKSPACE_DELETES_BLOCKS`.
+
+Attach that flag only to the editor action that actually uses that chord on the current platform:
+
+- macOS: `editor_view:delete_all_left` (`cmd-backspace`)
+- Windows/Linux: `editor:delete_word_left` (`ctrl-backspace`)
+
+Do not attach it to the other platform's keystroke for the same action (e.g. Linux `ctrl-y` for delete-all-left must keep working).
+
+Long-running-command bindings that also use `cmd-backspace` / `ctrl-backspace` add `!id!("TerminalView_HasDeletableBlockSelection")` so a block selection wins.
+
+### Model + view
+
+`BlockList::remove_blocks_at_indices` skips the active index, removes high-to-low, and returns the removed `BlockId`s. The view remaps bookmark / hover / mouse-down / filter-editor indices by arithmetic, clears selection, re-runs or clears find, and sends `ModelEvent::DeleteBlockIds`.
+
+### Persistence
+
+New `ModelEvent::DeleteBlockIds(Vec<BlockId>)` → `delete_blocks_by_ids`. Distinct from pane-wide `DeleteBlocks(pane_id)`.
+
+## Testing and validation
+
+
+| Product invariant                                                               | Verification                                                                                                                                                                                                      |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. `⌘/Ctrl+Backspace` deletes non-active selection; plain Backspace still edits | `cmd_or_ctrl_backspace_deletes_selected_blocks_when_editor_is_focused`; `backspace_edits_input_when_blocks_are_selected`; `test_delete_selected_blocks`                                                           |
+| 2. No selection / only-active → editor chord; active never deleted              | `cmd_or_ctrl_backspace_edits_input_when_no_blocks_are_selected`; `cmd_or_ctrl_backspace_edits_input_when_only_active_block_is_selected`; `test_delete_blocks_skips_active_block`; `test_remove_blocks_at_indices` |
+| 3. Context menu                                                                 | `test_context_menu_includes_delete_when_completed_block_is_selected`; `test_context_menu_omits_delete_when_only_active_block_is_selected`                                                                         |
+| 4–5. Editable Blocks shortcut + Blocks menu                                     | Binding registration + Resource Center catalog + `CustomAction::DeleteBlocks` in `make_new_blocks_menu`; manual: Settings remap, confirm editor chord returns                                                     |
+| 6. Order, bookmarks, selection                                                  | `test_delete_selected_blocks`                                                                                                                                                                                     |
+| 7. Session restore                                                              | Manual: delete, restore pane, blocks stay gone                                                                                                                                                                    |
+| 8. Find                                                                         | Covered in `delete_blocks` (re-run / clear matches); manual with find bar open                                                                                                                                    |
+| 9. IME                                                                          | Same predicate as other terminal bindings; manual if an IME is available                                                                                                                                          |
+| 10. Clear Blocks unchanged                                                      | Existing clear-buffer tests                                                                                                                                                                                       |
+
+
+Manual: select completed blocks, `⌘/Ctrl+Backspace`; unmodified Backspace still edits; overflow/right-click and Blocks menu **Delete Selected Blocks**; rebound shortcut; restore session.
+
+## Parallelization
+
+Not useful — keymap, view, model, and persistence are coupled and the implementation already lives in one diff.
+
+## Risks
+
+- Rebinding `terminal:delete_blocks` to another editor-owned key does not get a yield flag. Only the default `cmdorctrl-backspace` chord is special-cased.
+- Persistence send failure is logged; the in-memory list is already updated.
+
+
+
+## Follow-ups
+
+- Update public docs in [warpdotdev/docs](https://github.com/warpdotdev/docs): Blocks table on [keyboard shortcuts](https://docs.warp.dev/getting-started/keyboard-shortcuts) (`⌘+Backspace` / `Ctrl+Backspace` · Delete Selected Blocks · `terminal:delete_blocks`) and a short section on [block actions](https://docs.warp.dev/terminal/blocks/block-actions). Those pages are not in this repo; `BLOCKS_KEYBINDINGS` already matches the in-app catalog.
+- History purge.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Closes https://github.com/warpdotdev/warp/issues/50

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
