### PR TITLE
Shared-session cancel terminates the in-flight agent command

### DIFF
--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -67,27 +67,24 @@ impl BlocklistAIController {
             })
     }
 
-    /// Handle a shared cancel control action and cancel the provided conversation
-    /// (if it exists and is live).
-    pub fn handle_shared_session_cancel_action(
-        &mut self,
+    /// Resolves a shared cancel control action to the live, not-yet-finished conversation bound
+    /// to `server_conversation_token`, if any. A finished conversation is not returned so that a
+    /// late or duplicate cancel cannot overwrite its terminal status.
+    pub fn conversation_for_shared_session_cancel_action(
+        &self,
         server_conversation_token: ServerConversationToken,
         ctx: &mut ModelContext<Self>,
-    ) {
-        let Some(conversation_id) = self.find_existing_conversation_by_server_token(
+    ) -> Option<AIConversationId> {
+        let conversation_id = self.find_existing_conversation_by_server_token(
             &server_conversation_token.to_string(),
             ctx,
-        ) else {
-            return;
-        };
-
-        if BlocklistAIHistoryModel::as_ref(ctx).is_conversation_live(conversation_id) {
-            self.cancel_conversation_progress(
-                conversation_id,
-                super::CancellationReason::ManuallyCancelled,
-                ctx,
-            );
-        }
+        )?;
+        let history = BlocklistAIHistoryModel::as_ref(ctx);
+        let is_cancellable = history.is_conversation_live(conversation_id)
+            && history
+                .conversation(&conversation_id)
+                .is_some_and(|conversation| !conversation.status().is_done());
+        is_cancellable.then_some(conversation_id)
     }
 
     /// Apply agent session events to the current conversation state.

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -1216,10 +1216,10 @@ impl TerminalManager<TerminalView> {
                         server_conversation_token,
                     } => {
                         terminal_view.update(ctx, |view, ctx| {
-                            view.ai_controller().update(ctx, |controller, ctx| {
-                                controller
-                                    .handle_shared_session_cancel_action(*server_conversation_token, ctx);
-                            });
+                            view.handle_shared_session_cancel_action(
+                                *server_conversation_token,
+                                ctx,
+                            );
                         });
                     }
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8897,6 +8897,24 @@ impl TerminalView {
         }
     }
 
+    /// Handles a shared-session cancel control action (a viewer's stop or a server-side steering
+    /// interrupt) for the live conversation bound to `server_conversation_token`. The conversation
+    /// is stopped the same way a local stop is, so an in-flight agent command is interrupted along
+    /// with the turn rather than left running to completion.
+    #[cfg(feature = "local_tty")]
+    pub(crate) fn handle_shared_session_cancel_action(
+        &mut self,
+        server_conversation_token: SessionSharingServerConversationToken,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let conversation_id = self.ai_controller.update(ctx, |controller, ctx| {
+            controller.conversation_for_shared_session_cancel_action(server_conversation_token, ctx)
+        });
+        if let Some(conversation_id) = conversation_id {
+            self.stop_local_agent_conversation(conversation_id, ctx);
+        }
+    }
+
     fn user_write_ctrl_c_to_pty(&mut self, ctx: &mut ViewContext<Self>) {
         self.write_user_bytes_to_pty(vec![escape_sequences::C0::ETX], ctx);
     }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -7172,6 +7172,185 @@ fn ctrl_c_after_transfer_takeover_does_not_cancel_conversation() {
     })
 }
 
