### PR TITLE
Queue follow-up injections for warp agent, using new steering mode

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1137,7 +1137,7 @@ impl AgentDriver {
             let terminal = terminal_driver.as_ref(ctx).terminal_view().clone();
             terminal.update(ctx, |terminal, ctx| {
                 terminal.ai_controller().update(ctx, |controller, ctx| {
-                    controller.prepare_native_prompt_queue(restored_conversation_id, ctx);
+                    controller.bind_native_prompt_conversation(restored_conversation_id, ctx);
                 });
             });
         }
@@ -1294,7 +1294,7 @@ impl AgentDriver {
         let terminal = self.terminal_driver.as_ref(ctx).terminal_view().clone();
         terminal.update(ctx, |terminal, ctx| {
             terminal.ai_controller().update(ctx, |controller, ctx| {
-                controller.stop_native_prompt_queue(ctx);
+                controller.unbind_native_prompt_conversation(ctx);
             });
         });
         let Some(conversation_id) = self.run_conversation_id else {
@@ -3582,14 +3582,7 @@ impl AgentDriver {
                     return;
                 }
                 let queue = QueuedQueryModel::as_ref(ctx);
-                if let Some(error) = queue.injection_error(conversation_id) {
-                    queue_run_exit.complete_with_optional_idle(
-                        me.idle_on_fail,
-                        SDKConversationOutputStatus::Error {
-                            error: RenderableAIError::other(error.to_owned(), false),
-                        },
-                    );
-                } else if !queue.has_pending_native_injections(conversation_id)
+                if !queue.has_pending_native_injections(conversation_id)
                     && BlocklistAIHistoryModel::as_ref(ctx)
                         .conversation(&conversation_id)
                         .is_some_and(|conversation| {
@@ -4025,6 +4018,19 @@ impl AgentDriver {
                     }
                 })
             });
+
+            // Flush any startup follow-ups that arrived while the initial prompt was being
+            // prepared. Must run after the update above returns, since `drain_native_startup_queue`
+            // targets this terminal surface's *active* conversation, which the initial send just set.
+            if let Some(conversation_id) = prepared_conversation_id {
+                self.terminal_driver.update(ctx, |td, ctx| {
+                    td.with_terminal_view(ctx, |terminal, ctx| {
+                        terminal.ai_controller().update(ctx, |controller, ctx| {
+                            controller.drain_native_startup_queue(conversation_id, ctx);
+                        });
+                    });
+                });
+            }
         }
 
         if self.skip_initial_turn
@@ -4032,10 +4038,12 @@ impl AgentDriver {
         {
             QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
                 queue.finish_native_setup(conversation_id, ctx);
-                queue.finish_native_initial_turn(conversation_id, ctx);
             });
             self.terminal_driver.update(ctx, |td, ctx| {
                 td.with_terminal_view(ctx, |terminal, ctx| {
+                    terminal.ai_controller().update(ctx, |controller, ctx| {
+                        controller.drain_native_startup_queue(conversation_id, ctx);
+                    });
                     terminal.drain_queued_prompts(conversation_id, FinishReason::Complete, ctx);
                 });
             });

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -64,6 +64,7 @@ use crate::ai::ambient_agents::{
 };
 use crate::ai::bedrock_credentials;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
+use crate::ai::blocklist::block::FinishReason;
 use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
 use crate::ai::blocklist::orchestration_event_streamer::{
     register_agent_event_consumer, unregister_agent_event_consumer,
@@ -72,7 +73,7 @@ use crate::ai::blocklist::orchestration_events::OrchestrationEventService;
 use crate::ai::blocklist::pending_cli_harness_prompt_queue::PendingCliHarnessPromptQueue;
 use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate, FinalizeReason,
-    finalize_recording_for_conversation,
+    QueuedQueryEvent, QueuedQueryModel, finalize_recording_for_conversation,
 };
 use crate::ai::cloud_environments::{
     AmbientAgentEnvironment, CloudAmbientAgentEnvironment, GithubRepo, SourceRepo,
@@ -1127,6 +1128,19 @@ impl AgentDriver {
             ctx,
         )?;
 
+        // Sharing starts asynchronously from terminal creation, before run_internal's setup waits.
+        log::info!(
+            "event=driver_queue_configuration task_id={task_id:?} harness={selected_harness} sharing_requested={should_share} native_queue_enabled={}",
+            selected_harness == Harness::Oz && (should_share || task_id.is_some()),
+        );
+        if selected_harness == Harness::Oz && (should_share || task_id.is_some()) {
+            let terminal = terminal_driver.as_ref(ctx).terminal_view().clone();
+            terminal.update(ctx, |terminal, ctx| {
+                terminal.ai_controller().update(ctx, |controller, ctx| {
+                    controller.prepare_native_prompt_queue(restored_conversation_id, ctx);
+                });
+            });
+        }
         // Subscribe to TerminalDriver events for task-specific handling.
         ctx.subscribe_to_model(&terminal_driver, |me, _, event, ctx| {
             me.handle_terminal_driver_event(event, ctx);
@@ -1277,6 +1291,12 @@ impl AgentDriver {
     /// Pair to the registration in `new` / `execute_run`. No-op when
     /// nothing was registered.
     fn unregister_streamer_consumer(&self, ctx: &mut ModelContext<Self>) {
+        let terminal = self.terminal_driver.as_ref(ctx).terminal_view().clone();
+        terminal.update(ctx, |terminal, ctx| {
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                controller.stop_native_prompt_queue(ctx);
+            });
+        });
         let Some(conversation_id) = self.run_conversation_id else {
             return;
         };
@@ -3539,7 +3559,50 @@ impl AgentDriver {
                 run_exit = run_exit.with_wait(wait);
             }
         }
-        let restored_conversation_id = self.restored_conversation_id;
+        let terminal = self.terminal_driver.as_ref(ctx).terminal_view();
+        let prepared_conversation_id = terminal
+            .as_ref(ctx)
+            .ai_controller()
+            .as_ref(ctx)
+            .native_prompt_conversation_id();
+        let restored_conversation_id = prepared_conversation_id.or(self.restored_conversation_id);
+        let queue_run_exit = run_exit.clone();
+        if let Some(conversation_id) = prepared_conversation_id {
+            let queue_run_exit = queue_run_exit.clone();
+            ctx.subscribe_to_model(&QueuedQueryModel::handle(ctx), move |me, _, event, ctx| {
+                let event_id = match event {
+                    QueuedQueryEvent::DispatchStateChanged { conversation_id }
+                    | QueuedQueryEvent::Removed {
+                        conversation_id, ..
+                    }
+                    | QueuedQueryEvent::Cleared { conversation_id } => *conversation_id,
+                    _ => return,
+                };
+                if event_id != conversation_id {
+                    return;
+                }
+                let queue = QueuedQueryModel::as_ref(ctx);
+                if let Some(error) = queue.injection_error(conversation_id) {
+                    queue_run_exit.complete_with_optional_idle(
+                        me.idle_on_fail,
+                        SDKConversationOutputStatus::Error {
+                            error: RenderableAIError::other(error.to_owned(), false),
+                        },
+                    );
+                } else if !queue.has_pending_native_injections(conversation_id)
+                    && BlocklistAIHistoryModel::as_ref(ctx)
+                        .conversation(&conversation_id)
+                        .is_some_and(|conversation| {
+                            conversation.status() == &ConversationStatus::Success
+                        })
+                {
+                    queue_run_exit.complete_with_optional_idle(
+                        me.idle_on_complete,
+                        SDKConversationOutputStatus::Success,
+                    );
+                }
+            });
+        }
 
         // ServerSide prompts enter the agent view and emit
         // `CloudModeSetupPhaseEnded` to tear down the Cloud Mode Setup V2 chip.
@@ -3567,7 +3630,7 @@ impl AgentDriver {
                         .send_cloud_mode_setup_phase_ended_for_shared_session();
                 })
             });
-            if self.skip_initial_turn {
+            if self.skip_initial_turn && prepared_conversation_id.is_none() {
                 run_exit.complete_with_optional_idle(
                     self.idle_on_complete,
                     SDKConversationOutputStatus::Success,
@@ -3770,6 +3833,17 @@ impl AgentDriver {
                             }
                         };
 
+                        if matches!(output_status, SDKConversationOutputStatus::Success)
+                            && QueuedQueryModel::as_ref(ctx).has_pending_native_injections(*conversation_id)
+                        {
+                            log::info!(
+                                "event=worker_exit_deferred task_id={:?} conversation_id={conversation_id} reason=pending_native_injections queue_len={}",
+                                me.task_id, QueuedQueryModel::as_ref(ctx).queue(*conversation_id).len(),
+                            );
+                            run_exit.cancel_idle_timeout();
+                            return;
+                        }
+
                         // Errors here are terminal: in-flight recoveries surface as
                         // TransientError (handled above). Whether the process outlives either
                         // kind of terminal status is controlled by the `--idle-on-complete` /
@@ -3912,6 +3986,15 @@ impl AgentDriver {
                                 AgentViewEntryOrigin::Cli,
                                 ctx,
                             );
+                        } else if let Some(conversation_id) = prepared_conversation_id {
+                            terminal.ai_controller().update(ctx, |controller, ctx| {
+                                controller.send_user_query_in_conversation_no_lrc_subagent(
+                                    prompt_str,
+                                    conversation_id,
+                                    None,
+                                    ctx,
+                                );
+                            });
                         } else {
                             terminal.set_ai_input_mode_with_query(Some(&prompt_str), ctx);
                             terminal
@@ -3942,6 +4025,35 @@ impl AgentDriver {
                     }
                 })
             });
+        }
+
+        if self.skip_initial_turn
+            && let Some(conversation_id) = prepared_conversation_id
+        {
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.finish_native_setup(conversation_id, ctx);
+                queue.finish_native_initial_turn(conversation_id, ctx);
+            });
+            self.terminal_driver.update(ctx, |td, ctx| {
+                td.with_terminal_view(ctx, |terminal, ctx| {
+                    terminal.drain_queued_prompts(conversation_id, FinishReason::Complete, ctx);
+                });
+            });
+            if !QueuedQueryModel::as_ref(ctx).has_pending_native_injections(conversation_id)
+                && !self
+                    .terminal_driver
+                    .as_ref(ctx)
+                    .terminal_view()
+                    .as_ref(ctx)
+                    .ai_controller()
+                    .as_ref(ctx)
+                    .has_active_stream_for_conversation(conversation_id, ctx)
+            {
+                queue_run_exit.complete_with_optional_idle(
+                    self.idle_on_complete,
+                    SDKConversationOutputStatus::Success,
+                );
+            }
         }
 
         // Wrap `internal_rx` instead of returning it directly: once the run's `on_commit` has

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -4019,14 +4019,17 @@ impl AgentDriver {
                 })
             });
 
-            // Flush any startup follow-ups that arrived while the initial prompt was being
-            // prepared. Must run after the update above returns, since `drain_native_startup_queue`
-            // targets this terminal surface's *active* conversation, which the initial send just set.
+            // Dispatch any shared-session startup follow-up that arrived while the initial
+            // prompt was being prepared. Must run after the update above returns, since
+            // `dispatch_next_shared_session_row` targets this terminal surface's *active*
+            // conversation, which the initial send just set. If more than one row accumulated,
+            // the rest are picked up one at a time by `Steering`'s piggyback-on-next-request
+            // mechanism or the idle-triggered drain, not flushed here all at once.
             if let Some(conversation_id) = prepared_conversation_id {
                 self.terminal_driver.update(ctx, |td, ctx| {
                     td.with_terminal_view(ctx, |terminal, ctx| {
                         terminal.ai_controller().update(ctx, |controller, ctx| {
-                            controller.drain_native_startup_queue(conversation_id, ctx);
+                            controller.dispatch_next_shared_session_row(conversation_id, ctx);
                         });
                     });
                 });
@@ -4042,7 +4045,7 @@ impl AgentDriver {
             self.terminal_driver.update(ctx, |td, ctx| {
                 td.with_terminal_view(ctx, |terminal, ctx| {
                     terminal.ai_controller().update(ctx, |controller, ctx| {
-                        controller.drain_native_startup_queue(conversation_id, ctx);
+                        controller.dispatch_next_shared_session_row(conversation_id, ctx);
                     });
                     terminal.drain_queued_prompts(conversation_id, FinishReason::Complete, ctx);
                 });

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -4021,7 +4021,7 @@ impl AgentDriver {
 
             // Dispatch any shared-session startup follow-up that arrived while the initial
             // prompt was being prepared. Must run after the update above returns, since
-            // `dispatch_next_shared_session_row` targets this terminal surface's *active*
+            // `dispatch_queued_warp_agent_prompt` targets this terminal surface's *active*
             // conversation, which the initial send just set. If more than one row accumulated,
             // the rest are picked up one at a time by `Steering`'s piggyback-on-next-request
             // mechanism or the idle-triggered drain, not flushed here all at once.
@@ -4029,7 +4029,11 @@ impl AgentDriver {
                 self.terminal_driver.update(ctx, |td, ctx| {
                     td.with_terminal_view(ctx, |terminal, ctx| {
                         terminal.ai_controller().update(ctx, |controller, ctx| {
-                            controller.dispatch_next_shared_session_row(conversation_id, ctx);
+                            controller.dispatch_queued_warp_agent_prompt(
+                                conversation_id,
+                                None,
+                                ctx,
+                            );
                         });
                     });
                 });
@@ -4042,11 +4046,13 @@ impl AgentDriver {
             QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
                 queue.finish_native_setup(conversation_id, ctx);
             });
+            // No prompt was ever sent for a promptless run, so the conversation is definitely
+            // idle here: `drain_queued_prompts` alone is sufficient, since it already detects a
+            // shared-session head row and delegates to the controller itself. A separate,
+            // preceding dispatch call would race it -- starting a second row's stream before the
+            // first produced any output cancels the first, silently dropping it.
             self.terminal_driver.update(ctx, |td, ctx| {
                 td.with_terminal_view(ctx, |terminal, ctx| {
-                    terminal.ai_controller().update(ctx, |controller, ctx| {
-                        controller.dispatch_next_shared_session_row(conversation_id, ctx);
-                    });
                     terminal.drain_queued_prompts(conversation_id, FinishReason::Complete, ctx);
                 });
             });

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -1641,7 +1641,7 @@ fn native_startup_queue_prevents_exit_until_pending_rows_are_removed() {
 }
 
 #[test]
-fn native_promptless_setup_dispatches_every_queued_prompt_at_once() {
+fn native_promptless_setup_dispatches_only_the_head_queued_prompt() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let terminal = add_window_with_terminal(&mut app, None);
@@ -1665,16 +1665,24 @@ fn native_promptless_setup_dispatches_every_queued_prompt_at_once() {
             id
         });
         let _driver = driver_wired_for_terminal(&mut app, terminal, None);
-        // Both queued prompts are sent as soon as setup finishes, without waiting for either
-        // turn to complete: "first" is interrupted by "second" the same way a live follow-up
-        // submitted mid-stream would interrupt it.
+        // Only the head ("first") is sent as soon as setup finishes; "second" stays queued for
+        // the next natural request boundary (a tool-result follow-up) or the conversation going
+        // idle, rather than being dispatched right away and interrupting "first"'s barely-started
+        // stream before it produces any output.
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
             let conversation = history.conversation(&id).unwrap();
-            assert_eq!(conversation.exchange_count(), 2);
+            assert_eq!(conversation.exchange_count(), 1);
             assert_eq!(conversation.status(), &ConversationStatus::InProgress);
         });
         QueuedQueryModel::handle(&app).read(&app, |queue, _| {
-            assert!(!queue.has_queue(id));
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["second"],
+            );
         });
     });
 }

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -48,8 +48,8 @@ use crate::ai::blocklist::orchestration_events::{
     OrchestrationEventService, PendingEvent, PendingEventDetail,
 };
 use crate::ai::blocklist::{
-    BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel, RequestInput, ResponseStream,
-    ResponseStreamId,
+    BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel, QueuedQueryOrigin, RequestInput,
+    ResponseStream, ResponseStreamId,
 };
 use crate::ai::cloud_environments::{GithubRepo, SourceRepo};
 use crate::ai::llms::LLMId;
