### PR TITLE
Fix select-to-buffer shortcuts in code editor

### DIFF
--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -467,6 +467,22 @@ pub fn init(app: &mut AppContext) {
         )
         .with_context_predicate(text_entry.clone())
         .with_mac_key_binding("shift-ctrl-E"),
+        EditableBinding::new(
+            "editor_view:move_to_and_select_buffer_start",
+            "Select and move to the top",
+            CodeEditorViewAction::SelectToBufferStart,
+        )
+        .with_context_predicate(text_entry.clone())
+        .with_mac_key_binding("cmd-shift-up")
+        .with_linux_or_windows_key_binding("ctrl-shift-home"),
+        EditableBinding::new(
+            "editor_view:move_to_and_select_buffer_end",
+            "Select and move to the bottom",
+            CodeEditorViewAction::SelectToBufferEnd,
+        )
+        .with_context_predicate(text_entry.clone())
+        .with_mac_key_binding("cmd-shift-down")
+        .with_linux_or_windows_key_binding("ctrl-shift-end"),
         // `shift-end` is registered on all platforms for this action.
         EditableBinding::new(
             "editor_view:select_to_line_end",
@@ -636,6 +652,8 @@ pub enum CodeEditorViewAction {
     SelectForwardsByWord,
     SelectToLineStart,
     SelectToLineEnd,
+    SelectToBufferStart,
+    SelectToBufferEnd,
     SelectAll,
     ToggleDiffNav(Option<Range<LineCount>>),
     HiddenSectionExpansion {
@@ -775,6 +793,8 @@ impl CodeEditorViewAction {
             | Self::SelectForwardsByWord
             | Self::SelectToLineStart
             | Self::SelectToLineEnd
+            | Self::SelectToBufferStart
+            | Self::SelectToBufferEnd
             | Self::SelectAll
             | Self::ToggleDiffNav(_)
             | Self::MoveUp
@@ -910,6 +930,12 @@ impl TypedActionView for CodeEditorView {
             }),
             SelectToLineEnd => self.model.update(ctx, |model, ctx| {
                 model.select_to_paragraph_end(ctx);
+            }),
+            SelectToBufferStart => self.model.update(ctx, |model, ctx| {
+                model.select_to_buffer_start(ctx);
+            }),
+            SelectToBufferEnd => self.model.update(ctx, |model, ctx| {
+                model.select_to_buffer_end(ctx);
             }),
             SelectAll => self.model.update(ctx, |model, ctx| {
                 model.select_all(ctx);

--- a/app/src/code/editor/view/view_tests.rs
+++ b/app/src/code/editor/view/view_tests.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use string_offset::CharOffset;
 use warp_core::ui::appearance::Appearance;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_util::user_input::UserInput;
@@ -85,5 +86,90 @@ fn test_interaction_state_prevents_editing() {
         });
 
         assert_eq!(text.as_str(), "abc");
+    });
+}
+
+#[test]
+fn test_select_to_buffer_boundaries() {
+    App::test((), |mut app| async move {
+        let (_window, editor_view) = initialize_editor(&mut app);
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(
+                &CodeEditorViewAction::UserTyped(UserInput::new("first\nsecond")),
+                ctx,
+            );
+            let max_offset = view.model.as_ref(ctx).max_character_offset(ctx);
+
+            view.handle_action(&CodeEditorViewAction::SelectToBufferStart, ctx);
+            let selection = view
+                .model
+                .as_ref(ctx)
+                .buffer_selection_model()
+                .as_ref(ctx)
+                .selection_offsets()[0];
+            assert_eq!(selection.head, CharOffset::from(1));
+            assert_eq!(selection.tail, max_offset);
+
+            view.handle_action(&CodeEditorViewAction::CursorAtBufferStart, ctx);
+            view.handle_action(&CodeEditorViewAction::SelectToBufferEnd, ctx);
+            let selection = view
+                .model
+                .as_ref(ctx)
+                .buffer_selection_model()
+                .as_ref(ctx)
+                .selection_offsets()[0];
+            assert_eq!(selection.head, max_offset);
+            assert_eq!(selection.tail, CharOffset::from(1));
+        });
+    });
+}
+
+#[test]
+fn test_select_to_buffer_boundary_preserves_reverse_selection_anchor() {
+    App::test((), |mut app| async move {
+        let (_window, editor_view) = initialize_editor(&mut app);
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(
+                &CodeEditorViewAction::UserTyped(UserInput::new("first\nsecond")),
+                ctx,
+            );
+            let max_offset = view.model.as_ref(ctx).max_character_offset(ctx);
+
+            view.handle_action(&CodeEditorViewAction::SelectToBufferStart, ctx);
+            view.handle_action(&CodeEditorViewAction::SelectRight, ctx);
+            view.handle_action(&CodeEditorViewAction::SelectToBufferStart, ctx);
+
+            let selection = view
+                .model
+                .as_ref(ctx)
+                .buffer_selection_model()
+                .as_ref(ctx)
+                .selection_offsets()[0];
+            assert_eq!(selection.head, CharOffset::from(1));
+            assert_eq!(selection.tail, max_offset);
+        });
+    });
+}
+
+#[test]
+fn test_select_to_buffer_boundaries_in_empty_editor() {
+    App::test((), |mut app| async move {
+        let (_window, editor_view) = initialize_editor(&mut app);
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::SelectToBufferStart, ctx);
+            view.handle_action(&CodeEditorViewAction::SelectToBufferEnd, ctx);
+
+            let selection = view
+                .model
+                .as_ref(ctx)
+                .buffer_selection_model()
+                .as_ref(ctx)
+                .selection_offsets()[0];
+            assert_eq!(selection.head, CharOffset::from(1));
+            assert_eq!(selection.tail, CharOffset::from(1));
+        });
     });
 }

