### PR TITLE
[Chat] Handle attribution token proto

### DIFF
--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -393,6 +393,7 @@ impl ConvertToExchanges for &api::Task {
                         user_query_mode: convert_user_query_mode(user_query.mode.as_ref()),
                         running_command: None,
                         intended_agent: Some(user_query.intended_agent()),
+                        attribution_token: None,
                     });
                     true
                 }
@@ -411,6 +412,7 @@ impl ConvertToExchanges for &api::Task {
                                 user_query_mode: UserQueryMode::default(), // SystemQuery doesn't have mode field
                                 running_command: None,
                                 intended_agent: None,
+                                attribution_token: None,
                             });
                             true
                         }

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -867,6 +867,7 @@ pub fn user_inputs_from_messages(messages: &[api::Message]) -> Vec<AIAgentInput>
                     user_query_mode: convert_user_query_mode(uq.mode.as_ref()),
                     running_command: None,
                     intended_agent: Some(uq.intended_agent()),
+                    attribution_token: None,
                 });
             }
             api::message::Message::SystemQuery(sq) => {

--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -224,6 +224,7 @@ pub(super) fn convert_input(
                                         .collect(),
                                     mode: None,
                                     intended_agent: Default::default(),
+                                    attribution_token: String::new(),
                                 }
                             }),
                         },
@@ -290,6 +291,7 @@ fn convert_input_to_user_input(
             user_query_mode,
             running_command: None,
             intended_agent,
+            attribution_token,
             ..
         } => Ok(
             api::request::input::user_inputs::user_input::Input::UserQuery(
@@ -298,6 +300,8 @@ fn convert_input_to_user_input(
                     referenced_attachments: referenced_attachments.into_iter().map(|(k, attachment)| (k, attachment.into())).collect(),
                     mode: Some(user_query_mode.into()),
                     intended_agent: intended_agent.map(|agent| agent.into()).unwrap_or_default(),
+                    // Opaque and server-issued; echoed verbatim, never parsed.
+                    attribution_token: attribution_token.unwrap_or_default(),
                 },
             ),
         ),
@@ -314,6 +318,7 @@ fn convert_input_to_user_input(
                 requested_command_id,
                 is_alt_screen_active,
             }),
