### PR TITLE
Add missing WINDOWS variant to RunnerOS client enum

### DIFF
--- a/app/src/ai/agent_sdk/runner.rs
+++ b/app/src/ai/agent_sdk/runner.rs
@@ -341,6 +341,7 @@ fn build_create_input(args: CreateRunnerArgs, owner: GqlOwner) -> UpsertRunnerIn
                 version: args.macos_version.map(macos_version_to_gql),
             }),
         ),
+        RunnerOsArg::Windows => (None, None),
     };
 
     let instance_shape = match (args.vcpus, args.memory_gb) {
@@ -379,6 +380,7 @@ fn build_update_input(args: &UpdateRunnerArgs, existing: &RunnerConfig) -> Resul
     let effective_os_arg = match effective_os {
         RunnerOs::Linux => RunnerOsArg::Linux,
         RunnerOs::Macos => RunnerOsArg::Macos,
+        RunnerOs::Windows => RunnerOsArg::Windows,
     };
     validate_os_config(
         effective_os_arg,
@@ -405,6 +407,7 @@ fn build_update_input(args: &UpdateRunnerArgs, existing: &RunnerConfig) -> Resul
                 .or_else(|| existing.mac.as_ref().and_then(|m| m.version));
             (None, Some(MacOsConfigInput { version }))
         }
+        RunnerOs::Windows => (None, None),
     };
 
     // vCPUs and memory can be updated independently; each unspecified dimension
@@ -477,12 +480,13 @@ fn os_to_gql(os: RunnerOsArg) -> RunnerOs {
     match os {
         RunnerOsArg::Linux => RunnerOs::Linux,
         RunnerOsArg::Macos => RunnerOs::Macos,
+        RunnerOsArg::Windows => RunnerOs::Windows,
     }
 }
 
 /// Resolve a [`RunnerArchArg`] into a concrete [`RunnerArch`], mapping `auto`
-/// to the default architecture for the given OS (x86-64 on Linux, aarch64 on
-/// macOS).
+/// to the default architecture for the given OS (x86-64 on Linux and Windows,
+/// aarch64 on macOS).
 fn resolve_arch(arch: RunnerArchArg, os: RunnerOsArg) -> RunnerArch {
     match arch {
         RunnerArchArg::X8664 => RunnerArch::X8664,
@@ -490,6 +494,7 @@ fn resolve_arch(arch: RunnerArchArg, os: RunnerOsArg) -> RunnerArch {
         RunnerArchArg::Auto => match os {
             RunnerOsArg::Linux => RunnerArch::X8664,
             RunnerOsArg::Macos => RunnerArch::Aarch64,
+            RunnerOsArg::Windows => RunnerArch::X8664,
         },
     }
 }

--- a/app/src/ai/runner_display.rs
+++ b/app/src/ai/runner_display.rs
@@ -17,6 +17,7 @@ pub fn os_display(os: RunnerOs) -> &'static str {
     match os {
         RunnerOs::Linux => "Linux",
         RunnerOs::Macos => "macOS",
+        RunnerOs::Windows => "Windows",
     }
 }
 
@@ -43,6 +44,7 @@ pub fn icon_for(os: RunnerOs) -> Icon {
     match os {
         RunnerOs::Linux => Icon::Linux,
         RunnerOs::Macos => Icon::Apple,
+        RunnerOs::Windows => Icon::Powershell,
     }
 }
 

--- a/crates/graphql/src/api/queries/get_runners.rs
+++ b/crates/graphql/src/api/queries/get_runners.rs
@@ -24,6 +24,8 @@ pub enum RunnerOs {
     Linux,
     #[cynic(rename = "MACOS")]
     Macos,
+    #[cynic(rename = "WINDOWS")]
+    Windows,
 }
 
 #[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/warp_cli/src/runner.rs
+++ b/crates/warp_cli/src/runner.rs
@@ -25,6 +25,8 @@ pub enum RunnerOsArg {
     Linux,
     #[value(name = "macos")]
     Macos,
+    #[value(name = "windows")]
+    Windows,
 }
 
 /// Target CPU architecture for a runner sandbox.
