### PR TITLE
Update triage taxonomy with agent: primary types and agent:priority-high

### DIFF
--- a/.agents/skills/triage-issue-local/SKILL.md
+++ b/.agents/skills/triage-issue-local/SKILL.md
@@ -24,7 +24,7 @@ marks as overridable.
 - When the issue includes screenshots, videos, logs, stack traces, or command output, use them as primary evidence and ask follow-up questions only for missing details that cannot be inferred from that evidence.
 - Before asking any follow-up questions, check the Warp documentation and the repository's existing feature set to determine whether the desired behavior the reporter is describing is already supported. If an existing feature, setting, or workflow satisfies the request, recommend it to the reporter instead of treating the issue as a bug or feature gap.
 - If the report is about billing (pricing, plans, subscriptions, payments, refunds, invoices, AI request quotas, charges) or about appeals (account suspensions, bans, takedowns, abuse decisions, or other account-status disputes), do not attempt to triage it as an actionable bug or feature request. Instead, notify the reporter that these requests must go through Warp's support channels (https://docs.warp.dev/support-and-community/troubleshooting-and-support/sending-us-feedback) and direct them there for resolution. Apply the relevant `area:billing` or `area:auth` label as appropriate so the issue is still routed correctly.
-- Classify issues into at least one primary agent type (`agent:bug`, `agent:feature`, `agent:security`, `agent:documentation`), except billing or appeals reports which route to support via `warp:needs-support`. Explicitly bias towards tagging regressions ("broke in recent version", "worked in previous build"), panics/crashes, and security reports with `priority:high`.
+- Classify issues into at least one primary agent type (`agent:bug`, `agent:feature`, `agent:security`, `agent:documentation`), except billing or appeals reports which route to support via `warp:needs-support`. Explicitly bias towards tagging regressions ("broke in recent version", "worked in previous build"), panics/crashes, and security reports with `agent:priority-high`.
 
 ## Follow-up question limit
 
@@ -32,7 +32,7 @@ Ask **at most 2 follow-up questions** per triage response. Each question must be
 
 ## Label taxonomy
 
-The label taxonomy for this repository is managed in `.github/issue-triage/config.json`. Prefer labels from that configuration, especially the `area:*`, `os:*`, `repro:*`, `accessibility`, `needs-info`, `duplicate`, `priority:high`, and primary agent issue-type labels (`agent:bug`, `agent:feature`, `agent:security`, `agent:documentation`). Do not invent new labels unless the prompt explicitly allows it.
+The label taxonomy for this repository is managed in `.github/issue-triage/config.json`. Prefer labels from that configuration, especially the `area:*`, `os:*`, `repro:*`, `accessibility`, `needs-info`, `duplicate`, `agent:priority-high`, and primary agent issue-type labels (`agent:bug`, `agent:feature`, `agent:security`, `agent:documentation`). Do not invent new labels unless the prompt explicitly allows it.
 
 ### Primary issue types
 
@@ -44,7 +44,7 @@ Every issue should be classified with at least one primary agent type label:
 
 ### Priority
 
-- `priority:high`: High-priority issues that are immediately escalated for internal review. Tag issues with `priority:high` when there is evidence of a regression ("broke in recent version", "worked in previous build"), panic or crash, data loss, or a security vulnerability.
+- `agent:priority-high`: High-priority issues that are immediately escalated. Assigned by Warp triage agent. Tag issues with `agent:priority-high` when there is evidence of a regression ("broke in recent version", "worked in previous build"), panic or crash, data loss, or a security vulnerability.
 
 Evaluate `ready-to-implement` during triage instead of relying on issue-template defaults. For bug reports, apply `ready-to-implement` only when the issue is reproducible from the provided evidence or straightforward local verification and the likely fix appears narrow enough to implement without a product spec, design mocks, or substantial investigation. If the bug is not reproducible, lacks a clear fix path, requires product/design decisions, or needs deeper technical discovery, omit `ready-to-implement` and prefer `needs-info`, `ready-to-spec`, `needs-mocks`, or the appropriate `repro:*` label.
 