+            attribution_token,
             ..
         } => {
             Ok(api::request::input::user_inputs::user_input::Input::CliAgentUserQuery(
@@ -323,6 +328,7 @@ fn convert_input_to_user_input(
                             referenced_attachments: referenced_attachments.into_iter().map(|(k, attachment)| (k, attachment.into())).collect(),
                             mode: Some(user_query_mode.into()),
                             intended_agent: api::AgentType::Cli.into(),
+                            attribution_token: attribution_token.unwrap_or_default(),
                         }),
                     running_command: Some(api::RunningShellCommand{
                         command,

--- a/app/src/ai/agent/api/convert_to_tests.rs
+++ b/app/src/ai/agent/api/convert_to_tests.rs
@@ -4,10 +4,49 @@ use warp_multi_agent_api as api;
 
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
-    AIAgentActionResult, AIAgentActionResultType, AIAgentContext,
-    TransferShellCommandControlToUserResult,
+    AIAgentActionResult, AIAgentActionResultType, AIAgentContext, AIAgentInput,
+    TransferShellCommandControlToUserResult, UserQueryMode,
 };
 use crate::terminal::model::block::BlockId;
+
+fn user_query_input(attribution_token: Option<String>) -> AIAgentInput {
+    AIAgentInput::UserQuery {
+        query: "follow up".to_string(),
+        context: std::sync::Arc::new([]),
+        static_query_type: None,
+        referenced_attachments: std::collections::HashMap::new(),
+        user_query_mode: UserQueryMode::Normal,
+        running_command: None,
+        intended_agent: None,
+        attribution_token,
+    }
+}
+
+fn convert_to_api_user_query(input: AIAgentInput) -> api::request::input::UserQuery {
+    match super::convert_input_to_user_input(input).unwrap() {
+        api::request::input::user_inputs::user_input::Input::UserQuery(user_query) => user_query,
+        other => panic!("Expected user-query input, got {other:?}"),
+    }
+}
+
+/// The token is opaque and server-issued; the client echoes it verbatim on the proto `UserQuery`.
+#[test]
+fn user_query_converts_attribution_token() {
+    let user_query = convert_to_api_user_query(user_query_input(Some(
+        "opaque-attribution-token".to_string(),
+    )));
+
+    assert_eq!(user_query.query, "follow up");
+    assert_eq!(user_query.attribution_token, "opaque-attribution-token");
+}
+
+/// Locally typed queries have no token; the proto field is left at its empty default.
+#[test]
+fn user_query_without_attribution_token_serializes_empty() {
+    let user_query = convert_to_api_user_query(user_query_input(None));
+
+    assert_eq!(user_query.attribution_token, "");
+}
 
 #[test]
 fn git_context_converts_repository_and_pull_request_metadata() {

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -2887,6 +2887,10 @@ pub enum AIAgentInput {
         user_query_mode: UserQueryMode,
         running_command: Option<RunningCommand>,
         intended_agent: Option<AgentType>,
+        /// Opaque, server-issued attribution token for follow-ups injected into a shared
+        /// session. The client never parses it; it is echoed verbatim on the request's
+        /// `UserQuery.attribution_token`. `None` for queries the user typed locally.
+        attribution_token: Option<String>,
     },
 
     AutoCodeDiffQuery {

--- a/app/src/ai/blocklist/block/find_tests.rs
+++ b/app/src/ai/blocklist/block/find_tests.rs
@@ -14,6 +14,7 @@ fn user_query_input(query: &str, mode: UserQueryMode) -> AIAgentInput {
         user_query_mode: mode,
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     }
 }
 

--- a/app/src/ai/blocklist/block/view_impl/common_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/common_tests.rs
@@ -61,6 +61,7 @@ fn query_prefix_highlight_len_does_not_guess_from_plain_user_query_text() {
         user_query_mode: UserQueryMode::Normal,
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     };
 
     assert_eq!(
@@ -79,6 +80,7 @@ fn query_prefix_highlight_len_keeps_existing_plan_highlighting() {
         user_query_mode: UserQueryMode::Plan,
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     };
 
     assert_eq!(

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -416,6 +416,9 @@ struct InputQuery {
     /// When `Some`, this submission is a fired queued-prompt row; the send path resolves the
     /// row's stored attachments by this id instead of the live input staging.
     queued_query_id: Option<QueuedQueryId>,
+    /// Opaque, server-issued attribution token for follow-ups injected into a shared
+    /// session; echoed verbatim on the outgoing `UserQuery`. `None` for local submissions.
+    attribution_token: Option<String>,
 }
 
 impl InputQuery {
@@ -712,6 +715,10 @@ impl BlocklistAIController {
         }
 
         if let Some(slash_command_request) = SlashCommandRequest::from_query(query.as_str()) {
+            // attribution_token cannot be carried here (see warp-server
+            // specs/user-query-attribution PRODUCT.md B24): slash commands build their own
+            // request and never produce a `UserQuery`.
+            //
             // Only fired queued rows carry `queued_query_id`. For those rows, keep slash commands
             // (e.g. queued `/compact`) on the conversation they were queued on; direct slash
             // submissions still re-derive their target from the current UI selection.
@@ -804,6 +811,7 @@ impl BlocklistAIController {
 
         let additional_attachments = input_query.additional_attachments;
         let queued_query_id = input_query.queued_query_id;
+        let attribution_token = input_query.attribution_token;
         let ai_input = match input_query.input_query {
             InputQueryType::UserSubmittedQueryFromInput {
                 static_query_type,
@@ -833,6 +841,7 @@ impl BlocklistAIController {
                     running_command,
                     additional_attachments,
                     prompt_attachments,
+                    attribution_token,
                     self.context_model.as_ref(ctx),
                     self.active_session.as_ref(ctx),
                     ctx,
@@ -1055,6 +1064,7 @@ impl BlocklistAIController {
                     },
                     additional_attachments: HashMap::new(),
                     queued_query_id,
+                    attribution_token: None,
                 },
                 entrypoint_type,
                 participant_id,
@@ -1072,6 +1082,7 @@ impl BlocklistAIController {
                     },
                     additional_attachments: HashMap::new(),
                     queued_query_id,
+                    attribution_token: None,
                 },
                 entrypoint_type,
                 participant_id,
@@ -1098,6 +1109,7 @@ impl BlocklistAIController {
             EntrypointType::AgentInitiated,
             /*is_queued_prompt*/ false,
             /*queued_query_id*/ None,
+            /*attribution_token*/ None,
             ctx,
         );
     }
@@ -1120,6 +1132,7 @@ impl BlocklistAIController {
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ false,
             /*queued_query_id*/ None,
+            /*attribution_token*/ None,
             ctx,
         )
     }
@@ -1145,17 +1158,20 @@ impl BlocklistAIController {
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ true,
             Some(queued_query_id),
+            /*attribution_token*/ None,
             ctx,
         );
     }
 
-    /// Sends the given user query to the AI model, with additional referenced attachments.
+    /// Sends the given user query to the AI model, with additional referenced attachments and
+    /// an optional opaque attribution token (set for follow-ups injected into a shared session).
     pub fn send_user_query_in_conversation_with_attachments(
         &mut self,
         query: String,
         conversation_id: AIConversationId,
         participant_id: Option<ParticipantId>,
         additional_attachments: HashMap<String, AIAgentAttachment>,
+        attribution_token: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) {
         self.send_user_query_in_conversation_internal(
@@ -1167,6 +1183,7 @@ impl BlocklistAIController {
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ false,
             /*queued_query_id*/ None,
+            attribution_token,
             ctx,
         );
     }
@@ -1191,6 +1208,7 @@ impl BlocklistAIController {
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ false,
             /*queued_query_id*/ None,
+            /*attribution_token*/ None,
             ctx,
         );
     }
@@ -1206,6 +1224,7 @@ impl BlocklistAIController {
         entrypoint_type: EntrypointType,
         is_queued_prompt: bool,
         queued_query_id: Option<QueuedQueryId>,
+        attribution_token: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
         let is_viewer = self
@@ -1320,6 +1339,7 @@ impl BlocklistAIController {
                 },
                 additional_attachments,
                 queued_query_id,
+                attribution_token,
             },
             entrypoint_type,
             participant_id,
@@ -1346,6 +1366,7 @@ impl BlocklistAIController {
                 },
                 additional_attachments: HashMap::new(),
                 queued_query_id: None,
+                attribution_token: None,
             },
             EntrypointType::ZeroStateAgentModePromptSuggestion,
             participant_id,
@@ -1383,6 +1404,7 @@ impl BlocklistAIController {
                 input_query: InputQueryType::AIInputType { ai_input },
                 additional_attachments: HashMap::new(),
                 queued_query_id: None,
+                attribution_token: None,
             },
             EntrypointType::UserInitiated,
             participant_id,
@@ -1565,6 +1587,7 @@ impl BlocklistAIController {
                 },
                 additional_attachments: HashMap::new(),
                 queued_query_id: None,
+                attribution_token: None,
             },
             EntrypointType::TriggerPassiveSuggestion {
                 trigger: trigger_type,
@@ -3534,6 +3557,7 @@ fn input_for_query(
     running_command: Option<RunningCommand>,
     additional_attachments: HashMap<String, AIAgentAttachment>,
     prompt_attachments: Vec<PendingAttachment>,
+    attribution_token: Option<String>,
     context_model: &BlocklistAIContextModel,
     active_session: &ActiveSession,
     app: &AppContext,
@@ -3580,6 +3604,7 @@ fn input_for_query(
         user_query_mode,
         running_command,
         intended_agent,
+        attribution_token,
     }
 }
 

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -668,6 +668,7 @@ impl BlocklistAIController {
         server_conversation_token: Option<ServerConversationToken>,
         attachments: Vec<AgentAttachment>,
         participant_id: ParticipantId,
+        attribution_token: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) {
         // Map server token to sharer's local conversation ID
@@ -730,6 +731,7 @@ impl BlocklistAIController {
                 conversation_id,
                 participant_id,
                 HashMap::new(),
+                attribution_token,
                 ctx,
             );
             return;
@@ -745,6 +747,7 @@ impl BlocklistAIController {
                 conversation_id,
                 participant_id,
                 HashMap::new(),
+                attribution_token,
                 ctx,
             );
             return;
@@ -756,6 +759,7 @@ impl BlocklistAIController {
                 conversation_id,
                 participant_id,
                 HashMap::new(),
+                attribution_token,
                 ctx,
             );
             return;
@@ -828,6 +832,7 @@ impl BlocklistAIController {
                     conversation_id,
                     participant_id,
                     file_attachments,
+                    attribution_token,
                     ctx,
                 );
             },
@@ -873,6 +878,7 @@ impl BlocklistAIController {
         conversation_id: Option<AIConversationId>,
         participant_id: ParticipantId,
         file_attachments: HashMap<String, AIAgentAttachment>,
+        attribution_token: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) {
         if let Some(conversation_id) = conversation_id {
@@ -892,6 +898,7 @@ impl BlocklistAIController {
                 conversation_id,
                 Some(participant_id),
                 file_attachments,
+                attribution_token,
                 ctx,
             );
         } else {
@@ -938,11 +945,15 @@ impl BlocklistAIController {
                     conversation_id,
                     Some(participant_id),
                     file_attachments,
+                    attribution_token,
                     ctx,
                 );
                 return;
             }
 
+            // Legacy non-AgentView path: the new-conversation entry point has no attachment or
+            // attribution_token plumbing, so the token is dropped here. Cloud-run hosts, the
+            // only senders of injected follow-ups, always have AgentView enabled.
             self.send_user_query_in_new_conversation(
                 prompt,
                 None,

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -160,6 +160,7 @@ fn input_for_query_converts_prompt_attachments_and_ignores_live_staging() {
                 None,
                 HashMap::new(),
                 prompt_attachments,
+                /*attribution_token*/ None,
                 context_model.as_ref(ctx),
                 active_session.as_ref(ctx),
                 ctx,
@@ -203,6 +204,57 @@ fn input_for_query_converts_prompt_attachments_and_ignores_live_staging() {
             assert!(referenced_attachments.contains_key("notes.txt"));
             assert!(referenced_attachments.contains_key("notes.txt (1)"));
             assert!(!referenced_attachments.contains_key("live.txt"));
+        });
+    });
+}
+
+/// The attribution token is opaque to the client: `input_for_query` must place it on the
+/// `UserQuery` untouched so it can be echoed to the server.
+#[test]
+fn input_for_query_carries_attribution_token() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |terminal, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    history_model.start_new_conversation(terminal.id(), false, false, false, ctx)
+                });
+
+            let controller = terminal.ai_controller();
+            let context_model = controller.as_ref(ctx).context_model.clone();
+            let active_session = controller.as_ref(ctx).active_session.clone();
+            let task_id = TaskId::new("test-task".to_owned());
+
+            let input = super::input_for_query(
+                "injected follow-up".to_owned(),
+                &task_id,
+                conversation_id,
+                None,
+                UserQueryMode::Normal,
+                None,
+                HashMap::new(),
+                vec![],
+                Some("opaque-attribution-token".to_owned()),
+                context_model.as_ref(ctx),
+                active_session.as_ref(ctx),
+                ctx,
+            );
+
+            let AIAgentInput::UserQuery {
+                query,
+                attribution_token,
+                ..
+            } = input
+            else {
+                panic!("expected UserQuery");
+            };
+            assert_eq!(query, "injected follow-up");
+            assert_eq!(
+                attribution_token.as_deref(),
+                Some("opaque-attribution-token")
+            );
         });
     });
 }

