### PR TITLE
fix(windows): expose Acrylic tint color/opacity settings, applied outside winit

### DIFF
--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -692,6 +692,8 @@ pub fn create_transferred_window(
             title: Some(WINDOW_TITLE.to_owned()),
             background_blur_radius_pixels: Some(*window_settings.background_blur_radius),
             background_backdrop: *window_settings.background_backdrop,
+            background_backdrop_tint_color: *window_settings.background_backdrop_tint_color,
+            background_backdrop_tint_opacity: *window_settings.background_backdrop_tint_opacity,
             on_gpu_driver_selected: on_gpu_driver_selected_callback(),
             ..Default::default()
         },
@@ -754,11 +756,18 @@ fn open_from_restored(arg: &OpenFromRestoredArg, ctx: &mut AppContext) {
     if let Some(app_state) = &arg.app_state {
         maybe_register_global_window_shortcuts(global_resource_handles.clone(), ctx);
 
-        let (background_blur_radius_pixels, background_backdrop) = {
+        let (
+            background_blur_radius_pixels,
+            background_backdrop,
+            background_backdrop_tint_color,
+            background_backdrop_tint_opacity,
+        ) = {
             let window_settings = WindowSettings::as_ref(ctx);
             (
                 Some(*window_settings.background_blur_radius),
                 *window_settings.background_backdrop,
+                *window_settings.background_backdrop_tint_color,
+                *window_settings.background_backdrop_tint_opacity,
             )
         };
 
@@ -791,6 +800,8 @@ fn open_from_restored(arg: &OpenFromRestoredArg, ctx: &mut AppContext) {
                             fullscreen_state: window.fullscreen_state,
                             background_blur_radius_pixels,
                             background_backdrop,
+                            background_backdrop_tint_color,
+                            background_backdrop_tint_opacity,
                             // Don't use the quake window for positioning new windows.
                             anchor_new_windows_from_closed_position:
                                 NextNewWindowsHasThisWindowsBoundsUponClose::No,
@@ -834,6 +845,8 @@ fn open_from_restored(arg: &OpenFromRestoredArg, ctx: &mut AppContext) {
                                 fullscreen_state: window.fullscreen_state,
                                 background_blur_radius_pixels,
                                 background_backdrop,
+                                background_backdrop_tint_color,
+                                background_backdrop_tint_opacity,
                                 on_gpu_driver_selected: on_gpu_driver_selected_callback(),
                                 ..Default::default()
                             },
@@ -886,6 +899,8 @@ fn open_from_restored(arg: &OpenFromRestoredArg, ctx: &mut AppContext) {
                         fullscreen_state: window.fullscreen_state,
                         background_blur_radius_pixels,
                         background_backdrop,
+                        background_backdrop_tint_color,
+                        background_backdrop_tint_opacity,
                         on_gpu_driver_selected: on_gpu_driver_selected_callback(),
                         ..Default::default()
                     },
@@ -1288,6 +1303,8 @@ fn default_window_options(window_settings: &WindowSettings, ctx: &AppContext) ->
         title: Some("Warp".to_owned()),
         background_blur_radius_pixels: Some(*window_settings.background_blur_radius),
         background_backdrop: *window_settings.background_backdrop,
+        background_backdrop_tint_color: *window_settings.background_backdrop_tint_color,
+        background_backdrop_tint_opacity: *window_settings.background_backdrop_tint_opacity,
         on_gpu_driver_selected: on_gpu_driver_selected_callback(),
         ..Default::default()
     }
@@ -1473,6 +1490,9 @@ fn toggle_quake_mode_window(global_resource_handles: &GlobalResourceHandles, ctx
                     title: Some("Warp".to_owned()),
                     background_blur_radius_pixels: Some(*window_settings.background_blur_radius),
                     background_backdrop: *window_settings.background_backdrop,
+                    background_backdrop_tint_color: *window_settings.background_backdrop_tint_color,
+                    background_backdrop_tint_opacity: *window_settings
+                        .background_backdrop_tint_opacity,
                     // Ignore the quake window for positioning the next window
                     anchor_new_windows_from_closed_position:
                         warpui::NextNewWindowsHasThisWindowsBoundsUponClose::No,

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -18,7 +18,7 @@ use warpui::elements::{
 use warpui::fonts::{FamilyId, FontInfo, Weight};
 use warpui::keymap::{ContextPredicate, FixedBinding};
 use warpui::platform::{
-    Cursor, FilePickerConfiguration, GraphicsBackend, SystemTheme, WindowBackdrop,
+    AcrylicTintColor, Cursor, FilePickerConfiguration, GraphicsBackend, SystemTheme, WindowBackdrop,
 };
 use warpui::rendering::ThinStrokes;
 use warpui::ui_components::button::ButtonVariant;
@@ -86,7 +86,8 @@ use crate::util::bindings;
 use crate::view_components::action_button::{ActionButton, ButtonSize, NakedTheme};
 use crate::view_components::{Dropdown, DropdownItem, FilterableDropdown};
 use crate::window_settings::{
-    BackgroundBackdrop, BackgroundBlurRadius, BackgroundOpacity, LeftPanelVisibilityAcrossTabs,
+    BackgroundBackdrop, BackgroundBackdropTintColor, BackgroundBackdropTintOpacity,
+    BackgroundBlurRadius, BackgroundOpacity, LeftPanelVisibilityAcrossTabs,
     OpenWindowsAtCustomSize, WindowSettings, WindowSettingsChangedEvent, ZoomLevel,
 };
 use crate::workspace::WorkspaceAction;
@@ -497,6 +498,9 @@ pub enum AppearancePageAction {
     ToggleUseLatestUserPromptAsConversationTitleInTabNames,
     ToggleLigatureRendering,
     SetWindowBackdrop(WindowBackdrop),
+    SetAcrylicTintColor(AcrylicTintColor),
+    SetAcrylicTintOpacity(f32),
+    AcrylicTintOpacitySliderDragged(f32),
     ToggleLeftPanelVisibility,
     ToggleToolsPanelProjectExplorer,
     ToggleToolsPanelGlobalSearch,
@@ -541,6 +545,8 @@ pub struct AppearanceSettingsPageView {
     enforce_min_contrast_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
     input_mode_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
     window_backdrop_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
+    acrylic_tint_color_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
+    acrylic_tint_opacity_slider_state: SliderStateHandle,
     input_type_radio_state: RadioButtonStateHandle,
     app_icon_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
     workspace_decorations_dropdown: ViewHandle<Dropdown<AppearancePageAction>>,
@@ -627,6 +633,11 @@ impl TypedActionView for AppearanceSettingsPageView {
             ToggleAllAvailableFonts => self.toggle_all_available_fonts(ctx),
             ToggleDimInactivePanes => self.toggle_dim_inactive_panes(ctx),
             SetWindowBackdrop(backdrop) => self.set_window_backdrop(*backdrop, ctx),
+            SetAcrylicTintColor(tint_color) => self.set_acrylic_tint_color(*tint_color, ctx),
+            SetAcrylicTintOpacity(value) => self.set_acrylic_tint_opacity(*value, true, ctx),
+            AcrylicTintOpacitySliderDragged(value) => {
+                self.set_acrylic_tint_opacity(*value, false, ctx)
+            }
             ToggleLeftPanelVisibility => self.toggle_left_panel_visibility(ctx),
             ToggleToolsPanelProjectExplorer => {
                 CodeSettings::handle(ctx).update(ctx, |settings, ctx| {
@@ -1016,6 +1027,19 @@ impl AppearanceSettingsPageView {
                         );
                     });
                 }
+                WindowSettingsChangedEvent::BackgroundBackdropTintColor { .. } => {
+                    let tint_color = *WindowSettings::as_ref(ctx).background_backdrop_tint_color;
+                    me.acrylic_tint_color_dropdown.update(ctx, |dropdown, ctx| {
+                        dropdown.set_selected_by_action(
+                            AppearancePageAction::SetAcrylicTintColor(tint_color),
+                            ctx,
+                        );
+                    });
+                }
+                WindowSettingsChangedEvent::BackgroundBackdropTintOpacity { .. } => {
+                    // Reset the slider state so that it uses the current opacity value on the next render.
+                    me.acrylic_tint_opacity_slider_state.reset_offset();
+                }
                 WindowSettingsChangedEvent::ZoomLevel { .. } => {
                     let zoom_level = *WindowSettings::as_ref(ctx).zoom_level;
 
@@ -1326,6 +1350,8 @@ impl AppearanceSettingsPageView {
             thin_strokes_dropdown,
             input_mode_dropdown,
             window_backdrop_dropdown: Self::build_window_backdrop_dropdown(ctx),
+            acrylic_tint_color_dropdown: Self::build_acrylic_tint_color_dropdown(ctx),
+            acrylic_tint_opacity_slider_state: Default::default(),
             input_type_radio_state,
             app_icon_dropdown,
             enforce_min_contrast_dropdown,
@@ -2330,6 +2356,39 @@ impl AppearanceSettingsPageView {
         ctx.notify();
     }
 
+    fn set_acrylic_tint_color(
+        &mut self,
+        tint_color: AcrylicTintColor,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        WindowSettings::handle(ctx).update(ctx, |window_settings, ctx| {
+            report_if_error!(
+                window_settings
+                    .background_backdrop_tint_color
+                    .set_value(tint_color, ctx)
+            );
+        });
+        ctx.notify();
+    }
+
+    fn set_acrylic_tint_opacity(
+        &mut self,
+        opacity_value: f32,
+        should_set_defaults: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if should_set_defaults {
+            WindowSettings::handle(ctx).update(ctx, |window_settings, ctx| {
+                report_if_error!(
+                    window_settings
+                        .background_backdrop_tint_opacity
+                        .set_value(opacity_value as u8, ctx)
+                );
+            });
+        }
+        ctx.notify();
+    }
+
     pub fn toggle_left_panel_visibility(&mut self, ctx: &mut ViewContext<Self>) {
         WindowSettings::handle(ctx).update(ctx, |window_settings, ctx| {
             report_if_error!(
@@ -2604,6 +2663,40 @@ impl AppearanceSettingsPageView {
             WindowBackdrop::Mica => "Mica",
             WindowBackdrop::Acrylic => "Acrylic",
             WindowBackdrop::MicaAlt => "Mica Alt",
+        }
+    }
+
+    fn build_acrylic_tint_color_dropdown(
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<Dropdown<AppearancePageAction>> {
+        ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_items(
+                AcrylicTintColor::ALL
+                    .into_iter()
+                    .map(|tint_color| {
+                        DropdownItem::new(
+                            Self::acrylic_tint_color_dropdown_item_label(tint_color),
+                            AppearancePageAction::SetAcrylicTintColor(tint_color),
+                        )
+                    })
+                    .collect(),
+                ctx,
+            );
+            dropdown.set_selected_by_action(
+                AppearancePageAction::SetAcrylicTintColor(
+                    *WindowSettings::as_ref(ctx).background_backdrop_tint_color,
+                ),
+                ctx,
+            );
+            dropdown
+        })
+    }
+
+    fn acrylic_tint_color_dropdown_item_label(tint_color: AcrylicTintColor) -> &'static str {
+        match tint_color {
+            AcrylicTintColor::Dark => "Dark",
+            AcrylicTintColor::Light => "Light",
         }
     }
     fn build_workspace_decoration_visibility_dropdown(
@@ -3471,7 +3564,7 @@ impl SettingsWidget for WindowBackdropWidget {
     type View = AppearanceSettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "window backdrop material blur acrylic mica"
+        "window backdrop material blur acrylic mica tint color opacity"
     }
 
     fn render(
@@ -3495,6 +3588,60 @@ impl SettingsWidget for WindowBackdropWidget {
             None,
             &view.window_backdrop_dropdown,
         ));
+        if *WindowSettings::as_ref(app).background_backdrop == WindowBackdrop::Acrylic {
+            col.add_child(render_dropdown_item(
+                appearance,
+                "Acrylic tint",
+                None,
+                None,
+                LocalOnlyIconState::for_setting(
+                    BackgroundBackdropTintColor::storage_key(),
+                    BackgroundBackdropTintColor::sync_to_cloud(),
+                    &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                    app,
+                ),
+                None,
+                &view.acrylic_tint_color_dropdown,
+            ));
+
+            let tint_opacity_value = *WindowSettings::as_ref(app).background_backdrop_tint_opacity;
+            col.add_child(render_body_item::<AppearancePageAction>(
+                format!("Acrylic tint opacity: {tint_opacity_value}"),
+                None,
+                LocalOnlyIconState::for_setting(
+                    BackgroundBackdropTintOpacity::storage_key(),
+                    BackgroundBackdropTintOpacity::sync_to_cloud(),
+                    &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                    app,
+                ),
+                ToggleState::Enabled,
+                appearance,
+                appearance
+                    .ui_builder()
+                    .slider(view.acrylic_tint_opacity_slider_state.clone())
+                    .with_range(
+                        BackgroundBackdropTintOpacity::MIN as f32
+                            ..BackgroundBackdropTintOpacity::MAX as f32,
+                    )
+                    .with_default_value(tint_opacity_value as f32)
+                    .with_style(UiComponentStyles {
+                        width: Some(OPACITY_SLIDER_WIDTH),
+                        margin: Some(Coords::default().top(3.).bottom(3.)),
+                        ..Default::default()
+                    })
+                    .on_drag(|ctx, _, val| {
+                        ctx.dispatch_typed_action(
+                            AppearancePageAction::AcrylicTintOpacitySliderDragged(val),
+                        )
+                    })
+                    .on_change(|ctx, _, val| {
+                        ctx.dispatch_typed_action(AppearancePageAction::SetAcrylicTintOpacity(val))
+                    })
+                    .build()
+                    .finish(),
+                None,
+            ));
+        }
         if let Some(window) = app.windows().platform_window(view.window_id)
             && !window.supports_transparency()
             && window.graphics_backend() != GraphicsBackend::Gl

--- a/app/src/undo_close/stack.rs
+++ b/app/src/undo_close/stack.rs
@@ -262,14 +262,27 @@ impl UndoCloseStack {
                 );
 
                 let window_id = data.window_id;
-                let (background_blur_radius_pixels, background_backdrop) = {
+                let (
+                    background_blur_radius_pixels,
+                    background_backdrop,
+                    background_backdrop_tint_color,
+                    background_backdrop_tint_opacity,
+                ) = {
                     let window_settings = WindowSettings::as_ref(ctx);
                     (
                         Some(*window_settings.background_blur_radius),
                         *window_settings.background_backdrop,
+                        *window_settings.background_backdrop_tint_color,
+                        *window_settings.background_backdrop_tint_opacity,
                     )
                 };
-                ctx.reopen_closed_window(*data, background_blur_radius_pixels, background_backdrop);
+                ctx.reopen_closed_window(
+                    *data,
+                    background_blur_radius_pixels,
+                    background_backdrop,
+                    background_backdrop_tint_color,
+                    background_backdrop_tint_opacity,
+                );
 
                 if let Some(workspace) = window_workspace(window_id, ctx) {
                     workspace.update(ctx, |workspace, ctx| {

--- a/app/src/window_settings.rs
+++ b/app/src/window_settings.rs
@@ -1,7 +1,7 @@
 use settings::macros::define_settings_group;
 use settings::{RespectUserSyncSetting, Setting as _, SupportedPlatforms, SyncToCloud};
 use warp_errors::report_if_error;
-use warpui::platform::WindowBackdrop;
+use warpui::platform::{AcrylicTintColor, WindowBackdrop};
 use warpui::{AppContext, SingletonEntity, WindowId};
 
 define_settings_group!(WindowSettings, settings: [
@@ -36,6 +36,26 @@ define_settings_group!(WindowSettings, settings: [
         storage_key: "OverrideBlurTexture",
         toml_path: "appearance.window.override_blur_texture",
         description: "Deprecated legacy setting for the Acrylic window backdrop.",
+    },
+    background_backdrop_tint_color: BackgroundBackdropTintColor {
+        type: AcrylicTintColor,
+        default: AcrylicTintColor::Dark,
+        supported_platforms: SupportedPlatforms::WINDOWS,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        surface: settings::SettingSurfaces::GUI,
+        private: false,
+        toml_path: "appearance.window.backdrop_tint_color",
+        description: "The tint color used behind the Acrylic window backdrop.",
+    },
+    background_backdrop_tint_opacity: BackgroundBackdropTintOpacity {
+        type: u8,
+        default: 80,
+        supported_platforms: SupportedPlatforms::WINDOWS,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        surface: settings::SettingSurfaces::GUI,
+        private: false,
+        toml_path: "appearance.window.backdrop_tint_opacity",
+        description: "The opacity of the tint used behind the Acrylic window backdrop, from 10 to 100 percent.",
     },
     background_opacity: BackgroundOpacity {
         type: u8,
@@ -170,6 +190,15 @@ impl BackgroundBlurRadius {
         } else {
             new_value
         }
+    }
+}
+
+impl BackgroundBackdropTintOpacity {
+    pub const MIN: u8 = 10;
+    pub const MAX: u8 = 100;
+
+    fn validate(&self, new_value: u8) -> u8 {
+        new_value.clamp(Self::MIN, Self::MAX)
     }
 }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18295,10 +18295,15 @@ impl Workspace {
             WindowSettingsChangedEvent::BackgroundOpacity { .. } => {
                 ctx.notify();
             }
-            WindowSettingsChangedEvent::BackgroundBackdrop { .. } => {
-                let backdrop = *WindowSettings::as_ref(ctx).background_backdrop;
+            WindowSettingsChangedEvent::BackgroundBackdrop { .. }
+            | WindowSettingsChangedEvent::BackgroundBackdropTintColor { .. }
+            | WindowSettingsChangedEvent::BackgroundBackdropTintOpacity { .. } => {
+                let window_settings = WindowSettings::as_ref(ctx);
+                let backdrop = *window_settings.background_backdrop;
+                let tint_color = *window_settings.background_backdrop_tint_color;
+                let tint_opacity = *window_settings.background_backdrop_tint_opacity;
                 if let Some(window) = ctx.windows().platform_window(ctx.window_id()) {
-                    window.set_background_backdrop(backdrop);
+                    window.set_background_backdrop(backdrop, tint_color, tint_opacity);
                 }
             }
             WindowSettingsChangedEvent::LeftPanelVisibilityAcrossTabs { .. } => {

--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -37,8 +37,8 @@ use super::windows::{WindowAttributeErr, get_system_caption_button_bounds, set_w
 #[cfg(not(target_family = "wasm"))]
 use crate::platform::WindowBounds;
 use crate::platform::{
-    self, Cursor, FullscreenState, GraphicsBackend, TerminationMode, WindowBackdrop,
-    WindowFocusBehavior, WindowOptions, WindowStyle,
+    self, AcrylicTintColor, Cursor, FullscreenState, GraphicsBackend, TerminationMode,
+    WindowBackdrop, WindowFocusBehavior, WindowOptions, WindowStyle,
 };
 use crate::rendering::wgpu::{
     Renderer, Resources, adapter_has_rendering_offset_bug, from_wgpu_backend, renderer,
@@ -72,8 +72,35 @@ fn winit_backdrop(backdrop: WindowBackdrop) -> BackdropType {
     match backdrop {
         WindowBackdrop::None => BackdropType::None,
         WindowBackdrop::Mica => BackdropType::MainWindow,
-        WindowBackdrop::Acrylic => BackdropType::TransientWindow,
+        // Acrylic is applied via a custom accent-policy call (see `apply_acrylic_tint`
+        // below and `WindowExt::set_acrylic_tint`) rather than through winit, since
+        // `BackdropType::TransientWindow` has no way to customize the tint color and
+        // defaults to a light underpaint that clashes with dark themes (warpdotdev/warp#11940).
+        WindowBackdrop::Acrylic => BackdropType::None,
         WindowBackdrop::MicaAlt => BackdropType::TabbedWindow,
+    }
+}
+
+/// Applies (or clears) the custom Acrylic tint accent policy for `window` based on the
+/// currently selected `backdrop`. Must be called any time the backdrop type or tint
+/// settings change, so a window switching away from Acrylic never keeps a stale accent
+/// policy applied.
+#[cfg(windows)]
+fn apply_acrylic_tint(
+    window: &winit::window::Window,
+    backdrop: WindowBackdrop,
+    tint_color: AcrylicTintColor,
+    tint_opacity: u8,
+) {
+    use super::windows::WindowExt;
+
+    let result = if backdrop == WindowBackdrop::Acrylic {
+        window.set_acrylic_tint(tint_color, tint_opacity)
+    } else {
+        window.clear_acrylic_tint()
+    };
+    if let Err(e) = result {
+        report_error!(anyhow::Error::new(e).context("Failed to update acrylic tint"));
     }
 }
 
@@ -1455,6 +1482,13 @@ fn create_window(
                 report_error!(anyhow::Error::new(e).context("Failed to mark window as cloaked"));
             };
 
+            apply_acrylic_tint(
+                window,
+                window_options.background_backdrop,
+                window_options.background_backdrop_tint_color,
+                window_options.background_backdrop_tint_opacity,
+            );
+
             if let Some(adjustment) = maybe_adjust_window_vertically(window) {
                 let direction = if adjustment > 0 { "down" } else { "up" };
                 log::info!(
@@ -1589,11 +1623,17 @@ impl crate::platform::Window for Window {
     }
 
     #[cfg_attr(not(windows), allow(unused_variables))]
-    fn set_background_backdrop(&self, backdrop: WindowBackdrop) {
+    fn set_background_backdrop(
+        &self,
+        backdrop: WindowBackdrop,
+        tint_color: AcrylicTintColor,
+        tint_opacity: u8,
+    ) {
         #[cfg(windows)]
         {
             if let Some(inner) = self.inner.borrow().as_ref() {
                 inner.window.set_system_backdrop(winit_backdrop(backdrop));
+                apply_acrylic_tint(&inner.window, backdrop, tint_color, tint_opacity);
             }
         }
     }

--- a/crates/warpui/src/windowing/winit/windows/window_ext.rs
+++ b/crates/warpui/src/windowing/winit/windows/window_ext.rs
@@ -1,4 +1,7 @@
-use windows::Win32::Foundation::{COLORREF, FALSE, HWND, TRUE};
+use std::ffi::c_void;
+
+use warpui_core::platform::AcrylicTintColor;
+use windows::Win32::Foundation::{COLORREF, FALSE, GetLastError, HWND, TRUE};
 use windows::Win32::Graphics::Dwm::{DWMWA_CLOAK, DwmSetWindowAttribute};
 use windows::Win32::UI::WindowsAndMessaging::{
     GWL_EXSTYLE, GetWindowLongPtrW, LWA_ALPHA, SetLayeredWindowAttributes, SetWindowLongPtrW,
@@ -14,6 +17,68 @@ pub enum Error {
     InvalidWindowHandle,
     #[error("Unknown error")]
     Other(#[from] windows::core::Error),
+    #[error("SetWindowCompositionAttribute failed (GetLastError = {0:#x})")]
+    AccentPolicyFailed(u32),
+}
+
+/// `WCA_ACCENT_POLICY`, the attribute identifier used with
+/// `SetWindowCompositionAttribute` to control a window's blur/acrylic accent.
+/// This API is undocumented but stable and widely relied upon (e.g. by
+/// Windows Terminal, Firefox, and the `window-vibrancy` crate) as the only way
+/// to customize the tint color behind an acrylic blur; winit's system backdrop
+/// API has no equivalent.
+const WCA_ACCENT_POLICY: u32 = 19;
+
+const ACCENT_DISABLED: u32 = 0;
+const ACCENT_ENABLE_ACRYLICBLURBEHIND: u32 = 4;
+
+#[repr(C)]
+struct AccentPolicy {
+    accent_state: u32,
+    accent_flags: u32,
+    /// ABGR-encoded gradient color: alpha in the high byte, then blue, green, red.
+    gradient_color: u32,
+    animation_id: u32,
+}
+
+#[repr(C)]
+struct WindowCompositionAttributeData {
+    attribute: u32,
+    data: *mut c_void,
+    size: usize,
+}
+
+unsafe extern "system" {
+    /// Undocumented Win32 API (`user32.dll`) used to apply the legacy blur/acrylic
+    /// accent policy to a window. Not exposed by the `windows` crate.
+    fn SetWindowCompositionAttribute(hwnd: HWND, data: *mut WindowCompositionAttributeData)
+    -> BOOL;
+}
+
+/// Builds the ABGR gradient color expected by [`AccentPolicy`] from a tint color and
+/// an opacity percentage (0-100).
+fn gradient_color(tint_color: AcrylicTintColor, tint_opacity: u8) -> u32 {
+    let rgb: u32 = match tint_color {
+        AcrylicTintColor::Dark => 0x000000,
+        AcrylicTintColor::Light => 0xFFFFFF,
+    };
+    let alpha = (tint_opacity.min(100) as u32 * 255) / 100;
+    (alpha << 24) | rgb
+}
+
+/// Applies the given accent policy to `hwnd` via `SetWindowCompositionAttribute`.
+fn set_accent_policy(hwnd: HWND, mut policy: AccentPolicy) -> Result<(), Error> {
+    let mut data = WindowCompositionAttributeData {
+        attribute: WCA_ACCENT_POLICY,
+        data: &mut policy as *mut AccentPolicy as *mut c_void,
+        size: size_of::<AccentPolicy>(),
+    };
+    let ok = unsafe { SetWindowCompositionAttribute(hwnd, &mut data) };
+    if ok.as_bool() {
+        Ok(())
+    } else {
+        Err(Error::AccentPolicyFailed(unsafe { GetLastError().0 }))
+    }
 }
 
 /// Extension trait for Windows specific logic on a [`winit::window::Window`].
@@ -27,6 +92,17 @@ pub trait WindowExt {
     /// cross-window tab-drag preview relies on while hovering over a target
     /// window's tab bar.
     fn set_alpha(&self, alpha: f32) -> Result<(), Error>;
+
+    /// Enables the Acrylic blur-behind accent with a custom tint, bypassing winit's
+    /// system backdrop API (which has no way to customize the tint color and
+    /// defaults to a light underpaint that clashes with dark themes).
+    fn set_acrylic_tint(&self, tint_color: AcrylicTintColor, tint_opacity: u8)
+    -> Result<(), Error>;
+
+    /// Clears any accent policy previously applied by [`WindowExt::set_acrylic_tint`].
+    /// Must be called when switching away from the Acrylic backdrop so no stale
+    /// native state lingers on the window.
+    fn clear_acrylic_tint(&self) -> Result<(), Error>;
 }
 
 impl WindowExt for Window {
@@ -77,5 +153,47 @@ impl WindowExt for Window {
         }
 
         Ok(())
+    }
+
+    fn set_acrylic_tint(
+        &self,
+        tint_color: AcrylicTintColor,
+        tint_opacity: u8,
+    ) -> Result<(), Error> {
+        let Ok(RawWindowHandle::Win32(handle)) = self
+            .window_handle()
+            .map(|window_handle| window_handle.as_raw())
+        else {
+            return Err(Error::InvalidWindowHandle);
+        };
+
+        set_accent_policy(
+            HWND(handle.hwnd.get() as _),
+            AccentPolicy {
+                accent_state: ACCENT_ENABLE_ACRYLICBLURBEHIND,
+                accent_flags: 0,
+                gradient_color: gradient_color(tint_color, tint_opacity),
+                animation_id: 0,
+            },
+        )
+    }
+
+    fn clear_acrylic_tint(&self) -> Result<(), Error> {
+        let Ok(RawWindowHandle::Win32(handle)) = self
+            .window_handle()
+            .map(|window_handle| window_handle.as_raw())
+        else {
+            return Err(Error::InvalidWindowHandle);
+        };
+
+        set_accent_policy(
+            HWND(handle.hwnd.get() as _),
+            AccentPolicy {
+                accent_state: ACCENT_DISABLED,
+                accent_flags: 0,
+                gradient_color: 0,
+                animation_id: 0,
+            },
+        )
     }
 }

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -2493,6 +2493,8 @@ impl AppContext {
             fullscreen_state,
             background_blur_radius_pixels,
             background_backdrop,
+            background_backdrop_tint_color,
+            background_backdrop_tint_opacity,
             anchor_new_windows_from_closed_position,
             on_gpu_driver_selected: on_gpu_driver_reported,
             window_instance,
@@ -2521,6 +2523,8 @@ impl AppContext {
             style: window_style,
             background_blur_radius_pixels,
             background_backdrop,
+            background_backdrop_tint_color,
+            background_backdrop_tint_opacity,
             gpu_power_preference: self.rendering_config.gpu_power_preference,
             backend_preference: self.rendering_config.backend_preference,
             on_gpu_device_info_reported: on_gpu_driver_reported.unwrap_or(Box::new(|_| {})),
@@ -2826,6 +2830,8 @@ impl AppContext {
         data: ClosedWindowData,
         background_blur_radius_pixels: Option<u8>,
         background_backdrop: platform::WindowBackdrop,
+        background_backdrop_tint_color: platform::AcrylicTintColor,
+        background_backdrop_tint_opacity: u8,
     ) {
         let ClosedWindowData {
             window_id,
@@ -2855,6 +2861,8 @@ impl AppContext {
         let add_window_options = AddWindowOptions {
             background_blur_radius_pixels,
             background_backdrop,
+            background_backdrop_tint_color,
+            background_backdrop_tint_opacity,
             window_bounds: WindowBounds::ExactPosition(bounds),
             // TODO(alokedesai): Determine if, and how, we want to pass the on_gpu_driver_reported
             // callback from the original window back to this window.

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -161,6 +161,8 @@ struct GlobalShortcut {
 pub struct AddWindowOptions {
     pub background_blur_radius_pixels: Option<u8>,
     pub background_backdrop: platform::WindowBackdrop,
+    pub background_backdrop_tint_color: platform::AcrylicTintColor,
+    pub background_backdrop_tint_opacity: u8,
     pub window_style: WindowStyle,
     pub window_bounds: WindowBounds,
     pub title: Option<String>,

--- a/crates/warpui_core/src/platform/mod.rs
+++ b/crates/warpui_core/src/platform/mod.rs
@@ -72,6 +72,28 @@ impl WindowBackdrop {
 #[cfg(feature = "settings_value")]
 impl settings_value::SettingsValue for WindowBackdrop {}
 
+/// The tint color used behind the [`WindowBackdrop::Acrylic`] material.
+///
+/// Acrylic is applied via a custom accent-policy call rather than through winit,
+/// since winit's system backdrop API has no way to customize this tint (see
+/// `WindowExt::set_acrylic_tint` in the winit windowing backend). This is ignored
+/// for all other [`WindowBackdrop`] variants.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema_gen", derive(schemars::JsonSchema))]
+pub enum AcrylicTintColor {
+    #[default]
+    Dark,
+    Light,
+}
+
+impl AcrylicTintColor {
+    pub const ALL: [Self; 2] = [Self::Dark, Self::Light];
+}
+
+#[cfg(feature = "settings_value")]
+impl settings_value::SettingsValue for AcrylicTintColor {}
+
 /// Type of the callback function that provides the result of requesting
 /// desktop notification permissions.
 pub type RequestNotificationPermissionsCallback =
@@ -113,6 +135,8 @@ pub struct WindowOptions {
     pub style: WindowStyle,
     pub background_blur_radius_pixels: Option<u8>,
     pub background_backdrop: WindowBackdrop,
+    pub background_backdrop_tint_color: AcrylicTintColor,
+    pub background_backdrop_tint_opacity: u8,
     pub gpu_power_preference: GPUPowerPreference,
     pub backend_preference: Option<GraphicsBackend>,
     pub on_gpu_device_info_reported: Box<OnGPUDeviceSelected>,
@@ -135,6 +159,14 @@ impl std::fmt::Debug for WindowOptions {
                 &self.background_blur_radius_pixels,
             )
             .field("background_backdrop", &self.background_backdrop)
+            .field(
+                "background_backdrop_tint_color",
+                &self.background_backdrop_tint_color,
+            )
+            .field(
+                "background_backdrop_tint_opacity",
+                &self.background_backdrop_tint_opacity,
+            )
             .field("gpu_power_preference", &self.gpu_power_preference)
             .field("backend_preference", &self.backend_preference)
             .field("window_instance", &self.window_instance)
@@ -466,7 +498,13 @@ pub trait Window: 'static + WindowContext + std::any::Any {
     fn toggle_maximized(&self);
     fn toggle_fullscreen(&self);
     fn fullscreen_state(&self) -> FullscreenState;
-    fn set_background_backdrop(&self, _backdrop: WindowBackdrop) {}
+    fn set_background_backdrop(
+        &self,
+        _backdrop: WindowBackdrop,
+        _tint_color: AcrylicTintColor,
+        _tint_opacity: u8,
+    ) {
+    }
     /// Whether the window has the native OS window frame (title bar and buttons).
     fn uses_native_window_decorations(&self) -> bool;
     fn set_titlebar_height(&self, height: f64);


### PR DESCRIPTION
## Description
Fixes #11940. On Windows, selecting the "Acrylic" window backdrop used winit's `BackdropType::TransientWindow`, which delegates the blur tint entirely to the OS and defaults to a light underpaint — this clashes with dark themes and can't be customized.

This PR bypasses winit for the Acrylic backdrop and applies it directly via the legacy `SetWindowCompositionAttribute` / `ACCENT_ENABLE_ACRYLICBLURBEHIND` accent-policy API (the same approach used by Windows Terminal, Firefox, and the `window-vibrancy` crate), which does support a custom tint color. Two new Windows-only settings are exposed in Settings → Appearance → Window, shown only when Acrylic is selected:
- **Acrylic tint**: Dark (default) or Light
- **Acrylic tint opacity**: 10-100%

Mica/Mica Alt/None continue to use winit's system backdrop unchanged.

### Key changes
- `crates/warpui_core/src/platform/mod.rs`: new `AcrylicTintColor` enum, threaded through `WindowOptions`/`AddWindowOptions`, and `Window::set_background_backdrop` now takes the tint color/opacity alongside the backdrop type.
- `crates/warpui/src/windowing/winit/windows/window_ext.rs`: new `WindowExt::set_acrylic_tint`/`clear_acrylic_tint`, implemented via a manual `SetWindowCompositionAttribute` FFI declaration (not exposed by the `windows` crate).
- `crates/warpui/src/windowing/winit/window.rs`: Acrylic now always maps to `BackdropType::None` for winit and is applied via the new native call instead, both at window creation and on setting changes.
- `app/src/window_settings.rs` / `app/src/settings_view/appearance_page.rs`: new `background_backdrop_tint_color` / `background_backdrop_tint_opacity` settings and their UI, rendered as sub-rows of the existing "Window backdrop" widget only when Acrylic is selected.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo check -p warpui_core -p warpui -p warp`
- `cargo clippy -p warpui_core -p warpui -p warp --all-targets --tests -- -D warnings`
- `./script/format`
- [ ] I have manually tested my changes locally with `./script/run`

I was unable to manually verify the rendered tint visually or take screenshots in this environment (no GUI/computer-use available here), so this needs verification on a real Windows machine before merging — screenshots showing the Acrylic backdrop with a dark theme, before/after this change, would be great to add here.

### Screenshots / Videos
_Not available from this environment — see note above._

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
