### PR TITLE
Copy the current line when nothing is selected, and paste it back as a line

### DIFF
--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -1909,28 +1909,61 @@ impl CodeEditorModel {
         ctx.clipboard().write(clipboard);
     }
 
-    /// Copy the line holding the primary cursor, including its trailing newline.
+    /// The text of the line holding the primary cursor, including its trailing
+    /// newline when the line has one.
     ///
-    /// An empty document has no line to copy, and this leaves the clipboard alone
-    /// rather than clearing it.
-    pub fn copy_current_line(&self, ctx: &mut ModelContext<Self>) {
-        let Some(range) = self.current_line_range(ctx) else {
-            return;
-        };
-        let clipboard = self.read_text_as_clipboard_content(range, ctx);
-        ctx.clipboard().write(clipboard);
+    /// `None` in a document with no line to read, so a caller can leave the
+    /// clipboard alone instead of clearing it.
+    pub fn current_line_text(&self, ctx: &AppContext) -> Option<String> {
+        let range = self.current_line_bounds(ctx);
+        if range.start >= range.end {
+            return None;
+        }
+        let buffer = self.content().as_ref(ctx);
+        Some(buffer.text_in_range(range).into_string())
+    }
+
+    /// Insert `text` as a whole line above the line holding the primary cursor.
+    ///
+    /// This is the paste half of a line-wise copy. Inserting at the start of the
+    /// line rather than at the caret is what keeps a copied line a line: pasting
+    /// at the caret would split whichever line the caret happened to sit in. The
+    /// insert lands before the cursor, so the cursor rides down with the text it
+    /// was already on.
+    pub fn paste_line_above_cursor(&mut self, text: &str, ctx: &mut ModelContext<Self>) {
+        let line_start = self.current_line_bounds(ctx).start;
+        // Normalize to exactly one trailing newline, so the inserted text occupies
+        // its own line whatever the clipboard happened to carry.
+        let without_newline = text.strip_suffix('\n').unwrap_or(text);
+        let line = format!("{without_newline}\n");
+        let edits = vec1![(line, line_start..line_start)];
+
+        let selection_model = self.selection_model.clone();
+        self.update_content(
+            |mut content, ctx| {
+                content.apply_edit(
+                    BufferEditAction::InsertAtCharOffsetRanges { edits: &edits },
+                    EditOrigin::UserInitiated,
+                    selection_model,
+                    ctx,
+                );
+            },
+            ctx,
+        );
+        self.validate(ctx);
     }
 
     /// The character range of the line holding the primary cursor. The range runs
     /// to the start of the next line, so it carries the trailing newline whenever
-    /// the line has one, and stops at the end of the buffer on the last line.
-    fn current_line_range(&self, ctx: &AppContext) -> Option<Range<CharOffset>> {
+    /// the line has one, and stops at the end of the buffer on the last line. It
+    /// is empty only in a document that has no line at all.
+    fn current_line_bounds(&self, ctx: &AppContext) -> Range<CharOffset> {
         let buffer = self.content().as_ref(ctx);
         let cursor = self.selections(ctx).first().head;
         let row = cursor.to_buffer_point(buffer).row;
         let start = Point::new(row, 0).to_buffer_char_offset(buffer);
         let end = Point::new(row + 1, 0).to_buffer_char_offset(buffer);
-        (start < end).then_some(start..end)
+        start..end
     }
 
     #[cfg(windows)]

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -1909,6 +1909,30 @@ impl CodeEditorModel {
         ctx.clipboard().write(clipboard);
     }
 
+    /// Copy the line holding the primary cursor, including its trailing newline.
+    ///
+    /// An empty document has no line to copy, and this leaves the clipboard alone
+    /// rather than clearing it.
+    pub fn copy_current_line(&self, ctx: &mut ModelContext<Self>) {
+        let Some(range) = self.current_line_range(ctx) else {
+            return;
+        };
+        let clipboard = self.read_text_as_clipboard_content(range, ctx);
+        ctx.clipboard().write(clipboard);
+    }
+
+    /// The character range of the line holding the primary cursor. The range runs
+    /// to the start of the next line, so it carries the trailing newline whenever
+    /// the line has one, and stops at the end of the buffer on the last line.
+    fn current_line_range(&self, ctx: &AppContext) -> Option<Range<CharOffset>> {
+        let buffer = self.content().as_ref(ctx);
+        let cursor = self.selections(ctx).first().head;
+        let row = cursor.to_buffer_point(buffer).row;
+        let start = Point::new(row, 0).to_buffer_char_offset(buffer);
+        let end = Point::new(row + 1, 0).to_buffer_char_offset(buffer);
+        (start < end).then_some(start..end)
+    }
+
     #[cfg(windows)]
     /// If there is selected text, copy it. Otherwise, emit an event to allow
     /// an ancestor to handle the `WindowsCtrlC` event.

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -283,6 +283,9 @@ pub struct CodeEditorView {
     /// The offset where find references card is anchored (if showing).
     find_references_anchor_offset: Option<CharOffset>,
     window_id: WindowId,
+    /// Whether a copy with an empty selection copies the line holding the cursor.
+    /// See [`CodeEditorView::with_copy_line_when_selection_is_empty`].
+    copy_line_when_selection_is_empty: bool,
 }
 
 impl CodeEditorView {
@@ -430,6 +433,7 @@ impl CodeEditorView {
             show_find_references_provider: render_options.show_find_references_provider,
             find_references_anchor_offset: None,
             window_id: ctx.window_id(),
+            copy_line_when_selection_is_empty: false,
         }
     }
 
@@ -492,6 +496,19 @@ impl CodeEditorView {
     /// Enables clicking on diff hunk gutter elements to collapse changed sections.
     pub fn with_collapsible_diffs(mut self, enabled: bool) -> Self {
         self.display_options.collapsible_diffs = enabled;
+        self
+    }
+
+    /// Copies the line holding the cursor when a copy runs with an empty selection,
+    /// matching VS Code and Zed.
+    ///
+    /// This is off by default and belongs only to editors that own their copy
+    /// shortcut outright. An editor embedded in an AI block, a diff view, or the
+    /// terminal must keep the default, because those surfaces rely on
+    /// [`CodeEditorEvent::CopiedEmptyText`] to hand an empty-selection copy to the
+    /// parent view that holds the real selection.
+    pub fn with_copy_line_when_selection_is_empty(mut self) -> Self {
+        self.copy_line_when_selection_is_empty = true;
         self
     }
 

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -1001,14 +1001,25 @@ impl TypedActionView for CodeEditorView {
             // The owner of the editor can also perform a copy by accessing the selected text and copying it to the clipboard.
             // This is the case when the code block is owned by an AIBlock and unfocused.
             Copy => {
-                self.model.update(ctx, |model, ctx| {
-                    model.copy(ctx);
-                });
-                // It's possible that the copy action was dispatched to the focused editor even when
-                // the user intended to copy selected text from a parent view (i.e. an `AIBlock`).
-                // The `CopiedEmptyText` event gives the parent view a signal to attempt a copy action.
-                if self.selected_text(ctx).is_none() {
-                    ctx.emit(CodeEditorEvent::CopiedEmptyText);
+                let has_selection = self.selected_text(ctx).is_some();
+                // An editor that owns its copy shortcut outright copies the line holding
+                // the cursor instead of clearing the clipboard. Every other editor keeps
+                // the default, because a parent view may hold the selection the user
+                // meant to copy.
+                if !has_selection && self.copy_line_when_selection_is_empty {
+                    self.model.update(ctx, |model, ctx| {
+                        model.copy_current_line(ctx);
+                    });
+                } else {
+                    self.model.update(ctx, |model, ctx| {
+                        model.copy(ctx);
+                    });
+                    // It's possible that the copy action was dispatched to the focused editor even when
+                    // the user intended to copy selected text from a parent view (i.e. an `AIBlock`).
+                    // The `CopiedEmptyText` event gives the parent view a signal to attempt a copy action.
+                    if !has_selection {
+                        ctx.emit(CodeEditorEvent::CopiedEmptyText);
+                    }
                 }
             }
             #[cfg(windows)]

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -8,6 +8,7 @@ use std::ops::Range;
 use lazy_static::lazy_static;
 use rangemap::RangeSet;
 use string_offset::CharOffset;
+use vim::vim::MotionType;
 use warp_editor::content::version::BufferVersion;
 use warp_editor::editor::{EmbeddedItemModel, RunnableCommandModel, TextDecoration};
 use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
@@ -20,7 +21,7 @@ use warpui::elements::Axis;
 use warpui::event::ModifiersState;
 use warpui::keymap::{EditableBinding, FixedBinding, Keystroke, PerPlatformKeystroke};
 use warpui::units::Pixels;
-use warpui::{AppContext, TypedActionView, ViewContext, WeakViewHandle};
+use warpui::{AppContext, SingletonEntity, TypedActionView, ViewContext, WeakViewHandle};
 
 use crate::cmd_or_ctrl_shift;
 use crate::code::editor::line::EditorLineLocation;
@@ -31,6 +32,7 @@ use crate::editor::InteractionState;
 use crate::features::FeatureFlag;
 use crate::notebooks::editor::model::word_unit;
 use crate::util::bindings::CustomAction;
+use crate::vim_registers::{RegisterContent, VimRegisters};
 
 /// Limit the keybindings that conflict with the Agent Mode embedded editor.
 const NON_EDITABLE_KEYMAP_CONTEXT: &str = "NonEditableKeymapContext";
@@ -990,9 +992,30 @@ impl TypedActionView for CodeEditorView {
                 }
             }
             SelectionEnd => self.selection_end(ctx),
-            Paste => self.model.update(ctx, |model, ctx| {
-                model.paste(ctx);
-            }),
+            Paste => {
+                // A line copied with an empty selection goes back as a whole line above the
+                // cursor's line, the way VS Code and Zed paste one. `read_from_register`
+                // compares its stored entry against the live system clipboard, so anything
+                // copied since, in this app or another, falls back to a char-wise paste on
+                // its own.
+                let line_wise = if self.copy_line_when_selection_is_empty {
+                    VimRegisters::handle(ctx)
+                        .update(ctx, |registers, ctx| registers.read_from_register('+', ctx))
+                        .filter(|content| content.motion_type == MotionType::Linewise)
+                } else {
+                    None
+                };
+
+                if let Some(RegisterContent { text, .. }) = line_wise {
+                    self.model.update(ctx, |model, ctx| {
+                        model.paste_line_above_cursor(&text, ctx);
+                    });
+                } else {
+                    self.model.update(ctx, |model, ctx| {
+                        model.paste(ctx);
+                    });
+                }
+            }
             Cut => self.model.update(ctx, |model, ctx| {
                 model.cut(ctx);
             }),
@@ -1007,9 +1030,16 @@ impl TypedActionView for CodeEditorView {
                 // the default, because a parent view may hold the selection the user
                 // meant to copy.
                 if !has_selection && self.copy_line_when_selection_is_empty {
-                    self.model.update(ctx, |model, ctx| {
-                        model.copy_current_line(ctx);
-                    });
+                    let line = self.model.as_ref(ctx).current_line_text(ctx);
+                    if let Some(line) = line {
+                        // Writing through the system-clipboard register puts the text on the
+                        // clipboard and records that it was a whole line, which is what lets
+                        // the matching paste put it back as a line. Plain clipboard text
+                        // would land at the caret and split the line pasted into.
+                        VimRegisters::handle(ctx).update(ctx, |registers, ctx| {
+                            registers.write_to_register('+', line, MotionType::Linewise, ctx);
+                        });
+                    }
                 } else {
                     self.model.update(ctx, |model, ctx| {
                         model.copy(ctx);

--- a/app/src/code/editor/view/view_tests.rs
+++ b/app/src/code/editor/view/view_tests.rs
@@ -188,6 +188,67 @@ fn copying_an_empty_document_leaves_the_clipboard_untouched() {
 }
 
 #[test]
+fn pastes_a_copied_line_above_the_cursor_line() {
+    App::test((), |mut app| async move {
+        let editor_view = initialize_editor_copying_the_cursor_line(&mut app, "alpha\nbeta");
+
+        let text = editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+            view.handle_action(&CodeEditorViewAction::CursorAtBufferEnd, ctx);
+            view.handle_action(&CodeEditorViewAction::Paste, ctx);
+            view.text(ctx)
+        });
+
+        assert_eq!(text.as_str(), "alpha\nalpha\nbeta");
+    });
+}
+
+#[test]
+fn pastes_a_copied_line_whole_when_the_cursor_sits_mid_line() {
+    App::test((), |mut app| async move {
+        let editor_view =
+            initialize_editor_copying_the_cursor_line(&mut app, "    alpha\nbeta\ngamma");
+
+        let text = editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+            view.handle_action(&CodeEditorViewAction::MoveToLineEnd, ctx);
+            view.handle_action(&CodeEditorViewAction::Paste, ctx);
+            view.text(ctx)
+        });
+
+        assert_eq!(
+            text.as_str(),
+            "    alpha\n    alpha\nbeta\ngamma",
+            "a line-wise paste must not split the line the caret happens to sit in"
+        );
+    });
+}
+
+#[test]
+fn an_editor_that_delegates_empty_copies_pastes_at_the_caret() {
+    App::test((), |mut app| async move {
+        let (_window, editor_view) = initialize_editor(&mut app);
+        app.update(|ctx| {
+            ctx.clipboard()
+                .write(ClipboardContent::plain_text("X".to_string()))
+        });
+
+        let text = editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::UserTyped(UserInput::new("ab")), ctx);
+            view.handle_action(&CodeEditorViewAction::MoveLeft, ctx);
+            view.handle_action(&CodeEditorViewAction::Paste, ctx);
+            view.text(ctx)
+        });
+
+        assert_eq!(
+            text.as_str(),
+            "aXb",
+            "an editor that has not opted in keeps the char-wise paste at the caret"
+        );
+    });
+}
+
+#[test]
 fn an_editor_that_delegates_empty_copies_does_not_take_the_cursor_line() {
     App::test((), |mut app| async move {
         let (_window, editor_view) = initialize_editor(&mut app);

--- a/app/src/code/editor/view/view_tests.rs
+++ b/app/src/code/editor/view/view_tests.rs
@@ -225,6 +225,27 @@ fn pastes_a_copied_line_whole_when_the_cursor_sits_mid_line() {
 }
 
 #[test]
+fn a_cut_with_no_selection_leaves_no_stale_line_wise_paste() {
+    App::test((), |mut app| async move {
+        let editor_view = initialize_editor_copying_the_cursor_line(&mut app, "alpha\nbeta");
+
+        let text = editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+            view.handle_action(&CodeEditorViewAction::CursorAtBufferEnd, ctx);
+            view.handle_action(&CodeEditorViewAction::Cut, ctx);
+            view.handle_action(&CodeEditorViewAction::Paste, ctx);
+            view.text(ctx)
+        });
+
+        assert_eq!(
+            text.as_str(),
+            "alpha\nbet",
+            "a cut clears the clipboard, so the paste after it must insert nothing rather than replay the line copied earlier"
+        );
+    });
+}
+
+#[test]
 fn an_editor_that_delegates_empty_copies_pastes_at_the_caret() {
     App::test((), |mut app| async move {
         let (_window, editor_view) = initialize_editor(&mut app);

--- a/app/src/code/editor/view/view_tests.rs
+++ b/app/src/code/editor/view/view_tests.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use warp_core::ui::appearance::Appearance;
+use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_util::user_input::UserInput;
+use warpui::clipboard::ClipboardContent;
 use warpui::elements::ScrollbarWidth;
 use warpui::elements::new_scrollable::ScrollableAppearance;
 use warpui::platform::WindowStyle;
@@ -23,6 +25,47 @@ use crate::workspace::sync_inputs::SyncedInputState;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
 fn initialize_editor(app: &mut App) -> (WindowId, ViewHandle<CodeEditorView>) {
+    initialize_editor_singletons(app);
+
+    let (window, editor_view) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+        CodeEditorView::new(
+            None,
+            None,
+            CodeEditorRenderOptions::new(VerticalExpansionBehavior::GrowToMaxHeight),
+            ctx,
+        )
+        .with_horizontal_scrollbar_appearance(ScrollableAppearance::new(ScrollbarWidth::Auto, true))
+    });
+
+    (window, editor_view)
+}
+
+/// Adds an editor that owns its copy shortcut outright, seeded with `buffer_content`
+/// and the cursor at the start of the buffer.
+fn initialize_editor_copying_the_cursor_line(
+    app: &mut App,
+    buffer_content: &str,
+) -> ViewHandle<CodeEditorView> {
+    initialize_editor_singletons(app);
+
+    let buffer_content = buffer_content.to_string();
+    app.add_window(WindowStyle::NotStealFocus, move |ctx| {
+        let mut editor = CodeEditorView::new(
+            None,
+            None,
+            CodeEditorRenderOptions::new(VerticalExpansionBehavior::GrowToMaxHeight),
+            ctx,
+        )
+        .with_copy_line_when_selection_is_empty();
+        editor.reset(InitialBufferState::plain_text(&buffer_content), ctx);
+        editor.handle_action(&CodeEditorViewAction::CursorAtBufferStart, ctx);
+        editor
+    })
+    .1
+}
+
+/// Registers the singleton models that a [`CodeEditorView`] depends on.
+fn initialize_editor_singletons(app: &mut App) {
     initialize_settings_for_tests(app);
 
     // Add all required singleton models for EditorView dependencies
@@ -48,18 +91,6 @@ fn initialize_editor(app: &mut App) -> (WindowId, ViewHandle<CodeEditorView>) {
             ctx,
         )
     });
-
-    let (window, editor_view) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
-        CodeEditorView::new(
-            None,
-            None,
-            CodeEditorRenderOptions::new(VerticalExpansionBehavior::GrowToMaxHeight),
-            ctx,
-        )
-        .with_horizontal_scrollbar_appearance(ScrollableAppearance::new(ScrollbarWidth::Auto, true))
-    });
-
-    (window, editor_view)
 }
 
 #[test]
