### PR TITLE
Keep the glyph under a CLI agent's own cursor when rich input is open

### DIFF
--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -712,10 +712,10 @@ pub struct BlockListElement {
 
     use_ligature_rendering: bool,
 
-    /// When true, suppresses cursor rendering for CLI agents when rich input is open. For agents that draw their own cursor (SHOW_CURSOR off),
-    /// the cursor cell is skipped. For agents that let Warp draw the cursor
-    /// (SHOW_CURSOR on), the `draw_cursor` call and cursor contrast colouring
-    /// are suppressed instead.
+    /// When true, suppresses Warp's own cursor for CLI agents while rich input is open: both the
+    /// `draw_cursor` overlay and the contrast colouring of the cell under the cursor. The cell
+    /// itself is still rendered, so an agent drawing its own cursor (SHOW_CURSOR off) keeps the
+    /// glyph underneath it.
     hide_cursor_cell: bool,
 
     /// Child Elements to use for rich content inserted into the block list

--- a/app/src/terminal/blockgrid_renderer.rs
+++ b/app/src/terminal/blockgrid_renderer.rs
@@ -31,10 +31,10 @@ pub struct GridRenderParams {
     pub size_info: SizeInfo,
     pub cell_size: Vector2F,
     pub use_ligature_rendering: bool,
-    /// When true, suppresses cursor rendering for CLI agents when rich input is open. For agents that draw their own cursor (SHOW_CURSOR off),
-    /// the cursor cell is skipped. For agents that let Warp draw the cursor
-    /// (SHOW_CURSOR on), the `draw_cursor` call and cursor contrast colouring
-    /// are suppressed instead.
+    /// When true, suppresses Warp's own cursor for CLI agents while rich input is open: both the
+    /// `draw_cursor` overlay and the contrast colouring of the cell under the cursor. The cell
+    /// itself is still rendered, so an agent drawing its own cursor (SHOW_CURSOR off) keeps the
+    /// glyph underneath it.
     pub hide_cursor_cell: bool,
 }
 

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -284,6 +284,26 @@ where
     None
 }
 
+/// Whether the cell under the cursor should be painted with the cursor's
+/// contrast colouring.
+///
+/// `hide_cursor_cell` means CLI agent rich input is open, so Warp suppresses
+/// its own cursor overlay (`draw_cursor` is gated on the same flag in
+/// `block_list_element` and `alt_screen_element`). Colouring a cell as though a
+/// cursor sat on it while no cursor is drawn would be wrong, hence the guard.
+///
+/// What this must *not* do is skip the cell: the glyph underneath an agent's
+/// own cursor still has to be painted. Claude Code puts the first character of
+/// its `Press up to edit queued messages` hint on its cursor cell, and dropping
+/// the cell rendered that as `ress` (#15624).
+fn should_apply_cursor_contrast(
+    hide_cursor_cell: bool,
+    cursor_is_on_cell: bool,
+    visible_cursor_shape: Option<CursorShape>,
+) -> bool {
+    !hide_cursor_cell && cursor_is_on_cell && visible_cursor_shape == Some(CursorShape::Block)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn render_grid<'a>(
     grid: &GridHandler,
@@ -643,17 +663,6 @@ fn render_grid_without_ligatures<'a>(
         for col in 0..grid.columns() {
             let current_point = Point::new(row_idx, col);
 
-            // Skip the cursor cell when CLI agent rich input is open
-            // AND the agent draws its own cursor (SHOW_CURSOR is off).
-            // When Warp draws the cursor (SHOW_CURSOR on), we keep the cell
-            // and only suppress the draw_cursor call.
-            if hide_cursor_cell
-                && visible_cursor_shape.is_none()
-                && current_point == grid.cursor_render_point()
-            {
-                continue;
-            }
-
             // Determine if we need to override the cell to display the marked text.
             if current_point >= grid.cursor_point() {
                 // Account for a wide char spacer cell if necessary.
@@ -808,12 +817,11 @@ fn render_grid_without_ligatures<'a>(
                 });
             }
 
