### PR TITLE
Document the Warp for OSS factory in CONTRIBUTING and FAQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,19 @@ Thanks for helping improve Warp! This guide explains how to open issues, propose
 - Feature requests must be marked `ready-to-spec` or `ready-to-implement` before PRs are accepted.
 - Issues marked `warp:reserved-internal` are being handled by the Warp team and are not open for contributor PRs.
 - Specs are the place where technical and design discussion on larger issues happen.
-- Oz automatically triages incoming issues and reviews open PRs.
+- The **Warp for OSS** factory — a [Warp Factory](https://warp.dev/factories) — automatically triages incoming issues and reviews open PRs. It posts as `warp-factories`; mention it with **@warp-factory**.
 - Implementation PRs must include proof of manual testing.
 
 ## How Contributing to Warp Works
 
-Warp's contribution model is shaped by [Oz](https://oz.warp.dev), an agent that automates parts of triage, spec writing, implementation, and review. Compared with a typical open-source repository, a few things work differently here:
+Warp's contribution model is shaped by the **Warp for OSS** factory, a [Warp Factory](https://warp.dev/factories) that automates parts of triage, spec writing, implementation, and review. The factory's definition is open source at [`warpdotdev/warp-factories-open-source`](https://github.com/warpdotdev/warp-factories-open-source), and every comment it posts links to the run that produced it ("Open session" / "View run") so you can see exactly what it did. Compared with a typical open-source repository, a few things work differently here:
 
 - **Issues are the starting point for everything.** Discussion, scoping, and design happen on the issue before any PR is opened.
 - **Feature requests differ from bug fixes:**
   - Features are gated by readiness labels — `ready-to-spec`, then `ready-to-implement` once the design is settled — that signal when contributors can pick up the work. Discussion alone is not approval to begin work.
   - Feature work needs a written spec first: feature requests go through a spec PR (a *product spec* + *tech spec* committed under [`specs/`](specs/)) before any code is written.
   - Bug fixes can go straight to a code PR once the report is reproducible or otherwise actionable; they do not require spec PRs unless the scope or design is unclear.
-- **Review is largely automated.** When you open a PR, Oz is auto-assigned and produces an initial review. Once Oz approves, it automatically requests a follow-up review from a Warp team subject-matter expert — you do not need to assign human reviewers yourself.
+- **Review is largely automated.** When you open a PR, the factory produces an initial review. Once the factory's review is accepted, it automatically requests a follow-up review from the owning Warp team subject-matter expert — you do not need to assign human reviewers yourself.
 
 ### Readiness labels
 
@@ -32,13 +32,15 @@ The Warp team applies one of the following labels when an issue is ready for con
 - **`ready-to-spec`** — The problem is understood but the design is open. Open a spec PR with a *product spec* (`product.md`) and a *tech spec* (`tech.md`) under [`specs/`](specs/) — see [Opening a Spec PR](#opening-a-spec-pr) for what goes in each. This label is **reserved for feature requests**.
 - **`ready-to-implement`** — The issue is ready for a code PR. For bugs, this means the report is sufficiently reproducible or actionable and the likely fix does not need a spec, mocks, or deeper investigation.
 - **`needs-mocks`** — Design mocks are required before implementation can begin. Wait for the Warp team to land them.
-- **`warp:reserved-internal`** — The Warp team is reserving this work for internal implementation or alignment. Do not open a spec or code PR for issues with this label; Oz will reject contributor PRs linked to them with an explanatory comment.
+- **`warp:reserved-internal`** — The Warp team is reserving this work for internal implementation or alignment. Do not open a spec or code PR for issues with this label; the factory's review will flag contributor PRs linked to them with an explanatory note.
 
 Anyone can pick up a ready issue — readiness labels are not assignments, and the best implementation wins through normal review. If an issue has been sitting un-triaged or you'd like readiness re-evaluated, mention **@oss-maintainers** in a comment to flag it for the team.
 
+The factory also applies informational labels: `factory:warp-for-oss` marks issues and PRs it has touched, and `needs-info` means triage is waiting on details from the reporter. If you've answered a `needs-info` question, mention **@warp-factory** in your reply to have the issue re-triaged.
+
 ## Contribution Flow
 
-Steps owned by you (the contributor) are shown in yellow; steps owned by the Warp team or Oz are shown in blue.
+Steps owned by you (the contributor) are shown in yellow; steps owned by the Warp team or the factory are shown in blue.
 
 ```mermaid
 flowchart TD
@@ -48,7 +50,7 @@ flowchart TD
     D --> E[Open code PR]
     C -- specs approved --> E
     B -- ready-to-implement<br/>(actionable bugs or settled designs) --> E
-    E --> F[Oz review → SME review → CI → merge]
+    E --> F[Factory review → SME review → CI → merge]
 
     classDef contributor fill:#fef3c7,stroke:#b45309,color:#78350f;
     classDef warpTeam fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
@@ -72,7 +74,7 @@ A good bug report includes:
 - Warp version and OS (see `Settings → About`).
 - Logs, screenshots, or screen recordings when relevant.
 
-Once an issue is triaged as an actionable bug (by Oz's triage agent or a maintainer), it may be labeled **`ready-to-implement`** so you can pick it up and open a code PR.
+Once an issue is triaged as an actionable bug (by the factory's triage stage or a maintainer), it may be labeled **`ready-to-implement`** so you can pick it up and open a code PR.
 
 ### Feature requests
 
@@ -106,7 +108,7 @@ To open a spec PR:
 
 1. Add `specs/GH<issue-number>/product.md` and `specs/GH<issue-number>/tech.md`. See [`specs/GH408/`](specs/GH408/), [`specs/GH1063/`](specs/GH1063/), and [`specs/GH1066/`](specs/GH1066/) for examples of well-structured specs, and browse the rest of [`specs/`](specs/) for more. After common skills are installed, the `/write-product-spec` and `/write-tech-spec` skills are available to scaffold these for you.
 2. Use the PR as the home for product and technical discussion.
-3. Once the specs are approved, implementation generally continues on the same PR. In rarer cases — for example, if a large spec is merged on its own so the implementation can be broken up — it can move to a linked follow-up PR.
+3. A maintainer marks the spec approved by applying the `plan-approved` label (or commenting `@warp-factory spec approved`). Once the specs are approved, implementation generally continues on the same PR. In rarer cases — for example, if a large spec is merged on its own so the implementation can be broken up — it can move to a linked follow-up PR.
 
 ## Opening a Code PR
 
@@ -118,13 +120,13 @@ For issues labeled `ready-to-implement`:
 4. Open a PR using the [pull request template](.github/pull_request_template.md) and add a changelog entry (`CHANGELOG-NEW-FEATURE`, `CHANGELOG-IMPROVEMENT`, or `CHANGELOG-BUG-FIX`); omit only for docs-only or refactoring-only changes.
 5. Keep the PR focused on a single logical change and merge `master` in before the PR enters review.
 
-You **do not need to manually request reviewers**. Oz is auto-assigned to PRs that target a ready issue and produces an initial review. After Oz approves, it automatically requests a follow-up review from the appropriate Warp team subject-matter expert.
+You **do not need to manually request reviewers**. The factory reviews every non-draft PR when it is opened and produces an initial review. After the factory's review is accepted, it automatically requests a follow-up review from the appropriate Warp team subject-matter expert.
 
-After you push changes that address Oz's feedback, comment `/warp-agent-review` on the PR to request a re-review — you can do this up to **three times** per PR. If something looks stuck or you need more reviews than that, mention **@oss-maintainers** on the PR to escalate to the team.
+New commits alone do not trigger another factory review. After you push changes that address the factory's feedback, comment `@warp-factory /review` on the PR to request a re-review — external contributors can request up to **five factory review passes per PR per day**. (The older `/warp-agent-review` command still works when it appears in a comment that mentions `@warp-factory`; maintainers can also apply the `factory-review` label.) If something looks stuck or you need more reviews than that, mention **@oss-maintainers** on the PR to escalate to the team.
 
 **You must include proof of [manual testing](#manual-testing)**. For small, isolated, and visual changes, you should include **before and after screenshots**. For larger, broad, or interactive changes, you should also include a **narrated screen recording**.
 
-If a maintainer requests changes to your PR, you will need to request `/warp-agent-review` again and pass it before a re-review can be requested. Oz will request the re-review for you automatically once you pass its reviews.
+If a maintainer requests changes to your PR, request a fresh factory review with `@warp-factory /review` once you've addressed them. The factory will request the maintainer re-review for you automatically once its review is accepted.
 
 ### PRs opened without a linked issue
 
@@ -140,7 +142,7 @@ Then, **ensure your PR passes code review and includes relevant tests** per our 
 
 You can use **any coding agent** to implement a contribution — for example, Warp's built-in agent, Claude Code, Codex, Gemini CLI, or others — or no agent at all. This repository ships agent-readable context (skills under [`.agents/skills/`](.agents/skills/), specs under [`specs/`](specs/), and [`AGENTS.md`](AGENTS.md)) that any harness supporting these formats can pick up.
 
-If you'd rather have an **Oz cloud agent** implement a ready issue for you, mention **@oss-maintainers** on the issue to request it. Approved requests run **for free** on complimentary Oz credits — you don't need to set up your own Oz account or pay for compute.
+If you'd rather have the **factory** implement a ready issue for you, mention **@oss-maintainers** on the issue to request it; a maintainer assigns or mentions **@warp-factory** to start the work. Approved requests run **for free** on Warp's credits — you don't need to set up your own Warp account or pay for compute. (A readiness label on its own never starts factory work — assignment or a mention by a maintainer does.)
 
 While you can use coding agents for implementation, we expect contributors to **collaborate with us personally**. This means that you should not be using agents like OpenClaw to engage in conversation with our team. Our maintainers will always talk to you as a human, so please talk to us as a human as well.
 
@@ -148,14 +150,16 @@ While you can use coding agents for implementation, we expect contributors to **
 
 All pull requests go through a two-stage review process:
 
-1. **Oz review** — When you open a PR, [Oz](https://warp.dev/oz) is automatically assigned and produces the first review. Oz checks for correctness, style, test coverage, and alignment with the linked issue and any associated specs.
-2. **Warp team review** — Only after Oz has **approved** the PR is it routed to a Warp team subject-matter expert for a final human review. PRs that have not yet been approved by Oz will not be assigned to a team member.
+1. **Factory review** — When you open a PR, the [Warp for OSS factory](https://github.com/warpdotdev/warp-factories-open-source) produces the first review, including a security pass. It checks for correctness, style, test coverage, and alignment with the linked issue and any associated specs. The review is advisory — the factory never merges or closes PRs.
+2. **Warp team review** — Only after the factory's review is **accepted** is the PR routed to the owning Warp team subject-matter expert for a final human review. PRs that have not yet passed factory review will not be assigned to a team member.
 
-You do not need to manually request reviewers at any stage. After pushing changes that address Oz's feedback, comment `/warp-agent-review` on the PR to request a re-review — you can do this up to **three times** per PR. If something looks stuck or you need additional reviews, mention **@oss-maintainers** on the PR to escalate to the team.
+You do not need to manually request reviewers at any stage. After pushing changes that address the factory's feedback, comment `@warp-factory /review` on the PR to request a re-review (up to **five passes per PR per day** for external contributors). If something looks stuck or you need additional reviews, mention **@oss-maintainers** on the PR to escalate to the team.
+
+Every factory comment and review ends with "Open session" and "View run" links to the run that produced it. Viewing them currently requires a Warp account; we're working on making them viewable without one.
 
 ### Stale PRs with requested changes
 
-If a review (from Oz or a maintainer) leaves your PR with **changes requested** and it then goes quiet, automation follows up and eventually closes it so the review queue stays current. This applies only to external-contributor PRs with an active requested-changes review.
+If a review (from the factory or a maintainer) leaves your PR with **changes requested** and it then goes quiet, automation follows up and eventually closes it so the review queue stays current. This applies only to external-contributor PRs with an active requested-changes review.
 
 - **Reminders** are posted at **7** and **10** days of inactivity, with the **day-10 reminder serving as the final warning**.
 - The PR is **automatically closed at ~14 days** of inactivity — but only after that final warning, so you always get a heads-up first.

--- a/FAQ.md
+++ b/FAQ.md
@@ -38,17 +38,17 @@ macOS, Linux, and Windows are all supported. Platform-specific setup is handled 
 
 ### Will my PR be reviewed by a human or by an agent?
 
-Both. When you open a PR, Oz is auto-assigned and produces an initial review. Once Oz approves, it automatically requests a follow-up review from a Warp team subject-matter expert. You don't need to assign reviewers manually.
+Both. When you open a PR, the **Warp for OSS** factory (a [Warp Factory](https://warp.dev/factories)) produces an initial review, including a security pass. Once the factory's review is accepted, it automatically requests a follow-up review from the owning Warp team subject-matter expert. You don't need to assign reviewers manually. The factory posts as `warp-factories`, and every comment links to the run that produced it.
 
 ### My PR has been sitting without review — what do I do?
 
-After you push changes that address Oz's feedback, comment `/warp-agent-review` on the PR (up to three times per PR) to request a re-review. If something looks stuck or you've used your re-reviews, mention **@oss-maintainers** to escalate to the team.
+New commits alone don't trigger another factory review. After you push changes that address the factory's feedback, comment `@warp-factory /review` on the PR (up to five passes per PR per day for external contributors) to request a re-review. If something looks stuck or you've used your re-reviews, mention **@oss-maintainers** to escalate to the team.
 
 ### What's the difference between a contributor and a collaborator?
 
 A **contributor** is anyone who contributes to the project — by filing an issue, opening a PR, helping triage, or participating in discussion. Most people who help out are contributors. You don't need permission or a status of any kind; just file an issue or open a PR.
 
-A **collaborator** is a formal GitHub role we grant to contributors with a track record of merged PRs in this repo. Collaborators get expanded permissions: applying and managing issue labels, dispatching Oz directly with `@oz` on any ready issue, and using complimentary Oz credits for work in this repo.
+A **collaborator** is a formal GitHub role we grant to contributors with a track record of merged PRs in this repo. Collaborators get expanded permissions: applying and managing issue labels, dispatching the factory directly by mentioning `@warp-factory` on any ready issue, and using complimentary Warp credits for work in this repo.
 
 ### How do I become a collaborator?
 
@@ -68,19 +68,27 @@ That said, we plan to support [ACP (agent client protocol)](https://agentclientp
 
 [This is tracked on our roadmap](https://github.com/warpdotdev/warp/issues/9233), and we will update the community as we explore this.
 
-### How can I get Oz to implement an issue for me?
+### How can I get the factory to implement an issue for me?
 
-Mention **@oss-maintainers** on any issue with a readiness label and ask. Approved requests run on **complimentary Oz credits** — you don't need to set up your own Oz account or pay for compute.
+Mention **@oss-maintainers** on any issue with a readiness label and ask; a maintainer assigns or mentions `@warp-factory` to start the work. Approved requests run on **complimentary Warp credits** — you don't need to set up your own Warp account or pay for compute.
 
-Once you're a collaborator, you can mention `@oz` directly on any ready issue to dispatch it without waiting for a maintainer.
+Once you're a collaborator, you can mention `@warp-factory` directly on any ready issue to dispatch it without waiting for a maintainer. A readiness label on its own never starts factory work — assignment or a mention does.
+
+### What is the Warp for OSS factory?
+
+It's the [Warp Factory](https://warp.dev/factories) that runs this repo's automation: issue triage (with duplicate detection and owner routing), spec writing and implementation on gated issues, and PR review with a security pass. Its definition — agents, automations, skills, and scorers — is open source at [`warpdotdev/warp-factories-open-source`](https://github.com/warpdotdev/warp-factories-open-source); the `default/` tree there is a copyable template you can use to run the same workflow on your own project.
+
+### Can I see what the factory actually did?
+
+Every factory comment ends with "Open session" and "View run" links to the run that produced it. Viewing them currently requires a Warp account; making them viewable without one is in progress.
 
 ### Do I have to pay anything to contribute here?
 
-No. Contributing by hand or with your own agent is free. Oz runs on Warp's credits for approved requests on this repo, and is free for collaborators contributing back to it.
+No. Contributing by hand or with your own agent is free. The factory runs on Warp's credits for approved requests on this repo, and is free for collaborators contributing back to it.
 
 ### Are agent-generated PRs held to the same bar as human ones?
 
-Yes. The same Oz + SME review, the same tests, and the same `./script/format` / `cargo clippy` / presubmit checks apply regardless of who (or what) wrote the code. Whether a PR is hand-written or agent-written doesn't change the quality bar — it changes how quickly you can iterate to meet it.
+Yes. The same factory + SME review, the same tests, and the same `./script/format` / `cargo clippy` / presubmit checks apply regardless of who (or what) wrote the code. Whether a PR is hand-written or agent-written doesn't change the quality bar — it changes how quickly you can iterate to meet it.
 
 ### Will my issues, comments, or code be used to train models?
 
@@ -90,19 +98,19 @@ No. Warp does not use contributions to this repository, or the discussion around
 
 ### Is Warp fully open source?
 
-The Warp **client** is open source: the app and most crates are licensed under [AGPL v3](LICENSE-AGPL), and the UI framework crates (`warpui_core`, `warpui`) are licensed under [MIT](LICENSE-MIT). The **server**, the **Warp Drive backend**, and **Oz** (our agent orchestration layer) are not in this repository and remain proprietary today.
+The Warp **client** is open source: the app and most crates are licensed under [AGPL v3](LICENSE-AGPL), and the UI framework crates (`warpui_core`, `warpui`) are licensed under [MIT](LICENSE-MIT). The **server**, the **Warp Drive backend**, and the **Warp Factories platform** (our agent orchestration layer) are not in this repository and remain proprietary today. The definition of the factory that runs this repo's automation is open source at [`warpdotdev/warp-factories-open-source`](https://github.com/warpdotdev/warp-factories-open-source).
 
 ### What lives in this repo and what doesn't?
 
 **In this repo:** the Warp client app, the WarpUI framework, integration tests, agent skills, and feature specs.
 
-**Not in this repo:** the server, the Drive backend, hosted authentication, and Oz orchestration.
+**Not in this repo:** the server, the Drive backend, hosted authentication, and the Warp Factories platform.
 
 ### Can I run Warp without signing in or using Warp's cloud?
 
 Some functionality works fully locally; other features (Drive sync, hosted-model agents, team features) require Warp's backend. We're working to make the locally-runnable surface clearer over time, including more explicit controls in onboarding.
 
-### Will the server or Oz ever be open-sourced?
+### Will the server or the factory platform ever be open-sourced?
 
 We haven't committed to a date and don't want to overpromise. Opening the client under AGPL is a one-way door, and opening the server would be a similar commitment — we'll be explicit when and if we make it.
 


### PR DESCRIPTION
## Description
The repo's automation is moving from the Oz webhook workflows (`oz-for-oss`) to the **Warp for OSS** factory, a Warp Factory whose definition lives in [`warpdotdev/warp-factories-open-source`](https://github.com/warpdotdev/warp-factories-open-source). This updates the contributor-facing docs to match the new contract:

- Bot identity: posts as `warp-factories`, mention with **@warp-factory** (replaces Oz / `@oz`).
- Re-review: `@warp-factory /review` (`/warp-agent-review` still honored when the comment mentions `@warp-factory`; maintainers can use the `factory-review` label). Budget is **5 passes per PR per day** for external contributors (was 3 total). New commits alone don't trigger a re-review.
- Spec approval: `plan-approved` label or `@warp-factory spec approved`.
- Factory-applied labels: `factory:warp-for-oss`, `needs-info` (mention `@warp-factory` after answering to re-triage).
- Readiness labels never start factory work on their own — assignment or a mention does.
- Every factory comment links "Open session" / "View run"; currently requires a Warp account.
- New FAQ entries: what the factory is (with the copyable `default/` template) and how to see what it did.
- "Oz orchestration" → "Warp Factories platform" in the what's-open-source section.

**Draft until cutover:** merge together with the factory going live on this repo (warp-factories-open-source#2) and the `@oz-agent` redirect. Not touched: `README.md` (already references Warp Factories), `.github/STAKEHOLDERS`, `close_stale_fix_prs.yml` (unrelated CI-fix branch convention).

## Linked Issue
Docs-only change accompanying the factory migration; no linked issue.
- [x] Docs-only — no readiness label required.
- [x] No UI changes.

## Testing
Docs-only; rendered Markdown reviewed locally. No code changes.

- [x] N/A — no runtime behavior changed.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Warp <agent@warp.dev>