@@ -1623,6 +1623,48 @@ fn native_startup_queue_prevents_exit_until_pending_rows_are_removed() {
                     "followup".into(),
                     ParticipantId::new(),
                     vec![],
+                ),
+                ctx,
+            )
+        });
+        complete_mock_stream_successfully(&mut app, &stream);
+        OrchestrationEventService::handle(&app).read(&app, |service, _| {
+            assert!(!service.is_conversation_exiting(id));
+        });
+        QueuedQueryModel::handle(&app).update(&mut app, |queue, ctx| {
+            assert!(queue.remove_by_id(id, queued_id, ctx).is_some());
+        });
+        OrchestrationEventService::handle(&app).read(&app, |service, _| {
+            assert!(service.is_conversation_exiting(id));
+        });
+    });
+}
+
+#[test]
+fn native_startup_queue_prevents_exit_until_a_local_row_is_removed() {
+    // Regression test: exit-deferral must not be specific to shared-session-injected rows --
+    // a plain local row (e.g. queued via `/queue` against this same conversation) has to hold
+    // the run open exactly the same way, since `dispatch_queued_warp_agent_prompt` dispatches
+    // either kind identically.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let (terminal_id, controller) = terminal.read(&app, |terminal, _| {
+            (terminal.id(), terminal.ai_controller().clone())
+        });
+        let (id, stream) =
+            conversation_with_in_progress_mock_stream(&mut app, terminal_id, &controller);
+        controller.update(&mut app, |controller, ctx| {
+            controller.bind_native_prompt_conversation(Some(id), ctx);
+        });
+        let _driver = driver_wired_for_terminal(&mut app, terminal, None);
+
+        let queued_id = QueuedQueryModel::handle(&app).update(&mut app, |queue, ctx| {
+            queue.append(
+                id,
+                QueuedQuery::new(
+                    "local followup".into(),
+                    QueuedQueryOrigin::QueueSlashCommand,
                 ),
                 ctx,
             )

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -11,6 +11,7 @@ use cloud_object_models::CodeForge;
 use futures::channel::oneshot;
 use futures::executor::block_on;
 use repo_metadata::{DirectoryWatcher, RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
+use session_sharing_protocol::common::ParticipantId;
 use tempfile::TempDir;
 use warp_cli::agent::Harness;
 use warp_cli::skill::SkillSpec;
@@ -47,7 +48,8 @@ use crate::ai::blocklist::orchestration_events::{
     OrchestrationEventService, PendingEvent, PendingEventDetail,
 };
 use crate::ai::blocklist::{
-    BlocklistAIHistoryModel, RequestInput, ResponseStream, ResponseStreamId,
+    BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel, RequestInput, ResponseStream,
+    ResponseStreamId,
 };
 use crate::ai::cloud_environments::{GithubRepo, SourceRepo};
 use crate::ai::llms::LLMId;
@@ -1593,6 +1595,87 @@ fn driver_wired_for_terminal(
         driver.execute_run(AgentRunPrompt::Local(String::new()), ctx)
     });
     driver_handle
+}
+
+#[test]
+fn native_startup_queue_prevents_exit_until_pending_rows_are_removed() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let (terminal_id, controller) = terminal.read(&app, |terminal, _| {
+            (terminal.id(), terminal.ai_controller().clone())
+        });
+        let (id, stream) =
+            conversation_with_in_progress_mock_stream(&mut app, terminal_id, &controller);
+        controller.update(&mut app, |controller, ctx| {
+            controller.prepare_native_prompt_queue(Some(id), ctx);
+        });
+        let queued_id = QueuedQueryModel::handle(&app).update(&mut app, |queue, ctx| {
+            queue.append(
+                id,
+                QueuedQuery::new_shared_session_prompt(
+                    "followup".into(),
+                    ParticipantId::new(),
+                    vec![],
+                ),
+                ctx,
+            )
+        });
+        let _driver = driver_wired_for_terminal(&mut app, terminal, None);
+        complete_mock_stream_successfully(&mut app, &stream);
+        OrchestrationEventService::handle(&app).read(&app, |service, _| {
+            assert!(!service.is_conversation_exiting(id));
+        });
+        QueuedQueryModel::handle(&app).update(&mut app, |queue, ctx| {
+            assert!(queue.remove_by_id(id, queued_id, ctx).is_some());
+        });
+        OrchestrationEventService::handle(&app).read(&app, |service, _| {
+            assert!(service.is_conversation_exiting(id));
+        });
+    });
+}
+
+#[test]
+fn native_promptless_setup_dispatches_only_the_first_queued_prompt() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
+        let id = controller.update(&mut app, |controller, ctx| {
+            let id = controller.prepare_native_prompt_queue(None, ctx);
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "first".into(),
+                None,
+                vec![],
+                ParticipantId::new(),
+                ctx,
+            );
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "second".into(),
+                None,
+                vec![],
+                ParticipantId::new(),
+                ctx,
+            );
+            id
+        });
+        let _driver = driver_wired_for_terminal(&mut app, terminal, None);
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            let conversation = history.conversation(&id).unwrap();
+            assert_eq!(conversation.exchange_count(), 1);
+            assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+        });
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["second"]
+            );
+        });
+    });
 }
 
 /// QUALITY-1801 regression: a child agent's message, queued in

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -1608,8 +1608,14 @@ fn native_startup_queue_prevents_exit_until_pending_rows_are_removed() {
         let (id, stream) =
             conversation_with_in_progress_mock_stream(&mut app, terminal_id, &controller);
         controller.update(&mut app, |controller, ctx| {
-            controller.prepare_native_prompt_queue(Some(id), ctx);
+            controller.bind_native_prompt_conversation(Some(id), ctx);
         });
+        // The driver's own skip_initial_turn dispatch drains an (empty, at this point) startup
+        // queue for `id` here, so it doesn't disturb the mock stream created above.
+        let _driver = driver_wired_for_terminal(&mut app, terminal, None);
+
+        // A row queued for this conversation after setup has finished keeps the driver from
+        // exiting even once the (unrelated, pre-existing) stream finishes successfully.
         let queued_id = QueuedQueryModel::handle(&app).update(&mut app, |queue, ctx| {
             queue.append(
                 id,
@@ -1621,7 +1627,6 @@ fn native_startup_queue_prevents_exit_until_pending_rows_are_removed() {
                 ctx,
             )
         });
-        let _driver = driver_wired_for_terminal(&mut app, terminal, None);
         complete_mock_stream_successfully(&mut app, &stream);
         OrchestrationEventService::handle(&app).read(&app, |service, _| {
             assert!(!service.is_conversation_exiting(id));
@@ -1636,13 +1641,13 @@ fn native_startup_queue_prevents_exit_until_pending_rows_are_removed() {
 }
 
 #[test]
-fn native_promptless_setup_dispatches_only_the_first_queued_prompt() {
+fn native_promptless_setup_dispatches_every_queued_prompt_at_once() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let terminal = add_window_with_terminal(&mut app, None);
         let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
         let id = controller.update(&mut app, |controller, ctx| {
-            let id = controller.prepare_native_prompt_queue(None, ctx);
+            let id = controller.bind_native_prompt_conversation(None, ctx);
             controller.execute_warp_agent_prompt_from_shared_session_injection(
                 "first".into(),
                 None,
@@ -1660,20 +1665,16 @@ fn native_promptless_setup_dispatches_only_the_first_queued_prompt() {
             id
         });
         let _driver = driver_wired_for_terminal(&mut app, terminal, None);
+        // Both queued prompts are sent as soon as setup finishes, without waiting for either
+        // turn to complete: "first" is interrupted by "second" the same way a live follow-up
+        // submitted mid-stream would interrupt it.
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
             let conversation = history.conversation(&id).unwrap();
-            assert_eq!(conversation.exchange_count(), 1);
+            assert_eq!(conversation.exchange_count(), 2);
             assert_eq!(conversation.status(), &ConversationStatus::InProgress);
         });
         QueuedQueryModel::handle(&app).read(&app, |queue, _| {
-            assert_eq!(
-                queue
-                    .queue(id)
-                    .iter()
-                    .map(QueuedQuery::text)
-                    .collect::<Vec<_>>(),
-                vec!["second"]
-            );
+            assert!(!queue.has_queue(id));
         });
     });
 }

--- a/app/src/ai/attachment_utils.rs
+++ b/app/src/ai/attachment_utils.rs
@@ -2,11 +2,16 @@
 //! and building attachment maps).
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use warp_errors::report_error;
 
 /// Max file attachment size is 10 MB.
 pub(crate) const MAX_ATTACHMENT_SIZE_BYTES: usize = 10 * 1024 * 1024;
 
 use crate::ai::agent::AIAgentAttachment;
+use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::server::server_api::ai::AIClient;
 
 /// Returns the per-session directory for downloading file attachments,
 /// based on the agent's working directory.
@@ -79,3 +84,69 @@ pub(crate) async fn download_file(
     async_fs::write(dest, &bytes).await?;
     Ok(bytes.len())
 }
+
+/// Downloads `file_downloads` (attachment id, display name pairs) from `task_id`'s task
+/// attachments into `dest_dir`, best-effort: a failure looking up download URLs, creating
+/// `dest_dir`, or downloading an individual file is logged and skipped rather than aborting the
+/// whole batch. Callers attaching the result to a prompt should send it regardless of whether
+/// this returns every attachment, some, or none -- a download failure is never a reason to drop
+/// the prompt itself.
+pub(crate) async fn download_task_file_attachments(
+    ai_client: Arc<dyn AIClient>,
+    http_client: Arc<http_client::Client>,
+    task_id: AmbientAgentTaskId,
+    dest_dir: PathBuf,
+    file_downloads: Vec<(String, String)>,
+) -> Vec<DownloadedAttachment> {
+    let attachment_ids: Vec<String> = file_downloads.iter().map(|(id, _)| id.clone()).collect();
+    let download_urls = match ai_client
+        .download_task_attachments(&task_id, &attachment_ids)
+        .await
+    {
+        Ok(resp) => resp
+            .attachments
+            .into_iter()
+            .map(|att| (att.attachment_id, att.download_url))
+            .collect::<HashMap<_, _>>(),
+        Err(e) => {
+            report_error!(
+                e.context("Failed to get download URLs for task"),
+                extra: { "task_id" => %task_id }
+            );
+            return Vec::new();
+        }
+    };
+
+    if let Err(e) = async_fs::create_dir_all(&dest_dir).await {
+        report_error!(anyhow::Error::new(e).context("Failed to create attachments directory"));
+        return Vec::new();
+    }
+
+    let mut downloaded = Vec::new();
+    for (attachment_id, file_name) in &file_downloads {
+        let Some(url) = download_urls.get(attachment_id) else {
+            log::warn!("No download URL for attachment {attachment_id}");
+            continue;
+        };
+        let safe_name = sanitize_filename(file_name).to_owned();
+        let dest = dest_dir.join(format!("{attachment_id}_{safe_name}"));
+        match download_file(&http_client, url, &dest).await {
+            Ok(_) => downloaded.push(DownloadedAttachment {
+                file_id: attachment_id.clone(),
+                file_name: safe_name,
+                file_path: dest.to_string_lossy().into_owned(),
+            }),
+            Err(e) => {
+                report_error!(
+                    e.context("Failed to download attachment"),
+                    extra: { "file_name" => %safe_name }
+                );
+            }
+        }
+    }
+    downloaded
+}
+
+#[cfg(test)]
+#[path = "attachment_utils_tests.rs"]
+mod tests;

--- a/app/src/ai/attachment_utils_tests.rs
+++ b/app/src/ai/attachment_utils_tests.rs
@@ -1,0 +1,141 @@
+use std::sync::Arc;
+
+use mockito::{Matcher, Server};
+use tempfile::TempDir;
+
+use super::*;
+use crate::server::server_api::ai::{
+    AttachmentDownloadInfo, DownloadAttachmentsResponse, MockAIClient,
+};
+
+fn fake_task_id() -> AmbientAgentTaskId {
+    "550e8400-e29b-41d4-a716-446655440000".parse().unwrap()
+}
+
+fn download_path(attachment_id: &str) -> Matcher {
+    Matcher::Regex(format!("^/download/{attachment_id}$"))
+}
+
+/// A plain HTTP client with no proxy/TLS-cert config and a disabled connection pool, so tests
+/// don't hold sockets open past their return (see the identical helper in
+/// `ai::agent_sdk::test_support`, not reusable here across module boundaries).
+fn test_http_client() -> Arc<http_client::Client> {
+    let builder = reqwest::ClientBuilder::new()
+        .tls_certs_only([])
+        .no_proxy()
+        .pool_max_idle_per_host(0);
+    Arc::new(
+        http_client::Client::from_client_builder(builder)
+            .expect("should not fail to build test http client"),
+    )
+}
+
+// A download failure -- whether resolving URLs or fetching an individual file -- must never
+// cause the whole batch to error out: the caller always sends the prompt these attachments are
+// for, with whatever (possibly empty) subset actually downloaded.
+
+#[tokio::test]
+async fn url_lookup_failure_returns_empty_without_erroring() {
+    let mut mock = MockAIClient::new();
+    mock.expect_download_task_attachments()
+        .times(1)
+        .returning(|_task_id, _ids| Err(anyhow::anyhow!("simulated URL lookup failure")));
+
+    let dest_dir = TempDir::new().unwrap();
+    let result = download_task_file_attachments(
+        Arc::new(mock),
+        test_http_client(),
+        fake_task_id(),
+        dest_dir.path().to_path_buf(),
+        vec![("attachment-1".to_string(), "file1.txt".to_string())],
+    )
+    .await;
+
+    assert!(result.is_empty());
+}
+
+#[tokio::test]
+async fn per_file_failure_is_skipped_while_others_still_download() {
+    let mut server = Server::new_async().await;
+    let ok_mock = server
+        .mock("GET", download_path("ok-uuid"))
+        .with_status(200)
+        .with_body("present")
+        .expect(1)
+        .create_async()
+        .await;
+    let bad_mock = server
+        .mock("GET", download_path("bad-uuid"))
+        .with_status(404)
+        .with_body("not found")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let server_url = server.url();
+    let mut mock = MockAIClient::new();
+    mock.expect_download_task_attachments()
+        .times(1)
+        .returning(move |_task_id, _ids| {
+            Ok(DownloadAttachmentsResponse {
+                attachments: vec![
+                    AttachmentDownloadInfo {
+                        attachment_id: "ok-uuid".to_string(),
+                        download_url: format!("{server_url}/download/ok-uuid"),
+                    },
+                    AttachmentDownloadInfo {
+                        attachment_id: "bad-uuid".to_string(),
+                        download_url: format!("{server_url}/download/bad-uuid"),
+                    },
+                ],
+            })
+        });
+
+    let dest_dir = TempDir::new().unwrap();
+    let downloaded = download_task_file_attachments(
+        Arc::new(mock),
+        test_http_client(),
+        fake_task_id(),
+        dest_dir.path().to_path_buf(),
+        vec![
+            ("ok-uuid".to_string(), "ok.txt".to_string()),
+            ("bad-uuid".to_string(), "bad.txt".to_string()),
+        ],
+    )
+    .await;
+
+    assert_eq!(downloaded.len(), 1);
+    assert_eq!(downloaded[0].file_id, "ok-uuid");
+    assert_eq!(
+        std::fs::read_to_string(&downloaded[0].file_path).unwrap(),
+        "present"
+    );
+    ok_mock.assert_async().await;
+    bad_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn missing_download_url_for_an_attachment_is_skipped() {
+    // The server can omit an attachment from the response entirely (e.g. it expired); that
+    // specific file is skipped rather than the whole batch failing.
+    let mut mock = MockAIClient::new();
+    mock.expect_download_task_attachments()
+        .times(1)
+        .returning(|_task_id, _ids| {
+            Ok(DownloadAttachmentsResponse {
+                attachments: vec![],
+            })
+        });
+
+    let dest_dir = TempDir::new().unwrap();
+    let downloaded = download_task_file_attachments(
+        Arc::new(mock),
+        test_http_client(),
+        fake_task_id(),
+        dest_dir.path().to_path_buf(),
+        vec![("missing-uuid".to_string(), "missing.txt".to_string())],
+    )
+    .await;
+
+    assert!(downloaded.is_empty());
+}

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2775,12 +2775,6 @@ impl BlocklistAIController {
         // Remove any locked pending-LRC queries so they don't linger after cancellation.
         QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
             model.remove_pending_lrc_rows(conversation_id, ctx);
-            if matches!(
-                reason.conversation_outcome(),
-                CancellationOutcome::Cancelled
-            ) {
-                model.cancel_injection_dispatch(conversation_id, ctx);
-            }
         });
 
         if !self

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2865,6 +2865,22 @@ impl BlocklistAIController {
             .has_active_stream_for_conversation(conversation_id, app)
     }
 
+    /// True when nothing prevents dispatching a fresh, automatic request for `conversation_id`
+    /// right now: native setup (if any) has finished, and no response stream is currently
+    /// active. Every automatic dispatch trigger -- the post-enqueue idle fast path and the
+    /// FIFO-head case of [`Self::dispatch_queued_warp_agent_prompt`] -- must check this before
+    /// firing, so two dispatch attempts can never race and cancel each other. Does not apply to
+    /// an explicit user override (e.g. "Send now"), which is allowed to interrupt an active
+    /// stream on purpose.
+    pub(crate) fn can_dispatch_queued_warp_agent_prompt(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &AppContext,
+    ) -> bool {
+        !QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(conversation_id)
+            && !self.has_active_stream_for_conversation(conversation_id, ctx)
+    }
+
     #[cfg(test)]
     pub fn register_mock_stream_for_test(
         &mut self,

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -1612,7 +1612,7 @@ impl BlocklistAIController {
     /// Only pops a plain, unlocked, non-edited prompt row (`AutofireAction::Submit`); a shell
     /// command, a row being edited, or a shared-session row carrying a file attachment that
     /// still needs downloading are left queued for `TerminalView::drain_queued_prompts` (or, for
-    /// a shared-session row, `Self::dispatch_next_shared_session_row`) to handle once the
+    /// a shared-session row, `Self::dispatch_queued_warp_agent_prompt`) to handle once the
     /// conversation goes idle, since none of those can be folded synchronously into an
     /// already-in-flight request.
     fn steer_head_prompt_for_request(

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -22,7 +22,7 @@ use input_context::{input_context_for_request, parse_context_attachments};
 use itertools::Itertools;
 use parking_lot::FairMutex;
 use pending_response_streams::PendingResponseStreams;
-use session_sharing_protocol::common::ParticipantId;
+use session_sharing_protocol::common::{AgentAttachment, ParticipantId};
 pub use slash_command::*;
 use warp_core::assertions::safe_assert;
 use warp_errors::report_error;
@@ -41,7 +41,7 @@ use super::orchestration_event_streamer::{
     OrchestrationEventStreamer, OrchestrationEventStreamerEvent,
 };
 use super::orchestration_events::{OrchestrationEventService, OrchestrationEventServiceEvent};
-use super::queued_query::{QueuedQueryId, QueuedQueryModel};
+use super::queued_query::{AutofireAction, QueuedQueryId, QueuedQueryModel};
 use super::{BlocklistAIInputModel, ResponseStreamId};
 use crate::ai::AIRequestUsageModel;
 use crate::ai::agent::api::{self, ServerConversationToken};
@@ -1601,6 +1601,117 @@ impl BlocklistAIController {
             .push((suggestion, trigger));
     }
 
+    /// If `conversation_id`'s queue is in `Steering` mode and has an eligible head row queued,
+    /// pops that row and returns it built as a fresh `AIAgentInput::UserQuery`, ready to append
+    /// to whichever request the caller is about to send for this conversation (a tool-result
+    /// follow-up, an orchestration-event injection, or a direct send). Also updates the current
+    /// response initiator when the row came from a shared-session participant -- callers must
+    /// invoke this *before* reading [`Self::get_current_response_initiator`] to build their own
+    /// `RequestInput`, so the exchange is attributed correctly.
+    ///
+    /// Only pops a plain, unlocked, non-edited prompt row (`AutofireAction::Submit`); a shell
+    /// command, a row being edited, or a shared-session row carrying a file attachment that
+    /// still needs downloading are left queued for `TerminalView::drain_queued_prompts` (or, for
+    /// a shared-session row, `Self::dispatch_next_shared_session_row`) to handle once the
+    /// conversation goes idle, since none of those can be folded synchronously into an
+    /// already-in-flight request.
+    fn steer_head_prompt_for_request(
+        &mut self,
+        conversation_id: AIConversationId,
+        task_id: &TaskId,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<AIAgentInput> {
+        if !QueuedQueryModel::as_ref(ctx).is_steering(conversation_id)
+            || QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(conversation_id)
+        {
+            return None;
+        }
+        let Some(AutofireAction::Submit { query_id, .. }) =
+            QueuedQueryModel::as_ref(ctx).peek_autofire(conversation_id)
+        else {
+            return None;
+        };
+        let row = QueuedQueryModel::as_ref(ctx)
+            .queue(conversation_id)
+            .iter()
+            .find(|row| row.id() == query_id)?
+            .clone();
+
+        let (participant_id, prompt_attachments) =
+            if let Some((participant_id, attachments)) = row.shared_session_prompt() {
+                if attachments
+                    .iter()
+                    .any(|attachment| matches!(attachment, AgentAttachment::FileReference { .. }))
+                {
+                    // Needs an async download before it can be turned into a `UserQuery`;
+                    // leave it queued for the idle-triggered dispatch instead.
+                    return None;
+                }
+                let mut block_ids = Vec::new();
+                let mut selected_text_parts = Vec::new();
+                for attachment in attachments {
+                    match attachment {
+                        AgentAttachment::BlockReference { block_id } => {
+                            block_ids.push(BlockId::from(block_id.to_string()));
+                        }
+                        AgentAttachment::PlainText { content } => {
+                            selected_text_parts.push(content.clone());
+                        }
+                        AgentAttachment::FileReference { .. } => {
+                            unreachable!("file attachments were already excluded above")
+                        }
+                    }
+                }
+                self.context_model.update(ctx, |context_model, ctx| {
+                    if !block_ids.is_empty() {
+                        context_model.set_pending_context_block_ids(block_ids, false, ctx);
+                    }
+                    if !selected_text_parts.is_empty() {
+                        context_model.set_pending_context_selected_text(
+                            Some(selected_text_parts.join("\n")),
+                            false,
+                            ctx,
+                        );
+                    }
+                });
+                (Some(participant_id.clone()), Vec::new())
+            } else {
+                (
+                    None,
+                    QueuedQueryModel::as_ref(ctx)
+                        .attachments_for(conversation_id, query_id)
+                        .to_vec(),
+                )
+            };
+
+        if let Some(participant_id) = participant_id {
+            self.set_current_response_initiator(participant_id);
+        }
+
+        let input = input_for_query(
+            row.text().to_owned(),
+            task_id,
+            conversation_id,
+            None,
+            UserQueryMode::Normal,
+            None,
+            HashMap::new(),
+            prompt_attachments,
+            self.context_model.as_ref(ctx),
+            self.active_session.as_ref(ctx),
+            ctx,
+        );
+
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.remove_fired_row(conversation_id, query_id, ctx);
+        });
+        log::info!(
+            "event=steered_prompt_included conversation_id={conversation_id} query_id={query_id:?}"
+        );
+
+        Some(input)
+    }
+
     fn send_follow_up_for_conversation(
         &mut self,
         conversation_id: AIConversationId,
@@ -1620,7 +1731,13 @@ impl BlocklistAIController {
         let finished_results = self.action_model.update(ctx, |action_model, _| {
             action_model.drain_finished_action_results(conversation_id)
         });
-        if finished_results.is_empty() {
+        let root_task_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .map(|conversation| conversation.get_root_task_id().clone());
+        let steered_input = root_task_id
+            .as_ref()
+            .and_then(|task_id| self.steer_head_prompt_for_request(conversation_id, task_id, ctx));
+        if finished_results.is_empty() && steered_input.is_none() {
             return;
         }
 
@@ -1654,6 +1771,14 @@ impl BlocklistAIController {
             &scope,
             ctx,
         );
+
+        if let (Some(steered_input), Some(root_task_id)) = (steered_input, root_task_id) {
+            request_input
+                .input_messages
+                .entry(root_task_id)
+                .or_default()
+                .push(steered_input);
+        }
 
         // Include any pending orchestration events in this follow-up rather
         // than waiting for a separate idle injection turn. Skip when a server
@@ -1949,19 +2074,34 @@ impl BlocklistAIController {
             action_model.cancel_wait_for_events_for_conversation(conversation_id, ctx);
         });
 
+        let root_task_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .map(|conversation| conversation.get_root_task_id().clone());
+        let steered_input = root_task_id.as_ref().and_then(|root_task_id| {
+            self.steer_head_prompt_for_request(conversation_id, root_task_id, ctx)
+        });
+
         let scope = ResolvedTeamScope::from_scope(&self.team_context(ctx));
+        let mut request_input = RequestInput::for_task(
+            inputs,
+            task_id,
+            &self.active_session,
+            self.get_current_response_initiator(),
+            conversation_id,
+            self.terminal_surface_id,
+            &scope,
+            ctx,
+        );
+        if let (Some(steered_input), Some(root_task_id)) = (steered_input, root_task_id) {
+            request_input
+                .input_messages
+                .entry(root_task_id)
+                .or_default()
+                .push(steered_input);
+        }
         if self
             .send_request_input(
-                RequestInput::for_task(
-                    inputs,
-                    task_id,
-                    &self.active_session,
-                    self.get_current_response_initiator(),
-                    conversation_id,
-                    self.terminal_surface_id,
-                    &scope,
-                    ctx,
-                ),
+                request_input,
                 None,
                 RecoveryBudget::fresh(),
                 /*is_queued_prompt*/ false,

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -8,6 +8,7 @@ mod pending_response_streams;
 pub mod response_stream;
 pub(super) mod shared_session;
 mod slash_command;
+mod startup_queue;
 use std::collections::{HashMap, HashSet};
 #[cfg(not(target_family = "wasm"))]
 use std::path::PathBuf;
@@ -339,6 +340,7 @@ pub struct BlocklistAIController {
     should_refresh_available_llms_on_stream_finish: bool,
 
     shared_session_state: shared_session::SharedSessionState,
+    native_prompt_conversation_id: Option<AIConversationId>,
 
     /// Ambient agent task ID attached to this controller. This is a property of the controller, and not an individual
     /// conversation, because the ambient agent task driver owns the entire Warp window working on a task, and any
@@ -648,6 +650,7 @@ impl BlocklistAIController {
             team_context_resolver,
             should_refresh_available_llms_on_stream_finish: false,
             shared_session_state: shared_session::SharedSessionState::default(),
+            native_prompt_conversation_id: None,
             ambient_agent_task_id: None,
             attachments_download_dir: None,
             pending_auto_resume_handles: HashMap::new(),
@@ -1361,7 +1364,14 @@ impl BlocklistAIController {
         ctx: &mut ModelContext<Self>,
     ) {
         let participant_id = self.get_sharer_participant_id();
-        let which_task = match self.context_model.as_ref(ctx).selected_conversation_id(ctx) {
+        let target_conversation =
+            if matches!(ai_input, AIAgentInput::StartFromAmbientRunPrompt { .. }) {
+                self.native_prompt_conversation_id
+                    .or_else(|| self.context_model.as_ref(ctx).selected_conversation_id(ctx))
+            } else {
+                self.context_model.as_ref(ctx).selected_conversation_id(ctx)
+            };
+        let which_task = match target_conversation {
             Some(id) => {
                 let Some(conversation) = BlocklistAIHistoryModel::as_ref(ctx).conversation(&id)
                 else {
@@ -2664,6 +2674,11 @@ impl BlocklistAIController {
             }
         }
 
+        if self.native_prompt_conversation_id == Some(conversation_id) && !is_passive_request {
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.finish_native_setup(conversation_id, ctx);
+            });
+        }
         ctx.emit(BlocklistAIControllerEvent::SentRequest {
             contains_user_query: input_contains_user_query,
             is_queued_prompt,
@@ -2760,6 +2775,12 @@ impl BlocklistAIController {
         // Remove any locked pending-LRC queries so they don't linger after cancellation.
         QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
             model.remove_pending_lrc_rows(conversation_id, ctx);
+            if matches!(
+                reason.conversation_outcome(),
+                CancellationOutcome::Cancelled
+            ) {
+                model.cancel_injection_dispatch(conversation_id, ctx);
+            }
         });
 
         if !self

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -681,6 +681,15 @@ impl BlocklistAIController {
         ctx: &mut ModelContext<Self>,
     ) {
         // Map server token to sharer's local conversation ID
+        if self.queue_native_startup_injection(
+            &prompt,
+            server_conversation_token.as_ref(),
+            &attachments,
+            &participant_id,
+            ctx,
+        ) {
+            return;
+        }
         let conversation_id = server_conversation_token
             .and_then(|id| self.find_existing_conversation_by_server_token(&id.to_string(), ctx))
             .and_then(

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -680,8 +680,10 @@ impl BlocklistAIController {
         participant_id: ParticipantId,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Map server token to sharer's local conversation ID
-        if self.queue_native_startup_injection(
+        // Route through the bound native conversation, if any -- see
+        // `route_native_startup_injection`'s doc comment for why this must fully own dispatch
+        // once bound, rather than falling back to token resolution below.
+        if self.route_native_startup_injection(
             &prompt,
             server_conversation_token.as_ref(),
             &attachments,

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -18,9 +18,7 @@ use crate::ai::agent::conversation::{AIConversationId, ConversationStatus, TaskS
 use crate::ai::agent::{AIAgentActionId, AIAgentAttachment, EntrypointType};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::attachment_utils::{
-    DownloadedAttachment, build_file_attachment_map, download_file, sanitize_filename,
-};
+use crate::ai::attachment_utils::{build_file_attachment_map, download_task_file_attachments};
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 use crate::ai::blocklist::local_agent_task_sync_model::LocalAgentTaskSyncModel;
@@ -783,65 +781,16 @@ impl BlocklistAIController {
         };
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        let server_api = ServerApiProvider::as_ref(ctx).get();
-        let attachment_ids: Vec<String> = file_downloads.iter().map(|(id, _)| id.clone()).collect();
+        let http_client = ServerApiProvider::as_ref(ctx).get_http_client();
 
-        // Fetch presigned download URLs from the server, download files to disk,
-        // then build the attachment map from only the successfully downloaded files.
         ctx.spawn(
-            async move {
-                let download_urls = match ai_client
-                    .download_task_attachments(&task_id, &attachment_ids)
-                    .await
-                {
-                    Ok(resp) => resp
-                        .attachments
-                        .into_iter()
-                        .map(|att| (att.attachment_id, att.download_url))
-                        .collect::<std::collections::HashMap<_, _>>(),
-                    Err(e) => {
-                        report_error!(
-                            e.context("Failed to get download URLs for task"),
-                            extra: { "task_id" => %task_id }
-                        );
-                        return vec![];
-                    }
-                };
-
-                if let Err(e) = async_fs::create_dir_all(&attachment_dir).await {
-                    report_error!(
-                        anyhow::Error::new(e).context("Failed to create attachments directory")
-                    );
-                    return vec![];
-                }
-
-                let mut downloaded = Vec::new();
-                for (attachment_id, file_name) in &file_downloads {
-                    let Some(url) = download_urls.get(attachment_id) else {
-                        log::warn!("No download URL for attachment {attachment_id}");
-                        continue;
-                    };
-                    let safe_name = sanitize_filename(file_name).to_string();
-                    let dest = attachment_dir.join(format!("{attachment_id}_{safe_name}"));
-
-                    match download_file(server_api.http_client(), url, &dest).await {
-                        Ok(_) => {
-                            downloaded.push(DownloadedAttachment {
-                                file_id: attachment_id.clone(),
-                                file_name: safe_name,
-                                file_path: dest.to_string_lossy().into_owned(),
-                            });
-                        }
-                        Err(e) => {
-                            report_error!(
-                                e.context("Failed to download attachment"),
-                                extra: { "file_name" => %safe_name }
-                            );
-                        }
-                    }
-                }
-                downloaded
-            },
+            download_task_file_attachments(
+                ai_client,
+                http_client,
+                task_id,
+                attachment_dir,
+                file_downloads,
+            ),
             move |controller, downloaded, ctx| {
                 let file_attachments = build_file_attachment_map(&downloaded);
                 controller.send_warp_agent_prompt_from_shared_session_injection(

--- a/app/src/ai/blocklist/controller/startup_queue.rs
+++ b/app/src/ai/blocklist/controller/startup_queue.rs
@@ -13,7 +13,9 @@ use crate::ai::attachment_utils::{
     DownloadedAttachment, build_file_attachment_map, download_file, sanitize_filename,
 };
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
-use crate::ai::blocklist::{BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel};
+use crate::ai::blocklist::{
+    BlocklistAIHistoryModel, QueuedPromptDeliveryMode, QueuedQuery, QueuedQueryModel,
+};
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::BlockId;
 
@@ -42,7 +44,10 @@ impl BlocklistAIController {
             self.terminal_surface_id,
             restored_conversation_id.is_some(),
         );
-        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| queue.begin_native_setup(id, ctx));
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.begin_native_setup(id, ctx);
+            queue.set_delivery_mode(id, QueuedPromptDeliveryMode::Steering);
+        });
         id
     }
 
@@ -68,9 +73,13 @@ impl BlocklistAIController {
     }
 
     /// Routes a shared-session-injected prompt while this controller is bound to a native
-    /// conversation: queues it behind an existing backlog (startup still in progress, or a
-    /// prior injection is still being drained), or -- once there's nothing to hold it behind --
-    /// dispatches it immediately into the bound conversation.
+    /// conversation: always queues it (preserving FIFO order with anything already queued),
+    /// then immediately attempts to dispatch the queue's head via
+    /// [`Self::dispatch_next_shared_session_row`] when nothing is currently streaming for the
+    /// conversation. When a stream *is* active, the row is left queued for the `Steering`
+    /// dispatch mechanism to pick up at the next natural request boundary (or the existing
+    /// idle-triggered drain once the turn finishes) -- dispatching immediately in that case
+    /// would interrupt whatever's already in flight, dropping it before it produces any output.
     ///
     /// Returns `true` when the caller (`execute_warp_agent_prompt_from_shared_session_injection`
     /// and friends) must not fall through to legacy conversation resolution for this prompt:
@@ -115,49 +124,34 @@ impl BlocklistAIController {
             participant_id.clone(),
             attachments.to_vec(),
         );
-        if self.should_queue_rather_than_dispatch(id, ctx) {
-            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-                queue.append(id, row, ctx);
-            });
-        } else {
-            self.send_native_startup_injection(id, row, ctx);
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.append(id, row, ctx);
+        });
+        if !QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(id)
+            && !self.has_active_stream_for_conversation(id, ctx)
+        {
+            self.dispatch_next_shared_session_row(id, ctx);
         }
         true
     }
 
-    /// True when a fresh injection for `conversation_id` must be held rather than dispatched
-    /// immediately: startup hasn't finished, something else is still queued ahead of it, or a
-    /// CLI subagent is currently running (interrupting an in-progress shell command is more
-    /// disruptive than interrupting an LLM turn). `TerminalView::drain_queued_prompts` retries
-    /// the drain on every subsequent turn completion, so a held-back row is not stuck.
-    fn should_queue_rather_than_dispatch(
-        &self,
-        conversation_id: AIConversationId,
-        ctx: &ModelContext<Self>,
-    ) -> bool {
-        QueuedQueryModel::as_ref(ctx).has_pending_native_injections(conversation_id)
-            || BlocklistAIHistoryModel::as_ref(ctx)
-                .conversation(&conversation_id)
-                .is_some_and(|conversation| conversation.has_active_subagent())
-    }
-
-    /// Sends every prompt queued for `conversation_id` while native setup was in progress, in
-    /// FIFO order, without waiting for any of their turns to complete: each successive send
-    /// interrupts whatever the previous one started, the same way a live follow-up submitted
-    /// while a turn is still streaming does (`send_query`'s cancel-then-resend via
-    /// `cancel_conversation_progress`). No-ops when nothing is queued.
+    /// Dispatches the head shared-session-injected row queued for `conversation_id`, if any --
+    /// used at points already known to be safe (native setup just finished, no stream currently
+    /// active for the conversation, or an explicit "Send now" override) so a queued injection
+    /// isn't left waiting behind `Steering`'s piggyback opportunities, which only fire while a
+    /// turn is actually in flight producing tool results or orchestration events. No-ops when
+    /// the head row isn't a shared-session injection.
     ///
-    /// Deferred (leaving the queue untouched) while a CLI subagent is active for
-    /// `conversation_id`; `TerminalView::drain_queued_prompts` re-attempts this drain the next
-    /// time any turn completes, so a deferred backlog still gets flushed promptly.
+    /// Deferred (leaving the row queued) while a CLI subagent is active for `conversation_id`
+    /// (interrupting an in-progress shell command is more disruptive than interrupting an LLM
+    /// turn); `TerminalView::drain_queued_prompts` re-attempts this the next time any turn
+    /// completes, so a deferred row is not stuck.
     ///
-    /// Must be called after the caller's own send (if any) has fully completed -- in particular,
-    /// after `BlocklistAIHistoryModel::mark_active_conversation_id` has run for it -- since each
-    /// row's cancel-then-resend keys off the terminal surface's *active* conversation, which is
-    /// only set once a send finishes. `AgentDriver::execute_run` is responsible for calling this
-    /// at the right point (right after dispatching the initial prompt, or immediately after
-    /// `finish_native_setup` for a promptless run).
-    pub(crate) fn drain_native_startup_queue(
+    /// Only ever dispatches **one** row: callers that want every currently-queued row flushed
+    /// (e.g. an explicit "Send now") must call this again once the previous row's send settles,
+    /// not loop over it synchronously -- looping would cancel each row's request before the
+    /// previous one produced any output, silently dropping every row but the last.
+    pub(crate) fn dispatch_next_shared_session_row(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
@@ -171,21 +165,24 @@ impl BlocklistAIController {
             );
             return;
         }
-        let rows = QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-            queue.drain_shared_session_injections(conversation_id, ctx)
-        });
-        if rows.is_empty() {
+        let Some(row) = QueuedQueryModel::as_ref(ctx)
+            .queue(conversation_id)
+            .first()
+            .filter(|row| row.shared_session_prompt().is_some())
+            .cloned()
+        else {
             return;
-        }
+        };
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.remove_fired_row(conversation_id, row.id(), ctx);
+        });
         log::info!(
-            "event=native_queue_drain_started task_id={:?} terminal_id={:?} conversation_id={conversation_id} row_count={}",
+            "event=native_queue_row_dispatched task_id={:?} terminal_id={:?} conversation_id={conversation_id} query_id={:?}",
             self.ambient_agent_task_id,
             self.terminal_surface_id,
-            rows.len(),
+            row.id(),
         );
-        for row in rows {
-            self.send_native_startup_injection(conversation_id, row, ctx);
-        }
+        self.send_native_startup_injection(conversation_id, row, ctx);
     }
 
     /// Resolves `row`'s attachments and sends it into `conversation_id` via the normal

--- a/app/src/ai/blocklist/controller/startup_queue.rs
+++ b/app/src/ai/blocklist/controller/startup_queue.rs
@@ -22,6 +22,7 @@ impl BlocklistAIController {
     /// delivering startup follow-ups, so `route_native_startup_injection` knows which
     /// conversation to target for the rest of this run. Idempotent: returns the existing
     /// binding if one is already in place.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn bind_native_prompt_conversation(
         &mut self,
         restored_conversation_id: Option<AIConversationId>,
@@ -49,13 +50,17 @@ impl BlocklistAIController {
         id
     }
 
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn native_prompt_conversation_id(&self) -> Option<AIConversationId> {
         self.native_prompt_conversation_id
     }
 
     /// Unbinds this controller from its native conversation, dropping any prompts still queued
     /// for it (e.g. the run ended before setup finished, or before a dispatch that was deferred
-    /// behind an active CLI subagent could go out).
+    /// behind an active CLI subagent could go out) and releasing the native setup barrier if it
+    /// was still held -- otherwise this conversation would stay permanently dispatch-blocked for
+    /// any future local queueing against it, since nothing else would ever release that barrier.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn unbind_native_prompt_conversation(&mut self, ctx: &mut ModelContext<Self>) {
         let Some(id) = self.native_prompt_conversation_id.take() else {
             return;
@@ -68,6 +73,7 @@ impl BlocklistAIController {
         );
         QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
             queue.clear_queue(id, ctx);
+            queue.finish_native_setup(id, ctx);
         });
     }
 
@@ -204,8 +210,12 @@ impl BlocklistAIController {
         );
         if row.shared_session_prompt().is_some() {
             // `send_native_startup_injection` takes ownership of the row directly rather than
-            // re-resolving it by id, so it's safe to remove up front.
+            // re-resolving it by id, so it's safe to remove up front. Arming the in-flight
+            // marker first (in the same update call, before removal's `Removed` event is
+            // delivered) keeps `has_pending_native_injections` true across the async download
+            // gap that can follow -- see that method's doc comment.
             QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.arm_download_in_flight(conversation_id);
                 queue.remove_fired_row(conversation_id, row_id, ctx);
             });
             self.send_native_startup_injection(conversation_id, row, ctx);
@@ -337,7 +347,10 @@ impl BlocklistAIController {
 
     /// Sends the fully-resolved `text`/`file_attachments` into `conversation_id`, via the same
     /// path used for a live (non-startup) shared-session follow-up targeting an existing
-    /// conversation (`send_warp_agent_prompt_from_shared_session_injection`).
+    /// conversation (`send_warp_agent_prompt_from_shared_session_injection`). Every path that
+    /// removed a row via [`QueuedQueryModel::arm_download_in_flight`] funnels through here, so
+    /// clearing that marker unconditionally at the top covers all of them, including the two
+    /// synchronous paths that never needed a download in the first place.
     fn dispatch_native_startup_injection(
         &mut self,
         conversation_id: AIConversationId,
@@ -346,6 +359,9 @@ impl BlocklistAIController {
         file_attachments: HashMap<String, AIAgentAttachment>,
         ctx: &mut ModelContext<Self>,
     ) {
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, _ctx| {
+            queue.clear_download_in_flight(conversation_id);
+        });
         if FeatureFlag::AgentView.is_enabled() {
             self.context_model.update(ctx, |context_model, ctx| {
                 context_model.set_pending_query_state_for_existing_conversation(

--- a/app/src/ai/blocklist/controller/startup_queue.rs
+++ b/app/src/ai/blocklist/controller/startup_queue.rs
@@ -1,29 +1,28 @@
 use std::collections::HashMap;
 
-use anyhow::{Context as _, anyhow};
+use anyhow::Context as _;
 use session_sharing_protocol::common::{AgentAttachment, ParticipantId, ServerConversationToken};
+use warp_core::features::FeatureFlag;
 use warp_errors::report_error;
-use warp_multi_agent_api::AgentType;
 use warpui::{ModelContext, SingletonEntity};
 
-use super::input_context::{input_context_for_request, parse_context_attachments};
-use super::response_stream::RecoveryBudget;
-use super::{BlocklistAIController, RequestInput};
-use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
-use crate::ai::agent::{
-    AIAgentAttachment, AIAgentContext, AIAgentInput, EntrypointType, RequestMetadata,
-    extract_user_query_mode,
-};
+use super::BlocklistAIController;
+use crate::ai::agent::AIAgentAttachment;
+use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::attachment_utils::{
     DownloadedAttachment, build_file_attachment_map, download_file, sanitize_filename,
 };
-use crate::ai::blocklist::{BlocklistAIHistoryModel, QueuedQuery, QueuedQueryId, QueuedQueryModel};
+use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
+use crate::ai::blocklist::{BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel};
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::BlockId;
-use crate::workspaces::user_workspaces::ResolvedTeamScope;
 
 impl BlocklistAIController {
-    pub(crate) fn prepare_native_prompt_queue(
+    /// Binds this controller to a native conversation before session sharing can begin
+    /// delivering startup follow-ups, so `route_native_startup_injection` knows which
+    /// conversation to target for the rest of this run. Idempotent: returns the existing
+    /// binding if one is already in place.
+    pub(crate) fn bind_native_prompt_conversation(
         &mut self,
         restored_conversation_id: Option<AIConversationId>,
         ctx: &mut ModelContext<Self>,
@@ -50,23 +49,41 @@ impl BlocklistAIController {
     pub(crate) fn native_prompt_conversation_id(&self) -> Option<AIConversationId> {
         self.native_prompt_conversation_id
     }
-    pub(crate) fn stop_native_prompt_queue(&mut self, ctx: &mut ModelContext<Self>) {
-        if let Some(id) = self.native_prompt_conversation_id.take() {
-            log::info!(
-                "event=native_queue_stopped task_id={:?} terminal_id={:?} conversation_id={id} unsent_count={}",
-                self.ambient_agent_task_id,
-                self.terminal_surface_id,
-                QueuedQueryModel::as_ref(ctx).queue(id).len(),
-            );
-            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-                queue.cancel_injection_dispatch(id, ctx);
-                queue.begin_native_setup(id, ctx);
-            });
-        }
+
+    /// Unbinds this controller from its native conversation, dropping any startup follow-ups
+    /// that never made it out (e.g. the run ended before setup finished).
+    pub(crate) fn unbind_native_prompt_conversation(&mut self, ctx: &mut ModelContext<Self>) {
+        let Some(id) = self.native_prompt_conversation_id.take() else {
+            return;
+        };
+        let unsent_count = QueuedQueryModel::as_ref(ctx).queue(id).len();
+        log::info!(
+            "event=native_queue_stopped task_id={:?} terminal_id={:?} conversation_id={id} unsent_count={unsent_count}",
+            self.ambient_agent_task_id,
+            self.terminal_surface_id,
+        );
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.drain_shared_session_injections(id, ctx);
+        });
     }
 
-    pub(super) fn queue_native_startup_injection(
-        &self,
+    /// Routes a shared-session-injected prompt while this controller is bound to a native
+    /// conversation: queues it behind an existing backlog (startup still in progress, or a
+    /// prior injection is still being drained), or -- once there's nothing to hold it behind --
+    /// dispatches it immediately into the bound conversation.
+    ///
+    /// Returns `true` when the caller (`execute_warp_agent_prompt_from_shared_session_injection`
+    /// and friends) must not fall through to legacy conversation resolution for this prompt:
+    /// covers every case where this controller is bound to a native conversation, whether the
+    /// prompt was queued, dispatched immediately, or rejected outright for naming a different
+    /// conversation's token. Returns `false` only when this controller isn't bound to a native
+    /// conversation at all, in which case the caller's own token/selected-conversation
+    /// resolution is the correct behavior. Bypassing to that legacy resolution once bound would
+    /// be wrong: it has no way to find this binding once the conversation already has exchanges
+    /// but hasn't been assigned a server token yet, which is routinely true for every follow-up
+    /// after the first.
+    pub(super) fn route_native_startup_injection(
+        &mut self,
         prompt: &str,
         token: Option<&ServerConversationToken>,
         attachments: &[AgentAttachment],
@@ -82,14 +99,6 @@ impl BlocklistAIController {
             );
             return false;
         };
-        if !QueuedQueryModel::as_ref(ctx).has_pending_native_injections(id) {
-            log::info!(
-                "event=injection_bypassed_queue task_id={:?} terminal_id={:?} conversation_id={id} participant_id={participant_id} reason=no_startup_backlog",
-                self.ambient_agent_task_id,
-                self.terminal_surface_id,
-            );
-            return false;
-        }
         if let Some(token) = token
             && let Some(target) =
                 self.find_existing_conversation_by_server_token(&token.to_string(), ctx)
@@ -101,68 +110,167 @@ impl BlocklistAIController {
             );
             return true;
         }
-        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-            queue.append(
-                id,
-                QueuedQuery::new_shared_session_prompt(
-                    prompt.to_owned(),
-                    participant_id.clone(),
-                    attachments.to_vec(),
-                )
-                .with_shared_session_target(token.cloned()),
-                ctx,
-            );
-        });
+        let row = QueuedQuery::new_shared_session_prompt(
+            prompt.to_owned(),
+            participant_id.clone(),
+            attachments.to_vec(),
+        );
+        if self.should_queue_rather_than_dispatch(id, ctx) {
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.append(id, row, ctx);
+            });
+        } else {
+            self.send_native_startup_injection(id, row, ctx);
+        }
         true
     }
 
-    pub(crate) fn send_queued_shared_session_prompt(
+    /// True when a fresh injection for `conversation_id` must be held rather than dispatched
+    /// immediately: startup hasn't finished, something else is still queued ahead of it, or a
+    /// CLI subagent is currently running (interrupting an in-progress shell command is more
+    /// disruptive than interrupting an LLM turn). `TerminalView::drain_queued_prompts` retries
+    /// the drain on every subsequent turn completion, so a held-back row is not stuck.
+    fn should_queue_rather_than_dispatch(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &ModelContext<Self>,
+    ) -> bool {
+        QueuedQueryModel::as_ref(ctx).has_pending_native_injections(conversation_id)
+            || BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .is_some_and(|conversation| conversation.has_active_subagent())
+    }
+
+    /// Sends every prompt queued for `conversation_id` while native setup was in progress, in
+    /// FIFO order, without waiting for any of their turns to complete: each successive send
+    /// interrupts whatever the previous one started, the same way a live follow-up submitted
+    /// while a turn is still streaming does (`send_query`'s cancel-then-resend via
+    /// `cancel_conversation_progress`). No-ops when nothing is queued.
+    ///
+    /// Deferred (leaving the queue untouched) while a CLI subagent is active for
+    /// `conversation_id`; `TerminalView::drain_queued_prompts` re-attempts this drain the next
+    /// time any turn completes, so a deferred backlog still gets flushed promptly.
+    ///
+    /// Must be called after the caller's own send (if any) has fully completed -- in particular,
+    /// after `BlocklistAIHistoryModel::mark_active_conversation_id` has run for it -- since each
+    /// row's cancel-then-resend keys off the terminal surface's *active* conversation, which is
+    /// only set once a send finishes. `AgentDriver::execute_run` is responsible for calling this
+    /// at the right point (right after dispatching the initial prompt, or immediately after
+    /// `finish_native_setup` for a promptless run).
+    pub(crate) fn drain_native_startup_queue(
         &mut self,
         conversation_id: AIConversationId,
-        query_id: QueuedQueryId,
         ctx: &mut ModelContext<Self>,
     ) {
-        let has_active_stream = self.has_active_stream_for_conversation(conversation_id, ctx);
         let has_active_subagent = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
             .is_some_and(|conversation| conversation.has_active_subagent());
-        if has_active_stream || has_active_subagent {
+        if has_active_subagent {
             log::info!(
-                "event=dispatch_deferred conversation_id={conversation_id} query_id={query_id:?} active_stream={has_active_stream} active_subagent={has_active_subagent}",
+                "event=native_queue_drain_deferred conversation_id={conversation_id} reason=active_subagent",
             );
             return;
         }
-        let row = QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-            queue.claim_injection(conversation_id, query_id, ctx)
+        let rows = QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.drain_shared_session_injections(conversation_id, ctx)
         });
-        let Some(row) = row else { return };
-        let (_, attachments) = row.shared_session_prompt().unwrap();
-        let files: Vec<_> = attachments
-            .iter()
-            .filter_map(|attachment| match attachment {
-                AgentAttachment::FileReference {
-                    attachment_id,
-                    file_name,
-                } => Some((attachment_id.clone(), file_name.clone())),
-                AgentAttachment::PlainText { .. } | AgentAttachment::BlockReference { .. } => None,
-            })
-            .collect();
-        if files.is_empty() {
-            self.finish_queued_injection(conversation_id, row, Ok(HashMap::new()), ctx);
+        if rows.is_empty() {
             return;
         }
         log::info!(
+            "event=native_queue_drain_started task_id={:?} terminal_id={:?} conversation_id={conversation_id} row_count={}",
+            self.ambient_agent_task_id,
+            self.terminal_surface_id,
+            rows.len(),
+        );
+        for row in rows {
+            self.send_native_startup_injection(conversation_id, row, ctx);
+        }
+    }
+
+    /// Resolves `row`'s attachments and sends it into `conversation_id` via the normal
+    /// existing-conversation follow-up path, which cancels any turn already in flight before
+    /// sending. Block and plain-text attachments are staged onto the live context model (the
+    /// same way `execute_warp_agent_prompt_from_shared_session_injection` stages them for a
+    /// live, non-startup injection) so the standard send path picks them up automatically; file
+    /// attachments are downloaded asynchronously first.
+    fn send_native_startup_injection(
+        &mut self,
+        conversation_id: AIConversationId,
+        row: QueuedQuery,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some((participant_id, attachments)) = row.shared_session_prompt() else {
+            report_error!(
+                "Expected a shared-session-injected row to send to a native conversation"
+            );
+            return;
+        };
+        let participant_id = participant_id.clone();
+        let attachments = attachments.to_vec();
+        let query_id = row.id();
+        let text = row.text().to_owned();
+
+        let mut block_ids = Vec::new();
+        let mut selected_text_parts = Vec::new();
+        let mut file_downloads: Vec<(String, String)> = Vec::new();
+        for attachment in attachments {
+            match attachment {
+                AgentAttachment::BlockReference { block_id } => {
+                    block_ids.push(BlockId::from(block_id.to_string()));
+                }
+                AgentAttachment::PlainText { content } => {
+                    selected_text_parts.push(content);
+                }
+                AgentAttachment::FileReference {
+                    attachment_id,
+                    file_name,
+                } => {
+                    file_downloads.push((attachment_id, file_name));
+                }
+            }
+        }
+        self.context_model.update(ctx, |context_model, ctx| {
+            if !block_ids.is_empty() {
+                context_model.set_pending_context_block_ids(block_ids, false, ctx);
+            }
+            if !selected_text_parts.is_empty() {
+                context_model.set_pending_context_selected_text(
+                    Some(selected_text_parts.join("\n")),
+                    false,
+                    ctx,
+                );
+            }
+        });
+
+        if file_downloads.is_empty() {
+            self.dispatch_native_startup_injection(
+                conversation_id,
+                text,
+                participant_id,
+                HashMap::new(),
+                ctx,
+            );
+            return;
+        }
+
+        log::info!(
             "event=queued_attachment_download_started conversation_id={conversation_id} query_id={query_id:?} file_count={}",
-            files.len(),
+            file_downloads.len(),
         );
         let Some((task_id, directory)) = self
             .ambient_agent_task_id
             .zip(self.attachments_download_dir.clone())
         else {
-            self.finish_queued_injection(
+            report_error!(
+                "Missing native attachment download configuration for a queued startup injection",
+                extra: { "conversation_id" => %conversation_id, "query_id" => ?query_id }
+            );
+            self.dispatch_native_startup_injection(
                 conversation_id,
-                row,
-                Err(anyhow!("Missing native attachment download configuration")),
+                text,
+                participant_id,
+                HashMap::new(),
                 ctx,
             );
             return;
@@ -171,11 +279,14 @@ impl BlocklistAIController {
         let api = ServerApiProvider::as_ref(ctx).get();
         ctx.spawn(
             async move {
-                let ids = files.iter().map(|(id, _)| id.clone()).collect::<Vec<_>>();
+                let ids = file_downloads
+                    .iter()
+                    .map(|(id, _)| id.clone())
+                    .collect::<Vec<_>>();
                 let urls = client.download_task_attachments(&task_id, &ids).await?;
                 async_fs::create_dir_all(&directory).await?;
                 let mut downloads = Vec::new();
-                for (id, name) in files {
+                for (id, name) in file_downloads {
                     let url = urls
                         .attachments
                         .iter()
@@ -190,144 +301,53 @@ impl BlocklistAIController {
                         file_path: path.to_string_lossy().into_owned(),
                     });
                 }
-                Ok(build_file_attachment_map(&downloads))
+                anyhow::Ok(build_file_attachment_map(&downloads))
             },
-            move |controller, result, ctx| {
-                controller.finish_queued_injection(conversation_id, row, result, ctx)
+            move |controller, result, ctx| match result {
+                Ok(file_attachments) => controller.dispatch_native_startup_injection(
+                    conversation_id,
+                    text,
+                    participant_id,
+                    file_attachments,
+                    ctx,
+                ),
+                Err(error) => {
+                    report_error!(
+                        error.context("Could not download attachments for a queued startup prompt"),
+                        extra: { "conversation_id" => %conversation_id, "query_id" => ?query_id }
+                    );
+                }
             },
         );
     }
 
-    fn finish_queued_injection(
+    /// Sends the fully-resolved `text`/`file_attachments` into `conversation_id`, via the same
+    /// path used for a live (non-startup) shared-session follow-up targeting an existing
+    /// conversation (`send_warp_agent_prompt_from_shared_session_injection`).
+    fn dispatch_native_startup_injection(
         &mut self,
         conversation_id: AIConversationId,
-        row: QueuedQuery,
-        files: anyhow::Result<HashMap<String, AIAgentAttachment>>,
+        text: String,
+        participant_id: ParticipantId,
+        file_attachments: HashMap<String, AIAgentAttachment>,
         ctx: &mut ModelContext<Self>,
     ) {
-        if !QueuedQueryModel::as_ref(ctx).is_injection_dispatch_current(conversation_id, row.id()) {
-            log::info!(
-                "event=dispatch_abandoned conversation_id={conversation_id} query_id={:?} reason=claim_invalidated",
-                row.id(),
-            );
-            return;
-        }
-        let result = files.and_then(|files| {
-            let request = self.queued_injection_request(conversation_id, &row, files, ctx)?;
-            if let Some(participant_id) = request.shared_session_response_initiator.clone() {
-                self.set_current_response_initiator(participant_id);
-            }
-            self.send_request_input(
-                request,
-                Some(RequestMetadata {
-                    is_autodetected_user_query: false,
-                    entrypoint: EntrypointType::SharedSession,
-                    is_auto_resume_after_error: false,
-                }),
-                RecoveryBudget::fresh(),
-                true,
-                ctx,
-            )
-            .map(|(_, stream_id)| {
-                log::info!(
-                    "event=dispatch_accepted task_id={:?} terminal_id={:?} conversation_id={conversation_id} query_id={:?} stream_id={stream_id:?} queue_len_after={}",
-                    self.ambient_agent_task_id, self.terminal_surface_id, row.id(),
-                    QueuedQueryModel::as_ref(ctx).queue(conversation_id).len().saturating_sub(1),
+        if FeatureFlag::AgentView.is_enabled() {
+            self.context_model.update(ctx, |context_model, ctx| {
+                context_model.set_pending_query_state_for_existing_conversation(
+                    conversation_id,
+                    AgentViewEntryOrigin::SharedSessionSelection,
+                    ctx,
                 );
-            })
-        });
-        let error = result.err().map(|error| {
-            report_error!(
-                error.context("Could not dispatch queued native prompt"),
-                extra: { "conversation_id" => %conversation_id, "query_id" => ?row.id(), "terminal_id" => ?self.terminal_surface_id }
-            );
-            "Could not send a queued prompt. The unsent prompt remains queued.".to_owned()
-        });
-        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-            queue.finish_injection_dispatch(conversation_id, row.id(), error, ctx);
-        });
-    }
-
-    fn queued_injection_request(
-        &self,
-        conversation_id: AIConversationId,
-        row: &QueuedQuery,
-        files: HashMap<String, AIAgentAttachment>,
-        ctx: &ModelContext<Self>,
-    ) -> anyhow::Result<RequestInput> {
-        let conversation = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&conversation_id)
-            .context("Queued native conversation no longer exists")?;
-        if let Some(token) = row.shared_session_target()
-            && conversation
-                .server_conversation_token()
-                .map(|value| value.as_str())
-                != Some(token.to_string().as_str())
-        {
-            return Err(anyhow!(
-                "Queued prompt targets a different server conversation"
-            ));
+            });
         }
-        if matches!(
-            conversation.status(),
-            ConversationStatus::Cancelled | ConversationStatus::Error
-        ) {
-            return Err(anyhow!(
-                "Queued native conversation stopped before dispatch"
-            ));
-        }
-        let task_id = conversation.get_root_task_id().clone();
-        let (participant_id, attachments) = row
-            .shared_session_prompt()
-            .context("Expected an injected prompt")?;
-        let context_model = self.context_model.as_ref(ctx);
-        let mut extra_context = Vec::new();
-        for attachment in attachments {
-            match attachment {
-                AgentAttachment::PlainText { content } => {
-                    extra_context.push(AIAgentContext::SelectedText(content.clone()))
-                }
-                AgentAttachment::BlockReference { block_id } => {
-                    if let Some(context) = context_model
-                        .transform_block_to_context(&BlockId::from(block_id.to_string()), false)
-                    {
-                        extra_context.push(context);
-                    }
-                }
-                AgentAttachment::FileReference { .. } => {}
-            }
-        }
-        let context = input_context_for_request(
-            false,
-            context_model,
-            self.active_session.as_ref(ctx),
-            Some(conversation_id),
-            extra_context,
+        self.send_user_query_in_conversation_with_attachments(
+            text,
+            conversation_id,
+            Some(participant_id),
+            file_attachments,
             ctx,
         );
-        let (query, user_query_mode) = extract_user_query_mode(row.text().to_owned());
-        let mut referenced_attachments = parse_context_attachments(&query, context_model, ctx);
-        referenced_attachments.extend(files);
-        let input = AIAgentInput::UserQuery {
-            query,
-            context,
-            static_query_type: None,
-            referenced_attachments,
-            user_query_mode,
-            running_command: None,
-            intended_agent: Some(AgentType::Primary),
-        };
-        let scope = ResolvedTeamScope::from_scope(&self.team_context(ctx));
-        Ok(RequestInput::for_task(
-            vec![input],
-            task_id,
-            &self.active_session,
-            Some(participant_id.clone()),
-            conversation_id,
-            self.terminal_surface_id,
-            &scope,
-            ctx,
-        ))
     }
 }
 

--- a/app/src/ai/blocklist/controller/startup_queue.rs
+++ b/app/src/ai/blocklist/controller/startup_queue.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use anyhow::Context as _;
 use session_sharing_protocol::common::{AgentAttachment, ParticipantId, ServerConversationToken};
 use warp_core::features::FeatureFlag;
 use warp_errors::report_error;
@@ -9,12 +8,11 @@ use warpui::{ModelContext, SingletonEntity};
 use super::BlocklistAIController;
 use crate::ai::agent::AIAgentAttachment;
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::attachment_utils::{
-    DownloadedAttachment, build_file_attachment_map, download_file, sanitize_filename,
-};
+use crate::ai::attachment_utils::{build_file_attachment_map, download_task_file_attachments};
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::{
-    BlocklistAIHistoryModel, QueuedPromptDeliveryMode, QueuedQuery, QueuedQueryModel,
+    AutofireAction, BlocklistAIHistoryModel, QueuedPromptDeliveryMode, QueuedQuery, QueuedQueryId,
+    QueuedQueryModel,
 };
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::BlockId;
@@ -75,7 +73,7 @@ impl BlocklistAIController {
     /// Routes a shared-session-injected prompt while this controller is bound to a native
     /// conversation: always queues it (preserving FIFO order with anything already queued),
     /// then immediately attempts to dispatch the queue's head via
-    /// [`Self::dispatch_next_shared_session_row`] when nothing is currently streaming for the
+    /// [`Self::dispatch_queued_warp_agent_prompt`] when nothing is currently streaming for the
     /// conversation. When a stream *is* active, the row is left queued for the `Steering`
     /// dispatch mechanism to pick up at the next natural request boundary (or the existing
     /// idle-triggered drain once the turn finishes) -- dispatching immediately in that case
@@ -127,33 +125,40 @@ impl BlocklistAIController {
         QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
             queue.append(id, row, ctx);
         });
-        if !QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(id)
-            && !self.has_active_stream_for_conversation(id, ctx)
-        {
-            self.dispatch_next_shared_session_row(id, ctx);
+        if self.can_dispatch_queued_warp_agent_prompt(id, ctx) {
+            self.dispatch_queued_warp_agent_prompt(id, None, ctx);
         }
         true
     }
 
-    /// Dispatches the head shared-session-injected row queued for `conversation_id`, if any --
-    /// used at points already known to be safe (native setup just finished, no stream currently
-    /// active for the conversation, or an explicit "Send now" override) so a queued injection
-    /// isn't left waiting behind `Steering`'s piggyback opportunities, which only fire while a
-    /// turn is actually in flight producing tool results or orchestration events. No-ops when
-    /// the head row isn't a shared-session injection.
+    /// Dispatches a queued prompt row for `conversation_id` as its own fresh request, regardless
+    /// of whether it originated locally or from a shared-session injection: a local prompt via
+    /// [`Self::send_queued_user_query_in_conversation`], a shared-session-injected prompt via
+    /// the attachment-staging/download pipeline in [`Self::send_native_startup_injection`]. A
+    /// shell command, a locked row, or a row currently being edited is left queued for
+    /// `TerminalInput`/`TerminalView::drain_queued_prompts` to handle instead, since those need
+    /// the editor and PTY access this controller doesn't have.
     ///
-    /// Deferred (leaving the row queued) while a CLI subagent is active for `conversation_id`
-    /// (interrupting an in-progress shell command is more disruptive than interrupting an LLM
-    /// turn); `TerminalView::drain_queued_prompts` re-attempts this the next time any turn
-    /// completes, so a deferred row is not stuck.
+    /// `query_id` selects a specific row -- used by an explicit override such as "Send now",
+    /// which may target a row other than the head and is allowed to interrupt an active stream
+    /// on purpose. `None` dispatches the head row in FIFO order, and only if
+    /// [`QueuedQueryModel::peek_autofire`] says it's a plain, unlocked, non-edited row; used by
+    /// every automatic trigger, which must check [`Self::can_dispatch_queued_warp_agent_prompt`]
+    /// first so this never interrupts an active stream.
+    ///
+    /// Either way, deferred (leaving the row queued) while a CLI subagent is active for
+    /// `conversation_id`, since interrupting an in-progress shell command is more disruptive
+    /// than interrupting an LLM turn; `TerminalView::drain_queued_prompts` re-attempts this the
+    /// next time any turn completes, so a deferred row is not stuck.
     ///
     /// Only ever dispatches **one** row: callers that want every currently-queued row flushed
-    /// (e.g. an explicit "Send now") must call this again once the previous row's send settles,
-    /// not loop over it synchronously -- looping would cancel each row's request before the
-    /// previous one produced any output, silently dropping every row but the last.
-    pub(crate) fn dispatch_next_shared_session_row(
+    /// must call this again once the previous row's send settles, not loop over it synchronously
+    /// -- looping would cancel each row's request before the previous one produced any output,
+    /// silently dropping every row but the last.
+    pub(crate) fn dispatch_queued_warp_agent_prompt(
         &mut self,
         conversation_id: AIConversationId,
+        query_id: Option<QueuedQueryId>,
         ctx: &mut ModelContext<Self>,
     ) {
         let has_active_subagent = BlocklistAIHistoryModel::as_ref(ctx)
@@ -165,24 +170,58 @@ impl BlocklistAIController {
             );
             return;
         }
-        let Some(row) = QueuedQueryModel::as_ref(ctx)
-            .queue(conversation_id)
-            .first()
-            .filter(|row| row.shared_session_prompt().is_some())
-            .cloned()
-        else {
+        let row = match query_id {
+            Some(query_id) => QueuedQueryModel::as_ref(ctx)
+                .queue(conversation_id)
+                .iter()
+                .find(|row| row.id() == query_id)
+                .filter(|row| !row.is_command())
+                .cloned(),
+            // Only a plain, unlocked, non-edited row is safe to fire automatically here; a
+            // command, a locked row, or one being edited needs `TerminalInput`/
+            // `drain_queued_prompts` instead, so leave it queued for those to pick up.
+            None => match QueuedQueryModel::as_ref(ctx).peek_autofire(conversation_id) {
+                Some(AutofireAction::Submit { query_id, .. }) => QueuedQueryModel::as_ref(ctx)
+                    .queue(conversation_id)
+                    .iter()
+                    .find(|row| row.id() == query_id)
+                    .cloned(),
+                Some(
+                    AutofireAction::ExecuteCommand { .. } | AutofireAction::PopFromEditMode { .. },
+                )
+                | None => None,
+            },
+        };
+        let Some(row) = row else {
             return;
         };
-        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-            queue.remove_fired_row(conversation_id, row.id(), ctx);
-        });
+        let row_id = row.id();
         log::info!(
-            "event=native_queue_row_dispatched task_id={:?} terminal_id={:?} conversation_id={conversation_id} query_id={:?}",
+            "event=native_queue_row_dispatched task_id={:?} terminal_id={:?} conversation_id={conversation_id} query_id={row_id:?}",
             self.ambient_agent_task_id,
             self.terminal_surface_id,
-            row.id(),
         );
-        self.send_native_startup_injection(conversation_id, row, ctx);
+        if row.shared_session_prompt().is_some() {
+            // `send_native_startup_injection` takes ownership of the row directly rather than
+            // re-resolving it by id, so it's safe to remove up front.
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.remove_fired_row(conversation_id, row_id, ctx);
+            });
+            self.send_native_startup_injection(conversation_id, row, ctx);
+        } else {
+            // The send path resolves this row's attachments by id, so it must still be in the
+            // queue when this is called; remove it only afterward.
+            self.send_queued_user_query_in_conversation(
+                row.text().to_owned(),
+                conversation_id,
+                None,
+                row_id,
+                ctx,
+            );
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.remove_fired_row(conversation_id, row_id, ctx);
+            });
+        }
     }
 
     /// Resolves `row`'s attachments and sends it into `conversation_id` via the normal
@@ -272,48 +311,25 @@ impl BlocklistAIController {
             );
             return;
         };
-        let client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        let api = ServerApiProvider::as_ref(ctx).get();
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let http_client = ServerApiProvider::as_ref(ctx).get_http_client();
         ctx.spawn(
-            async move {
-                let ids = file_downloads
-                    .iter()
-                    .map(|(id, _)| id.clone())
-                    .collect::<Vec<_>>();
-                let urls = client.download_task_attachments(&task_id, &ids).await?;
-                async_fs::create_dir_all(&directory).await?;
-                let mut downloads = Vec::new();
-                for (id, name) in file_downloads {
-                    let url = urls
-                        .attachments
-                        .iter()
-                        .find(|attachment| attachment.attachment_id == id)
-                        .context("Missing queued attachment download URL")?;
-                    let name = sanitize_filename(&name).to_owned();
-                    let path = directory.join(format!("{id}_{name}"));
-                    download_file(api.http_client(), &url.download_url, &path).await?;
-                    downloads.push(DownloadedAttachment {
-                        file_id: id,
-                        file_name: name,
-                        file_path: path.to_string_lossy().into_owned(),
-                    });
-                }
-                anyhow::Ok(build_file_attachment_map(&downloads))
-            },
-            move |controller, result, ctx| match result {
-                Ok(file_attachments) => controller.dispatch_native_startup_injection(
+            download_task_file_attachments(
+                ai_client,
+                http_client,
+                task_id,
+                directory,
+                file_downloads,
+            ),
+            move |controller, downloaded, ctx| {
+                let file_attachments = build_file_attachment_map(&downloaded);
+                controller.dispatch_native_startup_injection(
                     conversation_id,
                     text,
                     participant_id,
                     file_attachments,
                     ctx,
-                ),
-                Err(error) => {
-                    report_error!(
-                        error.context("Could not download attachments for a queued startup prompt"),
-                        extra: { "conversation_id" => %conversation_id, "query_id" => ?query_id }
-                    );
-                }
+                );
             },
         );
     }

--- a/app/src/ai/blocklist/controller/startup_queue.rs
+++ b/app/src/ai/blocklist/controller/startup_queue.rs
@@ -53,8 +53,9 @@ impl BlocklistAIController {
         self.native_prompt_conversation_id
     }
 
-    /// Unbinds this controller from its native conversation, dropping any startup follow-ups
-    /// that never made it out (e.g. the run ended before setup finished).
+    /// Unbinds this controller from its native conversation, dropping any prompts still queued
+    /// for it (e.g. the run ended before setup finished, or before a dispatch that was deferred
+    /// behind an active CLI subagent could go out).
     pub(crate) fn unbind_native_prompt_conversation(&mut self, ctx: &mut ModelContext<Self>) {
         let Some(id) = self.native_prompt_conversation_id.take() else {
             return;
@@ -66,7 +67,7 @@ impl BlocklistAIController {
             self.terminal_surface_id,
         );
         QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-            queue.drain_shared_session_injections(id, ctx);
+            queue.clear_queue(id, ctx);
         });
     }
 

--- a/app/src/ai/blocklist/controller/startup_queue.rs
+++ b/app/src/ai/blocklist/controller/startup_queue.rs
@@ -1,0 +1,336 @@
+use std::collections::HashMap;
+
+use anyhow::{Context as _, anyhow};
+use session_sharing_protocol::common::{AgentAttachment, ParticipantId, ServerConversationToken};
+use warp_errors::report_error;
+use warp_multi_agent_api::AgentType;
+use warpui::{ModelContext, SingletonEntity};
+
+use super::input_context::{input_context_for_request, parse_context_attachments};
+use super::response_stream::RecoveryBudget;
+use super::{BlocklistAIController, RequestInput};
+use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::{
+    AIAgentAttachment, AIAgentContext, AIAgentInput, EntrypointType, RequestMetadata,
+    extract_user_query_mode,
+};
+use crate::ai::attachment_utils::{
+    DownloadedAttachment, build_file_attachment_map, download_file, sanitize_filename,
+};
+use crate::ai::blocklist::{BlocklistAIHistoryModel, QueuedQuery, QueuedQueryId, QueuedQueryModel};
+use crate::server::server_api::ServerApiProvider;
+use crate::terminal::model::BlockId;
+use crate::workspaces::user_workspaces::ResolvedTeamScope;
+
+impl BlocklistAIController {
+    pub(crate) fn prepare_native_prompt_queue(
+        &mut self,
+        restored_conversation_id: Option<AIConversationId>,
+        ctx: &mut ModelContext<Self>,
+    ) -> AIConversationId {
+        if let Some(id) = self.native_prompt_conversation_id {
+            return id;
+        }
+        let id = restored_conversation_id.unwrap_or_else(|| {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.start_new_conversation(self.terminal_surface_id, false, false, false, ctx)
+            })
+        });
+        self.native_prompt_conversation_id = Some(id);
+        log::info!(
+            "event=native_queue_initialized task_id={:?} terminal_id={:?} conversation_id={id} resumed={}",
+            self.ambient_agent_task_id,
+            self.terminal_surface_id,
+            restored_conversation_id.is_some(),
+        );
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| queue.begin_native_setup(id, ctx));
+        id
+    }
+
+    pub(crate) fn native_prompt_conversation_id(&self) -> Option<AIConversationId> {
+        self.native_prompt_conversation_id
+    }
+    pub(crate) fn stop_native_prompt_queue(&mut self, ctx: &mut ModelContext<Self>) {
+        if let Some(id) = self.native_prompt_conversation_id.take() {
+            log::info!(
+                "event=native_queue_stopped task_id={:?} terminal_id={:?} conversation_id={id} unsent_count={}",
+                self.ambient_agent_task_id,
+                self.terminal_surface_id,
+                QueuedQueryModel::as_ref(ctx).queue(id).len(),
+            );
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.cancel_injection_dispatch(id, ctx);
+                queue.begin_native_setup(id, ctx);
+            });
+        }
+    }
+
+    pub(super) fn queue_native_startup_injection(
+        &self,
+        prompt: &str,
+        token: Option<&ServerConversationToken>,
+        attachments: &[AgentAttachment],
+        participant_id: &ParticipantId,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let Some(id) = self.native_prompt_conversation_id else {
+            log::info!(
+                "event=injection_bypassed_queue task_id={:?} terminal_id={:?} participant_id={participant_id} reason=no_native_binding has_target_token={}",
+                self.ambient_agent_task_id,
+                self.terminal_surface_id,
+                token.is_some(),
+            );
+            return false;
+        };
+        if !QueuedQueryModel::as_ref(ctx).has_pending_native_injections(id) {
+            log::info!(
+                "event=injection_bypassed_queue task_id={:?} terminal_id={:?} conversation_id={id} participant_id={participant_id} reason=no_startup_backlog",
+                self.ambient_agent_task_id,
+                self.terminal_surface_id,
+            );
+            return false;
+        }
+        if let Some(token) = token
+            && let Some(target) =
+                self.find_existing_conversation_by_server_token(&token.to_string(), ctx)
+            && target != id
+        {
+            report_error!(
+                "Rejected a startup injection targeting a different native conversation",
+                extra: { "conversation_id" => %id, "target_conversation_id" => %target, "terminal_id" => ?self.terminal_surface_id }
+            );
+            return true;
+        }
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.append(
+                id,
+                QueuedQuery::new_shared_session_prompt(
+                    prompt.to_owned(),
+                    participant_id.clone(),
+                    attachments.to_vec(),
+                )
+                .with_shared_session_target(token.cloned()),
+                ctx,
+            );
+        });
+        true
+    }
+
+    pub(crate) fn send_queued_shared_session_prompt(
+        &mut self,
+        conversation_id: AIConversationId,
+        query_id: QueuedQueryId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let has_active_stream = self.has_active_stream_for_conversation(conversation_id, ctx);
+        let has_active_subagent = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .is_some_and(|conversation| conversation.has_active_subagent());
+        if has_active_stream || has_active_subagent {
+            log::info!(
+                "event=dispatch_deferred conversation_id={conversation_id} query_id={query_id:?} active_stream={has_active_stream} active_subagent={has_active_subagent}",
+            );
+            return;
+        }
+        let row = QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.claim_injection(conversation_id, query_id, ctx)
+        });
+        let Some(row) = row else { return };
+        let (_, attachments) = row.shared_session_prompt().unwrap();
+        let files: Vec<_> = attachments
+            .iter()
+            .filter_map(|attachment| match attachment {
+                AgentAttachment::FileReference {
+                    attachment_id,
+                    file_name,
+                } => Some((attachment_id.clone(), file_name.clone())),
+                AgentAttachment::PlainText { .. } | AgentAttachment::BlockReference { .. } => None,
+            })
+            .collect();
+        if files.is_empty() {
+            self.finish_queued_injection(conversation_id, row, Ok(HashMap::new()), ctx);
+            return;
+        }
+        log::info!(
+            "event=queued_attachment_download_started conversation_id={conversation_id} query_id={query_id:?} file_count={}",
+            files.len(),
+        );
+        let Some((task_id, directory)) = self
+            .ambient_agent_task_id
+            .zip(self.attachments_download_dir.clone())
+        else {
+            self.finish_queued_injection(
+                conversation_id,
+                row,
+                Err(anyhow!("Missing native attachment download configuration")),
+                ctx,
+            );
+            return;
+        };
+        let client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let api = ServerApiProvider::as_ref(ctx).get();
+        ctx.spawn(
+            async move {
+                let ids = files.iter().map(|(id, _)| id.clone()).collect::<Vec<_>>();
+                let urls = client.download_task_attachments(&task_id, &ids).await?;
+                async_fs::create_dir_all(&directory).await?;
+                let mut downloads = Vec::new();
+                for (id, name) in files {
+                    let url = urls
+                        .attachments
+                        .iter()
+                        .find(|attachment| attachment.attachment_id == id)
+                        .context("Missing queued attachment download URL")?;
+                    let name = sanitize_filename(&name).to_owned();
+                    let path = directory.join(format!("{id}_{name}"));
+                    download_file(api.http_client(), &url.download_url, &path).await?;
+                    downloads.push(DownloadedAttachment {
+                        file_id: id,
+                        file_name: name,
+                        file_path: path.to_string_lossy().into_owned(),
+                    });
+                }
+                Ok(build_file_attachment_map(&downloads))
+            },
+            move |controller, result, ctx| {
+                controller.finish_queued_injection(conversation_id, row, result, ctx)
+            },
+        );
+    }
+
+    fn finish_queued_injection(
+        &mut self,
+        conversation_id: AIConversationId,
+        row: QueuedQuery,
+        files: anyhow::Result<HashMap<String, AIAgentAttachment>>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if !QueuedQueryModel::as_ref(ctx).is_injection_dispatch_current(conversation_id, row.id()) {
+            log::info!(
+                "event=dispatch_abandoned conversation_id={conversation_id} query_id={:?} reason=claim_invalidated",
+                row.id(),
+            );
+            return;
+        }
+        let result = files.and_then(|files| {
+            let request = self.queued_injection_request(conversation_id, &row, files, ctx)?;
+            if let Some(participant_id) = request.shared_session_response_initiator.clone() {
+                self.set_current_response_initiator(participant_id);
+            }
+            self.send_request_input(
+                request,
+                Some(RequestMetadata {
+                    is_autodetected_user_query: false,
+                    entrypoint: EntrypointType::SharedSession,
+                    is_auto_resume_after_error: false,
+                }),
+                RecoveryBudget::fresh(),
+                true,
+                ctx,
+            )
+            .map(|(_, stream_id)| {
+                log::info!(
+                    "event=dispatch_accepted task_id={:?} terminal_id={:?} conversation_id={conversation_id} query_id={:?} stream_id={stream_id:?} queue_len_after={}",
+                    self.ambient_agent_task_id, self.terminal_surface_id, row.id(),
+                    QueuedQueryModel::as_ref(ctx).queue(conversation_id).len().saturating_sub(1),
+                );
+            })
+        });
+        let error = result.err().map(|error| {
+            report_error!(
+                error.context("Could not dispatch queued native prompt"),
+                extra: { "conversation_id" => %conversation_id, "query_id" => ?row.id(), "terminal_id" => ?self.terminal_surface_id }
+            );
+            "Could not send a queued prompt. The unsent prompt remains queued.".to_owned()
+        });
+        QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+            queue.finish_injection_dispatch(conversation_id, row.id(), error, ctx);
+        });
+    }
+
+    fn queued_injection_request(
+        &self,
+        conversation_id: AIConversationId,
+        row: &QueuedQuery,
+        files: HashMap<String, AIAgentAttachment>,
+        ctx: &ModelContext<Self>,
+    ) -> anyhow::Result<RequestInput> {
+        let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .context("Queued native conversation no longer exists")?;
+        if let Some(token) = row.shared_session_target()
+            && conversation
+                .server_conversation_token()
+                .map(|value| value.as_str())
+                != Some(token.to_string().as_str())
+        {
+            return Err(anyhow!(
+                "Queued prompt targets a different server conversation"
+            ));
+        }
+        if matches!(
+            conversation.status(),
+            ConversationStatus::Cancelled | ConversationStatus::Error
+        ) {
+            return Err(anyhow!(
+                "Queued native conversation stopped before dispatch"
+            ));
+        }
+        let task_id = conversation.get_root_task_id().clone();
+        let (participant_id, attachments) = row
+            .shared_session_prompt()
+            .context("Expected an injected prompt")?;
+        let context_model = self.context_model.as_ref(ctx);
+        let mut extra_context = Vec::new();
+        for attachment in attachments {
+            match attachment {
+                AgentAttachment::PlainText { content } => {
+                    extra_context.push(AIAgentContext::SelectedText(content.clone()))
+                }
+                AgentAttachment::BlockReference { block_id } => {
+                    if let Some(context) = context_model
+                        .transform_block_to_context(&BlockId::from(block_id.to_string()), false)
+                    {
+                        extra_context.push(context);
+                    }
+                }
+                AgentAttachment::FileReference { .. } => {}
+            }
+        }
+        let context = input_context_for_request(
+            false,
+            context_model,
+            self.active_session.as_ref(ctx),
+            Some(conversation_id),
+            extra_context,
+            ctx,
+        );
+        let (query, user_query_mode) = extract_user_query_mode(row.text().to_owned());
+        let mut referenced_attachments = parse_context_attachments(&query, context_model, ctx);
+        referenced_attachments.extend(files);
+        let input = AIAgentInput::UserQuery {
+            query,
+            context,
+            static_query_type: None,
+            referenced_attachments,
+            user_query_mode,
+            running_command: None,
+            intended_agent: Some(AgentType::Primary),
+        };
+        let scope = ResolvedTeamScope::from_scope(&self.team_context(ctx));
+        Ok(RequestInput::for_task(
+            vec![input],
+            task_id,
+            &self.active_session,
+            Some(participant_id.clone()),
+            conversation_id,
+            self.terminal_surface_id,
+            &scope,
+            ctx,
+        ))
+    }
+}
+
+#[cfg(test)]
+#[path = "startup_queue_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/controller/startup_queue_tests.rs
+++ b/app/src/ai/blocklist/controller/startup_queue_tests.rs
@@ -22,7 +22,7 @@ fn user_queries_in_order(history: &BlocklistAIHistoryModel, id: AIConversationId
 }
 
 #[test]