--- a/app/src/ai/blocklist/handoff/pipeline_tests.rs
+++ b/app/src/ai/blocklist/handoff/pipeline_tests.rs
@@ -45,6 +45,7 @@ fn exchange_with_working_directory(
             user_query_mode: UserQueryMode::Normal,
             running_command: None,
             intended_agent: None,
+            attribution_token: None,
         }],
         output_status,
         added_message_ids: HashSet::new(),

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -303,6 +303,7 @@ fn create_exchange_with_query(
             user_query_mode: UserQueryMode::default(),
             running_command: None,
             intended_agent: None,
+            attribution_token: None,
         }],
         output_status: AIAgentOutputStatus::Finished {
             finished_output: FinishedAIAgentOutput::Success {

--- a/app/src/ai/blocklist/persistence.rs
+++ b/app/src/ai/blocklist/persistence.rs
@@ -126,6 +126,7 @@ impl TryFrom<PersistedAIInputType> for AIAgentInput {
                 user_query_mode: UserQueryMode::default(),
                 running_command: None,
                 intended_agent: None,
+                attribution_token: None,
             }),
         }
     }

--- a/app/src/persistence/block_list_tests.rs
+++ b/app/src/persistence/block_list_tests.rs
@@ -249,6 +249,7 @@ fn empty_input_skip_filters_out_non_query_inputs() {
         user_query_mode: UserQueryMode::default(),
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     };
     let non_query = AIAgentInput::ResumeConversation {
         context: Default::default(),

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -2465,6 +2465,7 @@ fn seed_in_progress_conversation(
                 user_query_mode: UserQueryMode::Normal,
                 running_command: None,
                 intended_agent: None,
+                attribution_token: None,
             }],
             output_status: AIAgentOutputStatus::Streaming { output: None },
             added_message_ids: HashSet::new(),

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -128,6 +128,10 @@ fn accept_agent_prompt(
         .session(terminal_view_id)
         .is_some();
     if has_active_cli_agent {
+        // attribution_token cannot be carried here (see warp-server
+        // specs/user-query-attribution PRODUCT.md B24): the prompt goes to the
+        // CLI's PTY as plain text, not through a `UserQuery`.
+        //
         // Reuse the rich input submit pipeline so agent-specific
         // strategies are applied. Bypasses the rich-input-UI side effects
         // (telemetry, draft clear, editor buffer clear, pending-image consumption).
@@ -151,6 +155,7 @@ fn accept_agent_prompt(
                 request.server_conversation_token,
                 request.attachments.clone(),
                 participant_id.clone(),
+                request.attribution_token.clone(),
                 ctx,
             );
         });

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -953,6 +953,8 @@ impl Network {
             server_conversation_token,
             prompt,
             attachments,
+            // Only warp-server-injected follow-ups carry an attribution token.
+            attribution_token: None,
         };
         self.send_message_to_server(UpstreamMessage::SendAgentPrompt(request));
     }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -23517,6 +23517,7 @@ impl TerminalView {
             user_query_mode: UserQueryMode::default(),
             running_command: None,
             intended_agent: None,
+            attribution_token: None,
         }];
 
         // Create a real conversation in the history model for this dummy block so it renders.

