### PR TITLE
REMOTE-2111: promote PeriodicHandoffCheckpoints to PREVIEW_FLAGS

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -965,7 +965,8 @@ pub enum FeatureFlag {
     /// Enables periodic workspace-handoff checkpoints during a cloud agent run,
     /// rather than only uploading a workspace snapshot once at end-of-run.
     /// Requires `OzHandoff` to also be enabled; a no-op for local runs and when
-    /// `--no-snapshot` is set. Off by default while the coordinator rolls out.
+    /// `--no-snapshot` is set. Enabled for dogfood and preview builds while the
+    /// coordinator bakes ahead of a stable rollout.
     PeriodicHandoffCheckpoints,
 
     /// Observes Ctrl-C (`0x03`) written on the shared-session viewer input
@@ -1068,7 +1069,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::BoxDrawingGlyphs,
     FeatureFlag::PricingTransparency,
-    FeatureFlag::PeriodicHandoffCheckpoints,
     FeatureFlag::CtrlCCancelsThirdPartyHarness,
     FeatureFlag::WarpingModelName,
     FeatureFlag::LrcActivitySignal,
@@ -1081,6 +1081,7 @@ pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::NativeShellCompletions,
     FeatureFlag::ShellWidgetHandoff,
     FeatureFlag::HistorySearchRankingV2,
+    FeatureFlag::PeriodicHandoffCheckpoints,
 ];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).


### PR DESCRIPTION
## What this does
Second stage of the staged rollout for the periodic workspace-handoff checkpoint coordinator (previously enabled for dogfood only in #15026, after #14589, #14573, #14588). Moves `FeatureFlag::PeriodicHandoffCheckpoints` from `DOGFOOD_FLAGS` to `PREVIEW_FLAGS` so the coordinator bakes on preview/canary builds before promoting to `RELEASE_FLAGS` (or enabling it by default) for stable.

Dogfood coverage is preserved: `PREVIEW_FLAGS` is automatically included in dogfood builds, so removing the flag from `DOGFOOD_FLAGS` is a no-op for dogfood.

`OzHandoff` (the other prerequisite flag) remains enabled by default for all builds via the `oz_handoff` Cargo default feature, so no additional change is needed there.

## Linked Issue
- [x] https://linear.app/warpdotdev/issue/REMOTE-2111

## Testing
- [x] `cargo check -p warp_features`, `cargo clippy -p warp_features --all-targets --all-features -- -D warnings`, `cargo test -p warp_features`, and `cargo fmt --check -p warp_features` all pass.
- No UI-testable behavior; this only changes which build channel the flag is active on.

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
