### PR TITLE
Feature/codex embedded agent provider

### DIFF
--- a/CODEX_APP_SERVER_CHANGES.md
+++ b/CODEX_APP_SERVER_CHANGES.md
@@ -1,0 +1,21 @@
+# Warp embedded Codex/ChatGPT provider — change summary
+
+Base: `warpdotdev/warp@86cfeb9006da7865d7f27f33228ed0f581d49f02`
+
+## Delivered behaviour
+
+1. `Codex (ChatGPT)` is registered in the model selector of Warp's embedded Cmd+Return Agent.
+2. Selecting it intercepts the Agent request before Warp constructs a hosted inference request.
+3. Warp runs the installed `codex app-server` locally and adapts its JSONL event stream into
+   native Warp `ResponseEvent`, task, and message actions.
+4. Follow-up prompts resume the same Codex thread through a namespaced local conversation token.
+5. Codex thread identifiers are stripped before any later hosted Warp request, preventing local
+   provider state from leaking to the hosted backend.
+6. ChatGPT connect/status/disconnect controls live in Warp Agent's Custom Inference settings.
+7. ChatGPT credentials remain in Codex's credential store and are never copied into Warp settings.
+8. The existing `warp codex ...` commands remain available for diagnostics and scripting, but are
+   supplementary to the embedded provider.
+9. Native desktop sessions are supported; remote/cloud/shared execution fails closed rather than
+   pretending the local provider is portable.
+
+See `docs/CODEX_APP_SERVER.md` for setup, architecture, limitations, and validation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3143,6 +3143,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex_app_server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-process",
+ "command",
+ "futures-lite 1.13.0",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15210,6 +15223,7 @@ dependencies = [
  "cloud_object_persistence",
  "cloud_objects",
  "cocoa 0.26.0",
+ "codex_app_server",
  "comfy-table",
  "command",
  "command-corrections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ command-signatures-v2 = { path = "crates/command-signatures-v2" }
 cloud_objects = { path = "crates/cloud_objects" }
 cloud_object_client = { path = "crates/cloud_object_client" }
 cloud_object_persistence = { path = "crates/cloud_object_persistence" }
+codex_app_server = { path = "crates/codex_app_server" }
 cloud_object_models = { path = "crates/cloud_object_models" }
 computer_use = { path = "crates/computer_use" }
 field_mask = { path = "crates/field_mask" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -303,6 +303,7 @@ winit = { workspace = true }
 wgpu.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+codex_app_server.workspace = true
 app-installation-detection.workspace = true
 async-io.workspace = true
 axum.workspace = true

--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_family = "wasm"))]
+mod codex;
 pub(crate) mod convert_conversation;
 mod convert_from;
 mod convert_to;

--- a/app/src/ai/agent/api/codex.rs
+++ b/app/src/ai/agent/api/codex.rs
@@ -1,0 +1,582 @@
+//! Adapter between the local Codex app-server protocol and Warp's embedded
+//! multi-agent response stream.
+//!
+//! This is intentionally a provider at the Agent API boundary: selecting the
+//! synthetic `Codex (ChatGPT)` model in the Cmd+Return Agent routes the request
+//! here instead of launching a terminal CLI session or calling Warp's hosted
+//! inference endpoint.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context as _, anyhow, bail};
+use codex_app_server::{
+    ApprovalPolicy, Client, ClientOptions, Notification, SandboxMode, ServerRequest,
+    ServerRequestResponse, ThreadOptions, TurnEvent,
+};
+use futures_util::StreamExt as _;
+use serde_json::json;
+use warp_multi_agent_api as api;
+use warp_multi_agent_api::client_action as api_client_action;
+use warp_multi_agent_api::response_event as api_response_event;
+use warp_multi_agent_api::response_event::stream_finished as stream_finished_event;
+
+use super::{ConvertToAPITypeError, RequestParams, ResponseStream, ServerConversationToken};
+use crate::ai::agent::AIAgentInput;
+use crate::server::server_api::AIApiError;
+
+const CONVERSATION_TOKEN_PREFIX: &str = "codex-app-server:";
+pub(super) fn is_codex_conversation_token(token: &ServerConversationToken) -> bool {
+    token.as_str().starts_with(CONVERSATION_TOKEN_PREFIX)
+}
+
+fn thread_id_from_conversation_token(token: &ServerConversationToken) -> Option<&str> {
+    token
+        .as_str()
+        .strip_prefix(CONVERSATION_TOKEN_PREFIX)
+        .filter(|thread_id| !thread_id.is_empty())
+}
+
+fn conversation_token_for_thread(thread_id: &str) -> ServerConversationToken {
+    ServerConversationToken::new(format!("{CONVERSATION_TOKEN_PREFIX}{thread_id}"))
+}
+
+pub(super) async fn generate_codex_app_server_output(
+    params: RequestParams,
+    cancellation_rx: futures::channel::oneshot::Receiver<()>,
+) -> Result<ResponseStream, ConvertToAPITypeError> {
+    let stream = async_stream::stream! {
+        if params.session_context.is_remote() {
+            yield Err(api_error(anyhow!(
+                "Codex (ChatGPT) currently supports local Warp sessions only; switch to a local tab or select another Agent model"
+            )));
+            return;
+        }
+
+        // Passive prompt-suggestion requests are implementation details of
+        // Warp's hosted harness and have no direct Codex app-server analogue.
+        // Complete them as a no-op rather than creating a persisted Codex
+        // thread that the user never sees.
+        if !params.input.is_empty()
+            && params.input.iter().all(|input| {
+                matches!(input, AIAgentInput::TriggerPassiveSuggestion { .. })
+            })
+        {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let conversation_id = params
+                .conversation_token
+                .as_ref()
+                .filter(|token| is_codex_conversation_token(token))
+                .map(|token| token.as_str().to_owned())
+                .unwrap_or_else(|| {
+                    format!("{CONVERSATION_TOKEN_PREFIX}passive-{}", uuid::Uuid::new_v4())
+                });
+            yield Ok(stream_init_event(conversation_id, request_id));
+            yield Ok(stream_finished_event());
+            return;
+        }
+
+        let prompt = match prompt_for_request(&params) {
+            Ok(prompt) => prompt,
+            Err(error) => {
+                yield Err(api_error(error));
+                return;
+            }
+        };
+        let cwd = params
+            .session_context
+            .current_working_directory()
+            .as_ref()
+            .map(PathBuf::from)
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let mut client = match Client::spawn(ClientOptions::default()).await {
+            Ok(client) => client,
+            Err(error) => {
+                yield Err(api_error(error.context(
+                    "Could not start the local Codex app-server. Install the Codex CLI or set WARP_CODEX_PATH"
+                )));
+                return;
+            }
+        };
+        let account = match client.account(false).await {
+            Ok(status) => status,
+            Err(error) => {
+                yield Err(api_error(error.context("Could not read the Codex account")));
+                return;
+            }
+        };
+        if account.account.is_none() {
+                yield Err(api_error(anyhow!(
+                    "Codex is not signed in. Open Warp Settings → AI → Warp Agent → Custom Inference and connect ChatGPT"
+                )));
+                return;
+        }
+
+        let mut options = ThreadOptions::new(cwd);
+        options.thread_source = "warp-embedded-agent".to_owned();
+        configure_permissions(&params, &mut options);
+
+        let existing_thread_id = params
+            .conversation_token
+            .as_ref()
+            .and_then(thread_id_from_conversation_token)
+            .map(str::to_owned);
+        let thread_id = match existing_thread_id {
+            Some(thread_id) => match client.resume_thread(&thread_id, &options).await {
+                Ok(thread_id) => thread_id,
+                Err(error) => {
+                    yield Err(api_error(error));
+                    return;
+                }
+            },
+            None => match client.start_thread(&options).await {
+                Ok(thread_id) => thread_id,
+                Err(error) => {
+                    yield Err(api_error(error));
+                    return;
+                }
+            },
+        };
+
+        let mut pre_turn_notifications = Vec::new();
+        let mut server_request_handler = safe_embedded_server_request;
+        let turn_id = match client
+            .start_turn(
+                &thread_id,
+                &prompt,
+                &mut |notification| pre_turn_notifications.push(notification.clone()),
+                &mut server_request_handler,
+            )
+            .await
+        {
+            Ok(turn_id) => turn_id,
+            Err(error) => {
+                yield Err(api_error(error));
+                return;
+            }
+        };
+
+        // A brand-new Warp conversation starts with an optimistic local root
+        // task. Give it a stable provider-backed id so the normal CreateTask
+        // action upgrades that optimistic task exactly as the hosted API does.
+        // Existing/forked conversations keep their current root task id so
+        // switching providers does not duplicate the visible transcript.
+        let needs_task_creation = params.conversation_token.is_none()
+            && params.forked_from_conversation_token.is_none();
+        let root_task_id = if needs_task_creation {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            root_task_id(&params.tasks).unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+        };
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let conversation_token = conversation_token_for_thread(&thread_id);
+
+        yield Ok(stream_init_event(
+            conversation_token.as_str().to_owned(),
+            turn_id.clone(),
+        ));
+        if needs_task_creation || params.tasks.is_empty() {
+            yield Ok(client_action_event(api_client_action::Action::CreateTask(
+                api_client_action::CreateTask {
+                    task: Some(api::Task {
+                        id: root_task_id.clone(),
+                        description: String::new(),
+                        dependencies: None,
+                        messages: vec![],
+                        summary: String::new(),
+                        server_data: String::new(),
+                    }),
+                },
+            )));
+        }
+        yield Ok(client_action_event(api_client_action::Action::AddMessagesToTask(
+            api_client_action::AddMessagesToTask {
+                task_id: root_task_id.clone(),
+                messages: vec![agent_output_message(
+                    &root_task_id,
+                    &message_id,
+                    &turn_id,
+                    String::new(),
+                )],
+            },
+        )));
+
+        let mut accumulated_text = String::new();
+        let mut terminal_error: Option<String> = None;
+
+        for notification in pre_turn_notifications {
+            if let Some(event) = translate_notification(
+                &notification,
+                &root_task_id,
+                &message_id,
+                &turn_id,
+                &mut accumulated_text,
+                &mut terminal_error,
+            ) {
+                yield Ok(event);
+            }
+        }
+
+        loop {
+            match client
+                .next_turn_event(&thread_id, &turn_id, &mut server_request_handler)
+                .await
+            {
+                Ok(TurnEvent::Notification(notification)) => {
+                    if let Some(event) = translate_notification(
+                        &notification,
+                        &root_task_id,
+                        &message_id,
+                        &turn_id,
+                        &mut accumulated_text,
+                        &mut terminal_error,
+                    ) {
+                        yield Ok(event);
+                    }
+                }
+                Ok(TurnEvent::Completed(result)) => {
+                    if let Some(error) = result.error.or(terminal_error) {
+                        yield Err(api_error(anyhow!("Codex turn failed: {error}")));
+                        return;
+                    }
+                    if result.status != "completed" {
+                        yield Err(api_error(anyhow!(
+                            "Codex turn ended with status {}",
+                            result.status
+                        )));
+                        return;
+                    }
+                    yield Ok(stream_finished_event());
+                    return;
+                }
+                Err(error) => {
+                    yield Err(api_error(error));
+                    return;
+                }
+            }
+        }
+    };
+
+    Ok(Box::pin(stream.take_until(cancellation_rx)))
+}
+
+fn configure_permissions(params: &RequestParams, options: &mut ThreadOptions) {
+    // Warp's embedded tool-approval UI and Codex's bidirectional approval
+    // callbacks are distinct protocols. Run Codex non-interactively inside a
+    // workspace sandbox for normal embedded use. Only Warp's explicit
+    // unsupervised + unsandboxed execution mode maps to full access.
+    options.approval_policy = ApprovalPolicy::Never;
+    options.sandbox = if matches!(params.autonomy_level, api::AutonomyLevel::Unsupervised)
+        && matches!(params.isolation_level, api::IsolationLevel::None)
+    {
+        SandboxMode::DangerFullAccess
+    } else {
+        SandboxMode::WorkspaceWrite
+    };
+}
+
+fn prompt_for_request(params: &RequestParams) -> anyhow::Result<String> {
+    let mut parts = Vec::new();
+
+    // When a user switches an existing Warp-hosted conversation to Codex, the
+    // Codex thread has no prior rollout. Carry the visible transcript into the
+    // first Codex prompt. Subsequent Codex turns resume their own persisted
+    // thread and do not duplicate the transcript.
+    let switching_from_another_provider = params
+        .conversation_token
+        .as_ref()
+        .is_some_and(|token| !is_codex_conversation_token(token));
+    if switching_from_another_provider {
+        let transcript = visible_task_transcript(&params.tasks);
+        if !transcript.is_empty() {
+            parts.push(format!(
+                "Existing Warp Agent conversation context:\n\n{transcript}"
+            ));
+        }
+    }
+
+    for input in &params.input {
+        match input {
+            AIAgentInput::UserQuery { query, .. }
+            | AIAgentInput::AutoCodeDiffQuery { query, .. }
+            | AIAgentInput::CreateNewProject { query, .. } => parts.push(query.clone()),
+            AIAgentInput::CloneRepository { .. }
+            | AIAgentInput::InitProjectRules { .. }
+            | AIAgentInput::CreateEnvironment { .. }
+            | AIAgentInput::PassiveSuggestionResult { .. } => {
+                if let Some(query) = input.display_query() {
+                    parts.push(query);
+                }
+            }
+            AIAgentInput::CodeReview {
+                review_comments, ..
+            } => parts.push(crate::terminal::cli_agent::build_review_prompt(
+                review_comments,
+            )),
+            AIAgentInput::SummarizeConversation { prompt, .. } => parts.push(
+                prompt
+                    .clone()
+                    .unwrap_or_else(|| "Summarize this conversation.".to_owned()),
+            ),
+            AIAgentInput::InvokeSkill {
+                skill, user_query, ..
+            } => {
+                let query = user_query
+                    .as_ref()
+                    .map(|query| query.query.as_str())
+                    .filter(|query| !query.is_empty())
+                    .unwrap_or("Follow the skill instructions.");
+                parts.push(format!(
+                    "Use the following skill named `{}`:\n\n{}\n\nUser request:\n{}",
+                    skill.name, skill.content, query
+                ));
+            }
+            AIAgentInput::ResumeConversation { .. } => {
+                parts.push("Continue the current task.".to_owned());
+            }
+            AIAgentInput::ActionResult { .. }
+            | AIAgentInput::MessagesReceivedFromAgents { .. }
+            | AIAgentInput::EventsFromAgents { .. }
+            | AIAgentInput::OrchestrationConfigUpdate { .. } => {
+                parts.push(input.to_string());
+            }
+            AIAgentInput::StartFromAmbientRunPrompt { .. } => {
+                bail!("Codex (ChatGPT) cannot resolve a cloud ambient-run prompt locally")
+            }
+            AIAgentInput::TriggerPassiveSuggestion { .. } => {}
+        }
+    }
+
+    let prompt = parts
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n");
+    if prompt.is_empty() {
+        bail!("The Codex provider received no text input to send")
+    }
+    Ok(prompt)
+}
+
+fn visible_task_transcript(tasks: &[api::Task]) -> String {
+    let mut lines = Vec::new();
+    for task in tasks {
+        for message in &task.messages {
+            match message.message.as_ref() {
+                Some(api::message::Message::UserQuery(query)) if !query.query.is_empty() => {
+                    lines.push(format!("USER: {}", query.query));
+                }
+                Some(api::message::Message::AgentOutput(output)) if !output.text.is_empty() => {
+                    lines.push(format!("ASSISTANT: {}", output.text));
+                }
+                _ => {}
+            }
+        }
+    }
+    lines.join("\n\n")
+}
+
+fn root_task_id(tasks: &[api::Task]) -> Option<String> {
+    tasks
+        .iter()
+        .find(|task| {
+            task.dependencies
+                .as_ref()
+                .is_none_or(|dependencies| dependencies.parent_task_id.is_empty())
+        })
+        .or_else(|| tasks.first())
+        .map(|task| task.id.clone())
+        .filter(|id| !id.is_empty())
+}
+
+fn translate_notification(
+    notification: &Notification,
+    task_id: &str,
+    message_id: &str,
+    request_id: &str,
+    accumulated_text: &mut String,
+    terminal_error: &mut Option<String>,
+) -> Option<api::ResponseEvent> {
+    if let Some(delta) = notification.agent_message_delta() {
+        accumulated_text.push_str(delta);
+        return Some(append_agent_output_event(
+            task_id,
+            message_id,
+            request_id,
+            delta.to_owned(),
+        ));
+    }
+
+    if let Some(completed) = notification.completed_agent_message() {
+        if accumulated_text.is_empty() {
+            accumulated_text.push_str(completed);
+            return Some(append_agent_output_event(
+                task_id,
+                message_id,
+                request_id,
+                completed.to_owned(),
+            ));
+        }
+        if let Some(suffix) = completed.strip_prefix(accumulated_text.as_str())
+            && !suffix.is_empty()
+        {
+            accumulated_text.push_str(suffix);
+            return Some(append_agent_output_event(
+                task_id,
+                message_id,
+                request_id,
+                suffix.to_owned(),
+            ));
+        }
+        if completed != accumulated_text {
+            *accumulated_text = completed.to_owned();
+            return Some(update_agent_output_event(
+                task_id,
+                message_id,
+                request_id,
+                completed.to_owned(),
+            ));
+        }
+    }
+
+    if let Some(warning) = notification.warning_message() {
+        log::warn!("Codex app-server warning: {warning}");
+    }
+    if let Some(error) = notification.error_message() {
+        *terminal_error = Some(error.to_owned());
+    }
+    None
+}
+
+fn safe_embedded_server_request(request: &ServerRequest) -> ServerRequestResponse {
+    // In normal operation ApprovalPolicy::Never means command/file approvals
+    // are not requested. If a newer server still asks, fail closed rather than
+    // silently broadening access beyond the configured sandbox.
+    match request.method.as_str() {
+        "item/commandExecution/requestApproval" | "item/fileChange/requestApproval" => {
+            ServerRequestResponse::result(json!({ "decision": "decline" }))
+        }
+        "execCommandApproval" | "applyPatchApproval" => ServerRequestResponse::result(json!({
+            "decision": { "denied": { "rejection": "Warp embedded Codex provider denied an unexpected approval request" } },
+        })),
+        "item/permissions/requestApproval" => ServerRequestResponse::result(json!({
+            "permissions": { "fileSystem": null, "network": null },
+            "scope": "turn",
+        })),
+        "item/tool/requestUserInput" => ServerRequestResponse::result(json!({ "answers": {} })),
+        "mcpServer/elicitation/request" => {
+            ServerRequestResponse::result(json!({ "action": "decline" }))
+        }
+        "item/tool/call" => ServerRequestResponse::result(json!({
+            "success": false,
+            "contentItems": [{
+                "type": "inputText",
+                "text": "Warp has no matching dynamic tool implementation",
+            }],
+        })),
+        method => ServerRequestResponse::method_not_found(method),
+    }
+}
+
+fn stream_init_event(conversation_id: String, request_id: String) -> api::ResponseEvent {
+    api::ResponseEvent {
+        r#type: Some(api_response_event::Type::Init(
+            api_response_event::StreamInit {
+                conversation_id,
+                request_id,
+                run_id: String::new(),
+            },
+        )),
+    }
+}
+
+fn client_action_event(action: api_client_action::Action) -> api::ResponseEvent {
+    api::ResponseEvent {
+        r#type: Some(api_response_event::Type::ClientActions(
+            api_response_event::ClientActions {
+                actions: vec![api::ClientAction {
+                    action: Some(action),
+                }],
+            },
+        )),
+    }
+}
+
+fn agent_output_message(
+    task_id: &str,
+    message_id: &str,
+    request_id: &str,
+    text: String,
+) -> api::Message {
+    api::Message {
+        id: message_id.to_owned(),
+        task_id: task_id.to_owned(),
+        request_id: request_id.to_owned(),
+        message: Some(api::message::Message::AgentOutput(
+            api::message::AgentOutput { text },
+        )),
+        ..Default::default()
+    }
+}
+
+fn append_agent_output_event(
+    task_id: &str,
+    message_id: &str,
+    request_id: &str,
+    delta: String,
+) -> api::ResponseEvent {
+    client_action_event(api_client_action::Action::AppendToMessageContent(
+        api_client_action::AppendToMessageContent {
+            task_id: task_id.to_owned(),
+            message: Some(agent_output_message(task_id, message_id, request_id, delta)),
+            mask: Some(prost_types::FieldMask {
+                paths: vec!["agent_output.text".to_owned()],
+            }),
+        },
+    ))
+}
+
+fn update_agent_output_event(
+    task_id: &str,
+    message_id: &str,
+    request_id: &str,
+    text: String,
+) -> api::ResponseEvent {
+    client_action_event(api_client_action::Action::UpdateTaskMessage(
+        api_client_action::UpdateTaskMessage {
+            task_id: task_id.to_owned(),
+            message: Some(agent_output_message(task_id, message_id, request_id, text)),
+            mask: Some(prost_types::FieldMask {
+                paths: vec!["agent_output.text".to_owned()],
+            }),
+        },
+    ))
+}
+
+fn stream_finished_event() -> api::ResponseEvent {
+    api::ResponseEvent {
+        r#type: Some(api_response_event::Type::Finished(
+            api_response_event::StreamFinished {
+                reason: Some(stream_finished_event::Reason::Done(
+                    stream_finished_event::Done {},
+                )),
+                conversation_usage_metadata: None,
+                token_usage: vec![],
+                should_refresh_model_config: false,
+                #[allow(deprecated)]
+                request_cost: None,
+                request_charges: None,
+            },
+        )),
+    }
+}
+
+fn api_error(error: anyhow::Error) -> Arc<AIApiError> {
+    Arc::new(AIApiError::Other(error))
+}
+
+#[cfg(test)]
+#[path = "codex_tests.rs"]
+mod tests;