+/// Subscribes to the terminal view's PTY writes so tests can assert on the bytes forwarded to the
+/// shell.
+fn capture_pty_writes(
+    app: &mut App,
+    terminal: &ViewHandle<TerminalView>,
+) -> Rc<RefCell<Vec<Vec<u8>>>> {
+    let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+    let writes = pty_writes.clone();
+    app.update(|ctx| {
+        ctx.subscribe_to_view(terminal, move |_, event, _| {
+            if let Event::WriteBytesToPty { bytes } = event {
+                writes.borrow_mut().push(bytes.to_vec());
+            }
+        });
+    });
+    pty_writes
+}
+
+/// Starts an in-progress conversation bound to a server token whose agent-requested command is
+/// still running in the active block.
+fn start_conversation_with_running_agent_command(
+    view: &mut TerminalView,
+    server_conversation_token: &SessionSharingServerConversationToken,
+    ctx: &mut ViewContext<TerminalView>,
+) -> AIConversationId {
+    let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+        let conversation_id =
+            history.start_new_conversation(view.view_id, false, false, false, ctx);
+        history.set_server_conversation_token_for_conversation(
+            conversation_id,
+            server_conversation_token.to_string(),
+        );
+        conversation_id
+    });
+
+    let mut model = view.model.lock();
+    model.simulate_long_running_block("echo step-one; sleep 12; echo done-one", "step-one");
+    model
+        .block_list_mut()
+        .active_block_mut()
+        .set_agent_interaction_mode_for_requested_command(
+            AIAgentActionId::from("requested-command".to_owned()),
+            None,
+            conversation_id,
+        );
+    conversation_id
+}
+
+#[test]
+fn shared_session_cancel_action_interrupts_running_agent_command() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes = capture_pty_writes(&mut app, &terminal);
+        let server_conversation_token = SessionSharingServerConversationToken::new();
+
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            start_conversation_with_running_agent_command(view, &server_conversation_token, ctx)
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_shared_session_cancel_action(server_conversation_token, ctx);
+        });
+
+        assert_eq!(*pty_writes.borrow(), vec![vec![C0::ETX]]);
+        terminal.read(&app, |_, ctx| {
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
+        });
+    })
+}
+
+#[test]
+fn shared_session_cancel_action_releases_agent_controlled_command_before_interrupting() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes = capture_pty_writes(&mut app, &terminal);
+        let server_conversation_token = SessionSharingServerConversationToken::new();
+
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            let conversation_id = start_conversation_with_running_agent_command(
+                view,
+                &server_conversation_token,
+                ctx,
+            );
+            let task_id = TaskId::new("test-cli-subagent".to_owned());
+            view.model
+                .lock()
+                .block_list_mut()
+                .active_block_mut()
+                .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
+                .expect("command should become agent monitored");
+            assert!(
+                view.model
+                    .lock()
+                    .block_list()
+                    .active_block()
+                    .is_agent_in_control()
+            );
+            conversation_id
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_shared_session_cancel_action(server_conversation_token, ctx);
+        });
+
+        // The agent-controlled block would otherwise swallow the Ctrl-C (see
+        // `write_user_bytes_to_pty`), so control must be handed to the user for teardown first.
+        assert_eq!(*pty_writes.borrow(), vec![vec![C0::ETX]]);
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            let active_block = model.block_list().active_block();
+            assert!(!active_block.is_agent_in_control());
+            assert!(
+                !active_block
+                    .long_running_control_state()
+                    .is_some_and(|state| state.should_auto_resume())
+            );
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
+        });
+    })
+}
+
+#[test]
+fn shared_session_cancel_action_ignores_unknown_and_finished_conversations() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes = capture_pty_writes(&mut app, &terminal);
+        let server_conversation_token = SessionSharingServerConversationToken::new();
+
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            start_conversation_with_running_agent_command(view, &server_conversation_token, ctx)
+        });
+
+        // A token that isn't bound to any conversation on this surface is a no-op.
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_shared_session_cancel_action(
+                SessionSharingServerConversationToken::new(),
+                ctx,
+            );
+        });
+        assert!(pty_writes.borrow().is_empty());
+
+        // A cancel that arrives after the conversation already finished must neither interrupt
+        // the command nor overwrite the terminal status.
+        terminal.update(&mut app, |view, ctx| {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.update_conversation_status(
+                    view.view_id,
+                    conversation_id,
+                    ConversationStatus::Success,
+                    ctx,
+                );
+            });
+            view.handle_shared_session_cancel_action(server_conversation_token, ctx);
+        });
+        assert!(pty_writes.borrow().is_empty());
+        terminal.read(&app, |_, ctx| {
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::Success);
+        });
+    })
+}
+
 #[test]
 fn completed_user_controlled_lrc_resumes_when_not_suppressed() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