@@ -206,7 +208,7 @@ pub struct DeleteRunnerArgs {
 ///
 /// Mirrors the server rule: Linux config (`--docker-image`) is only valid for
 /// `--os linux`, and macOS config (`--macos-version`) is only valid for
-/// `--os macos`.
+/// `--os macos`. Windows accepts neither, since it has no OS-specific config.
 pub fn validate_os_config(
     os: RunnerOsArg,
     docker_image: Option<&str>,
@@ -221,6 +223,14 @@ pub fn validate_os_config(
         RunnerOsArg::Macos => {
             if docker_image.is_some() {
                 return Err("--docker-image can only be used with --os linux".to_string());
+            }
+        }
+        RunnerOsArg::Windows => {
+            if docker_image.is_some() {
+                return Err("--docker-image can only be used with --os linux".to_string());
+            }
+            if macos_version.is_some() {
+                return Err("--macos-version can only be used with --os macos".to_string());
             }
         }
     }

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -3035,6 +3035,7 @@ type RunnerInstanceShape {
 enum RunnerOS {
   LINUX
   MACOS
+  WINDOWS
 }
 
 """Target CPU architecture for a runner sandbox."""


### PR DESCRIPTION
## Summary

Fixes bug from [REMOTE-3178](https://linear.app/warpdotdev/issue/REMOTE-3178/factory-agent-dispatch-fails-on-non-default-runners-mcp-config): `oz-dev runner list` (and any other client command that fetches runner data) failed outright whenever a Windows runner existed in scope:

```
Error: Failed to deserialize GraphQL response: reqwest::Error { kind: Decode, source: Error("unknown variant `WINDOWS`, expected `LINUX` or `MACOS`", line: 1, column: 210) }
```

The vendored GraphQL schema (`crates/warp_graphql_schema/api/schema.graphql`) and the cynic-derived `RunnerOs` client enum only declared `LINUX`/`MACOS`. `warp-server`'s schema already defines `WINDOWS` (added for REMOTE-2469), so any GraphQL response naming a Windows runner failed to decode client-side.

## Changes

- Added `WINDOWS` to `RunnerOS` in the vendored schema and the `RunnerOs` cynic enum.
- Extended every exhaustive match over `RunnerOs`/`RunnerOsArg` accordingly, so the fix actually compiles and behaves sensibly end to end:
  - `runner_display.rs`: display label (`"Windows"`) and icon (reuses the existing `Icon::Powershell`, matching how `ShellIndicatorType` already represents Windows shells elsewhere in this codebase).
  - `agent_sdk/runner.rs`: `runner create`/`runner update` input construction (a Windows runner has no OS-specific `mac`/`linux` config block, same shape as the server schema), `os_to_gql`, and `resolve_arch`'s `auto` default (x86-64, matching Linux).
  - `warp_cli/src/runner.rs`: added `RunnerOsArg::Windows` and extended `validate_os_config` to reject `--docker-image`/`--macos-version` for Windows, same as it already does for the mismatched existing OS.

## Verification

- `cargo check -p warp_graphql_schema -p warp_graphql -p warp_cli`: clean.
- `cargo check -p warp --lib --tests`: clean (confirms the app crate and its existing runner tests compile against the extended enum).
- `cargo fmt --check -p warp -p warp_cli -p warp_graphql`: clean.
- Could not run `cargo clippy` in this environment due to an unrelated, pre-existing `command-signatures-v2` JS build-script/Node-version issue unrelated to this change (fails identically on a clean checkout with no changes applied).
- `cargo test` for this crate hits a SIGKILL (OOM) in this sandboxed environment during test-binary compilation, unrelated to this change; `cargo check --tests` (type-check only, no codegen) passed instead as a substitute.

<!-- warp:pr-description-artifacts start -->
<!-- warp:pr-description-artifacts end -->
