### PR TITLE
Validate Claude Code session restoration requirements

### DIFF
--- a/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
@@ -206,10 +206,8 @@ impl ClaudeHarness {
         let config_root = claude_config_dir().context("Failed to resolve Claude config dir")?;
         write_envelope(&remote.envelope, &config_root)
             .context("Failed to rehydrate Claude transcript for wake")?;
-        if let Err(error) = write_session_index_entry(remote.session_id, &working_dir, &config_root)
-        {
-            log::warn!("Failed to update Claude sessions-index.json for wake: {error:#}");
-        }
+        write_session_index_entry(remote.session_id, &working_dir, &config_root)
+            .context("Failed to update Claude sessions-index.json for wake")?;
 
         let state_dir = parent_bridge_root()?.join(remote.session_id.to_string());
         ensure_parent_bridge_state_dir(&state_dir)?;

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
@@ -7,10 +7,11 @@
 //! - [`ClaudeResumeInfo`] — everything the harness runner needs to resume an existing
 //!   Claude conversation: the Warp server conversation id to reuse, the Claude session uuid
 //!   to pass to `claude --resume`, and the decoded envelope to rehydrate onto disk.
-//! - [`write_session_index_entry`] — best-effort update of `~/.claude/sessions-index.json`
-//!   so Claude's `--resume <uuid>` lookup can find the freshly-rehydrated jsonl. Upstream
-//!   versions vary in how they use this index (claude-code#33912, #39667, #5768); we write
-//!   a conservative entry and log on failure.
+//! - [`write_session_index_entry`] — update of `~/.claude/sessions-index.json` so Claude's
+//!   `--resume <uuid>` lookup can find the freshly-rehydrated jsonl. Upstream versions vary in
+//!   how they use this index (claude-code#33912, #39667, #5768); we write a conservative entry.
+//!   Callers treat write failures as hard errors rather than warnings, since this index is required
+//!   by some Claude Code versions.
 //!
 //! Split out from `claude_code.rs` so the `AIClient` transcript-fetch impl can deserialize
 //! envelopes without pulling in the rest of the harness runner.
@@ -62,9 +63,10 @@ pub(crate) struct ClaudeResumeInfo {
     pub(crate) conversation_id: AIConversationId,
     /// The Claude session uuid to pass to `claude --resume`. Matches `envelope.uuid`.
     pub(crate) session_id: Uuid,
-    /// Envelope from the server. Its `cwd` field is rewritten to the current run's working
-    /// directory before being written to disk, so `claude --resume <uuid>` finds the jsonl under
-    /// `~/.claude/projects/<encoded(new_cwd)>/`.
+    /// Envelope from the server. Its `cwd` field must match the current run's working directory
+    /// — [`rehydrate_claude_transcript`] rejects the resume rather than silently rewriting `cwd`,
+    /// since jsonl entries embed their own `cwd` fields that can't be retroactively fixed up, and
+    /// a rewritten top-level `cwd` alone would still leave those stale.
     pub(crate) envelope: ClaudeTranscriptEnvelope,
 }
 
@@ -247,17 +249,33 @@ pub(crate) fn write_envelope(
     Ok(())
 }
 
+/// Rehydrate a Claude transcript fetched for a `--conversation` cloud resume.
+///
+/// Requires `envelope.cwd` (the working directory the session was originally saved under) to
+/// match `local_cwd` (this run's working directory) exactly. Claude's `--resume <uuid>` lookup
+/// is scoped to the project directory derived from the literal cwd string, and each jsonl entry
+/// also embeds its own `cwd` field that isn't rewritten here — so resuming under a different
+/// directory would either leave Claude unable to find the session at all, or hand it a
+/// transcript with a `cwd` that no longer matches where it's actually running. Both are worse
+/// than failing loudly up front.
 pub(crate) fn rehydrate_claude_transcript(
     envelope: &mut ClaudeTranscriptEnvelope,
     local_cwd: &Path,
 ) -> Result<ClaudeLocalContinuation> {
-    envelope.cwd = local_cwd.to_path_buf();
+    if envelope.cwd != local_cwd {
+        anyhow::bail!(
+            "Unable to resume Claude session {}: it was saved with working directory {}, but \
+             this run's working directory is {}.",
+            envelope.uuid,
+            envelope.cwd.display(),
+            local_cwd.display()
+        );
+    }
     let session_id = envelope.uuid;
     let config_root = claude_config_dir().context("Failed to resolve Claude config dir")?;
     write_envelope(envelope, &config_root).context("Failed to rehydrate Claude transcript")?;
-    if let Err(e) = write_session_index_entry(session_id, local_cwd, &config_root) {
-        log::warn!("Failed to update Claude sessions-index.json: {e:#}");
-    }
+    write_session_index_entry(session_id, local_cwd, &config_root)
+        .context("Failed to update Claude sessions-index.json")?;
 
     Ok(ClaudeLocalContinuation {
         command: format!("claude --resume {session_id}"),
@@ -337,9 +355,8 @@ pub(crate) fn rehydrate_claude_transcript_from_reader(
         .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?;
     write_envelope_for_local_continuation(&envelope, &home_dir, &config_root)
         .context("Failed to rehydrate Claude transcript for local continuation")?;
-    if let Err(e) = write_session_index_entry(session_id, &home_dir, &config_root) {
-        log::warn!("Failed to update Claude sessions-index.json: {e:#}");
-    }
+    write_session_index_entry(session_id, &home_dir, &config_root)
+        .context("Failed to update Claude sessions-index.json")?;
     Ok(ClaudeLocalContinuation {
         command: format!("claude --resume {session_id}"),
     })
@@ -356,9 +373,8 @@ const SESSIONS_INDEX_FILENAME: &str = "sessions-index.json";
 /// mirrors the fragments documented in claude-code#33912 / #39667 / #5768. Unknown fields are
 /// preserved on existing entries, and we never remove other entries.
 ///
-/// Best-effort: callers should log a warning on failure rather than aborting the run — if the
-/// index is missing or wrong, `--resume` simply falls back to "No conversation found" and the
-/// resumed run surfaces the expected resume-failure error.
+/// A missing or malformed index file is treated as an empty index and overwritten rather than
+/// failing (see the read branch below).
 pub(crate) fn write_session_index_entry(
     session_uuid: Uuid,
     cwd: &Path,

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript_tests.rs
@@ -167,6 +167,100 @@ fn write_envelope_round_trip() {
 }
 
 #[test]
+#[serial_test::serial]
+fn rehydrate_claude_transcript_fails_on_cwd_mismatch() {
+    let config_dir = TempDir::new().unwrap();
+    let old_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
+    // SAFETY: `#[serial_test::serial]` ensures no other thread reads or writes the process
+    // environment concurrently with this test.
+    unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", config_dir.path()) };
+
+    let uuid = Uuid::new_v4();
+    let mut envelope = ClaudeTranscriptEnvelope {
+        cwd: Path::new("/original/cwd").to_path_buf(),
+        uuid,
+        claude_version: None,
+        entries: vec![serde_json::json!({"type": "user"})],
+        subagents: HashMap::new(),
+        todos: HashMap::new(),
+    };
+
+    let err = rehydrate_claude_transcript(&mut envelope, Path::new("/different/cwd")).unwrap_err();
+    assert!(
+        err.to_string().contains("Unable to resume Claude session"),
+        "unexpected error message: {err:#}"
+    );
+    // Nothing should have been written when the cwd doesn't match.
+    assert!(!config_dir.path().join("projects").exists());
+    assert!(!config_dir.path().join(SESSIONS_INDEX_FILENAME).exists());
+
+    match old_config_dir {
+        // SAFETY: `#[serial_test::serial]` ensures no other thread reads or writes the process
+        // environment concurrently with this test.
+        Some(dir) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", dir) },
+        // SAFETY: See above.
+        None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn rehydrate_claude_transcript_succeeds_when_cwd_matches() {
+    let config_dir = TempDir::new().unwrap();
+    let old_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
+    // SAFETY: `#[serial_test::serial]` ensures no other thread reads or writes the process
+    // environment concurrently with this test.
+    unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", config_dir.path()) };
+
+    let cwd = Path::new("/matching/cwd");
+    let uuid = Uuid::new_v4();
+    let mut envelope = ClaudeTranscriptEnvelope {
+        cwd: cwd.to_path_buf(),
+        uuid,
+        claude_version: None,
+        entries: vec![serde_json::json!({"type": "user"})],
+        subagents: HashMap::new(),
+        todos: HashMap::new(),
+    };
+
+    let continuation = rehydrate_claude_transcript(&mut envelope, cwd).unwrap();
+    assert_eq!(continuation.command, format!("claude --resume {uuid}"));
+
+    let session_file = config_dir
+        .path()
+        .join("projects")
+        .join(encode_cwd(cwd))
+        .join(format!("{uuid}.jsonl"));
+    assert!(session_file.exists(), "session JSONL missing");
+
+    let index: serde_json::Value =
+        serde_json::from_slice(&fs::read(config_dir.path().join(SESSIONS_INDEX_FILENAME)).unwrap())
+            .unwrap();
+    assert_eq!(index[uuid.to_string()]["sessionId"], uuid.to_string());
+
+    match old_config_dir {
+        // SAFETY: `#[serial_test::serial]` ensures no other thread reads or writes the process
+        // environment concurrently with this test.
+        Some(dir) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", dir) },
+        // SAFETY: See above.
+        None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
+    }
+}
+
+#[test]
+fn write_session_index_entry_fails_when_index_path_is_a_directory() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join(SESSIONS_INDEX_FILENAME)).unwrap();
+
+    let uuid = Uuid::new_v4();
+    let err = write_session_index_entry(uuid, Path::new("/my/project"), tmp.path()).unwrap_err();
+    assert!(
+        err.to_string().contains(SESSIONS_INDEX_FILENAME),
+        "unexpected error message: {err:#}"
+    );
+}
+
+#[test]
 fn write_session_index_entry_creates_missing_file() {
     let tmp = TempDir::new().unwrap();
     let uuid = Uuid::new_v4();


### PR DESCRIPTION
## Description

This makes two changes to harden our Claude Code multi-harness support:
1. If writing `sessions-index.json` fails, we abort rather than logging a warning. Some Claude Code versions require this file to restore previous sessions.
2. The session-restoration flow rejects transcripts with a `cwd` that does not match the initial harness working directory. Claude Code sessions are CWD-scoped, so a session with a different CWD will not be findable.

This came out of investigating a Claude Code cloud agent error, which @vorporeal fixed in #15787

## Linked Issue

None

## Testing

- [X] Added unit tests
- [ ] I have manually tested my changes locally with `./script/run`: multi-harness requires a valid workload token, so can't easily be tested locally

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

