### PR TITLE
Fix broken mock closure arity blocking CI on master

### DIFF
--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -1739,7 +1739,7 @@ fn repeated_viewer_registration_starts_one_ancestor_seed_fetch() {
         let mut mock = MockAIClient::new();
         mock.expect_list_ambient_agent_tasks()
             .times(1)
-            .returning(|_, _| Err(anyhow::anyhow!("fetch observed")));
+            .returning(|_, _, _| Err(anyhow::anyhow!("fetch observed")));
         let ai_client: Arc<dyn AIClient> = Arc::new(mock);
         let server_api = ServerApiProvider::new_for_test().get();
         let streamer = app.add_singleton_model(|ctx| {


### PR DESCRIPTION
## Description
`master` fails to compile its test target: `AIClient::list_ambient_agent_tasks` gained a third parameter in #15811, but one mock closure in `orchestration_event_streamer_tests.rs` was never updated to match:

```
error[E0593]: closure is expected to take 3 arguments, but it takes 2 arguments
  --> app/src/ai/blocklist/orchestration_event_streamer_tests.rs:1742:14
```

This blocks Formatting + Clippy and Run tests CI (all platforms) for every PR based on current `master`. Confirmed by building a clean `master` checkout in isolation, no other changes applied.

Fix: `|_, _|` → `|_, _, _|` on the closure, which returns a canned error regardless of input.

## Linked Issue
No linked GitHub issue; urgent trunk-CI fix.

## Testing
- [x] `cargo check -p warp --tests --lib` passes
- [x] `cargo nextest run -p warp repeated_viewer_registration_starts_one_ancestor_seed_fetch` passes
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass
- [ ] `./script/run` not applicable — one-line test-only fix

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>