### PR TITLE
Spec: notify for Codex permission requests only when a human decision is required

### DIFF
--- a/specs/GH15933/product.md
+++ b/specs/GH15933/product.md
@@ -1,0 +1,81 @@
+# PRODUCT.md — Notify for Codex permission requests only when a human decision is required
+
+Issue: https://github.com/warpdotdev/warp/issues/15933
+
+## Summary
+
+When Codex is configured with an automatic approvals reviewer, a permission request is often answered without the user ever being asked.
+Warp currently raises a needs-attention notification for every such request, so the notification stops meaning "you have to act".
+This spec defines the behavior Warp should have instead: a needs-attention notification is raised for a Codex permission request only once Codex has determined that a human decision is required.
+
+## Problem
+
+Codex resolves a permission request through a configured reviewer:
+
+```toml
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
+```
+
+With that configuration many requests are approved by the reviewer and the session keeps running, never blocking on the user.
+Warp still notifies, because the only signal it receives is emitted when the request is raised rather than when it is resolved.
+
+The cost is concentrated exactly where the notification is supposed to help.
+A user running several Codex sessions cannot tell which one actually stopped for them, and turning needs-attention notifications off also silences the requests that genuinely wait for a human.
+The same signal drives Warp's in-app session status, so the vertical tab and agent chip also claim attention is needed while nothing is waiting.
+
+## Goals / Non-goals
+
+**In scope**
+
+- The condition under which Warp raises a needs-attention notification for a Codex permission request.
+- The in-app session status shown for a request that is under automatic review rather than waiting on the user.
+- The behavior required when Codex or the plugin is too old to report the distinction.
+- Behavior across every value of `approvals_reviewer`, not only `auto_review`.
+
+**Out of scope**
+
+- Completion, failure, and idle notifications, which keep their current behavior.
+- The notification surfaces themselves — desktop notification, banner, tab and footer chrome are unchanged in appearance and placement.
+- Warp's own Agent Mode approvals, which do not go through the CLI agent session protocol.
+- Claude Code and other CLI agents, whose plugins answer to a different upstream contract. Whether this should extend to them is left to the open questions below.
+- Any change to how the user answers a permission request once they have been notified.
+
+## Behavior
+
+1. A Codex permission request that Codex resolves without asking the user raises no needs-attention notification, at any point in its lifetime. This covers a request approved by the automatic reviewer and a request allowed by policy without review.
+
+2. A Codex permission request that reaches the user and waits for their decision raises exactly one needs-attention notification, subject to the existing gate in (3). The notification's title and description keep their current content: the session's query or summary, and the request's own summary text.
+
+3. The existing suppression gate is unchanged: a needs-attention notification is raised only while the user is navigated away from the window holding that session. A request that waits for the user while its window is focused raises no notification, as today.
+
+4. The notification is raised no earlier than the moment Codex has determined a human decision is required. A notification that is raised when the request is created, and would have to be withdrawn once the reviewer answers, does not satisfy this spec — a desktop notification cannot be withdrawn once delivered.
+
+5. Suppression is never achieved by delaying or by guessing. A notification is withheld only on a signal that the request is being handled without the user; it is never withheld on a timer, a heuristic about the tool being requested, or on the mere presence of `approvals_reviewer` in the configuration.
+
+6. When the reviewer declines a request and Codex then asks the user, that request raises a needs-attention notification under (2). A decline followed by Codex abandoning the action without asking the user raises no needs-attention notification.
+
+7. When automatic review does not produce an answer — it times out, errors, or is interrupted — and Codex asks the user as a result, the request raises a needs-attention notification under (2). The user is never left silently waiting because a reviewer failed.
+
+8. A request that waits a long time under review and only then reaches the user still raises its notification at that later moment. Suppression while a request is under review is never permanent.
+
+9. While a request is under automatic review, the session's in-app status does not claim that the user must act. The vertical tab, agent icon, and footer do not show the needs-attention treatment they show for a request that is waiting on the user.
+   **Open question:** whether a request under review presents as ordinary in-progress work, or as a distinct third state visible in those surfaces. A distinct state is more informative and is a wider change; in-progress is the smaller change and loses the information that a request was raised at all.
+
+10. Rich input behavior follows the same distinction. Rich input closes for a request that waits on the user, because answering it needs the terminal, and stays open for a request under automatic review.
+
+11. When several Codex sessions run at once, each session's notifications follow (1) through (10) from that session's own requests. A request under review in one session never suppresses or raises a notification for another.
+
+12. When Codex or the plugin cannot report whether a request reached the user, Warp keeps the current behavior for that session and notifies on every permission request. A session that cannot be told apart notifies too often, exactly as today; it is never silenced. Trading a false notification for a missed one is a regression, not a partial fix.
+
+13. A user who configures no automatic reviewer sees no change whatsoever. Every permission request reaches them, and every one of them notifies under (2) and (3).
+
+14. The user's answer continues to clear the state a request created. Once a request is resolved by any route — the user answered, the reviewer answered, the tool ran, a new prompt was submitted, or the session ended — the session leaves the blocked presentation and its request summary stops appearing in the tab title and other surfaces that fall back to it.
+
+15. Completion and failure notifications are untouched by this change. A session that finishes its turn notifies on completion, and one that fails notifies on failure, regardless of how any permission request within that turn was resolved.
+
+## Open questions
+
+- Whether Warp should surface a setting for this behavior, or whether notifying only on human-required requests is simply correct and needs no toggle. No setting is proposed here.
+- Whether this treatment should extend to the other CLI agents that emit permission requests through the same protocol, once their upstreams can report the same distinction.
+- The question in invariant (9), on how a request under automatic review presents in-app.