-fn startup_injections_queued_before_the_initial_prompt_are_all_sent_once_it_goes_out() {
+fn startup_injections_queued_before_the_initial_prompt_are_dispatched_one_at_a_time() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
@@ -60,22 +60,30 @@ fn startup_injections_queued_before_the_initial_prompt_are_all_sent_once_it_goes
             terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
         });
 
-        // Mirrors what `AgentDriver::execute_run` does: send the initial prompt, then drain.
+        // Mirrors what `AgentDriver::execute_run` does: send the initial prompt, then dispatch
+        // the head of the backlog.
         controller.update(&mut app, |controller, ctx| {
             controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-            controller.drain_native_startup_queue(id, ctx);
+            controller.dispatch_next_shared_session_row(id, ctx);
         });
 
-        QueuedQueryModel::handle(&app).read(&app, |queue, _| assert!(!queue.has_queue(id)));
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["prompt3"],
+                "only the head row (prompt2) should have been dispatched; prompt3 waits for the \
+                 next natural boundary or the conversation going idle again"
+            );
+        });
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
             assert_eq!(
                 user_queries_in_order(history, id),
-                vec![
-                    "prompt1".to_owned(),
-                    "prompt2".to_owned(),
-                    "prompt3".to_owned()
-                ],
-                "all three should be sent, in order, without waiting for any turn to complete"
+                vec!["prompt1".to_owned(), "prompt2".to_owned()],
+                "prompt1 and prompt2 should both have been sent, each as its own exchange"
             );
         });
         controller.read(&app, |controller, ctx| {
@@ -85,15 +93,15 @@ fn startup_injections_queued_before_the_initial_prompt_are_all_sent_once_it_goes
             assert_eq!(
                 streams.len(),
                 1,
-                "only the last prompt's turn should still be active; the earlier two were \
-                 interrupted the same way a rapid live follow-up interrupts a prior turn"
+                "prompt2's turn should be active; prompt1's was interrupted the same way a \
+                 rapid live follow-up interrupts a prior turn"
             );
         });
     });
 }
 
 #[test]
