### PR TITLE
Add configurable CLI-agent state colors to vertical tabs

### DIFF
--- a/app/src/ai/custom_endpoints.rs
+++ b/app/src/ai/custom_endpoints.rs
@@ -45,6 +45,8 @@ impl CustomEndpointSettingsModel {
                     model.sync_or_migrate(ctx);
                 }
                 WarpConfigUpdateEvent::Themes
+                | WarpConfigUpdateEvent::AgentTabStyles
+                | WarpConfigUpdateEvent::AgentTabStylesError(_)
                 | WarpConfigUpdateEvent::LocalUserWorkflows
                 | WarpConfigUpdateEvent::LaunchConfigs
                 | WarpConfigUpdateEvent::TabConfigs

--- a/app/src/integration_testing/agent_state_visuals.rs
+++ b/app/src/integration_testing/agent_state_visuals.rs
@@ -1,0 +1,63 @@
+use warpui::{App, AppContext, EntityId, SingletonEntity, ViewHandle};
+
+use crate::terminal::TerminalView;
+use crate::terminal::cli_agent_sessions::event::CLI_AGENT_NOTIFICATION_SENTINEL;
+use crate::terminal::cli_agent_sessions::{CLIAgentDisplayState, CLIAgentSessionsModel};
+use crate::terminal::model_events::ModelEvent;
+use crate::user_config::WarpConfig;
+use crate::user_config::agent_tab_styles::{AgentTabColor, AgentTabStyles};
+
+pub fn agent_tab_styles_path() -> std::path::PathBuf {
+    crate::user_config::agent_tab_styles_path()
+}
+
+pub fn cli_agent_display_state(
+    app: &AppContext,
+    terminal_view_id: EntityId,
+) -> Option<&'static str> {
+    CLIAgentSessionsModel::as_ref(app)
+        .display_state(terminal_view_id)
+        .map(|state| match state {
+            CLIAgentDisplayState::Idle => "idle",
+            CLIAgentDisplayState::Processing => "processing",
+            CLIAgentDisplayState::Success => "success",
+            CLIAgentDisplayState::NeedsAttention => "needs_attention",
+        })
+}
+
+pub fn agent_tab_styles_are_default(app: &AppContext) -> bool {
+    WarpConfig::as_ref(app).agent_tab_styles() == &AgentTabStyles::default()
+}
+
+pub fn agent_tab_style_color(app: &AppContext, state: &str) -> &'static str {
+    let styles = &WarpConfig::as_ref(app).agent_tab_styles().states;
+    let color = match state {
+        "idle" => styles.idle.color,
+        "processing" => styles.processing.color,
+        "success" => styles.success.color,
+        "needs_attention" => styles.needs_attention.color,
+        other => panic!("unknown agent-tab state {other}"),
+    };
+    match color {
+        AgentTabColor::Red => "red",
+        AgentTabColor::Green => "green",
+        AgentTabColor::Yellow => "yellow",
+        AgentTabColor::Blue => "blue",
+        AgentTabColor::Magenta => "magenta",
+        AgentTabColor::Cyan => "cyan",
+    }
+}
+
+pub fn emit_cli_agent_notification(
+    app: &mut App,
+    terminal: &ViewHandle<TerminalView>,
+    body: String,
+) {
+    let dispatcher = terminal.read(app, |terminal, _| terminal.model_event_dispatcher().clone());
+    dispatcher.update(app, |_, ctx| {
+        ctx.emit(ModelEvent::PluggableNotification {
+            title: Some(CLI_AGENT_NOTIFICATION_SENTINEL.to_string()),
+            body,
+        });
+    });
+}

--- a/app/src/integration_testing/mod.rs
+++ b/app/src/integration_testing/mod.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use warpui::{App, AssetProvider, View, ViewHandle, WindowId};
 
 pub mod agent_mode;
+pub mod agent_state_visuals;
 pub mod ai_document;
 pub mod assertions;
 pub mod block;

