### PR TITLE
Add Use your OpenAI ChatGPT subscription in Agent settings

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -155,7 +155,7 @@ use ai::execution_profiles::editor::ExecutionProfileEditorManager;
 use ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use ai::metadata_project_rules::read_project_rule_contents;
 use ai::persisted_workspace::PersistedWorkspace;
-use auth::auth_manager::AuthManager;
+use auth::auth_manager::{AuthManager, AuthManagerEvent};
 use auth::auth_state::{AuthState, AuthStateProvider};
 use code::editor_management::CodeManager;
 use code::opened_files::OpenedFilesModel;
@@ -1791,6 +1791,15 @@ pub(crate) fn initialize_app(
             });
         },
     );
+    ctx.subscribe_to_model(&AuthManager::handle(ctx), |_, event, ctx| {
+        if matches!(event, AuthManagerEvent::AuthComplete)
+            && FeatureFlag::ChatGPTSubscription.is_enabled()
+        {
+            ::ai::api_keys::ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                manager.complete_chatgpt_oauth_if_pending(ctx);
+            });
+        }
+    });
 
     ctx.add_singleton_model(AntivirusInfo::new);
 

--- a/app/src/settings_view/warp_agent_page.rs
+++ b/app/src/settings_view/warp_agent_page.rs
@@ -22,6 +22,7 @@ use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
 use pathfinder_geometry::vector::vec2f;
 use settings::{Setting, ToggleableSetting};
 use strum::IntoEnumIterator;
+use url::Url;
 #[cfg(not(target_family = "wasm"))]
 use uuid::Uuid;
 use warp_core::channel::ChannelState;
@@ -79,7 +80,7 @@ use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::geap_credentials::force_refresh_geap_credentials;
 use crate::ai::llms::{LLMId, LLMPreferences, LLMProvider, is_using_api_key_for_provider};
 use crate::appearance::{Appearance, AppearanceEvent};
-use crate::auth::AuthStateProvider;
+use crate::auth::{AuthManager, AuthStateProvider};
 use crate::editor::{
     EditorOptions, EditorView, Event as EditorEvent, PropagateAndNoOpNavigationKeys,
     SingleLineEditorOptions, TextColors, TextOptions,
@@ -1909,6 +1910,46 @@ impl WarpAgentPageView {
         });
     }
 
+    /// Opens Sign in with ChatGPT in the browser. warp-server runs the confidential
+    /// OAuth exchange and links the ChatGPT `sub` to this Warp account; the desktop
+    /// continue URL is the same `/login/remote` handoff used for sign-in.
+    fn start_chatgpt_oauth(&mut self, ctx: &mut ViewContext<Self>) {
+        use crate::ToastStack;
+        use crate::view_components::{DismissibleToast, ToastLink};
+        use crate::workspace::WorkspaceAction;
+
+        const CONNECT_TOAST_OBJECT_ID: &str = "chatgpt_oauth_connect_toast";
+
+        ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+            manager.set_chatgpt_oauth_pending(true, ctx);
+        });
+
+        let authorize_url = AuthManager::handle(ctx).update(ctx, |auth_manager, _ctx| {
+            let continue_url = auth_manager.sign_in_url();
+            let mut start = Url::parse(&format!("{}/auth/openai", ChannelState::server_root_url()))
+                .expect("server_root_url is a valid URL");
+            start
+                .query_pairs_mut()
+                .append_pair("continueUrl", &continue_url);
+            start.to_string()
+        });
+        ctx.open_url(&authorize_url);
+
+        let window_id = ctx.window_id();
+        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            let toast = DismissibleToast::default(
+                "Opening your browser to connect your ChatGPT subscription…".to_string(),
+            )
+            .with_object_id(CONNECT_TOAST_OBJECT_ID.to_string())
+            .with_link(
+                ToastLink::new("Copy URL".to_string())
+                    .with_onclick_action(WorkspaceAction::CopyTextToClipboard(authorize_url)),
+            );
+            toast_stack.add_persistent_toast(toast, window_id, ctx);
+        });
+        ctx.notify();
+    }
+
     /// Tears down a cancelled attempt: clears state and dismisses the
     /// connect toast.
     #[cfg(not(target_family = "wasm"))]