-fn live_injection_after_setup_bypasses_the_queue_and_interrupts_the_active_turn() {
+fn live_injection_while_a_turn_is_active_is_queued_instead_of_interrupting_it() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
@@ -107,7 +115,7 @@ fn live_injection_after_setup_bypasses_the_queue_and_interrupts_the_active_turn(
         });
         let initial_streams = controller.update(&mut app, |controller, ctx| {
             controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-            controller.drain_native_startup_queue(id, ctx);
+            controller.dispatch_next_shared_session_row(id, ctx);
             assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
             controller
                 .in_flight_response_streams
@@ -115,8 +123,9 @@ fn live_injection_after_setup_bypasses_the_queue_and_interrupts_the_active_turn(
         });
         assert_eq!(initial_streams.len(), 1);
 
-        // Nothing is queued ahead of it and setup already finished, so this must bypass the
-        // queue entirely and interrupt the active turn -- the same way a live follow-up would.
+        // A stream is already active for the conversation, so this must be queued rather than
+        // dispatched immediately -- dispatching now would interrupt prompt1's turn before it
+        // produced any output, silently dropping it.
         controller.update(&mut app, |controller, ctx| {
             controller.execute_warp_agent_prompt_from_shared_session_injection(
                 "prompt2".into(),
@@ -127,20 +136,28 @@ fn live_injection_after_setup_bypasses_the_queue_and_interrupts_the_active_turn(
             );
         });
         controller.read(&app, |controller, ctx| {
-            assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
+            assert_eq!(
+                QueuedQueryModel::as_ref(ctx)
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["prompt2"],
+                "prompt2 should be queued, not dispatched, while prompt1's turn is active"
+            );
             let after_streams = controller
                 .in_flight_response_streams
                 .stream_ids_for_conversation(id, ctx);
-            assert_eq!(after_streams.len(), 1);
-            assert_ne!(
+            assert_eq!(
                 after_streams, initial_streams,
-                "prompt2 should have interrupted prompt1's stream with its own"
+                "prompt1's stream should be untouched"
             );
         });
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
             assert_eq!(
                 user_queries_in_order(history, id),
-                vec!["prompt1".to_owned(), "prompt2".to_owned()]
+                vec!["prompt1".to_owned()],
+                "prompt2 should not have been sent yet"
             );
         });
     });
@@ -215,7 +232,7 @@ fn drained_injection_stages_attachments_and_attributes_the_exchange_to_its_parti
         });
         controller.update(&mut app, |controller, ctx| {
             controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-            controller.drain_native_startup_queue(id, ctx);
+            controller.dispatch_next_shared_session_row(id, ctx);
         });
 
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {

--- a/app/src/ai/blocklist/controller/startup_queue_tests.rs
+++ b/app/src/ai/blocklist/controller/startup_queue_tests.rs
@@ -467,6 +467,27 @@ fn native_initial_prompt_uses_its_bound_conversation_without_agent_view() {
 }
 
 #[test]
+fn unbind_native_prompt_conversation_releases_the_setup_barrier() {
+    // Regression test: unbinding while setup never finished must not leave the conversation
+    // permanently dispatch-blocked, since nothing else would ever release that barrier.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                let id = controller.bind_native_prompt_conversation(None, ctx);
+                assert!(QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(id));
+
+                controller.unbind_native_prompt_conversation(ctx);
+
+                assert!(!QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(id));
+                assert!(!QueuedQueryModel::as_ref(ctx).has_pending_native_injections(id));
+            });
+        });
+    });
+}
+
+#[test]
 fn unbind_native_prompt_conversation_drops_any_prompts_still_queued() {
     // Covers both a shared-session-injected row and a plain local row (e.g. from `/queue`
     // against this same conversation while it's native-bound) -- unbinding must clear the

--- a/app/src/ai/blocklist/controller/startup_queue_tests.rs
+++ b/app/src/ai/blocklist/controller/startup_queue_tests.rs
@@ -468,6 +468,9 @@ fn native_initial_prompt_uses_its_bound_conversation_without_agent_view() {
 
 #[test]
 fn unbind_native_prompt_conversation_drops_any_prompts_still_queued() {
+    // Covers both a shared-session-injected row and a plain local row (e.g. from `/queue`
+    // against this same conversation while it's native-bound) -- unbinding must clear the
+    // whole queue, not just the shared-session-injected rows within it.
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let terminal = add_window_with_terminal(&mut app, None);
@@ -481,7 +484,17 @@ fn unbind_native_prompt_conversation_drops_any_prompts_still_queued() {
                     ParticipantId::new(),
                     ctx,
                 );
-                assert_eq!(QueuedQueryModel::as_ref(ctx).queue(id).len(), 1);
+                QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                    queue.append(
+                        id,
+                        QueuedQuery::new(
+                            "local pending".into(),
+                            QueuedQueryOrigin::QueueSlashCommand,
+                        ),
+                        ctx,
+                    );
+                });
+                assert_eq!(QueuedQueryModel::as_ref(ctx).queue(id).len(), 2);
 
                 controller.unbind_native_prompt_conversation(ctx);
 

--- a/app/src/ai/blocklist/controller/startup_queue_tests.rs
+++ b/app/src/ai/blocklist/controller/startup_queue_tests.rs
@@ -1,0 +1,430 @@
+use std::collections::HashMap;
+
+use session_sharing_protocol::common::{AgentAttachment, ParticipantId};
+use uuid::Uuid;
+use warp_core::features::FeatureFlag;
+use warp_multi_agent_api::response_event::StreamInit;
+use warpui::{App, ModelContext, SingletonEntity};
+
+use super::*;
+use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
+use crate::ai::blocklist::{BlocklistAIControllerEvent, QueuedQueryOrigin};
+use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
+
+fn finish_turn(
+    controller: &mut BlocklistAIController,
+    conversation_id: AIConversationId,
+    ctx: &mut ModelContext<BlocklistAIController>,
+) {
+    let streams = controller
+        .in_flight_response_streams
+        .stream_ids_for_conversation(conversation_id, ctx);
+    assert_eq!(streams.len(), 1);
+    let stream_id = streams[0].clone();
+    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+        let server_token = history
+            .conversation(&conversation_id)
+            .unwrap()
+            .server_conversation_token()
+            .map(|token| token.as_str().to_owned())
+            .unwrap_or_else(|| "550e8400-e29b-41d4-a716-446655440a00".into());
+        history.initialize_output_for_response_stream(
+            &stream_id,
+            conversation_id,
+            controller.terminal_surface_id,
+            StreamInit {
+                request_id: "test-request".into(),
+                conversation_id: server_token,
+                run_id: String::new(),
+            },
+            ctx,
+        );
+        history.mark_response_stream_completed_successfully(
+            &stream_id,
+            conversation_id,
+            controller.terminal_surface_id,
+            ctx,
+        );
+    });
+    controller
+        .in_flight_response_streams
+        .cleanup_stream(&stream_id);
+    ctx.emit(BlocklistAIControllerEvent::FinishedReceivingOutput {
+        stream_id,
+        conversation_id,
+    });
+}
+
+#[test]
+fn startup_injections_continue_after_each_turn_without_losing_the_middle_prompt() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _queue_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(false);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
+        let participant = ParticipantId::new();
+        let id = controller.update(&mut app, |controller, ctx| {
+            let id = controller.prepare_native_prompt_queue(None, ctx);
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt2".into(),
+                None,
+                vec![],
+                participant.clone(),
+                ctx,
+            );
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt3".into(),
+                None,
+                vec![],
+                participant.clone(),
+                ctx,
+            );
+            assert_eq!(
+                BlocklistAIHistoryModel::as_ref(ctx)
+                    .conversation(&id)
+                    .unwrap()
+                    .exchange_count(),
+                0
+            );
+            assert!(QueuedQueryModel::as_ref(ctx).peek_autofire(id).is_none());
+            id
+        });
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
+        });
+        controller.update(&mut app, |controller, ctx| {
+            controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
+        });
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.input().update(ctx, |input, ctx| {
+                input.replace_buffer_content("local draft", ctx)
+            });
+        });
+        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["prompt3"]
+            );
+        });
+        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            let conversation = history.conversation(&id).unwrap();
+            let prompts: Vec<_> = conversation
+                .root_task_exchanges()
+                .flat_map(|exchange| exchange.input.iter())
+                .filter_map(|input| match input {
+                    AIAgentInput::UserQuery { query, .. } => Some(query.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(prompts, vec!["prompt1", "prompt2", "prompt3"]);
+        });
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| assert!(!queue.has_queue(id)));
+        terminal.read(&app, |terminal, ctx| {
+            assert_eq!(terminal.input().as_ref(ctx).buffer_text(ctx), "local draft")
+        });
+    });
+}
+
+#[test]
+fn injections_during_initial_turn_queue_without_interrupting_it() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
+        let id = controller.update(&mut app, |controller, ctx| {
+            controller.prepare_native_prompt_queue(None, ctx)
+        });
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
+        });
+        let token = ServerConversationToken::from_uuid(Uuid::new_v4());
+        let initial_streams = controller.update(&mut app, |controller, ctx| {
+            controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
+            let streams = controller
+                .in_flight_response_streams
+                .stream_ids_for_conversation(id, ctx);
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.initialize_output_for_response_stream(
+                    &streams[0],
+                    id,
+                    controller.terminal_surface_id,
+                    StreamInit {
+                        request_id: "initial-request".into(),
+                        conversation_id: token.to_string(),
+                        run_id: String::new(),
+                    },
+                    ctx,
+                );
+            });
+            assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
+            streams
+        });
+        controller.update(&mut app, |controller, ctx| {
+            let participant = ParticipantId::new();
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt2".into(),
+                Some(token),
+                vec![],
+                participant.clone(),
+                ctx,
+            );
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt3".into(),
+                Some(token),
+                vec![],
+                participant,
+                ctx,
+            );
+            assert_eq!(
+                controller
+                    .in_flight_response_streams
+                    .stream_ids_for_conversation(id, ctx),
+                initial_streams,
+                "startup injections must not cancel the initial stream",
+            );
+            assert_eq!(
+                QueuedQueryModel::as_ref(ctx)
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["prompt2", "prompt3"]
+            );
+        });
+        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["prompt3"]
+            );
+        });
+        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            let prompts: Vec<_> = history
+                .conversation(&id)
+                .unwrap()
+                .root_task_exchanges()
+                .flat_map(|exchange| exchange.input.iter())
+                .filter_map(|input| match input {
+                    AIAgentInput::UserQuery { query, .. } => Some(query.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(prompts, vec!["prompt1", "prompt2", "prompt3"]);
+        });
+    });
+}
+
+#[test]
+fn queued_injection_context_keeps_attribution_and_does_not_consume_live_staging() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                let id = controller.prepare_native_prompt_queue(None, ctx);
+                controller.context_model.update(ctx, |context, ctx| {
+                    context.set_pending_context_selected_text(
+                        Some("local selection".into()),
+                        false,
+                        ctx,
+                    );
+                });
+                let participant = ParticipantId::new();
+                let row = QueuedQuery::new_shared_session_prompt(
+                    "prompt2".into(),
+                    participant.clone(),
+                    vec![AgentAttachment::PlainText {
+                        content: "remote context".into(),
+                    }],
+                );
+                let request = controller
+                    .queued_injection_request(id, &row, HashMap::new(), ctx)
+                    .unwrap();
+                assert_eq!(request.conversation_id, id);
+                assert_eq!(request.shared_session_response_initiator, Some(participant));
+                let AIAgentInput::UserQuery { context, .. } = request.all_inputs().next().unwrap()
+                else {
+                    panic!("expected prompt")
+                };
+                let selected: Vec<_> = context
+                    .iter()
+                    .filter_map(|context| match context {
+                        AIAgentContext::SelectedText(text) => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(selected, vec!["remote context"]);
+                assert_eq!(
+                    controller
+                        .context_model
+                        .as_ref(ctx)
+                        .pending_context_selected_text()
+                        .map(String::as_str),
+                    Some("local selection")
+                );
+            });
+        });
+    });
+}
+
+#[test]
+fn startup_injections_reuse_the_restored_conversation() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |terminal, ctx| {
+            let restored = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.start_new_conversation(terminal.id(), false, false, false, ctx)
+            });
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                assert_eq!(
+                    controller.prepare_native_prompt_queue(Some(restored), ctx),
+                    restored
+                );
+                assert_eq!(controller.prepare_native_prompt_queue(None, ctx), restored);
+                controller.execute_warp_agent_prompt_from_shared_session_injection(
+                    "followup".into(),
+                    None,
+                    vec![],
+                    ParticipantId::new(),
+                    ctx,
+                );
+                let row = &QueuedQueryModel::as_ref(ctx).queue(restored)[0];
+                assert_eq!(row.text(), "followup");
+                assert_eq!(row.origin(), QueuedQueryOrigin::SharedSessionInjection);
+                assert_eq!(
+                    BlocklistAIHistoryModel::as_ref(ctx)
+                        .conversation(&restored)
+                        .unwrap()
+                        .exchange_count(),
+                    0
+                );
+            });
+        });
+    });
+}
+
+#[test]
+fn startup_injection_retains_a_token_until_the_initial_response_binds_it() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                let id = controller.prepare_native_prompt_queue(None, ctx);
+                let token = ServerConversationToken::from_uuid(Uuid::new_v4());
+                controller.execute_warp_agent_prompt_from_shared_session_injection(
+                    "followup".into(),
+                    Some(token),
+                    vec![],
+                    ParticipantId::new(),
+                    ctx,
+                );
+                let row = QueuedQueryModel::as_ref(ctx).queue(id)[0].clone();
+                assert_eq!(row.shared_session_target(), Some(&token));
+                assert!(
+                    controller
+                        .queued_injection_request(id, &row, HashMap::new(), ctx)
+                        .is_err()
+                );
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
+                    history.set_server_conversation_token_for_conversation(id, token.to_string());
+                });
+                assert_eq!(
+                    controller
+                        .queued_injection_request(id, &row, HashMap::new(), ctx)
+                        .unwrap()
+                        .conversation_id,
+                    id
+                );
+            });
+        });
+    });
+}
+
+#[test]
+fn native_initial_prompt_uses_its_bound_conversation_without_agent_view() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(false);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                let id = controller.prepare_native_prompt_queue(None, ctx);
+                controller.execute_warp_agent_prompt_from_shared_session_injection(
+                    "followup".into(),
+                    None,
+                    vec![],
+                    ParticipantId::new(),
+                    ctx,
+                );
+                controller.send_ai_input_with_context(
+                    |context| AIAgentInput::StartFromAmbientRunPrompt {
+                        ambient_run_id: "550e8400-e29b-41d4-a716-446655440a00".into(),
+                        context,
+                        runtime_skill: None,
+                        attachments_dir: None,
+                    },
+                    ctx,
+                );
+                assert_eq!(
+                    BlocklistAIHistoryModel::as_ref(ctx)
+                        .conversation(&id)
+                        .unwrap()
+                        .exchange_count(),
+                    1
+                );
+                assert!(QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(id));
+                assert_eq!(QueuedQueryModel::as_ref(ctx).queue(id).len(), 1);
+            });
+        });
+    });
+}
+
+#[test]
+fn stopped_worker_cannot_dispatch_a_downloaded_prompt() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                let id = controller.prepare_native_prompt_queue(None, ctx);
+                let row = QueuedQuery::new_shared_session_prompt(
+                    "pending".into(),
+                    ParticipantId::new(),
+                    vec![],
+                );
+                let query_id = row.id();
+                QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                    queue.append(id, row.clone(), ctx);
+                    queue.finish_native_setup(id, ctx);
+                    queue.finish_native_initial_turn(id, ctx);
+                    assert!(queue.claim_injection(id, query_id, ctx).is_some());
+                });
+                controller.stop_native_prompt_queue(ctx);
+                controller.finish_queued_injection(id, row, Ok(HashMap::new()), ctx);
+                assert_eq!(
+                    BlocklistAIHistoryModel::as_ref(ctx)
+                        .conversation(&id)
+                        .unwrap()
+                        .exchange_count(),
+                    0
+                );
+                assert_eq!(QueuedQueryModel::as_ref(ctx).queue(id).len(), 1);
+            });
+        });
+    });
+}

