### PR TITLE
Add Hermes CLI agent rich status support

### DIFF
--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -261,6 +261,8 @@ impl CLIAgent {
             CLIAgent::Auggie => Some(Icon::AuggieLogo),
             CLIAgent::CursorCli => Some(Icon::CursorLogo),
             CLIAgent::Goose => Some(Icon::GooseLogo),
+            // Ships without a brand asset until an officially licensed SVG is
+            // available, same as Vibe below.
             CLIAgent::Hermes => None,
             // Vibe is recognized but ships without a brand asset. The brand color
             // still drives the toolbar tile; an `Icon::MistralLogo` can be wired

--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -47,6 +47,7 @@ pub fn is_agent_supported(agent: &CLIAgent) -> bool {
             | CLIAgent::Droid
             | CLIAgent::Pi
             | CLIAgent::OhMyPi
+            | CLIAgent::Hermes
             | CLIAgent::WarpTui
     )
 }
@@ -57,9 +58,10 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         // Auggie and Pi are supported via community-maintained plugins
         // (https://github.com/augmentmoogi/auggie-warp,
         // https://github.com/badlogic/pi-mono). OhMyPi emits these structured
-        // OSC 777 events natively. Droid can be supported by user-configured
-        // hooks or future integrations that emit the same events. We don't ship
-        // install flows for these agents here — we just listen.
+        // OSC 777 events natively. Droid and Hermes can be supported by
+        // user-configured hooks or future integrations that emit the same
+        // events. We don't ship install flows for these agents here — we
+        // just listen.
         // WarpTui emits OSC 777 events directly (no external plugin needed).
         CLIAgent::Claude
         | CLIAgent::OpenCode
@@ -68,10 +70,10 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         | CLIAgent::Droid
         | CLIAgent::Pi
         | CLIAgent::OhMyPi
+        | CLIAgent::Hermes
         | CLIAgent::WarpTui => Some(Box::new(DefaultSessionListener)),
         CLIAgent::Codex => Some(Box::new(CodexSessionHandler)),
-        CLIAgent::Hermes
-        | CLIAgent::Amp
+        CLIAgent::Amp
         | CLIAgent::Copilot
         | CLIAgent::CursorCli
         | CLIAgent::Goose

--- a/app/src/terminal/cli_agent_sessions/listener/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod_tests.rs
@@ -246,6 +246,28 @@ fn droid_default_handler_forwards_permission_request() {
 }
 
 #[test]
+fn hermes_end_to_end_parsing_and_handling() {
+    let mut handler = create_handler(&CLIAgent::Hermes).expect("should create handler");
+
+    let stop_body =
+        r#"{"v":1,"agent":"hermes","event":"stop","session_id":"sess-7","query":"fix the bug"}"#;
+    let parsed_stop = handler
+        .try_parse(Some(CLI_AGENT_NOTIFICATION_SENTINEL), stop_body, false)
+        .expect("should parse stop");
+    assert_eq!(parsed_stop.agent, CLIAgent::Hermes);
+    assert_eq!(parsed_stop.event, CLIAgentEventType::Stop);
+    assert_eq!(parsed_stop.payload.query.as_deref(), Some("fix the bug"));
+    assert!(handler.handle_event(parsed_stop).is_some());
+
+    let approval_body = r#"{"v":1,"agent":"hermes","event":"permission_request","summary":"Approve?","tool_name":"Bash"}"#;
+    let parsed_approval = handler
+        .try_parse(Some(CLI_AGENT_NOTIFICATION_SENTINEL), approval_body, false)
+        .expect("should parse permission_request");
+    assert_eq!(parsed_approval.event, CLIAgentEventType::PermissionRequest);
+    assert!(handler.handle_event(parsed_approval).is_some());
+}
+
+#[test]
 fn warp_tui_notifications_are_supported() {
     assert!(is_agent_supported(&CLIAgent::WarpTui));
     let mut handler = create_handler(&CLIAgent::WarpTui).expect("should create handler");

--- a/app/src/terminal/cli_agent_sessions/listener/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod_tests.rs
@@ -247,6 +247,7 @@ fn droid_default_handler_forwards_permission_request() {
 
 #[test]
 fn hermes_end_to_end_parsing_and_handling() {
+    assert!(is_agent_supported(&CLIAgent::Hermes));
     let mut handler = create_handler(&CLIAgent::Hermes).expect("should create handler");
 
     let stop_body =

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -661,3 +661,20 @@ fn test_warp_tui_variant_properties() {
         CLIAgent::WarpTui
     );
 }
+
+#[test]
+fn test_hermes_variant_properties() {
+    assert_eq!(CLIAgent::Hermes.command_prefix(), "hermes");
+    assert_eq!(CLIAgent::Hermes.display_name(), "Hermes");
+    assert_eq!(
+        CLIAgent::Hermes.brand_color(),
+        Some(ColorU::new(124, 58, 237, 255))
+    );
+    // Deliberately None until an officially licensed SVG is available (same as Vibe).
+    assert!(CLIAgent::Hermes.icon().is_none());
+    assert_eq!(CLIAgent::Hermes.brand_icon_color(), ColorU::white());
+    assert_eq!(
+        CLIAgent::from_serialized_name(&CLIAgent::Hermes.to_serialized_name()),
+        CLIAgent::Hermes
+    );
+}


### PR DESCRIPTION
## Description

Registers the Hermes CLI agent (Nous Research) with the CLI agent session listener so structured `warp://cli-agent` OSC 777 events carrying `"agent":"hermes"` produce tab status badges and notification mailbox entries — the same treatment Droid, Pi, OhMyPi, and Auggie already get.

Hermes is already a recognized `CLIAgent` (command prefix, display name, brand color, skill providers), but `create_handler` had no arm for it, so `is_agent_supported` returned false and Hermes events were silently dropped at the routing layer.

What changes:
- `CLIAgent::Hermes` joins the `DefaultSessionListener` arm of `create_handler` — Hermes events need no special filtering, and user-configured hooks or future integrations can emit the standard protocol today (e.g. the community [warp-hermes](https://github.com/DarkGenius/warp-hermes) hook set).
- `is_agent_supported` now derives from `create_handler(agent).is_some()` so the supported-agent list cannot drift between the two functions.
- The brand icon intentionally stays unwired (`icon() = None`) until an officially licensed SVG is available — the same bar the Vibe comment below it documents. Related: #14844.

## Linked Issue

Closes #15666

Related: #14844 (Hermes empty brand circle — icon deliberately out of scope here), #12556 (closed desktop-notification request that Hermes hooks emitting this protocol address).

## Testing

Added:
- `hermes_end_to_end_parsing_and_handling` — sentinel-titled `stop` and `permission_request` payloads round-trip through `try_parse` and `handle_event` for a Hermes handler.
- `test_hermes_variant_properties` — command prefix, display name, brand color, serialized-name round-trip, and pins the deliberate `icon() == None` until licensed art exists.

Ran:
- `cargo nextest run -p warp cli_agent` — 236/236 pass
- `cargo clippy -p warp -p warp_core --all-targets -- -D warnings` — clean
- `./script/format` — clean

Manual GUI verification via `./script/run` was not performed: the change only extends listener registration to an agent whose events flow through agent-agnostic code paths already covered by the existing Droid/Pi/Auggie tests.

CHANGELOG-IMPROVEMENT: Warp now surfaces tab status badges and mailbox notifications for the Hermes CLI agent via the warp://cli-agent OSC 777 protocol.
