### PR TITLE
feat(GH2818): open launch configurations and tab configs with a keyboard shortcut

### DIFF
--- a/app/src/config_keybindings.rs
+++ b/app/src/config_keybindings.rs
@@ -1,0 +1,166 @@
+//! Derives editable keybindings from the user's saved launch configurations and tab configs.
+//!
+//! Every loaded config registers one binding — `launch_config:open:<name>` /
+//! `tab_config:open:<file stem>`, the same identifiers the `warp://launch` and
+//! `warp://tab_config` URIs accept — with no default keystroke. Users assign keys in
+//! Settings → Keyboard Shortcuts or `keybindings.yaml` like any other action. Bindings are
+//! re-registered whenever the configs reload from disk; custom triggers assigned before a
+//! binding registers (configs load asynchronously after `keybindings.yaml` is applied) still
+//! take effect because the keymap remembers triggers by name.
+
+use std::collections::HashSet;
+
+use warp_core::context_flag::ContextFlag;
+use warpui::keymap::{BindingDescription, EditableBinding};
+use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
+
+use crate::features::FeatureFlag;
+use crate::launch_configs::launch_config::LaunchConfig;
+use crate::settings_view::keybindings::{KeybindingChangedEvent, KeybindingChangedNotifier};
+use crate::tab_configs::TabConfig;
+use crate::user_config::{WarpConfig, WarpConfigUpdateEvent};
+use crate::util::bindings::BindingGroup;
+use crate::workspace::WorkspaceAction;
+
+/// Name prefix for bindings that open a launch configuration.
+pub const LAUNCH_CONFIG_BINDING_PREFIX: &str = "launch_config:open:";
+/// Name prefix for bindings that open a tab config.
+pub const TAB_CONFIG_BINDING_PREFIX: &str = "tab_config:open:";
+
+pub fn init(app: &mut AppContext) {
+    app.add_singleton_model(ConfigKeybindings::new);
+}
+
+/// Singleton that keeps the keymap's config-derived bindings in sync with [`WarpConfig`].
+pub struct ConfigKeybindings {}
+
+impl Entity for ConfigKeybindings {
+    type Event = ();
+}
+
+impl SingletonEntity for ConfigKeybindings {}
+
+impl ConfigKeybindings {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        ctx.subscribe_to_model(&WarpConfig::handle(ctx), Self::handle_config_event);
+        Self::register_bindings(ctx);
+        Self {}
+    }
+
+    fn handle_config_event(
+        &mut self,
+        _: ModelHandle<WarpConfig>,
+        event: &WarpConfigUpdateEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if matches!(
+            event,
+            WarpConfigUpdateEvent::LaunchConfigs | WarpConfigUpdateEvent::TabConfigs
+        ) {
+            Self::register_bindings(ctx);
+        }
+    }
+
+    fn register_bindings(ctx: &mut ModelContext<Self>) {
+        let (launch_bindings, tab_bindings) = if FeatureFlag::ConfigKeybindings.is_enabled() {
+            let warp_config_handle = WarpConfig::handle(ctx);
+            let warp_config = warp_config_handle.as_ref(ctx);
+            (
+                launch_config_bindings(warp_config.launch_configs()),
+                tab_config_bindings(warp_config.tab_configs()),
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
+        ctx.replace_editable_bindings_with_prefix(LAUNCH_CONFIG_BINDING_PREFIX, launch_bindings);
+        ctx.replace_editable_bindings_with_prefix(TAB_CONFIG_BINDING_PREFIX, tab_bindings);
+
+        KeybindingChangedNotifier::handle(ctx).update(ctx, |_me, ctx| {
+            ctx.emit(KeybindingChangedEvent::BindingsReloaded);
+        });
+    }
+}
+
+/// Builds one binding per launch configuration, keyed by the config's `name` — the identifier
+/// `warp://launch/<name>` accepts. Duplicate names (case-insensitive) keep the first loaded
+/// config, matching URI resolution.
+fn launch_config_bindings(configs: &[LaunchConfig]) -> Vec<EditableBinding> {
+    use warpui::keymap::macros::*;
+
+    let mut seen = HashSet::new();
+    configs
+        .iter()
+        .filter(|config| {
+            let is_new = seen.insert(config.name.to_lowercase());
+            if !is_new {
+                log::warn!(
+                    "duplicate launch configuration name '{}'; only the first gets a keybinding",
+                    config.name
+                );
+            }
+            is_new
+        })
+        .map(|config| {
+            EditableBinding::new(
+                format!("{LAUNCH_CONFIG_BINDING_PREFIX}{}", config.name),
+                BindingDescription::new_preserve_case(format!(
+                    "Open Launch Configuration \"{}\"",
+                    config.name
+                )),
+                WorkspaceAction::OpenLaunchConfigNamed {
+                    name: config.name.clone(),
+                },
+            )
+            .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+            .with_group(BindingGroup::LaunchConfigurations.as_str())
+            .with_enabled(|| ContextFlag::LaunchConfigurations.is_enabled())
+        })
+        .collect()
+}
+
+/// Builds one binding per tab config, keyed by the config file's stem — the identifier
+/// `warp://tab_config/<stem>` accepts. Configs without a UTF-8 file stem are skipped;
+/// duplicate stems (case-insensitive) keep the first loaded config.
+fn tab_config_bindings(configs: &[TabConfig]) -> Vec<EditableBinding> {
+    use warpui::keymap::macros::*;
+
+    let mut seen = HashSet::new();
+    configs
+        .iter()
+        .filter_map(|config| {
+            let Some(stem) = config.file_stem() else {
+                log::warn!(
+                    "tab config '{}' has no UTF-8 file stem; skipping keybinding",
+                    config.name
+                );
+                return None;
+            };
+            if !seen.insert(stem.to_lowercase()) {
+                log::warn!(
+                    "duplicate tab config file stem '{stem}'; only the first gets a keybinding"
+                );
+                return None;
+            }
+            Some(
+                EditableBinding::new(
+                    format!("{TAB_CONFIG_BINDING_PREFIX}{stem}"),
+                    BindingDescription::new_preserve_case(format!(
+                        "Open Tab Config \"{}\"",
+                        config.name
+                    )),
+                    WorkspaceAction::OpenTabConfigNamed {
+                        file_stem: stem.to_string(),
+                    },
+                )
+                .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+                .with_group(BindingGroup::TabConfigs.as_str())
+                .with_enabled(|| FeatureFlag::TabConfigs.is_enabled()),
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "config_keybindings_tests.rs"]
+mod tests;

--- a/app/src/config_keybindings_tests.rs
+++ b/app/src/config_keybindings_tests.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::{
+    LAUNCH_CONFIG_BINDING_PREFIX, TAB_CONFIG_BINDING_PREFIX, launch_config_bindings,
+    tab_config_bindings,
+};
+use crate::launch_configs::launch_config::LaunchConfig;
+use crate::tab_configs::TabConfig;
+
+fn launch_config(name: &str) -> LaunchConfig {
+    LaunchConfig {
+        name: name.to_string(),
+        active_window_index: None,
+        windows: Vec::new(),
+    }
+}
+
+fn tab_config(name: &str, source_path: Option<&str>) -> TabConfig {
+    TabConfig {
+        name: name.to_string(),
+        title: None,
+        color: None,
+        panes: Vec::new(),
+        params: HashMap::new(),
+        source_path: source_path.map(PathBuf::from),
+    }
+}
+
+#[test]
+fn test_launch_config_binding_names_use_config_name() {
+    let bindings = launch_config_bindings(&[launch_config("backend"), launch_config("My App")]);
+    let names: Vec<String> = bindings
+        .iter()
+        .map(|binding| binding.name().to_string())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            format!("{LAUNCH_CONFIG_BINDING_PREFIX}backend"),
+            format!("{LAUNCH_CONFIG_BINDING_PREFIX}My App"),
+        ]
+    );
+}
+
+#[test]
+fn test_duplicate_launch_config_names_keep_first() {
+    let bindings = launch_config_bindings(&[launch_config("Backend"), launch_config("backend")]);
+    assert_eq!(bindings.len(), 1);
+    assert_eq!(
+        bindings[0].name(),
+        format!("{LAUNCH_CONFIG_BINDING_PREFIX}Backend")
+    );
+}
+
+#[test]
+fn test_tab_config_binding_names_use_file_stem() {
+    let bindings = tab_config_bindings(&[tab_config(
+        "Frontend",
+        Some("/tmp/tab_configs/frontend.toml"),
+    )]);
+    assert_eq!(bindings.len(), 1);
+    assert_eq!(
+        bindings[0].name(),
+        format!("{TAB_CONFIG_BINDING_PREFIX}frontend")
+    );
+}
+
+#[test]
+fn test_tab_config_without_source_path_is_skipped() {
+    let bindings = tab_config_bindings(&[
+        tab_config("unsaved", None),
+        tab_config("saved", Some("/x/saved.toml")),
+    ]);
+    assert_eq!(bindings.len(), 1);
+    assert_eq!(
+        bindings[0].name(),
+        format!("{TAB_CONFIG_BINDING_PREFIX}saved")
+    );
+}
+
+#[test]
+fn test_duplicate_tab_config_stems_keep_first() {
+    let bindings = tab_config_bindings(&[
+        tab_config("first", Some("/a/Repo.toml")),
+        tab_config("second", Some("/b/repo.toml")),
+    ]);
+    assert_eq!(bindings.len(), 1);
+    assert_eq!(
+        bindings[0].name(),
+        format!("{TAB_CONFIG_BINDING_PREFIX}Repo")
+    );
+}

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -1142,11 +1142,12 @@ impl DisplayChip {
         ctx.subscribe_to_model(
             &KeybindingChangedNotifier::handle(ctx),
             |me, _, event, ctx| {
-                let KeybindingChangedEvent::BindingChanged {
+                if let KeybindingChangedEvent::BindingChanged {
                     binding_name,
                     new_trigger,
-                } = event;
-                if binding_name == TOGGLE_RIGHT_PANEL_BINDING_NAME {
+                } = event
+                    && binding_name == TOGGLE_RIGHT_PANEL_BINDING_NAME
+                {
                     me.code_review_keybinding = new_trigger.as_ref().map(|k| k.displayed());
                     ctx.notify();
                 }

--- a/app/src/editor/accept_autosuggestion_keybinding_view.rs
+++ b/app/src/editor/accept_autosuggestion_keybinding_view.rs
@@ -120,6 +120,7 @@ impl AcceptAutosuggestionKeybinding {
                     me.update_menu_selected_item(ctx);
                 }
             }
+            KeybindingChangedEvent::BindingsReloaded => {}
         });
 
         let mut me = Self {

--- a/app/src/launch_configs/launch_config.rs
+++ b/app/src/launch_configs/launch_config.rs
@@ -34,6 +34,15 @@ impl LaunchConfig {
     }
 }
 
+/// Case-insensitive lookup of a launch configuration by its `name` — the identifier
+/// `warp://launch/<name>` URIs and `launch_config:open:<name>` keybindings use.
+pub fn find_by_name<'a>(configs: &'a [LaunchConfig], name: &str) -> Option<&'a LaunchConfig> {
+    let name = name.to_lowercase();
+    configs
+        .iter()
+        .find(|config| config.name.to_lowercase() == name)
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct WindowTemplate {
     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2067,7 +2067,6 @@ pub(crate) fn initialize_app(
     menu::init(ctx);
     tips::tip_view::init(ctx);
     launch_configs::init(ctx);
-    config_keybindings::init(ctx);
     workflows::init(ctx);
     themes::theme_chooser::init(ctx);
     themes::theme_creator_modal::init(ctx);
@@ -2110,6 +2109,8 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(|_| SystemStats::new());
     workspace::auto_handoff::init(ctx);
     ctx.add_singleton_model(|_| KeybindingChangedNotifier::new());
+    // Requires the WarpConfig singleton and the KeybindingChangedNotifier registered above.
+    config_keybindings::init(ctx);
     ctx.add_singleton_model(|_| TabShortcutModifierState::new());
     ctx.add_singleton_model(|_| search::command_palette::SelectedItems::new());
     ctx.add_singleton_model(search::files::model::FileSearchModel::new);

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -20,6 +20,7 @@ mod coding_entrypoints;
 mod coding_panel_enablement_state;
 mod command_palette;
 mod completer;
+mod config_keybindings;
 #[allow(dead_code)]
 mod context_chips;
 #[cfg(enable_crash_recovery)]
@@ -2066,6 +2067,7 @@ pub(crate) fn initialize_app(
     menu::init(ctx);
     tips::tip_view::init(ctx);
     launch_configs::init(ctx);
+    config_keybindings::init(ctx);
     workflows::init(ctx);
     themes::theme_chooser::init(ctx);
     themes::theme_creator_modal::init(ctx);

--- a/app/src/notebooks/editor/keys.rs
+++ b/app/src/notebooks/editor/keys.rs
@@ -44,11 +44,12 @@ impl NotebookKeybindings {
         event: &KeybindingChangedEvent,
         ctx: &mut ModelContext<Self>,
     ) {
-        let KeybindingChangedEvent::BindingChanged {
+        if let KeybindingChangedEvent::BindingChanged {
             binding_name,
             new_trigger,
-        } = event;
-        if binding_name == RUN_COMMANDS_KEYBINDING_NAME {
+        } = event
+            && binding_name == RUN_COMMANDS_KEYBINDING_NAME
+        {
             self.run_commands_keybinding = new_trigger.as_ref().map(|key| key.displayed());
             ctx.notify();
         }

--- a/app/src/resource_center/keybindings_page.rs
+++ b/app/src/resource_center/keybindings_page.rs
@@ -197,6 +197,9 @@ impl KeybindingsView {
                     ctx.notify();
                 }
             }
+            KeybindingChangedEvent::BindingsReloaded => {
+                self.rebuild_bindings(TabSettings::handle(ctx), ctx);
+            }
         }
     }
 

--- a/app/src/resource_center/section_views/feature_section.rs
+++ b/app/src/resource_center/section_views/feature_section.rs
@@ -128,6 +128,7 @@ impl FeatureSectionView {
                     ctx.notify();
                 }
             }
+            KeybindingChangedEvent::BindingsReloaded => {}
         }
     }
 

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -613,7 +613,7 @@ fn open_launch_config(arg: &OpenLaunchConfigArg, ctx: &mut AppContext) {
 
     send_telemetry_from_app_ctx!(
         TelemetryEvent::OpenLaunchConfig {
-            ui_location: crate::server::telemetry::LaunchConfigUiLocation::Uri,
+            ui_location: arg.ui_location,
             open_in_active_window: arg.open_in_active_window,
         },
         ctx

--- a/app/src/search/action/search_item.rs
+++ b/app/src/search/action/search_item.rs
@@ -199,6 +199,8 @@ impl SearchItemIcon for BindingGroup {
             Self::Notifications => Icon::Bell,
             Self::EnvVarCollection => Icon::EnvVarCollection,
             Self::Terminal => Icon::Terminal,
+            Self::LaunchConfigurations => Icon::Navigation,
+            Self::TabConfigs => Icon::Grid,
         }
     }
 
@@ -211,6 +213,8 @@ impl SearchItemIcon for BindingGroup {
             | Self::AutoUpdate
             | Self::Folders
             | Self::Terminal
+            | Self::LaunchConfigurations
+            | Self::TabConfigs
             | Self::Notifications => appearance.theme().foreground().into_solid(),
             Self::WarpAi if !FeatureFlag::AgentMode.is_enabled() => {
                 ColorU::from_u32(colors::WARP_AI)

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -609,6 +609,7 @@ pub enum LaunchConfigUiLocation {
     AppMenu,
     TabMenu,
     Uri,
+    Keybinding,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]

--- a/app/src/settings_view/keybindings.rs
+++ b/app/src/settings_view/keybindings.rs
@@ -75,6 +75,9 @@ pub enum KeybindingChangedEvent {
         binding_name: String,
         new_trigger: Option<Keystroke>,
     },
+    /// The set of registered editable bindings changed — e.g. bindings derived from launch
+    /// configurations or tab configs were re-registered after a reload from disk.
+    BindingsReloaded,
 }
 
 impl Entity for KeybindingChangedNotifier {
@@ -511,6 +514,15 @@ impl KeybindingsView {
 
         let search_bar = ctx.add_typed_action_view(|_| SearchBar::new(search_editor.clone()));
 
+        let bindings_notifier = KeybindingChangedNotifier::handle(ctx);
+        ctx.subscribe_to_model(&bindings_notifier, |me, _, event, ctx| {
+            // Only refresh once the page has been shown; `on_page_selected` builds the initial
+            // list.
+            if matches!(event, KeybindingChangedEvent::BindingsReloaded) && me.bindings.is_some() {
+                me.rebuild_binding_list(ctx);
+            }
+        });
+
         let page = PageType::new_monolith(KeybindingsWidget::default(), None, false);
         Self {
             page,
@@ -522,6 +534,62 @@ impl KeybindingsView {
             search_editor,
             conflict_map: Default::default(),
         }
+    }
+
+    /// Rebuilds the cached binding list, rows, and conflict map from the keymap's currently
+    /// registered editable bindings.
+    fn rebuild_binding_list(&mut self, ctx: &mut ViewContext<Self>) {
+        // `from_editable_lens` materializes any dynamic description resolver
+        // before caching, so the dedup below (which compares descriptions)
+        // sees concrete strings.
+        let lenses: Vec<_> = ctx.editable_bindings().collect();
+        self.bindings = Some(
+            lenses
+                .into_iter()
+                .map(|lens| CommandBinding::from_editable_lens(lens, ctx))
+                .sorted_by(|a, b| {
+                    // Sort by description then name so that we can deduplicate bindings by name.
+                    a.description
+                        .in_context(DescriptionContext::Default)
+                        .cmp(b.description.in_context(DescriptionContext::Default))
+                        .then(a.name.cmp(&b.name))
+                })
+                // Effectively, editable bindings can only be used by one view, because the
+                // corresponding context predicate and typed action are view-specific.
+                //
+                // If multiple views need equivalent bindings, we handle this by declaring
+                // duplicates with the same name and description, but different actions and
+                // predicates. Because bindings are saved/loaded by name, changes to one binding
+                // will affect the others. To reduce clutter, only show one binding for a given name
+                // and description.
+                //
+                // There are some bindings with the same name, but different descriptions. Because
+                // we sort by description first, those bindings won't be deduplicated. This is
+                // alright for now, since those bindings have slightly different semantics despite
+                // being linked (e.g. find in block vs. find in terminal).
+                //
+                // TODO: Long-term, we should instead refactor TypedActionView so that common
+                // bindings can be declared once and handled by multiple views.
+                .dedup_by(|a, b| a.name == b.name && a.description == b.description)
+                .collect(),
+        );
+        self.rows = Some(
+            self.bindings
+                .iter()
+                .flatten()
+                .map(|b| (None, b))
+                .map(KeybindingRow::from)
+                .collect(),
+        );
+
+        self.conflict_map = self
+            .bindings
+            .iter()
+            .flatten()
+            .map(|binding| binding.trigger.clone())
+            .collect();
+
+        ctx.notify();
     }
 
     /// Searches for a keybinding as if the user had typed the query into the search
@@ -749,56 +817,7 @@ impl SettingsPageMeta for KeybindingsView {
     fn on_page_selected(&mut self, allow_steal_focus: bool, ctx: &mut ViewContext<Self>) {
         // Reset previous modifying_row state.
         self.modifying_row = None;
-        // `from_editable_lens` materializes any dynamic description resolver
-        // before caching, so the dedup below (which compares descriptions)
-        // sees concrete strings.
-        let lenses: Vec<_> = ctx.editable_bindings().collect();
-        self.bindings = Some(
-            lenses
-                .into_iter()
-                .map(|lens| CommandBinding::from_editable_lens(lens, ctx))
-                .sorted_by(|a, b| {
-                    // Sort by description then name so that we can deduplicate bindings by name.
-                    a.description
-                        .in_context(DescriptionContext::Default)
-                        .cmp(b.description.in_context(DescriptionContext::Default))
-                        .then(a.name.cmp(&b.name))
-                })
-                // Effectively, editable bindings can only be used by one view, because the
-                // corresponding context predicate and typed action are view-specific.
-                //
-                // If multiple views need equivalent bindings, we handle this by declaring
-                // duplicates with the same name and description, but different actions and
-                // predicates. Because bindings are saved/loaded by name, changes to one binding
-                // will affect the others. To reduce clutter, only show one binding for a given name
-                // and description.
-                //
-                // There are some bindings with the same name, but different descriptions. Because
-                // we sort by description first, those bindings won't be deduplicated. This is
-                // alright for now, since those bindings have slightly different semantics despite
-                // being linked (e.g. find in block vs. find in terminal).
-                //
-                // TODO: Long-term, we should instead refactor TypedActionView so that common
-                // bindings can be declared once and handled by multiple views.
-                .dedup_by(|a, b| a.name == b.name && a.description == b.description)
-                .collect(),
-        );
-        self.rows = Some(
-            self.bindings
-                .iter()
-                .flatten()
-                .map(|b| (None, b))
-                .map(KeybindingRow::from)
-                .collect(),
-        );
-
-        // Populate the conflict map at startup.
-        self.conflict_map = self
-            .bindings
-            .iter()
-            .flatten()
-            .map(|binding| binding.trigger.clone())
-            .collect();
+        self.rebuild_binding_list(ctx);
 
         self.search_editor.update(ctx, |editor, ctx| {
             editor.clear_buffer_and_reset_undo_stack(ctx);

--- a/app/src/tab_configs/tab_config.rs
+++ b/app/src/tab_configs/tab_config.rs
@@ -176,6 +176,12 @@ impl TabConfig {
             .collect()
     }
 
+    /// The stem of the file this config was loaded from — the stable identity used by
+    /// `warp://tab_config/<stem>` URIs and `tab_config:open:<stem>` keybindings.
+    pub fn file_stem(&self) -> Option<&str> {
+        self.source_path.as_ref()?.file_stem()?.to_str()
+    }
+
     pub(crate) fn is_worktree(&self) -> bool {
         self.panes.iter().any(|pane| {
             pane.commands.as_ref().is_some_and(|commands| {
@@ -201,6 +207,16 @@ impl TabConfig {
                     })
             })
     }
+}
+
+/// Case-insensitive lookup of a tab config by the stem of the file it was loaded from.
+pub fn find_by_file_stem<'a>(configs: &'a [TabConfig], file_stem: &str) -> Option<&'a TabConfig> {
+    let target = file_stem.to_lowercase();
+    configs.iter().find(|config| {
+        config
+            .file_stem()
+            .is_some_and(|stem| stem.to_lowercase() == target)
+    })
 }
 
 /// Renders a [`TabConfig`] with the given param values into a [`PaneTemplateType`]

--- a/app/src/terminal/keys.rs
+++ b/app/src/terminal/keys.rs
@@ -79,7 +79,10 @@ impl TerminalKeybindings {
         let KeybindingChangedEvent::BindingChanged {
             binding_name,
             new_trigger,
-        } = event;
+        } = event
+        else {
+            return;
+        };
         if binding_name == SET_INPUT_MODE_AGENT_ACTION_NAME {
             self.set_input_mode_agent_keybinding = new_trigger.as_ref().map(|key| key.displayed());
             ctx.notify();

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -788,10 +788,7 @@ fn find_matching_config_name<'a>(
     target_name: &str,
     configs: &'a [LaunchConfig],
 ) -> Option<&'a LaunchConfig> {
-    let target_name_lower = target_name.to_lowercase();
-    configs
-        .iter()
-        .find(|&config| config.name.to_lowercase() == target_name_lower)
+    crate::launch_configs::launch_config::find_by_name(configs, target_name)
 }
 
 /// Handles `warp://tab_config/<name>` deeplinks.

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -808,6 +808,8 @@ pub enum BindingGroup {
     Notifications,
     EnvVarCollection,
     Terminal,
+    LaunchConfigurations,
+    TabConfigs,
 }
 
 impl BindingGroup {
@@ -826,6 +828,8 @@ impl BindingGroup {
             Self::Notifications => "notifications",
             Self::EnvVarCollection => "env_var_collections",
             Self::Terminal => "terminal",
+            Self::LaunchConfigurations => "launch_configurations",
+            Self::TabConfigs => "tab_configs",
         }
     }
 

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -505,11 +505,12 @@ impl ActionButton {
                 ctx.subscribe_to_model(
                     &KeybindingChangedNotifier::handle(ctx),
                     move |me, _, event, ctx| {
-                        let KeybindingChangedEvent::BindingChanged {
+                        if let KeybindingChangedEvent::BindingChanged {
                             binding_name,
                             new_trigger,
-                        } = event;
-                        if binding_name == name {
+                        } = event
+                            && binding_name == name
+                        {
                             me.cached_keystroke = new_trigger.clone();
                             ctx.notify();
                         }

--- a/app/src/view_components/agent_toast.rs
+++ b/app/src/view_components/agent_toast.rs
@@ -58,11 +58,12 @@ impl AgentToastStack {
         ctx.subscribe_to_model(
             &KeybindingChangedNotifier::handle(ctx),
             move |me, _, event, ctx| {
-                let KeybindingChangedEvent::BindingChanged {
+                if let KeybindingChangedEvent::BindingChanged {
                     binding_name,
                     new_trigger,
-                } = event;
-                if binding_name == "workspace:jump_to_latest_toast" {
+                } = event
+                    && binding_name == "workspace:jump_to_latest_toast"
+                {
                     me.jump_to_toast_shortcut = new_trigger.clone();
                     ctx.notify();
                 }

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -331,6 +331,16 @@ pub enum WorkspaceAction {
     },
     OpenLaunchConfigSaveModal,
     SelectTabConfig(TabConfig),
+    /// Opens the launch configuration with this name into the active window, resolving it from
+    /// `WarpConfig` at dispatch time so keybindings never act on stale contents.
+    OpenLaunchConfigNamed {
+        name: String,
+    },
+    /// Opens the tab config whose file has this stem in the active window, resolving it from
+    /// `WarpConfig` at dispatch time so keybindings never act on stale contents.
+    OpenTabConfigNamed {
+        file_stem: String,
+    },
     DispatchToSettingsTab(SettingsTabAction),
     ToggleResourceCenter,
     ToggleUserMenu,
@@ -1000,6 +1010,8 @@ impl WorkspaceAction {
             | SummarizeAIConversation { .. }
             | OpenRepository { .. }
             | SelectTabConfig(_)
+            | OpenLaunchConfigNamed { .. }
+            | OpenTabConfigNamed { .. }
             | ToggleVerticalTabsPanel
             | OpenVerticalTabsPanel => true, // actions that actually change a state of the state of user's
             // workspace would most likely require a save, so that if the app gets

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -7232,6 +7232,59 @@ impl Workspace {
 
     /// Opens a tab config, showing the param-fill modal when the config has parameters,
     /// or opening the tab directly when there are no parameters.
+    /// Opens the launch configuration with the given name (case-insensitive) into the active
+    /// window, resolving it from [`WarpConfig`] so keybindings never act on stale contents.
+    fn open_launch_config_by_name(&mut self, name: &str, ctx: &mut ViewContext<Self>) {
+        let launch_config = crate::launch_configs::launch_config::find_by_name(
+            WarpConfig::handle(ctx).as_ref(ctx).launch_configs(),
+            name,
+        )
+        .cloned();
+        match launch_config {
+            Some(launch_config) => ctx.dispatch_global_action(
+                "root_view:open_launch_config",
+                OpenLaunchConfigArg {
+                    launch_config,
+                    ui_location: LaunchConfigUiLocation::Keybinding,
+                    open_in_active_window: true,
+                },
+            ),
+            None => {
+                log::warn!("no launch configuration named '{name}' for keybinding");
+                self.toast_stack.update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(format!(
+                            "Launch configuration \"{name}\" not found"
+                        )),
+                        ctx,
+                    );
+                });
+            }
+        }
+    }
+
+    /// Opens the tab config whose file has the given stem (case-insensitive) in this window,
+    /// resolving it from [`WarpConfig`] so keybindings never act on stale contents.
+    fn open_tab_config_by_stem(&mut self, file_stem: &str, ctx: &mut ViewContext<Self>) {
+        let tab_config = crate::tab_configs::tab_config::find_by_file_stem(
+            WarpConfig::handle(ctx).as_ref(ctx).tab_configs(),
+            file_stem,
+        )
+        .cloned();
+        match tab_config {
+            Some(tab_config) => self.open_tab_config(tab_config, ctx),
+            None => {
+                log::warn!("no tab config with file stem '{file_stem}' for keybinding");
+                self.toast_stack.update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(format!("Tab config \"{file_stem}\" not found")),
+                        ctx,
+                    );
+                });
+            }
+        }
+    }
+
     pub(crate) fn open_tab_config(
         &mut self,
         tab_config: crate::tab_configs::TabConfig,
@@ -19047,12 +19100,14 @@ impl Workspace {
             KeybindingChangedEvent::BindingChanged {
                 binding_name,
                 new_trigger: new_trigger_option,
-            } => self
-                .cached_keybindings
-                .entry(binding_name.to_owned())
-                .and_modify(|keystroke| {
-                    *keystroke = new_trigger_option.as_ref().map(|key| key.displayed())
-                }),
+            } => {
+                self.cached_keybindings
+                    .entry(binding_name.to_owned())
+                    .and_modify(|keystroke| {
+                        *keystroke = new_trigger_option.as_ref().map(|key| key.displayed())
+                    });
+            }
+            KeybindingChangedEvent::BindingsReloaded => {}
         };
         ctx.notify()
     }
@@ -24203,6 +24258,12 @@ impl TypedActionView for Workspace {
             }
             SelectTabConfig(tab_config) => {
                 self.open_tab_config(tab_config.clone(), ctx);
+            }
+            OpenLaunchConfigNamed { name } => {
+                self.open_launch_config_by_name(name, ctx);
+            }
+            OpenTabConfigNamed { file_stem } => {
+                self.open_tab_config_by_stem(file_stem, ctx);
             }
             OpenNewWorktreeModal => {
                 let cwd = self

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -384,7 +384,8 @@ impl LeftPanelView {
         ctx.subscribe_to_model(
             &KeybindingChangedNotifier::handle(ctx),
             |me, _, event, ctx| match event {
-                KeybindingChangedEvent::BindingChanged { .. } => {
+                KeybindingChangedEvent::BindingChanged { .. }
+                | KeybindingChangedEvent::BindingsReloaded => {
                     for button in &mut me.toolbelt_buttons {
                         button.tooltip_keybinding =
                             toolbelt_tooltip_keybinding(&button.tooltip_keybinding_names, ctx);

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -808,6 +808,10 @@ pub enum FeatureFlag {
     /// Enables tab configs — user-definable TOML templates for launching custom tab layouts.
     TabConfigs,
 
+    /// Enables keybindings derived from saved launch configurations and tab configs
+    /// (`launch_config:open:<name>` / `tab_config:open:<file stem>`).
+    ConfigKeybindings,
+
     /// Enables Warp local control through the standalone warpctrl CLI.
     WarpControlCli,
 
@@ -1020,6 +1024,7 @@ pub const LOCAL_FLAGS: &[FeatureFlag] = &[FeatureFlag::LocalClaudeCodexChildHarn
 /// Features enabled for the development team.  The expectation is that, over
 /// time, these will move on to PREVIEW_FLAGS before being launched.
 pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
+    FeatureFlag::ConfigKeybindings,
     FeatureFlag::LogExpensiveFramesInSentry,
     FeatureFlag::ToggleBootstrapBlock,
     FeatureFlag::CreatingSharedSessions,

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -1820,6 +1820,18 @@ impl AppContext {
         self.keystroke_matcher.register_editable_bindings(actions);
     }
 
+    /// Removes every editable binding whose name starts with `prefix`, then registers
+    /// `bindings` in their place. Used for bindings derived from user-editable state (e.g.
+    /// saved launch configurations) that are re-registered whenever that state reloads.
+    pub fn replace_editable_bindings_with_prefix<A: IntoIterator<Item = EditableBinding>>(
+        &mut self,
+        prefix: &str,
+        bindings: A,
+    ) {
+        self.keystroke_matcher
+            .replace_editable_bindings_with_prefix(prefix, bindings);
+    }
+
     /// Set a custom trigger for a given editable binding name
     ///
     /// This will override the default trigger for that action

--- a/crates/warpui_core/src/keymap.rs
+++ b/crates/warpui_core/src/keymap.rs
@@ -27,7 +27,7 @@ pub struct Keymap {
     editable_bindings: Vec<Tracked<EditableBinding>>,
     /// A mapping from binding name to indices in `editable_bindings` of bindings with
     /// that name, stored in the order they were registered.
-    editable_bindings_by_name: HashMap<&'static str, Vec<usize>>,
+    editable_bindings_by_name: HashMap<Cow<'static, str>, Vec<usize>>,
 
     // We store a copy of the bindings, filtered down to only ones that are
     // triggered by a custom action.  This is done to optimize the lookups
@@ -35,6 +35,12 @@ pub struct Keymap {
     // a `[WarpDelegate menuNeedsUpdate]` selector.
     fixed_custom_action_bindings: Vec<FixedBinding>,
     editable_custom_action_bindings: Vec<Tracked<EditableBinding>>,
+
+    /// Custom triggers keyed by binding name, including names with no registered binding yet.
+    /// Bindings registered later (e.g. derived from launch configurations, which load
+    /// asynchronously after `keybindings.yaml` is applied) pick their custom trigger up from
+    /// here at registration time.
+    custom_triggers: HashMap<String, Trigger>,
 }
 
 // Custom actions should be identified by a unique integer called their tag.
@@ -291,7 +297,7 @@ pub struct FixedBinding {
 /// for `custom_trigger`.
 #[derive(Clone)]
 pub struct EditableBinding {
-    name: &'static str,
+    name: Cow<'static, str>,
     description: BindingDescription,
     action: Arc<dyn Action>,
     context_predicate: ContextPredicate,
@@ -305,7 +311,7 @@ pub struct EditableBinding {
 
 /// A lens into an editable binding, allowing for the trigger to be updated where necessary
 pub struct EditableBindingLens<'a> {
-    pub name: &'static str,
+    pub name: &'a str,
     pub description: &'a BindingDescription,
     pub action: &'a Arc<dyn Action>,
     context: &'a ContextPredicate,
@@ -404,22 +410,64 @@ impl Keymap {
     /// via the `set_custom_trigger` method.
     fn register_editable_bindings<A: IntoIterator<Item = EditableBinding>>(&mut self, actions: A) {
         let start_idx = self.editable_bindings.len();
-        self.editable_bindings
-            .extend(actions.into_iter().map(Tracked::new));
+        let new_bindings: Vec<_> = actions
+            .into_iter()
+            .map(|mut binding| {
+                if let Some(trigger) = self.custom_triggers.get(&*binding.name) {
+                    binding.custom_trigger = Some(trigger.clone());
+                }
+                Tracked::new(binding)
+            })
+            .collect();
+        self.editable_bindings.extend(new_bindings);
         for (idx, binding) in self.editable_bindings.iter().enumerate().skip(start_idx) {
             if matches!(binding.trigger, Trigger::Custom(_)) {
                 self.editable_custom_action_bindings
                     .push(Tracked::new((*binding).clone()));
             }
             self.editable_bindings_by_name
-                .entry(binding.name)
+                .entry(binding.name.clone())
                 .or_default()
                 .push(idx);
         }
     }
 
+    /// Removes every editable binding whose name starts with `prefix`, then registers
+    /// `bindings` in their place. Used for bindings derived from user-editable state (saved
+    /// launch configurations and tab configs) that must be re-registered whenever that state
+    /// reloads.
+    fn replace_editable_bindings_with_prefix<A: IntoIterator<Item = EditableBinding>>(
+        &mut self,
+        prefix: &str,
+        bindings: A,
+    ) {
+        self.editable_bindings
+            .retain(|binding| !binding.name.starts_with(prefix));
+        self.editable_custom_action_bindings
+            .retain(|binding| !binding.name.starts_with(prefix));
+        // Removal shifts indices in `editable_bindings`, so the by-name index is rebuilt from
+        // scratch rather than patched.
+        self.editable_bindings_by_name.clear();
+        for (idx, binding) in self.editable_bindings.iter().enumerate() {
+            self.editable_bindings_by_name
+                .entry(binding.name.clone())
+                .or_default()
+                .push(idx);
+        }
+        self.register_editable_bindings(bindings);
+    }
+
     /// Updates the custom trigger for a given editable binding.
     fn update_custom_trigger(&mut self, name: &str, trigger: Option<Trigger>) {
+        match &trigger {
+            Some(trigger) => {
+                self.custom_triggers
+                    .insert(name.to_string(), trigger.clone());
+            }
+            None => {
+                self.custom_triggers.remove(name);
+            }
+        }
         for binding in self
             .editable_custom_action_bindings
             .iter_mut()
@@ -643,15 +691,16 @@ impl FixedBinding {
 }
 
 impl EditableBinding {
-    pub fn new<D, A>(name: &'static str, description: D, action: A) -> Self
+    pub fn new<N, D, A>(name: N, description: D, action: A) -> Self
     where
+        N: Into<Cow<'static, str>>,
         D: Into<BindingDescription>,
         A: Action,
     {
         // Note: Explicitly not supporting registering legacy actions, as they will be removed
         // when the conversion to editable bindings is complete
         EditableBinding {
-            name,
+            name: name.into(),
             description: description.into(),
             action: Arc::new(action),
             context_predicate: ContextPredicate::Just(true),
@@ -661,6 +710,11 @@ impl EditableBinding {
             custom_trigger: None,
             id: BindingId::new(),
         }
+    }
+
+    /// The unique name this binding is registered and persisted under.
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn with_context_predicate(mut self, context: ContextPredicate) -> Self {
@@ -746,7 +800,7 @@ impl EditableBinding {
             (&self.trigger, None)
         };
         EditableBindingLens {
-            name: self.name,
+            name: &self.name,
             description: &self.description,
             action: &self.action,
             context: &self.context_predicate,

--- a/crates/warpui_core/src/keymap/matcher.rs
+++ b/crates/warpui_core/src/keymap/matcher.rs
@@ -130,6 +130,32 @@ impl Matcher {
         self.keymap.register_editable_bindings(actions.into_iter());
     }
 
+    /// Removes every editable binding whose name starts with `prefix`, then registers
+    /// `bindings` in their place.
+    pub fn replace_editable_bindings_with_prefix<A: IntoIterator<Item = EditableBinding>>(
+        &mut self,
+        prefix: &str,
+        bindings: A,
+    ) {
+        self.pending.clear();
+
+        let bindings = match &self.custom_trigger_to_keystroke_fn {
+            None => Either::Left(bindings),
+            Some(custom_tag_to_keystroke) => {
+                let bindings = bindings.into_iter().map(|mut editable_binding| {
+                    editable_binding.trigger = Self::convert_custom_trigger_to_keystroke_trigger(
+                        editable_binding.trigger,
+                        custom_tag_to_keystroke,
+                    );
+                    editable_binding
+                });
+                Either::Right(bindings)
+            }
+        };
+        self.keymap
+            .replace_editable_bindings_with_prefix(prefix, bindings.into_iter());
+    }
+
     /// Set a custom trigger for a given editable binding name.
     ///
     /// This will override the default trigger for that action.

--- a/crates/warpui_core/src/keymap_tests.rs
+++ b/crates/warpui_core/src/keymap_tests.rs
@@ -541,3 +541,68 @@ fn test_binding_description_resolve_dynamic_override_falls_back_to_custom_contex
         assert_eq!(resolved, "menu-static");
     });
 }
+
+#[test]
+fn test_custom_trigger_applies_to_binding_registered_later() {
+    #[derive(Debug)]
+    struct TestAction;
+
+    let mut map = Keymap::default();
+    let custom = Keystroke::parse("ctrl-alt-1").unwrap();
+    map.update_custom_trigger(
+        "launch_config:open:backend",
+        Some(Trigger::Keystrokes(vec![custom.clone()])),
+    );
+
+    map.register_editable_bindings([EditableBinding::new(
+        String::from("launch_config:open:backend"),
+        "Open Launch Configuration \"backend\"",
+        TestAction,
+    )]);
+
+    let binding = map
+        .get_binding_by_name("launch_config:open:backend")
+        .unwrap();
+    match binding.trigger {
+        Trigger::Keystrokes(keystrokes) => {
+            assert_eq!(keystrokes, std::slice::from_ref(&custom));
+        }
+        _ => panic!("Expected keystroke trigger"),
+    }
+}
+
+#[test]
+fn test_replace_editable_bindings_with_prefix() {
+    #[derive(Debug)]
+    struct TestAction;
+
+    let mut map = Keymap::default();
+    map.register_editable_bindings([
+        EditableBinding::new("other:action", "Other action", TestAction).with_key_binding("cmd-1"),
+        EditableBinding::new(String::from("cfg:1"), "Config one", TestAction),
+        EditableBinding::new(String::from("cfg:2"), "Config two", TestAction),
+    ]);
+    let custom = Keystroke::parse("ctrl-2").unwrap();
+    map.update_custom_trigger("cfg:2", Some(Trigger::Keystrokes(vec![custom.clone()])));
+
+    map.replace_editable_bindings_with_prefix(
+        "cfg:",
+        [
+            EditableBinding::new(String::from("cfg:2"), "Config two", TestAction),
+            EditableBinding::new(String::from("cfg:3"), "Config three", TestAction),
+        ],
+    );
+
+    assert!(map.get_binding_by_name("other:action").is_some());
+    assert!(map.get_binding_by_name("cfg:1").is_none());
+    assert!(map.get_binding_by_name("cfg:3").is_some());
+
+    // The custom trigger assigned before the replace survives re-registration.
+    let replaced = map.get_binding_by_name("cfg:2").unwrap();
+    match replaced.trigger {
+        Trigger::Keystrokes(keystrokes) => {
+            assert_eq!(keystrokes, std::slice::from_ref(&custom));
+        }
+        _ => panic!("Expected keystroke trigger"),
+    }
+}

--- a/resources/bundled/skills/change-keybinding/SKILL.md
+++ b/resources/bundled/skills/change-keybinding/SKILL.md
@@ -47,6 +47,11 @@ Defaults are compiled into Warp and are **not** discoverable from the keybinding
 
 2. **By description or current key combo** ("rebind the command palette to cmd-p", "change ctrl+space to ctrl+s"): you don't have the action name and cannot reliably guess it. Do not invent one. Direct the user to the **keybindings editor** (`workspace:show_keybinding_settings`, default `cmd-ctrl-k` on macOS; **Settings → Keyboard Shortcuts** on other platforms) — they can search by description or current shortcut there and either edit the binding in place or share the canonical `namespace:action_name` so you can write it.
 
+3. **By saved config** ("open my `backend` launch config with ctrl-alt-1"): every saved launch configuration and tab config registers its own action, so the name is derivable:
+   - `launch_config:open:<name>` — `<name>` is the launch configuration's `name` field, exactly as written in its YAML (same identifier `warp://launch/<name>` accepts).
+   - `tab_config:open:<file-stem>` — the tab config's file name without the `.toml` extension (same identifier `warp://tab_config/<stem>` accepts).
+   These appear in the keybindings editor as `Open Launch Configuration "<name>"` / `Open Tab Config "<name>"` and have no default keystroke.
+
 ## Workflow
 
 1. Determine which action to remap and the new trigger (see "Identifying the action").

--- a/specs/GH2818/product.md
+++ b/specs/GH2818/product.md
@@ -1,0 +1,167 @@
+# Product Spec: Open a launch configuration or tab config with a keyboard shortcut
+
+**Issue:** [warpdotdev/warp#2818](https://github.com/warpdotdev/warp/issues/2818)
+
+**Figma:** none provided
+
+## Summary
+
+Let users bind a keyboard shortcut to any saved **launch configuration** or **tab config**, so a
+single keystroke opens a new tab (or set of tabs) in a specific directory with a specific layout.
+Every config the user has on disk shows up as an assignable action in **Settings → Keyboard
+Shortcuts**, exactly like a built-in action, and the assignment is stored in the existing
+`keybindings.yaml`. No new file format and no new settings surface are introduced.
+
+This is the pathway proposed in the issue: rather than a one-off "new tab in directory X"
+binding, shortcuts attach to the two config primitives Warp already has for "open a session in a
+known place with a known shape".
+
+## Problem
+
+Warp can set a *default* directory for new tabs, and it can open a saved launch configuration or
+tab config from the command palette, the `+` menu, the app menu, or a `warp://` URI. What it
+cannot do is open a specific one from the keyboard. A developer who bounces between three
+repositories has to reach for the palette, type, and confirm every time; a muscle-memory
+`ctrl-alt-1` / `ctrl-alt-2` / `ctrl-alt-3` is not possible.
+
+The keybinding system today is a fixed, compiled-in list of actions. A user-authored config is not
+an action, so there is nothing to bind to. The feature is "make each saved config an action".
+
+## Goals
+
+- Every loaded launch configuration and tab config is bindable from Settings → Keyboard Shortcuts
+  and from `keybindings.yaml`, with no shortcut assigned by default.
+- Pressing the shortcut opens the config **in the active window** so the result is a new tab (or
+  tabs), matching the issue's intent.
+- Configs added, removed, or renamed on disk update the set of bindable actions without a
+  restart, reusing the existing file watcher.
+- Reuse the existing keybinding editor, conflict indication, persistence, and reset/remove
+  affordances unchanged.
+
+## Non-goals
+
+- A generic "open a new tab at `<path>`" binding with the path written inline in
+  `keybindings.yaml`. Bindings stay a flat `action → keystroke` map; the path lives in the config.
+- Declaring the shortcut *inside* the launch config / tab config file (a shareable default). Listed
+  as a follow-up; it layers cleanly on top of this design.
+- Hot-reloading `keybindings.yaml` itself. As today, edits to that file take effect on the next
+  launch; edits made through Settings take effect immediately.
+- Showing config actions in the Resource Center keybindings cheat-sheet (its sections are curated
+  static lists).
+- The headless TUI (`warp_tui`) — it has a separate keybinding system and no configs.
+
+## Behavior invariants
+
+### Discoverability and assignment
+
+1. For every launch configuration loaded from `~/.warp/launch_configurations/`, Settings →
+   Keyboard Shortcuts lists an action described as `Open launch configuration "<name>"`, where
+   `<name>` is the config's `name` field. It has no shortcut until the user assigns one.
+2. For every tab config loaded from `~/.warp/tab_configs/`, the page lists
+   `Open tab config "<name>"`, where `<name>` is the config's `name` field. It has no shortcut until
+   the user assigns one.
+3. Searching the Keyboard Shortcuts page by the config's name, or by "launch configuration" /
+   "tab config", finds the action.
+4. Assigning, changing, removing (`none`), or resetting a shortcut for a config action behaves
+   identically to a built-in action: the same editor row, the same conflict indication when the
+   keystroke is already taken, the same persistence. Reset returns the action to *unbound*, since
+   there is no compiled-in default.
+5. The assignment is persisted in `keybindings.yaml` under a stable key:
+   - launch configuration: `"launch_config:open:<name>"` — `<name>` is the config's `name`, the
+     same identifier `warp://launch/<name>` accepts;
+   - tab config: `"tab_config:open:<file-stem>"` — the TOML file name without extension, the
+     same identifier `warp://tab_config/<file-stem>` accepts.
+   A user who writes such a key by hand (quoted, as all action keys are) gets the same result after
+   the next launch.
+
+### Triggering
+
+6. Pressing a bound launch-configuration shortcut while a Warp window is focused opens that
+   configuration into the **active window**: its tabs are appended to the current window and the
+   configuration's active tab is focused — the same behavior as the command palette's
+   "open in active window" affordance. If the configuration defines more than one window, it
+   opens new windows exactly as it does from the palette or `+` menu today.
+7. Pressing a bound tab-config shortcut opens that tab config in the active window: immediately
+   when the config has no parameters, otherwise the existing parameter modal opens first — the
+   same behavior as choosing it from the `+` menu.
+8. Config shortcuts fire in the same contexts as `workspace:new_tab` (including when a terminal
+   pane has keyboard focus) and are suppressed in the same contexts (e.g. while a pane is being
+   dragged).
+9. If the bound config cannot be found when the key is pressed (it was deleted and the reload
+   raced the keystroke), Warp shows an ephemeral toast `Launch configuration "<name>" not found`
+   / `Tab config "<file-stem>" not found` and does nothing else.
+
+### Lifecycle
+
+10. Adding, removing, or renaming a config file updates the set of actions without a restart. If
+    the Keyboard Shortcuts page is open, its list refreshes.
+11. Removing a config leaves its `keybindings.yaml` entry in place and inert. Re-adding a config
+    with the same name / file stem re-activates the stored shortcut without user action.
+12. If two launch configurations share a `name` (case-insensitive), or two tab configs share a
+    file stem, exactly one action is registered — the first loaded — and a warning is logged.
+    This mirrors how `warp://launch/<name>` resolves duplicates today.
+13. Config actions are gated by the same availability as the configs themselves: launch
+    configuration actions are absent when launch configurations are disabled for the account,
+    tab config actions are absent when tab configs are disabled.
+14. With the feature's rollout flag off, no config actions are registered; any stored
+    `launch_config:open:*` / `tab_config:open:*` entries in `keybindings.yaml` are ignored.
+
+### Edge cases
+
+15. Names containing spaces, quotes, colons, or non-ASCII characters are used verbatim in the
+    description and in the `keybindings.yaml` key; keys are quoted so YAML parses them.
+16. A tab config whose file stem is not valid UTF-8 is skipped with a warning; every other config
+    still registers.
+17. Accessibility: the Settings row is announced with its full description
+    (`Open launch configuration "<name>"`) and is fully operable from the keyboard, like every
+    other row. The toast in (9) is announced like other ephemeral toasts.
+
+## Example
+
+```yaml
+# ~/.warp/launch_configurations/backend.yaml
+name: backend
+windows:
+  - tabs:
+      - title: api
+        layout:
+          cwd: ~/code/backend
+```
+
+```toml
+# ~/.warp/tab_configs/frontend.toml
+name = "Frontend"
+title = "web"
+[[panes]]
+id = "root"
+type = "terminal"
+directory = "~/code/frontend"
+```
+
+After the two files are loaded, Settings → Keyboard Shortcuts shows
+`Open launch configuration "backend"` and `Open tab config "Frontend"`. The user assigns
+`ctrl-alt-1` and `ctrl-alt-2`. `keybindings.yaml` now contains:
+
+```yaml
+"launch_config:open:backend": ctrl-alt-1
+"tab_config:open:frontend": ctrl-alt-2
+```
+
+From then on `ctrl-alt-1` appends an `api` tab rooted at `~/code/backend` to the current window
+and focuses it; `ctrl-alt-2` opens a `web` tab rooted at `~/code/frontend`.
+
+## Open questions
+
+1. **Active window vs. new window for launch configurations.** This spec proposes "active window"
+   for the keyboard path because the issue is about tabs and the URI/menu paths already cover the
+   new-window case. Alternative: keep new-window parity with the palette's plain Enter, and offer a
+   second action per config for the active-window variant. Two actions per config doubles the list
+   in Settings; the proposal is one action, active-window semantics.
+2. **Shortcut declared in the config file.** Should `keybinding:` be accepted in the launch
+   config YAML / tab config TOML as a *default* (overridable in Settings)? It makes shortcuts
+   travel with shared configs. Deferred to a follow-up so this change stays inside the existing
+   keybinding model; nothing here precludes it.
+3. **Telemetry granularity.** The launch-configuration open event already records the UI
+   location; a `Keybinding` value is added. Tab config open events currently do not record a
+   source; adding one touches the exhaustive telemetry table and is left to the maintainers'
+   preference.

--- a/specs/GH2818/tech.md
+++ b/specs/GH2818/tech.md
@@ -1,0 +1,361 @@
+# Tech Spec: Open a launch configuration or tab config with a keyboard shortcut
+
+**Issue:** [warpdotdev/warp#2818](https://github.com/warpdotdev/warp/issues/2818)
+
+**Product spec:** [`specs/GH2818/product.md`](product.md)
+
+Line references are against `master` at `d5d12d90f`.
+
+## Context
+
+### Keybindings are a static, compiled-in list
+
+- `crates/warpui_core/src/keymap.rs:293-305` — `EditableBinding { name: &'static str, description,
+  action: Arc<dyn Action>, context_predicate, enabled_predicate, trigger, custom_trigger, group:
+  Option<&'static str>, id }`. `EditableBinding::new(name: &'static str, …)` at `:646`.
+- `keymap.rs:25-39` — `Keymap` holds `editable_bindings: Vec<Tracked<EditableBinding>>` and an
+  index `editable_bindings_by_name: HashMap<&'static str, Vec<usize>>` (`:33`).
+- `keymap.rs:405-419` — `register_editable_bindings` is **append-only**; there is no API to remove
+  or replace editable bindings (verified: no `remove`/`retain`/`unregister` in the file).
+- `keymap.rs:422-432` — `update_custom_trigger(name, trigger)` iterates the bindings already
+  registered under `name`. A custom trigger set for a name that is **not yet registered is silently
+  dropped**.
+- `crates/warpui_core/src/keymap/matcher.rs:111-133` (`register_editable_bindings`),
+  `:136-141` (`set_custom_trigger(name: String, …)`), `:145-151` (`remove_custom_trigger`) —
+  thin wrappers that clear `pending` keystrokes and forward to the `Keymap`.
+- `crates/warpui_core/src/core/app.rs:1804-1810`, `:1814-1816`, `:1833-1839` — the
+  `AppContext` surface for the above. Registration is legal at any time, not only during init.
+- `keymap.rs:237` — `EnabledPredicate = fn() -> bool` (capture-free), used via `with_enabled`.
+
+The user's overrides live in `keybindings.yaml`:
+
+- `app/src/keyboard.rs:33` (`KEYBINDINGS_FILE_NAME`), `:37-58` `load_custom_keybindings` reads the
+  file and calls `app.set_custom_trigger(name, …)` per entry; `:64` `write_custom_keybinding(name:
+  String, …)`; `:79` `remove_custom_keybinding`; `:95-97` `keybinding_file_path()`. The on-disk map
+  is already `String`-keyed; only the registration side is `&'static`.
+- `app/src/lib.rs:3078` — `load_custom_keybindings` runs in `launch()`. The `WarpConfig`
+  singleton is created earlier at `app/src/lib.rs:1498`, but it loads launch configs and tab
+  configs **asynchronously** (`app/src/user_config/native.rs:31-52`), so config-derived bindings
+  will always register *after* the custom triggers have been applied. Combined with the
+  silent-drop behavior above, dynamic bindings need the keymap to remember pending triggers.
+
+### How the workspace declares bindings today
+
+- `app/src/workspace/mod.rs:709-716` — `NEW_TAB_BINDING_NAME` → `WorkspaceAction::AddDefaultTab`,
+  `.with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))`,
+  `.with_enabled(|| ContextFlag::CreateNewSession.is_enabled())`.
+- `mod.rs:1152-1162` — `"workspace:toggle_launch_config_palette"` gated with
+  `.with_enabled(|| ContextFlag::LaunchConfigurations.is_enabled())`.
+- `app/src/workspace/action.rs:129` — `WorkspaceAction` (`#[derive(Debug, Clone)]`), handled in
+  `Workspace::handle_action` (`app/src/workspace/view.rs:24070-24075` shows `SelectTabConfig` and
+  `SelectNewSessionMenuItem`). `action.rs:932` `should_save_app_state_on_action` matches variants
+  exhaustively, so new variants must be added there.
+
+### Launch configurations
+
+- `app/src/launch_configs/launch_config.rs:16-21` — `LaunchConfig { name: String,
+  active_window_index, windows: Vec<WindowTemplate> }`; `:182-190` `TabTemplate { title, layout:
+  PaneTemplateType, commands, color }`; `:275` `make_mock_single_window_launch_config()` (tests).
+- `app/src/user_config/mod.rs:90-103` — `WarpConfig { launch_configs, tab_configs, … }`;
+  accessors `launch_configs()` / `tab_configs()` at `:118-124`; dirs at `:210-217`.
+- `app/src/user_config/mod.rs:55-65` — `WarpConfigUpdateEvent::{LaunchConfigs, TabConfigs, …}`
+  emitted after the initial async load and after every directory change
+  (`user_config/native.rs:119-137`). `app/src/search/command_palette/launch_config/data_source.rs:51-60`
+  is the canonical subscriber pattern.
+- Opening: `app/src/root_view.rs:250-259` `OpenLaunchConfigArg { launch_config, ui_location,
+  open_in_active_window }` dispatched as the global action `"root_view:open_launch_config"`, handled
+  by `open_launch_config` at `root_view.rs:565-613`. With `open_in_active_window && windows.len()
+  == 1` it calls `Workspace::open_launch_config_window` (`workspace/view.rs:3895-3929`), which
+  appends the template's tabs via `add_tab_with_pane_layout` and focuses the active one.
+  Otherwise it opens new windows. The palette's `execute_result` already uses
+  `open_in_active_window: true` (`command_palette/launch_config/search_item.rs:66-70`).
+- Existing entry points all set a `LaunchConfigUiLocation`
+  (`app/src/server/telemetry/events.rs:608-613`: `CommandPalette | AppMenu | TabMenu | Uri`):
+  palette `command_palette/view.rs:884-896`, app menu `app_menus.rs:940-960`, `+` menu
+  `workspace/view.rs:7094-7124`, URI `uri/mod.rs:211-232`.
+- Identity: the URI path resolves a config by `name`, case-insensitively
+  (`uri/mod.rs:769-793` `find_matching_config` / `find_matching_config_name`).
+- Pre-existing bug worth fixing in passing: `root_view.rs:606-612` reports
+  `LaunchConfigUiLocation::Uri` in `TelemetryEvent::OpenLaunchConfig` regardless of
+  `arg.ui_location`.
+
+### Tab configs
+
+- `app/src/tab_configs/tab_config.rs:138-165` — `TabConfig { name, title, color, panes, params,
+  source_path: Option<PathBuf> /* #[serde(skip)] */ }`.
+- `workspace/view.rs:7152-7192` — `Workspace::open_tab_config(tab_config, ctx)`: no params →
+  `open_tab_config_with_params` (`:7126-7150`, renders and calls `add_tab_with_pane_layout`) and
+  emits `TabConfigsTelemetryEvent::ExistingConfigOpened { open_mode: Direct, … }`; with params →
+  opens `tab_config_params_modal`.
+- Identity: `warp://tab_config/<stem>` resolves by the **file stem** of `source_path`,
+  case-insensitively (`uri/mod.rs:853-866` `find_matching_tab_config`).
+- Gating: `FeatureFlag::TabConfigs` (`crates/warp_features/src/lib.rs:809`), checked in
+  `user_config/native.rs:45,130`.
+
+### Settings → Keyboard Shortcuts
+
+- `app/src/settings_view/keybindings.rs:749-813` — `on_page_selected` rebuilds the list from
+  `ctx.editable_bindings()` → `CommandBinding::from_editable_lens`
+  (`app/src/util/bindings.rs:765-774`, `name: lens.name.into()` → `String`), sorted by description,
+  de-duplicated by `(name, description)`, and seeds the `ConflictMap`. Anything registered in the
+  keymap appears here automatically; the list is only rebuilt when the page is (re)selected.
+- `keybindings.rs:670-701` — `confirm_keystroke_editing` persists via `set_custom_keybinding`
+  and emits `TelemetryEvent::KeybindingChanged { action: name, … }`.
+- `keybindings.rs:59-84` — `KeybindingChangedNotifier` / `KeybindingChangedEvent`, already used
+  by the Resource Center page to rebuild on changes (`resource_center/keybindings_page.rs:177`).
+- `util/bindings.rs:817-838` — `BindingGroup::as_str` / `from_str` (via `enum_iterator::all`).
+- `resources/bundled/skills/change-keybinding/SKILL.md` — the bundled agent skill documenting the
+  `keybindings.yaml` format and how to identify action names.
+
+### Integration-test precedents
+
+- `crates/integration/src/test/launch_configs.rs:27` `test_add_launch_config_to_warp_config`
+  writes a config into `integration_testing::launch_configs::launch_configs_dir()` with
+  `WARP_CONFIG_WATCHER_DELAY_MS=10` and waits for the palette to pick it up.
+- `launch_configs.rs:258` `test_open_launch_config_in_active_window` dispatches
+  `root_view:open_launch_config` with `open_in_active_window: true` and asserts
+  `assert_num_windows_open(1)` / `assert_tab_count(3)`.
+- `crates/integration/src/test.rs:1659-1668` writes a fake `keybindings.yaml` via
+  `integration_testing::create_file_with_contents(…, &keybinding_file_path())`, then drives the
+  binding with `TestStep::with_keystrokes` (`crates/warpui_core/src/integration/step.rs:402`).
+
+## Proposed changes
+
+### 1. Keymap: allow owned binding names
+
+`crates/warpui_core/src/keymap.rs`
+
+- `EditableBinding.name: Cow<'static, str>`; `EditableBindingLens.name: &'a str`;
+  `Keymap.editable_bindings_by_name: HashMap<Cow<'static, str>, Vec<usize>>`
+  (`Cow<'static, str>: Borrow<str>`, so `get_binding_by_name(&str)` is unchanged).
+- `EditableBinding::new(name: impl Into<Cow<'static, str>>, …)`. Every existing call site passes
+  a string literal and compiles unchanged; `CommandBinding::from_editable_lens` already converts
+  with `.into()`.
+- `FixedBinding` is untouched.
+
+### 2. Keymap: remember custom triggers for names registered later
+
+`crates/warpui_core/src/keymap.rs`
+
+- Add `custom_triggers: HashMap<String, Option<Trigger>>` to `Keymap`.
+- `update_custom_trigger(name, trigger)` records into the map unconditionally, then applies to
+  currently registered bindings as today. `None` (from `remove_custom_trigger`) removes the entry.
+- `register_editable_bindings` applies `custom_triggers.get(name)` to each new binding.
+
+This makes the order of `load_custom_keybindings` and any registration irrelevant. It also fixes
+the latent hazard for built-in bindings registered lazily (none today, but the API allows it).
+
+### 3. Keymap / Matcher / AppContext: replace a namespace of editable bindings
+
+`crates/warpui_core/src/keymap.rs`, `keymap/matcher.rs`, `core/app.rs`
+
+```rust
+/// Drops every editable binding whose name starts with `prefix`, then registers `bindings`.
+pub fn replace_editable_bindings_with_prefix<A>(&mut self, prefix: &str, bindings: A)
+where
+    A: IntoIterator<Item = EditableBinding>;
+```
+
+- Removes matching entries from `editable_bindings` and `editable_custom_action_bindings`,
+  rebuilds `editable_bindings_by_name` from scratch (indices shift on removal), then delegates to
+  `register_editable_bindings` so pending custom triggers (§2) apply.
+- `Matcher` wrapper clears `pending` like its siblings; `AppContext` exposes it with the same
+  shape as `register_editable_bindings` (`app.rs:1804`).
+- Prefixes are owned by exactly one caller each (§5), so a full rebuild of the index on every
+  config reload is acceptable: the list is a few hundred entries and reloads are user-driven.
+
+### 4. Workspace actions that resolve a config by identity at dispatch time
+
+`app/src/workspace/action.rs`, `app/src/workspace/view.rs`
+
+```rust
+/// Opens the launch configuration with this `name`, resolved from `WarpConfig` when dispatched.
+OpenLaunchConfigNamed { name: String },
+/// Opens the tab config whose file stem is `file_stem`, resolved from `WarpConfig` when dispatched.
+OpenTabConfigNamed { file_stem: String },
+```
+
+- The action carries an identifier rather than a `LaunchConfig`/`TabConfig` snapshot so the
+  binding never opens stale contents and stays cheap to clone and log.
+- Handler for `OpenLaunchConfigNamed`: look up `WarpConfig::handle(ctx).as_ref(ctx).launch_configs()`
+  by name, case-insensitively (reuse `find_matching_config_name`; move it out of `uri/mod.rs`
+  into `launch_configs/` so both call sites share it), then
+  `ctx.dispatch_global_action("root_view:open_launch_config", OpenLaunchConfigArg {
+  launch_config, ui_location: LaunchConfigUiLocation::Keybinding, open_in_active_window: true })`.
+- Handler for `OpenTabConfigNamed`: look up `tab_configs()` by `source_path` file stem,
+  case-insensitively (reuse `find_matching_tab_config`, moved next to `TabConfig`), then
+  `self.open_tab_config(config.clone(), ctx)` — params modal included for free.
+- Not found: `log::warn!` and an ephemeral toast through the workspace's
+  `DismissibleToastStack::add_ephemeral_toast` (`app/src/workspace/toast_stack.rs:24`) with the
+  text from product invariant 9.
+- Add both variants to `should_save_app_state_on_action` (`action.rs:932`) alongside
+  `SelectTabConfig` / `OpenLaunchConfigSaveModal`, and to any other exhaustive `match` over
+  `WorkspaceAction` the compiler points at (no `_` arms per AGENTS.md).
+
+### 5. `config_keybindings`: derive bindings from `WarpConfig` and keep them in sync
+
+New module `app/src/config_keybindings.rs` (+ `config_keybindings_tests.rs`), `init(app)` called
+from `app/src/lib.rs` right after `WarpConfig` is added (`lib.rs:1498`).
+
+- A small singleton model subscribes to `WarpConfig` and, on init and on
+  `WarpConfigUpdateEvent::LaunchConfigs | TabConfigs`, rebuilds:
+
+  ```rust
+  const LAUNCH_CONFIG_BINDING_PREFIX: &str = "launch_config:open:";
+  const TAB_CONFIG_BINDING_PREFIX: &str = "tab_config:open:";
+
+  EditableBinding::new(
+      format!("{LAUNCH_CONFIG_BINDING_PREFIX}{name}"),
+      format!("Open launch configuration \"{name}\""),
+      WorkspaceAction::OpenLaunchConfigNamed { name: name.clone() },
+  )
+  .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging"))
+  .with_group(BindingGroup::LaunchConfigurations.as_str())
+  .with_enabled(|| ContextFlag::LaunchConfigurations.is_enabled())
+  ```
+
+  and the tab-config twin (`file_stem` in the name, `config.name` in the description,
+  `.with_enabled(|| FeatureFlag::TabConfigs.is_enabled())`).
+- Identity rules: launch configs keyed by `name`, tab configs by `source_path` file stem — the
+  same keys the URI handlers accept, so documentation can describe one identifier per config type.
+  Duplicates (case-insensitive) keep the first and `log::warn!`; tab configs without a UTF-8 stem
+  are skipped with a warning.
+- Publishes with `ctx.replace_editable_bindings_with_prefix(LAUNCH_CONFIG_BINDING_PREFIX, …)` and
+  the tab-config equivalent, then emits a new `KeybindingChangedEvent::BindingsReloaded` on
+  `KeybindingChangedNotifier`.
+- `BindingGroup` gains `LaunchConfigurations` (`"launch_configurations"`) and `TabConfigs`
+  (`"tab_configs"`) in `util/bindings.rs:817-832`; `from_str` picks them up via `all::<Self>()`.
+- `settings_view/keybindings.rs`: subscribe to `KeybindingChangedEvent::BindingsReloaded` and
+  re-run the list build from `on_page_selected` (extract it into `rebuild_bindings`) so an open
+  page reflects config changes (product invariant 10). The Resource Center page ignores the event:
+  its sections are static allow-lists (`keybindings_page.rs:229-260`).
+- No `CustomAction` is registered for these bindings, so they do not appear in the macOS app
+  menus; the launch-configuration menu already lists configs by name.
+
+### 6. Telemetry
+
+- `LaunchConfigUiLocation::Keybinding` (`events.rs:608-613`).
+- `root_view.rs:606-612`: report `arg.ui_location` instead of the hardcoded `Uri`.
+- Optional, per product open question 3: add `open_source: TabConfigOpenSource { Menu, Uri,
+  Keybinding }` to `TabConfigsTelemetryEvent::ExistingConfigOpened` (`tab_configs/telemetry.rs`),
+  which requires updating the exhaustive telemetry table test in `events_tests.rs`. If declined,
+  tab-config opens via keybinding are still counted under the existing event.
+
+### 7. Feature flag
+
+- `FeatureFlag::ConfigKeybindings` in `crates/warp_features/src/lib.rs`, on in `DOGFOOD_FLAGS`
+  (`:1002`). `config_keybindings::init` returns early when disabled, so nothing registers and
+  stored `keybindings.yaml` entries are inert (product invariant 14). Runtime check, not `cfg`,
+  per AGENTS.md.
+
+### 8. Documentation shipped with the app
+
+- `resources/bundled/skills/change-keybinding/SKILL.md` → "Identifying the action": document the
+  two name patterns and that the description in Settings is
+  `Open launch configuration "<name>"` / `Open tab config "<name>"`, so the agent can write the
+  key directly when the user names a config.
+
+## End-to-end flow
+
+1. Startup: `WarpConfig::new` kicks off the async load; `launch()` applies `keybindings.yaml`
+   through `set_custom_trigger`, which now also records into `Keymap.custom_triggers` (§2).
+2. The load completes and emits `WarpConfigUpdateEvent::LaunchConfigs`. `config_keybindings`
+   builds one `EditableBinding` per config and calls `replace_editable_bindings_with_prefix`
+   (§3). Registration applies the remembered trigger for `"launch_config:open:backend"`.
+3. The user presses `ctrl-alt-1` with a terminal focused. The matcher resolves the binding in the
+   `Workspace` context and dispatches `WorkspaceAction::OpenLaunchConfigNamed { name: "backend" }`.
+4. `Workspace::handle_action` resolves the config from `WarpConfig` and dispatches
+   `root_view:open_launch_config` with `open_in_active_window: true`;
+   `open_launch_config` → `open_launch_config_window` appends and focuses the tab.
+5. The user edits `backend.yaml` → the watcher fires → `LaunchConfigs` → step 2 repeats; the
+   binding is re-registered with the same name and keeps its trigger. Deleting the file removes
+   the binding; the `keybindings.yaml` entry stays and re-applies if the file returns.
+6. Settings → Keyboard Shortcuts: `on_page_selected` lists the config actions; assigning a key
+   goes through `confirm_keystroke_editing` → `set_custom_keybinding` → file + keymap, exactly as
+   for built-ins.
+
+## Testing and validation
+
+### Unit tests
+
+- `crates/warpui_core/src/keymap_tests.rs`
+  - `test_custom_trigger_applies_to_binding_registered_later` (invariant 5/11 mechanics): set a
+    trigger for an unregistered name, register, assert the lens trigger.
+  - `test_replace_editable_bindings_with_prefix` : register `a:x`, `cfg:1`, `cfg:2`; replace
+    `cfg:` with `cfg:2`, `cfg:3`; assert `get_binding_by_name` for all five names, that
+    `custom_action_bindings` no longer contains the dropped ones, and that a custom trigger for
+    `cfg:2` survives the replace.
+  - `test_editable_binding_owned_name`: an `EditableBinding::new(String::from(…))` round-trips
+    through `bindings()` and `get_binding_by_name`.
+- `app/src/config_keybindings_tests.rs`
+  - Name/description derivation for launch configs and tab configs (invariants 1, 2, 5, 15).
+  - Case-insensitive duplicate collapse keeps the first (invariant 12); non-UTF-8 stem skipped
+    (invariant 16).
+  - Feature flag off → no bindings (invariant 14), using the existing `FeatureFlag` test helpers.
+- `app/src/workspace/view_tests.rs`: `OpenLaunchConfigNamed` with an unknown name adds one
+  ephemeral toast and dispatches nothing (invariant 9).
+
+### Integration tests (`crates/integration/src/test/launch_configs.rs`, registered in
+`crates/integration/tests/integration/ui_tests.rs`)
+
+- `test_open_launch_config_via_keybinding` (invariants 6, 8): setup writes a single-window,
+  single-tab launch config whose `cwd` is a temp dir into `launch_configs_dir()` and
+  `"launch_config:open:<name>": ctrl-alt-1` into `keybinding_file_path()` (precedents
+  `launch_configs.rs:27`, `test.rs:1659-1668`); wait for the palette data source to see the
+  config; `.with_keystrokes(&["ctrl-alt-1"])`; assert `assert_num_windows_open(1)`,
+  `assert_tab_count(2)`, focused tab index 1; run `pwd` in it and `validate_block_output` against
+  the temp dir.
+- `test_open_tab_config_via_keybinding` (invariant 7): same shape with a param-less
+  `tab_configs_dir()` TOML and `"tab_config:open:<stem>": ctrl-alt-2`.
+- `test_config_keybinding_follows_file_lifecycle` (invariants 10, 11): after the first open,
+  delete the config file, wait for reload, press the key, assert tab count unchanged; restore the
+  file, wait, press, assert a tab was added.
+- `test_config_keybinding_conflict_shown_in_settings` (invariant 4): open Settings → Keyboard
+  Shortcuts (`KeybindingsView` is already reached in `test.rs:2909`), assign a key already used by
+  `workspace:new_tab`, assert the conflict indicator on both rows.
+
+### Manual verification (attach to the implementation PR)
+
+- Screen recording: create the two example configs from `product.md`, open Settings → Keyboard
+  Shortcuts, search "launch", assign `ctrl-alt-1` and `ctrl-alt-2`, show `keybindings.yaml`,
+  press both keys with a terminal focused, show the resulting tabs' `pwd`.
+- Delete `backend.yaml` while Settings is open → row disappears; recreate → row returns with the
+  shortcut.
+- Multi-window launch config bound to a key → opens new windows as today.
+- Toggle `FeatureFlag::ConfigKeybindings` off → rows gone, key inert.
+
+### Tooling
+
+`./script/presubmit` (fmt, clippy `-D warnings`, `cargo nextest run`). The `Cow<'static, str>`
+change touches every `EditableBinding::new` call only through type inference; no call-site edits
+are expected, which presubmit confirms.
+
+## Risks and mitigations
+
+- **Index invalidation in `Keymap`.** Removing entries shifts `Vec` indices that
+  `editable_bindings_by_name` stores. Mitigation: rebuild the index inside
+  `replace_editable_bindings_with_prefix` and cover it with the unit test above; the only mutation
+  paths remain `register_*` and this one function.
+- **macOS menu cache.** `editable_custom_action_bindings` is a filtered copy consulted from
+  `menuNeedsUpdate`. Config bindings never carry `Trigger::Custom`, but the replace path still
+  prunes the copy so a future `with_custom_action` on them cannot leave stale menu entries.
+- **Startup ordering.** Covered by §2; without it, shortcuts would work only after the user
+  re-saved them in Settings. The unit test `test_custom_trigger_applies_to_binding_registered_later`
+  guards the invariant.
+- **Name collisions with built-in namespaces.** `launch_config:` and `tab_config:` are not used
+  by any existing binding (all built-ins are `workspace:`, `terminal:`, `editor_view:`, …). A
+  debug assertion in `config_keybindings` rejects a prefix that already has registrations.
+- **Rename semantics.** Renaming a config changes its identity and orphans the stored shortcut
+  (invariant 11). This matches URIs and is called out in the SKILL.md update; the follow-up
+  `keybinding:` field would make shortcuts travel with the file.
+- **Behavioral change for keyboard path only.** `open_in_active_window: true` is new only for the
+  keyboard entry point; palette, menu, and URI behavior is untouched.
+
+## Follow-ups
+
+- `keybinding:` field in launch config YAML / tab config TOML as a default trigger (product open
+  question 2): parse with `Keystroke::parse` (`keymap.rs:897`), pass as `.with_key_binding(…)`
+  in §5, and surface parse errors through the existing `TabConfigErrors` toast path.
+- Show the assigned shortcut next to each config in the `+` menu and the launch-configuration
+  palette rows, the way built-in palette entries show theirs.
+- Public docs (docs.warp.dev keybindings and launch-configuration pages).


### PR DESCRIPTION
## Description

Closes #2818 — implements the issue: bind a keyboard shortcut to any saved **launch configuration** or **tab config**, so one keystroke opens a new tab (or tabs) in a specific directory with a specific layout — the pathway the issue proposes.

Every loaded config registers a regular `EditableBinding` — `launch_config:open:<name>` / `tab_config:open:<file-stem>`, the same identifiers the `warp://launch` and `warp://tab_config` URIs accept — with no default keystroke. Users assign keys in **Settings → Keyboard Shortcuts** or `keybindings.yaml` exactly like any built-in action; pressing the key opens the config into the **active window** (`open_in_active_window: true`), i.e. a new tab in the chosen directory. Bindings re-register on config hot-reload, and the Keyboard Shortcuts page refreshes live.

This PR contains both the spec (`specs/GH2818/product.md` + `tech.md`, first commit) and the implementation, per the contribution flow's "implementation generally continues on the same PR".

Keymap changes that make config-derived bindings possible:
- `EditableBinding` names are `Cow<'static, str>` so bindings can be derived from user data; every existing literal call site compiles unchanged.
- The keymap remembers custom triggers by name and applies them to bindings registered later — configs load asynchronously *after* `keybindings.yaml` is applied, so without this every stored shortcut for a config binding would be silently dropped at startup.
- `replace_editable_bindings_with_prefix()` re-registers a namespace of bindings when configs reload, rebuilding the by-name index.

Also adds `LaunchConfigUiLocation::Keybinding` and fixes a pre-existing telemetry bug: `open_launch_config` reported every open as `Uri` regardless of the actual entry point.

Gated behind a new dogfood flag `FeatureFlag::ConfigKeybindings`; launch/tab bindings additionally respect `ContextFlag::LaunchConfigurations` / `FeatureFlag::TabConfigs`.

## Linked Issue

#2818

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement` — **not yet**; I've asked @oss-maintainers on the issue for a readiness re-triage. Opening per the "PRs opened without a linked issue" guidance so the spec + code can host the review.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

**Automated** — `./script/presubmit` run locally: fmt ✓, clang-format ✓, wgslfmt ✓, workspace clippy `--all-features -D warnings` ✓, `cargo nextest run --workspace`: 11,927/11,933 passed. The 6 failures are environmental on my machine, not this diff: 5 SSH shell-integration tests that need a local SSH fixture (uniform ~42s timeouts), and `warp_search_core::test_searcher_async_rebuild_is_not_delayed_when_its_marker_is_never_sent`, which passes 3/3 when run in isolation (timing-sensitive under full-suite load; untouched by this PR).

New tests:
- `keymap_tests.rs`: custom trigger applies to a binding registered later; `replace_editable_bindings_with_prefix` drops only the prefixed namespace, rebuilds the by-name index, and preserves custom triggers across re-registration.
- New `config_keybindings_tests.rs`: binding-name derivation for launch configs (by `name`) and tab configs (by file stem), case-insensitive duplicate collapse keeping the first config (matching URI resolution), and skipping tab configs with no UTF-8 file stem.

**Manual** (macOS, OSS debug build): created a launch configuration and two tab configs, assigned `cmd-alt-1/2/3` via both `keybindings.yaml` and the Settings editor; each keystroke opens the expected tab(s) in the expected cwd in the current window; the multi-tab launch configuration opens both tabs and focuses its active tab; editing/removing a binding in Settings works with the usual conflict indication; adding/removing config files updates the action list without restart; pressing a binding whose config was deleted shows a "not found" toast.

*Disclosure:* since OSS builds don't carry `DOGFOOD_FLAGS`, manual testing force-enabled `FeatureFlag::ConfigKeybindings` via a local-only `oss.rs` tweak that is not part of this PR.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos


https://github.com/user-attachments/assets/70de6fbe-a757-4552-b5a0-47e0074ccde6

<img width="1576" height="300" alt="tab_configs_keybinding" src="https://github.com/user-attachments/assets/dba5e3a0-bd08-4146-a57a-094456313e1c" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NEW-FEATURE: Bind a keyboard shortcut to any saved launch configuration or tab config and open it in the current window with one keystroke.