--- a/app/src/ai/blocklist/controller/startup_queue_tests.rs
+++ b/app/src/ai/blocklist/controller/startup_queue_tests.rs
@@ -1,71 +1,36 @@
-use std::collections::HashMap;
-
-use session_sharing_protocol::common::{AgentAttachment, ParticipantId};
 use uuid::Uuid;
-use warp_core::features::FeatureFlag;
-use warp_multi_agent_api::response_event::StreamInit;
-use warpui::{App, ModelContext, SingletonEntity};
+use warpui::App;
 
 use super::*;
-use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
-use crate::ai::blocklist::{BlocklistAIControllerEvent, QueuedQueryOrigin};
+use crate::ai::agent::{AIAgentContext, AIAgentInput};
+use crate::ai::blocklist::QueuedQueryOrigin;
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
 
-fn finish_turn(
-    controller: &mut BlocklistAIController,
-    conversation_id: AIConversationId,
-    ctx: &mut ModelContext<BlocklistAIController>,
-) {
-    let streams = controller
-        .in_flight_response_streams
-        .stream_ids_for_conversation(conversation_id, ctx);
-    assert_eq!(streams.len(), 1);
-    let stream_id = streams[0].clone();
-    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-        let server_token = history
-            .conversation(&conversation_id)
-            .unwrap()
-            .server_conversation_token()
-            .map(|token| token.as_str().to_owned())
-            .unwrap_or_else(|| "550e8400-e29b-41d4-a716-446655440a00".into());
-        history.initialize_output_for_response_stream(
-            &stream_id,
-            conversation_id,
-            controller.terminal_surface_id,
-            StreamInit {
-                request_id: "test-request".into(),
-                conversation_id: server_token,
-                run_id: String::new(),
-            },
-            ctx,
-        );
-        history.mark_response_stream_completed_successfully(
-            &stream_id,
-            conversation_id,
-            controller.terminal_surface_id,
-            ctx,
-        );
-    });
-    controller
-        .in_flight_response_streams
-        .cleanup_stream(&stream_id);
-    ctx.emit(BlocklistAIControllerEvent::FinishedReceivingOutput {
-        stream_id,
-        conversation_id,
-    });
+/// The text of every `UserQuery` input across `id`'s root-task exchanges, in the order they
+/// were appended to history.
+fn user_queries_in_order(history: &BlocklistAIHistoryModel, id: AIConversationId) -> Vec<String> {
+    history
+        .conversation(&id)
+        .unwrap()
+        .root_task_exchanges()
+        .flat_map(|exchange| exchange.input.iter())
+        .filter_map(|input| match input {
+            AIAgentInput::UserQuery { query, .. } => Some(query.clone()),
+            _ => None,
+        })
+        .collect()
 }
 
 #[test]
-fn startup_injections_continue_after_each_turn_without_losing_the_middle_prompt() {
+fn startup_injections_queued_before_the_initial_prompt_are_all_sent_once_it_goes_out() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
-        let _queue_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(false);
         let terminal = add_window_with_terminal(&mut app, None);
         let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
         let participant = ParticipantId::new();
         let id = controller.update(&mut app, |controller, ctx| {
-            let id = controller.prepare_native_prompt_queue(None, ctx);
+            let id = controller.bind_native_prompt_conversation(None, ctx);
             controller.execute_warp_agent_prompt_from_shared_session_injection(
                 "prompt2".into(),
                 None,
@@ -79,116 +44,6 @@ fn startup_injections_continue_after_each_turn_without_losing_the_middle_prompt(
                 vec![],
                 participant.clone(),
                 ctx,
-            );
-            assert_eq!(
-                BlocklistAIHistoryModel::as_ref(ctx)
-                    .conversation(&id)
-                    .unwrap()
-                    .exchange_count(),
-                0
-            );
-            assert!(QueuedQueryModel::as_ref(ctx).peek_autofire(id).is_none());
-            id
-        });
-        terminal.update(&mut app, |terminal, ctx| {
-            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
-        });
-        controller.update(&mut app, |controller, ctx| {
-            controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-        });
-        terminal.update(&mut app, |terminal, ctx| {
-            terminal.input().update(ctx, |input, ctx| {
-                input.replace_buffer_content("local draft", ctx)
-            });
-        });
-        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
-        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
-            assert_eq!(
-                queue
-                    .queue(id)
-                    .iter()
-                    .map(QueuedQuery::text)
-                    .collect::<Vec<_>>(),
-                vec!["prompt3"]
-            );
-        });
-        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
-        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
-            let conversation = history.conversation(&id).unwrap();
-            let prompts: Vec<_> = conversation
-                .root_task_exchanges()
-                .flat_map(|exchange| exchange.input.iter())
-                .filter_map(|input| match input {
-                    AIAgentInput::UserQuery { query, .. } => Some(query.as_str()),
-                    _ => None,
-                })
-                .collect();
-            assert_eq!(prompts, vec!["prompt1", "prompt2", "prompt3"]);
-        });
-        QueuedQueryModel::handle(&app).read(&app, |queue, _| assert!(!queue.has_queue(id)));
-        terminal.read(&app, |terminal, ctx| {
-            assert_eq!(terminal.input().as_ref(ctx).buffer_text(ctx), "local draft")
-        });
-    });
-}
-
-#[test]
-fn injections_during_initial_turn_queue_without_interrupting_it() {
-    App::test((), |mut app| async move {
-        initialize_app_for_terminal_view(&mut app);
-        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
-        let terminal = add_window_with_terminal(&mut app, None);
-        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
-        let id = controller.update(&mut app, |controller, ctx| {
-            controller.prepare_native_prompt_queue(None, ctx)
-        });
-        terminal.update(&mut app, |terminal, ctx| {
-            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
-        });
-        let token = ServerConversationToken::from_uuid(Uuid::new_v4());
-        let initial_streams = controller.update(&mut app, |controller, ctx| {
-            controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-            let streams = controller
-                .in_flight_response_streams
-                .stream_ids_for_conversation(id, ctx);
-            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-                history.initialize_output_for_response_stream(
-                    &streams[0],
-                    id,
-                    controller.terminal_surface_id,
-                    StreamInit {
-                        request_id: "initial-request".into(),
-                        conversation_id: token.to_string(),
-                        run_id: String::new(),
-                    },
-                    ctx,
-                );
-            });
-            assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
-            streams
-        });
-        controller.update(&mut app, |controller, ctx| {
-            let participant = ParticipantId::new();
-            controller.execute_warp_agent_prompt_from_shared_session_injection(
-                "prompt2".into(),
-                Some(token),
-                vec![],
-                participant.clone(),
-                ctx,
-            );
-            controller.execute_warp_agent_prompt_from_shared_session_injection(
-                "prompt3".into(),
-                Some(token),
-                vec![],
-                participant,
-                ctx,
-            );
-            assert_eq!(
-                controller
-                    .in_flight_response_streams
-                    .stream_ids_for_conversation(id, ctx),
-                initial_streams,
-                "startup injections must not cancel the initial stream",
             );
             assert_eq!(
                 QueuedQueryModel::as_ref(ctx)
@@ -196,86 +51,200 @@ fn injections_during_initial_turn_queue_without_interrupting_it() {
                     .iter()
                     .map(QueuedQuery::text)
                     .collect::<Vec<_>>(),
-                vec!["prompt2", "prompt3"]
+                vec!["prompt2", "prompt3"],
+                "both should be held behind the not-yet-sent initial prompt"
             );
+            id
         });
-        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
-        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
-            assert_eq!(
-                queue
-                    .queue(id)
-                    .iter()
-                    .map(QueuedQuery::text)
-                    .collect::<Vec<_>>(),
-                vec!["prompt3"]
-            );
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
         });
-        controller.update(&mut app, |controller, ctx| finish_turn(controller, id, ctx));
+
+        // Mirrors what `AgentDriver::execute_run` does: send the initial prompt, then drain.
+        controller.update(&mut app, |controller, ctx| {
+            controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
+            controller.drain_native_startup_queue(id, ctx);
+        });
+
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| assert!(!queue.has_queue(id)));
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
-            let prompts: Vec<_> = history
-                .conversation(&id)
-                .unwrap()
-                .root_task_exchanges()
-                .flat_map(|exchange| exchange.input.iter())
-                .filter_map(|input| match input {
-                    AIAgentInput::UserQuery { query, .. } => Some(query.as_str()),
-                    _ => None,
-                })
-                .collect();
-            assert_eq!(prompts, vec!["prompt1", "prompt2", "prompt3"]);
+            assert_eq!(
+                user_queries_in_order(history, id),
+                vec![
+                    "prompt1".to_owned(),
+                    "prompt2".to_owned(),
+                    "prompt3".to_owned()
+                ],
+                "all three should be sent, in order, without waiting for any turn to complete"
+            );
+        });
+        controller.read(&app, |controller, ctx| {
+            let streams = controller
+                .in_flight_response_streams
+                .stream_ids_for_conversation(id, ctx);
+            assert_eq!(
+                streams.len(),
+                1,
+                "only the last prompt's turn should still be active; the earlier two were \
+                 interrupted the same way a rapid live follow-up interrupts a prior turn"
+            );
         });
     });
 }
 
 #[test]
-fn queued_injection_context_keeps_attribution_and_does_not_consume_live_staging() {
+fn live_injection_after_setup_bypasses_the_queue_and_interrupts_the_active_turn() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
+        let id = controller.update(&mut app, |controller, ctx| {
+            controller.bind_native_prompt_conversation(None, ctx)
+        });
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
+        });
+        let initial_streams = controller.update(&mut app, |controller, ctx| {
+            controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
+            controller.drain_native_startup_queue(id, ctx);
+            assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
+            controller
+                .in_flight_response_streams
+                .stream_ids_for_conversation(id, ctx)
+        });
+        assert_eq!(initial_streams.len(), 1);
+
+        // Nothing is queued ahead of it and setup already finished, so this must bypass the
+        // queue entirely and interrupt the active turn -- the same way a live follow-up would.
+        controller.update(&mut app, |controller, ctx| {
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt2".into(),
+                None,
+                vec![],
+                ParticipantId::new(),
+                ctx,
+            );
+        });
+        controller.read(&app, |controller, ctx| {
+            assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
+            let after_streams = controller
+                .in_flight_response_streams
+                .stream_ids_for_conversation(id, ctx);
+            assert_eq!(after_streams.len(), 1);
+            assert_ne!(
+                after_streams, initial_streams,
+                "prompt2 should have interrupted prompt1's stream with its own"
+            );
+        });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                user_queries_in_order(history, id),
+                vec!["prompt1".to_owned(), "prompt2".to_owned()]
+            );
+        });
+    });
+}
+
+#[test]
+fn route_native_startup_injection_rejects_a_prompt_targeting_a_different_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let terminal = add_window_with_terminal(&mut app, None);
+        let other_token_str = "550e8400-e29b-41d4-a716-446655440b00";
+        let other_id = terminal.update(&mut app, |terminal, ctx| {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                let other_id =
+                    history.start_new_conversation(terminal.id(), false, false, false, ctx);
+                history.set_server_conversation_token_for_conversation(
+                    other_id,
+                    other_token_str.to_owned(),
+                );
+                other_id
+            })
+        });
+        let other_token =
+            ServerConversationToken::from_uuid(Uuid::parse_str(other_token_str).unwrap());
+
         terminal.update(&mut app, |terminal, ctx| {
             terminal.ai_controller().update(ctx, |controller, ctx| {
-                let id = controller.prepare_native_prompt_queue(None, ctx);
-                controller.context_model.update(ctx, |context, ctx| {
-                    context.set_pending_context_selected_text(
-                        Some("local selection".into()),
-                        false,
-                        ctx,
-                    );
-                });
-                let participant = ParticipantId::new();
-                let row = QueuedQuery::new_shared_session_prompt(
-                    "prompt2".into(),
-                    participant.clone(),
-                    vec![AgentAttachment::PlainText {
-                        content: "remote context".into(),
-                    }],
+                let id = controller.bind_native_prompt_conversation(None, ctx);
+                controller.execute_warp_agent_prompt_from_shared_session_injection(
+                    "wrong target".into(),
+                    Some(other_token),
+                    vec![],
+                    ParticipantId::new(),
+                    ctx,
                 );
-                let request = controller
-                    .queued_injection_request(id, &row, HashMap::new(), ctx)
-                    .unwrap();
-                assert_eq!(request.conversation_id, id);
-                assert_eq!(request.shared_session_response_initiator, Some(participant));
-                let AIAgentInput::UserQuery { context, .. } = request.all_inputs().next().unwrap()
-                else {
-                    panic!("expected prompt")
-                };
-                let selected: Vec<_> = context
-                    .iter()
-                    .filter_map(|context| match context {
-                        AIAgentContext::SelectedText(text) => Some(text.as_str()),
-                        _ => None,
-                    })
-                    .collect();
-                assert_eq!(selected, vec!["remote context"]);
-                assert_eq!(
-                    controller
-                        .context_model
-                        .as_ref(ctx)
-                        .pending_context_selected_text()
-                        .map(String::as_str),
-                    Some("local selection")
-                );
+                assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
             });
+        });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                history.conversation(&other_id).unwrap().exchange_count(),
+                0,
+                "the wrongly-targeted conversation must not have received the prompt"
+            );
+        });
+    });
+}
+
+#[test]
+fn drained_injection_stages_attachments_and_attributes_the_exchange_to_its_participant() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
+        let participant = ParticipantId::new();
+        let id = controller.update(&mut app, |controller, ctx| {
+            let id = controller.bind_native_prompt_conversation(None, ctx);
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt2".into(),
+                None,
+                vec![AgentAttachment::PlainText {
+                    content: "remote context".into(),
+                }],
+                participant.clone(),
+                ctx,
+            );
+            id
+        });
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
+        });
+        controller.update(&mut app, |controller, ctx| {
+            controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
+            controller.drain_native_startup_queue(id, ctx);
+        });
+
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            let conversation = history.conversation(&id).unwrap();
+            let exchange = conversation
+                .root_task_exchanges()
+                .find(|exchange| {
+                    exchange.input.iter().any(|input| {
+                        matches!(input, AIAgentInput::UserQuery { query, .. } if query == "prompt2")
+                    })
+                })
+                .expect("prompt2's exchange should exist");
+            assert_eq!(exchange.response_initiator, Some(participant));
+            let context = exchange
+                .input
+                .iter()
+                .find_map(|input| match input {
+                    AIAgentInput::UserQuery { context, .. } => Some(context),
+                    _ => None,
+                })
+                .unwrap();
+            let selected: Vec<_> = context
+                .iter()
+                .filter_map(|context| match context {
+                    AIAgentContext::SelectedText(text) => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(selected, vec!["remote context"]);
         });
     });
 }
@@ -291,10 +260,13 @@ fn startup_injections_reuse_the_restored_conversation() {
             });
             terminal.ai_controller().update(ctx, |controller, ctx| {
                 assert_eq!(
-                    controller.prepare_native_prompt_queue(Some(restored), ctx),
+                    controller.bind_native_prompt_conversation(Some(restored), ctx),
                     restored
                 );
-                assert_eq!(controller.prepare_native_prompt_queue(None, ctx), restored);
+                assert_eq!(
+                    controller.bind_native_prompt_conversation(None, ctx),
+                    restored
+                );
                 controller.execute_warp_agent_prompt_from_shared_session_injection(
                     "followup".into(),
                     None,
@@ -318,44 +290,6 @@ fn startup_injections_reuse_the_restored_conversation() {
 }
 
 #[test]
-fn startup_injection_retains_a_token_until_the_initial_response_binds_it() {
-    App::test((), |mut app| async move {
-        initialize_app_for_terminal_view(&mut app);
-        let terminal = add_window_with_terminal(&mut app, None);
-        terminal.update(&mut app, |terminal, ctx| {
-            terminal.ai_controller().update(ctx, |controller, ctx| {
-                let id = controller.prepare_native_prompt_queue(None, ctx);
-                let token = ServerConversationToken::from_uuid(Uuid::new_v4());
-                controller.execute_warp_agent_prompt_from_shared_session_injection(
-                    "followup".into(),
-                    Some(token),
-                    vec![],
-                    ParticipantId::new(),
-                    ctx,
-                );
-                let row = QueuedQueryModel::as_ref(ctx).queue(id)[0].clone();
-                assert_eq!(row.shared_session_target(), Some(&token));
-                assert!(
-                    controller
-                        .queued_injection_request(id, &row, HashMap::new(), ctx)
-                        .is_err()
-                );
-                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
-                    history.set_server_conversation_token_for_conversation(id, token.to_string());
-                });
-                assert_eq!(
-                    controller
-                        .queued_injection_request(id, &row, HashMap::new(), ctx)
-                        .unwrap()
-                        .conversation_id,
-                    id
-                );
-            });
-        });
-    });
-}
-
-#[test]
 fn native_initial_prompt_uses_its_bound_conversation_without_agent_view() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
@@ -363,7 +297,7 @@ fn native_initial_prompt_uses_its_bound_conversation_without_agent_view() {
         let terminal = add_window_with_terminal(&mut app, None);
         terminal.update(&mut app, |terminal, ctx| {
             terminal.ai_controller().update(ctx, |controller, ctx| {
-                let id = controller.prepare_native_prompt_queue(None, ctx);
+                let id = controller.bind_native_prompt_conversation(None, ctx);
                 controller.execute_warp_agent_prompt_from_shared_session_injection(
                     "followup".into(),
                     None,
@@ -387,7 +321,11 @@ fn native_initial_prompt_uses_its_bound_conversation_without_agent_view() {
                         .exchange_count(),
                     1
                 );
-                assert!(QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(id));
+                // The initial send finishes the setup barrier immediately (it does not wait for
+                // this turn to complete); the queued follow-up is left untouched until something
+                // explicitly drains it (`AgentDriver::execute_run` does so right after this send
+                // in production).
+                assert!(!QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(id));
                 assert_eq!(QueuedQueryModel::as_ref(ctx).queue(id).len(), 1);
             });
         });
@@ -395,27 +333,26 @@ fn native_initial_prompt_uses_its_bound_conversation_without_agent_view() {
 }
 
 #[test]
-fn stopped_worker_cannot_dispatch_a_downloaded_prompt() {
+fn unbind_native_prompt_conversation_drops_any_prompts_still_queued() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let terminal = add_window_with_terminal(&mut app, None);
         terminal.update(&mut app, |terminal, ctx| {
             terminal.ai_controller().update(ctx, |controller, ctx| {
-                let id = controller.prepare_native_prompt_queue(None, ctx);
-                let row = QueuedQuery::new_shared_session_prompt(
+                let id = controller.bind_native_prompt_conversation(None, ctx);
+                controller.execute_warp_agent_prompt_from_shared_session_injection(
                     "pending".into(),
-                    ParticipantId::new(),
+                    None,
                     vec![],
+                    ParticipantId::new(),
+                    ctx,
                 );
-                let query_id = row.id();
-                QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
-                    queue.append(id, row.clone(), ctx);
-                    queue.finish_native_setup(id, ctx);
-                    queue.finish_native_initial_turn(id, ctx);
-                    assert!(queue.claim_injection(id, query_id, ctx).is_some());
-                });
-                controller.stop_native_prompt_queue(ctx);
-                controller.finish_queued_injection(id, row, Ok(HashMap::new()), ctx);
+                assert_eq!(QueuedQueryModel::as_ref(ctx).queue(id).len(), 1);
+
+                controller.unbind_native_prompt_conversation(ctx);
+
+                assert_eq!(controller.native_prompt_conversation_id(), None);
+                assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
                 assert_eq!(
                     BlocklistAIHistoryModel::as_ref(ctx)
                         .conversation(&id)
@@ -423,7 +360,6 @@ fn stopped_worker_cannot_dispatch_a_downloaded_prompt() {
                         .exchange_count(),
                     0
                 );
-                assert_eq!(QueuedQueryModel::as_ref(ctx).queue(id).len(), 1);
             });
         });
     });

--- a/app/src/ai/blocklist/controller/startup_queue_tests.rs
+++ b/app/src/ai/blocklist/controller/startup_queue_tests.rs
@@ -64,7 +64,7 @@ fn startup_injections_queued_before_the_initial_prompt_are_dispatched_one_at_a_t
         // the head of the backlog.
         controller.update(&mut app, |controller, ctx| {
             controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-            controller.dispatch_next_shared_session_row(id, ctx);
+            controller.dispatch_queued_warp_agent_prompt(id, None, ctx);
         });
 
         QueuedQueryModel::handle(&app).read(&app, |queue, _| {
@@ -115,7 +115,7 @@ fn live_injection_while_a_turn_is_active_is_queued_instead_of_interrupting_it() 
         });
         let initial_streams = controller.update(&mut app, |controller, ctx| {
             controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-            controller.dispatch_next_shared_session_row(id, ctx);
+            controller.dispatch_queued_warp_agent_prompt(id, None, ctx);
             assert!(!QueuedQueryModel::as_ref(ctx).has_queue(id));
             controller
                 .in_flight_response_streams
@@ -158,6 +158,123 @@ fn live_injection_while_a_turn_is_active_is_queued_instead_of_interrupting_it() 
                 user_queries_in_order(history, id),
                 vec!["prompt1".to_owned()],
                 "prompt2 should not have been sent yet"
+            );
+        });
+    });
+}
+
+#[test]
+fn dispatch_queued_warp_agent_prompt_with_an_explicit_id_targets_that_row_not_the_head() {
+    // Regression test: "Send now" on a specific queued row must dispatch that exact row, even
+    // when it isn't the head, rather than silently substituting whatever's at the head.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
+        let participant = ParticipantId::new();
+        let (id, second_row_id) = controller.update(&mut app, |controller, ctx| {
+            let id = controller.bind_native_prompt_conversation(None, ctx);
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt2".into(),
+                None,
+                vec![],
+                participant.clone(),
+                ctx,
+            );
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "prompt3".into(),
+                None,
+                vec![],
+                participant.clone(),
+                ctx,
+            );
+            let second_row_id = QueuedQueryModel::as_ref(ctx).queue(id)[1].id();
+            (id, second_row_id)
+        });
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
+        });
+
+        controller.update(&mut app, |controller, ctx| {
+            controller.dispatch_queued_warp_agent_prompt(id, Some(second_row_id), ctx);
+        });
+
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["prompt2"],
+                "the targeted row (prompt3) should be dispatched and removed; prompt2 -- the \
+                 head -- should be untouched"
+            );
+        });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                user_queries_in_order(history, id),
+                vec!["prompt3".to_owned()],
+                "the explicitly targeted row should have been sent"
+            );
+        });
+    });
+}
+
+#[test]
+fn dispatch_queued_warp_agent_prompt_respects_fifo_order_across_mixed_row_kinds() {
+    // Regression test: the automatic (head-only) dispatch path must not special-case shared-
+    // session rows -- a local prompt sitting ahead of a shared-session row in the queue must
+    // still be the one dispatched, not silently skipped.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let controller = terminal.read(&app, |terminal, _| terminal.ai_controller().clone());
+        let id = controller.update(&mut app, |controller, ctx| {
+            let id = controller.bind_native_prompt_conversation(None, ctx);
+            QueuedQueryModel::handle(ctx).update(ctx, |queue, ctx| {
+                queue.append(
+                    id,
+                    QueuedQuery::new("local prompt".into(), QueuedQueryOrigin::QueueSlashCommand),
+                    ctx,
+                );
+            });
+            controller.execute_warp_agent_prompt_from_shared_session_injection(
+                "shared prompt".into(),
+                None,
+                vec![],
+                ParticipantId::new(),
+                ctx,
+            );
+            id
+        });
+        terminal.update(&mut app, |terminal, ctx| {
+            terminal.enter_agent_view(None, Some(id), AgentViewEntryOrigin::Cli, ctx);
+        });
+
+        controller.update(&mut app, |controller, ctx| {
+            controller.send_user_query_in_conversation("initial".into(), id, None, ctx);
+            controller.dispatch_queued_warp_agent_prompt(id, None, ctx);
+        });
+
+        QueuedQueryModel::handle(&app).read(&app, |queue, _| {
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["shared prompt"],
+                "the local prompt at the head should have been dispatched, in FIFO order; the \
+                 shared-session row behind it should still be waiting"
+            );
+        });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                user_queries_in_order(history, id),
+                vec!["initial".to_owned(), "local prompt".to_owned()],
             );
         });
     });