--- a/specs/GH15933/tech.md
+++ b/specs/GH15933/tech.md
@@ -37,13 +37,24 @@ Worth noting: `permission_replied` is parsed and handled by the client but **no 
 
 So the answer to the question this spec exists to settle is **no**: Codex offers no event that separates "a reviewer is deciding" from "a human is being asked". The work this issue needs starts with a contract change, not with a plugin edit.
 
-One point remains observational rather than measured. That the `PermissionRequest` hook fires *before* the reviewer answers is reported by the issue author against 0.153.4 and accepted in triage (`repro:high`), and it is consistent with a hook that returns a decision into the chain — but it was not reproduced under instrumentation for this spec. It does not change the conclusion: whichever order the two run in, the payload in (2) carries nothing that distinguishes the outcome, and (1) means nothing fires afterward to correct it.
+One point remains observational rather than measured. That the `PermissionRequest` hook fires *before* the reviewer answers is reported by the issue author against 0.153.4 and accepted in triage (`repro:high`), and it is consistent with a hook that returns a decision into the chain — but it was not reproduced under instrumentation for this spec. It does not change the conclusion: whichever order the two run in, the payload described above carries nothing that distinguishes the outcome, and the catalogue means nothing fires afterward to correct it.
 
 ## Proposed changes
 
-### 1. Propose a resolution-time hook event upstream — `openai/codex`
+### 1. Propose a resolution-time hook event, and a way to detect it, upstream — `openai/codex`
 
-Add a hook event that fires at the moment Codex determines a permission request requires a human decision, carrying at least the `session_id`, `turn_id`, and `tool_name` of the request it refers to, so a consumer can correlate it with the `PermissionRequest` that opened it.
+Two things are needed, and asking for only the first leaves the plugin unable to use it safely.
+
+**The event.** A hook event that fires at the moment Codex determines a permission request requires a human decision, carrying at least the `session_id`, `turn_id`, and `tool_name` of the request it refers to, so a consumer can correlate it with the `PermissionRequest` that opened it.
+
+**A capability signal the hook process can read.** Without one, a plugin cannot tell "this Codex will fire the escalation event, so stay quiet at request time" from "this Codex never will, so notify now" — and guessing wrong in the quiet direction is the silent miss invariant 12 forbids. The absence of an event is not observable at the moment the decision has to be made.
+
+The shape has a precedent in this same integration, running the other way. `plugins/warp/scripts/should-use-structured.sh` gates every structured emission on `WARP_CLI_AGENT_PROTOCOL_VERSION` and `WARP_CLIENT_VERSION`, environment variables Warp exports into the Codex process, and `build-payload.sh` negotiates `min(plugin_current, warp_declared)` from them. What is missing is the symmetric direction: Codex advertising its own hook capability to the hook process it spawns.
+
+Either form works, in this order of preference:
+
+1. A capability or hook-protocol version in the hook environment or payload, which lets a plugin ask "does this build fire the escalation event" rather than inferring it from a release number.
+2. Codex's own version, which reduces the gate to a version comparison. `CODEX_VERSION` appears in the binary in the same symbol run as `CODEX_PLUGIN_METRICS_OUTPUT` and `CODEX_PERMISSION_PROFILE`, which suggests the plugin subprocess environment — but it was **not confirmed to reach a hook process**, because hooks do not fire in an unauthenticated `codex exec` (see Risks). If it already does reach hooks, this half of the request costs upstream nothing and only the event remains.
 
 This is the only proposal here that satisfies the product spec, and the reason is worth stating because the cheaper alternative looks adequate until invariant 12 is applied to it:
 