--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -38,6 +38,22 @@ pub enum CLIAgentSessionStatus {
     Cancelled,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CLIAgentDisplayState {
+    Idle,
+    Processing,
+    Success,
+    NeedsAttention,
+}
+
+pub(crate) fn should_acknowledge_success(
+    is_active_window: bool,
+    focused_terminal_view_id: Option<EntityId>,
+    successful_terminal_view_id: EntityId,
+) -> bool {
+    is_active_window && focused_terminal_view_id == Some(successful_terminal_view_id)
+}
+
 impl CLIAgentSessionStatus {
     pub fn to_conversation_status(&self) -> crate::ai::agent::conversation::ConversationStatus {
         use crate::ai::agent::conversation::ConversationStatus;
@@ -339,6 +355,7 @@ struct CtrlCCancelState {
     /// against arming on the optimistic `InProgress` status set when a
     /// session is first registered, before any turn has actually started.
     has_seen_prompt_submit: bool,
+    successful_result_acknowledged: bool,
     /// Abort handle for the in-flight grace-window timer, if armed.
     pending_cancel: Option<SpawnedFutureHandle>,
     /// Identifies the window `pending_cancel` belongs to. `SpawnedFutureHandle::abort`
@@ -381,6 +398,62 @@ impl CLIAgentSessionsModel {
 
     pub fn session(&self, terminal_view_id: EntityId) -> Option<&CLIAgentSession> {
         self.sessions.get(&terminal_view_id)
+    }
+
+    pub fn has_seen_prompt_submit(&self, terminal_view_id: EntityId) -> bool {
+        self.ctrl_c_cancel_state
+            .get(&terminal_view_id)
+            .is_some_and(|state| state.has_seen_prompt_submit)
+    }
+
+    pub fn display_state(&self, terminal_view_id: EntityId) -> Option<CLIAgentDisplayState> {
+        let session = self.sessions.get(&terminal_view_id)?;
+        let presentation = self.ctrl_c_cancel_state.get(&terminal_view_id);
+        Some(match session.status {
+            CLIAgentSessionStatus::InProgress => {
+                if self.has_seen_prompt_submit(terminal_view_id) {
+                    CLIAgentDisplayState::Processing
+                } else {
+                    CLIAgentDisplayState::Idle
+                }
+            }
+            CLIAgentSessionStatus::Success => {
+                if presentation.is_some_and(|state| state.successful_result_acknowledged) {
+                    CLIAgentDisplayState::Idle
+                } else {
+                    CLIAgentDisplayState::Success
+                }
+            }
+            CLIAgentSessionStatus::Failed { .. } | CLIAgentSessionStatus::Blocked { .. } => {
+                CLIAgentDisplayState::NeedsAttention
+            }
+            CLIAgentSessionStatus::Cancelled => CLIAgentDisplayState::Idle,
+        })
+    }
+
+    pub fn acknowledge_success(
+        &mut self,
+        terminal_view_id: EntityId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(session) = self.sessions.get(&terminal_view_id) else {
+            return;
+        };
+        if !matches!(session.status, CLIAgentSessionStatus::Success) {
+            return;
+        }
+        let state = self
+            .ctrl_c_cancel_state
+            .entry(terminal_view_id)
+            .or_default();
+        if state.successful_result_acknowledged {
+            return;
+        }
+        state.successful_result_acknowledged = true;
+        ctx.emit(CLIAgentSessionsModelEvent::SessionUpdated {
+            terminal_view_id,
+            agent: session.agent,
+        });
     }
 
     /// Returns `true` if the rich input editor is currently open for this terminal.
@@ -495,10 +568,17 @@ impl CLIAgentSessionsModel {
             self.abort_pending_cancel(terminal_view_id);
         }
         if matches!(event.event, CLIAgentEventType::PromptSubmit) {
+            let state = self
+                .ctrl_c_cancel_state
+                .entry(terminal_view_id)
+                .or_default();
+            state.has_seen_prompt_submit = true;
+            state.successful_result_acknowledged = false;
+        } else if matches!(event.event, CLIAgentEventType::Stop) {
             self.ctrl_c_cancel_state
                 .entry(terminal_view_id)
                 .or_default()
-                .has_seen_prompt_submit = true;
+                .successful_result_acknowledged = false;
         }
 
         let session = self

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -7,8 +7,9 @@ use super::event::{
     CLIAgentEvent, CLIAgentEventPayload, CLIAgentEventSource, CLIAgentEventType, parse_event,
 };
 use super::{
-    CLIAgentInputEntrypoint, CLIAgentInputState, CLIAgentSession, CLIAgentSessionContext,
-    CLIAgentSessionStatus, CLIAgentSessionsModel,
+    CLIAgentDisplayState, CLIAgentInputEntrypoint, CLIAgentInputState, CLIAgentSession,
+    CLIAgentSessionContext, CLIAgentSessionStatus, CLIAgentSessionsModel,
+    should_acknowledge_success,
 };
 use crate::ai::blocklist::{InputConfig, InputType};
 use crate::terminal::CLIAgent;
@@ -746,6 +747,100 @@ fn plugin_event(source: CLIAgentEventSource, event: CLIAgentEventType) -> CLIAge
 
 fn rich_event(event: CLIAgentEventType) -> CLIAgentEvent {
     plugin_event(CLIAgentEventSource::RichPlugin, event)
+}
+
+#[test]
+fn cli_agent_display_state_transitions() {
+    App::test((), |mut app| async move {
+        let model = app.add_singleton_model(|_| CLIAgentSessionsModel::new());
+        let view_id = EntityId::new();
+        model.update(&mut app, |model, ctx| {
+            model.set_session(
+                view_id,
+                cli_agent_session(CLIAgentSessionStatus::InProgress, true),
+                ctx,
+            );
+        });
+        assert_eq!(
+            model.read(&app, |model, _| model.display_state(view_id)),
+            Some(CLIAgentDisplayState::Idle)
+        );
+
+        for (event, expected) in [
+            (
+                CLIAgentEventType::PromptSubmit,
+                CLIAgentDisplayState::Processing,
+            ),
+            (CLIAgentEventType::Stop, CLIAgentDisplayState::Success),
+            (
+                CLIAgentEventType::PermissionRequest,
+                CLIAgentDisplayState::NeedsAttention,
+            ),
+            (
+                CLIAgentEventType::StopFailure,
+                CLIAgentDisplayState::NeedsAttention,
+            ),
+            (
+                CLIAgentEventType::PromptSubmit,
+                CLIAgentDisplayState::Processing,
+            ),
+        ] {
+            model.update(&mut app, |model, ctx| {
+                model.update_from_event(view_id, &rich_event(event), ctx);
+            });
+            assert_eq!(
+                model.read(&app, |model, _| model.display_state(view_id)),
+                Some(expected)
+            );
+        }
+
+        model.update(&mut app, |model, ctx| model.force_cancel(view_id, ctx));
+        assert_eq!(
+            model.read(&app, |model, _| model.display_state(view_id)),
+            Some(CLIAgentDisplayState::Idle)
+        );
+    });
+}
+
+#[test]
+fn cli_agent_success_acknowledgement() {
+    App::test((), |mut app| async move {
+        let model = app.add_singleton_model(|_| CLIAgentSessionsModel::new());
+        let view_id = EntityId::new();
+        model.update(&mut app, |model, ctx| {
+            model.set_session(
+                view_id,
+                cli_agent_session(CLIAgentSessionStatus::Success, true),
+                ctx,
+            );
+        });
+
+        assert_eq!(
+            model.read(&app, |model, _| model.display_state(view_id)),
+            Some(CLIAgentDisplayState::Success)
+        );
+        let other_view_id = EntityId::new();
+        assert!(!should_acknowledge_success(false, Some(view_id), view_id));
+        assert!(!should_acknowledge_success(
+            true,
+            Some(other_view_id),
+            view_id
+        ));
+        assert!(should_acknowledge_success(true, Some(view_id), view_id));
+        model.update(&mut app, |model, ctx| {
+            model.acknowledge_success(view_id, ctx)
+        });
+        assert_eq!(
+            model.read(&app, |model, _| model.display_state(view_id)),
+            Some(CLIAgentDisplayState::Idle)
+        );
+        assert!(!model.read(&app, |model, _| model.has_seen_prompt_submit(view_id)));
+        assert_eq!(
+            model.read(&app, |model, _| model.display_state(view_id)),
+            Some(CLIAgentDisplayState::Idle),
+            "acknowledged success must not reappear after focus moves away"
+        );
+    });
 }
 
 #[test]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7890,7 +7890,7 @@ impl TerminalView {
         self.sessions.as_ref(ctx)
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "integration_tests"))]
     pub fn model_event_dispatcher(&self) -> &ModelHandle<ModelEventDispatcher> {
         &self.model_events_handle
     }

--- a/app/src/ui_components/icon_with_status.rs
+++ b/app/src/ui_components/icon_with_status.rs
@@ -57,6 +57,13 @@ impl StatusBadgeStyle {
     };
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum StatusBadgeMode {
+    Default,
+    Hidden,
+    Override { icon: WarpIcon, color: ColorU },
+}
+
 // Neutral variants have no overlay, so they fill the full `total_size` bounding box. The
 // inner glyph occupies `NEUTRAL_GLYPH_RATIO * total_size`, matching the old sizing where
 // a 24px container held a 16px glyph (16/24 ≈ 0.667).
@@ -194,6 +201,26 @@ pub(crate) fn render_icon_with_status_with_badge_style(
     theme: &WarpTheme,
     status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
+    render_icon_with_status_with_badge_override(
+        variant,
+        total_size,
+        overlay_extra_overhang_ratio,
+        badge_style,
+        StatusBadgeMode::Default,
+        theme,
+        status_container_background,
+    )
+}
+
+pub(crate) fn render_icon_with_status_with_badge_override(
+    variant: IconWithStatusVariant,
+    total_size: f32,
+    overlay_extra_overhang_ratio: f32,
+    badge_style: StatusBadgeStyle,
+    badge_mode: StatusBadgeMode,
+    theme: &WarpTheme,
+    status_container_background: WarpThemeFill,
+) -> Box<dyn Element> {
     let sub_text = theme.sub_text_color(theme.background());
 
     match variant {
@@ -221,6 +248,7 @@ pub(crate) fn render_icon_with_status_with_badge_style(
                 total_size,
                 overlay_extra_overhang_ratio,
                 badge_style,
+                badge_mode,
                 theme,
                 status_container_background,
             )
@@ -249,6 +277,7 @@ pub(crate) fn render_icon_with_status_with_badge_style(
                 total_size,
                 overlay_extra_overhang_ratio,
                 badge_style,
+                badge_mode,
                 theme,
                 status_container_background,
             )
@@ -264,10 +293,31 @@ pub(crate) fn render_icon_with_status_with_badge_style(
             total_size,
             overlay_extra_overhang_ratio,
             badge_style,
+            badge_mode,
             theme,
             status_container_background,
         ),
     }
+}
+
+/// Applies an explicit status badge to an already-rendered icon while preserving its footprint.
+pub(crate) fn render_element_with_status_badge_override(
+    element: Box<dyn Element>,
+    total_size: f32,
+    badge_style: StatusBadgeStyle,
+    badge_mode: StatusBadgeMode,
+    theme: &WarpTheme,
+    status_container_background: WarpThemeFill,
+) -> Box<dyn Element> {
+    render_with_optional_status_badge(
+        element,
+        None,
+        total_size,
+        0.,
+        (badge_style, badge_mode),
+        theme,
+        status_container_background,
+    )
 }
 
 fn warp_agent_circle_colors(theme: &WarpTheme, is_ambient: bool) -> (WarpThemeFill, WarpThemeFill) {
@@ -340,6 +390,7 @@ fn attach_status_overlay(
     total_size: f32,
     overlay_extra_overhang_ratio: f32,
     badge_style: StatusBadgeStyle,
+    badge_mode: StatusBadgeMode,
     theme: &WarpTheme,
     status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
@@ -357,7 +408,7 @@ fn attach_status_overlay(
             status,
             total_size,
             overlay_extra_overhang_ratio,
-            badge_style,
+            (badge_style, badge_mode),
             theme,
             status_container_background,
         )
@@ -439,11 +490,19 @@ fn render_with_optional_status_badge(
     status: Option<&ConversationStatus>,
     total_size: f32,
     overlay_extra_overhang_ratio: f32,
-    badge_style: StatusBadgeStyle,
+    badge: (StatusBadgeStyle, StatusBadgeMode),
     theme: &WarpTheme,
     status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
-    let Some(status) = status else {
+    let (badge_style, badge_mode) = badge;
+    let icon_and_color = match badge_mode {
+        StatusBadgeMode::Default => {
+            status.map(|status| status.status_icon_and_color(theme, StatusColorStyle::Standard))
+        }
+        StatusBadgeMode::Hidden => None,
+        StatusBadgeMode::Override { icon, color } => Some((icon, color)),
+    };
+    let Some((icon, color)) = icon_and_color else {
         // No status badge: still reserve the full `total_size` footprint the caller
         // asked for, so badged and un-badged variants occupy identical space.
         // `ConstrainedBox` only tightens constraints — it does not center — so the
@@ -454,7 +513,6 @@ fn render_with_optional_status_badge(
             .with_height(total_size)
             .finish();
     };
-    let (icon, color) = status.status_icon_and_color(theme, StatusColorStyle::Standard);
     let badge_icon_diameter = badge_icon_size(total_size, badge_style);
     let pad = badge_padding(total_size, badge_style);
     let badge_icon = ConstrainedBox::new(icon.to_warpui_icon(WarpThemeFill::Solid(color)).finish())

--- a/app/src/ui_components/icon_with_status.rs
+++ b/app/src/ui_components/icon_with_status.rs
@@ -3,6 +3,8 @@ use pathfinder_geometry::vector::vec2f;
 use warp_core::ui::icons::Icon as WarpIcon;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::{ColorScheme, Fill as WarpThemeFill, WarpTheme};
+#[cfg(test)]
+use warpui::elements::SavePosition;
 use warpui::elements::{
     ChildAnchor, ConstrainedBox, Container, CornerRadius, Element, OffsetPositioning, ParentAnchor,
     ParentElement, ParentOffsetBounds, Radius, Stack,
@@ -32,6 +34,11 @@ const DEFAULT_BADGE_RATIO: f32 = 0.57;
 const DEFAULT_BADGE_ICON_RATIO: f32 = 0.34;
 const CLOUD_RATIO: f32 = 0.57;
 const STATUS_IN_CLOUD_RATIO: f32 = 0.285;
+
+#[cfg(test)]
+pub(crate) const TEST_BADGE_RING_POSITION_ID: &str = "icon_with_status_badge_ring";
+#[cfg(test)]
+pub(crate) const TEST_BADGE_ICON_POSITION_ID: &str = "icon_with_status_badge_icon";
 
 /// Status-badge geometry override. Pass [`StatusBadgeStyle::DEFAULT`] for today's look.
 #[derive(Clone, Copy)]
@@ -519,6 +526,8 @@ fn render_with_optional_status_badge(
         .with_width(badge_icon_diameter)
         .with_height(badge_icon_diameter)
         .finish();
+    #[cfg(test)]
+    let badge_icon = SavePosition::new(badge_icon, TEST_BADGE_ICON_POSITION_ID).finish();
     let inner_radius = match badge_style.inner_shape {
         BadgeInnerShape::Circle => Radius::Percentage(50.),
         BadgeInnerShape::RoundedSquare { radius_px } => Radius::Pixels(radius_px),
@@ -533,6 +542,8 @@ fn render_with_optional_status_badge(
         .with_background(status_container_background)
         .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)))
         .finish();
+    #[cfg(test)]
+    let badge_with_ring = SavePosition::new(badge_with_ring, TEST_BADGE_RING_POSITION_ID).finish();
 
     let badge_corner_offset = corner_overlay_offset(total_size, overlay_extra_overhang_ratio);
     let mut stack = Stack::new().with_child(

--- a/app/src/user_config/agent_tab_styles.rs
+++ b/app/src/user_config/agent_tab_styles.rs
@@ -1,0 +1,240 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use warp_core::ui::theme::AnsiColorIdentifier;
+
+pub const FILE_NAME: &str = "agent_tab_styles.yaml";
+pub const ANNOTATED_DEFAULT: &str = r#"# Agent-state styling for the vertical-tabs sidebar.
+# Colors are Warp's theme-aware ANSI colors: red, green, yellow, blue, magenta, cyan.
+version: 1
+
+states:
+  idle:
+    color: blue
+    badge_size: regular
+    layers: [tab_bg, badge_icon]
+  processing:
+    color: yellow
+    badge_size: bigger
+    layers: [tab_bg, badge_icon]
+  success:
+    color: green
+    badge_size: big
+    layers: [tab_bg, tab_text, badge_icon]
+  needs_attention:
+    color: red
+    badge_size: bigger
+    layers: [tab_bg, tab_text, badge_icon]
+
+group_outline:
+  # Empty disables automatic outlines. The group UUID chooses one entry stably.
+  colors: [blue, magenta, cyan, green]
+"#;
+
+#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTabColor {
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+}
+
+impl From<AgentTabColor> for AnsiColorIdentifier {
+    fn from(value: AgentTabColor) -> Self {
+        match value {
+            AgentTabColor::Red => Self::Red,
+            AgentTabColor::Green => Self::Green,
+            AgentTabColor::Yellow => Self::Yellow,
+            AgentTabColor::Blue => Self::Blue,
+            AgentTabColor::Magenta => Self::Magenta,
+            AgentTabColor::Cyan => Self::Cyan,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTabBadgeSize {
+    Regular,
+    Big,
+    Bigger,
+}
+
+impl AgentTabBadgeSize {
+    pub fn scale(self) -> f32 {
+        match self {
+            Self::Regular => 1.,
+            Self::Big => 1.25,
+            Self::Bigger => 1.5,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTabStyleLayer {
+    TabBg,
+    TabText,
+    BadgeIcon,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentTabStateStyle {
+    pub color: AgentTabColor,
+    pub badge_size: AgentTabBadgeSize,
+    pub layers: Vec<AgentTabStyleLayer>,
+}
+
+impl AgentTabStateStyle {
+    pub fn has_layer(&self, layer: AgentTabStyleLayer) -> bool {
+        self.layers.contains(&layer)
+    }
+}
+
+impl Default for AgentTabStateStyle {
+    fn default() -> Self {
+        Self {
+            color: AgentTabColor::Blue,
+            badge_size: AgentTabBadgeSize::Regular,
+            layers: vec![AgentTabStyleLayer::TabBg, AgentTabStyleLayer::BadgeIcon],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentTabStates {
+    pub idle: AgentTabStateStyle,
+    pub processing: AgentTabStateStyle,
+    pub success: AgentTabStateStyle,
+    pub needs_attention: AgentTabStateStyle,
+}
+
+impl Default for AgentTabStates {
+    fn default() -> Self {
+        Self {
+            idle: AgentTabStateStyle::default(),
+            processing: AgentTabStateStyle {
+                color: AgentTabColor::Yellow,
+                badge_size: AgentTabBadgeSize::Bigger,
+                ..AgentTabStateStyle::default()
+            },
+            success: AgentTabStateStyle {
+                color: AgentTabColor::Green,
+                badge_size: AgentTabBadgeSize::Big,
+                layers: vec![
+                    AgentTabStyleLayer::TabBg,
+                    AgentTabStyleLayer::TabText,
+                    AgentTabStyleLayer::BadgeIcon,
+                ],
+            },
+            needs_attention: AgentTabStateStyle {
+                color: AgentTabColor::Red,
+                badge_size: AgentTabBadgeSize::Bigger,
+                layers: vec![
+                    AgentTabStyleLayer::TabBg,
+                    AgentTabStyleLayer::TabText,
+                    AgentTabStyleLayer::BadgeIcon,
+                ],
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentTabGroupOutline {
+    pub colors: Vec<AgentTabColor>,
+}
+
+impl Default for AgentTabGroupOutline {
+    fn default() -> Self {
+        Self {
+            colors: vec![
+                AgentTabColor::Blue,
+                AgentTabColor::Magenta,
+                AgentTabColor::Cyan,
+                AgentTabColor::Green,
+            ],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentTabStyles {
+    version: u8,
+    pub states: AgentTabStates,
+    pub group_outline: AgentTabGroupOutline,
+}
+
+impl Default for AgentTabStyles {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            states: AgentTabStates::default(),
+            group_outline: AgentTabGroupOutline::default(),
+        }
+    }
+}
+
+impl AgentTabStyles {
+    pub fn parse(yaml: &str) -> Result<Self, String> {
+        let mut value = serde_yaml::to_value(Self::default()).map_err(|error| error.to_string())?;
+        merge_yaml(
+            &mut value,
+            serde_yaml::from_str(yaml).map_err(|error| error.to_string())?,
+        );
+        let config: Self = serde_yaml::from_value(value).map_err(|error| error.to_string())?;
+        if config.version != 1 {
+            return Err(format!(
+                "unsupported version {}; expected 1",
+                config.version
+            ));
+        }
+        for (name, style) in [
+            ("idle", &config.states.idle),
+            ("processing", &config.states.processing),
+            ("success", &config.states.success),
+            ("needs_attention", &config.states.needs_attention),
+        ] {
+            if style.layers.len() != style.layers.iter().collect::<HashSet<_>>().len() {
+                return Err(format!("state {name} contains duplicate layers"));
+            }
+        }
+        if config.group_outline.colors.len()
+            != config
+                .group_outline
+                .colors
+                .iter()
+                .collect::<HashSet<_>>()
+                .len()
+        {
+            return Err("group_outline contains duplicate colors".to_string());
+        }
+        Ok(config)
+    }
+}
+
+fn merge_yaml(base: &mut serde_yaml::Value, overlay: serde_yaml::Value) {
+    match (base, overlay) {
+        (serde_yaml::Value::Mapping(base), serde_yaml::Value::Mapping(overlay)) => {
+            for (key, value) in overlay {
+                if let Some(base_value) = base.get_mut(&key) {
+                    merge_yaml(base_value, value);
+                } else {
+                    base.insert(key, value);
+                }
+            }
+        }
+        (base, overlay) => *base = overlay,
+    }
+}
+
+#[cfg(test)]
+#[path = "agent_tab_styles_tests.rs"]
+mod tests;

--- a/app/src/user_config/agent_tab_styles_tests.rs
+++ b/app/src/user_config/agent_tab_styles_tests.rs
@@ -1,0 +1,41 @@
+use super::{
+    ANNOTATED_DEFAULT, AgentTabBadgeSize, AgentTabColor, AgentTabStyleLayer, AgentTabStyles,
+};
+
+#[test]
+fn agent_tab_styles_config_contract() {
+    let defaults = AgentTabStyles::default();
+    assert_eq!(
+        AgentTabStyles::parse(ANNOTATED_DEFAULT),
+        Ok(defaults.clone())
+    );
+
+    let partial = AgentTabStyles::parse("version: 1\nstates:\n  success:\n    color: cyan\n")
+        .expect("partial config should inherit defaults");
+    assert_eq!(partial.states.success.color, AgentTabColor::Cyan);
+    assert_eq!(partial.states.success.badge_size, AgentTabBadgeSize::Big);
+    assert_eq!(
+        partial.states.success.layers,
+        [
+            AgentTabStyleLayer::TabBg,
+            AgentTabStyleLayer::TabText,
+            AgentTabStyleLayer::BadgeIcon
+        ]
+    );
+    assert_eq!(partial.states.processing, defaults.states.processing);
+
+    for invalid in [
+        "version: 2",
+        "version: 1\nunknown: true",
+        "version: 1\nstates:\n  idle:\n    color: orange",
+        "version: 1\nstates:\n  idle:\n    badge_size: huge",
+        "version: 1\nstates:\n  idle:\n    layers: [tab_bg, unknown]",
+        "version: 1\nstates:\n  idle:\n    layers: [tab_bg, tab_bg]",
+        "version: 1\ngroup_outline:\n  colors: [blue, blue]",
+    ] {
+        assert!(
+            AgentTabStyles::parse(invalid).is_err(),
+            "accepted {invalid}"
+        );
+    }
+}

--- a/app/src/user_config/mod.rs
+++ b/app/src/user_config/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_tab_styles;
 pub mod util;
 
 #[cfg_attr(not(target_family = "wasm"), path = "native.rs")]
@@ -16,6 +17,7 @@ use lazy_static::lazy_static;
 use warp_core::ui::theme::WarpTheme;
 use warpui::{Entity, ModelContext, SingletonEntity};
 
+use self::agent_tab_styles::AgentTabStyles;
 use crate::ai::custom_model_routers::{CustomModelRouter, ModelConfigError};
 use crate::launch_configs::launch_config::LaunchConfig;
 use crate::tab_configs::{TabConfig, TabConfigError};
@@ -53,6 +55,8 @@ lazy_static! {
 
 #[derive(Clone)]
 pub enum WarpConfigUpdateEvent {
+    AgentTabStyles,
+    AgentTabStylesError(String),
     Themes,
     #[cfg_attr(not(feature = "local_fs"), expect(dead_code))]
     LocalUserWorkflows,
@@ -88,6 +92,7 @@ pub enum WarpConfigUpdateEvent {
 /// (`settings.toml`, `keybindings.yaml`, `user_preferences.json`).
 #[derive(Default)]
 pub struct WarpConfig {
+    agent_tab_styles: AgentTabStyles,
     launch_configs: Vec<LaunchConfig>,
     tab_configs: Vec<TabConfig>,
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
@@ -117,6 +122,10 @@ impl WarpConfig {
 
     pub fn launch_configs(&self) -> &Vec<LaunchConfig> {
         &self.launch_configs
+    }
+
+    pub fn agent_tab_styles(&self) -> &AgentTabStyles {
+        &self.agent_tab_styles
     }
 
     pub fn tab_configs(&self) -> &Vec<TabConfig> {
@@ -209,6 +218,10 @@ pub fn workflows_dir() -> PathBuf {
 /// configurations.
 pub fn launch_configs_dir() -> PathBuf {
     base_dir().join("launch_configurations")
+}
+
+pub fn agent_tab_styles_path() -> PathBuf {
+    base_dir().join(agent_tab_styles::FILE_NAME)
 }
 
 /// Returns the path to the directory containing the user's tab configs.

--- a/app/src/user_config/native.rs
+++ b/app/src/user_config/native.rs
@@ -7,14 +7,15 @@ use itertools::Itertools;
 use repo_metadata::RepositoryUpdate;
 use warpui::{ModelContext, ModelHandle, SingletonEntity};
 
+use super::agent_tab_styles::{ANNOTATED_DEFAULT, AgentTabStyles};
 use super::util::{
     for_each_dir_entry, has_name, is_config_file, parse_model_config_dir_entry,
     parse_multi_launch_config_dir_entry, parse_multi_workflow_dir_entry,
     parse_single_theme_dir_entry, parse_tab_config_dir_entry,
 };
 use super::{
-    LAUNCH_CONFIG_COMMENT, WarpConfigUpdateEvent, custom_model_routers_dir, launch_configs_dir,
-    tab_configs_dir, themes_dir, workflows_dir,
+    LAUNCH_CONFIG_COMMENT, WarpConfigUpdateEvent, agent_tab_styles_path, custom_model_routers_dir,
+    launch_configs_dir, tab_configs_dir, themes_dir, workflows_dir,
 };
 use crate::ai::custom_model_routers::{CustomModelRouter, ModelConfigError};
 use crate::features::FeatureFlag;
@@ -29,6 +30,13 @@ use crate::workflows::workflow::Workflow;
 
 impl super::WarpConfig {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        let agent_tab_styles_path = agent_tab_styles_path();
+        ensure_agent_tab_styles_file(&agent_tab_styles_path);
+        let agent_tab_styles =
+            load_agent_tab_styles(&agent_tab_styles_path).unwrap_or_else(|error| {
+                log::warn!("Failed to load agent tab styles; using defaults: {error}");
+                AgentTabStyles::default()
+            });
         // Load launch configs, and workflows from disk asynchronously on a background
         // thread.
         //
@@ -81,6 +89,7 @@ impl super::WarpConfig {
         );
 
         Self {
+            agent_tab_styles,
             theme_config: load_theme_configs(&themes_dir()),
             ..Default::default()
         }
@@ -93,6 +102,23 @@ impl super::WarpConfig {
         ctx: &mut ModelContext<Self>,
     ) {
         let WarpManagedPathsWatcherEvent::FilesChanged(update) = event;
+
+        if repository_update_touches_path(update, &agent_tab_styles_path()) {
+            let path = agent_tab_styles_path();
+            let _ = ctx.spawn(
+                async move { load_agent_tab_styles(&path) },
+                |me, result, ctx| match result {
+                    Ok(config) => {
+                        me.agent_tab_styles = config;
+                        ctx.emit(WarpConfigUpdateEvent::AgentTabStyles);
+                    }
+                    Err(error) => {
+                        log::warn!("Failed to reload agent tab styles; keeping last-known-good config: {error}");
+                        ctx.emit(WarpConfigUpdateEvent::AgentTabStylesError(error));
+                    }
+                },
+            );
+        }
 
         if update_touches_dir(update, &themes_dir()) {
             let theme_dir = themes_dir();
@@ -240,6 +266,27 @@ impl super::WarpConfig {
         writer.write_all(LAUNCH_CONFIG_COMMENT.as_bytes())?;
         serde_yaml::to_writer(writer, &launch_config)?;
         Ok(file_name)
+    }
+}
+
+fn ensure_agent_tab_styles_file(path: &Path) {
+    let result = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .and_then(|mut file| file.write_all(ANNOTATED_DEFAULT.as_bytes()));
+    if let Err(error) = result
+        && error.kind() != io::ErrorKind::AlreadyExists
+    {
+        log::warn!("Failed to create default agent tab styles file: {error}");
+    }
+}
+
+fn load_agent_tab_styles(path: &Path) -> Result<AgentTabStyles, String> {
+    match fs::read_to_string(path) {
+        Ok(yaml) => AgentTabStyles::parse(&yaml),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(AgentTabStyles::default()),
+        Err(error) => Err(error.to_string()),
     }
 }
 

--- a/app/src/view_components/dismissible_toast.rs
+++ b/app/src/view_components/dismissible_toast.rs
@@ -214,6 +214,14 @@ impl<A: Action + Clone> DismissibleToastStack<A> {
     pub fn has_toasts(&self) -> bool {
         !self.toasts.is_empty()
     }
+
+    #[cfg(feature = "integration_tests")]
+    pub fn integration_test_object_id_count(&self, object_id: &str) -> usize {
+        self.toasts
+            .iter()
+            .filter(|toast| toast.dismissible_toast.object_id.as_deref() == Some(object_id))
+            .count()
+    }
 }
 
 impl<A: Action + Clone> View for DismissibleToastStack<A> {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5338,6 +5338,42 @@ impl Workspace {
         self.tabs.get(index).and_then(|tab| tab.color())
     }
 
+    #[cfg(feature = "integration_tests")]
+    pub fn integration_test_agent_tab_styles_toast_count(&self, ctx: &AppContext) -> usize {
+        self.toast_stack
+            .as_ref(ctx)
+            .integration_test_object_id_count("agent_tab_styles_error")
+    }
+
+    #[cfg(feature = "integration_tests")]
+    pub fn integration_test_set_all_tab_colors(
+        &mut self,
+        color: AnsiColorIdentifier,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        for index in 0..self.tabs.len() {
+            self.set_tab_color(index, SelectedTabColor::Color(color), ctx);
+        }
+    }
+
+    #[cfg(feature = "integration_tests")]
+    pub fn integration_test_group_all_tabs(
+        &mut self,
+        color: AnsiColorIdentifier,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let mut group = TabGroup::new();
+        group.name = Some("Agent state group".to_string());
+        group.color = SelectedTabColor::Color(color);
+        let group_id = group.id;
+        self.tab_groups.insert(group_id, group);
+        for tab in &mut self.tabs {
+            tab.group_id = Some(group_id);
+            tab.pinned = false;
+        }
+        ctx.notify();
+    }
+
     /// Finds the pane containing a terminal viewing the given ambient agent conversation,
     /// returning None if the ambient conversation is not open in any tab.
     fn find_pane_with_ambient_agent_conversation(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -390,7 +390,10 @@ use crate::terminal::available_shells::AvailableShells;
 use crate::terminal::block_list_viewport::InputMode;
 #[cfg(not(target_family = "wasm"))]
 use crate::terminal::cli_agent_sessions::plugin_manager::{PluginModalKind, plugin_manager_for};
-use crate::terminal::cli_agent_sessions::{CLIAgentSessionsModel, CLIAgentSessionsModelEvent};
+use crate::terminal::cli_agent_sessions::{
+    CLIAgentSessionStatus, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
+    should_acknowledge_success,
+};
 use crate::terminal::enable_auto_reload_modal::{
     EnableAutoReloadModal, EnableAutoReloadModalEvent,
 };
@@ -2731,6 +2734,21 @@ impl Workspace {
     ) {
         ctx.subscribe_to_model(&WarpConfig::handle(ctx), move |_me, _, event, ctx| {
             match event {
+                WarpConfigUpdateEvent::AgentTabStyles => {
+                    toast_stack.update(ctx, |toast_stack, ctx| {
+                        toast_stack.dismiss_older_toasts("agent_tab_styles_error", ctx);
+                    });
+                    ctx.notify();
+                }
+                WarpConfigUpdateEvent::AgentTabStylesError(error) => {
+                    let toast = DismissibleToast::error(format!(
+                        "Failed to load agent tab styles: {error}"
+                    ))
+                    .with_object_id("agent_tab_styles_error".to_string());
+                    toast_stack.update(ctx, |toast_stack, ctx| {
+                        toast_stack.add_persistent_toast(toast, ctx);
+                    });
+                }
                 WarpConfigUpdateEvent::TabConfigs => {
                     // On every tab config reload, dismiss error toasts for
                     // files that now parse successfully.  The model has already
@@ -3777,6 +3795,24 @@ impl Workspace {
         event: &CLIAgentSessionsModelEvent,
         ctx: &mut ViewContext<Self>,
     ) {
+        if let CLIAgentSessionsModelEvent::StatusChanged {
+            terminal_view_id,
+            status: CLIAgentSessionStatus::Success,
+            ..
+        } = event
+            && should_acknowledge_success(
+                ctx.windows().active_window() == Some(ctx.window_id()),
+                self.active_tab_pane_group()
+                    .as_ref(ctx)
+                    .focused_session_view(ctx)
+                    .map(|view| view.id()),
+                *terminal_view_id,
+            )
+        {
+            CLIAgentSessionsModel::handle(ctx).update(ctx, |model, ctx| {
+                model.acknowledge_success(*terminal_view_id, ctx);
+            });
+        }
         if matches!(
             event,
             CLIAgentSessionsModelEvent::Started { .. }
@@ -5460,6 +5496,9 @@ impl Workspace {
         if let Some(terminal_view_id) = focused_terminal_view_id {
             let is_active_window = ctx.windows().active_window() == Some(ctx.window_id());
             if is_active_window {
+                CLIAgentSessionsModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.acknowledge_success(terminal_view_id, ctx);
+                });
                 AgentNotificationsModel::handle(ctx).update(ctx, |model, ctx| {
                     model.mark_items_from_terminal_view_read(terminal_view_id, ctx);
                 });

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -59,15 +59,22 @@ use crate::tab::{
     SelectedTabColor, TAB_INDICATOR_SYNCED_COLOR, TabData, reveals_tab_shortcut_hints,
     tab_activate_binding_name, tab_position_id,
 };
-use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
+use crate::terminal::cli_agent_sessions::listener::is_agent_supported;
+use crate::terminal::cli_agent_sessions::{CLIAgentDisplayState, CLIAgentSessionsModel};
 use crate::terminal::session_settings::SessionSettings;
 use crate::terminal::view::TerminalViewState;
 use crate::terminal::{CLIAgent, TerminalView};
 use crate::themes::theme::Fill as ThemeFill;
 use crate::ui_components::agent_icon::terminal_view_agent_icon_variant;
 use crate::ui_components::buttons::combo_inner_button;
-use crate::ui_components::icon_with_status::{IconWithStatusVariant, render_icon_with_status};
+use crate::ui_components::icon_with_status::{
+    BadgeInnerShape, IconWithStatusVariant, StatusBadgeMode, StatusBadgeStyle,
+    render_element_with_status_badge_override, render_icon_with_status,
+    render_icon_with_status_with_badge_override,
+};
 use crate::ui_components::icons::Icon as UiIcon;
+use crate::user_config::WarpConfig;
+use crate::user_config::agent_tab_styles::{AgentTabStateStyle, AgentTabStyleLayer};
 use crate::util::bindings::keybinding_name_to_display_string;
 use crate::util::color::Opacity;
 use crate::workspace::action::{NewSessionMenuAnchor, WorkspaceAction};
@@ -131,6 +138,126 @@ const VERTICAL_TABS_ICON_SIZE: f32 = 24.;
 /// Icon size for the per-line conversation status pill in Summary mode. Pairs with
 /// `STATUS_ELEMENT_PADDING` (2px) for an overall ~14px element next to a 12pt title.
 const VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE: f32 = 10.;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ResolvedCLIAgentStyle {
+    state: CLIAgentDisplayState,
+    color: AnsiColorIdentifier,
+    badge_icon: WarpIcon,
+    badge_scale: f32,
+    tab_bg: bool,
+    tab_text: bool,
+    badge: bool,
+}
+
+impl ResolvedCLIAgentStyle {
+    fn background(self, theme: &WarpTheme) -> Option<ThemeFill> {
+        self.tab_bg.then(|| {
+            self.color
+                .to_ansi_color(&theme.terminal_colors().normal)
+                .into()
+        })
+    }
+
+    fn text_color(self, theme: &WarpTheme) -> Option<WarpThemeFill> {
+        self.tab_text.then(|| {
+            theme
+                .ansi_fg(self.color.to_ansi_color(&theme.terminal_colors().normal))
+                .into()
+        })
+    }
+
+    fn badge_mode(self, theme: &WarpTheme) -> StatusBadgeMode {
+        if self.badge {
+            StatusBadgeMode::Override {
+                icon: self.badge_icon,
+                color: theme.ansi_fg(self.color.to_ansi_color(&theme.terminal_colors().normal)),
+            }
+        } else {
+            StatusBadgeMode::Hidden
+        }
+    }
+
+    fn badge_style(self) -> StatusBadgeStyle {
+        StatusBadgeStyle {
+            ring_ratio: 0.57 * self.badge_scale,
+            icon_ratio: 0.34 * self.badge_scale,
+            inner_shape: BadgeInnerShape::Circle,
+        }
+    }
+}
+
+fn style_for_display_state(
+    state: CLIAgentDisplayState,
+    badge_icon: WarpIcon,
+    config: &AgentTabStateStyle,
+) -> ResolvedCLIAgentStyle {
+    ResolvedCLIAgentStyle {
+        state,
+        color: config.color.into(),
+        badge_icon,
+        badge_scale: config.badge_size.scale(),
+        tab_bg: config.has_layer(AgentTabStyleLayer::TabBg),
+        tab_text: config.has_layer(AgentTabStyleLayer::TabText),
+        badge: config.has_layer(AgentTabStyleLayer::BadgeIcon),
+    }
+}
+
+fn cli_agent_style_for_terminal(
+    terminal_view_id: EntityId,
+    is_ambient: bool,
+    app: &AppContext,
+) -> Option<ResolvedCLIAgentStyle> {
+    let model = CLIAgentSessionsModel::as_ref(app);
+    let session = model.session(terminal_view_id)?;
+    if !supports_cli_agent_sidebar_style(
+        session.agent,
+        session.supports_rich_status(),
+        session.is_remote(),
+        is_ambient,
+        is_agent_supported(&session.agent),
+    ) {
+        return None;
+    }
+    let state = model.display_state(terminal_view_id)?;
+    let styles = &WarpConfig::as_ref(app).agent_tab_styles().states;
+    let config = match state {
+        CLIAgentDisplayState::Idle => &styles.idle,
+        CLIAgentDisplayState::Processing => &styles.processing,
+        CLIAgentDisplayState::Success => &styles.success,
+        CLIAgentDisplayState::NeedsAttention => &styles.needs_attention,
+    };
+    let badge_icon = if state == CLIAgentDisplayState::Idle {
+        WarpIcon::Circle
+    } else {
+        session
+            .status
+            .to_conversation_status()
+            .status_icon_and_color(Appearance::as_ref(app).theme(), StatusColorStyle::Standard)
+            .0
+    };
+    Some(style_for_display_state(state, badge_icon, config))
+}
+
+fn supports_cli_agent_sidebar_style(
+    agent: CLIAgent,
+    supports_rich_status: bool,
+    is_remote: bool,
+    is_ambient: bool,
+    is_supported: bool,
+) -> bool {
+    supports_rich_status
+        && !is_remote
+        && !is_ambient
+        && !matches!(agent, CLIAgent::Unknown)
+        && is_supported
+}
+
+fn aggregate_cli_styles(
+    styles: impl IntoIterator<Item = ResolvedCLIAgentStyle>,
+) -> Option<ResolvedCLIAgentStyle> {
+    styles.into_iter().max_by_key(|style| style.state)
+}
 
 fn vtab_pane_row_position_id(pane_group_id: EntityId, pane_id: PaneId) -> String {
     format!("vertical_tabs:pane_row:{pane_group_id:?}:{pane_id}")
@@ -275,15 +402,27 @@ enum TerminalPrimaryLineFont {
 
 fn render_pane_icon_with_status(
     variant: IconWithStatusVariant,
+    cli_style: Option<ResolvedCLIAgentStyle>,
     theme: &WarpTheme,
 ) -> Box<dyn Element> {
-    render_icon_with_status(
-        variant,
-        VERTICAL_TABS_ICON_SIZE,
-        0.,
-        theme,
-        theme.background(),
-    )
+    match cli_style {
+        Some(style) => render_icon_with_status_with_badge_override(
+            variant,
+            VERTICAL_TABS_ICON_SIZE,
+            0.,
+            style.badge_style(),
+            style.badge_mode(theme),
+            theme,
+            theme.background(),
+        ),
+        None => render_icon_with_status(
+            variant,
+            VERTICAL_TABS_ICON_SIZE,
+            0.,
+            theme,
+            theme.background(),
+        ),
+    }
 }
 
 #[derive(Clone, Default)]
@@ -400,6 +539,7 @@ fn render_pane_row_element(
         is_in_multi_selection,
         is_in_multi_tab_selection,
         pane_color,
+        cli_style,
         badge_mouse_states: _,
         detail_hover_state,
         display_granularity,
@@ -428,7 +568,9 @@ fn render_pane_row_element(
             .with_corner_radius(corner_radius);
 
         if let Some(background) = pane_row_background(
-            pane_color,
+            cli_style
+                .and_then(|style| style.background(theme))
+                .or(pane_color),
             is_selected,
             is_in_multi_selection,
             state.is_hovered(),
@@ -843,6 +985,7 @@ struct PaneProps<'a> {
     /// otherwise the single-pane menu.
     is_in_multi_tab_selection: bool,
     pane_color: Option<ThemeFill>,
+    cli_style: Option<ResolvedCLIAgentStyle>,
     badge_mouse_states: PaneRowBadgeMouseStates,
     detail_hover_state: VerticalTabsDetailHoverState,
     display_granularity: VerticalTabsDisplayGranularity,
@@ -899,6 +1042,17 @@ enum VerticalTabsResolvedMode {
     Summary,
 }
 
+fn cli_style_for_vertical_mode(
+    mode: VerticalTabsResolvedMode,
+    pane_style: Option<ResolvedCLIAgentStyle>,
+    summary_style: Option<ResolvedCLIAgentStyle>,
+) -> Option<ResolvedCLIAgentStyle> {
+    match mode {
+        VerticalTabsResolvedMode::Panes | VerticalTabsResolvedMode::FocusedSession => pane_style,
+        VerticalTabsResolvedMode::Summary => summary_style,
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum SummaryPaneKind {
     Terminal,
@@ -944,6 +1098,7 @@ struct VerticalTabsSummaryPrimaryLabel {
     /// Some when the contributing pane is a conversation with a known status. Drives the
     /// per-line status pill prefix in Summary mode.
     status: Option<ConversationStatus>,
+    cli_style: Option<ResolvedCLIAgentStyle>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -952,6 +1107,7 @@ struct VerticalTabsSummaryData {
     working_directories: Vec<String>,
     branch_entries: Vec<VerticalTabsSummaryBranchEntry>,
     has_unread_activity: bool,
+    cli_style: Option<ResolvedCLIAgentStyle>,
 }
 
 impl TabGroupColorMode {
@@ -1027,6 +1183,7 @@ fn push_normalized_unique_summary_label(
     seen: &mut HashMap<String, ()>,
     text: &str,
     status: Option<ConversationStatus>,
+    cli_style: Option<ResolvedCLIAgentStyle>,
 ) {
     let Some(normalized) = normalize_summary_text(text) else {
         return;
@@ -1038,6 +1195,7 @@ fn push_normalized_unique_summary_label(
     values.push(VerticalTabsSummaryPrimaryLabel {
         text: normalized,
         status,
+        cli_style,
     });
 }
 
@@ -2215,7 +2373,7 @@ fn render_tab_group_internal(
                     }
                     handles[..branch_line_count].to_vec()
                 };
-                let Some(pane_props) = PaneProps::new(
+                let Some(mut pane_props) = PaneProps::new(
                     pane_group,
                     *pane_id,
                     pane_group_id,
@@ -2245,6 +2403,11 @@ fn render_tab_group_internal(
                 ) else {
                     return Empty::new().finish();
                 };
+                pane_props.cli_style = cli_style_for_vertical_mode(
+                    resolved_mode,
+                    pane_props.cli_style,
+                    summary.as_ref().and_then(|summary| summary.cli_style),
+                );
                 rows.add_child(render_summary_tab_item(
                     pane_props,
                     summary
@@ -2305,6 +2468,8 @@ fn render_tab_group_internal(
                 ) else {
                     continue;
                 };
+                pane_props.cli_style =
+                    cli_style_for_vertical_mode(resolved_mode, pane_props.cli_style, None);
                 if stack_panes_flush {
                     pane_props.stack_position = PaneRowStackPosition::Flush {
                         is_first: row_idx == 0,
@@ -3294,10 +3459,11 @@ fn render_group_header(props: GroupHeaderProps<'_>, app: &AppContext) -> Box<dyn
 
 fn render_passive_terminal_diff_stats_badge(
     git_line_changes: &GitLineChanges,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     render_badge_container(
-        render_vtab_diff_stats_content(git_line_changes, appearance),
+        render_vtab_diff_stats_content(git_line_changes, text_color, appearance),
         internal_colors::fg_overlay_1(appearance.theme()),
     )
 }
@@ -3448,10 +3614,18 @@ fn shortcut_hint_label(props: &PaneProps<'_>, app: &AppContext) -> Option<String
 
 /// Inline label showing the switch-to-tab keyboard shortcut, mirroring the
 /// horizontal tab bar's `TabComponent::render_shortcut_hint`.
-fn render_shortcut_hint(label: &str, appearance: &Appearance) -> Box<dyn Element> {
+fn render_shortcut_hint(
+    label: &str,
+    text_color: Option<WarpThemeFill>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
     let theme = appearance.theme();
     Text::new_inline(label.to_string(), appearance.ui_font_family(), 12.)
-        .with_color(theme.sub_text_color(theme.background()).into())
+        .with_color(
+            text_color
+                .unwrap_or_else(|| theme.sub_text_color(theme.background()))
+                .into(),
+        )
         .finish()
 }
 
@@ -3501,9 +3675,11 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
     let font_family = appearance.ui_font_family();
+    let cli_text_color = props.cli_style.and_then(|style| style.text_color(theme));
 
     let icon = render_pane_icon_with_status(
         resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app),
+        props.cli_style,
         theme,
     );
 
@@ -3538,11 +3714,15 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
                     || {
                         Text::new_inline(props.displayed_title().to_string(), font_family, 12.)
                             .with_clip(ClipConfig::ellipsis())
-                            .with_color(theme.main_text_color(theme.background()).into())
+                            .with_color(
+                                cli_text_color
+                                    .unwrap_or_else(|| theme.main_text_color(theme.background()))
+                                    .into(),
+                            )
                             .finish()
                     },
                     12.,
-                    theme.main_text_color(theme.background()),
+                    cli_text_color.unwrap_or_else(|| theme.main_text_color(theme.background())),
                     ClipConfig::ellipsis(),
                     appearance,
                     app,
@@ -3559,7 +3739,7 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
         }
         if let Some(label) = shortcut_hint_label(&props, app) {
             title_row.add_child(
-                Container::new(render_shortcut_hint(&label, appearance))
+                Container::new(render_shortcut_hint(&label, cli_text_color, appearance))
                     .with_margin_left(4.)
                     .finish(),
             );
@@ -3580,7 +3760,11 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
             content_col.add_child(
                 Text::new_inline(effective_subtitle, font_family, 12.)
                     .with_clip(subtitle_clip)
-                    .with_color(theme.sub_text_color(theme.background()).into())
+                    .with_color(
+                        cli_text_color
+                            .unwrap_or_else(|| theme.sub_text_color(theme.background()))
+                            .into(),
+                    )
                     .finish(),
             );
         }
@@ -3764,6 +3948,7 @@ fn build_vertical_tabs_summary_data(
     let mut working_directory_seen = HashMap::new();
     let mut branch_entries = Vec::new();
     let mut has_unread_activity = false;
+    let mut cli_styles = Vec::new();
 
     for pane_id in visible_pane_ids {
         let Some(pane) = pane_group.pane_by_id(*pane_id) else {
@@ -3804,11 +3989,18 @@ fn build_vertical_tabs_summary_data(
                     terminal_view.last_completed_command_text(),
                 );
                 let status = summary_conversation_status_for_terminal(terminal_view, app);
+                let cli_style = cli_agent_style_for_terminal(
+                    terminal_view.id(),
+                    terminal_view.is_ambient_agent_session(app),
+                    app,
+                );
+                cli_styles.extend(cli_style);
                 push_normalized_unique_summary_label(
                     &mut primary_labels,
                     &mut primary_seen,
                     primary_label.text(),
                     status,
+                    cli_style,
                 );
 
                 if let Some(working_directory) = working_directory {
@@ -3846,6 +4038,7 @@ fn build_vertical_tabs_summary_data(
                     &mut primary_seen,
                     &pane_title,
                     None,
+                    None,
                 );
                 push_normalized_unique_summary_text(
                     &mut working_directories,
@@ -3869,6 +4062,7 @@ fn build_vertical_tabs_summary_data(
                     &mut primary_seen,
                     &pane_title,
                     None,
+                    None,
                 );
             }
         }
@@ -3881,6 +4075,7 @@ fn build_vertical_tabs_summary_data(
         working_directories,
         branch_entries: coalesce_summary_branch_entries(branch_entries),
         has_unread_activity,
+        cli_style: aggregate_cli_styles(cli_styles),
     }
 }
 
@@ -3926,6 +4121,17 @@ impl<'a> PaneProps<'a> {
             pane_configuration.title().trim(),
             pane_configuration.title_secondary().trim(),
         );
+        let cli_style = match &typed {
+            TypedPane::Terminal(terminal_pane) => {
+                let terminal_view = terminal_pane.terminal_view(app);
+                cli_agent_style_for_terminal(
+                    terminal_view.id(),
+                    terminal_view.as_ref(app).is_ambient_agent_session(app),
+                    app,
+                )
+            }
+            _ => None,
+        };
 
         Some(Self {
             pane_id,
@@ -3950,6 +4156,7 @@ impl<'a> PaneProps<'a> {
             is_in_multi_selection,
             is_in_multi_tab_selection,
             pane_color: pane_row_state.pane_color,
+            cli_style,
             badge_mouse_states: pane_row_state.badge_mouse_states,
             detail_hover_state,
             display_granularity,
@@ -4422,8 +4629,10 @@ fn render_terminal_row_content(
     app: &AppContext,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
-    let main_text_color = theme.main_text_color(theme.background());
-    let sub_text_color = theme.sub_text_color(theme.background());
+    let cli_text_color = props.cli_style.and_then(|style| style.text_color(theme));
+    let main_text_color =
+        cli_text_color.unwrap_or_else(|| theme.main_text_color(theme.background()));
+    let sub_text_color = cli_text_color.unwrap_or_else(|| theme.sub_text_color(theme.background()));
     let primary_info = *TabSettings::as_ref(app).vertical_tabs_primary_info.value();
 
     let title_text = terminal_view.terminal_title_from_shell();
@@ -4525,7 +4734,8 @@ fn render_terminal_row_content(
         first_line,
         row_shows_synced_inputs_indicator(props, app),
         has_unread_activity(&props.typed, app),
-        shortcut_hint_label(props, app).map(|label| render_shortcut_hint(&label, appearance)),
+        shortcut_hint_label(props, app)
+            .map(|label| render_shortcut_hint(&label, cli_text_color, appearance)),
         theme,
     );
 
@@ -4542,6 +4752,7 @@ fn render_terminal_row_content(
             metadata_left,
             chip_entrypoint_for_granularity(props.display_granularity),
             &props.badge_mouse_states,
+            cli_text_color,
             appearance,
             app,
         ))
@@ -4731,13 +4942,29 @@ fn render_summary_tab_item(
 
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
-    let main_text_color = theme.main_text_color(theme.background());
-    let sub_text_color = theme.sub_text_color(theme.background());
+    let cli_text_color = props.cli_style.and_then(|style| style.text_color(theme));
+    let main_text_color =
+        cli_text_color.unwrap_or_else(|| theme.main_text_color(theme.background()));
+    let sub_text_color = cli_text_color.unwrap_or_else(|| theme.sub_text_color(theme.background()));
     let icon = summary_pane_kind_icons
-        .map(|icons| render_summary_pane_kind_icons(icons, VERTICAL_TABS_ICON_SIZE, appearance))
+        .map(|icons| {
+            let icon = render_summary_pane_kind_icons(icons, VERTICAL_TABS_ICON_SIZE, appearance);
+            match props.cli_style {
+                Some(style) => render_element_with_status_badge_override(
+                    icon,
+                    VERTICAL_TABS_ICON_SIZE,
+                    style.badge_style(),
+                    style.badge_mode(theme),
+                    theme,
+                    theme.background(),
+                ),
+                None => icon,
+            }
+        })
         .unwrap_or_else(|| {
             render_pane_icon_with_status(
                 resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app),
+                props.cli_style,
                 theme,
             )
         });
@@ -4776,7 +5003,9 @@ fn render_summary_tab_item(
                     .iter()
                     .take(MAX_VISIBLE_PRIMARY_LABELS)
                     .collect();
-                let reserve_prefix_slot = visible_labels.iter().any(|label| label.status.is_some());
+                let reserve_prefix_slot = visible_labels.iter().any(|label| {
+                    label.cli_style.is_some_and(|style| style.badge) || label.status.is_some()
+                });
 
                 for (idx, label) in visible_labels.iter().enumerate() {
                     let line = render_summary_primary_label_line(
@@ -4816,7 +5045,8 @@ fn render_summary_tab_item(
         title_region.finish(),
         row_shows_synced_inputs_indicator(&props, app),
         summary.has_unread_activity,
-        shortcut_hint_label(&props, app).map(|label| render_shortcut_hint(&label, appearance)),
+        shortcut_hint_label(&props, app)
+            .map(|label| render_shortcut_hint(&label, cli_text_color, appearance)),
         theme,
     ));
 
@@ -4881,6 +5111,7 @@ fn render_summary_tab_item(
                 branch_entry,
                 pr_badge_mouse_states.get(idx).cloned(),
                 pr_chip_entrypoint,
+                cli_text_color,
                 appearance,
             ))
             .with_margin_top(REGION_GAP)
@@ -4926,19 +5157,45 @@ fn render_summary_primary_label_line(
     let prefix_slot_size = VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE + STATUS_ELEMENT_PADDING * 2.;
     let text = render_text_line(&label.text, text_color, ClipConfig::end(), appearance);
 
-    let prefix: Option<Box<dyn Element>> = match (label.status.as_ref(), reserve_prefix_slot) {
-        (Some(status), _) => Some(render_status_element(
+    let empty_prefix = || {
+        ConstrainedBox::new(Empty::new().finish())
+            .with_width(prefix_slot_size)
+            .with_height(prefix_slot_size)
+            .finish()
+    };
+    let prefix: Option<Box<dyn Element>> = if let Some(style) = label.cli_style {
+        if style.badge {
+            let size = VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE * style.badge_scale;
+            Some(
+                ConstrainedBox::new(
+                    style
+                        .badge_icon
+                        .to_warpui_icon(WarpThemeFill::Solid(
+                            appearance.theme().ansi_fg(
+                                style
+                                    .color
+                                    .to_ansi_color(&appearance.theme().terminal_colors().normal),
+                            ),
+                        ))
+                        .finish(),
+                )
+                .with_width(size)
+                .with_height(size)
+                .finish(),
+            )
+        } else {
+            reserve_prefix_slot.then(empty_prefix)
+        }
+    } else if let Some(status) = label.status.as_ref() {
+        Some(render_status_element(
             status,
             VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE,
             appearance,
-        )),
-        (None, true) => Some(
-            ConstrainedBox::new(Empty::new().finish())
-                .with_width(prefix_slot_size)
-                .with_height(prefix_slot_size)
-                .finish(),
-        ),
-        (None, false) => None,
+        ))
+    } else if reserve_prefix_slot {
+        Some(empty_prefix())
+    } else {
+        None
     };
 
     let Some(prefix) = prefix else {
@@ -5197,10 +5454,11 @@ fn render_summary_branch_line(
     entry: &VerticalTabsSummaryBranchEntry,
     pr_badge_mouse_state: Option<MouseStateHandle>,
     pr_chip_entrypoint: VerticalTabsChipEntrypoint,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
-    let sub_text_color = theme.sub_text_color(theme.background());
+    let sub_text_color = text_color.unwrap_or_else(|| theme.sub_text_color(theme.background()));
     let mut row = Flex::row()
         .with_main_axis_size(MainAxisSize::Max)
         .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
@@ -5219,7 +5477,7 @@ fn render_summary_branch_line(
     let mut has_right_badges = false;
     if let Some(diff_stats) = &entry.diff_stats {
         right_badges.add_child(render_passive_terminal_diff_stats_badge(
-            diff_stats, appearance,
+            diff_stats, text_color, appearance,
         ));
         has_right_badges = true;
     }
@@ -5237,6 +5495,7 @@ fn render_summary_branch_line(
                 pull_request_url.clone(),
                 pr_chip_entrypoint,
                 mouse_state,
+                text_color,
                 appearance,
             ));
             has_right_badges = true;
@@ -5245,6 +5504,7 @@ fn render_summary_branch_line(
             if let Some(pull_request_label) = &entry.pull_request_label {
                 right_badges.add_child(render_passive_terminal_pull_request_badge(
                     pull_request_label,
+                    text_color,
                     appearance,
                 ));
                 has_right_badges = true;
@@ -5358,11 +5618,12 @@ fn render_terminal_metadata_line(
     left_content: MetadataLeftContent,
     row_entrypoint: VerticalTabsChipEntrypoint,
     badge_mouse_states: &PaneRowBadgeMouseStates,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
     app: &AppContext,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
-    let sub_text_color = theme.sub_text_color(theme.background());
+    let sub_text_color = text_color.unwrap_or_else(|| theme.sub_text_color(theme.background()));
 
     let mut meta = Flex::row()
         .with_main_axis_size(MainAxisSize::Max)
@@ -5396,10 +5657,10 @@ fn render_terminal_metadata_line(
     // 4px gap between the text and the first chip — matching the spacing between chips.
     if let Some(right_badges) = render_terminal_right_badges(
         terminal_view,
-        pane_group_id,
-        pane_id,
+        (pane_group_id, pane_id),
         row_entrypoint,
         badge_mouse_states,
+        text_color,
         appearance,
         app,
     ) {
@@ -5414,13 +5675,14 @@ fn render_terminal_metadata_line(
 
 fn render_terminal_right_badges(
     terminal_view: &TerminalView,
-    pane_group_id: EntityId,
-    pane_id: PaneId,
+    pane: (EntityId, PaneId),
     entrypoint: VerticalTabsChipEntrypoint,
     badge_mouse_states: &PaneRowBadgeMouseStates,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
     app: &AppContext,
 ) -> Option<Box<dyn Element>> {
+    let (pane_group_id, pane_id) = pane;
     let show_diff_stats = *TabSettings::as_ref(app)
         .vertical_tabs_show_diff_stats
         .value();
@@ -5439,6 +5701,7 @@ fn render_terminal_right_badges(
             pane_id,
             entrypoint,
             badge_mouse_states.diff_stats.clone(),
+            text_color,
             appearance,
         ));
         has_badges = true;
@@ -5451,6 +5714,7 @@ fn render_terminal_right_badges(
             pull_request_url,
             entrypoint,
             badge_mouse_states.pull_request.clone(),
+            text_color,
             appearance,
         ));
         has_badges = true;
@@ -5465,6 +5729,7 @@ fn render_terminal_diff_stats_badge(
     pane_id: PaneId,
     entrypoint: VerticalTabsChipEntrypoint,
     mouse_state: MouseStateHandle,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
@@ -5476,7 +5741,7 @@ fn render_terminal_diff_stats_badge(
             internal_colors::fg_overlay_1(theme)
         };
         render_badge_container(
-            render_vtab_diff_stats_content(git_line_changes, appearance),
+            render_vtab_diff_stats_content(git_line_changes, text_color, appearance),
             bg,
         )
     })
@@ -5501,6 +5766,7 @@ fn render_terminal_pull_request_badge(
     url: String,
     entrypoint: VerticalTabsChipEntrypoint,
     mouse_state: MouseStateHandle,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
@@ -5511,7 +5777,10 @@ fn render_terminal_pull_request_badge(
         } else {
             internal_colors::fg_overlay_1(theme)
         };
-        render_badge_container(render_pull_request_badge_content(&label, appearance), bg)
+        render_badge_container(
+            render_pull_request_badge_content(&label, text_color, appearance),
+            bg,
+        )
     })
     .on_click(move |ctx, app, _| {
         send_telemetry_from_app_ctx!(
@@ -5526,10 +5795,11 @@ fn render_terminal_pull_request_badge(
 
 fn render_passive_terminal_pull_request_badge(
     label: &str,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     render_badge_container(
-        render_pull_request_badge_content(label, appearance),
+        render_pull_request_badge_content(label, text_color, appearance),
         internal_colors::fg_overlay_1(appearance.theme()),
     )
 }
@@ -5553,6 +5823,7 @@ fn render_compact_non_terminal_title(
 
 fn render_vtab_diff_stats_content(
     line_changes: &GitLineChanges,
+    text_color: Option<WarpThemeFill>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let font_family = appearance.ui_font_family();
@@ -5564,13 +5835,17 @@ fn render_vtab_diff_stats_content(
             row.add_child(Text::new_inline(" ", font_family, font_size).finish());
         }
 
-        let color = if token.starts_with('+') {
-            add_color(appearance)
-        } else if token.starts_with('-') {
-            remove_color(appearance)
-        } else {
-            internal_colors::neutral_6(appearance.theme())
-        };
+        let color = text_color
+            .map(WarpThemeFill::into_solid)
+            .unwrap_or_else(|| {
+                if token.starts_with('+') {
+                    add_color(appearance)
+                } else if token.starts_with('-') {
+                    remove_color(appearance)
+                } else {
+                    internal_colors::neutral_6(appearance.theme())
+                }
+            });
 
         row.add_child(
             Text::new_inline(token.clone(), font_family, font_size)
@@ -5591,10 +5866,14 @@ fn render_badge_container(content: Box<dyn Element>, background: ThemeFill) -> B
         .finish()
 }
 
-fn render_pull_request_badge_content(label: &str, appearance: &Appearance) -> Box<dyn Element> {
+fn render_pull_request_badge_content(
+    label: &str,
+    text_color: Option<WarpThemeFill>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
     let theme = appearance.theme();
-    let main_text_color = theme.main_text_color(theme.background());
-    let sub_text_color = theme.sub_text_color(theme.background());
+    let main_text_color = text_color.unwrap_or_else(|| theme.main_text_color(theme.background()));
+    let sub_text_color = text_color.unwrap_or_else(|| theme.sub_text_color(theme.background()));
     Flex::row()
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
         .with_spacing(4.)
@@ -6892,6 +7171,7 @@ fn render_terminal_detail_section(
             props.pane_id,
             VerticalTabsChipEntrypoint::DetailsSidecar,
             props.badge_mouse_states.diff_stats.clone(),
+            None,
             appearance,
         ));
         has_right_badges = true;
@@ -6902,6 +7182,7 @@ fn render_terminal_detail_section(
             pull_request_url,
             VerticalTabsChipEntrypoint::DetailsSidecar,
             props.badge_mouse_states.pull_request.clone(),
+            None,
             appearance,
         ));
         has_right_badges = true;
@@ -7251,13 +7532,16 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
     let effective_subtitle = props.subtitle.clone();
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
-    let main_text_color = theme.main_text_color(theme.background());
-    let sub_text_color = theme.sub_text_color(theme.background());
+    let cli_text_color = props.cli_style.and_then(|style| style.text_color(theme));
+    let main_text_color =
+        cli_text_color.unwrap_or_else(|| theme.main_text_color(theme.background()));
+    let sub_text_color = cli_text_color.unwrap_or_else(|| theme.sub_text_color(theme.background()));
     let font_family = appearance.ui_font_family();
     let has_indicator = props.typed.badge(app).is_some() || has_unread_activity(&props.typed, app);
 
     let icon = render_pane_icon_with_status(
         resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app),
+        props.cli_style,
         theme,
     );
 
@@ -7404,7 +7688,8 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
         title_element,
         row_shows_synced_inputs_indicator(&props, app),
         has_indicator,
-        shortcut_hint_label(&props, app).map(|label| render_shortcut_hint(&label, appearance)),
+        shortcut_hint_label(&props, app)
+            .map(|label| render_shortcut_hint(&label, cli_text_color, appearance)),
         theme,
     );
 

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -3,23 +3,26 @@ use std::path::PathBuf;
 
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
+use warp_core::ui::Icon as WarpIcon;
+use warp_core::ui::theme::AnsiColorIdentifier;
 use warpui::EntityId;
 use warpui::elements::PositionedElementOffsetBounds;
 
 use super::{
     AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons, TerminalAgentText,
     TerminalPrimaryLineData, TerminalPrimaryLineFont, VerticalTabsDetailTarget,
-    VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
-    VerticalTabsSummaryPrimaryLabel, branch_label_display, coalesce_summary_branch_entries,
+    VerticalTabsDetailTargetKind, VerticalTabsResolvedMode, VerticalTabsSummaryBranchEntry,
+    VerticalTabsSummaryData, VerticalTabsSummaryPrimaryLabel, aggregate_cli_styles,
+    branch_label_display, cli_style_for_vertical_mode, coalesce_summary_branch_entries,
     code_detail_kind_label, compact_branch_subtitle_display, detail_sidecar_width_and_bounds,
     detail_target_for_hovered_row, non_terminal_search_text_fragments,
     pane_ids_for_display_granularity, pane_search_text_fragments, preferred_agent_tab_titles,
     push_normalized_unique_summary_label, search_fragments_contain_query,
     select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
     should_show_tab_group_header, shows_synced_inputs_indicator,
-    sort_summary_primary_labels_status_first, summary_overflow_count,
-    summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
-    terminal_pull_request_badge_label, terminal_search_text_fragments,
+    sort_summary_primary_labels_status_first, style_for_display_state, summary_overflow_count,
+    summary_search_text_fragments, supports_cli_agent_sidebar_style, terminal_kind_badge_label,
+    terminal_primary_line_data, terminal_pull_request_badge_label, terminal_search_text_fragments,
     terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
     vtab_diff_stats_text,
 };
@@ -30,18 +33,161 @@ use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
 use crate::tab::{ShortcutModifierKind, reveals_shortcut_hints};
 use crate::terminal::CLIAgent;
+use crate::terminal::cli_agent_sessions::CLIAgentDisplayState;
+use crate::user_config::agent_tab_styles::{
+    AgentTabBadgeSize, AgentTabColor, AgentTabStateStyle, AgentTabStyleLayer,
+};
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 
 fn label(text: &str) -> VerticalTabsSummaryPrimaryLabel {
     VerticalTabsSummaryPrimaryLabel {
         text: text.to_string(),
         status: None,
+        cli_style: None,
     }
 }
 
 fn pane_id() -> PaneId {
     TerminalPaneId::dummy_terminal_pane_id().into()
 }
+
+fn agent_style_config(
+    badge_size: AgentTabBadgeSize,
+    layers: Vec<AgentTabStyleLayer>,
+) -> AgentTabStateStyle {
+    AgentTabStateStyle {
+        color: AgentTabColor::Magenta,
+        badge_size,
+        layers,
+    }
+}
+
+#[test]
+fn cli_agent_visual_layers_and_badge_sizes() {
+    for (layer, expected) in [
+        (AgentTabStyleLayer::TabBg, (true, false, false)),
+        (AgentTabStyleLayer::TabText, (false, true, false)),
+        (AgentTabStyleLayer::BadgeIcon, (false, false, true)),
+    ] {
+        let style = style_for_display_state(
+            CLIAgentDisplayState::Processing,
+            WarpIcon::Circle,
+            &agent_style_config(AgentTabBadgeSize::Regular, vec![layer]),
+        );
+        assert_eq!((style.tab_bg, style.tab_text, style.badge), expected);
+        assert_eq!(style.color, AnsiColorIdentifier::Magenta);
+    }
+
+    for (size, scale) in [
+        (AgentTabBadgeSize::Regular, 1.),
+        (AgentTabBadgeSize::Big, 1.25),
+        (AgentTabBadgeSize::Bigger, 1.5),
+    ] {
+        let style = style_for_display_state(
+            CLIAgentDisplayState::Success,
+            WarpIcon::Check,
+            &agent_style_config(size, vec![AgentTabStyleLayer::BadgeIcon]),
+        );
+        let badge = style.badge_style();
+        assert_eq!(badge.ring_ratio, 0.57 * scale);
+        assert_eq!(badge.icon_ratio, 0.34 * scale);
+    }
+}
+
+#[test]
+fn cli_agent_style_precedence() {
+    let manual_or_directory = Some(AnsiColorIdentifier::Yellow);
+    let enabled = style_for_display_state(
+        CLIAgentDisplayState::Processing,
+        WarpIcon::Circle,
+        &agent_style_config(AgentTabBadgeSize::Regular, vec![AgentTabStyleLayer::TabBg]),
+    );
+    let disabled = style_for_display_state(
+        CLIAgentDisplayState::Processing,
+        WarpIcon::Circle,
+        &agent_style_config(AgentTabBadgeSize::Regular, vec![]),
+    );
+    assert_eq!(
+        Some(enabled.color)
+            .filter(|_| enabled.tab_bg)
+            .or(manual_or_directory),
+        Some(AnsiColorIdentifier::Magenta)
+    );
+    assert_eq!(
+        Some(disabled.color)
+            .filter(|_| disabled.tab_bg)
+            .or(manual_or_directory),
+        manual_or_directory
+    );
+}
+
+#[test]
+fn cli_agent_style_all_vertical_modes() {
+    let config = agent_style_config(
+        AgentTabBadgeSize::Regular,
+        vec![AgentTabStyleLayer::BadgeIcon],
+    );
+    let pane_style =
+        style_for_display_state(CLIAgentDisplayState::Processing, WarpIcon::Circle, &config);
+    let summary_style = aggregate_cli_styles([
+        pane_style,
+        style_for_display_state(CLIAgentDisplayState::Idle, WarpIcon::Circle, &config),
+        style_for_display_state(CLIAgentDisplayState::Success, WarpIcon::Check, &config),
+        style_for_display_state(
+            CLIAgentDisplayState::NeedsAttention,
+            WarpIcon::Circle,
+            &config,
+        ),
+    ]);
+    assert_eq!(
+        summary_style.map(|style| style.state),
+        Some(CLIAgentDisplayState::NeedsAttention)
+    );
+
+    for _is_grouped in [false, true] {
+        assert_eq!(
+            cli_style_for_vertical_mode(VerticalTabsResolvedMode::Panes, Some(pane_style), None),
+            Some(pane_style)
+        );
+        assert_eq!(
+            cli_style_for_vertical_mode(
+                VerticalTabsResolvedMode::FocusedSession,
+                Some(pane_style),
+                None,
+            ),
+            Some(pane_style)
+        );
+        assert_eq!(
+            cli_style_for_vertical_mode(
+                VerticalTabsResolvedMode::Summary,
+                Some(pane_style),
+                summary_style,
+            ),
+            summary_style
+        );
+    }
+}
+
+#[test]
+fn cli_agent_style_surface_isolation() {
+    assert!(supports_cli_agent_sidebar_style(
+        CLIAgent::Claude,
+        true,
+        false,
+        false,
+        true,
+    ));
+    for excluded in [
+        supports_cli_agent_sidebar_style(CLIAgent::Claude, false, false, false, true),
+        supports_cli_agent_sidebar_style(CLIAgent::Claude, true, true, false, true),
+        supports_cli_agent_sidebar_style(CLIAgent::Claude, true, false, true, true),
+        supports_cli_agent_sidebar_style(CLIAgent::Claude, true, false, false, false),
+        supports_cli_agent_sidebar_style(CLIAgent::Unknown, true, false, false, true),
+    ] {
+        assert!(!excluded);
+    }
+}
+
 fn code_summary_kind(title: &str) -> SummaryPaneKind {
     SummaryPaneKind::Code {
         title: title.to_string(),
@@ -1041,12 +1187,13 @@ fn summary_overflow_count_caps_visible_region() {
 fn primary_labels_dedupe_preserves_first_seen_status() {
     let mut values = Vec::new();
     let mut seen = std::collections::HashMap::new();
-    push_normalized_unique_summary_label(&mut values, &mut seen, "  cargo   test  ", None);
+    push_normalized_unique_summary_label(&mut values, &mut seen, "  cargo   test  ", None, None);
     push_normalized_unique_summary_label(
         &mut values,
         &mut seen,
         "cargo test",
         Some(ConversationStatus::InProgress),
+        None,
     );
 
     assert_eq!(
@@ -1054,6 +1201,7 @@ fn primary_labels_dedupe_preserves_first_seen_status() {
         vec![VerticalTabsSummaryPrimaryLabel {
             text: "cargo test".to_string(),
             status: None,
+            cli_style: None,
         }]
     );
 }
@@ -1067,14 +1215,16 @@ fn primary_labels_preserve_status_through_aggregation() {
         &mut seen,
         "Plan a refactor",
         Some(ConversationStatus::InProgress),
+        None,
     );
     push_normalized_unique_summary_label(
         &mut values,
         &mut seen,
         "Investigate failure",
         Some(ConversationStatus::Success),
+        None,
     );
-    push_normalized_unique_summary_label(&mut values, &mut seen, "cargo build", None);
+    push_normalized_unique_summary_label(&mut values, &mut seen, "cargo build", None, None);
 
     assert_eq!(
         values,
@@ -1082,14 +1232,17 @@ fn primary_labels_preserve_status_through_aggregation() {
             VerticalTabsSummaryPrimaryLabel {
                 text: "Plan a refactor".to_string(),
                 status: Some(ConversationStatus::InProgress),
+                cli_style: None,
             },
             VerticalTabsSummaryPrimaryLabel {
                 text: "Investigate failure".to_string(),
                 status: Some(ConversationStatus::Success),
+                cli_style: None,
             },
             VerticalTabsSummaryPrimaryLabel {
                 text: "cargo build".to_string(),
                 status: None,
+                cli_style: None,
             },
         ]
     );
@@ -1101,22 +1254,27 @@ fn sort_summary_primary_labels_moves_status_first_and_preserves_order() {
         VerticalTabsSummaryPrimaryLabel {
             text: "plain terminal".to_string(),
             status: None,
+            cli_style: None,
         },
         VerticalTabsSummaryPrimaryLabel {
             text: "first conversation".to_string(),
             status: Some(ConversationStatus::InProgress),
+            cli_style: None,
         },
         VerticalTabsSummaryPrimaryLabel {
             text: "code pane".to_string(),
             status: None,
+            cli_style: None,
         },
         VerticalTabsSummaryPrimaryLabel {
             text: "second conversation".to_string(),
             status: Some(ConversationStatus::Success),
+            cli_style: None,
         },
         VerticalTabsSummaryPrimaryLabel {
             text: "last terminal".to_string(),
             status: None,
+            cli_style: None,
         },
     ];
 
@@ -1128,22 +1286,27 @@ fn sort_summary_primary_labels_moves_status_first_and_preserves_order() {
             VerticalTabsSummaryPrimaryLabel {
                 text: "first conversation".to_string(),
                 status: Some(ConversationStatus::InProgress),
+                cli_style: None,
             },
             VerticalTabsSummaryPrimaryLabel {
                 text: "second conversation".to_string(),
                 status: Some(ConversationStatus::Success),
+                cli_style: None,
             },
             VerticalTabsSummaryPrimaryLabel {
                 text: "plain terminal".to_string(),
                 status: None,
+                cli_style: None,
             },
             VerticalTabsSummaryPrimaryLabel {
                 text: "code pane".to_string(),
                 status: None,
+                cli_style: None,
             },
             VerticalTabsSummaryPrimaryLabel {
                 text: "last terminal".to_string(),
                 status: None,
+                cli_style: None,
             },
         ]
     );
@@ -1188,6 +1351,7 @@ fn summary_search_fragments_include_hidden_overflow_values() {
             VerticalTabsSummaryPrimaryLabel {
                 text: "Claude".to_string(),
                 status: Some(ConversationStatus::InProgress),
+                cli_style: None,
             },
             label("Warp Agent"),
             label("cargo"),
@@ -1230,6 +1394,7 @@ fn summary_search_fragments_include_hidden_overflow_values() {
             },
         ],
         has_unread_activity: false,
+        cli_style: None,
     };
 
     let fragments = summary_search_text_fragments(&summary, Some("Custom tab"));

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -1,12 +1,19 @@
 use std::iter::once;
 use std::path::PathBuf;
 
+use pathfinder_color::ColorU;
 use pathfinder_geometry::rect::RectF;
-use pathfinder_geometry::vector::Vector2F;
+use pathfinder_geometry::vector::{Vector2F, vec2f};
 use warp_core::ui::Icon as WarpIcon;
 use warp_core::ui::theme::AnsiColorIdentifier;
-use warpui::EntityId;
-use warpui::elements::PositionedElementOffsetBounds;
+use warpui::elements::{
+    ConstrainedBox, Empty, ParentElement, PositionedElementOffsetBounds, SavePosition, Stack,
+};
+use warpui::platform::WindowStyle;
+use warpui::{
+    App, Element, Entity, EntityId, EntityIdSet, Presenter, TypedActionView, View,
+    WindowInvalidation,
+};
 
 use super::{
     AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons, TerminalAgentText,
@@ -34,6 +41,11 @@ use crate::safe_triangle::SafeTriangle;
 use crate::tab::{ShortcutModifierKind, reveals_shortcut_hints};
 use crate::terminal::CLIAgent;
 use crate::terminal::cli_agent_sessions::CLIAgentDisplayState;
+use crate::themes::default_themes::dark_theme;
+use crate::ui_components::icon_with_status::{
+    StatusBadgeMode, StatusBadgeStyle, TEST_BADGE_ICON_POSITION_ID, TEST_BADGE_RING_POSITION_ID,
+    render_element_with_status_badge_override,
+};
 use crate::user_config::agent_tab_styles::{
     AgentTabBadgeSize, AgentTabColor, AgentTabStateStyle, AgentTabStyleLayer,
 };
@@ -62,6 +74,51 @@ fn agent_style_config(
     }
 }
 
+const TEST_BADGE_ROOT_POSITION_ID: &str = "cli_agent_badge_root";
+
+struct BadgeGeometryView(StatusBadgeStyle);
+
+impl Entity for BadgeGeometryView {
+    type Event = ();
+}
+
+impl View for BadgeGeometryView {
+    fn ui_name() -> &'static str {
+        "AgentStateBadgeGeometryTestView"
+    }
+
+    fn render(&self, _app: &warpui::AppContext) -> Box<dyn warpui::Element> {
+        let theme = dark_theme();
+        let base = ConstrainedBox::new(Empty::new().finish())
+            .with_width(40.)
+            .with_height(40.)
+            .finish();
+        Stack::new()
+            .with_child(
+                SavePosition::new(
+                    render_element_with_status_badge_override(
+                        base,
+                        40.,
+                        self.0,
+                        StatusBadgeMode::Override {
+                            icon: WarpIcon::Check,
+                            color: ColorU::new(0, 200, 120, 255),
+                        },
+                        &theme,
+                        theme.background(),
+                    ),
+                    TEST_BADGE_ROOT_POSITION_ID,
+                )
+                .finish(),
+            )
+            .finish()
+    }
+}
+
+impl TypedActionView for BadgeGeometryView {
+    type Action = ();
+}
+
 #[test]
 fn cli_agent_visual_layers_and_badge_sizes() {
     for (layer, expected) in [
@@ -78,20 +135,49 @@ fn cli_agent_visual_layers_and_badge_sizes() {
         assert_eq!(style.color, AnsiColorIdentifier::Magenta);
     }
 
-    for (size, scale) in [
-        (AgentTabBadgeSize::Regular, 1.),
-        (AgentTabBadgeSize::Big, 1.25),
-        (AgentTabBadgeSize::Bigger, 1.5),
-    ] {
-        let style = style_for_display_state(
-            CLIAgentDisplayState::Success,
-            WarpIcon::Check,
-            &agent_style_config(size, vec![AgentTabStyleLayer::BadgeIcon]),
-        );
-        let badge = style.badge_style();
-        assert_eq!(badge.ring_ratio, 0.57 * scale);
-        assert_eq!(badge.icon_ratio, 0.34 * scale);
-    }
+    App::test((), |mut app| async move {
+        for (size, scale) in [
+            (AgentTabBadgeSize::Regular, 1.),
+            (AgentTabBadgeSize::Big, 1.25),
+            (AgentTabBadgeSize::Bigger, 1.5),
+        ] {
+            let style = style_for_display_state(
+                CLIAgentDisplayState::Success,
+                WarpIcon::Check,
+                &agent_style_config(size, vec![AgentTabStyleLayer::BadgeIcon]),
+            );
+            let (window_id, _view) = app.add_window(WindowStyle::NotStealFocus, move |_| {
+                BadgeGeometryView(style.badge_style())
+            });
+            let root_id = app.root_view_id(window_id).expect("root view should exist");
+            let mut presenter = Presenter::new(window_id);
+            app.update(|ctx| {
+                presenter.invalidate(
+                    WindowInvalidation {
+                        updated: EntityIdSet::from_iter([root_id]),
+                        ..Default::default()
+                    },
+                    ctx,
+                );
+                presenter.build_scene(vec2f(80., 80.), 1., None, ctx);
+                let cache = presenter.position_cache();
+                let root = cache
+                    .get_position(TEST_BADGE_ROOT_POSITION_ID)
+                    .expect("rendered badge root should be positioned");
+                let ring = cache
+                    .get_position(TEST_BADGE_RING_POSITION_ID)
+                    .expect("rendered badge ring should be positioned");
+                let icon = cache
+                    .get_position(TEST_BADGE_ICON_POSITION_ID)
+                    .expect("rendered badge icon should be positioned");
+                assert_eq!((root.width(), root.height()), (40., 40.));
+                assert!((ring.width() - 40. * 0.57 * scale).abs() < 0.01);
+                assert!((ring.height() - 40. * 0.57 * scale).abs() < 0.01);
+                assert!((icon.width() - 40. * 0.34 * scale).abs() < 0.01);
+                assert!((icon.height() - 40. * 0.34 * scale).abs() < 0.01);
+            });
+        }
+    })
 }
 
 #[test]

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -418,6 +418,9 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_execution_profile_model_persists_and_hot_reloads_settings_file);
     register_test!(test_settings_file_migration_from_native_store);
     register_test!(test_settings_file_hot_reload_applies_new_values);
+    register_test!(test_agent_tab_styles_config_lifecycle);
+    register_test!(test_cli_agent_event_routes_and_acknowledgement);
+    register_test!(vertical_tabs_state_and_badge_matrix_warposs);
 
     register_test!(test_settings_error_banner_on_startup_with_invalid_toml);
     register_test!(test_settings_error_banner_on_startup_with_invalid_value);

--- a/crates/integration/src/test.rs
+++ b/crates/integration/src/test.rs
@@ -3,6 +3,7 @@
 //! to be run.
 
 mod agent_mode;
+mod agent_state_visuals;
 mod ai_assistant;
 mod ai_document;
 mod block_filtering;
@@ -49,6 +50,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 pub use agent_mode::*;
+pub use agent_state_visuals::*;
 pub use ai_assistant::*;
 pub use ai_document::*;
 use anyhow::{Result, anyhow};

--- a/crates/integration/src/test/agent_state_visuals.rs
+++ b/crates/integration/src/test/agent_state_visuals.rs
@@ -1,0 +1,530 @@
+//! End-to-end coverage for configurable CLI-agent state visuals.
+
+use std::time::Duration;
+
+use settings::Setting as _;
+use warp::cmd_or_ctrl_shift;
+use warp::features::FeatureFlag;
+use warp::integration_testing::agent_state_visuals::{
+    agent_tab_style_color, agent_tab_styles_are_default, agent_tab_styles_path,
+    cli_agent_display_state, emit_cli_agent_notification,
+};
+use warp::integration_testing::step::new_step_with_default_assertions;
+use warp::integration_testing::terminal::wait_until_bootstrapped_single_pane_for_tab;
+use warp::integration_testing::view_getters::{terminal_view, workspace_view};
+use warp::themes::theme::AnsiColorIdentifier;
+use warp::workspace::tab_settings::{
+    TabSettings, VerticalTabsDisplayGranularity, VerticalTabsTabItemMode,
+};
+use warpui_core::integration::{AssertionCallback, TestStep};
+use warpui_core::{SingletonEntity, async_assert, async_assert_eq};
+
+use super::{Builder, new_builder};
+
+const ANNOTATED_DEFAULT: &str = r#"# Agent-state styling for the vertical-tabs sidebar.
+# Colors are Warp's theme-aware ANSI colors: red, green, yellow, blue, magenta, cyan.
+version: 1
+
+states:
+  idle:
+    color: blue
+    badge_size: regular
+    layers: [tab_bg, badge_icon]
+  processing:
+    color: yellow
+    badge_size: bigger
+    layers: [tab_bg, badge_icon]
+  success:
+    color: green
+    badge_size: big
+    layers: [tab_bg, tab_text, badge_icon]
+  needs_attention:
+    color: red
+    badge_size: bigger
+    layers: [tab_bg, tab_text, badge_icon]
+
+group_outline:
+  # Empty disables automatic outlines. The group UUID chooses one entry stably.
+  colors: [blue, magenta, cyan, green]
+"#;
+
+const PRECEDENCE_CONFIG: &str = r#"version: 1
+states:
+  idle:
+    color: blue
+    badge_size: regular
+    layers: [badge_icon]
+  processing:
+    color: yellow
+    badge_size: bigger
+    layers: [tab_bg]
+  success:
+    color: green
+    badge_size: big
+    layers: [tab_text, badge_icon]
+  needs_attention:
+    color: red
+    badge_size: bigger
+    layers: [tab_bg, tab_text, badge_icon]
+group_outline:
+  colors: [cyan]
+"#;
+
+fn config_path() -> std::path::PathBuf {
+    agent_tab_styles_path()
+}
+
+fn fast(step: TestStep) -> TestStep {
+    step.set_post_step_pause(Duration::from_millis(75))
+        .set_pause_on_failure(Duration::ZERO)
+}
+
+fn assert_cli_state(tab_index: usize, expected: &'static str) -> AssertionCallback {
+    Box::new(move |app, window_id| {
+        let view_id = terminal_view(app, window_id, tab_index, 0).id();
+        let state = app.read(|ctx| cli_agent_display_state(ctx, view_id));
+        async_assert_eq!(
+            state,
+            Some(expected),
+            "tab {tab_index} should be in {expected}"
+        )
+    })
+}
+
+fn assert_error_toast_count(expected: usize) -> AssertionCallback {
+    Box::new(move |app, window_id| {
+        let workspace = workspace_view(app, window_id);
+        workspace.read(app, |workspace, ctx| {
+            async_assert_eq!(
+                workspace.integration_test_agent_tab_styles_toast_count(ctx),
+                expected
+            )
+        })
+    })
+}
+
+fn notification_body(event: &str, fields: &str) -> String {
+    format!(r#"{{"v":1,"agent":"claude","event":"{event}","session_id":"s1-01"{fields}}}"#)
+}
+
+fn send_notification(tab_index: usize, event: &str, fields: &str) -> TestStep {
+    let body = notification_body(event, fields);
+    fast(
+        TestStep::new("Emit CLI-agent notification through terminal dispatcher").with_action(
+            move |app, window_id, _| {
+                let terminal = terminal_view(app, window_id, tab_index, 0);
+                emit_cli_agent_notification(app, &terminal, body.clone());
+            },
+        ),
+    )
+}
+
+fn set_active_pane_name(name: &'static str) -> TestStep {
+    fast(
+        TestStep::new("Name active agent-state pane").with_action(move |app, window_id, _| {
+            let workspace = workspace_view(app, window_id);
+            let pane_group = workspace.read(app, |workspace, _| {
+                workspace
+                    .get_pane_group_view(workspace.active_tab_index())
+                    .expect("active pane group should exist")
+                    .clone()
+            });
+            pane_group.update(app, |pane_group, ctx| {
+                let pane_id = pane_group.focused_pane_id(ctx);
+                pane_group
+                    .pane_by_id(pane_id)
+                    .expect("focused pane should exist")
+                    .pane_configuration()
+                    .update(ctx, |configuration, ctx| {
+                        configuration.set_custom_vertical_tabs_title(name, ctx);
+                    });
+            });
+        }),
+    )
+}
+
+fn set_vertical_mode(
+    granularity: VerticalTabsDisplayGranularity,
+    tab_mode: VerticalTabsTabItemMode,
+) -> TestStep {
+    fast(
+        TestStep::new("Set vertical tab rendering mode").with_action(move |app, _, _| {
+            TabSettings::handle(app).update(app, |settings, ctx| {
+                settings
+                    .use_vertical_tabs
+                    .set_value(true, ctx)
+                    .expect("vertical tabs should enable");
+                settings
+                    .vertical_tabs_display_granularity
+                    .set_value(granularity, ctx)
+                    .expect("granularity should update");
+                settings
+                    .vertical_tabs_tab_item_mode
+                    .set_value(tab_mode, ctx)
+                    .expect("tab item mode should update");
+            });
+        }),
+    )
+}
+
+fn set_horizontal_tabs() -> TestStep {
+    fast(
+        TestStep::new("Render excluded horizontal-tab surface").with_action(|app, _, _| {
+            TabSettings::handle(app).update(app, |settings, ctx| {
+                settings
+                    .use_vertical_tabs
+                    .set_value(false, ctx)
+                    .expect("vertical tabs should disable");
+            });
+        }),
+    )
+}
+
+fn set_manual_colors() -> TestStep {
+    fast(
+        TestStep::new("Set manual tab colors for precedence").with_action(|app, window_id, _| {
+            workspace_view(app, window_id).update(app, |workspace, ctx| {
+                workspace.integration_test_set_all_tab_colors(AnsiColorIdentifier::Magenta, ctx);
+            });
+        }),
+    )
+}
+
+fn group_all_tabs() -> TestStep {
+    fast(
+        TestStep::new("Group all agent tabs with independent group color").with_action(
+            |app, window_id, _| {
+                workspace_view(app, window_id).update(app, |workspace, ctx| {
+                    workspace.integration_test_group_all_tabs(AnsiColorIdentifier::Cyan, ctx);
+                });
+            },
+        ),
+    )
+}
+
+pub fn test_agent_tab_styles_config_lifecycle() -> Builder {
+    new_builder()
+        .with_timeout(Duration::from_secs(5 * 60))
+        .with_setup(|utils| {
+            utils.set_env("WARP_CONFIG_WATCHER_DELAY_MS", Some("10".to_string()));
+            let path = config_path();
+            std::fs::create_dir_all(path.parent().expect("config parent should exist"))
+                .expect("config parent should be created");
+            if path.exists() {
+                std::fs::remove_file(path).expect("old agent style config should be removed");
+            }
+        })
+        .with_step(
+            wait_until_bootstrapped_single_pane_for_tab(0).add_named_assertion(
+                "annotated defaults created and loaded on startup",
+                |app, _| {
+                    let created = std::fs::read_to_string(config_path()).ok();
+                    async_assert!(
+                        created.as_deref() == Some(ANNOTATED_DEFAULT)
+                            && app.read(agent_tab_styles_are_default),
+                        "startup should create and load the exact annotated defaults"
+                    )
+                },
+            ),
+        )
+        .with_step(
+            TestStep::new("Hot reload a valid agent style config")
+                .set_timeout(Duration::from_secs(30))
+                .with_setup(|_| {
+                    std::fs::write(
+                        config_path(),
+                        "version: 1\nstates:\n  success:\n    color: cyan\n",
+                    )
+                    .expect("valid config should be written");
+                })
+                .add_named_assertion("valid reload applied", |app, _| {
+                    async_assert_eq!(
+                        app.read(|ctx| agent_tab_style_color(ctx, "success")),
+                        "cyan"
+                    )
+                })
+                .add_assertion(assert_error_toast_count(0)),
+        )
+        .with_step(
+            TestStep::new("Reject invalid hot reload and show one error toast")
+                .set_timeout(Duration::from_secs(30))
+                .with_setup(|_| {
+                    std::fs::write(config_path(), "version: 2\n")
+                        .expect("invalid config should be written");
+                })
+                .add_named_assertion("last-known-good config retained", |app, _| {
+                    async_assert_eq!(
+                        app.read(|ctx| agent_tab_style_color(ctx, "success")),
+                        "cyan"
+                    )
+                })
+                .add_assertion(assert_error_toast_count(1)),
+        )
+        .with_step(
+            TestStep::new("A second invalid reload replaces rather than duplicates the toast")
+                .set_timeout(Duration::from_secs(30))
+                .with_setup(|_| {
+                    std::fs::write(config_path(), "version: 1\nunknown: true\n")
+                        .expect("second invalid config should be written");
+                })
+                .add_named_assertion("last-known-good still retained", |app, _| {
+                    async_assert_eq!(
+                        app.read(|ctx| agent_tab_style_color(ctx, "success")),
+                        "cyan"
+                    )
+                })
+                .add_assertion(assert_error_toast_count(1)),
+        )
+        .with_step(
+            TestStep::new("Delete config and immediately restore compiled defaults")
+                .set_timeout(Duration::from_secs(30))
+                .with_setup(|_| {
+                    std::fs::remove_file(config_path()).expect("config should be deleted");
+                })
+                .add_named_assertion("deletion loaded defaults", |app, _| {
+                    async_assert!(app.read(agent_tab_styles_are_default))
+                })
+                .add_assertion(assert_error_toast_count(0)),
+        )
+}
+
+pub fn test_cli_agent_event_routes_and_acknowledgement() -> Builder {
+    FeatureFlag::PluggableNotifications.set_enabled(true);
+
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            send_notification(0, "session_start", "").add_named_assertion(
+                "TerminalView route registered idle session",
+                assert_cli_state(0, "idle"),
+            ),
+        )
+        .with_step(
+            send_notification(0, "prompt_submit", r#","query":"Route coverage""#)
+                .add_named_assertion(
+                    "listener route applied prompt",
+                    assert_cli_state(0, "processing"),
+                ),
+        )
+        .with_step(
+            new_step_with_default_assertions("Create another focused tab")
+                .with_keystrokes(&[cmd_or_ctrl_shift("t")]),
+        )
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(1))
+        .with_step(
+            send_notification(0, "stop", r#","query":"Route coverage""#).add_named_assertion(
+                "unfocused completion remains unseen",
+                assert_cli_state(0, "success"),
+            ),
+        )
+        .with_step(
+            new_step_with_default_assertions("Focus completed session")
+                .with_keystrokes(&["cmdorctrl-1"])
+                .add_named_assertion(
+                    "focus subscription acknowledges success",
+                    assert_cli_state(0, "idle"),
+                ),
+        )
+        .with_step(send_notification(
+            0,
+            "prompt_submit",
+            r#","query":"Focused completion""#,
+        ))
+        .with_step(
+            send_notification(0, "stop", r#","query":"Focused completion""#).add_named_assertion(
+                "completion subscription acknowledges success",
+                assert_cli_state(0, "idle"),
+            ),
+        )
+}
+
+pub fn vertical_tabs_state_and_badge_matrix_warposs() -> Builder {
+    FeatureFlag::VerticalTabs.set_enabled(true);
+    FeatureFlag::VerticalTabsSummaryMode.set_enabled(true);
+    FeatureFlag::GroupedTabs.set_enabled(true);
+    FeatureFlag::PluggableNotifications.set_enabled(true);
+
+    new_builder()
+        .with_timeout(Duration::from_secs(5 * 60))
+        .with_setup(|utils| {
+            utils.set_env(
+                "WARPUI_USE_REAL_DISPLAY_IN_INTEGRATION_TESTS",
+                Some("1".to_string()),
+            );
+            utils.set_env("WARP_CONFIG_WATCHER_DELAY_MS", Some("10".to_string()));
+            let path = config_path();
+            std::fs::create_dir_all(path.parent().expect("config parent should exist"))
+                .expect("config parent should be created");
+            std::fs::write(path, PRECEDENCE_CONFIG).expect("precedence config should be written");
+        })
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(send_notification(0, "session_start", ""))
+        .with_step(set_active_pane_name(
+            "Idle — regular badge; manual background",
+        ))
+        .with_step(
+            new_step_with_default_assertions("Create Processing tab")
+                .with_keystrokes(&[cmd_or_ctrl_shift("t")]),
+        )
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(1))
+        .with_step(send_notification(1, "session_start", ""))
+        .with_step(send_notification(
+            1,
+            "prompt_submit",
+            r#","query":"Processing — bigger badge suppressed""#,
+        ))
+        .with_step(set_active_pane_name(
+            "Processing — state background; badge suppressed",
+        ))
+        .with_step(
+            new_step_with_default_assertions("Create Success tab")
+                .with_keystrokes(&[cmd_or_ctrl_shift("t")]),
+        )
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(2))
+        .with_step(send_notification(2, "session_start", ""))
+        .with_step(send_notification(
+            2,
+            "prompt_submit",
+            r#","query":"Success — big badge and text""#,
+        ))
+        .with_step(set_active_pane_name("Success — big badge and state text"))
+        .with_step(
+            new_step_with_default_assertions("Create Needs Attention tab")
+                .with_keystrokes(&[cmd_or_ctrl_shift("t")]),
+        )
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(3))
+        .with_step(send_notification(
+            2,
+            "stop",
+            r#","query":"Success — big badge and text""#,
+        ))
+        .with_step(send_notification(3, "session_start", ""))
+        .with_step(send_notification(
+            3,
+            "prompt_submit",
+            r#","query":"Needs Attention — bigger badge""#,
+        ))
+        .with_step(send_notification(
+            3,
+            "permission_request",
+            r#","summary":"Needs Attention — bigger badge""#,
+        ))
+        .with_step(set_active_pane_name(
+            "Needs Attention — bigger badge and state colors",
+        ))
+        .with_step(
+            TestStep::new("All four routed states are present")
+                .set_timeout(Duration::from_secs(30))
+                .add_assertion(assert_cli_state(0, "idle"))
+                .add_assertion(assert_cli_state(1, "processing"))
+                .add_assertion(assert_cli_state(2, "success"))
+                .add_assertion(assert_cli_state(3, "needs_attention")),
+        )
+        .with_step(
+            new_step_with_default_assertions("Focus unseen Success and acknowledge it")
+                .with_keystrokes(&["cmdorctrl-3"])
+                .add_assertion(assert_cli_state(2, "idle")),
+        )
+        .with_step(send_notification(
+            2,
+            "prompt_submit",
+            r#","query":"Success — big badge and text""#,
+        ))
+        .with_step(
+            new_step_with_default_assertions("Return focus to Needs Attention")
+                .with_keystrokes(&["cmdorctrl-4"])
+                .add_assertion(assert_cli_state(2, "processing")),
+        )
+        .with_step(
+            send_notification(2, "stop", r#","query":"Success — big badge and text""#)
+                .set_timeout(Duration::from_secs(30))
+                .add_assertion(assert_cli_state(2, "success")),
+        )
+        .with_step(send_notification(
+            3,
+            "prompt_submit",
+            r#","query":"Focused stop""#,
+        ))
+        .with_step(
+            send_notification(3, "stop", r#","query":"Focused stop""#).add_named_assertion(
+                "focused completion acknowledged",
+                assert_cli_state(3, "idle"),
+            ),
+        )
+        .with_step(send_notification(
+            3,
+            "prompt_submit",
+            r#","query":"Needs Attention — bigger badge""#,
+        ))
+        .with_step(send_notification(
+            3,
+            "permission_request",
+            r#","summary":"Needs Attention — bigger badge""#,
+        ))
+        .with_step(set_manual_colors())
+        .with_step(set_horizontal_tabs())
+        .with_step(
+            TestStep::new("Capture excluded horizontal tabs")
+                .with_take_screenshot("horizontal_tabs_excluded_surface.png"),
+        )
+        .with_step(set_vertical_mode(
+            VerticalTabsDisplayGranularity::Panes,
+            VerticalTabsTabItemMode::FocusedSession,
+        ))
+        .with_step(
+            TestStep::new("Capture ungrouped Panes matrix")
+                .with_take_screenshot("vertical_tabs_state_and_badge_matrix_warposs.png"),
+        )
+        .with_step(set_vertical_mode(
+            VerticalTabsDisplayGranularity::Tabs,
+            VerticalTabsTabItemMode::FocusedSession,
+        ))
+        .with_step(
+            TestStep::new("Capture ungrouped Focused Session")
+                .with_take_screenshot("ungrouped_focused_session.png"),
+        )
+        .with_step(set_vertical_mode(
+            VerticalTabsDisplayGranularity::Tabs,
+            VerticalTabsTabItemMode::Summary,
+        ))
+        .with_step(
+            TestStep::new("Capture ungrouped Summary aggregation")
+                .with_take_screenshot("ungrouped_summary.png"),
+        )
+        .with_step(group_all_tabs())
+        .with_step(set_vertical_mode(
+            VerticalTabsDisplayGranularity::Panes,
+            VerticalTabsTabItemMode::FocusedSession,
+        ))
+        .with_step(
+            TestStep::new("Capture grouped Panes matrix").with_take_screenshot("grouped_panes.png"),
+        )
+        .with_step(set_vertical_mode(
+            VerticalTabsDisplayGranularity::Tabs,
+            VerticalTabsTabItemMode::FocusedSession,
+        ))
+        .with_step(
+            TestStep::new("Capture grouped Focused Session")
+                .with_take_screenshot("grouped_focused_session.png"),
+        )
+        .with_step(set_vertical_mode(
+            VerticalTabsDisplayGranularity::Tabs,
+            VerticalTabsTabItemMode::Summary,
+        ))
+        .with_step(
+            TestStep::new("Capture grouped Summary aggregation")
+                .with_take_screenshot("grouped_summary.png"),
+        )
+        .with_step(
+            TestStep::new("Verify routed states survive every render path")
+                .add_assertion(assert_cli_state(0, "idle"))
+                .add_assertion(assert_cli_state(1, "processing"))
+                .add_assertion(assert_cli_state(2, "success"))
+                .add_assertion(assert_cli_state(3, "needs_attention"))
+                .add_named_assertion("four tabs remain", |app, window_id| {
+                    let count = workspace_view(app, window_id)
+                        .read(app, |workspace, _| workspace.tab_count());
+                    async_assert_eq!(count, 4)
+                }),
+        )
+}


### PR DESCRIPTION
## Description

Adds a CLI-agent-only presentation layer for vertical tabs so parallel agent sessions expose four glanceable states: Idle, Processing, Success (finished and unseen), and Needs attention. Styling is configured through `agent_tab_styles.yaml` with independent background, text, and badge layers plus three badge scales.

The implementation keeps Warp Agent Mode, ambient/cloud agents, horizontal tabs, conversation surfaces, and existing manual/directory colors unchanged. Successful results remain visible until the terminal is focused in the active window; blocked and failed states persist until a later agent event changes them.

This draft intentionally contains only the shared state/config/rendering implementation and its tests. It excludes fork governance, 42labs adapters, install scripts, and unrelated group styling.

## Linked Issue

Closes #13287.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. It is currently `needs-mocks`; the implementation-neutral mock and state proposal are attached in [this issue comment](https://github.com/warpdotdev/warp/issues/13287#issuecomment-5589426037). This PR stays draft pending maintainer readiness/design direction.
- [x] Screenshots are included below.

## Testing

- `cargo test -p warp --lib cli_agent_ -- --nocapture` — 208 passed
- `cargo test -p warp --lib agent_tab_styles_config_contract` — 1 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check upstream/master...HEAD` — passed
- Workspace Clippy was attempted after the focused tests; the host exhausted disk space while compiling dependencies, with no source diagnostic.

- [x] I manually tested the same feature commits in a locally bundled Warp OSS build and verified Idle, Processing, Success, and Needs attention across the vertical sidebar. The final merged fork build was also installed, code-sign verified, launched, and runtime-checked.

### Screenshots / Videos

<img width="1672" height="941" alt="Proposed and implemented CLI-agent state colors for vertical tabs" src="https://github.com/user-attachments/assets/904f201e-446c-4a0b-b246-afe54f01e317" />

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp Agent Mode

CHANGELOG-NEW-FEATURE: Added configurable vertical-tab colors and badges for CLI-agent lifecycle states.