### PR TITLE
Add docker-registry secret type to `oz secret create` CLI

### DIFF
--- a/app/src/ai/agent_sdk/secret.rs
+++ b/app/src/ai/agent_sdk/secret.rs
@@ -14,9 +14,8 @@ use warp_cli::secret::{
     ListSecretsArgs, SecretCommand, SecretType, UpdateSecretArgs, ValueArgs,
 };
 
-/// Mirrors the server's registry-host format check (a bare host, no scheme or path), so a
-/// malformed host is caught before prompting for the remaining fields or making a network
-/// request, matching the same rule the web UI enforces client-side.
+/// Mirrors the server's registry-host format check (a bare host, no scheme or path), matching
+/// the same rule the web UI enforces client-side.
 fn validate_registry_host(host: &str) -> Result<()> {
     if host.contains("://") || host.contains('/') {
         anyhow::bail!("Registry host must not include a scheme or path.");

--- a/app/src/ai/agent_sdk/secret.rs
+++ b/app/src/ai/agent_sdk/secret.rs
@@ -13,15 +13,6 @@ use warp_cli::secret::{
     AnthropicMethod, CodexMethod, CreateProvider, CreateSecretArgs, DeleteSecretArgs,
     ListSecretsArgs, SecretCommand, SecretType, UpdateSecretArgs, ValueArgs,
 };
-
-/// Mirrors the server's registry-host format check (a bare host, no scheme or path), matching
-/// the same rule the web UI enforces client-side.
-fn validate_registry_host(host: &str) -> Result<()> {
-    if host.contains("://") || host.contains('/') {
-        anyhow::bail!("Registry host must not include a scheme or path.");
-    }
-    Ok(())
-}
 use warp_core::features::FeatureFlag;
 use warp_graphql::managed_secrets::{ManagedSecret, ManagedSecretType};
 use warp_graphql::object::SpaceType;
@@ -910,6 +901,15 @@ fn read_bedrock_access_key_secret_value(
     )))
 }
 
