### PR TITLE
Fix panel resize drag lag and clamp jumps

### DIFF
--- a/crates/warpui_core/src/elements/gui/resizable.rs
+++ b/crates/warpui_core/src/elements/gui/resizable.rs
@@ -107,7 +107,7 @@ impl ResizableState {
     ) -> Option<Vector2F> {
         let mut resized = false;
 
-        if let Some(origin) = origin {
+        if origin.is_some() {
             let delta = match dragbar_side {
                 DragBarSide::Right => new_position.x() - old_position.x(),
                 DragBarSide::Left => old_position.x() - new_position.x(),
@@ -123,22 +123,6 @@ impl ResizableState {
             }
             let size = self.size;
 
-            // The last position should reflect the latest position of the dragbar.
-            let last_position = match dragbar_side {
-                // With a right-side dragbar, the latest position of the dragbar will
-                // be the old origin of the element plus the new width/height.
-                DragBarSide::Right => origin + vec2f(size, 0.),
-                // With a left-side dragbar, the latest position of the dragbar will
-                // be the old origin of the element minus the bounded delta of the drag.
-                DragBarSide::Left => origin - vec2f(size - old_size, 0.),
-                // With a bottom-side dragbar, the latest position of the dragbar will
-                // be the old origin of the element plus the new height.
-                DragBarSide::Bottom => origin + vec2f(0., size),
-                // With a top-side dragbar, the latest position of the dragbar will
-                // be the old origin of the element minus the bounded delta of the drag.
-                DragBarSide::Top => origin - vec2f(0., size - old_size),
-            };
-
             let origin_delta = match dragbar_side {
                 DragBarSide::Right => Vector2F::zero(),
                 DragBarSide::Left => vec2f(old_size - size, 0.),
@@ -146,7 +130,9 @@ impl ResizableState {
                 DragBarSide::Top => vec2f(0., old_size - size),
             };
 
-            self.mode = ResizableMode::Dragging { last_position };
+            self.mode = ResizableMode::Dragging {
+                last_position: new_position,
+            };
 
             if resized { Some(origin_delta) } else { None }
         } else {
@@ -500,3 +486,7 @@ fn dispatch_callback(callback: Option<&mut Handler>, ctx: &mut EventContext, app
         callback(ctx, app);
     }
 }
+
+#[cfg(test)]
+#[path = "resizable_tests.rs"]
+mod tests;

--- a/crates/warpui_core/src/elements/gui/resizable_tests.rs
+++ b/crates/warpui_core/src/elements/gui/resizable_tests.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+#[test]
+fn clamped_resize_tracks_cursor_when_drag_direction_reverses() {
+    let cases = [
+        (
+            "right",
+            DragBarSide::Right,
+            vec2f(100., 0.),
+            vec2f(120., 0.),
+            vec2f(115., 0.),
+        ),
+        (
+            "left",
+            DragBarSide::Left,
+            vec2f(0., 0.),
+            vec2f(-20., 0.),
+            vec2f(-15., 0.),
+        ),
+        (
+            "bottom",
+            DragBarSide::Bottom,
+            vec2f(0., 100.),
+            vec2f(0., 120.),
+            vec2f(0., 115.),
+        ),
+        (
+            "top",
+            DragBarSide::Top,
+            vec2f(0., 0.),
+            vec2f(0., -20.),
+            vec2f(0., -15.),
+        ),
+    ];
+
+    for (name, side, start, past_max, reversed) in cases {
+        let mut state = ResizableState::new(100.);
+        state.bounds = Some((50., 110.));
+        state.begin_resizing(start);
+
+        state.check_for_resize(past_max, Some(Vector2F::zero()), side);
+        assert_eq!(state.size(), 110., "{name} drag should clamp at max");
+
+        state.check_for_resize(reversed, Some(Vector2F::zero()), side);
+        assert_eq!(
+            state.size(),
+            105.,
+            "{name} drag should respond immediately after reversing"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Tracks the actual cursor position between resizable-panel drag events instead of reconstructing the dragbar position from the clamped panel size.

This prevents drag deltas from accumulating error when the panel reaches its minimum or maximum size, so reversing direction responds immediately instead of lagging or jumping.

Adds regression coverage for right, left, bottom, and top dragbars crossing a maximum bound and reversing direction.

## Linked Issue

Fixes #10321

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Passed locally on Windows:

- `./script/format --check`
- `cargo test -p warpui_core clamped_resize_tracks_cursor_when_drag_direction_reverses`
- `cargo clippy -p warpui_core --all-targets --tests -- -D warnings`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Manual Wayland verification is pending.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed resizable panels lagging or jumping after the cursor reaches a size boundary and reverses direction.