@@ -85,5 +116,94 @@ fn test_interaction_state_prevents_editing() {
         });
 
         assert_eq!(text.as_str(), "abc");
+    });
+}
+
+#[test]
+fn copies_the_cursor_line_when_the_selection_is_empty() {
+    App::test((), |mut app| async move {
+        let editor_view = initialize_editor_copying_the_cursor_line(&mut app, "alpha\nbeta");
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+        });
+
+        assert_eq!(
+            app.update(|ctx| ctx.clipboard().read().plain_text),
+            "alpha\n",
+            "an empty-selection copy should take the cursor's line and its newline"
+        );
+    });
+}
+
+#[test]
+fn copies_the_last_line_without_a_trailing_newline() {
+    App::test((), |mut app| async move {
+        let editor_view = initialize_editor_copying_the_cursor_line(&mut app, "alpha\nbeta");
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::CursorAtBufferEnd, ctx);
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+        });
+
+        assert_eq!(app.update(|ctx| ctx.clipboard().read().plain_text), "beta");
+    });
+}
+
+#[test]
+fn copies_only_the_selection_when_one_exists() {
+    App::test((), |mut app| async move {
+        let editor_view = initialize_editor_copying_the_cursor_line(&mut app, "alpha\nbeta");
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::CursorAtBufferEnd, ctx);
+            view.handle_action(&CodeEditorViewAction::SelectLeft, ctx);
+            view.handle_action(&CodeEditorViewAction::SelectLeft, ctx);
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+        });
+
+        assert_eq!(app.update(|ctx| ctx.clipboard().read().plain_text), "ta");
+    });
+}
+
+#[test]
+fn copying_an_empty_document_leaves_the_clipboard_untouched() {
+    App::test((), |mut app| async move {
+        let editor_view = initialize_editor_copying_the_cursor_line(&mut app, "");
+        app.update(|ctx| {
+            ctx.clipboard()
+                .write(ClipboardContent::plain_text("kept".to_string()))
+        });
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+        });
+
+        assert_eq!(
+            app.update(|ctx| ctx.clipboard().read().plain_text),
+            "kept",
+            "an empty document has no line to copy, so the clipboard must survive"
+        );
+    });
+}
+
+#[test]
+fn an_editor_that_delegates_empty_copies_does_not_take_the_cursor_line() {
+    App::test((), |mut app| async move {
+        let (_window, editor_view) = initialize_editor(&mut app);
+
+        editor_view.update(&mut app, |view, ctx| {
+            view.handle_action(
+                &CodeEditorViewAction::UserTyped(UserInput::new("alpha")),
+                ctx,
+            );
+            view.handle_action(&CodeEditorViewAction::Copy, ctx);
+        });
+
+        assert_eq!(
+            app.update(|ctx| ctx.clipboard().read().plain_text),
+            "",
+            "an embedded editor hands an empty-selection copy to its parent view instead"
+        );
     });
 }

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -394,6 +394,7 @@ impl CodeView {
                                 true,
                             ),
                         )
