### PR TITLE
Queue 3p follow-ups until setup done, never create a native conversation for CLI-harness ambient tasks

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -92,6 +92,12 @@ impl ServerConversationToken {
     }
 }
 
+impl std::fmt::Display for ServerConversationToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 #[cfg(test)]
 #[path = "api_tests.rs"]
 mod tests;

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -39,7 +39,9 @@ use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 use warp_managed_secrets::ManagedSecretValue;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::r#async::{FutureExt, TimeoutError, Timer};
-use warpui::{AppContext, Entity, ModelContext, ModelHandle, ModelSpawner, SingletonEntity};
+use warpui::{
+    AppContext, Entity, EntityId, ModelContext, ModelHandle, ModelSpawner, SingletonEntity,
+};
 
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
 use crate::ai::agent::{
@@ -224,6 +226,15 @@ const TASK_STATUS_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 const MANAGED_MCP_RESOLVE_MAX_ATTEMPTS: usize = 6;
 /// Timeout for individual harness auth preflight commands.
 const PREFLIGHT_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bounded fallback for draining `PendingCliHarnessPromptQueue`: some CLI-harness sessions
+/// (e.g. Codex using only its OSC 9 notification fallback, when the platform plugin is
+/// unavailable or disabled) never emit a genuine `CLIAgentSessionsModelEvent::StatusChanged`
+/// with `CLIAgentSessionStatus::InProgress` — Codex's OSC 9 path only ever produces opaque
+/// `Stop` notifications, which map to `Success`, not `InProgress`. Once this window elapses
+/// after harness setup, drain and deliver any still-queued prompts anyway rather than losing
+/// them forever; draining is idempotent, so this is a no-op when the normal `InProgress`-driven
+/// drain already ran.
+const PENDING_CLI_HARNESS_PROMPT_QUEUE_FALLBACK_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const WARP_DRIVE_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
 /// Maximum time to wait for an automatic error resume before propagating the error.
 /// If no follow-up status arrives within this window, the driver terminates with the
@@ -5005,6 +5016,22 @@ impl AgentDriver {
             LocalAgentTaskSyncModel::handle(ctx).update(ctx, |model, ctx| {
                 model.register_cli_session(terminal_view_id, task_id, ctx);
             });
+
+            // See `PENDING_CLI_HARNESS_PROMPT_QUEUE_FALLBACK_DRAIN_TIMEOUT`: bounded fallback
+            // in case this session never emits a genuine `StatusChanged{InProgress}` (e.g. a
+            // Codex session on the OSC 9 fallback path).
+            ctx.spawn(
+                async move {
+                    Timer::after(PENDING_CLI_HARNESS_PROMPT_QUEUE_FALLBACK_DRAIN_TIMEOUT).await;
+                },
+                move |me, _, ctx| {
+                    me.drain_and_deliver_pending_cli_harness_prompts(
+                        task_id,
+                        terminal_view_id,
+                        ctx,
+                    );
+                },
+            );
         }
 
         ctx.subscribe_to_model(&CLIAgentSessionsModel::handle(ctx), move |me, _, event, ctx| match event {
@@ -5057,6 +5084,20 @@ impl AgentDriver {
                                 me.task_id
                             );
                             harness_exit.cancel_idle_timeout();
+
+                            // A genuine, plugin-reported confirmation that the harness is
+                            // already running — unlike the synthetic `InProgress` optimistically
+                            // set at registration (which never emits `StatusChanged`; see
+                            // `LocalAgentTaskSyncModel::register_cli_session`) — so it's safe to
+                            // deliver any shared-session prompts queued while waiting for this
+                            // task's harness session to start.
+                            if let Some(task_id) = me.task_id {
+                                me.drain_and_deliver_pending_cli_harness_prompts(
+                                    task_id,
+                                    terminal_view_id,
+                                    ctx,
+                                );
+                            }
                         }
                     }
                 }
@@ -5090,36 +5131,38 @@ impl AgentDriver {
                         |_, _, _| {},
                     );
                 }
-                // Deliver shared-session prompts that were queued (see `accept_agent_prompt` in
-                // `terminal_view_adaptor.rs`) while this task's CLI-harness session was
-                // registered but not yet started, now that it has a live PTY to write into.
-                CLIAgentSessionsModelEvent::Started {
-                    terminal_view_id: event_tid,
-                    ..
-                } => {
-                    if *event_tid != terminal_view_id {
-                        return;
-                    }
-                    let Some(task_id) = me.task_id else {
-                        return;
-                    };
-                    let queued = PendingCliHarnessPromptQueue::handle(ctx)
-                        .update(ctx, |queue, _ctx| queue.drain(task_id));
-                    for prompt in queued {
-                        log::info!(
-                            "Ambient agent CLI lifecycle: event=shared_session_prompt_delivered \
-                             task_id={task_id} terminal_view_id={terminal_view_id:?} \
-                             participant_id={:?}",
-                            prompt.participant_id
-                        );
-                        me.terminal_driver.update(ctx, |terminal_driver, ctx| {
-                            terminal_driver.send_text_to_cli(prompt.prompt, ctx);
-                        });
-                    }
-                }
-                CLIAgentSessionsModelEvent::InputSessionChanged { .. }
+                CLIAgentSessionsModelEvent::Started { .. }
+                | CLIAgentSessionsModelEvent::InputSessionChanged { .. }
                 | CLIAgentSessionsModelEvent::Ended { .. } => {}
             });
+    }
+
+    /// Drains and delivers, as genuine PTY follow-ups via `TerminalDriver::send_text_to_cli`,
+    /// any shared-session prompts queued (see `accept_agent_prompt` in
+    /// `terminal_view_adaptor.rs`) while `task_id`'s CLI-harness session had no live PTY yet.
+    /// Safe to call from multiple triggers (the normal `StatusChanged{InProgress}` signal and
+    /// the bounded fallback timeout) since draining is idempotent: nothing happens once the
+    /// queue for this task is already empty.
+    fn drain_and_deliver_pending_cli_harness_prompts(
+        &self,
+        task_id: AmbientAgentTaskId,
+        terminal_view_id: EntityId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let queued = PendingCliHarnessPromptQueue::handle(ctx)
+            .update(ctx, |queue, _ctx| queue.drain(task_id));
+        for prompt in queued {
+            log::info!(
+                "Delivering a shared-session prompt that had been queued while waiting for \
+                 this task's CLI-harness session to start (event=queued_shared_session_prompt_delivered \
+                 task_id={task_id} terminal_view_id={terminal_view_id:?} \
+                 participant_id={:?})",
+                prompt.participant_id
+            );
+            self.terminal_driver.update(ctx, |terminal_driver, ctx| {
+                terminal_driver.send_text_to_cli(prompt.prompt, ctx);
+            });
+        }
     }
 
     /// Removes the task mapping registered for CLI agent session status updates, and drops any

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -65,7 +65,9 @@ use crate::ai::ambient_agents::{
 };
 use crate::ai::bedrock_credentials;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
-use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
+use crate::ai::blocklist::local_agent_task_sync_model::{
+    LocalAgentTaskSyncModel, LocalAgentTaskSyncModelEvent,
+};
 use crate::ai::blocklist::orchestration_event_streamer::{
     register_agent_event_consumer, unregister_agent_event_consumer,
 };
@@ -5005,6 +5007,37 @@ impl AgentDriver {
                 model.register_cli_session(terminal_view_id, task_id, ctx);
             });
         }