@@ -55,17 +66,20 @@ The event's name and exact payload are upstream's to choose. What this spec asks
 
 ### 2. Emit on the new event instead — `warpdotdev/codex-warp`
 
-Once the event exists, `hooks.json` registers it and a new script emits the `permission_request` OSC 777 event that `on-permission-request.sh` emits today. `on-permission-request.sh` stops emitting `permission_request`.
+Once (1) exists, `hooks.json` registers the escalation event **in addition to** `PermissionRequest`, never in place of it, and a new `on-permission-escalated.sh` emits the `permission_request` OSC 777 event that `on-permission-request.sh` emits today.
 
-Register the new event **in addition to** `PermissionRequest`, not in place of it, and gate the emission inside the scripts rather than by which hooks are registered. That keeps invariant 12 satisfiable: a plugin running against a Codex that does not fire the new event keeps notifying from `PermissionRequest`, which is today's behavior, rather than going silent.
+Which of the two scripts actually emits is decided at runtime by the capability signal from (1), not by which hooks are registered:
+
+- **Capability present.** `on-permission-request.sh` emits nothing, and `on-permission-escalated.sh` emits `permission_request`. This is the behavior the issue asks for.
+- **Capability absent.** `on-permission-request.sh` emits `permission_request` exactly as it does today, and `on-permission-escalated.sh` never runs because the event never fires. The user gets today's over-notification rather than silence, satisfying invariant 12.
+
+The gate belongs in `should-use-structured.sh` alongside the checks already there, so both directions of capability negotiation live in one file and a script that forgets to consult it fails toward emitting.
+
+**Without the capability signal from (1), this change cannot be made safely at all.** A plugin that simply moved the emission would go quiet on every Codex build that does not fire the escalation event, which is a worse regression than the bug being fixed. That dependency is the reason (1) asks for two things rather than one.
 
 The existing OSC 777 protocol needs no new event name. `permission_request` already means "blocked on the user" to the client, which is precisely what it would now mean.
 
-### 3. Emit `permission_replied` — `warpdotdev/codex-warp`
-
-Independently of (1), the plugin should emit `permission_replied` when a request is resolved, so the client's blocked status clears on the request's own resolution rather than waiting for the next `tool_complete`. The client already parses and handles it; there is simply no producer. This is a small correctness improvement and does not by itself address the issue.
-
-### 4. Warp client — no protocol change required
+### 3. Warp client — no protocol change required
 
 With (1) and (2) in place, the client needs no change to satisfy invariants 1 through 8, 11, and 13 through 15: `permission_request` continues to mean `Blocked`, the navigated-away gate continues to apply, and the existing clearing paths continue to work.
 
@@ -82,9 +96,13 @@ Product invariants are numbered in [`product.md`](./product.md); each is listed 
 
 **Plugin scripts, `warpdotdev/codex-warp`.** Shell-level tests over the emission decision, driving each script with a recorded hook payload on stdin and asserting the OSC 777 body:
 
-- Invariant 1: the new event absent, `PermissionRequest` alone, emits nothing under (2)'s gating.
-- Invariants 2 and 6: the new event fires, `permission_request` is emitted once with the summary built from `tool_name` and `tool_input`.
-- Invariant 12: a payload from a Codex that does not fire the new event still emits on `PermissionRequest`. This is the case most worth pinning, because its failure mode is silence.
+The capability gate from (2) is what these tests are really pinning, so each case names which side of it it drives.
+
+- Invariant 1: capability present, `PermissionRequest` alone — `on-permission-request.sh` emits nothing.
+- Invariants 2 and 6: capability present, the escalation event fires — `on-permission-escalated.sh` emits `permission_request` once, with the summary built from `tool_name` and `tool_input`.
+- Invariant 12: capability absent, `PermissionRequest` alone — `on-permission-request.sh` still emits `permission_request`. This is the case most worth pinning, because its failure mode is silence rather than a visible error.
+- The gate's own falsifiability: a case that removes the capability signal and asserts the emission comes back. A gate that is never observed failing is not evidence, and this one decides between over-notifying and going quiet.
+- Exactly one emission per request across both scripts, so a build where both paths fire does not double-notify.
 
 **Manual validation.** The distinction under test only exists in a real Codex session, so this cannot be reduced to unit tests. On macOS, with Warp navigated away from the Codex pane:
 