-            // Don't apply cursor contrast colouring when hide_cursor_cell
-            // is active — the cursor itself won't be drawn, so the cell
-            // should render with its normal colours.
-            let cursor_color = (!hide_cursor_cell
-                && grid.cursor_point() == Point::new(offset_row, col)
-                && visible_cursor_shape == Some(CursorShape::Block))
+            let cursor_color = should_apply_cursor_contrast(
+                hide_cursor_cell,
+                grid.cursor_point() == Point::new(offset_row, col),
+                visible_cursor_shape,
+            )
             .then(|| theme.cursor().into_solid());
             cached_background_color = render_cell(
                 grid,
@@ -1186,17 +1194,6 @@ fn render_grid_with_ligatures<'a>(
 
             let current_point = Point::new(row_idx, col);
 
-            // Skip the cursor cell when CLI agent rich input is open
-            // AND the agent draws its own cursor (SHOW_CURSOR is off).
-            // When Warp draws the cursor (SHOW_CURSOR on), we keep the cell
-            // and only suppress the draw_cursor call.
-            if hide_cursor_cell
-                && visible_cursor_shape.is_none()
-                && current_point == grid.cursor_render_point()
-            {
-                continue;
-            }
-
             // Determine if we need to override the cell to display the marked text.
             if current_point >= grid.cursor_point() {
                 // Account for a wide char spacer cell if necessary.
@@ -1356,12 +1353,11 @@ fn render_grid_with_ligatures<'a>(
                 });
             }
 
-            // Don't apply cursor contrast colouring when hide_cursor_cell
-            // is active — the cursor itself won't be drawn, so the cell
-            // should render with its normal colours.
-            let cursor_color = (!hide_cursor_cell
-                && grid.cursor_point() == Point::new(offset_row, col)
-                && visible_cursor_shape == Some(CursorShape::Block))
+            let cursor_color = should_apply_cursor_contrast(
+                hide_cursor_cell,
+                grid.cursor_point() == Point::new(offset_row, col),
+                visible_cursor_shape,
+            )
             .then(|| theme.cursor().into_solid());
             let cell_colors = cell_colors(
                 cell,

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -284,18 +284,11 @@ where
     None
 }
 
-/// Whether the cell under the cursor should be painted with the cursor's
-/// contrast colouring.
+/// Whether the cell under the cursor should be painted with the cursor's contrast colouring.
 ///
-/// `hide_cursor_cell` means CLI agent rich input is open, so Warp suppresses
-/// its own cursor overlay (`draw_cursor` is gated on the same flag in
-/// `block_list_element` and `alt_screen_element`). Colouring a cell as though a
-/// cursor sat on it while no cursor is drawn would be wrong, hence the guard.
-///
-/// What this must *not* do is skip the cell: the glyph underneath an agent's
-/// own cursor still has to be painted. Claude Code puts the first character of
-/// its `Press up to edit queued messages` hint on its cursor cell, and dropping
-/// the cell rendered that as `ress` (#15624).
+/// `hide_cursor_cell` suppresses the colouring because no cursor will be painted on the cell;
+/// the cell itself must still be rendered, so that a glyph sitting under an agent's own cursor
+/// is not dropped.
 fn should_apply_cursor_contrast(
     hide_cursor_cell: bool,
     cursor_is_on_cell: bool,
@@ -686,8 +679,11 @@ fn render_grid_without_ligatures<'a>(
                         next_marked_text_cell_is_wide_char_spacer = true;
                     }
 
