### PR TITLE
feat(agent): support self-hosted GitLab runtimes

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -806,6 +806,16 @@ pub enum AgentDriverError {
     ConversationLoadFailed(String),
     #[error("Failed to initialize AWS Bedrock credentials: {0}")]
     AwsBedrockCredentialsFailed(String),
+    #[error("The worker could not reach the GitLab instance.")]
+    GitLabWorkerConnectivityFailed,
+    #[error("The worker could not establish trusted TLS with the GitLab instance.")]
+    GitLabWorkerTlsFailed,
+    #[error("The worker GitLab credential was rejected.")]
+    GitLabWorkerAuthenticationFailed,
+    #[error("The worker GitLab credential cannot access a required repository.")]
+    GitLabWorkerRepositoryAccessDenied,
+    #[error("The worker could not access a required GitLab remote with Git.")]
+    GitLabWorkerGitAccessFailed,
     #[error(
         "Conversation {conversation_id} was produced by the {expected} harness, but --harness {got} was requested. \
          Re-run with --harness {expected} (or omit --harness to match) to continue this conversation."
@@ -992,6 +1002,15 @@ impl AgentDriver {
                 });
 
         let mut env_vars = build_secret_env_vars(&secrets);
+        if let Some(task_bin_dir) = git_credentials::task_bin_dir() {
+            let mut paths = vec![task_bin_dir];
+            if let Some(path) = std::env::var_os("PATH") {
+                paths.extend(std::env::split_paths(&path));
+            }
+            let path = std::env::join_paths(paths)
+                .map_err(|error| AgentDriverError::ConfigBuildFailed(error.into()))?;
+            env_vars.insert(OsString::from("PATH"), path);
+        }
 
         // Inject cloud provider env vars.
         cloud_provider::collect_env_vars(&cloud_providers, &mut env_vars)?;