--- a/.agents/skills/triage-issue-local/SKILL.md
+++ b/.agents/skills/triage-issue-local/SKILL.md
@@ -24,6 +24,7 @@ marks as overridable.
 - When the issue includes screenshots, videos, logs, stack traces, or command output, use them as primary evidence and ask follow-up questions only for missing details that cannot be inferred from that evidence.
 - Before asking any follow-up questions, check the Warp documentation and the repository's existing feature set to determine whether the desired behavior the reporter is describing is already supported. If an existing feature, setting, or workflow satisfies the request, recommend it to the reporter instead of treating the issue as a bug or feature gap.
 - If the report is about billing (pricing, plans, subscriptions, payments, refunds, invoices, AI request quotas, charges) or about appeals (account suspensions, bans, takedowns, abuse decisions, or other account-status disputes), do not attempt to triage it as an actionable bug or feature request. Instead, notify the reporter that these requests must go through Warp's support channels (https://docs.warp.dev/support-and-community/troubleshooting-and-support/sending-us-feedback) and direct them there for resolution. Apply the relevant `area:billing` or `area:auth` label as appropriate so the issue is still routed correctly.
+- Classify issues into at least one primary type (`bug`, `feature`, `security`, `documentation`). Explicitly bias towards tagging regressions ("broke in recent version", "worked in previous build"), panics/crashes, and security reports with `priority:high`.
 
 ## Follow-up question limit
 
@@ -31,7 +32,19 @@ Ask **at most 2 follow-up questions** per triage response. Each question must be
 
 ## Label taxonomy
 
-The label taxonomy for this repository is managed in `.github/issue-triage/config.json`. Prefer labels from that configuration, especially the `area:*`, `os:*`, `repro:*`, `accessibility`, `needs-info`, `duplicate`, and primary issue-type labels. Do not invent new labels unless the prompt explicitly allows it.
+The label taxonomy for this repository is managed in `.github/issue-triage/config.json`. Prefer labels from that configuration, especially the `area:*`, `os:*`, `repro:*`, `accessibility`, `needs-info`, `duplicate`, `priority:high`, and primary issue-type labels (`bug`, `feature`, `security`, `documentation`). Do not invent new labels unless the prompt explicitly allows it.
+
+### Primary issue types
+
+Every issue should be classified with at least one primary type label:
+- `bug`: Something isn't working.
+- `feature`: This issue is a feature request, not a bug report.
+- `security`: Security vulnerability or report.
+- `documentation`: Improvements or additions to documentation.
+
+### Priority
+
+- `priority:high`: High-priority regression, crash, data loss, or security issue. Tag issues with `priority:high` when there is evidence of a regression ("broke in recent version", "worked in previous build"), panic or crash, data loss, or a security vulnerability.
 
 Evaluate `ready-to-implement` during triage instead of relying on issue-template defaults. For bug reports, apply `ready-to-implement` only when the issue is reproducible from the provided evidence or straightforward local verification and the likely fix appears narrow enough to implement without a product spec, design mocks, or substantial investigation. If the bug is not reproducible, lacks a clear fix path, requires product/design decisions, or needs deeper technical discovery, omit `ready-to-implement` and prefer `needs-info`, `ready-to-spec`, `needs-mocks`, or the appropriate `repro:*` label.
 

--- a/.agents/skills/triage-issue-local/SKILL.md
+++ b/.agents/skills/triage-issue-local/SKILL.md
@@ -24,7 +24,7 @@ marks as overridable.
 - When the issue includes screenshots, videos, logs, stack traces, or command output, use them as primary evidence and ask follow-up questions only for missing details that cannot be inferred from that evidence.
 - Before asking any follow-up questions, check the Warp documentation and the repository's existing feature set to determine whether the desired behavior the reporter is describing is already supported. If an existing feature, setting, or workflow satisfies the request, recommend it to the reporter instead of treating the issue as a bug or feature gap.
 - If the report is about billing (pricing, plans, subscriptions, payments, refunds, invoices, AI request quotas, charges) or about appeals (account suspensions, bans, takedowns, abuse decisions, or other account-status disputes), do not attempt to triage it as an actionable bug or feature request. Instead, notify the reporter that these requests must go through Warp's support channels (https://docs.warp.dev/support-and-community/troubleshooting-and-support/sending-us-feedback) and direct them there for resolution. Apply the relevant `area:billing` or `area:auth` label as appropriate so the issue is still routed correctly.
