### PR TITLE
Fix crash when promoting an end-of-line cell to a wide char.

### DIFF
--- a/crates/warp_terminal/src/model/grid/ansi_handler.rs
+++ b/crates/warp_terminal/src/model/grid/ansi_handler.rs
@@ -8,9 +8,9 @@ mod tab_stops;
 
 use std::cmp::min;
 use std::collections::HashMap;
-use std::io;
 use std::ops::Range;
 use std::sync::Arc;
+use std::{io, mem};
 
 use base64::Engine as _;
 use bounded_vec_deque::BoundedVecDeque;
@@ -211,13 +211,6 @@ impl ansi::Handler for GridHandler {
             if self.grid[row][col].flags.contains(Flags::WIDE_CHAR_SPACER) {
                 col = col.saturating_sub(1);
             }
-            let original_cell = if col + 1 == num_cols
-                && !self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP)
-            {
-                Some(self.grid[row][col].clone())
-            } else {
-                None
-            };
 
             let old_cell_content_width = match self.grid[row][col].raw_content() {
                 CharOrStr::Str(s) => s.width(),
@@ -229,7 +222,11 @@ impl ansi::Handler for GridHandler {
                 },
             };
 
-            self.grid[row][col].push_zerowidth(c, /* log_long_grapheme_warnings */ true);
+            // A rejected append cannot change the cell's width, so there is no structural work to do.
+            if !self.grid[row][col].push_zerowidth(c, /* log_long_grapheme_warnings */ true) {
+                return;
+            }
+
             let cell_content_width = match self.grid[row][col].raw_content() {
                 CharOrStr::Str(s) => s.width(),
                 // Note that we should never reach here since we are pushing a zerowidth character,
@@ -250,7 +247,16 @@ impl ansi::Handler for GridHandler {
                 && cell_content_width == 2
                 && self.ansi_handler_state.supports_emoji_presentation_selector
             {
-                let mut wide_cell = self.grid[row][col].clone();
+                let mut wide_cell = mem::take(&mut self.grid[row][col]);
+                if col + 1 == num_cols
+                    && !self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP)
+                {
+                    // Remove the selector rather than leave a wide grapheme without room for its spacer.
+                    let popped = wide_cell.pop_zerowidth();
+                    debug_assert_eq!(popped, Some(c));
+                    self.grid[row][col] = wide_cell;
+                    return;
+                }
                 wide_cell.flags.remove(
                     Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER | Flags::WRAPLINE,
                 );
@@ -259,10 +265,7 @@ impl ansi::Handler for GridHandler {
                 self.update_cursor(|cursor| {
                     cursor.point.col = col;
                 });
-                if !self.write_wide_char(base_char, |cell| *cell = wide_cell) {
-                    self.grid[row][col] =
-                        original_cell.expect("rejected promotion should have an original cell");
-                }
+                self.write_wide_char(base_char, |cell| *cell = wide_cell);
             }
             return;
         }
@@ -1484,14 +1487,14 @@ impl GridHandler {
         });
     }
 