Required for the conversation-steering interrupt e2e (warp-server warpdotdev/warp-server#16958, session-sharing warpdotdev/session-sharing#517, follows warpdotdev/warp-internal#27914).

### Staging evidence

With the sharer bypass from #27914, a steering interrupt reaches the sharer as `ControlActionRequested { action: CancelConversation { server_conversation_token } }` and the turn is cancelled (no further LLM requests; `TOOL_RESULT cancel: cancelled` is carried with the next request). But the agent's in-flight tool command kept running to natural completion: `echo step-one; sleep 12; echo done-one` finished its full 12 s after the interrupt (`CommandExecutionFinished` ~12–13 s after start in every run). Product decision: an interrupt must terminate the running command as well as cancel the turn.

### Local stop vs. shared-session cancel (before this PR)

* **Local stop kills the command.** The pill-bar Stop/Kill (`pane_group/pane/terminal_pane.rs`) and the second Ctrl-C after a Stop takeover (`view.rs` `ctrl_c_to_active_block`) both go through `TerminalView::stop_local_agent_conversation`, which calls `cancel_conversation_progress(ManuallyCancelled)`, releases an agent-controlled block via `set_user_control_for_teardown()`, and writes Ctrl-C (ETX) to the PTY. Rewind does the same.
* **Shared-session cancel did not.** `terminal_view_adaptor.rs` → `BlocklistAIController::handle_shared_session_cancel_action` → `cancel_conversation_progress` only. For a running `RequestCommandOutput`, `ShellCommandExecutor::cancel_execution` just drops the block-finished / force-refresh oneshot senders so the action resolves `Cancelled`; nothing touches the PTY, so the child process runs to completion.

### Change

* `NetworkEvent::ControlActionRequested { CancelConversation }` now calls a new `TerminalView::handle_shared_session_cancel_action(token)`, which resolves the token to the live conversation and then calls the existing `stop_local_agent_conversation`. Viewer-initiated stop and server-side steering both arrive through this handler, so both get the same behaviour. The local stop primitive is unchanged.
* `BlocklistAIController::handle_shared_session_cancel_action` becomes `conversation_for_shared_session_cancel_action`: a pure resolver returning the live, **not-yet-finished** conversation bound to the token. This is a small deliberate tightening: a late/duplicate cancel for a conversation that already reached `Success`/`Error`/`Cancelled` is now a no-op (previously it only reset the sharer's input mode) instead of being able to flip the terminal status to `Cancelled` via the stop primitive.

Expected result on staging: the command block finishes within ~1 s of the interrupt (exit 130) rather than at natural completion, and the tool result reports cancellation promptly.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

New unit tests in `app/src/terminal/view_tests.rs`:
* `shared_session_cancel_action_interrupts_running_agent_command` — agent-requested command running in the active block; cancel writes exactly one ETX to the PTY and the conversation ends `Cancelled`.
* `shared_session_cancel_action_releases_agent_controlled_command_before_interrupting` — CLI-subagent-controlled block (which would otherwise swallow the Ctrl-C in `write_user_bytes_to_pty`) is handed to the user for teardown, ETX is written, no auto-resume.
* `shared_session_cancel_action_ignores_unknown_and_finished_conversations` — unknown token and already-`Success` conversation: no PTY write, status preserved.

Commands run:
* `./script/format` then `./script/format --check` — pass
* `cargo clippy -p warp --all-targets --tests -- -D warnings` — pass
* `cargo nextest run -p warp -E 'test(shared_session_cancel_action) | test(ctrl_c_after_stop_takeover) | test(ctrl_c_after_transfer_takeover) | test(completed_user_controlled_lrc)'` — 7/7 pass

- [ ] I have manually tested my changes locally with `./script/run` (not run; needs the steering e2e on staging — see evidence above for the pre-change baseline)

## Follow-up: run state after interrupt (proposal, not implemented)

Today `LocalAgentTaskSyncModel::map_conversation_status` (`app/src/ai/blocklist/local_agent_task_sync_model.rs`) maps `ConversationStatus::Cancelled` → `(AgentTaskState::Cancelled, "Cancelled by user")` and pushes it to warp-server, which runs `TransitionTaskToCancelled` (cancels a bound Factory task, notifies GitHub/Linear/Jira/lifecycle, expires queued follow-ups; the run becomes non-resumable once the session idles out). For a shared-session-originated cancel (steering interrupt or viewer stop) the desired run state is the idle shape a completed turn leaves: report `AgentTaskState::Succeeded` with status message `"Turn interrupted"`, while the transcript still shows the exchange as cancelled.

**Why the reason isn't available to the sync model today.** The only place a `CancellationReason` is recorded is on the exchange, in `FinishedAIAgentOutput::Cancelled { reason }`, and only when an in-flight *stream* is cancelled (`AIConversation::mark_request_cancelled`). In the interrupt case there is no stream: the turn is mid-tool-call, so the conversation is moved to `Cancelled` by the controller's `FinishedAction` handler (`controller.rs`, the "mixed results → Cancelled" branch) and by `stop_local_agent_conversation`'s direct `update_conversation_status(Cancelled)` — neither carries a reason. So the exchange is not a reliable place to look.

**Proposal.**
1. `app/src/ai/agent/mod.rs`: add `CancellationReason::SharedSessionControl`. `conversation_outcome()` → `CancellationOutcome::Cancelled`; `Display` → `"shared session control action"`. (Only these two matches are exhaustive over the enum.)
2. `app/src/ai/agent/conversation.rs`: mirror the existing `status_error: Option<RenderableAIError>` pattern with `status_cancellation_reason: Option<CancellationReason>`, set by a new `update_status_with_cancellation_reason(status, reason, ...)` (cleared when the status is not `Cancelled`), exposed via `status_cancellation_reason()`; `BlocklistAIHistoryModel` gets the matching `update_conversation_status_with_cancellation_reason`. Persist it alongside `status_error` if that is persisted (check `conversation_yaml` / the persisted conversation state; a restart mid-interrupt is an edge case, not a blocker).
3. Plumb the reason: `TerminalView::stop_local_agent_conversation(conversation_id, reason, ctx)` takes the `CancellationReason` (local callers pass `ManuallyCancelled`, the new `handle_shared_session_cancel_action` passes `SharedSessionControl`) and forwards it to `cancel_conversation_progress`, to its direct `Cancelled` status write, and — via `BlocklistAIActionEvent::FinishedAction { cancellation_reason }` — the controller's `FinishedAction` handler records it when it writes `Cancelled`. `mark_request_cancelled` already has the reason and should record it too, so the stream-cancel path is covered for free.
4. `local_agent_task_sync_model.rs`: in `map_conversation_status`, `ConversationStatus::Cancelled` matches on `conversation.status_cancellation_reason()`: `Some(SharedSessionControl)` → `(AgentTaskState::Succeeded, Some(TaskStatusUpdate::message("Turn interrupted")))`; anything else keeps `(Cancelled, "Cancelled by user")`. The reason is available where the update is computed because `on_conversation_status_updated` runs off `BlocklistAIHistoryEvent::UpdatedConversationStatus` and reads the conversation from the history model synchronously, after the status (and reason) have been written.
5. Tests: `local_agent_task_sync_model_tests.rs` — `map_conversation_status` with `Cancelled` + `SharedSessionControl` → `Succeeded`/"Turn interrupted", and `Cancelled` + `ManuallyCancelled`/`None` → unchanged; `view_tests.rs` — `handle_shared_session_cancel_action` records `SharedSessionControl` on the conversation while a local Ctrl-C stop records `ManuallyCancelled`.

Caveat to confirm with the server side: reporting `Succeeded` for an interrupted turn means the run shows as succeeded in lists until the next turn; if a distinct state is preferred the mapping in step 4 is the single place to change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Stopping a shared Agent Mode conversation from a viewer or via conversation steering now interrupts the agent's running command instead of letting it run to completion.

---
Conversation: https://staging.warp.dev/conversation/8eaf5a4f-d303-465a-8498-f6267e0a0347
Run: https://platform.staging.warp.dev/runs/01a084d0-cfc8-7b67-b960-97c4e2622c47