@@ -2366,6 +2407,8 @@ pub enum WarpAgentPageAction {
     ConnectGrokSubscription,
     CancelGrokSubscriptionConnect,
     DisconnectGrokSubscription,
+    ConnectChatGPTSubscription,
+    DisconnectChatGPTSubscription,
 
     #[cfg(feature = "local_fs")]
     SetConversationLayout(crate::util::file::external_editor::settings::OpenConversationPreference),
@@ -2940,6 +2983,23 @@ impl TypedActionView for WarpAgentPageView {
                 crate::ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                     let toast = crate::view_components::DismissibleToast::default(
                         "SuperGrok subscription disconnected".to_string(),
+                    );
+                    toast_stack.add_ephemeral_toast(toast, window_id, ctx);
+                });
+                ctx.notify();
+            }
+            WarpAgentPageAction::ConnectChatGPTSubscription => {
+                self.start_chatgpt_oauth(ctx);
+            }
+            WarpAgentPageAction::DisconnectChatGPTSubscription => {
+                ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                    manager.set_chatgpt_connection(None, ctx);
+                });
+
+                let window_id = ctx.window_id();
+                crate::ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    let toast = crate::view_components::DismissibleToast::default(
+                        "ChatGPT subscription disconnected".to_string(),
                     );
                     toast_stack.add_ephemeral_toast(toast, window_id, ctx);
                 });
@@ -4791,6 +4851,9 @@ struct ApiKeysWidget {
     grok_cancel_button: ViewHandle<ActionButton>,
     grok_cancelling_button: ViewHandle<ActionButton>,
     grok_disconnect_button: ViewHandle<ActionButton>,
+    chatgpt_connect_button: ViewHandle<ActionButton>,
+    chatgpt_connecting_button: ViewHandle<ActionButton>,
+    chatgpt_disconnect_button: ViewHandle<ActionButton>,
 
     can_use_warp_credits_for_fallback: SwitchStateHandle,
     upgrade_highlight_index: HighlightedHyperlink,
@@ -4958,7 +5021,32 @@ impl ApiKeysWidget {
                     ctx.dispatch_typed_action(WarpAgentPageAction::DisconnectGrokSubscription);
                 })
         });