-    fn write_wide_char(&mut self, c: char, update_wide_cell: impl FnOnce(&mut Cell)) -> bool {
+    fn write_wide_char(&mut self, c: char, update_wide_cell: impl FnOnce(&mut Cell)) {
         let num_cols = self.columns();
         if self.grid.cursor().point.col + 1 >= num_cols {
             if !self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP) {
                 self.move_cursor_forward(|cursor| {
                     cursor.input_needs_wrap = true;
                 });
-                return false;
+                return;
             }
 
             let leading_spacer = self.write_at_cursor(cell::DEFAULT_CHAR);
@@ -1514,7 +1517,6 @@ impl GridHandler {
         spacer.flags.insert(Flags::WIDE_CHAR_SPACER);
         spacer.set_hyperlink_id(hyperlink_id);
         self.advance_cursor_by_one_cell();
-        true
     }
 
     /// Insert a linebreak at the current cursor position.

--- a/crates/warp_terminal/src/model/grid/ansi_handler.rs
+++ b/crates/warp_terminal/src/model/grid/ansi_handler.rs
@@ -211,6 +211,23 @@ impl ansi::Handler for GridHandler {
             if self.grid[row][col].flags.contains(Flags::WIDE_CHAR_SPACER) {
                 col = col.saturating_sub(1);
             }
+            let original_cell = if col + 1 == num_cols
+                && !self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP)
+            {
+                Some(self.grid[row][col].clone())
+            } else {
+                None
+            };
+
+            let old_cell_content_width = match self.grid[row][col].raw_content() {
+                CharOrStr::Str(s) => s.width(),
+                CharOrStr::Char(c) => match c.width() {
+                    Some(width) => width,
+                    None => {
+                        return;
+                    }
+                },
+            };
 
             self.grid[row][col].push_zerowidth(c, /* log_long_grapheme_warnings */ true);
             let cell_content_width = match self.grid[row][col].raw_content() {
@@ -229,19 +246,23 @@ impl ansi::Handler for GridHandler {
             // Bash and Fish support emoji variation selectors, but Zsh does not in bracketed paste
             // mode. Specifically, this references sequences such as \0x2601\0xFE0F (☁️),
             // which are commonly used in prompts e.g. GCloud prompt chip in Starship.
-            if cell_content_width == 2
+            if old_cell_content_width != cell_content_width
+                && cell_content_width == 2
                 && self.ansi_handler_state.supports_emoji_presentation_selector
             {
-                // Current cursor cell contains a wide character (double-width).
-                self.grid[row][col].flags.insert(Flags::WIDE_CHAR);
+                let mut wide_cell = self.grid[row][col].clone();
+                wide_cell.flags.remove(
+                    Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER | Flags::WRAPLINE,
+                );
+                let base_char = wide_cell.c;
 
-                // Insert spacer at the next cell.
-                self.write_at_cursor(cell::DEFAULT_CHAR)
-                    .flags
-                    .insert(Flags::WIDE_CHAR_SPACER);
-
-                // Update cursor appropriately before early-return.
-                self.advance_cursor_by_one_cell();
+                self.update_cursor(|cursor| {
+                    cursor.point.col = col;
+                });
+                if !self.write_wide_char(base_char, |cell| *cell = wide_cell) {
+                    self.grid[row][col] =
+                        original_cell.expect("rejected promotion should have an original cell");
+                }
             }
             return;
         }
@@ -279,37 +300,10 @@ impl ansi::Handler for GridHandler {
 
         if width == 1 {
             self.write_at_cursor(c);
+            self.advance_cursor_by_one_cell();
         } else {
-            if self.grid.cursor().point.col + 1 >= num_cols {
-                if self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP) {
-                    // Insert placeholder before wide char if glyph does not fit in this row.
-                    self.write_at_cursor(cell::DEFAULT_CHAR)
-                        .flags
-                        .insert(Flags::LEADING_WIDE_CHAR_SPACER);
-                    self.wrapline();
-                } else {
-                    // Prevent out of bounds crash when linewrapping is disabled.
-                    self.move_cursor_forward(|cursor| {
-                        cursor.input_needs_wrap = true;
-                    });
-                    return;
-                }
-            }
-
-            // Write full width glyph to current cursor cell.
-            self.write_at_cursor(c).flags.insert(Flags::WIDE_CHAR);
-
-            // Write spacer to cell following the wide glyph.
-            self.move_cursor_forward(|cursor| {
-                cursor.point.col += 1;
-            });
-
-            self.write_at_cursor(cell::DEFAULT_CHAR)
-                .flags
-                .insert(Flags::WIDE_CHAR_SPACER);
+            self.write_wide_char(c, |_| {});
         }
-
-        self.advance_cursor_by_one_cell();
     }
 
     fn goto(&mut self, row: VisibleRow, column: usize) {
@@ -1488,6 +1482,39 @@ impl GridHandler {
                 cursor.input_needs_wrap = true;
             }
         });
+    }
+
+    fn write_wide_char(&mut self, c: char, update_wide_cell: impl FnOnce(&mut Cell)) -> bool {
+        let num_cols = self.columns();
+        if self.grid.cursor().point.col + 1 >= num_cols {
+            if !self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP) {
+                self.move_cursor_forward(|cursor| {
+                    cursor.input_needs_wrap = true;
+                });
+                return false;
+            }
+
+            let leading_spacer = self.write_at_cursor(cell::DEFAULT_CHAR);
+            leading_spacer.flags.insert(Flags::LEADING_WIDE_CHAR_SPACER);
+            leading_spacer.set_hyperlink_id(None);
+            self.wrapline();
+        }
+
+        let hyperlink_id = {
+            let wide_cell = self.write_at_cursor(c);
+            update_wide_cell(wide_cell);
+            wide_cell.flags.insert(Flags::WIDE_CHAR);
+            wide_cell.hyperlink_id()
+        };
+
+        self.move_cursor_forward(|cursor| {
+            cursor.point.col += 1;
+        });
+        let spacer = self.write_at_cursor(cell::DEFAULT_CHAR);
+        spacer.flags.insert(Flags::WIDE_CHAR_SPACER);
+        spacer.set_hyperlink_id(hyperlink_id);
+        self.advance_cursor_by_one_cell();
+        true
     }
 
     /// Insert a linebreak at the current cursor position.