@@ -232,7 +349,7 @@ fn drained_injection_stages_attachments_and_attributes_the_exchange_to_its_parti
         });
         controller.update(&mut app, |controller, ctx| {
             controller.send_user_query_in_conversation("prompt1".into(), id, None, ctx);
-            controller.dispatch_next_shared_session_row(id, ctx);
+            controller.dispatch_queued_warp_agent_prompt(id, None, ctx);
         });
 
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -132,7 +132,8 @@ pub(crate) use persistence::PersistedAIInputType;
 pub use persistence::maybe_build_ai_query_upsert_event;
 pub(crate) use persistence::{PersistedAIInput, SerializedBlockListItem};
 pub(crate) use queued_query::{
-    AutofireAction, QueuedQuery, QueuedQueryId, QueuedQueryOrigin, is_lrc_auto_queue_active,
+    AutofireAction, QueuedPromptDeliveryMode, QueuedQuery, QueuedQueryId, QueuedQueryOrigin,
+    is_lrc_auto_queue_active,
 };
 #[cfg_attr(not(feature = "tui"), allow(unused_imports))]
 pub use queued_query::{QueuedQueryEvent, QueuedQueryModel};

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -190,6 +190,25 @@ pub enum AutofireAction {
     },
 }
 
+/// How queued prompts for a conversation are delivered to the agent. Selected per-conversation;
+/// not user-facing yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum QueuedPromptDeliveryMode {
+    /// The next queued row is sent only once the conversation fully finishes on its own
+    /// (`FinishedReceivingOutput` with a genuine finish reason). Used for local queueing
+    /// surfaces (`/queue`, the auto-queue toggle, LRC auto-queue).
+    #[default]
+    Queueing,
+    /// A queued row is sent on the next request made for the conversation -- a natural
+    /// continuation (e.g. a tool-result follow-up or an orchestration-event injection) if one
+    /// occurs first, otherwise the conversation going fully idle -- rather than always waiting
+    /// for the whole turn to finish. Each row is still sent as its own individual
+    /// request/exchange, never combined with another queued row. Set automatically for
+    /// conversations bound to an ambient/Oz-driven native run
+    /// (`BlocklistAIController::bind_native_prompt_conversation`).
+    Steering,
+}
+
 /// Per-conversation queue / edit / toggle state.
 /// Lives inside [`QueuedQueryModel::queues`]; a missing key means empty queue, no edit in
 /// progress, and no explicit auto-queue override (so the cached default from
