### PR TITLE
fix(terminal): let mouse events through kitty graphics image placements

### DIFF
--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -591,7 +591,7 @@ fn render_grid_without_ligatures<'a>(
         }
 
         if !foreground_image_ids.is_empty() {
-            ctx.scene.start_layer(warpui::ClipBounds::ActiveLayer);
+            start_foreground_image_layer(ctx.scene);
             for image_placement in foreground_image_ids {
                 if let Some((image_metadata, image_placement_data)) = image_metadata
                     .get(&image_placement.image_id)
@@ -1100,7 +1100,7 @@ fn render_grid_with_ligatures<'a>(
         }
 
         if !foreground_image_ids.is_empty() {
-            ctx.scene.start_layer(warpui::ClipBounds::ActiveLayer);
+            start_foreground_image_layer(ctx.scene);
             for image_placement in foreground_image_ids {
                 if let Some((image_metadata, image_placement_data)) = image_metadata
                     .get(&image_placement.image_id)
@@ -1847,6 +1847,19 @@ fn render_glyph_svg(
             log::warn!("Icon image should be static");
         }
     }
+}
+
+/// Starts the layer that foreground (non-negative z-index) image placements are painted
+/// into.
+///
+/// The layer sits above the layer the grid was painted into, so without opting out of hit
+/// testing its recorded hit rects would make the cells underneath an image look covered and
+/// every pointer event landing on them would be dropped before it reached the grid. Image
+/// placements are decorative, so the layer is marked click-through and pointer events pass
+/// through to the grid below.
+fn start_foreground_image_layer(scene: &mut Scene) {
+    scene.start_layer(warpui::ClipBounds::ActiveLayer);
+    scene.set_active_layer_click_through();
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -1,9 +1,11 @@
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::{Vector2F, vec2f};
+use warpui::Scene;
+use warpui::elements::Point as ScenePoint;
 use warpui::fonts::Cache as FontCache;
 use warpui::units::{IntoLines, Lines, Pixels};
 
-use super::{CachedBackgroundColor, active_or_next_match};
+use super::{CachedBackgroundColor, active_or_next_match, start_foreground_image_layer};
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
@@ -261,4 +263,25 @@ fn test_calculate_selection_bounds() {
     assert_selection_bounds(5.into_lines()); // Without scroll clipping
     assert_selection_bounds(10.into_lines()); // Without scroll clipping (but on the cusp of clipping)
     assert_selection_bounds(80.into_lines()); // With scroll clipping
+}
+
+/// Regression test for a kitty graphics placement swallowing every pointer event that landed
+/// on the cells it covered. Foreground placements are painted into a layer above the grid, so
+/// that layer has to be click-through for the grid underneath to keep receiving mouse events
+/// (wheel included), which is what alt-screen apps rely on to get mouse reports.
+#[test]
+fn test_foreground_image_layer_does_not_cover_the_grid() {
+    let mut scene = Scene::new(1., Default::default());
+
+    // Stand in for the grid painting its cells.
+    scene.draw_rect_with_hit_recording(RectF::new(vec2f(0., 0.), vec2f(200., 200.)));
+    let grid_z_index = scene.z_index();
+
+    start_foreground_image_layer(&mut scene);
+    scene.draw_rect_with_hit_recording(RectF::new(vec2f(30., 30.), vec2f(100., 100.)));
+    scene.stop_layer();
+
+    // A wheel event landing inside the placement is not considered covered, so it is still
+    // dispatched to the grid rather than dropped at the z-index check.
+    assert!(!scene.is_covered(ScenePoint::new(80., 80., grid_z_index)));
 }

--- a/crates/warpui_core/src/scene_tests.rs
+++ b/crates/warpui_core/src/scene_tests.rs
@@ -1,6 +1,7 @@
 use pathfinder_geometry::vector::vec2f;
 
 use super::*;
+use crate::image_cache::test_utils::make_static_image;
 use crate::rendering;
 
 #[test]
@@ -67,4 +68,45 @@ fn test_click_through_layer_does_not_cover_lower_layers() {
     scene.draw_rect_with_hit_recording(RectF::new(vec2f(0., 0.), vec2f(100., 100.)));
 
     assert!(!scene.is_covered(Point::new(10., 10., ZIndex::new(0))));
+}
+
+#[test]
+fn test_click_through_layer_with_image_does_not_cover_lower_layers() {
+    let mut scene = Scene::new(1., rendering::Config::default());
+
+    // The layer an element such as the terminal grid paints into.
+    scene.draw_rect_with_hit_recording(RectF::new(vec2f(0., 0.), vec2f(100., 100.)));
+    let grid_z_index = scene.z_index();
+
+    // An image painted on top of it, on a click-through layer.
+    scene.start_layer(ClipBounds::ActiveLayer);
+    scene.set_active_layer_click_through();
+    scene.draw_image(
+        RectF::new(vec2f(20., 20.), vec2f(40., 40.)),
+        make_static_image(40, 40),
+        1.,
+        CornerRadius::default(),
+    );
+
+    // A point inside the image's bounds still reaches the layer below it.
+    assert!(!scene.is_covered(Point::new(30., 30., grid_z_index)));
+}
+
+#[test]
+fn test_image_on_regular_layer_covers_lower_layers() {
+    let mut scene = Scene::new(1., rendering::Config::default());
+
+    scene.draw_rect_with_hit_recording(RectF::new(vec2f(0., 0.), vec2f(100., 100.)));
+    let grid_z_index = scene.z_index();
+
+    scene.start_layer(ClipBounds::ActiveLayer);
+    scene.draw_image(
+        RectF::new(vec2f(20., 20.), vec2f(40., 40.)),
+        make_static_image(40, 40),
+        1.,
+        CornerRadius::default(),
+    );
+
+    assert!(scene.is_covered(Point::new(30., 30., grid_z_index)));
+    assert!(!scene.is_covered(Point::new(80., 80., grid_z_index)));
 }


### PR DESCRIPTION
## Description

Foreground kitty graphics placements (`z_index >= 0`, the kitty default) are painted into a layer that `render_grid` pushes with `Scene::start_layer` after the grid has already painted its cells. `Scene::draw_image` records a hit rect for every image it draws, and the layer it lands on is a plain `Layer::default()` with `click_through == false`. Because `AltScreenElement::paint` captures its z-index at the start of paint — before `render_grid` pushes that image layer — the image layer sits strictly above the alt-screen element's own z-index, so `Scene::is_covered` reports every point inside the placement as covered. `DispatchedEvent::at_z_index` then returns `None` for scroll-wheel and button events there and `AltScreenElement::dispatch_event` bails out early. The result is that an alt-screen app which has enabled mouse reporting receives no reports at all for cells an image covers — not wheel, not clicks — and no view scroll happens either, since the event is dropped before the scroll-vs-report decision is reached. Image alpha is irrelevant; a fully transparent PNG records the same hit rect, which is why a full-pane placement makes an entire pane look mouse-dead. `BlockListElement` is unaffected because it records `child_max_z_index` at the end of paint.

Image placements are decorative terminal content and should never capture pointer input, so this marks that layer click-through via the existing `Scene::set_active_layer_click_through`, which `Scene::is_covered` already skips. The two identical `start_layer` call sites in `render_grid` (the plain and the ligature path) now go through a small `start_foreground_image_layer` helper so the intent is documented in one place and the two paths cannot drift. Nothing else about how images are painted changes — they still render above the cells, they just no longer swallow events aimed at the grid underneath.

## Linked Issue

Closes #15882

The issue is triaged as `bug` / `repro:high` / `factory-auto-implement`. It does not carry `ready-to-implement`, so the box below is left unticked — filed ahead of triage as a bug fix per CONTRIBUTING.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `app/src/terminal/grid_renderer_tests.rs` — `test_foreground_image_layer_does_not_cover_the_grid` is the regression test: it paints a stand-in grid layer, calls `start_foreground_image_layer`, records a hit rect inside it, and asserts a wheel position over the placement is not covered at the grid's z-index. That is exactly the check `DispatchedEvent::at_z_index` performs before `AltScreenElement::dispatch_event` returns `false`, so it fails on `master` and passes with the fix.
- `crates/warpui_core/src/scene_tests.rs` — two tests covering the scene behaviour the fix relies on. `test_click_through_layer_with_image_does_not_cover_lower_layers` goes through `Scene::draw_image` (rather than `draw_rect_with_hit_recording`, as the existing click-through test does) to confirm an image's recorded hit rect on a click-through layer does not cover a lower z-index, and `test_image_on_regular_layer_covers_lower_layers` pins the opposite for a normal layer, which is the behaviour that produced the bug.

Presubmit: this machine only has the Command Line Tools, not full Xcode, so `crates/warpui`'s build script cannot run `xcrun metal` and `./script/presubmit` cannot complete end to end here. The parts that do not need the Metal toolchain all pass — `./script/format --check`, `./script/check_no_inline_test_modules`, the factory-files validator, and `cargo clippy -p warpui_core --all-targets --tests -- -D warnings`. To get the app crate compiled and the tests run I stubbed `xcrun metal`/`metallib` locally (nothing in the repo changed): with that in place `cargo clippy -p warp --lib --tests -- -D warnings` is clean and `cargo test -p warp --lib -- terminal::grid_renderer::tests` and `cargo test -p warpui_core --lib -- scene::tests` both pass, 7 and 6 tests respectively. CI should cover the full presubmit on a machine with the Metal toolchain.

Manual check: the `repro.py` script in the issue is the reproduction. It enters the alternate screen, enables SGR mouse reporting, places one translucent 700x320 PNG with `\x1b_Ga=T,f=100,C=1,m=0;<base64>\x1b\\`, and prints a numbered line per mouse report. On a current build, scrolling with the pointer inside the image's outline prints nothing while scrolling one column outside it reports normally, and deleting the images with `a=d` makes reports resume everywhere — the column-precise behaviour that pointed at the scene hit rect rather than a mode reset. The expected behaviour after this change is a report per notch whether or not the pointer is over the placement, matching kitty, WezTerm and Ghostty.

I could not launch a local dev build to capture before/after screenshots for the same Metal toolchain reason. Happy to add them if a reviewer wants them, or if it is easier the repro script above reproduces it in a few seconds on any build.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed mouse events (scroll and clicks) being dropped for terminal cells covered by a kitty graphics image, which made alternate-screen apps with mouse reporting enabled appear unresponsive over images.