--- a/app/src/terminal/view/use_agent_footer/mod_tests.rs
+++ b/app/src/terminal/view/use_agent_footer/mod_tests.rs
@@ -146,6 +146,7 @@ fn insert_pending_ai_block(
             user_query_mode: UserQueryMode::default(),
             running_command: None,
             intended_agent: None,
+            attribution_token: None,
         }],
     ));
     let ai_block = ctx.add_typed_action_view(|ctx| {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -1606,6 +1606,7 @@ fn agent_view_user_query_input(query: &str) -> AIAgentInput {
         user_query_mode: UserQueryMode::Normal,
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     }
 }
 
@@ -2188,6 +2189,7 @@ fn agent_jump_user_query(query: &str) -> AIAgentInput {
         user_query_mode: UserQueryMode::Normal,
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     }
 }
 
@@ -2376,6 +2378,7 @@ fn restoring_conversation_to_new_pane_transfers_blocks_from_previous_terminal_su
                     user_query_mode: UserQueryMode::Normal,
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 }],
                 ctx,
             );
@@ -2490,6 +2493,7 @@ fn clicking_old_banner_for_open_conversation_focuses_current_terminal_surface_wi
                     user_query_mode: UserQueryMode::Normal,
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 }],
                 ctx,
             );
@@ -2630,6 +2634,7 @@ fn appended_exchange_renders_in_current_terminal_surface_after_conversation_tran
                     user_query_mode: UserQueryMode::Normal,
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 }],
                 ctx,
             );