@@ -199,10 +218,11 @@ struct ConversationQueueState {
     queue: Vec<QueuedQuery>,
     /// True from when this conversation is bound for native startup injections until its
     /// initial prompt is actually sent. Sharing can deliver startup follow-ups during this
-    /// window; they are held in `queue` and flushed all at once, in FIFO order, the moment this
-    /// flag clears (see `BlocklistAIController::drain_native_startup_queue`) rather than being
-    /// drained one at a time as turns complete.
+    /// window; they are held in `queue` until setup finishes, at which point normal dispatch
+    /// (steering or idle-drain, depending on `delivery_mode`) takes over.
     native_setup_pending: bool,
+    /// How queued rows for this conversation are delivered. See [`QueuedPromptDeliveryMode`].
+    delivery_mode: QueuedPromptDeliveryMode,
     editing: Option<QueuedQueryId>,
     /// Explicit per-conversation override. `None` defers to the model's cached
     /// `default_mode`; `Some` means the user has toggled this conversation
@@ -300,10 +320,10 @@ impl QueuedQueryModel {
     }
 
     /// Clears the native setup barrier once the initial prompt has actually been sent. Does
-    /// *not* drain any prompts that arrived in the meantime -- the caller
-    /// (`BlocklistAIController::drain_native_startup_queue`) does that immediately afterward,
-    /// once it's safe to do so (see that method's doc comment for why the two can't be combined
-    /// into one step here).
+    /// *not* dispatch any prompt that arrived in the meantime -- the caller
+    /// (`BlocklistAIController::dispatch_next_shared_session_row`) does that immediately
+    /// afterward, once it's safe to do so (see that method's doc comment for why the two can't
+    /// be combined into one step here).
     pub(crate) fn finish_native_setup(
         &mut self,
         conversation_id: AIConversationId,
@@ -329,6 +349,35 @@ impl QueuedQueryModel {
             .is_some_and(|state| state.native_setup_pending)
     }
 
+    /// Sets the delivery mode for `conversation_id`'s queue. See [`QueuedPromptDeliveryMode`].
+    pub(crate) fn set_delivery_mode(
+        &mut self,
+        conversation_id: AIConversationId,
+        mode: QueuedPromptDeliveryMode,
+    ) {
+        self.queues
+            .entry(conversation_id)
+            .or_default()
+            .delivery_mode = mode;
+    }
+
+    /// Returns the delivery mode for `conversation_id`'s queue, defaulting to `Queueing` when no
+    /// mode has been explicitly set. See [`QueuedPromptDeliveryMode`].
+    pub(crate) fn delivery_mode(
+        &self,
+        conversation_id: AIConversationId,
+    ) -> QueuedPromptDeliveryMode {
+        self.queues
+            .get(&conversation_id)
+            .map(|state| state.delivery_mode)
+            .unwrap_or_default()
+    }
+
+    /// True when `conversation_id`'s queue is in `Steering` mode.
+    pub(crate) fn is_steering(&self, conversation_id: AIConversationId) -> bool {
+        self.delivery_mode(conversation_id) == QueuedPromptDeliveryMode::Steering
+    }
+
     /// True when `conversation_id` still has native startup work outstanding: either setup
     /// hasn't finished yet, or one or more shared-session follow-ups are still queued waiting
     /// to be drained (e.g. a drain was deferred because a CLI subagent was active). Used by the
@@ -345,9 +394,8 @@ impl QueuedQueryModel {
 
     /// Removes and returns every shared-session-injected row queued for `conversation_id`, in
     /// FIFO order, emitting a `Removed` event for each. Used by
-    /// `BlocklistAIController::drain_native_startup_queue` to atomically claim the whole
-    /// startup backlog before dispatching it, so a row can never be edited, reordered, or
-    /// double-dispatched once its send is underway.
+    /// `BlocklistAIController::unbind_native_prompt_conversation` to drop any startup follow-ups
+    /// that never made it out when the run ends.
     pub(crate) fn drain_shared_session_injections(
         &mut self,
         conversation_id: AIConversationId,
@@ -417,11 +465,12 @@ impl QueuedQueryModel {
     ) {
         match event {
             BlocklistAIHistoryEvent::UpdatedConversationStatus { .. } => {
-                // Native startup follow-ups no longer wait on turn completion here: they're
-                // flushed all at once as soon as setup finishes (see
-                // `BlocklistAIController::drain_native_startup_queue`). `TerminalView`'s own
-                // turn-completion drain (`drain_queued_prompts`) re-attempts that drain as a
-                // fallback for the rare case where it was deferred (an active CLI subagent).
+                // Steering-mode conversations don't rely on this event to deliver queued rows:
+                // they're dispatched one at a time as soon as a natural request boundary occurs
+                // (see `BlocklistAIController::steer_head_prompt_for_request` and
+                // `dispatch_next_shared_session_row`). `TerminalView`'s own turn-completion
+                // drain (`drain_queued_prompts`) remains the fallback for both modes once a
+                // turn genuinely finishes.
             }
             BlocklistAIHistoryEvent::RemoveConversation {
                 conversation_id, ..

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -321,7 +321,7 @@ impl QueuedQueryModel {
 
     /// Clears the native setup barrier once the initial prompt has actually been sent. Does
     /// *not* dispatch any prompt that arrived in the meantime -- the caller
-    /// (`BlocklistAIController::dispatch_next_shared_session_row`) does that immediately
+    /// (`BlocklistAIController::dispatch_queued_warp_agent_prompt`) does that immediately
     /// afterward, once it's safe to do so (see that method's doc comment for why the two can't
     /// be combined into one step here).
     pub(crate) fn finish_native_setup(
@@ -379,24 +379,21 @@ impl QueuedQueryModel {
     }
 
     /// True when `conversation_id` still has native startup work outstanding: either setup
-    /// hasn't finished yet, or one or more shared-session follow-ups are still queued waiting
-    /// to be drained (e.g. a drain was deferred because a CLI subagent was active). Used by the
-    /// ambient driver to know whether to keep the run alive for pending injections.
+    /// hasn't finished yet, or one or more rows are still queued waiting to be dispatched (e.g.
+    /// a dispatch was deferred because a CLI subagent was active). Used by the ambient driver to
+    /// know whether to keep the run alive for pending injections.
     pub(crate) fn has_pending_native_injections(&self, conversation_id: AIConversationId) -> bool {
-        self.queues.get(&conversation_id).is_some_and(|state| {
-            state.native_setup_pending
-                || state
-                    .queue
-                    .iter()
-                    .any(|row| row.shared_session_prompt().is_some())
-        })
+        self.queues
+            .get(&conversation_id)
+            .is_some_and(|state| state.native_setup_pending || !state.queue.is_empty())
     }
 
-    /// Removes and returns every shared-session-injected row queued for `conversation_id`, in
-    /// FIFO order, emitting a `Removed` event for each. Used by
-    /// `BlocklistAIController::unbind_native_prompt_conversation` to drop any startup follow-ups
-    /// that never made it out when the run ends.
-    pub(crate) fn drain_shared_session_injections(
+    /// Removes and returns every row queued for `conversation_id`, in FIFO order, emitting a
+    /// `Removed` event for each. Used by
+    /// `BlocklistAIController::unbind_native_prompt_conversation` to drop any prompts that never
+    /// made it out when the run ends, regardless of whether they were queued locally or via a
+    /// shared-session injection.
+    pub(crate) fn clear_queue(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
@@ -404,25 +401,15 @@ impl QueuedQueryModel {
         let Some(state) = self.queues.get_mut(&conversation_id) else {
             return Vec::new();
         };
-        let mut drained = Vec::new();
-        state.queue.retain(|row| {
-            if row.shared_session_prompt().is_some() {
-                drained.push(row.clone());
-                false
-            } else {
-                true
-            }
-        });
-        for row in &drained {
-            if state.editing == Some(row.id) {
-                state.editing = None;
-            }
+        let cleared = std::mem::take(&mut state.queue);
+        state.editing = None;
+        for row in &cleared {
             ctx.emit(QueuedQueryEvent::Removed {
                 conversation_id,
                 query_id: row.id,
             });
         }
-        drained
+        cleared
     }
 
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
@@ -468,7 +455,7 @@ impl QueuedQueryModel {
                 // Steering-mode conversations don't rely on this event to deliver queued rows:
                 // they're dispatched one at a time as soon as a natural request boundary occurs
                 // (see `BlocklistAIController::steer_head_prompt_for_request` and
-                // `dispatch_next_shared_session_row`). `TerminalView`'s own turn-completion
+                // `dispatch_queued_warp_agent_prompt`). `TerminalView`'s own turn-completion
                 // drain (`drain_queued_prompts`) remains the fallback for both modes once a
                 // turn genuinely finishes.
             }

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use session_sharing_protocol::common::{AgentAttachment, ParticipantId, ServerConversationToken};
 use uuid::Uuid;
 use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity};
 
@@ -28,6 +29,8 @@ impl QueuedQueryId {
 pub enum QueuedQueryOrigin {
     /// Filed while the initial Cloud Mode prompt waits to be handed off.
     InitialCloudMode,
+    /// Received through session sharing while a native run was starting.
+    SharedSessionInjection,
     /// Filed via the `/queue <prompt>` slash command.
     QueueSlashCommand,
     /// Filed via the auto-queue toggle in the warping indicator.
@@ -45,13 +48,17 @@ pub enum QueuedQueryOrigin {
     ForkAndCompactSlashCommand,
 }
 
-/// Whether a queued row is an agent prompt or a shell command. Attachments live inside the
-/// `Prompt` variant so a `Command` structurally cannot carry any.
+/// Whether a queued row is a local prompt, an attributed shared-session prompt, or a command.
 #[derive(Debug, Clone)]
 enum QueuedQueryKind {
     /// An agent prompt, with any image/file attachments captured from the input when it was
     /// queued. The attachments fire with the prompt and are dropped when the row is removed.
     Prompt { attachments: Vec<PendingAttachment> },
+    SharedSessionPrompt {
+        participant_id: ParticipantId,
+        attachments: Vec<AgentAttachment>,
+        server_conversation_token: Option<ServerConversationToken>,
+    },
     /// A shell command run in the terminal (or via the shared session for cloud panes).
     Command,
 }
@@ -66,6 +73,56 @@ pub struct QueuedQuery {
 }
 
 impl QueuedQuery {
+    pub(crate) fn new_shared_session_prompt(
+        text: String,
+        participant_id: ParticipantId,
+        attachments: Vec<AgentAttachment>,
+    ) -> Self {
+        Self {
+            id: QueuedQueryId::new(),
+            text,
+            origin: QueuedQueryOrigin::SharedSessionInjection,
+            kind: QueuedQueryKind::SharedSessionPrompt {
+                participant_id,
+                attachments,
+                server_conversation_token: None,
+            },
+        }
+    }
+
+    pub(crate) fn shared_session_prompt(&self) -> Option<(&ParticipantId, &[AgentAttachment])> {
+        match &self.kind {
+            QueuedQueryKind::SharedSessionPrompt {
+                participant_id,
+                attachments,
+                ..
+            } => Some((participant_id, attachments)),
+            QueuedQueryKind::Prompt { .. } | QueuedQueryKind::Command => None,
+        }
+    }
+    pub(crate) fn with_shared_session_target(
+        mut self,
+        token: Option<ServerConversationToken>,
+    ) -> Self {
+        if let QueuedQueryKind::SharedSessionPrompt {
+            server_conversation_token,
+            ..
+        } = &mut self.kind
+        {
+            *server_conversation_token = token;
+        }
+        self
+    }
+
+    pub(crate) fn shared_session_target(&self) -> Option<&ServerConversationToken> {
+        match &self.kind {
+            QueuedQueryKind::SharedSessionPrompt {
+                server_conversation_token,
+                ..
+            } => server_conversation_token.as_ref(),
+            QueuedQueryKind::Prompt { .. } | QueuedQueryKind::Command => None,
+        }
+    }
     pub fn new(text: String, origin: QueuedQueryOrigin) -> Self {
         Self::new_with_attachments(text, origin, Vec::new())
     }
@@ -113,7 +170,7 @@ impl QueuedQuery {
     pub fn attachments(&self) -> &[PendingAttachment] {
         match &self.kind {
             QueuedQueryKind::Prompt { attachments } => attachments,
-            QueuedQueryKind::Command => &[],
+            QueuedQueryKind::Command | QueuedQueryKind::SharedSessionPrompt { .. } => &[],
         }
     }
 
@@ -165,6 +222,11 @@ pub enum AutofireAction {
 #[derive(Default)]
 struct ConversationQueueState {
     queue: Vec<QueuedQuery>,
+    native_setup_pending: bool,
+    /// Sharing can deliver startup follow-ups after the initial request has already been sent.
+    native_initial_turn_pending: bool,
+    injection_dispatch: Option<QueuedQueryId>,
+    injection_error: Option<String>,
     editing: Option<QueuedQueryId>,
     /// Explicit per-conversation override. `None` defers to the model's cached
     /// `default_mode`; `Some` means the user has toggled this conversation
@@ -197,6 +259,9 @@ pub struct QueuedQueryModel {
 /// to so subscribers can filter to the conversation they care about.
 #[derive(Debug, Clone)]
 pub enum QueuedQueryEvent {
+    DispatchStateChanged {
+        conversation_id: AIConversationId,
+    },
     Appended {
         conversation_id: AIConversationId,
         query_id: QueuedQueryId,
@@ -246,6 +311,143 @@ impl Entity for QueuedQueryModel {
 impl SingletonEntity for QueuedQueryModel {}
 
 impl QueuedQueryModel {
+    pub(crate) fn begin_native_setup(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.queues
+            .entry(conversation_id)
+            .or_default()
+            .native_setup_pending = true;
+        ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
+    }
+
+    pub(crate) fn finish_native_setup(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if let Some(state) = self.queues.get_mut(&conversation_id)
+            && state.native_setup_pending
+        {
+            state.native_setup_pending = false;
+            state.native_initial_turn_pending = true;
+            log::info!(
+                "event=setup_released conversation_id={conversation_id} initial_turn_pending=true queue_len={}",
+                state.queue.len(),
+            );
+            ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
+        }
+    }
+
+    pub(crate) fn is_dispatch_blocked(&self, conversation_id: AIConversationId) -> bool {
+        self.queues.get(&conversation_id).is_some_and(|state| {
+            state.native_setup_pending
+                || state.native_initial_turn_pending
+                || state.injection_dispatch.is_some()
+                || state.injection_error.is_some()
+        })
+    }
+
+    pub(crate) fn has_pending_native_injections(&self, conversation_id: AIConversationId) -> bool {
+        self.queues.get(&conversation_id).is_some_and(|state| {
+            state.native_setup_pending
+                || state.native_initial_turn_pending
+                || state.injection_dispatch.is_some()
+                || state
+                    .queue
+                    .iter()
+                    .any(|row| row.shared_session_prompt().is_some())
+        })
+    }
+
+    pub(crate) fn injection_error(&self, conversation_id: AIConversationId) -> Option<&str> {
+        self.queues
+            .get(&conversation_id)?
+            .injection_error
+            .as_deref()
+    }
+
+    pub(crate) fn finish_native_initial_turn(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if let Some(state) = self.queues.get_mut(&conversation_id)
+            && !state.native_setup_pending
+            && state.native_initial_turn_pending
+        {
+            state.native_initial_turn_pending = false;
+            log::info!(
+                "event=native_initial_turn_released conversation_id={conversation_id} queue_len={}",
+                state.queue.len(),
+            );
+            ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
+        }
+    }
+
+    pub(crate) fn cancel_injection_dispatch(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if let Some(state) = self.queues.get_mut(&conversation_id)
+            && state.injection_dispatch.take().is_some()
+        {
+            state.injection_error = Some("Queued prompt delivery was cancelled.".to_owned());
+            ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
+        }
+    }
+
+    pub(crate) fn claim_injection(
+        &mut self,
+        conversation_id: AIConversationId,
+        query_id: QueuedQueryId,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<QueuedQuery> {
+        if self.is_dispatch_blocked(conversation_id) {
+            return None;
+        }
+        let state = self.queues.get_mut(&conversation_id)?;
+        let row = state.queue.first()?;
+        if row.id != query_id || row.shared_session_prompt().is_none() {
+            return None;
+        }
+        let row = row.clone();
+        state.injection_dispatch = Some(query_id);
+        ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
+        Some(row)
+    }
+
+    pub(crate) fn is_injection_dispatch_current(
+        &self,
+        conversation_id: AIConversationId,
+        query_id: QueuedQueryId,
+    ) -> bool {
+        self.queues.get(&conversation_id).is_some_and(|state| {
+            state.injection_dispatch == Some(query_id) && state.injection_error.is_none()
+        })
+    }
+
+    pub(crate) fn finish_injection_dispatch(
+        &mut self,
+        conversation_id: AIConversationId,
+        query_id: QueuedQueryId,
+        error: Option<String>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if !self.is_injection_dispatch_current(conversation_id, query_id) {
+            return;
+        }
+        let state = self.queues.get_mut(&conversation_id).unwrap();
+        state.injection_dispatch = None;
+        state.injection_error = error;
+        if state.injection_error.is_none() {
+            self.remove_fired_row(conversation_id, query_id, ctx);
+        }
+        ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
+    }
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         // Drop queue/toggle state for any conversation that is removed, deleted, or cleared
         // from its owning terminal view. Agent-view exit is intentionally NOT subscribed to:
@@ -285,6 +487,18 @@ impl QueuedQueryModel {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
+            BlocklistAIHistoryEvent::UpdatedConversationStatus {
+                conversation_id, ..
+            } => {
+                let turn_finished = BlocklistAIHistoryModel::as_ref(ctx)
+                    .conversation(conversation_id)
+                    .is_some_and(|conversation| {
+                        conversation.status().is_done() && !conversation.has_active_subagent()
+                    });
+                if turn_finished {
+                    self.finish_native_initial_turn(*conversation_id, ctx);
+                }
+            }
             BlocklistAIHistoryEvent::RemoveConversation {
                 conversation_id, ..
             }
@@ -310,7 +524,14 @@ impl QueuedQueryModel {
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) {
-        if self.queues.remove(&conversation_id).is_some() {
+        if let Some(state) = self.queues.remove(&conversation_id) {
+            if !state.queue.is_empty() {
+                log::warn!(
+                    "event=queue_discarded conversation_id={conversation_id} reason=conversation_removed queue_len={} dispatch_in_flight={}",
+                    state.queue.len(),
+                    state.injection_dispatch.is_some(),
+                );
+            }
             ctx.emit(QueuedQueryEvent::Cleared { conversation_id });
         }
     }
@@ -334,10 +555,12 @@ impl QueuedQueryModel {
     /// conversation finishes successfully. Mirrors [`Self::peek_autofire`]'s gating: false for an
     /// empty queue or a locked head row (which never auto-fires).
     pub fn has_autofireable_prompt(&self, conversation_id: AIConversationId) -> bool {
-        self.queues
-            .get(&conversation_id)
-            .and_then(|state| state.queue.first())
-            .is_some_and(|first| !first.is_locked())
+        !self.is_dispatch_blocked(conversation_id)
+            && self
+                .queues
+                .get(&conversation_id)
+                .and_then(|state| state.queue.first())
+                .is_some_and(|first| !first.is_locked())
     }
 
     /// Marks that a dispatched queued command is running for `conversation_id`. While set, the
@@ -537,6 +760,16 @@ impl QueuedQueryModel {
     ) -> QueuedQueryId {
         let query_id = query.id;
         let state = self.queues.entry(conversation_id).or_default();
+        log::info!(
+            "event=queued_prompt_appended conversation_id={conversation_id} query_id={query_id:?} origin={:?} participant_id={:?} queue_len={} setup_pending={} initial_turn_pending={}",
+            query.origin,
+            query
+                .shared_session_prompt()
+                .map(|(participant_id, _)| participant_id),
+            state.queue.len() + 1,
+            state.native_setup_pending,
+            state.native_initial_turn_pending,
+        );
         state.queue.push(query);
         ctx.emit(QueuedQueryEvent::Appended {
             conversation_id,
@@ -555,8 +788,13 @@ impl QueuedQueryModel {
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) -> Option<QueuedQuery> {
+        if self.is_dispatch_blocked(conversation_id) {
+            return None;
+        }
         let state = self.queues.get_mut(&conversation_id)?;
-        if state.queue.first()?.is_locked() {
+        if state.queue.first()?.is_locked()
+            || state.queue.first()?.shared_session_prompt().is_some()
+        {
             return None;
         }
         let popped = state.queue.remove(0);
@@ -575,6 +813,24 @@ impl QueuedQueryModel {
     /// empty queue or a locked head ([`QueuedQuery::is_locked`]). The caller removes the row via
     /// [`Self::remove_fired_row`] once it has been dispatched or restored to the input.
     pub fn peek_autofire(&self, conversation_id: AIConversationId) -> Option<AutofireAction> {
+        if let Some(state) = self.queues.get(&conversation_id)
+            && !state.queue.is_empty()
+            && (self.is_dispatch_blocked(conversation_id) || state.queue[0].is_locked())
+        {
+            log::info!(
+                "event=queue_drain_blocked conversation_id={conversation_id} queue_len={} head_id={:?} setup_pending={} initial_turn_pending={} dispatch_in_flight={} dispatch_failed={} head_locked={}",
+                state.queue.len(),
+                state.queue[0].id,
+                state.native_setup_pending,
+                state.native_initial_turn_pending,
+                state.injection_dispatch.is_some(),
+                state.injection_error.is_some(),
+                state.queue[0].is_locked(),
+            );
+        }
+        if self.is_dispatch_blocked(conversation_id) {
+            return None;
+        }
         let state = self.queues.get(&conversation_id)?;
         let first = state.queue.first()?;
         if first.is_locked() {
@@ -616,6 +872,12 @@ impl QueuedQueryModel {
         let Some(idx) = state.queue.iter().position(|q| q.id == query_id) else {
             return;
         };
+        if state.queue[idx].shared_session_prompt().is_none() {
+            log::info!(
+                "event=queued_prompt_removed conversation_id={conversation_id} query_id={query_id:?} reason=dispatched_or_restored queue_len_after={}",
+                state.queue.len() - 1,
+            );
+        }
         state.queue.remove(idx);
         if state.editing == Some(query_id) {
             state.editing = None;
@@ -640,6 +902,10 @@ impl QueuedQueryModel {
             return;
         }
         let insert_index = insert_index.min(state.queue.len());
+        log::warn!(
+            "event=restored_after_failed_send conversation_id={conversation_id} query_id={query_id:?} index={insert_index} queue_len_after={}",
+            state.queue.len() + 1,
+        );
         state.queue.insert(insert_index, query);
         ctx.emit(QueuedQueryEvent::Appended {
             conversation_id,
@@ -674,9 +940,13 @@ impl QueuedQueryModel {
     ) -> Option<QueuedQuery> {
         let state = self.queues.get_mut(&conversation_id)?;
         let idx = state.queue.iter().position(|q| q.id == query_id)?;
-        if state.queue[idx].is_locked() {
+        if state.queue[idx].is_locked() || state.injection_dispatch == Some(query_id) {
             return None;
         }
+        log::info!(
+            "event=deleted conversation_id={conversation_id} query_id={query_id:?} queue_len_after={}",
+            state.queue.len() - 1,
+        );
         let removed = state.queue.remove(idx);
         if state.editing == Some(query_id) {
             state.editing = None;
@@ -733,7 +1003,10 @@ impl QueuedQueryModel {
             return;
         };
         let head_is_locked = state.queue.first().is_some_and(|row| row.is_locked());
-        if state.queue[source_idx].is_locked() || (target_index == 0 && head_is_locked) {
+        if state.injection_dispatch.is_some()
+            || state.queue[source_idx].is_locked()
+            || (target_index == 0 && head_is_locked)
+        {
             return;
         }
         let row = state.queue.remove(source_idx);
@@ -757,7 +1030,7 @@ impl QueuedQueryModel {
         if !state
             .queue
             .iter()
-            .any(|q| q.id == query_id && !q.is_locked())
+            .any(|q| q.id == query_id && !q.is_locked() && q.shared_session_prompt().is_none())
         {
             return;
         }

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -232,6 +232,10 @@ struct ConversationQueueState {
     /// dispatched and cleared when it finishes; keeps the queue accepting new rows while the
     /// agent is idle and gates the next drain until the command completes.
     command_in_flight: bool,
+    /// True while a shared-session row's file-attachment download is in flight, after the row
+    /// has already been removed from `queue` but before the resulting request has actually been
+    /// sent. See [`QueuedQueryModel::arm_download_in_flight`].
+    download_in_flight: bool,
     /// Manual queue toggle made during an agent-requested long-running command. Cleared when
     /// the command ends; never touches `queue_next_prompt_override`.
     queue_next_lrc_prompt_override: Option<bool>,
@@ -307,6 +311,7 @@ impl Entity for QueuedQueryModel {
 impl SingletonEntity for QueuedQueryModel {}
 
 impl QueuedQueryModel {
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn begin_native_setup(
         &mut self,
         conversation_id: AIConversationId,
@@ -350,6 +355,7 @@ impl QueuedQueryModel {
     }
 
     /// Sets the delivery mode for `conversation_id`'s queue. See [`QueuedPromptDeliveryMode`].
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn set_delivery_mode(
         &mut self,
         conversation_id: AIConversationId,
@@ -379,13 +385,36 @@ impl QueuedQueryModel {
     }
 
     /// True when `conversation_id` still has native startup work outstanding: either setup
-    /// hasn't finished yet, or one or more rows are still queued waiting to be dispatched (e.g.
-    /// a dispatch was deferred because a CLI subagent was active). Used by the ambient driver to
-    /// know whether to keep the run alive for pending injections.
+    /// hasn't finished yet, one or more rows are still queued waiting to be dispatched (e.g. a
+    /// dispatch was deferred because a CLI subagent was active), or a dispatched row's file
+    /// attachments are still downloading (see [`Self::arm_download_in_flight`]). Used by the
+    /// ambient driver to know whether to keep the run alive for pending injections.
     pub(crate) fn has_pending_native_injections(&self, conversation_id: AIConversationId) -> bool {
+        self.queues.get(&conversation_id).is_some_and(|state| {
+            state.native_setup_pending || !state.queue.is_empty() || state.download_in_flight
+        })
+    }
+
+    /// Marks `conversation_id` as having a shared-session row's file-attachment download in
+    /// flight. Called right before the row is removed from the queue to start that download, so
+    /// [`Self::has_pending_native_injections`] stays true across the gap between removing the
+    /// row and the resulting request actually being sent -- otherwise the ambient driver could
+    /// see an empty queue and a terminal conversation status and exit before the download
+    /// completes and the prompt goes out.
+    pub(crate) fn arm_download_in_flight(&mut self, conversation_id: AIConversationId) {
         self.queues
-            .get(&conversation_id)
-            .is_some_and(|state| state.native_setup_pending || !state.queue.is_empty())
+            .entry(conversation_id)
+            .or_default()
+            .download_in_flight = true;
+    }
+
+    /// Clears the marker set by [`Self::arm_download_in_flight`], once the request it was
+    /// guarding has actually been sent (successfully or not). Safe to call unconditionally, even
+    /// when nothing was armed (e.g. a row with no file attachments never needed a download).
+    pub(crate) fn clear_download_in_flight(&mut self, conversation_id: AIConversationId) {
+        if let Some(state) = self.queues.get_mut(&conversation_id) {
+            state.download_in_flight = false;
+        }
     }
 
     /// Removes and returns every row queued for `conversation_id`, in FIFO order, emitting a
@@ -393,6 +422,7 @@ impl QueuedQueryModel {
     /// `BlocklistAIController::unbind_native_prompt_conversation` to drop any prompts that never
     /// made it out when the run ends, regardless of whether they were queued locally or via a
     /// shared-session injection.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn clear_queue(
         &mut self,
         conversation_id: AIConversationId,

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use session_sharing_protocol::common::{AgentAttachment, ParticipantId, ServerConversationToken};
+use session_sharing_protocol::common::{AgentAttachment, ParticipantId};
 use uuid::Uuid;
 use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity};
 
@@ -57,7 +57,6 @@ enum QueuedQueryKind {
     SharedSessionPrompt {
         participant_id: ParticipantId,
         attachments: Vec<AgentAttachment>,
-        server_conversation_token: Option<ServerConversationToken>,
     },
     /// A shell command run in the terminal (or via the shared session for cloud panes).
     Command,
@@ -85,7 +84,6 @@ impl QueuedQuery {
             kind: QueuedQueryKind::SharedSessionPrompt {
                 participant_id,
                 attachments,
-                server_conversation_token: None,
             },
         }
     }
@@ -95,34 +93,11 @@ impl QueuedQuery {
             QueuedQueryKind::SharedSessionPrompt {
                 participant_id,
                 attachments,
-                ..
             } => Some((participant_id, attachments)),
             QueuedQueryKind::Prompt { .. } | QueuedQueryKind::Command => None,
         }
     }
-    pub(crate) fn with_shared_session_target(
-        mut self,
-        token: Option<ServerConversationToken>,
-    ) -> Self {
-        if let QueuedQueryKind::SharedSessionPrompt {
-            server_conversation_token,
-            ..
-        } = &mut self.kind
-        {
-            *server_conversation_token = token;
-        }
-        self
-    }
 
-    pub(crate) fn shared_session_target(&self) -> Option<&ServerConversationToken> {
-        match &self.kind {
-            QueuedQueryKind::SharedSessionPrompt {
-                server_conversation_token,
-                ..
-            } => server_conversation_token.as_ref(),
-            QueuedQueryKind::Prompt { .. } | QueuedQueryKind::Command => None,
-        }
-    }
     pub fn new(text: String, origin: QueuedQueryOrigin) -> Self {
         Self::new_with_attachments(text, origin, Vec::new())
     }
@@ -222,11 +197,12 @@ pub enum AutofireAction {
 #[derive(Default)]
 struct ConversationQueueState {
     queue: Vec<QueuedQuery>,
+    /// True from when this conversation is bound for native startup injections until its
+    /// initial prompt is actually sent. Sharing can deliver startup follow-ups during this
+    /// window; they are held in `queue` and flushed all at once, in FIFO order, the moment this
+    /// flag clears (see `BlocklistAIController::drain_native_startup_queue`) rather than being
+    /// drained one at a time as turns complete.
     native_setup_pending: bool,
-    /// Sharing can deliver startup follow-ups after the initial request has already been sent.
-    native_initial_turn_pending: bool,
-    injection_dispatch: Option<QueuedQueryId>,
-    injection_error: Option<String>,
     editing: Option<QueuedQueryId>,
     /// Explicit per-conversation override. `None` defers to the model's cached
     /// `default_mode`; `Some` means the user has toggled this conversation
@@ -323,6 +299,11 @@ impl QueuedQueryModel {
         ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
     }
 
+    /// Clears the native setup barrier once the initial prompt has actually been sent. Does
+    /// *not* drain any prompts that arrived in the meantime -- the caller
+    /// (`BlocklistAIController::drain_native_startup_queue`) does that immediately afterward,
+    /// once it's safe to do so (see that method's doc comment for why the two can't be combined
+    /// into one step here).
     pub(crate) fn finish_native_setup(
         &mut self,
         conversation_id: AIConversationId,
@@ -332,29 +313,29 @@ impl QueuedQueryModel {
             && state.native_setup_pending
         {
             state.native_setup_pending = false;
-            state.native_initial_turn_pending = true;
             log::info!(
-                "event=setup_released conversation_id={conversation_id} initial_turn_pending=true queue_len={}",
+                "event=setup_released conversation_id={conversation_id} queue_len={}",
                 state.queue.len(),
             );
             ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
         }
     }
 
+    /// True while native startup follow-ups for `conversation_id` must be held rather than
+    /// dispatched (auto-fire, "Send now", and Enter-to-send all consult this).
     pub(crate) fn is_dispatch_blocked(&self, conversation_id: AIConversationId) -> bool {
-        self.queues.get(&conversation_id).is_some_and(|state| {
-            state.native_setup_pending
-                || state.native_initial_turn_pending
-                || state.injection_dispatch.is_some()
-                || state.injection_error.is_some()
-        })
+        self.queues
+            .get(&conversation_id)
+            .is_some_and(|state| state.native_setup_pending)
     }
 
+    /// True when `conversation_id` still has native startup work outstanding: either setup
+    /// hasn't finished yet, or one or more shared-session follow-ups are still queued waiting
+    /// to be drained (e.g. a drain was deferred because a CLI subagent was active). Used by the
+    /// ambient driver to know whether to keep the run alive for pending injections.
     pub(crate) fn has_pending_native_injections(&self, conversation_id: AIConversationId) -> bool {
         self.queues.get(&conversation_id).is_some_and(|state| {
             state.native_setup_pending
-                || state.native_initial_turn_pending
-                || state.injection_dispatch.is_some()
                 || state
                     .queue
                     .iter()
@@ -362,92 +343,40 @@ impl QueuedQueryModel {
         })
     }
 
-    pub(crate) fn injection_error(&self, conversation_id: AIConversationId) -> Option<&str> {
-        self.queues
-            .get(&conversation_id)?
-            .injection_error
-            .as_deref()
-    }
-
-    pub(crate) fn finish_native_initial_turn(
+    /// Removes and returns every shared-session-injected row queued for `conversation_id`, in
+    /// FIFO order, emitting a `Removed` event for each. Used by
+    /// `BlocklistAIController::drain_native_startup_queue` to atomically claim the whole
+    /// startup backlog before dispatching it, so a row can never be edited, reordered, or
+    /// double-dispatched once its send is underway.
+    pub(crate) fn drain_shared_session_injections(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
-    ) {
-        if let Some(state) = self.queues.get_mut(&conversation_id)
-            && !state.native_setup_pending
-            && state.native_initial_turn_pending
-        {
-            state.native_initial_turn_pending = false;
-            log::info!(
-                "event=native_initial_turn_released conversation_id={conversation_id} queue_len={}",
-                state.queue.len(),
-            );
-            ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
+    ) -> Vec<QueuedQuery> {
+        let Some(state) = self.queues.get_mut(&conversation_id) else {
+            return Vec::new();
+        };
+        let mut drained = Vec::new();
+        state.queue.retain(|row| {
+            if row.shared_session_prompt().is_some() {
+                drained.push(row.clone());
+                false
+            } else {
+                true
+            }
+        });
+        for row in &drained {
+            if state.editing == Some(row.id) {
+                state.editing = None;
+            }
+            ctx.emit(QueuedQueryEvent::Removed {
+                conversation_id,
+                query_id: row.id,
+            });
         }
+        drained
     }
 
-    pub(crate) fn cancel_injection_dispatch(
-        &mut self,
-        conversation_id: AIConversationId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        if let Some(state) = self.queues.get_mut(&conversation_id)
-            && state.injection_dispatch.take().is_some()
-        {
-            state.injection_error = Some("Queued prompt delivery was cancelled.".to_owned());
-            ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
-        }
-    }
-
-    pub(crate) fn claim_injection(
-        &mut self,
-        conversation_id: AIConversationId,
-        query_id: QueuedQueryId,
-        ctx: &mut ModelContext<Self>,
-    ) -> Option<QueuedQuery> {
-        if self.is_dispatch_blocked(conversation_id) {
-            return None;
-        }
-        let state = self.queues.get_mut(&conversation_id)?;
-        let row = state.queue.first()?;
-        if row.id != query_id || row.shared_session_prompt().is_none() {
-            return None;
-        }
-        let row = row.clone();
-        state.injection_dispatch = Some(query_id);
-        ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
-        Some(row)
-    }
-
-    pub(crate) fn is_injection_dispatch_current(
-        &self,
-        conversation_id: AIConversationId,
-        query_id: QueuedQueryId,
-    ) -> bool {
-        self.queues.get(&conversation_id).is_some_and(|state| {
-            state.injection_dispatch == Some(query_id) && state.injection_error.is_none()
-        })
-    }
-
-    pub(crate) fn finish_injection_dispatch(
-        &mut self,
-        conversation_id: AIConversationId,
-        query_id: QueuedQueryId,
-        error: Option<String>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        if !self.is_injection_dispatch_current(conversation_id, query_id) {
-            return;
-        }
-        let state = self.queues.get_mut(&conversation_id).unwrap();
-        state.injection_dispatch = None;
-        state.injection_error = error;
-        if state.injection_error.is_none() {
-            self.remove_fired_row(conversation_id, query_id, ctx);
-        }
-        ctx.emit(QueuedQueryEvent::DispatchStateChanged { conversation_id });
-    }
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         // Drop queue/toggle state for any conversation that is removed, deleted, or cleared
         // from its owning terminal view. Agent-view exit is intentionally NOT subscribed to:
@@ -487,17 +416,12 @@ impl QueuedQueryModel {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
-            BlocklistAIHistoryEvent::UpdatedConversationStatus {
-                conversation_id, ..
-            } => {
-                let turn_finished = BlocklistAIHistoryModel::as_ref(ctx)
-                    .conversation(conversation_id)
-                    .is_some_and(|conversation| {
-                        conversation.status().is_done() && !conversation.has_active_subagent()
-                    });
-                if turn_finished {
-                    self.finish_native_initial_turn(*conversation_id, ctx);
-                }
+            BlocklistAIHistoryEvent::UpdatedConversationStatus { .. } => {
+                // Native startup follow-ups no longer wait on turn completion here: they're
+                // flushed all at once as soon as setup finishes (see
+                // `BlocklistAIController::drain_native_startup_queue`). `TerminalView`'s own
+                // turn-completion drain (`drain_queued_prompts`) re-attempts that drain as a
+                // fallback for the rare case where it was deferred (an active CLI subagent).
             }
             BlocklistAIHistoryEvent::RemoveConversation {
                 conversation_id, ..
@@ -527,9 +451,8 @@ impl QueuedQueryModel {
         if let Some(state) = self.queues.remove(&conversation_id) {
             if !state.queue.is_empty() {
                 log::warn!(
-                    "event=queue_discarded conversation_id={conversation_id} reason=conversation_removed queue_len={} dispatch_in_flight={}",
+                    "event=queue_discarded conversation_id={conversation_id} reason=conversation_removed queue_len={}",
                     state.queue.len(),
-                    state.injection_dispatch.is_some(),
                 );
             }
             ctx.emit(QueuedQueryEvent::Cleared { conversation_id });
@@ -761,14 +684,13 @@ impl QueuedQueryModel {
         let query_id = query.id;
         let state = self.queues.entry(conversation_id).or_default();
         log::info!(
-            "event=queued_prompt_appended conversation_id={conversation_id} query_id={query_id:?} origin={:?} participant_id={:?} queue_len={} setup_pending={} initial_turn_pending={}",
+            "event=queued_prompt_appended conversation_id={conversation_id} query_id={query_id:?} origin={:?} participant_id={:?} queue_len={} setup_pending={}",
             query.origin,
             query
                 .shared_session_prompt()
                 .map(|(participant_id, _)| participant_id),
             state.queue.len() + 1,
             state.native_setup_pending,
-            state.native_initial_turn_pending,
         );
         state.queue.push(query);
         ctx.emit(QueuedQueryEvent::Appended {
@@ -818,13 +740,10 @@ impl QueuedQueryModel {
             && (self.is_dispatch_blocked(conversation_id) || state.queue[0].is_locked())
         {
             log::info!(
-                "event=queue_drain_blocked conversation_id={conversation_id} queue_len={} head_id={:?} setup_pending={} initial_turn_pending={} dispatch_in_flight={} dispatch_failed={} head_locked={}",
+                "event=queue_drain_blocked conversation_id={conversation_id} queue_len={} head_id={:?} setup_pending={} head_locked={}",
                 state.queue.len(),
                 state.queue[0].id,
                 state.native_setup_pending,
-                state.native_initial_turn_pending,
-                state.injection_dispatch.is_some(),
-                state.injection_error.is_some(),
                 state.queue[0].is_locked(),
             );
         }
@@ -940,7 +859,7 @@ impl QueuedQueryModel {
     ) -> Option<QueuedQuery> {
         let state = self.queues.get_mut(&conversation_id)?;
         let idx = state.queue.iter().position(|q| q.id == query_id)?;
-        if state.queue[idx].is_locked() || state.injection_dispatch == Some(query_id) {
+        if state.queue[idx].is_locked() {
             return None;
         }
         log::info!(
@@ -1003,10 +922,7 @@ impl QueuedQueryModel {
             return;
         };
         let head_is_locked = state.queue.first().is_some_and(|row| row.is_locked());
-        if state.injection_dispatch.is_some()
-            || state.queue[source_idx].is_locked()
-            || (target_index == 0 && head_is_locked)
-        {
+        if state.queue[source_idx].is_locked() || (target_index == 0 && head_is_locked) {
             return;
         }
         let row = state.queue.remove(source_idx);

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -389,6 +389,7 @@ impl QueuedQueryModel {
     /// dispatch was deferred because a CLI subagent was active), or a dispatched row's file
     /// attachments are still downloading (see [`Self::arm_download_in_flight`]). Used by the
     /// ambient driver to know whether to keep the run alive for pending injections.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn has_pending_native_injections(&self, conversation_id: AIConversationId) -> bool {
         self.queues.get(&conversation_id).is_some_and(|state| {
             state.native_setup_pending || !state.queue.is_empty() || state.download_in_flight

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -976,6 +976,34 @@ fn command_in_flight_flag_arms_and_clears() {
 }
 
 #[test]
+fn download_in_flight_flag_arms_and_clears() {
+    with_model(|mut app, model, _events| {
+        let conv = AIConversationId::new();
+        model.read(&app, |m, _| assert!(!m.has_pending_native_injections(conv)));
+
+        // Arming works even with an empty queue -- the whole point is to cover the gap after a
+        // shared-session row has already been removed but before its download-gated request has
+        // actually been sent.
+        model.update(&mut app, |m, _| m.arm_download_in_flight(conv));
+        model.read(&app, |m, _| assert!(m.has_pending_native_injections(conv)));
+
+        model.update(&mut app, |m, _| m.clear_download_in_flight(conv));
+        model.read(&app, |m, _| assert!(!m.has_pending_native_injections(conv)));
+    });
+}
+
+#[test]
+fn clear_download_in_flight_is_a_no_op_when_nothing_was_armed() {
+    with_model(|mut app, model, _events| {
+        let conv = AIConversationId::new();
+        // Every synchronous dispatch path clears unconditionally, including the two that never
+        // needed a download in the first place; this must not panic or create a stray entry.
+        model.update(&mut app, |m, _| m.clear_download_in_flight(conv));
+        model.read(&app, |m, _| assert!(!m.has_pending_native_injections(conv)));
+    });
+}
+
+#[test]
 fn delete_conversation_clears_in_flight_command() {
     with_model(|mut app, model, _events| {
         let history = BlocklistAIHistoryModel::handle(&app);

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -67,15 +67,15 @@ fn native_setup_barrier_blocks_dispatch_until_finished() {
             );
             assert!(queue.has_pending_native_injections(id));
 
-            // The barrier -- not `drain_shared_session_injections` itself -- is what gates
-            // when a caller is allowed to drain; the row sits untouched until then.
+            // The barrier -- not `clear_queue` itself -- is what gates when a caller is
+            // allowed to dispatch; the row sits untouched until then.
             queue.finish_native_setup(id, ctx);
             assert!(!queue.is_dispatch_blocked(id));
             assert!(queue.has_pending_native_injections(id));
 
-            let drained = queue.drain_shared_session_injections(id, ctx);
-            assert_eq!(drained.len(), 1);
-            assert_eq!(drained[0].text(), "first");
+            let cleared = queue.clear_queue(id, ctx);
+            assert_eq!(cleared.len(), 1);
+            assert_eq!(cleared[0].text(), "first");
             assert!(!queue.has_pending_native_injections(id));
 
             // Idempotent once already released.
@@ -86,51 +86,42 @@ fn native_setup_barrier_blocks_dispatch_until_finished() {
 }
 
 #[test]
-fn drain_shared_session_injections_removes_only_shared_session_rows_in_fifo_order() {
+fn clear_queue_removes_every_row_regardless_of_origin_in_fifo_order() {
     with_model(|mut app, model, events| {
         let id = AIConversationId::new();
-        let (first, second, local) = model.update(&mut app, |queue, ctx| {
-            let first = queue.append(
+        let (shared, local, command) = model.update(&mut app, |queue, ctx| {
+            let shared = queue.append(
                 id,
                 QueuedQuery::new_shared_session_prompt(
-                    "first".into(),
+                    "shared".into(),
                     ParticipantId::new(),
                     vec![],
                 ),
                 ctx,
             );
             let local = queue.append(id, user_query("local"), ctx);
-            let second = queue.append(
-                id,
-                QueuedQuery::new_shared_session_prompt(
-                    "second".into(),
-                    ParticipantId::new(),
-                    vec![],
-                ),
-                ctx,
-            );
-            (first, second, local)
+            let command = queue.append(id, command_query("ls"), ctx);
+            (shared, local, command)
         });
         events.borrow_mut().clear();
 
-        let drained = model.update(&mut app, |queue, ctx| {
-            queue.drain_shared_session_injections(id, ctx)
-        });
+        let cleared = model.update(&mut app, |queue, ctx| queue.clear_queue(id, ctx));
         assert_eq!(
-            drained.iter().map(QueuedQuery::text).collect::<Vec<_>>(),
-            vec!["first", "second"]
+            cleared.iter().map(QueuedQuery::text).collect::<Vec<_>>(),
+            vec!["shared", "local", "ls"],
+            "every row is cleared regardless of origin, in FIFO order"
         );
-        assert_eq!(drained[0].id(), first);
-        assert_eq!(drained[1].id(), second);
+        assert_eq!(cleared[0].id(), shared);
+        assert_eq!(cleared[1].id(), local);
+        assert_eq!(cleared[2].id(), command);
 
         model.read(&app, |queue, _| {
-            let remaining = queue.queue(id);
-            assert_eq!(remaining.len(), 1);
-            assert_eq!(remaining[0].id(), local);
+            assert!(!queue.has_queue(id));
+            assert!(!queue.has_pending_native_injections(id));
         });
 
         let evts = events.borrow();
-        assert_eq!(evts.len(), 2);
+        assert_eq!(evts.len(), 3);
         assert!(evts.iter().all(|e| matches!(
             e,
             QueuedQueryEvent::Removed { conversation_id, .. } if *conversation_id == id
@@ -139,18 +130,14 @@ fn drain_shared_session_injections_removes_only_shared_session_rows_in_fifo_orde
 }
 
 #[test]
-fn drain_shared_session_injections_no_ops_when_nothing_queued() {
+fn clear_queue_no_ops_when_nothing_queued() {
     with_model(|mut app, model, events| {
         let id = AIConversationId::new();
-        append_user(&model, &mut app, id, "local only");
         events.borrow_mut().clear();
 
-        let drained = model.update(&mut app, |queue, ctx| {
-            queue.drain_shared_session_injections(id, ctx)
-        });
-        assert!(drained.is_empty());
+        let cleared = model.update(&mut app, |queue, ctx| queue.clear_queue(id, ctx));
+        assert!(cleared.is_empty());
         assert!(events.borrow().is_empty());
-        model.read(&app, |queue, _| assert_eq!(queue.queue(id).len(), 1));
     });
 }
 

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -48,11 +48,48 @@ fn user_query(text: &str) -> QueuedQuery {
 }
 
 #[test]
-fn startup_queue_claims_only_one_fifo_row_until_dispatch_finishes() {
+fn native_setup_barrier_blocks_dispatch_until_finished() {
     with_model(|mut app, model, _| {
         let id = AIConversationId::new();
-        let (first, second) = model.update(&mut app, |queue, ctx| {
+        model.update(&mut app, |queue, ctx| {
             queue.begin_native_setup(id, ctx);
+            assert!(queue.is_dispatch_blocked(id));
+            assert!(queue.has_pending_native_injections(id));
+
+            queue.append(
+                id,
+                QueuedQuery::new_shared_session_prompt(
+                    "first".into(),
+                    ParticipantId::new(),
+                    vec![],
+                ),
+                ctx,
+            );
+            assert!(queue.has_pending_native_injections(id));
+
+            // The barrier -- not `drain_shared_session_injections` itself -- is what gates
+            // when a caller is allowed to drain; the row sits untouched until then.
+            queue.finish_native_setup(id, ctx);
+            assert!(!queue.is_dispatch_blocked(id));
+            assert!(queue.has_pending_native_injections(id));
+
+            let drained = queue.drain_shared_session_injections(id, ctx);
+            assert_eq!(drained.len(), 1);
+            assert_eq!(drained[0].text(), "first");
+            assert!(!queue.has_pending_native_injections(id));
+
+            // Idempotent once already released.
+            queue.finish_native_setup(id, ctx);
+            assert!(!queue.is_dispatch_blocked(id));
+        });
+    });
+}
+
+#[test]
+fn drain_shared_session_injections_removes_only_shared_session_rows_in_fifo_order() {
+    with_model(|mut app, model, events| {
+        let id = AIConversationId::new();
+        let (first, second, local) = model.update(&mut app, |queue, ctx| {
             let first = queue.append(
                 id,
                 QueuedQuery::new_shared_session_prompt(
@@ -62,6 +99,7 @@ fn startup_queue_claims_only_one_fifo_row_until_dispatch_finishes() {
                 ),
                 ctx,
             );
+            let local = queue.append(id, user_query("local"), ctx);
             let second = queue.append(
                 id,
                 QueuedQuery::new_shared_session_prompt(
@@ -71,86 +109,48 @@ fn startup_queue_claims_only_one_fifo_row_until_dispatch_finishes() {
                 ),
                 ctx,
             );
-            assert!(queue.claim_injection(id, first, ctx).is_none());
-            queue.finish_native_setup(id, ctx);
-            queue.finish_native_initial_turn(id, ctx);
-            assert!(queue.claim_injection(id, second, ctx).is_none());
-            assert!(queue.claim_injection(id, first, ctx).is_some());
-            assert!(queue.claim_injection(id, first, ctx).is_none());
-            assert!(queue.peek_autofire(id).is_none());
-            assert!(queue.remove_by_id(id, first, ctx).is_none());
-            (first, second)
+            (first, second, local)
         });
-        model.update(&mut app, |queue, ctx| {
-            queue.finish_injection_dispatch(id, first, None, ctx);
-            queue.finish_injection_dispatch(id, first, None, ctx);
-            assert_eq!(queue.queue(id).len(), 1);
-            assert_eq!(
-                queue.claim_injection(id, second, ctx).unwrap().text(),
-                "second"
-            );
+        events.borrow_mut().clear();
+
+        let drained = model.update(&mut app, |queue, ctx| {
+            queue.drain_shared_session_injections(id, ctx)
         });
+        assert_eq!(
+            drained.iter().map(QueuedQuery::text).collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+        assert_eq!(drained[0].id(), first);
+        assert_eq!(drained[1].id(), second);
+
+        model.read(&app, |queue, _| {
+            let remaining = queue.queue(id);
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(remaining[0].id(), local);
+        });
+
+        let evts = events.borrow();
+        assert_eq!(evts.len(), 2);
+        assert!(evts.iter().all(|e| matches!(
+            e,
+            QueuedQueryEvent::Removed { conversation_id, .. } if *conversation_id == id
+        )));
     });
 }
 
 #[test]
-fn empty_native_queue_captures_injections_until_initial_turn_finishes() {
-    with_model(|mut app, model, _| {
+fn drain_shared_session_injections_no_ops_when_nothing_queued() {
+    with_model(|mut app, model, events| {
         let id = AIConversationId::new();
-        model.update(&mut app, |queue, ctx| {
-            queue.begin_native_setup(id, ctx);
-            queue.finish_native_initial_turn(id, ctx);
-            assert!(queue.is_dispatch_blocked(id));
-            queue.finish_native_setup(id, ctx);
-            assert!(!queue.has_queue(id));
-            assert!(queue.has_pending_native_injections(id));
-            assert!(queue.is_dispatch_blocked(id));
-            queue.finish_native_initial_turn(id, ctx);
-            assert!(!queue.has_pending_native_injections(id));
-            assert!(!queue.is_dispatch_blocked(id));
-            queue.finish_native_setup(id, ctx);
-            assert!(!queue.has_pending_native_injections(id));
-        });
-    });
-}
+        append_user(&model, &mut app, id, "local only");
+        events.borrow_mut().clear();
 
-#[test]
-fn failed_startup_dispatch_retains_unsent_rows_and_stops_auto_drain() {
-    with_model(|mut app, model, _| {
-        let id = AIConversationId::new();
-        model.update(&mut app, |queue, ctx| {
-            let first = queue.append(
-                id,
-                QueuedQuery::new_shared_session_prompt(
-                    "first".into(),
-                    ParticipantId::new(),
-                    vec![],
-                ),
-                ctx,
-            );
-            queue.append(
-                id,
-                QueuedQuery::new_shared_session_prompt(
-                    "second".into(),
-                    ParticipantId::new(),
-                    vec![],
-                ),
-                ctx,
-            );
-            assert!(queue.claim_injection(id, first, ctx).is_some());
-            queue.finish_injection_dispatch(id, first, Some("download failed".into()), ctx);
-            assert_eq!(
-                queue
-                    .queue(id)
-                    .iter()
-                    .map(QueuedQuery::text)
-                    .collect::<Vec<_>>(),
-                vec!["first", "second"]
-            );
-            assert_eq!(queue.injection_error(id), Some("download failed"));
-            assert!(queue.peek_autofire(id).is_none());
-            assert!(queue.pop_front(id, ctx).is_none());
+        let drained = model.update(&mut app, |queue, ctx| {
+            queue.drain_shared_session_injections(id, ctx)
         });
+        assert!(drained.is_empty());
+        assert!(events.borrow().is_empty());
+        model.read(&app, |queue, _| assert_eq!(queue.queue(id).len(), 1));
     });
 }
 

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -5,6 +5,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use session_sharing_protocol::common::ParticipantId;
 use warpui::{App, SingletonEntity};
 
 use super::{
@@ -44,6 +45,113 @@ where
 
 fn user_query(text: &str) -> QueuedQuery {
     QueuedQuery::new(text.to_owned(), QueuedQueryOrigin::QueueSlashCommand)
+}
+
+#[test]
+fn startup_queue_claims_only_one_fifo_row_until_dispatch_finishes() {
+    with_model(|mut app, model, _| {
+        let id = AIConversationId::new();
+        let (first, second) = model.update(&mut app, |queue, ctx| {
+            queue.begin_native_setup(id, ctx);
+            let first = queue.append(
+                id,
+                QueuedQuery::new_shared_session_prompt(
+                    "first".into(),
+                    ParticipantId::new(),
+                    vec![],
+                ),
+                ctx,
+            );
+            let second = queue.append(
+                id,
+                QueuedQuery::new_shared_session_prompt(
+                    "second".into(),
+                    ParticipantId::new(),
+                    vec![],
+                ),
+                ctx,
+            );
+            assert!(queue.claim_injection(id, first, ctx).is_none());
+            queue.finish_native_setup(id, ctx);
+            queue.finish_native_initial_turn(id, ctx);
+            assert!(queue.claim_injection(id, second, ctx).is_none());
+            assert!(queue.claim_injection(id, first, ctx).is_some());
+            assert!(queue.claim_injection(id, first, ctx).is_none());
+            assert!(queue.peek_autofire(id).is_none());
+            assert!(queue.remove_by_id(id, first, ctx).is_none());
+            (first, second)
+        });
+        model.update(&mut app, |queue, ctx| {
+            queue.finish_injection_dispatch(id, first, None, ctx);
+            queue.finish_injection_dispatch(id, first, None, ctx);
+            assert_eq!(queue.queue(id).len(), 1);
+            assert_eq!(
+                queue.claim_injection(id, second, ctx).unwrap().text(),
+                "second"
+            );
+        });
+    });
+}
+
+#[test]
+fn empty_native_queue_captures_injections_until_initial_turn_finishes() {
+    with_model(|mut app, model, _| {
+        let id = AIConversationId::new();
+        model.update(&mut app, |queue, ctx| {
+            queue.begin_native_setup(id, ctx);
+            queue.finish_native_initial_turn(id, ctx);
+            assert!(queue.is_dispatch_blocked(id));
+            queue.finish_native_setup(id, ctx);
+            assert!(!queue.has_queue(id));
+            assert!(queue.has_pending_native_injections(id));
+            assert!(queue.is_dispatch_blocked(id));
+            queue.finish_native_initial_turn(id, ctx);
+            assert!(!queue.has_pending_native_injections(id));
+            assert!(!queue.is_dispatch_blocked(id));
+            queue.finish_native_setup(id, ctx);
+            assert!(!queue.has_pending_native_injections(id));
+        });
+    });
+}
+
+#[test]
+fn failed_startup_dispatch_retains_unsent_rows_and_stops_auto_drain() {
+    with_model(|mut app, model, _| {
+        let id = AIConversationId::new();
+        model.update(&mut app, |queue, ctx| {
+            let first = queue.append(
+                id,
+                QueuedQuery::new_shared_session_prompt(
+                    "first".into(),
+                    ParticipantId::new(),
+                    vec![],
+                ),
+                ctx,
+            );
+            queue.append(
+                id,
+                QueuedQuery::new_shared_session_prompt(
+                    "second".into(),
+                    ParticipantId::new(),
+                    vec![],
+                ),
+                ctx,
+            );
+            assert!(queue.claim_injection(id, first, ctx).is_some());
+            queue.finish_injection_dispatch(id, first, Some("download failed".into()), ctx);
+            assert_eq!(
+                queue
+                    .queue(id)
+                    .iter()
+                    .map(QueuedQuery::text)
+                    .collect::<Vec<_>>(),
+                vec!["first", "second"]
+            );
+            assert_eq!(queue.injection_error(id), Some("download failed"));
+            assert!(queue.peek_autofire(id).is_none());
+            assert!(queue.pop_front(id, ctx).is_none());
+        });
+    });
 }
 
 fn initial_cloud_mode_query(text: &str) -> QueuedQuery {

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1163,6 +1163,7 @@ pub enum LoginEventSource {
 #[serde(rename_all = "snake_case")]
 pub enum TelemetryQueuedQueryOrigin {
     InitialCloudMode,
+    SharedSessionInjection,
     QueueSlashCommand,
     AutoQueueToggle,
     LrcAutoQueue,
@@ -1175,6 +1176,7 @@ impl From<QueuedQueryOrigin> for TelemetryQueuedQueryOrigin {
     fn from(origin: QueuedQueryOrigin) -> Self {
         match origin {
             QueuedQueryOrigin::InitialCloudMode => Self::InitialCloudMode,
+            QueuedQueryOrigin::SharedSessionInjection => Self::SharedSessionInjection,
             QueuedQueryOrigin::QueueSlashCommand => Self::QueueSlashCommand,
             QueuedQueryOrigin::AutoQueueToggle => Self::AutoQueueToggle,
             QueuedQueryOrigin::LrcAutoQueue => Self::LrcAutoQueue,

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -4326,11 +4326,11 @@ impl Input {
             .iter()
             .any(|row| row.id() == query_id && row.shared_session_prompt().is_some())
         {
-            // "Send now" on a shared-session-injected row dispatches it immediately, the same
-            // way `BlocklistAIController::dispatch_next_shared_session_row` otherwise dispatches
-            // the head row once it's safe to do so.
+            // "Send now" targets the clicked row specifically, which may not be the queue head
+            // (e.g. after reordering) -- passing `query_id` through dispatches that exact row
+            // instead of whatever currently happens to be at the head.
             self.ai_controller.update(ctx, |controller, ctx| {
-                controller.dispatch_next_shared_session_row(conversation_id, ctx);
+                controller.dispatch_queued_warp_agent_prompt(conversation_id, Some(query_id), ctx);
             });
             return;
         }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -4326,8 +4326,11 @@ impl Input {
             .iter()
             .any(|row| row.id() == query_id && row.shared_session_prompt().is_some())
         {
+            // "Send now" on a shared-session-injected row flushes the whole startup backlog
+            // together, consistent with how it's otherwise drained
+            // (`BlocklistAIController::drain_native_startup_queue`).
             self.ai_controller.update(ctx, |controller, ctx| {
-                controller.send_queued_shared_session_prompt(conversation_id, query_id, ctx);
+                controller.drain_native_startup_queue(conversation_id, ctx);
             });
             return;
         }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -4326,11 +4326,11 @@ impl Input {
             .iter()
             .any(|row| row.id() == query_id && row.shared_session_prompt().is_some())
         {
-            // "Send now" on a shared-session-injected row flushes the whole startup backlog
-            // together, consistent with how it's otherwise drained
-            // (`BlocklistAIController::drain_native_startup_queue`).
+            // "Send now" on a shared-session-injected row dispatches it immediately, the same
+            // way `BlocklistAIController::dispatch_next_shared_session_row` otherwise dispatches
+            // the head row once it's safe to do so.
             self.ai_controller.update(ctx, |controller, ctx| {
-                controller.drain_native_startup_queue(conversation_id, ctx);
+                controller.dispatch_next_shared_session_row(conversation_id, ctx);
             });
             return;
         }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -4318,6 +4318,19 @@ impl Input {
         ctx: &mut ViewContext<Self>,
     ) {
         // Read the origin before dispatch; the row is removed once it fires.
+        if QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(conversation_id) {
+            return;
+        }
+        if QueuedQueryModel::as_ref(ctx)
+            .queue(conversation_id)
+            .iter()
+            .any(|row| row.id() == query_id && row.shared_session_prompt().is_some())
+        {
+            self.ai_controller.update(ctx, |controller, ctx| {
+                controller.send_queued_shared_session_prompt(conversation_id, query_id, ctx);
+            });
+            return;
+        }
         let origin = QueuedQueryModel::as_ref(ctx)
             .queue(conversation_id)
             .iter()

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -138,6 +138,9 @@ fn accept_agent_prompt(
         .session(terminal_view_id)
         .is_some();
     if has_active_cli_agent {
+        log::info!(
+            "event=prompt_routed terminal_id={terminal_view_id:?} participant_id={participant_id} destination=live_cli",
+        );
         // Reuse the rich input submit pipeline so agent-specific
         // strategies are applied. Bypasses the rich-input-UI side effects
         // (telemetry, draft clear, editor buffer clear, pending-image consumption).
@@ -154,6 +157,9 @@ fn accept_agent_prompt(
     if let Some(task_id) =
         LocalAgentTaskSyncModel::as_ref(ctx).cli_harness_task_id_for_terminal_view(terminal_view_id)
     {
+        log::info!(
+            "event=prompt_routed terminal_id={terminal_view_id:?} participant_id={participant_id} task_id={task_id} destination=pending_cli",
+        );
         if !request.attachments.is_empty() {
             log::warn!(
                 "accept_agent_prompt: dropping {} file attachment(s) from a shared-session \
@@ -184,6 +190,10 @@ fn accept_agent_prompt(
         });
 
         view.ai_controller().update(ctx, |ai_controller, ctx| {
+            log::info!(
+                "event=prompt_routed terminal_id={terminal_view_id:?} participant_id={participant_id} destination=native bound_conversation_id={:?}",
+                ai_controller.native_prompt_conversation_id(),
+            );
             ai_controller.execute_warp_agent_prompt_from_shared_session_injection(
                 request.prompt.clone(),
                 request.server_conversation_token,
@@ -1449,11 +1459,15 @@ impl TerminalManager<TerminalView> {
                 // shared-session prompt is observable for diagnosing lost or misrouted prompts.
                 log::info!(
                     "Received shared-session agent prompt request id={id:?} \
-                     participant_id={participant_id} has_server_conversation_token={}",
+                     participant_id={participant_id} terminal_id={:?} has_server_conversation_token={}",
+                    terminal_view.id(),
                     request.server_conversation_token.is_some()
                 );
 
                 if !FeatureFlag::AgentSharedSessions.is_enabled() {
+                    log::info!(
+                        "event=prompt_rejected request_id={id:?} reason=agent_shared_sessions_disabled",
+                    );
                     return;
                 }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5622,14 +5622,13 @@ impl TerminalView {
                                 row.id() == query_id && row.shared_session_prompt().is_some()
                             })
                         {
-                            // TODO: Deliver startup injections together when Oz supports non-interrupting
-                            // batch delivery, consistent with third-party harness startup queue draining.
+                            // Native startup injections are normally fully drained the moment
+                            // setup finishes (`BlocklistAIController::drain_native_startup_queue`,
+                            // called from `AgentDriver::execute_run`); reaching a shared-session
+                            // row here means a prior drain was deferred (e.g. an active CLI
+                            // subagent), so retry the same drain-all now that this turn finished.
                             self.ai_controller.update(ctx, |controller, ctx| {
-                                controller.send_queued_shared_session_prompt(
-                                    conversation_id,
-                                    query_id,
-                                    ctx,
-                                );
+                                controller.drain_native_startup_queue(conversation_id, ctx);
                             });
                             return;
                         }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5468,6 +5468,14 @@ impl TerminalView {
                 && let Some(reason) = self.finish_reason_for_conversation(*conversation_id, ctx)
             {
                 self.drain_queued_prompts(*conversation_id, reason, ctx);
+            } else if QueuedQueryModel::as_ref(ctx).has_queue(*conversation_id) {
+                log::info!(
+                    "event=turn_drain_deferred terminal_id={:?} conversation_id={conversation_id} active_subagent={has_active_subagent} has_finished_block={} queue_len={}",
+                    self.view_id,
+                    self.finish_reason_for_conversation(*conversation_id, ctx)
+                        .is_some(),
+                    QueuedQueryModel::as_ref(ctx).queue(*conversation_id).len(),
+                );
             }
 
             // If the most recent action in the current interaction turn created or updated a plan
@@ -5584,7 +5592,7 @@ impl TerminalView {
 
     /// Drains one prompt from the queued-query singleton for `conversation_id` when that
     /// conversation finishes.
-    fn drain_queued_prompts(
+    pub(crate) fn drain_queued_prompts(
         &mut self,
         conversation_id: AIConversationId,
         finish_reason: FinishReason,
@@ -5596,6 +5604,9 @@ impl TerminalView {
                 let first_row_is_in_edit_mode =
                     QueuedQueryModel::as_ref(ctx).first_row_is_in_edit_mode(conversation_id);
                 if first_row_is_in_edit_mode && !input_is_empty {
+                    log::info!(
+                        "event=turn_drain_deferred conversation_id={conversation_id} reason=editing_head_with_local_draft",
+                    );
                     return;
                 }
 
@@ -5604,6 +5615,24 @@ impl TerminalView {
                 let action = QueuedQueryModel::as_ref(ctx).peek_autofire(conversation_id);
                 match action {
                     Some(AutofireAction::Submit { query_id, text }) => {
+                        if QueuedQueryModel::as_ref(ctx)
+                            .queue(conversation_id)
+                            .iter()
+                            .any(|row| {
+                                row.id() == query_id && row.shared_session_prompt().is_some()
+                            })
+                        {
+                            // TODO: Deliver startup injections together when Oz supports non-interrupting
+                            // batch delivery, consistent with third-party harness startup queue draining.
+                            self.ai_controller.update(ctx, |controller, ctx| {
+                                controller.send_queued_shared_session_prompt(
+                                    conversation_id,
+                                    query_id,
+                                    ctx,
+                                );
+                            });
+                            return;
+                        }
                         self.input.update(ctx, |input, ctx| {
                             input.submit_queued_prompt_for_active_pane(
                                 text,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5548,6 +5548,7 @@ impl TerminalView {
         let id = QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
             model.append(conversation_id, QueuedQuery::new(prompt, origin), ctx)
         });
+        self.maybe_dispatch_steering_prompt_now(conversation_id, ctx);
         Some(id)
     }
 
@@ -5582,12 +5583,37 @@ impl TerminalView {
                     ctx,
                 );
             });
+            self.maybe_dispatch_steering_prompt_now(conversation_id, ctx);
         } else {
             self.send_user_query_after_next_conversation_finished(
                 prompt, /* show_close_button */ true, /* show_send_now_button */ false,
                 ctx,
             );
         }
+    }
+
+    /// If `conversation_id`'s queue is in `Steering` mode and nothing is currently streaming for
+    /// it, attempts to dispatch the just-queued row immediately rather than waiting for a future
+    /// turn-completion event that may never come (e.g. the conversation has nothing else in
+    /// flight right now). No-ops when a stream is already active for the conversation --
+    /// `Steering`'s piggyback-on-next-request and idle-drain mechanisms pick the row up once
+    /// that stream's turn produces a natural boundary, so firing here too would interrupt it.
+    fn maybe_dispatch_steering_prompt_now(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !QueuedQueryModel::as_ref(ctx).is_steering(conversation_id) {
+            return;
+        }
+        if self
+            .ai_controller
+            .as_ref(ctx)
+            .has_active_stream_for_conversation(conversation_id, ctx)
+        {
+            return;
+        }
+        self.drain_queued_prompts(conversation_id, FinishReason::Complete, ctx);
     }
 
     /// Drains one prompt from the queued-query singleton for `conversation_id` when that
@@ -5622,13 +5648,13 @@ impl TerminalView {
                                 row.id() == query_id && row.shared_session_prompt().is_some()
                             })
                         {
-                            // Native startup injections are normally fully drained the moment
-                            // setup finishes (`BlocklistAIController::drain_native_startup_queue`,
-                            // called from `AgentDriver::execute_run`); reaching a shared-session
-                            // row here means a prior drain was deferred (e.g. an active CLI
-                            // subagent), so retry the same drain-all now that this turn finished.
+                            // Shared-session injections are normally dispatched via `Steering`'s
+                            // piggyback-on-next-request mechanism, or immediately when queued
+                            // while idle; reaching one here means neither applied (e.g. a prior
+                            // dispatch was deferred because a CLI subagent was active), so try
+                            // dispatching the head row now that this turn finished.
                             self.ai_controller.update(ctx, |controller, ctx| {
-                                controller.drain_native_startup_queue(conversation_id, ctx);
+                                controller.dispatch_next_shared_session_row(conversation_id, ctx);
                             });
                             return;
                         }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5654,7 +5654,11 @@ impl TerminalView {
                             // dispatch was deferred because a CLI subagent was active), so try
                             // dispatching the head row now that this turn finished.
                             self.ai_controller.update(ctx, |controller, ctx| {
-                                controller.dispatch_next_shared_session_row(conversation_id, ctx);
+                                controller.dispatch_queued_warp_agent_prompt(
+                                    conversation_id,
+                                    None,
+                                    ctx,
+                                );
                             });
                             return;
                         }

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -965,6 +965,11 @@ impl AmbientAgentViewModel {
         let request = RunFollowupRequest {
             message: prompt.clone(),
         };
+        if self.pending_followup_prompt.is_some() {
+            log::warn!(
+                "event=viewer_followup_slot_replaced task_id={task_id} route=setup_failure_debug",
+            );
+        }
         self.pending_followup_prompt = Some(prompt);
         ctx.emit(AmbientAgentViewModelEvent::FollowupDispatched);
 
@@ -1001,6 +1006,9 @@ impl AmbientAgentViewModel {
             None,
         );
 
+        if self.pending_followup_prompt.is_some() {
+            log::warn!("event=viewer_followup_slot_replaced task_id={task_id} route=run_followup",);
+        }
         self.pending_followup_prompt = Some(prompt);
         self.status = Status::WaitingForSession {
             progress: AgentProgress::new(),

--- a/app/src/terminal/view/pending_user_query.rs
+++ b/app/src/terminal/view/pending_user_query.rs
@@ -188,6 +188,16 @@ impl TerminalView {
         show_send_now_button: bool,
         ctx: &mut ViewContext<Self>,
     ) {
+        if self.queued_prompt_callback.is_some() {
+            log::warn!(
+                "event=legacy_queued_prompt_replaced terminal_id={:?} conversation_id={:?} queued_prompts_v2={}",
+                self.view_id,
+                self.ai_context_model
+                    .as_ref(ctx)
+                    .selected_conversation_id(ctx),
+                FeatureFlag::QueuedPromptsV2.is_enabled(),
+            );
+        }
         if FeatureFlag::PendingUserQueryIndicator.is_enabled() {
             self.insert_pending_user_query_block(
                 prompt.clone(),
@@ -199,6 +209,11 @@ impl TerminalView {
         }
         // Replace any previously queued prompt so the latest one always wins.
         self.queued_prompt_callback = Some(Box::new(move |terminal_view, reason, ctx| {
+            log::info!(
+                "event=legacy_queue_callback_fired terminal_id={:?} success={}",
+                terminal_view.view_id,
+                matches!(reason, FinishReason::Complete),
+            );
             if FeatureFlag::PendingUserQueryIndicator.is_enabled() {
                 terminal_view.remove_pending_user_query_block(ctx);
             }

--- a/app/src/terminal/view/queued_prompts_panel.rs
+++ b/app/src/terminal/view/queued_prompts_panel.rs
@@ -130,7 +130,7 @@ fn build_row_state(
         })
     });
 
-    if is_initial_cloud_mode_prompt {
+    if is_initial_cloud_mode_prompt || origin == QueuedQueryOrigin::SharedSessionInjection {
         edit_button.update(ctx, |button, ctx| button.set_disabled(true, ctx));
     }
 
@@ -341,6 +341,7 @@ impl QueuedPromptsPanelView {
         };
         let queue_model = QueuedQueryModel::as_ref(ctx);
         self.enter_sends_queued_prompt(ctx)
+            && !queue_model.is_dispatch_blocked(conv_id)
             && queue_model.editing_row(conv_id).is_none()
             && queue_model
                 .queue(conv_id)
@@ -419,9 +420,10 @@ impl QueuedPromptsPanelView {
             .iter()
             .map(|query| (query.id(), query.origin()))
             .collect();
-        let cloud_setup_in_progress = rows
-            .first()
-            .is_some_and(|(_, origin)| *origin == QueuedQueryOrigin::InitialCloudMode);
+        let cloud_setup_in_progress = QueuedQueryModel::as_ref(ctx).is_dispatch_blocked(conv_id)
+            || rows
+                .first()
+                .is_some_and(|(_, origin)| *origin == QueuedQueryOrigin::InitialCloudMode);
         let lrc_subagent_in_progress = self
             .cli_subagent_controller
             .as_ref(ctx)
@@ -513,6 +515,7 @@ impl QueuedPromptsPanelView {
                 conversation_id, ..
             }
             | QueuedQueryEvent::RowUnlocked { conversation_id }
+            | QueuedQueryEvent::DispatchStateChanged { conversation_id }
             | QueuedQueryEvent::Reordered { conversation_id }
             | QueuedQueryEvent::EditEntered {
                 conversation_id, ..
@@ -601,7 +604,8 @@ impl QueuedPromptsPanelView {
                 // A new row queued while the locked initial row is present must start disabled.
                 self.update_send_now_availability(ctx);
             }
-            QueuedQueryEvent::RowUnlocked { .. } => {
+            QueuedQueryEvent::RowUnlocked { .. }
+            | QueuedQueryEvent::DispatchStateChanged { .. } => {
                 self.update_send_now_availability(ctx);
             }
             QueuedQueryEvent::Reordered { .. }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -2096,6 +2096,7 @@ impl TuiTerminalSessionView {
                 }
                 QueuedQueryEvent::DefaultModeChanged => ctx.notify(),
                 QueuedQueryEvent::Appended { .. }
+                | QueuedQueryEvent::DispatchStateChanged { .. }
                 | QueuedQueryEvent::RowUnlocked { .. }
                 | QueuedQueryEvent::Removed { .. }
                 | QueuedQueryEvent::Reordered { .. }


### PR DESCRIPTION
## Description
Queued prompts for a conversation are delivered under one of two modes, stored per conversation on `QueuedQueryModel` (`QueuedPromptDeliveryMode`):
- **Steering**, set automatically for Oz ambient-agent-driven conversations by `bind_native_prompt_conversation`: a queued prompt goes out on the next request made for the conversation — a tool-result follow-up, an orchestration-event injection, or the conversation going idle — instead of waiting for the whole turn to finish. Each prompt is still sent as its own request/exchange; queued prompts are never combined into one exchange.
- **Queueing**, used everywhere else (local `/queue`, the auto-queue toggle, LRC auto-queue): the next queued row is sent only once the conversation finishes on its own.

For a Steering conversation, `route_native_startup_injection` always appends an incoming prompt to the queue, then dispatches the head row via `dispatch_queued_warp_agent_prompt` when `can_dispatch_queued_warp_agent_prompt` confirms nothing is currently streaming and native setup has finished. `dispatch_queued_warp_agent_prompt` is a single controller-level entry point that dispatches whichever queued row it can resolve and send on its own — a local prompt via `send_queued_user_query_in_conversation`, a shared-session-injected prompt via attachment staging/download — regardless of which origin queued it; a shell command, a locked row, or a row being edited is left for `TerminalInput`/`TerminalView::drain_queued_prompts`, which need editor and PTY access the controller doesn't have. It takes an optional specific row id: `None` dispatches the head in FIFO order (every automatic trigger), `Some(id)` targets an explicit row such as "Send now", which may not be the head and is allowed to interrupt an active stream on purpose.

When a turn is already active, `steer_head_prompt_for_request` folds the head queued row into whichever request the conversation naturally sends next (`send_follow_up_for_conversation`, `inject_pending_events_for_request`) as an additional input, so the model sees it as soon as possible without interrupting the turn in flight or waiting for full completion.

Downloading a shared-session prompt's file attachments is best-effort: `download_task_file_attachments` (shared by the live and queued injection paths) logs and skips a failed URL lookup, directory creation, or individual file download rather than aborting the send — the prompt still reaches the conversation, with whatever attachments succeeded.

### Scope and tradeoffs
- A shared-session row carrying a file attachment that still needs downloading can't be resolved synchronously, so it's excluded from the piggyback path and only dispatched via the idle-triggered drain.
- Mode selection is not user-facing yet; Steering is set automatically and cannot currently be toggled.
- Shared-session viewer queue display/synchronization remains out of scope.

### Review guide
Start with `queued_query.rs` for `QueuedPromptDeliveryMode` storage and the per-row eligibility rules (`peek_autofire`) both modes share. Then `controller/startup_queue.rs` for `dispatch_queued_warp_agent_prompt` and `route_native_startup_injection`, and `controller.rs` for `can_dispatch_queued_warp_agent_prompt` and `steer_head_prompt_for_request`'s two call sites. `terminal/view.rs`'s `maybe_dispatch_steering_prompt_now`/`drain_queued_prompts` and `terminal/input.rs`'s `send_queued_row_immediately` cover the local-queueing and "Send now" side. `attachment_utils.rs` has the shared download helper.

[Implementation plan](https://staging.warp.dev/drive/notebook/Oz3uEHLh7CnSvDELpSvEzG) · [Development conversation](https://staging.warp.dev/conversation/c5dcedb1-fc2f-4885-8976-30b779fa7699)

## Linked Issue
No linked issue was provided.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. — No linked issue.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). — No screenshots; the only UI-visible change is treating `SharedSessionInjection` rows like `InitialCloudMode` in the queued-prompts panel, with no new surface to capture.

## Testing
`cargo check -p warp`, `./script/format --check`, and all three presubmit Clippy variants (`cargo clippy --workspace --exclude warp_completer --all-targets --tests`, `cargo clippy -p warp --all-targets --tests`, `cargo clippy -p warp_completer --all-targets --tests`, all with `-D warnings`) passed. The `ai::blocklist`, `ai::agent_sdk`, `terminal::view`, `terminal::input`, and `ai::attachment_utils` nextest suites passed in full (2139 tests). The full workspace test suite was not run.

Not verified: end-to-end delivery against a live Oz shared-session worker.

- [ ] I have manually tested my changes locally with `./script/run` — Not yet verified against a live worker; see above.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Fixed native Oz follow-up prompts interrupting one another instead of each reaching the agent.

Co-Authored-By: Warp <agent@warp.dev>
