### PR TITLE
Prevent background SSH prompts from stealing focus

### DIFF
--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -3890,6 +3890,90 @@ fn test_focused_pane_is_synchronized_with_application_focus() {
     });
 }
 
+#[test]
+fn test_background_ssh_remote_server_choice_does_not_steal_pane_focus() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let pane_group = mock_pane_group(
+            &mut app,
+            MockOptions {
+                layout: PanesLayout::Template(PaneTemplateType::PaneBranchTemplate {
+                    split_direction:
+                        crate::launch_configs::launch_config::SplitDirection::Horizontal,
+                    panes: vec![
+                        PaneTemplateType::PaneTemplate {
+                            is_focused: Some(true),
+                            cwd: "/".into(),
+                            commands: vec![],
+                            pane_mode: PaneMode::Terminal,
+                            shell: None,
+                        },
+                        PaneTemplateType::PaneTemplate {
+                            is_focused: None,
+                            cwd: "/".into(),
+                            commands: vec![],
+                            pane_mode: PaneMode::Terminal,
+                            shell: None,
+                        },
+                    ],
+                }),
+                ..Default::default()
+            },
+        );
+
+        let (background_pane_id, foreground_pane_id) = pane_group.read(&app, |panes, _| {
+            (
+                panes.pane_id_from_index(0).expect("background pane"),
+                panes.pane_id_from_index(1).expect("foreground pane"),
+            )
+        });
+
+        pane_group.update(&mut app, |panes, ctx| {
+            panes.focus_pane(foreground_pane_id, true, ctx);
+        });
+
+        let (background_terminal, foreground_terminal, dispatcher) =
+            pane_group.read(&app, |panes, ctx| {
+                let background_terminal = panes
+                    .terminal_view_from_pane_id(background_pane_id, ctx)
+                    .expect("background terminal");
+                let foreground_terminal = panes
+                    .terminal_view_from_pane_id(foreground_pane_id, ctx)
+                    .expect("foreground terminal");
+                let dispatcher = background_terminal
+                    .read(ctx, |terminal, _| terminal.model_event_dispatcher().clone());
+                (background_terminal, foreground_terminal, dispatcher)
+            });
+
+        foreground_terminal.update(&mut app, |_, ctx| {
+            assert!(ctx.is_self_or_child_focused());
+        });
+        background_terminal.update(&mut app, |_, ctx| {
+            assert!(!ctx.is_self_or_child_focused());
+        });
+
+        dispatcher.update(&mut app, |dispatcher, ctx| {
+            dispatcher.request_remote_server_block(warp_core::SessionId::from(42), ctx);
+        });
+        futures_lite::future::yield_now().await;
+
+        pane_group.read(&app, |panes, ctx| {
+            assert_eq!(panes.focused_pane_id(ctx), foreground_pane_id);
+            assert_eq!(
+                panes.active_session_id(ctx),
+                foreground_pane_id.as_terminal_pane_id()
+            );
+        });
+        foreground_terminal.update(&mut app, |_, ctx| {
+            assert!(ctx.is_self_or_child_focused());
+        });
+        background_terminal.update(&mut app, |_, ctx| {
+            assert!(!ctx.is_self_or_child_focused());
+        });
+    });
+}
+
 /// APP-5243: closing a file pane only hides it while undo-close is available, and the same view is
 /// reattached without reopening its file. Releasing the file on close would therefore leave a
 /// restored pane rendering content that can never update again. The file is released only once the

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -9889,11 +9889,17 @@ impl TerminalView {
     fn clear_ssh_blocks(&mut self, ctx: &mut ViewContext<Self>) {
         self.dismiss_warpify_banner(&RememberForWarpification::DoNotRememberSSHHost, ctx);
         if let Some(ssh_block) = self.warpify_state.ssh_block_state() {
+            // Removing a focused rich-content child clears its focus, so remember whether this
+            // terminal owned focus before removing the block. A background terminal must not
+            // reclaim application focus while replacing its SSH status block.
+            let should_redetermine_focus = ctx.is_self_or_child_focused();
             let view_id = ssh_block.get_block_view_id();
 
             self.remove_ssh_block_by_id(view_id);
 
-            self.redetermine_global_focus(ctx);
+            if should_redetermine_focus {
+                self.redetermine_global_focus(ctx);
+            }
 
             self.warpify_state.clear_ssh_block_state();
         }
@@ -13029,7 +13035,7 @@ impl TerminalView {
             ctx,
         );
 
-        self.redetermine_global_focus(ctx);
+        self.redetermine_terminal_focus(ctx);
     }
 
     /// Returns a clone of the `SshRemoteServerChoiceView` handle for the

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -105,6 +105,53 @@ fn add_window_with_cloud_mode_terminal(app: &mut App) -> ViewHandle<TerminalView
     terminal
 }
 