-- Classify issues into at least one primary type (`bug`, `feature`, `security`, `documentation`). Explicitly bias towards tagging regressions ("broke in recent version", "worked in previous build"), panics/crashes, and security reports with `priority:high`.
+- Classify issues into at least one primary agent type (`agent:bug`, `agent:feature`, `agent:security`, `agent:documentation`), except billing or appeals reports which route to support via `warp:needs-support`. Explicitly bias towards tagging regressions ("broke in recent version", "worked in previous build"), panics/crashes, and security reports with `priority:high`.
 
 ## Follow-up question limit
 
@@ -32,19 +32,19 @@ Ask **at most 2 follow-up questions** per triage response. Each question must be
 
 ## Label taxonomy
 
-The label taxonomy for this repository is managed in `.github/issue-triage/config.json`. Prefer labels from that configuration, especially the `area:*`, `os:*`, `repro:*`, `accessibility`, `needs-info`, `duplicate`, `priority:high`, and primary issue-type labels (`bug`, `feature`, `security`, `documentation`). Do not invent new labels unless the prompt explicitly allows it.
+The label taxonomy for this repository is managed in `.github/issue-triage/config.json`. Prefer labels from that configuration, especially the `area:*`, `os:*`, `repro:*`, `accessibility`, `needs-info`, `duplicate`, `priority:high`, and primary agent issue-type labels (`agent:bug`, `agent:feature`, `agent:security`, `agent:documentation`). Do not invent new labels unless the prompt explicitly allows it.
 
 ### Primary issue types
 
-Every issue should be classified with at least one primary type label:
-- `bug`: Something isn't working.
-- `feature`: This issue is a feature request, not a bug report.
-- `security`: Security vulnerability or report.
-- `documentation`: Improvements or additions to documentation.
+Every issue should be classified with at least one primary agent type label:
+- `agent:bug`: Bugs/regressions. Assigned by Warp triage agent.
+- `agent:feature`: This issue is a feature request, not a bug report. Assigned by Warp triage agent.
+- `agent:security`: Security issues/vulnerabilities that are immediately escalated. Assigned by Warp triage agent.
+- `agent:documentation`: Missing documentation. Assigned by Warp triage agent.
 
 ### Priority
 
-- `priority:high`: High-priority regression, crash, data loss, or security issue. Tag issues with `priority:high` when there is evidence of a regression ("broke in recent version", "worked in previous build"), panic or crash, data loss, or a security vulnerability.
+- `priority:high`: High-priority issues that are immediately escalated for internal review. Tag issues with `priority:high` when there is evidence of a regression ("broke in recent version", "worked in previous build"), panic or crash, data loss, or a security vulnerability.
 
 Evaluate `ready-to-implement` during triage instead of relying on issue-template defaults. For bug reports, apply `ready-to-implement` only when the issue is reproducible from the provided evidence or straightforward local verification and the likely fix appears narrow enough to implement without a product spec, design mocks, or substantial investigation. If the bug is not reproducible, lacks a clear fix path, requires product/design decisions, or needs deeper technical discovery, omit `ready-to-implement` and prefer `needs-info`, `ready-to-spec`, `needs-mocks`, or the appropriate `repro:*` label.
 

--- a/.github/issue-triage/config.json
+++ b/.github/issue-triage/config.json
@@ -4,21 +4,25 @@
       "color": "d73a4a",
       "description": "Something isn't working."
     },