+
+        // Deliver shared-session prompts that were queued (see `send_shared_session_query`)
+        // while this task's CLI-harness session was registered but not yet started. Once the
+        // session starts, `LocalAgentTaskSyncModel` hands them back here so they can be
+        // written into the now-live PTY as genuine follow-ups instead of being dropped or
+        // misrouted into a new native conversation.
+        ctx.subscribe_to_model(
+            &LocalAgentTaskSyncModel::handle(ctx),
+            move |me, _, event, ctx| match event {
+                LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
+                    terminal_view_id: event_tid,
+                    prompts,
+                    ..
+                } => {
+                    if *event_tid != terminal_view_id {
+                        return;
+                    }
+                    for queued in prompts {
+                        log::info!(
+                            "Ambient agent CLI lifecycle: event=shared_session_prompt_delivered \
+                             terminal_view_id={terminal_view_id:?} participant_id={:?}",
+                            queued.participant_id
+                        );
+                        let prompt = queued.prompt.clone();
+                        me.terminal_driver.update(ctx, |terminal_driver, ctx| {
+                            terminal_driver.send_text_to_cli(prompt, ctx);
+                        });
+                    }
+                }
+            },
+        );
 
         ctx.subscribe_to_model(&CLIAgentSessionsModel::handle(ctx), move |me, _, event, ctx| match event {
                 CLIAgentSessionsModelEvent::StatusChanged {

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -5017,9 +5017,9 @@ impl AgentDriver {
             &LocalAgentTaskSyncModel::handle(ctx),
             move |me, _, event, ctx| match event {
                 LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
+                    task_id,
                     terminal_view_id: event_tid,
                     prompts,
-                    ..
                 } => {
                     if *event_tid != terminal_view_id {
                         return;
@@ -5027,7 +5027,8 @@ impl AgentDriver {
                     for queued in prompts {
                         log::info!(
                             "Ambient agent CLI lifecycle: event=shared_session_prompt_delivered \
-                             terminal_view_id={terminal_view_id:?} participant_id={:?}",
+                             task_id={task_id:?} terminal_view_id={terminal_view_id:?} \
+                             participant_id={:?}",
                             queued.participant_id
                         );
                         let prompt = queued.prompt.clone();

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -65,13 +65,12 @@ use crate::ai::ambient_agents::{
 };
 use crate::ai::bedrock_credentials;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
-use crate::ai::blocklist::local_agent_task_sync_model::{
-    LocalAgentTaskSyncModel, LocalAgentTaskSyncModelEvent,
-};
+use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
 use crate::ai::blocklist::orchestration_event_streamer::{
     register_agent_event_consumer, unregister_agent_event_consumer,
 };
 use crate::ai::blocklist::orchestration_events::OrchestrationEventService;
+use crate::ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue;
 use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIPermissions,
     ConversationStatusUpdate, FinalizeReason, finalize_recording_for_conversation,
@@ -5008,38 +5007,6 @@ impl AgentDriver {
             });
         }
 
-        // Deliver shared-session prompts that were queued (see `send_shared_session_query`)
-        // while this task's CLI-harness session was registered but not yet started. Once the
-        // session starts, `LocalAgentTaskSyncModel` hands them back here so they can be
-        // written into the now-live PTY as genuine follow-ups instead of being dropped or
-        // misrouted into a new native conversation.
-        ctx.subscribe_to_model(
-            &LocalAgentTaskSyncModel::handle(ctx),
-            move |me, _, event, ctx| match event {
-                LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
-                    task_id,
-                    terminal_view_id: event_tid,
-                    prompts,
-                } => {
-                    if *event_tid != terminal_view_id {
-                        return;
-                    }
-                    for queued in prompts {
-                        log::info!(
-                            "Ambient agent CLI lifecycle: event=shared_session_prompt_delivered \
-                             task_id={task_id:?} terminal_view_id={terminal_view_id:?} \
-                             participant_id={:?}",
-                            queued.participant_id
-                        );
-                        let prompt = queued.prompt.clone();
-                        me.terminal_driver.update(ctx, |terminal_driver, ctx| {
-                            terminal_driver.send_text_to_cli(prompt, ctx);
-                        });
-                    }
-                }
-            },
-        );
-
         ctx.subscribe_to_model(&CLIAgentSessionsModel::handle(ctx), move |me, _, event, ctx| match event {
                 CLIAgentSessionsModelEvent::StatusChanged {
                     terminal_view_id: event_tid,
@@ -5123,18 +5090,51 @@ impl AgentDriver {
                         |_, _, _| {},
                     );
                 }
-                CLIAgentSessionsModelEvent::Started { .. }
-                | CLIAgentSessionsModelEvent::InputSessionChanged { .. }
+                // Deliver shared-session prompts that were queued (see `accept_agent_prompt` in
+                // `terminal_view_adaptor.rs`) while this task's CLI-harness session was
+                // registered but not yet started, now that it has a live PTY to write into.
+                CLIAgentSessionsModelEvent::Started {
+                    terminal_view_id: event_tid,
+                    ..
+                } => {
+                    if *event_tid != terminal_view_id {
+                        return;
+                    }
+                    let Some(task_id) = me.task_id else {
+                        return;
+                    };
+                    let queued = PendingCliHarnessPromptQueue::handle(ctx)
+                        .update(ctx, |queue, _ctx| queue.drain(task_id));
+                    for prompt in queued {
+                        log::info!(
+                            "Ambient agent CLI lifecycle: event=shared_session_prompt_delivered \
+                             task_id={task_id} terminal_view_id={terminal_view_id:?} \
+                             participant_id={:?}",
+                            prompt.participant_id
+                        );
+                        me.terminal_driver.update(ctx, |terminal_driver, ctx| {
+                            terminal_driver.send_text_to_cli(prompt.prompt, ctx);
+                        });
+                    }
+                }
+                CLIAgentSessionsModelEvent::InputSessionChanged { .. }
                 | CLIAgentSessionsModelEvent::Ended { .. } => {}
             });
     }
 
-    /// Removes the task mapping registered for CLI agent session status updates.
+    /// Removes the task mapping registered for CLI agent session status updates, and drops any
+    /// shared-session prompts still queued for it (its CLI-harness session either never started
+    /// or already ended).
     fn unregister_cli_agent_task_sync(&self, ctx: &mut ModelContext<Self>) {
         let terminal_view_id = self.terminal_driver.as_ref(ctx).terminal_view().id();
         LocalAgentTaskSyncModel::handle(ctx).update(ctx, |model, _| {
             model.unregister_cli_session(terminal_view_id);
         });
+        if let Some(task_id) = self.task_id {
+            PendingCliHarnessPromptQueue::handle(ctx).update(ctx, |queue, _ctx| {
+                queue.clear(task_id);
+            });
+        }
     }
 
     /// Handle events re-emitted by the `TerminalDriver`.

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -226,15 +226,18 @@ const TASK_STATUS_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 const MANAGED_MCP_RESOLVE_MAX_ATTEMPTS: usize = 6;
 /// Timeout for individual harness auth preflight commands.
 const PREFLIGHT_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
-/// Bounded fallback for draining `PendingCliHarnessPromptQueue`: some CLI-harness sessions
-/// (e.g. Codex using only its OSC 9 notification fallback, when the platform plugin is
-/// unavailable or disabled) never emit a genuine `CLIAgentSessionsModelEvent::StatusChanged`
-/// with `CLIAgentSessionStatus::InProgress` — Codex's OSC 9 path only ever produces opaque
-/// `Stop` notifications, which map to `Success`, not `InProgress`. Once this window elapses
-/// after harness setup, drain and deliver any still-queued prompts anyway rather than losing
-/// them forever; draining is idempotent, so this is a no-op when the normal `InProgress`-driven
-/// drain already ran.
-const PENDING_CLI_HARNESS_PROMPT_QUEUE_FALLBACK_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+/// Last-resort bound for draining `PendingCliHarnessPromptQueue` when the CLI-harness plugin
+/// never reports `CLIAgentSessionsModelEvent::StatusChanged` with `CLIAgentSessionStatus::InProgress`
+/// — the normal drain signal. Finding anything still queued once this window elapses is not a
+/// routine race: a healthy plugin reports `InProgress` almost immediately after the harness
+/// starts processing its turn, so hitting this fallback indicates a broken or missing plugin
+/// integration (e.g. a Codex session on the OSC 9 fallback, whose notifications only ever map
+/// to `Success`, never `InProgress`). Draining is idempotent, so this is a silent no-op in the
+/// healthy case where the normal drain already ran. Set below the ~10 minutes the server allows
+/// before it expects the agent to have started working after a run is claimed, so this fallback
+/// still has a chance to recover queued prompts before the server considers the run stalled.
+const PENDING_CLI_HARNESS_PROMPT_QUEUE_FALLBACK_DRAIN_TIMEOUT: Duration =
+    Duration::from_secs(8 * 60);
 pub(crate) const WARP_DRIVE_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
 /// Maximum time to wait for an automatic error resume before propagating the error.
 /// If no follow-up status arrives within this window, the driver terminates with the
@@ -5025,11 +5028,20 @@ impl AgentDriver {
                     Timer::after(PENDING_CLI_HARNESS_PROMPT_QUEUE_FALLBACK_DRAIN_TIMEOUT).await;
                 },
                 move |me, _, ctx| {
-                    me.drain_and_deliver_pending_cli_harness_prompts(
+                    let delivered_count = me.drain_and_deliver_pending_cli_harness_prompts(
                         task_id,
                         terminal_view_id,
                         ctx,
                     );
+                    if delivered_count > 0 {
+                        log::warn!(
+                            "Ambient agent CLI lifecycle: unexpectedly had to fall back to a \
+                             bounded timeout to drain {delivered_count} queued shared-session \
+                             prompt(s) for task {task_id} — the CLI-harness plugin never reported \
+                             InProgress; this likely indicates a broken or missing plugin \
+                             integration. terminal_view_id={terminal_view_id:?}"
+                        );
+                    }
                 },
             );
         }
@@ -5140,6 +5152,8 @@ impl AgentDriver {
     /// Drains and delivers, as genuine PTY follow-ups via `TerminalDriver::send_text_to_cli`,
     /// any shared-session prompts queued (see `accept_agent_prompt` in
     /// `terminal_view_adaptor.rs`) while `task_id`'s CLI-harness session had no live PTY yet.
+    /// Returns how many prompts were delivered, so callers (e.g. the bounded fallback timeout)
+    /// can tell an empty, already-drained queue apart from one that genuinely had work pending.
     /// Safe to call from multiple triggers (the normal `StatusChanged{InProgress}` signal and
     /// the bounded fallback timeout) since draining is idempotent: nothing happens once the
     /// queue for this task is already empty.
@@ -5148,9 +5162,10 @@ impl AgentDriver {
         task_id: AmbientAgentTaskId,
         terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
-    ) {
+    ) -> usize {
         let queued = PendingCliHarnessPromptQueue::handle(ctx)
             .update(ctx, |queue, _ctx| queue.drain(task_id));
+        let delivered_count = queued.len();
         for prompt in queued {
             log::info!(
                 "Delivering a shared-session prompt that had been queued while waiting for \
@@ -5163,6 +5178,7 @@ impl AgentDriver {
                 terminal_driver.send_text_to_cli(prompt.prompt, ctx);
             });
         }
+        delivered_count
     }
 
     /// Removes the task mapping registered for CLI agent session status updates, and drops any

--- a/app/src/ai/agent_sdk/driver/checkpoint_coordinator_tests.rs
+++ b/app/src/ai/agent_sdk/driver/checkpoint_coordinator_tests.rs
@@ -14,7 +14,7 @@ use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use super::*;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent_sdk::test_support::build_test_http_client;
 use crate::ai::artifacts::Artifact;
 use crate::server::server_api::harness_support::{
@@ -91,18 +91,18 @@ impl FailingUploadTargetsClient {
 
 #[async_trait]
 impl HarnessSupportClient for FailingUploadTargetsClient {
-    async fn create_external_conversation(&self, _format: &str) -> Result<AIConversationId> {
+    async fn create_external_conversation(&self, _format: &str) -> Result<ServerConversationToken> {
         unimplemented!("not used by the coordinator")
     }
     async fn get_transcript_upload_target(
         &self,
-        _conversation_id: &AIConversationId,
+        _conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         unimplemented!("not used by the coordinator")
     }
     async fn get_block_snapshot_upload_target(
         &self,
-        _conversation_id: &AIConversationId,
+        _conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         unimplemented!("not used by the coordinator")
     }
@@ -191,18 +191,18 @@ impl RecordingClient {
 
 #[async_trait]
 impl HarnessSupportClient for RecordingClient {
-    async fn create_external_conversation(&self, _format: &str) -> Result<AIConversationId> {
+    async fn create_external_conversation(&self, _format: &str) -> Result<ServerConversationToken> {
         unimplemented!("not used by the coordinator")
     }
     async fn get_transcript_upload_target(
         &self,
-        _conversation_id: &AIConversationId,
+        _conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         unimplemented!("not used by the coordinator")
     }
     async fn get_block_snapshot_upload_target(
         &self,
-        _conversation_id: &AIConversationId,
+        _conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         unimplemented!("not used by the coordinator")
     }

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -27,7 +27,7 @@ use super::{
     HarnessCleanupDisposition, HarnessRunner, JSONMCPServer, ResumePayload, SavePoint,
     ThirdPartyHarness, cli_agent_session_status, write_temp_file,
 };
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent_sdk::setup_observability::{
     OzRunTimelineEvent, SetupClientEventReporter, SetupStep,
 };
@@ -114,7 +114,7 @@ impl ThirdPartyHarness for ClaudeHarness {
     /// so the user sees a resume-specific error rather than a generic load failure.
     async fn fetch_resume_payload(
         &self,
-        conversation_id: &AIConversationId,
+        conversation_id: &ServerConversationToken,
         harness_support_client: Arc<dyn HarnessSupportClient>,
     ) -> Result<Option<ResumePayload>, AgentDriverError> {
         let envelope: ClaudeTranscriptEnvelope =
@@ -122,7 +122,7 @@ impl ThirdPartyHarness for ClaudeHarness {
                 .await?;
         let session_id = envelope.uuid;
         Ok(Some(ResumePayload::Claude(ClaudeResumeInfo {
-            conversation_id: *conversation_id,
+            conversation_id: conversation_id.clone(),
             session_id,
             envelope,
         })))
@@ -225,7 +225,7 @@ enum ClaudeRunnerState {
     Preexec,
     /// The harness command is running (or has finished).
     Running {
-        conversation_id: AIConversationId,
+        conversation_id: ServerConversationToken,
         block_id: BlockId,
     },
 }
@@ -252,7 +252,7 @@ struct ClaudeHarnessRunner {
     /// When resuming an existing conversation, we pin the runner's server conversation id
     /// up front instead of calling `create_external_conversation` in [`HarnessRunner::start`].
     /// Subsequent saves overwrite the same GCS objects keyed by this id.
-    preexisting_conversation_id: Option<AIConversationId>,
+    preexisting_conversation_id: Option<ServerConversationToken>,
 }
 
 impl ClaudeHarnessRunner {
@@ -450,10 +450,10 @@ impl HarnessRunner for ClaudeHarnessRunner {
         // Otherwise create a fresh external conversation record for this run.
         // TODO(REMOTE-1149): `create_external_conversation` currently won't work for local CLI
         // runs. We should either support it or have a fallback.
-        let conversation_id = match self.preexisting_conversation_id {
+        let conversation_id = match &self.preexisting_conversation_id {
             Some(id) => {
                 log::info!("Resuming external conversation {id}");
-                id
+                id.clone()
             }
             None => {
                 let id = setup_events
@@ -572,7 +572,7 @@ impl HarnessRunner for ClaudeHarnessRunner {
             ClaudeRunnerState::Running {
                 conversation_id,
                 block_id,
-            } => (*conversation_id, block_id.clone()),
+            } => (conversation_id.clone(), block_id.clone()),
         };
 
         let claude_version = self.resolve_claude_version(foreground).await;
@@ -586,12 +586,12 @@ impl HarnessRunner for ClaudeHarnessRunner {
                 foreground,
                 &self.terminal_driver,
                 client,
-                conversation_id,
+                &conversation_id,
                 block_id,
             ),
             upload_transcript(
                 client,
-                conversation_id,
+                &conversation_id,
                 session_id,
                 working_dir,
                 claude_version
@@ -616,7 +616,7 @@ impl HarnessRunner for ClaudeHarnessRunner {
 /// Upload the Claude Code session transcript to the server.
 async fn upload_transcript(
     client: &dyn HarnessSupportClient,
-    conversation_id: AIConversationId,
+    conversation_id: &ServerConversationToken,
     session_id: Uuid,
     working_dir: &Path,
     claude_version: Option<String>,
@@ -634,7 +634,7 @@ async fn upload_transcript(
     .await
     .context("read_envelope task panicked")??;
     let target = client
-        .get_transcript_upload_target(&conversation_id)
+        .get_transcript_upload_target(conversation_id)
         .await
         .with_context(|| format!("Failed to get transcript upload target for {conversation_id}"))?;
     upload_to_target(client.http_client(), &target, body).await

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
 use warp_core::safe_warn;
 
 use super::json_utils::entries_to_jsonl;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 
 /// JSON envelope sent to the server representing a complete Claude Code session.
 ///
@@ -59,7 +59,7 @@ pub(crate) struct ClaudeResumeInfo {
     /// The Warp server-side conversation id. The runner stores this instead of calling
     /// `create_external_conversation` so subsequent transcript/block-snapshot uploads overwrite
     /// the same GCS objects.
-    pub(crate) conversation_id: AIConversationId,
+    pub(crate) conversation_id: ServerConversationToken,
     /// The Claude session uuid to pass to `claude --resume`. Matches `envelope.uuid`.
     pub(crate) session_id: Uuid,
     /// Envelope from the server. Its `cwd` field is rewritten to the current run's working

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -29,7 +29,7 @@ use super::json_utils::read_json_file_or_default;
 use super::{
     HarnessRunner, JSONMCPServer, ResumePayload, SavePoint, ThirdPartyHarness, write_temp_file,
 };
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent_sdk::setup_observability::{
     OzRunTimelineEvent, SetupClientEventReporter, SetupStep,
 };
@@ -102,7 +102,7 @@ impl ThirdPartyHarness for CodexHarness {
     /// [`ResumePayload::Codex`].
     async fn fetch_resume_payload(
         &self,
-        conversation_id: &AIConversationId,
+        conversation_id: &ServerConversationToken,
         harness_support_client: Arc<dyn HarnessSupportClient>,
     ) -> Result<Option<ResumePayload>, AgentDriverError> {
         let envelope: CodexTranscriptEnvelope =
@@ -110,7 +110,7 @@ impl ThirdPartyHarness for CodexHarness {
                 .await?;
         let session_id = envelope.session_id;
         Ok(Some(ResumePayload::Codex(CodexResumeInfo {
-            conversation_id: *conversation_id,
+            conversation_id: conversation_id.clone(),
             session_id,
             envelope,
         })))
@@ -204,7 +204,7 @@ fn codex_command(cli_name: &str, session_id: Option<&Uuid>, prompt_path: &str) -
 enum CodexRunnerState {
     Preexec,
     Running {
-        conversation_id: AIConversationId,
+        conversation_id: ServerConversationToken,
         block_id: BlockId,
     },
 }
@@ -225,7 +225,7 @@ struct CodexHarnessRunner {
     /// directory walk and read the JSONL file directly.
     transcript_path: OnceLock<PathBuf>,
     /// Optionally supply an existing conversation ID.
-    preexisting_conversation_id: Option<AIConversationId>,
+    preexisting_conversation_id: Option<ServerConversationToken>,
 }
 
 impl CodexHarnessRunner {
@@ -315,10 +315,10 @@ impl HarnessRunner for CodexHarnessRunner {
         setup_events: &SetupClientEventReporter,
     ) -> Result<CommandHandle, AgentDriverError> {
         // Resume runs reuse the prior server conversation id; fresh runs mint a new one.
-        let conversation_id = match self.preexisting_conversation_id {
+        let conversation_id = match &self.preexisting_conversation_id {
             Some(id) => {
                 log::info!("Resuming external conversation {id}");
-                id
+                id.clone()
             }
             None => {
                 let id = setup_events
@@ -441,7 +441,7 @@ impl HarnessRunner for CodexHarnessRunner {
             CodexRunnerState::Running {
                 conversation_id,
                 block_id,
-            } => (*conversation_id, block_id.clone()),
+            } => (conversation_id.clone(), block_id.clone()),
         };
 
         let session_id = self.session_id.get().copied();
@@ -454,10 +454,10 @@ impl HarnessRunner for CodexHarnessRunner {
                 foreground,
                 &self.terminal_driver,
                 client,
-                conversation_id,
+                &conversation_id,
                 block_id,
             ),
-            upload_transcript(client, conversation_id, session_id, rollout_path, is_final),
+            upload_transcript(client, &conversation_id, session_id, rollout_path, is_final),
         )?;
         Ok(())
     }
@@ -467,7 +467,7 @@ impl HarnessRunner for CodexHarnessRunner {
 /// been captured yet or no rollout file is on disk yet.
 async fn upload_transcript(
     client: &dyn HarnessSupportClient,
-    conversation_id: AIConversationId,
+    conversation_id: &ServerConversationToken,
     session_id: Option<Uuid>,
     transcript_path: Option<PathBuf>,
     is_final: bool,
@@ -504,7 +504,7 @@ async fn upload_transcript(
     .context("read_envelope task panicked")??;
 
     let target = client
-        .get_transcript_upload_target(&conversation_id)
+        .get_transcript_upload_target(conversation_id)
         .await
         .with_context(|| format!("Failed to get transcript upload target for {conversation_id}"))?;
     upload_to_target(client.http_client(), &target, body).await?;

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use super::super::codex_transcript::CodexTranscriptEnvelope;
 use super::*;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 use crate::server::server_api::harness_support::MockHarnessSupportClient;
 
 #[test]
@@ -702,7 +702,7 @@ async fn fetch_resume_payload_maps_404_to_resume_state_missing() {
     let mut mock = MockHarnessSupportClient::new();
     mock.expect_fetch_transcript()
         .returning(|| Err(anyhow::anyhow!("upstream returned status 404")));
-    let conversation_id = AIConversationId::new();
+    let conversation_id = ServerConversationToken::new("test-conversation-id".to_string());
 
     let result = CodexHarness
         .fetch_resume_payload(&conversation_id, Arc::new(mock))
@@ -721,7 +721,7 @@ async fn fetch_resume_payload_maps_other_errors_to_load_failed() {
     let mut mock = MockHarnessSupportClient::new();
     mock.expect_fetch_transcript()
         .returning(|| Err(anyhow::anyhow!("connection reset")));
-    let conversation_id = AIConversationId::new();
+    let conversation_id = ServerConversationToken::new("test-conversation-id".to_string());
 
     let result = CodexHarness
         .fetch_resume_payload(&conversation_id, Arc::new(mock))
@@ -856,7 +856,7 @@ async fn fetch_resume_payload_returns_codex_variant_on_success() {
     let mut mock = MockHarnessSupportClient::new();
     mock.expect_fetch_transcript()
         .returning(move || Ok(bytes::Bytes::from(bytes.clone())));
-    let conversation_id = AIConversationId::new();
+    let conversation_id = ServerConversationToken::new("test-conversation-id".to_string());
 
     let payload = CodexHarness
         .fetch_resume_payload(&conversation_id, Arc::new(mock))

--- a/app/src/ai/agent_sdk/driver/harness/codex_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_transcript.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::json_utils::entries_to_jsonl;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 
 /// Env var codex honors to override `~/.codex` (see codex `core/src/config/mod.rs`).
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
@@ -78,7 +78,7 @@ pub(crate) struct CodexSessionMetadata {
 pub(crate) struct CodexResumeInfo {
     /// Warp server-side conversation id. Reused so subsequent transcript/block-snapshot
     /// uploads overwrite the same GCS objects.
-    pub(crate) conversation_id: AIConversationId,
+    pub(crate) conversation_id: ServerConversationToken,
     /// Codex session uuid passed to `codex resume <session_id>`. Matches `envelope.session_id`.
     pub(crate) session_id: Uuid,
     /// Envelope fetched from the server, written back to disk before launching codex.

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -21,7 +21,7 @@ use super::{
     HarnessCleanupDisposition, HarnessRunner, JSONMCPServer, ResumePayload, SavePoint,
     ThirdPartyHarness, write_temp_file,
 };
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent_sdk::setup_observability::{
     OzRunTimelineEvent, SetupClientEventReporter, SetupStep,
 };
@@ -109,7 +109,7 @@ fn gemini_command(cli_name: &str, prompt_path: &str) -> String {
 enum GeminiRunnerState {
     Preexec,
     Running {
-        conversation_id: AIConversationId,
+        conversation_id: ServerConversationToken,
         block_id: BlockId,
     },
 }
@@ -229,7 +229,7 @@ impl HarnessRunner for GeminiHarnessRunner {
             GeminiRunnerState::Running {
                 conversation_id,
                 block_id,
-            } => (*conversation_id, block_id.clone()),
+            } => (conversation_id.clone(), block_id.clone()),
         };
 
         // TODO(REMOTE-1408) Also save the conversation transcript.
@@ -237,7 +237,7 @@ impl HarnessRunner for GeminiHarnessRunner {
             foreground,
             &self.terminal_driver,
             self.client.as_ref(),
-            conversation_id,
+            &conversation_id,
             block_id,
         )
         .await

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -26,7 +26,7 @@ use super::{
     OZ_MESSAGE_LISTENER_STATE_ROOT_ENV, WARP_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV,
     WARP_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent_sdk::setup_observability::SetupClientEventReporter;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::ambient_agents::task::HarnessModelConfig;
@@ -99,7 +99,7 @@ impl TryFrom<ResumePayload> for CodexResumeInfo {
 /// Fetch the harness transcript for `conversation_id` and deserialize it into `E`.
 pub(super) async fn fetch_transcript_envelope<E: serde::de::DeserializeOwned>(
     harness_label: &str,
-    conversation_id: &AIConversationId,
+    conversation_id: &ServerConversationToken,
     client: Arc<dyn HarnessSupportClient>,
 ) -> Result<E, AgentDriverError> {
     let bytes = client.fetch_transcript().await.map_err(|err| {
@@ -181,7 +181,7 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
     /// [`AgentDriverError::ConversationResumeStateMissing`] tagged with the harness label).
     async fn fetch_resume_payload(
         &self,
-        _conversation_id: &AIConversationId,
+        _conversation_id: &ServerConversationToken,
         _harness_support_client: Arc<dyn HarnessSupportClient>,
     ) -> Result<Option<ResumePayload>, AgentDriverError> {
         Ok(None)
@@ -620,12 +620,12 @@ pub(super) fn write_temp_file(
 /// Upload a [`SerializedBlock`] as the JSON block snapshot for a third-party harness conversation.
 pub(crate) async fn upload_block_snapshot(
     client: &dyn HarnessSupportClient,
-    conversation_id: AIConversationId,
+    conversation_id: &ServerConversationToken,
     block: SerializedBlock,
 ) -> Result<()> {
     log::info!("Uploading block snapshot for CLI agent to conversation {conversation_id}");
     let target = client
-        .get_block_snapshot_upload_target(&conversation_id)
+        .get_block_snapshot_upload_target(conversation_id)
         .await
         .with_context(|| {
             format!("Unable to get block upload slot for conversation {conversation_id}")
@@ -645,7 +645,7 @@ pub(super) async fn upload_current_block_snapshot(
     foreground: &ModelSpawner<AgentDriver>,
     terminal_driver: &ModelHandle<TerminalDriver>,
     client: &dyn HarnessSupportClient,
-    conversation_id: AIConversationId,
+    conversation_id: &ServerConversationToken,
     block_id: BlockId,
 ) -> Result<()> {
     let td = terminal_driver.clone();

--- a/app/src/ai/agent_sdk/driver/snapshot_tests.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot_tests.rs
@@ -10,7 +10,7 @@ use tempfile::{Builder as TempDirBuilder, TempDir};
 use tokio::runtime::Runtime;
 
 use super::*;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent_sdk::retry::MAX_ATTEMPTS;
 use crate::ai::agent_sdk::test_support::build_test_http_client;
 use crate::ai::artifacts::Artifact;
@@ -118,13 +118,13 @@ impl TestClient {
 
 #[async_trait]
 impl HarnessSupportClient for TestClient {
-    async fn create_external_conversation(&self, _format: &str) -> Result<AIConversationId> {
+    async fn create_external_conversation(&self, _format: &str) -> Result<ServerConversationToken> {
         unimplemented!("not used by upload_snapshot_from_declarations_file")
     }
 
     async fn get_transcript_upload_target(
         &self,
-        _conversation_id: &AIConversationId,
+        _conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         unimplemented!("not used by upload_snapshot_from_declarations_file")
     }
@@ -135,7 +135,7 @@ impl HarnessSupportClient for TestClient {
 
     async fn get_block_snapshot_upload_target(
         &self,
-        _conversation_id: &AIConversationId,
+        _conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         unimplemented!("not used by upload_snapshot_from_declarations_file")
     }

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1442,8 +1442,7 @@ impl AgentDriverRunner {
                 let harness_support_client = foreground
                     .spawn(|_, ctx| ServerApiProvider::as_ref(ctx).get_harness_support_client())
                     .await?;
-                let resume_conversation_id = AIConversationId::try_from(conversation_id.clone())
-                    .map_err(|err| AgentDriverError::ConversationLoadFailed(format!("{err:#}")))?;
+                let resume_conversation_id = ServerConversationToken::new(conversation_id.clone());
                 Ok(
                     h.fetch_resume_payload(&resume_conversation_id, harness_support_client)
                         .await?

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -8,6 +8,7 @@ use iso8601_duration::Duration as Iso8601Duration;
 use serde::{Deserialize, Serialize};
 use session_sharing_protocol::common::SessionId;
 use url::Url;
+use warp_cli::agent::Harness;
 use warp_core::ui::theme::WarpTheme;
 use warp_errors::report_error;
 use warpui::color::ColorU;
@@ -369,6 +370,26 @@ impl AmbientAgentTask {
     /// exists yet. A later prompt reuses the persisted conversation instead.
     pub fn is_open_for_setup_failure_debug_bootstrap(&self) -> bool {
         self.is_setup_failure_debug_session_open() && self.conversation_id().is_none()
+    }
+
+    /// The third-party CLI harness this task is configured to run, if any. `None` means the
+    /// task runs on Warp's native Oz harness (the default when no harness is configured), whose
+    /// conversations are represented locally in `BlocklistAIHistoryModel`. A `Some` task has no
+    /// such local conversation, whether or not its CLI-harness session has started yet — callers
+    /// that route or gate on "is this task backed by a native conversation" must check this
+    /// independent of runtime CLI-session state.
+    pub fn third_party_harness_type(&self) -> Option<Harness> {
+        let harness_type = self
+            .agent_config_snapshot
+            .as_ref()
+            .and_then(|config| config.harness.as_ref())?
+            .harness_type;
+        (harness_type != Harness::Oz).then_some(harness_type)
+    }
+
+    /// Whether this task is configured for a third-party CLI harness rather than Oz.
+    pub fn is_third_party_harness(&self) -> bool {
+        self.third_party_harness_type().is_some()
     }
 
     /// Returns true when this task's source must not accept user-triggered cloud follow-ups.

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -22,6 +22,9 @@ use crate::ai::attachment_utils::{
 };
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
+use crate::ai::blocklist::local_agent_task_sync_model::{
+    LocalAgentTaskSyncModel, QueuedSharedSessionPrompt,
+};
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::block::BlockId;
 use crate::workspaces::user_workspaces::ResolvedTeamScope;
@@ -845,6 +848,18 @@ impl BlocklistAIController {
         })
     }
 
+    /// Whether this controller's ambient task is already backed by a registered
+    /// CLI-harness (third-party) session. When true, `send_shared_session_query` must
+    /// not create a native `AIConversation` for a no-token prompt: CLI-harness runs are
+    /// represented by `LocalAgentTaskSyncModel`/`CLIAgentSessionsModel`, never by
+    /// `BlocklistAIHistoryModel`, so a fallback-created conversation would silently
+    /// become the run's wrong canonical conversation ID once it reports a server token.
+    fn is_ambient_task_backed_by_cli_harness(&self, ctx: &AppContext) -> bool {
+        self.ambient_agent_task_id.is_some_and(|task_id| {
+            LocalAgentTaskSyncModel::as_ref(ctx).is_task_backed_by_cli_harness(task_id)
+        })
+    }
+
     /// Tags `conversation_id` as a setup-failure debug bootstrap so `LocalAgentTaskSyncModel`
     /// stops deriving task lifecycle updates from it. Must run before the first exchange can
     /// report a server token, which would otherwise trigger an erroneous `IN_PROGRESS` report.
@@ -899,6 +914,35 @@ impl BlocklistAIController {
             // update can fire (REMOTE-2661).
             let bootstraps_setup_failure_debug =
                 self.is_open_for_setup_failure_debug_bootstrap(ctx);
+
+            if !bootstraps_setup_failure_debug
+                && let Some(task_id) = self.ambient_agent_task_id
+                && self.is_ambient_task_backed_by_cli_harness(ctx)
+            {
+                log::info!(
+                    "send_shared_session_query: task {task_id} is backed by a registered CLI \
+                     harness session with no live PTY yet; queuing prompt instead of creating \
+                     a native conversation (participant_id={participant_id:?})"
+                );
+                if !file_attachments.is_empty() {
+                    log::warn!(
+                        "send_shared_session_query: dropping {} file attachment(s) from a \
+                         queued CLI-harness shared-session prompt for task {task_id}; \
+                         attachment delivery to a CLI harness PTY is not supported",
+                        file_attachments.len()
+                    );
+                }
+                LocalAgentTaskSyncModel::handle(ctx).update(ctx, |model, _ctx| {
+                    model.queue_shared_session_prompt_for_cli_harness(
+                        task_id,
+                        QueuedSharedSessionPrompt {
+                            prompt,
+                            participant_id,
+                        },
+                    );
+                });
+                return;
+            }
 
             if FeatureFlag::AgentView.is_enabled() {
                 // If we're already in an empty agent view conversation, reuse it

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -17,6 +17,7 @@ use super::{BlocklistAIController, RequestInput, SessionContext};
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus, TaskSyncMode};
 use crate::ai::agent::{AIAgentActionId, AIAgentAttachment, EntrypointType};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::attachment_utils::{
     DownloadedAttachment, build_file_attachment_map, download_file, sanitize_filename,
 };
@@ -854,6 +855,26 @@ impl BlocklistAIController {
         })
     }
 
+    /// The task ID a no-token prompt landing right now must not spawn a native `AIConversation`
+    /// for, because it is (or is configured to be) backed by a third-party CLI-harness session.
+    /// Two independent signals are checked, since either can be true without the other:
+    /// - `LocalAgentTaskSyncModel::task_id_for_terminal_view`: the harness session has been
+    ///   registered for this pane (true from harness setup time, before its process launches).
+    /// - `AmbientAgentTask::is_third_party_harness`: the task's stored config says it runs on a
+    ///   third-party harness, independent of whether a session has registered for this pane yet
+    ///   (e.g. very early in setup, or if registration is ever skipped by a bug).
+    fn cli_harness_backed_task_id(&self, ctx: &AppContext) -> Option<AmbientAgentTaskId> {
+        LocalAgentTaskSyncModel::as_ref(ctx)
+            .task_id_for_terminal_view(self.terminal_surface_id)
+            .or_else(|| {
+                self.ambient_agent_task_id.filter(|task_id| {
+                    AgentConversationsModel::as_ref(ctx)
+                        .get_task_data(task_id)
+                        .is_some_and(|task| task.is_third_party_harness())
+                })
+            })
+    }
+
     /// Tags `conversation_id` as a setup-failure debug bootstrap so `LocalAgentTaskSyncModel`
     /// stops deriving task lifecycle updates from it. Must run before the first exchange can
     /// report a server token, which would otherwise trigger an erroneous `IN_PROGRESS` report.
@@ -920,8 +941,7 @@ impl BlocklistAIController {
             // these prompts to `PendingCliHarnessPromptQueue` before they ever reach this
             // method; reaching here for such a task means that gate was bypassed by a bug.
             if !bootstraps_setup_failure_debug
-                && let Some(task_id) = LocalAgentTaskSyncModel::as_ref(ctx)
-                    .task_id_for_terminal_view(self.terminal_surface_id)
+                && let Some(task_id) = self.cli_harness_backed_task_id(ctx)
             {
                 report_error!(
                     "Refused to create a native conversation for a task backed by a registered \

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -22,9 +22,7 @@ use crate::ai::attachment_utils::{
 };
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
-use crate::ai::blocklist::local_agent_task_sync_model::{
-    LocalAgentTaskSyncModel, QueuedSharedSessionPrompt,
-};
+use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::block::BlockId;
 use crate::workspaces::user_workspaces::ResolvedTeamScope;
@@ -664,8 +662,16 @@ impl BlocklistAIController {
         }
     }
 
-    /// Execute an agent prompt on behalf of the viewer.
-    pub fn execute_agent_prompt_for_shared_session(
+    /// Execute an agent prompt on behalf of the viewer, against Warp's native Oz harness.
+    ///
+    /// Callers must have already routed away third-party-harness-backed tasks: this method (and
+    /// `send_warp_agent_prompt_from_shared_session_injection`, which it feeds into) can only
+    /// resolve or create *native* `AIConversation`s, so calling it for a task whose canonical
+    /// representation is a CLI-harness session would either miss (its conversation is never in
+    /// `BlocklistAIHistoryModel`) or, on the no-token fallback path, wrongly create one. See
+    /// `accept_agent_prompt` (`terminal_view_adaptor.rs`) for the routing choke point that
+    /// guarantees this.
+    pub fn execute_warp_agent_prompt_from_shared_session_injection(
         &mut self,
         prompt: String,
         server_conversation_token: Option<ServerConversationToken>,
@@ -728,7 +734,7 @@ impl BlocklistAIController {
 
         // If there are no file downloads (or the feature is disabled), send the query immediately.
         if file_downloads.is_empty() || !FeatureFlag::CloudModeImageContext.is_enabled() {
-            self.send_shared_session_query(
+            self.send_warp_agent_prompt_from_shared_session_injection(
                 prompt,
                 conversation_id,
                 participant_id,
@@ -743,7 +749,7 @@ impl BlocklistAIController {
             report_error!(
                 "No attachments_download_dir set on controller, cannot process file attachments"
             );
-            self.send_shared_session_query(
+            self.send_warp_agent_prompt_from_shared_session_injection(
                 prompt,
                 conversation_id,
                 participant_id,
@@ -754,7 +760,7 @@ impl BlocklistAIController {
         };
         let Some(task_id) = self.ambient_agent_task_id else {
             report_error!("No task_id available to download attachments");
-            self.send_shared_session_query(
+            self.send_warp_agent_prompt_from_shared_session_injection(
                 prompt,
                 conversation_id,
                 participant_id,
@@ -826,7 +832,7 @@ impl BlocklistAIController {
             },
             move |controller, downloaded, ctx| {
                 let file_attachments = build_file_attachment_map(&downloaded);
-                controller.send_shared_session_query(
+                controller.send_warp_agent_prompt_from_shared_session_injection(
                     prompt,
                     conversation_id,
                     participant_id,
@@ -845,18 +851,6 @@ impl BlocklistAIController {
             AgentConversationsModel::as_ref(ctx)
                 .get_task_data(&task_id)
                 .is_some_and(|task| task.is_open_for_setup_failure_debug_bootstrap())
-        })
-    }
-
-    /// Whether this controller's ambient task is already backed by a registered
-    /// CLI-harness (third-party) session. When true, `send_shared_session_query` must
-    /// not create a native `AIConversation` for a no-token prompt: CLI-harness runs are
-    /// represented by `LocalAgentTaskSyncModel`/`CLIAgentSessionsModel`, never by
-    /// `BlocklistAIHistoryModel`, so a fallback-created conversation would silently
-    /// become the run's wrong canonical conversation ID once it reports a server token.
-    fn is_ambient_task_backed_by_cli_harness(&self, ctx: &AppContext) -> bool {
-        self.ambient_agent_task_id.is_some_and(|task_id| {
-            LocalAgentTaskSyncModel::as_ref(ctx).is_task_backed_by_cli_harness(task_id)
         })
     }
 
@@ -880,9 +874,11 @@ impl BlocklistAIController {
         });
     }
 
-    /// Helper to send a shared-session query, used both for immediate sends
-    /// (no file attachments) and deferred sends (after file downloads complete).
-    fn send_shared_session_query(
+    /// Helper to send a prompt against Warp's native Oz harness, used both for immediate sends
+    /// (no file attachments) and deferred sends (after file downloads complete). Only ever
+    /// resolves or creates a native `AIConversation` — see the doc comment on
+    /// `execute_warp_agent_prompt_from_shared_session_injection`, this method's sole caller.
+    fn send_warp_agent_prompt_from_shared_session_injection(
         &mut self,
         prompt: String,
         conversation_id: Option<AIConversationId>,
@@ -915,32 +911,24 @@ impl BlocklistAIController {
             let bootstraps_setup_failure_debug =
                 self.is_open_for_setup_failure_debug_bootstrap(ctx);
 
+            // Defense-in-depth (REMOTE-2661): a task backed by a registered CLI-harness session
+            // must never get a native `AIConversation` from a no-token prompt — its canonical
+            // representation lives in `LocalAgentTaskSyncModel`/`CLIAgentSessionsModel`, never
+            // in `BlocklistAIHistoryModel`, so a conversation created here would silently become
+            // the run's wrong canonical conversation ID once it reports a server token.
+            // `accept_agent_prompt` (`terminal_view_adaptor.rs`) is the primary gate that routes
+            // these prompts to `PendingCliHarnessPromptQueue` before they ever reach this
+            // method; reaching here for such a task means that gate was bypassed by a bug.
             if !bootstraps_setup_failure_debug
-                && let Some(task_id) = self.ambient_agent_task_id
-                && self.is_ambient_task_backed_by_cli_harness(ctx)
+                && let Some(task_id) = LocalAgentTaskSyncModel::as_ref(ctx)
+                    .task_id_for_terminal_view(self.terminal_surface_id)
             {
-                log::info!(
-                    "send_shared_session_query: task {task_id} is backed by a registered CLI \
-                     harness session with no live PTY yet; queuing prompt instead of creating \
-                     a native conversation (participant_id={participant_id:?})"
+                report_error!(
+                    "Refused to create a native conversation for a task backed by a registered \
+                     CLI-harness session; this prompt should have been routed to \
+                     PendingCliHarnessPromptQueue by accept_agent_prompt",
+                    extra: { "task_id" => %task_id }
                 );
-                if !file_attachments.is_empty() {
-                    log::warn!(
-                        "send_shared_session_query: dropping {} file attachment(s) from a \
-                         queued CLI-harness shared-session prompt for task {task_id}; \
-                         attachment delivery to a CLI harness PTY is not supported",
-                        file_attachments.len()
-                    );
-                }
-                LocalAgentTaskSyncModel::handle(ctx).update(ctx, |model, _ctx| {
-                    model.queue_shared_session_prompt_for_cli_harness(
-                        task_id,
-                        QueuedSharedSessionPrompt {
-                            prompt,
-                            participant_id,
-                        },
-                    );
-                });
                 return;
             }
 

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -858,14 +858,14 @@ impl BlocklistAIController {
     /// The task ID a no-token prompt landing right now must not spawn a native `AIConversation`
     /// for, because it is (or is configured to be) backed by a third-party CLI-harness session.
     /// Two independent signals are checked, since either can be true without the other:
-    /// - `LocalAgentTaskSyncModel::task_id_for_terminal_view`: the harness session has been
+    /// - `LocalAgentTaskSyncModel::cli_harness_task_id_for_terminal_view`: the harness session has been
     ///   registered for this pane (true from harness setup time, before its process launches).
     /// - `AmbientAgentTask::is_third_party_harness`: the task's stored config says it runs on a
     ///   third-party harness, independent of whether a session has registered for this pane yet
     ///   (e.g. very early in setup, or if registration is ever skipped by a bug).
     fn cli_harness_backed_task_id(&self, ctx: &AppContext) -> Option<AmbientAgentTaskId> {
         LocalAgentTaskSyncModel::as_ref(ctx)
-            .task_id_for_terminal_view(self.terminal_surface_id)
+            .cli_harness_task_id_for_terminal_view(self.terminal_surface_id)
             .or_else(|| {
                 self.ambient_agent_task_id.filter(|task_id| {
                     AgentConversationsModel::as_ref(ctx)

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use futures::channel::oneshot;
-use session_sharing_protocol::common::SessionId;
+use session_sharing_protocol::common::{ParticipantId, SessionId};
 use update_queue::LocalTaskUpdateQueue;
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 use warpui::{Entity, EntityId, ModelContext, SingletonEntity};
@@ -54,9 +54,36 @@ pub struct LocalAgentTaskSyncModel {
     /// acknowledged. Used by the agent driver to decide whether a terminal
     /// state still needs to be reported before the process exits.
     confirmed_terminal_states: HashMap<AmbientAgentTaskId, AgentTaskState>,
+    /// Shared-session-injected prompts queued for a task whose CLI-harness session is
+    /// registered (`register_cli_session`) but hasn't started yet, so there is no live PTY
+    /// to deliver them into. Drained once `CLIAgentSessionsModelEvent::Started` fires for
+    /// the registered terminal view; see `on_cli_session_started`.
+    pending_shared_session_prompts: HashMap<AmbientAgentTaskId, Vec<QueuedSharedSessionPrompt>>,
 }
 
-pub enum LocalAgentTaskSyncModelEvent {}
+pub enum LocalAgentTaskSyncModelEvent {
+    /// A CLI-harness session started for a task that had shared-session prompts queued
+    /// while its session wasn't yet live (see `queue_shared_session_prompt_for_cli_harness`).
+    /// Carries the queued prompts so a subscriber (the agent driver) can deliver them as
+    /// genuine PTY follow-ups to the now-running CLI harness.
+    SharedSessionPromptsReadyForCliHarness {
+        task_id: AmbientAgentTaskId,
+        terminal_view_id: EntityId,
+        prompts: Vec<QueuedSharedSessionPrompt>,
+    },
+}
+
+/// A shared-session-injected prompt captured by `send_shared_session_query` for a task
+/// backed by a registered 3rd-party CLI-harness session that hasn't started yet (see
+/// `LocalAgentTaskSyncModel::is_task_backed_by_cli_harness`). Delivered as a genuine PTY
+/// follow-up once the harness session starts, instead of being dropped or misrouted into a
+/// new native `AIConversation`.
+#[derive(Clone, Debug)]
+pub(crate) struct QueuedSharedSessionPrompt {
+    pub(crate) prompt: String,
+    pub(crate) participant_id: ParticipantId,
+}
+
 /// Aggregated update to send via `AIClient::update_agent_task`. Field names
 /// match the server input shape so it is unambiguous which value flows to
 /// which server field.
@@ -106,6 +133,7 @@ impl LocalAgentTaskSyncModel {
             update_queue: LocalTaskUpdateQueue::default(),
             idle_waiters: HashMap::new(),
             confirmed_terminal_states: HashMap::new(),
+            pending_shared_session_prompts: HashMap::new(),
         }
     }
 
@@ -214,6 +242,36 @@ impl LocalAgentTaskSyncModel {
         self.cli_session_task_ids.get(&terminal_view_id).copied()
     }
 
+    /// Returns whether `task_id` is currently backed by a registered CLI-harness
+    /// (third-party) session, i.e. `register_cli_session` has been called for it and
+    /// it hasn't been unregistered since. `send_shared_session_query` uses this to
+    /// avoid ever creating a native `AIConversation` for a task whose canonical
+    /// representation is a CLI-harness session: `BlocklistAIHistoryModel` never has
+    /// one for these tasks, so a fallback-created conversation would silently become
+    /// the run's wrong canonical conversation ID once it reports a server token.
+    pub fn is_task_backed_by_cli_harness(&self, task_id: AmbientAgentTaskId) -> bool {
+        self.cli_session_task_ids.values().any(|&id| id == task_id)
+    }
+
+    /// Queues a shared-session-injected prompt for `task_id` because its CLI-harness
+    /// session is registered but hasn't started yet, so there's no live PTY to deliver
+    /// it into. Drained once the session starts; see `on_cli_session_started`.
+    pub(crate) fn queue_shared_session_prompt_for_cli_harness(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        prompt: QueuedSharedSessionPrompt,
+    ) {
+        log::info!(
+            "LocalAgentTaskSyncModel: queuing shared-session prompt for task {task_id} \
+             pending CLI-harness session start (participant_id={:?})",
+            prompt.participant_id
+        );
+        self.pending_shared_session_prompts
+            .entry(task_id)
+            .or_default()
+            .push(prompt);
+    }
+
     /// Stops reporting CLI agent status changes for a completed driver run.
     /// Task updates accepted before unregistration remain queued until delivery
     /// finishes.
@@ -221,6 +279,7 @@ impl LocalAgentTaskSyncModel {
     pub fn unregister_cli_session(&mut self, terminal_view_id: EntityId) {
         if let Some(task_id) = self.cli_session_task_ids.remove(&terminal_view_id) {
             self.update_queue.remove_task(&task_id);
+            self.pending_shared_session_prompts.remove(&task_id);
         }
     }
 
@@ -276,6 +335,11 @@ impl LocalAgentTaskSyncModel {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
+            CLIAgentSessionsModelEvent::Started {
+                terminal_view_id, ..
+            } => {
+                self.on_cli_session_started(*terminal_view_id, ctx);
+            }
             CLIAgentSessionsModelEvent::StatusChanged {
                 terminal_view_id,
                 status,
@@ -285,11 +349,35 @@ impl LocalAgentTaskSyncModel {
             }
             // Pane-scoped CLI agent sessions can end between preflight, the
             // harness, and follow-ups, but the mapping belongs to the driver run.
-            CLIAgentSessionsModelEvent::Started { .. }
-            | CLIAgentSessionsModelEvent::InputSessionChanged { .. }
+            CLIAgentSessionsModelEvent::InputSessionChanged { .. }
             | CLIAgentSessionsModelEvent::Ended { .. }
             | CLIAgentSessionsModelEvent::SessionUpdated { .. } => {}
         }
+    }
+
+    /// Drains and re-emits any shared-session prompts queued for this task while its
+    /// CLI-harness session was registered but not yet started (see
+    /// `queue_shared_session_prompt_for_cli_harness`), so a subscriber can deliver them
+    /// as genuine PTY follow-ups now that the session is live.
+    fn on_cli_session_started(&mut self, terminal_view_id: EntityId, ctx: &mut ModelContext<Self>) {
+        let Some(&task_id) = self.cli_session_task_ids.get(&terminal_view_id) else {
+            return;
+        };
+        let Some(prompts) = self.pending_shared_session_prompts.remove(&task_id) else {
+            return;
+        };
+        log::info!(
+            "LocalAgentTaskSyncModel: CLI harness session started for task {task_id}; \
+             delivering {} queued shared-session prompt(s)",
+            prompts.len()
+        );
+        ctx.emit(
+            LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
+                task_id,
+                terminal_view_id,
+                prompts,
+            },
+        );
     }
 
     fn on_conversation_status_updated(

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use futures::channel::oneshot;
-use session_sharing_protocol::common::{ParticipantId, SessionId};
+use session_sharing_protocol::common::SessionId;
 use update_queue::LocalTaskUpdateQueue;
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 use warpui::{Entity, EntityId, ModelContext, SingletonEntity};
@@ -54,35 +54,9 @@ pub struct LocalAgentTaskSyncModel {
     /// acknowledged. Used by the agent driver to decide whether a terminal
     /// state still needs to be reported before the process exits.
     confirmed_terminal_states: HashMap<AmbientAgentTaskId, AgentTaskState>,
-    /// Shared-session-injected prompts queued for a task whose CLI-harness session is
-    /// registered (`register_cli_session`) but hasn't started yet, so there is no live PTY
-    /// to deliver them into. Drained once `CLIAgentSessionsModelEvent::Started` fires for
-    /// the registered terminal view; see `on_cli_session_started`.
-    pending_shared_session_prompts: HashMap<AmbientAgentTaskId, Vec<QueuedSharedSessionPrompt>>,
 }
 
-pub enum LocalAgentTaskSyncModelEvent {
-    /// A CLI-harness session started for a task that had shared-session prompts queued
-    /// while its session wasn't yet live (see `queue_shared_session_prompt_for_cli_harness`).
-    /// Carries the queued prompts so a subscriber (the agent driver) can deliver them as
-    /// genuine PTY follow-ups to the now-running CLI harness.
-    SharedSessionPromptsReadyForCliHarness {
-        task_id: AmbientAgentTaskId,
-        terminal_view_id: EntityId,
-        prompts: Vec<QueuedSharedSessionPrompt>,
-    },
-}
-
-/// A shared-session-injected prompt captured by `send_shared_session_query` for a task
-/// backed by a registered 3rd-party CLI-harness session that hasn't started yet (see
-/// `LocalAgentTaskSyncModel::is_task_backed_by_cli_harness`). Delivered as a genuine PTY
-/// follow-up once the harness session starts, instead of being dropped or misrouted into a
-/// new native `AIConversation`.
-#[derive(Clone, Debug)]
-pub(crate) struct QueuedSharedSessionPrompt {
-    pub(crate) prompt: String,
-    pub(crate) participant_id: ParticipantId,
-}
+pub enum LocalAgentTaskSyncModelEvent {}
 
 /// Aggregated update to send via `AIClient::update_agent_task`. Field names
 /// match the server input shape so it is unambiguous which value flows to
@@ -133,7 +107,6 @@ impl LocalAgentTaskSyncModel {
             update_queue: LocalTaskUpdateQueue::default(),
             idle_waiters: HashMap::new(),
             confirmed_terminal_states: HashMap::new(),
-            pending_shared_session_prompts: HashMap::new(),
         }
     }
 
@@ -242,36 +215,6 @@ impl LocalAgentTaskSyncModel {
         self.cli_session_task_ids.get(&terminal_view_id).copied()
     }
 
-    /// Returns whether `task_id` is currently backed by a registered CLI-harness
-    /// (third-party) session, i.e. `register_cli_session` has been called for it and
-    /// it hasn't been unregistered since. `send_shared_session_query` uses this to
-    /// avoid ever creating a native `AIConversation` for a task whose canonical
-    /// representation is a CLI-harness session: `BlocklistAIHistoryModel` never has
-    /// one for these tasks, so a fallback-created conversation would silently become
-    /// the run's wrong canonical conversation ID once it reports a server token.
-    pub fn is_task_backed_by_cli_harness(&self, task_id: AmbientAgentTaskId) -> bool {
-        self.cli_session_task_ids.values().any(|&id| id == task_id)
-    }
-
-    /// Queues a shared-session-injected prompt for `task_id` because its CLI-harness
-    /// session is registered but hasn't started yet, so there's no live PTY to deliver
-    /// it into. Drained once the session starts; see `on_cli_session_started`.
-    pub(crate) fn queue_shared_session_prompt_for_cli_harness(
-        &mut self,
-        task_id: AmbientAgentTaskId,
-        prompt: QueuedSharedSessionPrompt,
-    ) {
-        log::info!(
-            "LocalAgentTaskSyncModel: queuing shared-session prompt for task {task_id} \
-             pending CLI-harness session start (participant_id={:?})",
-            prompt.participant_id
-        );
-        self.pending_shared_session_prompts
-            .entry(task_id)
-            .or_default()
-            .push(prompt);
-    }
-
     /// Stops reporting CLI agent status changes for a completed driver run.
     /// Task updates accepted before unregistration remain queued until delivery
     /// finishes.
@@ -279,7 +222,6 @@ impl LocalAgentTaskSyncModel {
     pub fn unregister_cli_session(&mut self, terminal_view_id: EntityId) {
         if let Some(task_id) = self.cli_session_task_ids.remove(&terminal_view_id) {
             self.update_queue.remove_task(&task_id);
-            self.pending_shared_session_prompts.remove(&task_id);
         }
     }
 
@@ -335,11 +277,6 @@ impl LocalAgentTaskSyncModel {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
-            CLIAgentSessionsModelEvent::Started {
-                terminal_view_id, ..
-            } => {
-                self.on_cli_session_started(*terminal_view_id, ctx);
-            }
             CLIAgentSessionsModelEvent::StatusChanged {
                 terminal_view_id,
                 status,
@@ -349,35 +286,11 @@ impl LocalAgentTaskSyncModel {
             }
             // Pane-scoped CLI agent sessions can end between preflight, the
             // harness, and follow-ups, but the mapping belongs to the driver run.
-            CLIAgentSessionsModelEvent::InputSessionChanged { .. }
+            CLIAgentSessionsModelEvent::Started { .. }
+            | CLIAgentSessionsModelEvent::InputSessionChanged { .. }
             | CLIAgentSessionsModelEvent::Ended { .. }
             | CLIAgentSessionsModelEvent::SessionUpdated { .. } => {}
         }
-    }
-
-    /// Drains and re-emits any shared-session prompts queued for this task while its
-    /// CLI-harness session was registered but not yet started (see
-    /// `queue_shared_session_prompt_for_cli_harness`), so a subscriber can deliver them
-    /// as genuine PTY follow-ups now that the session is live.
-    fn on_cli_session_started(&mut self, terminal_view_id: EntityId, ctx: &mut ModelContext<Self>) {
-        let Some(&task_id) = self.cli_session_task_ids.get(&terminal_view_id) else {
-            return;
-        };
-        let Some(prompts) = self.pending_shared_session_prompts.remove(&task_id) else {
-            return;
-        };
-        log::info!(
-            "LocalAgentTaskSyncModel: CLI harness session started for task {task_id}; \
-             delivering {} queued shared-session prompt(s)",
-            prompts.len()
-        );
-        ctx.emit(
-            LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
-                task_id,
-                terminal_view_id,
-                prompts,
-            },
-        );
     }
 
     fn on_conversation_status_updated(

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -188,7 +188,7 @@ impl LocalAgentTaskSyncModel {
     /// `terminal_view_id → task_id` mapping, without enqueuing the
     /// IN_PROGRESS report that `register_cli_session` sends via the real
     /// `AIClient`. Use this in tests that only need
-    /// `task_id_for_terminal_view` to resolve (e.g. exercising
+    /// `cli_harness_task_id_for_terminal_view` to resolve (e.g. exercising
     /// `TerminalView::conversation_id_for_cli_status_updates`).
     #[cfg(test)]
     pub(crate) fn register_cli_session_for_test(
@@ -208,7 +208,7 @@ impl LocalAgentTaskSyncModel {
     /// unrelated to its CLI-harness session (e.g. an earlier native Agent
     /// Mode conversation). Returns `None` for a purely interactive CLI agent
     /// session with no ambient task behind it.
-    pub fn task_id_for_terminal_view(
+    pub fn cli_harness_task_id_for_terminal_view(
         &self,
         terminal_view_id: EntityId,
     ) -> Option<AmbientAgentTaskId> {

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use anyhow::anyhow;
 use session_sharing_protocol::common::{ParticipantId, SessionId};
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
-use warpui::App;
 use warpui::r#async::FutureExt as _;
+use warpui::{App, SingletonEntity};
 
 use super::super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use super::{

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -5,11 +5,14 @@ use std::time::Duration;
 use anyhow::anyhow;
 use session_sharing_protocol::common::SessionId;
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
+use warpui::App;
 use warpui::r#async::FutureExt as _;
-use warpui::{App, SingletonEntity};
 
 use super::super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
-use super::{classify_renderable_error, map_cli_session_status, map_conversation_status};
+use super::{
+    LocalAgentTaskSyncModel, classify_renderable_error, map_cli_session_status,
+    map_conversation_status,
+};
 use crate::ai::agent::conversation::{
     AIConversation, AIConversationId, ConversationStatus, TaskSyncMode,
 };

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -3,15 +3,15 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::anyhow;
-use session_sharing_protocol::common::SessionId;
+use session_sharing_protocol::common::{ParticipantId, SessionId};
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 use warpui::App;
 use warpui::r#async::FutureExt as _;
 
 use super::super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use super::{
-    LocalAgentTaskSyncModel, classify_renderable_error, map_cli_session_status,
-    map_conversation_status,
+    LocalAgentTaskSyncModel, LocalAgentTaskSyncModelEvent, QueuedSharedSessionPrompt,
+    classify_renderable_error, map_cli_session_status, map_conversation_status,
 };
 use crate::ai::agent::conversation::{
     AIConversation, AIConversationId, ConversationStatus, TaskSyncMode,
@@ -625,6 +625,181 @@ fn emit_cli_status(
             status,
             session_context: Box::default(),
         });
+    });
+}
+
+fn emit_cli_started(
+    cli_sessions_model: &warpui::ModelHandle<CLIAgentSessionsModel>,
+    app: &mut App,
+    terminal_view_id: warpui::EntityId,
+) {
+    cli_sessions_model.update(app, |_, ctx| {
+        ctx.emit(CLIAgentSessionsModelEvent::Started {
+            terminal_view_id,
+            agent: CLIAgent::Claude,
+        });
+    });
+}
+
+// --- CLI-harness detection and shared-session prompt queueing ---
+
+/// `send_shared_session_query` relies on this to decide it must never create a native
+/// conversation for a task whose canonical representation is a CLI-harness session.
+#[test]
+fn is_task_backed_by_cli_harness_reflects_registration_lifecycle() {
+    App::test((), |mut app| async move {
+        let (model, _counter) = install_model_with_call_counter(&mut app);
+        let terminal_view_id = warpui::EntityId::new();
+        let task_id = fixed_task_id();
+
+        let backed_before_registration = model.update(&mut app, |model, _| {
+            model.is_task_backed_by_cli_harness(task_id)
+        });
+        assert!(
+            !backed_before_registration,
+            "an unregistered task must not be considered CLI-harness-backed"
+        );
+
+        model.update(&mut app, |model, ctx| {
+            model.register_cli_session(terminal_view_id, task_id, ctx);
+        });
+        let backed_after_registration = model.update(&mut app, |model, _| {
+            model.is_task_backed_by_cli_harness(task_id)
+        });
+        assert!(
+            backed_after_registration,
+            "a registered CLI-harness session must mark its task as backed"
+        );
+
+        model.update(&mut app, |model, _| {
+            model.unregister_cli_session(terminal_view_id);
+        });
+        let backed_after_unregister = model.update(&mut app, |model, _| {
+            model.is_task_backed_by_cli_harness(task_id)
+        });
+        assert!(
+            !backed_after_unregister,
+            "unregistering the CLI-harness session must clear the backed status"
+        );
+
+        pump_spawned_tasks().await;
+    });
+}
+
+/// A shared-session prompt queued while a task's CLI-harness session is registered but not
+/// yet started must not be dropped: it stays queued until the session starts, at which point
+/// it is drained and re-emitted (for the agent driver to deliver as a genuine PTY follow-up).
+#[test]
+fn queued_shared_session_prompt_is_delivered_once_cli_session_starts() {
+    App::test((), |mut app| async move {
+        let (model, _counter) = install_model_with_call_counter(&mut app);
+        let cli_sessions_model = CLIAgentSessionsModel::handle(&app);
+        let terminal_view_id = warpui::EntityId::new();
+        let task_id = fixed_task_id();
+        let participant_id = ParticipantId::new();
+
+        model.update(&mut app, |model, ctx| {
+            model.register_cli_session(terminal_view_id, task_id, ctx);
+        });
+
+        model.update(&mut app, |model, _| {
+            model.queue_shared_session_prompt_for_cli_harness(
+                task_id,
+                QueuedSharedSessionPrompt {
+                    prompt: "do the thing".to_string(),
+                    participant_id: participant_id.clone(),
+                },
+            );
+        });
+
+        let delivered = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let delivered_for_sub = delivered.clone();
+        let model_for_subscription = model.clone();
+        model.update(&mut app, move |_, ctx| {
+            ctx.subscribe_to_model(&model_for_subscription, move |_, _, event, _| {
+                let LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
+                    task_id: event_task_id,
+                    terminal_view_id: event_terminal_view_id,
+                    prompts,
+                } = event;
+                delivered_for_sub.borrow_mut().push((
+                    *event_task_id,
+                    *event_terminal_view_id,
+                    prompts.clone(),
+                ));
+            });
+        });
+
+        // Not started yet: the prompt must remain queued, not be delivered or dropped.
+        pump_spawned_tasks().await;
+        assert!(
+            delivered.borrow().is_empty(),
+            "prompt must not be delivered before the CLI-harness session starts"
+        );
+
+        emit_cli_started(&cli_sessions_model, &mut app, terminal_view_id);
+        pump_spawned_tasks().await;
+
+        let delivered = delivered.borrow();
+        assert_eq!(
+            delivered.len(),
+            1,
+            "exactly one delivery event must fire once the session starts"
+        );
+        let (event_task_id, event_terminal_view_id, prompts) = &delivered[0];
+        assert_eq!(*event_task_id, task_id);
+        assert_eq!(*event_terminal_view_id, terminal_view_id);
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].prompt, "do the thing");
+        assert_eq!(prompts[0].participant_id, participant_id);
+    });
+}
+
+/// Once delivered, a queued prompt must not be delivered again on a later session start
+/// (e.g. after a resumed/second CLI-harness session for the same task).
+#[test]
+fn queued_shared_session_prompt_is_only_delivered_once() {
+    App::test((), |mut app| async move {
+        let (model, _counter) = install_model_with_call_counter(&mut app);
+        let cli_sessions_model = CLIAgentSessionsModel::handle(&app);
+        let terminal_view_id = warpui::EntityId::new();
+        let task_id = fixed_task_id();
+
+        model.update(&mut app, |model, ctx| {
+            model.register_cli_session(terminal_view_id, task_id, ctx);
+        });
+        model.update(&mut app, |model, _| {
+            model.queue_shared_session_prompt_for_cli_harness(
+                task_id,
+                QueuedSharedSessionPrompt {
+                    prompt: "only once".to_string(),
+                    participant_id: ParticipantId::new(),
+                },
+            );
+        });
+
+        let delivery_count = Arc::new(AtomicUsize::new(0));
+        let delivery_count_for_sub = delivery_count.clone();
+        let model_for_subscription = model.clone();
+        model.update(&mut app, move |_, ctx| {
+            ctx.subscribe_to_model(&model_for_subscription, move |_, _, _event, _| {
+                delivery_count_for_sub.fetch_add(1, Ordering::SeqCst);
+            });
+        });
+
+        emit_cli_started(&cli_sessions_model, &mut app, terminal_view_id);
+        pump_spawned_tasks().await;
+        assert_eq!(delivery_count.load(Ordering::SeqCst), 1);
+
+        // A second Started event for the same terminal view (e.g. a resumed session) must not
+        // redeliver an already-drained queue.
+        emit_cli_started(&cli_sessions_model, &mut app, terminal_view_id);
+        pump_spawned_tasks().await;
+        assert_eq!(
+            delivery_count.load(Ordering::SeqCst),
+            1,
+            "an already-drained queue must not be redelivered"
+        );
     });
 }
 

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -648,6 +648,7 @@ fn emit_cli_started(
 #[test]
 fn is_task_backed_by_cli_harness_reflects_registration_lifecycle() {
     App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let (model, _counter) = install_model_with_call_counter(&mut app);
         let terminal_view_id = warpui::EntityId::new();
         let task_id = fixed_task_id();
@@ -692,6 +693,7 @@ fn is_task_backed_by_cli_harness_reflects_registration_lifecycle() {
 #[test]
 fn queued_shared_session_prompt_is_delivered_once_cli_session_starts() {
     App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let (model, _counter) = install_model_with_call_counter(&mut app);
         let cli_sessions_model = CLIAgentSessionsModel::handle(&app);
         let terminal_view_id = warpui::EntityId::new();
@@ -760,6 +762,7 @@ fn queued_shared_session_prompt_is_delivered_once_cli_session_starts() {
 #[test]
 fn queued_shared_session_prompt_is_only_delivered_once() {
     App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let (model, _counter) = install_model_with_call_counter(&mut app);
         let cli_sessions_model = CLIAgentSessionsModel::handle(&app);
         let terminal_view_id = warpui::EntityId::new();

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -714,11 +714,13 @@ fn queued_shared_session_prompt_is_delivered_once_cli_session_starts() {
             );
         });
 
+        // Subscribe via `AppContext` (not `LocalAgentTaskSyncModel`'s own `ModelContext`):
+        // a model may not subscribe to its own events.
         let delivered = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
         let delivered_for_sub = delivered.clone();
         let model_for_subscription = model.clone();
-        model.update(&mut app, move |_, ctx| {
-            ctx.subscribe_to_model(&model_for_subscription, move |_, _, event, _| {
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&model_for_subscription, move |_, event, _ctx| {
                 let LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
                     task_id: event_task_id,
                     terminal_view_id: event_terminal_view_id,
@@ -781,11 +783,13 @@ fn queued_shared_session_prompt_is_only_delivered_once() {
             );
         });
 
+        // Subscribe via `AppContext` (not `LocalAgentTaskSyncModel`'s own `ModelContext`):
+        // a model may not subscribe to its own events.
         let delivery_count = Arc::new(AtomicUsize::new(0));
         let delivery_count_for_sub = delivery_count.clone();
         let model_for_subscription = model.clone();
-        model.update(&mut app, move |_, ctx| {
-            ctx.subscribe_to_model(&model_for_subscription, move |_, _, _event, _| {
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&model_for_subscription, move |_, _event, _ctx| {
                 delivery_count_for_sub.fetch_add(1, Ordering::SeqCst);
             });
         });

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -3,16 +3,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::anyhow;
-use session_sharing_protocol::common::{ParticipantId, SessionId};
+use session_sharing_protocol::common::SessionId;
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 use warpui::r#async::FutureExt as _;
 use warpui::{App, SingletonEntity};
 
 use super::super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
-use super::{
-    LocalAgentTaskSyncModel, LocalAgentTaskSyncModelEvent, QueuedSharedSessionPrompt,
-    classify_renderable_error, map_cli_session_status, map_conversation_status,
-};
+use super::{classify_renderable_error, map_cli_session_status, map_conversation_status};
 use crate::ai::agent::conversation::{
     AIConversation, AIConversationId, ConversationStatus, TaskSyncMode,
 };
@@ -625,188 +622,6 @@ fn emit_cli_status(
             status,
             session_context: Box::default(),
         });
-    });
-}
-
-fn emit_cli_started(
-    cli_sessions_model: &warpui::ModelHandle<CLIAgentSessionsModel>,
-    app: &mut App,
-    terminal_view_id: warpui::EntityId,
-) {
-    cli_sessions_model.update(app, |_, ctx| {
-        ctx.emit(CLIAgentSessionsModelEvent::Started {
-            terminal_view_id,
-            agent: CLIAgent::Claude,
-        });
-    });
-}
-
-// --- CLI-harness detection and shared-session prompt queueing ---
-
-/// `send_shared_session_query` relies on this to decide it must never create a native
-/// conversation for a task whose canonical representation is a CLI-harness session.
-#[test]
-fn is_task_backed_by_cli_harness_reflects_registration_lifecycle() {
-    App::test((), |mut app| async move {
-        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        let (model, _counter) = install_model_with_call_counter(&mut app);
-        let terminal_view_id = warpui::EntityId::new();
-        let task_id = fixed_task_id();
-
-        let backed_before_registration = model.update(&mut app, |model, _| {
-            model.is_task_backed_by_cli_harness(task_id)
-        });
-        assert!(
-            !backed_before_registration,
-            "an unregistered task must not be considered CLI-harness-backed"
-        );
-
-        model.update(&mut app, |model, ctx| {
-            model.register_cli_session(terminal_view_id, task_id, ctx);
-        });
-        let backed_after_registration = model.update(&mut app, |model, _| {
-            model.is_task_backed_by_cli_harness(task_id)
-        });
-        assert!(
-            backed_after_registration,
-            "a registered CLI-harness session must mark its task as backed"
-        );
-
-        model.update(&mut app, |model, _| {
-            model.unregister_cli_session(terminal_view_id);
-        });
-        let backed_after_unregister = model.update(&mut app, |model, _| {
-            model.is_task_backed_by_cli_harness(task_id)
-        });
-        assert!(
-            !backed_after_unregister,
-            "unregistering the CLI-harness session must clear the backed status"
-        );
-
-        pump_spawned_tasks().await;
-    });
-}
-
-/// A shared-session prompt queued while a task's CLI-harness session is registered but not
-/// yet started must not be dropped: it stays queued until the session starts, at which point
-/// it is drained and re-emitted (for the agent driver to deliver as a genuine PTY follow-up).
-#[test]
-fn queued_shared_session_prompt_is_delivered_once_cli_session_starts() {
-    App::test((), |mut app| async move {
-        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        let (model, _counter) = install_model_with_call_counter(&mut app);
-        let cli_sessions_model = CLIAgentSessionsModel::handle(&app);
-        let terminal_view_id = warpui::EntityId::new();
-        let task_id = fixed_task_id();
-        let participant_id = ParticipantId::new();
-
-        model.update(&mut app, |model, ctx| {
-            model.register_cli_session(terminal_view_id, task_id, ctx);
-        });
-
-        model.update(&mut app, |model, _| {
-            model.queue_shared_session_prompt_for_cli_harness(
-                task_id,
-                QueuedSharedSessionPrompt {
-                    prompt: "do the thing".to_string(),
-                    participant_id: participant_id.clone(),
-                },
-            );
-        });
-
-        // Subscribe via `AppContext` (not `LocalAgentTaskSyncModel`'s own `ModelContext`):
-        // a model may not subscribe to its own events.
-        let delivered = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
-        let delivered_for_sub = delivered.clone();
-        let model_for_subscription = model.clone();
-        app.update(|ctx| {
-            ctx.subscribe_to_model(&model_for_subscription, move |_, event, _ctx| {
-                let LocalAgentTaskSyncModelEvent::SharedSessionPromptsReadyForCliHarness {
-                    task_id: event_task_id,
-                    terminal_view_id: event_terminal_view_id,
-                    prompts,
-                } = event;
-                delivered_for_sub.borrow_mut().push((
-                    *event_task_id,
-                    *event_terminal_view_id,
-                    prompts.clone(),
-                ));
-            });
-        });
-
-        // Not started yet: the prompt must remain queued, not be delivered or dropped.
-        pump_spawned_tasks().await;
-        assert!(
-            delivered.borrow().is_empty(),
-            "prompt must not be delivered before the CLI-harness session starts"
-        );
-
-        emit_cli_started(&cli_sessions_model, &mut app, terminal_view_id);
-        pump_spawned_tasks().await;
-
-        let delivered = delivered.borrow();
-        assert_eq!(
-            delivered.len(),
-            1,
-            "exactly one delivery event must fire once the session starts"
-        );
-        let (event_task_id, event_terminal_view_id, prompts) = &delivered[0];
-        assert_eq!(*event_task_id, task_id);
-        assert_eq!(*event_terminal_view_id, terminal_view_id);
-        assert_eq!(prompts.len(), 1);
-        assert_eq!(prompts[0].prompt, "do the thing");
-        assert_eq!(prompts[0].participant_id, participant_id);
-    });
-}
-
-/// Once delivered, a queued prompt must not be delivered again on a later session start
-/// (e.g. after a resumed/second CLI-harness session for the same task).
-#[test]
-fn queued_shared_session_prompt_is_only_delivered_once() {
-    App::test((), |mut app| async move {
-        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        let (model, _counter) = install_model_with_call_counter(&mut app);
-        let cli_sessions_model = CLIAgentSessionsModel::handle(&app);
-        let terminal_view_id = warpui::EntityId::new();
-        let task_id = fixed_task_id();
-
-        model.update(&mut app, |model, ctx| {
-            model.register_cli_session(terminal_view_id, task_id, ctx);
-        });
-        model.update(&mut app, |model, _| {
-            model.queue_shared_session_prompt_for_cli_harness(
-                task_id,
-                QueuedSharedSessionPrompt {
-                    prompt: "only once".to_string(),
-                    participant_id: ParticipantId::new(),
-                },
-            );
-        });
-
-        // Subscribe via `AppContext` (not `LocalAgentTaskSyncModel`'s own `ModelContext`):
-        // a model may not subscribe to its own events.
-        let delivery_count = Arc::new(AtomicUsize::new(0));
-        let delivery_count_for_sub = delivery_count.clone();
-        let model_for_subscription = model.clone();
-        app.update(|ctx| {
-            ctx.subscribe_to_model(&model_for_subscription, move |_, _event, _ctx| {
-                delivery_count_for_sub.fetch_add(1, Ordering::SeqCst);
-            });
-        });
-
-        emit_cli_started(&cli_sessions_model, &mut app, terminal_view_id);
-        pump_spawned_tasks().await;
-        assert_eq!(delivery_count.load(Ordering::SeqCst), 1);
-
-        // A second Started event for the same terminal view (e.g. a resumed session) must not
-        // redeliver an already-drained queue.
-        emit_cli_started(&cli_sessions_model, &mut app, terminal_view_id);
-        pump_spawned_tasks().await;
-        assert_eq!(
-            delivery_count.load(Ordering::SeqCst),
-            1,
-            "an already-drained queue must not be redelivered"
-        );
     });
 }
 

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod orchestration_event_streamer;
 pub(crate) mod orchestration_events;
 pub(crate) mod orchestration_topology;
 mod passive_suggestions;
+pub(crate) mod pending_cli_harness_prompt_queue;
 pub(crate) mod queued_query;
 pub(super) use controller::RequestInput;
 pub mod history_model;

--- a/app/src/ai/blocklist/pending_cli_harness_prompt_queue.rs
+++ b/app/src/ai/blocklist/pending_cli_harness_prompt_queue.rs
@@ -8,6 +8,9 @@ use crate::ai::ambient_agents::AmbientAgentTaskId;
 /// A shared-session-injected prompt queued for a task whose CLI-harness session is registered
 /// (see `LocalAgentTaskSyncModel::register_cli_session`) but hasn't started a live PTY yet.
 /// File attachments are not supported here — see `PendingCliHarnessPromptQueue::queue`.
+///
+/// CLI-harness sessions only exist on local/native builds, so this whole type is unread on wasm.
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 #[derive(Clone, Debug)]
 pub(crate) struct QueuedCliHarnessPrompt {
     pub(crate) prompt: String,
@@ -24,6 +27,9 @@ pub(crate) struct QueuedCliHarnessPrompt {
 /// `AgentDriver::subscribe_to_cli_agent_session_events` drains a task's queue directly when its
 /// `CLIAgentSessionsModelEvent::Started` fires, delivering each prompt as a genuine PTY
 /// follow-up via `TerminalDriver::send_text_to_cli`.
+///
+/// CLI-harness sessions only exist on local/native builds, so `pending` is unread on wasm.
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 #[derive(Default)]
 pub(crate) struct PendingCliHarnessPromptQueue {
     pending: HashMap<AmbientAgentTaskId, Vec<QueuedCliHarnessPrompt>>,
@@ -37,6 +43,7 @@ impl PendingCliHarnessPromptQueue {
     }
 
     /// Queues `prompt` for `task_id`'s not-yet-started CLI-harness session.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn queue(&mut self, task_id: AmbientAgentTaskId, prompt: QueuedCliHarnessPrompt) {
         log::info!(
             "PendingCliHarnessPromptQueue: queuing shared-session prompt for task {task_id} \
@@ -48,12 +55,14 @@ impl PendingCliHarnessPromptQueue {
 
     /// Removes and returns any prompts queued for `task_id`, in FIFO order. Called once the
     /// task's CLI-harness session starts.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn drain(&mut self, task_id: AmbientAgentTaskId) -> Vec<QueuedCliHarnessPrompt> {
         self.pending.remove(&task_id).unwrap_or_default()
     }
 
     /// Drops any prompts queued for `task_id` without delivering them, e.g. when its CLI
     /// session's driver run ends before the harness ever started.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn clear(&mut self, task_id: AmbientAgentTaskId) {
         self.pending.remove(&task_id);
     }

--- a/app/src/ai/blocklist/pending_cli_harness_prompt_queue.rs
+++ b/app/src/ai/blocklist/pending_cli_harness_prompt_queue.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+
+use session_sharing_protocol::common::ParticipantId;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use crate::ai::ambient_agents::AmbientAgentTaskId;
+
+/// A shared-session-injected prompt queued for a task whose CLI-harness session is registered
+/// (see `LocalAgentTaskSyncModel::register_cli_session`) but hasn't started a live PTY yet.
+/// File attachments are not supported here — see `PendingCliHarnessPromptQueue::queue`.
+#[derive(Clone, Debug)]
+pub(crate) struct QueuedCliHarnessPrompt {
+    pub(crate) prompt: String,
+    pub(crate) participant_id: ParticipantId,
+}
+
+/// Holds shared-session-injected prompts for third-party-harness ambient tasks whose CLI
+/// session has been registered (`LocalAgentTaskSyncModel::register_cli_session`) but has no
+/// live PTY yet, so there is nowhere to deliver them. `accept_agent_prompt`
+/// (`terminal_view_adaptor.rs`) queues here instead of falling through to the Oz-only
+/// `BlocklistAIController` path, which must never create a native `AIConversation` for a
+/// task backed by a third-party harness.
+///
+/// `AgentDriver::subscribe_to_cli_agent_session_events` drains a task's queue directly when its
+/// `CLIAgentSessionsModelEvent::Started` fires, delivering each prompt as a genuine PTY
+/// follow-up via `TerminalDriver::send_text_to_cli`.
+#[derive(Default)]
+pub(crate) struct PendingCliHarnessPromptQueue {
+    pending: HashMap<AmbientAgentTaskId, Vec<QueuedCliHarnessPrompt>>,
+}
+
+pub(crate) enum PendingCliHarnessPromptQueueEvent {}
+
+impl PendingCliHarnessPromptQueue {
+    pub fn new(_ctx: &mut ModelContext<Self>) -> Self {
+        Self::default()
+    }
+
+    /// Queues `prompt` for `task_id`'s not-yet-started CLI-harness session.
+    pub(crate) fn queue(&mut self, task_id: AmbientAgentTaskId, prompt: QueuedCliHarnessPrompt) {
+        log::info!(
+            "PendingCliHarnessPromptQueue: queuing shared-session prompt for task {task_id} \
+             pending CLI-harness session start (participant_id={:?})",
+            prompt.participant_id
+        );
+        self.pending.entry(task_id).or_default().push(prompt);
+    }
+
+    /// Removes and returns any prompts queued for `task_id`, in FIFO order. Called once the
+    /// task's CLI-harness session starts.
+    pub(crate) fn drain(&mut self, task_id: AmbientAgentTaskId) -> Vec<QueuedCliHarnessPrompt> {
+        self.pending.remove(&task_id).unwrap_or_default()
+    }
+
+    /// Drops any prompts queued for `task_id` without delivering them, e.g. when its CLI
+    /// session's driver run ends before the harness ever started.
+    pub(crate) fn clear(&mut self, task_id: AmbientAgentTaskId) {
+        self.pending.remove(&task_id);
+    }
+}
+
+impl Entity for PendingCliHarnessPromptQueue {
+    type Event = PendingCliHarnessPromptQueueEvent;
+}
+
+impl SingletonEntity for PendingCliHarnessPromptQueue {}
+
+#[cfg(test)]
+#[path = "pending_cli_harness_prompt_queue_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/pending_cli_harness_prompt_queue_tests.rs
+++ b/app/src/ai/blocklist/pending_cli_harness_prompt_queue_tests.rs
@@ -1,0 +1,86 @@
+use session_sharing_protocol::common::ParticipantId;
+
+use super::{PendingCliHarnessPromptQueue, QueuedCliHarnessPrompt};
+use crate::ai::ambient_agents::AmbientAgentTaskId;
+
+fn fixed_task_id() -> AmbientAgentTaskId {
+    "550e8400-e29b-41d4-a716-446655440a00"
+        .parse()
+        .expect("valid task id")
+}
+
+#[test]
+fn drain_on_empty_queue_returns_empty_vec() {
+    let mut queue = PendingCliHarnessPromptQueue::default();
+    assert!(queue.drain(fixed_task_id()).is_empty());
+}
+
+#[test]
+fn queued_prompts_are_drained_in_fifo_order() {
+    let mut queue = PendingCliHarnessPromptQueue::default();
+    let task_id = fixed_task_id();
+
+    queue.queue(
+        task_id,
+        QueuedCliHarnessPrompt {
+            prompt: "first".to_string(),
+            participant_id: ParticipantId::new(),
+        },
+    );
+    queue.queue(
+        task_id,
+        QueuedCliHarnessPrompt {
+            prompt: "second".to_string(),
+            participant_id: ParticipantId::new(),
+        },
+    );
+
+    let drained = queue.drain(task_id);
+    assert_eq!(drained.len(), 2);
+    assert_eq!(drained[0].prompt, "first");
+    assert_eq!(drained[1].prompt, "second");
+
+    // Draining again must not redeliver.
+    assert!(queue.drain(task_id).is_empty());
+}
+
+#[test]
+fn queues_for_different_tasks_are_independent() {
+    let mut queue = PendingCliHarnessPromptQueue::default();
+    let task_a: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-446655440a00"
+        .parse()
+        .expect("valid task id");
+    let task_b: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-446655440a01"
+        .parse()
+        .expect("valid task id");
+
+    queue.queue(
+        task_a,
+        QueuedCliHarnessPrompt {
+            prompt: "for a".to_string(),
+            participant_id: ParticipantId::new(),
+        },
+    );
+
+    assert!(queue.drain(task_b).is_empty());
+    let drained_a = queue.drain(task_a);
+    assert_eq!(drained_a.len(), 1);
+    assert_eq!(drained_a[0].prompt, "for a");
+}
+
+#[test]
+fn clear_drops_queued_prompts_without_delivering() {
+    let mut queue = PendingCliHarnessPromptQueue::default();
+    let task_id = fixed_task_id();
+
+    queue.queue(
+        task_id,
+        QueuedCliHarnessPrompt {
+            prompt: "dropped".to_string(),
+            participant_id: ParticipantId::new(),
+        },
+    );
+    queue.clear(task_id);
+
+    assert!(queue.drain(task_id).is_empty());
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2249,6 +2249,9 @@ pub(crate) fn initialize_app(
         ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel::new,
     );
     ctx.add_singleton_model(
+        ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue::new,
+    );
+    ctx.add_singleton_model(
         ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer::new,
     );
 

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -184,6 +184,7 @@ fn initialize_app_with_history(app: &mut App, conversations: Vec<AgentConversati
     app.add_singleton_model(|_| CLIAgentSessionsModel::new());
     app.add_singleton_model(OrchestrationEventService::new);
     app.add_singleton_model(LocalAgentTaskSyncModel::new);
+    app.add_singleton_model(crate::ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue::new);
     app.add_singleton_model(OrchestrationEventStreamer::new);
     app.add_singleton_model(|_| ActiveAgentViewsModel::new());
     app.add_singleton_model(crate::ai::blocklist::BlocklistAIPermissions::new);

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -184,7 +184,9 @@ fn initialize_app_with_history(app: &mut App, conversations: Vec<AgentConversati
     app.add_singleton_model(|_| CLIAgentSessionsModel::new());
     app.add_singleton_model(OrchestrationEventService::new);
     app.add_singleton_model(LocalAgentTaskSyncModel::new);
-    app.add_singleton_model(crate::ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue::new);
+    app.add_singleton_model(
+        crate::ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue::new,
+    );
     app.add_singleton_model(OrchestrationEventStreamer::new);
     app.add_singleton_model(|_| ActiveAgentViewsModel::new());
     app.add_singleton_model(crate::ai::blocklist::BlocklistAIPermissions::new);

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -12,7 +12,7 @@ use super::ServerApi;
 #[cfg(feature = "local_fs")]
 pub use super::presigned_upload::FileUploadBody;
 pub use super::presigned_upload::UploadBody;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::api::ServerConversationToken;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_sdk::retry::with_bounded_retry;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -297,19 +297,21 @@ impl ReportShutdownRequest {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 pub trait HarnessSupportClient: 'static + Send + Sync {
-    /// Create a new external conversation for a third-party harness.
-    async fn create_external_conversation(&self, format: &str) -> Result<AIConversationId>;
+    /// Create a new external conversation for a third-party harness. Returns a
+    /// server-issued [`ServerConversationToken`], not a client-local `AIConversationId`:
+    /// a 3rd-party-harness conversation is never represented in `BlocklistAIHistoryModel`.
+    async fn create_external_conversation(&self, format: &str) -> Result<ServerConversationToken>;
 
     /// Get a presigned upload target for the conversation's raw transcript.
     async fn get_transcript_upload_target(
         &self,
-        conversation_id: &AIConversationId,
+        conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget>;
 
     /// Get a presigned upload target for the conversation's block snapshot.
     async fn get_block_snapshot_upload_target(
         &self,
-        conversation_id: &AIConversationId,
+        conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget>;
 
     /// Resolve the prompt for a third-party harness run for a task stored on the server.
@@ -486,7 +488,7 @@ impl ServerApi {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl HarnessSupportClient for ServerApi {
-    async fn create_external_conversation(&self, format: &str) -> Result<AIConversationId> {
+    async fn create_external_conversation(&self, format: &str) -> Result<ServerConversationToken> {
         let response: CreateExternalConversationResponse = self
             .post_public_api(
                 "harness-support/external-conversation",
@@ -496,13 +498,12 @@ impl HarnessSupportClient for ServerApi {
             )
             .await?;
 
-        AIConversationId::try_from(response.conversation_id)
-            .context("Server returned an invalid conversation ID")
+        Ok(ServerConversationToken::new(response.conversation_id))
     }
 
     async fn get_transcript_upload_target(
         &self,
-        conversation_id: &AIConversationId,
+        conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         self.post_public_api(
             "harness-support/transcript",
@@ -515,7 +516,7 @@ impl HarnessSupportClient for ServerApi {
 
     async fn get_block_snapshot_upload_target(
         &self,
-        conversation_id: &AIConversationId,
+        conversation_id: &ServerConversationToken,
     ) -> Result<UploadTarget> {
         self.post_public_api(
             "harness-support/block-snapshot",

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -31,6 +31,10 @@ use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::AIConversation;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
+use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
+use crate::ai::blocklist::pending_cli_harness_prompt_queue::{
+    PendingCliHarnessPromptQueue, QueuedCliHarnessPrompt,
+};
 use crate::ai::blocklist::{
     BlocklistAIContextEvent, BlocklistAIContextModel, BlocklistAIControllerEvent,
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, InputConfig, SerializedBlockListItem,
@@ -114,9 +118,15 @@ async fn is_setup_failure_debug_prompt_authorized(
         .unwrap_or(false)
 }
 
-/// Honors an already-authorized agent prompt: writes it to the CLI harness PTY when one is
-/// active, or executes it against the Oz harness otherwise. Callers must have already checked
-/// that `participant_id` may submit this prompt.
+/// Honors an already-authorized agent prompt. Callers must have already checked that
+/// `participant_id` may submit this prompt. Routes to exactly one of three destinations:
+/// - A live CLI-harness PTY, when one is already running for this pane.
+/// - `PendingCliHarnessPromptQueue`, when this pane's task is configured for (registered
+///   against) a third-party CLI harness whose session hasn't started a live PTY yet. This must
+///   never fall through to the Oz path below: a 3rd-party-harness task has no local
+///   `AIConversation` representation, so doing so would spawn a wrong, native "canonical"
+///   conversation for the run (see `PendingCliHarnessPromptQueue`'s doc comment).
+/// - The Oz harness, via `BlocklistAIController`, for every other (genuinely native) case.
 fn accept_agent_prompt(
     terminal_view: &ViewHandle<TerminalView>,
     request: AgentPromptRequest,
@@ -137,16 +147,44 @@ fn accept_agent_prompt(
         return;
     }
 
+    // `register_cli_session` runs at harness setup time, before the harness process is
+    // launched (see its call site in `AgentDriver::subscribe_to_cli_agent_session_events`), so
+    // this is true independent of whether the CLI-harness session above has actually started a
+    // live PTY yet.
+    if let Some(task_id) =
+        LocalAgentTaskSyncModel::as_ref(ctx).task_id_for_terminal_view(terminal_view_id)
+    {
+        if !request.attachments.is_empty() {
+            log::warn!(
+                "accept_agent_prompt: dropping {} file attachment(s) from a shared-session \
+                 prompt queued for task {task_id}'s not-yet-started CLI-harness session; \
+                 attachment delivery to a CLI harness PTY is not supported",
+                request.attachments.len()
+            );
+        }
+        PendingCliHarnessPromptQueue::handle(ctx).update(ctx, |queue, _ctx| {
+            queue.queue(
+                task_id,
+                QueuedCliHarnessPrompt {
+                    prompt: request.prompt.clone(),
+                    participant_id: participant_id.clone(),
+                },
+            );
+        });
+        return;
+    }
+
     // Execute the agent prompt in the Oz-harness case.
     terminal_view.update(ctx, |view, ctx| {
         // Restore the sharer's frozen visual state. The buffer is cleared by
-        // system_clear_buffer when SentRequest fires from execute_agent_prompt_for_shared_session.
+        // system_clear_buffer when SentRequest fires from
+        // execute_warp_agent_prompt_from_shared_session_injection.
         view.input().update(ctx, |input, ctx| {
             input.unfreeze_agent_input(false, ctx);
         });
 
         view.ai_controller().update(ctx, |ai_controller, ctx| {
-            ai_controller.execute_agent_prompt_for_shared_session(
+            ai_controller.execute_warp_agent_prompt_from_shared_session_injection(
                 request.prompt.clone(),
                 request.server_conversation_token,
                 request.attachments.clone(),

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -1425,6 +1425,16 @@ impl TerminalManager<TerminalView> {
                 participant_id,
                 request,
             } => {
+                // Unconditional receipt log: recorded regardless of how this prompt is
+                // eventually routed or rejected below (feature-flag gate, permission checks,
+                // live PTY / PendingCliHarnessPromptQueue / Oz routing), so every received
+                // shared-session prompt is observable for diagnosing lost or misrouted prompts.
+                log::info!(
+                    "Received shared-session agent prompt request id={id:?} \
+                     participant_id={participant_id} has_server_conversation_token={}",
+                    request.server_conversation_token.is_some()
+                );
+
                 if !FeatureFlag::AgentSharedSessions.is_enabled() {
                     return;
                 }

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -152,7 +152,7 @@ fn accept_agent_prompt(
     // this is true independent of whether the CLI-harness session above has actually started a
     // live PTY yet.
     if let Some(task_id) =
-        LocalAgentTaskSyncModel::as_ref(ctx).task_id_for_terminal_view(terminal_view_id)
+        LocalAgentTaskSyncModel::as_ref(ctx).cli_harness_task_id_for_terminal_view(terminal_view_id)
     {
         if !request.attachments.is_empty() {
             log::warn!(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13590,8 +13590,8 @@ impl TerminalView {
         &self,
         ctx: &AppContext,
     ) -> Option<AIConversationId> {
-        let task_id =
-            LocalAgentTaskSyncModel::as_ref(ctx).task_id_for_terminal_view(self.view_id)?;
+        let task_id = LocalAgentTaskSyncModel::as_ref(ctx)
+            .cli_harness_task_id_for_terminal_view(self.view_id)?;
         let matches_task = |conversation: &&AIConversation| conversation.task_id() == Some(task_id);
 
         let history_model = BlocklistAIHistoryModel::as_ref(ctx);

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -21,6 +21,7 @@ use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::Orchestratio
 use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
 use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 use crate::ai::blocklist::orchestration_events::OrchestrationEventService;
+use crate::ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue;
 use crate::ai::blocklist::{
     BlocklistAIHistoryModel, BlocklistAIPermissions, QueuedQueryModel, SerializedBlockListItem,
 };
@@ -117,6 +118,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(|_| CLIAgentSessionsModel::new());
     app.add_singleton_model(OrchestrationEventService::new);
     app.add_singleton_model(LocalAgentTaskSyncModel::new);
+    app.add_singleton_model(PendingCliHarnessPromptQueue::new);
     app.add_singleton_model(OrchestrationEventStreamer::new);
     app.add_singleton_model(|_| ActiveAgentViewsModel::new());
     app.add_singleton_model(BlocklistAIPermissions::new);

--- a/app/src/tui_test_support.rs
+++ b/app/src/tui_test_support.rs
@@ -19,6 +19,7 @@ use crate::ai::blocklist::history_model::AIQueryHistoryOutputStatus;
 use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
 use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 use crate::ai::blocklist::orchestration_events::OrchestrationEventService;
+use crate::ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue;
 use crate::ai::blocklist::{
     BlocklistAIActionModel, BlocklistAIHistoryModel, BlocklistAIPermissions, PersistedAIInput,
     PersistedAIInputType, QueuedQueryModel,
@@ -385,6 +386,7 @@ pub fn register_tui_session_view_test_singletons(app: &mut warpui::App) {
     app.add_singleton_model(|_| CLIAgentSessionsModel::new());
     app.add_singleton_model(OrchestrationEventService::new);
     app.add_singleton_model(LocalAgentTaskSyncModel::new);
+    app.add_singleton_model(PendingCliHarnessPromptQueue::new);
     app.add_singleton_model(OrchestrationEventStreamer::new);
     app.add_singleton_model(|_| ActiveAgentViewsModel::new());
     app.add_singleton_model(|_| GitRepoModels::new());


### PR DESCRIPTION
## Problem

For a third-party-harness (e.g. Claude Code) ambient agent run, a shared-session-injected prompt/follow-up that arrives before the CLI harness session is fully live could fall through the Oz-only prompt path and create a brand-new native `AIConversation`. That conversation's server token then gets reported via `UpdateAgentTask`, silently overwriting the run's real conversation ID and permanently breaking follow-ups for that run (`could not update agent conversation ID: invalid state`, repeated on every retry until cancelled).

This is the client-side slice of a cross-repo fix. We queue 3p follow-ups until the 3p harness starts. We also improve logging, function naming, and types

## Changes

- `terminal_view_adaptor.rs`: `accept_agent_prompt` is now the single choke point that routes an incoming agent prompt to exactly one destination: a live CLI-harness PTY, a new `PendingCliHarnessPromptQueue` (for a task registered against a third-party harness whose session hasn't started a live PTY yet, detected via `LocalAgentTaskSyncModel::task_id_for_terminal_view` independent of session-start state), or Warp's native Oz harness for every other case.
- New `PendingCliHarnessPromptQueue` singleton (`app/src/ai/blocklist/pending_cli_harness_prompt_queue.rs`): a minimal FIFO queue, keyed by `AmbientAgentTaskId`, holding text-only prompts (file attachments are dropped with a warning log, since CLI-harness PTY delivery doesn't support them) until the task's harness session starts.
- `AgentDriver::subscribe_to_cli_agent_session_events`: drains the queue on `CLIAgentSessionsModelEvent::StatusChanged{InProgress}` — a genuine, plugin-reported confirmation the harness is already running, rather than the earlier `Started` event which fires at command-detection time, before the harness has processed anything. A bounded 8-minute fallback timer (below the ~10 minutes the server allows before expecting the agent to have started working) drains anyway if no qualifying event ever arrives; draining is idempotent, so the fallback is a silent no-op once the normal path has already delivered. If the fallback timer actually finds prompts to deliver, it logs a warning, since a healthy plugin reports `InProgress` almost immediately — this indicates a broken or missing plugin integration (e.g. a Codex session using only the OSC 9 notification fallback, whose events never map to `InProgress`). Each prompt is delivered as a genuine PTY follow-up via `TerminalDriver::send_text_to_cli`; the queue is cleared on `unregister_cli_agent_task_sync`.
- `BlocklistAIController`: renamed `execute_agent_prompt_for_shared_session` → `execute_warp_agent_prompt_from_shared_session_injection` and `send_shared_session_query` → `send_warp_agent_prompt_from_shared_session_injection`, with doc comments clarifying these are now Oz/native-only, since third-party-harness routing is decided upstream in `accept_agent_prompt`.
- Added a defense-in-depth guard in `send_warp_agent_prompt_from_shared_session_injection`'s no-token fallback: refuses to create a native conversation (and reports an error) for a task that is CLI-harness-backed, checking two independent signals — the runtime registration (`task_id_for_terminal_view`) and the task's stored config (`AmbientAgentTask::is_third_party_harness`) — so the check still holds even before a session ever registers, honoring the existing setup-failure-debug-bootstrap exception.
- `LocalAgentTaskSyncModel` stays a pure task-state-sync model (the queueing responsibility moved to the new dedicated singleton above).
- `HarnessSupportClient` and third-party harness runners (Claude Code, Codex, Gemini) now use the safer `ServerConversationToken` type instead of the client-local `AIConversationId` for third-party-harness conversation identifiers, since these conversations are never represented in `BlocklistAIHistoryModel`.
- Added an unconditional receipt log at the top of the `NetworkEvent::AgentPromptRequested` handler in `terminal_view_adaptor.rs` (before the feature-flag check and any permission/routing logic), recording the request id, participant id, and whether a `server_conversation_token` was present, so every received shared-session prompt is observable regardless of how it's later routed or rejected.
- Added/updated unit tests covering: `PendingCliHarnessPromptQueue` (FIFO drain, per-task isolation, clear), and the `LocalAgentTaskSyncModel` test suite trimmed of the now-removed queueing responsibility.

## Validation

### Roland manual testing using e2e test

[Modified e2e tests](https://github.com/warpdotdev/oz-e2e-tests/pull/14) to send multiple followups in succession while sandbox closed, along with https://github.com/warpdotdev/session-sharing-server/pull/516. Claude code combines them in one prompt, while codex sends both individually. Both 3p harnesses queue until the first prompt is done. Not ideal but acceptable for now

<img width="1486" height="1014" alt="Screenshot 2026-09-08 at 2 51 10 PM" src="https://github.com/user-attachments/assets/a2026b17-1092-47e8-8c70-1f4425274572" />
<img width="1489" height="1027" alt="Screenshot 2026-09-08 at 2 51 23 PM" src="https://github.com/user-attachments/assets/e5071a68-61c6-465f-9be5-fcddfc1c6c6b" />


- `cargo check -p warp` (lib and `--tests`), `cargo fmt -p warp --check`, and `cargo test -p warp --lib` filtered to the touched modules (`pending_cli_harness_prompt_queue`, `local_agent_task_sync_model`, `shared_session`, `terminal_view_adaptor`, `checkpoint_coordinator`, `codex_tests`, `snapshot_tests`, `agent_driver`/`driver`): 433 passed, 1 unrelated pre-existing flaky failure (`cloud_provider::gcp::tests::best_effort_command_is_killed_on_timeout`, passes in isolation) as of commit 82ea3499c, confirmed by the orchestrating agent on a machine with sufficient memory (this sandbox OOMs partway through compiling the `warp` crate on every attempt).
- `cargo fmt -p warp --check`: clean as of the latest commit.
- Latest commit's (ae44f901c) compile/test status not yet independently re-verified due to the sandbox's memory limit; manual review confirms no dangling references to removed/renamed symbols.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->

Co-Authored-By: Warp <agent@warp.dev>

