### PR TITLE
Preserve recordings when agent conversations remain in progress

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1170,24 +1170,28 @@ impl BlocklistAIActionModel {
         });
         #[cfg(not(target_family = "wasm"))]
         {
-            // Cancelling a conversation kills the running ffmpeg process
-            // without uploading the partial recording, so pass
-            // `should_upload = false`.
-            if let Some(finalization) = finalize_recording_for_conversation(
-                conversation_id,
-                FinalizeReason::RunCancelled,
-                false,
-                ctx,
-            ) {
-                ctx.spawn(
-                    async move { finalization.resolve().await },
-                    |_model, (result, actual_reason), _ctx| {
-                        log::info!(
-                            "Recording finalization after conversation cancellation completed \
-                             (reason={actual_reason:?}): {result:?}"
-                        );
-                    },
-                );
+            // KeepInProgress supersedes current actions without ending the conversation, so its
+            // recording remains owned by the continuing conversation.
+            if should_finalize_recording_after_action_cancellation(reason) {
+                // Cancelling a conversation kills the running ffmpeg process
+                // without uploading the partial recording, so pass
+                // `should_upload = false`.
+                if let Some(finalization) = finalize_recording_for_conversation(
+                    conversation_id,
+                    FinalizeReason::RunCancelled,
+                    false,
+                    ctx,
+                ) {
+                    ctx.spawn(
+                        async move { finalization.resolve().await },
+                        |_model, (result, actual_reason), _ctx| {
+                            log::info!(
+                                "Recording finalization after conversation cancellation completed \
+                                 (reason={actual_reason:?}): {result:?}"
+                            );
+                        },
+                    );
+                }
             }
         }
 
@@ -1531,6 +1535,15 @@ impl BlocklistAIActionModel {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
+fn should_finalize_recording_after_action_cancellation(reason: Option<CancellationReason>) -> bool {
+    reason.is_none_or(|reason| {
+        !matches!(
+            reason.conversation_outcome(),
+            CancellationOutcome::KeepInProgress
+        )
+    })
+}
 #[derive(Debug, Clone)]
 pub enum BlocklistAIActionEvent {
     /// Emitted when the action with the given ID is enqueued for execution.

--- a/app/src/ai/blocklist/action_model_tests.rs
+++ b/app/src/ai/blocklist/action_model_tests.rs
@@ -100,3 +100,32 @@ fn finished_results_stay_in_original_action_order() {
         AIAgentActionId::from("third".to_owned())
     );
 }
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn continuing_conversation_does_not_finalize_recording_when_actions_are_cancelled() {
+    assert!(!should_finalize_recording_after_action_cancellation(Some(
+        CancellationReason::FollowUpSubmitted {
+            is_for_same_conversation: true,
+        }
+    )));
+    assert!(!should_finalize_recording_after_action_cancellation(Some(
+        CancellationReason::CLISubagentUserTakeover
+    )));
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn terminal_conversation_finalizes_recording_when_actions_are_cancelled() {
+    assert!(should_finalize_recording_after_action_cancellation(Some(
+        CancellationReason::ManuallyCancelled
+    )));
+    assert!(should_finalize_recording_after_action_cancellation(Some(
+        CancellationReason::FollowUpSubmitted {
+            is_for_same_conversation: false,
+        }
+    )));
+    assert!(should_finalize_recording_after_action_cancellation(Some(
+        CancellationReason::AgentExitedShell
+    )));
+}

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -7,6 +7,8 @@ use ai::api_keys::{
     GeapCredentialsState,
 };
 use chrono::Local;
+#[cfg(not(target_family = "wasm"))]
+use computer_use::RecordingHandle;
 use uuid::Uuid;
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api::response_event;
@@ -20,6 +22,8 @@ use crate::ai::agent::{
     PassiveSuggestionTrigger, UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+#[cfg(not(target_family = "wasm"))]
+use crate::ai::blocklist::RecordingController;
 use crate::ai::blocklist::orchestration_events::{
     OrchestrationEventService, PendingEvent, PendingEventDetail,
 };
@@ -241,6 +245,53 @@ fn cancelling_conversation_aborts_pending_auto_resume() {
                         .contains_key(&conversation_id)
                 );
             });
+        });
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn keep_in_progress_action_cleanup_preserves_active_recording() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        app.add_singleton_model(|_| RecordingController::new());
+        let terminal = add_window_with_terminal(&mut app, None);
+        let conversation_id = AIConversationId::new();
+
+        app.update(|ctx| {
+            RecordingController::handle(ctx).update(ctx, |controller, _| {
+                controller.try_begin_start(conversation_id).unwrap();
+                let (handle, _) = RecordingHandle::new_test(1, 1);
+                controller.finish_start(
+                    "recording".to_owned(),
+                    conversation_id,
+                    handle,
+                    15,
+                    None,
+                    None,
+                    computer_use::Target::Screen,
+                );
+            });
+        });
+
+        terminal.update(&mut app, |terminal, ctx| {
+            let action_model = terminal.ai_controller().as_ref(ctx).action_model.clone();
+            action_model.update(ctx, |action_model, ctx| {
+                action_model.cancel_all_pending_actions(
+                    conversation_id,
+                    Some(CancellationReason::FollowUpSubmitted {
+                        is_for_same_conversation: true,
+                    }),
+                    ctx,
+                );
+            });
+        });
+
+        app.update(|ctx| {
+            assert_eq!(
+                RecordingController::as_ref(ctx).active_recording_id(),
+                Some("recording")
+            );
         });
     });
 }


### PR DESCRIPTION
## Description
Same-conversation follow-ups intentionally cancel the superseded response stream and pending actions while keeping the conversation InProgress. However, we observe that cancel_all_pending_actions also unconditionally finalizes an active Computer Use recording as RunCancelled as part of client clean-up. When Computer Use later emits stopRecording, the recording controller returned the retained StopRecordingResult::Cancelled. With no active stream or follow-up request, the FinishedAction fallback then transitioned the entire conversation to Cancelled. This was identified while investigating Factory tasks incorrectly reported as “Cancelled by user.”

This change skips recording finalization when the cancellation reason maps to CancellationOutcome::KeepInProgress. Pending actions and the superseded response stream are still cancelled normally. Terminal cancellation outcomes continue to finalize recordings as before.


## Testing
•  ./script/format --check
•  All Clippy commands from script/presubmit
•  Added and ran focused tests verifying: KeepInProgress cancellation preserves an active recording, same-conversation follow-ups and CLI subagent takeover skip recording finalization, and terminal cancellation outcomes continue to finalize recordings.
- [ ] I have manually tested my changes locally with `./script/run`


<!--
## Changelog Entries for Stable
CHANGELOG-NONE
-->