+struct TwoTerminalTestView {
+    background: ViewHandle<TerminalView>,
+    foreground: ViewHandle<TerminalView>,
+}
+
+impl Entity for TwoTerminalTestView {
+    type Event = ();
+}
+
+impl View for TwoTerminalTestView {
+    fn ui_name() -> &'static str {
+        "TwoTerminalTestView"
+    }
+
+    fn render(&self, _app: &AppContext) -> Box<dyn Element> {
+        Flex::row()
+            .with_main_axis_size(warpui::elements::MainAxisSize::Max)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(Expanded::new(1., ChildView::new(&self.background).finish()).finish())
+            .with_child(Expanded::new(1., ChildView::new(&self.foreground).finish()).finish())
+            .finish()
+    }
+}
+
+impl TypedActionView for TwoTerminalTestView {
+    type Action = ();
+}
+
+fn add_window_with_two_terminals(
+    app: &mut App,
+) -> (ViewHandle<TerminalView>, ViewHandle<TerminalView>) {
+    let tips_model = app.add_model(|_| Default::default());
+    let (_, root) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+        let background = ctx
+            .add_typed_action_view(|ctx| TerminalView::new_for_test(tips_model.clone(), None, ctx));
+        let foreground = ctx
+            .add_typed_action_view(|ctx| TerminalView::new_for_test(tips_model.clone(), None, ctx));
+        TwoTerminalTestView {
+            background,
+            foreground,
+        }
+    });
+    root.read(app, |root, _| {
+        (root.background.clone(), root.foreground.clone())
+    })
+}
+
 /// Builds a resumable, owned (created by the current test user) Oz cloud task so
 /// `resolve_ai_query_routing` classifies a pane bound to it as a `NewCloudVm` follow-up target.
 fn owned_resumable_oz_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
@@ -4091,6 +4138,76 @@ fn focused_terminal_publishes_remote_blocks_while_remote_session_ai_is_still_per
             );
         });
     })