@@ -3055,7 +3074,7 @@ impl AgentDriver {
 
             let harness = task.harness.harness();
             let setup_events_for_environment = setup_events.clone();
-            let source_repos_for_prepare = source_repos;
+            let source_repos_for_prepare = source_repos.clone();
             let prepare_outcome = foreground
                 .spawn(move |me, ctx| {
                     let working_dir = me.working_dir.clone();
@@ -3085,6 +3104,12 @@ impl AgentDriver {
                 Self::linger_after_failure(&foreground, "environment_setup", &error).await;
                 return Err(error);
             }
+            setup_events
+                .record_result(
+                    SetupStep::GitLabPreflight,
+                    Self::run_gitlab_preflight_checks(&source_repos, &foreground),
+                )
+                .await?;
 
             if let Some(file_based_discovery_rx) = file_based_discovery_rx {
                 // Await discovery: collect UUIDs of file-based MCP servers that were auto-started
@@ -3465,6 +3490,50 @@ impl AgentDriver {
         Ok(())
     }
 
+    async fn run_gitlab_preflight_checks(
+        repositories: &[SourceRepo],
+        foreground: &ModelSpawner<Self>,
+    ) -> Result<(), AgentDriverError> {
+        git_credentials::preflight_gitlab_network(repositories)
+            .await
+            .map_err(|error| match error {
+                git_credentials::GitLabPreflightError::Connectivity => {
+                    AgentDriverError::GitLabWorkerConnectivityFailed
+                }
+                git_credentials::GitLabPreflightError::Tls => {
+                    AgentDriverError::GitLabWorkerTlsFailed
+                }
+                git_credentials::GitLabPreflightError::Authentication => {
+                    AgentDriverError::GitLabWorkerAuthenticationFailed
+                }
+                git_credentials::GitLabPreflightError::RepositoryAccess => {
+                    AgentDriverError::GitLabWorkerRepositoryAccessDenied
+                }
+            })?;
+
+        let working_dir = foreground.spawn(|me, _| me.working_dir.clone()).await?;
+        let Some(command) =
+            git_credentials::gitlab_git_access_check_command(repositories, &working_dir)
+                .map_err(|_| AgentDriverError::GitLabWorkerRepositoryAccessDenied)?
+        else {
+            return Ok(());
+        };
+        let check = foreground
+            .spawn(move |me, ctx| {
+                me.terminal_driver.update(ctx, |driver, ctx| {
+                    driver.execute_silent_command(command, ctx)
+                })
+            })
+            .await?;
+        let output = check
+            .with_timeout(PREFLIGHT_CHECK_TIMEOUT)
+            .await
+            .map_err(|_| AgentDriverError::GitLabWorkerGitAccessFailed)??;
+        if !output.success() {
+            return Err(AgentDriverError::GitLabWorkerGitAccessFailed);
+        }
+        Ok(())
+    }
     /// Run a single preflight check command and return an error if it fails.
     async fn run_single_preflight(
         command: &str,

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1002,6 +1002,10 @@ impl AgentDriver {
                 });
 
         let mut env_vars = build_secret_env_vars(&secrets);
+        env_vars.extend(
+            git_credentials::task_environment_variables()
+                .map_err(AgentDriverError::ConfigBuildFailed)?,
+        );
         if let Some(task_bin_dir) = git_credentials::task_bin_dir() {
             let mut paths = vec![task_bin_dir];
             if let Some(path) = std::env::var_os("PATH") {
@@ -3044,6 +3048,14 @@ impl AgentDriver {
                 .unwrap_or_default(),
             additional_source_repos,
         )?;
+        if !source_repos.is_empty() {
+            setup_events
+                .record_result(
+                    SetupStep::GitLabPreflight,
+                    Self::run_gitlab_preflight_checks(&source_repos, &foreground),
+                )
+                .await?;
+        }
 
         if environment_opt.is_some() || !source_repos.is_empty() || !setup_commands.is_empty() {
             log::info!("Loading environment...");
@@ -3104,12 +3116,6 @@ impl AgentDriver {
                 Self::linger_after_failure(&foreground, "environment_setup", &error).await;
                 return Err(error);
             }
-            setup_events
-                .record_result(
-                    SetupStep::GitLabPreflight,
-                    Self::run_gitlab_preflight_checks(&source_repos, &foreground),
-                )
-                .await?;
 
             if let Some(file_based_discovery_rx) = file_based_discovery_rx {
                 // Await discovery: collect UUIDs of file-based MCP servers that were auto-started
@@ -3511,10 +3517,8 @@ impl AgentDriver {
                 }
             })?;
 
-        let working_dir = foreground.spawn(|me, _| me.working_dir.clone()).await?;
-        let Some(command) =
-            git_credentials::gitlab_git_access_check_command(repositories, &working_dir)
-                .map_err(|_| AgentDriverError::GitLabWorkerRepositoryAccessDenied)?
+        let Some(command) = git_credentials::gitlab_git_access_check_command(repositories)
+            .map_err(|_| AgentDriverError::GitLabWorkerRepositoryAccessDenied)?
         else {
             return Ok(());
         };

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -740,7 +740,7 @@ clone_repo() {
         let repo_name = format!("{}/{}", request.repo.owner, request.repo.repo);
         let repo_url = &request.clone_url;
         let escaped_repo_name = shell_escape_single_quotes(&repo_name, ShellType::Bash);
-        let escaped_repo_url = shell_escape_single_quotes(&repo_url, ShellType::Bash);
+        let escaped_repo_url = shell_escape_single_quotes(repo_url, ShellType::Bash);
         let escaped_target = shell_escape_single_quotes(&request.repo.repo, ShellType::Bash);
         let checkout_ref = request
             .checkout
@@ -868,7 +868,7 @@ async fn clone_repo(
         })
         .await
         .unwrap_or(ShellType::Bash);
-    let escaped_url = shell_escape_single_quotes(&repo_url, shell_type);
+    let escaped_url = shell_escape_single_quotes(repo_url, shell_type);
     let repo_dir = working_dir.join(&repo.repo);
     let commit_sha = match &request.checkout {
         Some(RepositoryHeadRef::CommitSha(commit_sha)) => Some(commit_sha.as_str()),

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -53,6 +53,8 @@ pub enum PrepareEnvironmentError {
     SetupCommand { command: String },
     #[error("Failed to change directory into {repo_name}")]
     ChangeDirectory { repo_name: String },
+    #[error("Failed to configure task-scoped repository credentials")]
+    CredentialSetup,
     #[error(
         "Repositories {first_owner}/{repo_name} and {second_owner}/{repo_name} share a clone directory name"
     )]
@@ -393,6 +395,8 @@ async fn prepare_environment_impl(
             repo_name: working_dir_string,
         });
     }
+    git_credentials::prepare_repository_credentials(source_repos)
+        .map_err(|_| PrepareEnvironmentError::CredentialSetup)?;
     let mut codebase_context_receivers = Vec::new();
 
     let environment_snapshot = if source_repos.is_empty() {
@@ -413,10 +417,8 @@ async fn prepare_environment_impl(
 
     if !source_repos.is_empty() {
         for repo in source_repos {
-            git_credentials::configure_repository_git_identity(
-                &working_dir.join(&repo.repo),
-                repo.code_forge.map(CodeForge::host).unwrap_or(""),
-            );
+            git_credentials::configure_repository_credentials(&working_dir.join(&repo.repo), repo)
+                .map_err(|_| PrepareEnvironmentError::CredentialSetup)?;
             register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
             if !is_sandbox && should_index_codebase {
                 let receiver = index_repo_codebase(
@@ -604,6 +606,7 @@ fn head_override_for_repo<'a>(
 #[derive(Debug, Clone)]
 struct RepositoryCloneRequest {
     repo: SourceRepo,
+    clone_url: String,
     checkout: Option<RepositoryHeadRef>,
 }
 
@@ -628,7 +631,13 @@ fn repository_clone_requests(
                 Some(head_override) => Some(head_override.head.clone()),
                 None => repo.checkout_ref.clone().map(RepositoryHeadRef::Branch),
             };
-            Ok(RepositoryCloneRequest { repo, checkout })
+            let clone_url = git_credentials::clone_url_for_repository(&repo)
+                .map_err(|_| PrepareEnvironmentError::CredentialSetup)?;
+            Ok(RepositoryCloneRequest {
+                repo,
+                clone_url,
+                checkout,
+            })
         })
         .collect()
 }
@@ -729,7 +738,7 @@ clone_repo() {
     let mut log_outputs = String::new();
     for (index, request) in repos.iter().enumerate() {
         let repo_name = format!("{}/{}", request.repo.owner, request.repo.repo);
-        let repo_url = request.repo.https_clone_url();
+        let repo_url = &request.clone_url;
         let escaped_repo_name = shell_escape_single_quotes(&repo_name, ShellType::Bash);
         let escaped_repo_url = shell_escape_single_quotes(&repo_url, ShellType::Bash);
         let escaped_target = shell_escape_single_quotes(&request.repo.repo, ShellType::Bash);
@@ -848,7 +857,7 @@ async fn clone_repo(
 ) -> Result<(), PrepareEnvironmentError> {
     let repo = &request.repo;
     let repo_name = format!("{}/{}", repo.owner, repo.repo);
-    let repo_url = repo.https_clone_url();
+    let repo_url = &request.clone_url;
     // Get the session's shell type for proper escaping, falling back to Bash
     // when the session is not yet bootstrapped or the spawn fails.
     let shell_type = spawner

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -180,7 +180,12 @@ fn branch_head_override(
 }
 
 fn clone_request(repo: SourceRepo, checkout: Option<RepositoryHeadRef>) -> RepositoryCloneRequest {
-    RepositoryCloneRequest { repo, checkout }
+    let clone_url = repo.https_clone_url();
+    RepositoryCloneRequest {
+        repo,
+        clone_url,
+        checkout,
+    }
 }
 
 fn named_checkout_request(repo: SourceRepo) -> RepositoryCloneRequest {
@@ -336,6 +341,25 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
     assert!(command.contains("===== platform/backend/api ====="));
     assert!(!command.contains("repository revision results"));
     assert!(command.contains("exit \"$failed\""));
+}
+
+#[test]
+fn clone_command_uses_an_explicit_self_hosted_origin_without_a_token() {
+    let request = RepositoryCloneRequest {
+        repo: SourceRepo::new(
+            CodeForge::GitLab,
+            "platform/backend".to_string(),
+            "api".to_string(),
+        ),
+        clone_url: "https://gitlab.example.com:8443/gitlab/platform/backend/api.git".to_string(),
+        checkout: None,
+    };
+
+    let command = build_parallel_clone_command(&[request], ShellType::Bash);
+
+    assert!(command.contains("https://gitlab.example.com:8443/gitlab/platform/backend/api.git"));
+    assert!(!command.contains("oauth2@"));
+    assert!(!command.contains("GITLAB_TOKEN"));
 }
 
 #[test]
@@ -514,11 +538,11 @@ fn clone_requests_use_each_repository_host() {
     let command = build_parallel_clone_command(&prepared, ShellType::Bash);
 
     assert_eq!(
-        prepared[0].repo.https_clone_url(),
+        prepared[0].clone_url,
         "https://github.com/warpdotdev/warp.git"
     );
     assert_eq!(
-        prepared[1].repo.https_clone_url(),
+        prepared[1].clone_url,
         "https://gitlab.com/platform/backend/api.git"
     );
     assert!(command.contains("https://github.com/warpdotdev/warp.git"));

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -274,6 +274,41 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
+        AgentDriverError::GitLabWorkerConnectivityFailed => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                "The worker could not reach the GitLab instance. Check DNS, routing, firewall rules, and the configured instance address, then retry.",
+                PlatformErrorCode::EnvironmentSetupFailed,
+            ),
+        ),
+        AgentDriverError::GitLabWorkerTlsFailed => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                "The worker could not establish trusted TLS with the GitLab instance. Install a publicly trusted certificate for the configured hostname, then retry.",
+                PlatformErrorCode::EnvironmentSetupFailed,
+            ),
+        ),
+        AgentDriverError::GitLabWorkerAuthenticationFailed => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                "The GitLab task credential was rejected. Repair the GitLab installation or mint a new Factory credential, then retry.",
+                PlatformErrorCode::AuthenticationRequired,
+            ),
+        ),
+        AgentDriverError::GitLabWorkerRepositoryAccessDenied => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                "The GitLab task credential cannot access a required repository. Repair the Factory project binding and installation membership, then retry.",
+                PlatformErrorCode::AuthenticationRequired,
+            ),
+        ),
+        AgentDriverError::GitLabWorkerGitAccessFailed => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                "Git could not access a required GitLab remote. Check the repository binding and worker network access, then retry.",
+                PlatformErrorCode::EnvironmentSetupFailed,
+            ),
+        ),
         AgentDriverError::ConversationLoadFailed(msg) => (
             AgentTaskState::Error,
             TaskStatusUpdate::with_error_code(

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -17,6 +17,50 @@ fn assert_state_and_code(
     );
 }
 
+#[test]
+fn gitlab_worker_preflight_failures_are_bounded_and_actionable() {
+    let cases = [
+        (
+            AgentDriverError::GitLabWorkerConnectivityFailed,
+            PlatformErrorCode::EnvironmentSetupFailed,
+            "DNS",
+        ),
+        (
+            AgentDriverError::GitLabWorkerTlsFailed,
+            PlatformErrorCode::EnvironmentSetupFailed,
+            "TLS",
+        ),
+        (
+            AgentDriverError::GitLabWorkerAuthenticationFailed,
+            PlatformErrorCode::AuthenticationRequired,
+            "credential was rejected",
+        ),
+        (
+            AgentDriverError::GitLabWorkerRepositoryAccessDenied,
+            PlatformErrorCode::AuthenticationRequired,
+            "required repository",
+        ),
+        (
+            AgentDriverError::GitLabWorkerGitAccessFailed,
+            PlatformErrorCode::EnvironmentSetupFailed,
+            "GitLab remote",
+        ),
+    ];
+
+    for (error, expected_code, message_fragment) in cases {
+        let (state, update) = classify_driver_error(&error);
+        assert_eq!(state, AgentTaskState::Failed);
+        assert_eq!(update.error_code, Some(expected_code));
+        assert!(
+            update.message.contains(message_fragment),
+            "{}",
+            update.message
+        );
+        assert!(!update.message.contains("gitlab.example.com"));
+        assert!(!update.message.contains("token"));
+    }
+}
+
 // --- Infrastructure errors → ERROR ---
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -379,7 +379,6 @@ fn replace_task_credentials(credentials: &[GitCredential]) -> Result<Vec<GitCred
     Ok(credentials)
 }
 
-
 fn select_credential_for_repository<'a>(
     credentials: &'a [GitCredential],
     repo: &SourceRepo,
@@ -940,10 +939,7 @@ fn apply_refreshed_credentials_at_home(
     replace_task_credentials(&credentials)?;
     if !credentials.is_empty() {
         std::fs::create_dir_all(task_credentials_root(home)).with_context(|| {
-            format!(
-                "Failed to create {}",
-                task_credentials_root(home).display()
-            )
+            format!("Failed to create {}", task_credentials_root(home).display())
         })?;
         install_glab_wrapper(&credentials, home)?;
     }
@@ -1017,8 +1013,7 @@ fn ipv6_address_is_public(address: Ipv6Addr) -> bool {
     }
     let segments = address.segments();
     (segments[0] & 0xe000) == 0x2000
-        && !(segments[0] == 0x2001
-            && (segments[1] <= 0x01ff || segments[1] == 0x0db8))
+        && !(segments[0] == 0x2001 && (segments[1] <= 0x01ff || segments[1] == 0x0db8))
         && segments[0] != 0x2002
         && !(segments[0] == 0x3fff && segments[1] & 0xf000 == 0)
 }
@@ -1060,9 +1055,7 @@ async fn resolve_public_addresses(
 }
 
 #[cfg(not(target_family = "wasm"))]
-async fn check_tcp_connectivity(
-    addresses: &[SocketAddr],
-) -> Result<(), GitLabPreflightError> {
+async fn check_tcp_connectivity(addresses: &[SocketAddr]) -> Result<(), GitLabPreflightError> {
     tokio::time::timeout(NETWORK_CONNECT_TIMEOUT, async {
         for address in addresses {
             if tokio::net::TcpStream::connect(address).await.is_ok() {

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsString;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -40,8 +40,8 @@ const NETWORK_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const NETWORK_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 static TASK_CREDENTIALS: RwLock<Vec<GitCredential>> = RwLock::new(Vec::new());
-static REPOSITORY_BINDINGS: RwLock<HashMap<(CodeForge, String), String>> =
-    RwLock::new(HashMap::new());
+static REPOSITORY_BINDINGS: LazyLock<RwLock<HashMap<(CodeForge, String), String>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 static GLAB_CONFIGS: RwLock<Vec<RegisteredGlabConfig>> = RwLock::new(Vec::new());
 
 #[derive(Clone)]
@@ -257,11 +257,12 @@ fn credential_origin(credential: &GitCredential) -> Result<Url> {
             .map_err(|_| anyhow::anyhow!("Invalid task Git credential port"))?;
     }
     let prefix = normalized_relative_prefix(&credential.relative_url_prefix)?;
-    origin.set_path(if prefix.is_empty() {
-        "/"
+    let path = if prefix.is_empty() {
+        "/".to_string()
     } else {
-        &format!("/{prefix}/")
-    });
+        format!("/{prefix}/")
+    };
+    origin.set_path(&path);
     Ok(origin)
 }
 

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -1,54 +1,115 @@
-/// Git credentials management for cloud agent sandboxes.
-///
-/// This module handles:
-/// - Writing provider credentials to `~/.git-credentials`, plus GitHub
-///   credentials to `~/.config/gh/hosts.yml`, without requiring environment
-///   variables.
-/// - One-time git configuration (`credential.helper store`, SSH→HTTPS URL
-///   rewrites).
-/// - Configuring the git user identity from the server-returned username/email.
-/// - An async refresh loop that periodically fetches a fresh token from the
-///   server and overwrites the credential files, keeping long-running agents
-///   authenticated for their entire duration.
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+//! Task-scoped Git credentials for cloud agent sandboxes.
+//!
+//! Tokens are stored only in owner-readable files. Git selects them by the
+//! complete HTTPS repository path, and each GitLab checkout receives a private
+//! `glab` configuration selected by a task-local wrapper.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-// Use the project's allowed Command wrapper (not std::process::Command, which is
-// disallowed by clippy rules because it flashes a terminal window on Windows).
+#[cfg(not(target_family = "wasm"))]
+use async_compat::Compat;
+use cloud_object_models::{CodeForge, SourceRepo};
 use command::blocking::Command as BlockingCommand;
+use serde::Serialize;
+use url::Url;
 
 use crate::server::server_api::ai::{AIClient, GitCredential, TaskGitCredentialsResponse};
 
-/// How long to wait between credential refresh attempts (~50 minutes, staying
-/// well ahead of the shortest-lived one-hour token expiry).
+/// Refresh before the shortest-lived one-hour token expires.
 pub(crate) const GIT_CREDENTIALS_REFRESH_INTERVAL: Duration = Duration::from_secs(50 * 60);
 
 const DEFAULT_GIT_NAME: &str = "Warp";
 const DEFAULT_GIT_EMAIL: &str = "agent@warp.dev";
 const GITHUB_HOST: &str = "github.com";
+const GITLAB_HOST: &str = "gitlab.com";
 const GH_HOSTS_FILENAME: &str = "hosts.yml";
-const GLAB_HOST: &str = "gitlab.com";
 const GLAB_CONFIG_FILENAME: &str = "config.yml";
+const TASK_CREDENTIALS_DIR: &str = ".warp/task-git";
+const TASK_CREDENTIALS_FILENAME: &str = "credentials";
+const TASK_BIN_DIRNAME: &str = "bin";
+const GLAB_WRAPPER_FILENAME: &str = "glab";
+const GLAB_REPOSITORY_CONFIG_KEY: &str = "warp.glabConfigDir";
+const NETWORK_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const NETWORK_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+static TASK_CREDENTIALS: RwLock<Vec<GitCredential>> = RwLock::new(Vec::new());
+static REPOSITORY_BINDINGS: RwLock<HashMap<(CodeForge, String), String>> =
+    RwLock::new(HashMap::new());
+static GLAB_CONFIGS: RwLock<Vec<RegisteredGlabConfig>> = RwLock::new(Vec::new());
+
+#[derive(Clone)]
+struct RegisteredGlabConfig {
+    credential_id: String,
+    config_dir: PathBuf,
+}
+
+fn merged_credentials_by_id(
+    existing: &[GitCredential],
+    refreshed: &[GitCredential],
+) -> Result<Vec<GitCredential>> {
+    let refreshed = unique_credentials_by_id(refreshed)?;
+    let mut merged = existing.to_vec();
+    for credential in refreshed {
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| existing.id == credential.id)
+        {
+            *existing = credential;
+        } else {
+            merged.push(credential);
+        }
+    }
+    Ok(merged)
+}
+
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitLabPreflightError {
+    #[error("The worker could not reach the GitLab instance.")]
+    Connectivity,
+    #[error("The worker could not establish trusted TLS with the GitLab instance.")]
+    Tls,
+    #[error("The worker GitLab credential was rejected.")]
+    Authentication,
+    #[error("The worker GitLab credential cannot access a required repository.")]
+    RepositoryAccess,
+}
 
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))
 }
 
-/// Write `content` to `path` using owner-only (0600) permissions.
-///
-/// On Unix the file is created with mode 0600 so no other user can read the
-/// credential material. On non-Unix platforms the function falls back to the
-/// standard write, relying on OS default permissions.
-fn write_secret_file(path: &std::path::Path, content: &str) -> Result<()> {
+fn task_credentials_root(home: &Path) -> PathBuf {
+    home.join(TASK_CREDENTIALS_DIR)
+}
+
+fn task_credentials_file(home: &Path) -> PathBuf {
+    task_credentials_root(home).join(TASK_CREDENTIALS_FILENAME)
+}
+
+fn task_bin_dir_for_home(home: &Path) -> PathBuf {
+    task_credentials_root(home).join(TASK_BIN_DIRNAME)
+}
+
+pub(crate) fn task_bin_dir() -> Option<PathBuf> {
+    let home = home_dir().ok()?;
+    let bin_dir = task_bin_dir_for_home(&home);
+    bin_dir
+        .join(GLAB_WRAPPER_FILENAME)
+        .is_file()
+        .then_some(bin_dir)
+}
+
+/// Write secret content with owner-only permissions.
+fn write_secret_file(path: &Path, content: &str) -> Result<()> {
     #[cfg(unix)]
     {
         use std::io::Write as _;
         use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -69,477 +130,992 @@ fn write_secret_file(path: &std::path::Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-fn git_credentials_line(cred: &GitCredential) -> String {
-    let userinfo = match &cred.username {
-        Some(username) => format!("{username}:{}", cred.token),
-        None => format!("x-access-token:{}", cred.token),
+#[cfg(unix)]
+fn write_executable_file(path: &Path, content: &str) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    write_secret_file(path, content)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("Failed to make {} executable", path.display()))
+}
+
+fn normalized_project_path(path: &str) -> Result<String> {
+    let path = path.trim().trim_matches('/');
+    let path = if path
+        .get(path.len().saturating_sub(4)..)
+        .is_some_and(|suffix| suffix.eq_ignore_ascii_case(".git"))
+    {
+        &path[..path.len() - 4]
+    } else {
+        path
     };
-    format!("https://{}@{}", userinfo, cred.host)
+    if path.is_empty()
+        || path.contains('\\')
+        || path
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        bail!("Invalid repository credential path");
+    }
+    Ok(path.to_string())
 }
 
-fn host_of_credentials_line(line: &str) -> Option<&str> {
-    line.rsplit_once('@').map(|(_, host)| host)
+fn project_key(path: &str) -> Result<String> {
+    normalized_project_path(path)
 }
 
-/// Keep one credential per host. Identical duplicates are dropped; conflicting
-/// token or identity fields for the same host are rejected so `gh`/`glab` YAML
-/// cannot grow duplicate mapping keys.
-fn unique_credentials_by_host(credentials: &[GitCredential]) -> Result<Vec<GitCredential>> {
-    let mut index_by_host = HashMap::new();
+fn source_repo_project_path(repo: &SourceRepo) -> String {
+    format!("{}/{}", repo.owner, repo.repo)
+}
+
+fn repository_binding_key(repo: &SourceRepo) -> Result<(CodeForge, String)> {
+    let code_forge = repo
+        .code_forge
+        .filter(|code_forge| !matches!(code_forge, CodeForge::None | CodeForge::Unknown))
+        .ok_or_else(|| anyhow::anyhow!("Repository has no supported code forge"))?;
+    Ok((code_forge, project_key(&source_repo_project_path(repo))?))
+}
+
+fn normalized_relative_prefix(prefix: &str) -> Result<String> {
+    let prefix = prefix.trim().trim_matches('/');
+    if prefix.contains('\\')
+        || (!prefix.is_empty()
+            && prefix
+                .split('/')
+                .any(|component| component.is_empty() || matches!(component, "." | "..")))
+    {
+        bail!("Invalid GitLab relative URL prefix");
+    }
+    Ok(prefix.to_string())
+}
+
+fn credential_origin(credential: &GitCredential) -> Result<Url> {
+    if credential.scheme != "https" {
+        bail!("Task Git credentials require HTTPS");
+    }
+    if credential.host.trim().is_empty()
+        || credential.host.trim() != credential.host
+        || credential.host.contains('/')
+        || credential.host.contains('@')
+    {
+        bail!("Invalid task Git credential host");
+    }
+    let mut origin = Url::parse("https://invalid/")
+        .context("Failed to initialize task Git credential origin")?;
+    origin
+        .set_host(Some(&credential.host))
+        .map_err(|_| anyhow::anyhow!("Invalid task Git credential host"))?;
+    if let Some(port) = credential.port {
+        let port = u16::try_from(port)
+            .ok()
+            .filter(|port| *port > 0)
+            .ok_or_else(|| anyhow::anyhow!("Invalid task Git credential port"))?;
+        origin
+            .set_port(Some(port))
+            .map_err(|_| anyhow::anyhow!("Invalid task Git credential port"))?;
+    }
+    let prefix = normalized_relative_prefix(&credential.relative_url_prefix)?;
+    origin.set_path(if prefix.is_empty() {
+        "/"
+    } else {
+        &format!("/{prefix}/")
+    });
+    Ok(origin)
+}
+
+fn credential_authority(credential: &GitCredential) -> Result<String> {
+    let origin = credential_origin(credential)?;
+    Ok(match origin.port() {
+        Some(port) => format!(
+            "{}:{port}",
+            origin
+                .host_str()
+                .ok_or_else(|| anyhow::anyhow!("Task Git credential origin has no host"))?
+        ),
+        None => origin
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("Task Git credential origin has no host"))?
+            .to_string(),
+    })
+}
+
+fn clone_url_for_path(credential: &GitCredential, project_path: &str) -> Result<String> {
+    let project_path = normalized_project_path(project_path)?;
+    let prefix = normalized_relative_prefix(&credential.relative_url_prefix)?;
+    let mut clone_url = credential_origin(credential)?;
+    let path = if prefix.is_empty() {
+        format!("/{project_path}.git")
+    } else {
+        format!("/{prefix}/{project_path}.git")
+    };
+    clone_url.set_path(&path);
+    Ok(clone_url.to_string())
+}
+
+fn is_gitlab_credential(credential: &GitCredential) -> bool {
+    credential.instance_uid.is_some()
+        || credential.installation_uid.is_some()
+        || credential.host.eq_ignore_ascii_case(GITLAB_HOST)
+}
+
+fn is_self_hosted_gitlab_credential(credential: &GitCredential) -> bool {
+    is_gitlab_credential(credential)
+        && (!credential.host.eq_ignore_ascii_case(GITLAB_HOST)
+            || credential.port.is_some()
+            || !credential.relative_url_prefix.trim_matches('/').is_empty())
+}
+
+fn credential_authorizes_path(credential: &GitCredential, path_key: &str) -> bool {
+    credential.project_paths.iter().any(|path| {
+        project_key(path).is_ok_and(|credential_path_key| credential_path_key == path_key)
+    })
+}
+fn credential_matches_forge(credential: &GitCredential, code_forge: Option<CodeForge>) -> bool {
+    match code_forge {
+        Some(CodeForge::GitHub) => {
+            credential.host.eq_ignore_ascii_case(GITHUB_HOST) && !is_gitlab_credential(credential)
+        }
+        Some(CodeForge::GitLab) => is_gitlab_credential(credential),
+        Some(CodeForge::None | CodeForge::Unknown) | None => false,
+    }
+}
+
+fn credentials_equal(left: &GitCredential, right: &GitCredential) -> bool {
+    left.id == right.id
+        && left.instance_uid == right.instance_uid
+        && left.installation_uid == right.installation_uid
+        && left.scheme == right.scheme
+        && left.host == right.host
+        && left.port == right.port
+        && left.relative_url_prefix == right.relative_url_prefix
+        && left.project_paths == right.project_paths
+        && left.token == right.token
+        && left.username == right.username
+        && left.email == right.email
+}
+
+/// Keep one credential per opaque ID. Different credentials may share a host.
+fn unique_credentials_by_id(credentials: &[GitCredential]) -> Result<Vec<GitCredential>> {
+    let mut index_by_id = HashMap::new();
     let mut unique = Vec::new();
-    for cred in credentials {
-        if let Some(&index) = index_by_host.get(&cred.host) {
+    for credential in credentials {
+        if credential.id.trim().is_empty() {
+            bail!("Task Git credential is missing an ID");
+        }
+        credential_origin(credential)?;
+        for project_path in &credential.project_paths {
+            normalized_project_path(project_path)?;
+        }
+
+        if let Some(&index) = index_by_id.get(&credential.id) {
             let existing: &GitCredential = &unique[index];
-            if existing.token != cred.token
-                || existing.username != cred.username
-                || existing.email != cred.email
-            {
-                bail!(
-                    "Conflicting git credentials for host {}; refusing to write duplicate mapping keys",
-                    cred.host
-                );
+            if !credentials_equal(existing, credential) {
+                bail!("Conflicting task Git credentials share an ID");
             }
             continue;
         }
-        index_by_host.insert(cred.host.clone(), unique.len());
-        unique.push(cred.clone());
+        index_by_id.insert(credential.id.clone(), unique.len());
+        unique.push(credential.clone());
     }
     Ok(unique)
 }
 
-/// Bootstrap has no prior credential store, so a one-host success would leave
-/// the other host unauthenticated for the first clone.
-pub(crate) fn credentials_for_bootstrap(
-    response: TaskGitCredentialsResponse,
-) -> Result<Vec<GitCredential>> {
-    if !response.failed_hosts.is_empty() {
-        bail!(
-            "Git credential bootstrap cannot proceed with failed hosts ({}); \
-             an all-or-nothing fetch is required before the first clone",
-            response.failed_hosts.join(", ")
-        );
-    }
-    unique_credentials_by_host(&response.credentials)
+fn task_credentials_snapshot() -> Result<Vec<GitCredential>> {
+    TASK_CREDENTIALS
+        .read()
+        .map(|credentials| credentials.clone())
+        .map_err(|_| anyhow::anyhow!("Task Git credential state is unavailable"))
 }
 
-/// Merge fresh credentials into the existing `~/.git-credentials` content,
-/// replacing the line for each refreshed host and preserving every other line.
-fn merge_git_credentials_file_content(existing: &str, credentials: &[GitCredential]) -> String {
-    let refreshed_hosts = credentials
+fn replace_task_credentials(credentials: &[GitCredential]) -> Result<Vec<GitCredential>> {
+    let credentials = unique_credentials_by_id(credentials)?;
+    let mut stored = TASK_CREDENTIALS
+        .write()
+        .map_err(|_| anyhow::anyhow!("Task Git credential state is unavailable"))?;
+    *stored = credentials.clone();
+    Ok(credentials)
+}
+
+fn merge_task_credentials(credentials: &[GitCredential]) -> Result<Vec<GitCredential>> {
+    let mut stored = TASK_CREDENTIALS
+        .write()
+        .map_err(|_| anyhow::anyhow!("Task Git credential state is unavailable"))?;
+    *stored = merged_credentials_by_id(&stored, credentials)?;
+    Ok(stored.clone())
+}
+
+fn select_credential_for_repository<'a>(
+    credentials: &'a [GitCredential],
+    repo: &SourceRepo,
+) -> Result<Option<&'a GitCredential>> {
+    let path_key = project_key(&source_repo_project_path(repo))?;
+    let exact = credentials
         .iter()
-        .map(|cred| cred.host.as_str())
+        .filter(|credential| {
+            credential_matches_forge(credential, repo.code_forge)
+                && credential_authorizes_path(credential, &path_key)
+        })
         .collect::<Vec<_>>();
+    match exact.as_slice() {
+        [credential] => return Ok(Some(*credential)),
+        [] => {}
+        _ => bail!("Multiple task Git credentials authorize the same repository path"),
+    }
+
+    let expected_host = repo.code_forge.map(CodeForge::host).unwrap_or_default();
+    let fallback = credentials
+        .iter()
+        .filter(|credential| {
+            credential_matches_forge(credential, repo.code_forge)
+                && credential.project_paths.is_empty()
+                && credential.host.eq_ignore_ascii_case(expected_host)
+        })
+        .collect::<Vec<_>>();
+    match fallback.as_slice() {
+        [credential] => Ok(Some(*credential)),
+        [] => Ok(None),
+        _ => bail!("Multiple host-wide task Git credentials match one repository"),
+    }
+}
+
+fn binding_credential_for_repository(
+    credentials: &[GitCredential],
+    repo: &SourceRepo,
+) -> Result<Option<GitCredential>> {
+    let key = repository_binding_key(repo)?;
+    if let Some(credential_id) = REPOSITORY_BINDINGS
+        .read()
+        .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?
+        .get(&key)
+        .cloned()
+    {
+        return credentials
+            .iter()
+            .find(|credential| credential.id == credential_id)
+            .cloned()
+            .map(Some)
+            .ok_or_else(|| anyhow::anyhow!("Task repository credential is unavailable"));
+    }
+    Ok(select_credential_for_repository(credentials, repo)?.cloned())
+}
+
+/// Register exact credential bindings before cloning and expand legacy
+/// host-wide credentials into the repositories required by this task.
+pub(crate) fn prepare_repository_credentials(repositories: &[SourceRepo]) -> Result<()> {
+    let credentials = task_credentials_snapshot()?;
+    let mut bindings = REPOSITORY_BINDINGS
+        .write()
+        .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?;
+    bindings.clear();
+
+    let has_self_hosted_gitlab = credentials.iter().any(is_self_hosted_gitlab_credential);
+    for repository in repositories {
+        let binding_key = repository_binding_key(repository)?;
+        match select_credential_for_repository(&credentials, repository)? {
+            Some(credential) => {
+                bindings.insert(binding_key, credential.id.clone());
+            }
+            None if repository.code_forge == Some(CodeForge::GitLab) && has_self_hosted_gitlab => {
+                bail!("A self-hosted GitLab repository has no task credential binding");
+            }
+            None => {}
+        }
+    }
+    drop(bindings);
+
+    write_task_credentials_file(&credentials, &home_dir()?)
+}
+
+/// Register one repository needed before environment metadata is available,
+/// such as a repository-qualified task skill.
+pub(crate) fn prepare_project_path(
+    code_forge: CodeForge,
+    owner: &str,
+    repository: &str,
+) -> Result<()> {
+    let source = SourceRepo::new(code_forge, owner.to_string(), repository.to_string());
+    let credentials = task_credentials_snapshot()?;
+    if let Some(credential) = select_credential_for_repository(&credentials, &source)? {
+        REPOSITORY_BINDINGS
+            .write()
+            .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?
+            .insert(repository_binding_key(&source)?, credential.id.clone());
+        write_task_credentials_file(&credentials, &home_dir()?)?;
+    }
+    Ok(())
+}
+
+/// Resolve an explicit, credential-owned clone origin. Public repositories
+/// without task credentials retain the managed forge URL.
+pub(crate) fn clone_url_for_repository(repo: &SourceRepo) -> Result<String> {
+    let credentials = task_credentials_snapshot()?;
+    match binding_credential_for_repository(&credentials, repo)? {
+        Some(credential) => clone_url_for_path(&credential, &source_repo_project_path(repo)),
+        None => Ok(repo.https_clone_url()),
+    }
+}
+
+fn paths_for_credential(credential: &GitCredential) -> Result<BTreeSet<String>> {
+    let mut paths = credential
+        .project_paths
+        .iter()
+        .map(|path| normalized_project_path(path))
+        .collect::<Result<BTreeSet<_>>>()?;
+    let bindings = REPOSITORY_BINDINGS
+        .read()
+        .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?;
+    paths.extend(
+        bindings
+            .iter()
+            .filter(|(_, credential_id)| *credential_id == &credential.id)
+            .map(|((_, path), _)| path.clone()),
+    );
+    Ok(paths)
+}
+
+fn credential_store_line(credential: &GitCredential, project_path: &str) -> Result<String> {
+    let mut url = Url::parse(&clone_url_for_path(credential, project_path)?)
+        .context("Invalid task Git credential repository URL")?;
+    let username = credential.username.as_deref().unwrap_or_else(|| {
+        if is_gitlab_credential(credential) {
+            "oauth2"
+        } else {
+            "x-access-token"
+        }
+    });
+    url.set_username(username)
+        .map_err(|_| anyhow::anyhow!("Invalid task Git credential username"))?;
+    url.set_password(Some(&credential.token))
+        .map_err(|_| anyhow::anyhow!("Invalid task Git credential token"))?;
+    Ok(url.to_string())
+}
+
+fn write_task_credentials_file(credentials: &[GitCredential], home: &Path) -> Result<()> {
+    let root = task_credentials_root(home);
+    std::fs::create_dir_all(&root)
+        .with_context(|| format!("Failed to create {}", root.display()))?;
+    let path = task_credentials_file(home);
+    let tmp_path = path.with_extension("tmp");
 
     let mut lines = Vec::new();
-    for line in existing.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let superseded =
-            host_of_credentials_line(trimmed).is_some_and(|host| refreshed_hosts.contains(&host));
-        if !superseded {
-            lines.push(trimmed.to_string());
+    for credential in credentials {
+        for project_path in paths_for_credential(credential)? {
+            lines.push(credential_store_line(credential, &project_path)?);
         }
     }
-    for cred in credentials {
-        lines.push(git_credentials_line(cred));
-    }
-
     let mut content = lines.join("\n");
     if !content.is_empty() {
         content.push('\n');
     }
-    content
-}
-
-/// Write `~/.git-credentials`, replacing the entry for each host in
-/// `credentials` and leaving every other host's entry in place.
-///
-/// Each credential entry is formatted as:
-/// - `https://{username}:{token}@{host}` when a username is present
-/// - `https://x-access-token:{token}@{host}` for service-account tokens
-///
-/// The write is done atomically: a temporary file is written then renamed.
-fn write_git_credentials_file(credentials: &[GitCredential]) -> Result<()> {
-    if credentials.is_empty() {
-        return Ok(());
-    }
-
-    let home = home_dir()?;
-    let path = home.join(".git-credentials");
-    let tmp_path = home.join(".git-credentials.tmp");
-    let existing = std::fs::read_to_string(&path).unwrap_or_default();
-    let content = merge_git_credentials_file_content(&existing, credentials);
     write_secret_file(&tmp_path, &content)?;
-    std::fs::rename(&tmp_path, &path).with_context(|| {
-        format!(
-            "Failed to rename {} to {}",
-            tmp_path.display(),
-            path.display()
-        )
-    })?;
-
-    Ok(())
+    std::fs::rename(&tmp_path, &path)
+        .with_context(|| format!("Failed to install {}", path.display()))
 }
 
-/// Write `~/.config/gh/hosts.yml` so the `gh` CLI is authenticated.
-///
-/// The YAML format is stable for `gh` v2+:
-/// ```yaml
-/// github.com:
-///     oauth_token: TOKEN
-///     git_protocol: https
-///     user: USERNAME
-/// ```
-///
-/// The write is atomic: a temporary file is written then renamed.
-fn write_gh_hosts_yml(credentials: &[GitCredential], home: &std::path::Path) -> Result<()> {
+fn write_gh_hosts_yml(credentials: &[GitCredential], home: &Path) -> Result<()> {
     let github_credentials = credentials
         .iter()
-        .filter(|credential| credential.host == GITHUB_HOST)
+        .filter(|credential| credential.host.eq_ignore_ascii_case(GITHUB_HOST))
         .collect::<Vec<_>>();
     if github_credentials.is_empty() {
         return Ok(());
     }
+    if github_credentials.len() > 1 {
+        bail!("Multiple GitHub task credentials cannot share the gh host configuration");
+    }
+
     let gh_config_dir = home.join(".config").join("gh");
     std::fs::create_dir_all(&gh_config_dir)
         .with_context(|| format!("Failed to create {}", gh_config_dir.display()))?;
     let path = gh_config_dir.join(GH_HOSTS_FILENAME);
     let tmp_path = gh_config_dir.join(format!("{GH_HOSTS_FILENAME}.tmp"));
-
-    let mut yaml = String::new();
-    for cred in github_credentials {
-        yaml.push_str(&format!("{}:\n", cred.host));
-        yaml.push_str(&format!("    oauth_token: {}\n", cred.token));
-        yaml.push_str("    git_protocol: https\n");
-        if let Some(username) = &cred.username {
-            yaml.push_str(&format!("    user: {username}\n"));
-        }
+    let credential = github_credentials[0];
+    let mut yaml = format!(
+        "{}:\n    oauth_token: {}\n    git_protocol: https\n",
+        credential.host, credential.token
+    );
+    if let Some(username) = &credential.username {
+        yaml.push_str(&format!("    user: {username}\n"));
     }
 
     write_secret_file(&tmp_path, &yaml)?;
-    std::fs::rename(&tmp_path, &path).with_context(|| {
-        format!(
-            "Failed to rename {} to {}",
-            tmp_path.display(),
-            path.display()
-        )
-    })?;
-
-    Ok(())
+    std::fs::rename(&tmp_path, &path)
+        .with_context(|| format!("Failed to install {}", path.display()))
 }
 
-/// Write `~/.config/glab-cli/config.yml` so the `glab` CLI is authenticated.
-///
-/// The YAML format for glab is:
-/// ```yaml
-/// hosts:
-///     gitlab.com:
-///         token: TOKEN
-///         git_protocol: https
-///         api_protocol: https
-/// ```
-///
-/// The write is atomic: a temporary file is written then renamed.
-fn write_glab_config(credentials: &[GitCredential], home: &std::path::Path) -> Result<()> {
-    let gitlab_credentials = credentials
-        .iter()
-        .filter(|credential| credential.host == GLAB_HOST)
-        .collect::<Vec<_>>();
-    if gitlab_credentials.is_empty() {
-        return Ok(());
-    }
-    let glab_config_dir = home.join(".config").join("glab-cli");
-    std::fs::create_dir_all(&glab_config_dir)
-        .with_context(|| format!("Failed to create {}", glab_config_dir.display()))?;
-    let path = glab_config_dir.join(GLAB_CONFIG_FILENAME);
-    let tmp_path = glab_config_dir.join(format!("{GLAB_CONFIG_FILENAME}.tmp"));
-
-    let mut yaml = String::new();
-    yaml.push_str("hosts:\n");
-    for cred in gitlab_credentials {
-        yaml.push_str(&format!("    {}:\n", cred.host));
-        yaml.push_str(&format!("        token: {}\n", cred.token));
-        yaml.push_str("        git_protocol: https\n");
-        yaml.push_str("        api_protocol: https\n");
-    }
-
-    write_secret_file(&tmp_path, &yaml)?;
-    std::fs::rename(&tmp_path, &path).with_context(|| {
-        format!(
-            "Failed to rename {} to {}",
-            tmp_path.display(),
-            path.display()
-        )
-    })?;
-
-    Ok(())
-}
-
-/// Formats non-sensitive metadata for verifying local credential injection.
-pub(crate) fn credential_diagnostics(
-    credentials: &[GitCredential],
-    failed_hosts: &[String],
-) -> String {
-    let mut entries = credentials
-        .iter()
-        .map(|credential| {
-            format!(
-                "{}(refreshed, token_present={}, username_present={})",
-                credential.host,
-                !credential.token.is_empty(),
-                credential.username.is_some()
-            )
-        })
-        .collect::<Vec<_>>();
-    entries.extend(
-        failed_hosts
-            .iter()
-            .map(|host| format!("{host}(stale, refresh failed; existing credential kept)")),
-    );
-    entries.join(", ")
-}
-
-pub(crate) fn write_git_credentials(credentials: &[GitCredential]) -> Result<()> {
-    write_git_credentials_with_failures(credentials, &[])
-}
-
-pub(crate) fn write_git_credentials_with_failures(
-    credentials: &[GitCredential],
-    failed_hosts: &[String],
-) -> Result<()> {
-    let credentials = unique_credentials_by_host(credentials)?;
-    let credentials = credentials.as_slice();
-    if credentials.is_empty() {
-        if !failed_hosts.is_empty() {
-            log::info!(
-                "Wrote 0 git credential(s) to the local credential store: {}",
-                credential_diagnostics(credentials, failed_hosts)
-            );
-        }
-        return Ok(());
-    }
-    let home = home_dir()?;
-    let outcomes = [
-        write_git_credentials_file(credentials),
-        write_gh_hosts_yml(credentials, &home),
-        write_glab_config(credentials, &home),
-    ];
-    let mut first_error = None;
-    for outcome in outcomes {
-        if let Err(e) = outcome {
-            log::warn!("Failed to write a git credential store: {e:#}");
-            first_error.get_or_insert(e);
-        }
-    }
-    log::info!(
-        "Wrote {} git credential(s) to the local credential store: {}",
-        credentials.len(),
-        credential_diagnostics(credentials, failed_hosts)
-    );
-    match first_error {
-        Some(e) => Err(e),
-        None => Ok(()),
-    }
-}
-
-pub(crate) fn configure_git_credentials(credentials: &[GitCredential]) -> Result<()> {
-    let credentials = unique_credentials_by_host(credentials)?;
-    if credentials.is_empty() {
-        return Ok(());
-    }
-    setup_git_config(&credentials);
-    configure_git_identity(&credentials);
-    record_host_identities(&credentials);
-    write_git_credentials(&credentials)
-}
-
-/// Run a git config command, logging a warning on failure rather than
-/// propagating the error (git may not be installed in all sandboxes).
-fn run_git_config(key: &str, value: &str) {
-    match BlockingCommand::new("git")
-        .args(["config", "--global", key, value])
-        .output()
-    {
-        Ok(output) if output.status.success() => {}
-        Ok(output) => {
-            log::warn!(
-                "git config --global {key} failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-        Err(e) => {
-            log::warn!("Failed to run git config --global {key}: {e}");
-        }
-    }
-}
-
-/// Like [`run_git_config`] but passes `--add` so the new value is appended to
-/// any existing values for `key` rather than replacing them.
-fn run_git_config_add(key: &str, value: &str) {
-    match BlockingCommand::new("git")
-        .args(["config", "--global", "--add", key, value])
-        .output()
-    {
-        Ok(output) if output.status.success() => {}
-        Ok(output) => {
-            log::warn!(
-                "git config --global --add {key} failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-        Err(e) => {
-            log::warn!("Failed to run git config --global --add {key}: {e}");
-        }
-    }
-}
-
-/// Run one-time git configuration that is set at startup and never needs to
-/// be refreshed:
-/// - `credential.helper store` so git reads `~/.git-credentials`
-/// - SSH→HTTPS URL rewrites for each credential host, covering both the
-///   scp-style (`git@{host}:`) and explicit-protocol (`ssh://git@{host}/`)
-///   URL forms, so operations on either form use HTTPS credentials instead
-///   of looking for an SSH key.
-pub(crate) fn setup_git_config(credentials: &[GitCredential]) {
-    run_git_config("credential.helper", "store");
-    // Use --add for both forms per host so all values coexist as a
-    // multi-value key rather than each entry overwriting the previous one.
-    for cred in credentials {
-        let host = &cred.host;
-        run_git_config_add(
-            &format!("url.https://{host}/.insteadOf"),
-            &format!("ssh://git@{host}/"),
-        );
-        run_git_config_add(
-            &format!("url.https://{host}/.insteadOf"),
-            &format!("git@{host}:"),
-        );
-    }
-}
-
-/// Configure the global git user identity from the server-returned credential.
-///
-/// Uses the first credential's `username`/`email` fields, falling back to the
-/// Warp defaults when either is absent (e.g. service-account principals).
-pub(crate) fn configure_git_identity(credentials: &[GitCredential]) {
-    let (name, email) = identity_of(credentials.first());
-    run_git_config("user.name", &name);
-    run_git_config("user.email", &email);
-}
-
-#[derive(Clone)]
-struct HostIdentity {
+#[derive(Serialize)]
+struct GlabConfig {
+    git_protocol: &'static str,
     host: String,
-    name: String,
-    email: String,
+    no_prompt: bool,
+    telemetry: bool,
+    hosts: BTreeMap<String, GlabHostConfig>,
 }
 
-static HOST_IDENTITIES: RwLock<Vec<HostIdentity>> = RwLock::new(Vec::new());
+#[derive(Serialize)]
+struct GlabHostConfig {
+    api_protocol: String,
+    api_host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subfolder: Option<String>,
+    token: String,
+    git_protocol: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+}
 
-fn record_host_identities(credentials: &[GitCredential]) {
-    let identities = credentials
-        .iter()
-        .map(|c| {
-            let (name, email) = identity_of(Some(c));
-            HostIdentity {
-                host: c.host.clone(),
-                name,
-                email,
-            }
-        })
-        .collect::<Vec<_>>();
-    match HOST_IDENTITIES.write() {
-        Ok(mut stored) => *stored = identities,
-        Err(e) => log::warn!("Failed to record git author identities: {e}"),
+fn glab_config_yaml(credential: &GitCredential) -> Result<String> {
+    let authority = credential_authority(credential)?;
+    let prefix = normalized_relative_prefix(&credential.relative_url_prefix)?;
+    let mut hosts = BTreeMap::new();
+    hosts.insert(
+        authority.clone(),
+        GlabHostConfig {
+            api_protocol: credential.scheme.clone(),
+            api_host: authority,
+            subfolder: (!prefix.is_empty()).then_some(prefix),
+            token: credential.token.clone(),
+            git_protocol: "https",
+            user: credential.username.clone(),
+        },
+    );
+    let origin = credential_origin(credential)?;
+    serde_yaml::to_string(&GlabConfig {
+        git_protocol: "https",
+        host: origin.as_str().trim_end_matches('/').to_string(),
+        no_prompt: true,
+        telemetry: false,
+        hosts,
+    })
+    .context("Failed to serialize repository-local glab configuration")
+}
+
+fn write_glab_config_for_credential(credential: &GitCredential, config_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(config_dir)
+        .with_context(|| format!("Failed to create {}", config_dir.display()))?;
+    let path = config_dir.join(GLAB_CONFIG_FILENAME);
+    let tmp_path = config_dir.join(format!("{GLAB_CONFIG_FILENAME}.tmp"));
+    write_secret_file(&tmp_path, &glab_config_yaml(credential)?)?;
+    std::fs::rename(&tmp_path, &path)
+        .with_context(|| format!("Failed to install {}", path.display()))
+}
+
+fn shell_single_quote(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
+}
+
+#[cfg(unix)]
+fn find_real_glab(wrapper_path: &Path) -> Option<PathBuf> {
+    std::env::var_os("PATH")
+        .into_iter()
+        .flat_map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
+        .map(|dir| dir.join(GLAB_WRAPPER_FILENAME))
+        .find(|candidate| candidate.is_file() && candidate != wrapper_path)
+}
+
+#[cfg(unix)]
+fn glab_wrapper_script(real_glab: &Path) -> String {
+    let real_glab = shell_single_quote(&real_glab.to_string_lossy());
+    format!(
+        "#!/bin/sh\n\
+         unset GITLAB_HOST GITLAB_TOKEN\n\
+         repo_root=\"$(git rev-parse --show-toplevel 2>/dev/null)\" || exec '{real_glab}' \"$@\"\n\
+         config_dir=\"$(git -C \"$repo_root\" config --local --path --get {GLAB_REPOSITORY_CONFIG_KEY} 2>/dev/null)\"\n\
+         if [ -n \"$config_dir\" ]; then\n\
+           GLAB_CONFIG_DIR=\"$config_dir\" exec '{real_glab}' \"$@\"\n\
+         fi\n\
+         exec '{real_glab}' \"$@\"\n"
+    )
+}
+
+fn install_glab_wrapper(credentials: &[GitCredential], home: &Path) -> Result<()> {
+    if !credentials.iter().any(is_gitlab_credential) {
+        return Ok(());
     }
+
+    #[cfg(unix)]
+    {
+        let bin_dir = task_bin_dir_for_home(home);
+        std::fs::create_dir_all(&bin_dir)
+            .with_context(|| format!("Failed to create {}", bin_dir.display()))?;
+        let wrapper_path = bin_dir.join(GLAB_WRAPPER_FILENAME);
+        let real_glab = find_real_glab(&wrapper_path)
+            .ok_or_else(|| anyhow::anyhow!("The glab executable is required for GitLab tasks"))?;
+        write_executable_file(&wrapper_path, &glab_wrapper_script(&real_glab))?;
+    }
+    Ok(())
+}
+
+fn repository_glab_config_dir(repository_dir: &Path) -> Result<PathBuf> {
+    let directory = repository_dir.to_string_lossy();
+    let output = BlockingCommand::new("git")
+        .args([
+            "-C",
+            directory.as_ref(),
+            "rev-parse",
+            "--git-path",
+            "warp/glab-cli",
+        ])
+        .output()
+        .context("Failed to locate the repository Git directory")?;
+    if !output.status.success() {
+        bail!("Failed to locate the repository Git directory");
+    }
+    let path = PathBuf::from(String::from_utf8(output.stdout)?.trim());
+    Ok(if path.is_absolute() {
+        path
+    } else {
+        repository_dir.join(path)
+    })
+}
+
+fn run_repository_git_config(repository_dir: &Path, key: &str, value: &str) -> Result<()> {
+    let directory = repository_dir.to_string_lossy();
+    let output = BlockingCommand::new("git")
+        .args(["-C", directory.as_ref(), "config", key, value])
+        .output()
+        .context("Failed to configure a task repository")?;
+    if !output.status.success() {
+        bail!("Failed to configure a task repository");
+    }
+    Ok(())
+}
+
+fn register_glab_config(credential_id: &str, config_dir: &Path) -> Result<()> {
+    let mut configs = GLAB_CONFIGS
+        .write()
+        .map_err(|_| anyhow::anyhow!("Repository-local glab state is unavailable"))?;
+    if let Some(config) = configs
+        .iter_mut()
+        .find(|config| config.config_dir == config_dir)
+    {
+        config.credential_id = credential_id.to_string();
+    } else {
+        configs.push(RegisteredGlabConfig {
+            credential_id: credential_id.to_string(),
+            config_dir: config_dir.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+fn write_registered_glab_configs(credentials: &[GitCredential]) -> Result<()> {
+    let configs = GLAB_CONFIGS
+        .read()
+        .map_err(|_| anyhow::anyhow!("Repository-local glab state is unavailable"))?
+        .clone();
+    for config in configs {
+        let credential = credentials
+            .iter()
+            .find(|credential| credential.id == config.credential_id)
+            .ok_or_else(|| anyhow::anyhow!("Repository-local glab credential is unavailable"))?;
+        write_glab_config_for_credential(credential, &config.config_dir)?;
+    }
+    Ok(())
 }
 
 fn identity_of(credential: Option<&GitCredential>) -> (String, String) {
     match credential {
-        Some(c) => (
-            c.username
+        Some(credential) => (
+            credential
+                .username
                 .as_deref()
                 .unwrap_or(DEFAULT_GIT_NAME)
                 .to_string(),
-            c.email.as_deref().unwrap_or(DEFAULT_GIT_EMAIL).to_string(),
+            credential
+                .email
+                .as_deref()
+                .unwrap_or(DEFAULT_GIT_EMAIL)
+                .to_string(),
         ),
         None => (DEFAULT_GIT_NAME.to_string(), DEFAULT_GIT_EMAIL.to_string()),
     }
 }
 
-fn select_host_identity<'a>(
-    identities: &'a [HostIdentity],
-    host: &str,
-) -> Option<&'a HostIdentity> {
-    identities
-        .iter()
-        .find(|identity| identity.host == host)
-        .or_else(|| identities.first())
-}
+/// Install identity and repository-local `glab` configuration after cloning.
+pub(crate) fn configure_repository_credentials(
+    repository_dir: &Path,
+    repository: &SourceRepo,
+) -> Result<()> {
+    let credentials = task_credentials_snapshot()?;
+    let credential = binding_credential_for_repository(&credentials, repository)?;
+    let (name, email) = identity_of(credential.as_ref());
+    run_repository_git_config(repository_dir, "user.name", &name)?;
+    run_repository_git_config(repository_dir, "user.email", &email)?;
 
-fn recorded_identity_for_host(host: &str) -> Option<(String, String)> {
-    let stored = HOST_IDENTITIES.read().ok()?;
-    let matched = select_host_identity(&stored, host)?;
-    Some((matched.name.clone(), matched.email.clone()))
-}
-
-/// Write `user.name`/`user.email` into one repository's local git config,
-/// selecting the identity of the forge that hosts it.
-pub(crate) fn configure_repository_git_identity(repository_dir: &std::path::Path, host: &str) {
-    let Some((name, email)) = recorded_identity_for_host(host) else {
-        return;
+    let Some(credential) = credential.filter(is_gitlab_credential) else {
+        return Ok(());
     };
-    run_repository_git_config(repository_dir, "user.name", &name);
-    run_repository_git_config(repository_dir, "user.email", &email);
+    let config_dir = repository_glab_config_dir(repository_dir)?;
+    write_glab_config_for_credential(&credential, &config_dir)?;
+    run_repository_git_config(
+        repository_dir,
+        GLAB_REPOSITORY_CONFIG_KEY,
+        &config_dir.to_string_lossy(),
+    )?;
+    register_glab_config(&credential.id, &config_dir)
 }
 
-fn run_repository_git_config(repository_dir: &std::path::Path, key: &str, value: &str) {
-    let dir = repository_dir.to_string_lossy();
-    match BlockingCommand::new("git")
-        .args(["-C", dir.as_ref(), "config", key, value])
+fn run_git_config(args: &[&str]) -> Result<()> {
+    let output = BlockingCommand::new("git")
+        .arg("config")
+        .arg("--global")
+        .args(args)
         .output()
-    {
-        Ok(output) if output.status.success() => {}
-        Ok(output) => {
-            log::warn!(
-                "git -C {} config {key} failed: {}",
-                repository_dir.display(),
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-        Err(e) => {
-            log::warn!(
-                "Failed to run git -C {} config {key}: {e}",
-                repository_dir.display()
-            );
-        }
+        .context("Failed to run global Git configuration")?;
+    if !output.status.success() {
+        bail!("Failed to run global Git configuration");
+    }
+    Ok(())
+}
+
+fn clear_git_credential_helpers() -> Result<()> {
+    let output = BlockingCommand::new("git")
+        .args(["config", "--global", "--unset-all", "credential.helper"])
+        .output()
+        .context("Failed to clear global Git credential helpers")?;
+    if output.status.success() || output.status.code() == Some(5) {
+        Ok(())
+    } else {
+        bail!("Failed to clear global Git credential helpers")
     }
 }
 
-/// Write refreshed credentials and report whether every host succeeded.
-///
-/// Returns `Ok(true)` when every applicable forge refreshed, and `Ok(false)`
-/// when some refreshed and others failed. Returns `Err` when the local write
-/// fails.
+fn setup_git_config(credentials: &[GitCredential], home: &Path) -> Result<()> {
+    clear_git_credential_helpers()?;
+    let helper = format!(
+        "store --file={}",
+        task_credentials_file(home).to_string_lossy()
+    );
+    run_git_config(&["credential.helper", &helper])?;
+    run_git_config(&["credential.useHttpPath", "true"])?;
+
+    let mut configured_origins = HashSet::new();
+    for credential in credentials {
+        let origin = credential_origin(credential)?;
+        let rewrite_base = origin.as_str().to_string();
+        if !configured_origins.insert(rewrite_base.clone()) {
+            continue;
+        }
+        let key = format!("url.{rewrite_base}.insteadOf");
+        let ssh_url = format!("ssh://git@{}/", credential.host);
+        run_git_config(&["--add", &key, &ssh_url])?;
+        let scp_url = format!("git@{}:", credential.host);
+        run_git_config(&["--add", &key, &scp_url])?;
+    }
+    Ok(())
+}
+
+fn configure_global_git_identity(credentials: &[GitCredential]) -> Result<()> {
+    let (name, email) = identity_of(credentials.first());
+    run_git_config(&["user.name", &name])?;
+    run_git_config(&["user.email", &email])
+}
+
+/// Bootstrap has no previous store, so partial failure cannot safely proceed.
+pub(crate) fn credentials_for_bootstrap(
+    response: TaskGitCredentialsResponse,
+) -> Result<Vec<GitCredential>> {
+    if !response.failed_hosts.is_empty() {
+        bail!(
+            "Git credential bootstrap cannot proceed because one or more credentials failed to refresh"
+        );
+    }
+    unique_credentials_by_id(&response.credentials)
+}
+
+/// Formats non-sensitive metadata for local credential diagnostics.
+pub(crate) fn credential_diagnostics(
+    credentials: &[GitCredential],
+    failed_hosts: &[String],
+) -> String {
+    let refreshed = credentials
+        .iter()
+        .map(|credential| {
+            format!(
+                "{}(refreshed, token_present={}, username_present={})",
+                credential.id,
+                !credential.token.is_empty(),
+                credential.username.is_some()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "{refreshed}; failed_credential_count={}",
+        failed_hosts.len()
+    )
+}
+
+pub(crate) fn configure_git_credentials(credentials: &[GitCredential]) -> Result<()> {
+    let credentials = replace_task_credentials(credentials)?;
+    REPOSITORY_BINDINGS
+        .write()
+        .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?
+        .clear();
+    GLAB_CONFIGS
+        .write()
+        .map_err(|_| anyhow::anyhow!("Repository-local glab state is unavailable"))?
+        .clear();
+    if credentials.is_empty() {
+        return Ok(());
+    }
+    let home = home_dir()?;
+    std::fs::create_dir_all(task_credentials_root(&home)).with_context(|| {
+        format!(
+            "Failed to create {}",
+            task_credentials_root(&home).display()
+        )
+    })?;
+    install_glab_wrapper(&credentials, &home)?;
+    setup_git_config(&credentials, &home)?;
+    configure_global_git_identity(&credentials)?;
+    write_task_credentials_file(&credentials, &home)?;
+    write_gh_hosts_yml(&credentials, &home)?;
+    log::info!(
+        "Configured {} task Git credential(s): {}",
+        credentials.len(),
+        credential_diagnostics(&credentials, &[])
+    );
+    Ok(())
+}
+
 fn apply_refreshed_credentials(response: TaskGitCredentialsResponse) -> Result<bool> {
     if response.credentials.is_empty() && response.failed_hosts.is_empty() {
-        log::debug!("No git credentials returned during refresh; skipping file write");
+        log::debug!("No Git credentials returned during refresh; skipping file write");
         return Ok(true);
     }
 
-    write_git_credentials_with_failures(&response.credentials, &response.failed_hosts)
-        .context("Failed to write refreshed git credentials")?;
-    log::info!("Git credentials refreshed successfully");
+    let credentials = merge_task_credentials(&response.credentials)?;
+    let home = home_dir()?;
+    write_task_credentials_file(&credentials, &home)
+        .context("Failed to write refreshed task Git credentials")?;
+    write_gh_hosts_yml(&credentials, &home)
+        .context("Failed to write refreshed GitHub CLI credentials")?;
+    write_registered_glab_configs(&credentials)
+        .context("Failed to write refreshed repository-local glab credentials")?;
+    log::info!(
+        "Refreshed task Git credentials: {}",
+        credential_diagnostics(&response.credentials, &response.failed_hosts)
+    );
     Ok(response.failed_hosts.is_empty())
 }
 
-/// Perform one git credentials refresh attempt.
-///
-/// Returns `Ok(true)` when every applicable forge refreshed, and `Ok(false)`
-/// when some refreshed and others failed. Returns `Err` when the workload-token
-/// issuance, the server call, or the local credential write fails.
+fn self_hosted_gitlab_credentials_for_repositories(
+    repositories: &[SourceRepo],
+) -> Result<Vec<(GitCredential, Vec<String>)>> {
+    let credentials = task_credentials_snapshot()?;
+    let mut by_id = BTreeMap::<String, (GitCredential, Vec<String>)>::new();
+    for repository in repositories {
+        let Some(credential) = binding_credential_for_repository(&credentials, repository)? else {
+            continue;
+        };
+        if !is_self_hosted_gitlab_credential(&credential) {
+            continue;
+        }
+        let project_path = normalized_project_path(&source_repo_project_path(repository))?;
+        by_id
+            .entry(credential.id.clone())
+            .or_insert_with(|| (credential, Vec::new()))
+            .1
+            .push(project_path);
+    }
+    Ok(by_id.into_values().collect())
+}
+
+fn transport_error_is_tls(error: &reqwest::Error) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    [
+        "certificate",
+        "tls",
+        "ssl",
+        "unknown issuer",
+        "invalid peer",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle))
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn check_tcp_connectivity(credential: &GitCredential) -> Result<(), GitLabPreflightError> {
+    let port = credential
+        .port
+        .map(u16::try_from)
+        .transpose()
+        .map_err(|_| GitLabPreflightError::Connectivity)?
+        .unwrap_or(443);
+    let host = credential.host.clone();
+    tokio::time::timeout(NETWORK_CONNECT_TIMEOUT, async move {
+        let addresses = tokio::net::lookup_host((host.as_str(), port))
+            .await
+            .map_err(|_| GitLabPreflightError::Connectivity)?;
+        for address in addresses {
+            if tokio::net::TcpStream::connect(address).await.is_ok() {
+                return Ok(());
+            }
+        }
+        Err(GitLabPreflightError::Connectivity)
+    })
+    .await
+    .map_err(|_| GitLabPreflightError::Connectivity)?
+}
+
+fn endpoint_url(credential: &GitCredential, suffix: &str) -> Result<Url> {
+    let prefix = normalized_relative_prefix(&credential.relative_url_prefix)?;
+    let mut url = credential_origin(credential)?;
+    let path = if prefix.is_empty() {
+        format!("/{suffix}")
+    } else {
+        format!("/{prefix}/{suffix}")
+    };
+    url.set_path(&path);
+    Ok(url)
+}
+
+fn project_api_url(credential: &GitCredential, project_path: &str) -> Result<Url> {
+    let mut url = endpoint_url(credential, "api/v4/projects")?;
+    url.path_segments_mut()
+        .map_err(|_| anyhow::anyhow!("Invalid GitLab project API URL"))?
+        .push(project_path);
+    Ok(url)
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn preflight_gitlab_credential(
+    credential: &GitCredential,
+    project_paths: &[String],
+) -> Result<(), GitLabPreflightError> {
+    Compat::new(async {
+        check_tcp_connectivity(credential).await?;
+
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .connect_timeout(NETWORK_CONNECT_TIMEOUT)
+            .timeout(NETWORK_REQUEST_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|_| GitLabPreflightError::Tls)?;
+
+        let tls_response = client
+            .get(
+                endpoint_url(credential, "-/readiness")
+                    .map_err(|_| GitLabPreflightError::Connectivity)?,
+            )
+            .send()
+            .await;
+        if let Err(error) = tls_response {
+            return Err(if transport_error_is_tls(&error) {
+                GitLabPreflightError::Tls
+            } else {
+                GitLabPreflightError::Connectivity
+            });
+        }
+
+        let api_response = client
+            .get(
+                endpoint_url(credential, "api/v4/user")
+                    .map_err(|_| GitLabPreflightError::Authentication)?,
+            )
+            .bearer_auth(&credential.token)
+            .send()
+            .await
+            .map_err(|error| {
+                if transport_error_is_tls(&error) {
+                    GitLabPreflightError::Tls
+                } else {
+                    GitLabPreflightError::Connectivity
+                }
+            })?;
+        if !api_response.status().is_success() {
+            return Err(GitLabPreflightError::Authentication);
+        }
+
+        for project_path in project_paths {
+            let repository_response = client
+                .get(
+                    project_api_url(credential, project_path)
+                        .map_err(|_| GitLabPreflightError::RepositoryAccess)?,
+                )
+                .bearer_auth(&credential.token)
+                .send()
+                .await
+                .map_err(|error| {
+                    if transport_error_is_tls(&error) {
+                        GitLabPreflightError::Tls
+                    } else {
+                        GitLabPreflightError::Connectivity
+                    }
+                })?;
+            if repository_response.status() == reqwest::StatusCode::UNAUTHORIZED {
+                return Err(GitLabPreflightError::Authentication);
+            }
+            if !repository_response.status().is_success() {
+                return Err(GitLabPreflightError::RepositoryAccess);
+            }
+        }
+        Ok(())
+    })
+    .await
+}
+
+/// Run bounded DNS/TCP, TLS, API-authentication, and repository checks.
+pub(crate) async fn preflight_gitlab_network(
+    repositories: &[SourceRepo],
+) -> Result<(), GitLabPreflightError> {
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let targets = self_hosted_gitlab_credentials_for_repositories(repositories)
+            .map_err(|_| GitLabPreflightError::RepositoryAccess)?;
+        for (credential, project_paths) in targets {
+            preflight_gitlab_credential(&credential, &project_paths).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Build a token-free Git remote check for every self-hosted GitLab checkout.
+pub(crate) fn gitlab_git_access_check_command(
+    repositories: &[SourceRepo],
+    working_dir: &Path,
+) -> Result<Option<String>> {
+    let credentials = task_credentials_snapshot()?;
+    let mut repositories_to_check = Vec::new();
+    for repository in repositories {
+        let Some(credential) = binding_credential_for_repository(&credentials, repository)? else {
+            continue;
+        };
+        if is_self_hosted_gitlab_credential(&credential) {
+            repositories_to_check.push((
+                repository,
+                clone_url_for_path(&credential, &source_repo_project_path(repository))?,
+            ));
+        }
+    }
+    Ok(git_access_check_command(
+        &repositories_to_check,
+        working_dir,
+    ))
+}
+
+fn git_access_check_command(
+    repositories: &[(&SourceRepo, String)],
+    working_dir: &Path,
+) -> Option<String> {
+    let mut script = String::new();
+    for (repository, clone_url) in repositories {
+        let repository_dir = working_dir.join(&repository.repo);
+        let repository_dir = shell_single_quote(&repository_dir.to_string_lossy());
+        let clone_url = shell_single_quote(clone_url);
+        script.push_str(&format!(
+            "git -C '{repository_dir}' ls-remote --exit-code '{clone_url}' HEAD >/dev/null 2>&1 || exit 1\n"
+        ));
+    }
+    if script.is_empty() {
+        return None;
+    }
+    Some(format!("sh -c '{}'", shell_single_quote(&script)))
+}
+
 #[tracing::instrument(name = "git_credentials::try_refresh", skip_all, err, fields(
     tags.cloud_agent = true,
     task_id,
@@ -548,40 +1124,23 @@ async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<boo
     let workload_token =
         warp_isolation_platform::issue_workload_token(Some(Duration::from_secs(5 * 60)))
             .await
-            .context("Failed to issue workload token for git credentials refresh")?
+            .context("Failed to issue workload token for Git credentials refresh")?
             .token;
 
     let response = ai_client
         .get_task_git_credentials(task_id.to_string(), workload_token, true)
         .await
-        .context("Failed to fetch git credentials from server")?;
+        .context("Failed to fetch Git credentials from server")?;
 
     apply_refreshed_credentials(response)
 }
 
-/// Infinite async loop that refreshes git credentials every
-/// [`GIT_CREDENTIALS_REFRESH_INTERVAL`].
-///
-/// On each iteration:
-/// 1. Issue a short-lived workload token.
-/// 2. Call `taskGitCredentials` to get a fresh token from the server.
-/// 3. Overwrite `~/.git-credentials` and refresh GitHub credentials in
-///    `~/.config/gh/hosts.yml`.
-///
-/// On transient failure, the refresh is retried up to three times with
-/// exponential backoff (1 min, 2 min, 4 min), keeping all retries within the
-/// ~10-minute buffer before the one-hour token expires. If all retries fail,
-/// a warning is logged and the next refresh is scheduled after the normal
-/// interval.
-///
-/// This future never resolves — it is designed to be raced with the harness
-/// execution future via `futures::select!` and dropped when the harness
-/// completes.
+/// Refresh task credentials until the harness finishes and drops this future.
 pub(crate) async fn refresh_loop(task_id: String, ai_client: Arc<dyn AIClient>) {
     loop {
         warpui::r#async::Timer::after(GIT_CREDENTIALS_REFRESH_INTERVAL).await;
 
-        log::info!("Refreshing git credentials for task {task_id}");
+        log::info!("Refreshing Git credentials for task {task_id}");
 
         let backoff_delays = [
             Duration::from_secs(60),
@@ -595,8 +1154,7 @@ pub(crate) async fn refresh_loop(task_id: String, ai_client: Arc<dyn AIClient>) 
                 Ok(false) if attempt < backoff_delays.len() => {
                     let delay = backoff_delays[attempt];
                     log::warn!(
-                        "Git credentials refreshed for some forges but not others (attempt {}); \
-                         retrying the remaining ones in {}s",
+                        "Git credentials refreshed partially (attempt {}); retrying in {}s",
                         attempt + 1,
                         delay.as_secs()
                     );
@@ -605,26 +1163,24 @@ pub(crate) async fn refresh_loop(task_id: String, ai_client: Arc<dyn AIClient>) 
                 }
                 Ok(false) => {
                     log::warn!(
-                        "Git credentials still stale for some forges after {} attempts; \
-                         those forges may lose access before the next refresh cycle",
+                        "Some Git credentials remain stale after {} attempts",
                         attempt + 1
                     );
                     break;
                 }
-                Err(e) if attempt < backoff_delays.len() => {
+                Err(error) if attempt < backoff_delays.len() => {
                     let delay = backoff_delays[attempt];
                     log::warn!(
-                        "Git credentials refresh failed (attempt {}): {e:#}; retrying in {}s",
+                        "Git credentials refresh failed (attempt {}): {error:#}; retrying in {}s",
                         attempt + 1,
                         delay.as_secs()
                     );
                     warpui::r#async::Timer::after(delay).await;
                     attempt += 1;
                 }
-                Err(e) => {
+                Err(error) => {
                     log::warn!(
-                        "Git credentials refresh failed after {} attempts: {e:#}; \
-                         credentials may expire before next refresh cycle",
+                        "Git credentials refresh failed after {} attempts: {error:#}",
                         attempt + 1
                     );
                     break;

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -1016,7 +1016,8 @@ fn ipv6_address_is_public(address: Ipv6Addr) -> bool {
     }
     let segments = address.segments();
     (segments[0] & 0xe000) == 0x2000
-        && !(segments[0] == 0x2001 && segments[1] <= 0x01ff)
+        && !(segments[0] == 0x2001
+            && (segments[1] <= 0x01ff || segments[1] == 0x0db8))
         && segments[0] != 0x2002
         && !(segments[0] == 0x3fff && segments[1] & 0xf000 == 0)
 }

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -407,6 +407,9 @@ pub(crate) fn prepare_repository_credentials(repositories: &[SourceRepo]) -> Res
         .write()
         .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?;
     bindings.clear();
+    if credentials.is_empty() {
+        return Ok(());
+    }
 
     let has_self_hosted_gitlab = credentials.iter().any(is_self_hosted_gitlab_credential);
     for repository in repositories {
@@ -738,14 +741,15 @@ pub(crate) fn configure_repository_credentials(
     repository: &SourceRepo,
 ) -> Result<()> {
     let credentials = task_credentials_snapshot()?;
-    let credential = binding_credential_for_repository(&credentials, repository)?;
-    let (name, email) = identity_of(credential.as_ref());
-    run_repository_git_config(repository_dir, "user.name", &name)?;
-    run_repository_git_config(repository_dir, "user.email", &email)?;
-
-    let Some(credential) = credential.filter(is_gitlab_credential) else {
+    let Some(credential) = binding_credential_for_repository(&credentials, repository)? else {
         return Ok(());
     };
+    let (name, email) = identity_of(Some(&credential));
+    run_repository_git_config(repository_dir, "user.name", &name)?;
+    run_repository_git_config(repository_dir, "user.email", &email)?;
+    if !is_gitlab_credential(&credential) {
+        return Ok(());
+    }
     let config_dir = repository_glab_config_dir(repository_dir)?;
     write_glab_config_for_credential(&credential, &config_dir)?;
     run_repository_git_config(

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -1015,7 +1015,10 @@ fn ipv6_address_is_public(address: Ipv6Addr) -> bool {
         return ipv4_address_is_public(address);
     }
     let segments = address.segments();
-    (segments[0] & 0xe000) == 0x2000 && !(segments[0] == 0x2001 && segments[1] == 0x0db8)
+    (segments[0] & 0xe000) == 0x2000
+        && !(segments[0] == 0x2001 && segments[1] <= 0x01ff)
+        && segments[0] != 0x2002
+        && !(segments[0] == 0x3fff && segments[1] & 0xf000 == 0)
 }
 
 fn ip_address_is_public(address: IpAddr) -> bool {

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -4,7 +4,9 @@
 //! complete HTTPS repository path, and each GitLab checkout receives a private
 //! `glab` configuration selected by a task-local wrapper.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ffi::OsString;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -26,6 +28,7 @@ const DEFAULT_GIT_NAME: &str = "Warp";
 const DEFAULT_GIT_EMAIL: &str = "agent@warp.dev";
 const GITHUB_HOST: &str = "github.com";
 const GITLAB_HOST: &str = "gitlab.com";
+const GH_CONFIG_DIRNAME: &str = "gh";
 const GH_HOSTS_FILENAME: &str = "hosts.yml";
 const GLAB_CONFIG_FILENAME: &str = "config.yml";
 const TASK_CREDENTIALS_DIR: &str = ".warp/task-git";
@@ -47,23 +50,50 @@ struct RegisteredGlabConfig {
     config_dir: PathBuf,
 }
 
-fn merged_credentials_by_id(
-    existing: &[GitCredential],
-    refreshed: &[GitCredential],
-) -> Result<Vec<GitCredential>> {
-    let refreshed = unique_credentials_by_id(refreshed)?;
-    let mut merged = existing.to_vec();
-    for credential in refreshed {
-        if let Some(existing) = merged
-            .iter_mut()
-            .find(|existing| existing.id == credential.id)
+fn remove_owned_directory(path: &Path) -> Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("Failed to remove {}", path.display())),
+    }
+}
+
+fn remove_glab_config_directories(configs: &[RegisteredGlabConfig]) -> Result<()> {
+    let mut cleanup_error = None;
+    for config in configs {
+        if let Err(error) = remove_owned_directory(&config.config_dir)
+            && cleanup_error.is_none()
         {
-            *existing = credential;
-        } else {
-            merged.push(credential);
+            cleanup_error = Some(error);
         }
     }
-    Ok(merged)
+    match cleanup_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+fn clear_task_credential_state(home: &Path) -> Result<()> {
+    replace_task_credentials(&[])?;
+    REPOSITORY_BINDINGS
+        .write()
+        .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?
+        .clear();
+    let glab_configs = {
+        let mut configs = GLAB_CONFIGS
+            .write()
+            .map_err(|_| anyhow::anyhow!("Repository-local glab state is unavailable"))?;
+        std::mem::take(&mut *configs)
+    };
+    let mut cleanup_error = remove_owned_directory(&task_credentials_root(home)).err();
+    if let Err(error) = remove_glab_config_directories(&glab_configs)
+        && cleanup_error.is_none()
+    {
+        cleanup_error = Some(error);
+    }
+    match cleanup_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
@@ -94,7 +124,19 @@ fn task_bin_dir_for_home(home: &Path) -> PathBuf {
     task_credentials_root(home).join(TASK_BIN_DIRNAME)
 }
 
+fn task_gh_config_dir(home: &Path) -> PathBuf {
+    task_credentials_root(home).join(GH_CONFIG_DIRNAME)
+}
+
 pub(crate) fn task_bin_dir() -> Option<PathBuf> {
+    let has_gitlab_credential = TASK_CREDENTIALS
+        .read()
+        .ok()?
+        .iter()
+        .any(is_gitlab_credential);
+    if !has_gitlab_credential {
+        return None;
+    }
     let home = home_dir().ok()?;
     let bin_dir = task_bin_dir_for_home(&home);
     bin_dir
@@ -336,13 +378,6 @@ fn replace_task_credentials(credentials: &[GitCredential]) -> Result<Vec<GitCred
     Ok(credentials)
 }
 
-fn merge_task_credentials(credentials: &[GitCredential]) -> Result<Vec<GitCredential>> {
-    let mut stored = TASK_CREDENTIALS
-        .write()
-        .map_err(|_| anyhow::anyhow!("Task Git credential state is unavailable"))?;
-    *stored = merged_credentials_by_id(&stored, credentials)?;
-    Ok(stored.clone())
-}
 
 fn select_credential_for_repository<'a>(
     credentials: &'a [GitCredential],
@@ -527,7 +562,7 @@ fn write_gh_hosts_yml(credentials: &[GitCredential], home: &Path) -> Result<()> 
         bail!("Multiple GitHub task credentials cannot share the gh host configuration");
     }
 
-    let gh_config_dir = home.join(".config").join("gh");
+    let gh_config_dir = task_gh_config_dir(home);
     std::fs::create_dir_all(&gh_config_dir)
         .with_context(|| format!("Failed to create {}", gh_config_dir.display()))?;
     let path = gh_config_dir.join(GH_HOSTS_FILENAME);
@@ -702,16 +737,17 @@ fn register_glab_config(credential_id: &str, config_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn write_registered_glab_configs(credentials: &[GitCredential]) -> Result<()> {
+fn sync_registered_glab_configs(credentials: &[GitCredential]) -> Result<()> {
     let configs = GLAB_CONFIGS
         .read()
         .map_err(|_| anyhow::anyhow!("Repository-local glab state is unavailable"))?
         .clone();
     for config in configs {
-        let credential = credentials
-            .iter()
-            .find(|credential| credential.id == config.credential_id)
-            .ok_or_else(|| anyhow::anyhow!("Repository-local glab credential is unavailable"))?;
+        let Some(credential) = credentials.iter().find(|credential| {
+            credential.id == config.credential_id && is_gitlab_credential(credential)
+        }) else {
+            continue;
+        };
         write_glab_config_for_credential(credential, &config.config_dir)?;
     }
     Ok(())
@@ -760,41 +796,21 @@ pub(crate) fn configure_repository_credentials(
     register_glab_config(&credential.id, &config_dir)
 }
 
-fn run_git_config(args: &[&str]) -> Result<()> {
-    let output = BlockingCommand::new("git")
-        .arg("config")
-        .arg("--global")
-        .args(args)
-        .output()
-        .context("Failed to run global Git configuration")?;
-    if !output.status.success() {
-        bail!("Failed to run global Git configuration");
-    }
-    Ok(())
-}
-
-fn clear_git_credential_helpers() -> Result<()> {
-    let output = BlockingCommand::new("git")
-        .args(["config", "--global", "--unset-all", "credential.helper"])
-        .output()
-        .context("Failed to clear global Git credential helpers")?;
-    if output.status.success() || output.status.code() == Some(5) {
-        Ok(())
-    } else {
-        bail!("Failed to clear global Git credential helpers")
-    }
-}
-
-fn setup_git_config(credentials: &[GitCredential], home: &Path) -> Result<()> {
-    clear_git_credential_helpers()?;
+fn task_git_config_entries(
+    credentials: &[GitCredential],
+    home: &Path,
+) -> Result<Vec<(String, String)>> {
     let helper = format!(
         "store --file={}",
         task_credentials_file(home).to_string_lossy()
     );
-    run_git_config(&["credential.helper", &helper])?;
-    run_git_config(&["credential.useHttpPath", "true"])?;
+    let mut entries = vec![
+        ("credential.helper".to_string(), String::new()),
+        ("credential.helper".to_string(), helper),
+        ("credential.useHttpPath".to_string(), "true".to_string()),
+    ];
 
-    let mut configured_origins = HashSet::new();
+    let mut configured_origins = BTreeSet::new();
     for credential in credentials {
         let origin = credential_origin(credential)?;
         let rewrite_base = origin.as_str().to_string();
@@ -803,37 +819,64 @@ fn setup_git_config(credentials: &[GitCredential], home: &Path) -> Result<()> {
         }
         let key = format!("url.{rewrite_base}.insteadOf");
         let ssh_url = format!("ssh://git@{}/", credential.host);
-        run_git_config(&["--add", &key, &ssh_url])?;
+        entries.push((key.clone(), ssh_url));
         let scp_url = format!("git@{}:", credential.host);
-        run_git_config(&["--add", &key, &scp_url])?;
+        entries.push((key, scp_url));
     }
-    Ok(())
+    Ok(entries)
 }
 
-fn configure_global_git_identity(credentials: &[GitCredential]) -> Result<()> {
-    let (name, email) = identity_of(credentials.first());
-    run_git_config(&["user.name", &name])?;
-    run_git_config(&["user.email", &email])
+fn task_environment_variables_for(
+    credentials: &[GitCredential],
+    home: &Path,
+) -> Result<Vec<(OsString, OsString)>> {
+    if credentials.is_empty() {
+        return Ok(Vec::new());
+    }
+    let entries = task_git_config_entries(credentials, home)?;
+    let mut variables = Vec::with_capacity(entries.len() * 2 + 2);
+    variables.push((
+        OsString::from("GIT_CONFIG_COUNT"),
+        OsString::from(entries.len().to_string()),
+    ));
+    for (index, (key, value)) in entries.into_iter().enumerate() {
+        variables.push((
+            OsString::from(format!("GIT_CONFIG_KEY_{index}")),
+            OsString::from(key),
+        ));
+        variables.push((
+            OsString::from(format!("GIT_CONFIG_VALUE_{index}")),
+            OsString::from(value),
+        ));
+    }
+    if credentials
+        .iter()
+        .any(|credential| credential.host.eq_ignore_ascii_case(GITHUB_HOST))
+    {
+        variables.push((
+            OsString::from("GH_CONFIG_DIR"),
+            task_gh_config_dir(home).into_os_string(),
+        ));
+    }
+    Ok(variables)
+}
+pub(crate) fn task_environment_variables() -> Result<Vec<(OsString, OsString)>> {
+    let credentials = task_credentials_snapshot()?;
+    if credentials.is_empty() {
+        return Ok(Vec::new());
+    }
+    task_environment_variables_for(&credentials, &home_dir()?)
 }
 
-/// Bootstrap has no previous store, so partial failure cannot safely proceed.
 pub(crate) fn credentials_for_bootstrap(
     response: TaskGitCredentialsResponse,
 ) -> Result<Vec<GitCredential>> {
-    if !response.failed_hosts.is_empty() {
-        bail!(
-            "Git credential bootstrap cannot proceed because one or more credentials failed to refresh"
-        );
-    }
     unique_credentials_by_id(&response.credentials)
 }
 
 /// Formats non-sensitive metadata for local credential diagnostics.
-pub(crate) fn credential_diagnostics(
-    credentials: &[GitCredential],
-    failed_hosts: &[String],
-) -> String {
-    let refreshed = credentials
+pub(crate) fn credential_diagnostics(credentials: &[GitCredential]) -> String {
+    credentials
         .iter()
         .map(|credential| {
             format!(
@@ -844,27 +887,16 @@ pub(crate) fn credential_diagnostics(
             )
         })
         .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        "{refreshed}; failed_credential_count={}",
-        failed_hosts.len()
-    )
+        .join(", ")
 }
 
 pub(crate) fn configure_git_credentials(credentials: &[GitCredential]) -> Result<()> {
+    let home = home_dir()?;
+    clear_task_credential_state(&home)?;
     let credentials = replace_task_credentials(credentials)?;
-    REPOSITORY_BINDINGS
-        .write()
-        .map_err(|_| anyhow::anyhow!("Task repository credential state is unavailable"))?
-        .clear();
-    GLAB_CONFIGS
-        .write()
-        .map_err(|_| anyhow::anyhow!("Repository-local glab state is unavailable"))?
-        .clear();
     if credentials.is_empty() {
         return Ok(());
     }
-    let home = home_dir()?;
     std::fs::create_dir_all(task_credentials_root(&home)).with_context(|| {
         format!(
             "Failed to create {}",
@@ -872,37 +904,59 @@ pub(crate) fn configure_git_credentials(credentials: &[GitCredential]) -> Result
         )
     })?;
     install_glab_wrapper(&credentials, &home)?;
-    setup_git_config(&credentials, &home)?;
-    configure_global_git_identity(&credentials)?;
     write_task_credentials_file(&credentials, &home)?;
     write_gh_hosts_yml(&credentials, &home)?;
     log::info!(
         "Configured {} task Git credential(s): {}",
         credentials.len(),
-        credential_diagnostics(&credentials, &[])
+        credential_diagnostics(&credentials)
     );
     Ok(())
 }
 
-fn apply_refreshed_credentials(response: TaskGitCredentialsResponse) -> Result<bool> {
-    if response.credentials.is_empty() && response.failed_hosts.is_empty() {
-        log::debug!("No Git credentials returned during refresh; skipping file write");
-        return Ok(true);
-    }
+fn apply_refreshed_credentials(response: TaskGitCredentialsResponse) -> Result<()> {
+    apply_refreshed_credentials_at_home(response, &home_dir()?)
+}
 
-    let credentials = merge_task_credentials(&response.credentials)?;
-    let home = home_dir()?;
-    write_task_credentials_file(&credentials, &home)
+fn apply_refreshed_credentials_at_home(
+    response: TaskGitCredentialsResponse,
+    home: &Path,
+) -> Result<()> {
+    let credentials = unique_credentials_by_id(&response.credentials)?;
+    let glab_configs = GLAB_CONFIGS
+        .read()
+        .map_err(|_| anyhow::anyhow!("Repository-local glab state is unavailable"))?
+        .clone();
+    let mut cleanup_error = remove_owned_directory(&task_credentials_root(home)).err();
+    if let Err(error) = remove_glab_config_directories(&glab_configs)
+        && cleanup_error.is_none()
+    {
+        cleanup_error = Some(error);
+    }
+    if let Some(error) = cleanup_error {
+        return Err(error).context("Failed to clear task Git credential files before refresh");
+    }
+    replace_task_credentials(&credentials)?;
+    if !credentials.is_empty() {
+        std::fs::create_dir_all(task_credentials_root(home)).with_context(|| {
+            format!(
+                "Failed to create {}",
+                task_credentials_root(home).display()
+            )
+        })?;
+        install_glab_wrapper(&credentials, home)?;
+    }
+    write_task_credentials_file(&credentials, home)
         .context("Failed to write refreshed task Git credentials")?;
-    write_gh_hosts_yml(&credentials, &home)
+    write_gh_hosts_yml(&credentials, home)
         .context("Failed to write refreshed GitHub CLI credentials")?;
-    write_registered_glab_configs(&credentials)
+    sync_registered_glab_configs(&credentials)
         .context("Failed to write refreshed repository-local glab credentials")?;
     log::info!(
         "Refreshed task Git credentials: {}",
-        credential_diagnostics(&response.credentials, &response.failed_hosts)
+        credential_diagnostics(&credentials)
     );
-    Ok(response.failed_hosts.is_empty())
+    Ok(())
 }
 
 fn self_hosted_gitlab_credentials_for_repositories(
@@ -939,9 +993,42 @@ fn transport_error_is_tls(error: &reqwest::Error) -> bool {
     .iter()
     .any(|needle| message.contains(needle))
 }
+fn ipv4_address_is_public(address: Ipv4Addr) -> bool {
+    let [first, second, third, _] = address.octets();
+    !(first == 0
+        || first == 10
+        || first == 127
+        || first >= 224
+        || (first == 100 && (64..=127).contains(&second))
+        || (first == 169 && second == 254)
+        || (first == 172 && (16..=31).contains(&second))
+        || (first == 192 && second == 0 && matches!(third, 0 | 2))
+        || (first == 192 && second == 88 && third == 99)
+        || (first == 192 && second == 168)
+        || (first == 198 && matches!(second, 18 | 19))
+        || (first == 198 && second == 51 && third == 100)
+        || (first == 203 && second == 0 && third == 113))
+}
+
+fn ipv6_address_is_public(address: Ipv6Addr) -> bool {
+    if let Some(address) = address.to_ipv4_mapped() {
+        return ipv4_address_is_public(address);
+    }
+    let segments = address.segments();
+    (segments[0] & 0xe000) == 0x2000 && !(segments[0] == 0x2001 && segments[1] == 0x0db8)
+}
+
+fn ip_address_is_public(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => ipv4_address_is_public(address),
+        IpAddr::V6(address) => ipv6_address_is_public(address),
+    }
+}
 
 #[cfg(not(target_family = "wasm"))]
-async fn check_tcp_connectivity(credential: &GitCredential) -> Result<(), GitLabPreflightError> {
+async fn resolve_public_addresses(
+    credential: &GitCredential,
+) -> Result<Vec<SocketAddr>, GitLabPreflightError> {
     let port = credential
         .port
         .map(u16::try_from)
@@ -949,10 +1036,29 @@ async fn check_tcp_connectivity(credential: &GitCredential) -> Result<(), GitLab
         .map_err(|_| GitLabPreflightError::Connectivity)?
         .unwrap_or(443);
     let host = credential.host.clone();
-    tokio::time::timeout(NETWORK_CONNECT_TIMEOUT, async move {
-        let addresses = tokio::net::lookup_host((host.as_str(), port))
+    let addresses = tokio::time::timeout(NETWORK_CONNECT_TIMEOUT, async move {
+        tokio::net::lookup_host((host.as_str(), port))
             .await
-            .map_err(|_| GitLabPreflightError::Connectivity)?;
+            .map(|addresses| addresses.collect::<BTreeSet<_>>())
+            .map_err(|_| GitLabPreflightError::Connectivity)
+    })
+    .await
+    .map_err(|_| GitLabPreflightError::Connectivity)??;
+    if addresses.is_empty()
+        || addresses
+            .iter()
+            .any(|address| !ip_address_is_public(address.ip()))
+    {
+        return Err(GitLabPreflightError::Connectivity);
+    }
+    Ok(addresses.into_iter().collect())
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn check_tcp_connectivity(
+    addresses: &[SocketAddr],
+) -> Result<(), GitLabPreflightError> {
+    tokio::time::timeout(NETWORK_CONNECT_TIMEOUT, async {
         for address in addresses {
             if tokio::net::TcpStream::connect(address).await.is_ok() {
                 return Ok(());
@@ -990,13 +1096,15 @@ async fn preflight_gitlab_credential(
     project_paths: &[String],
 ) -> Result<(), GitLabPreflightError> {
     Compat::new(async {
-        check_tcp_connectivity(credential).await?;
+        let addresses = resolve_public_addresses(credential).await?;
+        check_tcp_connectivity(&addresses).await?;
 
         let client = reqwest::Client::builder()
             .no_proxy()
             .connect_timeout(NETWORK_CONNECT_TIMEOUT)
             .timeout(NETWORK_REQUEST_TIMEOUT)
             .redirect(reqwest::redirect::Policy::none())
+            .resolve_to_addrs(&credential.host, &addresses)
             .build()
             .map_err(|_| GitLabPreflightError::Tls)?;
 
@@ -1080,7 +1188,6 @@ pub(crate) async fn preflight_gitlab_network(
 /// Build a token-free Git remote check for every self-hosted GitLab checkout.
 pub(crate) fn gitlab_git_access_check_command(
     repositories: &[SourceRepo],
-    working_dir: &Path,
 ) -> Result<Option<String>> {
     let credentials = task_credentials_snapshot()?;
     let mut repositories_to_check = Vec::new();
@@ -1095,36 +1202,33 @@ pub(crate) fn gitlab_git_access_check_command(
             ));
         }
     }
-    Ok(git_access_check_command(
-        &repositories_to_check,
-        working_dir,
-    ))
+    Ok(git_access_check_command(&repositories_to_check))
 }
 
-fn git_access_check_command(
-    repositories: &[(&SourceRepo, String)],
-    working_dir: &Path,
-) -> Option<String> {
-    let mut script = String::new();
-    for (repository, clone_url) in repositories {
-        let repository_dir = working_dir.join(&repository.repo);
-        let repository_dir = shell_single_quote(&repository_dir.to_string_lossy());
-        let clone_url = shell_single_quote(clone_url);
-        script.push_str(&format!(
-            "git -C '{repository_dir}' ls-remote --exit-code '{clone_url}' HEAD >/dev/null 2>&1 || exit 1\n"
-        ));
-    }
+fn git_access_check_command(repositories: &[(&SourceRepo, String)]) -> Option<String> {
+    let script = git_access_check_script(repositories);
     if script.is_empty() {
         return None;
     }
     Some(format!("sh -c '{}'", shell_single_quote(&script)))
 }
 
+fn git_access_check_script(repositories: &[(&SourceRepo, String)]) -> String {
+    let mut script = String::new();
+    for (_, clone_url) in repositories {
+        let clone_url = shell_single_quote(clone_url);
+        script.push_str(&format!(
+            "git ls-remote --exit-code '{clone_url}' HEAD >/dev/null 2>&1 || exit 1\n"
+        ));
+    }
+    script
+}
+
 #[tracing::instrument(name = "git_credentials::try_refresh", skip_all, err, fields(
     tags.cloud_agent = true,
     task_id,
 ))]
-async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<bool> {
+async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<()> {
     let workload_token =
         warp_isolation_platform::issue_workload_token(Some(Duration::from_secs(5 * 60)))
             .await
@@ -1132,7 +1236,7 @@ async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<boo
             .token;
 
     let response = ai_client
-        .get_task_git_credentials(task_id.to_string(), workload_token, true)
+        .get_task_git_credentials(task_id.to_string(), workload_token)
         .await
         .context("Failed to fetch Git credentials from server")?;
 
@@ -1154,24 +1258,7 @@ pub(crate) async fn refresh_loop(task_id: String, ai_client: Arc<dyn AIClient>) 
         let mut attempt = 0usize;
         loop {
             match try_refresh(&task_id, &ai_client).await {
-                Ok(true) => break,
-                Ok(false) if attempt < backoff_delays.len() => {
-                    let delay = backoff_delays[attempt];
-                    log::warn!(
-                        "Git credentials refreshed partially (attempt {}); retrying in {}s",
-                        attempt + 1,
-                        delay.as_secs()
-                    );
-                    warpui::r#async::Timer::after(delay).await;
-                    attempt += 1;
-                }
-                Ok(false) => {
-                    log::warn!(
-                        "Some Git credentials remain stale after {} attempts",
-                        attempt + 1
-                    );
-                    break;
-                }
+                Ok(()) => break,
                 Err(error) if attempt < backoff_delays.len() => {
                     let delay = backoff_delays[attempt];
                     log::warn!(

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -1,9 +1,11 @@
 use std::io::Write as _;
 use std::process::Stdio;
+use std::sync::Mutex;
 
 use command::blocking::Command;
 
 use super::*;
+static CREDENTIAL_STATE_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 fn gitlab_credential(id: &str, project_path: &str, token: &str) -> GitCredential {
     GitCredential {
@@ -82,13 +84,14 @@ fn explicit_clone_url_preserves_port_prefix_and_has_no_token() {
     let credential = gitlab_credential("one", "platform/backend.git", "secret-token");
 
     let clone_url = clone_url_for_path(&credential, "platform/backend").unwrap();
+    let parsed = Url::parse(&clone_url).unwrap();
 
-    assert_eq!(
-        clone_url,
-        "https://gitlab.example.com:8443/gitlab/platform/backend.git"
-    );
-    assert!(!clone_url.contains("secret-token"));
-    assert!(!clone_url.contains('@'));
+    assert_eq!(parsed.scheme(), "https");
+    assert_eq!(parsed.host_str(), Some("gitlab.example.com"));
+    assert_eq!(parsed.port(), Some(8443));
+    assert_eq!(parsed.path(), "/gitlab/platform/backend.git");
+    assert_eq!(parsed.username(), "");
+    assert_eq!(parsed.password(), None);
 }
 
 #[test]
@@ -261,52 +264,34 @@ fn ordinary_glab_wrapper_discovers_each_checkout_config() {
     assert_eq!(selected_tokens, ["token-one", "token-two"]);
 }
 
-#[test]
-fn refresh_merges_by_credential_id_instead_of_host() {
-    let credentials = merged_credentials_by_id(
-        &[
-            gitlab_credential("one", "group/one", "old-one"),
-            gitlab_credential("two", "group/two", "old-two"),
-        ],
-        &[gitlab_credential("two", "group/two", "new-two")],
-    )
-    .unwrap();
-
-    assert_eq!(credentials[0].token, "old-one");
-    assert_eq!(credentials[1].token, "new-two");
-}
 
 #[test]
 fn diagnostics_do_not_expose_tokens_hosts_or_identity() {
-    let diagnostics = credential_diagnostics(
-        &[gitlab_credential(
-            "credential-one",
-            "group/one",
-            "secret-token",
-        )],
-        &["gitlab.example.com".to_string()],
-    );
+    let diagnostics = credential_diagnostics(&[gitlab_credential(
+        "credential-one",
+        "group/one",
+        "secret-token",
+    )]);
 
     assert!(diagnostics.contains("credential-one"));
-    assert!(diagnostics.contains("failed_credential_count=1"));
     assert!(!diagnostics.contains("secret-token"));
     assert!(!diagnostics.contains("gitlab.example.com"));
     assert!(!diagnostics.contains("oauth2"));
 }
 
 #[test]
-fn bootstrap_rejects_any_partial_failure_without_naming_hosts() {
-    let error = credentials_for_bootstrap(TaskGitCredentialsResponse {
+fn bootstrap_accepts_the_authoritative_credential_set() {
+    let credentials = credentials_for_bootstrap(TaskGitCredentialsResponse {
         credentials: vec![github_credential()],
-        failed_hosts: vec!["customer-gitlab.example.com".to_string()],
     })
-    .unwrap_err();
+    .unwrap();
 
-    assert!(!error.to_string().contains("customer-gitlab.example.com"));
+    assert_eq!(credentials.len(), 1);
+    assert_eq!(credentials[0].id, "github");
 }
 
 #[test]
-fn git_preflight_command_has_no_tokens() {
+fn git_preflight_script_checks_exact_remote_urls_without_local_checkouts() {
     let repositories = [
         SourceRepo::new(CodeForge::GitLab, "group".to_string(), "one".to_string()),
         SourceRepo::new(CodeForge::GitLab, "group".to_string(), "two".to_string()),
@@ -324,16 +309,172 @@ fn git_preflight_command_has_no_tokens() {
         })
         .collect::<Vec<_>>();
 
-    let command = git_access_check_command(&repositories, Path::new("/workspace")).unwrap();
+    let script = git_access_check_script(&repositories);
 
-    assert!(command.contains("/workspace/one"));
-    assert!(command.contains("/workspace/two"));
-    assert!(command.contains(
-        "ls-remote --exit-code 'https://gitlab.example.com:8443/gitlab/group/one.git' HEAD"
-    ));
-    assert!(!command.contains("token-one"));
-    assert!(!command.contains("token-two"));
-    assert!(!command.contains("GITLAB_TOKEN"));
+    assert_eq!(
+        script,
+        "git ls-remote --exit-code 'https://gitlab.example.com:8443/gitlab/group/one.git' HEAD >/dev/null 2>&1 || exit 1\n\
+         git ls-remote --exit-code 'https://gitlab.example.com:8443/gitlab/group/two.git' HEAD >/dev/null 2>&1 || exit 1\n"
+    );
+}
+
+#[test]
+fn task_git_configuration_is_environment_scoped_and_path_aware() {
+    let home = Path::new("/home/agent");
+    let entries = task_git_config_entries(
+        &[gitlab_credential("one", "group/one", "token-one")],
+        home,
+    )
+    .unwrap();
+
+    assert_eq!(
+        entries,
+        vec![
+            ("credential.helper".to_string(), String::new()),
+            (
+                "credential.helper".to_string(),
+                "store --file=/home/agent/.warp/task-git/credentials".to_string(),
+            ),
+            ("credential.useHttpPath".to_string(), "true".to_string()),
+            (
+                "url.https://gitlab.example.com:8443/gitlab/.insteadOf".to_string(),
+                "ssh://git@gitlab.example.com/".to_string(),
+            ),
+            (
+                "url.https://gitlab.example.com:8443/gitlab/.insteadOf".to_string(),
+                "git@gitlab.example.com:".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn task_environment_keeps_github_cli_configuration_task_local() {
+    let home = Path::new("/home/agent");
+    let variables = task_environment_variables_for(&[github_credential()], home)
+        .unwrap()
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(
+        variables.get(&OsString::from("GH_CONFIG_DIR")),
+        Some(&OsString::from("/home/agent/.warp/task-git/gh"))
+    );
+    assert_eq!(
+        variables.get(&OsString::from("GIT_CONFIG_COUNT")),
+        Some(&OsString::from("5"))
+    );
+}
+
+#[test]
+fn task_cleanup_removes_all_memory_and_filesystem_state() {
+    let _guard = CREDENTIAL_STATE_TEST_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let credentials = vec![gitlab_credential("one", "group/one", "token-one")];
+    replace_task_credentials(&credentials).unwrap();
+    REPOSITORY_BINDINGS.write().unwrap().insert(
+        (CodeForge::GitLab, "group/one".to_string()),
+        "one".to_string(),
+    );
+    GLAB_CONFIGS.write().unwrap().push(RegisteredGlabConfig {
+        credential_id: "one".to_string(),
+        config_dir: home.join("repository-glab"),
+    });
+    std::fs::create_dir_all(home.join("repository-glab")).unwrap();
+    std::fs::write(home.join("repository-glab/config.yml"), "stale-token").unwrap();
+    let task_root = task_credentials_root(home);
+    std::fs::create_dir_all(task_root.join("bin")).unwrap();
+    std::fs::write(task_root.join("bin/glab"), "stale").unwrap();
+
+    clear_task_credential_state(home).unwrap();
+
+    assert!(task_credentials_snapshot().unwrap().is_empty());
+    assert!(REPOSITORY_BINDINGS.read().unwrap().is_empty());
+    assert!(GLAB_CONFIGS.read().unwrap().is_empty());
+    assert!(!task_root.exists());
+    assert!(!home.join("repository-glab").exists());
+}
+
+#[test]
+fn refresh_replaces_the_complete_credential_set_and_revokes_omitted_tokens() {
+    let _guard = CREDENTIAL_STATE_TEST_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    replace_task_credentials(&[gitlab_credential(
+        "gitlab",
+        "group/one",
+        "old-gitlab-token",
+    )])
+    .unwrap();
+    let glab_dir = home.join("repository-glab");
+    std::fs::create_dir_all(&glab_dir).unwrap();
+    std::fs::write(glab_dir.join("config.yml"), "old-gitlab-token").unwrap();
+    GLAB_CONFIGS.write().unwrap().push(RegisteredGlabConfig {
+        credential_id: "gitlab".to_string(),
+        config_dir: glab_dir.clone(),
+    });
+    let task_root = task_credentials_root(home);
+    std::fs::create_dir_all(task_root.join("bin")).unwrap();
+    std::fs::write(task_root.join("bin/glab"), "old-gitlab-token").unwrap();
+
+    apply_refreshed_credentials_at_home(
+        TaskGitCredentialsResponse {
+            credentials: vec![github_credential()],
+        },
+        home,
+    )
+    .unwrap();
+
+    let credentials = task_credentials_snapshot().unwrap();
+    assert_eq!(credentials.len(), 1);
+    assert_eq!(credentials[0].id, "github");
+    assert!(!glab_dir.exists());
+    assert!(!task_root.join("bin/glab").exists());
+    let store = std::fs::read_to_string(task_credentials_file(home)).unwrap();
+    assert!(store.contains("github-token"));
+    assert!(!store.contains("old-gitlab-token"));
+    let gh_config = std::fs::read_to_string(task_gh_config_dir(home).join(GH_HOSTS_FILENAME)).unwrap();
+    assert!(gh_config.contains("github-token"));
+    assert!(!gh_config.contains("old-gitlab-token"));
+
+    clear_task_credential_state(home).unwrap();
+}
+#[test]
+fn public_address_policy_rejects_private_reserved_and_mixed_dns_members() {
+    for address in [
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(198, 18, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
+        IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::LOCALHOST),
+        IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 1)),
+    ] {
+        assert!(!ip_address_is_public(address), "{address}");
+    }
+    for address in [
+        IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+        IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111)),
+    ] {
+        assert!(ip_address_is_public(address), "{address}");
+    }
+
+    let mixed = [
+        IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+    ];
+    assert!(!mixed.into_iter().all(ip_address_is_public));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -204,12 +204,11 @@ fn ordinary_glab_wrapper_discovers_each_checkout_config() {
     .unwrap();
     let wrapper = temp.path().join("glab");
     write_executable_file(&wrapper, &glab_wrapper_script(&fake_glab)).unwrap();
+    let existing_paths = std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
+        .unwrap_or_default();
     let path = std::env::join_paths(
-        std::iter::once(temp.path().to_path_buf()).chain(
-            std::env::var_os("PATH")
-                .into_iter()
-                .flat_map(|path| std::env::split_paths(&path)),
-        ),
+        std::iter::once(temp.path().to_path_buf()).chain(existing_paths),
     )
     .unwrap();
 

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -207,10 +207,9 @@ fn ordinary_glab_wrapper_discovers_each_checkout_config() {
     let existing_paths = std::env::var_os("PATH")
         .map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
         .unwrap_or_default();
-    let path = std::env::join_paths(
-        std::iter::once(temp.path().to_path_buf()).chain(existing_paths),
-    )
-    .unwrap();
+    let path =
+        std::env::join_paths(std::iter::once(temp.path().to_path_buf()).chain(existing_paths))
+            .unwrap();
 
     let mut selected_tokens = Vec::new();
     for (name, credential) in [
@@ -262,7 +261,6 @@ fn ordinary_glab_wrapper_discovers_each_checkout_config() {
 
     assert_eq!(selected_tokens, ["token-one", "token-two"]);
 }
-
 
 #[test]
 fn diagnostics_do_not_expose_tokens_hosts_or_identity() {
@@ -320,11 +318,9 @@ fn git_preflight_script_checks_exact_remote_urls_without_local_checkouts() {
 #[test]
 fn task_git_configuration_is_environment_scoped_and_path_aware() {
     let home = Path::new("/home/agent");
-    let entries = task_git_config_entries(
-        &[gitlab_credential("one", "group/one", "token-one")],
-        home,
-    )
-    .unwrap();
+    let entries =
+        task_git_config_entries(&[gitlab_credential("one", "group/one", "token-one")], home)
+            .unwrap();
 
     assert_eq!(
         entries,
@@ -400,12 +396,8 @@ fn refresh_replaces_the_complete_credential_set_and_revokes_omitted_tokens() {
     let _guard = CREDENTIAL_STATE_TEST_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path();
-    replace_task_credentials(&[gitlab_credential(
-        "gitlab",
-        "group/one",
-        "old-gitlab-token",
-    )])
-    .unwrap();
+    replace_task_credentials(&[gitlab_credential("gitlab", "group/one", "old-gitlab-token")])
+        .unwrap();
     let glab_dir = home.join("repository-glab");
     std::fs::create_dir_all(&glab_dir).unwrap();
     std::fs::write(glab_dir.join("config.yml"), "old-gitlab-token").unwrap();
@@ -433,7 +425,8 @@ fn refresh_replaces_the_complete_credential_set_and_revokes_omitted_tokens() {
     let store = std::fs::read_to_string(task_credentials_file(home)).unwrap();
     assert!(store.contains("github-token"));
     assert!(!store.contains("old-gitlab-token"));
-    let gh_config = std::fs::read_to_string(task_gh_config_dir(home).join(GH_HOSTS_FILENAME)).unwrap();
+    let gh_config =
+        std::fs::read_to_string(task_gh_config_dir(home).join(GH_HOSTS_FILENAME)).unwrap();
     assert!(gh_config.contains("github-token"));
     assert!(!gh_config.contains("old-gitlab-token"));
 

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -457,7 +457,11 @@ fn public_address_policy_rejects_private_reserved_and_mixed_dns_members() {
         IpAddr::V6(Ipv6Addr::LOCALHOST),
         IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)),
         IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0x2001, 2, 0, 0, 0, 0, 0, 1)),
         IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0x2002, 0x0a00, 1, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0x3fff, 0, 0, 0, 0, 0, 0, 1)),
         IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 1)),
     ] {
         assert!(!ip_address_is_public(address), "{address}");

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -1,342 +1,357 @@
+use std::io::Write as _;
+use std::process::Stdio;
+
+use command::blocking::Command;
+
 use super::*;
-use crate::server::server_api::ai::TaskGitCredentialsResponse;
 
-#[test]
-fn write_gh_hosts_yml_uses_gh_cli_filename() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let gh_config_dir = temp_dir.path().join(".config").join("gh");
-
-    write_gh_hosts_yml(
-        &[GitCredential {
-            token: "token".to_string(),
-            username: Some("octocat".to_string()),
-            email: Some("octocat@example.com".to_string()),
-            host: "github.com".to_string(),
-        }],
-        temp_dir.path(),
-    )?;
-
-    let hosts_path = gh_config_dir.join(GH_HOSTS_FILENAME);
-    assert!(hosts_path.exists());
-    assert!(
-        !gh_config_dir
-            .join(format!("{GH_HOSTS_FILENAME}.tmp"))
-            .exists()
-    );
-
-    let hosts = std::fs::read_to_string(hosts_path)?;
-    assert!(hosts.contains("github.com:"));
-    assert!(hosts.contains("    oauth_token: token"));
-    assert!(hosts.contains("    git_protocol: https"));
-    assert!(hosts.contains("    user: octocat"));
-
-    Ok(())
-}
-
-#[test]
-fn write_gh_hosts_yml_excludes_gitlab_credentials() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let gh_config_dir = temp_dir.path().join(".config").join("gh");
-
-    write_gh_hosts_yml(
-        &[
-            GitCredential {
-                token: "github-token".to_string(),
-                username: Some("octocat".to_string()),
-                email: None,
-                host: "github.com".to_string(),
-            },
-            GitCredential {
-                token: "gitlab-token".to_string(),
-                username: Some("oauth2".to_string()),
-                email: None,
-                host: "gitlab.com".to_string(),
-            },
-        ],
-        temp_dir.path(),
-    )?;
-
-    let hosts = std::fs::read_to_string(gh_config_dir.join(GH_HOSTS_FILENAME))?;
-    assert!(hosts.contains("github.com:"));
-    assert!(!hosts.contains("gitlab.com:"));
-    assert!(!hosts.contains("gitlab-token"));
-
-    Ok(())
-}
-
-#[test]
-fn write_gh_hosts_yml_skips_gitlab_only_credentials() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-
-    write_gh_hosts_yml(
-        &[GitCredential {
-            token: "gitlab-token".to_string(),
-            username: Some("oauth2".to_string()),
-            email: None,
-            host: "gitlab.com".to_string(),
-        }],
-        temp_dir.path(),
-    )?;
-
-    assert!(!temp_dir.path().join(".config").join("gh").exists());
-
-    Ok(())
+fn gitlab_credential(id: &str, project_path: &str, token: &str) -> GitCredential {
+    GitCredential {
+        id: id.to_string(),
+        instance_uid: Some("instance-uid".to_string()),
+        installation_uid: Some(format!("installation-{id}")),
+        scheme: "https".to_string(),
+        host: "gitlab.example.com".to_string(),
+        port: Some(8443),
+        relative_url_prefix: "gitlab".to_string(),
+        project_paths: vec![project_path.to_string()],
+        token: token.to_string(),
+        username: Some("oauth2".to_string()),
+        email: Some(format!("{id}@example.com")),
+    }
 }
 
 fn github_credential() -> GitCredential {
     GitCredential {
+        id: "github".to_string(),
+        instance_uid: None,
+        installation_uid: None,
+        scheme: "https".to_string(),
+        host: "github.com".to_string(),
+        port: None,
+        relative_url_prefix: String::new(),
+        project_paths: vec!["warpdotdev/warp".to_string()],
         token: "github-token".to_string(),
-        username: None,
+        username: Some("warp-agent[bot]".to_string()),
         email: None,
-        host: "github.com".to_string(),
     }
 }
 
-fn gitlab_credential() -> GitCredential {
-    GitCredential {
-        token: "gitlab-token".to_string(),
-        username: Some("oauth2".to_string()),
-        email: None,
-        host: "gitlab.com".to_string(),
+fn git_credential_from_store(store: &Path, project_path: &str) -> String {
+    let mut child = Command::new("git")
+        .args(["credential-store", "--file", store.to_str().unwrap(), "get"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    write!(
+        child.stdin.as_mut().unwrap(),
+        "protocol=https\nhost=gitlab.example.com:8443\npath=gitlab/{project_path}.git\n\n"
+    )
+    .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn project_path_normalization_accepts_optional_git_suffix() {
+    assert_eq!(
+        normalized_project_path("/platform/backend.git/").unwrap(),
+        "platform/backend"
+    );
+    assert_eq!(
+        project_key("Platform/Backend.GIT").unwrap(),
+        "Platform/Backend"
+    );
+}
+
+#[test]
+fn project_path_normalization_rejects_unsafe_segments() {
+    for invalid in ["", "group//repo", "group/../repo", r"group\repo"] {
+        assert!(normalized_project_path(invalid).is_err(), "{invalid}");
     }
 }
 
 #[test]
-fn merged_credentials_include_each_provider_host() {
-    let content =
-        merge_git_credentials_file_content("", &[github_credential(), gitlab_credential()]);
+fn explicit_clone_url_preserves_port_prefix_and_has_no_token() {
+    let credential = gitlab_credential("one", "platform/backend.git", "secret-token");
+
+    let clone_url = clone_url_for_path(&credential, "platform/backend").unwrap();
 
     assert_eq!(
-        content,
-        "https://x-access-token:github-token@github.com\n\
-         https://oauth2:gitlab-token@gitlab.com\n"
+        clone_url,
+        "https://gitlab.example.com:8443/gitlab/platform/backend.git"
     );
+    assert!(!clone_url.contains("secret-token"));
+    assert!(!clone_url.contains('@'));
 }
 
 #[test]
-fn merged_credentials_replace_only_the_refreshed_host() {
-    let existing = "https://x-access-token:stale-github@github.com\n\
-                    https://oauth2:stale-gitlab@gitlab.com\n";
+fn project_api_path_is_encoded_once() {
+    let credential = gitlab_credential("one", "platform/backend", "secret-token");
 
-    let content = merge_git_credentials_file_content(existing, &[github_credential()]);
-
-    assert!(content.contains("https://x-access-token:github-token@github.com"));
-    assert!(!content.contains("stale-github"));
-    assert!(content.contains("https://oauth2:stale-gitlab@gitlab.com"));
-}
-
-#[test]
-fn merged_credentials_preserve_an_unrelated_host() {
-    let existing = "https://user:token@git.example.com\n";
-
-    let content = merge_git_credentials_file_content(existing, &[github_credential()]);
+    let url = project_api_url(&credential, "platform/backend").unwrap();
 
     assert_eq!(
-        content,
-        "https://user:token@git.example.com\n\
-         https://x-access-token:github-token@github.com\n"
+        url.as_str(),
+        "https://gitlab.example.com:8443/gitlab/api/v4/projects/platform%2Fbackend"
     );
+    assert!(!url.as_str().contains("%252F"));
 }
 
 #[test]
-fn credential_diagnostics_reports_presence_without_values() {
-    let diagnostics = credential_diagnostics(
-        &[GitCredential {
-            token: "secret-token".to_string(),
-            username: Some("oauth2".to_string()),
-            email: Some("user@example.com".to_string()),
-            host: "gitlab.com".to_string(),
-        }],
-        &[],
-    );
-
-    assert_eq!(
-        diagnostics,
-        "gitlab.com(refreshed, token_present=true, username_present=true)"
-    );
-    assert!(!diagnostics.contains("secret-token"));
-    assert!(!diagnostics.contains("oauth2"));
-    assert!(!diagnostics.contains("user@example.com"));
-}
-
-#[test]
-fn credential_diagnostics_names_the_stale_host() {
-    let diagnostics = credential_diagnostics(&[github_credential()], &["gitlab.com".to_string()]);
-
-    assert!(diagnostics.contains("github.com(refreshed"));
-    assert!(diagnostics.contains("gitlab.com(stale"));
-}
-
-#[test]
-fn repository_identity_selects_the_matching_host() {
-    let identities = [
-        HostIdentity {
-            host: "github.com".to_string(),
-            name: "warp-agent[bot]".to_string(),
-            email: "bot@users.noreply.github.com".to_string(),
-        },
-        HostIdentity {
-            host: "gitlab.com".to_string(),
-            name: "warp-factory-1".to_string(),
-            email: "1-warp-factory-1@users.noreply.gitlab.com".to_string(),
-        },
-    ];
-
-    let matched = select_host_identity(&identities, "gitlab.com").expect("an identity");
-    assert_eq!(matched.name, "warp-factory-1");
-    assert_eq!(matched.email, "1-warp-factory-1@users.noreply.gitlab.com");
-}
-
-#[test]
-fn repository_identity_falls_back_to_the_primary_forge() {
-    let identities = [HostIdentity {
-        host: "github.com".to_string(),
-        name: "warp-agent[bot]".to_string(),
-        email: "bot@users.noreply.github.com".to_string(),
-    }];
-
-    let matched = select_host_identity(&identities, "gitlab.com").expect("an identity");
-    assert_eq!(matched.name, "warp-agent[bot]");
-
-    assert!(select_host_identity(&[], "github.com").is_none());
-}
-
-#[test]
-fn unique_credentials_drop_identical_duplicate_hosts() {
-    let unique = unique_credentials_by_host(&[github_credential(), github_credential()]).unwrap();
-
-    assert_eq!(unique.len(), 1);
-    assert_eq!(unique[0].host, "github.com");
-    assert_eq!(unique[0].token, "github-token");
-}
-
-#[test]
-fn unique_credentials_reject_conflicting_duplicate_hosts() {
-    let mut conflicting = github_credential();
-    conflicting.token = "other-github-token".to_string();
-
-    let error = unique_credentials_by_host(&[github_credential(), conflicting]).unwrap_err();
-    assert!(error.to_string().contains("github.com"));
-}
-
-#[test]
-fn bootstrap_rejects_a_one_host_failure() {
-    let error = credentials_for_bootstrap(TaskGitCredentialsResponse {
-        credentials: vec![github_credential()],
-        failed_hosts: vec!["gitlab.com".to_string()],
-    })
-    .unwrap_err();
-
-    assert!(error.to_string().contains("gitlab.com"));
-    assert!(error.to_string().contains("all-or-nothing"));
-}
-
-#[test]
-fn bootstrap_accepts_complete_multi_host_credentials() {
-    let credentials = credentials_for_bootstrap(TaskGitCredentialsResponse {
-        credentials: vec![github_credential(), gitlab_credential()],
-        failed_hosts: vec![],
-    })
+fn credential_ids_allow_separate_tokens_on_one_host() {
+    let credentials = unique_credentials_by_id(&[
+        gitlab_credential("one", "group/one", "token-one"),
+        gitlab_credential("two", "group/two", "token-two"),
+    ])
     .unwrap();
 
     assert_eq!(credentials.len(), 2);
+    assert_eq!(credentials[0].host, credentials[1].host);
+    assert_ne!(credentials[0].id, credentials[1].id);
 }
 
 #[test]
-fn write_glab_config_uses_glab_cli_filename() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let glab_config_dir = temp_dir.path().join(".config").join("glab-cli");
+fn conflicting_duplicate_credential_ids_are_rejected() {
+    let error = unique_credentials_by_id(&[
+        gitlab_credential("same", "group/one", "token-one"),
+        gitlab_credential("same", "group/two", "token-two"),
+    ])
+    .unwrap_err();
 
-    write_glab_config(
-        &[GitCredential {
-            token: "gitlab-token".to_string(),
-            username: Some("oauth2".to_string()),
-            email: Some("user@example.com".to_string()),
-            host: "gitlab.com".to_string(),
-        }],
-        temp_dir.path(),
-    )?;
+    assert!(error.to_string().contains("share an ID"));
+}
 
-    let config_path = glab_config_dir.join(GLAB_CONFIG_FILENAME);
-    assert!(config_path.exists());
+#[test]
+fn exact_path_does_not_cross_forge_boundaries() {
+    let repository = SourceRepo::new(CodeForge::GitHub, "group".to_string(), "one".to_string());
+    let credential = gitlab_credential("one", "group/one", "token-one");
+
     assert!(
-        !glab_config_dir
-            .join(format!("{GLAB_CONFIG_FILENAME}.tmp"))
-            .exists()
+        select_credential_for_repository(&[credential], &repository)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn exact_path_store_selects_separate_tokens_on_one_host() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = temp.path().join("credentials");
+    let one = gitlab_credential("one", "group/one", "token-one");
+    let two = gitlab_credential("two", "group/two.git", "token-two");
+    std::fs::write(
+        &store,
+        format!(
+            "{}\n{}\n",
+            credential_store_line(&one, "group/one").unwrap(),
+            credential_store_line(&two, "group/two").unwrap()
+        ),
+    )
+    .unwrap();
+
+    let first = git_credential_from_store(&store, "group/one");
+    let second = git_credential_from_store(&store, "group/two");
+
+    assert!(first.contains("password=token-one"));
+    assert!(!first.contains("token-two"));
+    assert!(second.contains("password=token-two"));
+    assert!(!second.contains("token-one"));
+}
+
+#[test]
+fn glab_yaml_uses_valid_hosts_shape_and_subfolder() {
+    let yaml =
+        glab_config_yaml(&gitlab_credential("one", "group/one", "repository-token")).unwrap();
+    let value: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+
+    assert_eq!(
+        value["host"].as_str(),
+        Some("https://gitlab.example.com:8443/gitlab")
+    );
+    assert_eq!(
+        value["hosts"]["gitlab.example.com:8443"]["subfolder"].as_str(),
+        Some("gitlab")
+    );
+    assert_eq!(
+        value["hosts"]["gitlab.example.com:8443"]["token"].as_str(),
+        Some("repository-token")
+    );
+    assert_eq!(
+        value["hosts"]["gitlab.example.com:8443"]["git_protocol"].as_str(),
+        Some("https")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn ordinary_glab_wrapper_discovers_each_checkout_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let fake_glab = temp.path().join("real-glab");
+    write_executable_file(
+        &fake_glab,
+        "#!/bin/sh\nprintf '%s\\n%s\\n%s\\n' \"$GLAB_CONFIG_DIR\" \"${GITLAB_TOKEN+set}\" \"${GITLAB_HOST+set}\"\n",
+    )
+    .unwrap();
+    let wrapper = temp.path().join("glab");
+    write_executable_file(&wrapper, &glab_wrapper_script(&fake_glab)).unwrap();
+    let path = std::env::join_paths(
+        std::iter::once(temp.path().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .into_iter()
+                .flat_map(|path| std::env::split_paths(&path)),
+        ),
+    )
+    .unwrap();
+
+    let mut selected_tokens = Vec::new();
+    for (name, credential) in [
+        ("one", gitlab_credential("one", "group/one", "token-one")),
+        ("two", gitlab_credential("two", "group/two", "token-two")),
+    ] {
+        let repository = temp.path().join(name);
+        std::fs::create_dir(&repository).unwrap();
+        let init = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repository)
+            .status()
+            .unwrap();
+        assert!(init.success());
+        let config_dir = repository.join(".git/warp/glab-cli");
+        write_glab_config_for_credential(&credential, &config_dir).unwrap();
+        run_repository_git_config(
+            &repository,
+            GLAB_REPOSITORY_CONFIG_KEY,
+            &config_dir.to_string_lossy(),
+        )
+        .unwrap();
+
+        let output = Command::new("sh")
+            .args(["-c", "glab"])
+            .current_dir(&repository)
+            .env("PATH", &path)
+            .env("GITLAB_HOST", "wrong.example.com")
+            .env("GITLAB_TOKEN", "ambient-token")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let output = String::from_utf8(output.stdout).unwrap();
+        let mut output_lines = output.lines();
+        let selected_dir = PathBuf::from(output_lines.next().unwrap());
+        assert_eq!(output_lines.next(), Some(""));
+        assert_eq!(output_lines.next(), Some(""));
+        let config: serde_yaml::Value = serde_yaml::from_str(
+            &std::fs::read_to_string(selected_dir.join("config.yml")).unwrap(),
+        )
+        .unwrap();
+        selected_tokens.push(
+            config["hosts"]["gitlab.example.com:8443"]["token"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+        );
+    }
+
+    assert_eq!(selected_tokens, ["token-one", "token-two"]);
+}
+
+#[test]
+fn refresh_merges_by_credential_id_instead_of_host() {
+    let credentials = merged_credentials_by_id(
+        &[
+            gitlab_credential("one", "group/one", "old-one"),
+            gitlab_credential("two", "group/two", "old-two"),
+        ],
+        &[gitlab_credential("two", "group/two", "new-two")],
+    )
+    .unwrap();
+
+    assert_eq!(credentials[0].token, "old-one");
+    assert_eq!(credentials[1].token, "new-two");
+}
+
+#[test]
+fn diagnostics_do_not_expose_tokens_hosts_or_identity() {
+    let diagnostics = credential_diagnostics(
+        &[gitlab_credential(
+            "credential-one",
+            "group/one",
+            "secret-token",
+        )],
+        &["gitlab.example.com".to_string()],
     );
 
-    let config = std::fs::read_to_string(config_path)?;
-    assert!(config.contains("hosts:"));
-    assert!(config.contains("    gitlab.com:"));
-    assert!(config.contains("        token: gitlab-token"));
-    assert!(config.contains("        git_protocol: https"));
-    assert!(config.contains("        api_protocol: https"));
-
-    Ok(())
+    assert!(diagnostics.contains("credential-one"));
+    assert!(diagnostics.contains("failed_credential_count=1"));
+    assert!(!diagnostics.contains("secret-token"));
+    assert!(!diagnostics.contains("gitlab.example.com"));
+    assert!(!diagnostics.contains("oauth2"));
 }
 
 #[test]
-fn write_glab_config_excludes_github_credentials() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let glab_config_dir = temp_dir.path().join(".config").join("glab-cli");
-
-    write_glab_config(
-        &[
-            GitCredential {
-                token: "github-token".to_string(),
-                username: Some("octocat".to_string()),
-                email: None,
-                host: "github.com".to_string(),
-            },
-            GitCredential {
-                token: "gitlab-token".to_string(),
-                username: Some("oauth2".to_string()),
-                email: None,
-                host: "gitlab.com".to_string(),
-            },
-        ],
-        temp_dir.path(),
-    )?;
-
-    let config = std::fs::read_to_string(glab_config_dir.join(GLAB_CONFIG_FILENAME))?;
-    assert!(config.contains("gitlab.com:"));
-    assert!(!config.contains("github.com:"));
-    assert!(!config.contains("github-token"));
-
-    Ok(())
-}
-
-#[test]
-fn write_glab_config_skips_github_only_credentials() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-
-    write_glab_config(
-        &[GitCredential {
-            token: "github-token".to_string(),
-            username: Some("octocat".to_string()),
-            email: None,
-            host: "github.com".to_string(),
-        }],
-        temp_dir.path(),
-    )?;
-
-    assert!(!temp_dir.path().join(".config").join("glab-cli").exists());
-
-    Ok(())
-}
-
-#[test]
-fn refreshed_credentials_return_err_when_the_local_write_fails() {
-    let mut conflicting = github_credential();
-    conflicting.token = "other-github-token".to_string();
-
-    let error = apply_refreshed_credentials(TaskGitCredentialsResponse {
-        credentials: vec![github_credential(), conflicting],
-        failed_hosts: vec![],
+fn bootstrap_rejects_any_partial_failure_without_naming_hosts() {
+    let error = credentials_for_bootstrap(TaskGitCredentialsResponse {
+        credentials: vec![github_credential()],
+        failed_hosts: vec!["customer-gitlab.example.com".to_string()],
     })
     .unwrap_err();
 
-    let message = format!("{error:#}");
-    assert!(message.contains("Failed to write refreshed git credentials"));
-    assert!(message.contains("github.com"));
+    assert!(!error.to_string().contains("customer-gitlab.example.com"));
+}
+
+#[test]
+fn git_preflight_command_has_no_tokens() {
+    let repositories = [
+        SourceRepo::new(CodeForge::GitLab, "group".to_string(), "one".to_string()),
+        SourceRepo::new(CodeForge::GitLab, "group".to_string(), "two".to_string()),
+    ];
+    let repositories = repositories
+        .iter()
+        .map(|repository| {
+            (
+                repository,
+                format!(
+                    "https://gitlab.example.com:8443/gitlab/group/{}.git",
+                    repository.repo
+                ),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let command = git_access_check_command(&repositories, Path::new("/workspace")).unwrap();
+
+    assert!(command.contains("/workspace/one"));
+    assert!(command.contains("/workspace/two"));
+    assert!(command.contains(
+        "ls-remote --exit-code 'https://gitlab.example.com:8443/gitlab/group/one.git' HEAD"
+    ));
+    assert!(!command.contains("token-one"));
+    assert!(!command.contains("token-two"));
+    assert!(!command.contains("GITLAB_TOKEN"));
+}
+
+#[test]
+fn managed_forge_fallback_remains_explicit_when_no_task_credential_matches() {
+    let repository = SourceRepo::new(
+        CodeForge::GitHub,
+        "warpdotdev".to_string(),
+        "warp".to_string(),
+    );
+
+    assert_eq!(
+        select_credential_for_repository(&[], &repository)
+            .unwrap()
+            .map(|credential| credential.id.as_str()),
+        None
+    );
+    assert_eq!(
+        repository.https_clone_url(),
+        "https://github.com/warpdotdev/warp.git"
+    );
 }

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -976,6 +976,16 @@ impl AgentDriverRunner {
         if needs_clone {
             let org = skill_spec.org.as_ref().expect("org checked above");
             let repo_name = skill_spec.repo.as_ref().expect("repo checked above");
+            driver::git_credentials::prepare_project_path(
+                cloud_object_models::CodeForge::GitHub,
+                org,
+                repo_name,
+            )
+            .map_err(|error| {
+                AgentDriverError::SkillResolutionFailed(format!(
+                    "Failed to configure task Git credentials for skill resolution: {error:#}"
+                ))
+            })?;
             log::info!("Cloning {org}/{repo_name} for skill resolution in sandboxed mode");
             setup_events
                 .record_result(SetupStep::SkillRepoClone, async {

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -855,11 +855,8 @@ impl AgentDriverRunner {
         ))
         .await?
         .token;
-        // Bootstrap has no prior credential store, so a one-host success would
-        // leave the other host unauthenticated for the first clone. Partial
-        // refresh is reserved for later cycles after stores exist.
         let response = ai_client
-            .get_task_git_credentials(task_id_str, workload_token, false)
+            .get_task_git_credentials(task_id_str, workload_token)
             .await?;
         driver::git_credentials::credentials_for_bootstrap(response)
     }
@@ -869,6 +866,11 @@ impl AgentDriverRunner {
         task_id_str: &str,
         args: &RunAgentArgs,
     ) -> Result<(), AgentDriverError> {
+        driver::git_credentials::configure_git_credentials(&[]).map_err(|err| {
+            AgentDriverError::SkillResolutionFailed(format!(
+                "Failed to clear task Git credentials before skill resolution: {err:#}"
+            ))
+        })?;
         if warp_isolation_platform::detect().is_none() && args.configure_git_credentials_with_github
         {
             foreground
@@ -986,10 +988,12 @@ impl AgentDriverRunner {
                     "Failed to configure task Git credentials for skill resolution: {error:#}"
                 ))
             })?;
+            let task_environment = driver::git_credentials::task_environment_variables()
+                .map_err(AgentDriverError::ConfigBuildFailed)?;
             log::info!("Cloning {org}/{repo_name} for skill resolution in sandboxed mode");
             setup_events
                 .record_result(SetupStep::SkillRepoClone, async {
-                    clone_repo_for_skill(org, repo_name, working_dir)
+                    clone_repo_for_skill(org, repo_name, working_dir, &task_environment)
                         .await
                         .map_err(|err| {
                             AgentDriverError::SkillResolutionFailed(format_skill_resolution_error(

--- a/app/src/ai/agent_sdk/setup_observability.rs
+++ b/app/src/ai/agent_sdk/setup_observability.rs
@@ -198,6 +198,7 @@ pub(crate) enum SetupStep {
     EnvironmentCodebaseIndexing,
     FileBasedMcpDiscovery,
     FileBasedMcpReadiness,
+    GitLabPreflight,
     EnvironmentSkillLoading,
     GlobalSkillLoading,
     SkillsDirsLoading,
@@ -277,6 +278,9 @@ impl SetupStep {
             }
             Self::FileBasedMcpReadiness => {
                 span_and_name!("setup_file_based_mcp_readiness")
+            }
+            Self::GitLabPreflight => {
+                span_and_name!("setup_gitlab_preflight")
             }
             Self::EnvironmentSkillLoading => {
                 span_and_name!("setup_environment_skill_loading")

--- a/app/src/ai/skills/resolve_skill_spec.rs
+++ b/app/src/ai/skills/resolve_skill_spec.rs
@@ -11,6 +11,7 @@
 //! - Applies consistent skill-directory precedence (e.g. `.claude/` vs `.codex/`, etc.).
 //! - Falls back to scanning disk when the manager cache has not warmed yet.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use ai::skills::{
@@ -146,6 +147,7 @@ pub async fn clone_repo_for_skill(
     org: &str,
     repo: &str,
     working_dir: &Path,
+    task_environment: &[(OsString, OsString)],
 ) -> Result<(), ResolveSkillError> {
     let repo_url = format!("https://github.com/{org}/{repo}.git");
     let target_dir = working_dir.join(repo);
@@ -177,11 +179,14 @@ pub async fn clone_repo_for_skill(
         target_dir.display()
     );
 
-    let output = AsyncCommand::new("git")
+    let mut command = AsyncCommand::new("git");
+    command
+        .envs(task_environment.iter().cloned())
         .arg("clone")
         .arg(&repo_url)
         .arg(&target_dir)
-        .current_dir(working_dir)
+        .current_dir(working_dir);
+    let output = command
         .output()
         .await
         .map_err(|e| ResolveSkillError::CloneFailed {

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -177,6 +177,14 @@ fn public_api_user_query_mode(mode: UserQueryMode) -> &'static str {
     }
 }
 
+fn legacy_git_credential_id(host: &str) -> String {
+    use std::hash::{Hash as _, Hasher as _};
+
+    let mut hasher = std::hash::DefaultHasher::new();
+    host.to_ascii_lowercase().hash(&mut hasher);
+    format!("legacy:{:016x}", hasher.finish())
+}
+
 fn serialize_user_query_mode_for_public_api<S>(
     mode: &UserQueryMode,
     serializer: S,
@@ -1759,7 +1767,7 @@ fn into_legacy_git_credential(
     credential: warp_graphql::queries::task_git_credentials::TaskGitCredentialLegacy,
 ) -> GitCredential {
     GitCredential {
-        id: format!("legacy:{}", credential.host),
+        id: legacy_git_credential_id(&credential.host),
         instance_uid: None,
         installation_uid: None,
         scheme: "https".to_string(),

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -716,20 +716,37 @@ pub struct CreateFileArtifactUploadResponse {
 /// A single git credential entry returned by `taskGitCredentials`.
 #[derive(Clone)]
 pub struct GitCredential {
+    /// Opaque task-scoped identity used to merge refreshes safely.
+    pub id: String,
+    /// GitLab instance connection identity, when applicable.
+    pub instance_uid: Option<String>,
+    /// GitLab root-group installation identity, when applicable.
+    pub installation_uid: Option<String>,
+    /// URL scheme for clone, API, and credential matching.
+    pub scheme: String,
+    /// The git hosting provider hostname.
+    pub host: String,
+    /// A non-default origin port.
+    pub port: Option<i32>,
+    /// GitLab's relative URL prefix, without leading or trailing slashes.
+    pub relative_url_prefix: String,
+    /// Exact forge-relative repository paths authorized by this credential.
+    pub project_paths: Vec<String>,
     /// The provider's OAuth or installation access token.
     pub token: String,
     /// The provider-specific git username, when available.
     pub username: Option<String>,
     /// The provider account's email, when available.
     pub email: Option<String>,
-    /// The managed git host, such as `"github.com"` or `"gitlab.com"`.
-    pub host: String,
 }
 
 impl std::fmt::Debug for GitCredential {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GitCredential")
-            .field("host", &self.host)
+            .field("id", &self.id)
+            .field("instance_uid", &self.instance_uid)
+            .field("installation_uid", &self.installation_uid)
+            .field("project_path_count", &self.project_paths.len())
             .field("username_present", &self.username.is_some())
             .field("email_present", &self.email.is_some())
             .field("token_present", &!self.token.is_empty())
@@ -1705,7 +1722,7 @@ impl ServerApi {
                     credentials: output
                         .credentials
                         .into_iter()
-                        .map(into_git_credential)
+                        .map(into_legacy_git_credential)
                         .collect(),
                     failed_hosts: Vec::new(),
                 })
@@ -1724,18 +1741,54 @@ fn into_git_credential(
     credential: warp_graphql::queries::task_git_credentials::TaskGitCredential,
 ) -> GitCredential {
     GitCredential {
+        id: credential.id.into_inner(),
+        instance_uid: credential.instance_uid.map(cynic::Id::into_inner),
+        installation_uid: credential.installation_uid.map(cynic::Id::into_inner),
+        scheme: credential.scheme,
+        host: credential.host,
+        port: credential.port,
+        relative_url_prefix: credential.relative_url_prefix,
+        project_paths: credential.project_paths,
         token: credential.token,
         username: credential.username,
         email: credential.email,
+    }
+}
+
+fn into_legacy_git_credential(
+    credential: warp_graphql::queries::task_git_credentials::TaskGitCredentialLegacy,
+) -> GitCredential {
+    GitCredential {
+        id: format!("legacy:{}", credential.host),
+        instance_uid: None,
+        installation_uid: None,
+        scheme: "https".to_string(),
         host: credential.host,
+        port: None,
+        relative_url_prefix: String::new(),
+        project_paths: Vec::new(),
+        token: credential.token,
+        username: credential.username,
+        email: credential.email,
     }
 }
 
 fn is_unknown_git_credential_schema_error(error: &anyhow::Error) -> bool {
     let message = error.to_string();
-    let names_partial_refresh_field =
-        message.contains("failedHosts") || message.contains("acceptsPartialRefresh");
-    names_partial_refresh_field
+    let names_compatibility_field = [
+        "failedHosts",
+        "acceptsPartialRefresh",
+        "instanceUid",
+        "installationUid",
+        "scheme",
+        "port",
+        "relativeUrlPrefix",
+        "projectPaths",
+    ]
+    .iter()
+    .any(|field| message.contains(field))
+        || message.contains("TaskGitCredential") && message.contains("\"id\"");
+    names_compatibility_field
         && (message.contains("Cannot query field")
             || message.contains("Unknown argument")
             || message.contains("is not defined by type"))
@@ -2794,7 +2847,7 @@ impl AIClient for ServerApi {
             Ok(response) => Ok(response),
             Err(error) if is_unknown_git_credential_schema_error(&error) => {
                 log::info!(
-                    "taskGitCredentials partial-refresh fields are unavailable; falling back to the pre-deploy schema"
+                    "taskGitCredentials credential fields are unavailable; falling back to the legacy schema"
                 );
                 self.get_task_git_credentials_legacy(task_id, workload_token)
                     .await

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -763,10 +763,9 @@ impl std::fmt::Debug for GitCredential {
 }
 
 /// One credential-retrieval cycle's outcome.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct TaskGitCredentialsResponse {
     pub credentials: Vec<GitCredential>,
-    pub failed_hosts: Vec<String>,
 }
 
 /// Filter parameters for listing ambient agent tasks.
@@ -1486,7 +1485,6 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         task_id: String,
         workload_token: String,
-        accepts_partial_refresh: bool,
     ) -> anyhow::Result<TaskGitCredentialsResponse, anyhow::Error>;
 
     async fn get_task_attachments(
@@ -1676,13 +1674,11 @@ impl ServerApi {
         &self,
         task_id: String,
         workload_token: String,
-        accepts_partial_refresh: bool,
     ) -> anyhow::Result<TaskGitCredentialsResponse, anyhow::Error> {
         let variables = TaskGitCredentialsVariables {
             input: TaskGitCredentialsInput {
                 task_id: cynic::Id::new(task_id),
                 workload_token,
-                accepts_partial_refresh: Some(accepts_partial_refresh),
             },
             request_context: get_request_context(),
         };
@@ -1697,7 +1693,6 @@ impl ServerApi {
                         .into_iter()
                         .map(into_git_credential)
                         .collect(),
-                    failed_hosts: output.failed_hosts,
                 })
             }
             TaskGitCredentialsResult::UserFacingError(error) => {
@@ -1732,7 +1727,6 @@ impl ServerApi {
                         .into_iter()
                         .map(into_legacy_git_credential)
                         .collect(),
-                    failed_hosts: Vec::new(),
                 })
             }
             TaskGitCredentialsLegacyResult::UserFacingError(error) => {
@@ -1784,8 +1778,6 @@ fn into_legacy_git_credential(
 fn is_unknown_git_credential_schema_error(error: &anyhow::Error) -> bool {
     let message = error.to_string();
     let names_compatibility_field = [
-        "failedHosts",
-        "acceptsPartialRefresh",
         "instanceUid",
         "installationUid",
         "scheme",
@@ -2845,11 +2837,7 @@ impl AIClient for ServerApi {
         accepts_partial_refresh: bool,
     ) -> anyhow::Result<TaskGitCredentialsResponse, anyhow::Error> {
         match self
-            .get_task_git_credentials_current(
-                task_id.clone(),
-                workload_token.clone(),
-                accepts_partial_refresh,
-            )
+            .get_task_git_credentials_current(task_id.clone(), workload_token.clone())
             .await
         {
             Ok(response) => Ok(response),

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2834,7 +2834,6 @@ impl AIClient for ServerApi {
         &self,
         task_id: String,
         workload_token: String,
-        accepts_partial_refresh: bool,
     ) -> anyhow::Result<TaskGitCredentialsResponse, anyhow::Error> {
         match self
             .get_task_git_credentials_current(task_id.clone(), workload_token.clone())

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -1307,13 +1307,7 @@ fn upload_url_fallback_is_uploaded_as_a_put_with_its_content_type() {
 }
 
 #[test]
-fn unknown_git_credential_schema_error_matches_undeployed_partial_refresh_fields() {
-    assert!(is_unknown_git_credential_schema_error(&anyhow::anyhow!(
-        "Cannot query field \"failedHosts\" on type \"TaskGitCredentialsOutput\""
-    )));
-    assert!(is_unknown_git_credential_schema_error(&anyhow::anyhow!(
-        "Unknown argument \"acceptsPartialRefresh\" on field \"taskGitCredentials\""
-    )));
+fn unknown_git_credential_schema_error_matches_undeployed_authority_fields() {
     assert!(is_unknown_git_credential_schema_error(&anyhow::anyhow!(
         "Cannot query field \"instanceUid\" on type \"TaskGitCredential\""
     )));

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -48,10 +48,7 @@ fn legacy_git_credential_id_does_not_expose_the_host() {
 
     assert!(id.starts_with("legacy:"));
     assert!(!id.contains("customer-gitlab.example.com"));
-    assert_eq!(
-        id,
-        legacy_git_credential_id("CUSTOMER-GITLAB.EXAMPLE.COM")
-    );
+    assert_eq!(id, legacy_git_credential_id("CUSTOMER-GITLAB.EXAMPLE.COM"));
     assert_ne!(id, legacy_git_credential_id("other.example.com"));
 }
 

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -13,6 +13,7 @@ use super::{
     ReadAgentMessageResponse, RunFollowupRequest, RunSortBy, RunSortOrder, SpawnAgentRequest,
     TaskListFilter, UploadFieldValue, UserQueryMode, build_fork_conversation_url,
     build_list_agent_runs_url, build_run_followup_url, is_unknown_git_credential_schema_error,
+    legacy_git_credential_id,
 };
 use crate::notebooks::NotebookId;
 use crate::server::server_api::presigned_upload::upload_to_target;
@@ -39,6 +40,19 @@ fn ambient_agent_headers_for_task_overrides_existing_cloud_agent_header() {
             task_scoped_id.to_string()
         )]
     );
+}
+
+#[test]
+fn legacy_git_credential_id_does_not_expose_the_host() {
+    let id = legacy_git_credential_id("customer-gitlab.example.com");
+
+    assert!(id.starts_with("legacy:"));
+    assert!(!id.contains("customer-gitlab.example.com"));
+    assert_eq!(
+        id,
+        legacy_git_credential_id("CUSTOMER-GITLAB.EXAMPLE.COM")
+    );
+    assert_ne!(id, legacy_git_credential_id("other.example.com"));
 }
 
 #[test]

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -1300,6 +1300,12 @@ fn unknown_git_credential_schema_error_matches_undeployed_partial_refresh_fields
     assert!(is_unknown_git_credential_schema_error(&anyhow::anyhow!(
         "Unknown argument \"acceptsPartialRefresh\" on field \"taskGitCredentials\""
     )));
+    assert!(is_unknown_git_credential_schema_error(&anyhow::anyhow!(
+        "Cannot query field \"instanceUid\" on type \"TaskGitCredential\""
+    )));
+    assert!(is_unknown_git_credential_schema_error(&anyhow::anyhow!(
+        "Cannot query field \"id\" on type \"TaskGitCredential\""
+    )));
     assert!(!is_unknown_git_credential_schema_error(&anyhow::anyhow!(
         "Failed to fetch task git credentials"
     )));

--- a/crates/graphql/src/api/queries/task_git_credentials.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials.rs
@@ -28,8 +28,6 @@ pub struct TaskGitCredentialsVariables {
 pub struct TaskGitCredentialsInput {
     pub task_id: cynic::Id,
     pub workload_token: String,
-    #[cynic(skip_serializing_if = "Option::is_none")]
-    pub accepts_partial_refresh: Option<bool>,
 }
 
 #[derive(cynic::InlineFragments, Debug)]
@@ -43,11 +41,9 @@ pub enum TaskGitCredentialsResult {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct TaskGitCredentialsOutput {
     pub credentials: Vec<TaskGitCredential>,
-    pub failed_hosts: Vec<String>,
 }
 
-/// Pre-#16215 operation: omits `acceptsPartialRefresh` and `failedHosts` so a
-/// server that has not deployed those fields can still validate the query.
+/// Legacy operation for a server that has not deployed the authority fields.
 pub mod legacy {
     use crate::error::UserFacingError;
     use crate::request_context::RequestContext;

--- a/crates/graphql/src/api/queries/task_git_credentials.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials.rs
@@ -49,7 +49,6 @@ pub struct TaskGitCredentialsOutput {
 /// Pre-#16215 operation: omits `acceptsPartialRefresh` and `failedHosts` so a
 /// server that has not deployed those fields can still validate the query.
 pub mod legacy {
-    use super::TaskGitCredential;
     use crate::error::UserFacingError;
     use crate::request_context::RequestContext;
     use crate::schema;
@@ -93,21 +92,37 @@ pub mod legacy {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "TaskGitCredentialsOutput")]
     pub struct TaskGitCredentialsLegacyOutput {
-        pub credentials: Vec<TaskGitCredential>,
+        pub credentials: Vec<TaskGitCredentialLegacy>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "TaskGitCredential")]
+    pub struct TaskGitCredentialLegacy {
+        pub token: String,
+        pub username: Option<String>,
+        pub email: Option<String>,
+        pub host: String,
     }
 }
 
 pub use legacy::{
-    TaskGitCredentialsLegacy, TaskGitCredentialsLegacyInput, TaskGitCredentialsLegacyResult,
-    TaskGitCredentialsLegacyVariables,
+    TaskGitCredentialLegacy, TaskGitCredentialsLegacy, TaskGitCredentialsLegacyInput,
+    TaskGitCredentialsLegacyResult, TaskGitCredentialsLegacyVariables,
 };
 
 #[derive(cynic::QueryFragment, Debug)]
 pub struct TaskGitCredential {
+    pub id: cynic::Id,
+    pub instance_uid: Option<cynic::Id>,
+    pub installation_uid: Option<cynic::Id>,
+    pub scheme: String,
+    pub host: String,
+    pub port: Option<i32>,
+    pub relative_url_prefix: String,
+    pub project_paths: Vec<String>,
     pub token: String,
     pub username: Option<String>,
     pub email: Option<String>,
-    pub host: String,
 }
 
 #[cfg(test)]

--- a/crates/graphql/src/api/queries/task_git_credentials_tests.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials_tests.rs
@@ -19,17 +19,15 @@ fn request_context() -> RequestContext {
 }
 
 #[test]
-fn current_query_selects_partial_refresh_fields() {
+fn current_query_selects_authority_fields() {
     let operation = TaskGitCredentials::build(TaskGitCredentialsVariables {
         input: TaskGitCredentialsInput {
             task_id: cynic::Id::new("task"),
             workload_token: "token".to_string(),
-            accepts_partial_refresh: Some(true),
         },
         request_context: request_context(),
     });
 
-    assert!(operation.query.contains("failedHosts"));
     assert!(operation.query.contains("credentials"));
     for field in [
         "id",
@@ -52,21 +50,7 @@ fn current_query_selects_partial_refresh_fields() {
 }
 
 #[test]
-fn bootstrap_query_still_selects_failed_hosts() {
-    let operation = TaskGitCredentials::build(TaskGitCredentialsVariables {
-        input: TaskGitCredentialsInput {
-            task_id: cynic::Id::new("task"),
-            workload_token: "token".to_string(),
-            accepts_partial_refresh: Some(false),
-        },
-        request_context: request_context(),
-    });
-
-    assert!(operation.query.contains("failedHosts"));
-}
-
-#[test]
-fn legacy_query_omits_partial_refresh_fields() {
+fn legacy_query_omits_authority_fields() {
     let operation = TaskGitCredentialsLegacy::build(TaskGitCredentialsLegacyVariables {
         input: TaskGitCredentialsLegacyInput {
             task_id: cynic::Id::new("task"),
@@ -75,8 +59,6 @@ fn legacy_query_omits_partial_refresh_fields() {
         request_context: request_context(),
     });
 
-    assert!(!operation.query.contains("acceptsPartialRefresh"));
-    assert!(!operation.query.contains("failedHosts"));
     assert!(operation.query.contains("credentials"));
     for field in [
         "id",

--- a/crates/graphql/src/api/queries/task_git_credentials_tests.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials_tests.rs
@@ -18,6 +18,11 @@ fn request_context() -> RequestContext {
     }
 }
 
+fn query_selects_field(query: &str, field: &str) -> bool {
+    query
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+        .any(|token| token == field)
+}
 #[test]
 fn current_query_selects_authority_fields() {
     let operation = TaskGitCredentials::build(TaskGitCredentialsVariables {
@@ -43,7 +48,7 @@ fn current_query_selects_authority_fields() {
         "token",
     ] {
         assert!(
-            operation.query.contains(field),
+            query_selects_field(&operation.query, field),
             "current query must select {field}"
         );
     }
@@ -70,7 +75,7 @@ fn legacy_query_omits_authority_fields() {
         "projectPaths",
     ] {
         assert!(
-            !operation.query.contains(field),
+            !query_selects_field(&operation.query, field),
             "legacy query must not select {field}"
         );
     }

--- a/crates/graphql/src/api/queries/task_git_credentials_tests.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials_tests.rs
@@ -31,6 +31,24 @@ fn current_query_selects_partial_refresh_fields() {
 
     assert!(operation.query.contains("failedHosts"));
     assert!(operation.query.contains("credentials"));
+    for field in [
+        "id",
+        "instanceUid",
+        "installationUid",
+        "scheme",
+        "host",
+        "port",
+        "relativeUrlPrefix",
+        "projectPaths",
+        "username",
+        "email",
+        "token",
+    ] {
+        assert!(
+            operation.query.contains(field),
+            "current query must select {field}"
+        );
+    }
 }
 
 #[test]
@@ -60,4 +78,18 @@ fn legacy_query_omits_partial_refresh_fields() {
     assert!(!operation.query.contains("acceptsPartialRefresh"));
     assert!(!operation.query.contains("failedHosts"));
     assert!(operation.query.contains("credentials"));
+    for field in [
+        "id",
+        "instanceUid",
+        "installationUid",
+        "scheme",
+        "port",
+        "relativeUrlPrefix",
+        "projectPaths",
+    ] {
+        assert!(
+            !operation.query.contains(field),
+            "legacy query must not select {field}"
+        );
+    }
 }

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -3741,16 +3741,6 @@ type TaskGitCredential {
 
 """Input for the taskGitCredentials query."""
 input TaskGitCredentialsInput {
-  """
-  Whether the caller can handle a response in which one forge's credential is
-  fresh and another's failed. A caller that opts in must merge the fresh
-  credentials over its existing stores rather than rebuilding them from the
-  response, since a host absent from `credentials` may simply not have been
-  refreshed this cycle. Absent or false preserves the all-or-nothing
-  behavior, so a caller that rebuilds its stores wholesale never sees a
-  partial list.
-  """
-  acceptsPartialRefresh: Boolean
 
   """The ID of the task."""
   taskId: ID!
@@ -3760,20 +3750,8 @@ input TaskGitCredentialsInput {
 }
 
 type TaskGitCredentialsOutput implements Response {
-  """The credentials that were freshly issued this cycle."""
+  """The complete credential set for this task."""
   credentials: [TaskGitCredential!]!
-
-  """
-  Hosts whose credential could not be issued this cycle because of a
-  transient failure. A host listed here is distinct from one that is simply
-  absent from `credentials`: absent means the run has no repository on that
-  forge and needs no credential there, while listed here means the caller
-  should keep whatever it already has for that host and retry.
-
-  Only populated when the request set `acceptsPartialRefresh`; otherwise a
-  failure on any forge fails the whole request.
-  """
-  failedHosts: [String!]!
   responseContext: ResponseContext!
 }
 

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -3699,16 +3699,35 @@ type TaskAttachment {
   mimeType: String!
 }
 
-"""A set of git credentials for a single hosting provider."""
+"""A task-scoped git credential for one provider authority."""
 type TaskGitCredential {
   """
   The email address associated with the token, if available.
   Null for service-account (installation) tokens.
   """
   email: String
+  """An opaque task-scoped identifier for this credential."""
+  id: ID!
 
   """The git hosting provider (e.g. "github.com")."""
   host: String!
+  """The GitLab instance connection UID, when this is a GitLab credential."""
+  instanceUid: ID
+
+  """The GitLab root-group installation UID, when this is a GitLab credential."""
+  installationUid: ID
+
+  """The optional non-default port for the git hosting instance."""
+  port: Int
+
+  """The exact repository paths that this credential authorizes."""
+  projectPaths: [String!]!
+
+  """The GitLab relative URL prefix without a leading or trailing slash."""
+  relativeUrlPrefix: String!
+
+  """The URL scheme for clone, API, and credential matching."""
+  scheme: String!
 
   """The OAuth or installation access token."""
   token: String!
@@ -3741,7 +3760,7 @@ input TaskGitCredentialsInput {
 }
 
 type TaskGitCredentialsOutput implements Response {
-  """The credentials that were freshly issued this cycle, one per host."""
+  """The credentials that were freshly issued this cycle."""
   credentials: [TaskGitCredential!]!
 
   """


### PR DESCRIPTION
## Description
Add task-scoped credentials for managed and approved self-hosted GitLab instances.

- Build exact HTTPS clone origins with the configured host, port, prefix, and project path.
- Store Git credentials by full repository path and remove stale tokens during refresh.
- Keep GitHub CLI and GitLab CLI configuration local to each task and checkout.
- Reject unsafe network targets, pin validated public addresses, and run repository preflight checks.
- Preserve compatibility with the current and legacy task credential GraphQL schemas.

## Linked Issue
No linked issue.

## Testing
- `./script/format --check`
- `./script/check_no_inline_test_modules`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo check -p warp --lib`
- `cargo test -p warp_graphql --lib api::queries::task_git_credentials::tests`
- `cargo test -p warp --lib ai::agent_sdk::driver::git_credentials::tests`

- [ ] I have manually tested my changes locally with `./script/run`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode.

<!-- warp:pr-description-artifacts start -->
_Plans_:
- _[Implement self-hosted GitLab support for Factories](https://staging.warp.dev/drive/notebook/YpCGO9XJu8tWPRnNH9ISvQ)_
<!-- warp:pr-description-artifacts end -->

CHANGELOG-IMPROVEMENT: Cloud agent tasks can use approved self-hosted GitLab repositories.