--- a/crates/warp_terminal/src/model/grid/cell.rs
+++ b/crates/warp_terminal/src/model/grid/cell.rs
@@ -210,8 +210,43 @@ impl Cell {
     /// a row from flat scrollback storage, where the stored content was
     /// already capped on the way in) should pass `false` to suppress
     /// that redundant warning.
+    ///
+    /// Returns whether the character was appended. A return value of
+    /// `false` means that the grapheme was already at the size cap and the
+    /// cell was not changed.
     #[inline]
-    pub fn push_zerowidth(&mut self, c: char, log_long_grapheme_warnings: bool) {
+    pub fn push_zerowidth(&mut self, c: char, log_long_grapheme_warnings: bool) -> bool {
+        if let Some(zerowidth) = self
+            .extra
+            .as_deref_mut()
+            .and_then(|extra| extra.cell_with_zero_width.as_mut())
+        {
+            let old_len = zerowidth.len();
+            let new_len = old_len + c.len_utf8();
+            if new_len > MAX_GRAPHEME_BYTES {
+                // The accumulated grapheme cluster would exceed our
+                // per-cell cap, which is in turn well below the
+                // scrollback chunk size.  Silently drop additional
+                // zero-width characters: logging every dropped
+                // character would produce a flood of spam for
+                // pathological streams.
+                return false;
+            }
+            zerowidth.push(c);
+            // Log exactly once, on the push that first takes this cell
+            // across the soft threshold.  This surfaces unusually-large
+            // graphemes in logs without producing per-character spam.
+            if log_long_grapheme_warnings
+                && old_len < WARN_GRAPHEME_BYTES
+                && new_len >= WARN_GRAPHEME_BYTES
+            {
+                log::warn!(
+                    "cell grapheme has accumulated {new_len} bytes of zero-width content (base char {:?}); further zero-width pushes beyond {MAX_GRAPHEME_BYTES} bytes will be dropped",
+                    self.c,
+                );
+            }
+            return true;
+        }
         // If we're adding a zero-width character to this cell, but it has not
         // had any content set yet, set the content to a space.  This preserves
         // its visual appearance, but clearly marks the cell as having been
@@ -221,40 +256,34 @@ impl Cell {
         }
 
         let extra = self.extra.get_or_insert_with(Box::default);
-        match &mut extra.cell_with_zero_width {
-            Some(zerowidth) => {
-                let old_len = zerowidth.len();
-                let new_len = old_len + c.len_utf8();
-                if new_len > MAX_GRAPHEME_BYTES {
-                    // The accumulated grapheme cluster would exceed our
-                    // per-cell cap, which is in turn well below the
-                    // scrollback chunk size.  Silently drop additional
-                    // zero-width characters: logging every dropped
-                    // character would produce a flood of spam for
-                    // pathological streams.
-                    return;
-                }
-                zerowidth.push(c);
-                // Log exactly once, on the push that first takes this cell
-                // across the soft threshold.  This surfaces unusually-large
-                // graphemes in logs without producing per-character spam.
-                if log_long_grapheme_warnings
-                    && old_len < WARN_GRAPHEME_BYTES
-                    && new_len >= WARN_GRAPHEME_BYTES
-                {
-                    log::warn!(
-                        "cell grapheme has accumulated {new_len} bytes of zero-width content (base char {:?}); further zero-width pushes beyond {MAX_GRAPHEME_BYTES} bytes will be dropped",
-                        self.c,
-                    );
-                }
-            }
-            None => {
-                // First zero-width push seeds the string with the base
-                // character.  The base character is always a single `char`,
-                // so it cannot by itself exceed the cap.
-                extra.cell_with_zero_width = Some(format!("{}{}", self.c, c));
-            }
+        // The first zero-width push seeds the string with the base
+        // character.  The base character is always a single `char`, so it
+        // cannot by itself exceed the cap.
+        extra.cell_with_zero_width = Some(format!("{}{}", self.c, c));
+        true
+    }
+
+    /// Removes and returns the most recently appended zero-width character.
+    #[inline]
+    pub fn pop_zerowidth(&mut self) -> Option<char> {
+        let base_char_len = self.c.len_utf8();
+        let extra = self.extra.as_deref_mut()?;
+        let content = extra.cell_with_zero_width.as_mut()?;
+        if content.len() <= base_char_len {
+            return None;
         }
+
+        let popped = content.pop();
+        if content.len() == base_char_len {
+            extra.cell_with_zero_width = None;
+        }
+        let extra_is_empty = extra.cell_with_zero_width.is_none()
+            && extra.end_of_prompt.is_none()
+            && extra.hyperlink_id.is_none();
+        if extra_is_empty {
+            self.extra = None;
+        }
+        popped
     }
 
     /// Returns whether cell is the end of prompt content (contains `EndOfPromptMarker`).

--- a/crates/warp_terminal/src/model/grid/cell_tests.rs
+++ b/crates/warp_terminal/src/model/grid/cell_tests.rs
@@ -58,9 +58,11 @@ fn push_zerowidth_caps_accumulated_grapheme() {
     let zwj = '\u{200D}';
     let zwj_bytes = zwj.len_utf8();
     let pushes = (MAX_GRAPHEME_BYTES * 10) / zwj_bytes;
+    let mut rejected_push = false;
     for _ in 0..pushes {
-        cell.push_zerowidth(zwj, /* log_long_grapheme_warnings */ true);
+        rejected_push |= !cell.push_zerowidth(zwj, /* log_long_grapheme_warnings */ true);
     }
+    assert!(rejected_push);
 
     let CharOrStr::Str(content) = cell.raw_content() else {
         panic!("cell should have accumulated zero-width content as a string");
@@ -99,4 +101,23 @@ fn push_zerowidth_seeds_base_char_on_first_push() {
 
     cell.push_zerowidth('\u{0301}', /* log_long_grapheme_warnings */ true);
     assert_eq!(cell.raw_content(), CharOrStr::Str("x\u{0301}"));
+}
+
+#[test]
+fn pop_zerowidth_restores_previous_cell_content() {
+    let mut cell = Cell {
+        c: 'x',
+        ..Cell::default()
+    };
+    let original_cell = cell.clone();
+
+    assert!(cell.push_zerowidth('\u{0301}', /* log_long_grapheme_warnings */ true));
+    let cell_with_first_zerowidth = cell.clone();
+    assert!(cell.push_zerowidth('\u{200D}', /* log_long_grapheme_warnings */ true));
+
+    assert_eq!(cell.pop_zerowidth(), Some('\u{200D}'));
+    assert_eq!(cell, cell_with_first_zerowidth);
+    assert_eq!(cell.pop_zerowidth(), Some('\u{0301}'));
+    assert_eq!(cell, original_cell);
+    assert_eq!(cell.pop_zerowidth(), None);
 }

--- a/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
@@ -111,7 +111,9 @@ impl Iterator for RowIterator<'_> {
             // first seen on the ANSI-input path, so a warning here would
             // be redundant and would fire every time a row is
             // rematerialized (e.g. on scroll or resize).
-            chars.for_each(|c| cell.push_zerowidth(c, /* log_long_grapheme_warnings */ false));
+            chars.for_each(|c| {
+                cell.push_zerowidth(c, /* log_long_grapheme_warnings */ false);
+            });
 
             cell.fg = fg;
             cell.bg = bg;

--- a/crates/warp_terminal/src/model/grid/flat_storage/testing.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/testing.rs
@@ -122,7 +122,9 @@ impl ToRows for &str {
             cell.c = chars.next().unwrap();
             // Add any remaining chars in the grapheme to the cell as zero-width
             // characters.
-            chars.for_each(|c| cell.push_zerowidth(c, /* log_long_grapheme_warnings */ true));
+            chars.for_each(|c| {
+                cell.push_zerowidth(c, /* log_long_grapheme_warnings */ true);
+            });
 
             // If the grapheme takes up two cells, mark the following cell as
             // a spacer.

--- a/crates/warp_terminal/src/model/grid/grid_handler_tests.rs
+++ b/crates/warp_terminal/src/model/grid/grid_handler_tests.rs
@@ -1505,6 +1505,130 @@ fn test_emoji_variation_selector() {
 }
 
 #[test]
+fn emoji_variation_selector_wraps_width_promotion_at_last_column() {
+    let mut grid = GridHandler::new_for_test(2, 4);
+    grid.input('a');
+    grid.input('b');
+    grid.input('c');
+    grid.input('\u{26A0}');
+
+    grid.input('\u{FE0F}');
+
+    let storage = grid.grid_storage();
+    assert_eq!(storage[VisibleRow(0)][3].c, '\0');
+    assert!(
+        storage[VisibleRow(0)][3]
+            .flags
+            .contains(Flags::LEADING_WIDE_CHAR_SPACER)
+    );
+    assert!(storage[VisibleRow(0)][3].flags.contains(Flags::WRAPLINE));
+    assert!(matches!(
+        storage[VisibleRow(1)][0].content_for_display(),
+        CharOrStr::Str("⚠️")
+    ));
+    assert!(storage[VisibleRow(1)][0].flags.contains(Flags::WIDE_CHAR));
+    assert!(
+        storage[VisibleRow(1)][1]
+            .flags
+            .contains(Flags::WIDE_CHAR_SPACER)
+    );
+    assert_eq!(grid.cursor_point(), Point::new(1, 2));
+}
+
+#[test]
+fn emoji_variation_selector_drops_width_promotion_when_line_wrap_is_disabled() {
+    let mut grid = GridHandler::new_for_test(2, 4);
+    grid.unset_mode(ansi::Mode::LineWrap);
+    grid.input('a');
+    grid.input('b');
+    grid.input('c');
+    grid.input('\u{26A0}');
+
+    grid.input('\u{FE0F}');
+
+    let storage = grid.grid_storage();
+    assert!(matches!(
+        storage[VisibleRow(0)][3].content_for_display(),
+        CharOrStr::Char('⚠')
+    ));
+    assert!(
+        !storage[VisibleRow(0)][3].flags.intersects(
+            Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER
+        )
+    );
+    assert_eq!(grid.cursor_point(), Point::new(0, 3));
+}
+
+#[test]
+fn emoji_variation_selector_does_not_advance_already_wide_grapheme() {
+    let mut grid = GridHandler::new_for_test(2, 6);
+    grid.input('😀');
+
+    grid.input('\u{FE0F}');
+    grid.input('x');
+
+    let storage = grid.grid_storage();
+    assert!(matches!(
+        storage[VisibleRow(0)][0].content_for_display(),
+        CharOrStr::Str("😀️")
+    ));
+    assert!(storage[VisibleRow(0)][0].flags.contains(Flags::WIDE_CHAR));
+    assert!(
+        storage[VisibleRow(0)][1]
+            .flags
+            .contains(Flags::WIDE_CHAR_SPACER)
+    );
+    assert_eq!(storage[VisibleRow(0)][2].c, 'x');
+    assert!(
+        !storage[VisibleRow(0)][2]
+            .flags
+            .contains(Flags::WIDE_CHAR_SPACER)
+    );
+    assert_eq!(grid.cursor_point(), Point::new(0, 3));
+}
+
+#[test]
+fn wide_character_spacers_inherit_the_base_cell_hyperlink() {
+    let mut grid = GridHandler::new_for_test(2, 8);
+    input_hyperlinked(&mut grid, "https://wide.example.com", "😀");
+    input_hyperlinked(&mut grid, "https://promoted.example.com", "\u{26A0}");
+
+    grid.input('\u{FE0F}');
+
+    let storage = grid.grid_storage();
+    let wide_hyperlink_id = storage[VisibleRow(0)][0]
+        .hyperlink_id()
+        .expect("wide character should have a hyperlink");
+    assert_eq!(
+        storage[VisibleRow(0)][1].hyperlink_id(),
+        Some(wide_hyperlink_id)
+    );
+
+    let promoted_hyperlink_id = storage[VisibleRow(0)][2]
+        .hyperlink_id()
+        .expect("promoted character should have a hyperlink");
+    assert_ne!(wide_hyperlink_id, promoted_hyperlink_id);
+    assert_eq!(
+        storage[VisibleRow(0)][3].hyperlink_id(),
+        Some(promoted_hyperlink_id)
+    );
+}
+
+#[test]
+fn leading_wide_character_spacer_is_not_hyperlinked() {
+    let mut grid = GridHandler::new_for_test(2, 2);
+    grid.input('a');
+    input_hyperlinked(&mut grid, "https://example.com", "😀");
+
+    let storage = grid.grid_storage();
+    assert_eq!(storage[VisibleRow(0)][1].hyperlink_id(), None);
+    let hyperlink_id = storage[VisibleRow(1)][0]
+        .hyperlink_id()
+        .expect("wide character should have a hyperlink");
+    assert_eq!(storage[VisibleRow(1)][1].hyperlink_id(), Some(hyperlink_id));
+}
+
+#[test]
 pub fn test_grid_agnostic_point() {
     let mut grid = mock_blockgrid(
         "\


### PR DESCRIPTION
## Description
Fixes a terminal-grid invariant violation that could crash background processing after a variation selector changed a grapheme from one cell wide to two cells wide at the end of a row.

The zero-width input path previously applied the normal interior promotion logic even when no cell remained for the wide-character spacer. This could create inconsistent wide-character metadata that later caused `FlatStorage` row reconstruction to access a cell past the end of the row.

This change:
- Applies wide-character layout only when a zero-width character changes the grapheme width.
- Uses one helper for normal wide-character writes and width promotion, including wrapping, spacer creation, hyperlink propagation, and cursor advancement.
- Moves an end-of-row promoted grapheme to the next row when line wrapping is enabled.
- Removes the new selector and keeps the original narrow grapheme when line wrapping is disabled.
- Makes zero-width appends reversible without cloning the cell.
- Avoids inserting a second spacer when a selector is added to an already-wide grapheme.

## Linked Issue
Fixes #15753.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots or video are not applicable because this is an internal grid-invariant fix without a manual reproduction.

## Testing
- Added regression tests for end-of-row width promotion, disabled line wrapping, already-wide graphemes, wide-character hyperlink propagation, and leading spacer hyperlinks.
- Added unit coverage for accepted and rejected zero-width appends and exact rollback behavior.
- `cargo nextest run -p warp_terminal -E 'test(push_zerowidth) | test(pop_zerowidth) | test(emoji_variation_selector) | test(wide_character_spacers_inherit_the_base_cell_hyperlink) | test(leading_wide_character_spacer_is_not_hyperlinked)'`
- `cargo check -p warp_terminal`
- `./script/format --check`
- `git diff --check`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode ([conversation](https://staging.warp.dev/conversation/89071654-e400-4748-8726-0f0b3f9a3c5f))

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed a crash when a character at the end of a terminal line changes from single-width to double-width.

Co-Authored-By: Warp <agent@warp.dev>