-    "feature": {
+    "agent:bug": {
+      "color": "8ff8fd",
+      "description": "Bugs/regressions. Assigned by Warp triage agent."
+    },
+    "agent:feature": {
       "color": "f47f64",
-      "description": "This issue is a feature request, not a bug report."
+      "description": "This issue is a feature request, not a bug report. Assigned by Warp triage agent."
+    },
+    "agent:security": {
+      "color": "a0ce9f",
+      "description": "Security issues/vulnerabilities that are immediately escalated. Assigned by Warp triage agent."
+    },
+    "agent:documentation": {
+      "color": "5f966f",
+      "description": "Missing documentation. Assigned by Warp triage agent."
     },
     "enhancement": {
       "color": "a2eeef",
       "description": "New feature or request."
-    },
-    "documentation": {
-      "color": "0075ca",
-      "description": "Improvements or additions to documentation."
-    },
-    "security": {
-      "color": "e11d48",
-      "description": "Security vulnerability or report."
     },
     "duplicate": {
       "color": "cfd3d7",
@@ -46,7 +50,7 @@
     },
     "priority:high": {
       "color": "b60205",
-      "description": "High-priority regression, crash, data loss, or security issue."
+      "description": "High-priority issues that are immediately escalated for internal review."
     },
     "repro:high": {
       "color": "b60205",

--- a/.github/issue-triage/config.json
+++ b/.github/issue-triage/config.json
@@ -48,9 +48,9 @@
       "color": "0e8a16",
       "description": "The issue is ready for implementation work."
     },
-    "priority:high": {
+    "agent:priority-high": {
       "color": "b60205",
-      "description": "High-priority issues that are immediately escalated for internal review."
+      "description": "High-priority issues that are immediately escalated. Assigned by Warp triage agent."
     },
     "repro:high": {
       "color": "b60205",

--- a/.github/issue-triage/config.json
+++ b/.github/issue-triage/config.json
@@ -4,6 +4,10 @@
       "color": "d73a4a",
       "description": "Something isn't working."
     },
+    "feature": {
+      "color": "f47f64",
+      "description": "This issue is a feature request, not a bug report."
+    },
     "enhancement": {
       "color": "a2eeef",
       "description": "New feature or request."
@@ -11,6 +15,10 @@
     "documentation": {
       "color": "0075ca",
       "description": "Improvements or additions to documentation."
+    },
+    "security": {
+      "color": "e11d48",
+      "description": "Security vulnerability or report."
     },
     "duplicate": {
       "color": "cfd3d7",
@@ -35,6 +43,10 @@
     "ready-to-implement": {
       "color": "0e8a16",
       "description": "The issue is ready for implementation work."
+    },
+    "priority:high": {
+      "color": "b60205",
+      "description": "High-priority regression, crash, data loss, or security issue."
     },
     "repro:high": {
       "color": "b60205",


### PR DESCRIPTION
## Description

Updates the repository's issue triage configuration and companion triage skill to encode provenance directly into agent-assigned classifications (`agent:bug`, `agent:feature`, `agent:security`, `agent:documentation`) and support urgent issue prioritization with `agent:priority-high`.

### What changed
- `.github/issue-triage/config.json`: Added `agent:bug` (`#8ff8fd`), `agent:feature` (`#f47f64`), `agent:security` (`#a0ce9f`), `agent:documentation` (`#5f966f`), and `agent:priority-high` (`#b60205`) label definitions.
- `.agents/skills/triage-issue-local/SKILL.md`: Documented the primary agent types and `agent:priority-high` in the label taxonomy section and updated heuristics to direct the triage agent to classify issues into primary agent types (exempting billing/appeals reports that route to support via `warp:needs-support`) and explicitly bias toward applying `agent:priority-high` to regressions ("broke in recent version", "worked before"), crashes/panics, data loss, and security vulnerabilities.

### Stack & Connections
This PR is part of a 3-repo stack to pause non-KTLO triage noise ahead of Factory GA:
- **`warpdotdev/warp`** (this PR): Defines the agent label taxonomy and repository-local skill guidance.
- **`warpdotdev/oz-for-oss`** (PR https://github.com/warpdotdev/oz-for-oss/pull/500): Updates the automated triage workflow to classify issues into primary agent types, parametrize primary types in prompt construction, and preserve `agent:priority-high` during retriage.
- **`warpdotdev/ossie`** (PR https://github.com/warpdotdev/ossie/pull/64): Updates issue triage Slack alerts to suppress individual messages/pings for non-prioritized issues, reserving individual Slack alerts for `agent:security` and `agent:priority-high` issues.

Co-Authored-By: Warp <agent@warp.dev>