--- a/app/src/integration_testing/goto_line.rs
+++ b/app/src/integration_testing/goto_line.rs
@@ -1,4 +1,5 @@
 use settings::Setting as _;
+use string_offset::CharOffset;
 use warp_editor::content::buffer::ToBufferPoint;
 use warpui::integration::AssertionCallback;
 use warpui::{App, SingletonEntity, ViewHandle, WindowId, async_assert, async_assert_eq};
@@ -41,6 +42,12 @@ pub fn goto_line_confirm(app: &mut App, window_id: WindowId, input: &str) {
         view.goto_line_confirm_for_test(&input_owned, ctx);
     });
 }
+
+pub fn focus_file_code_editor(app: &mut App, window_id: WindowId) {
+    let editor = file_code_editor_view(app, window_id);
+    editor.update(app, |view, ctx| view.focus(ctx));
+}
+
 pub fn set_code_editor_line_number_mode(app: &mut App, mode: CodeEditorLineNumberMode) {
     app.update(|ctx| {
         AppEditorSettings::handle(ctx).update(ctx, |settings, ctx| {
@@ -135,6 +142,44 @@ pub fn assert_cursor_at_line_and_column(
         async_assert!(
             line_match && col_match,
             "Expected cursor at line {expected_line} col {expected_column}, got line {cursor_row} col {cursor_col}",
+        )
+    })
+}
+
+#[derive(Clone, Copy)]
+pub enum CodeEditorBufferBoundary {
+    Start,
+    End,
+}
+
+pub fn assert_code_editor_selection_to_buffer_boundary(
+    boundary: CodeEditorBufferBoundary,
+    expected_anchor_line: usize,
+    expected_anchor_column: usize,
+) -> AssertionCallback {
+    Box::new(move |app, window_id| {
+        let editor = file_code_editor_view(app, window_id);
+        let (head_matches, anchor_line, anchor_column) = editor.read(app, |editor, ctx| {
+            let selection_model = editor.model.as_ref(ctx).buffer_selection_model();
+            let selection = selection_model.as_ref(ctx).selection_offsets()[0];
+            let buffer = editor.model.as_ref(ctx).buffer().as_ref(ctx);
+            let expected_head = match boundary {
+                CodeEditorBufferBoundary::Start => CharOffset::from(1),
+                CodeEditorBufferBoundary::End => buffer.max_charoffset(),
+            };
+            let anchor = selection.tail.to_buffer_point(buffer);
+            (
+                selection.head == expected_head,
+                anchor.row as usize,
+                anchor.column as usize,
+            )
+        });
+
+        async_assert!(
+            head_matches
+                && anchor_line == expected_anchor_line
+                && anchor_column == expected_anchor_column,
+            "Expected selection head at the buffer boundary with anchor at line {expected_anchor_line} col {expected_anchor_column}, got head_matches={head_matches}, anchor line {anchor_line} col {anchor_column}",
         )
     })
 }

--- a/crates/editor/src/model.rs
+++ b/crates/editor/src/model.rs
@@ -451,6 +451,22 @@ pub trait CoreEditorModel: Entity {
         self.validate(ctx);
     }
 
+    /// Extends the selection to the start of the buffer.
+    fn select_to_buffer_start(&mut self, ctx: &mut ModelContext<Self::T>) {
+        self.selection_model().update(ctx, |selection, ctx| {
+            selection.extend_selection(TextDirection::Backwards, TextUnit::BufferBoundary, ctx);
+        });
+        self.validate(ctx);
+    }
+
+    /// Extends the selection to the end of the buffer.
+    fn select_to_buffer_end(&mut self, ctx: &mut ModelContext<Self::T>) {
+        self.selection_model().update(ctx, |selection, ctx| {
+            selection.extend_selection(TextDirection::Forwards, TextUnit::BufferBoundary, ctx);
+        });
+        self.validate(ctx);
+    }
+
     /// Extends the selection to the start of the paragraph that the cursor is on.
     fn select_to_paragraph_start(&mut self, ctx: &mut ModelContext<Self::T>) {
         self.selection_model().update(ctx, |selection, ctx| {

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -58,6 +58,8 @@ pub enum TextUnit {
     Line,
     /// Move to the paragraph boundaries (the start or end of a hard-wrapped line).
     ParagraphBoundary,
+    /// Move to the start or end of the buffer.
+    BufferBoundary,
 }
 
 /// The mode for selection dragging.
@@ -818,6 +820,10 @@ impl SelectionModel {
             TextUnit::Line => self.navigate_line(start, direction, step_size, goal_x, ctx),
             TextUnit::LineBoundary => self.navigate_line_boundary(start, direction, ctx),
             TextUnit::ParagraphBoundary => self.navigate_paragraph_boundary(start, direction, ctx),
+            TextUnit::BufferBoundary => NavigationResult::for_offset(match direction {
+                TextDirection::Backwards => CharOffset::from(1),
+                TextDirection::Forwards => self.content.as_ref(ctx).max_charoffset(),
+            }),
         }
     }
 

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -491,6 +491,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_goto_line_jumps_to_line);
     register_test!(test_goto_line_with_column);
     register_test!(test_goto_line_clamps_out_of_range);
+    register_test!(test_code_editor_select_to_buffer_boundaries_with_shortcuts);
     register_test!(test_code_editor_line_numbers_default_to_absolute);
     register_test!(test_code_editor_relative_line_numbers_follow_cursor);
 

--- a/crates/integration/src/test/goto_line.rs
+++ b/crates/integration/src/test/goto_line.rs
@@ -1,8 +1,9 @@
 use regex::Regex;
 use warp::integration_testing::goto_line::{
-    assert_code_editor_line_numbers, assert_cursor_at_line, assert_cursor_at_line_and_column,
-    assert_goto_line_dialog_is_open, goto_line_confirm, open_goto_line_dialog,
-    set_code_editor_line_number_mode,
+    CodeEditorBufferBoundary, assert_code_editor_line_numbers,
+    assert_code_editor_selection_to_buffer_boundary, assert_cursor_at_line,
+    assert_cursor_at_line_and_column, assert_goto_line_dialog_is_open, focus_file_code_editor,
+    goto_line_confirm, open_goto_line_dialog, set_code_editor_line_number_mode,
 };
 use warp::integration_testing::step::new_step_with_default_assertions;
 use warp::integration_testing::tab::assert_pane_title;
@@ -37,6 +38,15 @@ fn create_multiline_test_file_content() -> String {
         .collect::<Vec<_>>()
         .join("\n")
 }
+
+#[cfg(target_os = "macos")]
+const SELECT_TO_BUFFER_START_KEY: &str = "cmd-shift-up";
+#[cfg(not(target_os = "macos"))]
+const SELECT_TO_BUFFER_START_KEY: &str = "ctrl-shift-home";
+#[cfg(target_os = "macos")]
+const SELECT_TO_BUFFER_END_KEY: &str = "cmd-shift-down";
+#[cfg(not(target_os = "macos"))]
+const SELECT_TO_BUFFER_END_KEY: &str = "ctrl-shift-end";
 
 fn file_open_steps(builder: Builder) -> Builder {
     builder
@@ -135,6 +145,44 @@ pub fn test_goto_line_clamps_out_of_range() -> Builder {
             new_step_with_default_assertions("Verify cursor clamped to last line")
                 .add_assertion(assert_goto_line_dialog_is_open(false))
                 .add_assertion(assert_cursor_at_line(20)),
+        )
+}
+
+pub fn test_code_editor_select_to_buffer_boundaries_with_shortcuts() -> Builder {
+    file_open_steps(new_builder())
+        .with_step(
+            new_step_with_default_assertions("Place cursor in the middle of the file")
+                .with_action(|app, window_id, _| {
+                    goto_line_confirm(app, window_id, "10:3");
+                    focus_file_code_editor(app, window_id);
+                })
+                .add_assertion(assert_cursor_at_line_and_column(10, 3)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Select from cursor to start of file")
+                .with_keystrokes(&[SELECT_TO_BUFFER_START_KEY])
+                .add_assertion(assert_code_editor_selection_to_buffer_boundary(
+                    CodeEditorBufferBoundary::Start,
+                    10,
+                    3,
+                )),
+        )
+        .with_step(
+            new_step_with_default_assertions("Reset cursor in the middle of the file")
+                .with_action(|app, window_id, _| {
+                    goto_line_confirm(app, window_id, "10:3");
+                    focus_file_code_editor(app, window_id);
+                })
+                .add_assertion(assert_cursor_at_line_and_column(10, 3)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Select from cursor to end of file")
+                .with_keystrokes(&[SELECT_TO_BUFFER_END_KEY])
+                .add_assertion(assert_code_editor_selection_to_buffer_boundary(
+                    CodeEditorBufferBoundary::End,
+                    10,
+                    3,
+                )),
         )
 }
 

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -357,6 +357,7 @@ integration_tests! {
     test_goto_line_jumps_to_line,
     test_goto_line_with_column,
     test_goto_line_clamps_out_of_range,
+    test_code_editor_select_to_buffer_boundaries_with_shortcuts,
     test_code_editor_line_numbers_default_to_absolute,
     test_code_editor_relative_line_numbers_follow_cursor,
 


### PR DESCRIPTION
## Description

Adds the missing select-to-buffer behavior to Warp's built-in code editor:

- reuses the existing editable action IDs so current custom keybindings continue to work
- maps `Ctrl+Shift+Home/End` on Windows/Linux and `Cmd+Shift+Up/Down` on macOS
- extends the selection head to the buffer boundary while preserving its anchor
- covers both directions, reverse selections, the empty-buffer edge case, and real shortcut dispatch

This builds on the approach from #14466 by @dk3yyyy. Joshua Nwachinemere is credited with a co-author trailer in the commit.

## Linked Issue

Closes #10521

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format --check`
- `cargo test -p warp --lib test_select_to_buffer --no-fail-fast` (3 passed)
- `cargo test -p warp_editor --no-fail-fast` (501 passed; 1 doc-test ignored)
- `cargo run -p integration --bin integration -- test_code_editor_select_to_buffer_boundaries_with_shortcuts`
- `cargo clippy -p warp_editor -p warp --lib --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

The end-to-end shortcut flow was exercised against a real display on macOS with the equivalent `Cmd+Shift+Up/Down` bindings, as shown below. The Windows `Ctrl+Shift+Home/End` chord was not manually tested on a Windows host; its platform-specific binding is covered by the same typed-action path and the OS-conditional integration test.

### Screenshots / Videos

https://github.com/user-attachments/assets/e2fbeb2a-f521-4fb0-9758-cd9633cfe3e4

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed select-to-file-start/end shortcuts in the built-in code editor.
