### PR TITLE
Skip project rule files under gitignored directories

### DIFF
--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -272,9 +272,12 @@ impl Entry {
         // ignored/symlinked), a classification failure at the root propagates to
         // the caller, preserving existing error behavior.
         if let Some(state) = standing_queries.as_deref_mut() {
-            state
-                .results
-                .record_path(&root_path, root_path.is_dir(), state.definitions);
+            state.results.record_path(
+                &root_path,
+                root_path.is_dir(),
+                ancestor_is_ignored,
+                state.definitions,
+            );
         }
         match evaluate_entry(
             &root_path,
@@ -378,6 +381,7 @@ impl Entry {
                             state.results.record_path(
                                 &child_path,
                                 child_path.is_dir(),
+                                job.ignored,
                                 state.definitions,
                             );
                         }
@@ -1006,6 +1010,9 @@ fn descend_allowlist_matches(suffix: &[Component<'_>]) -> bool {
 /// pruned to avoid following trees outside the repository, and any other
 /// gitignored directory is pruned so we don't register watches on
 /// `node_modules`, build output, vendored deps, etc.
+///
+/// `gitignores` is the repository's root + global set; `.gitignore` files in
+/// directories between `repo_root` and `path` are consulted as well.
 pub fn should_watch_repo_directory(
     path: &Path,
     repo_root: &Path,
@@ -1032,9 +1039,36 @@ pub fn should_watch_repo_directory(
     !matches_gitignores(
         path,
         path.is_dir(),
-        gitignores,
+        &gitignores_for_path_in_repo(repo_root, path, gitignores),
         /* check_ancestors */ true,
     )
+}
+
+/// Extends `base` (the repository's root + global gitignores) with every `.gitignore` found in
+/// the directories strictly between `repo_root` and `path`, ordered root-first, so that `path`
+/// is matched the way git matches it. `.gitignore` files inside `path` itself are not included
+/// because they cannot ignore `path`; tree traversal picks those up when it descends.
+pub fn gitignores_for_path_in_repo(
+    repo_root: &Path,
+    path: &Path,
+    base: &[Arc<Gitignore>],
+) -> Vec<Arc<Gitignore>> {
+    let mut gitignores = base.to_vec();
+    let Ok(relative) = path.strip_prefix(repo_root) else {
+        return gitignores;
+    };
+    let Some(relative_parent) = relative.parent() else {
+        return gitignores;
+    };
+    let mut directory = repo_root.to_path_buf();
+    for component in relative_parent.components() {
+        directory.push(component);
+        let gitignore_path = directory.join(".gitignore");
+        if gitignore_path.is_file() {
+            gitignores.push(gitignore_cache::get_or_parse(&gitignore_path));
+        }
+    }
+    gitignores
 }
 
 /// Returns whether `path` is a symlink or is below one.
@@ -1071,11 +1105,8 @@ fn is_within_symlink(path: &Path, repo_root: &Path) -> bool {
 /// gitignored subtrees.
 ///
 /// `gitignores` should be the repo's root + global gitignores (as produced by
-/// [`gitignores_for_directory`]), matching `Repository::check_gitignore_status`
-/// so descend decisions and the downstream `is_ignored` tagging stay
-/// consistent. Nested per-directory `.gitignore` files are not consulted here
-/// (same limitation as the existing tagging), which can only cause us to
-/// over-watch, never to miss events.
+/// [`gitignores_for_directory`]); nested per-directory `.gitignore` files are
+/// resolved per path by [`should_watch_repo_directory`].
 #[cfg(feature = "local_fs")]
 pub fn repo_watch_filter(
     repo_root: PathBuf,

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -228,6 +228,42 @@ fn should_watch_prunes_gitignored_directory() {
     ));
 }
 
+#[test]
+fn should_watch_prunes_nested_gitignored_directory() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+    fs::create_dir_all(root.join("client/node_modules/pkg")).unwrap();
+    fs::create_dir(root.join("client/src")).unwrap();
+    // Only the nested `.gitignore` ignores `client/node_modules`; the root one is unrelated.
+    let gitignores = vec![gitignore_rooted(&root, "/dist/\n")];
+    fs::write(root.join("client/.gitignore"), "/node_modules\n").unwrap();
+
+    assert!(super::should_watch_repo_directory(
+        &root.join("client"),
+        &root,
+        &gitignores,
+        &[]
+    ));
+    assert!(super::should_watch_repo_directory(
+        &root.join("client/src"),
+        &root,
+        &gitignores,
+        &[]
+    ));
+    assert!(!super::should_watch_repo_directory(
+        &root.join("client/node_modules"),
+        &root,
+        &gitignores,
+        &[]
+    ));
+    assert!(!super::should_watch_repo_directory(
+        &root.join("client/node_modules/pkg"),
+        &root,
+        &gitignores,
+        &[]
+    ));
+}
+
 #[cfg(unix)]
 #[test]
 fn should_watch_prunes_directory_symlinks_and_their_descendants() {
@@ -593,6 +629,64 @@ fn standing_queries_report_symlinked_skills_without_materializing_symlinked_dire
         },
     );
 }
+/// Rule files under a gitignored directory (root-level or nested `.gitignore`) are not project
+/// rules, but a rule file that is itself gitignored inside a tracked directory still is.
+#[test]
+fn standing_queries_skip_rules_below_ignored_directories() {
+    virtual_fs::VirtualFS::test("standing_queries_skip_ignored_rules", |dirs, mut vfs| {
+        vfs.mkdir("repo/vendor")
+            .mkdir("repo/client/node_modules/pkg")
+            .with_files(vec![
+                virtual_fs::Stub::FileWithContent("repo/.gitignore", "/vendor/\n/WARP.md\n"),
+                virtual_fs::Stub::FileWithContent("repo/WARP.md", "personal rules"),
+                virtual_fs::Stub::FileWithContent("repo/vendor/AGENTS.md", "vendored"),
+                virtual_fs::Stub::FileWithContent("repo/client/.gitignore", "/node_modules\n"),
+                virtual_fs::Stub::FileWithContent("repo/client/AGENTS.md", "client rules"),
+                virtual_fs::Stub::FileWithContent(
+                    "repo/client/node_modules/pkg/AGENTS.md",
+                    "dependency",
+                ),
+            ]);
+        let repo = dirs.tests().join("repo");
+
+        let mut files = Vec::new();
+        let mut gitignores = Vec::new();
+        let mut results = StandingQueryResults::default();
+        // `Include` descends into ignored directories, so this exercises the recording
+        // decision itself rather than relying on ignored directories staying lazy.
+        run(Entry::build_tree_with_standing_queries(
+            &repo,
+            &mut files,
+            &mut gitignores,
+            None,
+            super::BuildTreeOptions {
+                max_depth: 200,
+                current_depth: 0,
+                ignored_path_strategy: &IgnoredPathStrategy::Include,
+                force_included_paths: &[],
+                budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
+            },
+            false,
+            &mut results,
+            &StandingQueryDefinitions::default(),
+        ))
+        .unwrap();
+
+        let rule_paths = results
+            .project_rules()
+            .map(|content| content.path.clone())
+            .collect::<Vec<_>>();
+        let standardized = |relative: &str| {
+            warp_util::standardized_path::StandardizedPath::try_from_local(&repo.join(relative))
+                .unwrap()
+        };
+        assert!(rule_paths.contains(&standardized("WARP.md")));
+        assert!(rule_paths.contains(&standardized("client/AGENTS.md")));
+        assert!(!rule_paths.contains(&standardized("vendor/AGENTS.md")));
+        assert!(!rule_paths.contains(&standardized("client/node_modules/pkg/AGENTS.md")));
+    });
+}
+
 #[test]
 fn standing_queries_do_not_report_rules_below_an_unloaded_shallow_directory() {
     virtual_fs::VirtualFS::test("standing_queries_report_shallow_rules", |dirs, mut vfs| {

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -46,7 +46,7 @@ use warp_util::standardized_path::StandardizedPath;
 use crate::entry::LAZY_LOAD_FILE_LIMIT;
 use crate::entry::{
     BudgetExceededBehavior, BuildTreeError, BuildTreeOptions, Entry, FileId, IgnoredPathStrategy,
-    matches_force_included_path,
+    gitignores_for_path_in_repo, matches_force_included_path,
 };
 use crate::repository::Repository;
 use crate::standing_queries::{
@@ -628,6 +628,7 @@ impl LocalRepoMetadataModel {
         for (repo_path, repo_scoped_update) in repo_updates {
             if let Some(IndexedRepoState::Indexed(state)) = self.repositories.get(&repo_path) {
                 let repo_path_clone = repo_path.clone();
+                let repo_root = repo_path.to_local_path_lossy();
                 let gitignores_clone = state.gitignores.clone();
                 let force_included_paths = self.force_included_paths.clone();
                 let standing_query_definitions = self.standing_query_definitions.clone();
@@ -639,6 +640,7 @@ impl LocalRepoMetadataModel {
                     async move {
                         let (mutations, standing_results, removed_roots) =
                             Self::compute_file_tree_mutations(
+                                &repo_root,
                                 &repo_scoped_update,
                                 &gitignores_clone,
                                 &force_included_paths,
@@ -1477,10 +1479,14 @@ impl LocalRepoMetadataModel {
         let Some(IndexedRepoState::Indexed(state)) = self.repositories.get(repo_root) else {
             return false;
         };
-        let Some(local) = dir_path.to_local_path() else {
+        let (Some(local_root), Some(local)) = (repo_root.to_local_path(), dir_path.to_local_path())
+        else {
             return false;
         };
-        Self::path_is_ignored(&local, &state.gitignores)
+        Self::path_is_ignored(
+            &local,
+            &gitignores_for_path_in_repo(&local_root, &local, &state.gitignores),
+        )
     }
 
     /// Checks whether the parent directory of `path` is loaded in the given entry.
@@ -1497,11 +1503,16 @@ impl LocalRepoMetadataModel {
     /// gitignore checks) and returns a lightweight list of mutations that can
     /// be applied to the tree on the main thread without cloning it.
     ///
+    /// `gitignores` is the repository's root + global set; `.gitignore` files
+    /// in directories between `repo_root` and each changed path are consulted
+    /// as well.
+    ///
     /// When `lazy_load` is true (lazy non-git roots), newly added directories
     /// are emitted as unloaded placeholders rather than fully-materialized
     /// subtrees, matching the lazy tree model; the directory is materialized
     /// (and watched) on demand when the user expands it via `load_directory`.
     async fn compute_file_tree_mutations(
+        repo_root: &Path,
         update: &RepoUpdate,
         gitignores: &[Arc<Gitignore>],
         force_included_paths: &[PathBuf],
@@ -1536,7 +1547,8 @@ impl LocalRepoMetadataModel {
                 continue;
             }
 
-            let is_ignored = Self::path_is_ignored(path_to_add, gitignores);
+            let gitignores = gitignores_for_path_in_repo(repo_root, path_to_add, gitignores);
+            let is_ignored = Self::path_is_ignored(path_to_add, &gitignores);
 
             if path_to_add.is_dir() {
                 if lazy_load {
@@ -1560,7 +1572,7 @@ impl LocalRepoMetadataModel {
                 }
 
                 let mut files = Vec::new();
-                let mut gitignores = gitignores.to_owned();
+                let mut gitignores = gitignores;
                 let mut file_limit = MAX_FILES_PER_REPO;
                 match Entry::build_tree_with_standing_queries(
                     path_to_add,
@@ -1608,7 +1620,15 @@ impl LocalRepoMetadataModel {
                     }
                 }
             } else {
-                standing_results.record_path(path_to_add, false, standing_query_definitions);
+                let ancestor_is_ignored = path_to_add
+                    .parent()
+                    .is_some_and(|parent| Self::path_is_ignored(parent, &gitignores));
+                standing_results.record_path(
+                    path_to_add,
+                    false,
+                    ancestor_is_ignored,
+                    standing_query_definitions,
+                );
                 let extension = path_to_add
                     .extension()
                     .and_then(|ext| ext.to_str().map(|s| s.to_owned()));

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -1377,6 +1377,7 @@ fn test_update_file_tree_entry_respects_gitignore() {
         // Compute mutations on the "background thread" then apply on the "main thread".
         let standing_query_definitions = Default::default();
         let (mutations, _, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+            repo_path,
             &update,
             &gitignores,
             &[],
@@ -1877,6 +1878,7 @@ fn added_symlinked_skill_directory_refreshes_provider_without_canonical_tree_mut
         };
         let (mutations, discovered, removed_roots) =
             block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &repo,
                 &update,
                 &[],
                 &[],
@@ -1919,6 +1921,7 @@ fn unrelated_skill_support_file_does_not_refresh_project_skills() {
             ..Default::default()
         };
         let (_, discovered, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+            &repo,
             &update,
             &[],
             &[],
@@ -1930,11 +1933,66 @@ fn unrelated_skill_support_file_does_not_refresh_project_skills() {
     });
 }
 
+/// A watcher event for a rule file created under a directory that only a nested `.gitignore`
+/// ignores (e.g. `yarn install` populating `client/node_modules`) must not surface a project
+/// rule, and the ignored directory itself stays an unloaded placeholder.
+#[test]
+fn watcher_added_rule_below_nested_gitignored_directory_is_not_recorded() {
+    VirtualFS::test("watcher_nested_gitignored_rule", |dirs, mut vfs| {
+        vfs.mkdir("repo/client/node_modules/pkg").with_files(vec![
+            Stub::FileWithContent("repo/.gitignore", "/dist/\n"),
+            Stub::FileWithContent("repo/client/.gitignore", "/node_modules\n"),
+            Stub::FileWithContent("repo/client/AGENTS.md", "client rules"),
+            Stub::FileWithContent("repo/client/node_modules/pkg/AGENTS.md", "dependency"),
+        ]);
+        let repo = dirs.tests().join("repo");
+        let pkg_dir = repo.join("client/node_modules/pkg");
+        let dependency_rule = pkg_dir.join("AGENTS.md");
+        let client_rule = repo.join("client/AGENTS.md");
+
+        let gitignores = crate::gitignores_for_directory(&repo);
+        let definitions = StandingQueryDefinitions::default();
+        let update = RepoUpdate {
+            added: vec![
+                pkg_dir.clone(),
+                dependency_rule.clone(),
+                client_rule.clone(),
+            ],
+            ..Default::default()
+        };
+        let (mutations, discovered, _) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &repo,
+                &update,
+                &gitignores,
+                &[],
+                &definitions,
+                false,
+            ));
+
+        let rule_paths = discovered
+            .project_rules()
+            .map(|content| content.path.clone())
+            .collect::<Vec<_>>();
+        assert!(rule_paths.contains(&StandardizedPath::try_from_local(&client_rule).unwrap()));
+        assert!(!rule_paths.contains(&StandardizedPath::try_from_local(&dependency_rule).unwrap()));
+
+        assert!(
+            mutations.iter().any(|mutation| matches!(
+                mutation,
+                FileTreeMutation::AddUnloadedDirectory { path, is_ignored: true } if path == &pkg_dir
+            )),
+            "nested-gitignored directory should be an ignored placeholder, got {mutations:?}"
+        );
+    });
+}
+
 #[test]
 fn removed_direct_skill_child_refreshes_provider_for_possible_symlink_removal() {
     VirtualFS::test("removed_direct_skill_child", |dirs, mut vfs| {
         vfs.mkdir("repo/.agents/skills");
-        let provider = dirs.tests().join("repo/.agents/skills");
+        let repo = dirs.tests().join("repo");
+        let provider = repo.join(".agents/skills");
 
         let mut definitions = StandingQueryDefinitions::default();
         definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
@@ -1943,6 +2001,7 @@ fn removed_direct_skill_child_refreshes_provider_for_possible_symlink_removal() 
             ..Default::default()
         };
         let (_, discovered, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+            &repo,
             &update,
             &[],
             &[],
@@ -3165,6 +3224,7 @@ fn incremental_force_included_dir_under_ignored_parent_matches_initial_index() {
             };
             let (mutations, _standing_results, _removed) =
                 block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                    &repo_local,
                     &update,
                     &gitignores,
                     &force_included,
@@ -3245,6 +3305,7 @@ fn incremental_deep_event_under_unloaded_ignored_dir_is_collapsed() {
             };
             let (mutations, _standing_results, _removed) =
                 block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                    &repo_local,
                     &update,
                     &gitignores,
                     &[], /* force_included_paths */
@@ -3324,6 +3385,7 @@ fn incremental_event_under_expanded_ignored_dir_keeps_it_loaded() {
             };
             let (mutations, _standing_results, _removed) =
                 block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                    &repo_local,
                     &update,
                     &gitignores,
                     &[], /* force_included_paths */
@@ -3634,6 +3696,7 @@ fn lazy_root_created_directory_inserted_as_placeholder() {
         // subtree is not materialized.
         let mut lazy_root = make_root();
         let (lazy_mutations, _, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+            repo_path,
             &update,
             &[],
             &[],
@@ -3663,6 +3726,7 @@ fn lazy_root_created_directory_inserted_as_placeholder() {
         let mut eager_root = make_root();
         let (eager_mutations, _, _) =
             block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                repo_path,
                 &update,
                 &[],
                 &[],

--- a/crates/repo_metadata/src/standing_queries.rs
+++ b/crates/repo_metadata/src/standing_queries.rs
@@ -111,6 +111,7 @@ impl StandingQueryResults {
         &mut self,
         path: &Path,
         is_directory: bool,
+        ancestor_is_ignored: bool,
         definitions: &StandingQueryDefinitions,
     ) {
         let standardized = StandardizedPath::from_local_absolute_unchecked(path);
@@ -122,7 +123,10 @@ impl StandingQueryResults {
             self.project_skills
                 .insert(StandingQueryContent::file(standardized.clone()));
         }
-        if !is_directory && definitions.is_project_rule_file(path) {
+        // Rules under gitignored directories (e.g. `node_modules`) aren't project guidance, but a
+        // directly-ignored rule file in a tracked directory may be a personal rule, so keep it.
+        // Skills are exempt: provider directories like `.agents/skills` are gitignored by design.
+        if !is_directory && !ancestor_is_ignored && definitions.is_project_rule_file(path) {
             self.project_rules
                 .insert(StandingQueryContent::file(standardized));
         }
@@ -156,7 +160,7 @@ impl StandingQueryResults {
 
         let skill_file = path.join("SKILL.md");
         if skill_file.is_file() {
-            self.record_path(&skill_file, false, definitions);
+            self.record_path(&skill_file, false, false, definitions);
         }
     }
     pub fn insert_project_skill(&mut self, content: StandingQueryContent) {

--- a/crates/repo_metadata/src/standing_queries_tests.rs
+++ b/crates/repo_metadata/src/standing_queries_tests.rs
@@ -24,10 +24,10 @@ fn records_provider_skill_files_and_project_rules() {
     let root_rule = repo_path("WARP.md");
     let nested_rule = repo_path("packages/api/AGENTS.md");
 
-    results.record_path(&skills_provider, true, &definitions);
-    results.record_path(&skill_file, false, &definitions);
-    results.record_path(&root_rule, false, &definitions);
-    results.record_path(&nested_rule, false, &definitions);
+    results.record_path(&skills_provider, true, false, &definitions);
+    results.record_path(&skill_file, false, false, &definitions);
+    results.record_path(&root_rule, false, false, &definitions);
+    results.record_path(&nested_rule, false, false, &definitions);
 
     assert!(
         results
@@ -84,9 +84,27 @@ fn support_file_beneath_skill_does_not_synthesize_provider_update() {
     let mut results = StandingQueryResults::default();
     let support_file = repo_path(".agents/skills/review/README.md");
 
-    results.record_path(&support_file, false, &definitions);
+    results.record_path(&support_file, false, false, &definitions);
 
     assert!(results.project_skills().next().is_none());
+}
+
+#[test]
+fn rule_below_ignored_ancestor_is_not_recorded_but_skill_is() {
+    let definitions = definitions();
+    let mut results = StandingQueryResults::default();
+    let vendored_rule = repo_path("node_modules/pkg/AGENTS.md");
+    let ignored_skill = repo_path(".agents/skills/review/SKILL.md");
+
+    results.record_path(&vendored_rule, false, true, &definitions);
+    results.record_path(&ignored_skill, false, true, &definitions);
+
+    assert!(results.project_rules().next().is_none());
+    assert!(
+        results
+            .project_skills()
+            .any(|content| content == &StandingQueryContent::file(standardized(&ignored_skill)))
+    );
 }
 
 /// Emulates the open `AGENTS.md` discovery contract that non-Warp agents follow:


### PR DESCRIPTION
## Description
Rule files (`WARP.md` / `AGENTS.md`) under gitignored directories are no longer discovered as project rules.

Motivation: in a factory run, `yarn install` created `client/node_modules/recharts/AGENTS.md`. It showed up in `available_rules`, which rewrote the first prompt message and invalidated ~200k cached tokens on every later turn.

Two parts:

1. **Rule recording respects gitignore.** Rules under a gitignored *ancestor* are skipped. Rules that are only *directly* gitignored (e.g. a personal `WARP.md`) are kept. Skills are exempt since `.agents/skills` etc. are gitignored by design.
2. **Nested `.gitignore` files are honored on the watcher path.** Only root + global gitignores were consulted before, so `client/node_modules` (ignored by `client/.gitignore`) looked tracked. A new helper resolves the gitignores between repo root and a path; the watcher update, the Linux descend filter, and on-demand subdir watches use it. Side effect: `yarn install` no longer registers inotify watches across `node_modules`.

## Testing
`cargo nextest run -p repo_metadata`: 145 passed, including four new tests. Clippy and fmt clean.

- [x] I have manually tested my changes locally with `./script/run` (covered by unit tests)
  - Ran locally and verified that project rules under node modules aren't included

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- Conversation: https://staging.warp.dev/conversation/01d5341a-30e2-405a-b892-a6cae78c016c -->

CHANGELOG-BUG-FIX: Rule files (`WARP.md`/`AGENTS.md`) inside gitignored directories such as `node_modules` are no longer picked up as project rules.