@@ -104,15 +122,15 @@ A screen recording of the second and third cases is the evidence worth attaching
 - The negative control fired, so that silence is meaningful: a `hooks.json` whose `SessionStart` value is a string rather than a sequence produces `warning: failed to parse hooks config <path>: invalid type: string ..., expected a sequence at line 4 column 58`. The file is read, and parse problems do surface.
 - That warning is a warning. Codex continued and printed its session header, so even a `hooks.json` that fails to deserialize does not stop Codex from starting.
 
-Since the unknown-name file deserialized without a warning, the known entries in that same map were retained. Whether the sibling hook then *executes* was not observable here: the positive control did not fire either, because `SessionStart` hooks did not run in an unauthenticated `codex exec`. Confirm that last step in an authenticated session before (2) ships, and repeat the whole probe against the oldest Codex the plugin supports rather than only against 0.154.0.
+Since the unknown-name file deserialized without a warning, the known entries in that same map were retained. Whether the sibling hook then *executes* was not observable here: the positive control did not fire either, with an omitted matcher and again with an explicit `startup|resume|clear` one, because `SessionStart` hooks do not run in an unauthenticated `codex exec` at all. That same limit is why the `CODEX_VERSION` question in (1) is left open rather than answered — a hook that never runs cannot report the environment it was given. Confirm both in an authenticated session before (2) ships, and repeat the whole probe against the oldest Codex the plugin supports rather than only against 0.154.0.
 
 **Silence is worse than noise.** Every proposal here is shaped by invariant 12, and the review of any implementation should check the failure direction first: a change that removes notifications for requests it cannot classify is a regression even if it fixes the reported case.
 
-**This spec depends on an upstream change.** Nothing in (1) is Warp's to land. (3) is independently shippable, and (2) is only shippable once (1) exists. If upstream declines, the issue has no correct fix under the current contract, and the honest outcome is to say so on the issue rather than to ship a heuristic.
+**This spec depends entirely on an upstream change, and nothing here ships without it.** Nothing in (1) is Warp's to land, (2) is unsafe to attempt before (1) exists, and (3) is the observation that the client needs no work rather than work of its own. If upstream declines, the issue has no correct fix under the current contract, and the honest outcome is to say so on the issue rather than to ship a heuristic.
 
 **The contract evidence is read from a binary.** Every claim in Context is from schemas and symbols embedded in Codex 0.154.0, not from published documentation. The shape is unlikely to be wrong, but the wording of an upstream proposal should be checked against Codex's own hook documentation first.
 
 ## Follow-ups
 
 - Whether the other CLI agent plugins that emit `permission_request` have the same gap against their own upstreams, tracked separately per the product spec's open questions.
-- `permission_replied` having no producer in either plugin, which (3) addresses for Codex only.
+- `permission_replied` having no producer in either plugin. An earlier draft of this spec proposed filling that slot as an independently shippable improvement; that was wrong, and it is recorded here rather than dropped because the reasoning generalizes. A producer would need to fire on the approved, denied, abandoned, timed-out, and user-answered paths, and Codex exposes an observable for exactly one of them: the tool running, which `on-post-tool-use.sh` already reports as `tool_complete`, and which the client already uses to clear `Blocked`. So a `permission_replied` producer built on today's contract would be redundant where it worked and silent everywhere else. It becomes worth doing once (1) lands, and not before.