@@ -2681,6 +2686,7 @@ fn appended_exchange_renders_in_current_terminal_surface_after_conversation_tran
                     user_query_mode: UserQueryMode::Normal,
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 }]);
                 let exchange_id = exchange.id;
                 conversation
@@ -3901,6 +3907,7 @@ fn pending_cloud_mode_query_waits_for_renderable_user_query_exchange() {
                     user_query_mode: UserQueryMode::default(),
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 },
                 ctx,
             );
@@ -3941,6 +3948,7 @@ fn pending_cloud_mode_query_clears_when_streaming_exchange_becomes_renderable() 
                     user_query_mode: UserQueryMode::Normal,
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 }],
                 ctx,
             );
@@ -9382,6 +9390,7 @@ fn close_find_bar_clears_ai_block_find_highlights() {
                     user_query_mode: UserQueryMode::Normal,
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 },
                 ctx,
             );
@@ -9517,6 +9526,7 @@ fn copy_selected_text_from_ai_block() {
                     user_query_mode: UserQueryMode::Normal,
                     running_command: None,
                     intended_agent: None,
+                    attribution_token: None,
                 },
                 ctx,
             );

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -2878,5 +2878,6 @@ fn query_input(query: &str) -> AIAgentInput {
         user_query_mode: UserQueryMode::default(),
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     }
 }

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -977,6 +977,7 @@ fn query_input(query: &str) -> AIAgentInput {
         user_query_mode: UserQueryMode::default(),
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     }
 }
 

--- a/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
@@ -1174,6 +1174,7 @@ fn query_input(query: &str) -> AIAgentInput {
         user_query_mode: UserQueryMode::default(),
         running_command: None,
         intended_agent: None,
+        attribution_token: None,
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- TUI: updates that impact Warp Agent CLI users, including shared Agent capabilities. Use `CHANGELOG-TUI` for text that should appear in the TUI zero state. It may be used alongside another changelog entry when a change affects multiple surfaces.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-TUI: {{text goes here...}}
CHANGELOG-NONE
-->
