### PR TITLE
Allow sharer-attributed shared-session control actions (steering interrupt)

### DIFF
--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -1172,26 +1172,44 @@ impl TerminalManager<TerminalView> {
                     return;
                 }
 
-                let viewer_is_executor = terminal_view
+                // Control actions injected via the server's conversation steering API are
+                // attributed to the sharer, who is never in its own viewer list, so they bypass
+                // the viewer role check just like injected agent prompts.
+                let mut is_sharer = false;
+                let viewer_role_opt = terminal_view
                     .as_ref(ctx)
                     .shared_session_presence_manager()
-                    .and_then(|manager| manager.as_ref(ctx).viewer_role(participant_id))
-                    .map(|role| role.can_execute())
-                    .unwrap_or_else(|| {
-                        log::warn!("Failed to get viewer's role during control action request");
-                        false
+                    .and_then(|manager| {
+                        let manager_ref = manager.as_ref(ctx);
+                        if manager_ref.sharer_id() == *participant_id {
+                            is_sharer = true;
+                            None
+                        } else {
+                            manager_ref.viewer_role(participant_id)
+                        }
                     });
 
-                if !viewer_is_executor {
-                    network.update(ctx, |network, _ctx| {
-                        network.send_control_action_rejection(
-                            participant_id.clone(),
-                            request_id.clone(),
-                            ControlActionFailureReason::InsufficientPermissions,
-                        );
-                    });
-                    return;
-                };
+                if !is_sharer {
+                    let viewer_is_executor = viewer_role_opt
+                        .map(|role| role.can_execute())
+                        .unwrap_or_else(|| {
+                            log::warn!(
+                                "Failed to get viewer's role during control action request for participant_id={participant_id} (not sharer)"
+                            );
+                            false
+                        });
+
+                    if !viewer_is_executor {
+                        network.update(ctx, |network, _ctx| {
+                            network.send_control_action_rejection(
+                                participant_id.clone(),
+                                request_id.clone(),
+                                ControlActionFailureReason::InsufficientPermissions,
+                            );
+                        });
+                        return;
+                    }
+                }
 
                 match action {
                     ControlAction::CancelConversation {


### PR DESCRIPTION
## Description

Supersedes warpdotdev/warp-internal#27904 (opened against the wrong repo; same commit, cherry-picked onto `master` here).

Injected `cancel_conversation` control actions (session-sharing `PUT /sessions/control/{sid}`, used by warp-server's new `POST /agent/conversations/{cid}/interrupt` for conversation steering) are delivered to the sharer as `DownstreamMessage::ControlActionRequested` with `participant_id` equal to the sharer's own participant id — session-sharing attributes injected actions to the sharer, exactly as it does for injected agent prompts.

The sharer-side `NetworkEvent::ControlActionRequested` handler in `app/src/terminal/local_tty/terminal_view_adaptor.rs` resolved the requester with `presence_manager.viewer_role(participant_id)`, which only consults present viewers. The sharer is never in its own viewer list, so every injected interrupt hit

```
Failed to get viewer's role during control action request
```

was rejected with `ControlActionFailureReason::InsufficientPermissions`, and `handle_shared_session_cancel_action` never ran — the turn kept going. Verified end to end on a local stack.

This mirrors the existing sharer bypass in the `NetworkEvent::AgentPromptRequested` handler in the same file: if `presence_manager.sharer_id() == participant_id`, allow; otherwise require `viewer_role(...).can_execute()`. The warn log now includes the participant id, matching the prompt handler.

**Viewer-originated cancels are unchanged.** Session-sharing still role-checks them in `try_send_control_action`, and the non-sharer branch here is the same viewer role check + `InsufficientPermissions` rejection as before. The bypass is strictly `participant_id == sharer_id`; the `None`-role case for non-sharer participants is not relaxed.

Required by the conversation steering interrupt work:
- warp-server: https://github.com/warpdotdev/warp-server/pull/16958
- session-sharing: https://github.com/warpdotdev/session-sharing-server/pull/517 (merged)

## Linked Issue
N/A — part of the conversation steering interrupt work linked above.

## Testing
- `./script/format --check` — pass
- `cargo clippy -p warp --all-targets --tests -- -D warnings` — pass
- No existing unit/integration tests cover the `ControlActionRequested` or `AgentPromptRequested` handlers in `terminal_view_adaptor.rs` (only the `network.rs` event forwarding is tested), so no test was added rather than building a new harness for this one-line-of-logic change.
- End-to-end reproduction of the bug (injected interrupt → warn log → turn continues) was done on a local stack prior to this change; the fix should be re-verified against warp-server #16958 + session-sharing #517.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Warp <agent@warp.dev>
