### PR TITLE
Separate workspace root and harness working directories.

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -4012,9 +4012,15 @@ impl AgentDriver {
         harness: &dyn ThirdPartyHarness,
         foreground: &ModelSpawner<Self>,
     ) -> Result<Arc<dyn harness::HarnessRunner>, AgentDriverError> {
-        let (harness_working_dir, task_id, server_api, managed_mcp_client, terminal_driver) =
-            foreground
-                .spawn(|me, ctx| {
+        let (
+            workspace_root,
+            harness_working_dir,
+            task_id,
+            server_api,
+            managed_mcp_client,
+            terminal_driver,
+        ) = foreground
+            .spawn(|me, ctx| {
                 if me.harness.is_some() {
                     log::error!(
                         "Attempted to prepare a third-party harness, but one was already configured"
@@ -4023,6 +4029,7 @@ impl AgentDriver {
                 }
 
                 Ok((
+                    me.working_dir.clone(),
                     me.harness_working_dir.clone(),
                     me.task_id,
                     ServerApiProvider::as_ref(ctx).get(),
@@ -4110,6 +4117,7 @@ impl AgentDriver {
                 system_prompt.as_deref(),
                 resumption_prompt.as_deref(),
                 server_context.as_deref(),
+                &workspace_root,
                 &harness_working_dir,
                 task_id,
                 server_api,

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -697,7 +697,10 @@ pub struct AgentDriverOptions {
 /// Its primary responsibility is to configure a headless terminal pane and execute an AI query within it.
 pub struct AgentDriver {
     terminal_driver: ModelHandle<terminal::TerminalDriver>,
+    /// Root directory for workspace-wide environment and snapshot operations.
     working_dir: PathBuf,
+    /// Directory where the selected harness runs.
+    harness_working_dir: PathBuf,
 
     /// Secrets available to the running agent.
     /// - Secrets are injected as environment variables when the terminal session is created.
@@ -1239,6 +1242,7 @@ impl AgentDriver {
 
         Ok(Self {
             terminal_driver,
+            harness_working_dir: working_dir.clone(),
             working_dir,
             secrets: Arc::new(secrets),
             resolved_env_vars,
@@ -1290,6 +1294,7 @@ impl AgentDriver {
         });
         Self {
             terminal_driver,
+            harness_working_dir: working_dir.clone(),
             working_dir,
             secrets: Arc::new(HashMap::new()),
             resolved_env_vars: Arc::new(HashMap::new()),
@@ -3278,12 +3283,18 @@ impl AgentDriver {
                 .await?
                 .await
                 .map_err(AgentDriverError::from);
-            if let Err(error) = prepare_outcome {
-                // A broken environment is the case post-failure retention exists for, so this
-                // failure must not take the session down with it on the way out.
-                Self::linger_after_failure(&foreground, "environment_setup", &error).await;
-                return Err(error);
-            }
+            let harness_working_dir = match prepare_outcome {
+                Ok(harness_working_dir) => harness_working_dir,
+                Err(error) => {
+                    // A broken environment is the case post-failure retention exists for, so this
+                    // failure must not take the session down with it on the way out.
+                    Self::linger_after_failure(&foreground, "environment_setup", &error).await;
+                    return Err(error);
+                }
+            };
+            foreground
+                .spawn(move |me, _| me.harness_working_dir = harness_working_dir)
+                .await?;
 
             if let Some(file_based_discovery_rx) = file_based_discovery_rx {
                 // Await discovery: collect UUIDs of file-based MCP servers that were auto-started
@@ -4001,8 +4012,9 @@ impl AgentDriver {
         harness: &dyn ThirdPartyHarness,
         foreground: &ModelSpawner<Self>,
     ) -> Result<Arc<dyn harness::HarnessRunner>, AgentDriverError> {
-        let (working_dir, task_id, server_api, managed_mcp_client, terminal_driver) = foreground
-            .spawn(|me, ctx| {
+        let (harness_working_dir, task_id, server_api, managed_mcp_client, terminal_driver) =
+            foreground
+                .spawn(|me, ctx| {
                 if me.harness.is_some() {
                     log::error!(
                         "Attempted to prepare a third-party harness, but one was already configured"
@@ -4011,7 +4023,7 @@ impl AgentDriver {
                 }
 
                 Ok((
-                    me.working_dir.clone(),
+                    me.harness_working_dir.clone(),
                     me.task_id,
                     ServerApiProvider::as_ref(ctx).get(),
                     ServerApiProvider::as_ref(ctx).get_managed_mcp_client(),
@@ -4098,7 +4110,7 @@ impl AgentDriver {
                 system_prompt.as_deref(),
                 resumption_prompt.as_deref(),
                 server_context.as_deref(),
-                &working_dir,
+                &harness_working_dir,
                 task_id,
                 server_api,
                 terminal_driver,

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -225,6 +225,8 @@ pub(crate) fn validate_repository_head_overrides(
 /// 3. Run any setup commands.
 /// 4. If there is only one repository, navigate into it.
 ///
+/// Returns the directory where the harness will run.
+///
 /// `is_sandbox` tells the preparer that `working_dir` only exists inside a
 /// Docker sandbox container and therefore the host filesystem can't be used
 /// for repo detection or indexing. This is an explicit signal from the
@@ -239,7 +241,7 @@ pub(crate) fn prepare_environment(
     setup_events: SetupClientEventReporter,
     environment_snapshot_reporter: EnvironmentSnapshotReporter,
     ctx: &mut ModelContext<TerminalDriver>,
-) -> impl Future<Output = Result<(), PrepareEnvironmentError>> + use<> {
+) -> impl Future<Output = Result<PathBuf, PrepareEnvironmentError>> + use<> {
     let spawner = ctx.spawner();
     async move {
         let RepositoryPreparationOptions {
@@ -380,7 +382,7 @@ async fn prepare_environment_impl(
     repo_channels: Arc<Mutex<HashMap<PathBuf, oneshot::Sender<()>>>>,
     setup_events: SetupClientEventReporter,
     environment_snapshot_reporter: EnvironmentSnapshotReporter,
-) -> Result<(), PrepareEnvironmentError> {
+) -> Result<PathBuf, PrepareEnvironmentError> {
     let working_dir_string = working_dir.to_string_lossy().to_string();
 
     // Position the session in `working_dir` before running any probes / clones.
@@ -524,7 +526,7 @@ async fn prepare_environment_impl(
 
     // If there's only one repo in the environment, start the agent in that repo.
     // This way, it doesn't have to locate the correct repo to work on.
-    if let Some(repo_name) = single_repo_name(source_repos) {
+    let harness_working_dir = if let Some(repo_name) = single_repo_name(source_repos) {
         safe_info!(
             safe: ("Changing directory into single repository"),
             full: ("Changing directory into single repository: {repo_name}")
@@ -533,8 +535,11 @@ async fn prepare_environment_impl(
         if exit_code != 0.into() {
             return Err(PrepareEnvironmentError::ChangeDirectory { repo_name });
         }
-    }
-    Ok(())
+        working_dir.join(repo_name)
+    } else {
+        working_dir.to_path_buf()
+    };
+    Ok(harness_working_dir)
 }
 
 fn record_codebase_indexing(

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -20,7 +20,7 @@ use super::super::terminal::{CommandHandle, TerminalDriver};
 use super::super::{AgentDriver, AgentDriverError};
 use super::claude_transcript::{
     ClaudeResumeInfo, ClaudeTranscriptEnvelope, claude_config_dir, home_dir_for_claude_config,
-    read_envelope, rehydrate_claude_transcript,
+    read_envelope, read_envelope_requiring_main_transcript, rehydrate_claude_transcript,
 };
 use super::json_utils::{read_json_file_or_default, write_json_file};
 use super::{
@@ -134,7 +134,7 @@ impl ThirdPartyHarness for ClaudeHarness {
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
         context: Option<&str>,
-        working_dir: &Path,
+        harness_working_dir: &Path,
         task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
@@ -145,12 +145,12 @@ impl ThirdPartyHarness for ClaudeHarness {
         _third_party_harness_model_config: Option<&HarnessModelConfig>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // Prepare the environment config files.
-        prepare_claude_environment_config(working_dir, resolved_env_vars).map_err(|error| {
-            AgentDriverError::HarnessConfigSetupFailed {
+        prepare_claude_environment_config(harness_working_dir, resolved_env_vars).map_err(
+            |error| AgentDriverError::HarnessConfigSetupFailed {
                 harness: self.cli_agent().command_prefix().to_owned(),
                 error,
-            }
-        })?;
+            },
+        )?;
 
         // The ResumePayload shouldn't contain non-Claude information, error if it does.
         let claude_resume = resume.map(ClaudeResumeInfo::try_from).transpose()?;
@@ -174,7 +174,7 @@ impl ThirdPartyHarness for ClaudeHarness {
             self.cli_agent().command_prefix(),
             &owned_prompt,
             system_prompt,
-            working_dir,
+            harness_working_dir,
             task_id,
             server_api,
             terminal_driver,
@@ -245,7 +245,7 @@ struct ClaudeHarnessRunner {
     terminal_driver: ModelHandle<TerminalDriver>,
     state: Mutex<ClaudeRunnerState>,
     session_id: Uuid,
-    working_dir: PathBuf,
+    harness_working_dir: PathBuf,
     parent_bridge: Option<MessageBridge>,
     /// Lazily cached output of `claude --version`.
     claude_version: Mutex<Option<String>>,
@@ -261,7 +261,7 @@ impl ClaudeHarnessRunner {
         cli_command: &str,
         prompt: &str,
         system_prompt: Option<&str>,
-        working_dir: &Path,
+        harness_working_dir: &Path,
         task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
@@ -279,7 +279,7 @@ impl ClaudeHarnessRunner {
                 session_id,
                 mut envelope,
             }) => {
-                rehydrate_claude_transcript(&mut envelope, working_dir)
+                rehydrate_claude_transcript(&mut envelope, harness_working_dir)
                     .map_err(AgentDriverError::ConfigBuildFailed)?;
                 (session_id, Some(conversation_id))
             }
@@ -328,7 +328,7 @@ impl ClaudeHarnessRunner {
             terminal_driver,
             state: Mutex::new(ClaudeRunnerState::Preexec),
             session_id,
-            working_dir: working_dir.to_path_buf(),
+            harness_working_dir: harness_working_dir.to_path_buf(),
             parent_bridge,
             claude_version: Mutex::new(None),
             preexisting_conversation_id,
@@ -579,7 +579,8 @@ impl HarnessRunner for ClaudeHarnessRunner {
 
         let client = self.client.as_ref();
         let session_id = self.session_id;
-        let working_dir = &self.working_dir;
+        let harness_working_dir = &self.harness_working_dir;
+        let require_main_transcript = matches!(save_point, SavePoint::Final);
 
         futures::try_join!(
             super::upload_current_block_snapshot(
@@ -593,8 +594,9 @@ impl HarnessRunner for ClaudeHarnessRunner {
                 client,
                 conversation_id,
                 session_id,
-                working_dir,
-                claude_version
+                harness_working_dir,
+                claude_version,
+                require_main_transcript,
             ),
         )?;
 
@@ -618,16 +620,21 @@ async fn upload_transcript(
     client: &dyn HarnessSupportClient,
     conversation_id: AIConversationId,
     session_id: Uuid,
-    working_dir: &Path,
+    harness_working_dir: &Path,
     claude_version: Option<String>,
+    require_main_transcript: bool,
 ) -> Result<()> {
     log::info!("Uploading Claude Code transcript to conversation {conversation_id}");
 
     let config_dir = claude_config_dir().context("Failed to resolve Claude config dir")?;
-    let working_dir = working_dir.to_path_buf();
+    let harness_working_dir = harness_working_dir.to_path_buf();
     let body = tokio::task::spawn_blocking(move || {
-        let mut envelope = read_envelope(session_id, &working_dir, &config_dir)
-            .with_context(|| format!("Failed to read transcript for session {session_id}"))?;
+        let mut envelope = if require_main_transcript {
+            read_envelope_requiring_main_transcript(session_id, &harness_working_dir, &config_dir)
+        } else {
+            read_envelope(session_id, &harness_working_dir, &config_dir)
+        }
+        .with_context(|| format!("Failed to read transcript for session {session_id}"))?;
         envelope.claude_version = claude_version;
         serde_json::to_vec(&envelope).context("Failed to serialize transcript envelope")
     })
@@ -640,16 +647,20 @@ async fn upload_transcript(
     upload_to_target(client.http_client(), &target, body).await
 }
 pub(crate) fn prepare_claude_environment_config(
-    working_dir: &Path,
+    harness_working_dir: &Path,
     resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Result<()> {
     let claude_json_path = claude_global_config_path()?;
     let claude_dir = claude_config_dir()?;
     let claude_settings_path = claude_dir.join(CLAUDE_SETTINGS_FILE_NAME);
     let api_key_suffix = resolve_anthropic_api_key_suffix(resolved_env_vars);
-    prepare_claude_config(&claude_json_path, working_dir, api_key_suffix.as_deref())?;
+    prepare_claude_config(
+        &claude_json_path,
+        harness_working_dir,
+        api_key_suffix.as_deref(),
+    )?;
     prepare_claude_settings(&claude_settings_path)?;
-    publish_warp_skill_dirs_for_claude(working_dir);
+    publish_warp_skill_dirs_for_claude(harness_working_dir);
     Ok(())
 }
 

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -20,7 +20,7 @@ use super::super::terminal::{CommandHandle, TerminalDriver};
 use super::super::{AgentDriver, AgentDriverError};
 use super::claude_transcript::{
     ClaudeResumeInfo, ClaudeTranscriptEnvelope, claude_config_dir, home_dir_for_claude_config,
-    read_envelope, read_envelope_requiring_main_transcript, rehydrate_claude_transcript,
+    read_envelope, rehydrate_claude_transcript,
 };
 use super::json_utils::{read_json_file_or_default, write_json_file};
 use super::{
@@ -629,11 +629,12 @@ async fn upload_transcript(
     let config_dir = claude_config_dir().context("Failed to resolve Claude config dir")?;
     let harness_working_dir = harness_working_dir.to_path_buf();
     let body = tokio::task::spawn_blocking(move || {
-        let mut envelope = if require_main_transcript {
-            read_envelope_requiring_main_transcript(session_id, &harness_working_dir, &config_dir)
-        } else {
-            read_envelope(session_id, &harness_working_dir, &config_dir)
-        }
+        let mut envelope = read_envelope(
+            session_id,
+            &harness_working_dir,
+            &config_dir,
+            require_main_transcript,
+        )
         .with_context(|| format!("Failed to read transcript for session {session_id}"))?;
         envelope.claude_version = claude_version;
         serde_json::to_vec(&envelope).context("Failed to serialize transcript envelope")

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -134,6 +134,7 @@ impl ThirdPartyHarness for ClaudeHarness {
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
         context: Option<&str>,
+        workspace_root: &Path,
         harness_working_dir: &Path,
         task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
@@ -145,12 +146,11 @@ impl ThirdPartyHarness for ClaudeHarness {
         _third_party_harness_model_config: Option<&HarnessModelConfig>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // Prepare the environment config files.
-        prepare_claude_environment_config(harness_working_dir, resolved_env_vars).map_err(
-            |error| AgentDriverError::HarnessConfigSetupFailed {
-                harness: self.cli_agent().command_prefix().to_owned(),
-                error,
-            },
-        )?;
+        prepare_claude_environment_config(workspace_root, harness_working_dir, resolved_env_vars)
+            .map_err(|error| AgentDriverError::HarnessConfigSetupFailed {
+            harness: self.cli_agent().command_prefix().to_owned(),
+            error,
+        })?;
 
         // The ResumePayload shouldn't contain non-Claude information, error if it does.
         let claude_resume = resume.map(ClaudeResumeInfo::try_from).transpose()?;
@@ -647,6 +647,7 @@ async fn upload_transcript(
     upload_to_target(client.http_client(), &target, body).await
 }
 pub(crate) fn prepare_claude_environment_config(
+    workspace_root: &Path,
     harness_working_dir: &Path,
     resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Result<()> {
@@ -660,37 +661,41 @@ pub(crate) fn prepare_claude_environment_config(
         api_key_suffix.as_deref(),
     )?;
     prepare_claude_settings(&claude_settings_path)?;
-    publish_warp_skill_dirs_for_claude(harness_working_dir);
+    publish_warp_skill_dirs_for_claude(workspace_root, harness_working_dir);
     Ok(())
 }
 
 /// Publish the skills listed in `WARP_SKILL_DIRS`, under their own names, as
-/// symlinks under `<working_dir>/.claude/skills`, so an agent running on
+/// symlinks under `<harness_working_dir>/.claude/skills`, so an agent running on
 /// Claude Code sees the same skills the Oz harness loads from
 /// `WARP_SKILL_DIRS`.
 ///
-/// Published into the task's own working directory rather than the Claude
-/// home skill root: Claude Code discovers `.claude/skills` by walking up from
-/// its starting directory to the repository root (or, absent a repository,
-/// just the starting directory itself), so a task's own working directory is
-/// a skill root Claude Code already searches on its own. This keeps
-/// concurrent tasks (e.g. on a self-hosted direct-backend worker sharing one
-/// host) from publishing into the same shared home directory. A published
-/// skill overrides any existing entry with the same name (see
-/// `skill_dirs_publish::publish_skill`), with the conflict-resolution
-/// behavior depending on whether this run is sandboxed (see
+/// Relative source directories are resolved from the workspace root, matching
+/// Oz. The links are published into the harness working directory because
+/// Claude Code discovers `.claude/skills` by walking up from its starting
+/// directory to the repository root (or, absent a repository, just the
+/// starting directory itself). This also keeps concurrent tasks from
+/// publishing into a shared home directory. A published skill overrides any
+/// existing entry with the same name (see
+/// `skill_dirs_publish::publish_skill`), with the conflict-resolution behavior
+/// depending on whether this run is sandboxed (see
 /// `warp_isolation_platform::detect`). A no-op when `WARP_SKILL_DIRS` is not
 /// configured for this run.
-fn publish_warp_skill_dirs_for_claude(working_dir: &Path) {
-    let source_dirs = super::skill_dirs_publish::warp_skill_source_dirs(working_dir);
+fn publish_warp_skill_dirs_for_claude(workspace_root: &Path, harness_working_dir: &Path) {
+    let source_dirs = super::skill_dirs_publish::warp_skill_source_dirs(workspace_root);
     if source_dirs.is_empty() {
         return;
     }
-    let skill_root = working_dir.join(".claude").join("skills");
+    let skill_root = harness_working_dir.join(".claude").join("skills");
     let is_sandbox = warp_isolation_platform::detect().is_some();
     let published =
         super::skill_dirs_publish::publish_skill_dirs(&skill_root, &source_dirs, is_sandbox);
-    if published > 0 {
+    super::skill_dirs_publish::exclude_published_skill_paths_from_git(
+        harness_working_dir,
+        &published,
+    );
+    if !published.is_empty() {
+        let published = published.len();
         safe_info!(
             safe: ("Published {published} WARP_SKILL_DIRS skill(s) to the Claude Code skill root"),
             full: (

--- a/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
@@ -199,7 +199,7 @@ impl ClaudeHarness {
         wake_message: Option<AgentMessageEventMetadata>,
     ) -> Result<String> {
         let working_dir = working_dir.unwrap_or_else(|| remote.envelope.cwd.clone());
-        prepare_claude_environment_config(&working_dir, &HashMap::new())
+        prepare_claude_environment_config(&working_dir, &working_dir, &HashMap::new())
             .context("Failed to prepare Claude environment for wake")?;
 
         remote.envelope.cwd = working_dir.clone();

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -860,7 +860,7 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
     assert!(!parent_bridge_hook_output_file(&state_dir).exists());
 
     let restored_envelope =
-        read_envelope(session_id, &working_dir, claude_config_dir.path()).unwrap();
+        read_envelope(session_id, &working_dir, claude_config_dir.path(), false).unwrap();
     assert_eq!(restored_envelope.cwd, working_dir);
     assert_eq!(
         restored_envelope.entries,

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -687,7 +687,7 @@ fn prepare_claude_environment_config_without_config_dir_uses_home_global_config(
     unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") };
 
     let working_dir = home_dir.path().join("workspace/project");
-    prepare_claude_environment_config(&working_dir, &HashMap::new()).unwrap();
+    prepare_claude_environment_config(&working_dir, &working_dir, &HashMap::new()).unwrap();
 
     assert!(home_dir.path().join(CLAUDE_JSON_FILE_NAME).exists());
     assert!(
@@ -732,7 +732,7 @@ fn prepare_claude_environment_config_with_config_dir_uses_dir_global_config() {
     unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", claude_config_dir.path()) };
 
     let working_dir = home_dir.path().join("workspace/project");
-    prepare_claude_environment_config(&working_dir, &HashMap::new()).unwrap();
+    prepare_claude_environment_config(&working_dir, &working_dir, &HashMap::new()).unwrap();
 
     assert!(
         claude_config_dir

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
@@ -114,26 +114,9 @@ pub(super) fn home_dir_for_claude_config() -> Option<PathBuf> {
 /// - `<config_root>/projects/<encoded_cwd>/<session_uuid>/subagents/*.jsonl` - subagents
 /// - `<config_root>/todos/<session_uuid>-agent-*.json` - per-agent todo lists
 ///
-/// If the main JSONL does not exist yet (e.g. during an early periodic save)
-/// the envelope is returned with an empty `entries` list rather than an error.
+/// If the main JSONL does not exist, `require_main_transcript` controls whether
+/// this returns an error or an envelope with an empty `entries` list.
 pub(crate) fn read_envelope(
-    session_uuid: Uuid,
-    cwd: &Path,
-    config_root: &Path,
-) -> Result<ClaudeTranscriptEnvelope> {
-    read_envelope_impl(session_uuid, cwd, config_root, false)
-}
-
-/// Assemble a [`ClaudeTranscriptEnvelope`], returning an error if the main transcript is absent.
-pub(crate) fn read_envelope_requiring_main_transcript(
-    session_uuid: Uuid,
-    cwd: &Path,
-    config_root: &Path,
-) -> Result<ClaudeTranscriptEnvelope> {
-    read_envelope_impl(session_uuid, cwd, config_root, true)
-}
-
-fn read_envelope_impl(
     session_uuid: Uuid,
     cwd: &Path,
     config_root: &Path,

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
@@ -121,11 +121,35 @@ pub(crate) fn read_envelope(
     cwd: &Path,
     config_root: &Path,
 ) -> Result<ClaudeTranscriptEnvelope> {
+    read_envelope_impl(session_uuid, cwd, config_root, false)
+}
+
+/// Assemble a [`ClaudeTranscriptEnvelope`], returning an error if the main transcript is absent.
+pub(crate) fn read_envelope_requiring_main_transcript(
+    session_uuid: Uuid,
+    cwd: &Path,
+    config_root: &Path,
+) -> Result<ClaudeTranscriptEnvelope> {
+    read_envelope_impl(session_uuid, cwd, config_root, true)
+}
+
+fn read_envelope_impl(
+    session_uuid: Uuid,
+    cwd: &Path,
+    config_root: &Path,
+    require_main_transcript: bool,
+) -> Result<ClaudeTranscriptEnvelope> {
     let encoded = encode_cwd(cwd);
     let projects_dir = config_root.join("projects").join(&encoded);
 
     // Main session transcript.
     let session_file = projects_dir.join(format!("{session_uuid}.jsonl"));
+    if require_main_transcript && !session_file.exists() {
+        anyhow::bail!(
+            "Claude Code transcript does not exist after harness termination: {}",
+            session_file.display()
+        );
+    }
     let entries = read_jsonl(&session_file)?;
 
     // Subagents are stored in a directory named after the session UUID.

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript_tests.rs
@@ -41,7 +41,7 @@ fn read_envelope_main_only() {
         "{\"type\":\"user\"}\n{\"type\":\"assistant\"}\n",
     );
 
-    let envelope = read_envelope(uuid, cwd, tmp.path()).unwrap();
+    let envelope = read_envelope(uuid, cwd, tmp.path(), false).unwrap();
     assert_eq!(
         envelope.entries,
         vec![
@@ -74,7 +74,7 @@ fn read_envelope_with_subagents() {
         "{\"type\":\"user\"}\n",
     );
 
-    let envelope = read_envelope(uuid, cwd, tmp.path()).unwrap();
+    let envelope = read_envelope(uuid, cwd, tmp.path(), false).unwrap();
     assert_eq!(
         envelope.subagents["agent-abc123def456"],
         vec![serde_json::json!({"type": "user"})]
@@ -88,7 +88,7 @@ fn read_envelope_missing_session_file() {
     let uuid = Uuid::new_v4();
 
     // No files created - should return Ok with empty entries rather than an error.
-    let envelope = read_envelope(uuid, cwd, tmp.path()).unwrap();
+    let envelope = read_envelope(uuid, cwd, tmp.path(), false).unwrap();
     assert!(envelope.entries.is_empty());
     assert!(envelope.subagents.is_empty());
     assert!(envelope.todos.is_empty());
@@ -162,7 +162,7 @@ fn write_envelope_round_trip() {
 
     write_envelope(&original, tmp.path()).unwrap();
 
-    let decoded = read_envelope(uuid, cwd, tmp.path()).unwrap();
+    let decoded = read_envelope(uuid, cwd, tmp.path(), false).unwrap();
     assert_eq!(decoded, original);
 }
 

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -122,7 +122,7 @@ impl ThirdPartyHarness for CodexHarness {
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
         context: Option<&str>,
-        working_dir: &Path,
+        harness_working_dir: &Path,
         _task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
@@ -134,7 +134,7 @@ impl ThirdPartyHarness for CodexHarness {
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // Prepare the environment config files.
         prepare_codex_environment_config(
-            working_dir,
+            harness_working_dir,
             system_prompt,
             resolved_env_vars,
             resolved_secrets,
@@ -170,7 +170,7 @@ impl ThirdPartyHarness for CodexHarness {
             self.cli_agent().command_prefix(),
             &owned_prompt,
             system_prompt,
-            working_dir,
+            harness_working_dir,
             client,
             terminal_driver,
             codex_resume,
@@ -234,7 +234,7 @@ impl CodexHarnessRunner {
         cli_command: &str,
         prompt: &str,
         _system_prompt: Option<&str>,
-        _working_dir: &Path,
+        harness_working_dir: &Path,
         client: Arc<dyn HarnessSupportClient>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<CodexResumeInfo>,
@@ -248,7 +248,7 @@ impl CodexHarnessRunner {
                 session_id,
                 mut envelope,
             }) => {
-                let continuation = rehydrate_codex_transcript(&mut envelope, _working_dir)
+                let continuation = rehydrate_codex_transcript(&mut envelope, harness_working_dir)
                     .map_err(AgentDriverError::ConfigBuildFailed)?;
                 (
                     Some(session_id),

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -122,6 +122,7 @@ impl ThirdPartyHarness for CodexHarness {
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
         context: Option<&str>,
+        workspace_root: &Path,
         harness_working_dir: &Path,
         _task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
@@ -134,6 +135,7 @@ impl ThirdPartyHarness for CodexHarness {
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // Prepare the environment config files.
         prepare_codex_environment_config(
+            workspace_root,
             harness_working_dir,
             system_prompt,
             resolved_env_vars,
@@ -536,7 +538,8 @@ const CODEX_MODEL_REASONING_EFFORT_KEY: &str = "model_reasoning_effort";
 /// release to change this.
 const CODEX_MODEL_MIGRATIONS_TARGET: &str = "gpt-5.4";
 fn prepare_codex_environment_config(
-    working_dir: &Path,
+    workspace_root: &Path,
+    harness_working_dir: &Path,
     system_prompt: Option<&str>,
     resolved_env_vars: &HashMap<OsString, OsString>,
     resolved_secrets: &HashMap<String, ManagedSecretValue>,
@@ -561,41 +564,45 @@ fn prepare_codex_environment_config(
 
     prepare_codex_config_toml(
         &codex_dir.join(CODEX_CONFIG_TOML_FILE_NAME),
-        working_dir,
+        harness_working_dir,
         resolved_mcp_servers,
         third_party_harness_model_config,
         openai_base_url.as_deref(),
     )?;
-    publish_warp_skill_dirs_for_codex(working_dir);
+    publish_warp_skill_dirs_for_codex(workspace_root, harness_working_dir);
     Ok(())
 }
 
 /// Publish the skills listed in `WARP_SKILL_DIRS`, under their own names, as
-/// symlinks under `<working_dir>/.agents/skills`, so an agent running on
+/// symlinks under `<harness_working_dir>/.agents/skills`, so an agent running on
 /// Codex sees the same skills the Oz harness loads from `WARP_SKILL_DIRS`.
 ///
-/// Published into the task's own working directory rather than `$HOME` or
-/// `CODEX_HOME`: Codex discovers `.agents/skills` as a REPO-scoped root by
-/// walking up from its starting directory to the repository root (falling
-/// back to just the starting directory itself when no repository is found),
-/// so a task's own working directory is a skill root Codex already searches
-/// on its own. This keeps concurrent tasks (e.g. on a self-hosted
-/// direct-backend worker sharing one host) from publishing into the same
-/// shared home directory. A published skill overrides any existing entry
-/// with the same name (see `skill_dirs_publish::publish_skill`), with the
-/// conflict-resolution behavior depending on whether this run is sandboxed
-/// (see `warp_isolation_platform::detect`). A no-op when `WARP_SKILL_DIRS`
-/// is not configured for this run.
-fn publish_warp_skill_dirs_for_codex(working_dir: &Path) {
-    let source_dirs = super::skill_dirs_publish::warp_skill_source_dirs(working_dir);
+/// Relative source directories are resolved from the workspace root, matching
+/// Oz. The links are published into the harness working directory because
+/// Codex discovers `.agents/skills` by walking up from its starting directory
+/// to the repository root (falling back to just the starting directory itself
+/// when no repository is found). This also keeps concurrent tasks from
+/// publishing into a shared home directory. A published skill overrides any
+/// existing entry with the same name (see
+/// `skill_dirs_publish::publish_skill`), with the conflict-resolution behavior
+/// depending on whether this run is sandboxed (see
+/// `warp_isolation_platform::detect`). A no-op when `WARP_SKILL_DIRS` is not
+/// configured for this run.
+fn publish_warp_skill_dirs_for_codex(workspace_root: &Path, harness_working_dir: &Path) {
+    let source_dirs = super::skill_dirs_publish::warp_skill_source_dirs(workspace_root);
     if source_dirs.is_empty() {
         return;
     }
-    let skill_root = working_dir.join(".agents").join("skills");
+    let skill_root = harness_working_dir.join(".agents").join("skills");
     let is_sandbox = warp_isolation_platform::detect().is_some();
     let published =
         super::skill_dirs_publish::publish_skill_dirs(&skill_root, &source_dirs, is_sandbox);
-    if published > 0 {
+    super::skill_dirs_publish::exclude_published_skill_paths_from_git(
+        harness_working_dir,
+        &published,
+    );
+    if !published.is_empty() {
+        let published = published.len();
         safe_info!(
             safe: ("Published {published} WARP_SKILL_DIRS skill(s) to the Codex skill root"),
             full: (

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -198,6 +198,7 @@ fn prepare_codex_environment_config_honors_codex_home() {
     let model_config = harness_model_config("gpt-5.5", None);
     let result = prepare_codex_environment_config(
         &working_dir,
+        &working_dir,
         Some("system prompt"),
         &resolved,
         &HashMap::new(),

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -60,6 +60,7 @@ impl ThirdPartyHarness for GeminiHarness {
         system_prompt: Option<&str>,
         _resumption_prompt: Option<&str>,
         context: Option<&str>,
+        _workspace_root: &Path,
         harness_working_dir: &Path,
         _task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -60,7 +60,7 @@ impl ThirdPartyHarness for GeminiHarness {
         system_prompt: Option<&str>,
         _resumption_prompt: Option<&str>,
         context: Option<&str>,
-        working_dir: &Path,
+        harness_working_dir: &Path,
         _task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
@@ -71,7 +71,7 @@ impl ThirdPartyHarness for GeminiHarness {
         _third_party_harness_model_config: Option<&HarnessModelConfig>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // Prepare the environment config files.
-        prepare_gemini_environment_config(working_dir, system_prompt).map_err(|error| {
+        prepare_gemini_environment_config(harness_working_dir, system_prompt).map_err(|error| {
             AgentDriverError::HarnessConfigSetupFailed {
                 harness: self.cli_agent().command_prefix().to_owned(),
                 error,
@@ -91,7 +91,6 @@ impl ThirdPartyHarness for GeminiHarness {
             self.cli_agent().command_prefix(),
             &effective_prompt,
             system_prompt,
-            working_dir,
             client,
             terminal_driver,
         )?))
@@ -130,7 +129,6 @@ impl GeminiHarnessRunner {
         cli_command: &str,
         prompt: &str,
         _system_prompt: Option<&str>,
-        _working_dir: &Path,
         client: Arc<dyn HarnessSupportClient>,
         terminal_driver: ModelHandle<TerminalDriver>,
     ) -> Result<Self, AgentDriverError> {
@@ -253,7 +251,7 @@ impl HarnessRunner for GeminiHarnessRunner {
 }
 
 fn prepare_gemini_environment_config(
-    working_dir: &Path,
+    harness_working_dir: &Path,
     system_prompt: Option<&str>,
 ) -> Result<()> {
     let home_dir =
@@ -265,7 +263,7 @@ fn prepare_gemini_environment_config(
     )?;
     prepare_gemini_trusted_folders(
         &gemini_dir.join(GEMINI_TRUSTED_FOLDERS_FILE_NAME),
-        working_dir,
+        harness_working_dir,
     )?;
     if let Some(prompt) = system_prompt {
         let prompt_path = gemini_dir.join(GEMINI_SYSTEM_PROMPT_FILE_NAME);

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -199,6 +199,9 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
     /// `resolved_secrets` provides the raw typed managed secrets so harnesses
     /// can read structured fields (e.g. `base_url`) without relying on env vars.
     ///
+    /// `workspace_root` is the root used for workspace-level inputs, while
+    /// `harness_working_dir` is the directory from which the CLI starts.
+    ///
     /// If `resume` is `Some`, the harness matches on its own [`ResumePayload`]
     /// variant and reuses stored session/conversation ids.
     #[allow(clippy::too_many_arguments)]
@@ -208,6 +211,7 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
         context: Option<&str>,
+        workspace_root: &Path,
         harness_working_dir: &Path,
         task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -208,7 +208,7 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
         context: Option<&str>,
-        working_dir: &Path,
+        harness_working_dir: &Path,
         task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,

--- a/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish.rs
+++ b/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish.rs
@@ -244,12 +244,22 @@ fn git_exclude_pattern(relative_path: &Path) -> Result<String> {
             relative_path.display()
         )
     })?;
+    if relative_path
+        .chars()
+        .any(|character| matches!(character, '\n' | '\r'))
+    {
+        anyhow::bail!("published skill path contains a line separator");
+    }
     let mut pattern = String::from("/");
-    for character in relative_path.replace('\\', "/").chars() {
-        if matches!(character, '\\' | ' ' | '*' | '?' | '[' | ']') {
+    for character in relative_path.chars() {
+        if character == std::path::MAIN_SEPARATOR {
+            pattern.push('/');
+        } else if matches!(character, '\\' | ' ' | '*' | '?' | '[' | ']') {
             pattern.push('\\');
+            pattern.push(character);
+        } else {
+            pattern.push(character);
         }
-        pattern.push(character);
     }
     Ok(pattern)
 }

--- a/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish.rs
+++ b/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish.rs
@@ -40,6 +40,8 @@
 
 use std::collections::HashSet;
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use ai::skills::{parse_skills_dirs_env, resolve_skills_dirs};
@@ -64,7 +66,7 @@ pub(super) fn warp_skill_source_dirs(working_dir: &Path) -> Vec<PathBuf> {
 
 /// Publish every skill found under `source_dirs` into `skill_root` as a
 /// symlink under the skill's own name, pointing at the real skill folder.
-/// Returns the number of skills published. See [`publish_skill`] for the
+/// Returns the paths of the published symlinks. See [`publish_skill`] for the
 /// conflict-resolution behavior `is_sandbox` selects.
 ///
 /// `source_dirs` is most-specific-first: when two directories contain a skill
@@ -82,13 +84,13 @@ pub(super) fn publish_skill_dirs(
     skill_root: &Path,
     source_dirs: &[PathBuf],
     is_sandbox: bool,
-) -> usize {
+) -> Vec<PathBuf> {
     if source_dirs.is_empty() {
-        return 0;
+        return Vec::new();
     }
 
     let mut published_names = HashSet::new();
-    let mut published = 0usize;
+    let mut published = Vec::new();
     for source_dir in source_dirs {
         let entries = match fs::read_dir(source_dir) {
             Ok(entries) => entries,
@@ -127,7 +129,7 @@ pub(super) fn publish_skill_dirs(
                 continue;
             }
             match publish_skill(skill_root, name, &source_path, is_sandbox) {
-                Ok(Some(_)) => published += 1,
+                Ok(Some(path)) => published.push(path),
                 Ok(None) => {
                     // Deliberately skipped (a real conflict outside a sandbox whose
                     // alternate name also conflicts) — already logged by publish_skill.
@@ -144,6 +146,113 @@ pub(super) fn publish_skill_dirs(
     published
 }
 
+/// Add the published skill symlinks to the repository-local Git exclude file.
+///
+/// Each pattern names one generated path relative to the repository root. This
+/// avoids hiding unrelated files elsewhere under the harness's skill root.
+/// Does nothing when `working_dir` is not in a Git worktree.
+pub(super) fn exclude_published_skill_paths_from_git(
+    working_dir: &Path,
+    published_paths: &[PathBuf],
+) {
+    if published_paths.is_empty() {
+        return;
+    }
+    if let Err(err) = write_published_skill_paths_to_git_exclude(working_dir, published_paths) {
+        safe_warn!(
+            safe: ("WARP_SKILL_DIRS publish: failed to exclude generated skill links from Git"),
+            full: (
+                "WARP_SKILL_DIRS publish: failed to exclude generated skill links under '{}': {err:#}",
+                working_dir.display()
+            )
+        );
+    }
+}
+
+fn write_published_skill_paths_to_git_exclude(
+    working_dir: &Path,
+    published_paths: &[PathBuf],
+) -> Result<()> {
+    let Ok(repository) = git2::Repository::discover(working_dir) else {
+        return Ok(());
+    };
+    let Some(repository_root) = repository.workdir() else {
+        return Ok(());
+    };
+    let exclude_path = repository.commondir().join("info").join("exclude");
+    let existing = match fs::read_to_string(&exclude_path) {
+        Ok(existing) => existing,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!("failed to read Git exclude file {}", exclude_path.display())
+            });
+        }
+    };
+    let existing_patterns = existing.lines().collect::<HashSet<_>>();
+    let mut additions = Vec::new();
+    for path in published_paths {
+        let relative_path = path.strip_prefix(repository_root).with_context(|| {
+            format!(
+                "published skill path {} is outside repository {}",
+                path.display(),
+                repository_root.display()
+            )
+        })?;
+        let pattern = git_exclude_pattern(relative_path)?;
+        if !existing_patterns.contains(pattern.as_str()) {
+            additions.push(pattern);
+        }
+    }
+    if additions.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(parent) = exclude_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create Git exclude directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    let mut appended = String::new();
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        appended.push('\n');
+    }
+    for pattern in additions {
+        appended.push_str(&pattern);
+        appended.push('\n');
+    }
+    let mut exclude = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude_path)
+        .with_context(|| format!("failed to open Git exclude file {}", exclude_path.display()))?;
+    exclude.write_all(appended.as_bytes()).with_context(|| {
+        format!(
+            "failed to update Git exclude file {}",
+            exclude_path.display()
+        )
+    })
+}
+
+fn git_exclude_pattern(relative_path: &Path) -> Result<String> {
+    let relative_path = relative_path.to_str().ok_or_else(|| {
+        anyhow::anyhow!(
+            "published skill path {} is not valid UTF-8",
+            relative_path.display()
+        )
+    })?;
+    let mut pattern = String::from("/");
+    for character in relative_path.replace('\\', "/").chars() {
+        if matches!(character, '\\' | ' ' | '*' | '?' | '[' | ']') {
+            pattern.push('\\');
+        }
+        pattern.push(character);
+    }
+    Ok(pattern)
+}
 /// Whether a publish target is already ours, missing, or occupied by
 /// something foreign to us.
 enum TargetOutcome {

--- a/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish_tests.rs
@@ -325,8 +325,7 @@ fn publish_skill_dirs_prefers_most_specific_directory_on_name_collision() {
     let skill_root = TempDir::new().unwrap();
 
     let published = publish_skill_dirs(skill_root.path(), &[specific_dir, general_dir], false);
-
-    assert_eq!(published, 2);
+    assert_eq!(published.len(), 2);
     assert_eq!(
         fs::read_link(skill_root.path().join("github")).unwrap(),
         specific_github
@@ -351,8 +350,7 @@ fn publish_skill_dirs_in_a_sandbox_overrides_an_existing_environment_skill_and_p
     fs::write(existing_target.join("SKILL.md"), "pre-existing skill").unwrap();
 
     let published = publish_skill_dirs(skill_root.path(), &[source_dir], true);
-
-    assert_eq!(published, 1);
+    assert_eq!(published.len(), 1);
     // The published skill wins under the real name...
     assert_eq!(
         fs::read_link(skill_root.path().join("github")).unwrap(),
@@ -375,8 +373,7 @@ fn publish_skill_dirs_skips_entries_without_skill_md() {
     let skill_root = TempDir::new().unwrap();
 
     let published = publish_skill_dirs(skill_root.path(), &[source_dir], false);
-
-    assert_eq!(published, 1);
+    assert_eq!(published.len(), 1);
     assert!(skill_root.path().join("github").exists());
     assert!(!skill_root.path().join("not-a-skill").exists());
 }
@@ -386,7 +383,7 @@ fn publish_skill_dirs_is_a_noop_for_empty_source_dirs() {
     let outer = TempDir::new().unwrap();
     let skill_root = outer.path().join("skills");
 
-    assert_eq!(publish_skill_dirs(&skill_root, &[], false), 0);
+    assert!(publish_skill_dirs(&skill_root, &[], false).is_empty());
     // Doesn't even create the skill root when there's nothing to publish.
     assert!(!skill_root.exists());
 }
@@ -401,7 +398,6 @@ fn publish_skill_dirs_recovers_from_missing_source_directory() {
     let skill_root = TempDir::new().unwrap();
 
     let published = publish_skill_dirs(skill_root.path(), &[missing_dir, present_dir], false);
-
-    assert_eq!(published, 1);
+    assert_eq!(published.len(), 1);
     assert!(skill_root.path().join("github").exists());
 }

--- a/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/skill_dirs_publish_tests.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
+use virtual_fs::VirtualFS;
 
 use super::*;
 
@@ -400,4 +401,55 @@ fn publish_skill_dirs_recovers_from_missing_source_directory() {
     let published = publish_skill_dirs(skill_root.path(), &[missing_dir, present_dir], false);
     assert_eq!(published.len(), 1);
     assert!(skill_root.path().join("github").exists());
+}
+
+#[test]
+fn git_exclude_pattern_anchors_and_escapes_git_metacharacters() {
+    let pattern = git_exclude_pattern(Path::new(".agents/skills/name with *?[brackets]")).unwrap();
+
+    assert_eq!(pattern, r"/.agents/skills/name\ with\ \*\?\[brackets\]");
+}
+
+#[cfg(unix)]
+#[test]
+fn git_exclude_pattern_escapes_a_literal_backslash_on_unix() {
+    let pattern = git_exclude_pattern(Path::new(r".agents/skills/name\with\backslashes")).unwrap();
+
+    assert_eq!(pattern, r"/.agents/skills/name\\with\\backslashes");
+}
+
+#[test]
+fn git_exclude_pattern_rejects_line_separators() {
+    for line_separator in ['\n', '\r'] {
+        let path = format!(".agents/skills/first{line_separator}/injected");
+
+        assert!(git_exclude_pattern(Path::new(&path)).is_err());
+    }
+}
+
+#[test]
+fn write_published_skill_paths_to_git_exclude_is_idempotent_and_preserves_existing_content() {
+    VirtualFS::test(
+        "write_published_skill_paths_to_git_exclude",
+        |dirs, _sandbox| {
+            let repository = git2::Repository::init(dirs.tests()).unwrap();
+            let repository_root = repository.workdir().unwrap();
+            let exclude_path = repository.commondir().join("info").join("exclude");
+            fs::write(&exclude_path, "existing-pattern").unwrap();
+            let github = repository_root.join(".claude/skills/github");
+            let linear = repository_root.join(".claude/skills/linear");
+
+            write_published_skill_paths_to_git_exclude(
+                repository_root,
+                std::slice::from_ref(&github),
+            )
+            .unwrap();
+            write_published_skill_paths_to_git_exclude(repository_root, &[github, linear]).unwrap();
+
+            assert_eq!(
+                fs::read_to_string(exclude_path).unwrap(),
+                "existing-pattern\n/.claude/skills/github\n/.claude/skills/linear\n"
+            );
+        },
+    );
 }

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -208,7 +208,7 @@ pub(super) async fn prepare_local_harness_child_launch(
             // auth/session state. We still prepare harness config files here,
             // but there are no Warp-managed secrets to materialize into the
             // hidden child pane.
-            prepare_claude_environment_config(&working_dir, &HashMap::new())
+            prepare_claude_environment_config(&working_dir, &working_dir, &HashMap::new())
                 .map_err(|error| error.to_string())?;
             if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
                 ensure_local_claude_child_plugins(manager.as_ref()).await;


### PR DESCRIPTION
## Description

Single-repository cloud workspaces can move a third-party harness from the workspace root into a cloned repository during environment setup. The agent driver previously used one directory for both workspace-level inputs and the harness working directory. As a result, Claude could look for its transcript under the workspace root even though it wrote the transcript under the repository. This could produce an empty uploaded transcript and prevent a later run from resuming.

This PR separates the two directory roles:

- The workspace root remains the base for workspace-level inputs, including relative `WARP_SKILL_DIRS` entries.
- The harness working directory controls CLI startup, harness configuration, and transcript lookup or rehydration.
- Claude final saves require the primary JSONL transcript. Periodic saves remain tolerant while the transcript is still being created. A final upload failure is logged and drops resumable state, but it does not fail an otherwise successful run.
- Claude and Codex publish skills under the harness working directory so each CLI can discover them from its launch location.
- Exact generated skill links are added to the repository-local Git exclude file. Failure to update the exclude file is logged and does not block the run.

Local Claude launch and wake paths use their existing directory for both roles, which preserves their current behavior.

## Linked Issue

None.

## Testing

- `./script/format`
- `git --no-pager diff --check`
- `cargo check -p warp`
- `cargo check -p warp --tests`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed transcript persistence and skill discovery for third-party agent harnesses in single-repository cloud workspaces.

Co-Authored-By: Warp <agent@warp.dev>
