### PR TITLE
Make Create New Window an editable keybinding

### DIFF
--- a/app/src/app_menus.rs
+++ b/app/src/app_menus.rs
@@ -983,7 +983,17 @@ fn make_new_elements_menu_items(ctx: &AppContext) -> Vec<MenuItem> {
         MenuItem::Custom(CustomMenuItem::new(
             "New Window",
             open_new_window,
-            no_updates,
+            move |_props: &MenuItemProperties, ctx: &mut AppContext| {
+                let mut changes = MenuItemPropertyChanges::default();
+                let trigger = Trigger::Custom(CustomAction::AddWindow.into());
+                let binding = ctx
+                    .get_key_bindings()
+                    .find(|b| b.trigger == &trigger || b.original_trigger == Some(&trigger));
+                if let Some(binding) = binding {
+                    changes.keystroke = Some(bindings::trigger_to_keystroke(binding.trigger));
+                }
+                changes
+            },
             Some(Keystroke::parse("cmd-n").expect("Valid keystroke")),
         )),
         MenuItem::Custom(CustomMenuItem::new(

--- a/app/src/resource_center/utils.rs
+++ b/app/src/resource_center/utils.rs
@@ -118,11 +118,6 @@ pub const FUNDAMENTALS_KEYBINDINGS: &[&str] = &[
 pub fn get_additional_keybindings() -> Vec<CommandBinding> {
     vec![
         CommandBinding::new(
-            "workspace:new_window".into(),
-            "Open New Window".into(),
-            Some(Keystroke::parse("cmd-n").expect("Valid keystroke")),
-        ),
-        CommandBinding::new(
             "workspace:hide_warp".into(),
             "Hide Warp".into(),
             Some(Keystroke::parse("cmd-h").expect("Valid keystroke")),

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -389,8 +389,6 @@ pub fn custom_tag_to_keystroke(custom: CustomTag) -> Option<Keystroke> {
                 Keystroke::parse("ctrl-alt-t").ok()
             }
         }
-
-        // This is one of the app's hardcoded keybindings.
         CustomAction::AddWindow => Keystroke::parse(cmd_or_ctrl_shift("n")).ok(),
         CustomAction::ToggleWarpDrive => {
             if OperatingSystem::get().is_mac() {

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -67,11 +67,11 @@ use crate::workspace::view::{
     LEFT_PANEL_AGENT_CONVERSATIONS_BINDING_NAME, LEFT_PANEL_GLOBAL_SEARCH_BINDING_NAME,
     LEFT_PANEL_PROJECT_EXPLORER_BINDING_NAME, LEFT_PANEL_WARP_DRIVE_BINDING_NAME,
     NEW_AGENT_TAB_BINDING_NAME, NEW_AMBIENT_AGENT_TAB_BINDING_NAME, NEW_FILE_BINDING_NAME,
-    NEW_TAB_BINDING_NAME, NEW_TERMINAL_TAB_BINDING_NAME, OPEN_GLOBAL_SEARCH_BINDING_NAME,
-    TOGGLE_CONVERSATION_LIST_VIEW_BINDING_NAME, TOGGLE_NOTIFICATION_MAILBOX_BINDING_NAME,
-    TOGGLE_PROJECT_EXPLORER_BINDING_NAME, TOGGLE_RIGHT_PANEL_BINDING_NAME,
-    TOGGLE_TAB_CONFIGS_MENU_BINDING_NAME, TOGGLE_VERTICAL_TABS_PANEL_BINDING_NAME,
-    TOGGLE_WARP_DRIVE_BINDING_NAME,
+    NEW_TAB_BINDING_NAME, NEW_TERMINAL_TAB_BINDING_NAME, NEW_WINDOW_BINDING_NAME,
+    OPEN_GLOBAL_SEARCH_BINDING_NAME, TOGGLE_CONVERSATION_LIST_VIEW_BINDING_NAME,
+    TOGGLE_NOTIFICATION_MAILBOX_BINDING_NAME, TOGGLE_PROJECT_EXPLORER_BINDING_NAME,
+    TOGGLE_RIGHT_PANEL_BINDING_NAME, TOGGLE_TAB_CONFIGS_MENU_BINDING_NAME,
+    TOGGLE_VERTICAL_TABS_PANEL_BINDING_NAME, TOGGLE_WARP_DRIVE_BINDING_NAME,
 };
 
 pub fn init(app: &mut AppContext) {
@@ -340,14 +340,16 @@ pub fn init(app: &mut AppContext) {
             "Switch to previous tab",
             id!("Workspace") & id!("Workspace_MultipleTabs"),
         ),
-        FixedBinding::custom(
-            CustomAction::AddWindow,
-            WorkspaceAction::AddWindow,
-            "Create New Window",
-            id!("Workspace"),
-        )
-        .with_enabled(|| ContextFlag::CreateNewSession.is_enabled()),
     ]);
+
+    app.register_editable_bindings([EditableBinding::new(
+        NEW_WINDOW_BINDING_NAME,
+        BindingDescription::new("Create New Window"),
+        WorkspaceAction::AddWindow,
+    )
+    .with_custom_action(CustomAction::AddWindow)
+    .with_context_predicate(id!("Workspace"))
+    .with_enabled(|| ContextFlag::CreateNewSession.is_enabled())]);
 
     app.register_editable_bindings([EditableBinding::new(
         NEW_FILE_BINDING_NAME,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -668,6 +668,7 @@ pub(crate) const TOGGLE_CONVERSATION_LIST_VIEW_BINDING_NAME: &str =
 pub(crate) const NEW_TAB_BINDING_NAME: &str = "workspace:new_tab";
 pub(crate) const NEW_TERMINAL_TAB_BINDING_NAME: &str = "workspace:new_terminal_tab";
 pub(crate) const NEW_FILE_BINDING_NAME: &str = "workspace:new_file";
+pub(crate) const NEW_WINDOW_BINDING_NAME: &str = "workspace:new_window";
 pub(crate) const NEW_AGENT_TAB_BINDING_NAME: &str = "workspace:new_agent_tab";
 pub(crate) const NEW_AMBIENT_AGENT_TAB_BINDING_NAME: &str = "workspace:new_ambient_agent_tab";
 pub(crate) const TOGGLE_TAB_CONFIGS_MENU_BINDING_NAME: &str = "workspace:toggle_tab_configs_menu";


### PR DESCRIPTION
## Description

Create New Window is now a named editable keybinding, `workspace:new_window`, shown in Settings → Keyboard shortcuts. The default stays Cmd+N on macOS and Ctrl+Shift+N on Linux and Windows. `keybindings.yaml` can remap it or unbind it with `none`. Unbind means Warp does not run Create New Window for that keystroke; File and Dock menus still open a Window.

This matches the New File cutover: named editable binding, attached `CustomAction::AddWindow`, Workspace context, gated on CreateNewSession. The nameless fixed shortcut is removed so Unbind can work. The resource-center stub that claimed `workspace:new_window` as "Open New Window" / Cmd+N is removed; the fundamentals list still points at the real binding.

## Linked Issue

Closes #15700

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

No new automated tests, same call as New File (#12979). Existing `util::bindings::tests` still pass.

Manual: built and ran with `./script/run` on Linux. Create New Window appears in Settings → Keyboard shortcuts. Ctrl+Shift+N still opens a Window on an unmodified install. Unbind via Settings / `"workspace:new_window": none` stops the keystroke from opening a Window. File → New Window still works.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Demo on Linux (`./script/run`): Create New Window appears in Settings → Keyboard shortcuts with default Ctrl+Shift+N, unbinding stops the keystroke from opening a Window, File → New Window still works.

[warp_new_window.webm](https://github.com/user-attachments/assets/58311350-4e8c-45b6-8996-7d23393085cf)


CHANGELOG-IMPROVEMENT: Create New Window is now an editable keyboard shortcut, so it can be remapped or unbound.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->