-        for button in [&grok_connect_button, &grok_disconnect_button] {
+        let chatgpt_connect_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Connect", SecondaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| {
+                    ctx.dispatch_typed_action(WarpAgentPageAction::ConnectChatGPTSubscription);
+                })
+        });
+        let chatgpt_connecting_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Connecting", SecondaryTheme).with_size(ButtonSize::Small)
+        });
+        chatgpt_connecting_button.update(ctx, |button, ctx| {
+            button.set_disabled(true, ctx);
+        });
+        let chatgpt_disconnect_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Disconnect", DangerSecondaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| {
+                    ctx.dispatch_typed_action(WarpAgentPageAction::DisconnectChatGPTSubscription);
+                })
+        });
+        for button in [
+            &grok_connect_button,
+            &grok_disconnect_button,
+            &chatgpt_connect_button,
+            &chatgpt_disconnect_button,
+        ] {
             button.update(ctx, |button, ctx| {
                 button.set_disabled(
                     !(is_any_ai_enabled && is_byo_enabled && member_byo_keys_allowed),
@@ -4969,7 +5057,12 @@ impl ApiKeysWidget {
 
         // The Grok subscription is BYO auth, so keep the buttons' enablement
         // in sync with the BYO API key policy, like the editors above.
-        let grok_buttons = [grok_connect_button.clone(), grok_disconnect_button.clone()];
+        let grok_buttons = [
+            grok_connect_button.clone(),
+            grok_disconnect_button.clone(),
+            chatgpt_connect_button.clone(),
+            chatgpt_disconnect_button.clone(),
+        ];
         ctx.subscribe_to_model(&workspace_handle, move |_, workspace, event, ctx| {
             if is_team_policy_change_for_window(event, ctx.window_id()) {
                 let is_any_ai_enabled = AISettings::handle(ctx).as_ref(ctx).is_any_ai_enabled(ctx);
@@ -5015,6 +5108,9 @@ impl ApiKeysWidget {
             grok_cancel_button,
             grok_cancelling_button,
             grok_disconnect_button,
+            chatgpt_connect_button,
+            chatgpt_connecting_button,
+            chatgpt_disconnect_button,
 
             can_use_warp_credits_for_fallback: Default::default(),
             upgrade_highlight_index: Default::default(),
@@ -5395,6 +5491,111 @@ impl ApiKeysWidget {
         column.finish()
     }
 
+    fn render_chatgpt_subscription_row(
+        &self,
+        appearance: &Appearance,
+        is_enabled: bool,
+        is_connecting: bool,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let chatgpt_connection = ApiKeyManager::as_ref(app).chatgpt_connection();
+
+        let text_color = styles::header_font_color(is_enabled, app);
+        let label = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(4.)
+            .with_child(
+                Text::new_inline("Use your", appearance.ui_font_family(), CONTENT_FONT_SIZE)
+                    .with_color(text_color.into())
+                    .finish(),
+            )
+            .with_child(
+                ConstrainedBox::new(Icon::OpenAILogo.to_warpui_icon(text_color).finish())
+                    .with_width(14.)
+                    .with_height(14.)
+                    .finish(),
+            )
+            .with_child(
+                Text::new_inline(
+                    "OpenAI ChatGPT subscription",
+                    appearance.ui_font_family(),
+                    CONTENT_FONT_SIZE,
+                )
+                .with_color(text_color.into())
+                .finish(),
+            )
+            .finish();
+
+        let button = if chatgpt_connection.is_some() {
+            &self.chatgpt_disconnect_button
+        } else if is_connecting {
+            &self.chatgpt_connecting_button
+        } else {
+            &self.chatgpt_connect_button
+        };
+
+        let header_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(Shrinkable::new(1., label).finish())
+            .with_child(button.as_ref(app).render(app))
+            .finish();
+
+        let description = Container::new(
+            Text::new(
+                "Connect your ChatGPT subscription to use OpenAI models in the Warp Agent through your OpenAI account.",
+                appearance.ui_font_family(),
+                CONTENT_FONT_SIZE,
+            )
+            .with_color(styles::description_font_color(is_enabled, app).into())
+            .soft_wrap(true)
+            .finish(),
+        )
+        .with_margin_right(styles::TOGGLE_WIDTH_MARGIN)
+        .finish();
+
+        let mut column = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(header_row)
+            .with_child(description);
+
+        if let Some(connection) = chatgpt_connection {
+            let connected_text = match connection.connected_at.map(DateTime::<Local>::from) {
+                Some(connected_at) => format!(
+                    "Connected on {}.",
+                    connected_at.format("%m/%d/%Y at %-I:%M%P")
+                ),
+                None => "Connected.".to_string(),
+            };
+            let check = ConstrainedBox::new(
+                Icon::Check
+                    .to_warpui_icon(appearance.theme().ansi_fg_green().into())
+                    .finish(),
+            )
+            .with_width(12.)
+            .with_height(12.)
+            .finish();
+            let status_text = Text::new_inline(
+                connected_text,
+                appearance.ui_font_family(),
+                CONTENT_FONT_SIZE,
+            )
+            .with_color(styles::description_font_color(is_enabled, app).into())
+            .finish();
+            column.add_child(
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(4.)
+                    .with_child(check)
+                    .with_child(status_text)
+                    .finish(),
+            );
+        }
+
+        column.finish()
+    }
+
     /// Paste-the-code fallback for the current SuperGrok connect attempt.
     #[cfg(not(target_family = "wasm"))]
     fn render_grok_manual_code_entry(
@@ -5517,7 +5718,7 @@ impl SettingsWidget for ApiKeysWidget {
     type View = WarpAgentPageView;
 
     fn search_terms(&self) -> &str {
-        "api keys bring your own byo openai anthropic google claude gemini gpt custom inference endpoint grok supergrok xai subscription"
+        "api keys bring your own byo openai anthropic google claude gemini gpt custom inference endpoint grok supergrok xai chatgpt subscription"
     }
 
     fn should_render(&self, app: &AppContext) -> bool {
@@ -5636,6 +5837,22 @@ impl SettingsWidget for ApiKeysWidget {
                         .finish(),
                 );
             }
+        }
+
+        if FeatureFlag::ChatGPTSubscription.is_enabled() && show_provider_keys {
+            let manager = ApiKeyManager::as_ref(app);
+            let is_chatgpt_connecting =
+                manager.chatgpt_oauth_pending() && manager.chatgpt_connection().is_none();
+            column.add_child(
+                Container::new(self.render_chatgpt_subscription_row(
+                    appearance,
+                    provider_keys_enabled,
+                    is_chatgpt_connecting,
+                    app,
+                ))
+                .with_margin_top(16.)
+                .finish(),
+            );
         }
 
         // Warp credit fallback applies to member-provided API keys, not custom endpoints.

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -39,6 +39,10 @@ const LEGACY_ENDPOINT_PREFIX: &str = "legacy-";
 /// a refresh lifecycle, not a user-pasted static key.
 const GROK_SECURE_STORAGE_KEY: &str = "GrokOAuthTokens";
 
+/// Secure-storage key for a connected ChatGPT subscription. This is only a
+/// local connection timestamp: identity linking lives on warp-server.
+const CHATGPT_SECURE_STORAGE_KEY: &str = "ChatGPTSubscriptionConnection";
+
 /// Emitted when user-provided API keys are updated in-memory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ApiKeyManagerEvent {
@@ -448,6 +452,15 @@ pub struct GrokTokens {
     pub connected_at: Option<SystemTime>,
 }
 
+/// Local record that the user completed Sign in with ChatGPT from this app.
+/// The ChatGPT `sub` is linked on warp-server; this only drives the settings UI.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ChatGPTConnection {
+    /// When the browser OAuth flow completed on this client.
+    #[serde(default)]
+    pub connected_at: Option<SystemTime>,
+}
+
 impl GrokTokens {
     /// Returns the access token whenever it is non-empty, regardless of
     /// expiry. Possibly-expired tokens are still sent so the server stays the
@@ -519,6 +532,11 @@ pub struct ApiKeyManager {
     /// separately from `keys` under [`GROK_SECURE_STORAGE_KEY`];
     /// `crate::grok_subscription` keeps these fresh.
     grok_tokens: Option<GrokTokens>,
+    /// Local ChatGPT subscription connection, if the user completed Sign in
+    /// with ChatGPT from this client.
+    chatgpt_connection: Option<ChatGPTConnection>,
+    /// True while a ChatGPT OAuth attempt is waiting on the browser callback.
+    chatgpt_oauth_pending: bool,
     /// Whether background refresh of `grok_tokens` is currently allowed.
     /// Mirrors the BYO API key policy, which lives in the app layer; wired in
     /// via `ApiKeyManager::set_grok_refresh_allowed` (`crate::grok_subscription`).
@@ -550,6 +568,7 @@ pub struct ApiKeyManager {
     pub(crate) geap_credentials_state: GeapCredentialsState,
     secure_storage_write_version: u64,
     grok_secure_storage_write_version: u64,
+    chatgpt_secure_storage_write_version: u64,
 }
 
 #[derive(Clone)]
@@ -605,6 +624,7 @@ impl ApiKeyManager {
         let custom_endpoint_keys = Self::load_custom_endpoint_keys_from_secure_storage(ctx);
         let resolved_custom_endpoints = keys.custom_endpoints.clone();
         let grok_tokens = Self::load_grok_tokens_from_secure_storage(ctx);
+        let chatgpt_connection = Self::load_chatgpt_connection_from_secure_storage(ctx);
         Self {
             keys,
             custom_endpoints: CustomEndpointState {
@@ -614,6 +634,8 @@ impl ApiKeyManager {
                 resolved: resolved_custom_endpoints,
             },
             grok_tokens,
+            chatgpt_connection,
+            chatgpt_oauth_pending: false,
             #[cfg(not(target_family = "wasm"))]
             grok_refresh_allowed: false,
             #[cfg(not(target_family = "wasm"))]
@@ -627,6 +649,7 @@ impl ApiKeyManager {
             geap_credentials_state: GeapCredentialsState::Missing,
             secure_storage_write_version: 0,
             grok_secure_storage_write_version: 0,
+            chatgpt_secure_storage_write_version: 0,
         }
     }
 
@@ -802,9 +825,50 @@ impl ApiKeyManager {
             || self.has_grok_subscription()
     }
 
-    /// Stores (or clears, with `None`) the xAI/Grok OAuth tokens and persists
-    /// them to secure storage. No-op when the value is unchanged so we don't
-    /// emit spurious events or schedule redundant keychain writes.
+    pub fn chatgpt_connection(&self) -> Option<&ChatGPTConnection> {
+        self.chatgpt_connection.as_ref()
+    }
+
+    pub fn chatgpt_oauth_pending(&self) -> bool {
+        self.chatgpt_oauth_pending
+    }
+
+    pub fn set_chatgpt_oauth_pending(&mut self, pending: bool, ctx: &mut ModelContext<Self>) {
+        if self.chatgpt_oauth_pending == pending {
+            return;
+        }
+        self.chatgpt_oauth_pending = pending;
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+    }
+
+    pub fn set_chatgpt_connection(
+        &mut self,
+        connection: Option<ChatGPTConnection>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.chatgpt_connection == connection {
+            self.chatgpt_oauth_pending = false;
+            return;
+        }
+        self.chatgpt_connection = connection;
+        self.chatgpt_oauth_pending = false;
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_chatgpt_connection_to_secure_storage(ctx);
+    }
+
+    /// Records a completed ChatGPT OAuth attempt started from this client.
+    pub fn complete_chatgpt_oauth_if_pending(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.chatgpt_oauth_pending {
+            return;
+        }
+        self.set_chatgpt_connection(
+            Some(ChatGPTConnection {
+                connected_at: Some(SystemTime::now()),
+            }),
+            ctx,
+        );
+    }
+
     pub fn set_grok_tokens(&mut self, tokens: Option<GrokTokens>, ctx: &mut ModelContext<Self>) {
         if self.grok_tokens == tokens {
             return;
@@ -1261,6 +1325,70 @@ impl ApiKeyManager {
                 report_error!(
                     anyhow::Error::new(e)
                         .context("Failed to persist Grok tokens to secure storage")
+                );
+            }
+        });
+    }
+
+    fn load_chatgpt_connection_from_secure_storage(
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<ChatGPTConnection> {
+        let json = match ctx.secure_storage().read_value(CHATGPT_SECURE_STORAGE_KEY) {
+            Ok(json) => json,
+            Err(e) => {
+                if !matches!(e, secure_storage::Error::NotFound) {
+                    report_error!(
+                        anyhow::Error::new(e)
+                            .context("Failed to read ChatGPT connection from secure storage")
+                    );
+                }
+                return None;
+            }
+        };
+
+        match serde_json::from_str(&json) {
+            Ok(connection) => Some(connection),
+            Err(e) => {
+                report_error!(
+                    anyhow::Error::new(e).context("Failed to deserialize ChatGPT connection")
+                );
+                None
+            }
+        }
+    }
+
+    fn write_chatgpt_connection_to_secure_storage(&mut self, ctx: &mut ModelContext<Self>) {
+        let payload = match self.chatgpt_connection.as_ref().map(serde_json::to_string) {
+            Some(Ok(json)) => Some(json),
+            Some(Err(e)) => {
+                report_error!(
+                    anyhow::Error::new(e).context("Failed to serialize ChatGPT connection")
+                );
+                return;
+            }
+            None => None,
+        };
+        self.chatgpt_secure_storage_write_version += 1;
+        let write_version = self.chatgpt_secure_storage_write_version;
+
+        ctx.spawn(async move { payload }, move |me, payload, ctx| {
+            if write_version != me.chatgpt_secure_storage_write_version {
+                return;
+            }
+            let result = match payload {
+                Some(ref json) => ctx
+                    .secure_storage()
+                    .write_value(CHATGPT_SECURE_STORAGE_KEY, json),
+                None => ctx
+                    .secure_storage()
+                    .remove_value(CHATGPT_SECURE_STORAGE_KEY),
+            };
+            if let Err(e) = result
+                && !matches!(e, secure_storage::Error::NotFound)
+            {
+                report_error!(
+                    anyhow::Error::new(e)
+                        .context("Failed to persist ChatGPT connection to secure storage")
                 );
             }
         });

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -122,6 +122,8 @@ fn make_manager_with_grok(keys: ApiKeys, grok_tokens: Option<GrokTokens>) -> Api
             resolved: custom_endpoints,
         },
         grok_tokens,
+        chatgpt_connection: None,
+        chatgpt_oauth_pending: false,
         #[cfg(not(target_family = "wasm"))]
         grok_refresh_allowed: false,
         #[cfg(not(target_family = "wasm"))]
@@ -135,6 +137,7 @@ fn make_manager_with_grok(keys: ApiKeys, grok_tokens: Option<GrokTokens>) -> Api
         geap_credentials_state: GeapCredentialsState::Missing,
         secure_storage_write_version: 0,
         grok_secure_storage_write_version: 0,
+        chatgpt_secure_storage_write_version: 0,
     }
 }
 

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -893,6 +893,10 @@ pub enum FeatureFlag {
     /// connect a Grok subscription instead of pasting an API key.
     SuperGrok,
 
+    /// Gates connecting a ChatGPT subscription via Sign in with ChatGPT.
+    /// Account linking is server-side (iss+client_id+sub), not local tokens.
+    ChatGPTSubscription,
+
     /// Gates Gemini Enterprise (GEAP) BYOLLM, which lets users
     /// route eliglible models to GEAP instead of Warp-managed inference.
     GeminiEnterprise,
@@ -995,7 +999,10 @@ static FEATURES_INITIALIZED: AtomicBool = AtomicBool::new(false);
 /// Features used in debugging.
 pub const DEBUG_FLAGS: &[FeatureFlag] = &[FeatureFlag::DebugMode, FeatureFlag::RuntimeFeatureFlags];
 /// Features enabled only for the WarpLocal developer build.
-pub const LOCAL_FLAGS: &[FeatureFlag] = &[FeatureFlag::LocalClaudeCodexChildHarnesses];
+pub const LOCAL_FLAGS: &[FeatureFlag] = &[
+    FeatureFlag::LocalClaudeCodexChildHarnesses,
+    FeatureFlag::ChatGPTSubscription,
+];
 
 /// Features enabled for the development team.  The expectation is that, over
 /// time, these will move on to PREVIEW_FLAGS before being launched.
@@ -1053,6 +1060,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::PeriodicHandoffCheckpoints,
     FeatureFlag::CtrlCCancelsThirdPartyHarness,
     FeatureFlag::WarpingModelName,
+    FeatureFlag::ChatGPTSubscription,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

Adds a SuperGrok-style **Use your OpenAI ChatGPT subscription** row on the Warp Agent settings page. Connect opens Sign in with ChatGPT on warp-server (`/auth/openai`) so the ChatGPT identity is linked to the Warp account by `iss`+`client_id`+`sub`, instead of storing local OAuth tokens like SuperGrok.

Depends on [warp-server#16285](https://github.com/warpdotdev/warp-server/pull/16285) for the server OIDC + account-linking flow.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## How

- Connect builds `{server_root}/auth/openai?continueUrl={/login/remote...}` so warp-server owns PKCE, ID-token verify, and `sub` linking.
- After the browser hands back to the desktop via the existing `warp://auth/desktop_redirect` login path, a pending attempt is marked connected locally (timestamp only).
- Disconnect clears the local connection record. Server-side unlink is not in this PR.
- Gated by `FeatureFlag::ChatGPTSubscription` (local + dogfood).

## Testing
- [x] `cargo check -p ai --lib` and `cargo check -p warp --lib`
- [x] `cargo clippy -p ai -p warp --lib --tests -- -D warnings`
- [x] `./script/format`
- [ ] I have manually tested my changes locally with `./script/run`

Manual E2E needs warp-server ChatGPT sign-in deployed (or local) plus OpenAI OAuth credentials.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Connect a ChatGPT subscription from Warp Agent settings via Sign in with ChatGPT.

Conversation: https://staging.warp.dev/conversation/888e862d-052e-4def-bb82-865867c529ac

Co-Authored-By: Warp <agent@warp.dev>