+                        .with_copy_line_when_selection_is_empty()
                     })
                 },
                 false,
@@ -438,6 +439,7 @@ impl CodeView {
                     true,
                 ),
             )
+            .with_copy_line_when_selection_is_empty()
         });
 
         ctx.add_typed_action_view(|ctx| {


### PR DESCRIPTION
## Description

In the code editor, a copy with an empty selection now copies the line holding the cursor, and pasting it puts that line back as a whole line above the cursor's line, the way VS Code and Zed do.
A copy with a selection is unchanged, and so is a paste of anything that was not copied this way.

Both halves are needed for the feature to be usable. A line copied with no selection but pasted at the caret splits whichever line the caret sits in, which is worse than the behavior the issue asks to replace.
The line-wise marker rides in the system-clipboard register through `VimRegisters::write_to_register`, which already exists for exactly this reason: its own doc comment says linewise motions "need to be pasted on their own line, NOT at the cursor position".
Reading it back through `read_from_register` compares the stored entry against the live system clipboard, so a copy made anywhere else in between falls back to a char-wise paste without any extra bookkeeping here.

The behavior is opt-in per surface, through a new `CodeEditorView::with_copy_line_when_selection_is_empty` builder, and only the standalone code editor in `app/src/code/view.rs` turns it on.
That restriction is the point of the change rather than an afterthought: `CodeEditorView` is embedded in AI blocks, diff views, the requested-command view, and the CLI subagent block, and every one of those relies on the editor emitting `CodeEditorEvent::CopiedEmptyText` when the selection is empty so the parent view can copy its own selection instead.
Copying a line unconditionally would make each embedded editor swallow a copy that belongs to its parent.

For the same reason the change stays out of `CodeEditorModel::copy`, which the TUI shares through `crates/warp_tui`, and leaves the `#[cfg(windows)] handle_windows_ctrl_c` path untouched, since Ctrl+C on Windows and Linux still has to reach the ancestor that treats it as an interrupt.
On macOS the copy binding resolves to Cmd+C (`cmd_or_ctrl_shift("c")` in `app/src/util/bindings.rs`), which is what issue #15849 describes; on other platforms the same action is Ctrl+Shift+C and is unaffected by the interrupt question.

## Linked Issue

Closes #15849.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Design notes

These are the choices made where the issue text left the scope open.

The issue says "at least in the code editor", so this enables the behavior for the standalone code editor only, and leaves every embedded editor on the existing delegation path.
Extending it to another surface later is one builder call at that surface's construction site.

The copied text carries the trailing newline, so pasting reinserts a whole line, which is what VS Code and Zed do.
On the last line of a buffer that has no trailing newline the copied text has none either, and the paste normalizes it back to exactly one so the pasted line always occupies its own line.

The paste is gated on the same per-surface flag as the copy, rather than living inside `CodeEditorModel::paste`.
Putting it in the model would change what Cmd+V does in every embedded editor and in the TUI, including for a vim user who yanked line-wise into `+`, which is a wider behavior change than this issue asks for.

The line-wise entry is written to the `+` register rather than to a new store of its own. `+` is the system clipboard by definition, so a line-wise copy recorded there is a statement about the clipboard rather than a borrowed vim detail, and a later `"+p` in vim mode pasting it as a line is consistent rather than surprising.

"Empty selection" reuses the predicate the surrounding code already used, `CodeEditorView::selected_text`, which reports `None` when the selected text is empty rather than when the selection range is collapsed.
The new behavior deliberately hangs off that same predicate instead of introducing a second notion of emptiness next to it.

Cut is left alone and tracked separately in #15968. VS Code and the JetBrains IDEs cut the whole line on an empty selection too, but this issue asks about copy, and `CodeEditorModel::cut` is `copy` followed by `backspace` on every surface that shares the model.
Nothing becomes inconsistent in the meantime, and `a_cut_with_no_selection_leaves_no_stale_line_wise_paste` pins that: a cut writes empty text to the clipboard without touching the register, so `read_from_register` sees the mismatch and the paste after it stays char-wise.

Only the primary cursor's line is copied.
VS Code copies one line per cursor when several are active, and matching that is left as a follow-up rather than folded into this change.

An empty document has no line to copy, so the clipboard is left as it is instead of being cleared.

No feature flag is introduced.
The change is confined to one surface and one action, and reverting it is a single-line removal at each construction site.

## Testing

Commands run locally against this branch:

- `cargo nextest run -p warp` over the six tests below — passed, 6 run and 6 passed.
- `./script/format --check` — passed.
- `./script/check_no_inline_test_modules` — passed.
- `cargo clippy -p warp --all-targets --tests -- -D warnings` — passed, no warnings.
- `cargo build --bin warp-oss` — passed.

`./script/presubmit` was not run end to end.
This machine has no `wgslfmt`, `clang-format` or `pwsh`, and the diff touches no `.wgsl`, `.c`, `.h` or `.ps1` file, so those steps would have failed on absent tooling rather than on this change.
The steps of it that do read this diff are the ones listed above.

Nine regression tests were added to `app/src/code/editor/view/view_tests.rs`:

1. `copies_the_cursor_line_when_the_selection_is_empty` covers the requested behavior, including the trailing newline.
2. `copies_the_last_line_without_a_trailing_newline` covers the final line of a buffer that does not end in a newline.
3. `copies_only_the_selection_when_one_exists` proves a non-empty selection still wins.
4. `copying_an_empty_document_leaves_the_clipboard_untouched` proves an empty document does not clobber existing clipboard content.
5. `an_editor_that_delegates_empty_copies_does_not_take_the_cursor_line` is the non-regression test for every embedded editor, which must keep handing the copy to its parent view.
6. `pastes_a_copied_line_above_the_cursor_line` covers the paste half from a different line than the one copied.
7. `pastes_a_copied_line_whole_when_the_cursor_sits_mid_line` is the regression test for pasting with the caret away from column zero, which is the case that splits a line when only the copy half is implemented.
8. `an_editor_that_delegates_empty_copies_pastes_at_the_caret` proves an editor that has not opted in still pastes char-wise at the caret.
9. `a_cut_with_no_selection_leaves_no_stale_line_wise_paste` proves a cut does not leave the earlier line copy behind for the next paste to replay.

Tests 1 and 2 read the same two-line buffer from different cursor positions, so together they show the copied range follows the cursor rather than a fixed row.
Tests 5 and 8 are the negative halves: they run the same two actions on an editor that has not opted in and assert the old behavior, which is what demonstrates the opt-in actually gates both halves rather than the behavior being unconditional.

No integration test is included, and that was a deliberate call rather than an omission.
The framework could carry one: `crates/integration/src/test/goto_line.rs` already opens a real file in the code editor, and `warp::integration_testing::clipboard::assert_clipboard_contains_string` already asserts clipboard contents, so the test would be a file-open flow followed by a `cmd-c` keystroke and that assertion.
What the end-to-end layer would add over the unit tests is the keybinding wiring, since the unit tests dispatch `CodeEditorViewAction::Copy` directly rather than pressing the key.
I am glad to add it if you would like that covered here.

### Screenshots / Videos

https://github.com/user-attachments/assets/ddae1746-8e90-45c9-96f5-973dd7d0ef8e

- [x] I have manually tested my changes locally with `./script/run`

The screen recording above has two segments. First, `json_serializable` is selected on purpose and copied and pasted, as the unchanged baseline: a copy with a selection still copies only the selection. Then, with the caret before `json_` and nothing selected, the same shortcut copies the whole indented line, and pasting with the caret partway along another line inserts it as a line above the cursor's line. The same steps are repeated in an AI block to show that an embedded editor still hands the copy to its parent.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Pressing the copy shortcut in the code editor with nothing selected now copies the current line, and pasting it inserts that line above the cursor's line.

