### PR TITLE
Fix macOS local run bundle format

### DIFF
--- a/script/macos/run
+++ b/script/macos/run
@@ -104,7 +104,7 @@ rm -rf "$WARP_APP_PATH"
 
 pushd app > /dev/null
 echo "Bundling app (bin: $WARP_BIN_NAME)..."
-cargo bundle --bin "$WARP_BIN_NAME" --features "$FEATURES" $PARAMS
+cargo bundle --bin "$WARP_BIN_NAME" --features "$FEATURES" --format osx $PARAMS
 echo "Successfully bundled..."
 popd > /dev/null
 

--- a/script/macos/test_run_bundle_format
+++ b/script/macos/test_run_bundle_format
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -e
+
+workspace_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+fake_bin="$temp_dir/bin"
+mkdir -p "$fake_bin"
+
+cat > "$fake_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+
+case "$1" in
+  metadata)
+    printf '{"target_directory":"%s"}\n' "$FAKE_TARGET_DIR"
+    ;;
+  bundle)
+    printf '%s\n' "$@" > "$CARGO_ARGS_FILE"
+    exit 42
+    ;;
+  *)
+    echo "Unexpected cargo command: $1" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/cargo"
+
+oss_args="$temp_dir/oss-args"
+oss_expected_args="$temp_dir/oss-expected-args"
+cat > "$oss_expected_args" <<'EOF'
+bundle
+--bin
+warp-oss
+--features
+gui
+--format
+osx
+--release
+EOF
+
+oss_status=0
+PATH="$fake_bin:$PATH" \
+  FAKE_TARGET_DIR="$temp_dir/oss-target" \
+  CARGO_ARGS_FILE="$oss_args" \
+  WARP_BIN_NAME="warp-oss" \
+  WARP_CHANNEL="oss" \
+  FEATURES="gui" \
+  "$workspace_root/script/macos/run" --dont-open --release || oss_status=$?
+
+if [[ "$oss_status" -ne 42 ]]; then
+  echo "Expected the OSS run to stop at cargo bundle with status 42, got $oss_status." >&2
+  exit 1
+fi
+diff -u "$oss_expected_args" "$oss_args"
+
+local_args="$temp_dir/local-args"
+local_expected_args="$temp_dir/local-expected-args"
+cat > "$local_expected_args" <<'EOF'
+bundle
+--bin
+warp
+--features
+gui,local-feature
+--format
+osx
+--profile
+test-profile
+EOF
+
+local_status=0
+PATH="$fake_bin:$PATH" \
+  FAKE_TARGET_DIR="$temp_dir/local-target" \
+  CARGO_ARGS_FILE="$local_args" \
+  WARP_BIN_NAME="warp" \
+  WARP_CHANNEL="local" \
+  FEATURES="gui,local-feature" \
+  "$workspace_root/script/macos/run" --dont-open --profile test-profile || local_status=$?
+
+if [[ "$local_status" -ne 42 ]]; then
+  echo "Expected the local run to stop at cargo bundle with status 42, got $local_status." >&2
+  exit 1
+fi
+diff -u "$local_expected_args" "$local_args"


### PR DESCRIPTION
## Description

`script/macos/run` only consumes the macOS app bundle, but `cargo-bundle` builds every applicable format when no format is specified. On newer macOS versions, the unnecessary DMG step can fail before resource preparation and signing.

This change restricts the local run path to the `osx` bundle and adds a shell regression test covering both OSS release arguments and Local custom-profile arguments. The release packaging path remains unchanged.

Thanks @creativerezz for the detailed reproduction and fix direction.

## Linked Issue

Fixes #15697

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Visual evidence is not applicable because this is a non-visual local build-script change; terminal verification is listed below.

## Testing

- [x] I have manually tested my changes locally with `WARP_SKIP_COMMON_SKILLS_INSTALL=1 ./script/run --dont-open`.
- [x] `./script/macos/test_run_bundle_format`
- [x] `bash -n script/macos/run script/macos/test_run_bundle_format`
- [x] `git diff --check`
- [x] `./script/format --check`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] `codesign --verify --deep --strict target/debug/bundle/osx/WarpOss.app`

The end-to-end run built exactly one `WarpOss.app`, completed resource preparation and codesigning, and did not invoke DMG or `hdiutil` packaging.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
