### PR TITLE
Fall back to a forge identity only when nothing else claimed a repo

### DIFF
--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -323,20 +323,6 @@ pub(crate) fn merge_repos_deduped(
     Ok(merged)
 }
 
-/// Reports whether `source_repos` span more than one distinct, clonable code-forge
-/// host (e.g. both `github.com` and `gitlab.com`).
-///
-/// A repo with no resolvable host (`CodeForge::host()` empty, e.g. `None`/`Unknown`)
-/// doesn't count toward the total, since it has no forge-specific identity of its own.
-fn repos_span_multiple_hosts(source_repos: &[SourceRepo]) -> bool {
-    let hosts: HashSet<&str> = source_repos
-        .iter()
-        .filter_map(|repo| repo.code_forge.map(CodeForge::host))
-        .filter(|host| !host.is_empty())
-        .collect();
-    hosts.len() > 1
-}
-
 /// Environment variable carrying the authenticated remote URL of a Factory's
 /// definition repository. Dispatch attaches it only to runs that execute as a
 /// Factory agent whose Factory definition lives in a Warp-managed repository.
@@ -411,6 +397,13 @@ async fn prepare_environment_impl(
     }
     let mut codebase_context_receivers = Vec::new();
 
+    // Snapshot the process-wide identity bootstrap set, before anything below
+    // (cloning, setup commands) has a chance to change it for a given repo.
+    // The post-setup-commands fallback below compares each repo's effective
+    // identity against this baseline to tell whether the customer already
+    // claimed that repo's identity, rather than assuming so from forge count.
+    let git_identity_baseline = git_credentials::global_git_identity();
+
     let environment_snapshot = if source_repos.is_empty() {
         EnvironmentSnapshot::empty()
     } else {
@@ -428,25 +421,7 @@ async fn prepare_environment_impl(
     environment_snapshot_reporter.report(environment_snapshot);
 
     if !source_repos.is_empty() {
-        // Only stamp a per-repo LOCAL git identity when the repos span more than
-        // one forge. Git's repo-local config always wins over `--global` config
-        // regardless of write order, so pinning an identity on every repo
-        // unconditionally would permanently defeat a customer's own
-        // `git config --global user.name/email` setup command for the common
-        // single-forge case: the bootstrap-time `configure_git_identity` call
-        // already sets a process-wide `--global` identity, and a later setup
-        // command legitimately overriding that value should stick. A genuinely
-        // mixed-forge sandbox still needs a per-repo override, since a single
-        // `--global` identity can't represent two forges' distinct identities
-        // at once (see specs/REMOTE-2942).
-        let needs_per_repo_identity = repos_span_multiple_hosts(source_repos);
         for repo in source_repos {
-            if needs_per_repo_identity {
-                git_credentials::configure_repository_git_identity(
-                    &working_dir.join(&repo.repo),
-                    repo.code_forge.map(CodeForge::host).unwrap_or(""),
-                );
-            }
             register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
             if !is_sandbox && should_index_codebase {
                 let receiver = index_repo_codebase(
@@ -539,6 +514,23 @@ async fn prepare_environment_impl(
     } else {
         Ok(())
     };
+
+    // Fill in a forge-appropriate identity for any repo whose effective
+    // identity is still exactly what bootstrap set — i.e. nothing (a setup
+    // command, or anything else run above) has claimed it yet. This runs
+    // after setup commands specifically so a customer's own git identity
+    // config always wins: repo-local config always beats `--global` config
+    // regardless of write order, so applying Warp's own fallback any earlier
+    // would permanently shadow a later customer override. Runs even if a
+    // setup command failed, so whatever happens next (e.g. a failure-linger
+    // session) still has a usable identity for every repo.
+    for repo in source_repos {
+        git_credentials::configure_repository_git_identity_if_unset(
+            &working_dir.join(&repo.repo),
+            repo.code_forge.map(CodeForge::host).unwrap_or(""),
+            git_identity_baseline.clone(),
+        );
+    }
 
     let remove_origins_result = if remove_repository_origins {
         remove_repository_origins_from_repos(source_repos, working_dir, spawner).await

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -323,6 +323,20 @@ pub(crate) fn merge_repos_deduped(
     Ok(merged)
 }
 
+/// Reports whether `source_repos` span more than one distinct, clonable code-forge
+/// host (e.g. both `github.com` and `gitlab.com`).
+///
+/// A repo with no resolvable host (`CodeForge::host()` empty, e.g. `None`/`Unknown`)
+/// doesn't count toward the total, since it has no forge-specific identity of its own.
+fn repos_span_multiple_hosts(source_repos: &[SourceRepo]) -> bool {
+    let hosts: HashSet<&str> = source_repos
+        .iter()
+        .filter_map(|repo| repo.code_forge.map(CodeForge::host))
+        .filter(|host| !host.is_empty())
+        .collect();
+    hosts.len() > 1
+}
+
 /// Environment variable carrying the authenticated remote URL of a Factory's
 /// definition repository. Dispatch attaches it only to runs that execute as a
 /// Factory agent whose Factory definition lives in a Warp-managed repository.
@@ -414,11 +428,25 @@ async fn prepare_environment_impl(
     environment_snapshot_reporter.report(environment_snapshot);
 
     if !source_repos.is_empty() {
+        // Only stamp a per-repo LOCAL git identity when the repos span more than
+        // one forge. Git's repo-local config always wins over `--global` config
+        // regardless of write order, so pinning an identity on every repo
+        // unconditionally would permanently defeat a customer's own
+        // `git config --global user.name/email` setup command for the common
+        // single-forge case: the bootstrap-time `configure_git_identity` call
+        // already sets a process-wide `--global` identity, and a later setup
+        // command legitimately overriding that value should stick. A genuinely
+        // mixed-forge sandbox still needs a per-repo override, since a single
+        // `--global` identity can't represent two forges' distinct identities
+        // at once (see specs/REMOTE-2942).
+        let needs_per_repo_identity = repos_span_multiple_hosts(source_repos);
         for repo in source_repos {
-            git_credentials::configure_repository_git_identity(
-                &working_dir.join(&repo.repo),
-                repo.code_forge.map(CodeForge::host).unwrap_or(""),
-            );
+            if needs_per_repo_identity {
+                git_credentials::configure_repository_git_identity(
+                    &working_dir.join(&repo.repo),
+                    repo.code_forge.map(CodeForge::host).unwrap_or(""),
+                );
+            }
             register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
             if !is_sandbox && should_index_codebase {
                 let receiver = index_repo_codebase(

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -11,8 +11,8 @@ use super::{
     PrepareEnvironmentError, RepositoryCloneRequest, build_parallel_clone_command,
     build_remove_repository_origins_command, build_resolved_head_command, checkout_command_for,
     checkout_result, environment_snapshot, is_valid_git_object_id, merge_repos_deduped,
-    parse_resolved_head_sha, parse_resolved_head_shas, repos_span_multiple_hosts,
-    repository_clone_requests, single_repo_name, validate_repository_head_overrides,
+    parse_resolved_head_sha, parse_resolved_head_shas, repository_clone_requests, single_repo_name,
+    validate_repository_head_overrides,
 };
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, SourceRepo};
 use crate::terminal::shell::ShellType;
@@ -270,45 +270,6 @@ fn merge_repos_supports_additional_only_and_empty_inputs() {
             .unwrap()
             .is_empty()
     );
-}
-
-#[test]
-fn repos_span_multiple_hosts_is_false_for_single_forge_environments() {
-    let repos = vec![
-        repo(CodeForge::GitHub, "warpdotdev", "warp"),
-        repo(CodeForge::GitHub, "warpdotdev", "warp-server"),
-    ];
-    assert!(!repos_span_multiple_hosts(&repos));
-}
-
-#[test]
-fn repos_span_multiple_hosts_is_false_for_zero_or_one_repos() {
-    assert!(!repos_span_multiple_hosts(&[]));
-    assert!(!repos_span_multiple_hosts(&[repo(
-        CodeForge::GitHub,
-        "warpdotdev",
-        "warp"
-    )]));
-}
-
-#[test]
-fn repos_span_multiple_hosts_is_true_for_mixed_forge_environments() {
-    let repos = vec![
-        repo(CodeForge::GitHub, "warpdotdev", "warp"),
-        repo(CodeForge::GitLab, "platform/backend", "api"),
-    ];
-    assert!(repos_span_multiple_hosts(&repos));
-}
-
-#[test]
-fn repos_span_multiple_hosts_ignores_repos_with_no_resolvable_host() {
-    let mut unhosted = repo(CodeForge::GitHub, "warpdotdev", "warp");
-    unhosted.code_forge = Some(CodeForge::None);
-    let repos = vec![
-        repo(CodeForge::GitHub, "warpdotdev", "warp-server"),
-        unhosted,
-    ];
-    assert!(!repos_span_multiple_hosts(&repos));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -11,8 +11,8 @@ use super::{
     PrepareEnvironmentError, RepositoryCloneRequest, build_parallel_clone_command,
     build_remove_repository_origins_command, build_resolved_head_command, checkout_command_for,
     checkout_result, environment_snapshot, is_valid_git_object_id, merge_repos_deduped,
-    parse_resolved_head_sha, parse_resolved_head_shas, repository_clone_requests, single_repo_name,
-    validate_repository_head_overrides,
+    parse_resolved_head_sha, parse_resolved_head_shas, repos_span_multiple_hosts,
+    repository_clone_requests, single_repo_name, validate_repository_head_overrides,
 };
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, SourceRepo};
 use crate::terminal::shell::ShellType;
@@ -270,6 +270,45 @@ fn merge_repos_supports_additional_only_and_empty_inputs() {
             .unwrap()
             .is_empty()
     );
+}
+
+#[test]
+fn repos_span_multiple_hosts_is_false_for_single_forge_environments() {
+    let repos = vec![
+        repo(CodeForge::GitHub, "warpdotdev", "warp"),
+        repo(CodeForge::GitHub, "warpdotdev", "warp-server"),
+    ];
+    assert!(!repos_span_multiple_hosts(&repos));
+}
+
+#[test]
+fn repos_span_multiple_hosts_is_false_for_zero_or_one_repos() {
+    assert!(!repos_span_multiple_hosts(&[]));
+    assert!(!repos_span_multiple_hosts(&[repo(
+        CodeForge::GitHub,
+        "warpdotdev",
+        "warp"
+    )]));
+}
+
+#[test]
+fn repos_span_multiple_hosts_is_true_for_mixed_forge_environments() {
+    let repos = vec![
+        repo(CodeForge::GitHub, "warpdotdev", "warp"),
+        repo(CodeForge::GitLab, "platform/backend", "api"),
+    ];
+    assert!(repos_span_multiple_hosts(&repos));
+}
+
+#[test]
+fn repos_span_multiple_hosts_ignores_repos_with_no_resolvable_host() {
+    let mut unhosted = repo(CodeForge::GitHub, "warpdotdev", "warp");
+    unhosted.code_forge = Some(CodeForge::None);
+    let repos = vec![
+        repo(CodeForge::GitHub, "warpdotdev", "warp-server"),
+        unhosted,
+    ];
+    assert!(!repos_span_multiple_hosts(&repos));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -654,18 +654,89 @@ fn recorded_identity_for_host(host: &str) -> Option<(String, String)> {
 /// Write `user.name`/`user.email` into one repository's LOCAL git config,
 /// selecting the identity of the forge that hosts it.
 ///
-/// Repo-local config always wins over `--global` config, so callers should
-/// only reach for this when a sandbox genuinely spans more than one forge and
-/// therefore can't rely on a single process-wide `--global` identity (set by
-/// [`configure_git_identity`]) to represent every repo correctly. Calling this
-/// unconditionally on a single-forge sandbox would permanently defeat a later
-/// `--global` override, such as a customer's own setup command.
-pub(crate) fn configure_repository_git_identity(repository_dir: &std::path::Path, host: &str) {
+/// Repo-local config always wins over `--global` config, so most callers want
+/// [`configure_repository_git_identity_if_unset`] instead, which only applies
+/// this when nothing has already claimed the repo's identity. Calling this
+/// unconditionally would permanently defeat a later `--global` override, such
+/// as a customer's own setup command.
+fn configure_repository_git_identity(repository_dir: &std::path::Path, host: &str) {
     let Some((name, email)) = recorded_identity_for_host(host) else {
         return;
     };
     run_repository_git_config(repository_dir, "user.name", &name);
     run_repository_git_config(repository_dir, "user.email", &email);
+}
+
+/// Reads a single git config key with `--get`, honoring git's own resolution
+/// order for `location` (e.g. `["--global"]` reads the process-wide value;
+/// `["-C", dir]` reads a repository's effective value, local over global over
+/// system). Returns `None` if the key is unset or the invocation fails.
+fn read_git_config(location: &[&str], key: &str) -> Option<String> {
+    let mut args = location.to_vec();
+    args.extend(["config", "--get", key]);
+    let output = BlockingCommand::new("git").args(&args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+/// The `user.name`/`user.email` pair currently in effect at `location` (see
+/// [`read_git_config`]). `None` unless both are set.
+fn read_git_identity(location: &[&str]) -> Option<(String, String)> {
+    let name = read_git_config(location, "user.name")?;
+    let email = read_git_config(location, "user.email")?;
+    Some((name, email))
+}
+
+/// The process-wide git identity right now. Intended to be snapshotted once,
+/// right after bootstrap (before any repo is cloned or any setup command
+/// runs), as the `baseline` for [`configure_repository_git_identity_if_unset`].
+pub(crate) fn global_git_identity() -> Option<(String, String)> {
+    read_git_identity(&["--global"])
+}
+
+/// The git identity currently in effect for `repository_dir` (local over
+/// global over system, exactly as git itself resolves it for a commit there).
+fn repository_git_identity(repository_dir: &std::path::Path) -> Option<(String, String)> {
+    read_git_identity(&["-C", &repository_dir.to_string_lossy()])
+}
+
+/// Reports whether `repository_dir`'s effective identity differs from
+/// `baseline`, meaning something — a customer's setup command, a repo-local
+/// config the agent ran itself, etc. — has already claimed an identity for
+/// this repo since `baseline` was captured.
+fn repository_identity_changed_since(
+    repository_dir: &std::path::Path,
+    baseline: Option<(String, String)>,
+) -> bool {
+    repository_git_identity(repository_dir) != baseline
+}
+
+/// Write `user.name`/`user.email` into one repository's LOCAL git config from
+/// the recorded identity for `host` — but only if nothing has changed the
+/// repo's effective identity away from `baseline` since it was captured.
+///
+/// This is how a forge-specific identity reaches a repo in a mixed-forge
+/// sandbox without permanently overriding a customer's own git identity:
+/// repo-local config always wins over `--global` config regardless of write
+/// order, so this can only safely run *after* setup commands (or anything
+/// else that might configure git identity) have had their chance, comparing
+/// against a `baseline` captured before any of that ran (see
+/// [`global_git_identity`]). A repo the customer's setup command already gave
+/// its own identity — globally, or locally for just that repo — is left
+/// alone; every other repo falls back to the forge-appropriate identity Warp
+/// resolved at bootstrap.
+pub(crate) fn configure_repository_git_identity_if_unset(
+    repository_dir: &std::path::Path,
+    host: &str,
+    baseline: Option<(String, String)>,
+) {
+    if repository_identity_changed_since(repository_dir, baseline) {
+        return;
+    }
+    configure_repository_git_identity(repository_dir, host);
 }
 
 fn run_repository_git_config(repository_dir: &std::path::Path, key: &str, value: &str) {

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -667,14 +667,34 @@ fn configure_repository_git_identity(repository_dir: &std::path::Path, host: &st
     run_repository_git_config(repository_dir, "user.email", &email);
 }
 
-/// Reads a single git config key with `--get`, honoring git's own resolution
-/// order for `location` (e.g. `["--global"]` reads the process-wide value;
-/// `["-C", dir]` reads a repository's effective value, local over global over
-/// system). Returns `None` if the key is unset or the invocation fails.
-fn read_git_config(location: &[&str], key: &str) -> Option<String> {
-    let mut args = location.to_vec();
-    args.extend(["config", "--get", key]);
-    let output = BlockingCommand::new("git").args(&args).output().ok()?;
+/// Where to read a git identity from: either the process-wide `--global`
+/// config, or a specific repository's effective config (local over global
+/// over system, exactly as git resolves it for a commit there).
+///
+/// `--global` is an option to the `config` subcommand, while `-C` is a
+/// top-level git option that must come *before* the subcommand, so the two
+/// scopes need different argument placement — this exists to keep that
+/// placement correct in one place rather than repeated at call sites.
+enum GitIdentityScope<'a> {
+    Global,
+    Repository(&'a std::path::Path),
+}
+
+/// Reads a single git config key with `--get` from `scope`. Returns `None` if
+/// the key is unset or the invocation fails.
+fn read_git_config(scope: &GitIdentityScope, key: &str) -> Option<String> {
+    let output = match scope {
+        GitIdentityScope::Global => BlockingCommand::new("git")
+            .args(["config", "--global", "--get", key])
+            .output(),
+        GitIdentityScope::Repository(dir) => {
+            let dir = dir.to_string_lossy();
+            BlockingCommand::new("git")
+                .args(["-C", dir.as_ref(), "config", "--get", key])
+                .output()
+        }
+    }
+    .ok()?;
     if !output.status.success() {
         return None;
     }
@@ -682,11 +702,11 @@ fn read_git_config(location: &[&str], key: &str) -> Option<String> {
     (!value.is_empty()).then_some(value)
 }
 
-/// The `user.name`/`user.email` pair currently in effect at `location` (see
+/// The `user.name`/`user.email` pair currently in effect at `scope` (see
 /// [`read_git_config`]). `None` unless both are set.
-fn read_git_identity(location: &[&str]) -> Option<(String, String)> {
-    let name = read_git_config(location, "user.name")?;
-    let email = read_git_config(location, "user.email")?;
+fn read_git_identity(scope: &GitIdentityScope) -> Option<(String, String)> {
+    let name = read_git_config(scope, "user.name")?;
+    let email = read_git_config(scope, "user.email")?;
     Some((name, email))
 }
 
@@ -694,13 +714,13 @@ fn read_git_identity(location: &[&str]) -> Option<(String, String)> {
 /// right after bootstrap (before any repo is cloned or any setup command
 /// runs), as the `baseline` for [`configure_repository_git_identity_if_unset`].
 pub(crate) fn global_git_identity() -> Option<(String, String)> {
-    read_git_identity(&["--global"])
+    read_git_identity(&GitIdentityScope::Global)
 }
 
 /// The git identity currently in effect for `repository_dir` (local over
 /// global over system, exactly as git itself resolves it for a commit there).
 fn repository_git_identity(repository_dir: &std::path::Path) -> Option<(String, String)> {
-    read_git_identity(&["-C", &repository_dir.to_string_lossy()])
+    read_git_identity(&GitIdentityScope::Repository(repository_dir))
 }
 
 /// Reports whether `repository_dir`'s effective identity differs from

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -651,8 +651,15 @@ fn recorded_identity_for_host(host: &str) -> Option<(String, String)> {
     Some((matched.name.clone(), matched.email.clone()))
 }
 
-/// Write `user.name`/`user.email` into one repository's local git config,
+/// Write `user.name`/`user.email` into one repository's LOCAL git config,
 /// selecting the identity of the forge that hosts it.
+///
+/// Repo-local config always wins over `--global` config, so callers should
+/// only reach for this when a sandbox genuinely spans more than one forge and
+/// therefore can't rely on a single process-wide `--global` identity (set by
+/// [`configure_git_identity`]) to represent every repo correctly. Calling this
+/// unconditionally on a single-forge sandbox would permanently defeat a later
+/// `--global` override, such as a customer's own setup command.
 pub(crate) fn configure_repository_git_identity(repository_dir: &std::path::Path, host: &str) {
     let Some((name, email)) = recorded_identity_for_host(host) else {
         return;

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -322,6 +322,80 @@ fn repository_identity_falls_back_to_the_primary_forge() {
     assert!(select_host_identity(&[], "github.com").is_none());
 }
 
+fn init_repo(dir: &std::path::Path) {
+    BlockingCommand::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(dir)
+        .output()
+        .expect("git init should succeed");
+}
+
+#[test]
+fn repository_identity_is_unchanged_when_it_matches_the_baseline() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    init_repo(temp_dir.path());
+    run_repository_git_config(temp_dir.path(), "user.name", "Warp");
+    run_repository_git_config(temp_dir.path(), "user.email", "agent@warp.dev");
+
+    let baseline = Some(("Warp".to_string(), "agent@warp.dev".to_string()));
+    assert!(!repository_identity_changed_since(
+        temp_dir.path(),
+        baseline
+    ));
+    Ok(())
+}
+
+#[test]
+fn repository_identity_is_changed_when_a_setup_command_overrides_it() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    init_repo(temp_dir.path());
+    run_repository_git_config(temp_dir.path(), "user.name", "Vercel Bot");
+    run_repository_git_config(temp_dir.path(), "user.email", "vercel-bot@example.com");
+
+    let baseline = Some(("Warp".to_string(), "agent@warp.dev".to_string()));
+    assert!(repository_identity_changed_since(temp_dir.path(), baseline));
+    Ok(())
+}
+
+#[test]
+fn repository_identity_is_changed_when_baseline_is_none_but_the_repo_has_one() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    init_repo(temp_dir.path());
+    run_repository_git_config(temp_dir.path(), "user.name", "Vercel Bot");
+    run_repository_git_config(temp_dir.path(), "user.email", "vercel-bot@example.com");
+
+    assert!(repository_identity_changed_since(temp_dir.path(), None));
+    Ok(())
+}
+
+#[test]
+fn configure_repository_git_identity_if_unset_skips_a_repo_the_customer_already_configured()
+-> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    init_repo(temp_dir.path());
+    run_repository_git_config(temp_dir.path(), "user.name", "Vercel Bot");
+    run_repository_git_config(temp_dir.path(), "user.email", "vercel-bot@example.com");
+
+    // The repo's identity already differs from `baseline`, so this must return
+    // before ever consulting HOST_IDENTITIES (via recorded_identity_for_host) —
+    // exercised here with a host that has no recorded identity, to make sure a
+    // changed repo is left alone rather than falling through to some default.
+    configure_repository_git_identity_if_unset(
+        temp_dir.path(),
+        "github.com",
+        Some(("Warp".to_string(), "agent@warp.dev".to_string())),
+    );
+
+    assert_eq!(
+        repository_git_identity(temp_dir.path()),
+        Some((
+            "Vercel Bot".to_string(),
+            "vercel-bot@example.com".to_string()
+        ))
+    );
+    Ok(())
+}
+
 #[test]
 fn unique_credentials_drop_identical_duplicate_hosts() {
     let unique = unique_credentials_by_host(&[github_credential(), github_credential()]).unwrap();

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -331,6 +331,60 @@ fn init_repo(dir: &std::path::Path) {
 }
 
 #[test]
+#[serial_test::serial]
+fn global_git_identity_reads_the_actual_global_config() -> Result<()> {
+    // #[serial] because this exercises the real `git config --global`
+    // invocation, which reads/writes process-wide state (the `--global`
+    // config file resolved from HOME) rather than a repo-local temp dir.
+    let temp_home = tempfile::tempdir()?;
+    let prev_home = std::env::var_os("HOME");
+    let prev_git_config_global = std::env::var_os("GIT_CONFIG_GLOBAL");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("HOME", temp_home.path()) };
+    // A `GIT_CONFIG_GLOBAL` override in the ambient environment would take
+    // priority over HOME and defeat this test's isolation.
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::remove_var("GIT_CONFIG_GLOBAL") };
+
+    let result = (|| -> Result<()> {
+        assert_eq!(
+            global_git_identity(),
+            None,
+            "no global identity should be configured in the fresh temp HOME yet"
+        );
+
+        run_git_config("user.name", "Warp");
+        run_git_config("user.email", "agent@warp.dev");
+
+        // This is the regression this test guards: `global_git_identity()` must
+        // issue `git config --global --get <key>` (an option to the `config`
+        // subcommand). Building it as `git --global config --get <key>` instead
+        // (`--global` as a top-level git option, which git rejects) would make
+        // this call fail silently and always return `None`, permanently
+        // defeating the `configure_repository_git_identity_if_unset` fallback
+        // logic that depends on a real baseline.
+        assert_eq!(
+            global_git_identity(),
+            Some(("Warp".to_string(), "agent@warp.dev".to_string()))
+        );
+        Ok(())
+    })();
+
+    match prev_home {
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(home) => unsafe { std::env::set_var("HOME", home) },
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+    match prev_git_config_global {
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(value) => unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", value) },
+        None => {}
+    }
+    result
+}
+
+#[test]
 fn repository_identity_is_unchanged_when_it_matches_the_baseline() -> Result<()> {
     let temp_dir = tempfile::tempdir()?;
     init_repo(temp_dir.path());

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -346,7 +346,7 @@ fn global_git_identity_reads_the_actual_global_config() -> Result<()> {
     // TODO: Audit that the environment access only happens in single-threaded code.
     unsafe { std::env::remove_var("GIT_CONFIG_GLOBAL") };
 
-    let result = (|| -> Result<()> {
+    let attempt = || -> Result<()> {
         assert_eq!(
             global_git_identity(),
             None,
@@ -368,7 +368,8 @@ fn global_git_identity_reads_the_actual_global_config() -> Result<()> {
             Some(("Warp".to_string(), "agent@warp.dev".to_string()))
         );
         Ok(())
-    })();
+    };
+    let result = attempt();
 
     match prev_home {
         // TODO: Audit that the environment access only happens in single-threaded code.
@@ -376,10 +377,9 @@ fn global_git_identity_reads_the_actual_global_config() -> Result<()> {
         // TODO: Audit that the environment access only happens in single-threaded code.
         None => unsafe { std::env::remove_var("HOME") },
     }
-    match prev_git_config_global {
+    if let Some(value) = prev_git_config_global {
         // TODO: Audit that the environment access only happens in single-threaded code.
-        Some(value) => unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", value) },
-        None => {}
+        unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", value) }
     }
     result
 }


### PR DESCRIPTION
## Description
Cloud agent sandboxes silently overrode a customer's own `git config --global user.name/email` setup command, so commits kept using Warp's identity instead of the customer's.

**Root cause**: `configure_repository_git_identity` unconditionally wrote a repo-*local* `user.name`/`user.email` right after cloning, before setup commands ran. Local config always beats `--global`, so a customer's later override never took effect. This per-repo stamp exists for a reason: mixed-forge sandboxes (e.g. GitHub + GitLab) need a different identity per repo, which a single `--global` value can't express.

**Fix**: snapshot the process-wide identity once at bootstrap, before any clone or setup command runs. After setup commands finish, only apply Warp's forge-appropriate identity to a repo if its *effective* identity still matches that snapshot. If it differs, something already claimed it (a `--global` override, a per-repo local one, etc.), so it's left alone. This also correctly handles a mixed-forge sandbox where the customer wants one shared identity across every repo.

## Linked Issue
- [ ] N/A — found and fixed while investigating a customer report of cloud agent commits authored with the wrong git identity.

## Testing
- Added unit tests for `repository_identity_changed_since` and `configure_repository_git_identity_if_unset` using real temp git repos.
- `environment` (43 tests) and `git_credentials` (25 tests) module suites pass; `cargo check`/`clippy -D warnings` clean for this diff.
- Not tested end-to-end in a live sandbox (no production credentials available here) — the fix is scoped to small, independently-testable pure functions.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed cloud agent commits sometimes ignoring a customer's `git config --global user.name/email` setup command.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