-                    let cursor_color = (grid.cursor_render_point() == Point::new(offset_row, col)
-                        && visible_cursor_shape == Some(CursorShape::Block))
+                    let cursor_color = should_apply_cursor_contrast(
+                        hide_cursor_cell,
+                        grid.cursor_render_point() == Point::new(offset_row, col),
+                        visible_cursor_shape,
+                    )
                     .then(|| theme.cursor().into_solid());
                     cached_background_color = render_cell(
                         grid,
@@ -1209,8 +1205,11 @@ fn render_grid_with_ligatures<'a>(
                     marked_text_cell.flags = Flags::UNDERLINE;
                     let cell_type = CellType::marked_text_char();
 
-                    let cursor_color = (grid.cursor_render_point() == Point::new(offset_row, col)
-                        && visible_cursor_shape == Some(CursorShape::Block))
+                    let cursor_color = should_apply_cursor_contrast(
+                        hide_cursor_cell,
+                        grid.cursor_render_point() == Point::new(offset_row, col),
+                        visible_cursor_shape,
+                    )
                     .then(|| theme.cursor().into_solid());
 
                     let cell_colors = cell_colors(

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -262,3 +262,46 @@ fn test_calculate_selection_bounds() {
     assert_selection_bounds(10.into_lines()); // Without scroll clipping (but on the cusp of clipping)
     assert_selection_bounds(80.into_lines()); // With scroll clipping
 }
+
+// Regression coverage for #15624: rich input over a CLI agent used to skip the
+// whole cursor cell, which dropped the glyph underneath the agent's own cursor
+// (Claude Code's `Press up to edit queued messages` rendered as `ress`). The
+// cell is now always painted; `hide_cursor_cell` only suppresses Warp's own
+// cursor — the overlay via `draw_cursor`, and the contrast colouring here.
+#[test]
+fn test_cursor_contrast_is_suppressed_only_where_warp_draws_the_cursor() {
+    use crate::terminal::model::ansi::CursorShape;
+    use grid_renderer::should_apply_cursor_contrast;
+
+    // Rich input closed: an on-cell block cursor is Warp's to draw, so the
+    // cell keeps its cursor colouring.
+    assert!(should_apply_cursor_contrast(
+        false,
+        true,
+        Some(CursorShape::Block)
+    ));
+
+    // Rich input open. Warp suppresses its cursor either way, so contrast must
+    // be off — whether the agent draws its own cursor (SHOW_CURSOR off, e.g.
+    // Claude Code) or relies on Warp's (SHOW_CURSOR on, e.g. OpenCode/Codex).
+    // Neither case may skip the cell itself; that is what #15624 was.
+    assert!(!should_apply_cursor_contrast(true, true, None));
+    assert!(!should_apply_cursor_contrast(
+        true,
+        true,
+        Some(CursorShape::Block)
+    ));
+
+    // No cursor on this cell, and non-block shapes never take the colouring.
+    assert!(!should_apply_cursor_contrast(
+        false,
+        false,
+        Some(CursorShape::Block)
+    ));
+    assert!(!should_apply_cursor_contrast(
+        false,
+        true,
+        Some(CursorShape::Underline)
+    ));
+    assert!(!should_apply_cursor_contrast(false, true, None));
+}

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -263,28 +263,19 @@ fn test_calculate_selection_bounds() {
     assert_selection_bounds(80.into_lines()); // With scroll clipping
 }
 
-// Regression coverage for #15624: rich input over a CLI agent used to skip the
-// whole cursor cell, which dropped the glyph underneath the agent's own cursor
-// (Claude Code's `Press up to edit queued messages` rendered as `ress`). The
-// cell is now always painted; `hide_cursor_cell` only suppresses Warp's own
-// cursor — the overlay via `draw_cursor`, and the contrast colouring here.
 #[test]
 fn test_cursor_contrast_is_suppressed_only_where_warp_draws_the_cursor() {
-    use crate::terminal::model::ansi::CursorShape;
     use grid_renderer::should_apply_cursor_contrast;
 
-    // Rich input closed: an on-cell block cursor is Warp's to draw, so the
-    // cell keeps its cursor colouring.
+    use crate::terminal::model::ansi::CursorShape;
+
     assert!(should_apply_cursor_contrast(
         false,
         true,
         Some(CursorShape::Block)
     ));
 
-    // Rich input open. Warp suppresses its cursor either way, so contrast must
-    // be off — whether the agent draws its own cursor (SHOW_CURSOR off, e.g.
-    // Claude Code) or relies on Warp's (SHOW_CURSOR on, e.g. OpenCode/Codex).
-    // Neither case may skip the cell itself; that is what #15624 was.
+    // Rich input open: Warp paints no cursor, whether or not the agent draws its own.
     assert!(!should_apply_cursor_contrast(true, true, None));
     assert!(!should_apply_cursor_contrast(
         true,
@@ -292,7 +283,6 @@ fn test_cursor_contrast_is_suppressed_only_where_warp_draws_the_cursor() {
         Some(CursorShape::Block)
     ));
 
-    // No cursor on this cell, and non-block shapes never take the colouring.
     assert!(!should_apply_cursor_contrast(
         false,
         false,


### PR DESCRIPTION
## Description

`hide_cursor_cell` was skipping the entire cursor cell in `grid_renderer`, not just Warp's cursor. When a CLI agent leaves `SHOW_CURSOR` off and parks its cursor on a character, that character stopped being painted — which is how Claude Code's `Press up to edit queued messages` hint came out as `ress up to edit queued messages`.

The skip was not carrying its weight. Both places that could draw a second cursor already gate on the same flag:

- `block_list_element.rs` — `draw_cursor` is behind `&& !block_grid_params.grid_render_params.hide_cursor_cell`
- `alt_screen_element.rs` — `cursor_visible && !self.grid_render_params.hide_cursor_cell`

So the `continue` in `grid_renderer` contributed nothing to *not drawing a cursor*; it only dropped the glyph. Removing it restores the character and cannot reintroduce a second cursor, because neither of those gates changes.

The flag's remaining job in this file — suppressing cursor contrast on a cell where no cursor will be drawn — was duplicated across the ligature and non-ligature paths and is now one named predicate, `should_apply_cursor_contrast`, whose doc comment records why the cell itself must never be skipped.

Picking this up from #11015, which took the same approach in May and has sat as a draft since. This lands it with the regression test that PR never got, plus a repro that doesn't depend on a particular agent build (below).

## Linked Issue

Fixes #15624

## Testing

- [x] `rustfmt --check --edition 2024` on both changed files
- [x] `cargo check -p warp --lib`
- [x] `cargo clippy -p warp --lib --tests -- -D warnings` — no issues
- [x] `cargo test -p warp --lib grid_renderer` — 17 passed
- [x] Manually tested with a local build (`./script/run`), before and after

I used `cargo test` rather than `cargo nextest run`; nextest isn't installed on this machine.

`test_cursor_contrast_is_suppressed_only_where_warp_draws_the_cursor` pins the acceptance criterion this change must *not* break: with rich input open, contrast stays off for both arms — the agent drawing its own cursor (`SHOW_CURSOR` off) and the agent relying on Warp's (`SHOW_CURSOR` on). I checked it isn't vacuous by dropping the `hide_cursor_cell` term from the predicate and confirming the test fails with `assertion failed: !should_apply_cursor_contrast(true, true, Some(CursorShape::Block))`.

### A note on reproducing this, which may explain why #11015 stalled

I could not reproduce the symptom with a real Claude Code session. I instrumented the skip site on an unfixed build and logged the two inputs while driving Claude Code v2.1.251 with rich input open: **317 samples, all `hide_cursor_cell=true, visible_cursor_shape=Some(Block)`, zero `None`.** The flag is live on that path, but that build keeps `SHOW_CURSOR` on, so the `is_none()` arm — the one that drops the glyph — never fires. Anyone testing this against current Claude Code will see nothing wrong.

What does reproduce it, deterministically and with no agent installed, is any command whose name matches a recognised agent prefix that turns the cursor off and leaves it on a printable cell:

```bash
mkdir -p /tmp/warp15624/bin
cat > /tmp/warp15624/bin/goose <<'SH'
#!/bin/bash
printf '\033[?25l'                          # SHOW_CURSOR off: the agent owns the cursor
printf 'Press up to edit queued messages\n'
printf '\033[1A\033[1G'                     # park the cursor on the leading 'P'
sleep 600
SH
chmod +x /tmp/warp15624/bin/goose
export PATH=/tmp/warp15624/bin:$PATH
goose        # then open rich input (^G)
```

With the skip in place that logs `hide_cursor_cell=true, visible_cursor_shape=None` and prints `ress`; without it, `Press`.

### Screenshots / Videos

Same command, same rich-input state, same window — only the build differs.

**Before** — the leading `P` is gone:

![before](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-15624/before_crop.png)

**After** — the glyph is painted, and Warp still draws no cursor of its own:

![after](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-15624/after_crop.png)

Full windows: [before](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-15624/before3_full.png) · [after](https://raw.githubusercontent.com/maxmilian/warp/pr-assets-15624/after3_full.png)
