### PR TITLE
fix: update js-yaml to 4.3.2 to resolve GHSA-2883-xcg3-v3hh

### DIFF
--- a/crates/warp_graphql_schema/package.json
+++ b/crates/warp_graphql_schema/package.json
@@ -18,7 +18,7 @@
     "lodash": "4.18.1",
     "@babel/core": "7.29.6",
     "brace-expansion": "^2.1.2",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^4.3.2",
     "shell-quote": "^1.9.0",
     "ws": "8.21.0"
   }

--- a/crates/warp_graphql_schema/yarn.lock
+++ b/crates/warp_graphql_schema/yarn.lock
@@ -1693,10 +1693,10 @@ jose@^5.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.0.0, js-yaml@^4.1.0, js-yaml@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
-  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
+js-yaml@^4.0.0, js-yaml@^4.1.0, js-yaml@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.2.tgz#8e44fb14a2643c59726bb15787b5f1512cb3d3fb"
+  integrity sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Description
Bumps the `js-yaml` resolution in `crates/warp_graphql_schema` from `^4.3.1` to `^4.3.2`, resolving a high-severity ReDoS/CPU-exhaustion advisory.

- **Advisory:** [GHSA-2883-xcg3-v3hh](https://github.com/nodeca/js-yaml/security/advisories/GHSA-2883-xcg3-v3hh) / [CVE-2026-84375](https://nvd.nist.gov/vuln/detail/CVE-2026-84375) (high, CVSS 7.5) — `maxTotalMergeKeys` does not limit CPU use for empty merge sources.
- **Dependabot alert:** https://github.com/warpdotdev/warp/security/dependabot/33
- **Dependency:** `js-yaml`, transitive dev dependency of the GraphQL codegen toolchain, `4.3.1` -> `4.3.2` (patch bump, no API changes).

### Why Dependabot couldn't do this
Dependabot reported `update_not_possible` ("One or more other dependencies require a version that is incompatible with this update"). The actual blocker is that `js-yaml` is pinned by a Yarn `resolutions` entry in `crates/warp_graphql_schema/package.json`, which Dependabot does not rewrite. Bumping the resolution to `^4.3.2` and refreshing the lockfile resolves it cleanly — all existing requirement ranges in the lockfile (`^4.0.0`, `^4.1.0`) are satisfied by `4.3.2`, so no other packages moved.

## Linked Issue
N/A — automated dependency/security fix.

## Testing
- `yarn install` regenerated `yarn.lock`; the only change is the single `js-yaml` entry moving to `4.3.2`.
- `yarn audit` reports **0 vulnerabilities** (previously flagged `js-yaml`); the advisory no longer appears.
- Smoke-tested the toolchain after the bump: `graphql-codegen` CLI runs, `tsc --noEmit` on `api/client-schema.ts` passes, and `require('js-yaml').load(...)` works.
- `yarn generate` was not run because it downloads the schema from the staging/local GraphQL server, which isn't reachable from this environment.
- No Rust sources changed, so `./script/format` / `cargo clippy` are not applicable to this diff.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