+/// Mirrors the server's registry-host format check (a bare host, no scheme or path), matching
+/// the same rule the web UI enforces client-side.
+fn validate_registry_host(host: &str) -> Result<()> {
+    if host.contains("://") || host.contains('/') {
+        anyhow::bail!("Registry host must not include a scheme or path.");
+    }
+    Ok(())
+}
+
 /// Read a container registry credential secret from dedicated CLI flags or interactive prompts.
 fn read_docker_registry_secret_value(
     host: Option<String>,
@@ -919,10 +919,13 @@ fn read_docker_registry_secret_value(
 ) -> Result<Option<ManagedSecretValue>> {
     const NON_INTERACTIVE_REQUIRED_MSG: &str = "Container registry credentials require --host, --username, and one of --password or --password-file in non-interactive mode";
 
+    // Check once and reuse: querying terminal status is a syscall.
+    let is_terminal = io::stdin().is_terminal();
+
     let host = match host {
         Some(v) if !v.is_empty() => v,
         _ => {
-            if !io::stdin().is_terminal() {
+            if !is_terminal {
                 return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
             }
             match inquire::Text::new("Registry host (e.g. ghcr.io):").prompt() {
@@ -940,7 +943,7 @@ fn read_docker_registry_secret_value(
     let username = match username {
         Some(v) if !v.is_empty() => v,
         _ => {
-            if !io::stdin().is_terminal() {
+            if !is_terminal {
                 return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
             }
             match inquire::Text::new("Registry username:").prompt() {
@@ -969,7 +972,7 @@ fn read_docker_registry_secret_value(
                     return Ok(None);
                 }
                 value.to_owned()
-            } else if !io::stdin().is_terminal() {
+            } else if !is_terminal {
                 return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
             } else {
                 match Password::new("Registry password or access token:")

--- a/app/src/ai/agent_sdk/secret.rs
+++ b/app/src/ai/agent_sdk/secret.rs
@@ -131,6 +131,7 @@ enum SecretInput {
         host: Option<String>,
         username: Option<String>,
         password: Option<String>,
+        password_file: Option<std::path::PathBuf>,
     },
 }
 
@@ -172,7 +173,8 @@ impl SecretInput {
                 host,
                 username,
                 password,
-            } => read_docker_registry_secret_value(host, username, password),
+                password_file,
+            } => read_docker_registry_secret_value(host, username, password, password_file),
         }
     }
 }
@@ -229,6 +231,7 @@ fn create_secret(ctx: &mut AppContext, args: CreateSecretArgs) -> Result<()> {
                 host: a.host,
                 username: a.username,
                 password: a.password,
+                password_file: a.password_file,
             },
             a.common.description,
             a.common.scope,
@@ -913,8 +916,9 @@ fn read_docker_registry_secret_value(
     host: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    password_file: Option<std::path::PathBuf>,
 ) -> Result<Option<ManagedSecretValue>> {
-    const NON_INTERACTIVE_REQUIRED_MSG: &str = "Container registry credentials require --host, --username, and --password in non-interactive mode";
+    const NON_INTERACTIVE_REQUIRED_MSG: &str = "Container registry credentials require --host, --username, and one of --password or --password-file in non-interactive mode";
 
     let host = match host {
         Some(v) if !v.is_empty() => v,
@@ -954,20 +958,33 @@ fn read_docker_registry_secret_value(
     let password = match password {
         Some(v) if !v.is_empty() => v,
         _ => {
-            if !io::stdin().is_terminal() {
-                return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
-            }
-            match Password::new("Registry password or access token:")
-                .with_display_toggle_enabled()
-                .without_confirmation()
-                .prompt()
-            {
-                Ok(value) if !value.is_empty() => value,
-                Ok(_) => return Ok(None),
-                Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+            if let Some(password_file) = password_file {
+                let value = fs::read_to_string(&password_file).with_context(|| {
+                    format!(
+                        "Failed to read registry password from: {}",
+                        password_file.display()
+                    )
+                })?;
+                let value = value.trim_end_matches(['\n', '\r']);
+                if value.is_empty() {
                     return Ok(None);
                 }
-                Err(err) => return Err(err.into()),
+                value.to_owned()
+            } else if !io::stdin().is_terminal() {
+                return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
+            } else {
+                match Password::new("Registry password or access token:")
+                    .with_display_toggle_enabled()
+                    .without_confirmation()
+                    .prompt()
+                {
+                    Ok(value) if !value.is_empty() => value,
+                    Ok(_) => return Ok(None),
+                    Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                        return Ok(None);
+                    }
+                    Err(err) => return Err(err.into()),
+                }
             }
         }
     };

--- a/app/src/ai/agent_sdk/secret.rs
+++ b/app/src/ai/agent_sdk/secret.rs
@@ -13,6 +13,16 @@ use warp_cli::secret::{
     AnthropicMethod, CodexMethod, CreateProvider, CreateSecretArgs, DeleteSecretArgs,
     ListSecretsArgs, SecretCommand, SecretType, UpdateSecretArgs, ValueArgs,
 };
+
+/// Mirrors the server's registry-host format check (a bare host, no scheme or path), so a
+/// malformed host is caught before prompting for the remaining fields or making a network
+/// request, matching the same rule the web UI enforces client-side.
+fn validate_registry_host(host: &str) -> Result<()> {
+    if host.contains("://") || host.contains('/') {
+        anyhow::bail!("Registry host must not include a scheme or path.");
+    }
+    Ok(())
+}
 use warp_core::features::FeatureFlag;
 use warp_graphql::managed_secrets::{ManagedSecret, ManagedSecretType};
 use warp_graphql::object::SpaceType;
@@ -116,6 +126,12 @@ enum SecretInput {
         value_args: ValueArgs,
         base_url: Option<String>,
     },
+    /// Multi-field container registry credential with dedicated CLI flags.
+    DockerRegistry {
+        host: Option<String>,
+        username: Option<String>,
+        password: Option<String>,
+    },
 }
 
 impl SecretInput {
@@ -152,6 +168,11 @@ impl SecretInput {
                 value_args,
                 base_url,
             } => read_openai_api_key_secret_value(&value_args, base_url),
+            SecretInput::DockerRegistry {
+                host,
+                username,
+                password,
+            } => read_docker_registry_secret_value(host, username, password),
         }
     }
 }
@@ -202,6 +223,16 @@ fn create_secret(ctx: &mut AppContext, args: CreateSecretArgs) -> Result<()> {
                 a.common.scope,
             ),
         },
+        Some(CreateProvider::DockerRegistry(a)) => (
+            a.common.name,
+            SecretInput::DockerRegistry {
+                host: a.host,
+                username: a.username,
+                password: a.password,
+            },
+            a.common.description,
+            a.common.scope,
+        ),
         None => {
             let name = args.name.ok_or_else(|| {
                 anyhow::anyhow!("Secret name is required. Usage: oz secret create <NAME>")
@@ -877,6 +908,75 @@ fn read_bedrock_access_key_secret_value(
     )))
 }
 
+/// Read a container registry credential secret from dedicated CLI flags or interactive prompts.
+fn read_docker_registry_secret_value(
+    host: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+) -> Result<Option<ManagedSecretValue>> {
+    const NON_INTERACTIVE_REQUIRED_MSG: &str = "Container registry credentials require --host, --username, and --password in non-interactive mode";
+
+    let host = match host {
+        Some(v) if !v.is_empty() => v,
+        _ => {
+            if !io::stdin().is_terminal() {
+                return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
+            }
+            match inquire::Text::new("Registry host (e.g. ghcr.io):").prompt() {
+                Ok(value) if !value.is_empty() => value,
+                Ok(_) => return Ok(None),
+                Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                    return Ok(None);
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+    };
+    validate_registry_host(&host)?;
+
+    let username = match username {
+        Some(v) if !v.is_empty() => v,
+        _ => {
+            if !io::stdin().is_terminal() {
+                return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
+            }
+            match inquire::Text::new("Registry username:").prompt() {
+                Ok(value) if !value.is_empty() => value,
+                Ok(_) => return Ok(None),
+                Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                    return Ok(None);
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+    };
+
+    let password = match password {
+        Some(v) if !v.is_empty() => v,
+        _ => {
+            if !io::stdin().is_terminal() {
+                return Err(anyhow::anyhow!(NON_INTERACTIVE_REQUIRED_MSG));
+            }
+            match Password::new("Registry password or access token:")
+                .with_display_toggle_enabled()
+                .without_confirmation()
+                .prompt()
+            {
+                Ok(value) if !value.is_empty() => value,
+                Ok(_) => return Ok(None),
+                Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                    return Ok(None);
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+    };
+
+    Ok(Some(ManagedSecretValue::docker_registry(
+        host, username, password,
+    )))
+}
+
 /// Finds the type of an existing secret by name and owner scope.
 fn find_secret_type(
     secrets: &[ManagedSecret],
@@ -908,3 +1008,7 @@ fn format_secret_type(type_: &ManagedSecretType) -> String {
         ManagedSecretType::DockerRegistry => "Container Registry Credential".to_string(),
     }
 }
+
+#[cfg(test)]
+#[path = "secret_tests.rs"]
+mod tests;

--- a/app/src/ai/agent_sdk/secret_tests.rs
+++ b/app/src/ai/agent_sdk/secret_tests.rs
@@ -2,9 +2,9 @@ use super::*;
 
 #[test]
 fn validate_registry_host_accepts_bare_host() {
-    for host in ["ghcr.io", "registry.example.com", "localhost:5000"] {
-        assert!(validate_registry_host(host).is_ok(), "host: {host}");
-    }
+    assert!(validate_registry_host("ghcr.io").is_ok());
+    assert!(validate_registry_host("registry.example.com").is_ok());
+    assert!(validate_registry_host("localhost:5000").is_ok());
 }
 
 #[test]
@@ -17,4 +17,25 @@ fn validate_registry_host_rejects_scheme() {
 fn validate_registry_host_rejects_path() {
     let err = validate_registry_host("ghcr.io/my-org").unwrap_err();
     assert!(err.to_string().contains("scheme or path"));
+}
+
+#[test]
+fn read_docker_registry_secret_value_reads_password_from_file() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let password_file = dir.path().join("password.txt");
+    fs::write(&password_file, "file-token\n").expect("write password file");
+
+    let value = read_docker_registry_secret_value(
+        Some("ghcr.io".to_string()),
+        Some("octocat".to_string()),
+        None,
+        Some(password_file),
+    )
+    .expect("read succeeds")
+    .expect("value present");
+
+    let json = serde_json::to_value(&value).expect("serialize");
+    assert_eq!(json["registry_host"], "ghcr.io");
+    assert_eq!(json["username"], "octocat");
+    assert_eq!(json["password"], "file-token");
 }

--- a/app/src/ai/agent_sdk/secret_tests.rs
+++ b/app/src/ai/agent_sdk/secret_tests.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[test]
+fn validate_registry_host_accepts_bare_host() {
+    for host in ["ghcr.io", "registry.example.com", "localhost:5000"] {
+        assert!(validate_registry_host(host).is_ok(), "host: {host}");
+    }
+}
+
+#[test]
+fn validate_registry_host_rejects_scheme() {
+    let err = validate_registry_host("https://ghcr.io").unwrap_err();
+    assert!(err.to_string().contains("scheme or path"));
+}
+
+#[test]
+fn validate_registry_host_rejects_path() {
+    let err = validate_registry_host("ghcr.io/my-org").unwrap_err();
+    assert!(err.to_string().contains("scheme or path"));
+}

--- a/crates/warp_cli/src/secret.rs
+++ b/crates/warp_cli/src/secret.rs
@@ -203,8 +203,17 @@ pub struct DockerRegistryCreateArgs {
     pub username: Option<String>,
 
     /// Registry password or access token. If not provided, prompts interactively.
-    #[arg(long = "password")]
+    ///
+    /// Prefer `--password-file` in non-interactive/scripted contexts: passing the password
+    /// directly on the command line can leak it via shell history or process listings (e.g.
+    /// `ps`).
+    #[arg(long = "password", conflicts_with = "password_file")]
     pub password: Option<String>,
+
+    /// File to read the registry password or access token from. Avoids exposing the value via
+    /// shell history or process listings the way `--password` can.
+    #[arg(long = "password-file")]
+    pub password_file: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/warp_cli/src/secret.rs
+++ b/crates/warp_cli/src/secret.rs
@@ -11,7 +11,8 @@ pub enum SecretCommand {
     /// Create a new secret.
     ///
     /// Use `oz secret create claude api-key <NAME>` to create a Claude/Anthropic auth secret,
-    /// or `oz secret create codex api-key <NAME>` to create a Codex/OpenAI auth secret.
+    /// `oz secret create codex api-key <NAME>` to create a Codex/OpenAI auth secret, or
+    /// `oz secret create docker-registry <NAME>` to create a container registry credential.
     Create(CreateSecretArgs),
     /// Delete a secret.
     Delete(DeleteSecretArgs),
@@ -68,6 +69,9 @@ pub enum CreateProvider {
     Anthropic(AnthropicCreateArgs),
     /// Create a Codex/OpenAI auth secret.
     Codex(CodexCreateArgs),
+    /// Create a container registry credential secret.
+    #[command(name = "docker-registry")]
+    DockerRegistry(DockerRegistryCreateArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -181,6 +185,26 @@ pub struct BedrockAccessKeyArgs {
     /// AWS region for the Bedrock endpoint. If not provided, prompts interactively.
     #[arg(long = "region")]
     pub region: Option<String>,
+}
+
+/// Arguments for creating a container registry credential secret.
+#[derive(Debug, Clone, Args)]
+pub struct DockerRegistryCreateArgs {
+    #[clap(flatten)]
+    pub common: CommonSecretCreateArgs,
+
+    /// Bare registry hostname, no scheme or path (e.g. ghcr.io). If not provided, prompts
+    /// interactively.
+    #[arg(long = "host")]
+    pub host: Option<String>,
+
+    /// Registry username. If not provided, prompts interactively.
+    #[arg(long = "username")]
+    pub username: Option<String>,
+
+    /// Registry password or access token. If not provided, prompts interactively.
+    #[arg(long = "password")]
+    pub password: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/warp_cli/src/secret_tests.rs
+++ b/crates/warp_cli/src/secret_tests.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 
-use super::{ListSecretsArgs, SecretCommand};
+use super::{CreateProvider, CreateSecretArgs, ListSecretsArgs, SecretCommand};
 
 #[derive(Debug, Parser)]
 struct TestSecret {
@@ -16,6 +16,18 @@ fn parse_list(argv: &[&str]) -> ListSecretsArgs {
         .command;
     let SecretCommand::List(args) = command else {
         panic!("expected list command");
+    };
+    args
+}
+
+fn parse_create(argv: &[&str]) -> CreateSecretArgs {
+    let mut full = vec!["test"];
+    full.extend_from_slice(argv);
+    let command = TestSecret::try_parse_from(full)
+        .expect("parse succeeds")
+        .command;
+    let SecretCommand::Create(args) = command else {
+        panic!("expected create command");
     };
     args
 }
@@ -46,4 +58,45 @@ fn list_accepts_personal_scope() {
 
     assert!(args.scope.personal);
     assert!(!args.scope.is_team());
+}
+
+#[test]
+fn create_docker_registry_parses_minimal() {
+    let args = parse_create(&["create", "docker-registry", "my-registry"]);
+    let Some(CreateProvider::DockerRegistry(docker_registry)) = &args.provider else {
+        panic!("expected docker-registry provider subcommand");
+    };
+
+    assert_eq!(docker_registry.common.name, "my-registry");
+    assert!(docker_registry.host.is_none());
+    assert!(docker_registry.username.is_none());
+    assert!(docker_registry.password.is_none());
+}
+
+#[test]
+fn create_docker_registry_accepts_host_username_password() {
+    let args = parse_create(&[
+        "create",
+        "docker-registry",
+        "my-registry",
+        "--host",
+        "ghcr.io",
+        "--username",
+        "octocat",
+        "--password",
+        "token-value",
+    ]);
+    let Some(CreateProvider::DockerRegistry(docker_registry)) = &args.provider else {
+        panic!("expected docker-registry provider subcommand");
+    };
+
+    assert_eq!(docker_registry.host.as_deref(), Some("ghcr.io"));
+    assert_eq!(docker_registry.username.as_deref(), Some("octocat"));
+    assert_eq!(docker_registry.password.as_deref(), Some("token-value"));
+}
+
+#[test]
+fn create_docker_registry_requires_name() {
+    let result = TestSecret::try_parse_from(["test", "create", "docker-registry"]);
+    assert!(result.is_err());
 }

--- a/crates/warp_cli/src/secret_tests.rs
+++ b/crates/warp_cli/src/secret_tests.rs
@@ -100,3 +100,41 @@ fn create_docker_registry_requires_name() {
     let result = TestSecret::try_parse_from(["test", "create", "docker-registry"]);
     assert!(result.is_err());
 }
+
+#[test]
+fn create_docker_registry_accepts_password_file() {
+    let args = parse_create(&[
+        "create",
+        "docker-registry",
+        "my-registry",
+        "--password-file",
+        "password.txt",
+    ]);
+    let Some(CreateProvider::DockerRegistry(docker_registry)) = &args.provider else {
+        panic!("expected docker-registry provider subcommand");
+    };
+
+    assert!(docker_registry.password.is_none());
+    assert_eq!(
+        docker_registry
+            .password_file
+            .as_ref()
+            .and_then(|p| p.to_str()),
+        Some("password.txt")
+    );
+}
+
+#[test]
+fn create_docker_registry_rejects_password_and_password_file() {
+    let result = TestSecret::try_parse_from([
+        "test",
+        "create",
+        "docker-registry",
+        "my-registry",
+        "--password",
+        "token-value",
+        "--password-file",
+        "password.txt",
+    ]);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Description
Adds a `docker-registry` provider subcommand to `oz secret create`, so users can create a `DOCKER_REGISTRY`-type managed secret from the CLI:

```
oz secret create docker-registry <NAME> [--host HOST] [--username USER] [--password PASS]
```

Any omitted field is prompted for interactively; non-interactive invocations require all three.

This gives customers with GitHub-synced (`file_managed`) Factories a way to create registry credentials today, since the web UI's only creation path for this secret type currently lives in a form that's inaccessible for those Factories (tracked separately in warp-server#17092, which fixes the web UI gap).

The underlying `ManagedSecretValue::docker_registry` constructor, encryption, and `createManagedSecret` mutation support already existed; this PR only adds the CLI arg-parsing and prompt-reading layers, plus client-side host format validation (no scheme or path) mirroring the server-side check.

## Linked Issue
No linked GitHub issue. This is a CLI-only follow-up to warp-server#17092.

## Testing
- [x] Added unit tests for CLI arg parsing (`crates/warp_cli/src/secret_tests.rs`) and host validation (`app/src/ai/agent_sdk/secret_tests.rs`)
- [x] `cargo check`, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` all pass for `warp_cli` and `warp`
- [ ] Manual testing with `./script/run` (not applicable — this is a CLI-only change; verified via `cargo run --bin warp -- secret create docker-registry --help`)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added `oz secret create docker-registry` to create container registry credential secrets from the CLI.

Co-Authored-By: Warp <agent@warp.dev>