--- a/app/src/ai/agent/api/codex_tests.rs
+++ b/app/src/ai/agent/api/codex_tests.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use serde_json::json;
+use warp_multi_agent_api as api;
+use warp_multi_agent_api::client_action as api_client_action;
+use warp_multi_agent_api::response_event as api_response_event;
+
+use super::*;
+
+#[test]
+fn codex_conversation_tokens_round_trip_thread_ids() {
+    let token = conversation_token_for_thread("thread-123");
+
+    assert!(is_codex_conversation_token(&token));
+    assert_eq!(
+        thread_id_from_conversation_token(&token),
+        Some("thread-123")
+    );
+    assert_eq!(
+        thread_id_from_conversation_token(&ServerConversationToken::new("hosted-id".to_owned())),
+        None
+    );
+}
+
+#[test]
+fn prompt_for_resume_uses_a_local_continuation_instruction() {
+    let mut params = RequestParams::new_for_test();
+    params.input = vec![AIAgentInput::ResumeConversation {
+        context: Arc::from([]),
+    }];
+
+    assert_eq!(
+        prompt_for_request(&params).unwrap(),
+        "Continue the current task."
+    );
+}
+
+#[test]
+fn provider_switch_carries_the_visible_warp_transcript_once() {
+    let mut params = RequestParams::new_for_test();
+    params.conversation_token = Some(ServerConversationToken::new("hosted-thread".to_owned()));
+    params.tasks = vec![api::Task {
+        id: "task-1".to_owned(),
+        messages: vec![
+            api::Message {
+                id: "user-1".to_owned(),
+                task_id: "task-1".to_owned(),
+                message: Some(api::message::Message::UserQuery(api::message::UserQuery {
+                    query: "Inspect this repository".to_owned(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            api::Message {
+                id: "assistant-1".to_owned(),
+                task_id: "task-1".to_owned(),
+                message: Some(api::message::Message::AgentOutput(
+                    api::message::AgentOutput {
+                        text: "I found the entry point.".to_owned(),
+                    },
+                )),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }];
+    params.input = vec![AIAgentInput::ResumeConversation {
+        context: Arc::from([]),
+    }];
+
+    let prompt = prompt_for_request(&params).unwrap();
+    assert!(prompt.contains("USER: Inspect this repository"));
+    assert!(prompt.contains("ASSISTANT: I found the entry point."));
+    assert!(prompt.contains("Continue the current task."));
+}
+
+#[test]
+fn agent_message_delta_maps_to_native_warp_append_action() {
+    let mut accumulated = String::new();
+    let mut terminal_error = None;
+    let event = translate_notification(
+        &Notification {
+            method: "item/agentMessage/delta".to_owned(),
+            params: json!({ "delta": "hello" }),
+        },
+        "task-1",
+        "message-1",
+        "request-1",
+        &mut accumulated,
+        &mut terminal_error,
+    )
+    .unwrap();
+
+    let Some(api_response_event::Type::ClientActions(actions)) = event.r#type else {
+        panic!("expected ClientActions event");
+    };
+    let Some(api_client_action::Action::AppendToMessageContent(append)) =
+        actions.actions[0].action.as_ref()
+    else {
+        panic!("expected AppendToMessageContent action");
+    };
+    assert_eq!(append.task_id, "task-1");
+    assert_eq!(
+        append.mask.as_ref().unwrap().paths,
+        vec!["agent_output.text".to_owned()]
+    );
+    let Some(api::message::Message::AgentOutput(output)) = append
+        .message
+        .as_ref()
+        .and_then(|message| message.message.as_ref())
+    else {
+        panic!("expected AgentOutput message");
+    };
+    assert_eq!(output.text, "hello");
+    assert_eq!(accumulated, "hello");
+    assert!(terminal_error.is_none());
+}
+
+#[test]
+fn embedded_permissions_fail_closed_except_for_explicit_unsandboxed_autonomy() {
+    let mut params = RequestParams::new_for_test();
+    let mut options = ThreadOptions::new(".");
+
+    params.autonomy_level = api::AutonomyLevel::Supervised;
+    params.isolation_level = api::IsolationLevel::None;
+    configure_permissions(&params, &mut options);
+    assert_eq!(options.approval_policy, ApprovalPolicy::Never);
+    assert_eq!(options.sandbox, SandboxMode::WorkspaceWrite);
+
+    params.autonomy_level = api::AutonomyLevel::Unsupervised;
+    params.isolation_level = api::IsolationLevel::None;
+    configure_permissions(&params, &mut options);
+    assert_eq!(options.sandbox, SandboxMode::DangerFullAccess);
+}
+
+#[test]
+fn finished_event_matches_warp_agent_success_protocol() {
+    let event = stream_finished_event();
+    let Some(api_response_event::Type::Finished(finished)) = event.r#type else {
+        panic!("expected Finished event");
+    };
+    assert!(matches!(
+        finished.reason,
+        Some(stream_finished_event::Reason::Done(_))
+    ));
+}

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -8,6 +8,7 @@ use warp_multi_agent_api as api;
 use super::convert_to::convert_input;
 use super::{ConvertToAPITypeError, RequestParams, ResponseStream};
 use crate::ai::agent::redaction;
+use crate::ai::llms::is_codex_app_server_model_id;
 use crate::server::server_api::{AIApiError, ServerApi};
 use crate::server::team_scope::RequestTeamScope;
 use crate::terminal::model::session::SessionType;
@@ -18,6 +19,29 @@ pub async fn generate_multi_agent_output(
     team_scope: RequestTeamScope,
     cancellation_rx: futures::channel::oneshot::Receiver<()>,
 ) -> Result<ResponseStream, ConvertToAPITypeError> {
+    if params.should_redact_secrets {
+        redaction::redact_inputs(&mut params.input);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    if is_codex_app_server_model_id(&params.model) {
+        return super::codex::generate_codex_app_server_output(params, cancellation_rx).await;
+    }
+
+    // A Codex app-server thread id is local provider state, not a Warp-hosted
+    // conversation id. When the user switches back to a hosted model, preserve
+    // the task transcript but start a fresh hosted conversation token instead
+    // of leaking an incompatible local identifier to the server.
+    #[cfg(not(target_family = "wasm"))]
+    if params
+        .conversation_token
+        .as_ref()
+        .is_some_and(super::codex::is_codex_conversation_token)
+    {
+        params.conversation_token = None;
+        params.forked_from_conversation_token = None;
+    }
+
     let supported_tools = params
         .supported_tools_override
         .take()
@@ -49,10 +73,6 @@ pub async fn generate_multi_agent_output(
                 )),
             },
         );
-    }
-
-    if params.should_redact_secrets {
-        redaction::redact_inputs(&mut params.input);
     }
 
     let api_keys = api_keys_with_warp_credit_fallback_setting(

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -79,6 +79,11 @@ pub fn byo_key_source_for_model(
     scope: &dyn TeamScope,
     app: &AppContext,
 ) -> Option<ByoKeySource> {
+    // The Codex app-server owns its ChatGPT credentials. It is intentionally
+    // not represented by Warp's BYO OpenAI API-key indicator.
+    if is_codex_app_server_model_id(&llm.id) {
+        return None;
+    }
     let workspaces = UserWorkspaces::as_ref(app);
     let is_custom_endpoint = LLMPreferences::as_ref(app)
         .custom_llm_info_for_id(&llm.id)
@@ -188,6 +193,61 @@ pub fn model_leading_icon(llm: &LLMInfo, flags: ModelIconFlags) -> Icon {
 pub const MODELS_BY_FEATURE_CACHE_KEY: &str = "AvailableLLMs";
 const CUSTOM_ENDPOINT_USAGE_FALLBACK_LABEL: &str = "Custom endpoint";
 const CLOUD_FALLBACK_OZ_MODEL_ID: &str = "auto";
+
+/// Synthetic Agent Mode model that routes the embedded Warp Agent through the
+/// locally installed Codex app-server and its ChatGPT authentication.
+pub const CODEX_APP_SERVER_MODEL_ID: &str = "codex-app-server";
+
+/// Returns whether an Agent Mode model id selects the local Codex app-server
+/// provider rather than Warp's hosted multi-agent endpoint.
+pub fn is_codex_app_server_model_id(id: &LLMId) -> bool {
+    id.as_str() == CODEX_APP_SERVER_MODEL_ID
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn codex_app_server_llm_info() -> &'static LLMInfo {
+    static MODEL: OnceLock<LLMInfo> = OnceLock::new();
+    MODEL.get_or_init(|| LLMInfo {
+        display_name: "Codex (ChatGPT)".to_owned(),
+        base_model_name: "Codex (ChatGPT)".to_owned(),
+        id: LLMId::from(CODEX_APP_SERVER_MODEL_ID),
+        reasoning_level: None,
+        usage_metadata: LLMUsageMetadata {
+            request_multiplier: 1,
+            credit_multiplier: None,
+        },
+        description: None,
+        disable_reason: None,
+        vision_supported: false,
+        spec: None,
+        provider: LLMProvider::OpenAI,
+        host_configs: HashMap::new(),
+        discount_percentage: None,
+        context_window: LLMContextWindow::default(),
+    })
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn local_agent_mode_llm_choices() -> std::iter::Once<&'static LLMInfo> {
+    std::iter::once(codex_app_server_llm_info())
+}
+
+#[cfg(target_family = "wasm")]
+fn local_agent_mode_llm_choices() -> std::iter::Empty<&'static LLMInfo> {
+    std::iter::empty()
+}
+
+fn local_agent_mode_llm_info_for_id(id: &LLMId) -> Option<&'static LLMInfo> {
+    #[cfg(not(target_family = "wasm"))]
+    {
+        is_codex_app_server_model_id(id).then(codex_app_server_llm_info)
+    }
+    #[cfg(target_family = "wasm")]
+    {
+        let _ = id;
+        None
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct LLMUsageMetadata {
@@ -917,6 +977,7 @@ impl LLMPreferences {
         app: &'a AppContext,
     ) -> Option<&'a LLMInfo> {
         Self::server_info_for_id_router_gated(available, id)
+            .or_else(|| local_agent_mode_llm_info_for_id(id))
             .or_else(|| self.custom_llm_info_for_id_if_enabled(id, app))
             .or_else(|| self.custom_router_llm_info_for_id_if_enabled(id))
     }
@@ -993,6 +1054,7 @@ impl LLMPreferences {
             .filter(move |llm| {
                 routers_enabled || !custom_model_routers::is_cloud_custom_router_id(llm.id.as_str())
             })
+            .chain(local_agent_mode_llm_choices())
             .chain(self.custom_llm_choices(app))
             .chain(self.custom_router_choices())
     }
@@ -1195,6 +1257,7 @@ impl LLMPreferences {
                     .feature_model_choice_for_team_uid(None)
                     .info_for_id(id)
             })
+            .or_else(|| local_agent_mode_llm_info_for_id(id))
             .or_else(|| self.custom_llm_info_for_id(id))
             .or_else(|| self.custom_router_llm_info_for_id(id))
     }
@@ -1221,7 +1284,8 @@ impl LLMPreferences {
     /// router entirely server-side (no local config or credentials needed), so
     /// they are treated as runnable here.
     pub fn is_cloud_runnable_oz_model_id(&self, id: &LLMId) -> bool {
-        !(self.custom_llm_info_for_id(id).is_some()
+        !(is_codex_app_server_model_id(id)
+            || self.custom_llm_info_for_id(id).is_some()
             || custom_model_routers::is_local_custom_router_id(id.as_str()))
     }
 

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -1311,3 +1311,15 @@ fn explicit_child_model_pin_preserves_gui_behavior_and_only_emits_for_effective_
         assert_eq!(active_model_events.get(), 1);
     });
 }
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn codex_app_server_model_is_registered_for_embedded_agent_mode() {
+    let model = codex_app_server_llm_info();
+
+    assert_eq!(model.id.as_str(), CODEX_APP_SERVER_MODEL_ID);
+    assert_eq!(model.display_name, "Codex (ChatGPT)");
+    assert_eq!(model.provider, LLMProvider::OpenAI);
+    assert!(is_codex_app_server_model_id(&model.id));
+    assert_eq!(local_agent_mode_llm_choices().count(), 1);
+}

--- a/app/src/codex_app_server.rs
+++ b/app/src/codex_app_server.rs
@@ -1,0 +1,429 @@
+use std::io::{self, Write as _};
+use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
+
+use anyhow::{Context, Result, bail};
+use codex_app_server::{
+    AccountStatus, AccountType, ApprovalPolicy, Client, ClientOptions, LoginChallenge, LoginMode,
+    SandboxMode, ServerRequest, ServerRequestResponse, ThreadOptions,
+};
+use serde_json::{Map, Value, json};
+use warp_cli::codex::{CodexArgs, CodexCommand};
+
+pub(crate) fn run(args: &CodexArgs) -> Result<()> {
+    futures_lite::future::block_on(run_async(args))
+}
+
+async fn run_async(args: &CodexArgs) -> Result<()> {
+    match &args.command {
+        CodexCommand::Login { device_code } => login(args, *device_code).await,
+        CodexCommand::Status { json, refresh } => status(args, *json, *refresh).await,
+        CodexCommand::Logout => logout(args).await,
+        CodexCommand::Chat {
+            prompt,
+            interactive,
+            model,
+            cwd,
+            read_only,
+            dangerously_bypass_approvals_and_sandbox,
+        } => {
+            chat(
+                args,
+                prompt.clone(),
+                *interactive,
+                model.clone(),
+                cwd.clone(),
+                *read_only,
+                *dangerously_bypass_approvals_and_sandbox,
+            )
+            .await
+        }
+    }
+}
+
+fn client_options(args: &CodexArgs) -> ClientOptions {
+    args.codex_path
+        .clone()
+        .map(ClientOptions::with_program)
+        .unwrap_or_default()
+}
+
+async fn login(args: &CodexArgs, device_code: bool) -> Result<()> {
+    let mut client = Client::spawn(client_options(args)).await?;
+    let challenge = client
+        .start_login(if device_code {
+            LoginMode::DeviceCode
+        } else {
+            LoginMode::Browser
+        })
+        .await?;
+
+    match &challenge {
+        LoginChallenge::Browser { auth_url, .. } => {
+            println!("Open this URL to sign in with ChatGPT:\n{auth_url}");
+            if launch_browser(auth_url) {
+                println!("Opened the ChatGPT sign-in page in your browser.");
+            }
+        }
+        LoginChallenge::DeviceCode {
+            verification_url,
+            user_code,
+            ..
+        } => {
+            println!("Open this URL:\n{verification_url}\n\nEnter code: {user_code}");
+            let _ = launch_browser(verification_url);
+        }
+    }
+
+    client.wait_for_login(challenge.login_id()).await?;
+    let status = client.account(false).await?;
+    println!("{}", connected_account_message(&status));
+    Ok(())
+}
+
+async fn status(args: &CodexArgs, as_json: bool, refresh: bool) -> Result<()> {
+    let mut client = Client::spawn(client_options(args)).await?;
+    let status = client.account(refresh).await?;
+    if as_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&account_status_json(&status))?
+        );
+    } else {
+        println!("{}", connected_account_message(&status));
+    }
+    Ok(())
+}
+
+async fn logout(args: &CodexArgs) -> Result<()> {
+    let mut client = Client::spawn(client_options(args)).await?;
+    client.logout().await?;
+    println!("Signed out of Codex.");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn chat(
+    args: &CodexArgs,
+    initial_prompt: Option<String>,
+    interactive_after_prompt: bool,
+    model: Option<String>,
+    cwd: Option<PathBuf>,
+    read_only: bool,
+    dangerously_bypass_approvals_and_sandbox: bool,
+) -> Result<()> {
+    let mut client = Client::spawn(client_options(args)).await?;
+    let account = client.account(false).await?;
+    if account.account.is_none() {
+        bail!("Codex is not signed in. Run `warp codex login` first");
+    }
+
+    let cwd = cwd
+        .map(Ok)
+        .unwrap_or_else(std::env::current_dir)
+        .context("Could not determine the Codex working directory")?;
+    let mut options = ThreadOptions::new(cwd);
+    options.model = model;
+    if read_only {
+        options.sandbox = SandboxMode::ReadOnly;
+    }
+    if dangerously_bypass_approvals_and_sandbox {
+        options.approval_policy = ApprovalPolicy::Never;
+        options.sandbox = SandboxMode::DangerFullAccess;
+    }
+
+    let thread_id = client.start_thread(&options).await?;
+    let should_be_interactive = initial_prompt.is_none() || interactive_after_prompt;
+    let mut next_prompt = initial_prompt;
+
+    loop {
+        let prompt = match next_prompt.take() {
+            Some(prompt) => prompt,
+            None if should_be_interactive => match read_chat_prompt()? {
+                Some(prompt) => prompt,
+                None => break,
+            },
+            None => break,
+        };
+
+        let mut emitted_agent_text = false;
+        let result = client
+            .run_turn(
+                &thread_id,
+                &prompt,
+                |notification| {
+                    if let Some(delta) = notification.agent_message_delta() {
+                        print!("{delta}");
+                        let _ = io::stdout().flush();
+                        emitted_agent_text = true;
+                    } else if !emitted_agent_text
+                        && let Some(message) = notification.completed_agent_message()
+                    {
+                        print!("{message}");
+                        let _ = io::stdout().flush();
+                        emitted_agent_text = true;
+                    } else if let Some(delta) = notification.command_output_delta() {
+                        eprint!("{delta}");
+                        let _ = io::stderr().flush();
+                    } else if let Some(delta) = notification.file_change_output_delta() {
+                        eprint!("{delta}");
+                        let _ = io::stderr().flush();
+                    } else if let Some(warning) = notification.warning_message() {
+                        eprintln!("[codex warning] {warning}");
+                    } else if let Some(error) = notification.error_message() {
+                        eprintln!("[codex error] {error}");
+                    }
+                },
+                interactive_server_request,
+            )
+            .await?;
+        if emitted_agent_text {
+            println!();
+        }
+        if let Some(error) = result.error {
+            bail!("Codex turn failed: {error}");
+        }
+        if result.status != "completed" {
+            bail!("Codex turn ended with status {}", result.status);
+        }
+
+        if !should_be_interactive {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn read_chat_prompt() -> Result<Option<String>> {
+    loop {
+        print!("codex> ");
+        io::stdout().flush()?;
+        let mut prompt = String::new();
+        if io::stdin().read_line(&mut prompt)? == 0 {
+            println!();
+            return Ok(None);
+        }
+        let prompt = prompt.trim_end();
+        if matches!(prompt, "/exit" | "/quit") {
+            return Ok(None);
+        }
+        if !prompt.is_empty() {
+            return Ok(Some(prompt.to_owned()));
+        }
+    }
+}
+
+fn interactive_server_request(request: &ServerRequest) -> ServerRequestResponse {
+    match request.method.as_str() {
+        "item/commandExecution/requestApproval" => {
+            let command = request
+                .params
+                .get("command")
+                .and_then(Value::as_str)
+                .unwrap_or("<command unavailable>");
+            let reason = request.params.get("reason").and_then(Value::as_str);
+            let cwd = request.params.get("cwd").and_then(Value::as_str);
+            let detail = format_approval_detail(command, reason, cwd);
+            approval_response(&format!("Codex wants to run:\n{detail}"), false)
+        }
+        "item/fileChange/requestApproval" => {
+            let reason = request
+                .params
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("Codex requested permission to change files");
+            approval_response(reason, false)
+        }
+        "execCommandApproval" | "applyPatchApproval" => {
+            let command = request
+                .params
+                .get("command")
+                .or_else(|| request.params.get("fileChanges"))
+                .map(Value::to_string)
+                .unwrap_or_else(|| "Codex requested an action".to_owned());
+            approval_response(&command, true)
+        }
+        "item/tool/requestUserInput" => answer_user_input(request),
+        "item/permissions/requestApproval" => {
+            eprintln!(
+                "Codex requested additional permissions; Warp declined the broad permission grant."
+            );
+            ServerRequestResponse::result(json!({
+                "permissions": { "fileSystem": null, "network": null },
+                "scope": "turn",
+            }))
+        }
+        "mcpServer/elicitation/request" => {
+            eprintln!("Codex requested MCP input; Warp declined this unsupported form prompt.");
+            ServerRequestResponse::result(json!({ "action": "decline" }))
+        }
+        "item/tool/call" => ServerRequestResponse::result(json!({
+            "success": false,
+            "contentItems": [{
+                "type": "inputText",
+                "text": "Warp has no matching dynamic tool implementation",
+            }],
+        })),
+        method => ServerRequestResponse::method_not_found(method),
+    }
+}
+
+fn format_approval_detail(command: &str, reason: Option<&str>, cwd: Option<&str>) -> String {
+    let mut detail = command.to_owned();
+    if let Some(cwd) = cwd {
+        detail.push_str(&format!("\nDirectory: {cwd}"));
+    }
+    if let Some(reason) = reason {
+        detail.push_str(&format!("\nReason: {reason}"));
+    }
+    detail
+}
+
+fn approval_response(message: &str, legacy: bool) -> ServerRequestResponse {
+    eprintln!("\n{message}");
+    eprint!("Allow? [y]es / [a]ll session / [N]o / [q]uit: ");
+    let _ = io::stderr().flush();
+    let mut response = String::new();
+    let choice = io::stdin()
+        .read_line(&mut response)
+        .ok()
+        .filter(|read| *read > 0)
+        .map(|_| response.trim().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    let decision = if legacy {
+        match choice.as_str() {
+            "y" | "yes" => Value::String("approved".to_owned()),
+            "a" | "all" => Value::String("approved_for_session".to_owned()),
+            "q" | "quit" | "cancel" => Value::String("abort".to_owned()),
+            _ => json!({ "denied": { "rejection": "Denied by the user in Warp" } }),
+        }
+    } else {
+        Value::String(
+            match choice.as_str() {
+                "y" | "yes" => "accept",
+                "a" | "all" => "acceptForSession",
+                "q" | "quit" | "cancel" => "cancel",
+                _ => "decline",
+            }
+            .to_owned(),
+        )
+    };
+    ServerRequestResponse::result(json!({ "decision": decision }))
+}
+
+fn answer_user_input(request: &ServerRequest) -> ServerRequestResponse {
+    let mut answers = Map::new();
+    let questions = request
+        .params
+        .get("questions")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    for question in questions {
+        let Some(id) = question.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let prompt = question
+            .get("question")
+            .and_then(Value::as_str)
+            .unwrap_or("Codex needs input");
+        eprint!("\n{prompt}: ");
+        let _ = io::stderr().flush();
+        let mut answer = String::new();
+        if io::stdin().read_line(&mut answer).unwrap_or(0) == 0 {
+            continue;
+        }
+        answers.insert(
+            id.to_owned(),
+            json!({ "answers": [answer.trim_end().to_owned()] }),
+        );
+    }
+
+    ServerRequestResponse::result(json!({ "answers": answers }))
+}
+
+pub(crate) fn launch_browser(url: &str) -> bool {
+    #[cfg(target_os = "macos")]
+    let result = ProcessCommand::new("open").arg(url).spawn();
+    #[cfg(target_os = "windows")]
+    let result = ProcessCommand::new("rundll32")
+        .arg("url.dll,FileProtocolHandler")
+        .arg(url)
+        .spawn();
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let result = ProcessCommand::new("xdg-open").arg(url).spawn();
+
+    result.is_ok()
+}
+
+pub(crate) async fn read_account(options: ClientOptions) -> Result<AccountStatus> {
+    let mut client = Client::spawn(options).await?;
+    client.account(false).await
+}
+
+pub(crate) async fn login_in_browser(options: ClientOptions) -> Result<AccountStatus> {
+    let mut client = Client::spawn(options).await?;
+    let challenge = client.start_login(LoginMode::Browser).await?;
+    let LoginChallenge::Browser { login_id, auth_url } = challenge else {
+        bail!("Codex returned an unexpected login challenge")
+    };
+    if !launch_browser(&auth_url) {
+        bail!("Could not open the ChatGPT login page: {auth_url}");
+    }
+    client.wait_for_login(&login_id).await?;
+    client.account(false).await
+}
+
+pub(crate) async fn disconnect(options: ClientOptions) -> Result<AccountStatus> {
+    let mut client = Client::spawn(options).await?;
+    client.logout().await?;
+    client.account(false).await
+}
+
+pub(crate) fn connected_account_message(status: &AccountStatus) -> String {
+    let Some(account) = &status.account else {
+        return "Not signed in to Codex. Run `warp codex login`.".to_owned();
+    };
+    let provider = match &account.account_type {
+        AccountType::ChatGpt => "ChatGPT",
+        AccountType::ApiKey => "OpenAI API key",
+        AccountType::AwsBedrock => "AWS Bedrock",
+        AccountType::Other(kind) => kind,
+    };
+    let mut message = format!("Signed in to Codex with {provider}");
+    if let Some(email) = &account.email {
+        message.push_str(&format!(" as {email}"));
+    }
+    if let Some(plan_type) = &account.plan_type {
+        message.push_str(&format!(" ({plan_type})"));
+    }
+    message.push('.');
+    message
+}
+
+fn account_status_json(status: &AccountStatus) -> Value {
+    let account = status.account.as_ref().map(|account| {
+        json!({
+            "type": match &account.account_type {
+                AccountType::ChatGpt => "chatgpt",
+                AccountType::ApiKey => "apiKey",
+                AccountType::AwsBedrock => "awsBedrock",
+                AccountType::Other(kind) => kind,
+            },
+            "email": account.email,
+            "planType": account.plan_type,
+        })
+    });
+    json!({
+        "signedIn": account.is_some(),
+        "account": account,
+        "requiresOpenaiAuth": status.requires_openai_auth,
+    })
+}
+
+#[cfg(test)]
+#[path = "codex_app_server_tests.rs"]
+mod tests;

--- a/app/src/codex_app_server_tests.rs
+++ b/app/src/codex_app_server_tests.rs
@@ -1,0 +1,20 @@
+use codex_app_server::{Account, AccountStatus, AccountType};
+
+use super::connected_account_message;
+
+#[test]
+fn formats_chatgpt_account_status_without_credentials() {
+    let message = connected_account_message(&AccountStatus {
+        account: Some(Account {
+            account_type: AccountType::ChatGpt,
+            email: Some("coder@example.com".to_owned()),
+            plan_type: Some("pro".to_owned()),
+        }),
+        requires_openai_auth: true,
+    });
+
+    assert_eq!(
+        message,
+        "Signed in to Codex with ChatGPT as coder@example.com (pro)."
+    );
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -16,6 +16,8 @@ mod chip_configurator;
 mod cloud_object;
 mod code;
 mod code_review;
+#[cfg(not(target_family = "wasm"))]
+mod codex_app_server;
 mod coding_entrypoints;
 mod coding_panel_enablement_state;
 mod command_palette;
@@ -788,6 +790,10 @@ pub fn run() -> Result<()> {
         }
         match command {
             warp_cli::Command::Worker(worker) => return run_worker_command(worker),
+            #[cfg(not(target_family = "wasm"))]
+            warp_cli::Command::Codex(codex_args) => {
+                return codex_app_server::run(codex_args);
+            }
             warp_cli::Command::Completions { shell } => {
                 return warp_cli::completions::generate_to_stdout(*shell);
             }

--- a/app/src/settings_view/warp_agent_page.rs
+++ b/app/src/settings_view/warp_agent_page.rs
@@ -18,6 +18,8 @@ use ::ai::grok_subscription::oauth::{
     self, ManualCodeExchange, OauthCancellationHandle, TokenResponse,
 };
 use chrono::{DateTime, Local};
+#[cfg(not(target_family = "wasm"))]
+use codex_app_server::{AccountStatus, ClientOptions};
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
 use pathfinder_geometry::vector::vec2f;
 use settings::{Setting, ToggleableSetting};
@@ -77,7 +79,9 @@ use crate::ai::blocklist::agent_view::agent_input_footer::editor::{
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::geap_credentials::force_refresh_geap_credentials;
-use crate::ai::llms::{LLMId, LLMPreferences, LLMProvider, is_using_api_key_for_provider};
+use crate::ai::llms::{
+    LLMId, LLMPreferences, LLMProvider, is_codex_app_server_model_id, is_using_api_key_for_provider,
+};
 use crate::appearance::{Appearance, AppearanceEvent};
 use crate::auth::AuthStateProvider;
 use crate::editor::{
@@ -603,6 +607,30 @@ fn member_byo_keys_allowed_for_view(ctx: &ViewContext<WarpAgentPageView>) -> boo
     workspaces.are_member_byo_keys_allowed(&team_scope)
 }
 
+#[cfg(not(target_family = "wasm"))]
+#[derive(Clone, Debug)]
+enum CodexAccountState {
+    Checking,
+    SignedOut,
+    SignedIn { summary: String },
+    Connecting,
+    Disconnecting,
+    Unavailable { error: String },
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl CodexAccountState {
+    fn from_status(status: AccountStatus) -> Self {
+        if status.account.is_some() {
+            Self::SignedIn {
+                summary: crate::codex_app_server::connected_account_message(&status),
+            }
+        } else {
+            Self::SignedOut
+        }
+    }
+}
+
 /// Object id shared by the SuperGrok connect-flow toasts, so a completion
 /// toast automatically replaces whichever one is currently showing.
 #[cfg(not(target_family = "wasm"))]
@@ -670,6 +698,9 @@ pub struct WarpAgentPageView {
     // Snapshot of the provider keys from the last `KeysUpdated`, used to detect a
     // newly added key and prompt the user to switch their default model.
     last_seen_provider_keys: ApiKeys,
+
+    #[cfg(not(target_family = "wasm"))]
+    codex_account_state: CodexAccountState,
 
     #[cfg(not(target_family = "wasm"))]
     grok_oauth_attempt: Option<GrokOauthAttempt>,
@@ -1160,7 +1191,7 @@ impl WarpAgentPageView {
             },
         );
 
-        Self {
+        let mut view = Self {
             page: Self::build_page(ctx),
             self_handle,
             voice_input_toggle_key_dropdown,
@@ -1186,10 +1217,81 @@ impl WarpAgentPageView {
             set_default_model_modal,
             last_seen_provider_keys,
             #[cfg(not(target_family = "wasm"))]
+            codex_account_state: CodexAccountState::Checking,
+            #[cfg(not(target_family = "wasm"))]
             grok_oauth_attempt: None,
             #[cfg(not(target_family = "wasm"))]
             grok_code_editor,
+        };
+        #[cfg(not(target_family = "wasm"))]
+        view.refresh_codex_account(ctx);
+        view
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn refresh_codex_account(&mut self, ctx: &mut ViewContext<Self>) {
+        self.codex_account_state = CodexAccountState::Checking;
+        ctx.notify();
+        ctx.spawn(
+            crate::codex_app_server::read_account(ClientOptions::default()),
+            |me, result, ctx| {
+                me.codex_account_state = match result {
+                    Ok(status) => CodexAccountState::from_status(status),
+                    Err(error) => CodexAccountState::Unavailable {
+                        error: error.to_string(),
+                    },
+                };
+                ctx.notify();
+            },
+        );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn connect_codex_chatgpt(&mut self, ctx: &mut ViewContext<Self>) {
+        if matches!(
+            self.codex_account_state,
+            CodexAccountState::Connecting | CodexAccountState::Disconnecting
+        ) {
+            return;
         }
+        self.codex_account_state = CodexAccountState::Connecting;
+        ctx.notify();
+        ctx.spawn(
+            crate::codex_app_server::login_in_browser(ClientOptions::default()),
+            |me, result, ctx| {
+                me.codex_account_state = match result {
+                    Ok(status) => CodexAccountState::from_status(status),
+                    Err(error) => CodexAccountState::Unavailable {
+                        error: error.to_string(),
+                    },
+                };
+                ctx.notify();
+            },
+        );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn disconnect_codex_chatgpt(&mut self, ctx: &mut ViewContext<Self>) {
+        if matches!(
+            self.codex_account_state,
+            CodexAccountState::Connecting | CodexAccountState::Disconnecting
+        ) {
+            return;
+        }
+        self.codex_account_state = CodexAccountState::Disconnecting;
+        ctx.notify();
+        ctx.spawn(
+            crate::codex_app_server::disconnect(ClientOptions::default()),
+            |me, result, ctx| {
+                me.codex_account_state = match result {
+                    Ok(status) => CodexAccountState::from_status(status),
+                    Err(error) => CodexAccountState::Unavailable {
+                        error: error.to_string(),
+                    },
+                };
+                ctx.notify();
+            },
+        );
     }
 
     fn update_voice_input_dropdown_enablement(&mut self, ctx: &mut ViewContext<Self>) {
@@ -1297,9 +1399,10 @@ impl WarpAgentPageView {
             let active = prefs.get_active_base_model(&scope, ctx, None);
             (active.id.clone(), active.provider)
         };
-        if LLMPreferences::as_ref(ctx)
-            .custom_llm_info_for_id(&active_id)
-            .is_some()
+        if is_codex_app_server_model_id(&active_id)
+            || LLMPreferences::as_ref(ctx)
+                .custom_llm_info_for_id(&active_id)
+                .is_some()
         {
             return true;
         }
@@ -2154,7 +2257,13 @@ impl WarpAgentPageView {
                     }
                 },
             ),
-            vec![Box::new(ApiKeysWidget::new(ctx))],
+            {
+                let mut widgets: Vec<Box<dyn SettingsWidget<View = Self>>> = Vec::new();
+                #[cfg(not(target_family = "wasm"))]
+                widgets.push(Box::new(CodexChatGptWidget::default()));
+                widgets.push(Box::new(ApiKeysWidget::new(ctx)));
+                widgets
+            },
         ));
 
         categories.push(Category::new(
@@ -2361,6 +2470,12 @@ pub enum WarpAgentPageAction {
     OpenAddCustomRouter,
 
     // Custom inference
+    #[cfg(not(target_family = "wasm"))]
+    RefreshCodexAccount,
+    #[cfg(not(target_family = "wasm"))]
+    ConnectCodexChatGpt,
+    #[cfg(not(target_family = "wasm"))]
+    DisconnectCodexChatGpt,
     OpenAddCustomEndpointModal,
     OpenEditCustomEndpointModal(usize),
     ConnectGrokSubscription,
@@ -2869,6 +2984,12 @@ impl TypedActionView for WarpAgentPageView {
             WarpAgentPageAction::OpenAddCustomRouter => {
                 ctx.emit(WarpAgentPageEvent::OpenCustomRouterEditor(None));
             }
+            #[cfg(not(target_family = "wasm"))]
+            WarpAgentPageAction::RefreshCodexAccount => self.refresh_codex_account(ctx),
+            #[cfg(not(target_family = "wasm"))]
+            WarpAgentPageAction::ConnectCodexChatGpt => self.connect_codex_chatgpt(ctx),
+            #[cfg(not(target_family = "wasm"))]
+            WarpAgentPageAction::DisconnectCodexChatGpt => self.disconnect_codex_chatgpt(ctx),
             WarpAgentPageAction::OpenAddCustomEndpointModal => {
                 self.show_add_custom_endpoint_modal(ctx);
             }
@@ -4780,6 +4901,168 @@ struct ProviderApiKeyEditor {
     provider: LLMProvider,
     editor: ViewHandle<EditorView>,
     team_key_info_tooltip: MouseStateHandle,
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[derive(Default)]
+struct CodexChatGptWidget {
+    button_mouse_state: MouseStateHandle,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl SettingsWidget for CodexChatGptWidget {
+    type View = WarpAgentPageView;
+
+    fn search_terms(&self) -> &str {
+        "codex chatgpt openai app server embedded agent provider login account"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        _app: &AppContext,
+    ) -> Box<dyn Element> {
+        let (status_text, button_label, action, disabled, button_variant) =
+            match &view.codex_account_state {
+                CodexAccountState::Checking => (
+                    "Checking the local Codex account…".to_owned(),
+                    "Checking…",
+                    None,
+                    true,
+                    ButtonVariant::Secondary,
+                ),
+                CodexAccountState::SignedOut => (
+                    "Not connected. Sign in with ChatGPT to use Codex in the embedded Warp Agent."
+                        .to_owned(),
+                    "Connect ChatGPT",
+                    Some(WarpAgentPageAction::ConnectCodexChatGpt),
+                    false,
+                    ButtonVariant::Accent,
+                ),
+                CodexAccountState::SignedIn { summary } => (
+                    summary.clone(),
+                    "Disconnect",
+                    Some(WarpAgentPageAction::DisconnectCodexChatGpt),
+                    false,
+                    ButtonVariant::Secondary,
+                ),
+                CodexAccountState::Connecting => (
+                    "Complete ChatGPT sign-in in your browser…".to_owned(),
+                    "Connecting…",
+                    None,
+                    true,
+                    ButtonVariant::Accent,
+                ),
+                CodexAccountState::Disconnecting => (
+                    "Disconnecting the Codex account…".to_owned(),
+                    "Disconnecting…",
+                    None,
+                    true,
+                    ButtonVariant::Secondary,
+                ),
+                CodexAccountState::Unavailable { error } => (
+                    format!("Codex app-server is unavailable: {error}"),
+                    "Retry",
+                    Some(WarpAgentPageAction::RefreshCodexAccount),
+                    false,
+                    ButtonVariant::Secondary,
+                ),
+            };
+
+        let foreground = appearance.theme().foreground();
+        let subtext = appearance
+            .theme()
+            .sub_text_color(appearance.theme().surface_1());
+        let title = Text::new(
+            "Codex with ChatGPT",
+            appearance.ui_font_family(),
+            CONTENT_FONT_SIZE,
+        )
+        .with_color(foreground.into())
+        .finish();
+        let status = Text::new(
+            status_text,
+            appearance.ui_font_family(),
+            appearance.ui_font_size(),
+        )
+        .with_color(subtext.into())
+        .finish();
+        let icon = ConstrainedBox::new(Icon::OpenAILogo.to_warpui_icon(foreground).finish())
+            .with_width(24.)
+            .with_height(24.)
+            .finish();
+
+        let mut button = appearance
+            .ui_builder()
+            .button(button_variant, self.button_mouse_state.clone())
+            .with_text_label(button_label.to_owned())
+            .with_style(UiComponentStyles {
+                font_size: Some(12.),
+                padding: Some(Coords::uniform(6.).left(12.).right(12.)),
+                ..Default::default()
+            });
+        if disabled {
+            button = button.disabled();
+        }
+        let button = button.build();
+        let button = if let Some(action) = action {
+            button
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(action.clone());
+                })
+                .finish()
+        } else {
+            button.finish()
+        };
+
+        let header = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_child(Container::new(icon).with_margin_right(10.).finish())
+                    .with_child(
+                        Shrinkable::new(
+                            1.,
+                            Flex::column()
+                                .with_child(title)
+                                .with_child(Container::new(status).with_margin_top(3.).finish())
+                                .finish(),
+                        )
+                        .finish(),
+                    )
+                    .finish(),
+            )
+            .with_child(Container::new(button).with_margin_left(12.).finish())
+            .finish();
+
+        let description = appearance
+            .ui_builder()
+            .paragraph(
+                "Select `Codex (ChatGPT)` in the Cmd+Return Agent model picker. Warp routes that embedded conversation directly through the installed `codex app-server`; Codex owns the credentials and Warp does not copy its access or refresh tokens.",
+            )
+            .with_style(UiComponentStyles {
+                font_size: Some(appearance.ui_font_size()),
+                font_color: Some(subtext.into_solid()),
+                margin: Some(
+                    Coords::default()
+                        .top(8.)
+                        .bottom(styles::DESCRIPTION_MARGIN_BOTTOM)
+                        .right(styles::TOGGLE_WIDTH_MARGIN),
+                ),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        Flex::column()
+            .with_child(header)
+            .with_child(description)
+            .finish()
+    }
 }
 
 struct ApiKeysWidget {

--- a/crates/codex_app_server/Cargo.toml
+++ b/crates/codex_app_server/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "codex_app_server"
+version = "0.1.0"
+edition = "2024"
+authors.workspace = true
+publish.workspace = true
+license.workspace = true
+description = "Native Codex app-server client used by Warp"
+
+[dependencies]
+anyhow.workspace = true
+command.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+async-process.workspace = true
+futures-lite.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/codex_app_server/src/client.rs
+++ b/crates/codex_app_server/src/client.rs
@@ -1,0 +1,534 @@
+use std::ffi::OsString;
+use std::process::Stdio;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_process::{Child, ChildStdin, ChildStdout};
+use command::r#async::Command;
+use futures_lite::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use serde_json::{Map, Value, json};
+
+use crate::types::{
+    AccountStatus, LoginChallenge, LoginMode, Notification, ServerRequest, ServerRequestResponse,
+    ThreadOptions, TurnEvent, TurnResult,
+};
+
+const CLIENT_NAME: &str = "warp";
+const CLIENT_TITLE: &str = "Warp Codex integration";
+const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Clone, Debug)]
+pub struct ClientOptions {
+    pub codex_program: OsString,
+}
+
+impl Default for ClientOptions {
+    fn default() -> Self {
+        Self {
+            codex_program: std::env::var_os("WARP_CODEX_PATH")
+                .unwrap_or_else(|| OsString::from("codex")),
+        }
+    }
+}
+
+impl ClientOptions {
+    pub fn with_program(program: impl Into<OsString>) -> Self {
+        Self {
+            codex_program: program.into(),
+        }
+    }
+}
+
+enum WireMessage {
+    Response {
+        id: Value,
+        result: Option<Value>,
+        error: Option<Value>,
+    },
+    Notification(Notification),
+    ServerRequest(ServerRequest),
+}
+
+pub struct Client {
+    child: Child,
+    input: BufWriter<ChildStdin>,
+    output: BufReader<ChildStdout>,
+    next_request_id: u64,
+}
+
+impl Client {
+    pub async fn spawn(options: ClientOptions) -> Result<Self> {
+        let mut command = Command::new(&options.codex_program);
+        command
+            .arg("app-server")
+            .arg("--listen")
+            .arg("stdio://")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+
+        let mut child = command.spawn().with_context(|| {
+            format!(
+                "Failed to launch Codex app-server using {:?}; install Codex or set WARP_CODEX_PATH",
+                options.codex_program
+            )
+        })?;
+        let input = child
+            .stdin
+            .take()
+            .context("Codex app-server did not expose stdin")?;
+        let output = child
+            .stdout
+            .take()
+            .context("Codex app-server did not expose stdout")?;
+
+        let mut client = Self {
+            child,
+            input: BufWriter::new(input),
+            output: BufReader::new(output),
+            next_request_id: 1,
+        };
+        client.initialize().await?;
+        Ok(client)
+    }
+
+    async fn initialize(&mut self) -> Result<()> {
+        self.request(
+            "initialize",
+            json!({
+                "clientInfo": {
+                    "name": CLIENT_NAME,
+                    "title": CLIENT_TITLE,
+                    "version": CLIENT_VERSION,
+                }
+            }),
+        )
+        .await
+        .context("Failed to initialize Codex app-server")?;
+        self.send_value(&json!({ "method": "initialized" }))
+            .await
+            .context("Failed to acknowledge Codex app-server initialization")
+    }
+
+    pub async fn account(&mut self, refresh_token: bool) -> Result<AccountStatus> {
+        let value = self
+            .request("account/read", json!({ "refreshToken": refresh_token }))
+            .await
+            .context("Failed to read the Codex account")?;
+        AccountStatus::from_value(value)
+    }
+
+    pub async fn start_login(&mut self, mode: LoginMode) -> Result<LoginChallenge> {
+        let params = match mode {
+            LoginMode::Browser => json!({ "type": "chatgpt" }),
+            LoginMode::DeviceCode => json!({ "type": "chatgptDeviceCode" }),
+        };
+        let value = self
+            .request("account/login/start", params)
+            .await
+            .context("Failed to start ChatGPT login through Codex")?;
+        LoginChallenge::from_value(value)
+    }
+
+    pub async fn wait_for_login(&mut self, login_id: &str) -> Result<()> {
+        loop {
+            match self.read_message().await? {
+                WireMessage::Notification(notification)
+                    if notification.method == "account/login/completed" =>
+                {
+                    let completed_login_id =
+                        notification.params.get("loginId").and_then(Value::as_str);
+                    if completed_login_id.is_some_and(|id| id != login_id) {
+                        continue;
+                    }
+                    if notification
+                        .params
+                        .get("success")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                    {
+                        return Ok(());
+                    }
+                    let error = notification
+                        .params
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .unwrap_or("ChatGPT login was not completed");
+                    bail!("{error}");
+                }
+                WireMessage::ServerRequest(request) => {
+                    let response = deny_server_request(&request);
+                    self.send_server_response(request.id, response).await?;
+                }
+                WireMessage::Response { .. } | WireMessage::Notification(_) => {}
+            }
+        }
+    }
+
+    pub async fn logout(&mut self) -> Result<()> {
+        self.request("account/logout", json!({}))
+            .await
+            .context("Failed to log out of Codex")?;
+        Ok(())
+    }
+
+    pub async fn start_thread(&mut self, options: &ThreadOptions) -> Result<String> {
+        let value = self
+            .request("thread/start", thread_params(options, None))
+            .await
+            .context("Failed to start a Codex thread")?;
+        thread_id_from_response(&value, "start")
+    }
+
+    /// Resume a persisted Codex thread and apply the current request's runtime
+    /// overrides. App-server returns the same thread shape as `thread/start`.
+    pub async fn resume_thread(
+        &mut self,
+        thread_id: &str,
+        options: &ThreadOptions,
+    ) -> Result<String> {
+        let value = self
+            .request("thread/resume", thread_params(options, Some(thread_id)))
+            .await
+            .with_context(|| format!("Failed to resume Codex thread {thread_id}"))?;
+        thread_id_from_response(&value, "resume")
+    }
+
+    /// Begin a turn and return its id without consuming the subsequent event
+    /// stream. Notifications received before the response are forwarded to the
+    /// supplied callback.
+    pub async fn start_turn<N, R>(
+        &mut self,
+        thread_id: &str,
+        prompt: &str,
+        on_notification: &mut N,
+        on_server_request: &mut R,
+    ) -> Result<String>
+    where
+        N: FnMut(&Notification),
+        R: FnMut(&ServerRequest) -> ServerRequestResponse,
+    {
+        let value = self
+            .request_with_hooks(
+                "turn/start",
+                json!({
+                    "threadId": thread_id,
+                    "input": [{ "type": "text", "text": prompt }],
+                }),
+                on_notification,
+                on_server_request,
+            )
+            .await
+            .context("Failed to start a Codex turn")?;
+        value
+            .get("turn")
+            .and_then(|turn| turn.get("id"))
+            .and_then(Value::as_str)
+            .context("Codex turn response did not include a turn id")
+            .map(str::to_owned)
+    }
+
+    /// Read one notification or the terminal result for an in-flight turn.
+    /// Server-initiated requests are answered through `on_server_request` and
+    /// are not exposed as stream events.
+    pub async fn next_turn_event<R>(
+        &mut self,
+        thread_id: &str,
+        turn_id: &str,
+        on_server_request: &mut R,
+    ) -> Result<TurnEvent>
+    where
+        R: FnMut(&ServerRequest) -> ServerRequestResponse,
+    {
+        loop {
+            match self.read_message().await? {
+                WireMessage::Notification(notification) => {
+                    if notification.method == "turn/completed"
+                        && notification
+                            .params
+                            .get("turn")
+                            .and_then(|turn| turn.get("id"))
+                            .and_then(Value::as_str)
+                            .is_none_or(|id| id == turn_id)
+                    {
+                        return Ok(TurnEvent::Completed(turn_result_from_notification(
+                            thread_id,
+                            turn_id,
+                            &notification,
+                        )?));
+                    }
+                    return Ok(TurnEvent::Notification(notification));
+                }
+                WireMessage::ServerRequest(request) => {
+                    let response = on_server_request(&request);
+                    self.send_server_response(request.id, response).await?;
+                }
+                WireMessage::Response { .. } => {
+                    // No client request is outstanding while consuming a turn.
+                    // Ignore late responses from optional app-server facilities.
+                }
+            }
+        }
+    }
+
+    pub async fn run_turn<N, R>(
+        &mut self,
+        thread_id: &str,
+        prompt: &str,
+        mut on_notification: N,
+        mut on_server_request: R,
+    ) -> Result<TurnResult>
+    where
+        N: FnMut(&Notification),
+        R: FnMut(&ServerRequest) -> ServerRequestResponse,
+    {
+        let turn_id = self
+            .start_turn(
+                thread_id,
+                prompt,
+                &mut on_notification,
+                &mut on_server_request,
+            )
+            .await?;
+
+        loop {
+            match self
+                .next_turn_event(thread_id, &turn_id, &mut on_server_request)
+                .await?
+            {
+                TurnEvent::Notification(notification) => on_notification(&notification),
+                TurnEvent::Completed(result) => return Ok(result),
+            }
+        }
+    }
+
+    async fn request(&mut self, method: &str, params: Value) -> Result<Value> {
+        self.request_with_hooks(method, params, &mut |_| {}, &mut deny_server_request)
+            .await
+    }
+
+    async fn request_with_hooks<N, R>(
+        &mut self,
+        method: &str,
+        params: Value,
+        on_notification: &mut N,
+        on_server_request: &mut R,
+    ) -> Result<Value>
+    where
+        N: FnMut(&Notification),
+        R: FnMut(&ServerRequest) -> ServerRequestResponse,
+    {
+        let id = self.next_request_id;
+        self.next_request_id += 1;
+        self.send_value(&json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+        .await?;
+
+        loop {
+            match self.read_message().await? {
+                WireMessage::Response {
+                    id: response_id,
+                    result,
+                    error,
+                } => {
+                    if response_id.as_u64() != Some(id) {
+                        bail!(
+                            "Codex app-server returned response id {response_id} while waiting for {id}"
+                        );
+                    }
+                    if let Some(error) = error {
+                        let code = error.get("code").and_then(Value::as_i64);
+                        let message = error
+                            .get("message")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown Codex app-server error");
+                        if let Some(code) = code {
+                            bail!("Codex app-server error {code}: {message}");
+                        }
+                        bail!("Codex app-server error: {message}");
+                    }
+                    return result.context("Codex app-server response did not include a result");
+                }
+                WireMessage::Notification(notification) => on_notification(&notification),
+                WireMessage::ServerRequest(request) => {
+                    let response = on_server_request(&request);
+                    self.send_server_response(request.id, response).await?;
+                }
+            }
+        }
+    }
+
+    async fn send_server_response(
+        &mut self,
+        id: Value,
+        response: ServerRequestResponse,
+    ) -> Result<()> {
+        let message = match response {
+            ServerRequestResponse::Result(result) => json!({ "id": id, "result": result }),
+            ServerRequestResponse::Error { code, message } => {
+                json!({ "id": id, "error": { "code": code, "message": message } })
+            }
+        };
+        self.send_value(&message).await
+    }
+
+    async fn send_value(&mut self, value: &Value) -> Result<()> {
+        let mut bytes = serde_json::to_vec(value).context("Failed to encode Codex RPC message")?;
+        bytes.push(b'\n');
+        self.input
+            .write_all(&bytes)
+            .await
+            .context("Failed to write to Codex app-server")?;
+        self.input
+            .flush()
+            .await
+            .context("Failed to flush Codex app-server request")
+    }
+
+    async fn read_message(&mut self) -> Result<WireMessage> {
+        loop {
+            let mut line = String::new();
+            let bytes_read = self
+                .output
+                .read_line(&mut line)
+                .await
+                .context("Failed to read from Codex app-server")?;
+            if bytes_read == 0 {
+                let status = self.child.try_status().ok().flatten();
+                return Err(anyhow!(
+                    "Codex app-server closed its output{}",
+                    status
+                        .map(|status| format!(" with status {status}"))
+                        .unwrap_or_default()
+                ));
+            }
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let mut value: Value = serde_json::from_str(&line)
+                .with_context(|| format!("Codex app-server emitted invalid JSON: {line:?}"))?;
+            let object = value
+                .as_object_mut()
+                .context("Codex app-server emitted a non-object JSON message")?;
+            let method = object
+                .remove("method")
+                .and_then(|method| method.as_str().map(str::to_owned));
+            let id = object.remove("id");
+            let params = object.remove("params").unwrap_or(Value::Null);
+
+            return match (method, id) {
+                (Some(method), Some(id)) => Ok(WireMessage::ServerRequest(ServerRequest {
+                    id,
+                    method,
+                    params,
+                })),
+                (Some(method), None) => {
+                    Ok(WireMessage::Notification(Notification { method, params }))
+                }
+                (None, Some(id)) => Ok(WireMessage::Response {
+                    id,
+                    result: object.remove("result"),
+                    error: object.remove("error"),
+                }),
+                (None, None) => Err(anyhow!("Codex app-server emitted an unrecognized message")),
+            };
+        }
+    }
+}
+
+fn thread_params(options: &ThreadOptions, thread_id: Option<&str>) -> Value {
+    let mut params = Map::new();
+    if let Some(thread_id) = thread_id {
+        params.insert("threadId".to_owned(), Value::String(thread_id.to_owned()));
+    }
+    params.insert(
+        "cwd".to_owned(),
+        Value::String(options.cwd.to_string_lossy().into_owned()),
+    );
+    params.insert(
+        "approvalPolicy".to_owned(),
+        Value::String(options.approval_policy.as_protocol().to_owned()),
+    );
+    params.insert(
+        "sandbox".to_owned(),
+        Value::String(options.sandbox.as_protocol().to_owned()),
+    );
+    if thread_id.is_none() {
+        params.insert(
+            "threadSource".to_owned(),
+            Value::String(options.thread_source.clone()),
+        );
+    }
+    if let Some(model) = &options.model {
+        params.insert("model".to_owned(), Value::String(model.clone()));
+    }
+    Value::Object(params)
+}
+
+fn thread_id_from_response(value: &Value, operation: &str) -> Result<String> {
+    value
+        .get("thread")
+        .and_then(|thread| thread.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .with_context(|| format!("Codex thread/{operation} response did not include a thread id"))
+}
+
+fn turn_result_from_notification(
+    thread_id: &str,
+    turn_id: &str,
+    notification: &Notification,
+) -> Result<TurnResult> {
+    let turn = notification
+        .params
+        .get("turn")
+        .context("Codex turn/completed notification did not include a turn")?;
+    let status = turn
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("completed")
+        .to_owned();
+    let error = turn
+        .get("error")
+        .filter(|error| !error.is_null())
+        .map(|error| {
+            error
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .unwrap_or_else(|| error.to_string())
+        });
+    Ok(TurnResult {
+        thread_id: thread_id.to_owned(),
+        turn_id: turn_id.to_owned(),
+        status,
+        error,
+    })
+}
+
+pub fn deny_server_request(request: &ServerRequest) -> ServerRequestResponse {
+    match request.method.as_str() {
+        "item/commandExecution/requestApproval" | "item/fileChange/requestApproval" => {
+            ServerRequestResponse::Result(json!({ "decision": "decline" }))
+        }
+        "execCommandApproval" | "applyPatchApproval" => ServerRequestResponse::Result(json!({
+            "decision": { "denied": { "rejection": "Denied by Warp" } },
+        })),
+        "item/permissions/requestApproval" => ServerRequestResponse::Result(json!({
+            "permissions": {
+                "fileSystem": null,
+                "network": null,
+            },
+            "scope": "turn",
+        })),
+        "item/tool/requestUserInput" => ServerRequestResponse::Result(json!({ "answers": {} })),
+        "mcpServer/elicitation/request" => {
+            ServerRequestResponse::Result(json!({ "action": "decline" }))
+        }
+        method => ServerRequestResponse::method_not_found(method),
+    }
+}

--- a/crates/codex_app_server/src/lib.rs
+++ b/crates/codex_app_server/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg(not(target_family = "wasm"))]
+
+mod client;
+mod types;
+
+pub use client::{Client, ClientOptions, deny_server_request};
+pub use types::{
+    Account, AccountStatus, AccountType, ApprovalPolicy, LoginChallenge, LoginMode, Notification,
+    SandboxMode, ServerRequest, ServerRequestResponse, ThreadOptions, TurnEvent, TurnResult,
+};
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/codex_app_server/src/tests.rs
+++ b/crates/codex_app_server/src/tests.rs
@@ -1,0 +1,145 @@
+use serde_json::json;
+
+use crate::{
+    AccountStatus, AccountType, LoginChallenge, Notification, ServerRequest, ServerRequestResponse,
+    deny_server_request,
+};
+
+#[test]
+fn parses_chatgpt_account_without_exposing_tokens() {
+    let status = AccountStatus::from_value(json!({
+        "account": {
+            "type": "chatgpt",
+            "email": "coder@example.com",
+            "planType": "pro",
+        },
+        "requiresOpenaiAuth": true,
+    }))
+    .unwrap();
+
+    let account = status.account.unwrap();
+    assert_eq!(account.account_type, AccountType::ChatGpt);
+    assert_eq!(account.email.as_deref(), Some("coder@example.com"));
+    assert_eq!(account.plan_type.as_deref(), Some("pro"));
+    assert!(status.requires_openai_auth);
+}
+
+#[test]
+fn parses_browser_and_device_login_challenges() {
+    let browser = LoginChallenge::from_value(json!({
+        "type": "chatgpt",
+        "loginId": "browser-id",
+        "authUrl": "https://example.com/login",
+    }))
+    .unwrap();
+    assert!(matches!(
+        browser,
+        LoginChallenge::Browser { login_id, auth_url }
+            if login_id == "browser-id" && auth_url == "https://example.com/login"
+    ));
+
+    let device = LoginChallenge::from_value(json!({
+        "type": "chatgptDeviceCode",
+        "loginId": "device-id",
+        "verificationUrl": "https://example.com/device",
+        "userCode": "ABCD-EFGH",
+    }))
+    .unwrap();
+    assert!(matches!(
+        device,
+        LoginChallenge::DeviceCode { login_id, verification_url, user_code }
+            if login_id == "device-id"
+                && verification_url == "https://example.com/device"
+                && user_code == "ABCD-EFGH"
+    ));
+}
+
+#[test]
+fn exposes_streaming_agent_message_deltas() {
+    let notification = Notification {
+        method: "item/agentMessage/delta".to_owned(),
+        params: json!({ "delta": "hello" }),
+    };
+    assert_eq!(notification.agent_message_delta(), Some("hello"));
+}
+
+#[test]
+fn extracts_completed_messages_and_tool_output() {
+    let completed = Notification {
+        method: "item/completed".to_owned(),
+        params: json!({
+            "item": {
+                "type": "agentMessage",
+                "id": "message-1",
+                "text": "complete answer",
+            },
+        }),
+    };
+    assert_eq!(completed.completed_agent_message(), Some("complete answer"));
+
+    let command_output = Notification {
+        method: "item/commandExecution/outputDelta".to_owned(),
+        params: json!({ "delta": "test output\n" }),
+    };
+    assert_eq!(command_output.command_output_delta(), Some("test output\n"));
+}
+
+#[test]
+fn default_server_request_handler_denies_mutating_approvals() {
+    for method in [
+        "item/commandExecution/requestApproval",
+        "item/fileChange/requestApproval",
+    ] {
+        let response = deny_server_request(&ServerRequest {
+            id: json!(1),
+            method: method.to_owned(),
+            params: json!({}),
+        });
+        assert_eq!(
+            response,
+            ServerRequestResponse::Result(json!({ "decision": "decline" }))
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires a recent Codex CLI and an authenticated account"]
+fn real_codex_app_server_smoke() {
+    futures_lite::future::block_on(async {
+        let mut client = crate::Client::spawn(crate::ClientOptions::default())
+            .await
+            .expect("start codex app-server");
+        let account = client.account(false).await.expect("read Codex account");
+        assert!(account.account.is_some(), "Codex must be signed in");
+
+        let mut options =
+            crate::ThreadOptions::new(std::env::current_dir().expect("resolve current directory"));
+        options.approval_policy = crate::ApprovalPolicy::Never;
+        options.sandbox = crate::SandboxMode::ReadOnly;
+        options.thread_source = "warp-live-smoke-test".to_owned();
+        let thread_id = client
+            .start_thread(&options)
+            .await
+            .expect("start read-only Codex thread");
+
+        let mut answer = String::new();
+        let result = client
+            .run_turn(
+                &thread_id,
+                "Reply with exactly WARP_CODEX_SMOKE_OK and nothing else.",
+                |notification| {
+                    if let Some(delta) = notification.agent_message_delta() {
+                        answer.push_str(delta);
+                    }
+                },
+                crate::deny_server_request,
+            )
+            .await
+            .expect("run Codex turn");
+        assert_eq!(result.status, "completed");
+        assert!(
+            answer.contains("WARP_CODEX_SMOKE_OK"),
+            "unexpected Codex response: {answer:?}"
+        );
+    });
+}

--- a/crates/codex_app_server/src/types.rs
+++ b/crates/codex_app_server/src/types.rs
@@ -1,0 +1,300 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::Value;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AccountType {
+    ChatGpt,
+    ApiKey,
+    AwsBedrock,
+    Other(String),
+}
+
+impl AccountType {
+    fn from_protocol(value: &str) -> Self {
+        match value {
+            "chatgpt" => Self::ChatGpt,
+            "apiKey" => Self::ApiKey,
+            "awsBedrock" | "bedrock" => Self::AwsBedrock,
+            other => Self::Other(other.to_owned()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Account {
+    pub account_type: AccountType,
+    pub email: Option<String>,
+    pub plan_type: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountStatus {
+    pub account: Option<Account>,
+    pub requires_openai_auth: bool,
+}
+
+impl AccountStatus {
+    pub(crate) fn from_value(value: Value) -> Result<Self> {
+        let requires_openai_auth = value
+            .get("requiresOpenaiAuth")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let account = value
+            .get("account")
+            .filter(|account| !account.is_null())
+            .map(|account| -> Result<Account> {
+                let account_type = account
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .context("Codex account response did not include an account type")?;
+                Ok(Account {
+                    account_type: AccountType::from_protocol(account_type),
+                    email: account
+                        .get("email")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned),
+                    plan_type: account
+                        .get("planType")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned),
+                })
+            })
+            .transpose()?;
+
+        Ok(Self {
+            account,
+            requires_openai_auth,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LoginMode {
+    #[default]
+    Browser,
+    DeviceCode,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LoginChallenge {
+    Browser {
+        login_id: String,
+        auth_url: String,
+    },
+    DeviceCode {
+        login_id: String,
+        verification_url: String,
+        user_code: String,
+    },
+}
+
+impl LoginChallenge {
+    pub fn login_id(&self) -> &str {
+        match self {
+            Self::Browser { login_id, .. } | Self::DeviceCode { login_id, .. } => login_id,
+        }
+    }
+
+    pub(crate) fn from_value(value: Value) -> Result<Self> {
+        let kind = value
+            .get("type")
+            .and_then(Value::as_str)
+            .context("Codex login response did not include a login type")?;
+        let login_id = value
+            .get("loginId")
+            .and_then(Value::as_str)
+            .context("Codex login response did not include a login id")?
+            .to_owned();
+
+        match kind {
+            "chatgpt" => Ok(Self::Browser {
+                login_id,
+                auth_url: value
+                    .get("authUrl")
+                    .and_then(Value::as_str)
+                    .context("Codex browser login response did not include an auth URL")?
+                    .to_owned(),
+            }),
+            "chatgptDeviceCode" => Ok(Self::DeviceCode {
+                login_id,
+                verification_url: value
+                    .get("verificationUrl")
+                    .and_then(Value::as_str)
+                    .context("Codex device login response did not include a verification URL")?
+                    .to_owned(),
+                user_code: value
+                    .get("userCode")
+                    .and_then(Value::as_str)
+                    .context("Codex device login response did not include a user code")?
+                    .to_owned(),
+            }),
+            other => Err(anyhow!("Unsupported Codex login response type: {other}")),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ApprovalPolicy {
+    Untrusted,
+    #[default]
+    OnRequest,
+    Never,
+}
+
+impl ApprovalPolicy {
+    pub(crate) fn as_protocol(self) -> &'static str {
+        match self {
+            Self::Untrusted => "untrusted",
+            Self::OnRequest => "on-request",
+            Self::Never => "never",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SandboxMode {
+    ReadOnly,
+    #[default]
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+impl SandboxMode {
+    pub(crate) fn as_protocol(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::WorkspaceWrite => "workspace-write",
+            Self::DangerFullAccess => "danger-full-access",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ThreadOptions {
+    pub cwd: PathBuf,
+    pub model: Option<String>,
+    pub approval_policy: ApprovalPolicy,
+    pub sandbox: SandboxMode,
+    pub thread_source: String,
+}
+
+impl ThreadOptions {
+    pub fn new(cwd: impl Into<PathBuf>) -> Self {
+        Self {
+            cwd: cwd.into(),
+            model: None,
+            approval_policy: ApprovalPolicy::OnRequest,
+            sandbox: SandboxMode::WorkspaceWrite,
+            thread_source: "warp".to_owned(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Notification {
+    pub method: String,
+    pub params: Value,
+}
+
+impl Notification {
+    pub fn agent_message_delta(&self) -> Option<&str> {
+        (self.method == "item/agentMessage/delta")
+            .then(|| self.params.get("delta").and_then(Value::as_str))
+            .flatten()
+    }
+
+    pub fn reasoning_delta(&self) -> Option<&str> {
+        matches!(
+            self.method.as_str(),
+            "item/reasoning/textDelta" | "item/reasoning/summaryTextDelta"
+        )
+        .then(|| self.params.get("delta").and_then(Value::as_str))
+        .flatten()
+    }
+
+    pub fn completed_agent_message(&self) -> Option<&str> {
+        (self.method == "item/completed")
+            .then(|| self.params.get("item"))
+            .flatten()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("agentMessage"))
+            .and_then(|item| item.get("text"))
+            .and_then(Value::as_str)
+    }
+
+    pub fn command_output_delta(&self) -> Option<&str> {
+        (self.method == "item/commandExecution/outputDelta")
+            .then(|| self.params.get("delta").and_then(Value::as_str))
+            .flatten()
+    }
+
+    pub fn file_change_output_delta(&self) -> Option<&str> {
+        (self.method == "item/fileChange/outputDelta")
+            .then(|| self.params.get("delta").and_then(Value::as_str))
+            .flatten()
+    }
+
+    pub fn warning_message(&self) -> Option<&str> {
+        (self.method == "warning")
+            .then(|| self.params.get("message").and_then(Value::as_str))
+            .flatten()
+    }
+
+    pub fn error_message(&self) -> Option<&str> {
+        (self.method == "error")
+            .then(|| self.params.get("error"))
+            .flatten()
+            .and_then(|error| {
+                error
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .or_else(|| error.as_str())
+            })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ServerRequest {
+    pub id: Value,
+    pub method: String,
+    pub params: Value,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ServerRequestResponse {
+    Result(Value),
+    Error { code: i64, message: String },
+}
+
+impl ServerRequestResponse {
+    pub fn result(value: Value) -> Self {
+        Self::Result(value)
+    }
+
+    pub fn method_not_found(method: &str) -> Self {
+        Self::Error {
+            code: -32601,
+            message: format!("Warp does not implement Codex server request {method}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TurnResult {
+    pub thread_id: String,
+    pub turn_id: String,
+    pub status: String,
+    pub error: Option<String>,
+}
+
+/// A single event observed while an app-server turn is running.
+///
+/// The low-level client exposes this so rich clients can translate Codex's
+/// streamed notifications into their own native event model without buffering
+/// the whole response first.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TurnEvent {
+    Notification(Notification),
+    Completed(TurnResult),
+}

--- a/crates/warp_cli/src/codex.rs
+++ b/crates/warp_cli/src/codex.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Clone, Args)]
+pub struct CodexArgs {
+    /// Override the Codex executable used to launch `codex app-server`.
+    #[arg(long, global = true, env = "WARP_CODEX_PATH")]
+    pub codex_path: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub command: CodexCommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum CodexCommand {
+    /// Sign in to Codex with a ChatGPT account.
+    Login {
+        /// Use the device-code flow instead of opening a browser callback flow.
+        #[arg(long)]
+        device_code: bool,
+    },
+
+    /// Show the active Codex account without exposing credentials.
+    Status {
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+
+        /// Ask Codex to refresh the account token before reporting status.
+        #[arg(long)]
+        refresh: bool,
+    },
+
+    /// Sign out of the active Codex account.
+    Logout,
+
+    /// Run Codex as a Warp-aware custom coding agent through app-server.
+    Chat {
+        /// Submit one prompt and exit. Without this flag, an interactive session starts.
+        #[arg(long, short = 'p')]
+        prompt: Option<String>,
+
+        /// Continue interactively after the initial prompt.
+        #[arg(long, requires = "prompt")]
+        interactive: bool,
+
+        /// Override the Codex model for this thread.
+        #[arg(long)]
+        model: Option<String>,
+
+        /// Working directory exposed to the Codex thread.
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+
+        /// Prevent Codex from modifying files.
+        #[arg(long, conflicts_with = "dangerously_bypass_approvals_and_sandbox")]
+        read_only: bool,
+
+        /// Disable approvals and grant unrestricted filesystem/network access.
+        #[arg(long)]
+        dangerously_bypass_approvals_and_sandbox: bool,
+    },
+}

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -21,6 +21,7 @@ pub use sort_order::SortOrderArg;
 
 pub mod agent;
 pub mod api_key;
+pub mod codex;
 pub mod completions;
 pub mod config_file;
 mod date_time;
@@ -657,6 +658,10 @@ pub enum Command {
     #[clap(flatten)]
     CommandLine(Box<CliCommand>),
 
+    /// Use ChatGPT-backed Codex through the local Codex app-server.
+    #[cfg(not(target_family = "wasm"))]
+    Codex(crate::codex::CodexArgs),
+
     /// Generate shell completions for your shell to stdout.
     ///
     ///
@@ -702,6 +707,8 @@ impl Command {
         match self {
             Command::Worker(_) => false,
             Command::CommandLine(_) | Command::DumpDebugInfo => true,
+            #[cfg(not(target_family = "wasm"))]
+            Command::Codex(_) => true,
             Command::Completions { .. } => true,
             #[cfg(not(target_family = "wasm"))]
             Command::DumpSettingsSchema { output_path } => output_path.is_none(),

--- a/docs/CODEX_APP_SERVER.md
+++ b/docs/CODEX_APP_SERVER.md
@@ -1,0 +1,172 @@
+# Embedded Codex (ChatGPT) provider for Warp Agent
+
+This fork makes Codex available as an inference provider inside Warp's embedded Agent—the
+conversation opened with **Cmd+Return**. It does not require users to launch a separate Codex
+terminal UI. Warp talks to the locally installed `codex app-server` over JSONL stdio and adapts
+its streamed events into Warp's native multi-agent conversation protocol.
+
+The implementation is based on upstream Warp commit
+`86cfeb9006da7865d7f27f33228ed0f581d49f02`.
+
+## User experience
+
+1. Install a recent Codex CLI that includes `codex app-server`.
+2. Open **Settings → AI → Warp Agent → Custom Inference**.
+3. In **Codex with ChatGPT**, select **Connect ChatGPT** and complete browser login.
+4. Open Warp Agent with **Cmd+Return**.
+5. Choose **Codex (ChatGPT)** in the model picker.
+6. Submit prompts in the normal embedded Warp Agent interface.
+
+The selected model is intercepted at Warp's Agent API boundary before a hosted Warp request is
+serialized. Requests using `Codex (ChatGPT)` are therefore sent to the local app-server instead
+of Warp's hosted multi-agent inference endpoint.
+
+## Embedded provider behaviour
+
+- Registers `Codex (ChatGPT)` as a native Agent Mode model.
+- Routes Cmd+Return Agent requests through `codex app-server`.
+- Converts Codex thread and turn events into Warp `ResponseEvent` values.
+- Streams assistant text into Warp through `AppendToMessageContent` actions.
+- Creates and updates normal Warp conversation tasks and messages.
+- Resumes follow-up prompts through Codex `thread/resume`.
+- Preserves visible transcript context when switching an existing hosted Warp conversation to
+  Codex.
+- Uses namespaced local continuation tokens so a Codex thread identifier is never sent to Warp's
+  hosted backend.
+- Starts a fresh hosted continuation when the user switches from Codex back to a hosted model.
+- Rejects use from Warp remote sessions because the app-server and credentials are local to the
+  desktop running Warp.
+
+## Authentication
+
+The settings-page **Connect ChatGPT** button asks Codex app-server to start its ChatGPT browser
+login flow. Warp opens the URL and waits for the app-server's completion event.
+
+Codex remains the credential owner. Warp does not copy or persist ChatGPT access or refresh
+tokens. It only displays non-secret account metadata returned by Codex, such as account type,
+email, and plan name.
+
+For a headless login flow, the supplementary command surface remains available:
+
+```sh
+warp codex login --device-code
+```
+
+Other account commands:
+
+```sh
+warp codex status
+warp codex status --json
+warp codex status --refresh
+warp codex logout
+```
+
+To use a Codex executable outside `PATH`:
+
+```sh
+export WARP_CODEX_PATH=/absolute/path/to/codex
+```
+
+or:
+
+```sh
+warp codex --codex-path /absolute/path/to/codex status
+```
+
+## Permissions and isolation
+
+The embedded provider runs Codex with `approvalPolicy = never` because Warp's embedded approval
+protocol and Codex's bidirectional approval callbacks are not interchangeable. Normal embedded
+Agent use is confined to Codex's `workspace-write` sandbox.
+
+Only Warp's explicit combination of unsupervised autonomy and no isolation maps to Codex
+`danger-full-access`. Unexpected approval, broad-permission, user-input, or dynamic-tool callbacks
+fail closed rather than silently granting access.
+
+## Conversation mapping
+
+Warp normally stores a server-issued conversation token. For this provider the token has the
+form:
+
+```text
+codex-app-server:<codex-thread-id>
+```
+
+The adapter strips the namespace only when calling Codex. Before any hosted Warp request is
+constructed, a Codex-namespaced token is removed. This separation prevents accidental crossover
+between local Codex threads and Warp-hosted conversation identifiers.
+
+For a new conversation, the adapter emits:
+
+1. `StreamInit`
+2. `CreateTask`
+3. `AddMessagesToTask` with an empty `AgentOutput`
+4. zero or more `AppendToMessageContent`/`UpdateTaskMessage` actions
+5. `StreamFinished`
+
+Existing conversations retain their visible root task and receive subsequent assistant messages
+on that task.
+
+## Current scope
+
+The integration is intentionally local-first:
+
+- Cmd+Return embedded Agent is supported on native desktop builds.
+- Warp web builds do not expose the local provider.
+- Remote Warp sessions, cloud agents, shared-session handoff, and ambient cloud runs do not route
+  through the desktop-local Codex process.
+- Assistant text is rendered natively in Warp. Codex command/file activity is performed by Codex
+  under its sandbox but is not yet reconstructed as Warp's proprietary tool cards.
+- Codex chooses its effective underlying model from its own configuration; the Warp picker exposes
+  the provider as one stable `Codex (ChatGPT)` entry.
+
+## Supplementary CLI
+
+The fork retains a direct command interface for diagnostics and scripting:
+
+```sh
+warp codex chat
+warp codex chat --prompt 'Review this repository.'
+warp codex chat --read-only --prompt 'Find correctness risks.'
+```
+
+This CLI is not the primary integration. The primary path is the embedded Cmd+Return Agent model
+selection described above.
+
+## Implementation map
+
+| Area | Path |
+|---|---|
+| App-server process and JSONL protocol | `crates/codex_app_server` |
+| Embedded response adapter | `app/src/ai/agent/api/codex.rs` |
+| Embedded request interception | `app/src/ai/agent/api/impl.rs` |
+| Agent model registration | `app/src/ai/llms.rs` |
+| ChatGPT account settings | `app/src/settings_view/warp_agent_page.rs` |
+| Supplementary command parser | `crates/warp_cli/src/codex.rs` |
+| Supplementary command runner | `app/src/codex_app_server.rs` |
+
+## Validation
+
+The provider has focused tests for:
+
+- native model registration;
+- Codex continuation-token namespacing;
+- hosted-to-Codex transcript transfer;
+- Codex delta to Warp message-action conversion;
+- sandbox/autonomy mapping;
+- successful stream completion;
+- app-server account parsing and login challenges;
+- command-line argument parsing.
+
+Recommended validation commands:
+
+```sh
+cargo fmt --all -- --check
+cargo test -p codex_app_server
+cargo test -p warp_cli --lib
+cargo check -p warp --lib
+cargo test -p warp --lib codex -- --nocapture
+cargo build -p warp --bin warp-oss
+```
+
+On macOS, Warp's native build requires a full Xcode installation with the Metal compiler.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