--- a/specs/GH15933/tech.md
+++ b/specs/GH15933/tech.md
@@ -1,0 +1,118 @@
+# TECH.md — Notify for Codex permission requests only when a human decision is required
+
+Issue: https://github.com/warpdotdev/warp/issues/15933
+Product spec: [`specs/GH15933/product.md`](./product.md)
+
+## Context
+
+Warp learns about a Codex permission request through three hops, and the behavior [`product.md`](./product.md) asks for is not expressible at the first one.
+
+```text
+Codex CLI  --PermissionRequest hook-->  codex-warp script  --OSC 777-->  Warp client
+```
+
+**Warp client.** The client is not where the problem lives, and it already does the right thing with the events it is given. References pinned to `a0627971`:
+
+- [`app/src/terminal/cli_agent_sessions/event/v1.rs:15-26 @ a0627971`](https://github.com/warpdotdev/warp/blob/a06279712f838d01295575b0dc0f14b7a34ba049/app/src/terminal/cli_agent_sessions/event/v1.rs#L15-L26) — the OSC 777 event names are parsed here. `tool_complete`, `permission_request`, and `permission_replied` are all already in the protocol.
+- [`app/src/terminal/cli_agent_sessions/mod.rs:238-245 @ a0627971`](https://github.com/warpdotdev/warp/blob/a06279712f838d01295575b0dc0f14b7a34ba049/app/src/terminal/cli_agent_sessions/mod.rs#L238-L245) — `PermissionRequest` sets `CLIAgentSessionStatus::Blocked` with the request summary.
+- [`app/src/terminal/cli_agent_sessions/mod.rs:253-258 @ a0627971`](https://github.com/warpdotdev/warp/blob/a06279712f838d01295575b0dc0f14b7a34ba049/app/src/terminal/cli_agent_sessions/mod.rs#L253-L258) — `PermissionReplied` returns a blocked session to `InProgress`. [`mod.rs:216-222`](https://github.com/warpdotdev/warp/blob/a06279712f838d01295575b0dc0f14b7a34ba049/app/src/terminal/cli_agent_sessions/mod.rs#L216-L222) does the same for `ToolComplete`.
+- [`app/src/terminal/cli_agent_sessions/mod.rs:184-194 @ a0627971`](https://github.com/warpdotdev/warp/blob/a06279712f838d01295575b0dc0f14b7a34ba049/app/src/terminal/cli_agent_sessions/mod.rs#L184-L194) — `clear_permission_scoped_state` drops the request summary whenever the session leaves the permission flow.
+- [`app/src/terminal/view.rs:13804-13835 @ a0627971`](https://github.com/warpdotdev/warp/blob/a06279712f838d01295575b0dc0f14b7a34ba049/app/src/terminal/view.rs#L13804-L13835) — a status change to `Blocked`, while the user is navigated away, becomes a `NotificationsTrigger::NeedsAttention` desktop notification. `view.rs:13783` closes rich input on the same transition.
+
+Two consequences follow from that code. Warp's *status* is already reversible: `permission_replied` and `tool_complete` both clear `Blocked`. Warp's *notification* is not, because a delivered desktop notification cannot be withdrawn. So the only place the decision can be made correctly is before the event is emitted, which puts it in the plugin, which puts it in what Codex tells the plugin.
+
+Worth noting: `permission_replied` is parsed and handled by the client but **no plugin script emits it today** — neither `warpdotdev/codex-warp` nor `warpdotdev/claude-code-warp` has a producer for it. It is a protocol slot with no writer.
+
+**Plugin.** [`plugins/warp/hooks/hooks.json`](https://github.com/warpdotdev/codex-warp/blob/main/plugins/warp/hooks/hooks.json) registers five events — `SessionStart`, `Stop`, `PermissionRequest`, `UserPromptSubmit`, `PostToolUse` — and [`plugins/warp/scripts/on-permission-request.sh`](https://github.com/warpdotdev/codex-warp/blob/main/plugins/warp/scripts/on-permission-request.sh) reads the hook payload from stdin, builds a summary from `tool_name` and `tool_input`, and emits `permission_request` unconditionally. It inspects no decision because the payload carries none.
+
+**Codex contract.** Evidence below is from Codex CLI 0.154.0 as installed on the development machine, one patch after the 0.153.4 the issue reports. The binary embeds draft-07 JSON Schema documents for every hook payload, which is a primary source for the contract's shape; it is not a substitute for Codex's published hook documentation, and each claim should be restated against that documentation before this spec is treated as settled.
+
+1. The hook catalogue has twelve events: `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `Stop`, `Interrupt`. **None of them fires when a permission request is resolved.**
+
+2. The `permission-request.command.input` schema carries exactly `agent_id`, `agent_type`, `cwd`, `hook_event_name`, `model`, `permission_mode`, `session_id`, `tool_input`, `tool_name`, `transcript_path`, `turn_id`. **There is no `approval_policy` and no `approvals_reviewer`.** The one adjacent field, `permission_mode`, does not substitute for them. Its schema enum is Claude Code's — `default`, `acceptEdits`, `plan`, `dontAsk`, `bypassPermissions` — rather than Codex's own `AskForApproval` (`on-failure`, `on-request`, `granular`, `never`, `untrusted`), and the only two values the hook runtime itself carries are `default` and `bypassPermissions`. Under the issue's configuration it reads `default` whether or not a reviewer will answer.
+
+3. The `permission-request.command.output` schema lets the hook return `behavior: allow | deny`, so the hook is an input to the approval chain rather than an observer of its outcome. Three fields in it — `interrupt`, `updatedInput`, `updatedPermissions` — are documented as reserved and currently fail closed, so the surface is still being built out.
+
+4. Automatic review is real and lives on a different surface: `ApprovalsReviewer` is `user | auto_review | guardian_subagent`, and the app-server side carries `AutoReviewRequired`, `StrictReviewRequiredNotification`, `RequestPermissionsEvent`, and a `disableAutoReview` requirement. None of this reaches a hook.
+
+So the answer to the question this spec exists to settle is **no**: Codex offers no event that separates "a reviewer is deciding" from "a human is being asked". The work this issue needs starts with a contract change, not with a plugin edit.
+
+One point remains observational rather than measured. That the `PermissionRequest` hook fires *before* the reviewer answers is reported by the issue author against 0.153.4 and accepted in triage (`repro:high`), and it is consistent with a hook that returns a decision into the chain — but it was not reproduced under instrumentation for this spec. It does not change the conclusion: whichever order the two run in, the payload in (2) carries nothing that distinguishes the outcome, and (1) means nothing fires afterward to correct it.
+
+## Proposed changes
+
+### 1. Propose a resolution-time hook event upstream — `openai/codex`
+
+Add a hook event that fires at the moment Codex determines a permission request requires a human decision, carrying at least the `session_id`, `turn_id`, and `tool_name` of the request it refers to, so a consumer can correlate it with the `PermissionRequest` that opened it.
+
+This is the only proposal here that satisfies the product spec, and the reason is worth stating because the cheaper alternative looks adequate until invariant 12 is applied to it:
+
+- **Adding the reviewer configuration to the `PermissionRequest` payload is not sufficient on its own.** It would tell the plugin that *a reviewer will look at this first*, never that *the reviewer declined*. A plugin that suppressed on it would go silent on exactly the requests that decline into a human decision — trading a false notification for a missed one, which invariant 12 forbids.
+- **Delaying the emission and retracting it is not available.** Invariant 4 rules out emitting and withdrawing, because a desktop notification cannot be withdrawn, and invariant 5 rules out waiting a fixed interval before emitting.
+- **`PostToolUse` cannot substitute.** It fires after the tool ran, so it can tell Warp a request was resolved but cannot prevent the notification that was already sent.
+
+The event's name and exact payload are upstream's to choose. What this spec asks for is its timing: it must fire when Codex decides to ask the user, not when the request is created.
+
+### 2. Emit on the new event instead — `warpdotdev/codex-warp`
+
+Once the event exists, `hooks.json` registers it and a new script emits the `permission_request` OSC 777 event that `on-permission-request.sh` emits today. `on-permission-request.sh` stops emitting `permission_request`.
+
+Register the new event **in addition to** `PermissionRequest`, not in place of it, and gate the emission inside the scripts rather than by which hooks are registered. That keeps invariant 12 satisfiable: a plugin running against a Codex that does not fire the new event keeps notifying from `PermissionRequest`, which is today's behavior, rather than going silent.
+
+The existing OSC 777 protocol needs no new event name. `permission_request` already means "blocked on the user" to the client, which is precisely what it would now mean.
+
+### 3. Emit `permission_replied` — `warpdotdev/codex-warp`
+
+Independently of (1), the plugin should emit `permission_replied` when a request is resolved, so the client's blocked status clears on the request's own resolution rather than waiting for the next `tool_complete`. The client already parses and handles it; there is simply no producer. This is a small correctness improvement and does not by itself address the issue.
+
+### 4. Warp client — no protocol change required
+
+With (1) and (2) in place, the client needs no change to satisfy invariants 1 through 8, 11, and 13 through 15: `permission_request` continues to mean `Blocked`, the navigated-away gate continues to apply, and the existing clearing paths continue to work.
+
+Two product invariants may need client work, and both are deliberately left open rather than designed here:
+
+- Invariant 9's open question, whether a request under automatic review should present as a distinct third state. A new state would touch `CLIAgentSessionStatus` at [`mod.rs:24-39`](https://github.com/warpdotdev/warp/blob/a06279712f838d01295575b0dc0f14b7a34ba049/app/src/terminal/cli_agent_sessions/mod.rs#L24-L39) and every surface that matches on it. Under (2) the smaller answer comes for free: with no event emitted, the session simply stays `InProgress`.
+- Invariant 12's version skew is handled in the plugin under (2), so the client needs no version gate. If that placement turns out to be wrong, the client already receives `plugin_version` on `session_start` and could gate on it.
+
+## Testing and validation
+
+Product invariants are numbered in [`product.md`](./product.md); each is listed here against what would prove it.
+
+**Warp client, `cargo nextest run -p warp -E 'test(cli_agent_sessions)'`.** The client's mapping is unchanged, so its existing coverage is the regression suite for invariants 1, 2, 14, and 15: `permission_request` maps to `Blocked`, `permission_replied` and `tool_complete` clear it, and `stop` and `stop_failure` are untouched. If invariant 9 resolves toward a distinct state, that state needs its own cases for the status mapping and for each surface that matches on `CLIAgentSessionStatus`.
+
+**Plugin scripts, `warpdotdev/codex-warp`.** Shell-level tests over the emission decision, driving each script with a recorded hook payload on stdin and asserting the OSC 777 body:
+
+- Invariant 1: the new event absent, `PermissionRequest` alone, emits nothing under (2)'s gating.
+- Invariants 2 and 6: the new event fires, `permission_request` is emitted once with the summary built from `tool_name` and `tool_input`.
+- Invariant 12: a payload from a Codex that does not fire the new event still emits on `PermissionRequest`. This is the case most worth pinning, because its failure mode is silence.
+
+**Manual validation.** The distinction under test only exists in a real Codex session, so this cannot be reduced to unit tests. On macOS, with Warp navigated away from the Codex pane:
+
+- `approvals_reviewer = "user"` with `approval_policy = "on-request"` — every permission request notifies. Invariant 13.
+- `approvals_reviewer = "auto_review"` with a request the reviewer approves — no notification, and the session keeps running. Invariant 1.
+- `approvals_reviewer = "auto_review"` with a request the reviewer declines into a human decision — one notification, arriving when Codex asks. Invariants 2, 4, 6.
+- Two Codex sessions in one window, one under review and one waiting on the user — exactly one notification. Invariant 11.
+- The same passes against a Codex build without the new event, to confirm today's behavior survives. Invariant 12.
+
+A screen recording of the second and third cases is the evidence worth attaching to the implementation PR, since the difference between them is a notification that does and does not appear.
+
+## Risks and mitigations
+
+**Registering an unknown event name in `hooks.json`.** (2) asks the plugin to register an event that older Codex builds do not know, which would matter a great deal if an unrecognized name took the rest of the file down with it. Measured against 0.154.0 with an isolated `CODEX_HOME`, it does not:
+
+- A `hooks.json` containing an unknown event name alongside a known one starts a session with no warning and no failure.
+- The negative control fired, so that silence is meaningful: a `hooks.json` whose `SessionStart` value is a string rather than a sequence produces `warning: failed to parse hooks config <path>: invalid type: string ..., expected a sequence at line 4 column 58`. The file is read, and parse problems do surface.
+- That warning is a warning. Codex continued and printed its session header, so even a `hooks.json` that fails to deserialize does not stop Codex from starting.
+
+Since the unknown-name file deserialized without a warning, the known entries in that same map were retained. Whether the sibling hook then *executes* was not observable here: the positive control did not fire either, because `SessionStart` hooks did not run in an unauthenticated `codex exec`. Confirm that last step in an authenticated session before (2) ships, and repeat the whole probe against the oldest Codex the plugin supports rather than only against 0.154.0.
+
+**Silence is worse than noise.** Every proposal here is shaped by invariant 12, and the review of any implementation should check the failure direction first: a change that removes notifications for requests it cannot classify is a regression even if it fixes the reported case.
+
+**This spec depends on an upstream change.** Nothing in (1) is Warp's to land. (3) is independently shippable, and (2) is only shippable once (1) exists. If upstream declines, the issue has no correct fix under the current contract, and the honest outcome is to say so on the issue rather than to ship a heuristic.
+
+**The contract evidence is read from a binary.** Every claim in Context is from schemas and symbols embedded in Codex 0.154.0, not from published documentation. The shape is unlikely to be wrong, but the wording of an upstream proposal should be checked against Codex's own hook documentation first.
+
+## Follow-ups
+
+- Whether the other CLI agent plugins that emit `permission_request` have the same gap against their own upstreams, tracked separately per the product spec's open questions.
+- `permission_replied` having no producer in either plugin, which (3) addresses for Codex only.


### PR DESCRIPTION
## Description

Adds `specs/GH15933/product.md` and `specs/GH15933/tech.md` for issue #15933, which asks that Warp notify for a Codex permission request only when the request actually needs a human.

The issue turns on one question: does Codex emit a reliable event that separates "the automatic reviewer is still deciding" from "a human decision is required"?
**It does not**, and the tech spec records the evidence rather than asserting it.
So the spec's recommendation is a contract change upstream in `openai/codex`, not a plugin edit — which means this is a spec that Warp cannot implement on its own, and saying so plainly is the point of it.

This is a spec-only change. No product code is touched.

## Linked Issue

Closes #15933.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). Not applicable: this PR adds two Markdown documents and no implementation.

## What the evidence says

Read from Codex CLI 0.154.0, one patch after the 0.153.4 the issue reports. The binary embeds draft-07 JSON Schema documents for every hook payload, which is what these claims come from.

The hook catalogue has twelve events — `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `Stop`, `Interrupt` — and **none of them fires when a permission request is resolved**.

The `permission-request.command.input` schema carries exactly `agent_id`, `agent_type`, `cwd`, `hook_event_name`, `model`, `permission_mode`, `session_id`, `tool_input`, `tool_name`, `transcript_path`, `turn_id`.
**There is no `approval_policy` and no `approvals_reviewer`.**
The one adjacent field, `permission_mode`, does not substitute: its enum is Claude Code's rather than Codex's own `AskForApproval`, the hook runtime carries only `default` and `bypassPermissions`, and under the issue's configuration it reads `default` whether or not a reviewer will answer.

Automatic review is real, and it lives on the app-server notification surface (`AutoReviewRequired`, `StrictReviewRequiredNotification`, `RequestPermissionsEvent`) rather than in the hook catalogue.
That surface is not reachable from this integration: per `specs/codex-warp-plugin/TECH.md`, Warp ingests plugin state as OSC 777 terminal notifications emitted by the plugin's hook scripts, so "consume the notifications instead" is a different architecture for both the plugin and the client rather than a smaller fix.

## Why the cheaper alternatives fail

The tech spec argues these out rather than leaving them for review to raise.

Adding the reviewer configuration to the `PermissionRequest` payload is not sufficient on its own.
It would tell the plugin that a reviewer will look at this first, never that the reviewer declined, so a plugin suppressing on it would go silent on exactly the requests that decline into a human decision.
That trades a false notification for a missed one, which the product spec's invariant 12 forbids.

Emitting and then withdrawing is not available, because a delivered desktop notification cannot be withdrawn, and waiting a fixed interval before emitting is excluded as guessing.

`PostToolUse` cannot substitute either: it fires after the tool ran, so it can tell Warp a request was resolved but cannot prevent the notification that was already sent.

## One thing the client already gets right

`permission_replied` and `tool_complete` both clear `CLIAgentSessionStatus::Blocked`, so Warp's **status** is already reversible; only the desktop notification is not.
That is why the decision has to be made before the event is emitted, which puts it in the plugin, which puts it in what Codex tells the plugin.

Worth flagging separately: `permission_replied` is parsed and handled by the client, but **no plugin script emits it** — neither `warpdotdev/codex-warp` nor `warpdotdev/claude-code-warp` has a producer for it. It is a protocol slot with no writer. The tech spec proposes filling it as an independently shippable improvement.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Not ticked, and deliberately. This PR adds two Markdown documents and changes no product code, so there is nothing to exercise in a running build.

What was verified instead:

- Every contract claim above comes from schemas and symbols in the Codex 0.154.0 binary, not from recollection. `strings` over a binary is a real primary source for what a build contains and is not a substitute for the published contract, which the tech spec says in its own words; the wording of any upstream proposal should be checked against Codex's hook documentation first.
- The tech spec's compatibility risk — that registering an unknown hook event name might take the whole `hooks.json` down — was measured directly against 0.154.0 with an isolated `CODEX_HOME`. An unknown event name is silently ignored, with no warning and no failure. The negative control fired, so that silence is evidence: a `hooks.json` whose `SessionStart` value is a string rather than a sequence produces `warning: failed to parse hooks config <path>: invalid type: string ..., expected a sequence at line 4 column 58`, and even that is a warning rather than fatal.
- Whether a sibling hook then executes is recorded as **not established**, because the positive control did not fire either: `SessionStart` hooks do not run in an unauthenticated `codex exec`, so the check could not reach the state it was meant to observe.
- That the `PermissionRequest` hook fires before the reviewer answers is recorded as observational — reported on the issue and accepted in triage, not reproduced under instrumentation here. It is not load-bearing: under either ordering the payload cannot distinguish, and nothing fires afterward to correct it.

All code references in the tech spec are pinned to `a06279712` and linked to the corresponding lines.

## Notes for review

**Directory naming.** This uses `specs/GH15933/` with lowercase `product.md` and `tech.md`, following the most recent GitHub-issue specs in this repository — `GH14069` and `GH11727`, both added in August. The `write-product-spec` skill's own contract says `specs/gh-15933/PRODUCT.md`, so I followed repository precedent over the skill where the two disagree. Happy to rename either way.

**Open questions are left open rather than answered.** The product spec's invariant 9 asks whether a request under automatic review should present as ordinary in-progress work or as a distinct third state; the smaller answer comes for free under the proposed design, and the more informative one is a wider change. That call belongs to whoever owns this area.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