+}
+
+#[test]
+fn focused_terminal_moves_focus_to_ssh_remote_server_choice() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |_view, ctx| ctx.focus_self());
+        let dispatcher = terminal.read(&app, |view, _| view.model_event_dispatcher().clone());
+        dispatcher.update(&mut app, |dispatcher, ctx| {
+            dispatcher.request_remote_server_block(SessionId::from(42), ctx);
+        });
+        futures_lite::future::yield_now().await;
+
+        terminal.update(&mut app, |view, ctx| {
+            let choice = view
+                .active_ssh_remote_server_choice_block()
+                .expect("SSH remote-server choice should be visible");
+            assert!(
+                choice.is_self_or_child_focused(ctx),
+                "the active terminal should move keyboard focus to the SSH choice"
+            );
+        });
+    });
+}
+
+#[test]
+fn background_terminal_replacing_ssh_block_does_not_steal_focus() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let (background_terminal, foreground_terminal) = add_window_with_two_terminals(&mut app);
+
+        let bootstrap_event = |session_id| SessionBootstrappedEvent {
+            session_id: SessionId::from(session_id),
+            spawning_command: "ssh example.com".to_string(),
+            shell: warp_terminal::shell::Shell::new(
+                warp_terminal::shell::ShellType::Zsh,
+                None,
+                None,
+                HashSet::new(),
+                Some("/bin/zsh".to_string()),
+            ),
+            subshell_info: None,
+            session_type: BootstrapSessionType::WarpifiedRemote,
+        };
+
+        background_terminal.update(&mut app, |view, ctx| {
+            view.add_bootstrap_success_block(bootstrap_event(42), ctx);
+        });
+        foreground_terminal.update(&mut app, |_view, ctx| ctx.focus_self());
+        foreground_terminal.update(&mut app, |_view, ctx| {
+            assert!(ctx.is_self_or_child_focused());
+        });
+
+        background_terminal.update(&mut app, |view, ctx| {
+            assert!(!ctx.is_self_or_child_focused());
+            view.add_bootstrap_success_block(bootstrap_event(43), ctx);
+        });
+
+        foreground_terminal.update(&mut app, |_view, ctx| {
+            assert!(
+                ctx.is_self_or_child_focused(),
+                "replacing an SSH status block in a background terminal must preserve focus"
+            );
+        });
+        background_terminal.update(&mut app, |_view, ctx| {
+            assert!(!ctx.is_self_or_child_focused());
+        });
+    });
 }
 
 /// The permission is re-minted on every decision from the focused terminal's handle, so an


### PR DESCRIPTION
## Description

SSH remote-server prompts created in a background tab or split could call the global focus recovery path and steal keyboard focus from the active terminal.

This change:

- uses terminal-scoped focus recovery when an SSH remote-server choice is shown;
- only restores focus after clearing an SSH block when that terminal owned focus beforehand;
- adds regression coverage for active-choice focus, background block replacement, and background split focus preservation.

The scope is limited to the SSH remote-server choice and SSH status-block replacement paths identified in this issue.

## Linked Issue

Fixes #3265

Also addresses the duplicate report in #13123.

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Screenshots of the user-visible behavior are included below.

## Testing

- [x] Regression test confirmed RED on `upstream/master`: the background SSH remote-server event moved focus away from the foreground pane.
- [x] `cargo test -p warp ssh -- --nocapture` — 22 passed.
- [x] `cargo clippy -p warp --all-targets -- -D warnings`
- [x] `./script/format --check`
- [x] `cargo nextest run -p warp_completer --features v2` — 131 passed, 4 skipped.
- [x] `CARGO_INCREMENTAL=0 cargo test --doc`
- [x] Manual real-display integration scenario covering a background tab, the active SSH choice, and a background split.
- [ ] I have manually tested my changes locally with `./script/run`

`./script/presubmit` completed every static check and ran 11,567 workspace tests: 11,562 passed and five existing gcloud SSH-fixture tests failed because `gcloud` is not installed in the local environment. The related SSH remote-server tests passed.

### Screenshots / Videos

**Background tab:** the foreground tab keeps keyboard focus and continues typing after the background SSH prompt is created.

<img width="1600" height="1000" alt="background_tab_keeps_focus" src="https://github.com/user-attachments/assets/f61f0616-e63e-4f62-9a55-7b1a03989ba1" />

**Active tab:** after explicitly switching back, the SSH remote-server choice is visible and its recommended action owns keyboard focus.

<img width="1600" height="1000" alt="active_ssh_choice" src="https://github.com/user-attachments/assets/fd871be6-dc49-4c03-8767-038baedce593" />

**Background split:** the prompt is visible in the left pane while the right pane retains the active focus accent, cursor, and typing.

<img width="1600" height="1000" alt="background_split_keeps_focus" src="https://github.com/user-attachments/assets/eda7f287-9da9-4e47-bec0-b147cf2c1a79" />

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevent background SSH remote-server prompts from stealing terminal focus.
